### PR TITLE
Fix some error messages

### DIFF
--- a/libbeat/cmd/modules.go
+++ b/libbeat/cmd/modules.go
@@ -91,7 +91,7 @@ func genEnableModulesCmd(name, version string, modulesFactory modulesManagerFact
 
 			for _, module := range args {
 				if !modules.Exists(module) {
-					fmt.Printf("Module %s doesn't exists!\n", module)
+					fmt.Printf("Module %s doesn't exist!\n", module)
 					os.Exit(1)
 				}
 
@@ -120,7 +120,7 @@ func genDisableModulesCmd(name, version string, modulesFactory modulesManagerFac
 
 			for _, module := range args {
 				if !modules.Exists(module) {
-					fmt.Fprintf(os.Stderr, "Module %s doesn't exists!\n", module)
+					fmt.Fprintf(os.Stderr, "Module %s doesn't exist!\n", module)
 					os.Exit(1)
 				}
 

--- a/libbeat/cmd/run.go
+++ b/libbeat/cmd/run.go
@@ -34,8 +34,8 @@ func genRunCmd(name, idxPrefix, version string, beatCreator beat.Creator, runFla
 	runCmd.Flags().AddGoFlag(flag.CommandLine.Lookup("configtest"))
 	runCmd.Flags().AddGoFlag(flag.CommandLine.Lookup("version"))
 
-	runCmd.Flags().MarkDeprecated("version", "version flag has been deprecated, use version subcommand")
-	runCmd.Flags().MarkDeprecated("configtest", "configtest flag has been deprecated, use test config subcommand")
+	runCmd.Flags().MarkDeprecated("version", "use version subcommand")
+	runCmd.Flags().MarkDeprecated("configtest", "use test config subcommand")
 
 	if runFlags != nil {
 		runCmd.Flags().AddFlagSet(runFlags)


### PR DESCRIPTION
Deprecation warnings printed duplicated info:
```
$ filebeat --version
Flag --version has been deprecated, version flag has been deprecated, use version subcommand
filebeat version 6.2.4 (amd64), libbeat 6.2.4
```
With this change:
```
$ filebeat --version
Flag --version has been deprecated, use version subcommand
filebeat version 7.0.0-alpha1 (amd64), libbeat 7.0.0-alpha1
```