### PR TITLE
Keep different registry entry per container stream

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -88,6 +88,7 @@ https://github.com/elastic/beats/compare/v6.2.3...master[Check the HEAD diff]
 - Fix a parsing issue in the syslog input for RFC3339 timestamp and time with nanoseconds. {pull}7046[7046]
 - Comply with PostgreSQL database name format {pull}7198[7198]
 - Fix an issue with an overflowing wait group when using the TCP input. {issue}7202[7202]
+- Keep different registry entry per container stream to avoid wrong offsets. {issue}7281[7281]
 
 *Heartbeat*
 - Fix race due to updates of shared a map, that was not supposed to be shared between multiple go-routines. {issue}6616[6616]

--- a/filebeat/input/docker/input.go
+++ b/filebeat/input/docker/input.go
@@ -55,7 +55,9 @@ func NewInput(
 	}
 
 	// Add stream to meta to ensure different state per stream
-	context.Meta["stream"] = config.Containers.Stream
+	if config.Containers.Stream != "all" {
+		context.Meta["stream"] = config.Containers.Stream
+	}
 
 	return log.NewInput(cfg, outletFactory, context)
 }

--- a/filebeat/input/docker/input.go
+++ b/filebeat/input/docker/input.go
@@ -53,6 +53,10 @@ func NewInput(
 	if err := cfg.SetBool("docker-json.partial", -1, config.Partial); err != nil {
 		return nil, errors.Wrap(err, "update input config")
 	}
+
+	// Add stream to meta to ensure different state per stream
+	context.Meta["stream"] = config.Containers.Stream
+
 	return log.NewInput(cfg, outletFactory, context)
 }
 

