### PR TITLE
libbeat: Get and initialize namespaces in mutual exclusion

### DIFF
--- a/libbeat/monitoring/namespace.go
+++ b/libbeat/monitoring/namespace.go
@@ -1,6 +1,15 @@
 package monitoring
 
-var namespaces = map[string]*Namespace{}
+import (
+	"sync"
+)
+
+var namespaces = struct {
+	sync.Mutex
+	m map[string]*Namespace
+}{
+	m: make(map[string]*Namespace),
+}
 
 // Namespace contains the name of the namespace and it's registry
 type Namespace struct {
@@ -8,21 +17,18 @@ type Namespace struct {
 	registry *Registry
 }
 
-func newNamespace(name string) *Namespace {
-	n := &Namespace{
-		name: name,
-	}
-	namespaces[name] = n
-	return n
-}
-
 // GetNamespace gets the namespace with the given name.
 // If the namespace does not exist yet, a new one is created.
 func GetNamespace(name string) *Namespace {
-	if n, ok := namespaces[name]; ok {
-		return n
+	namespaces.Lock()
+	defer namespaces.Unlock()
+
+	n, ok := namespaces.m[name]
+	if !ok {
+		n = &Namespace{name: name}
+		namespaces.m[name] = n
 	}
-	return newNamespace(name)
+	return n
 }
 
 // SetRegistry sets the registry of the namespace


### PR DESCRIPTION
There seems to be a race condition when getting monitoring namespaces, I haven't been able to reproduce it but I have seen this once:
```
fatal error: concurrent map writes

goroutine 81 [running]:
runtime.throw(0x2507adc, 0x15)
        /home/jaime/go/src/runtime/panic.go:616 +0x81 fp=0xc4204376e0 sp=0xc4204376c0 pc=0x1039011
runtime.mapassign_faststr(0x21a0b20, 0xc4200b9350, 0x24eb93a, 0x7, 0x34ba7a0)
        /home/jaime/go/src/runtime/hashmap_fast.go:779 +0x3ce fp=0xc420437750 sp=0xc4204376e0 pc=0x1019e2e
github.com/elastic/beats/libbeat/monitoring.newNamespace(...)
        /home/jaime/gocode/src/github.com/elastic/beats/libbeat/monitoring/namespace.go:15
github.com/elastic/beats/libbeat/monitoring.GetNamespace(...)
        /home/jaime/gocode/src/github.com/elastic/beats/libbeat/monitoring/namespace.go:25
github.com/elastic/beats/metricbeat/mb/module.(*Wrapper).Start.func1(0xc420268760, 0xc4200aa8a0, 0xc4204ee540, 0xc4202098a0)
        /home/jaime/gocode/src/github.com/elastic/beats/metricbeat/mb/module/wrapper.go:110 +0x324 fp=0xc4204377c0 sp=0xc420437750 pc=0x18c6da4
runtime.goexit()
        /home/jaime/go/src/runtime/asm_amd64.s:2361 +0x1 fp=0xc4204377c8 sp=0xc4204377c0 pc=0x10691b1
created by github.com/elastic/beats/metricbeat/mb/module.(*Wrapper).Start
        /home/jaime/gocode/src/github.com/elastic/beats/metricbeat/mb/module/wrapper.go:108 +0x145
```

This PR adds a mutex for namespaces.