### PR TITLE
Unify Kibana dashboard directory logic across Beats

### DIFF
--- a/CHANGELOG-developer.asciidoc
+++ b/CHANGELOG-developer.asciidoc
@@ -22,6 +22,7 @@ The list below covers the major changes between 6.3.0 and master only.
 - The beat.Pipeline is now passed to cfgfile.RunnerFactory. Beats using libbeat for module reloading or autodiscovery need to be adapted. {pull}7018[7017]
 - Moving of TLS helper functions and structs from `output/tls` to `tlscommon`. {pull}7054[7054]
 - Port fields.yml collector to Golang {pull}6911[6911]
+- Dashboards under _meta/kibana are expected to be decoded. See https://github.com/elastic/beats/pull/7224 for a conversion script. {pull}7265[7265]
 
 ==== Bugfixes
 

--- a/auditbeat/.gitignore
+++ b/auditbeat/.gitignore
@@ -1,5 +1,4 @@
 build
-_meta/kibana
 _meta/beat.yml
 _meta/beat.reference.yml
 module/*/_meta/config.yml

--- a/auditbeat/Makefile
+++ b/auditbeat/Makefile
@@ -79,8 +79,6 @@ collect-docs: python-env
 # Collects all module dashboards
 .PHONY: kibana
 kibana:
-	@-rm -rf _meta/kibana
-	@mkdir -p _meta/kibana
-	@-cp -pr module/*/_meta/kibana _meta/
-	@# Convert all dashboards to string
-	@python ${ES_BEATS}/libbeat/scripts/unpack_dashboards.py --glob="./_meta/kibana/6/dashboard/*.json"
+	@-rm -rf _meta/kibana.generated
+	@mkdir -p _meta/kibana.generated
+	@-cp -pr module/*/_meta/kibana/* _meta/kibana.generated

--- a/auditbeat/tests/system/test_base.py
+++ b/auditbeat/tests/system/test_base.py
@@ -63,7 +63,7 @@ class Test(BaseTest):
 
         dirs = [self.temp_dir("auditbeat_test")]
         with PathCleanup(dirs):
-            kibana_dir = os.path.join(self.beat_path, "_meta", "kibana")
+            kibana_dir = os.path.join(self.beat_path, "_meta", "kibana.generated")
             shutil.copytree(kibana_dir, os.path.join(self.working_dir, "kibana"))
 
             es = Elasticsearch([self.get_elasticsearch_url()])

--- a/filebeat/.gitignore
+++ b/filebeat/.gitignore
@@ -5,7 +5,6 @@
 filebeat
 
 build
-_meta/kibana
 _meta/module.generated
 _meta/beat.yml
 _meta/beat.reference.yml

--- a/filebeat/Dockerfile
+++ b/filebeat/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Nicolas Ruflin <ruflin@elastic.co>
 RUN set -x && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
-         netcat python-pip virtualenv && \
+         netcat python-pip rsync virtualenv && \
     apt-get clean
 
 RUN pip install --upgrade setuptools

--- a/filebeat/Makefile
+++ b/filebeat/Makefile
@@ -17,11 +17,9 @@ before-build:
 # Collects all module dashboards
 .PHONY: kibana
 kibana:
-	@rm -rf _meta/kibana
-	@mkdir -p _meta/kibana
-	@-cp -r module/*/_meta/kibana _meta/
-	@# Convert all dashboards to string
-	@python ${ES_BEATS}/libbeat/scripts/unpack_dashboards.py --glob="./_meta/kibana/6/dashboard/*.json"
+	@rm -rf _meta/kibana.generated
+	@mkdir -p _meta/kibana.generated
+	@-cp -pr module/*/_meta/kibana/* _meta/kibana.generated
 
 # Collects all modules files to be packaged in a temporary folder
 .PHONY: modules

--- a/filebeat/tests/system/test_modules.py
+++ b/filebeat/tests/system/test_modules.py
@@ -63,7 +63,7 @@ class Test(BaseTest):
                                             "/../../../../module")
 
         self.kibana_path = os.path.abspath(self.working_dir +
-                                           "/../../../../_meta/kibana")
+                                           "/../../../../_meta/kibana.generated")
 
         self.filebeat = os.path.abspath(self.working_dir +
                                         "/../../../../filebeat.test")

--- a/heartbeat/.gitignore
+++ b/heartbeat/.gitignore
@@ -4,7 +4,5 @@
 
 heartbeat
 
-_meta/kibana
-
 build
 /tests/load/logs

--- a/heartbeat/Makefile
+++ b/heartbeat/Makefile
@@ -31,8 +31,6 @@ create-monitor:
 # Collects all module dashboards
 .PHONY: kibana
 kibana:
-	@rm -rf _meta/kibana
-	@mkdir -p _meta/kibana
-	@-cp -r monitors/active/*/_meta/kibana _meta/
-	@# Convert all dashboards to string
-	@python ${ES_BEATS}/libbeat/scripts/unpack_dashboards.py --glob="./_meta/kibana/6/dashboard/*.json"
+	@rm -rf _meta/kibana.generated
+	@mkdir -p _meta/kibana.generated
+	@-cp -r monitors/active/*/_meta/kibana/* _meta/kibana.generated

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -342,10 +342,13 @@ endif
 	@mkdir -p docs
 	@${PYTHON_ENV}/bin/python ${ES_BEATS}/libbeat/scripts/generate_fields_docs.py $(PWD) ${BEAT_TITLE} ${ES_BEATS}
 
+	@mkdir -p $(PWD)/_meta/kibana.generated
 	@# Generate Kibana index pattern and copy dashboard files
 	if [ -d $(PWD)/_meta/kibana ]; then \
-		cp -r $(PWD)/_meta/kibana/ $(PWD)/_meta/kibana.generated; \
+		cp -pr $(PWD)/_meta/kibana/* $(PWD)/_meta/kibana.generated ; \
 	fi
+	@# Convert all dashboards to string
+	@python ${ES_BEATS}/libbeat/scripts/unpack_dashboards.py --glob="./_meta/kibana.generated/6/dashboard/*.json"
 	@mkdir -p $(PWD)/_meta/kibana.generated/5/index-pattern
 	@mkdir -p $(PWD)/_meta/kibana.generated/6/index-pattern
 	@go run ${ES_BEATS}/dev-tools/cmd/kibana_index_pattern/kibana_index_pattern.go -index '${BEAT_INDEX_PREFIX}-*' -beat-name ${BEAT_NAME} -beat-dir $(PWD) -version ${BEAT_VERSION}

--- a/metricbeat/.gitignore
+++ b/metricbeat/.gitignore
@@ -1,5 +1,4 @@
 build
-_meta/kibana
 _meta/beat.yml
 _meta/beat.reference.yml
 

--- a/metricbeat/Makefile
+++ b/metricbeat/Makefile
@@ -18,12 +18,9 @@ include ${ES_BEATS}/libbeat/scripts/Makefile
 # Collects all module dashboards
 .PHONY: kibana
 kibana:
-	@rm -rf _meta/kibana
-	@mkdir -p _meta/kibana
-	@-cp -r module/*/_meta/kibana _meta/
-	@-cp -r module/*/_meta/kibana _meta/
-	@# Convert all dashboards to string
-	@python ${ES_BEATS}/libbeat/scripts/unpack_dashboards.py --glob="./_meta/kibana/6/dashboard/*.json"
+	@rm -rf _meta/kibana.generated
+	@mkdir -p _meta/kibana.generated
+	@-cp -pr module/*/_meta/kibana/* _meta/kibana.generated
 
 # Collects all module docs
 .PHONY: collect-docs

--- a/metricbeat/tests/system/test_base.py
+++ b/metricbeat/tests/system/test_base.py
@@ -59,7 +59,7 @@ class Test(BaseTest):
         Test that the dashboards can be loaded with `setup --dashboards`
         """
 
-        kibana_dir = os.path.join(self.beat_path, "_meta", "kibana")
+        kibana_dir = os.path.join(self.beat_path, "_meta", "kibana.generated")
         shutil.copytree(kibana_dir, os.path.join(self.working_dir, "kibana"))
 
         es = Elasticsearch([self.get_elasticsearch_url()])

--- a/packetbeat/.gitignore
+++ b/packetbeat/.gitignore
@@ -10,7 +10,6 @@
 _obj
 _test
 _output
-_meta/kibana/*/index-pattern
 
 # Architecture specific extensions/prefixes
 *.[568vq]

--- a/packetbeat/_meta/kibana/6/dashboard/Packetbeat-cassandra.json
+++ b/packetbeat/_meta/kibana/6/dashboard/Packetbeat-cassandra.json
@@ -1,197 +1,939 @@
 {
-  "objects": [
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"index\":\"packetbeat-*\",\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}},\"filter\":[]}"
-        },
-        "title": "Cassandra ResponseKeyspace",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Cassandra ResponseKeyspace\",\"type\":\"pie\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"isDonut\":true,\"legendPosition\":\"right\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"cassandra.response.result.rows.meta.keyspace\",\"size\":10,\"order\":\"desc\",\"orderBy\":\"1\"}},{\"id\":\"3\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"cassandra.response.result.rows.meta.table\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}"
-      },
-      "id": "Cassandra-ResponseKeyspace",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"index\":\"packetbeat-*\",\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}},\"filter\":[]}"
-        },
-        "title": "Cassandra ResponseType",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Cassandra ResponseType\",\"type\":\"pie\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"isDonut\":false,\"legendPosition\":\"right\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"cassandra.response.result.type\",\"size\":10,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}"
-      },
-      "id": "Cassandra-ResponseType",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"index\":\"packetbeat-*\",\"query\":{\"query_string\":{\"query\":\"type:cassandra\",\"analyze_wildcard\":true}},\"filter\":[]}"
-        },
-        "title": "Cassandra ResponseTime",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Cassandra ResponseTime\",\"type\":\"line\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"showCircles\":true,\"smoothLines\":true,\"interpolate\":\"linear\",\"scale\":\"square root\",\"drawLinesBetweenPoints\":true,\"radiusRatio\":9,\"times\":[],\"addTimeMarker\":false,\"defaultYExtents\":false,\"setYExtents\":false,\"yAxis\":{},\"legendPosition\":\"right\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"percentiles\",\"schema\":\"metric\",\"params\":{\"field\":\"responsetime\",\"percents\":[5,25,50,75,95]}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"auto\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}"
-      },
-      "id": "Cassandra-ResponseTime",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"index\":\"packetbeat-*\",\"query\":{\"query_string\":{\"query\":\"type:cassandra\",\"analyze_wildcard\":true}},\"filter\":[]}"
-        },
-        "title": "Cassandra RequestCount",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Cassandra RequestCount\",\"type\":\"line\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"showCircles\":true,\"smoothLines\":true,\"interpolate\":\"linear\",\"scale\":\"square root\",\"drawLinesBetweenPoints\":true,\"radiusRatio\":9,\"times\":[],\"addTimeMarker\":false,\"defaultYExtents\":false,\"setYExtents\":false,\"yAxis\":{},\"legendPosition\":\"right\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"auto\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}"
-      },
-      "id": "Cassandra-RequestCount",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"index\":\"packetbeat-*\",\"query\":{\"query_string\":{\"query\":\"type:cassandra\",\"analyze_wildcard\":true}},\"filter\":[]}"
-        },
-        "title": "Cassandra Ops",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Cassandra Ops\",\"type\":\"pie\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"isDonut\":true,\"legendPosition\":\"right\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"cassandra.request.headers.op\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\"}},{\"id\":\"3\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"cassandra.response.headers.op\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}"
-      },
-      "id": "Cassandra-Ops",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"index\":\"packetbeat-*\",\"query\":{\"query_string\":{\"query\":\"type:cassandra\",\"analyze_wildcard\":true}},\"filter\":[]}"
-        },
-        "title": "Cassandra RequestCountStackByType",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Cassandra RequestCountStackByType\",\"type\":\"histogram\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"scale\":\"linear\",\"mode\":\"stacked\",\"times\":[],\"addTimeMarker\":false,\"defaultYExtents\":false,\"setYExtents\":false,\"yAxis\":{},\"legendPosition\":\"right\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"auto\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}},{\"id\":\"3\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"group\",\"params\":{\"field\":\"cassandra.request.headers.op\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}"
-      },
-      "id": "Cassandra-RequestCountStackByType",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"index\":\"packetbeat-*\",\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}},\"filter\":[]}"
-        },
-        "title": "Cassandra ResponseCountStackByType",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Cassandra ResponseCountStackByType\",\"type\":\"histogram\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"scale\":\"linear\",\"mode\":\"stacked\",\"times\":[],\"addTimeMarker\":false,\"defaultYExtents\":false,\"setYExtents\":false,\"yAxis\":{},\"legendPosition\":\"right\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"auto\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}},{\"id\":\"3\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"group\",\"params\":{\"field\":\"cassandra.response.headers.op\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}"
-      },
-      "id": "Cassandra-ResponseCountStackByType",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"index\":\"packetbeat-*\",\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}},\"filter\":[]}"
-        },
-        "title": "Cassandra RequestCountByType",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Cassandra RequestCountByType\",\"type\":\"line\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"showCircles\":true,\"smoothLines\":true,\"interpolate\":\"linear\",\"scale\":\"log\",\"drawLinesBetweenPoints\":false,\"radiusRatio\":\"13\",\"times\":[],\"addTimeMarker\":false,\"defaultYExtents\":false,\"setYExtents\":false,\"yAxis\":{},\"legendPosition\":\"right\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"auto\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}},{\"id\":\"3\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"group\",\"params\":{\"field\":\"cassandra.request.headers.op\",\"size\":10,\"order\":\"desc\",\"orderBy\":\"1\"}},{\"id\":\"4\",\"enabled\":true,\"type\":\"count\",\"schema\":\"radius\",\"params\":{}}],\"listeners\":{}}"
-      },
-      "id": "Cassandra-RequestCountByType",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"index\":\"packetbeat-*\",\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}},\"filter\":[]}"
-        },
-        "title": "Cassandra ResponseCountByType",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Cassandra: ResponseCountByType\",\"type\":\"line\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"showCircles\":true,\"smoothLines\":true,\"interpolate\":\"linear\",\"scale\":\"log\",\"drawLinesBetweenPoints\":false,\"radiusRatio\":\"15\",\"times\":[],\"addTimeMarker\":false,\"defaultYExtents\":false,\"setYExtents\":false,\"yAxis\":{}},\"aggs\":[{\"id\":\"1\",\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"auto\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}},{\"id\":\"3\",\"type\":\"terms\",\"schema\":\"group\",\"params\":{\"field\":\"cassandra.response.headers.op\",\"size\":10,\"order\":\"desc\",\"orderBy\":\"1\"}},{\"id\":\"4\",\"type\":\"count\",\"schema\":\"radius\",\"params\":{}}],\"listeners\":{}}"
-      },
-      "id": "Cassandra-ResponseCountByType",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}},\"language\":\"lucene\"},\"filter\":[]}"
-        },
-        "title": "Navigation",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Navigation\",\"type\":\"markdown\",\"params\":{\"markdown\":\"### Packetbeat:\\n\\n[Overview](#/dashboard/Packetbeat-Dashboard)\\n\\n[Flows](#/dashboard/Packetbeat-Flows)\\n\\n[Web transactions](#/dashboard/Packetbeat-HTTP)\\n\\n[MySQL performance](#/dashboard/Packetbeat-MySQL-performance)\\n\\n[PostgreSQL performance](#/dashboard/Packetbeat-PgSQL-performance)\\n\\n[MongoDB performance](#/dashboard/Packetbeat-MongoDB-performance)\\n\\n[Thrift-RPC performance](#/dashboard/Packetbeat-Thrift-performance)\\n\\n[NFS transactions](#/dashboard/Packetbeat-NFS)\\n\\n[Cassandra performance](#/dashboard/Packetbeat-Cassandra)\",\"fontSize\":\"10\"},\"aggs\":[]}"
-      },
-      "id": "Navigation",
-      "type": "visualization",
-      "version": 10
-    },
-    {
-      "attributes": {
-        "columns": [
-          "cassandra.request.query",
-          "cassandra.response.result.rows.meta.keyspace",
-          "cassandra.response.result.rows.meta.table",
-          "cassandra.response.result.rows.num_rows"
-        ],
-        "description": "",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"index\":\"packetbeat-*\",\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}},\"filter\":[{\"meta\":{\"negate\":false,\"index\":\"packetbeat-*\",\"key\":\"cassandra.request.headers.op\",\"value\":\"QUERY\",\"disabled\":false,\"alias\":null},\"query\":{\"match\":{\"cassandra.request.headers.op\":{\"query\":\"QUERY\",\"type\":\"phrase\"}}},\"$state\":{\"store\":\"appState\"}},{\"meta\":{\"negate\":true,\"index\":\"packetbeat-*\",\"key\":\"cassandra.response.headers.op\",\"value\":\"ERROR\",\"disabled\":false,\"alias\":null},\"query\":{\"match\":{\"cassandra.response.headers.op\":{\"query\":\"ERROR\",\"type\":\"phrase\"}}},\"$state\":{\"store\":\"appState\"}}],\"highlight\":{\"pre_tags\":[\"@kibana-highlighted-field@\"],\"post_tags\":[\"@/kibana-highlighted-field@\"],\"fields\":{\"*\":{}},\"require_field_match\":false,\"fragment_size\":2147483647}}"
-        },
-        "sort": [
-          "@timestamp",
-          "desc"
-        ],
-        "title": "Cassandra QueryView",
-        "version": 1
-      },
-      "id": "Cassandra-QueryView",
-      "type": "search",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[],\"query\":{\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}},\"language\":\"lucene\"},\"highlightAll\":true,\"version\":true}"
-        },
-        "optionsJSON": "{\"darkTheme\":false}",
-        "panelsJSON": "[{\"col\":10,\"id\":\"Cassandra-ResponseKeyspace\",\"panelIndex\":3,\"row\":3,\"size_x\":3,\"size_y\":2,\"type\":\"visualization\"},{\"col\":7,\"id\":\"Cassandra-ResponseType\",\"panelIndex\":4,\"row\":3,\"size_x\":3,\"size_y\":2,\"type\":\"visualization\"},{\"col\":1,\"id\":\"Cassandra-ResponseTime\",\"panelIndex\":9,\"row\":5,\"size_x\":12,\"size_y\":2,\"type\":\"visualization\"},{\"col\":4,\"id\":\"Cassandra-RequestCount\",\"panelIndex\":10,\"row\":1,\"size_x\":9,\"size_y\":2,\"type\":\"visualization\"},{\"col\":4,\"id\":\"Cassandra-Ops\",\"panelIndex\":11,\"row\":3,\"size_x\":3,\"size_y\":2,\"type\":\"visualization\"},{\"col\":1,\"id\":\"Cassandra-RequestCountStackByType\",\"panelIndex\":15,\"row\":7,\"size_x\":12,\"size_y\":2,\"type\":\"visualization\"},{\"col\":1,\"id\":\"Cassandra-ResponseCountStackByType\",\"panelIndex\":16,\"row\":9,\"size_x\":12,\"size_y\":2,\"type\":\"visualization\"},{\"col\":1,\"id\":\"Cassandra-RequestCountByType\",\"panelIndex\":17,\"row\":11,\"size_x\":6,\"size_y\":3,\"type\":\"visualization\"},{\"col\":7,\"id\":\"Cassandra-ResponseCountByType\",\"panelIndex\":18,\"row\":11,\"size_x\":6,\"size_y\":3,\"type\":\"visualization\"},{\"col\":1,\"id\":\"Navigation\",\"panelIndex\":19,\"row\":1,\"size_x\":3,\"size_y\":4,\"type\":\"visualization\"},{\"id\":\"Cassandra-QueryView\",\"type\":\"search\",\"panelIndex\":20,\"size_x\":12,\"size_y\":3,\"col\":1,\"row\":14,\"columns\":[\"cassandra.request.query\",\"cassandra.response.result.rows.meta.keyspace\",\"cassandra.response.result.rows.meta.table\",\"cassandra.response.result.rows.num_rows\"],\"sort\":[\"@timestamp\",\"desc\"]}]",
-        "timeRestore": false,
-        "title": "[Packetbeat] Cassandra",
-        "uiStateJSON": "{\"P-10\":{\"vis\":{\"legendOpen\":false}},\"P-17\":{\"vis\":{\"legendOpen\":false}},\"P-18\":{\"vis\":{\"legendOpen\":false}}}",
-        "version": 1
-      },
-      "id": "Packetbeat-Cassandra",
-      "type": "dashboard",
-      "version": 2
-    }
-  ],
-  "version": "6.0.0-beta1-SNAPSHOT"
+    "objects": [
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "index": "packetbeat-*", 
+                        "query": {
+                            "query_string": {
+                                "analyze_wildcard": true, 
+                                "query": "*"
+                            }
+                        }
+                    }
+                }, 
+                "title": "Cassandra ResponseKeyspace", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "field": "cassandra.response.result.rows.meta.keyspace", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 10
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "field": "cassandra.response.result.rows.meta.table", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTooltip": true, 
+                        "isDonut": true, 
+                        "legendPosition": "right", 
+                        "shareYAxis": true
+                    }, 
+                    "title": "Cassandra ResponseKeyspace", 
+                    "type": "pie"
+                }
+            }, 
+            "id": "Cassandra-ResponseKeyspace", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "index": "packetbeat-*", 
+                        "query": {
+                            "query_string": {
+                                "analyze_wildcard": true, 
+                                "query": "*"
+                            }
+                        }
+                    }
+                }, 
+                "title": "Cassandra ResponseType", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "field": "cassandra.response.result.type", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 10
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTooltip": true, 
+                        "isDonut": false, 
+                        "legendPosition": "right", 
+                        "shareYAxis": true
+                    }, 
+                    "title": "Cassandra ResponseType", 
+                    "type": "pie"
+                }
+            }, 
+            "id": "Cassandra-ResponseType", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "index": "packetbeat-*", 
+                        "query": {
+                            "query_string": {
+                                "analyze_wildcard": true, 
+                                "query": "type:cassandra"
+                            }
+                        }
+                    }
+                }, 
+                "title": "Cassandra ResponseTime", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "field": "responsetime", 
+                                "percents": [
+                                    5, 
+                                    25, 
+                                    50, 
+                                    75, 
+                                    95
+                                ]
+                            }, 
+                            "schema": "metric", 
+                            "type": "percentiles"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "defaultYExtents": false, 
+                        "drawLinesBetweenPoints": true, 
+                        "interpolate": "linear", 
+                        "legendPosition": "right", 
+                        "radiusRatio": 9, 
+                        "scale": "square root", 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "showCircles": true, 
+                        "smoothLines": true, 
+                        "times": [], 
+                        "yAxis": {}
+                    }, 
+                    "title": "Cassandra ResponseTime", 
+                    "type": "line"
+                }
+            }, 
+            "id": "Cassandra-ResponseTime", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "index": "packetbeat-*", 
+                        "query": {
+                            "query_string": {
+                                "analyze_wildcard": true, 
+                                "query": "type:cassandra"
+                            }
+                        }
+                    }
+                }, 
+                "title": "Cassandra RequestCount", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "defaultYExtents": false, 
+                        "drawLinesBetweenPoints": true, 
+                        "interpolate": "linear", 
+                        "legendPosition": "right", 
+                        "radiusRatio": 9, 
+                        "scale": "square root", 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "showCircles": true, 
+                        "smoothLines": true, 
+                        "times": [], 
+                        "yAxis": {}
+                    }, 
+                    "title": "Cassandra RequestCount", 
+                    "type": "line"
+                }
+            }, 
+            "id": "Cassandra-RequestCount", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "index": "packetbeat-*", 
+                        "query": {
+                            "query_string": {
+                                "analyze_wildcard": true, 
+                                "query": "type:cassandra"
+                            }
+                        }
+                    }
+                }, 
+                "title": "Cassandra Ops", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "field": "cassandra.request.headers.op", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "field": "cassandra.response.headers.op", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTooltip": true, 
+                        "isDonut": true, 
+                        "legendPosition": "right", 
+                        "shareYAxis": true
+                    }, 
+                    "title": "Cassandra Ops", 
+                    "type": "pie"
+                }
+            }, 
+            "id": "Cassandra-Ops", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "index": "packetbeat-*", 
+                        "query": {
+                            "query_string": {
+                                "analyze_wildcard": true, 
+                                "query": "type:cassandra"
+                            }
+                        }
+                    }
+                }, 
+                "title": "Cassandra RequestCountStackByType", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "field": "cassandra.request.headers.op", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "group", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "defaultYExtents": false, 
+                        "legendPosition": "right", 
+                        "mode": "stacked", 
+                        "scale": "linear", 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "times": [], 
+                        "yAxis": {}
+                    }, 
+                    "title": "Cassandra RequestCountStackByType", 
+                    "type": "histogram"
+                }
+            }, 
+            "id": "Cassandra-RequestCountStackByType", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "index": "packetbeat-*", 
+                        "query": {
+                            "query_string": {
+                                "analyze_wildcard": true, 
+                                "query": "*"
+                            }
+                        }
+                    }
+                }, 
+                "title": "Cassandra ResponseCountStackByType", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "field": "cassandra.response.headers.op", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "group", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "defaultYExtents": false, 
+                        "legendPosition": "right", 
+                        "mode": "stacked", 
+                        "scale": "linear", 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "times": [], 
+                        "yAxis": {}
+                    }, 
+                    "title": "Cassandra ResponseCountStackByType", 
+                    "type": "histogram"
+                }
+            }, 
+            "id": "Cassandra-ResponseCountStackByType", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "index": "packetbeat-*", 
+                        "query": {
+                            "query_string": {
+                                "analyze_wildcard": true, 
+                                "query": "*"
+                            }
+                        }
+                    }
+                }, 
+                "title": "Cassandra RequestCountByType", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "field": "cassandra.request.headers.op", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 10
+                            }, 
+                            "schema": "group", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "4", 
+                            "params": {}, 
+                            "schema": "radius", 
+                            "type": "count"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "defaultYExtents": false, 
+                        "drawLinesBetweenPoints": false, 
+                        "interpolate": "linear", 
+                        "legendPosition": "right", 
+                        "radiusRatio": "13", 
+                        "scale": "log", 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "showCircles": true, 
+                        "smoothLines": true, 
+                        "times": [], 
+                        "yAxis": {}
+                    }, 
+                    "title": "Cassandra RequestCountByType", 
+                    "type": "line"
+                }
+            }, 
+            "id": "Cassandra-RequestCountByType", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "index": "packetbeat-*", 
+                        "query": {
+                            "query_string": {
+                                "analyze_wildcard": true, 
+                                "query": "*"
+                            }
+                        }
+                    }
+                }, 
+                "title": "Cassandra ResponseCountByType", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "id": "3", 
+                            "params": {
+                                "field": "cassandra.response.headers.op", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 10
+                            }, 
+                            "schema": "group", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "id": "4", 
+                            "params": {}, 
+                            "schema": "radius", 
+                            "type": "count"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "defaultYExtents": false, 
+                        "drawLinesBetweenPoints": false, 
+                        "interpolate": "linear", 
+                        "radiusRatio": "15", 
+                        "scale": "log", 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "showCircles": true, 
+                        "smoothLines": true, 
+                        "times": [], 
+                        "yAxis": {}
+                    }, 
+                    "title": "Cassandra: ResponseCountByType", 
+                    "type": "line"
+                }
+            }, 
+            "id": "Cassandra-ResponseCountByType", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "analyze_wildcard": true, 
+                                    "query": "*"
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "title": "Navigation", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "fontSize": "10", 
+                        "markdown": "### Packetbeat:\n\n[Overview](#/dashboard/Packetbeat-Dashboard)\n\n[Flows](#/dashboard/Packetbeat-Flows)\n\n[Web transactions](#/dashboard/Packetbeat-HTTP)\n\n[MySQL performance](#/dashboard/Packetbeat-MySQL-performance)\n\n[PostgreSQL performance](#/dashboard/Packetbeat-PgSQL-performance)\n\n[MongoDB performance](#/dashboard/Packetbeat-MongoDB-performance)\n\n[Thrift-RPC performance](#/dashboard/Packetbeat-Thrift-performance)\n\n[NFS transactions](#/dashboard/Packetbeat-NFS)\n\n[Cassandra performance](#/dashboard/Packetbeat-Cassandra)"
+                    }, 
+                    "title": "Navigation", 
+                    "type": "markdown"
+                }
+            }, 
+            "id": "Navigation", 
+            "type": "visualization", 
+            "version": 10
+        }, 
+        {
+            "attributes": {
+                "columns": [
+                    "cassandra.request.query", 
+                    "cassandra.response.result.rows.meta.keyspace", 
+                    "cassandra.response.result.rows.meta.table", 
+                    "cassandra.response.result.rows.num_rows"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                }, 
+                                "meta": {
+                                    "alias": null, 
+                                    "disabled": false, 
+                                    "index": "packetbeat-*", 
+                                    "key": "cassandra.request.headers.op", 
+                                    "negate": false, 
+                                    "value": "QUERY"
+                                }, 
+                                "query": {
+                                    "match": {
+                                        "cassandra.request.headers.op": {
+                                            "query": "QUERY", 
+                                            "type": "phrase"
+                                        }
+                                    }
+                                }
+                            }, 
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                }, 
+                                "meta": {
+                                    "alias": null, 
+                                    "disabled": false, 
+                                    "index": "packetbeat-*", 
+                                    "key": "cassandra.response.headers.op", 
+                                    "negate": true, 
+                                    "value": "ERROR"
+                                }, 
+                                "query": {
+                                    "match": {
+                                        "cassandra.response.headers.op": {
+                                            "query": "ERROR", 
+                                            "type": "phrase"
+                                        }
+                                    }
+                                }
+                            }
+                        ], 
+                        "highlight": {
+                            "fields": {
+                                "*": {}
+                            }, 
+                            "fragment_size": 2147483647, 
+                            "post_tags": [
+                                "@/kibana-highlighted-field@"
+                            ], 
+                            "pre_tags": [
+                                "@kibana-highlighted-field@"
+                            ], 
+                            "require_field_match": false
+                        }, 
+                        "index": "packetbeat-*", 
+                        "query": {
+                            "query_string": {
+                                "analyze_wildcard": true, 
+                                "query": "*"
+                            }
+                        }
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "Cassandra QueryView", 
+                "version": 1
+            }, 
+            "id": "Cassandra-QueryView", 
+            "type": "search", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "analyze_wildcard": true, 
+                                    "query": "*"
+                                }
+                            }
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false
+                }, 
+                "panelsJSON": [
+                    {
+                        "col": 10, 
+                        "id": "Cassandra-ResponseKeyspace", 
+                        "panelIndex": 3, 
+                        "row": 3, 
+                        "size_x": 3, 
+                        "size_y": 2, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 7, 
+                        "id": "Cassandra-ResponseType", 
+                        "panelIndex": 4, 
+                        "row": 3, 
+                        "size_x": 3, 
+                        "size_y": 2, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "Cassandra-ResponseTime", 
+                        "panelIndex": 9, 
+                        "row": 5, 
+                        "size_x": 12, 
+                        "size_y": 2, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 4, 
+                        "id": "Cassandra-RequestCount", 
+                        "panelIndex": 10, 
+                        "row": 1, 
+                        "size_x": 9, 
+                        "size_y": 2, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 4, 
+                        "id": "Cassandra-Ops", 
+                        "panelIndex": 11, 
+                        "row": 3, 
+                        "size_x": 3, 
+                        "size_y": 2, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "Cassandra-RequestCountStackByType", 
+                        "panelIndex": 15, 
+                        "row": 7, 
+                        "size_x": 12, 
+                        "size_y": 2, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "Cassandra-ResponseCountStackByType", 
+                        "panelIndex": 16, 
+                        "row": 9, 
+                        "size_x": 12, 
+                        "size_y": 2, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "Cassandra-RequestCountByType", 
+                        "panelIndex": 17, 
+                        "row": 11, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 7, 
+                        "id": "Cassandra-ResponseCountByType", 
+                        "panelIndex": 18, 
+                        "row": 11, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "Navigation", 
+                        "panelIndex": 19, 
+                        "row": 1, 
+                        "size_x": 3, 
+                        "size_y": 4, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "columns": [
+                            "cassandra.request.query", 
+                            "cassandra.response.result.rows.meta.keyspace", 
+                            "cassandra.response.result.rows.meta.table", 
+                            "cassandra.response.result.rows.num_rows"
+                        ], 
+                        "id": "Cassandra-QueryView", 
+                        "panelIndex": 20, 
+                        "row": 14, 
+                        "size_x": 12, 
+                        "size_y": 3, 
+                        "sort": [
+                            "@timestamp", 
+                            "desc"
+                        ], 
+                        "type": "search"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Packetbeat] Cassandra", 
+                "uiStateJSON": {
+                    "P-10": {
+                        "vis": {
+                            "legendOpen": false
+                        }
+                    }, 
+                    "P-17": {
+                        "vis": {
+                            "legendOpen": false
+                        }
+                    }, 
+                    "P-18": {
+                        "vis": {
+                            "legendOpen": false
+                        }
+                    }
+                }, 
+                "version": 1
+            }, 
+            "id": "Packetbeat-Cassandra", 
+            "type": "dashboard", 
+            "version": 2
+        }
+    ], 
+    "version": "6.0.0-beta1-SNAPSHOT"
 }

