### PR TITLE
Fix autodiscover examples

### DIFF
--- a/filebeat/docs/autodiscover-docker-config.asciidoc
+++ b/filebeat/docs/autodiscover-docker-config.asciidoc
@@ -7,7 +7,7 @@ filebeat.autodiscover:
     - type: docker
       templates:
         - condition:
-            equals:
+            contains:
               docker.container.image: redis
           config:
             - type: docker
@@ -27,8 +27,8 @@ filebeat.autodiscover:
     - type: docker
       templates:
         - condition:
-            equals:
-              docker.container.image: "redis"
+            contains:
+              docker.container.image: redis
           config:
             - module: redis
               log:

--- a/metricbeat/docs/autodiscover-docker-config.asciidoc
+++ b/metricbeat/docs/autodiscover-docker-config.asciidoc
@@ -8,7 +8,7 @@ metricbeat.autodiscover:
       templates:
         - condition:
             contains:
-              docker.container.image: "redis"
+              docker.container.image: redis
           config:
             - module: redis
               metricsets: ["info", "keyspace"]


### PR DESCRIPTION
Using equal is not the good approach, as container name contains the
version too.

Closes #7161