### PR TITLE
Update ingest pipeline template for apache2 log

### DIFF
--- a/filebeat/module/apache2/access/ingest/default.json
+++ b/filebeat/module/apache2/access/ingest/default.json
@@ -5,7 +5,7 @@
       "field": "message",
       "patterns":[
         "%{IPORHOST:apache2.access.remote_ip} - %{DATA:apache2.access.user_name} \\[%{HTTPDATE:apache2.access.time}\\] \"%{WORD:apache2.access.method} %{DATA:apache2.access.url} HTTP/%{NUMBER:apache2.access.http_version}\" %{NUMBER:apache2.access.response_code} (?:%{NUMBER:apache2.access.body_sent.bytes}|-)( \"%{DATA:apache2.access.referrer}\")?( \"%{DATA:apache2.access.agent}\")?",
-        "%{IPORHOST:apache2.access.remote_ip} - %{DATA:apache2.access.user_name} \\[%{HTTPDATE:apache2.access.time}\\] \"-\" %{NUMBER:apache2.access.response_code} -"
+        "%{IPORHOST:apache2.access.remote_ip} - %{DATA:apache2.access.user_name} \\[%{HTTPDATE:apache2.access.time}\\] \"-\" %{NUMBER:apache2.access.response_code} "
         ],
       "ignore_missing": true
     }


### PR DESCRIPTION
Removed trailing `-` so that it will grok 408 response logs

@kvch this is regarding https://discuss.elastic.co/t/provided-grok-expressions-do-not-match-field-value-for-response-code-408/133776