--- a/packetbeat/_meta/kibana/6/dashboard/Packetbeat-dns-tunneling.json
+++ b/packetbeat/_meta/kibana/6/dashboard/Packetbeat-dns-tunneling.json
@@ -1,107 +1,465 @@
 {
-  "objects": [
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[]}"
-        },
-        "savedSearchId": "DNS",
-        "title": "Unique FQDNs per eTLD+1",
-        "uiStateJSON": "{\"vis\":{\"colors\":{\"Unique count of dns.question.name\":\"#E0752D\",\"Count\":\"#1F78C1\"}}}",
-        "version": 1,
-        "visState": "{\"title\":\"Unique FQDNs per eTLD+1\",\"type\":\"histogram\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"scale\":\"linear\",\"mode\":\"grouped\",\"times\":[],\"addTimeMarker\":false,\"defaultYExtents\":true,\"setYExtents\":false,\"yAxis\":{},\"legendPosition\":\"right\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"cardinality\",\"schema\":\"metric\",\"params\":{\"field\":\"dns.question.name\",\"customLabel\":\"Unique Subdomain Count\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"dns.question.etld_plus_one\",\"size\":20,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"Domains\"}}],\"listeners\":{}}"
-      },
-      "id": "Unique-FQDNs-per-eTLD 1",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[]}"
-        },
-        "savedSearchId": "DNS",
-        "title": "Unique FQDNs per eTLD+1 Table",
-        "uiStateJSON": "{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}}",
-        "version": 1,
-        "visState": "{\"title\":\"Unique FQDNs per eTLD+1 Table\",\"type\":\"table\",\"params\":{\"perPage\":10,\"showPartialRows\":false,\"showMeticsAtAllLevels\":false,\"sort\":{\"columnIndex\":null,\"direction\":null},\"showTotal\":false,\"totalFunc\":\"sum\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{\"customLabel\":\"\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"dns.question.etld_plus_one\",\"size\":20,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"ETLD+1\"}},{\"id\":\"3\",\"enabled\":true,\"type\":\"cardinality\",\"schema\":\"metric\",\"params\":{\"field\":\"dns.question.name\",\"customLabel\":\"Unique Domains\"}}],\"listeners\":{}}"
-      },
-      "id": "Unique-FQDNs-per-eTLD 1-Table",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[]}"
-        },
-        "savedSearchId": "DNS",
-        "title": "Bytes Transferred per Domain",
-        "uiStateJSON": "{\"vis\":{\"colors\":{\"Unique count of dns.question.name\":\"#E0752D\",\"Count\":\"#1F78C1\",\"Bytes Out\":\"#629E51\",\"Bytes In\":\"#F2C96D\"}}}",
-        "version": 1,
-        "visState": "{\"title\":\"Bytes Transferred per Domain\",\"type\":\"histogram\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"scale\":\"linear\",\"mode\":\"grouped\",\"times\":[],\"addTimeMarker\":false,\"defaultYExtents\":true,\"setYExtents\":false,\"yAxis\":{},\"legendPosition\":\"right\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"sum\",\"schema\":\"metric\",\"params\":{\"field\":\"bytes_out\",\"customLabel\":\"Bytes Out\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"dns.question.etld_plus_one\",\"size\":20,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"Domains\"}},{\"id\":\"3\",\"enabled\":true,\"type\":\"sum\",\"schema\":\"metric\",\"params\":{\"field\":\"bytes_in\",\"customLabel\":\"Bytes In\"}}],\"listeners\":{}}"
-      },
-      "id": "Bytes-Transferred-per-Domain",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"index\":\"packetbeat-*\",\"query\":{\"query_string\":{\"query\":\"type:dns\",\"analyze_wildcard\":true}},\"filter\":[]}"
-        },
-        "title": "Top Domains by Data Volume",
-        "uiStateJSON": "{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}}",
-        "version": 1,
-        "visState": "{\"title\":\"Top Domains by Data Volume\",\"type\":\"table\",\"params\":{\"perPage\":10,\"showPartialRows\":false,\"showMeticsAtAllLevels\":false,\"sort\":{\"columnIndex\":null,\"direction\":null},\"showTotal\":false,\"totalFunc\":\"sum\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"sum\",\"schema\":\"metric\",\"params\":{\"field\":\"bytes_in\",\"customLabel\":\"Bytes In\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"dns.question.etld_plus_one\",\"size\":20,\"order\":\"desc\",\"orderBy\":\"3\",\"customLabel\":\"ETLD+1\"}},{\"id\":\"3\",\"enabled\":true,\"type\":\"sum\",\"schema\":\"metric\",\"params\":{\"field\":\"bytes_out\",\"customLabel\":\"Bytes Out\"}}],\"listeners\":{}}"
-      },
-      "id": "dc743240-1665-11e7-a6de-cbac1a3d0a7d",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "columns": [
-          "_source"
-        ],
-        "description": "",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"index\":\"packetbeat-*\",\"query\":{\"query_string\":{\"query\":\"type: dns\",\"analyze_wildcard\":true}},\"filter\":[],\"highlight\":{\"pre_tags\":[\"@kibana-highlighted-field@\"],\"post_tags\":[\"@/kibana-highlighted-field@\"],\"fields\":{\"*\":{}},\"require_field_match\":false,\"fragment_size\":2147483647}}"
-        },
-        "sort": [
-          "@timestamp",
-          "desc"
-        ],
-        "title": "DNS",
-        "version": 1
-      },
-      "id": "DNS",
-      "type": "search",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[],\"query\":{\"query\":{\"query_string\":{\"query\":\"NOT dns.question.type:PTR\",\"analyze_wildcard\":true}},\"language\":\"lucene\"},\"highlightAll\":true,\"version\":true}"
-        },
-        "optionsJSON": "{\"darkTheme\":false}",
-        "panelsJSON": "[{\"col\":1,\"id\":\"Unique-FQDNs-per-eTLD 1\",\"panelIndex\":1,\"row\":1,\"size_x\":12,\"size_y\":4,\"type\":\"visualization\"},{\"col\":1,\"id\":\"Unique-FQDNs-per-eTLD 1-Table\",\"panelIndex\":2,\"row\":8,\"size_x\":6,\"size_y\":4,\"type\":\"visualization\"},{\"col\":1,\"id\":\"Bytes-Transferred-per-Domain\",\"panelIndex\":4,\"row\":5,\"size_x\":12,\"size_y\":3,\"type\":\"visualization\"},{\"col\":7,\"id\":\"dc743240-1665-11e7-a6de-cbac1a3d0a7d\",\"panelIndex\":5,\"row\":8,\"size_x\":6,\"size_y\":4,\"type\":\"visualization\"}]",
-        "timeRestore": false,
-        "title": "[Packetbeat] DNS Tunneling",
-        "uiStateJSON": "{\"P-1\":{\"spy\":{\"mode\":{\"fill\":false,\"name\":null}},\"vis\":{\"legendOpen\":false,\"colors\":{\"Unique count of dns.question.name\":\"#E0752D\",\"Count\":\"#1F78C1\",\"Unique Subdomain Count\":\"#EF843C\"}}},\"P-2\":{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}},\"P-4\":{\"vis\":{\"legendOpen\":false}},\"P-5\":{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}}}",
-        "version": 1
-      },
-      "id": "DNS-Unique-Domains",
-      "type": "dashboard",
-      "version": 2
-    }
-  ],
-  "version": "6.0.0-beta1-SNAPSHOT"
+    "objects": [
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "DNS", 
+                "title": "Unique FQDNs per eTLD+1", 
+                "uiStateJSON": {
+                    "vis": {
+                        "colors": {
+                            "Count": "#1F78C1", 
+                            "Unique count of dns.question.name": "#E0752D"
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Unique Subdomain Count", 
+                                "field": "dns.question.name"
+                            }, 
+                            "schema": "metric", 
+                            "type": "cardinality"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customLabel": "Domains", 
+                                "field": "dns.question.etld_plus_one", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 20
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "defaultYExtents": true, 
+                        "legendPosition": "right", 
+                        "mode": "grouped", 
+                        "scale": "linear", 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "times": [], 
+                        "yAxis": {}
+                    }, 
+                    "title": "Unique FQDNs per eTLD+1", 
+                    "type": "histogram"
+                }
+            }, 
+            "id": "Unique-FQDNs-per-eTLD 1", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "DNS", 
+                "title": "Unique FQDNs per eTLD+1 Table", 
+                "uiStateJSON": {
+                    "vis": {
+                        "params": {
+                            "sort": {
+                                "columnIndex": null, 
+                                "direction": null
+                            }
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": ""
+                            }, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customLabel": "ETLD+1", 
+                                "field": "dns.question.etld_plus_one", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 20
+                            }, 
+                            "schema": "bucket", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "customLabel": "Unique Domains", 
+                                "field": "dns.question.name"
+                            }, 
+                            "schema": "metric", 
+                            "type": "cardinality"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "perPage": 10, 
+                        "showMeticsAtAllLevels": false, 
+                        "showPartialRows": false, 
+                        "showTotal": false, 
+                        "sort": {
+                            "columnIndex": null, 
+                            "direction": null
+                        }, 
+                        "totalFunc": "sum"
+                    }, 
+                    "title": "Unique FQDNs per eTLD+1 Table", 
+                    "type": "table"
+                }
+            }, 
+            "id": "Unique-FQDNs-per-eTLD 1-Table", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "DNS", 
+                "title": "Bytes Transferred per Domain", 
+                "uiStateJSON": {
+                    "vis": {
+                        "colors": {
+                            "Bytes In": "#F2C96D", 
+                            "Bytes Out": "#629E51", 
+                            "Count": "#1F78C1", 
+                            "Unique count of dns.question.name": "#E0752D"
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Bytes Out", 
+                                "field": "bytes_out"
+                            }, 
+                            "schema": "metric", 
+                            "type": "sum"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customLabel": "Domains", 
+                                "field": "dns.question.etld_plus_one", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 20
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "customLabel": "Bytes In", 
+                                "field": "bytes_in"
+                            }, 
+                            "schema": "metric", 
+                            "type": "sum"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "defaultYExtents": true, 
+                        "legendPosition": "right", 
+                        "mode": "grouped", 
+                        "scale": "linear", 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "times": [], 
+                        "yAxis": {}
+                    }, 
+                    "title": "Bytes Transferred per Domain", 
+                    "type": "histogram"
+                }
+            }, 
+            "id": "Bytes-Transferred-per-Domain", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "index": "packetbeat-*", 
+                        "query": {
+                            "query_string": {
+                                "analyze_wildcard": true, 
+                                "query": "type:dns"
+                            }
+                        }
+                    }
+                }, 
+                "title": "Top Domains by Data Volume", 
+                "uiStateJSON": {
+                    "vis": {
+                        "params": {
+                            "sort": {
+                                "columnIndex": null, 
+                                "direction": null
+                            }
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Bytes In", 
+                                "field": "bytes_in"
+                            }, 
+                            "schema": "metric", 
+                            "type": "sum"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customLabel": "ETLD+1", 
+                                "field": "dns.question.etld_plus_one", 
+                                "order": "desc", 
+                                "orderBy": "3", 
+                                "size": 20
+                            }, 
+                            "schema": "bucket", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "customLabel": "Bytes Out", 
+                                "field": "bytes_out"
+                            }, 
+                            "schema": "metric", 
+                            "type": "sum"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "perPage": 10, 
+                        "showMeticsAtAllLevels": false, 
+                        "showPartialRows": false, 
+                        "showTotal": false, 
+                        "sort": {
+                            "columnIndex": null, 
+                            "direction": null
+                        }, 
+                        "totalFunc": "sum"
+                    }, 
+                    "title": "Top Domains by Data Volume", 
+                    "type": "table"
+                }
+            }, 
+            "id": "dc743240-1665-11e7-a6de-cbac1a3d0a7d", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "columns": [
+                    "_source"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlight": {
+                            "fields": {
+                                "*": {}
+                            }, 
+                            "fragment_size": 2147483647, 
+                            "post_tags": [
+                                "@/kibana-highlighted-field@"
+                            ], 
+                            "pre_tags": [
+                                "@kibana-highlighted-field@"
+                            ], 
+                            "require_field_match": false
+                        }, 
+                        "index": "packetbeat-*", 
+                        "query": {
+                            "query_string": {
+                                "analyze_wildcard": true, 
+                                "query": "type: dns"
+                            }
+                        }
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "DNS", 
+                "version": 1
+            }, 
+            "id": "DNS", 
+            "type": "search", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "analyze_wildcard": true, 
+                                    "query": "NOT dns.question.type:PTR"
+                                }
+                            }
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false
+                }, 
+                "panelsJSON": [
+                    {
+                        "col": 1, 
+                        "id": "Unique-FQDNs-per-eTLD 1", 
+                        "panelIndex": 1, 
+                        "row": 1, 
+                        "size_x": 12, 
+                        "size_y": 4, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "Unique-FQDNs-per-eTLD 1-Table", 
+                        "panelIndex": 2, 
+                        "row": 8, 
+                        "size_x": 6, 
+                        "size_y": 4, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "Bytes-Transferred-per-Domain", 
+                        "panelIndex": 4, 
+                        "row": 5, 
+                        "size_x": 12, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 7, 
+                        "id": "dc743240-1665-11e7-a6de-cbac1a3d0a7d", 
+                        "panelIndex": 5, 
+                        "row": 8, 
+                        "size_x": 6, 
+                        "size_y": 4, 
+                        "type": "visualization"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Packetbeat] DNS Tunneling", 
+                "uiStateJSON": {
+                    "P-1": {
+                        "spy": {
+                            "mode": {
+                                "fill": false, 
+                                "name": null
+                            }
+                        }, 
+                        "vis": {
+                            "colors": {
+                                "Count": "#1F78C1", 
+                                "Unique Subdomain Count": "#EF843C", 
+                                "Unique count of dns.question.name": "#E0752D"
+                            }, 
+                            "legendOpen": false
+                        }
+                    }, 
+                    "P-2": {
+                        "vis": {
+                            "params": {
+                                "sort": {
+                                    "columnIndex": null, 
+                                    "direction": null
+                                }
+                            }
+                        }
+                    }, 
+                    "P-4": {
+                        "vis": {
+                            "legendOpen": false
+                        }
+                    }, 
+                    "P-5": {
+                        "vis": {
+                            "params": {
+                                "sort": {
+                                    "columnIndex": null, 
+                                    "direction": null
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "version": 1
+            }, 
+            "id": "DNS-Unique-Domains", 
+            "type": "dashboard", 
+            "version": 2
+        }
+    ], 
+    "version": "6.0.0-beta1-SNAPSHOT"
 }

--- a/packetbeat/_meta/kibana/6/dashboard/Packetbeat-dns.json
+++ b/packetbeat/_meta/kibana/6/dashboard/Packetbeat-dns.json
@@ -1,118 +1,488 @@
 {
-  "objects": [
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[]}"
-        },
-        "savedSearchId": "DNS",
-        "title": "DNS Count and Response Time",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"DNS Count and Response Time\",\"type\":\"histogram\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"scale\":\"linear\",\"mode\":\"stacked\",\"times\":[],\"addTimeMarker\":false,\"defaultYExtents\":false,\"setYExtents\":false,\"yAxis\":{},\"legendPosition\":\"right\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"auto\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}},{\"id\":\"3\",\"enabled\":true,\"type\":\"histogram\",\"schema\":\"group\",\"params\":{\"field\":\"responsetime\",\"interval\":50,\"min_doc_count\":false,\"extended_bounds\":{}}}],\"listeners\":{}}"
-      },
-      "id": "DNS-Count-and-Response-Time",
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[]}"
-        },
-        "savedSearchId": "DNS",
-        "title": "DNS Query Summary",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"DNS Query Summary\",\"type\":\"metric\",\"params\":{\"fontSize\":\"17\",\"handleNoResults\":true},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"sum\",\"schema\":\"metric\",\"params\":{\"field\":\"bytes_in\",\"customLabel\":\"Bytes In\"}},{\"id\":\"3\",\"enabled\":true,\"type\":\"sum\",\"schema\":\"metric\",\"params\":{\"field\":\"bytes_out\",\"customLabel\":\"Bytes Out\"}},{\"id\":\"4\",\"enabled\":true,\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"responsetime\",\"customLabel\":\"Avg Response Time (ms)\"}}],\"listeners\":{}}"
-      },
-      "id": "DNS-Query-Summary",
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"index\":\"packetbeat-*\",\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}},\"filter\":[]}"
-        },
-        "title": "DNS Question Types",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"DNS Question Types\",\"type\":\"pie\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"isDonut\":false},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"dns.question.type\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}"
-      },
-      "id": "DNS-Question-Types",
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"index\":\"packetbeat-*\",\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"type: dns\"}},\"filter\":[]}"
-        },
-        "title": "DNS Request Status Over Time",
-        "uiStateJSON": "{\"vis\":{\"colors\":{\"Error\":\"#890F02\",\"OK\":\"#0A50A1\"}}}",
-        "version": 1,
-        "visState": "{\"title\":\"DNS Request Status Over Time\",\"type\":\"area\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"defaultYExtents\":false,\"interpolate\":\"linear\",\"mode\":\"stacked\",\"scale\":\"linear\",\"setYExtents\":false,\"shareYAxis\":true,\"smoothLines\":false,\"times\":[],\"yAxis\":{},\"legendPosition\":\"right\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"auto\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}},{\"id\":\"3\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"group\",\"params\":{\"field\":\"status\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}"
-      },
-      "id": "DNS-Request-Status-Over-Time",
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[],\"index\":\"packetbeat-*\",\"query\":{\"query_string\":{\"query\":\"type: dns AND status: OK\",\"analyze_wildcard\":true}},\"highlight\":{\"pre_tags\":[\"@kibana-highlighted-field@\"],\"post_tags\":[\"@/kibana-highlighted-field@\"],\"fields\":{\"*\":{}},\"require_field_match\":false,\"fragment_size\":2147483647}}"
-        },
-        "title": "DNS Top 10 Questions",
-        "uiStateJSON": "{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}}",
-        "version": 1,
-        "visState": "{\"title\":\"DNS Top 10 Questions\",\"type\":\"table\",\"params\":{\"perPage\":10,\"showPartialRows\":false,\"showMeticsAtAllLevels\":false,\"sort\":{\"columnIndex\":null,\"direction\":null},\"showTotal\":false,\"totalFunc\":\"sum\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"dns.question.name\",\"size\":30,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"Question\"}}],\"listeners\":{}}"
-      },
-      "id": "DNS-Top-10-Questions",
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[],\"index\":\"packetbeat-*\",\"query\":{\"query_string\":{\"query\":\"type: dns\",\"analyze_wildcard\":true}},\"highlight\":{\"pre_tags\":[\"@kibana-highlighted-field@\"],\"post_tags\":[\"@/kibana-highlighted-field@\"],\"fields\":{\"*\":{}},\"require_field_match\":false,\"fragment_size\":2147483647}}"
-        },
-        "title": "DNS Response Codes",
-        "uiStateJSON": "{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}}",
-        "version": 1,
-        "visState": "{\"title\":\"DNS Response Codes\",\"type\":\"table\",\"params\":{\"perPage\":10,\"showMeticsAtAllLevels\":false,\"showPartialRows\":false,\"sort\":{\"columnIndex\":null,\"direction\":null},\"showTotal\":false,\"totalFunc\":\"sum\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"dns.response_code\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"Response Code\"}}],\"listeners\":{}}"
-      },
-      "id": "DNS-Response-Codes",
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "columns": [
-          "_source"
-        ],
-        "description": "",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"index\":\"packetbeat-*\",\"query\":{\"query_string\":{\"query\":\"type: dns\",\"analyze_wildcard\":true}},\"filter\":[],\"highlight\":{\"pre_tags\":[\"@kibana-highlighted-field@\"],\"post_tags\":[\"@/kibana-highlighted-field@\"],\"fields\":{\"*\":{}},\"require_field_match\":false,\"fragment_size\":2147483647}}"
-        },
-        "sort": [
-          "@timestamp",
-          "desc"
-        ],
-        "title": "DNS",
-        "version": 1
-      },
-      "id": "DNS",
-      "type": "search",
-      "version": 10
-    }
-  ],
-  "version": "6.0.0-alpha3-SNAPSHOT"
+    "objects": [
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "DNS", 
+                "title": "DNS Count and Response Time", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "extended_bounds": {}, 
+                                "field": "responsetime", 
+                                "interval": 50, 
+                                "min_doc_count": false
+                            }, 
+                            "schema": "group", 
+                            "type": "histogram"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "defaultYExtents": false, 
+                        "legendPosition": "right", 
+                        "mode": "stacked", 
+                        "scale": "linear", 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "times": [], 
+                        "yAxis": {}
+                    }, 
+                    "title": "DNS Count and Response Time", 
+                    "type": "histogram"
+                }
+            }, 
+            "id": "DNS-Count-and-Response-Time", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "DNS", 
+                "title": "DNS Query Summary", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customLabel": "Bytes In", 
+                                "field": "bytes_in"
+                            }, 
+                            "schema": "metric", 
+                            "type": "sum"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "customLabel": "Bytes Out", 
+                                "field": "bytes_out"
+                            }, 
+                            "schema": "metric", 
+                            "type": "sum"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "4", 
+                            "params": {
+                                "customLabel": "Avg Response Time (ms)", 
+                                "field": "responsetime"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "fontSize": "17", 
+                        "handleNoResults": true
+                    }, 
+                    "title": "DNS Query Summary", 
+                    "type": "metric"
+                }
+            }, 
+            "id": "DNS-Query-Summary", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "index": "packetbeat-*", 
+                        "query": {
+                            "query_string": {
+                                "analyze_wildcard": true, 
+                                "query": "*"
+                            }
+                        }
+                    }
+                }, 
+                "title": "DNS Question Types", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "field": "dns.question.type", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTooltip": true, 
+                        "isDonut": false, 
+                        "legendPosition": "right", 
+                        "shareYAxis": true
+                    }, 
+                    "title": "DNS Question Types", 
+                    "type": "pie"
+                }
+            }, 
+            "id": "DNS-Question-Types", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "index": "packetbeat-*", 
+                        "query": {
+                            "query_string": {
+                                "analyze_wildcard": true, 
+                                "query": "type: dns"
+                            }
+                        }
+                    }
+                }, 
+                "title": "DNS Request Status Over Time", 
+                "uiStateJSON": {
+                    "vis": {
+                        "colors": {
+                            "Error": "#890F02", 
+                            "OK": "#0A50A1"
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "field": "status", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "group", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "defaultYExtents": false, 
+                        "interpolate": "linear", 
+                        "legendPosition": "right", 
+                        "mode": "stacked", 
+                        "scale": "linear", 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "smoothLines": false, 
+                        "times": [], 
+                        "yAxis": {}
+                    }, 
+                    "title": "DNS Request Status Over Time", 
+                    "type": "area"
+                }
+            }, 
+            "id": "DNS-Request-Status-Over-Time", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlight": {
+                            "fields": {
+                                "*": {}
+                            }, 
+                            "fragment_size": 2147483647, 
+                            "post_tags": [
+                                "@/kibana-highlighted-field@"
+                            ], 
+                            "pre_tags": [
+                                "@kibana-highlighted-field@"
+                            ], 
+                            "require_field_match": false
+                        }, 
+                        "index": "packetbeat-*", 
+                        "query": {
+                            "query_string": {
+                                "analyze_wildcard": true, 
+                                "query": "type: dns AND status: OK"
+                            }
+                        }
+                    }
+                }, 
+                "title": "DNS Top 10 Questions", 
+                "uiStateJSON": {
+                    "vis": {
+                        "params": {
+                            "sort": {
+                                "columnIndex": null, 
+                                "direction": null
+                            }
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customLabel": "Question", 
+                                "field": "dns.question.name", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 30
+                            }, 
+                            "schema": "bucket", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "perPage": 10, 
+                        "showMeticsAtAllLevels": false, 
+                        "showPartialRows": false, 
+                        "showTotal": false, 
+                        "sort": {
+                            "columnIndex": null, 
+                            "direction": null
+                        }, 
+                        "totalFunc": "sum"
+                    }, 
+                    "title": "DNS Top 10 Questions", 
+                    "type": "table"
+                }
+            }, 
+            "id": "DNS-Top-10-Questions", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlight": {
+                            "fields": {
+                                "*": {}
+                            }, 
+                            "fragment_size": 2147483647, 
+                            "post_tags": [
+                                "@/kibana-highlighted-field@"
+                            ], 
+                            "pre_tags": [
+                                "@kibana-highlighted-field@"
+                            ], 
+                            "require_field_match": false
+                        }, 
+                        "index": "packetbeat-*", 
+                        "query": {
+                            "query_string": {
+                                "analyze_wildcard": true, 
+                                "query": "type: dns"
+                            }
+                        }
+                    }
+                }, 
+                "title": "DNS Response Codes", 
+                "uiStateJSON": {
+                    "vis": {
+                        "params": {
+                            "sort": {
+                                "columnIndex": null, 
+                                "direction": null
+                            }
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customLabel": "Response Code", 
+                                "field": "dns.response_code", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "bucket", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "perPage": 10, 
+                        "showMeticsAtAllLevels": false, 
+                        "showPartialRows": false, 
+                        "showTotal": false, 
+                        "sort": {
+                            "columnIndex": null, 
+                            "direction": null
+                        }, 
+                        "totalFunc": "sum"
+                    }, 
+                    "title": "DNS Response Codes", 
+                    "type": "table"
+                }
+            }, 
+            "id": "DNS-Response-Codes", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "columns": [
+                    "_source"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlight": {
+                            "fields": {
+                                "*": {}
+                            }, 
+                            "fragment_size": 2147483647, 
+                            "post_tags": [
+                                "@/kibana-highlighted-field@"
+                            ], 
+                            "pre_tags": [
+                                "@kibana-highlighted-field@"
+                            ], 
+                            "require_field_match": false
+                        }, 
+                        "index": "packetbeat-*", 
+                        "query": {
+                            "query_string": {
+                                "analyze_wildcard": true, 
+                                "query": "type: dns"
+                            }
+                        }
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "DNS", 
+                "version": 1
+            }, 
+            "id": "DNS", 
+            "type": "search", 
+            "version": 10
+        }
+    ], 
+    "version": "6.0.0-alpha3-SNAPSHOT"
 }

