### PR TITLE
Move topic about contributing to end of book

### DIFF
--- a/auditbeat/docs/index.asciidoc
+++ b/auditbeat/docs/index.asciidoc
@@ -17,8 +17,6 @@ include::../../libbeat/docs/shared-beats-attributes.asciidoc[]
 
 include::./overview.asciidoc[]
 
-include::../../libbeat/docs/contributing-to-beats.asciidoc[]
-
 include::./getting-started.asciidoc[]
 
 include::../../libbeat/docs/repositories.asciidoc[]
@@ -40,3 +38,6 @@ include::../../libbeat/docs/shared-securing-beat.asciidoc[]
 include::./troubleshooting.asciidoc[]
 
 include::./faq.asciidoc[]
+
+include::../../libbeat/docs/contributing-to-beats.asciidoc[]
+

--- a/filebeat/docs/index.asciidoc
+++ b/filebeat/docs/index.asciidoc
@@ -17,8 +17,6 @@ include::../../libbeat/docs/shared-beats-attributes.asciidoc[]
 
 include::./overview.asciidoc[]
 
-include::../../libbeat/docs/contributing-to-beats.asciidoc[]
-
 include::./getting-started.asciidoc[]
 
 include::./modules-getting-started.asciidoc[]
@@ -46,3 +44,6 @@ include::./troubleshooting.asciidoc[]
 include::./faq.asciidoc[]
 
 include::./migration.asciidoc[]
+
+include::../../libbeat/docs/contributing-to-beats.asciidoc[]
+

--- a/heartbeat/docs/index.asciidoc
+++ b/heartbeat/docs/index.asciidoc
@@ -17,19 +17,11 @@ include::../../libbeat/docs/shared-beats-attributes.asciidoc[]
 
 include::./overview.asciidoc[]
 
-include::../../libbeat/docs/contributing-to-beats.asciidoc[]
-
 include::./getting-started.asciidoc[]
 
 include::../../libbeat/docs/repositories.asciidoc[]
 
 include::./setting-up-running.asciidoc[]
-
-//
-//include::./upgrading.asciidoc[]
-
-//
-//include::./how-heartbeat-works.asciidoc[]
 
 include::./configuring-howto.asciidoc[]
 
@@ -43,5 +35,5 @@ include::./troubleshooting.asciidoc[]
 
 include::./faq.asciidoc[]
 
-//
-//include::./heartbeat-devguide.asciidoc[]
+include::../../libbeat/docs/contributing-to-beats.asciidoc[]
+

--- a/libbeat/docs/contributing-to-beats.asciidoc
+++ b/libbeat/docs/contributing-to-beats.asciidoc
@@ -9,8 +9,8 @@
 //// include::../../libbeat/docs/contributing-to-beats.asciidoc[]
 //////////////////////////////////////////////////////////////////////////
 
-[[contributing-to-beats]]
-== Contributing to Beats
+["appendix",id="contributing-to-beats"]
+= Contributing to Beats
 
 The Beats are open source and we love to receive contributions from our
 community — you!

--- a/libbeat/docs/index.asciidoc
+++ b/libbeat/docs/index.asciidoc
@@ -19,8 +19,6 @@ include::./overview.asciidoc[]
 
 include::./communitybeats.asciidoc[]
 
-include::../../libbeat/docs/contributing-to-beats.asciidoc[]
-
 include::./gettingstarted.asciidoc[]
 
 include::./installing-beats.asciidoc[]
@@ -32,3 +30,5 @@ include::./upgrading.asciidoc[]
 include::./config-file-format.asciidoc[]
 
 include::./release.asciidoc[]
+
+include::../../libbeat/docs/contributing-to-beats.asciidoc[]

--- a/metricbeat/docs/index.asciidoc
+++ b/metricbeat/docs/index.asciidoc
@@ -17,8 +17,6 @@ include::../../libbeat/docs/shared-beats-attributes.asciidoc[]
 
 include::./overview.asciidoc[]
 
-include::../../libbeat/docs/contributing-to-beats.asciidoc[]
-
 include::./gettingstarted.asciidoc[]
 
 include::../../libbeat/docs/repositories.asciidoc[]
@@ -42,3 +40,5 @@ include::../../libbeat/docs/shared-securing-beat.asciidoc[]
 include::./troubleshooting.asciidoc[]
 
 include::./faq.asciidoc[]
+
+include::../../libbeat/docs/contributing-to-beats.asciidoc[]

--- a/packetbeat/docs/index.asciidoc
+++ b/packetbeat/docs/index.asciidoc
@@ -17,8 +17,6 @@ include::../../libbeat/docs/shared-beats-attributes.asciidoc[]
 
 include::./overview.asciidoc[]
 
-include::../../libbeat/docs/contributing-to-beats.asciidoc[]
-
 include::./gettingstarted.asciidoc[]
 
 include::../../libbeat/docs/repositories.asciidoc[]
@@ -42,3 +40,5 @@ include::./filtering.asciidoc[]
 include::./troubleshooting.asciidoc[]
 
 include::./faq.asciidoc[]
+
+include::../../libbeat/docs/contributing-to-beats.asciidoc[]

--- a/winlogbeat/docs/index.asciidoc
+++ b/winlogbeat/docs/index.asciidoc
@@ -17,8 +17,6 @@ include::../../libbeat/docs/shared-beats-attributes.asciidoc[]
 
 include::./overview.asciidoc[]
 
-include::../../libbeat/docs/contributing-to-beats.asciidoc[]
-
 include::./getting-started.asciidoc[]
 
 include::./setting-up-running.asciidoc[]
@@ -36,3 +34,6 @@ include::../../libbeat/docs/shared-securing-beat.asciidoc[]
 include::./troubleshooting.asciidoc[]
 
 include::./faq.asciidoc[]
+
+include::../../libbeat/docs/contributing-to-beats.asciidoc[]
+


### PR DESCRIPTION
Moves the topic about contributing to beats to the end of the book plus cleans up a few TOCs that had commented out stuff that's no longer relevant.