--- a/filebeat/input/file/state.go
+++ b/filebeat/input/file/state.go
@@ -2,7 +2,6 @@ package file
 
 import (
 	"os"
-	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -73,5 +72,8 @@ func (s *State) IsEqual(c *State) bool {
 
 // IsEmpty returns true if the state is empty
 func (s *State) IsEmpty() bool {
-	return reflect.DeepEqual(*s, State{})
+	return s.FileStateOS == file.StateOS{} &&
+		s.Source == "" &&
+		s.Meta == nil &&
+		s.Timestamp.IsZero()
 }

--- a/filebeat/input/file/state.go
+++ b/filebeat/input/file/state.go
@@ -1,27 +1,32 @@
 package file
 
 import (
+	"fmt"
 	"os"
+	"reflect"
 	"time"
+
+	"github.com/mitchellh/hashstructure"
 
 	"github.com/elastic/beats/libbeat/common/file"
 )
 
 // State is used to communicate the reading state of a file
 type State struct {
-	Id          string        `json:"-"` // local unique id to make comparison more efficient
-	Finished    bool          `json:"-"` // harvester state
-	Fileinfo    os.FileInfo   `json:"-"` // the file info
-	Source      string        `json:"source"`
-	Offset      int64         `json:"offset"`
-	Timestamp   time.Time     `json:"timestamp"`
-	TTL         time.Duration `json:"ttl"`
-	Type        string        `json:"type"`
+	Id          string            `json:"-"` // local unique id to make comparison more efficient
+	Finished    bool              `json:"-"` // harvester state
+	Fileinfo    os.FileInfo       `json:"-"` // the file info
+	Source      string            `json:"source"`
+	Offset      int64             `json:"offset"`
+	Timestamp   time.Time         `json:"timestamp"`
+	TTL         time.Duration     `json:"ttl"`
+	Type        string            `json:"type"`
+	Meta        map[string]string `json:"meta"`
 	FileStateOS file.StateOS
 }
 
 // NewState creates a new file state
-func NewState(fileInfo os.FileInfo, path string, t string) State {
+func NewState(fileInfo os.FileInfo, path string, t string, meta map[string]string) State {
 	return State{
 		Fileinfo:    fileInfo,
 		Source:      path,
@@ -30,6 +35,7 @@ func NewState(fileInfo os.FileInfo, path string, t string) State {
 		Timestamp:   time.Now(),
 		TTL:         -1, // By default, state does have an infinite ttl
 		Type:        t,
+		Meta:        meta,
 	}
 }
 
@@ -37,7 +43,8 @@ func NewState(fileInfo os.FileInfo, path string, t string) State {
 func (s *State) ID() string {
 	// Generate id on first request. This is needed as id is not set when converting back from json
 	if s.Id == "" {
-		s.Id = s.FileStateOS.String()
+		h, _ := hashstructure.Hash(s.Meta, nil)
+		s.Id = s.FileStateOS.String() + fmt.Sprintf("-%d", h)
 	}
 	return s.Id
 }
@@ -49,5 +56,5 @@ func (s *State) IsEqual(c *State) bool {
 
 // IsEmpty returns true if the state is empty
 func (s *State) IsEmpty() bool {
-	return *s == State{}
+	return reflect.DeepEqual(*s, State{})
 }

--- a/filebeat/input/input.go
+++ b/filebeat/input/input.go
@@ -70,6 +70,7 @@ func New(
 		Done:          input.done,
 		BeatDone:      input.beatDone,
 		DynamicFields: dynFields,
+		Meta:          map[string]string{},
 	}
 	var ipt Input
 	ipt, err = f(conf, outlet, context)

--- a/filebeat/input/log/input_test.go
+++ b/filebeat/input/log/input_test.go
@@ -64,6 +64,61 @@ func TestIsCleanInactive(t *testing.T) {
 	}
 }
 
+func TestMatchesMeta(t *testing.T) {
+	tests := []struct {
+		Input  *Input
+		Meta   map[string]string
+		Result bool
+	}{
+		{
+			Input: &Input{
+				meta: map[string]string{
+					"it": "matches",
+				},
+			},
+			Meta: map[string]string{
+				"it": "matches",
+			},
+			Result: true,
+		},
+		{
+			Input: &Input{
+				meta: map[string]string{
+					"it":     "doesnt",
+					"doesnt": "match",
+				},
+			},
+			Meta: map[string]string{
+				"it": "doesnt",
+			},
+			Result: false,
+		},
+		{
+			Input: &Input{
+				meta: map[string]string{
+					"it": "doesnt",
+				},
+			},
+			Meta: map[string]string{
+				"it":     "doesnt",
+				"doesnt": "match",
+			},
+			Result: false,
+		},
+		{
+			Input: &Input{
+				meta: map[string]string{},
+			},
+			Meta:   map[string]string{},
+			Result: true,
+		},
+	}
+
+	for _, test := range tests {
+		assert.Equal(t, test.Result, test.Input.matchesMeta(test.Meta))
+	}
+}
+
 type TestFileInfo struct {
 	time time.Time
 }

--- a/filebeat/input/registry.go
+++ b/filebeat/input/registry.go
@@ -14,6 +14,7 @@ type Context struct {
 	Done          chan struct{}
 	BeatDone      chan struct{}
 	DynamicFields *common.MapStrPointer
+	Meta          map[string]string
 }
 
 // Factory is used to register functions creating new Input instances.

--- a/filebeat/tests/system/test_registrar.py
+++ b/filebeat/tests/system/test_registrar.py
@@ -1506,3 +1506,58 @@ class Test(BaseTest):
                 "inode": stat.st_ino,
                 "device": stat.st_dev,
             }, file_state_os)
+
+    def test_registrar_meta(self):
+        """
+        Check that multiple entries for the same file are on the registry when they have
+        different meta
+        """
+
+        self.render_config_template(
+            type='docker',
+            input_raw='''
+  containers:
+    path: {path}
+    stream: stdout
+    ids:
+      - container_id
+- type: docker
+  containers:
+    path: {path}
+    stream: stderr
+    ids:
+      - container_id
+            '''.format(path=os.path.abspath(self.working_dir) + "/log/")
+        )
+        os.mkdir(self.working_dir + "/log/")
+        os.mkdir(self.working_dir + "/log/container_id")
+        testfile_path1 = self.working_dir + "/log/container_id/test.log"
+
+        with open(testfile_path1, 'w') as f:
+            for i in range(0, 10):
+                f.write('{"log":"hello\\n","stream":"stdout","time":"2018-04-13T13:39:57.924216596Z"}\n')
+                f.write('{"log":"hello\\n","stream":"stderr","time":"2018-04-13T13:39:57.924216596Z"}\n')
+
+        filebeat = self.start_beat()
+
+        self.wait_until(
+            lambda: self.output_has(lines=20),
+            max_timeout=15)
+
+        # wait until the registry file exist. Needed to avoid a race between
+        # the logging and actual writing the file. Seems to happen on Windows.
+
+        self.wait_until(
+            lambda: os.path.isfile(os.path.join(self.working_dir,
+                                                "registry")),
+            max_timeout=1)
+
+        filebeat.check_kill_and_wait()
+
+        # Check registry contains 2 entries with meta
+        data = self.get_registry()
+        assert len(data) == 2
+        assert data[0]["source"] == data[1]["source"]
+        assert data[0]["meta"]["stream"] in ("stdout", "stderr")
+        assert data[1]["meta"]["stream"] in ("stdout", "stderr")
+        assert data[0]["meta"]["stream"] != data[1]["meta"]["stream"]

--- a/filebeat/util/data.go
+++ b/filebeat/util/data.go
@@ -28,7 +28,7 @@ func (d *Data) GetState() file.State {
 
 // HasState returns true if the data object contains state data
 func (d *Data) HasState() bool {
-	return d.state != file.State{}
+	return !d.state.IsEmpty()
 }
 
 // GetEvent returns the event in the data object


### PR DESCRIPTION
This PR adds a metadata map to prospectors state. Adding metadata to states allows having a different state per unique metadata for the same file.

This change is used by the `docker` prospector to have different states per stream, as some users configure a container prospector per stream (`stdout` & `stderr`).

Probably fixes #7045