--- a/packetbeat/_meta/kibana/6/dashboard/Packetbeat-flows.json
+++ b/packetbeat/_meta/kibana/6/dashboard/Packetbeat-flows.json
@@ -1,131 +1,475 @@
 {
-  "objects": [
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}},\"language\":\"lucene\"},\"filter\":[]}"
-        },
-        "title": "Navigation",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Navigation\",\"type\":\"markdown\",\"params\":{\"markdown\":\"### Packetbeat:\\n\\n[Overview](#/dashboard/Packetbeat-Dashboard)\\n\\n[Flows](#/dashboard/Packetbeat-Flows)\\n\\n[Web transactions](#/dashboard/Packetbeat-HTTP)\\n\\n[MySQL performance](#/dashboard/Packetbeat-MySQL-performance)\\n\\n[PostgreSQL performance](#/dashboard/Packetbeat-PgSQL-performance)\\n\\n[MongoDB performance](#/dashboard/Packetbeat-MongoDB-performance)\\n\\n[Thrift-RPC performance](#/dashboard/Packetbeat-Thrift-performance)\\n\\n[NFS transactions](#/dashboard/Packetbeat-NFS)\\n\\n[Cassandra performance](#/dashboard/Packetbeat-Cassandra)\",\"fontSize\":\"10\"},\"aggs\":[]}"
-      },
-      "id": "Navigation",
-      "type": "visualization",
-      "version": 10
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[]}"
-        },
-        "savedSearchId": "Packetbeat-Flows-Search",
-        "title": "Connections over time",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Connections over time\",\"type\":\"area\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"smoothLines\":true,\"scale\":\"linear\",\"interpolate\":\"linear\",\"mode\":\"stacked\",\"times\":[],\"addTimeMarker\":false,\"defaultYExtents\":false,\"setYExtents\":false,\"yAxis\":{}},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"cardinality\",\"schema\":\"metric\",\"params\":{\"field\":\"flow_id\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"auto\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}"
-      },
-      "id": "Connections-over-time",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[]}"
-        },
-        "savedSearchId": "Packetbeat-Flows-Search",
-        "title": "Top hosts creating traffic",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Top hosts creating traffic\",\"type\":\"area\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"smoothLines\":true,\"scale\":\"linear\",\"interpolate\":\"linear\",\"mode\":\"stacked\",\"times\":[],\"addTimeMarker\":false,\"defaultYExtents\":false,\"setYExtents\":false,\"yAxis\":{}},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"sum\",\"schema\":\"metric\",\"params\":{\"field\":\"source.stats.net_bytes_total\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"auto\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}},{\"id\":\"3\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"group\",\"params\":{\"field\":\"source.ip\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}"
-      },
-      "id": "Top-hosts-creating-traffic",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[]}"
-        },
-        "savedSearchId": "Packetbeat-Flows-Search",
-        "title": "Top hosts receiving traffic",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Top hosts receiving traffic\",\"type\":\"area\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"smoothLines\":true,\"scale\":\"linear\",\"interpolate\":\"linear\",\"mode\":\"stacked\",\"times\":[],\"addTimeMarker\":false,\"defaultYExtents\":false,\"setYExtents\":false,\"yAxis\":{}},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"sum\",\"schema\":\"metric\",\"params\":{\"field\":\"dest.stats.net_bytes_total\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"auto\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}},{\"id\":\"3\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"group\",\"params\":{\"field\":\"dest.ip\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}"
-      },
-      "id": "Top-hosts-receiving-traffic",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[]}"
-        },
-        "savedSearchId": "Packetbeat-Flows-Search",
-        "title": "Network traffic between your hosts",
-        "uiStateJSON": "{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}}",
-        "version": 1,
-        "visState": "{\"title\":\"Network traffic between your hosts\",\"type\":\"table\",\"params\":{\"perPage\":10,\"showPartialRows\":false,\"showMeticsAtAllLevels\":false,\"sort\":{\"columnIndex\":null,\"direction\":null},\"showTotal\":false,\"totalFunc\":\"sum\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"sum\",\"schema\":\"metric\",\"params\":{\"field\":\"source.stats.net_bytes_total\",\"customLabel\":\"Source traffic\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"sum\",\"schema\":\"metric\",\"params\":{\"field\":\"dest.stats.net_bytes_total\",\"customLabel\":\"Destination traffic\"}},{\"id\":\"3\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"source.ip\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\"}},{\"id\":\"4\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"dest.ip\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}"
-      },
-      "id": "Network-traffic-between-your-hosts",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "columns": [
-          "type",
-          "start_time",
-          "last_time",
-          "source.ip",
-          "source.port",
-          "dest.ip",
-          "dest.port",
-          "source.stats.net_bytes_total",
-          "dest.stats.net_bytes_total"
-        ],
-        "description": "",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"index\":\"packetbeat-*\",\"filter\":[],\"highlight\":{\"pre_tags\":[\"@kibana-highlighted-field@\"],\"post_tags\":[\"@/kibana-highlighted-field@\"],\"fields\":{\"*\":{}},\"require_field_match\":false,\"fragment_size\":2147483647},\"query\":{\"query_string\":{\"query\":\"type: flow\",\"analyze_wildcard\":true}}}"
-        },
-        "sort": [
-          "@timestamp",
-          "desc"
-        ],
-        "title": "Packetbeat Flows Search",
-        "version": 1
-      },
-      "id": "Packetbeat-Flows-Search",
-      "type": "search",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[],\"query\":{\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}},\"language\":\"lucene\"},\"highlightAll\":true,\"version\":true}"
-        },
-        "optionsJSON": "{\"darkTheme\":false}",
-        "panelsJSON": "[{\"col\":1,\"id\":\"Navigation\",\"panelIndex\":2,\"row\":1,\"size_x\":3,\"size_y\":4,\"type\":\"visualization\"},{\"col\":4,\"id\":\"Connections-over-time\",\"panelIndex\":3,\"row\":1,\"size_x\":9,\"size_y\":5,\"type\":\"visualization\"},{\"col\":1,\"id\":\"Top-hosts-creating-traffic\",\"panelIndex\":1,\"row\":6,\"size_x\":6,\"size_y\":7,\"type\":\"visualization\"},{\"col\":7,\"id\":\"Top-hosts-receiving-traffic\",\"panelIndex\":4,\"row\":6,\"size_x\":6,\"size_y\":7,\"type\":\"visualization\"},{\"id\":\"Network-traffic-between-your-hosts\",\"type\":\"visualization\",\"panelIndex\":5,\"size_x\":12,\"size_y\":7,\"col\":1,\"row\":13}]",
-        "timeRestore": false,
-        "title": "[Packetbeat] Flows",
-        "uiStateJSON": "{\"P-5\":{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}}}",
-        "version": 1
-      },
-      "id": "Packetbeat-Flows",
-      "type": "dashboard",
-      "version": 2
-    }
-  ],
-  "version": "6.0.0-beta1-SNAPSHOT"
+    "objects": [
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "analyze_wildcard": true, 
+                                    "query": "*"
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "title": "Navigation", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "fontSize": "10", 
+                        "markdown": "### Packetbeat:\n\n[Overview](#/dashboard/Packetbeat-Dashboard)\n\n[Flows](#/dashboard/Packetbeat-Flows)\n\n[Web transactions](#/dashboard/Packetbeat-HTTP)\n\n[MySQL performance](#/dashboard/Packetbeat-MySQL-performance)\n\n[PostgreSQL performance](#/dashboard/Packetbeat-PgSQL-performance)\n\n[MongoDB performance](#/dashboard/Packetbeat-MongoDB-performance)\n\n[Thrift-RPC performance](#/dashboard/Packetbeat-Thrift-performance)\n\n[NFS transactions](#/dashboard/Packetbeat-NFS)\n\n[Cassandra performance](#/dashboard/Packetbeat-Cassandra)"
+                    }, 
+                    "title": "Navigation", 
+                    "type": "markdown"
+                }
+            }, 
+            "id": "Navigation", 
+            "type": "visualization", 
+            "version": 10
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Packetbeat-Flows-Search", 
+                "title": "Connections over time", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "field": "flow_id"
+                            }, 
+                            "schema": "metric", 
+                            "type": "cardinality"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "defaultYExtents": false, 
+                        "interpolate": "linear", 
+                        "legendPosition": "right", 
+                        "mode": "stacked", 
+                        "scale": "linear", 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "smoothLines": true, 
+                        "times": [], 
+                        "yAxis": {}
+                    }, 
+                    "title": "Connections over time", 
+                    "type": "area"
+                }
+            }, 
+            "id": "Connections-over-time", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Packetbeat-Flows-Search", 
+                "title": "Top hosts creating traffic", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "field": "source.stats.net_bytes_total"
+                            }, 
+                            "schema": "metric", 
+                            "type": "sum"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "field": "source.ip", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "group", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "defaultYExtents": false, 
+                        "interpolate": "linear", 
+                        "legendPosition": "right", 
+                        "mode": "stacked", 
+                        "scale": "linear", 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "smoothLines": true, 
+                        "times": [], 
+                        "yAxis": {}
+                    }, 
+                    "title": "Top hosts creating traffic", 
+                    "type": "area"
+                }
+            }, 
+            "id": "Top-hosts-creating-traffic", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Packetbeat-Flows-Search", 
+                "title": "Top hosts receiving traffic", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "field": "dest.stats.net_bytes_total"
+                            }, 
+                            "schema": "metric", 
+                            "type": "sum"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "field": "dest.ip", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "group", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "defaultYExtents": false, 
+                        "interpolate": "linear", 
+                        "legendPosition": "right", 
+                        "mode": "stacked", 
+                        "scale": "linear", 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "smoothLines": true, 
+                        "times": [], 
+                        "yAxis": {}
+                    }, 
+                    "title": "Top hosts receiving traffic", 
+                    "type": "area"
+                }
+            }, 
+            "id": "Top-hosts-receiving-traffic", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Packetbeat-Flows-Search", 
+                "title": "Network traffic between your hosts", 
+                "uiStateJSON": {
+                    "vis": {
+                        "params": {
+                            "sort": {
+                                "columnIndex": null, 
+                                "direction": null
+                            }
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": "Source traffic", 
+                                "field": "source.stats.net_bytes_total"
+                            }, 
+                            "schema": "metric", 
+                            "type": "sum"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customLabel": "Destination traffic", 
+                                "field": "dest.stats.net_bytes_total"
+                            }, 
+                            "schema": "metric", 
+                            "type": "sum"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "field": "source.ip", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "bucket", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "4", 
+                            "params": {
+                                "field": "dest.ip", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "bucket", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "perPage": 10, 
+                        "showMeticsAtAllLevels": false, 
+                        "showPartialRows": false, 
+                        "showTotal": false, 
+                        "sort": {
+                            "columnIndex": null, 
+                            "direction": null
+                        }, 
+                        "totalFunc": "sum"
+                    }, 
+                    "title": "Network traffic between your hosts", 
+                    "type": "table"
+                }
+            }, 
+            "id": "Network-traffic-between-your-hosts", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "columns": [
+                    "type", 
+                    "start_time", 
+                    "last_time", 
+                    "source.ip", 
+                    "source.port", 
+                    "dest.ip", 
+                    "dest.port", 
+                    "source.stats.net_bytes_total", 
+                    "dest.stats.net_bytes_total"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlight": {
+                            "fields": {
+                                "*": {}
+                            }, 
+                            "fragment_size": 2147483647, 
+                            "post_tags": [
+                                "@/kibana-highlighted-field@"
+                            ], 
+                            "pre_tags": [
+                                "@kibana-highlighted-field@"
+                            ], 
+                            "require_field_match": false
+                        }, 
+                        "index": "packetbeat-*", 
+                        "query": {
+                            "query_string": {
+                                "analyze_wildcard": true, 
+                                "query": "type: flow"
+                            }
+                        }
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "Packetbeat Flows Search", 
+                "version": 1
+            }, 
+            "id": "Packetbeat-Flows-Search", 
+            "type": "search", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "analyze_wildcard": true, 
+                                    "query": "*"
+                                }
+                            }
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false
+                }, 
+                "panelsJSON": [
+                    {
+                        "col": 1, 
+                        "id": "Navigation", 
+                        "panelIndex": 2, 
+                        "row": 1, 
+                        "size_x": 3, 
+                        "size_y": 4, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 4, 
+                        "id": "Connections-over-time", 
+                        "panelIndex": 3, 
+                        "row": 1, 
+                        "size_x": 9, 
+                        "size_y": 5, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "Top-hosts-creating-traffic", 
+                        "panelIndex": 1, 
+                        "row": 6, 
+                        "size_x": 6, 
+                        "size_y": 7, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 7, 
+                        "id": "Top-hosts-receiving-traffic", 
+                        "panelIndex": 4, 
+                        "row": 6, 
+                        "size_x": 6, 
+                        "size_y": 7, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "Network-traffic-between-your-hosts", 
+                        "panelIndex": 5, 
+                        "row": 13, 
+                        "size_x": 12, 
+                        "size_y": 7, 
+                        "type": "visualization"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Packetbeat] Flows", 
+                "uiStateJSON": {
+                    "P-5": {
+                        "vis": {
+                            "params": {
+                                "sort": {
+                                    "columnIndex": null, 
+                                    "direction": null
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "version": 1
+            }, 
+            "id": "Packetbeat-Flows", 
+            "type": "dashboard", 
+            "version": 2
+        }
+    ], 
+    "version": "6.0.0-beta1-SNAPSHOT"
 }

--- a/packetbeat/_meta/kibana/6/dashboard/Packetbeat-http.json
+++ b/packetbeat/_meta/kibana/6/dashboard/Packetbeat-http.json
@@ -1,152 +1,606 @@
 {
-  "objects": [
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\n  \"filter\": []\n}"
-        },
-        "savedSearchId": "71908f00-88ca-11e7-ad9c-db80de0bf8d3",
-        "title": "Web transactions",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\n  \"title\": \"Web transactions\",\n  \"type\": \"histogram\",\n  \"params\": {\n    \"shareYAxis\": true,\n    \"addTooltip\": true,\n    \"addLegend\": false,\n    \"mode\": \"stacked\",\n    \"defaultYExtents\": false,\n    \"scale\": \"linear\",\n    \"times\": [],\n    \"addTimeMarker\": false,\n    \"setYExtents\": false,\n    \"yAxis\": {}\n  },\n  \"aggs\": [\n    {\n      \"id\": \"1\",\n      \"type\": \"count\",\n      \"schema\": \"metric\",\n      \"params\": {}\n    },\n    {\n      \"id\": \"2\",\n      \"type\": \"date_histogram\",\n      \"schema\": \"segment\",\n      \"params\": {\n        \"field\": \"@timestamp\",\n        \"interval\": \"auto\",\n        \"customInterval\": \"2h\",\n        \"min_doc_count\": 1,\n        \"extended_bounds\": {}\n      }\n    }\n  ],\n  \"listeners\": {}\n}"
-      },
-      "id": "Web-transactions",
-      "type": "visualization",
-      "version": 3
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\n  \"filter\": [\n    {\n      \"$state\": {\n        \"store\": \"appState\"\n      },\n      \"meta\": {\n        \"disabled\": false,\n        \"index\": \"packetbeat-*\",\n        \"key\": \"type\",\n        \"negate\": false,\n        \"value\": \"http\",\n        \"alias\": null\n      },\n      \"query\": {\n        \"match\": {\n          \"type\": {\n            \"query\": \"http\",\n            \"type\": \"phrase\"\n          }\n        }\n      }\n    }\n  ],\n  \"index\": \"packetbeat-*\",\n  \"highlight\": {\n    \"pre_tags\": [\n      \"@kibana-highlighted-field@\"\n    ],\n    \"post_tags\": [\n      \"@/kibana-highlighted-field@\"\n    ],\n    \"fields\": {\n      \"*\": {}\n    }\n  },\n  \"query\": {\n    \"query_string\": {\n      \"query\": \"http.response.code: [300 TO *]\",\n      \"analyze_wildcard\": true\n    }\n  }\n}"
-        },
-        "title": "HTTP error codes",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\n  \"title\": \"HTTP error codes\",\n  \"type\": \"histogram\",\n  \"params\": {\n    \"shareYAxis\": true,\n    \"addTooltip\": true,\n    \"addLegend\": false,\n    \"mode\": \"stacked\",\n    \"defaultYExtents\": false,\n    \"scale\": \"linear\",\n    \"times\": [],\n    \"addTimeMarker\": false,\n    \"setYExtents\": false,\n    \"yAxis\": {}\n  },\n  \"aggs\": [\n    {\n      \"id\": \"1\",\n      \"type\": \"cardinality\",\n      \"schema\": \"metric\",\n      \"params\": {\n        \"field\": \"type\"\n      }\n    },\n    {\n      \"id\": \"2\",\n      \"type\": \"terms\",\n      \"schema\": \"segment\",\n      \"params\": {\n        \"field\": \"http.response.code\",\n        \"size\": 5,\n        \"order\": \"desc\",\n        \"orderBy\": \"1\"\n      }\n    }\n  ],\n  \"listeners\": {}\n}"
-      },
-      "id": "HTTP-error-codes",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\n  \"filter\": [\n    {\n      \"$state\": {\n        \"store\": \"appState\"\n      },\n      \"meta\": {\n        \"disabled\": false,\n        \"index\": \"packetbeat-*\",\n        \"key\": \"type\",\n        \"negate\": false,\n        \"value\": \"http\",\n        \"alias\": null\n      },\n      \"query\": {\n        \"match\": {\n          \"type\": {\n            \"query\": \"http\",\n            \"type\": \"phrase\"\n          }\n        }\n      }\n    }\n  ],\n  \"index\": \"packetbeat-*\",\n  \"highlight\": {\n    \"pre_tags\": [\n      \"@kibana-highlighted-field@\"\n    ],\n    \"post_tags\": [\n      \"@/kibana-highlighted-field@\"\n    ],\n    \"fields\": {\n      \"*\": {}\n    }\n  },\n  \"query\": {\n    \"query_string\": {\n      \"query\": \"!http.response.code: [200 TO 299]\",\n      \"analyze_wildcard\": true\n    }\n  }\n}"
-        },
-        "title": "HTTP error codes evolution",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\n  \"title\": \"HTTP error codes evolution\",\n  \"type\": \"line\",\n  \"params\": {\n    \"addLegend\": true,\n    \"addTooltip\": true,\n    \"defaultYExtents\": false,\n    \"shareYAxis\": true,\n    \"showCircles\": true,\n    \"smoothLines\": false,\n    \"interpolate\": \"linear\",\n    \"scale\": \"linear\",\n    \"drawLinesBetweenPoints\": true,\n    \"radiusRatio\": 9,\n    \"times\": [],\n    \"addTimeMarker\": false,\n    \"setYExtents\": false,\n    \"yAxis\": {}\n  },\n  \"aggs\": [\n    {\n      \"id\": \"1\",\n      \"type\": \"cardinality\",\n      \"schema\": \"metric\",\n      \"params\": {\n        \"field\": \"type\"\n      }\n    },\n    {\n      \"id\": \"2\",\n      \"type\": \"date_histogram\",\n      \"schema\": \"segment\",\n      \"params\": {\n        \"field\": \"@timestamp\",\n        \"interval\": \"auto\",\n        \"customInterval\": \"2h\",\n        \"min_doc_count\": 1,\n        \"extended_bounds\": {}\n      }\n    },\n    {\n      \"id\": \"3\",\n      \"type\": \"terms\",\n      \"schema\": \"group\",\n      \"params\": {\n        \"field\": \"http.response.code\",\n        \"size\": 5,\n        \"order\": \"desc\",\n        \"orderBy\": \"1\"\n      }\n    }\n  ],\n  \"listeners\": {}\n}"
-      },
-      "id": "HTTP-error-codes-evolution",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}},\"language\":\"lucene\"},\"filter\":[]}"
-        },
-        "title": "Navigation",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Navigation\",\"type\":\"markdown\",\"params\":{\"markdown\":\"### Packetbeat:\\n\\n[Overview](#/dashboard/Packetbeat-Dashboard)\\n\\n[Flows](#/dashboard/Packetbeat-Flows)\\n\\n[Web transactions](#/dashboard/Packetbeat-HTTP)\\n\\n[MySQL performance](#/dashboard/Packetbeat-MySQL-performance)\\n\\n[PostgreSQL performance](#/dashboard/Packetbeat-PgSQL-performance)\\n\\n[MongoDB performance](#/dashboard/Packetbeat-MongoDB-performance)\\n\\n[Thrift-RPC performance](#/dashboard/Packetbeat-Thrift-performance)\\n\\n[NFS transactions](#/dashboard/Packetbeat-NFS)\\n\\n[Cassandra performance](#/dashboard/Packetbeat-Cassandra)\",\"fontSize\":\"10\"},\"aggs\":[]}"
-      },
-      "id": "Navigation",
-      "type": "visualization",
-      "version": 10
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\n  \"filter\": []\n}"
-        },
-        "savedSearchId": "71908f00-88ca-11e7-ad9c-db80de0bf8d3",
-        "title": "Total number of HTTP transactions",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\n  \"title\": \"Total number of HTTP transactions\",\n  \"type\": \"metric\",\n  \"params\": {\n    \"fontSize\": \"37\",\n    \"handleNoResults\": true\n  },\n  \"aggs\": [\n    {\n      \"id\": \"1\",\n      \"type\": \"count\",\n      \"schema\": \"metric\",\n      \"params\": {}\n    }\n  ],\n  \"listeners\": {}\n}"
-      },
-      "id": "Total-number-of-HTTP-transactions",
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\n  \"filter\": []\n}"
-        },
-        "savedSearchId": "71908f00-88ca-11e7-ad9c-db80de0bf8d3",
-        "title": "HTTP codes for the top queries",
-        "version": 1,
-        "visState": "{\n  \"type\": \"pie\",\n  \"params\": {\n    \"shareYAxis\": true,\n    \"addTooltip\": true,\n    \"addLegend\": true,\n    \"isDonut\": false\n  },\n  \"aggs\": [\n    {\n      \"id\": \"1\",\n      \"type\": \"count\",\n      \"schema\": \"metric\",\n      \"params\": {}\n    },\n    {\n      \"id\": \"2\",\n      \"type\": \"terms\",\n      \"schema\": \"split\",\n      \"params\": {\n        \"field\": \"query\",\n        \"size\": 5,\n        \"order\": \"desc\",\n        \"orderBy\": \"1\",\n        \"row\": false\n      }\n    },\n    {\n      \"id\": \"3\",\n      \"type\": \"terms\",\n      \"schema\": \"segment\",\n      \"params\": {\n        \"field\": \"http.response.code\",\n        \"size\": 10,\n        \"order\": \"desc\",\n        \"orderBy\": \"1\"\n      }\n    }\n  ],\n  \"listeners\": {}\n}"
-      },
-      "id": "HTTP-codes-for-the-top-queries",
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\n  \"filter\": []\n}"
-        },
-        "savedSearchId": "71908f00-88ca-11e7-ad9c-db80de0bf8d3",
-        "title": "Top 10 HTTP requests",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\n  \"title\": \"Top 10 HTTP requests\",\n  \"type\": \"table\",\n  \"params\": {\n    \"perPage\": 10,\n    \"showPartialRows\": false,\n    \"showMeticsAtAllLevels\": false\n  },\n  \"aggs\": [\n    {\n      \"id\": \"1\",\n      \"type\": \"count\",\n      \"schema\": \"metric\",\n      \"params\": {}\n    },\n    {\n      \"id\": \"2\",\n      \"type\": \"terms\",\n      \"schema\": \"bucket\",\n      \"params\": {\n        \"field\": \"query\",\n        \"size\": 10,\n        \"order\": \"desc\",\n        \"orderBy\": \"1\"\n      }\n    }\n  ],\n  \"listeners\": {}\n}"
-      },
-      "id": "Top-10-HTTP-requests",
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "columns": [
-          "_source"
-        ],
-        "description": "",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"index\":\"packetbeat-*\",\"highlightAll\":true,\"version\":true,\"query\":{\"language\":\"lucene\",\"query\":\"*\"},\"filter\":[{\"meta\":{\"index\":\"packetbeat-*\",\"negate\":false,\"disabled\":false,\"alias\":null,\"type\":\"phrase\",\"key\":\"type\",\"value\":\"http\",\"params\":{\"query\":\"http\",\"type\":\"phrase\"}},\"query\":{\"match\":{\"type\":{\"query\":\"http\",\"type\":\"phrase\"}}},\"$state\":{\"store\":\"appState\"}}]}"
-        },
-        "sort": [
-          "@timestamp",
-          "desc"
-        ],
-        "title": "Web Transactions [Packetbeat]",
-        "version": 1
-      },
-      "id": "71908f00-88ca-11e7-ad9c-db80de0bf8d3",
-      "type": "search",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[],\"query\":{\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}},\"language\":\"lucene\"},\"highlightAll\":true,\"version\":true}"
-        },
-        "optionsJSON": "{\"darkTheme\":false}",
-        "panelsJSON": "[{\"col\":4,\"id\":\"Web-transactions\",\"row\":1,\"size_x\":9,\"size_y\":4,\"type\":\"visualization\",\"panelIndex\":1},{\"col\":1,\"id\":\"HTTP-error-codes\",\"row\":8,\"size_x\":6,\"size_y\":3,\"type\":\"visualization\",\"panelIndex\":2},{\"col\":7,\"id\":\"HTTP-error-codes-evolution\",\"row\":8,\"size_x\":6,\"size_y\":3,\"type\":\"visualization\",\"panelIndex\":3},{\"col\":1,\"id\":\"Navigation\",\"row\":1,\"size_x\":3,\"size_y\":4,\"type\":\"visualization\",\"panelIndex\":4},{\"col\":1,\"id\":\"Total-number-of-HTTP-transactions\",\"row\":5,\"size_x\":3,\"size_y\":3,\"type\":\"visualization\",\"panelIndex\":5},{\"col\":4,\"id\":\"HTTP-codes-for-the-top-queries\",\"row\":5,\"size_x\":9,\"size_y\":3,\"type\":\"visualization\",\"panelIndex\":6},{\"id\":\"Top-10-HTTP-requests\",\"type\":\"visualization\",\"size_x\":12,\"size_y\":5,\"col\":1,\"row\":11,\"panelIndex\":7}]",
-        "timeRestore": false,
-        "title": "[Packetbeat] HTTP",
-        "uiStateJSON": "{\"P-7\":{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}},\"P-5\":{\"vis\":{\"defaultColors\":{\"0 - 100\":\"rgb(0,104,55)\"}}}}",
-        "version": 1
-      },
-      "id": "Packetbeat-HTTP",
-      "type": "dashboard",
-      "version": 2
-    }
-  ],
-  "version": "6.0.0-beta1-SNAPSHOT"
+    "objects": [
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "71908f00-88ca-11e7-ad9c-db80de0bf8d3", 
+                "title": "Web transactions", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": false, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "defaultYExtents": false, 
+                        "mode": "stacked", 
+                        "scale": "linear", 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "times": [], 
+                        "yAxis": {}
+                    }, 
+                    "title": "Web transactions", 
+                    "type": "histogram"
+                }
+            }, 
+            "id": "Web-transactions", 
+            "type": "visualization", 
+            "version": 3
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                }, 
+                                "meta": {
+                                    "alias": null, 
+                                    "disabled": false, 
+                                    "index": "packetbeat-*", 
+                                    "key": "type", 
+                                    "negate": false, 
+                                    "value": "http"
+                                }, 
+                                "query": {
+                                    "match": {
+                                        "type": {
+                                            "query": "http", 
+                                            "type": "phrase"
+                                        }
+                                    }
+                                }
+                            }
+                        ], 
+                        "highlight": {
+                            "fields": {
+                                "*": {}
+                            }, 
+                            "post_tags": [
+                                "@/kibana-highlighted-field@"
+                            ], 
+                            "pre_tags": [
+                                "@kibana-highlighted-field@"
+                            ]
+                        }, 
+                        "index": "packetbeat-*", 
+                        "query": {
+                            "query_string": {
+                                "analyze_wildcard": true, 
+                                "query": "http.response.code: [300 TO *]"
+                            }
+                        }
+                    }
+                }, 
+                "title": "HTTP error codes", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "id": "1", 
+                            "params": {
+                                "field": "type"
+                            }, 
+                            "schema": "metric", 
+                            "type": "cardinality"
+                        }, 
+                        {
+                            "id": "2", 
+                            "params": {
+                                "field": "http.response.code", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": false, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "defaultYExtents": false, 
+                        "mode": "stacked", 
+                        "scale": "linear", 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "times": [], 
+                        "yAxis": {}
+                    }, 
+                    "title": "HTTP error codes", 
+                    "type": "histogram"
+                }
+            }, 
+            "id": "HTTP-error-codes", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                }, 
+                                "meta": {
+                                    "alias": null, 
+                                    "disabled": false, 
+                                    "index": "packetbeat-*", 
+                                    "key": "type", 
+                                    "negate": false, 
+                                    "value": "http"
+                                }, 
+                                "query": {
+                                    "match": {
+                                        "type": {
+                                            "query": "http", 
+                                            "type": "phrase"
+                                        }
+                                    }
+                                }
+                            }
+                        ], 
+                        "highlight": {
+                            "fields": {
+                                "*": {}
+                            }, 
+                            "post_tags": [
+                                "@/kibana-highlighted-field@"
+                            ], 
+                            "pre_tags": [
+                                "@kibana-highlighted-field@"
+                            ]
+                        }, 
+                        "index": "packetbeat-*", 
+                        "query": {
+                            "query_string": {
+                                "analyze_wildcard": true, 
+                                "query": "!http.response.code: [200 TO 299]"
+                            }
+                        }
+                    }
+                }, 
+                "title": "HTTP error codes evolution", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "id": "1", 
+                            "params": {
+                                "field": "type"
+                            }, 
+                            "schema": "metric", 
+                            "type": "cardinality"
+                        }, 
+                        {
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "id": "3", 
+                            "params": {
+                                "field": "http.response.code", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "group", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "defaultYExtents": false, 
+                        "drawLinesBetweenPoints": true, 
+                        "interpolate": "linear", 
+                        "radiusRatio": 9, 
+                        "scale": "linear", 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "showCircles": true, 
+                        "smoothLines": false, 
+                        "times": [], 
+                        "yAxis": {}
+                    }, 
+                    "title": "HTTP error codes evolution", 
+                    "type": "line"
+                }
+            }, 
+            "id": "HTTP-error-codes-evolution", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "analyze_wildcard": true, 
+                                    "query": "*"
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "title": "Navigation", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "fontSize": "10", 
+                        "markdown": "### Packetbeat:\n\n[Overview](#/dashboard/Packetbeat-Dashboard)\n\n[Flows](#/dashboard/Packetbeat-Flows)\n\n[Web transactions](#/dashboard/Packetbeat-HTTP)\n\n[MySQL performance](#/dashboard/Packetbeat-MySQL-performance)\n\n[PostgreSQL performance](#/dashboard/Packetbeat-PgSQL-performance)\n\n[MongoDB performance](#/dashboard/Packetbeat-MongoDB-performance)\n\n[Thrift-RPC performance](#/dashboard/Packetbeat-Thrift-performance)\n\n[NFS transactions](#/dashboard/Packetbeat-NFS)\n\n[Cassandra performance](#/dashboard/Packetbeat-Cassandra)"
+                    }, 
+                    "title": "Navigation", 
+                    "type": "markdown"
+                }
+            }, 
+            "id": "Navigation", 
+            "type": "visualization", 
+            "version": 10
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "71908f00-88ca-11e7-ad9c-db80de0bf8d3", 
+                "title": "Total number of HTTP transactions", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "fontSize": "37", 
+                        "handleNoResults": true
+                    }, 
+                    "title": "Total number of HTTP transactions", 
+                    "type": "metric"
+                }
+            }, 
+            "id": "Total-number-of-HTTP-transactions", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "71908f00-88ca-11e7-ad9c-db80de0bf8d3", 
+                "title": "HTTP codes for the top queries", 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "id": "2", 
+                            "params": {
+                                "field": "query", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "row": false, 
+                                "size": 5
+                            }, 
+                            "schema": "split", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "id": "3", 
+                            "params": {
+                                "field": "http.response.code", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 10
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTooltip": true, 
+                        "isDonut": false, 
+                        "shareYAxis": true
+                    }, 
+                    "type": "pie"
+                }
+            }, 
+            "id": "HTTP-codes-for-the-top-queries", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "71908f00-88ca-11e7-ad9c-db80de0bf8d3", 
+                "title": "Top 10 HTTP requests", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "id": "2", 
+                            "params": {
+                                "field": "query", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 10
+                            }, 
+                            "schema": "bucket", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "perPage": 10, 
+                        "showMeticsAtAllLevels": false, 
+                        "showPartialRows": false
+                    }, 
+                    "title": "Top 10 HTTP requests", 
+                    "type": "table"
+                }
+            }, 
+            "id": "Top-10-HTTP-requests", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "columns": [
+                    "_source"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                }, 
+                                "meta": {
+                                    "alias": null, 
+                                    "disabled": false, 
+                                    "index": "packetbeat-*", 
+                                    "key": "type", 
+                                    "negate": false, 
+                                    "params": {
+                                        "query": "http", 
+                                        "type": "phrase"
+                                    }, 
+                                    "type": "phrase", 
+                                    "value": "http"
+                                }, 
+                                "query": {
+                                    "match": {
+                                        "type": {
+                                            "query": "http", 
+                                            "type": "phrase"
+                                        }
+                                    }
+                                }
+                            }
+                        ], 
+                        "highlightAll": true, 
+                        "index": "packetbeat-*", 
+                        "query": {
+                            "language": "lucene", 
+                            "query": "*"
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "Web Transactions [Packetbeat]", 
+                "version": 1
+            }, 
+            "id": "71908f00-88ca-11e7-ad9c-db80de0bf8d3", 
+            "type": "search", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "analyze_wildcard": true, 
+                                    "query": "*"
+                                }
+                            }
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false
+                }, 
+                "panelsJSON": [
+                    {
+                        "col": 4, 
+                        "id": "Web-transactions", 
+                        "panelIndex": 1, 
+                        "row": 1, 
+                        "size_x": 9, 
+                        "size_y": 4, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "HTTP-error-codes", 
+                        "panelIndex": 2, 
+                        "row": 8, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 7, 
+                        "id": "HTTP-error-codes-evolution", 
+                        "panelIndex": 3, 
+                        "row": 8, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "Navigation", 
+                        "panelIndex": 4, 
+                        "row": 1, 
+                        "size_x": 3, 
+                        "size_y": 4, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "Total-number-of-HTTP-transactions", 
+                        "panelIndex": 5, 
+                        "row": 5, 
+                        "size_x": 3, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 4, 
+                        "id": "HTTP-codes-for-the-top-queries", 
+                        "panelIndex": 6, 
+                        "row": 5, 
+                        "size_x": 9, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "Top-10-HTTP-requests", 
+                        "panelIndex": 7, 
+                        "row": 11, 
+                        "size_x": 12, 
+                        "size_y": 5, 
+                        "type": "visualization"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Packetbeat] HTTP", 
+                "uiStateJSON": {
+                    "P-5": {
+                        "vis": {
+                            "defaultColors": {
+                                "0 - 100": "rgb(0,104,55)"
+                            }
+                        }
+                    }, 
+                    "P-7": {
+                        "vis": {
+                            "params": {
+                                "sort": {
+                                    "columnIndex": null, 
+                                    "direction": null
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "version": 1
+            }, 
+            "id": "Packetbeat-HTTP", 
+            "type": "dashboard", 
+            "version": 2
+        }
+    ], 
+    "version": "6.0.0-beta1-SNAPSHOT"
 }

--- a/packetbeat/_meta/kibana/6/dashboard/Packetbeat-mongodb.json
+++ b/packetbeat/_meta/kibana/6/dashboard/Packetbeat-mongodb.json
@@ -1,221 +1,847 @@
 {
-  "objects": [
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}},\"language\":\"lucene\"},\"filter\":[]}"
-        },
-        "title": "Navigation",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Navigation\",\"type\":\"markdown\",\"params\":{\"markdown\":\"### Packetbeat:\\n\\n[Overview](#/dashboard/Packetbeat-Dashboard)\\n\\n[Flows](#/dashboard/Packetbeat-Flows)\\n\\n[Web transactions](#/dashboard/Packetbeat-HTTP)\\n\\n[MySQL performance](#/dashboard/Packetbeat-MySQL-performance)\\n\\n[PostgreSQL performance](#/dashboard/Packetbeat-PgSQL-performance)\\n\\n[MongoDB performance](#/dashboard/Packetbeat-MongoDB-performance)\\n\\n[Thrift-RPC performance](#/dashboard/Packetbeat-Thrift-performance)\\n\\n[NFS transactions](#/dashboard/Packetbeat-NFS)\\n\\n[Cassandra performance](#/dashboard/Packetbeat-Cassandra)\",\"fontSize\":\"10\"},\"aggs\":[]}"
-      },
-      "id": "Navigation",
-      "type": "visualization",
-      "version": 10
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\n  \"filter\": []\n}"
-        },
-        "savedSearchId": "651fd6d0-88d0-11e7-ad9c-db80de0bf8d3",
-        "title": "MongoDB errors",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\n  \"title\": \"MongoDB errors\",\n  \"type\": \"line\",\n  \"params\": {\n    \"addLegend\": true,\n    \"addTimeMarker\": false,\n    \"addTooltip\": true,\n    \"defaultYExtents\": false,\n    \"drawLinesBetweenPoints\": true,\n    \"interpolate\": \"linear\",\n    \"radiusRatio\": 9,\n    \"scale\": \"linear\",\n    \"setYExtents\": false,\n    \"shareYAxis\": true,\n    \"showCircles\": true,\n    \"smoothLines\": false,\n    \"spyPerPage\": 10,\n    \"times\": [],\n    \"yAxis\": {}\n  },\n  \"aggs\": [\n    {\n      \"id\": \"1\",\n      \"type\": \"count\",\n      \"schema\": \"metric\",\n      \"params\": {}\n    },\n    {\n      \"id\": \"2\",\n      \"type\": \"date_histogram\",\n      \"schema\": \"segment\",\n      \"params\": {\n        \"field\": \"@timestamp\",\n        \"interval\": \"auto\",\n        \"customInterval\": \"2h\",\n        \"min_doc_count\": 1,\n        \"extended_bounds\": {}\n      }\n    },\n    {\n      \"id\": \"3\",\n      \"type\": \"terms\",\n      \"schema\": \"split\",\n      \"params\": {\n        \"field\": \"resource\",\n        \"size\": 3,\n        \"order\": \"desc\",\n        \"orderBy\": \"1\",\n        \"row\": true\n      }\n    },\n    {\n      \"id\": \"4\",\n      \"type\": \"terms\",\n      \"schema\": \"group\",\n      \"params\": {\n        \"field\": \"method\",\n        \"size\": 5,\n        \"order\": \"desc\",\n        \"orderBy\": \"1\"\n      }\n    }\n  ],\n  \"listeners\": {}\n}"
-      },
-      "id": "MongoDB-errors",
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[]}"
-        },
-        "savedSearchId": "MongoDB-transactions",
-        "title": "MongoDB commands",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"MongoDB commands\",\"type\":\"area\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"smoothLines\":true,\"scale\":\"linear\",\"interpolate\":\"linear\",\"mode\":\"silhouette\",\"times\":[],\"addTimeMarker\":false,\"defaultYExtents\":false,\"setYExtents\":false,\"yAxis\":{}},\"aggs\":[{\"id\":\"1\",\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"auto\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}},{\"id\":\"3\",\"type\":\"terms\",\"schema\":\"group\",\"params\":{\"field\":\"method\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}"
-      },
-      "id": "MongoDB-commands",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\n  \"filter\": []\n}"
-        },
-        "savedSearchId": "651fd6d0-88d0-11e7-ad9c-db80de0bf8d3",
-        "title": "MongoDB errors per collection",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\n  \"title\": \"MongoDB errors per collection\",\n  \"type\": \"line\",\n  \"params\": {\n    \"addLegend\": true,\n    \"addTimeMarker\": false,\n    \"addTooltip\": true,\n    \"defaultYExtents\": false,\n    \"drawLinesBetweenPoints\": true,\n    \"interpolate\": \"linear\",\n    \"radiusRatio\": 9,\n    \"scale\": \"linear\",\n    \"setYExtents\": false,\n    \"shareYAxis\": true,\n    \"showCircles\": true,\n    \"smoothLines\": false,\n    \"spyPerPage\": 10,\n    \"times\": [],\n    \"yAxis\": {}\n  },\n  \"aggs\": [\n    {\n      \"id\": \"1\",\n      \"type\": \"count\",\n      \"schema\": \"metric\",\n      \"params\": {}\n    },\n    {\n      \"id\": \"2\",\n      \"type\": \"date_histogram\",\n      \"schema\": \"segment\",\n      \"params\": {\n        \"field\": \"@timestamp\",\n        \"interval\": \"auto\",\n        \"customInterval\": \"2h\",\n        \"min_doc_count\": 1,\n        \"extended_bounds\": {}\n      }\n    },\n    {\n      \"id\": \"3\",\n      \"type\": \"terms\",\n      \"schema\": \"group\",\n      \"params\": {\n        \"field\": \"resource\",\n        \"size\": 5,\n        \"order\": \"desc\",\n        \"orderBy\": \"1\"\n      }\n    }\n  ],\n  \"listeners\": {}\n}"
-      },
-      "id": "MongoDB-errors-per-collection",
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[]}"
-        },
-        "savedSearchId": "MongoDB-transactions",
-        "title": "MongoDB in/out throughput",
-        "version": 1,
-        "visState": "{\"type\":\"line\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"showCircles\":true,\"smoothLines\":false,\"interpolate\":\"linear\",\"scale\":\"linear\",\"drawLinesBetweenPoints\":true,\"radiusRatio\":9,\"times\":[],\"addTimeMarker\":false,\"defaultYExtents\":false,\"setYExtents\":false,\"yAxis\":{}},\"aggs\":[{\"id\":\"1\",\"type\":\"sum\",\"schema\":\"metric\",\"params\":{\"field\":\"bytes_in\"}},{\"id\":\"2\",\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"auto\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}},{\"id\":\"4\",\"type\":\"sum\",\"schema\":\"metric\",\"params\":{\"field\":\"bytes_out\"}}],\"listeners\":{}}"
-      },
-      "id": "MongoDB-in-slash-out-throughput",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[]}"
-        },
-        "savedSearchId": "MongoDB-transactions",
-        "title": "MongoDB response times by collection",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"MongoDB response times by collection\",\"type\":\"line\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"showCircles\":true,\"smoothLines\":false,\"interpolate\":\"linear\",\"scale\":\"linear\",\"drawLinesBetweenPoints\":false,\"radiusRatio\":\"9\",\"times\":[],\"addTimeMarker\":false,\"defaultYExtents\":false,\"setYExtents\":false,\"yAxis\":{}},\"aggs\":[{\"id\":\"1\",\"type\":\"percentiles\",\"schema\":\"metric\",\"params\":{\"field\":\"responsetime\",\"percents\":[99]}},{\"id\":\"2\",\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"auto\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}},{\"id\":\"3\",\"type\":\"terms\",\"schema\":\"group\",\"params\":{\"field\":\"resource\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1.99\"}},{\"id\":\"4\",\"type\":\"count\",\"schema\":\"radius\",\"params\":{}}],\"listeners\":{}}"
-      },
-      "id": "MongoDB-response-times-by-collection",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[]}"
-        },
-        "savedSearchId": "MongoDB-transactions",
-        "title": "Top slowest MongoDB queries",
-        "version": 1,
-        "visState": "{\"type\":\"table\",\"params\":{\"perPage\":10,\"showPartialRows\":false,\"showMeticsAtAllLevels\":false},\"aggs\":[{\"id\":\"1\",\"type\":\"percentiles\",\"schema\":\"metric\",\"params\":{\"field\":\"responsetime\",\"percents\":[99]}},{\"id\":\"2\",\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"query\",\"size\":10,\"order\":\"desc\",\"orderBy\":\"1.99\"}}],\"listeners\":{}}"
-      },
-      "id": "Top-slowest-MongoDB-queries",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[]}"
-        },
-        "savedSearchId": "MongoDB-transactions-with-write-concern-0",
-        "title": "Number of MongoDB transactions with writeConcern w=0",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Number of MongoDB transactions with writeConcern w=0\",\"type\":\"line\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"showCircles\":true,\"smoothLines\":false,\"interpolate\":\"linear\",\"scale\":\"linear\",\"drawLinesBetweenPoints\":true,\"radiusRatio\":9,\"times\":[],\"addTimeMarker\":false,\"defaultYExtents\":false,\"setYExtents\":false,\"yAxis\":{}},\"aggs\":[{\"id\":\"1\",\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"auto\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}},{\"id\":\"3\",\"type\":\"count\",\"schema\":\"radius\",\"params\":{}}],\"listeners\":{}}"
-      },
-      "id": "Number-of-MongoDB-transactions-with-writeConcern-w-equal-0",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "columns": [
-          "_source"
-        ],
-        "description": "",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"index\":\"packetbeat-*\",\"highlightAll\":true,\"version\":true,\"query\":{\"query\":\"*\",\"language\":\"lucene\"},\"filter\":[{\"meta\":{\"index\":\"packetbeat-*\",\"negate\":false,\"disabled\":false,\"alias\":null,\"type\":\"phrase\",\"key\":\"type\",\"value\":\"mongodb\",\"params\":{\"query\":\"mongodb\",\"type\":\"phrase\"}},\"query\":{\"match\":{\"type\":{\"query\":\"mongodb\",\"type\":\"phrase\"}}},\"$state\":{\"store\":\"appState\"}},{\"meta\":{\"index\":\"packetbeat-*\",\"negate\":true,\"disabled\":false,\"alias\":null,\"type\":\"phrase\",\"key\":\"status\",\"value\":\"OK\",\"params\":{\"query\":\"OK\",\"type\":\"phrase\"}},\"query\":{\"match\":{\"status\":{\"query\":\"OK\",\"type\":\"phrase\"}}},\"$state\":{\"store\":\"appState\"}}]}"
-        },
-        "sort": [
-          "@timestamp",
-          "desc"
-        ],
-        "title": "MongoDB errors [Packetbeat]",
-        "version": 1
-      },
-      "id": "651fd6d0-88d0-11e7-ad9c-db80de0bf8d3",
-      "type": "search",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "columns": [
-          "method",
-          "type",
-          "path",
-          "responsetime",
-          "status",
-          "query"
-        ],
-        "description": "",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"index\":\"packetbeat-*\",\"highlight\":{\"pre_tags\":[\"@kibana-highlighted-field@\"],\"post_tags\":[\"@/kibana-highlighted-field@\"],\"fields\":{\"*\":{}},\"fragment_size\":2147483647},\"filter\":[{\"meta\":{\"disabled\":false,\"index\":\"packetbeat-*\",\"key\":\"type\",\"negate\":false,\"value\":\"mongodb\"},\"query\":{\"match\":{\"type\":{\"query\":\"mongodb\",\"type\":\"phrase\"}}}}],\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}}}"
-        },
-        "sort": [
-          "@timestamp",
-          "desc"
-        ],
-        "title": "MongoDB transactions",
-        "version": 1
-      },
-      "id": "MongoDB-transactions",
-      "type": "search",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "columns": [
-          "method",
-          "type",
-          "path",
-          "responsetime",
-          "status",
-          "query"
-        ],
-        "description": "",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"index\":\"packetbeat-*\",\"highlight\":{\"pre_tags\":[\"@kibana-highlighted-field@\"],\"post_tags\":[\"@/kibana-highlighted-field@\"],\"fields\":{\"*\":{}},\"fragment_size\":2147483647},\"filter\":[{\"meta\":{\"disabled\":false,\"index\":\"packetbeat-*\",\"key\":\"type\",\"negate\":false,\"value\":\"mongodb\"},\"query\":{\"match\":{\"type\":{\"query\":\"mongodb\",\"type\":\"phrase\"}}}}],\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"request: \\\"writeConcern w 0\\\"\"}}}"
-        },
-        "sort": [
-          "@timestamp",
-          "desc"
-        ],
-        "title": "MongoDB transactions with write concern 0",
-        "version": 1
-      },
-      "id": "MongoDB-transactions-with-write-concern-0",
-      "type": "search",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[],\"query\":{\"language\":\"lucene\",\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}}},\"highlightAll\":true,\"version\":true}"
-        },
-        "optionsJSON": "{\"darkTheme\":false}",
-        "panelsJSON": "[{\"col\":1,\"id\":\"Navigation\",\"panelIndex\":1,\"row\":1,\"size_x\":3,\"size_y\":4,\"type\":\"visualization\"},{\"col\":4,\"id\":\"MongoDB-errors\",\"panelIndex\":2,\"row\":1,\"size_x\":5,\"size_y\":4,\"type\":\"visualization\"},{\"col\":9,\"id\":\"MongoDB-commands\",\"panelIndex\":3,\"row\":1,\"size_x\":4,\"size_y\":4,\"type\":\"visualization\"},{\"col\":1,\"id\":\"MongoDB-errors-per-collection\",\"panelIndex\":4,\"row\":5,\"size_x\":4,\"size_y\":3,\"type\":\"visualization\"},{\"col\":5,\"id\":\"MongoDB-in-slash-out-throughput\",\"panelIndex\":5,\"row\":5,\"size_x\":4,\"size_y\":3,\"type\":\"visualization\"},{\"col\":1,\"id\":\"MongoDB-response-times-by-collection\",\"panelIndex\":6,\"row\":8,\"size_x\":8,\"size_y\":5,\"type\":\"visualization\"},{\"col\":9,\"id\":\"Top-slowest-MongoDB-queries\",\"panelIndex\":7,\"row\":8,\"size_x\":4,\"size_y\":5,\"type\":\"visualization\"},{\"col\":9,\"id\":\"Number-of-MongoDB-transactions-with-writeConcern-w-equal-0\",\"panelIndex\":8,\"row\":5,\"size_x\":4,\"size_y\":3,\"type\":\"visualization\"}]",
-        "timeRestore": false,
-        "title": "[Packetbeat] MongoDB",
-        "uiStateJSON": "{\"P-7\":{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}}}",
-        "version": 1
-      },
-      "id": "Packetbeat-MongoDB-performance",
-      "type": "dashboard",
-      "version": 2
-    }
-  ],
-  "version": "6.0.0-beta1-SNAPSHOT"
+    "objects": [
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "analyze_wildcard": true, 
+                                    "query": "*"
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "title": "Navigation", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "fontSize": "10", 
+                        "markdown": "### Packetbeat:\n\n[Overview](#/dashboard/Packetbeat-Dashboard)\n\n[Flows](#/dashboard/Packetbeat-Flows)\n\n[Web transactions](#/dashboard/Packetbeat-HTTP)\n\n[MySQL performance](#/dashboard/Packetbeat-MySQL-performance)\n\n[PostgreSQL performance](#/dashboard/Packetbeat-PgSQL-performance)\n\n[MongoDB performance](#/dashboard/Packetbeat-MongoDB-performance)\n\n[Thrift-RPC performance](#/dashboard/Packetbeat-Thrift-performance)\n\n[NFS transactions](#/dashboard/Packetbeat-NFS)\n\n[Cassandra performance](#/dashboard/Packetbeat-Cassandra)"
+                    }, 
+                    "title": "Navigation", 
+                    "type": "markdown"
+                }
+            }, 
+            "id": "Navigation", 
+            "type": "visualization", 
+            "version": 10
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "651fd6d0-88d0-11e7-ad9c-db80de0bf8d3", 
+                "title": "MongoDB errors", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "id": "3", 
+                            "params": {
+                                "field": "resource", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "row": true, 
+                                "size": 3
+                            }, 
+                            "schema": "split", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "id": "4", 
+                            "params": {
+                                "field": "method", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "group", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "defaultYExtents": false, 
+                        "drawLinesBetweenPoints": true, 
+                        "interpolate": "linear", 
+                        "radiusRatio": 9, 
+                        "scale": "linear", 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "showCircles": true, 
+                        "smoothLines": false, 
+                        "spyPerPage": 10, 
+                        "times": [], 
+                        "yAxis": {}
+                    }, 
+                    "title": "MongoDB errors", 
+                    "type": "line"
+                }
+            }, 
+            "id": "MongoDB-errors", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "MongoDB-transactions", 
+                "title": "MongoDB commands", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "id": "3", 
+                            "params": {
+                                "field": "method", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "group", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "defaultYExtents": false, 
+                        "interpolate": "linear", 
+                        "mode": "silhouette", 
+                        "scale": "linear", 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "smoothLines": true, 
+                        "times": [], 
+                        "yAxis": {}
+                    }, 
+                    "title": "MongoDB commands", 
+                    "type": "area"
+                }
+            }, 
+            "id": "MongoDB-commands", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "651fd6d0-88d0-11e7-ad9c-db80de0bf8d3", 
+                "title": "MongoDB errors per collection", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "id": "3", 
+                            "params": {
+                                "field": "resource", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "group", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "defaultYExtents": false, 
+                        "drawLinesBetweenPoints": true, 
+                        "interpolate": "linear", 
+                        "radiusRatio": 9, 
+                        "scale": "linear", 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "showCircles": true, 
+                        "smoothLines": false, 
+                        "spyPerPage": 10, 
+                        "times": [], 
+                        "yAxis": {}
+                    }, 
+                    "title": "MongoDB errors per collection", 
+                    "type": "line"
+                }
+            }, 
+            "id": "MongoDB-errors-per-collection", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "MongoDB-transactions", 
+                "title": "MongoDB in/out throughput", 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "id": "1", 
+                            "params": {
+                                "field": "bytes_in"
+                            }, 
+                            "schema": "metric", 
+                            "type": "sum"
+                        }, 
+                        {
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "id": "4", 
+                            "params": {
+                                "field": "bytes_out"
+                            }, 
+                            "schema": "metric", 
+                            "type": "sum"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "defaultYExtents": false, 
+                        "drawLinesBetweenPoints": true, 
+                        "interpolate": "linear", 
+                        "radiusRatio": 9, 
+                        "scale": "linear", 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "showCircles": true, 
+                        "smoothLines": false, 
+                        "times": [], 
+                        "yAxis": {}
+                    }, 
+                    "type": "line"
+                }
+            }, 
+            "id": "MongoDB-in-slash-out-throughput", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "MongoDB-transactions", 
+                "title": "MongoDB response times by collection", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "id": "1", 
+                            "params": {
+                                "field": "responsetime", 
+                                "percents": [
+                                    99
+                                ]
+                            }, 
+                            "schema": "metric", 
+                            "type": "percentiles"
+                        }, 
+                        {
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "id": "3", 
+                            "params": {
+                                "field": "resource", 
+                                "order": "desc", 
+                                "orderBy": "1.99", 
+                                "size": 5
+                            }, 
+                            "schema": "group", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "id": "4", 
+                            "params": {}, 
+                            "schema": "radius", 
+                            "type": "count"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "defaultYExtents": false, 
+                        "drawLinesBetweenPoints": false, 
+                        "interpolate": "linear", 
+                        "radiusRatio": "9", 
+                        "scale": "linear", 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "showCircles": true, 
+                        "smoothLines": false, 
+                        "times": [], 
+                        "yAxis": {}
+                    }, 
+                    "title": "MongoDB response times by collection", 
+                    "type": "line"
+                }
+            }, 
+            "id": "MongoDB-response-times-by-collection", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "MongoDB-transactions", 
+                "title": "Top slowest MongoDB queries", 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "id": "1", 
+                            "params": {
+                                "field": "responsetime", 
+                                "percents": [
+                                    99
+                                ]
+                            }, 
+                            "schema": "metric", 
+                            "type": "percentiles"
+                        }, 
+                        {
+                            "id": "2", 
+                            "params": {
+                                "field": "query", 
+                                "order": "desc", 
+                                "orderBy": "1.99", 
+                                "size": 10
+                            }, 
+                            "schema": "bucket", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "perPage": 10, 
+                        "showMeticsAtAllLevels": false, 
+                        "showPartialRows": false
+                    }, 
+                    "type": "table"
+                }
+            }, 
+            "id": "Top-slowest-MongoDB-queries", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "MongoDB-transactions-with-write-concern-0", 
+                "title": "Number of MongoDB transactions with writeConcern w=0", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "id": "3", 
+                            "params": {}, 
+                            "schema": "radius", 
+                            "type": "count"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "defaultYExtents": false, 
+                        "drawLinesBetweenPoints": true, 
+                        "interpolate": "linear", 
+                        "radiusRatio": 9, 
+                        "scale": "linear", 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "showCircles": true, 
+                        "smoothLines": false, 
+                        "times": [], 
+                        "yAxis": {}
+                    }, 
+                    "title": "Number of MongoDB transactions with writeConcern w=0", 
+                    "type": "line"
+                }
+            }, 
+            "id": "Number-of-MongoDB-transactions-with-writeConcern-w-equal-0", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "columns": [
+                    "_source"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                }, 
+                                "meta": {
+                                    "alias": null, 
+                                    "disabled": false, 
+                                    "index": "packetbeat-*", 
+                                    "key": "type", 
+                                    "negate": false, 
+                                    "params": {
+                                        "query": "mongodb", 
+                                        "type": "phrase"
+                                    }, 
+                                    "type": "phrase", 
+                                    "value": "mongodb"
+                                }, 
+                                "query": {
+                                    "match": {
+                                        "type": {
+                                            "query": "mongodb", 
+                                            "type": "phrase"
+                                        }
+                                    }
+                                }
+                            }, 
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                }, 
+                                "meta": {
+                                    "alias": null, 
+                                    "disabled": false, 
+                                    "index": "packetbeat-*", 
+                                    "key": "status", 
+                                    "negate": true, 
+                                    "params": {
+                                        "query": "OK", 
+                                        "type": "phrase"
+                                    }, 
+                                    "type": "phrase", 
+                                    "value": "OK"
+                                }, 
+                                "query": {
+                                    "match": {
+                                        "status": {
+                                            "query": "OK", 
+                                            "type": "phrase"
+                                        }
+                                    }
+                                }
+                            }
+                        ], 
+                        "highlightAll": true, 
+                        "index": "packetbeat-*", 
+                        "query": {
+                            "language": "lucene", 
+                            "query": "*"
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "MongoDB errors [Packetbeat]", 
+                "version": 1
+            }, 
+            "id": "651fd6d0-88d0-11e7-ad9c-db80de0bf8d3", 
+            "type": "search", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "columns": [
+                    "method", 
+                    "type", 
+                    "path", 
+                    "responsetime", 
+                    "status", 
+                    "query"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [
+                            {
+                                "meta": {
+                                    "disabled": false, 
+                                    "index": "packetbeat-*", 
+                                    "key": "type", 
+                                    "negate": false, 
+                                    "value": "mongodb"
+                                }, 
+                                "query": {
+                                    "match": {
+                                        "type": {
+                                            "query": "mongodb", 
+                                            "type": "phrase"
+                                        }
+                                    }
+                                }
+                            }
+                        ], 
+                        "highlight": {
+                            "fields": {
+                                "*": {}
+                            }, 
+                            "fragment_size": 2147483647, 
+                            "post_tags": [
+                                "@/kibana-highlighted-field@"
+                            ], 
+                            "pre_tags": [
+                                "@kibana-highlighted-field@"
+                            ]
+                        }, 
+                        "index": "packetbeat-*", 
+                        "query": {
+                            "query_string": {
+                                "analyze_wildcard": true, 
+                                "query": "*"
+                            }
+                        }
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "MongoDB transactions", 
+                "version": 1
+            }, 
+            "id": "MongoDB-transactions", 
+            "type": "search", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "columns": [
+                    "method", 
+                    "type", 
+                    "path", 
+                    "responsetime", 
+                    "status", 
+                    "query"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [
+                            {
+                                "meta": {
+                                    "disabled": false, 
+                                    "index": "packetbeat-*", 
+                                    "key": "type", 
+                                    "negate": false, 
+                                    "value": "mongodb"
+                                }, 
+                                "query": {
+                                    "match": {
+                                        "type": {
+                                            "query": "mongodb", 
+                                            "type": "phrase"
+                                        }
+                                    }
+                                }
+                            }
+                        ], 
+                        "highlight": {
+                            "fields": {
+                                "*": {}
+                            }, 
+                            "fragment_size": 2147483647, 
+                            "post_tags": [
+                                "@/kibana-highlighted-field@"
+                            ], 
+                            "pre_tags": [
+                                "@kibana-highlighted-field@"
+                            ]
+                        }, 
+                        "index": "packetbeat-*", 
+                        "query": {
+                            "query_string": {
+                                "analyze_wildcard": true, 
+                                "query": "request: \"writeConcern w 0\""
+                            }
+                        }
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "MongoDB transactions with write concern 0", 
+                "version": 1
+            }, 
+            "id": "MongoDB-transactions-with-write-concern-0", 
+            "type": "search", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "analyze_wildcard": true, 
+                                    "query": "*"
+                                }
+                            }
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false
+                }, 
+                "panelsJSON": [
+                    {
+                        "col": 1, 
+                        "id": "Navigation", 
+                        "panelIndex": 1, 
+                        "row": 1, 
+                        "size_x": 3, 
+                        "size_y": 4, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 4, 
+                        "id": "MongoDB-errors", 
+                        "panelIndex": 2, 
+                        "row": 1, 
+                        "size_x": 5, 
+                        "size_y": 4, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 9, 
+                        "id": "MongoDB-commands", 
+                        "panelIndex": 3, 
+                        "row": 1, 
+                        "size_x": 4, 
+                        "size_y": 4, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "MongoDB-errors-per-collection", 
+                        "panelIndex": 4, 
+                        "row": 5, 
+                        "size_x": 4, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 5, 
+                        "id": "MongoDB-in-slash-out-throughput", 
+                        "panelIndex": 5, 
+                        "row": 5, 
+                        "size_x": 4, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "MongoDB-response-times-by-collection", 
+                        "panelIndex": 6, 
+                        "row": 8, 
+                        "size_x": 8, 
+                        "size_y": 5, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 9, 
+                        "id": "Top-slowest-MongoDB-queries", 
+                        "panelIndex": 7, 
+                        "row": 8, 
+                        "size_x": 4, 
+                        "size_y": 5, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 9, 
+                        "id": "Number-of-MongoDB-transactions-with-writeConcern-w-equal-0", 
+                        "panelIndex": 8, 
+                        "row": 5, 
+                        "size_x": 4, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Packetbeat] MongoDB", 
+                "uiStateJSON": {
+                    "P-7": {
+                        "vis": {
+                            "params": {
+                                "sort": {
+                                    "columnIndex": null, 
+                                    "direction": null
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "version": 1
+            }, 
+            "id": "Packetbeat-MongoDB-performance", 
+            "type": "dashboard", 
+            "version": 2
+        }
+    ], 
+    "version": "6.0.0-beta1-SNAPSHOT"
 }

--- a/packetbeat/_meta/kibana/6/dashboard/Packetbeat-mysql.json
+++ b/packetbeat/_meta/kibana/6/dashboard/Packetbeat-mysql.json
@@ -1,197 +1,792 @@
 {
-  "objects": [
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[]}"
-        },
-        "savedSearchId": "MySQL-errors",
-        "title": "MySQL Errors",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"MySQL Errors\",\"type\":\"area\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":false,\"mode\":\"stacked\",\"defaultYExtents\":false,\"smoothLines\":false,\"scale\":\"linear\",\"interpolate\":\"linear\",\"times\":[],\"addTimeMarker\":false,\"setYExtents\":false,\"yAxis\":{}},\"aggs\":[{\"id\":\"1\",\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"auto\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}"
-      },
-      "id": "MySQL-Errors",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[]}"
-        },
-        "savedSearchId": "MySQL-Transactions",
-        "title": "MySQL Methods",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"MySQL Methods\",\"type\":\"area\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"mode\":\"wiggle\",\"defaultYExtents\":false,\"smoothLines\":false,\"scale\":\"linear\",\"interpolate\":\"linear\",\"times\":[],\"addTimeMarker\":false,\"setYExtents\":false,\"yAxis\":{}},\"aggs\":[{\"id\":\"1\",\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"auto\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}},{\"id\":\"3\",\"type\":\"terms\",\"schema\":\"group\",\"params\":{\"field\":\"method\",\"size\":20,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}"
-      },
-      "id": "MySQL-Methods",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}},\"language\":\"lucene\"},\"filter\":[]}"
-        },
-        "title": "Navigation",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Navigation\",\"type\":\"markdown\",\"params\":{\"markdown\":\"### Packetbeat:\\n\\n[Overview](#/dashboard/Packetbeat-Dashboard)\\n\\n[Flows](#/dashboard/Packetbeat-Flows)\\n\\n[Web transactions](#/dashboard/Packetbeat-HTTP)\\n\\n[MySQL performance](#/dashboard/Packetbeat-MySQL-performance)\\n\\n[PostgreSQL performance](#/dashboard/Packetbeat-PgSQL-performance)\\n\\n[MongoDB performance](#/dashboard/Packetbeat-MongoDB-performance)\\n\\n[Thrift-RPC performance](#/dashboard/Packetbeat-Thrift-performance)\\n\\n[NFS transactions](#/dashboard/Packetbeat-NFS)\\n\\n[Cassandra performance](#/dashboard/Packetbeat-Cassandra)\",\"fontSize\":\"10\"},\"aggs\":[]}"
-      },
-      "id": "Navigation",
-      "type": "visualization",
-      "version": 10
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[]}"
-        },
-        "savedSearchId": "MySQL-Transactions",
-        "title": "MySQL throughput",
-        "version": 1,
-        "visState": "{\"type\":\"line\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"defaultYExtents\":false},\"aggs\":[{\"id\":\"1\",\"type\":\"sum\",\"schema\":\"metric\",\"params\":{\"field\":\"bytes_out\"}},{\"id\":\"3\",\"type\":\"sum\",\"schema\":\"metric\",\"params\":{\"field\":\"bytes_in\"}},{\"id\":\"4\",\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"auto\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}"
-      },
-      "id": "MySQL-throughput",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[]}"
-        },
-        "savedSearchId": "MySQL-Transactions",
-        "title": "Most frequent MySQL queries",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Most frequent MySQL queries\",\"type\":\"table\",\"params\":{\"perPage\":10,\"showPartialRows\":false,\"showMeticsAtAllLevels\":false},\"aggs\":[{\"id\":\"1\",\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"query\",\"size\":10,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}"
-      },
-      "id": "Most-frequent-MySQL-queries",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[]}"
-        },
-        "savedSearchId": "MySQL-Transactions",
-        "title": "Slowest MySQL queries",
-        "version": 1,
-        "visState": "{\"type\":\"table\",\"params\":{\"perPage\":10,\"showPartialRows\":false,\"showMeticsAtAllLevels\":false},\"aggs\":[{\"id\":\"1\",\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"responsetime\"}},{\"id\":\"2\",\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"query\",\"size\":10,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}"
-      },
-      "id": "Slowest-MySQL-queries",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[]}"
-        },
-        "savedSearchId": "MySQL-Transactions",
-        "title": "Mysql response times percentiles",
-        "version": 1,
-        "visState": "{\"type\":\"line\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"defaultYExtents\":false},\"aggs\":[{\"id\":\"1\",\"type\":\"percentiles\",\"schema\":\"metric\",\"params\":{\"field\":\"responsetime\",\"percents\":[75,99,99.5]}},{\"id\":\"2\",\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"auto\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}"
-      },
-      "id": "Mysql-response-times-percentiles",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[]}"
-        },
-        "savedSearchId": "MySQL-Transactions",
-        "title": "MySQL Reads vs Writes",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"MySQL Reads vs Writes\",\"type\":\"area\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"mode\":\"stacked\",\"defaultYExtents\":false,\"smoothLines\":false,\"scale\":\"linear\",\"interpolate\":\"linear\",\"times\":[],\"addTimeMarker\":false,\"setYExtents\":false,\"yAxis\":{},\"type\":\"area\",\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"type\":\"category\",\"position\":\"bottom\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\"},\"labels\":{\"show\":true,\"truncate\":100},\"title\":{\"text\":\"@timestamp per 30 seconds\"}}],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"name\":\"LeftAxis-1\",\"type\":\"value\",\"position\":\"left\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\",\"mode\":\"normal\"},\"labels\":{\"show\":true,\"rotate\":0,\"filter\":false,\"truncate\":100},\"title\":{\"text\":\"Count\"}}],\"seriesParams\":[{\"show\":\"true\",\"type\":\"area\",\"mode\":\"stacked\",\"data\":{\"label\":\"Count\",\"id\":\"1\"},\"drawLinesBetweenPoints\":true,\"showCircles\":true,\"interpolate\":\"linear\",\"valueAxis\":\"ValueAxis-1\"}],\"legendPosition\":\"right\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"auto\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}},{\"id\":\"3\",\"enabled\":true,\"type\":\"filters\",\"schema\":\"group\",\"params\":{\"filters\":[{\"input\":{\"query\":{\"query_string\":{\"query\":\"method: SELECT\",\"analyze_wildcard\":true}}}},{\"input\":{\"query\":\"method: INSERT OR method: UPDATE OR method: DELETE\"}}]}}]}"
-      },
-      "id": "MySQL-Reads-vs-Writes",
-      "type": "visualization",
-      "version": 3
-    },
-    {
-      "attributes": {
-        "columns": [
-          "method",
-          "type",
-          "path",
-          "responsetime",
-          "status"
-        ],
-        "description": "",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"index\":\"packetbeat-*\",\"highlight\":{\"pre_tags\":[\"@kibana-highlighted-field@\"],\"post_tags\":[\"@/kibana-highlighted-field@\"],\"fields\":{\"*\":{}}},\"filter\":[{\"meta\":{\"disabled\":false,\"index\":\"packetbeat-*\",\"key\":\"type\",\"negate\":false,\"value\":\"mysql\"},\"query\":{\"match\":{\"type\":{\"query\":\"mysql\",\"type\":\"phrase\"}}}},{\"meta\":{\"index\":\"packetbeat-*\",\"negate\":true,\"key\":\"status\",\"value\":\"OK\",\"disabled\":false},\"query\":{\"match\":{\"status\":{\"query\":\"OK\",\"type\":\"phrase\"}}}}],\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}}}"
-        },
-        "sort": [
-          "@timestamp",
-          "desc"
-        ],
-        "title": "MySQL errors",
-        "version": 1
-      },
-      "id": "MySQL-errors",
-      "type": "search",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "columns": [
-          "method",
-          "type",
-          "path",
-          "responsetime",
-          "status"
-        ],
-        "description": "",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"index\":\"packetbeat-*\",\"highlight\":{\"pre_tags\":[\"@kibana-highlighted-field@\"],\"post_tags\":[\"@/kibana-highlighted-field@\"],\"fields\":{\"*\":{}}},\"filter\":[{\"meta\":{\"index\":\"packetbeat-*\",\"negate\":false,\"key\":\"type\",\"value\":\"mysql\",\"disabled\":false,\"type\":\"phrase\",\"params\":{\"query\":\"mysql\",\"type\":\"phrase\"},\"alias\":null},\"query\":{\"match\":{\"type\":{\"query\":\"mysql\",\"type\":\"phrase\"}}},\"$state\":{\"store\":\"appState\"}}],\"query\":{\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}},\"language\":\"lucene\"},\"highlightAll\":true,\"version\":true}"
-        },
-        "sort": [
-          "@timestamp",
-          "desc"
-        ],
-        "title": "MySQL Transactions [Packetbeat]",
-        "version": 1
-      },
-      "id": "MySQL-Transactions",
-      "type": "search",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[],\"query\":{\"language\":\"lucene\",\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}}},\"highlightAll\":true,\"version\":true}"
-        },
-        "optionsJSON": "{\"darkTheme\":false}",
-        "panelsJSON": "[{\"col\":4,\"id\":\"MySQL-Errors\",\"panelIndex\":1,\"row\":1,\"size_x\":5,\"size_y\":4,\"type\":\"visualization\"},{\"col\":9,\"id\":\"MySQL-Methods\",\"panelIndex\":2,\"row\":1,\"size_x\":4,\"size_y\":4,\"type\":\"visualization\"},{\"col\":1,\"id\":\"Navigation\",\"panelIndex\":3,\"row\":1,\"size_x\":3,\"size_y\":4,\"type\":\"visualization\"},{\"col\":7,\"id\":\"MySQL-throughput\",\"panelIndex\":4,\"row\":8,\"size_x\":6,\"size_y\":3,\"type\":\"visualization\"},{\"col\":1,\"id\":\"Most-frequent-MySQL-queries\",\"panelIndex\":5,\"row\":11,\"size_x\":6,\"size_y\":6,\"type\":\"visualization\"},{\"col\":7,\"id\":\"Slowest-MySQL-queries\",\"panelIndex\":6,\"row\":11,\"size_x\":6,\"size_y\":6,\"type\":\"visualization\"},{\"col\":1,\"id\":\"Mysql-response-times-percentiles\",\"panelIndex\":7,\"row\":5,\"size_x\":12,\"size_y\":3,\"type\":\"visualization\"},{\"col\":1,\"id\":\"MySQL-Reads-vs-Writes\",\"panelIndex\":8,\"row\":8,\"size_x\":6,\"size_y\":3,\"type\":\"visualization\"}]",
-        "timeRestore": false,
-        "title": "[Packetbeat] MySQL performance",
-        "uiStateJSON": "{\"P-5\":{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}},\"P-6\":{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}}}",
-        "version": 1
-      },
-      "id": "Packetbeat-MySQL-performance",
-      "type": "dashboard",
-      "version": 3
-    }
-  ],
-  "version": "6.0.0-beta1-SNAPSHOT"
+    "objects": [
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "MySQL-errors", 
+                "title": "MySQL Errors", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": false, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "defaultYExtents": false, 
+                        "interpolate": "linear", 
+                        "mode": "stacked", 
+                        "scale": "linear", 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "smoothLines": false, 
+                        "times": [], 
+                        "yAxis": {}
+                    }, 
+                    "title": "MySQL Errors", 
+                    "type": "area"
+                }
+            }, 
+            "id": "MySQL-Errors", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "MySQL-Transactions", 
+                "title": "MySQL Methods", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "id": "3", 
+                            "params": {
+                                "field": "method", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 20
+                            }, 
+                            "schema": "group", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "defaultYExtents": false, 
+                        "interpolate": "linear", 
+                        "mode": "wiggle", 
+                        "scale": "linear", 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "smoothLines": false, 
+                        "times": [], 
+                        "yAxis": {}
+                    }, 
+                    "title": "MySQL Methods", 
+                    "type": "area"
+                }
+            }, 
+            "id": "MySQL-Methods", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "analyze_wildcard": true, 
+                                    "query": "*"
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "title": "Navigation", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "fontSize": "10", 
+                        "markdown": "### Packetbeat:\n\n[Overview](#/dashboard/Packetbeat-Dashboard)\n\n[Flows](#/dashboard/Packetbeat-Flows)\n\n[Web transactions](#/dashboard/Packetbeat-HTTP)\n\n[MySQL performance](#/dashboard/Packetbeat-MySQL-performance)\n\n[PostgreSQL performance](#/dashboard/Packetbeat-PgSQL-performance)\n\n[MongoDB performance](#/dashboard/Packetbeat-MongoDB-performance)\n\n[Thrift-RPC performance](#/dashboard/Packetbeat-Thrift-performance)\n\n[NFS transactions](#/dashboard/Packetbeat-NFS)\n\n[Cassandra performance](#/dashboard/Packetbeat-Cassandra)"
+                    }, 
+                    "title": "Navigation", 
+                    "type": "markdown"
+                }
+            }, 
+            "id": "Navigation", 
+            "type": "visualization", 
+            "version": 10
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "MySQL-Transactions", 
+                "title": "MySQL throughput", 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "id": "1", 
+                            "params": {
+                                "field": "bytes_out"
+                            }, 
+                            "schema": "metric", 
+                            "type": "sum"
+                        }, 
+                        {
+                            "id": "3", 
+                            "params": {
+                                "field": "bytes_in"
+                            }, 
+                            "schema": "metric", 
+                            "type": "sum"
+                        }, 
+                        {
+                            "id": "4", 
+                            "params": {
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTooltip": true, 
+                        "defaultYExtents": false, 
+                        "shareYAxis": true
+                    }, 
+                    "type": "line"
+                }
+            }, 
+            "id": "MySQL-throughput", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "MySQL-Transactions", 
+                "title": "Most frequent MySQL queries", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "id": "2", 
+                            "params": {
+                                "field": "query", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 10
+                            }, 
+                            "schema": "bucket", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "perPage": 10, 
+                        "showMeticsAtAllLevels": false, 
+                        "showPartialRows": false
+                    }, 
+                    "title": "Most frequent MySQL queries", 
+                    "type": "table"
+                }
+            }, 
+            "id": "Most-frequent-MySQL-queries", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "MySQL-Transactions", 
+                "title": "Slowest MySQL queries", 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "id": "1", 
+                            "params": {
+                                "field": "responsetime"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "id": "2", 
+                            "params": {
+                                "field": "query", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 10
+                            }, 
+                            "schema": "bucket", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "perPage": 10, 
+                        "showMeticsAtAllLevels": false, 
+                        "showPartialRows": false
+                    }, 
+                    "type": "table"
+                }
+            }, 
+            "id": "Slowest-MySQL-queries", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "MySQL-Transactions", 
+                "title": "Mysql response times percentiles", 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "id": "1", 
+                            "params": {
+                                "field": "responsetime", 
+                                "percents": [
+                                    75, 
+                                    99, 
+                                    99.5
+                                ]
+                            }, 
+                            "schema": "metric", 
+                            "type": "percentiles"
+                        }, 
+                        {
+                            "id": "2", 
+                            "params": {
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTooltip": true, 
+                        "defaultYExtents": false, 
+                        "shareYAxis": true
+                    }, 
+                    "type": "line"
+                }
+            }, 
+            "id": "Mysql-response-times-percentiles", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "MySQL-Transactions", 
+                "title": "MySQL Reads vs Writes", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "filters": [
+                                    {
+                                        "input": {
+                                            "query": {
+                                                "query_string": {
+                                                    "analyze_wildcard": true, 
+                                                    "query": "method: SELECT"
+                                                }
+                                            }
+                                        }
+                                    }, 
+                                    {
+                                        "input": {
+                                            "query": "method: INSERT OR method: UPDATE OR method: DELETE"
+                                        }
+                                    }
+                                ]
+                            }, 
+                            "schema": "group", 
+                            "type": "filters"
+                        }
+                    ], 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "categoryAxes": [
+                            {
+                                "id": "CategoryAxis-1", 
+                                "labels": {
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "position": "bottom", 
+                                "scale": {
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {
+                                    "text": "@timestamp per 30 seconds"
+                                }, 
+                                "type": "category"
+                            }
+                        ], 
+                        "defaultYExtents": false, 
+                        "grid": {
+                            "categoryLines": false, 
+                            "style": {
+                                "color": "#eee"
+                            }
+                        }, 
+                        "interpolate": "linear", 
+                        "legendPosition": "right", 
+                        "mode": "stacked", 
+                        "scale": "linear", 
+                        "seriesParams": [
+                            {
+                                "data": {
+                                    "id": "1", 
+                                    "label": "Count"
+                                }, 
+                                "drawLinesBetweenPoints": true, 
+                                "interpolate": "linear", 
+                                "mode": "stacked", 
+                                "show": "true", 
+                                "showCircles": true, 
+                                "type": "area", 
+                                "valueAxis": "ValueAxis-1"
+                            }
+                        ], 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "smoothLines": false, 
+                        "times": [], 
+                        "type": "area", 
+                        "valueAxes": [
+                            {
+                                "id": "ValueAxis-1", 
+                                "labels": {
+                                    "filter": false, 
+                                    "rotate": 0, 
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "name": "LeftAxis-1", 
+                                "position": "left", 
+                                "scale": {
+                                    "mode": "normal", 
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {
+                                    "text": "Count"
+                                }, 
+                                "type": "value"
+                            }
+                        ], 
+                        "yAxis": {}
+                    }, 
+                    "title": "MySQL Reads vs Writes", 
+                    "type": "area"
+                }
+            }, 
+            "id": "MySQL-Reads-vs-Writes", 
+            "type": "visualization", 
+            "version": 3
+        }, 
+        {
+            "attributes": {
+                "columns": [
+                    "method", 
+                    "type", 
+                    "path", 
+                    "responsetime", 
+                    "status"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [
+                            {
+                                "meta": {
+                                    "disabled": false, 
+                                    "index": "packetbeat-*", 
+                                    "key": "type", 
+                                    "negate": false, 
+                                    "value": "mysql"
+                                }, 
+                                "query": {
+                                    "match": {
+                                        "type": {
+                                            "query": "mysql", 
+                                            "type": "phrase"
+                                        }
+                                    }
+                                }
+                            }, 
+                            {
+                                "meta": {
+                                    "disabled": false, 
+                                    "index": "packetbeat-*", 
+                                    "key": "status", 
+                                    "negate": true, 
+                                    "value": "OK"
+                                }, 
+                                "query": {
+                                    "match": {
+                                        "status": {
+                                            "query": "OK", 
+                                            "type": "phrase"
+                                        }
+                                    }
+                                }
+                            }
+                        ], 
+                        "highlight": {
+                            "fields": {
+                                "*": {}
+                            }, 
+                            "post_tags": [
+                                "@/kibana-highlighted-field@"
+                            ], 
+                            "pre_tags": [
+                                "@kibana-highlighted-field@"
+                            ]
+                        }, 
+                        "index": "packetbeat-*", 
+                        "query": {
+                            "query_string": {
+                                "analyze_wildcard": true, 
+                                "query": "*"
+                            }
+                        }
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "MySQL errors", 
+                "version": 1
+            }, 
+            "id": "MySQL-errors", 
+            "type": "search", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "columns": [
+                    "method", 
+                    "type", 
+                    "path", 
+                    "responsetime", 
+                    "status"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                }, 
+                                "meta": {
+                                    "alias": null, 
+                                    "disabled": false, 
+                                    "index": "packetbeat-*", 
+                                    "key": "type", 
+                                    "negate": false, 
+                                    "params": {
+                                        "query": "mysql", 
+                                        "type": "phrase"
+                                    }, 
+                                    "type": "phrase", 
+                                    "value": "mysql"
+                                }, 
+                                "query": {
+                                    "match": {
+                                        "type": {
+                                            "query": "mysql", 
+                                            "type": "phrase"
+                                        }
+                                    }
+                                }
+                            }
+                        ], 
+                        "highlight": {
+                            "fields": {
+                                "*": {}
+                            }, 
+                            "post_tags": [
+                                "@/kibana-highlighted-field@"
+                            ], 
+                            "pre_tags": [
+                                "@kibana-highlighted-field@"
+                            ]
+                        }, 
+                        "highlightAll": true, 
+                        "index": "packetbeat-*", 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "analyze_wildcard": true, 
+                                    "query": "*"
+                                }
+                            }
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "MySQL Transactions [Packetbeat]", 
+                "version": 1
+            }, 
+            "id": "MySQL-Transactions", 
+            "type": "search", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "analyze_wildcard": true, 
+                                    "query": "*"
+                                }
+                            }
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false
+                }, 
+                "panelsJSON": [
+                    {
+                        "col": 4, 
+                        "id": "MySQL-Errors", 
+                        "panelIndex": 1, 
+                        "row": 1, 
+                        "size_x": 5, 
+                        "size_y": 4, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 9, 
+                        "id": "MySQL-Methods", 
+                        "panelIndex": 2, 
+                        "row": 1, 
+                        "size_x": 4, 
+                        "size_y": 4, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "Navigation", 
+                        "panelIndex": 3, 
+                        "row": 1, 
+                        "size_x": 3, 
+                        "size_y": 4, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 7, 
+                        "id": "MySQL-throughput", 
+                        "panelIndex": 4, 
+                        "row": 8, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "Most-frequent-MySQL-queries", 
+                        "panelIndex": 5, 
+                        "row": 11, 
+                        "size_x": 6, 
+                        "size_y": 6, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 7, 
+                        "id": "Slowest-MySQL-queries", 
+                        "panelIndex": 6, 
+                        "row": 11, 
+                        "size_x": 6, 
+                        "size_y": 6, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "Mysql-response-times-percentiles", 
+                        "panelIndex": 7, 
+                        "row": 5, 
+                        "size_x": 12, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "MySQL-Reads-vs-Writes", 
+                        "panelIndex": 8, 
+                        "row": 8, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Packetbeat] MySQL performance", 
+                "uiStateJSON": {
+                    "P-5": {
+                        "vis": {
+                            "params": {
+                                "sort": {
+                                    "columnIndex": null, 
+                                    "direction": null
+                                }
+                            }
+                        }
+                    }, 
+                    "P-6": {
+                        "vis": {
+                            "params": {
+                                "sort": {
+                                    "columnIndex": null, 
+                                    "direction": null
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "version": 1
+            }, 
+            "id": "Packetbeat-MySQL-performance", 
+            "type": "dashboard", 
+            "version": 3
+        }
+    ], 
+    "version": "6.0.0-beta1-SNAPSHOT"
 }

--- a/packetbeat/_meta/kibana/6/dashboard/Packetbeat-nfs.json
+++ b/packetbeat/_meta/kibana/6/dashboard/Packetbeat-nfs.json
@@ -1,208 +1,838 @@
 {
-  "objects": [
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\n  \"filter\": []\n}"
-        },
-        "savedSearchId": "nfs",
-        "title": "NFS clients pie chart",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\n  \"title\": \"NFS clients pie chart\",\n  \"type\": \"pie\",\n  \"params\": {\n    \"shareYAxis\": true,\n    \"addTooltip\": true,\n    \"addLegend\": true,\n    \"isDonut\": true\n  },\n  \"aggs\": [\n    {\n      \"id\": \"1\",\n      \"type\": \"count\",\n      \"schema\": \"metric\",\n      \"params\": {}\n    },\n    {\n      \"id\": \"2\",\n      \"type\": \"terms\",\n      \"schema\": \"segment\",\n      \"params\": {\n        \"field\": \"rpc.cred.machinename\",\n        \"size\": 16,\n        \"order\": \"desc\",\n        \"orderBy\": \"1\"\n      }\n    }\n  ],\n  \"listeners\": {}\n}"
-      },
-      "id": "NFS-clients-pie-chart",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[]}"
-        },
-        "savedSearchId": "nfs",
-        "title": "NFS operations area chart",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"NFS operations area chart\",\"type\":\"area\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"smoothLines\":true,\"scale\":\"linear\",\"interpolate\":\"linear\",\"mode\":\"stacked\",\"times\":[],\"addTimeMarker\":false,\"defaultYExtents\":false,\"setYExtents\":false,\"yAxis\":{}},\"aggs\":[{\"id\":\"1\",\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"type\":\"terms\",\"schema\":\"group\",\"params\":{\"field\":\"nfs.opcode\",\"size\":16,\"order\":\"desc\",\"orderBy\":\"1\"}},{\"id\":\"3\",\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"auto\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}"
-      },
-      "id": "NFS-operations-area-chart",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\n  \"filter\": []\n}"
-        },
-        "savedSearchId": "nfs",
-        "title": "NFS top group pie chart",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\n  \"title\": \"New Visualization\",\n  \"type\": \"pie\",\n  \"params\": {\n    \"shareYAxis\": true,\n    \"addTooltip\": true,\n    \"addLegend\": true,\n    \"isDonut\": false\n  },\n  \"aggs\": [\n    {\n      \"id\": \"1\",\n      \"type\": \"count\",\n      \"schema\": \"metric\",\n      \"params\": {}\n    },\n    {\n      \"id\": \"2\",\n      \"type\": \"terms\",\n      \"schema\": \"segment\",\n      \"params\": {\n        \"field\": \"rpc.cred.gid\",\n        \"size\": 16,\n        \"order\": \"desc\",\n        \"orderBy\": \"1\"\n      }\n    }\n  ],\n  \"listeners\": {}\n}"
-      },
-      "id": "NFS-top-group-pie-chart",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\n  \"filter\": []\n}"
-        },
-        "savedSearchId": "nfs",
-        "title": "NFS top users pie chart",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\n  \"title\": \"New Visualization\",\n  \"type\": \"pie\",\n  \"params\": {\n    \"shareYAxis\": true,\n    \"addTooltip\": true,\n    \"addLegend\": true,\n    \"isDonut\": false\n  },\n  \"aggs\": [\n    {\n      \"id\": \"1\",\n      \"type\": \"count\",\n      \"schema\": \"metric\",\n      \"params\": {}\n    },\n    {\n      \"id\": \"2\",\n      \"type\": \"terms\",\n      \"schema\": \"segment\",\n      \"params\": {\n        \"field\": \"rpc.cred.uid\",\n        \"size\": 16,\n        \"order\": \"desc\",\n        \"orderBy\": \"1\"\n      }\n    }\n  ],\n  \"listeners\": {}\n}"
-      },
-      "id": "NFS-top-users-pie-chart",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[]}"
-        },
-        "savedSearchId": "nfs",
-        "title": "NFS response times",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"NFS response times\",\"type\":\"line\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"defaultYExtents\":true,\"drawLinesBetweenPoints\":true,\"interpolate\":\"linear\",\"radiusRatio\":\"9\",\"scale\":\"linear\",\"setYExtents\":false,\"shareYAxis\":true,\"showCircles\":true,\"smoothLines\":true,\"times\":[],\"yAxis\":{}},\"aggs\":[{\"id\":\"1\",\"type\":\"median\",\"schema\":\"metric\",\"params\":{\"field\":\"rpc.time\",\"percents\":[50]}},{\"id\":\"2\",\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"auto\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}"
-      },
-      "id": "NFS-response-times",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[]}"
-        },
-        "savedSearchId": "NFS-errors-search",
-        "title": "NFS errors",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"NFS errors\",\"type\":\"area\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"smoothLines\":false,\"scale\":\"linear\",\"interpolate\":\"linear\",\"mode\":\"stacked\",\"times\":[],\"addTimeMarker\":false,\"defaultYExtents\":false,\"setYExtents\":false,\"yAxis\":{}},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"auto\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}},{\"id\":\"3\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"group\",\"params\":{\"field\":\"nfs.status\",\"size\":12,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}"
-      },
-      "id": "NFS-errors",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[]}"
-        },
-        "savedSearchId": "nfs",
-        "title": "NFS operation table",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"NFS operation table\",\"type\":\"table\",\"params\":{\"perPage\":10,\"showPartialRows\":false,\"showMeticsAtAllLevels\":false},\"aggs\":[{\"id\":\"1\",\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"rpc.time\"}},{\"id\":\"2\",\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"nfs.opcode\",\"size\":16,\"order\":\"desc\",\"orderBy\":\"1\"}},{\"id\":\"3\",\"type\":\"count\",\"schema\":\"metric\",\"params\":{}}],\"listeners\":{}}"
-      },
-      "id": "NFS-operation-table",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[]}"
-        },
-        "savedSearchId": "nfs",
-        "title": "NFS bytes in / out",
-        "uiStateJSON": "{\"vis\":{\"colors\":{\"Sum of rpc.reply_size\":\"#7EB26D\"}}}",
-        "version": 1,
-        "visState": "{\"title\":\"NFS bytes in / out\",\"type\":\"line\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"showCircles\":true,\"smoothLines\":false,\"interpolate\":\"linear\",\"scale\":\"linear\",\"drawLinesBetweenPoints\":true,\"radiusRatio\":9,\"times\":[],\"addTimeMarker\":false,\"defaultYExtents\":false,\"setYExtents\":false,\"yAxis\":{}},\"aggs\":[{\"id\":\"1\",\"type\":\"sum\",\"schema\":\"metric\",\"params\":{\"field\":\"rpc.call_size\"}},{\"id\":\"2\",\"type\":\"sum\",\"schema\":\"metric\",\"params\":{\"field\":\"rpc.reply_size\"}},{\"id\":\"3\",\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"auto\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}"
-      },
-      "id": "NFS-bytes-in-slash-out",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}},\"language\":\"lucene\"},\"filter\":[]}"
-        },
-        "title": "Navigation",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Navigation\",\"type\":\"markdown\",\"params\":{\"markdown\":\"### Packetbeat:\\n\\n[Overview](#/dashboard/Packetbeat-Dashboard)\\n\\n[Flows](#/dashboard/Packetbeat-Flows)\\n\\n[Web transactions](#/dashboard/Packetbeat-HTTP)\\n\\n[MySQL performance](#/dashboard/Packetbeat-MySQL-performance)\\n\\n[PostgreSQL performance](#/dashboard/Packetbeat-PgSQL-performance)\\n\\n[MongoDB performance](#/dashboard/Packetbeat-MongoDB-performance)\\n\\n[Thrift-RPC performance](#/dashboard/Packetbeat-Thrift-performance)\\n\\n[NFS transactions](#/dashboard/Packetbeat-NFS)\\n\\n[Cassandra performance](#/dashboard/Packetbeat-Cassandra)\",\"fontSize\":\"10\"},\"aggs\":[]}"
-      },
-      "id": "Navigation",
-      "type": "visualization",
-      "version": 10
-    },
-    {
-      "attributes": {
-        "columns": [
-          "_source"
-        ],
-        "description": "",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"index\":\"packetbeat-*\",\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}},\"filter\":[{\"$state\":{\"store\":\"appState\"},\"meta\":{\"alias\":null,\"disabled\":false,\"index\":\"packetbeat-*\",\"key\":\"type\",\"negate\":false,\"value\":\"nfs\"},\"query\":{\"match\":{\"type\":{\"query\":\"nfs\",\"type\":\"phrase\"}}}}],\"highlight\":{\"pre_tags\":[\"@kibana-highlighted-field@\"],\"post_tags\":[\"@/kibana-highlighted-field@\"],\"fields\":{\"*\":{}},\"require_field_match\":false,\"fragment_size\":2147483647}}"
-        },
-        "sort": [
-          "@timestamp",
-          "desc"
-        ],
-        "title": "nfs",
-        "version": 1
-      },
-      "id": "nfs",
-      "type": "search",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "columns": [
-          "_source"
-        ],
-        "description": "",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"index\":\"packetbeat-*\",\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}},\"filter\":[{\"meta\":{\"negate\":false,\"index\":\"packetbeat-*\",\"key\":\"type\",\"value\":\"nfs\",\"disabled\":false,\"alias\":null},\"query\":{\"match\":{\"type\":{\"query\":\"nfs\",\"type\":\"phrase\"}}},\"$state\":{\"store\":\"appState\"}},{\"meta\":{\"negate\":true,\"index\":\"packetbeat-*\",\"key\":\"nfs.status\",\"value\":\"NFSERR_NOENT\",\"disabled\":false,\"alias\":null},\"query\":{\"match\":{\"nfs.status\":{\"query\":\"NFSERR_NOENT\",\"type\":\"phrase\"}}},\"$state\":{\"store\":\"appState\"}},{\"meta\":{\"negate\":true,\"index\":\"packetbeat-*\",\"key\":\"nfs.status\",\"value\":\"NFS_OK\",\"disabled\":false,\"alias\":null},\"query\":{\"match\":{\"nfs.status\":{\"query\":\"NFS_OK\",\"type\":\"phrase\"}}},\"$state\":{\"store\":\"appState\"}}],\"highlight\":{\"pre_tags\":[\"@kibana-highlighted-field@\"],\"post_tags\":[\"@/kibana-highlighted-field@\"],\"fields\":{\"*\":{}},\"require_field_match\":false,\"fragment_size\":2147483647}}"
-        },
-        "sort": [
-          "@timestamp",
-          "desc"
-        ],
-        "title": "NFS errors search",
-        "version": 1
-      },
-      "id": "NFS-errors-search",
-      "type": "search",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[],\"query\":{\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}},\"language\":\"lucene\"},\"highlightAll\":true,\"version\":true}"
-        },
-        "optionsJSON": "{\"darkTheme\":false}",
-        "panelsJSON": "[{\"col\":5,\"id\":\"NFS-clients-pie-chart\",\"panelIndex\":1,\"row\":1,\"size_x\":4,\"size_y\":5,\"type\":\"visualization\"},{\"col\":1,\"id\":\"NFS-operations-area-chart\",\"panelIndex\":3,\"row\":12,\"size_x\":6,\"size_y\":4,\"type\":\"visualization\"},{\"col\":9,\"id\":\"NFS-top-group-pie-chart\",\"panelIndex\":4,\"row\":1,\"size_x\":4,\"size_y\":2,\"type\":\"visualization\"},{\"col\":9,\"id\":\"NFS-top-users-pie-chart\",\"panelIndex\":5,\"row\":3,\"size_x\":4,\"size_y\":3,\"type\":\"visualization\"},{\"col\":7,\"id\":\"NFS-response-times\",\"panelIndex\":6,\"row\":6,\"size_x\":6,\"size_y\":3,\"type\":\"visualization\"},{\"col\":7,\"id\":\"NFS-errors\",\"panelIndex\":7,\"row\":9,\"size_x\":6,\"size_y\":3,\"type\":\"visualization\"},{\"col\":7,\"id\":\"NFS-operation-table\",\"panelIndex\":8,\"row\":12,\"size_x\":6,\"size_y\":4,\"type\":\"visualization\"},{\"col\":1,\"id\":\"NFS-bytes-in-slash-out\",\"panelIndex\":9,\"row\":6,\"size_x\":6,\"size_y\":6,\"type\":\"visualization\"},{\"id\":\"Navigation\",\"type\":\"visualization\",\"panelIndex\":10,\"size_x\":4,\"size_y\":5,\"col\":1,\"row\":1}]",
-        "timeRestore": false,
-        "title": "[Packetbeat] NFS",
-        "uiStateJSON": "{\"P-1\":{\"vis\":{\"legendOpen\":true}},\"P-4\":{\"spy\":{\"mode\":{\"fill\":false,\"name\":null}},\"vis\":{\"legendOpen\":true}},\"P-5\":{\"vis\":{\"legendOpen\":true}},\"P-6\":{\"vis\":{\"legendOpen\":false}},\"P-9\":{\"vis\":{\"legendOpen\":true}},\"P-8\":{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}}}",
-        "version": 1
-      },
-      "id": "Packetbeat-NFS",
-      "type": "dashboard",
-      "version": 2
-    }
-  ],
-  "version": "6.0.0-beta1-SNAPSHOT"
+    "objects": [
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "nfs", 
+                "title": "NFS clients pie chart", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "id": "2", 
+                            "params": {
+                                "field": "rpc.cred.machinename", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 16
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTooltip": true, 
+                        "isDonut": true, 
+                        "shareYAxis": true
+                    }, 
+                    "title": "NFS clients pie chart", 
+                    "type": "pie"
+                }
+            }, 
+            "id": "NFS-clients-pie-chart", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "nfs", 
+                "title": "NFS operations area chart", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "id": "2", 
+                            "params": {
+                                "field": "nfs.opcode", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 16
+                            }, 
+                            "schema": "group", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "id": "3", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "defaultYExtents": false, 
+                        "interpolate": "linear", 
+                        "mode": "stacked", 
+                        "scale": "linear", 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "smoothLines": true, 
+                        "times": [], 
+                        "yAxis": {}
+                    }, 
+                    "title": "NFS operations area chart", 
+                    "type": "area"
+                }
+            }, 
+            "id": "NFS-operations-area-chart", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "nfs", 
+                "title": "NFS top group pie chart", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "id": "2", 
+                            "params": {
+                                "field": "rpc.cred.gid", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 16
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTooltip": true, 
+                        "isDonut": false, 
+                        "shareYAxis": true
+                    }, 
+                    "title": "New Visualization", 
+                    "type": "pie"
+                }
+            }, 
+            "id": "NFS-top-group-pie-chart", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "nfs", 
+                "title": "NFS top users pie chart", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "id": "2", 
+                            "params": {
+                                "field": "rpc.cred.uid", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 16
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTooltip": true, 
+                        "isDonut": false, 
+                        "shareYAxis": true
+                    }, 
+                    "title": "New Visualization", 
+                    "type": "pie"
+                }
+            }, 
+            "id": "NFS-top-users-pie-chart", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "nfs", 
+                "title": "NFS response times", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "id": "1", 
+                            "params": {
+                                "field": "rpc.time", 
+                                "percents": [
+                                    50
+                                ]
+                            }, 
+                            "schema": "metric", 
+                            "type": "median"
+                        }, 
+                        {
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "defaultYExtents": true, 
+                        "drawLinesBetweenPoints": true, 
+                        "interpolate": "linear", 
+                        "radiusRatio": "9", 
+                        "scale": "linear", 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "showCircles": true, 
+                        "smoothLines": true, 
+                        "times": [], 
+                        "yAxis": {}
+                    }, 
+                    "title": "NFS response times", 
+                    "type": "line"
+                }
+            }, 
+            "id": "NFS-response-times", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "NFS-errors-search", 
+                "title": "NFS errors", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "field": "nfs.status", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 12
+                            }, 
+                            "schema": "group", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "defaultYExtents": false, 
+                        "interpolate": "linear", 
+                        "legendPosition": "right", 
+                        "mode": "stacked", 
+                        "scale": "linear", 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "smoothLines": false, 
+                        "times": [], 
+                        "yAxis": {}
+                    }, 
+                    "title": "NFS errors", 
+                    "type": "area"
+                }
+            }, 
+            "id": "NFS-errors", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "nfs", 
+                "title": "NFS operation table", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "id": "1", 
+                            "params": {
+                                "field": "rpc.time"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "id": "2", 
+                            "params": {
+                                "field": "nfs.opcode", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 16
+                            }, 
+                            "schema": "bucket", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "id": "3", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "perPage": 10, 
+                        "showMeticsAtAllLevels": false, 
+                        "showPartialRows": false
+                    }, 
+                    "title": "NFS operation table", 
+                    "type": "table"
+                }
+            }, 
+            "id": "NFS-operation-table", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "nfs", 
+                "title": "NFS bytes in / out", 
+                "uiStateJSON": {
+                    "vis": {
+                        "colors": {
+                            "Sum of rpc.reply_size": "#7EB26D"
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "id": "1", 
+                            "params": {
+                                "field": "rpc.call_size"
+                            }, 
+                            "schema": "metric", 
+                            "type": "sum"
+                        }, 
+                        {
+                            "id": "2", 
+                            "params": {
+                                "field": "rpc.reply_size"
+                            }, 
+                            "schema": "metric", 
+                            "type": "sum"
+                        }, 
+                        {
+                            "id": "3", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "defaultYExtents": false, 
+                        "drawLinesBetweenPoints": true, 
+                        "interpolate": "linear", 
+                        "radiusRatio": 9, 
+                        "scale": "linear", 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "showCircles": true, 
+                        "smoothLines": false, 
+                        "times": [], 
+                        "yAxis": {}
+                    }, 
+                    "title": "NFS bytes in / out", 
+                    "type": "line"
+                }
+            }, 
+            "id": "NFS-bytes-in-slash-out", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "analyze_wildcard": true, 
+                                    "query": "*"
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "title": "Navigation", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "fontSize": "10", 
+                        "markdown": "### Packetbeat:\n\n[Overview](#/dashboard/Packetbeat-Dashboard)\n\n[Flows](#/dashboard/Packetbeat-Flows)\n\n[Web transactions](#/dashboard/Packetbeat-HTTP)\n\n[MySQL performance](#/dashboard/Packetbeat-MySQL-performance)\n\n[PostgreSQL performance](#/dashboard/Packetbeat-PgSQL-performance)\n\n[MongoDB performance](#/dashboard/Packetbeat-MongoDB-performance)\n\n[Thrift-RPC performance](#/dashboard/Packetbeat-Thrift-performance)\n\n[NFS transactions](#/dashboard/Packetbeat-NFS)\n\n[Cassandra performance](#/dashboard/Packetbeat-Cassandra)"
+                    }, 
+                    "title": "Navigation", 
+                    "type": "markdown"
+                }
+            }, 
+            "id": "Navigation", 
+            "type": "visualization", 
+            "version": 10
+        }, 
+        {
+            "attributes": {
+                "columns": [
+                    "_source"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                }, 
+                                "meta": {
+                                    "alias": null, 
+                                    "disabled": false, 
+                                    "index": "packetbeat-*", 
+                                    "key": "type", 
+                                    "negate": false, 
+                                    "value": "nfs"
+                                }, 
+                                "query": {
+                                    "match": {
+                                        "type": {
+                                            "query": "nfs", 
+                                            "type": "phrase"
+                                        }
+                                    }
+                                }
+                            }
+                        ], 
+                        "highlight": {
+                            "fields": {
+                                "*": {}
+                            }, 
+                            "fragment_size": 2147483647, 
+                            "post_tags": [
+                                "@/kibana-highlighted-field@"
+                            ], 
+                            "pre_tags": [
+                                "@kibana-highlighted-field@"
+                            ], 
+                            "require_field_match": false
+                        }, 
+                        "index": "packetbeat-*", 
+                        "query": {
+                            "query_string": {
+                                "analyze_wildcard": true, 
+                                "query": "*"
+                            }
+                        }
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "nfs", 
+                "version": 1
+            }, 
+            "id": "nfs", 
+            "type": "search", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "columns": [
+                    "_source"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                }, 
+                                "meta": {
+                                    "alias": null, 
+                                    "disabled": false, 
+                                    "index": "packetbeat-*", 
+                                    "key": "type", 
+                                    "negate": false, 
+                                    "value": "nfs"
+                                }, 
+                                "query": {
+                                    "match": {
+                                        "type": {
+                                            "query": "nfs", 
+                                            "type": "phrase"
+                                        }
+                                    }
+                                }
+                            }, 
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                }, 
+                                "meta": {
+                                    "alias": null, 
+                                    "disabled": false, 
+                                    "index": "packetbeat-*", 
+                                    "key": "nfs.status", 
+                                    "negate": true, 
+                                    "value": "NFSERR_NOENT"
+                                }, 
+                                "query": {
+                                    "match": {
+                                        "nfs.status": {
+                                            "query": "NFSERR_NOENT", 
+                                            "type": "phrase"
+                                        }
+                                    }
+                                }
+                            }, 
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                }, 
+                                "meta": {
+                                    "alias": null, 
+                                    "disabled": false, 
+                                    "index": "packetbeat-*", 
+                                    "key": "nfs.status", 
+                                    "negate": true, 
+                                    "value": "NFS_OK"
+                                }, 
+                                "query": {
+                                    "match": {
+                                        "nfs.status": {
+                                            "query": "NFS_OK", 
+                                            "type": "phrase"
+                                        }
+                                    }
+                                }
+                            }
+                        ], 
+                        "highlight": {
+                            "fields": {
+                                "*": {}
+                            }, 
+                            "fragment_size": 2147483647, 
+                            "post_tags": [
+                                "@/kibana-highlighted-field@"
+                            ], 
+                            "pre_tags": [
+                                "@kibana-highlighted-field@"
+                            ], 
+                            "require_field_match": false
+                        }, 
+                        "index": "packetbeat-*", 
+                        "query": {
+                            "query_string": {
+                                "analyze_wildcard": true, 
+                                "query": "*"
+                            }
+                        }
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "NFS errors search", 
+                "version": 1
+            }, 
+            "id": "NFS-errors-search", 
+            "type": "search", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "analyze_wildcard": true, 
+                                    "query": "*"
+                                }
+                            }
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false
+                }, 
+                "panelsJSON": [
+                    {
+                        "col": 5, 
+                        "id": "NFS-clients-pie-chart", 
+                        "panelIndex": 1, 
+                        "row": 1, 
+                        "size_x": 4, 
+                        "size_y": 5, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "NFS-operations-area-chart", 
+                        "panelIndex": 3, 
+                        "row": 12, 
+                        "size_x": 6, 
+                        "size_y": 4, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 9, 
+                        "id": "NFS-top-group-pie-chart", 
+                        "panelIndex": 4, 
+                        "row": 1, 
+                        "size_x": 4, 
+                        "size_y": 2, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 9, 
+                        "id": "NFS-top-users-pie-chart", 
+                        "panelIndex": 5, 
+                        "row": 3, 
+                        "size_x": 4, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 7, 
+                        "id": "NFS-response-times", 
+                        "panelIndex": 6, 
+                        "row": 6, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 7, 
+                        "id": "NFS-errors", 
+                        "panelIndex": 7, 
+                        "row": 9, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 7, 
+                        "id": "NFS-operation-table", 
+                        "panelIndex": 8, 
+                        "row": 12, 
+                        "size_x": 6, 
+                        "size_y": 4, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "NFS-bytes-in-slash-out", 
+                        "panelIndex": 9, 
+                        "row": 6, 
+                        "size_x": 6, 
+                        "size_y": 6, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "Navigation", 
+                        "panelIndex": 10, 
+                        "row": 1, 
+                        "size_x": 4, 
+                        "size_y": 5, 
+                        "type": "visualization"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Packetbeat] NFS", 
+                "uiStateJSON": {
+                    "P-1": {
+                        "vis": {
+                            "legendOpen": true
+                        }
+                    }, 
+                    "P-4": {
+                        "spy": {
+                            "mode": {
+                                "fill": false, 
+                                "name": null
+                            }
+                        }, 
+                        "vis": {
+                            "legendOpen": true
+                        }
+                    }, 
+                    "P-5": {
+                        "vis": {
+                            "legendOpen": true
+                        }
+                    }, 
+                    "P-6": {
+                        "vis": {
+                            "legendOpen": false
+                        }
+                    }, 
+                    "P-8": {
+                        "vis": {
+                            "params": {
+                                "sort": {
+                                    "columnIndex": null, 
+                                    "direction": null
+                                }
+                            }
+                        }
+                    }, 
+                    "P-9": {
+                        "vis": {
+                            "legendOpen": true
+                        }
+                    }
+                }, 
+                "version": 1
+            }, 
+            "id": "Packetbeat-NFS", 
+            "type": "dashboard", 
+            "version": 2
+        }
+    ], 
+    "version": "6.0.0-beta1-SNAPSHOT"
 }

--- a/packetbeat/_meta/kibana/6/dashboard/Packetbeat-overview.json
+++ b/packetbeat/_meta/kibana/6/dashboard/Packetbeat-overview.json
@@ -1,339 +1,1164 @@
 {
-  "objects": [
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\n  \"filter\": []\n}"
-        },
-        "savedSearchId": "71908f00-88ca-11e7-ad9c-db80de0bf8d3",
-        "title": "Web transactions",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\n  \"title\": \"Web transactions\",\n  \"type\": \"histogram\",\n  \"params\": {\n    \"shareYAxis\": true,\n    \"addTooltip\": true,\n    \"addLegend\": false,\n    \"mode\": \"stacked\",\n    \"defaultYExtents\": false,\n    \"scale\": \"linear\",\n    \"times\": [],\n    \"addTimeMarker\": false,\n    \"setYExtents\": false,\n    \"yAxis\": {}\n  },\n  \"aggs\": [\n    {\n      \"id\": \"1\",\n      \"type\": \"count\",\n      \"schema\": \"metric\",\n      \"params\": {}\n    },\n    {\n      \"id\": \"2\",\n      \"type\": \"date_histogram\",\n      \"schema\": \"segment\",\n      \"params\": {\n        \"field\": \"@timestamp\",\n        \"interval\": \"auto\",\n        \"customInterval\": \"2h\",\n        \"min_doc_count\": 1,\n        \"extended_bounds\": {}\n      }\n    }\n  ],\n  \"listeners\": {}\n}"
-      },
-      "id": "Web-transactions",
-      "type": "visualization",
-      "version": 3
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\n  \"filter\": []\n}"
-        },
-        "savedSearchId": "800e2a00-88cb-11e7-ad9c-db80de0bf8d3",
-        "title": "DB transactions",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\n  \"title\": \"DB transactions\",\n  \"type\": \"histogram\",\n  \"params\": {\n    \"shareYAxis\": true,\n    \"addTooltip\": true,\n    \"addLegend\": true,\n    \"mode\": \"stacked\",\n    \"defaultYExtents\": false,\n    \"scale\": \"linear\",\n    \"times\": [],\n    \"addTimeMarker\": false,\n    \"setYExtents\": false,\n    \"yAxis\": {}\n  },\n  \"aggs\": [\n    {\n      \"id\": \"1\",\n      \"type\": \"count\",\n      \"schema\": \"metric\",\n      \"params\": {}\n    },\n    {\n      \"id\": \"2\",\n      \"type\": \"date_histogram\",\n      \"schema\": \"segment\",\n      \"params\": {\n        \"field\": \"@timestamp\",\n        \"interval\": \"auto\",\n        \"customInterval\": \"2h\",\n        \"min_doc_count\": 1,\n        \"extended_bounds\": {}\n      }\n    },\n    {\n      \"id\": \"3\",\n      \"type\": \"terms\",\n      \"schema\": \"group\",\n      \"params\": {\n        \"field\": \"type\",\n        \"size\": 5,\n        \"order\": \"desc\",\n        \"orderBy\": \"1\"\n      }\n    }\n  ],\n  \"listeners\": {}\n}"
-      },
-      "id": "DB-transactions",
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\n  \"filter\": []\n}"
-        },
-        "savedSearchId": "3dd366e0-88cc-11e7-ad9c-db80de0bf8d3",
-        "title": "Cache transactions",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\n  \"title\": \"Cache transactions\",\n  \"type\": \"histogram\",\n  \"params\": {\n    \"shareYAxis\": true,\n    \"addTooltip\": true,\n    \"addLegend\": false,\n    \"mode\": \"stacked\",\n    \"defaultYExtents\": false,\n    \"scale\": \"linear\",\n    \"times\": [],\n    \"addTimeMarker\": false,\n    \"setYExtents\": false,\n    \"yAxis\": {}\n  },\n  \"aggs\": [\n    {\n      \"id\": \"1\",\n      \"type\": \"count\",\n      \"schema\": \"metric\",\n      \"params\": {}\n    },\n    {\n      \"id\": \"2\",\n      \"type\": \"date_histogram\",\n      \"schema\": \"segment\",\n      \"params\": {\n        \"field\": \"@timestamp\",\n        \"interval\": \"auto\",\n        \"customInterval\": \"2h\",\n        \"min_doc_count\": 1,\n        \"extended_bounds\": {}\n      }\n    }\n  ],\n  \"listeners\": {}\n}"
-      },
-      "id": "Cache-transactions",
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\n  \"filter\": []\n}"
-        },
-        "savedSearchId": "d3089370-88cc-11e7-ad9c-db80de0bf8d3",
-        "title": "RPC transactions",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\n  \"title\": \"RPC transactions\",\n  \"type\": \"histogram\",\n  \"params\": {\n    \"shareYAxis\": true,\n    \"addTooltip\": true,\n    \"addLegend\": false,\n    \"mode\": \"stacked\",\n    \"defaultYExtents\": false,\n    \"scale\": \"linear\",\n    \"times\": [],\n    \"addTimeMarker\": false,\n    \"setYExtents\": false,\n    \"yAxis\": {}\n  },\n  \"aggs\": [\n    {\n      \"id\": \"1\",\n      \"type\": \"cardinality\",\n      \"schema\": \"metric\",\n      \"params\": {\n        \"field\": \"type\"\n      }\n    },\n    {\n      \"id\": \"2\",\n      \"type\": \"date_histogram\",\n      \"schema\": \"segment\",\n      \"params\": {\n        \"field\": \"@timestamp\",\n        \"interval\": \"auto\",\n        \"customInterval\": \"2h\",\n        \"min_doc_count\": 1,\n        \"extended_bounds\": {}\n      }\n    }\n  ],\n  \"listeners\": {}\n}"
-      },
-      "id": "RPC-transactions",
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[]}"
-        },
-        "savedSearchId": "Packetbeat-Search",
-        "title": "Response times percentiles",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Response times percentiles\",\"type\":\"line\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"showCircles\":true,\"smoothLines\":true,\"interpolate\":\"linear\",\"scale\":\"linear\",\"drawLinesBetweenPoints\":true,\"radiusRatio\":9,\"times\":[],\"addTimeMarker\":false,\"defaultYExtents\":false,\"setYExtents\":false,\"yAxis\":{},\"legendPosition\":\"right\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"percentiles\",\"schema\":\"metric\",\"params\":{\"field\":\"responsetime\",\"percents\":[75,95,99]}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"auto\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}"
-      },
-      "id": "Response-times-percentiles",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[]}"
-        },
-        "savedSearchId": "Transactions-errors",
-        "title": "Errors count over time",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"New Visualization\",\"type\":\"histogram\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"scale\":\"linear\",\"mode\":\"stacked\",\"times\":[],\"addTimeMarker\":false,\"defaultYExtents\":false,\"setYExtents\":false,\"yAxis\":{}},\"aggs\":[{\"id\":\"1\",\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"custom\",\"customInterval\":\"30s\",\"min_doc_count\":1,\"extended_bounds\":{}}},{\"id\":\"3\",\"type\":\"terms\",\"schema\":\"group\",\"params\":{\"field\":\"type\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}"
-      },
-      "id": "Errors-count-over-time",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[]}"
-        },
-        "savedSearchId": "Packetbeat-Search",
-        "title": "Errors vs successful transactions",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Errors vs successful transactions\",\"type\":\"histogram\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"scale\":\"linear\",\"mode\":\"percentage\",\"times\":[],\"addTimeMarker\":false,\"defaultYExtents\":false,\"setYExtents\":false,\"yAxis\":{}},\"aggs\":[{\"id\":\"1\",\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"auto\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}},{\"id\":\"3\",\"type\":\"terms\",\"schema\":\"group\",\"params\":{\"field\":\"status\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}"
-      },
-      "id": "Errors-vs-successful-transactions",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[]}"
-        },
-        "savedSearchId": "Packetbeat-Search",
-        "title": "Latency histogram",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Latency histogram\",\"type\":\"area\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"smoothLines\":true,\"scale\":\"linear\",\"interpolate\":\"linear\",\"mode\":\"stacked\",\"times\":[],\"addTimeMarker\":false,\"defaultYExtents\":false,\"setYExtents\":false,\"yAxis\":{},\"legendPosition\":\"right\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"responsetime\",\"interval\":10,\"extended_bounds\":{}}}],\"listeners\":{}}"
-      },
-      "id": "Latency-histogram",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"index\":\"packetbeat-*\",\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}},\"filter\":[]}"
-        },
-        "title": "Client locations",
-        "uiStateJSON": "{\"mapCenter\":[0,-0.17578125]}",
-        "version": 1,
-        "visState": "{\"aggs\":[{\"enabled\":true,\"id\":\"1\",\"params\":{},\"schema\":\"metric\",\"type\":\"count\"},{\"enabled\":true,\"id\":\"2\",\"params\":{\"autoPrecision\":true,\"field\":\"client_geoip.location\"},\"schema\":\"segment\",\"type\":\"geohash_grid\"}],\"listeners\":{},\"params\":{\"addTooltip\":true,\"heatBlur\":15,\"heatMaxZoom\":16,\"heatMinOpacity\":0.1,\"heatNormalizeData\":true,\"heatRadius\":25,\"isDesaturated\":true,\"mapCenter\":[15,5],\"mapType\":\"Scaled Circle Markers\",\"mapZoom\":2,\"wms\":{\"enabled\":false,\"options\":{\"attribution\":\"Maps provided by USGS\",\"format\":\"image/png\",\"layers\":\"0\",\"styles\":\"\",\"transparent\":true,\"version\":\"1.3.0\"},\"url\":\"https://basemap.nationalmap.gov/arcgis/services/USGSTopo/MapServer/WMSServer\"}},\"title\":\"Client locations\",\"type\":\"tile_map\"}"
-      },
-      "id": "Client-locations",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[]}"
-        },
-        "savedSearchId": "Packetbeat-Search",
-        "title": "Response times repartition",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Response times repartition\",\"type\":\"histogram\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"scale\":\"linear\",\"mode\":\"stacked\",\"times\":[],\"addTimeMarker\":false,\"defaultYExtents\":false,\"setYExtents\":false,\"yAxis\":{}},\"aggs\":[{\"id\":\"1\",\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"auto\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}},{\"id\":\"3\",\"type\":\"histogram\",\"schema\":\"group\",\"params\":{\"field\":\"responsetime\",\"interval\":10,\"extended_bounds\":{}}}],\"listeners\":{}}"
-      },
-      "id": "Response-times-repartition",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}},\"language\":\"lucene\"},\"filter\":[]}"
-        },
-        "title": "Navigation",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Navigation\",\"type\":\"markdown\",\"params\":{\"markdown\":\"### Packetbeat:\\n\\n[Overview](#/dashboard/Packetbeat-Dashboard)\\n\\n[Flows](#/dashboard/Packetbeat-Flows)\\n\\n[Web transactions](#/dashboard/Packetbeat-HTTP)\\n\\n[MySQL performance](#/dashboard/Packetbeat-MySQL-performance)\\n\\n[PostgreSQL performance](#/dashboard/Packetbeat-PgSQL-performance)\\n\\n[MongoDB performance](#/dashboard/Packetbeat-MongoDB-performance)\\n\\n[Thrift-RPC performance](#/dashboard/Packetbeat-Thrift-performance)\\n\\n[NFS transactions](#/dashboard/Packetbeat-NFS)\\n\\n[Cassandra performance](#/dashboard/Packetbeat-Cassandra)\",\"fontSize\":\"10\"},\"aggs\":[]}"
-      },
-      "id": "Navigation",
-      "type": "visualization",
-      "version": 10
-    },
-    {
-      "attributes": {
-        "columns": [
-          "_source"
-        ],
-        "description": "",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"index\":\"packetbeat-*\",\"highlightAll\":true,\"version\":true,\"query\":{\"language\":\"lucene\",\"query\":\"*\"},\"filter\":[{\"meta\":{\"index\":\"packetbeat-*\",\"negate\":false,\"disabled\":false,\"alias\":null,\"type\":\"phrase\",\"key\":\"type\",\"value\":\"http\",\"params\":{\"query\":\"http\",\"type\":\"phrase\"}},\"query\":{\"match\":{\"type\":{\"query\":\"http\",\"type\":\"phrase\"}}},\"$state\":{\"store\":\"appState\"}}]}"
-        },
-        "sort": [
-          "@timestamp",
-          "desc"
-        ],
-        "title": "Web Transactions [Packetbeat]",
-        "version": 1
-      },
-      "id": "71908f00-88ca-11e7-ad9c-db80de0bf8d3",
-      "type": "search",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "columns": [
-          "_source"
-        ],
-        "description": "",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"index\":\"packetbeat-*\",\"highlightAll\":true,\"version\":true,\"query\":{\"query\":\"\",\"language\":\"lucene\"},\"filter\":[{\"meta\":{\"index\":\"packetbeat-*\",\"type\":\"phrases\",\"key\":\"type\",\"value\":\"mysql, postgresql\",\"negate\":false,\"disabled\":false,\"alias\":null},\"query\":{\"bool\":{\"should\":[{\"match_phrase\":{\"type\":\"mysql\"}},{\"match_phrase\":{\"type\":\"postgresql\"}}],\"minimum_should_match\":1}},\"$state\":{\"store\":\"appState\"}}]}"
-        },
-        "sort": [
-          "@timestamp",
-          "desc"
-        ],
-        "title": "DB transactions",
-        "version": 1
-      },
-      "id": "800e2a00-88cb-11e7-ad9c-db80de0bf8d3",
-      "type": "search",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "columns": [
-          "_source"
-        ],
-        "description": "",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"index\":\"packetbeat-*\",\"highlightAll\":true,\"version\":true,\"query\":{\"query\":\"\",\"language\":\"lucene\"},\"filter\":[{\"meta\":{\"index\":\"packetbeat-*\",\"type\":\"phrases\",\"key\":\"type\",\"value\":\"redis, memcache\",\"negate\":false,\"disabled\":false,\"alias\":null},\"query\":{\"bool\":{\"should\":[{\"match_phrase\":{\"type\":\"redis\"}},{\"match_phrase\":{\"type\":\"memcache\"}}],\"minimum_should_match\":1}},\"$state\":{\"store\":\"appState\"}}]}"
-        },
-        "sort": [
-          "@timestamp",
-          "desc"
-        ],
-        "title": "Cache Transactions [Packetbeat]",
-        "version": 1
-      },
-      "id": "3dd366e0-88cc-11e7-ad9c-db80de0bf8d3",
-      "type": "search",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "columns": [
-          "_source"
-        ],
-        "description": "",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"index\":\"packetbeat-*\",\"highlightAll\":true,\"version\":true,\"query\":{\"query\":\"\",\"language\":\"lucene\"},\"filter\":[{\"meta\":{\"index\":\"packetbeat-*\",\"negate\":false,\"disabled\":false,\"alias\":null,\"type\":\"phrase\",\"key\":\"type\",\"value\":\"thrift\",\"params\":{\"query\":\"thrift\",\"type\":\"phrase\"}},\"query\":{\"match\":{\"type\":{\"query\":\"thrift\",\"type\":\"phrase\"}}},\"$state\":{\"store\":\"appState\"}}]}"
-        },
-        "sort": [
-          "@timestamp",
-          "desc"
-        ],
-        "title": "RPC transactions",
-        "version": 1
-      },
-      "id": "d3089370-88cc-11e7-ad9c-db80de0bf8d3",
-      "type": "search",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "columns": [
-          "client_ip",
-          "client_port",
-          "ip",
-          "port",
-          "type",
-          "query",
-          "method",
-          "responsetime",
-          "status"
-        ],
-        "description": "",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"index\":\"packetbeat-*\",\"filter\":[],\"highlight\":{\"pre_tags\":[\"@kibana-highlighted-field@\"],\"post_tags\":[\"@/kibana-highlighted-field@\"],\"fields\":{\"*\":{}},\"require_field_match\":false,\"fragment_size\":2147483647},\"query\":{\"query_string\":{\"query\":\"NOT type: flow\",\"analyze_wildcard\":true}}}"
-        },
-        "sort": [
-          "@timestamp",
-          "desc"
-        ],
-        "title": "Packetbeat Search",
-        "version": 1
-      },
-      "id": "Packetbeat-Search",
-      "type": "search",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "columns": [
-          "client_ip",
-          "client_port",
-          "ip",
-          "port",
-          "type",
-          "query",
-          "method",
-          "responsetime",
-          "status"
-        ],
-        "description": "",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"index\":\"packetbeat-*\",\"filter\":[],\"highlight\":{\"pre_tags\":[\"@kibana-highlighted-field@\"],\"post_tags\":[\"@/kibana-highlighted-field@\"],\"fields\":{\"*\":{}},\"require_field_match\":false,\"fragment_size\":2147483647},\"query\":{\"query_string\":{\"query\":\"!type: flow AND !status: OK\",\"analyze_wildcard\":true}}}"
-        },
-        "sort": [
-          "@timestamp",
-          "desc"
-        ],
-        "title": "Transactions errors",
-        "version": 1
-      },
-      "id": "Transactions-errors",
-      "type": "search",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "Packetbeat overview dashboard",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[],\"query\":{\"language\":\"lucene\",\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}}},\"highlightAll\":true,\"version\":true}"
-        },
-        "optionsJSON": "{\"darkTheme\":false}",
-        "panelsJSON": "[{\"col\":1,\"id\":\"Web-transactions\",\"row\":5,\"size_x\":3,\"size_y\":2,\"type\":\"visualization\",\"panelIndex\":1},{\"col\":4,\"id\":\"DB-transactions\",\"row\":5,\"size_x\":3,\"size_y\":2,\"type\":\"visualization\",\"panelIndex\":2},{\"col\":7,\"id\":\"Cache-transactions\",\"row\":5,\"size_x\":3,\"size_y\":2,\"type\":\"visualization\",\"panelIndex\":3},{\"col\":10,\"id\":\"RPC-transactions\",\"row\":5,\"size_x\":3,\"size_y\":2,\"type\":\"visualization\",\"panelIndex\":4},{\"col\":1,\"id\":\"Response-times-percentiles\",\"row\":10,\"size_x\":6,\"size_y\":3,\"type\":\"visualization\",\"panelIndex\":5},{\"col\":1,\"id\":\"Errors-count-over-time\",\"row\":13,\"size_x\":6,\"size_y\":3,\"type\":\"visualization\",\"panelIndex\":6},{\"col\":7,\"id\":\"Errors-vs-successful-transactions\",\"row\":10,\"size_x\":6,\"size_y\":3,\"type\":\"visualization\",\"panelIndex\":7},{\"col\":7,\"id\":\"Latency-histogram\",\"row\":13,\"size_x\":6,\"size_y\":3,\"type\":\"visualization\",\"panelIndex\":8},{\"col\":4,\"id\":\"Client-locations\",\"row\":1,\"size_x\":9,\"size_y\":4,\"type\":\"visualization\",\"panelIndex\":9},{\"col\":1,\"id\":\"Response-times-repartition\",\"row\":7,\"size_x\":12,\"size_y\":3,\"type\":\"visualization\",\"panelIndex\":10},{\"id\":\"Navigation\",\"type\":\"visualization\",\"size_x\":3,\"size_y\":4,\"col\":1,\"row\":1,\"panelIndex\":11}]",
-        "timeRestore": false,
-        "title": "[Packetbeat] Overview",
-        "uiStateJSON": "{\"P-9\":{\"mapZoom\":2,\"mapBounds\":{\"bottom_right\":{\"lat\":-54.97761367069625,\"lon\":153.984375},\"top_left\":{\"lat\":54.97761367069628,\"lon\":-153.984375}},\"mapCollar\":{\"top_left\":{\"lat\":90,\"lon\":-180},\"bottom_right\":{\"lat\":-90,\"lon\":180},\"zoom\":2}}}",
-        "version": 1
-      },
-      "id": "Packetbeat-Dashboard",
-      "type": "dashboard",
-      "version": 2
-    }
-  ],
-  "version": "6.0.0-beta1-SNAPSHOT"
+    "objects": [
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "71908f00-88ca-11e7-ad9c-db80de0bf8d3", 
+                "title": "Web transactions", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": false, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "defaultYExtents": false, 
+                        "mode": "stacked", 
+                        "scale": "linear", 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "times": [], 
+                        "yAxis": {}
+                    }, 
+                    "title": "Web transactions", 
+                    "type": "histogram"
+                }
+            }, 
+            "id": "Web-transactions", 
+            "type": "visualization", 
+            "version": 3
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "800e2a00-88cb-11e7-ad9c-db80de0bf8d3", 
+                "title": "DB transactions", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "id": "3", 
+                            "params": {
+                                "field": "type", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "group", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "defaultYExtents": false, 
+                        "mode": "stacked", 
+                        "scale": "linear", 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "times": [], 
+                        "yAxis": {}
+                    }, 
+                    "title": "DB transactions", 
+                    "type": "histogram"
+                }
+            }, 
+            "id": "DB-transactions", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "3dd366e0-88cc-11e7-ad9c-db80de0bf8d3", 
+                "title": "Cache transactions", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": false, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "defaultYExtents": false, 
+                        "mode": "stacked", 
+                        "scale": "linear", 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "times": [], 
+                        "yAxis": {}
+                    }, 
+                    "title": "Cache transactions", 
+                    "type": "histogram"
+                }
+            }, 
+            "id": "Cache-transactions", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "d3089370-88cc-11e7-ad9c-db80de0bf8d3", 
+                "title": "RPC transactions", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "id": "1", 
+                            "params": {
+                                "field": "type"
+                            }, 
+                            "schema": "metric", 
+                            "type": "cardinality"
+                        }, 
+                        {
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": false, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "defaultYExtents": false, 
+                        "mode": "stacked", 
+                        "scale": "linear", 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "times": [], 
+                        "yAxis": {}
+                    }, 
+                    "title": "RPC transactions", 
+                    "type": "histogram"
+                }
+            }, 
+            "id": "RPC-transactions", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Packetbeat-Search", 
+                "title": "Response times percentiles", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "field": "responsetime", 
+                                "percents": [
+                                    75, 
+                                    95, 
+                                    99
+                                ]
+                            }, 
+                            "schema": "metric", 
+                            "type": "percentiles"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "defaultYExtents": false, 
+                        "drawLinesBetweenPoints": true, 
+                        "interpolate": "linear", 
+                        "legendPosition": "right", 
+                        "radiusRatio": 9, 
+                        "scale": "linear", 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "showCircles": true, 
+                        "smoothLines": true, 
+                        "times": [], 
+                        "yAxis": {}
+                    }, 
+                    "title": "Response times percentiles", 
+                    "type": "line"
+                }
+            }, 
+            "id": "Response-times-percentiles", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Transactions-errors", 
+                "title": "Errors count over time", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "30s", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "custom", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "id": "3", 
+                            "params": {
+                                "field": "type", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "group", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "defaultYExtents": false, 
+                        "mode": "stacked", 
+                        "scale": "linear", 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "times": [], 
+                        "yAxis": {}
+                    }, 
+                    "title": "New Visualization", 
+                    "type": "histogram"
+                }
+            }, 
+            "id": "Errors-count-over-time", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Packetbeat-Search", 
+                "title": "Errors vs successful transactions", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "id": "3", 
+                            "params": {
+                                "field": "status", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "group", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "defaultYExtents": false, 
+                        "mode": "percentage", 
+                        "scale": "linear", 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "times": [], 
+                        "yAxis": {}
+                    }, 
+                    "title": "Errors vs successful transactions", 
+                    "type": "histogram"
+                }
+            }, 
+            "id": "Errors-vs-successful-transactions", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Packetbeat-Search", 
+                "title": "Latency histogram", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "extended_bounds": {}, 
+                                "field": "responsetime", 
+                                "interval": 10
+                            }, 
+                            "schema": "segment", 
+                            "type": "histogram"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "defaultYExtents": false, 
+                        "interpolate": "linear", 
+                        "legendPosition": "right", 
+                        "mode": "stacked", 
+                        "scale": "linear", 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "smoothLines": true, 
+                        "times": [], 
+                        "yAxis": {}
+                    }, 
+                    "title": "Latency histogram", 
+                    "type": "area"
+                }
+            }, 
+            "id": "Latency-histogram", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "index": "packetbeat-*", 
+                        "query": {
+                            "query_string": {
+                                "analyze_wildcard": true, 
+                                "query": "*"
+                            }
+                        }
+                    }
+                }, 
+                "title": "Client locations", 
+                "uiStateJSON": {
+                    "mapCenter": [
+                        0, 
+                        -0.17578125
+                    ]
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "autoPrecision": true, 
+                                "field": "client_geoip.location"
+                            }, 
+                            "schema": "segment", 
+                            "type": "geohash_grid"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addTooltip": true, 
+                        "heatBlur": 15, 
+                        "heatMaxZoom": 16, 
+                        "heatMinOpacity": 0.1, 
+                        "heatNormalizeData": true, 
+                        "heatRadius": 25, 
+                        "isDesaturated": true, 
+                        "mapCenter": [
+                            15, 
+                            5
+                        ], 
+                        "mapType": "Scaled Circle Markers", 
+                        "mapZoom": 2, 
+                        "wms": {
+                            "enabled": false, 
+                            "options": {
+                                "attribution": "Maps provided by USGS", 
+                                "format": "image/png", 
+                                "layers": "0", 
+                                "styles": "", 
+                                "transparent": true, 
+                                "version": "1.3.0"
+                            }, 
+                            "url": "https://basemap.nationalmap.gov/arcgis/services/USGSTopo/MapServer/WMSServer"
+                        }
+                    }, 
+                    "title": "Client locations", 
+                    "type": "tile_map"
+                }
+            }, 
+            "id": "Client-locations", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Packetbeat-Search", 
+                "title": "Response times repartition", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "id": "3", 
+                            "params": {
+                                "extended_bounds": {}, 
+                                "field": "responsetime", 
+                                "interval": 10
+                            }, 
+                            "schema": "group", 
+                            "type": "histogram"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "defaultYExtents": false, 
+                        "mode": "stacked", 
+                        "scale": "linear", 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "times": [], 
+                        "yAxis": {}
+                    }, 
+                    "title": "Response times repartition", 
+                    "type": "histogram"
+                }
+            }, 
+            "id": "Response-times-repartition", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "analyze_wildcard": true, 
+                                    "query": "*"
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "title": "Navigation", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "fontSize": "10", 
+                        "markdown": "### Packetbeat:\n\n[Overview](#/dashboard/Packetbeat-Dashboard)\n\n[Flows](#/dashboard/Packetbeat-Flows)\n\n[Web transactions](#/dashboard/Packetbeat-HTTP)\n\n[MySQL performance](#/dashboard/Packetbeat-MySQL-performance)\n\n[PostgreSQL performance](#/dashboard/Packetbeat-PgSQL-performance)\n\n[MongoDB performance](#/dashboard/Packetbeat-MongoDB-performance)\n\n[Thrift-RPC performance](#/dashboard/Packetbeat-Thrift-performance)\n\n[NFS transactions](#/dashboard/Packetbeat-NFS)\n\n[Cassandra performance](#/dashboard/Packetbeat-Cassandra)"
+                    }, 
+                    "title": "Navigation", 
+                    "type": "markdown"
+                }
+            }, 
+            "id": "Navigation", 
+            "type": "visualization", 
+            "version": 10
+        }, 
+        {
+            "attributes": {
+                "columns": [
+                    "_source"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                }, 
+                                "meta": {
+                                    "alias": null, 
+                                    "disabled": false, 
+                                    "index": "packetbeat-*", 
+                                    "key": "type", 
+                                    "negate": false, 
+                                    "params": {
+                                        "query": "http", 
+                                        "type": "phrase"
+                                    }, 
+                                    "type": "phrase", 
+                                    "value": "http"
+                                }, 
+                                "query": {
+                                    "match": {
+                                        "type": {
+                                            "query": "http", 
+                                            "type": "phrase"
+                                        }
+                                    }
+                                }
+                            }
+                        ], 
+                        "highlightAll": true, 
+                        "index": "packetbeat-*", 
+                        "query": {
+                            "language": "lucene", 
+                            "query": "*"
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "Web Transactions [Packetbeat]", 
+                "version": 1
+            }, 
+            "id": "71908f00-88ca-11e7-ad9c-db80de0bf8d3", 
+            "type": "search", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "columns": [
+                    "_source"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                }, 
+                                "meta": {
+                                    "alias": null, 
+                                    "disabled": false, 
+                                    "index": "packetbeat-*", 
+                                    "key": "type", 
+                                    "negate": false, 
+                                    "type": "phrases", 
+                                    "value": "mysql, postgresql"
+                                }, 
+                                "query": {
+                                    "bool": {
+                                        "minimum_should_match": 1, 
+                                        "should": [
+                                            {
+                                                "match_phrase": {
+                                                    "type": "mysql"
+                                                }
+                                            }, 
+                                            {
+                                                "match_phrase": {
+                                                    "type": "postgresql"
+                                                }
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        ], 
+                        "highlightAll": true, 
+                        "index": "packetbeat-*", 
+                        "query": {
+                            "language": "lucene", 
+                            "query": ""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "DB transactions", 
+                "version": 1
+            }, 
+            "id": "800e2a00-88cb-11e7-ad9c-db80de0bf8d3", 
+            "type": "search", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "columns": [
+                    "_source"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                }, 
+                                "meta": {
+                                    "alias": null, 
+                                    "disabled": false, 
+                                    "index": "packetbeat-*", 
+                                    "key": "type", 
+                                    "negate": false, 
+                                    "type": "phrases", 
+                                    "value": "redis, memcache"
+                                }, 
+                                "query": {
+                                    "bool": {
+                                        "minimum_should_match": 1, 
+                                        "should": [
+                                            {
+                                                "match_phrase": {
+                                                    "type": "redis"
+                                                }
+                                            }, 
+                                            {
+                                                "match_phrase": {
+                                                    "type": "memcache"
+                                                }
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        ], 
+                        "highlightAll": true, 
+                        "index": "packetbeat-*", 
+                        "query": {
+                            "language": "lucene", 
+                            "query": ""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "Cache Transactions [Packetbeat]", 
+                "version": 1
+            }, 
+            "id": "3dd366e0-88cc-11e7-ad9c-db80de0bf8d3", 
+            "type": "search", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "columns": [
+                    "_source"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                }, 
+                                "meta": {
+                                    "alias": null, 
+                                    "disabled": false, 
+                                    "index": "packetbeat-*", 
+                                    "key": "type", 
+                                    "negate": false, 
+                                    "params": {
+                                        "query": "thrift", 
+                                        "type": "phrase"
+                                    }, 
+                                    "type": "phrase", 
+                                    "value": "thrift"
+                                }, 
+                                "query": {
+                                    "match": {
+                                        "type": {
+                                            "query": "thrift", 
+                                            "type": "phrase"
+                                        }
+                                    }
+                                }
+                            }
+                        ], 
+                        "highlightAll": true, 
+                        "index": "packetbeat-*", 
+                        "query": {
+                            "language": "lucene", 
+                            "query": ""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "RPC transactions", 
+                "version": 1
+            }, 
+            "id": "d3089370-88cc-11e7-ad9c-db80de0bf8d3", 
+            "type": "search", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "columns": [
+                    "client_ip", 
+                    "client_port", 
+                    "ip", 
+                    "port", 
+                    "type", 
+                    "query", 
+                    "method", 
+                    "responsetime", 
+                    "status"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlight": {
+                            "fields": {
+                                "*": {}
+                            }, 
+                            "fragment_size": 2147483647, 
+                            "post_tags": [
+                                "@/kibana-highlighted-field@"
+                            ], 
+                            "pre_tags": [
+                                "@kibana-highlighted-field@"
+                            ], 
+                            "require_field_match": false
+                        }, 
+                        "index": "packetbeat-*", 
+                        "query": {
+                            "query_string": {
+                                "analyze_wildcard": true, 
+                                "query": "NOT type: flow"
+                            }
+                        }
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "Packetbeat Search", 
+                "version": 1
+            }, 
+            "id": "Packetbeat-Search", 
+            "type": "search", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "columns": [
+                    "client_ip", 
+                    "client_port", 
+                    "ip", 
+                    "port", 
+                    "type", 
+                    "query", 
+                    "method", 
+                    "responsetime", 
+                    "status"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlight": {
+                            "fields": {
+                                "*": {}
+                            }, 
+                            "fragment_size": 2147483647, 
+                            "post_tags": [
+                                "@/kibana-highlighted-field@"
+                            ], 
+                            "pre_tags": [
+                                "@kibana-highlighted-field@"
+                            ], 
+                            "require_field_match": false
+                        }, 
+                        "index": "packetbeat-*", 
+                        "query": {
+                            "query_string": {
+                                "analyze_wildcard": true, 
+                                "query": "!type: flow AND !status: OK"
+                            }
+                        }
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "Transactions errors", 
+                "version": 1
+            }, 
+            "id": "Transactions-errors", 
+            "type": "search", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "Packetbeat overview dashboard", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "analyze_wildcard": true, 
+                                    "query": "*"
+                                }
+                            }
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false
+                }, 
+                "panelsJSON": [
+                    {
+                        "col": 1, 
+                        "id": "Web-transactions", 
+                        "panelIndex": 1, 
+                        "row": 5, 
+                        "size_x": 3, 
+                        "size_y": 2, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 4, 
+                        "id": "DB-transactions", 
+                        "panelIndex": 2, 
+                        "row": 5, 
+                        "size_x": 3, 
+                        "size_y": 2, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 7, 
+                        "id": "Cache-transactions", 
+                        "panelIndex": 3, 
+                        "row": 5, 
+                        "size_x": 3, 
+                        "size_y": 2, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 10, 
+                        "id": "RPC-transactions", 
+                        "panelIndex": 4, 
+                        "row": 5, 
+                        "size_x": 3, 
+                        "size_y": 2, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "Response-times-percentiles", 
+                        "panelIndex": 5, 
+                        "row": 10, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "Errors-count-over-time", 
+                        "panelIndex": 6, 
+                        "row": 13, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 7, 
+                        "id": "Errors-vs-successful-transactions", 
+                        "panelIndex": 7, 
+                        "row": 10, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 7, 
+                        "id": "Latency-histogram", 
+                        "panelIndex": 8, 
+                        "row": 13, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 4, 
+                        "id": "Client-locations", 
+                        "panelIndex": 9, 
+                        "row": 1, 
+                        "size_x": 9, 
+                        "size_y": 4, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "Response-times-repartition", 
+                        "panelIndex": 10, 
+                        "row": 7, 
+                        "size_x": 12, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "Navigation", 
+                        "panelIndex": 11, 
+                        "row": 1, 
+                        "size_x": 3, 
+                        "size_y": 4, 
+                        "type": "visualization"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Packetbeat] Overview", 
+                "uiStateJSON": {
+                    "P-9": {
+                        "mapBounds": {
+                            "bottom_right": {
+                                "lat": -54.97761367069625, 
+                                "lon": 153.984375
+                            }, 
+                            "top_left": {
+                                "lat": 54.97761367069628, 
+                                "lon": -153.984375
+                            }
+                        }, 
+                        "mapCollar": {
+                            "bottom_right": {
+                                "lat": -90, 
+                                "lon": 180
+                            }, 
+                            "top_left": {
+                                "lat": 90, 
+                                "lon": -180
+                            }, 
+                            "zoom": 2
+                        }, 
+                        "mapZoom": 2
+                    }
+                }, 
+                "version": 1
+            }, 
+            "id": "Packetbeat-Dashboard", 
+            "type": "dashboard", 
+            "version": 2
+        }
+    ], 
+    "version": "6.0.0-beta1-SNAPSHOT"
 }

--- a/packetbeat/_meta/kibana/6/dashboard/Packetbeat-pgsql.json
+++ b/packetbeat/_meta/kibana/6/dashboard/Packetbeat-pgsql.json
@@ -1,197 +1,778 @@
 {
-  "objects": [
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}},\"language\":\"lucene\"},\"filter\":[]}"
-        },
-        "title": "Navigation",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Navigation\",\"type\":\"markdown\",\"params\":{\"markdown\":\"### Packetbeat:\\n\\n[Overview](#/dashboard/Packetbeat-Dashboard)\\n\\n[Flows](#/dashboard/Packetbeat-Flows)\\n\\n[Web transactions](#/dashboard/Packetbeat-HTTP)\\n\\n[MySQL performance](#/dashboard/Packetbeat-MySQL-performance)\\n\\n[PostgreSQL performance](#/dashboard/Packetbeat-PgSQL-performance)\\n\\n[MongoDB performance](#/dashboard/Packetbeat-MongoDB-performance)\\n\\n[Thrift-RPC performance](#/dashboard/Packetbeat-Thrift-performance)\\n\\n[NFS transactions](#/dashboard/Packetbeat-NFS)\\n\\n[Cassandra performance](#/dashboard/Packetbeat-Cassandra)\",\"fontSize\":\"10\"},\"aggs\":[]}"
-      },
-      "id": "Navigation",
-      "type": "visualization",
-      "version": 10
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[]}"
-        },
-        "savedSearchId": "PgSQL-errors",
-        "title": "PgSQL Errors",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"PgSQL Errors\",\"type\":\"area\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":false,\"mode\":\"stacked\",\"defaultYExtents\":false,\"smoothLines\":false,\"scale\":\"linear\",\"interpolate\":\"linear\",\"times\":[],\"addTimeMarker\":false,\"setYExtents\":false,\"yAxis\":{}},\"aggs\":[{\"id\":\"1\",\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"auto\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}"
-      },
-      "id": "PgSQL-Errors",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[]}"
-        },
-        "savedSearchId": "PgSQL-transactions",
-        "title": "PgSQL Methods",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"PgSQL Methods\",\"type\":\"area\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"mode\":\"wiggle\",\"defaultYExtents\":false,\"smoothLines\":false,\"scale\":\"linear\",\"interpolate\":\"linear\",\"times\":[],\"addTimeMarker\":false,\"setYExtents\":false,\"yAxis\":{}},\"aggs\":[{\"id\":\"1\",\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"auto\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}},{\"id\":\"3\",\"type\":\"terms\",\"schema\":\"group\",\"params\":{\"field\":\"method\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}"
-      },
-      "id": "PgSQL-Methods",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[]}"
-        },
-        "savedSearchId": "PgSQL-transactions",
-        "title": "PgSQL response times percentiles",
-        "version": 1,
-        "visState": "{\"type\":\"line\",\"params\":{\"addLegend\":true,\"addTooltip\":true,\"defaultYExtents\":false,\"shareYAxis\":true},\"aggs\":[{\"id\":\"1\",\"type\":\"percentiles\",\"schema\":\"metric\",\"params\":{\"field\":\"responsetime\",\"percents\":[75,99,99.5]}},{\"id\":\"2\",\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"auto\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}"
-      },
-      "id": "PgSQL-response-times-percentiles",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[]}"
-        },
-        "savedSearchId": "PgSQL-transactions",
-        "title": "PgSQL throughput",
-        "version": 1,
-        "visState": "{\"type\":\"line\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"defaultYExtents\":false},\"aggs\":[{\"id\":\"1\",\"type\":\"sum\",\"schema\":\"metric\",\"params\":{\"field\":\"bytes_out\"}},{\"id\":\"2\",\"type\":\"sum\",\"schema\":\"metric\",\"params\":{\"field\":\"bytes_in\"}},{\"id\":\"3\",\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"auto\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}"
-      },
-      "id": "PgSQL-throughput",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[]}"
-        },
-        "savedSearchId": "PgSQL-transactions",
-        "title": "PgSQL Reads vs Writes",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"PgSQL Reads vs Writes\",\"type\":\"area\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"mode\":\"stacked\",\"defaultYExtents\":false,\"smoothLines\":false,\"scale\":\"linear\",\"interpolate\":\"linear\",\"times\":[],\"addTimeMarker\":false,\"setYExtents\":false,\"yAxis\":{},\"type\":\"area\",\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"type\":\"category\",\"position\":\"bottom\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\"},\"labels\":{\"show\":true,\"truncate\":100},\"title\":{\"text\":\"@timestamp per 30 seconds\"}}],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"name\":\"LeftAxis-1\",\"type\":\"value\",\"position\":\"left\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\",\"mode\":\"normal\"},\"labels\":{\"show\":true,\"rotate\":0,\"filter\":false,\"truncate\":100},\"title\":{\"text\":\"Count\"}}],\"seriesParams\":[{\"show\":\"true\",\"type\":\"area\",\"mode\":\"stacked\",\"data\":{\"label\":\"Count\",\"id\":\"1\"},\"drawLinesBetweenPoints\":true,\"showCircles\":true,\"interpolate\":\"linear\",\"valueAxis\":\"ValueAxis-1\"}],\"legendPosition\":\"right\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"auto\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}},{\"id\":\"3\",\"enabled\":true,\"type\":\"filters\",\"schema\":\"group\",\"params\":{\"filters\":[{\"input\":{\"query\":{\"query_string\":{\"query\":\"method: SELECT\",\"analyze_wildcard\":true}}}},{\"input\":{\"query\":\"method: INSERT OR method: UPDATE OR method: DELETE\"}}]}}]}"
-      },
-      "id": "PgSQL-Reads-vs-Writes",
-      "type": "visualization",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[]}"
-        },
-        "savedSearchId": "PgSQL-transactions",
-        "title": "Most frequent PgSQL queries",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Most frequent PgSQL queries\",\"type\":\"table\",\"params\":{\"perPage\":10,\"showPartialRows\":false,\"showMeticsAtAllLevels\":false},\"aggs\":[{\"id\":\"1\",\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"query\",\"size\":10,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}"
-      },
-      "id": "Most-frequent-PgSQL-queries",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[]}"
-        },
-        "savedSearchId": "PgSQL-transactions",
-        "title": "Slowest PgSQL queries",
-        "version": 1,
-        "visState": "{\"type\":\"table\",\"params\":{\"perPage\":10,\"showPartialRows\":false,\"showMeticsAtAllLevels\":false},\"aggs\":[{\"id\":\"1\",\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"responsetime\"}},{\"id\":\"2\",\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"query\",\"size\":10,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}"
-      },
-      "id": "Slowest-PgSQL-queries",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "columns": [
-          "method",
-          "type",
-          "path",
-          "responsetime",
-          "status"
-        ],
-        "description": "",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"index\":\"packetbeat-*\",\"highlight\":{\"pre_tags\":[\"@kibana-highlighted-field@\"],\"post_tags\":[\"@/kibana-highlighted-field@\"],\"fields\":{\"*\":{}}},\"filter\":[{\"meta\":{\"disabled\":false,\"index\":\"packetbeat-*\",\"key\":\"type\",\"negate\":false,\"value\":\"pgsql\"},\"query\":{\"match\":{\"type\":{\"query\":\"pgsql\",\"type\":\"phrase\"}}}},{\"meta\":{\"index\":\"packetbeat-*\",\"negate\":true,\"key\":\"status\",\"value\":\"OK\",\"disabled\":false},\"query\":{\"match\":{\"status\":{\"query\":\"OK\",\"type\":\"phrase\"}}}}],\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}}}"
-        },
-        "sort": [
-          "@timestamp",
-          "desc"
-        ],
-        "title": "PgSQL errors",
-        "version": 1
-      },
-      "id": "PgSQL-errors",
-      "type": "search",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "columns": [
-          "method",
-          "type",
-          "path",
-          "responsetime",
-          "status"
-        ],
-        "description": "",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"index\":\"packetbeat-*\",\"highlight\":{\"pre_tags\":[\"@kibana-highlighted-field@\"],\"post_tags\":[\"@/kibana-highlighted-field@\"],\"fields\":{\"*\":{}}},\"filter\":[{\"meta\":{\"index\":\"packetbeat-*\",\"negate\":false,\"key\":\"type\",\"value\":\"pgsql\",\"disabled\":false},\"query\":{\"match\":{\"type\":{\"query\":\"pgsql\",\"type\":\"phrase\"}}}}],\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}}}"
-        },
-        "sort": [
-          "@timestamp",
-          "desc"
-        ],
-        "title": "PgSQL transactions",
-        "version": 1
-      },
-      "id": "PgSQL-transactions",
-      "type": "search",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[],\"query\":{\"language\":\"lucene\",\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}}},\"highlightAll\":true,\"version\":true}"
-        },
-        "optionsJSON": "{\"darkTheme\":false}",
-        "panelsJSON": "[{\"col\":1,\"id\":\"Navigation\",\"panelIndex\":1,\"row\":1,\"size_x\":3,\"size_y\":4,\"type\":\"visualization\"},{\"col\":4,\"id\":\"PgSQL-Errors\",\"panelIndex\":2,\"row\":1,\"size_x\":5,\"size_y\":4,\"type\":\"visualization\"},{\"col\":9,\"id\":\"PgSQL-Methods\",\"panelIndex\":3,\"row\":1,\"size_x\":4,\"size_y\":4,\"type\":\"visualization\"},{\"col\":1,\"id\":\"PgSQL-response-times-percentiles\",\"panelIndex\":4,\"row\":5,\"size_x\":12,\"size_y\":3,\"type\":\"visualization\"},{\"col\":7,\"id\":\"PgSQL-throughput\",\"panelIndex\":5,\"row\":8,\"size_x\":6,\"size_y\":3,\"type\":\"visualization\"},{\"col\":1,\"id\":\"PgSQL-Reads-vs-Writes\",\"panelIndex\":6,\"row\":8,\"size_x\":6,\"size_y\":3,\"type\":\"visualization\"},{\"col\":1,\"id\":\"Most-frequent-PgSQL-queries\",\"panelIndex\":7,\"row\":11,\"size_x\":6,\"size_y\":6,\"type\":\"visualization\"},{\"col\":7,\"id\":\"Slowest-PgSQL-queries\",\"panelIndex\":8,\"row\":11,\"size_x\":6,\"size_y\":6,\"type\":\"visualization\"}]",
-        "timeRestore": false,
-        "title": "[Packetbeat] PgSQL performance",
-        "uiStateJSON": "{\"P-7\":{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}},\"P-8\":{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}}}",
-        "version": 1
-      },
-      "id": "Packetbeat-PgSQL-performance",
-      "type": "dashboard",
-      "version": 2
-    }
-  ],
-  "version": "6.0.0-beta1-SNAPSHOT"
+    "objects": [
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "analyze_wildcard": true, 
+                                    "query": "*"
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "title": "Navigation", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "fontSize": "10", 
+                        "markdown": "### Packetbeat:\n\n[Overview](#/dashboard/Packetbeat-Dashboard)\n\n[Flows](#/dashboard/Packetbeat-Flows)\n\n[Web transactions](#/dashboard/Packetbeat-HTTP)\n\n[MySQL performance](#/dashboard/Packetbeat-MySQL-performance)\n\n[PostgreSQL performance](#/dashboard/Packetbeat-PgSQL-performance)\n\n[MongoDB performance](#/dashboard/Packetbeat-MongoDB-performance)\n\n[Thrift-RPC performance](#/dashboard/Packetbeat-Thrift-performance)\n\n[NFS transactions](#/dashboard/Packetbeat-NFS)\n\n[Cassandra performance](#/dashboard/Packetbeat-Cassandra)"
+                    }, 
+                    "title": "Navigation", 
+                    "type": "markdown"
+                }
+            }, 
+            "id": "Navigation", 
+            "type": "visualization", 
+            "version": 10
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "PgSQL-errors", 
+                "title": "PgSQL Errors", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": false, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "defaultYExtents": false, 
+                        "interpolate": "linear", 
+                        "mode": "stacked", 
+                        "scale": "linear", 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "smoothLines": false, 
+                        "times": [], 
+                        "yAxis": {}
+                    }, 
+                    "title": "PgSQL Errors", 
+                    "type": "area"
+                }
+            }, 
+            "id": "PgSQL-Errors", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "PgSQL-transactions", 
+                "title": "PgSQL Methods", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "id": "3", 
+                            "params": {
+                                "field": "method", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "group", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "defaultYExtents": false, 
+                        "interpolate": "linear", 
+                        "mode": "wiggle", 
+                        "scale": "linear", 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "smoothLines": false, 
+                        "times": [], 
+                        "yAxis": {}
+                    }, 
+                    "title": "PgSQL Methods", 
+                    "type": "area"
+                }
+            }, 
+            "id": "PgSQL-Methods", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "PgSQL-transactions", 
+                "title": "PgSQL response times percentiles", 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "id": "1", 
+                            "params": {
+                                "field": "responsetime", 
+                                "percents": [
+                                    75, 
+                                    99, 
+                                    99.5
+                                ]
+                            }, 
+                            "schema": "metric", 
+                            "type": "percentiles"
+                        }, 
+                        {
+                            "id": "2", 
+                            "params": {
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTooltip": true, 
+                        "defaultYExtents": false, 
+                        "shareYAxis": true
+                    }, 
+                    "type": "line"
+                }
+            }, 
+            "id": "PgSQL-response-times-percentiles", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "PgSQL-transactions", 
+                "title": "PgSQL throughput", 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "id": "1", 
+                            "params": {
+                                "field": "bytes_out"
+                            }, 
+                            "schema": "metric", 
+                            "type": "sum"
+                        }, 
+                        {
+                            "id": "2", 
+                            "params": {
+                                "field": "bytes_in"
+                            }, 
+                            "schema": "metric", 
+                            "type": "sum"
+                        }, 
+                        {
+                            "id": "3", 
+                            "params": {
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTooltip": true, 
+                        "defaultYExtents": false, 
+                        "shareYAxis": true
+                    }, 
+                    "type": "line"
+                }
+            }, 
+            "id": "PgSQL-throughput", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "PgSQL-transactions", 
+                "title": "PgSQL Reads vs Writes", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "filters": [
+                                    {
+                                        "input": {
+                                            "query": {
+                                                "query_string": {
+                                                    "analyze_wildcard": true, 
+                                                    "query": "method: SELECT"
+                                                }
+                                            }
+                                        }
+                                    }, 
+                                    {
+                                        "input": {
+                                            "query": "method: INSERT OR method: UPDATE OR method: DELETE"
+                                        }
+                                    }
+                                ]
+                            }, 
+                            "schema": "group", 
+                            "type": "filters"
+                        }
+                    ], 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "categoryAxes": [
+                            {
+                                "id": "CategoryAxis-1", 
+                                "labels": {
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "position": "bottom", 
+                                "scale": {
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {
+                                    "text": "@timestamp per 30 seconds"
+                                }, 
+                                "type": "category"
+                            }
+                        ], 
+                        "defaultYExtents": false, 
+                        "grid": {
+                            "categoryLines": false, 
+                            "style": {
+                                "color": "#eee"
+                            }
+                        }, 
+                        "interpolate": "linear", 
+                        "legendPosition": "right", 
+                        "mode": "stacked", 
+                        "scale": "linear", 
+                        "seriesParams": [
+                            {
+                                "data": {
+                                    "id": "1", 
+                                    "label": "Count"
+                                }, 
+                                "drawLinesBetweenPoints": true, 
+                                "interpolate": "linear", 
+                                "mode": "stacked", 
+                                "show": "true", 
+                                "showCircles": true, 
+                                "type": "area", 
+                                "valueAxis": "ValueAxis-1"
+                            }
+                        ], 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "smoothLines": false, 
+                        "times": [], 
+                        "type": "area", 
+                        "valueAxes": [
+                            {
+                                "id": "ValueAxis-1", 
+                                "labels": {
+                                    "filter": false, 
+                                    "rotate": 0, 
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "name": "LeftAxis-1", 
+                                "position": "left", 
+                                "scale": {
+                                    "mode": "normal", 
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {
+                                    "text": "Count"
+                                }, 
+                                "type": "value"
+                            }
+                        ], 
+                        "yAxis": {}
+                    }, 
+                    "title": "PgSQL Reads vs Writes", 
+                    "type": "area"
+                }
+            }, 
+            "id": "PgSQL-Reads-vs-Writes", 
+            "type": "visualization", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "PgSQL-transactions", 
+                "title": "Most frequent PgSQL queries", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "id": "2", 
+                            "params": {
+                                "field": "query", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 10
+                            }, 
+                            "schema": "bucket", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "perPage": 10, 
+                        "showMeticsAtAllLevels": false, 
+                        "showPartialRows": false
+                    }, 
+                    "title": "Most frequent PgSQL queries", 
+                    "type": "table"
+                }
+            }, 
+            "id": "Most-frequent-PgSQL-queries", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "PgSQL-transactions", 
+                "title": "Slowest PgSQL queries", 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "id": "1", 
+                            "params": {
+                                "field": "responsetime"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "id": "2", 
+                            "params": {
+                                "field": "query", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 10
+                            }, 
+                            "schema": "bucket", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "perPage": 10, 
+                        "showMeticsAtAllLevels": false, 
+                        "showPartialRows": false
+                    }, 
+                    "type": "table"
+                }
+            }, 
+            "id": "Slowest-PgSQL-queries", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "columns": [
+                    "method", 
+                    "type", 
+                    "path", 
+                    "responsetime", 
+                    "status"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [
+                            {
+                                "meta": {
+                                    "disabled": false, 
+                                    "index": "packetbeat-*", 
+                                    "key": "type", 
+                                    "negate": false, 
+                                    "value": "pgsql"
+                                }, 
+                                "query": {
+                                    "match": {
+                                        "type": {
+                                            "query": "pgsql", 
+                                            "type": "phrase"
+                                        }
+                                    }
+                                }
+                            }, 
+                            {
+                                "meta": {
+                                    "disabled": false, 
+                                    "index": "packetbeat-*", 
+                                    "key": "status", 
+                                    "negate": true, 
+                                    "value": "OK"
+                                }, 
+                                "query": {
+                                    "match": {
+                                        "status": {
+                                            "query": "OK", 
+                                            "type": "phrase"
+                                        }
+                                    }
+                                }
+                            }
+                        ], 
+                        "highlight": {
+                            "fields": {
+                                "*": {}
+                            }, 
+                            "post_tags": [
+                                "@/kibana-highlighted-field@"
+                            ], 
+                            "pre_tags": [
+                                "@kibana-highlighted-field@"
+                            ]
+                        }, 
+                        "index": "packetbeat-*", 
+                        "query": {
+                            "query_string": {
+                                "analyze_wildcard": true, 
+                                "query": "*"
+                            }
+                        }
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "PgSQL errors", 
+                "version": 1
+            }, 
+            "id": "PgSQL-errors", 
+            "type": "search", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "columns": [
+                    "method", 
+                    "type", 
+                    "path", 
+                    "responsetime", 
+                    "status"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [
+                            {
+                                "meta": {
+                                    "disabled": false, 
+                                    "index": "packetbeat-*", 
+                                    "key": "type", 
+                                    "negate": false, 
+                                    "value": "pgsql"
+                                }, 
+                                "query": {
+                                    "match": {
+                                        "type": {
+                                            "query": "pgsql", 
+                                            "type": "phrase"
+                                        }
+                                    }
+                                }
+                            }
+                        ], 
+                        "highlight": {
+                            "fields": {
+                                "*": {}
+                            }, 
+                            "post_tags": [
+                                "@/kibana-highlighted-field@"
+                            ], 
+                            "pre_tags": [
+                                "@kibana-highlighted-field@"
+                            ]
+                        }, 
+                        "index": "packetbeat-*", 
+                        "query": {
+                            "query_string": {
+                                "analyze_wildcard": true, 
+                                "query": "*"
+                            }
+                        }
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "PgSQL transactions", 
+                "version": 1
+            }, 
+            "id": "PgSQL-transactions", 
+            "type": "search", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "analyze_wildcard": true, 
+                                    "query": "*"
+                                }
+                            }
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false
+                }, 
+                "panelsJSON": [
+                    {
+                        "col": 1, 
+                        "id": "Navigation", 
+                        "panelIndex": 1, 
+                        "row": 1, 
+                        "size_x": 3, 
+                        "size_y": 4, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 4, 
+                        "id": "PgSQL-Errors", 
+                        "panelIndex": 2, 
+                        "row": 1, 
+                        "size_x": 5, 
+                        "size_y": 4, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 9, 
+                        "id": "PgSQL-Methods", 
+                        "panelIndex": 3, 
+                        "row": 1, 
+                        "size_x": 4, 
+                        "size_y": 4, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "PgSQL-response-times-percentiles", 
+                        "panelIndex": 4, 
+                        "row": 5, 
+                        "size_x": 12, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 7, 
+                        "id": "PgSQL-throughput", 
+                        "panelIndex": 5, 
+                        "row": 8, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "PgSQL-Reads-vs-Writes", 
+                        "panelIndex": 6, 
+                        "row": 8, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "Most-frequent-PgSQL-queries", 
+                        "panelIndex": 7, 
+                        "row": 11, 
+                        "size_x": 6, 
+                        "size_y": 6, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 7, 
+                        "id": "Slowest-PgSQL-queries", 
+                        "panelIndex": 8, 
+                        "row": 11, 
+                        "size_x": 6, 
+                        "size_y": 6, 
+                        "type": "visualization"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Packetbeat] PgSQL performance", 
+                "uiStateJSON": {
+                    "P-7": {
+                        "vis": {
+                            "params": {
+                                "sort": {
+                                    "columnIndex": null, 
+                                    "direction": null
+                                }
+                            }
+                        }
+                    }, 
+                    "P-8": {
+                        "vis": {
+                            "params": {
+                                "sort": {
+                                    "columnIndex": null, 
+                                    "direction": null
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "version": 1
+            }, 
+            "id": "Packetbeat-PgSQL-performance", 
+            "type": "dashboard", 
+            "version": 2
+        }
+    ], 
+    "version": "6.0.0-beta1-SNAPSHOT"
 }

--- a/packetbeat/_meta/kibana/6/dashboard/Packetbeat-thrift.json
+++ b/packetbeat/_meta/kibana/6/dashboard/Packetbeat-thrift.json
@@ -1,181 +1,597 @@
 {
-  "objects": [
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}},\"language\":\"lucene\"},\"filter\":[]}"
-        },
-        "title": "Navigation",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Navigation\",\"type\":\"markdown\",\"params\":{\"markdown\":\"### Packetbeat:\\n\\n[Overview](#/dashboard/Packetbeat-Dashboard)\\n\\n[Flows](#/dashboard/Packetbeat-Flows)\\n\\n[Web transactions](#/dashboard/Packetbeat-HTTP)\\n\\n[MySQL performance](#/dashboard/Packetbeat-MySQL-performance)\\n\\n[PostgreSQL performance](#/dashboard/Packetbeat-PgSQL-performance)\\n\\n[MongoDB performance](#/dashboard/Packetbeat-MongoDB-performance)\\n\\n[Thrift-RPC performance](#/dashboard/Packetbeat-Thrift-performance)\\n\\n[NFS transactions](#/dashboard/Packetbeat-NFS)\\n\\n[Cassandra performance](#/dashboard/Packetbeat-Cassandra)\",\"fontSize\":\"10\"},\"aggs\":[]}"
-      },
-      "id": "Navigation",
-      "type": "visualization",
-      "version": 10
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[]}"
-        },
-        "savedSearchId": "Thrift-transactions",
-        "title": "Thrift requests per minute",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Thrift requests per minute\",\"type\":\"histogram\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":false,\"mode\":\"stacked\",\"defaultYExtents\":false,\"scale\":\"linear\",\"times\":[],\"addTimeMarker\":false,\"setYExtents\":false,\"yAxis\":{}},\"aggs\":[{\"id\":\"1\",\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"m\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}"
-      },
-      "id": "Thrift-requests-per-minute",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[]}"
-        },
-        "savedSearchId": "Thrift-errors",
-        "title": "Thrift RPC Errors",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Thrift RPC Errors\",\"type\":\"area\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":false,\"mode\":\"stacked\",\"defaultYExtents\":false,\"smoothLines\":false,\"scale\":\"linear\",\"interpolate\":\"linear\",\"times\":[],\"addTimeMarker\":false,\"setYExtents\":false,\"yAxis\":{}},\"aggs\":[{\"id\":\"1\",\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"auto\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}}],\"listeners\":{}}"
-      },
-      "id": "Thrift-RPC-Errors",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[]}"
-        },
-        "savedSearchId": "Thrift-transactions",
-        "title": "Slowest Thrift RPC methods",
-        "version": 1,
-        "visState": "{\"type\":\"table\",\"params\":{\"perPage\":10,\"showPartialRows\":false,\"showMeticsAtAllLevels\":false},\"aggs\":[{\"id\":\"1\",\"type\":\"avg\",\"schema\":\"metric\",\"params\":{\"field\":\"responsetime\"}},{\"id\":\"2\",\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"method\",\"size\":10,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}"
-      },
-      "id": "Slowest-Thrift-RPC-methods",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[]}"
-        },
-        "savedSearchId": "Thrift-transactions",
-        "title": "Thrift response times percentiles",
-        "version": 1,
-        "visState": "{\"aggs\":[{\"id\":\"1\",\"params\":{\"field\":\"responsetime\",\"percents\":[75,99,99.5]},\"schema\":\"metric\",\"type\":\"percentiles\"},{\"id\":\"2\",\"params\":{\"extended_bounds\":{},\"field\":\"@timestamp\",\"interval\":\"auto\",\"min_doc_count\":1},\"schema\":\"segment\",\"type\":\"date_histogram\"}],\"listeners\":{},\"params\":{\"addLegend\":true,\"addTooltip\":true,\"defaultYExtents\":false,\"shareYAxis\":true},\"type\":\"line\"}"
-      },
-      "id": "Thrift-response-times-percentiles",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[]}"
-        },
-        "savedSearchId": "Thrift-transactions",
-        "title": "Top Thrift-RPC methods",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Top Thrift-RPC methods\",\"type\":\"histogram\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":false,\"mode\":\"stacked\",\"defaultYExtents\":false,\"scale\":\"linear\",\"times\":[],\"addTimeMarker\":false,\"setYExtents\":false,\"yAxis\":{}},\"aggs\":[{\"id\":\"1\",\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"method\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}"
-      },
-      "id": "Top-Thrift-RPC-methods",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\n  \"filter\": []\n}"
-        },
-        "savedSearchId": "Thrift-errors",
-        "title": "Top Thrift-RPC calls with errors",
-        "version": 1,
-        "visState": "{\n  \"type\": \"histogram\",\n  \"params\": {\n    \"shareYAxis\": true,\n    \"addTooltip\": true,\n    \"addLegend\": false,\n    \"mode\": \"stacked\",\n    \"defaultYExtents\": false\n  },\n  \"aggs\": [\n    {\n      \"id\": \"1\",\n      \"type\": \"count\",\n      \"schema\": \"metric\",\n      \"params\": {}\n    },\n    {\n      \"id\": \"2\",\n      \"type\": \"terms\",\n      \"schema\": \"segment\",\n      \"params\": {\n        \"field\": \"method\",\n        \"size\": 5,\n        \"order\": \"desc\",\n        \"orderBy\": \"1\"\n      }\n    }\n  ],\n  \"listeners\": {}\n}"
-      },
-      "id": "Top-Thrift-RPC-calls-with-errors",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "columns": [
-          "method",
-          "type",
-          "path",
-          "responsetime",
-          "status"
-        ],
-        "description": "",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"index\":\"packetbeat-*\",\"highlight\":{\"pre_tags\":[\"@kibana-highlighted-field@\"],\"post_tags\":[\"@/kibana-highlighted-field@\"],\"fields\":{\"*\":{}}},\"filter\":[{\"meta\":{\"index\":\"packetbeat-*\",\"negate\":false,\"key\":\"type\",\"value\":\"thrift\",\"disabled\":false},\"query\":{\"match\":{\"type\":{\"query\":\"thrift\",\"type\":\"phrase\"}}}}],\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"type: thrift\"}}}"
-        },
-        "sort": [
-          "@timestamp",
-          "desc"
-        ],
-        "title": "Thrift transactions",
-        "version": 1
-      },
-      "id": "Thrift-transactions",
-      "type": "search",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "columns": [
-          "method",
-          "type",
-          "path",
-          "responsetime",
-          "status"
-        ],
-        "description": "",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"index\":\"packetbeat-*\",\"highlight\":{\"pre_tags\":[\"@kibana-highlighted-field@\"],\"post_tags\":[\"@/kibana-highlighted-field@\"],\"fields\":{\"*\":{}}},\"filter\":[{\"meta\":{\"disabled\":false,\"index\":\"packetbeat-*\",\"key\":\"type\",\"negate\":false,\"value\":\"thrift\"},\"query\":{\"match\":{\"type\":{\"query\":\"thrift\",\"type\":\"phrase\"}}}},{\"meta\":{\"index\":\"packetbeat-*\",\"negate\":true,\"key\":\"status\",\"value\":\"OK\",\"disabled\":false},\"query\":{\"match\":{\"status\":{\"query\":\"OK\",\"type\":\"phrase\"}}}}],\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"type: thrift\"}}}"
-        },
-        "sort": [
-          "@timestamp",
-          "desc"
-        ],
-        "title": "Thrift errors",
-        "version": 1
-      },
-      "id": "Thrift-errors",
-      "type": "search",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[],\"query\":{\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}},\"language\":\"lucene\"},\"highlightAll\":true,\"version\":true}"
-        },
-        "optionsJSON": "{\"darkTheme\":false}",
-        "panelsJSON": "[{\"col\":1,\"id\":\"Navigation\",\"row\":1,\"size_x\":3,\"size_y\":4,\"type\":\"visualization\",\"panelIndex\":1},{\"col\":4,\"id\":\"Thrift-requests-per-minute\",\"row\":1,\"size_x\":5,\"size_y\":4,\"type\":\"visualization\",\"panelIndex\":2},{\"col\":9,\"id\":\"Thrift-RPC-Errors\",\"row\":1,\"size_x\":4,\"size_y\":4,\"type\":\"visualization\",\"panelIndex\":3},{\"col\":1,\"id\":\"Slowest-Thrift-RPC-methods\",\"row\":5,\"size_x\":6,\"size_y\":3,\"type\":\"visualization\",\"panelIndex\":4},{\"col\":7,\"id\":\"Thrift-response-times-percentiles\",\"row\":5,\"size_x\":6,\"size_y\":3,\"type\":\"visualization\",\"panelIndex\":5},{\"col\":1,\"id\":\"Top-Thrift-RPC-methods\",\"row\":8,\"size_x\":6,\"size_y\":4,\"type\":\"visualization\",\"panelIndex\":6},{\"col\":7,\"id\":\"Top-Thrift-RPC-calls-with-errors\",\"row\":8,\"size_x\":6,\"size_y\":4,\"type\":\"visualization\",\"panelIndex\":7}]",
-        "timeRestore": false,
-        "title": "[Packetbeat] Thrift performance",
-        "uiStateJSON": "{\"P-4\":{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}}}",
-        "version": 1
-      },
-      "id": "Packetbeat-Thrift-performance",
-      "type": "dashboard",
-      "version": 2
-    }
-  ],
-  "version": "6.0.0-beta1-SNAPSHOT"
+    "objects": [
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "analyze_wildcard": true, 
+                                    "query": "*"
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "title": "Navigation", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "fontSize": "10", 
+                        "markdown": "### Packetbeat:\n\n[Overview](#/dashboard/Packetbeat-Dashboard)\n\n[Flows](#/dashboard/Packetbeat-Flows)\n\n[Web transactions](#/dashboard/Packetbeat-HTTP)\n\n[MySQL performance](#/dashboard/Packetbeat-MySQL-performance)\n\n[PostgreSQL performance](#/dashboard/Packetbeat-PgSQL-performance)\n\n[MongoDB performance](#/dashboard/Packetbeat-MongoDB-performance)\n\n[Thrift-RPC performance](#/dashboard/Packetbeat-Thrift-performance)\n\n[NFS transactions](#/dashboard/Packetbeat-NFS)\n\n[Cassandra performance](#/dashboard/Packetbeat-Cassandra)"
+                    }, 
+                    "title": "Navigation", 
+                    "type": "markdown"
+                }
+            }, 
+            "id": "Navigation", 
+            "type": "visualization", 
+            "version": 10
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Thrift-transactions", 
+                "title": "Thrift requests per minute", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "m", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": false, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "defaultYExtents": false, 
+                        "mode": "stacked", 
+                        "scale": "linear", 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "times": [], 
+                        "yAxis": {}
+                    }, 
+                    "title": "Thrift requests per minute", 
+                    "type": "histogram"
+                }
+            }, 
+            "id": "Thrift-requests-per-minute", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Thrift-errors", 
+                "title": "Thrift RPC Errors", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": false, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "defaultYExtents": false, 
+                        "interpolate": "linear", 
+                        "mode": "stacked", 
+                        "scale": "linear", 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "smoothLines": false, 
+                        "times": [], 
+                        "yAxis": {}
+                    }, 
+                    "title": "Thrift RPC Errors", 
+                    "type": "area"
+                }
+            }, 
+            "id": "Thrift-RPC-Errors", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Thrift-transactions", 
+                "title": "Slowest Thrift RPC methods", 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "id": "1", 
+                            "params": {
+                                "field": "responsetime"
+                            }, 
+                            "schema": "metric", 
+                            "type": "avg"
+                        }, 
+                        {
+                            "id": "2", 
+                            "params": {
+                                "field": "method", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 10
+                            }, 
+                            "schema": "bucket", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "perPage": 10, 
+                        "showMeticsAtAllLevels": false, 
+                        "showPartialRows": false
+                    }, 
+                    "type": "table"
+                }
+            }, 
+            "id": "Slowest-Thrift-RPC-methods", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Thrift-transactions", 
+                "title": "Thrift response times percentiles", 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "id": "1", 
+                            "params": {
+                                "field": "responsetime", 
+                                "percents": [
+                                    75, 
+                                    99, 
+                                    99.5
+                                ]
+                            }, 
+                            "schema": "metric", 
+                            "type": "percentiles"
+                        }, 
+                        {
+                            "id": "2", 
+                            "params": {
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTooltip": true, 
+                        "defaultYExtents": false, 
+                        "shareYAxis": true
+                    }, 
+                    "type": "line"
+                }
+            }, 
+            "id": "Thrift-response-times-percentiles", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Thrift-transactions", 
+                "title": "Top Thrift-RPC methods", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "id": "2", 
+                            "params": {
+                                "field": "method", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": false, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "defaultYExtents": false, 
+                        "mode": "stacked", 
+                        "scale": "linear", 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "times": [], 
+                        "yAxis": {}
+                    }, 
+                    "title": "Top Thrift-RPC methods", 
+                    "type": "histogram"
+                }
+            }, 
+            "id": "Top-Thrift-RPC-methods", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": []
+                    }
+                }, 
+                "savedSearchId": "Thrift-errors", 
+                "title": "Top Thrift-RPC calls with errors", 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "id": "2", 
+                            "params": {
+                                "field": "method", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": false, 
+                        "addTooltip": true, 
+                        "defaultYExtents": false, 
+                        "mode": "stacked", 
+                        "shareYAxis": true
+                    }, 
+                    "type": "histogram"
+                }
+            }, 
+            "id": "Top-Thrift-RPC-calls-with-errors", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "columns": [
+                    "method", 
+                    "type", 
+                    "path", 
+                    "responsetime", 
+                    "status"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [
+                            {
+                                "meta": {
+                                    "disabled": false, 
+                                    "index": "packetbeat-*", 
+                                    "key": "type", 
+                                    "negate": false, 
+                                    "value": "thrift"
+                                }, 
+                                "query": {
+                                    "match": {
+                                        "type": {
+                                            "query": "thrift", 
+                                            "type": "phrase"
+                                        }
+                                    }
+                                }
+                            }
+                        ], 
+                        "highlight": {
+                            "fields": {
+                                "*": {}
+                            }, 
+                            "post_tags": [
+                                "@/kibana-highlighted-field@"
+                            ], 
+                            "pre_tags": [
+                                "@kibana-highlighted-field@"
+                            ]
+                        }, 
+                        "index": "packetbeat-*", 
+                        "query": {
+                            "query_string": {
+                                "analyze_wildcard": true, 
+                                "query": "type: thrift"
+                            }
+                        }
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "Thrift transactions", 
+                "version": 1
+            }, 
+            "id": "Thrift-transactions", 
+            "type": "search", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "columns": [
+                    "method", 
+                    "type", 
+                    "path", 
+                    "responsetime", 
+                    "status"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [
+                            {
+                                "meta": {
+                                    "disabled": false, 
+                                    "index": "packetbeat-*", 
+                                    "key": "type", 
+                                    "negate": false, 
+                                    "value": "thrift"
+                                }, 
+                                "query": {
+                                    "match": {
+                                        "type": {
+                                            "query": "thrift", 
+                                            "type": "phrase"
+                                        }
+                                    }
+                                }
+                            }, 
+                            {
+                                "meta": {
+                                    "disabled": false, 
+                                    "index": "packetbeat-*", 
+                                    "key": "status", 
+                                    "negate": true, 
+                                    "value": "OK"
+                                }, 
+                                "query": {
+                                    "match": {
+                                        "status": {
+                                            "query": "OK", 
+                                            "type": "phrase"
+                                        }
+                                    }
+                                }
+                            }
+                        ], 
+                        "highlight": {
+                            "fields": {
+                                "*": {}
+                            }, 
+                            "post_tags": [
+                                "@/kibana-highlighted-field@"
+                            ], 
+                            "pre_tags": [
+                                "@kibana-highlighted-field@"
+                            ]
+                        }, 
+                        "index": "packetbeat-*", 
+                        "query": {
+                            "query_string": {
+                                "analyze_wildcard": true, 
+                                "query": "type: thrift"
+                            }
+                        }
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "Thrift errors", 
+                "version": 1
+            }, 
+            "id": "Thrift-errors", 
+            "type": "search", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "analyze_wildcard": true, 
+                                    "query": "*"
+                                }
+                            }
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false
+                }, 
+                "panelsJSON": [
+                    {
+                        "col": 1, 
+                        "id": "Navigation", 
+                        "panelIndex": 1, 
+                        "row": 1, 
+                        "size_x": 3, 
+                        "size_y": 4, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 4, 
+                        "id": "Thrift-requests-per-minute", 
+                        "panelIndex": 2, 
+                        "row": 1, 
+                        "size_x": 5, 
+                        "size_y": 4, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 9, 
+                        "id": "Thrift-RPC-Errors", 
+                        "panelIndex": 3, 
+                        "row": 1, 
+                        "size_x": 4, 
+                        "size_y": 4, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "Slowest-Thrift-RPC-methods", 
+                        "panelIndex": 4, 
+                        "row": 5, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 7, 
+                        "id": "Thrift-response-times-percentiles", 
+                        "panelIndex": 5, 
+                        "row": 5, 
+                        "size_x": 6, 
+                        "size_y": 3, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "Top-Thrift-RPC-methods", 
+                        "panelIndex": 6, 
+                        "row": 8, 
+                        "size_x": 6, 
+                        "size_y": 4, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 7, 
+                        "id": "Top-Thrift-RPC-calls-with-errors", 
+                        "panelIndex": 7, 
+                        "row": 8, 
+                        "size_x": 6, 
+                        "size_y": 4, 
+                        "type": "visualization"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Packetbeat] Thrift performance", 
+                "uiStateJSON": {
+                    "P-4": {
+                        "vis": {
+                            "params": {
+                                "sort": {
+                                    "columnIndex": null, 
+                                    "direction": null
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "version": 1
+            }, 
+            "id": "Packetbeat-Thrift-performance", 
+            "type": "dashboard", 
+            "version": 2
+        }
+    ], 
+    "version": "6.0.0-beta1-SNAPSHOT"
 }

--- a/packetbeat/_meta/kibana/6/dashboard/Packetbeat-tls.json
+++ b/packetbeat/_meta/kibana/6/dashboard/Packetbeat-tls.json
@@ -1,374 +1,1629 @@
 {
-  "objects": [
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"query\":{\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}},\"language\":\"lucene\"},\"filter\":[]}"
-        },
-        "title": "Navigation",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Navigation\",\"type\":\"markdown\",\"params\":{\"markdown\":\"### Packetbeat:\\n\\n[Overview](#/dashboard/Packetbeat-Dashboard)\\n\\n[Flows](#/dashboard/Packetbeat-Flows)\\n\\n[Web transactions](#/dashboard/Packetbeat-HTTP)\\n\\n[MySQL performance](#/dashboard/Packetbeat-MySQL-performance)\\n\\n[PostgreSQL performance](#/dashboard/Packetbeat-PgSQL-performance)\\n\\n[MongoDB performance](#/dashboard/Packetbeat-MongoDB-performance)\\n\\n[Thrift-RPC performance](#/dashboard/Packetbeat-Thrift-performance)\\n\\n[NFS transactions](#/dashboard/Packetbeat-NFS)\\n\\n[Cassandra performance](#/dashboard/Packetbeat-Cassandra)\",\"fontSize\":\"10\"},\"aggs\":[]}"
-      },
-      "id": "Navigation",
-      "type": "visualization",
-      "updated_at": "2017-11-29T15:31:44.592Z",
-      "version": 10
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[],\"query\":{\"language\":\"lucene\",\"query\":\"\"}}"
-        },
-        "savedSearchId": "ffc3c0b0-d2d7-11e7-9914-4982455b3063",
-        "title": "TLS Sessions",
-        "uiStateJSON": "{\"vis\":{\"colors\":{\"false\":\"#E24D42\",\"true\":\"#7EB26D\"},\"legendOpen\":false}}",
-        "version": 1,
-        "visState": "{\"title\":\"TLS Sessions\",\"type\":\"histogram\",\"params\":{\"addLegend\":true,\"addTimeMarker\":false,\"addTooltip\":true,\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"labels\":{\"show\":true,\"truncate\":100},\"position\":\"bottom\",\"scale\":{\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{},\"type\":\"category\"}],\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"},\"valueAxis\":\"ValueAxis-1\"},\"legendPosition\":\"right\",\"seriesParams\":[{\"data\":{\"id\":\"1\",\"label\":\"Count\"},\"drawLinesBetweenPoints\":true,\"mode\":\"stacked\",\"show\":\"true\",\"showCircles\":true,\"type\":\"histogram\",\"valueAxis\":\"ValueAxis-1\"}],\"times\":[],\"type\":\"histogram\",\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"labels\":{\"filter\":false,\"rotate\":0,\"show\":true,\"truncate\":100},\"name\":\"LeftAxis-1\",\"position\":\"left\",\"scale\":{\"mode\":\"normal\",\"type\":\"linear\"},\"show\":true,\"style\":{},\"title\":{\"text\":\"Count\"},\"type\":\"value\"}]},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"auto\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{},\"customLabel\":\"Sessions per minute\"}},{\"id\":\"3\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"group\",\"params\":{\"field\":\"tls.handshake_completed\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\",\"json\":\"\",\"customLabel\":\"Handshake completed\"}}]}"
-      },
-      "id": "059fe5e0-d2dd-11e7-9914-4982455b3063",
-      "type": "visualization",
-      "updated_at": "2017-11-30T00:11:22.296Z",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"index\":\"packetbeat-*\",\"filter\":[{\"query\":{\"exists\":{\"field\":\"tls\"}},\"meta\":{\"index\":\"packetbeat-*\",\"disabled\":false,\"alias\":null,\"type\":\"custom\",\"key\":\"query\",\"value\":\"{\\\"exists\\\":{\\\"field\\\":\\\"tls\\\"}}\",\"negate\":false},\"$state\":{\"store\":\"appState\"}}],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
-        },
-        "title": "TLS Alerts",
-        "uiStateJSON": "{\"vis\":{\"colors\":{\"None\":\"#7EB26D\",\"handshake_failure\":\"#E24D42\"}}}",
-        "version": 1,
-        "visState": "{\"title\":\"TLS Alerts\",\"type\":\"pie\",\"params\":{\"type\":\"pie\",\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"isDonut\":true},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"tls.alert_types\",\"include\":\".*\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\",\"json\":\"{\\\"missing\\\": \\\"None\\\"}\"}}]}"
-      },
-      "id": "c14377a0-d353-11e7-9914-4982455b3063",
-      "type": "visualization",
-      "updated_at": "2017-11-29T15:31:44.592Z",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"index\":\"packetbeat-*\",\"filter\":[{\"meta\":{\"index\":\"packetbeat-*\",\"negate\":false,\"disabled\":false,\"alias\":null,\"type\":\"exists\",\"key\":\"tls.handshake_completed\",\"value\":\"exists\"},\"exists\":{\"field\":\"tls.handshake_completed\"},\"$state\":{\"store\":\"appState\"}}],\"query\":{\"language\":\"lucene\",\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}}}}"
-        },
-        "title": "Total Number of TLS Sessions",
-        "uiStateJSON": "{\"P-5\":{\"vis\":{\"defaultColors\":{\"0 - 100\":\"rgb(0,104,55)\"}}},\"P-7\":{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}}}",
-        "version": 1,
-        "visState": "{\"title\":\"Total Number of TLS Sessions\",\"type\":\"metric\",\"params\":{\"addTooltip\":true,\"addLegend\":false,\"type\":\"metric\",\"metric\":{\"percentageMode\":false,\"useRanges\":false,\"colorSchema\":\"Green to Red\",\"metricColorMode\":\"None\",\"colorsRange\":[{\"from\":0,\"to\":10000}],\"labels\":{\"show\":true},\"invertColors\":false,\"style\":{\"bgFill\":\"#000\",\"bgColor\":false,\"labelColor\":false,\"subText\":\"\",\"fontSize\":60}}},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}}]}"
-      },
-      "id": "061de380-d361-11e7-9914-4982455b3063",
-      "type": "visualization",
-      "updated_at": "2017-11-29T15:31:44.592Z",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[],\"query\":{\"language\":\"lucene\",\"query\":\"\"}}"
-        },
-        "savedSearchId": "94908e80-d2d8-11e7-9914-4982455b3063",
-        "title": "TLS Server Name Indication",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"TLS Server Name Indication\",\"type\":\"tagcloud\",\"params\":{\"maxFontSize\":64,\"minFontSize\":14,\"orientation\":\"single\",\"scale\":\"linear\",\"hideLabel\":false},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"tls.client_hello.extensions.server_name_indication\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"Server Name Indication\"}}]}"
-      },
-      "id": "a28d09d0-d361-11e7-9914-4982455b3063",
-      "type": "visualization",
-      "updated_at": "2017-11-29T15:31:44.592Z",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
-        },
-        "savedSearchId": "bf3d23b0-d37c-11e7-9914-4982455b3063",
-        "title": "TLS Versions",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"TLS Versions\",\"type\":\"pie\",\"params\":{\"type\":\"pie\",\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"isDonut\":true},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"tls.server_hello.version\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"TLS version\"}}]}"
-      },
-      "id": "0af0b790-d37d-11e7-9914-4982455b3063",
-      "type": "visualization",
-      "updated_at": "2017-11-29T15:31:44.592Z",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
-        },
-        "savedSearchId": "8f0ff590-d37d-11e7-9914-4982455b3063",
-        "title": "TLS Client Version",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"TLS Client Version\",\"type\":\"pie\",\"params\":{\"type\":\"pie\",\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"isDonut\":true},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"tls.client_hello.version\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"Client version\"}}]}"
-      },
-      "id": "ae6e33c0-d37d-11e7-9914-4982455b3063",
-      "type": "visualization",
-      "updated_at": "2017-11-29T15:31:44.592Z",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
-        },
-        "savedSearchId": "ffc3c0b0-d2d7-11e7-9914-4982455b3063",
-        "title": "TLS Session Resume",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"TLS Session Resume\",\"type\":\"pie\",\"params\":{\"type\":\"pie\",\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"isDonut\":true},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"tls.resumption_method\",\"exclude\":\"xxx-nope\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\",\"json\":\"{\\n\\\"missing\\\": \\\"none\\\"\\n}\"}}]}"
-      },
-      "id": "2c467370-d392-11e7-8fa0-232aa9259081",
-      "type": "visualization",
-      "updated_at": "2017-11-29T15:31:44.592Z",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
-        },
-        "savedSearchId": "ffc3c0b0-d2d7-11e7-9914-4982455b3063",
-        "title": "TLS Server Certificates",
-        "uiStateJSON": "{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}}",
-        "version": 1,
-        "visState": "{\"title\":\"TLS Server Certificates\",\"type\":\"table\",\"params\":{\"perPage\":10,\"showPartialRows\":false,\"showMeticsAtAllLevels\":false,\"sort\":{\"columnIndex\":null,\"direction\":null},\"showTotal\":false,\"totalFunc\":\"sum\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{\"customLabel\":\"\"}},{\"id\":\"4\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"tls.server_certificate.subject.common_name\",\"size\":10,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"Subject Common Name\"}},{\"id\":\"3\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"tls.server_certificate.subject.organization\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"Organization\"}}]}"
-      },
-      "id": "0958a910-d396-11e7-8fa0-232aa9259081",
-      "type": "visualization",
-      "updated_at": "2017-11-29T15:31:44.592Z",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
-        },
-        "savedSearchId": "ffc3c0b0-d2d7-11e7-9914-4982455b3063",
-        "title": "TLS Client Certificates",
-        "uiStateJSON": "{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}}",
-        "version": 1,
-        "visState": "{\"title\":\"TLS Client Certificates\",\"type\":\"table\",\"params\":{\"perPage\":10,\"showPartialRows\":false,\"showMeticsAtAllLevels\":false,\"sort\":{\"columnIndex\":null,\"direction\":null},\"showTotal\":false,\"totalFunc\":\"sum\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"tls.client_certificate.subject.common_name\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"Subject Common Name\"}},{\"id\":\"3\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"tls.client_certificate.signature_algorithm\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\",\"json\":\"{ \\\"missing\\\": \\\"N/A\\\" }\",\"customLabel\":\"Signature Algorithm\"}}]}"
-      },
-      "id": "86743f90-d396-11e7-8fa0-232aa9259081",
-      "type": "visualization",
-      "updated_at": "2017-11-29T15:31:44.592Z",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
-        },
-        "savedSearchId": "ffc3c0b0-d2d7-11e7-9914-4982455b3063",
-        "title": "TLS Cipher",
-        "uiStateJSON": "{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}}",
-        "version": 1,
-        "visState": "{\"title\":\"TLS Cipher\",\"type\":\"table\",\"params\":{\"perPage\":10,\"showPartialRows\":false,\"showMeticsAtAllLevels\":false,\"sort\":{\"columnIndex\":null,\"direction\":null},\"showTotal\":false,\"totalFunc\":\"sum\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"tls.server_hello.selected_cipher\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"Cipher\"}}]}"
-      },
-      "id": "463d2bf0-d3a8-11e7-9081-ab2af08e9961",
-      "type": "visualization",
-      "updated_at": "2017-11-29T15:31:44.592Z",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
-        },
-        "savedSearchId": "6b1b1360-d49d-11e7-996f-bd7c1ca4591b",
-        "title": "TLS Fingerprint",
-        "uiStateJSON": "{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}}",
-        "version": 1,
-        "visState": "{\"title\":\"TLS Fingerprint\",\"type\":\"table\",\"params\":{\"perPage\":10,\"showPartialRows\":false,\"showMeticsAtAllLevels\":false,\"sort\":{\"columnIndex\":null,\"direction\":null},\"showTotal\":false,\"totalFunc\":\"sum\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"tls.fingerprints.ja3.hash\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"JA3 Fingerprint\"}}]}"
-      },
-      "id": "ad2a8b50-d49d-11e7-996f-bd7c1ca4591b",
-      "type": "visualization",
-      "updated_at": "2017-11-29T15:31:44.592Z",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[{\"$state\":{\"store\":\"appState\"},\"meta\":{\"alias\":null,\"disabled\":false,\"index\":\"packetbeat-*\",\"key\":\"responsetime\",\"negate\":false,\"params\":{\"gte\":0,\"lt\":1000},\"type\":\"range\",\"value\":\"0 to 1,000\"},\"range\":{\"responsetime\":{\"gte\":0,\"lt\":1000}}}],\"query\":{\"language\":\"lucene\",\"query\":\"\"}}"
-        },
-        "savedSearchId": "8e2af860-d520-11e7-9fff-7b1ebf397ba9",
-        "title": "TLS handshake latency",
-        "uiStateJSON": "{\"vis\":{\"legendOpen\":false}}",
-        "version": 1,
-        "visState": "{\"title\":\"TLS handshake latency\",\"type\":\"area\",\"params\":{\"type\":\"area\",\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"type\":\"category\",\"position\":\"bottom\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\"},\"labels\":{\"show\":true,\"truncate\":100,\"filter\":true},\"title\":{}}],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"name\":\"LeftAxis-1\",\"type\":\"value\",\"position\":\"left\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\",\"mode\":\"normal\"},\"labels\":{\"show\":true,\"rotate\":0,\"filter\":false,\"truncate\":100},\"title\":{\"text\":\"Count\"}}],\"seriesParams\":[{\"show\":\"true\",\"type\":\"area\",\"mode\":\"stacked\",\"data\":{\"label\":\"Count\",\"id\":\"1\"},\"drawLinesBetweenPoints\":true,\"showCircles\":true,\"interpolate\":\"linear\",\"valueAxis\":\"ValueAxis-1\"}],\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"times\":[],\"addTimeMarker\":false},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"responsetime\",\"interval\":2,\"extended_bounds\":{},\"customLabel\":\"Handshake latency (milliseconds)\"}}]}"
-      },
-      "id": "d2e15950-d560-11e7-9fff-7b1ebf397ba9",
-      "type": "visualization",
-      "updated_at": "2017-11-30T00:10:49.715Z",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "columns": [
-          "_source"
-        ],
-        "description": "",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"index\":\"packetbeat-*\",\"highlightAll\":true,\"version\":true,\"query\":{\"language\":\"lucene\",\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}}},\"filter\":[{\"$state\":{\"store\":\"appState\"},\"exists\":{\"field\":\"tls.handshake_completed\"},\"meta\":{\"alias\":\"TLS sessions\",\"disabled\":false,\"index\":\"packetbeat-*\",\"key\":\"tls.handshake_completed\",\"negate\":false,\"type\":\"exists\",\"value\":\"exists\"}}]}"
-        },
-        "sort": [
-          "@timestamp",
-          "desc"
-        ],
-        "title": "TLS Sessions",
-        "version": 1
-      },
-      "id": "ffc3c0b0-d2d7-11e7-9914-4982455b3063",
-      "type": "search",
-      "updated_at": "2017-11-29T15:31:44.592Z",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "columns": [
-          "_source"
-        ],
-        "description": "",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"index\":\"packetbeat-*\",\"highlightAll\":true,\"version\":true,\"query\":{\"language\":\"lucene\",\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}}},\"filter\":[{\"meta\":{\"index\":\"packetbeat-*\",\"negate\":false,\"disabled\":false,\"alias\":null,\"type\":\"exists\",\"key\":\"tls.client_hello.extensions.server_name_indication\",\"value\":\"exists\"},\"exists\":{\"field\":\"tls.client_hello.extensions.server_name_indication\"},\"$state\":{\"store\":\"appState\"}}]}"
-        },
-        "sort": [
-          "@timestamp",
-          "desc"
-        ],
-        "title": "TLS Server Name Indication",
-        "version": 1
-      },
-      "id": "94908e80-d2d8-11e7-9914-4982455b3063",
-      "type": "search",
-      "updated_at": "2017-11-29T15:31:44.592Z",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "columns": [
-          "_source"
-        ],
-        "description": "",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"index\":\"packetbeat-*\",\"highlightAll\":true,\"version\":true,\"query\":{\"language\":\"lucene\",\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}}},\"filter\":[{\"meta\":{\"index\":\"packetbeat-*\",\"negate\":false,\"disabled\":false,\"alias\":null,\"type\":\"exists\",\"key\":\"tls.server_hello.version\",\"value\":\"exists\"},\"exists\":{\"field\":\"tls.server_hello.version\"},\"$state\":{\"store\":\"appState\"}}]}"
-        },
-        "sort": [
-          "@timestamp",
-          "desc"
-        ],
-        "title": "TLS Version",
-        "version": 1
-      },
-      "id": "bf3d23b0-d37c-11e7-9914-4982455b3063",
-      "type": "search",
-      "updated_at": "2017-11-29T15:31:44.592Z",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "columns": [
-          "_source"
-        ],
-        "description": "",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"index\":\"packetbeat-*\",\"highlightAll\":true,\"version\":true,\"query\":{\"language\":\"lucene\",\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}}},\"filter\":[{\"meta\":{\"index\":\"packetbeat-*\",\"negate\":false,\"disabled\":false,\"alias\":null,\"type\":\"exists\",\"key\":\"tls.client_hello.version\",\"value\":\"exists\"},\"exists\":{\"field\":\"tls.client_hello.version\"},\"$state\":{\"store\":\"appState\"}}]}"
-        },
-        "sort": [
-          "@timestamp",
-          "desc"
-        ],
-        "title": "TLS Client Version",
-        "version": 1
-      },
-      "id": "8f0ff590-d37d-11e7-9914-4982455b3063",
-      "type": "search",
-      "updated_at": "2017-11-29T15:31:44.592Z",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "columns": [
-          "_source"
-        ],
-        "description": "",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"index\":\"packetbeat-*\",\"highlightAll\":true,\"version\":true,\"query\":{\"query\":\"\",\"language\":\"lucene\"},\"filter\":[{\"meta\":{\"index\":\"packetbeat-*\",\"negate\":false,\"disabled\":false,\"alias\":null,\"type\":\"exists\",\"key\":\"tls.fingerprints.ja3.hash\",\"value\":\"exists\"},\"exists\":{\"field\":\"tls.fingerprints.ja3.hash\"},\"$state\":{\"store\":\"appState\"}}]}"
-        },
-        "sort": [
-          "@timestamp",
-          "desc"
-        ],
-        "title": "TLS Fingerprint",
-        "version": 1
-      },
-      "id": "6b1b1360-d49d-11e7-996f-bd7c1ca4591b",
-      "type": "search",
-      "updated_at": "2017-11-29T15:31:44.592Z",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "columns": [
-          "_source"
-        ],
-        "description": "",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"index\":\"packetbeat-*\",\"highlightAll\":true,\"version\":true,\"query\":{\"language\":\"lucene\",\"query\":\"\"},\"filter\":[{\"$state\":{\"store\":\"appState\"},\"exists\":{\"field\":\"tls.handshake_completed\"},\"meta\":{\"alias\":null,\"disabled\":false,\"index\":\"packetbeat-*\",\"key\":\"tls.handshake_completed\",\"negate\":false,\"type\":\"exists\",\"value\":\"exists\"}},{\"$state\":{\"store\":\"appState\"},\"exists\":{\"field\":\"responsetime\"},\"meta\":{\"alias\":null,\"disabled\":false,\"index\":\"packetbeat-*\",\"key\":\"responsetime\",\"negate\":false,\"type\":\"exists\",\"value\":\"exists\"}}]}"
-        },
-        "sort": [
-          "@timestamp",
-          "desc"
-        ],
-        "title": "TLS handshake latency",
-        "version": 1
-      },
-      "id": "8e2af860-d520-11e7-9fff-7b1ebf397ba9",
-      "type": "search",
-      "updated_at": "2017-11-29T16:33:23.311Z",
-      "version": 2
-    },
-    {
-      "attributes": {
-        "description": "TLS Sessions",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[],\"query\":{\"language\":\"lucene\",\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}}},\"highlightAll\":true,\"version\":true}"
-        },
-        "optionsJSON": "{\"darkTheme\":false,\"useMargins\":false}",
-        "panelsJSON": "[{\"panelIndex\":\"4\",\"gridData\":{\"x\":0,\"y\":0,\"w\":3,\"h\":4,\"i\":\"4\"},\"id\":\"Navigation\",\"type\":\"visualization\",\"version\":\"6.2.4\"},{\"panelIndex\":\"8\",\"gridData\":{\"x\":3,\"y\":0,\"w\":9,\"h\":4,\"i\":\"8\"},\"id\":\"059fe5e0-d2dd-11e7-9914-4982455b3063\",\"type\":\"visualization\",\"version\":\"6.2.4\"},{\"panelIndex\":\"9\",\"gridData\":{\"x\":3,\"y\":7,\"w\":3,\"h\":3,\"i\":\"9\"},\"id\":\"c14377a0-d353-11e7-9914-4982455b3063\",\"type\":\"visualization\",\"version\":\"6.2.4\"},{\"panelIndex\":\"10\",\"gridData\":{\"x\":0,\"y\":4,\"w\":3,\"h\":3,\"i\":\"10\"},\"id\":\"061de380-d361-11e7-9914-4982455b3063\",\"type\":\"visualization\",\"version\":\"6.2.4\"},{\"panelIndex\":\"11\",\"gridData\":{\"x\":0,\"y\":10,\"w\":12,\"h\":3,\"i\":\"11\"},\"id\":\"a28d09d0-d361-11e7-9914-4982455b3063\",\"type\":\"visualization\",\"version\":\"6.2.4\"},{\"panelIndex\":\"12\",\"gridData\":{\"x\":6,\"y\":7,\"w\":3,\"h\":3,\"i\":\"12\"},\"id\":\"0af0b790-d37d-11e7-9914-4982455b3063\",\"type\":\"visualization\",\"version\":\"6.2.4\"},{\"panelIndex\":\"13\",\"gridData\":{\"x\":9,\"y\":7,\"w\":3,\"h\":3,\"i\":\"13\"},\"id\":\"ae6e33c0-d37d-11e7-9914-4982455b3063\",\"type\":\"visualization\",\"version\":\"6.2.4\"},{\"panelIndex\":\"14\",\"gridData\":{\"x\":0,\"y\":7,\"w\":3,\"h\":3,\"i\":\"14\"},\"id\":\"2c467370-d392-11e7-8fa0-232aa9259081\",\"type\":\"visualization\",\"version\":\"6.2.4\"},{\"panelIndex\":\"15\",\"gridData\":{\"x\":0,\"y\":13,\"w\":6,\"h\":3,\"i\":\"15\"},\"id\":\"0958a910-d396-11e7-8fa0-232aa9259081\",\"type\":\"visualization\",\"version\":\"6.2.4\"},{\"panelIndex\":\"16\",\"gridData\":{\"x\":0,\"y\":16,\"w\":6,\"h\":3,\"i\":\"16\"},\"id\":\"86743f90-d396-11e7-8fa0-232aa9259081\",\"type\":\"visualization\",\"version\":\"6.2.4\"},{\"panelIndex\":\"17\",\"gridData\":{\"x\":6,\"y\":13,\"w\":6,\"h\":3,\"i\":\"17\"},\"id\":\"463d2bf0-d3a8-11e7-9081-ab2af08e9961\",\"type\":\"visualization\",\"version\":\"6.2.4\"},{\"panelIndex\":\"18\",\"gridData\":{\"x\":6,\"y\":16,\"w\":6,\"h\":3,\"i\":\"18\"},\"id\":\"ad2a8b50-d49d-11e7-996f-bd7c1ca4591b\",\"type\":\"visualization\",\"version\":\"6.2.4\"},{\"panelIndex\":\"19\",\"gridData\":{\"x\":3,\"y\":4,\"w\":9,\"h\":3,\"i\":\"19\"},\"version\":\"6.2.4\",\"type\":\"visualization\",\"id\":\"d2e15950-d560-11e7-9fff-7b1ebf397ba9\"}]",
-        "timeRestore": false,
-        "title": "[Packetbeat] TLS Sessions",
-        "uiStateJSON": "{\"P-15\":{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}},\"P-16\":{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}},\"P-17\":{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}},\"P-18\":{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}},\"P-5\":{\"vis\":{\"defaultColors\":{\"0 - 100\":\"rgb(0,104,55)\"}}},\"P-7\":{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}}}",
-        "version": 1
-      },
-      "id": "tls-sessions",
-      "type": "dashboard",
-      "updated_at": "2017-11-30T00:16:42.402Z",
-      "version": 2
-    }
-  ],
-  "version": "6.2.4"
+    "objects": [
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "analyze_wildcard": true, 
+                                    "query": "*"
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "title": "Navigation", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [], 
+                    "params": {
+                        "fontSize": "10", 
+                        "markdown": "### Packetbeat:\n\n[Overview](#/dashboard/Packetbeat-Dashboard)\n\n[Flows](#/dashboard/Packetbeat-Flows)\n\n[Web transactions](#/dashboard/Packetbeat-HTTP)\n\n[MySQL performance](#/dashboard/Packetbeat-MySQL-performance)\n\n[PostgreSQL performance](#/dashboard/Packetbeat-PgSQL-performance)\n\n[MongoDB performance](#/dashboard/Packetbeat-MongoDB-performance)\n\n[Thrift-RPC performance](#/dashboard/Packetbeat-Thrift-performance)\n\n[NFS transactions](#/dashboard/Packetbeat-NFS)\n\n[Cassandra performance](#/dashboard/Packetbeat-Cassandra)"
+                    }, 
+                    "title": "Navigation", 
+                    "type": "markdown"
+                }
+            }, 
+            "id": "Navigation", 
+            "type": "visualization", 
+            "updated_at": "2017-11-29T15:31:44.592Z", 
+            "version": 10
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "lucene", 
+                            "query": ""
+                        }
+                    }
+                }, 
+                "savedSearchId": "ffc3c0b0-d2d7-11e7-9914-4982455b3063", 
+                "title": "TLS Sessions", 
+                "uiStateJSON": {
+                    "vis": {
+                        "colors": {
+                            "false": "#E24D42", 
+                            "true": "#7EB26D"
+                        }, 
+                        "legendOpen": false
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "customLabel": "Sessions per minute", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "customLabel": "Handshake completed", 
+                                "field": "tls.handshake_completed", 
+                                "json": "", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "group", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "categoryAxes": [
+                            {
+                                "id": "CategoryAxis-1", 
+                                "labels": {
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "position": "bottom", 
+                                "scale": {
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {}, 
+                                "type": "category"
+                            }
+                        ], 
+                        "grid": {
+                            "categoryLines": false, 
+                            "style": {
+                                "color": "#eee"
+                            }, 
+                            "valueAxis": "ValueAxis-1"
+                        }, 
+                        "legendPosition": "right", 
+                        "seriesParams": [
+                            {
+                                "data": {
+                                    "id": "1", 
+                                    "label": "Count"
+                                }, 
+                                "drawLinesBetweenPoints": true, 
+                                "mode": "stacked", 
+                                "show": "true", 
+                                "showCircles": true, 
+                                "type": "histogram", 
+                                "valueAxis": "ValueAxis-1"
+                            }
+                        ], 
+                        "times": [], 
+                        "type": "histogram", 
+                        "valueAxes": [
+                            {
+                                "id": "ValueAxis-1", 
+                                "labels": {
+                                    "filter": false, 
+                                    "rotate": 0, 
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "name": "LeftAxis-1", 
+                                "position": "left", 
+                                "scale": {
+                                    "mode": "normal", 
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {
+                                    "text": "Count"
+                                }, 
+                                "type": "value"
+                            }
+                        ]
+                    }, 
+                    "title": "TLS Sessions", 
+                    "type": "histogram"
+                }
+            }, 
+            "id": "059fe5e0-d2dd-11e7-9914-4982455b3063", 
+            "type": "visualization", 
+            "updated_at": "2017-11-30T00:11:22.296Z", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                }, 
+                                "meta": {
+                                    "alias": null, 
+                                    "disabled": false, 
+                                    "index": "packetbeat-*", 
+                                    "key": "query", 
+                                    "negate": false, 
+                                    "type": "custom", 
+                                    "value": "{\"exists\":{\"field\":\"tls\"}}"
+                                }, 
+                                "query": {
+                                    "exists": {
+                                        "field": "tls"
+                                    }
+                                }
+                            }
+                        ], 
+                        "index": "packetbeat-*", 
+                        "query": {
+                            "language": "lucene", 
+                            "query": ""
+                        }
+                    }
+                }, 
+                "title": "TLS Alerts", 
+                "uiStateJSON": {
+                    "vis": {
+                        "colors": {
+                            "None": "#7EB26D", 
+                            "handshake_failure": "#E24D42"
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "field": "tls.alert_types", 
+                                "include": ".*", 
+                                "json": "{\"missing\": \"None\"}", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "params": {
+                        "addLegend": true, 
+                        "addTooltip": true, 
+                        "isDonut": true, 
+                        "legendPosition": "right", 
+                        "type": "pie"
+                    }, 
+                    "title": "TLS Alerts", 
+                    "type": "pie"
+                }
+            }, 
+            "id": "c14377a0-d353-11e7-9914-4982455b3063", 
+            "type": "visualization", 
+            "updated_at": "2017-11-29T15:31:44.592Z", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                }, 
+                                "exists": {
+                                    "field": "tls.handshake_completed"
+                                }, 
+                                "meta": {
+                                    "alias": null, 
+                                    "disabled": false, 
+                                    "index": "packetbeat-*", 
+                                    "key": "tls.handshake_completed", 
+                                    "negate": false, 
+                                    "type": "exists", 
+                                    "value": "exists"
+                                }
+                            }
+                        ], 
+                        "index": "packetbeat-*", 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "analyze_wildcard": true, 
+                                    "query": "*"
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "title": "Total Number of TLS Sessions", 
+                "uiStateJSON": {
+                    "P-5": {
+                        "vis": {
+                            "defaultColors": {
+                                "0 - 100": "rgb(0,104,55)"
+                            }
+                        }
+                    }, 
+                    "P-7": {
+                        "vis": {
+                            "params": {
+                                "sort": {
+                                    "columnIndex": null, 
+                                    "direction": null
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }
+                    ], 
+                    "params": {
+                        "addLegend": false, 
+                        "addTooltip": true, 
+                        "metric": {
+                            "colorSchema": "Green to Red", 
+                            "colorsRange": [
+                                {
+                                    "from": 0, 
+                                    "to": 10000
+                                }
+                            ], 
+                            "invertColors": false, 
+                            "labels": {
+                                "show": true
+                            }, 
+                            "metricColorMode": "None", 
+                            "percentageMode": false, 
+                            "style": {
+                                "bgColor": false, 
+                                "bgFill": "#000", 
+                                "fontSize": 60, 
+                                "labelColor": false, 
+                                "subText": ""
+                            }, 
+                            "useRanges": false
+                        }, 
+                        "type": "metric"
+                    }, 
+                    "title": "Total Number of TLS Sessions", 
+                    "type": "metric"
+                }
+            }, 
+            "id": "061de380-d361-11e7-9914-4982455b3063", 
+            "type": "visualization", 
+            "updated_at": "2017-11-29T15:31:44.592Z", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "lucene", 
+                            "query": ""
+                        }
+                    }
+                }, 
+                "savedSearchId": "94908e80-d2d8-11e7-9914-4982455b3063", 
+                "title": "TLS Server Name Indication", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customLabel": "Server Name Indication", 
+                                "field": "tls.client_hello.extensions.server_name_indication", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "params": {
+                        "hideLabel": false, 
+                        "maxFontSize": 64, 
+                        "minFontSize": 14, 
+                        "orientation": "single", 
+                        "scale": "linear"
+                    }, 
+                    "title": "TLS Server Name Indication", 
+                    "type": "tagcloud"
+                }
+            }, 
+            "id": "a28d09d0-d361-11e7-9914-4982455b3063", 
+            "type": "visualization", 
+            "updated_at": "2017-11-29T15:31:44.592Z", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "lucene", 
+                            "query": ""
+                        }
+                    }
+                }, 
+                "savedSearchId": "bf3d23b0-d37c-11e7-9914-4982455b3063", 
+                "title": "TLS Versions", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customLabel": "TLS version", 
+                                "field": "tls.server_hello.version", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "params": {
+                        "addLegend": true, 
+                        "addTooltip": true, 
+                        "isDonut": true, 
+                        "legendPosition": "right", 
+                        "type": "pie"
+                    }, 
+                    "title": "TLS Versions", 
+                    "type": "pie"
+                }
+            }, 
+            "id": "0af0b790-d37d-11e7-9914-4982455b3063", 
+            "type": "visualization", 
+            "updated_at": "2017-11-29T15:31:44.592Z", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "lucene", 
+                            "query": ""
+                        }
+                    }
+                }, 
+                "savedSearchId": "8f0ff590-d37d-11e7-9914-4982455b3063", 
+                "title": "TLS Client Version", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customLabel": "Client version", 
+                                "field": "tls.client_hello.version", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "params": {
+                        "addLegend": true, 
+                        "addTooltip": true, 
+                        "isDonut": true, 
+                        "legendPosition": "right", 
+                        "type": "pie"
+                    }, 
+                    "title": "TLS Client Version", 
+                    "type": "pie"
+                }
+            }, 
+            "id": "ae6e33c0-d37d-11e7-9914-4982455b3063", 
+            "type": "visualization", 
+            "updated_at": "2017-11-29T15:31:44.592Z", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "lucene", 
+                            "query": ""
+                        }
+                    }
+                }, 
+                "savedSearchId": "ffc3c0b0-d2d7-11e7-9914-4982455b3063", 
+                "title": "TLS Session Resume", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "exclude": "xxx-nope", 
+                                "field": "tls.resumption_method", 
+                                "json": "{\n\"missing\": \"none\"\n}", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "params": {
+                        "addLegend": true, 
+                        "addTooltip": true, 
+                        "isDonut": true, 
+                        "legendPosition": "right", 
+                        "type": "pie"
+                    }, 
+                    "title": "TLS Session Resume", 
+                    "type": "pie"
+                }
+            }, 
+            "id": "2c467370-d392-11e7-8fa0-232aa9259081", 
+            "type": "visualization", 
+            "updated_at": "2017-11-29T15:31:44.592Z", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "lucene", 
+                            "query": ""
+                        }
+                    }
+                }, 
+                "savedSearchId": "ffc3c0b0-d2d7-11e7-9914-4982455b3063", 
+                "title": "TLS Server Certificates", 
+                "uiStateJSON": {
+                    "vis": {
+                        "params": {
+                            "sort": {
+                                "columnIndex": null, 
+                                "direction": null
+                            }
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {
+                                "customLabel": ""
+                            }, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "4", 
+                            "params": {
+                                "customLabel": "Subject Common Name", 
+                                "field": "tls.server_certificate.subject.common_name", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 10
+                            }, 
+                            "schema": "bucket", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "customLabel": "Organization", 
+                                "field": "tls.server_certificate.subject.organization", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "bucket", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "params": {
+                        "perPage": 10, 
+                        "showMeticsAtAllLevels": false, 
+                        "showPartialRows": false, 
+                        "showTotal": false, 
+                        "sort": {
+                            "columnIndex": null, 
+                            "direction": null
+                        }, 
+                        "totalFunc": "sum"
+                    }, 
+                    "title": "TLS Server Certificates", 
+                    "type": "table"
+                }
+            }, 
+            "id": "0958a910-d396-11e7-8fa0-232aa9259081", 
+            "type": "visualization", 
+            "updated_at": "2017-11-29T15:31:44.592Z", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "lucene", 
+                            "query": ""
+                        }
+                    }
+                }, 
+                "savedSearchId": "ffc3c0b0-d2d7-11e7-9914-4982455b3063", 
+                "title": "TLS Client Certificates", 
+                "uiStateJSON": {
+                    "vis": {
+                        "params": {
+                            "sort": {
+                                "columnIndex": null, 
+                                "direction": null
+                            }
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customLabel": "Subject Common Name", 
+                                "field": "tls.client_certificate.subject.common_name", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "bucket", 
+                            "type": "terms"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "3", 
+                            "params": {
+                                "customLabel": "Signature Algorithm", 
+                                "field": "tls.client_certificate.signature_algorithm", 
+                                "json": "{ \"missing\": \"N/A\" }", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "bucket", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "params": {
+                        "perPage": 10, 
+                        "showMeticsAtAllLevels": false, 
+                        "showPartialRows": false, 
+                        "showTotal": false, 
+                        "sort": {
+                            "columnIndex": null, 
+                            "direction": null
+                        }, 
+                        "totalFunc": "sum"
+                    }, 
+                    "title": "TLS Client Certificates", 
+                    "type": "table"
+                }
+            }, 
+            "id": "86743f90-d396-11e7-8fa0-232aa9259081", 
+            "type": "visualization", 
+            "updated_at": "2017-11-29T15:31:44.592Z", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "lucene", 
+                            "query": ""
+                        }
+                    }
+                }, 
+                "savedSearchId": "ffc3c0b0-d2d7-11e7-9914-4982455b3063", 
+                "title": "TLS Cipher", 
+                "uiStateJSON": {
+                    "vis": {
+                        "params": {
+                            "sort": {
+                                "columnIndex": null, 
+                                "direction": null
+                            }
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customLabel": "Cipher", 
+                                "field": "tls.server_hello.selected_cipher", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "bucket", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "params": {
+                        "perPage": 10, 
+                        "showMeticsAtAllLevels": false, 
+                        "showPartialRows": false, 
+                        "showTotal": false, 
+                        "sort": {
+                            "columnIndex": null, 
+                            "direction": null
+                        }, 
+                        "totalFunc": "sum"
+                    }, 
+                    "title": "TLS Cipher", 
+                    "type": "table"
+                }
+            }, 
+            "id": "463d2bf0-d3a8-11e7-9081-ab2af08e9961", 
+            "type": "visualization", 
+            "updated_at": "2017-11-29T15:31:44.592Z", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "query": {
+                            "language": "lucene", 
+                            "query": ""
+                        }
+                    }
+                }, 
+                "savedSearchId": "6b1b1360-d49d-11e7-996f-bd7c1ca4591b", 
+                "title": "TLS Fingerprint", 
+                "uiStateJSON": {
+                    "vis": {
+                        "params": {
+                            "sort": {
+                                "columnIndex": null, 
+                                "direction": null
+                            }
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customLabel": "JA3 Fingerprint", 
+                                "field": "tls.fingerprints.ja3.hash", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "bucket", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "params": {
+                        "perPage": 10, 
+                        "showMeticsAtAllLevels": false, 
+                        "showPartialRows": false, 
+                        "showTotal": false, 
+                        "sort": {
+                            "columnIndex": null, 
+                            "direction": null
+                        }, 
+                        "totalFunc": "sum"
+                    }, 
+                    "title": "TLS Fingerprint", 
+                    "type": "table"
+                }
+            }, 
+            "id": "ad2a8b50-d49d-11e7-996f-bd7c1ca4591b", 
+            "type": "visualization", 
+            "updated_at": "2017-11-29T15:31:44.592Z", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                }, 
+                                "meta": {
+                                    "alias": null, 
+                                    "disabled": false, 
+                                    "index": "packetbeat-*", 
+                                    "key": "responsetime", 
+                                    "negate": false, 
+                                    "params": {
+                                        "gte": 0, 
+                                        "lt": 1000
+                                    }, 
+                                    "type": "range", 
+                                    "value": "0 to 1,000"
+                                }, 
+                                "range": {
+                                    "responsetime": {
+                                        "gte": 0, 
+                                        "lt": 1000
+                                    }
+                                }
+                            }
+                        ], 
+                        "query": {
+                            "language": "lucene", 
+                            "query": ""
+                        }
+                    }
+                }, 
+                "savedSearchId": "8e2af860-d520-11e7-9fff-7b1ebf397ba9", 
+                "title": "TLS handshake latency", 
+                "uiStateJSON": {
+                    "vis": {
+                        "legendOpen": false
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "customLabel": "Handshake latency (milliseconds)", 
+                                "extended_bounds": {}, 
+                                "field": "responsetime", 
+                                "interval": 2
+                            }, 
+                            "schema": "segment", 
+                            "type": "histogram"
+                        }
+                    ], 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "categoryAxes": [
+                            {
+                                "id": "CategoryAxis-1", 
+                                "labels": {
+                                    "filter": true, 
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "position": "bottom", 
+                                "scale": {
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {}, 
+                                "type": "category"
+                            }
+                        ], 
+                        "grid": {
+                            "categoryLines": false, 
+                            "style": {
+                                "color": "#eee"
+                            }
+                        }, 
+                        "legendPosition": "right", 
+                        "seriesParams": [
+                            {
+                                "data": {
+                                    "id": "1", 
+                                    "label": "Count"
+                                }, 
+                                "drawLinesBetweenPoints": true, 
+                                "interpolate": "linear", 
+                                "mode": "stacked", 
+                                "show": "true", 
+                                "showCircles": true, 
+                                "type": "area", 
+                                "valueAxis": "ValueAxis-1"
+                            }
+                        ], 
+                        "times": [], 
+                        "type": "area", 
+                        "valueAxes": [
+                            {
+                                "id": "ValueAxis-1", 
+                                "labels": {
+                                    "filter": false, 
+                                    "rotate": 0, 
+                                    "show": true, 
+                                    "truncate": 100
+                                }, 
+                                "name": "LeftAxis-1", 
+                                "position": "left", 
+                                "scale": {
+                                    "mode": "normal", 
+                                    "type": "linear"
+                                }, 
+                                "show": true, 
+                                "style": {}, 
+                                "title": {
+                                    "text": "Count"
+                                }, 
+                                "type": "value"
+                            }
+                        ]
+                    }, 
+                    "title": "TLS handshake latency", 
+                    "type": "area"
+                }
+            }, 
+            "id": "d2e15950-d560-11e7-9fff-7b1ebf397ba9", 
+            "type": "visualization", 
+            "updated_at": "2017-11-30T00:10:49.715Z", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "columns": [
+                    "_source"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                }, 
+                                "exists": {
+                                    "field": "tls.handshake_completed"
+                                }, 
+                                "meta": {
+                                    "alias": "TLS sessions", 
+                                    "disabled": false, 
+                                    "index": "packetbeat-*", 
+                                    "key": "tls.handshake_completed", 
+                                    "negate": false, 
+                                    "type": "exists", 
+                                    "value": "exists"
+                                }
+                            }
+                        ], 
+                        "highlightAll": true, 
+                        "index": "packetbeat-*", 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "analyze_wildcard": true, 
+                                    "query": "*"
+                                }
+                            }
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "TLS Sessions", 
+                "version": 1
+            }, 
+            "id": "ffc3c0b0-d2d7-11e7-9914-4982455b3063", 
+            "type": "search", 
+            "updated_at": "2017-11-29T15:31:44.592Z", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "columns": [
+                    "_source"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                }, 
+                                "exists": {
+                                    "field": "tls.client_hello.extensions.server_name_indication"
+                                }, 
+                                "meta": {
+                                    "alias": null, 
+                                    "disabled": false, 
+                                    "index": "packetbeat-*", 
+                                    "key": "tls.client_hello.extensions.server_name_indication", 
+                                    "negate": false, 
+                                    "type": "exists", 
+                                    "value": "exists"
+                                }
+                            }
+                        ], 
+                        "highlightAll": true, 
+                        "index": "packetbeat-*", 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "analyze_wildcard": true, 
+                                    "query": "*"
+                                }
+                            }
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "TLS Server Name Indication", 
+                "version": 1
+            }, 
+            "id": "94908e80-d2d8-11e7-9914-4982455b3063", 
+            "type": "search", 
+            "updated_at": "2017-11-29T15:31:44.592Z", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "columns": [
+                    "_source"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                }, 
+                                "exists": {
+                                    "field": "tls.server_hello.version"
+                                }, 
+                                "meta": {
+                                    "alias": null, 
+                                    "disabled": false, 
+                                    "index": "packetbeat-*", 
+                                    "key": "tls.server_hello.version", 
+                                    "negate": false, 
+                                    "type": "exists", 
+                                    "value": "exists"
+                                }
+                            }
+                        ], 
+                        "highlightAll": true, 
+                        "index": "packetbeat-*", 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "analyze_wildcard": true, 
+                                    "query": "*"
+                                }
+                            }
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "TLS Version", 
+                "version": 1
+            }, 
+            "id": "bf3d23b0-d37c-11e7-9914-4982455b3063", 
+            "type": "search", 
+            "updated_at": "2017-11-29T15:31:44.592Z", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "columns": [
+                    "_source"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                }, 
+                                "exists": {
+                                    "field": "tls.client_hello.version"
+                                }, 
+                                "meta": {
+                                    "alias": null, 
+                                    "disabled": false, 
+                                    "index": "packetbeat-*", 
+                                    "key": "tls.client_hello.version", 
+                                    "negate": false, 
+                                    "type": "exists", 
+                                    "value": "exists"
+                                }
+                            }
+                        ], 
+                        "highlightAll": true, 
+                        "index": "packetbeat-*", 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "analyze_wildcard": true, 
+                                    "query": "*"
+                                }
+                            }
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "TLS Client Version", 
+                "version": 1
+            }, 
+            "id": "8f0ff590-d37d-11e7-9914-4982455b3063", 
+            "type": "search", 
+            "updated_at": "2017-11-29T15:31:44.592Z", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "columns": [
+                    "_source"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                }, 
+                                "exists": {
+                                    "field": "tls.fingerprints.ja3.hash"
+                                }, 
+                                "meta": {
+                                    "alias": null, 
+                                    "disabled": false, 
+                                    "index": "packetbeat-*", 
+                                    "key": "tls.fingerprints.ja3.hash", 
+                                    "negate": false, 
+                                    "type": "exists", 
+                                    "value": "exists"
+                                }
+                            }
+                        ], 
+                        "highlightAll": true, 
+                        "index": "packetbeat-*", 
+                        "query": {
+                            "language": "lucene", 
+                            "query": ""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "TLS Fingerprint", 
+                "version": 1
+            }, 
+            "id": "6b1b1360-d49d-11e7-996f-bd7c1ca4591b", 
+            "type": "search", 
+            "updated_at": "2017-11-29T15:31:44.592Z", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "columns": [
+                    "_source"
+                ], 
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                }, 
+                                "exists": {
+                                    "field": "tls.handshake_completed"
+                                }, 
+                                "meta": {
+                                    "alias": null, 
+                                    "disabled": false, 
+                                    "index": "packetbeat-*", 
+                                    "key": "tls.handshake_completed", 
+                                    "negate": false, 
+                                    "type": "exists", 
+                                    "value": "exists"
+                                }
+                            }, 
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                }, 
+                                "exists": {
+                                    "field": "responsetime"
+                                }, 
+                                "meta": {
+                                    "alias": null, 
+                                    "disabled": false, 
+                                    "index": "packetbeat-*", 
+                                    "key": "responsetime", 
+                                    "negate": false, 
+                                    "type": "exists", 
+                                    "value": "exists"
+                                }
+                            }
+                        ], 
+                        "highlightAll": true, 
+                        "index": "packetbeat-*", 
+                        "query": {
+                            "language": "lucene", 
+                            "query": ""
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "sort": [
+                    "@timestamp", 
+                    "desc"
+                ], 
+                "title": "TLS handshake latency", 
+                "version": 1
+            }, 
+            "id": "8e2af860-d520-11e7-9fff-7b1ebf397ba9", 
+            "type": "search", 
+            "updated_at": "2017-11-29T16:33:23.311Z", 
+            "version": 2
+        }, 
+        {
+            "attributes": {
+                "description": "TLS Sessions", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "highlightAll": true, 
+                        "query": {
+                            "language": "lucene", 
+                            "query": {
+                                "query_string": {
+                                    "analyze_wildcard": true, 
+                                    "query": "*"
+                                }
+                            }
+                        }, 
+                        "version": true
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false, 
+                    "useMargins": false
+                }, 
+                "panelsJSON": [
+                    {
+                        "gridData": {
+                            "h": 4, 
+                            "i": "4", 
+                            "w": 3, 
+                            "x": 0, 
+                            "y": 0
+                        }, 
+                        "id": "Navigation", 
+                        "panelIndex": "4", 
+                        "type": "visualization", 
+                        "version": "6.2.4"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 4, 
+                            "i": "8", 
+                            "w": 9, 
+                            "x": 3, 
+                            "y": 0
+                        }, 
+                        "id": "059fe5e0-d2dd-11e7-9914-4982455b3063", 
+                        "panelIndex": "8", 
+                        "type": "visualization", 
+                        "version": "6.2.4"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "9", 
+                            "w": 3, 
+                            "x": 3, 
+                            "y": 7
+                        }, 
+                        "id": "c14377a0-d353-11e7-9914-4982455b3063", 
+                        "panelIndex": "9", 
+                        "type": "visualization", 
+                        "version": "6.2.4"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "10", 
+                            "w": 3, 
+                            "x": 0, 
+                            "y": 4
+                        }, 
+                        "id": "061de380-d361-11e7-9914-4982455b3063", 
+                        "panelIndex": "10", 
+                        "type": "visualization", 
+                        "version": "6.2.4"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "11", 
+                            "w": 12, 
+                            "x": 0, 
+                            "y": 10
+                        }, 
+                        "id": "a28d09d0-d361-11e7-9914-4982455b3063", 
+                        "panelIndex": "11", 
+                        "type": "visualization", 
+                        "version": "6.2.4"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "12", 
+                            "w": 3, 
+                            "x": 6, 
+                            "y": 7
+                        }, 
+                        "id": "0af0b790-d37d-11e7-9914-4982455b3063", 
+                        "panelIndex": "12", 
+                        "type": "visualization", 
+                        "version": "6.2.4"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "13", 
+                            "w": 3, 
+                            "x": 9, 
+                            "y": 7
+                        }, 
+                        "id": "ae6e33c0-d37d-11e7-9914-4982455b3063", 
+                        "panelIndex": "13", 
+                        "type": "visualization", 
+                        "version": "6.2.4"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "14", 
+                            "w": 3, 
+                            "x": 0, 
+                            "y": 7
+                        }, 
+                        "id": "2c467370-d392-11e7-8fa0-232aa9259081", 
+                        "panelIndex": "14", 
+                        "type": "visualization", 
+                        "version": "6.2.4"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "15", 
+                            "w": 6, 
+                            "x": 0, 
+                            "y": 13
+                        }, 
+                        "id": "0958a910-d396-11e7-8fa0-232aa9259081", 
+                        "panelIndex": "15", 
+                        "type": "visualization", 
+                        "version": "6.2.4"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "16", 
+                            "w": 6, 
+                            "x": 0, 
+                            "y": 16
+                        }, 
+                        "id": "86743f90-d396-11e7-8fa0-232aa9259081", 
+                        "panelIndex": "16", 
+                        "type": "visualization", 
+                        "version": "6.2.4"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "17", 
+                            "w": 6, 
+                            "x": 6, 
+                            "y": 13
+                        }, 
+                        "id": "463d2bf0-d3a8-11e7-9081-ab2af08e9961", 
+                        "panelIndex": "17", 
+                        "type": "visualization", 
+                        "version": "6.2.4"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "18", 
+                            "w": 6, 
+                            "x": 6, 
+                            "y": 16
+                        }, 
+                        "id": "ad2a8b50-d49d-11e7-996f-bd7c1ca4591b", 
+                        "panelIndex": "18", 
+                        "type": "visualization", 
+                        "version": "6.2.4"
+                    }, 
+                    {
+                        "gridData": {
+                            "h": 3, 
+                            "i": "19", 
+                            "w": 9, 
+                            "x": 3, 
+                            "y": 4
+                        }, 
+                        "id": "d2e15950-d560-11e7-9fff-7b1ebf397ba9", 
+                        "panelIndex": "19", 
+                        "type": "visualization", 
+                        "version": "6.2.4"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "[Packetbeat] TLS Sessions", 
+                "uiStateJSON": {
+                    "P-15": {
+                        "vis": {
+                            "params": {
+                                "sort": {
+                                    "columnIndex": null, 
+                                    "direction": null
+                                }
+                            }
+                        }
+                    }, 
+                    "P-16": {
+                        "vis": {
+                            "params": {
+                                "sort": {
+                                    "columnIndex": null, 
+                                    "direction": null
+                                }
+                            }
+                        }
+                    }, 
+                    "P-17": {
+                        "vis": {
+                            "params": {
+                                "sort": {
+                                    "columnIndex": null, 
+                                    "direction": null
+                                }
+                            }
+                        }
+                    }, 
+                    "P-18": {
+                        "vis": {
+                            "params": {
+                                "sort": {
+                                    "columnIndex": null, 
+                                    "direction": null
+                                }
+                            }
+                        }
+                    }, 
+                    "P-5": {
+                        "vis": {
+                            "defaultColors": {
+                                "0 - 100": "rgb(0,104,55)"
+                            }
+                        }
+                    }, 
+                    "P-7": {
+                        "vis": {
+                            "params": {
+                                "sort": {
+                                    "columnIndex": null, 
+                                    "direction": null
+                                }
+                            }
+                        }
+                    }
+                }, 
+                "version": 1
+            }, 
+            "id": "tls-sessions", 
+            "type": "dashboard", 
+            "updated_at": "2017-11-30T00:16:42.402Z", 
+            "version": 2
+        }
+    ], 
+    "version": "6.2.4"
 }

--- a/winlogbeat/.gitignore
+++ b/winlogbeat/.gitignore
@@ -5,7 +5,6 @@ winlogbeat
 _obj
 _test
 coverage
-_meta/kibana/*/index-pattern
 
 # Architecture specific extensions/prefixes
 *.[568vq]

--- a/winlogbeat/_meta/kibana/6/dashboard/Winlogbeat-overview.json
+++ b/winlogbeat/_meta/kibana/6/dashboard/Winlogbeat-overview.json
@@ -1,98 +1,366 @@
 {
-  "objects": [
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\n  \"index\": \"winlogbeat-*\",\n  \"query\": {\n    \"query_string\": {\n      \"query\": \"*\",\n      \"analyze_wildcard\": true\n    }\n  },\n  \"filter\": []\n}"
-        },
-        "title": "Number of Events Over Time By Event Log",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\n  \"type\": \"histogram\",\n  \"params\": {\n    \"shareYAxis\": true,\n    \"addTooltip\": true,\n    \"addLegend\": true,\n    \"scale\": \"linear\",\n    \"mode\": \"stacked\",\n    \"times\": [],\n    \"addTimeMarker\": false,\n    \"defaultYExtents\": false,\n    \"setYExtents\": false,\n    \"yAxis\": {}\n  },\n  \"aggs\": [\n    {\n      \"id\": \"1\",\n      \"type\": \"count\",\n      \"schema\": \"metric\",\n      \"params\": {}\n    },\n    {\n      \"id\": \"2\",\n      \"type\": \"date_histogram\",\n      \"schema\": \"segment\",\n      \"params\": {\n        \"field\": \"@timestamp\",\n        \"interval\": \"auto\",\n        \"customInterval\": \"2h\",\n        \"min_doc_count\": 1,\n        \"extended_bounds\": {}\n      }\n    },\n    {\n      \"id\": \"3\",\n      \"type\": \"terms\",\n      \"schema\": \"group\",\n      \"params\": {\n        \"field\": \"log_name\",\n        \"size\": 6,\n        \"order\": \"desc\",\n        \"orderBy\": \"1\"\n      }\n    }\n  ],\n  \"listeners\": {}\n}"
-      },
-      "id": "Number-of-Events-Over-Time-By-Event-Log",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"index\":\"winlogbeat-*\",\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}},\"filter\":[]}"
-        },
-        "title": "Number of Events",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"type\":\"metric\",\"params\":{\"fontSize\":60},\"aggs\":[{\"id\":\"1\",\"type\":\"count\",\"schema\":\"metric\",\"params\":{}}],\"listeners\":{}}"
-      },
-      "id": "Number-of-Events",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\n  \"index\": \"winlogbeat-*\",\n  \"query\": {\n    \"query_string\": {\n      \"query\": \"*\",\n      \"analyze_wildcard\": true\n    }\n  },\n  \"filter\": []\n}"
-        },
-        "title": "Top Event IDs",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\n  \"type\": \"table\",\n  \"params\": {\n    \"perPage\": 10,\n    \"showPartialRows\": false,\n    \"showMeticsAtAllLevels\": false\n  },\n  \"aggs\": [\n    {\n      \"id\": \"1\",\n      \"type\": \"count\",\n      \"schema\": \"metric\",\n      \"params\": {}\n    },\n    {\n      \"id\": \"2\",\n      \"type\": \"terms\",\n      \"schema\": \"bucket\",\n      \"params\": {\n        \"field\": \"event_id\",\n        \"size\": 5,\n        \"order\": \"desc\",\n        \"orderBy\": \"1\"\n      }\n    }\n  ],\n  \"listeners\": {}\n}"
-      },
-      "id": "Top-Event-IDs",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"index\":\"winlogbeat-*\",\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}},\"filter\":[]}"
-        },
-        "title": "Event Levels",
-        "uiStateJSON": "{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}}",
-        "version": 1,
-        "visState": "{\"title\":\"Event Levels\",\"type\":\"table\",\"params\":{\"perPage\":10,\"showPartialRows\":false,\"showMeticsAtAllLevels\":false,\"sort\":{\"columnIndex\":null,\"direction\":null},\"showTotal\":false,\"totalFunc\":\"sum\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"level\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}"
-      },
-      "id": "Event-Levels",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"index\":\"winlogbeat-*\",\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}},\"filter\":[]}"
-        },
-        "title": "Sources",
-        "uiStateJSON": "{}",
-        "version": 1,
-        "visState": "{\"title\":\"Sources\",\"type\":\"pie\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"isDonut\":false},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"source_name\",\"size\":7,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}"
-      },
-      "id": "Sources",
-      "type": "visualization",
-      "version": 1
-    },
-    {
-      "attributes": {
-        "description": "",
-        "hits": 0,
-        "kibanaSavedObjectMeta": {
-          "searchSourceJSON": "{\"filter\":[{\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"query\":\"*\"}}}]}"
-        },
-        "optionsJSON": "{\"darkTheme\":false}",
-        "panelsJSON": "[{\"col\":4,\"id\":\"Number-of-Events-Over-Time-By-Event-Log\",\"panelIndex\":1,\"row\":1,\"size_x\":9,\"size_y\":4,\"type\":\"visualization\"},{\"col\":1,\"id\":\"Number-of-Events\",\"panelIndex\":3,\"row\":1,\"size_x\":3,\"size_y\":4,\"type\":\"visualization\"},{\"col\":5,\"id\":\"Top-Event-IDs\",\"panelIndex\":4,\"row\":5,\"size_x\":4,\"size_y\":4,\"type\":\"visualization\"},{\"col\":9,\"id\":\"Event-Levels\",\"panelIndex\":5,\"row\":5,\"size_x\":4,\"size_y\":4,\"type\":\"visualization\"},{\"col\":1,\"id\":\"Sources\",\"panelIndex\":6,\"row\":5,\"size_x\":4,\"size_y\":4,\"type\":\"visualization\"}]",
-        "timeRestore": false,
-        "title": "Winlogbeat Dashboard",
-        "uiStateJSON": "{}",
-        "version": 1
-      },
-      "id": "Winlogbeat-Dashboard",
-      "type": "dashboard",
-      "version": 1
-    }
-  ],
-  "version": "6.0.0-alpha3-SNAPSHOT"
+    "objects": [
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "index": "winlogbeat-*", 
+                        "query": {
+                            "query_string": {
+                                "analyze_wildcard": true, 
+                                "query": "*"
+                            }
+                        }
+                    }
+                }, 
+                "title": "Number of Events Over Time By Event Log", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "id": "2", 
+                            "params": {
+                                "customInterval": "2h", 
+                                "extended_bounds": {}, 
+                                "field": "@timestamp", 
+                                "interval": "auto", 
+                                "min_doc_count": 1
+                            }, 
+                            "schema": "segment", 
+                            "type": "date_histogram"
+                        }, 
+                        {
+                            "id": "3", 
+                            "params": {
+                                "field": "log_name", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 6
+                            }, 
+                            "schema": "group", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTimeMarker": false, 
+                        "addTooltip": true, 
+                        "defaultYExtents": false, 
+                        "mode": "stacked", 
+                        "scale": "linear", 
+                        "setYExtents": false, 
+                        "shareYAxis": true, 
+                        "times": [], 
+                        "yAxis": {}
+                    }, 
+                    "type": "histogram"
+                }
+            }, 
+            "id": "Number-of-Events-Over-Time-By-Event-Log", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "index": "winlogbeat-*", 
+                        "query": {
+                            "query_string": {
+                                "analyze_wildcard": true, 
+                                "query": "*"
+                            }
+                        }
+                    }
+                }, 
+                "title": "Number of Events", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "fontSize": 60
+                    }, 
+                    "type": "metric"
+                }
+            }, 
+            "id": "Number-of-Events", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "index": "winlogbeat-*", 
+                        "query": {
+                            "query_string": {
+                                "analyze_wildcard": true, 
+                                "query": "*"
+                            }
+                        }
+                    }
+                }, 
+                "title": "Top Event IDs", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "id": "2", 
+                            "params": {
+                                "field": "event_id", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "bucket", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "perPage": 10, 
+                        "showMeticsAtAllLevels": false, 
+                        "showPartialRows": false
+                    }, 
+                    "type": "table"
+                }
+            }, 
+            "id": "Top-Event-IDs", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "index": "winlogbeat-*", 
+                        "query": {
+                            "query_string": {
+                                "analyze_wildcard": true, 
+                                "query": "*"
+                            }
+                        }
+                    }
+                }, 
+                "title": "Event Levels", 
+                "uiStateJSON": {
+                    "vis": {
+                        "params": {
+                            "sort": {
+                                "columnIndex": null, 
+                                "direction": null
+                            }
+                        }
+                    }
+                }, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "field": "level", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 5
+                            }, 
+                            "schema": "bucket", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "perPage": 10, 
+                        "showMeticsAtAllLevels": false, 
+                        "showPartialRows": false, 
+                        "showTotal": false, 
+                        "sort": {
+                            "columnIndex": null, 
+                            "direction": null
+                        }, 
+                        "totalFunc": "sum"
+                    }, 
+                    "title": "Event Levels", 
+                    "type": "table"
+                }
+            }, 
+            "id": "Event-Levels", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [], 
+                        "index": "winlogbeat-*", 
+                        "query": {
+                            "query_string": {
+                                "analyze_wildcard": true, 
+                                "query": "*"
+                            }
+                        }
+                    }
+                }, 
+                "title": "Sources", 
+                "uiStateJSON": {}, 
+                "version": 1, 
+                "visState": {
+                    "aggs": [
+                        {
+                            "enabled": true, 
+                            "id": "1", 
+                            "params": {}, 
+                            "schema": "metric", 
+                            "type": "count"
+                        }, 
+                        {
+                            "enabled": true, 
+                            "id": "2", 
+                            "params": {
+                                "field": "source_name", 
+                                "order": "desc", 
+                                "orderBy": "1", 
+                                "size": 7
+                            }, 
+                            "schema": "segment", 
+                            "type": "terms"
+                        }
+                    ], 
+                    "listeners": {}, 
+                    "params": {
+                        "addLegend": true, 
+                        "addTooltip": true, 
+                        "isDonut": false, 
+                        "legendPosition": "right", 
+                        "shareYAxis": true
+                    }, 
+                    "title": "Sources", 
+                    "type": "pie"
+                }
+            }, 
+            "id": "Sources", 
+            "type": "visualization", 
+            "version": 1
+        }, 
+        {
+            "attributes": {
+                "description": "", 
+                "hits": 0, 
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [
+                            {
+                                "query": {
+                                    "query_string": {
+                                        "analyze_wildcard": true, 
+                                        "query": "*"
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                }, 
+                "optionsJSON": {
+                    "darkTheme": false
+                }, 
+                "panelsJSON": [
+                    {
+                        "col": 4, 
+                        "id": "Number-of-Events-Over-Time-By-Event-Log", 
+                        "panelIndex": 1, 
+                        "row": 1, 
+                        "size_x": 9, 
+                        "size_y": 4, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "Number-of-Events", 
+                        "panelIndex": 3, 
+                        "row": 1, 
+                        "size_x": 3, 
+                        "size_y": 4, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 5, 
+                        "id": "Top-Event-IDs", 
+                        "panelIndex": 4, 
+                        "row": 5, 
+                        "size_x": 4, 
+                        "size_y": 4, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 9, 
+                        "id": "Event-Levels", 
+                        "panelIndex": 5, 
+                        "row": 5, 
+                        "size_x": 4, 
+                        "size_y": 4, 
+                        "type": "visualization"
+                    }, 
+                    {
+                        "col": 1, 
+                        "id": "Sources", 
+                        "panelIndex": 6, 
+                        "row": 5, 
+                        "size_x": 4, 
+                        "size_y": 4, 
+                        "type": "visualization"
+                    }
+                ], 
+                "timeRestore": false, 
+                "title": "Winlogbeat Dashboard", 
+                "uiStateJSON": {}, 
+                "version": 1
+            }, 
+            "id": "Winlogbeat-Dashboard", 
+            "type": "dashboard", 
+            "version": 1
+        }
+    ], 
+    "version": "6.0.0-alpha3-SNAPSHOT"
 }


### PR DESCRIPTION
Currently all dashboards end up under `_meta/kibana` in each Beat. The problem with this directory is that for some Beats it contains the automatically collected and generated files and for others the original. This prevents us from having decoded JSON files for all dashboards across Beats.

An other benefit of having the `kibana.generated` directory is that now `_meta/kibana` can become the place for dashboards across modules in one Beat without having to worry about overwriting / removing these dashboards.

Community Beats must convert their dashboards with the script under #7224.

Further changes:

* Decode Packetbeat and Winlogbeat dashboards
* Move encoding step to libbeat so it is applied automatically to all dashboards in the kibana.generated directory.
* Remove _meta/kibana from .gitignore as it can now be used to contain dashboards in all Beats.
* Adjust Makefiles for the new logic.
* Adjust tests to depend on kibana.generated directory