### PR TITLE
Ensure node and pod info are always present in state_container

### DIFF
--- a/metricbeat/helper/prometheus/metric.go
+++ b/metricbeat/helper/prometheus/metric.go
@@ -58,6 +58,12 @@ func LabelMetric(field, label string, lowercase bool) MetricMap {
 	}
 }
 
+// InfoMetric obtains info labels from the given metric and puts them
+// into events matching all the key labels present in the metric
+func InfoMetric() MetricMap {
+	return &infoMetric{}
+}
+
 type commonMetric struct {
 	field string
 }
@@ -175,5 +181,17 @@ func getLabel(metric *dto.Metric, name string) string {
 			return label.GetValue()
 		}
 	}
+	return ""
+}
+
+type infoMetric struct{}
+
+// GetValue returns the resulting value
+func (m *infoMetric) GetValue(metric *dto.Metric) interface{} {
+	return ""
+}
+
+// GetField returns the resulting field name
+func (m *infoMetric) GetField() string {
 	return ""
 }

--- a/metricbeat/helper/prometheus/prometheus.go
+++ b/metricbeat/helper/prometheus/prometheus.go
@@ -116,9 +116,9 @@ func (p *prometheus) GetProcessedMetrics(mapping *MetricsMapping) ([]common.MapS
 			for k, v := range getLabels(metric) {
 				if l, ok := mapping.Labels[k]; ok {
 					if l.IsKey() {
-						keyLabels[l.GetField()] = v
+						keyLabels.Put(l.GetField(), v)
 					} else {
-						labels[l.GetField()] = v
+						labels.Put(l.GetField(), v)
 					}
 				}
 			}
@@ -126,10 +126,10 @@ func (p *prometheus) GetProcessedMetrics(mapping *MetricsMapping) ([]common.MapS
 			event := getEvent(eventsMap, keyLabels)
 			// Empty field means we ignore the metric but still process its labels
 			if field != "" {
-				event[field] = value
+				event.Put(field, value)
 			}
 
-			event.Update(labels)
+			event.DeepUpdate(labels)
 		}
 	}
 
@@ -172,7 +172,7 @@ func getLabels(metric *dto.Metric) common.MapStr {
 	labels := common.MapStr{}
 	for _, label := range metric.GetLabel() {
 		if label.GetName() != "" && label.GetValue() != "" {
-			labels[label.GetName()] = label.GetValue()
+			labels.Put(label.GetName(), label.GetValue())
 		}
 	}
 	return labels

--- a/metricbeat/helper/prometheus/prometheus_test.go
+++ b/metricbeat/helper/prometheus/prometheus_test.go
@@ -73,7 +73,9 @@ func TestPrometheus(t *testing.T) {
 			},
 			expected: []common.MapStr{
 				common.MapStr{
-					"first.metric": 1.0,
+					"first": common.MapStr{
+						"metric": 1.0,
+					},
 				},
 			},
 		},
@@ -90,9 +92,13 @@ func TestPrometheus(t *testing.T) {
 			},
 			expected: []common.MapStr{
 				common.MapStr{
-					"first.metric":  1.0,
-					"labels.label1": "value1",
-					"labels.label2": "value2",
+					"first": common.MapStr{
+						"metric": 1.0,
+					},
+					"labels": common.MapStr{
+						"label1": "value1",
+						"label2": "value2",
+					},
 				},
 			},
 		},
@@ -109,12 +115,20 @@ func TestPrometheus(t *testing.T) {
 			},
 			expected: []common.MapStr{
 				common.MapStr{
-					"first.metric":  1.0,
-					"labels.label3": "Value3",
+					"first": common.MapStr{
+						"metric": 1.0,
+					},
+					"labels": common.MapStr{
+						"label3": "Value3",
+					},
 				},
 				common.MapStr{
-					"second.metric": 0.0,
-					"labels.label3": "othervalue",
+					"second": common.MapStr{
+						"metric": 0.0,
+					},
+					"labels": common.MapStr{
+						"label3": "othervalue",
+					},
 				},
 			},
 		},
@@ -132,10 +146,16 @@ func TestPrometheus(t *testing.T) {
 			},
 			expected: []common.MapStr{
 				common.MapStr{
-					"first.metric":  1.0,
-					"second.metric": 0.0,
-					"labels.label1": "value1",
-					"labels.label2": "value2",
+					"first": common.MapStr{
+						"metric": 1.0,
+					},
+					"second": common.MapStr{
+						"metric": 0.0,
+					},
+					"labels": common.MapStr{
+						"label1": "value1",
+						"label2": "value2",
+					},
 				},
 			},
 		},
@@ -152,8 +172,12 @@ func TestPrometheus(t *testing.T) {
 			},
 			expected: []common.MapStr{
 				common.MapStr{
-					"first.metric":  "works",
-					"labels.label1": "value1",
+					"first": common.MapStr{
+						"metric": "works",
+					},
+					"labels": common.MapStr{
+						"label1": "value1",
+					},
 				},
 			},
 		},
@@ -170,9 +194,15 @@ func TestPrometheus(t *testing.T) {
 			},
 			expected: []common.MapStr{
 				common.MapStr{
-					"first.metric":  true,
-					"second.metric": false,
-					"labels.label1": "value1",
+					"first": common.MapStr{
+						"metric": true,
+					},
+					"second": common.MapStr{
+						"metric": false,
+					},
+					"labels": common.MapStr{
+						"label1": "value1",
+					},
 				},
 			},
 		},
@@ -188,8 +218,12 @@ func TestPrometheus(t *testing.T) {
 			},
 			expected: []common.MapStr{
 				common.MapStr{
-					"first.metric":  "Value3",
-					"labels.label1": "value1",
+					"first": common.MapStr{
+						"metric": "Value3",
+					},
+					"labels": common.MapStr{
+						"label1": "value1",
+					},
 				},
 			},
 		},
@@ -205,8 +239,12 @@ func TestPrometheus(t *testing.T) {
 			},
 			expected: []common.MapStr{
 				common.MapStr{
-					"first.metric":  "foo",
-					"labels.label1": "value1",
+					"first": common.MapStr{
+						"metric": "foo",
+					},
+					"labels": common.MapStr{
+						"label1": "value1",
+					},
 				},
 			},
 		},
@@ -219,13 +257,15 @@ func TestPrometheus(t *testing.T) {
 			},
 			expected: []common.MapStr{
 				common.MapStr{
-					"summary.metric": common.MapStr{
-						"sum":   234892394.0,
-						"count": uint64(44000),
-						"percentile": common.MapStr{
-							"50": 29735.0,
-							"90": 47103.0,
-							"99": 50681.0,
+					"summary": common.MapStr{
+						"metric": common.MapStr{
+							"sum":   234892394.0,
+							"count": uint64(44000),
+							"percentile": common.MapStr{
+								"50": 29735.0,
+								"90": 47103.0,
+								"99": 50681.0,
+							},
 						},
 					},
 				},
@@ -240,18 +280,20 @@ func TestPrometheus(t *testing.T) {
 			},
 			expected: []common.MapStr{
 				common.MapStr{
-					"histogram.metric": common.MapStr{
-						"count": uint64(1),
-						"bucket": common.MapStr{
-							"1000000000": uint64(1),
-							"+Inf":       uint64(1),
-							"1000":       uint64(1),
-							"10000":      uint64(1),
-							"100000":     uint64(1),
-							"1000000":    uint64(1),
-							"100000000":  uint64(1),
+					"histogram": common.MapStr{
+						"metric": common.MapStr{
+							"count": uint64(1),
+							"bucket": common.MapStr{
+								"1000000000": uint64(1),
+								"+Inf":       uint64(1),
+								"1000":       uint64(1),
+								"10000":      uint64(1),
+								"100000":     uint64(1),
+								"1000000":    uint64(1),
+								"100000000":  uint64(1),
+							},
+							"sum": 117.0,
 						},
-						"sum": 117.0,
 					},
 				},
 			},

--- a/metricbeat/module/kubernetes/apiserver/_meta/test/metrics.expected
+++ b/metricbeat/module/kubernetes/apiserver/_meta/test/metrics.expected
@@ -3,11 +3,13 @@
 		"RootFields": null,
 		"ModuleFields": null,
 		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
-			"request.count": 10998,
-			"request.resource": "secrets",
-			"request.scope": "namespace",
-			"request.verb": "POST"
+			"request": {
+				"client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 1467,
+				"resource": "customresourcedefinitions",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
 		},
 		"Index": "",
 		"Namespace": "",
@@ -20,160 +22,44 @@
 		"RootFields": null,
 		"ModuleFields": null,
 		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:daemon-set-controller",
-			"request.count": 10,
-			"request.resource": "daemonsets",
-			"request.scope": "namespace",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:endpoint-controller",
-			"request.count": 1,
-			"request.resource": "endpoints",
-			"request.scope": "namespace",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "GoogleContainerEngine",
-			"request.count": 7198,
-			"request.resource": "pods",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:replicaset-controller",
-			"request.count": 45,
-			"request.resource": "pods",
-			"request.scope": "namespace",
-			"request.verb": "DELETE"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-scheduler/v1.8.8 (linux/amd64) kubernetes/6e5b33a/scheduler",
-			"request.count": 3,
-			"request.resource": "pods",
-			"request.scope": "namespace",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
-			"request.count": 15,
-			"request.resource": "pods",
-			"request.scope": "namespace",
-			"request.subresource": "log",
-			"request.verb": "CONNECT"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
-			"request.count": 65986,
-			"request.resource": "serviceaccounts",
-			"request.scope": "namespace",
-			"request.verb": "PATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "rescheduler/v0.0.0 (linux/amd64) kubernetes/$Format",
-			"request.count": 1474,
-			"request.resource": "nodes",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 1,
-					"1000000": 1,
-					"125000": 1,
-					"2000000": 1,
-					"250000": 1,
-					"4000000": 1,
-					"500000": 1,
-					"8000000": 1
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 1472,
+						"1000000": 0,
+						"125000": 0,
+						"2000000": 0,
+						"250000": 0,
+						"4000000": 0,
+						"500000": 0,
+						"8000000": 0
+					},
+					"count": 1472,
+					"sum": 659755004696
 				},
+				"resource": "poddisruptionbudgets",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
 				"count": 1,
-				"sum": 3552
-			},
-			"request.resource": "limitranges",
-			"request.scope": "namespace",
-			"request.verb": "GET"
+				"resource": "roles",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
 		},
 		"Index": "",
 		"Namespace": "",
@@ -186,24 +72,14 @@
 		"RootFields": null,
 		"ModuleFields": null,
 		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 9,
-					"1000000": 9,
-					"125000": 9,
-					"2000000": 9,
-					"250000": 9,
-					"4000000": 9,
-					"500000": 9,
-					"8000000": 9
-				},
-				"count": 9,
-				"sum": 99447
-			},
-			"request.resource": "nodes",
-			"request.scope": "cluster",
-			"request.subresource": "status",
-			"request.verb": "PUT"
+			"request": {
+				"client": "kube-scheduler/v1.8.8 (linux/amd64) kubernetes/6e5b33a/scheduler",
+				"count": 31,
+				"resource": "pods",
+				"scope": "namespace",
+				"subresource": "status",
+				"verb": "PUT"
+			}
 		},
 		"Index": "",
 		"Namespace": "",
@@ -216,11 +92,13 @@
 		"RootFields": null,
 		"ModuleFields": null,
 		"MetricSetFields": {
-			"request.client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 1473,
-			"request.resource": "serviceaccounts",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
+			"request": {
+				"client": "kube-scheduler/v1.8.8 (linux/amd64) kubernetes/6e5b33a/scheduler",
+				"count": 1482,
+				"resource": "services",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
 		},
 		"Index": "",
 		"Namespace": "",
@@ -233,275 +111,13 @@
 		"RootFields": null,
 		"ModuleFields": null,
 		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
-			"request.count": 1,
-			"request.resource": "podtemplates",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:persistent-volume-binder",
-			"request.count": 2,
-			"request.resource": "persistentvolumeclaims",
-			"request.scope": "namespace",
-			"request.verb": "PUT"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
-			"request.count": 43994,
-			"request.resource": "deployments",
-			"request.scope": "namespace",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
-			"request.count": 1,
-			"request.resource": "daemonsets",
-			"request.scope": "namespace",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 15,
-					"1000000": 0,
-					"125000": 0,
-					"2000000": 0,
-					"250000": 0,
-					"4000000": 0,
-					"500000": 0,
-					"8000000": 1
-				},
-				"count": 15,
-				"sum": 9995258313
-			},
-			"request.resource": "pods",
-			"request.scope": "namespace",
-			"request.subresource": "log",
-			"request.verb": "CONNECT"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "cluster-proportional-autoscaler/v1.6.5 (linux/amd64) kubernetes/$Format",
-			"request.count": 65893,
-			"request.resource": "nodes",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-dns/v0.0.0 (linux/amd64) kubernetes/$Format",
-			"request.count": 4,
-			"request.resource": "services",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
-			"request.count": 21997,
-			"request.resource": "daemonsets",
-			"request.scope": "namespace",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
-			"request.count": 21997,
-			"request.resource": "pods",
-			"request.scope": "namespace",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "node-problem-detector/v1.4.0 (linux/amd64) kubernetes/$Format",
-			"request.count": 8,
-			"request.resource": "nodes",
-			"request.scope": "cluster",
-			"request.subresource": "status",
-			"request.verb": "PATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "GoogleContainerEngine",
-			"request.count": 709,
-			"request.resource": "persistentvolumeclaims",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:cronjob-controller",
-			"request.count": 65929,
-			"request.resource": "cronjobs",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 1,
-			"request.resource": "endpoints",
-			"request.scope": "namespace",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubelet/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 1,
-			"request.resource": "configmaps",
-			"request.scope": "namespace",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 1,
-					"1000000": 1,
-					"125000": 0,
-					"2000000": 1,
-					"250000": 1,
-					"4000000": 1,
-					"500000": 1,
-					"8000000": 1
-				},
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
 				"count": 1,
-				"sum": 138053
-			},
-			"request.resource": "persistentvolumes",
-			"request.scope": "cluster",
-			"request.verb": "POST"
+				"resource": "namespaces",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
 		},
 		"Index": "",
 		"Namespace": "",
@@ -514,11 +130,13 @@
 		"RootFields": null,
 		"ModuleFields": null,
 		"MetricSetFields": {
-			"request.client": "gke-certificates-controller/v1.7.0 (linux/amd64) kubernetes/6b9ded1/certificate-controller",
-			"request.count": 1467,
-			"request.resource": "certificatesigningrequests",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
+			"request": {
+				"client": "kube-state-metrics/v0.0.0 (linux/amd64) kubernetes/$Format",
+				"count": 1478,
+				"resource": "daemonsets",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
 		},
 		"Index": "",
 		"Namespace": "",
@@ -531,24 +149,13 @@
 		"RootFields": null,
 		"ModuleFields": null,
 		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 293,
-					"1000000": 293,
-					"125000": 291,
-					"2000000": 293,
-					"250000": 293,
-					"4000000": 293,
-					"500000": 293,
-					"8000000": 293
-				},
-				"count": 293,
-				"sum": 4833955
-			},
-			"request.resource": "replicasets",
-			"request.scope": "namespace",
-			"request.subresource": "status",
-			"request.verb": "PUT"
+			"request": {
+				"client": "rescheduler/v0.0.0 (linux/amd64) kubernetes/$Format",
+				"count": 1467,
+				"resource": "pods",
+				"scope": "namespace",
+				"verb": "WATCH"
+			}
 		},
 		"Index": "",
 		"Namespace": "",
@@ -561,3293 +168,13 @@
 		"RootFields": null,
 		"ModuleFields": null,
 		"MetricSetFields": {
-			"request.client": "GoogleCloudConsole",
-			"request.count": 20,
-			"request.resource": "nodes",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-scheduler/v1.8.8 (linux/amd64) kubernetes/6e5b33a/scheduler",
-			"request.count": 160,
-			"request.resource": "events",
-			"request.scope": "namespace",
-			"request.verb": "PATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
-			"request.count": 7,
-			"request.resource": "configmaps",
-			"request.scope": "namespace",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
-			"request.count": 1,
-			"request.resource": "persistentvolumeclaims",
-			"request.scope": "namespace",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
-			"request.count": 10998,
-			"request.resource": "daemonsets",
-			"request.scope": "namespace",
-			"request.verb": "PATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 3,
-					"1000000": 3,
-					"125000": 3,
-					"2000000": 3,
-					"250000": 3,
-					"4000000": 3,
-					"500000": 3,
-					"8000000": 3
-				},
-				"count": 3,
-				"sum": 16257
-			},
-			"request.resource": "clusterroles",
-			"request.scope": "cluster",
-			"request.verb": "DELETE"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 710,
-					"1000000": 710,
-					"125000": 710,
-					"2000000": 710,
-					"250000": 710,
-					"4000000": 710,
-					"500000": 710,
-					"8000000": 710
-				},
-				"count": 710,
-				"sum": 1057701
-			},
-			"request.resource": "podtemplates",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
-			"request.count": 31,
-			"request.resource": "namespaces",
-			"request.scope": "cluster",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
-			"request.count": 8,
-			"request.resource": "clusterrolebindings",
-			"request.scope": "cluster",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
-			"request.count": 43991,
-			"request.resource": "clusterroles",
-			"request.scope": "cluster",
-			"request.verb": "PATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
-			"request.count": 2,
-			"request.resource": "rolebindings",
-			"request.scope": "namespace",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
-			"request.count": 4,
-			"request.resource": "services",
-			"request.scope": "namespace",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
-			"request.count": 21997,
-			"request.resource": "services",
-			"request.scope": "namespace",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "GoogleContainerEngine",
-			"request.count": 709,
-			"request.resource": "jobs",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
-			"request.count": 1,
-			"request.resource": "replicasets",
-			"request.scope": "namespace",
-			"request.verb": "PUT"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
-			"request.count": 1468,
-			"request.resource": "clusterroles",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:persistent-volume-binder",
-			"request.count": 1,
-			"request.resource": "events",
-			"request.scope": "namespace",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "heapster/v0.0.0 (linux/amd64) kubernetes/$Format",
-			"request.count": 4446,
-			"request.resource": "nodes",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 1,
-			"request.resource": "rolebindings",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 6,
-			"request.resource": "rolebindings",
-			"request.scope": "namespace",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 1,
-					"1000000": 1,
-					"125000": 1,
-					"2000000": 1,
-					"250000": 1,
-					"4000000": 1,
-					"500000": 1,
-					"8000000": 1
-				},
-				"count": 1,
-				"sum": 2419
-			},
-			"request.resource": "persistentvolumeclaims",
-			"request.scope": "namespace",
-			"request.subresource": "status",
-			"request.verb": "PUT"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 2926,
-					"1000000": 0,
-					"125000": 0,
-					"2000000": 0,
-					"250000": 0,
-					"4000000": 0,
-					"500000": 0,
-					"8000000": 0
-				},
-				"count": 2926,
-				"sum": 1319580992038
-			},
-			"request.resource": "rolebindings",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 1,
-			"request.resource": "endpoints",
-			"request.scope": "namespace",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
-			"request.count": 1,
-			"request.resource": "storageclasses",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubelet/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 7,
-			"request.resource": "services",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-scheduler/v1.8.8 (linux/amd64) kubernetes/6e5b33a/leader-election",
-			"request.count": 1,
-			"request.resource": "endpoints",
-			"request.scope": "namespace",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-scheduler/v1.8.8 (linux/amd64) kubernetes/6e5b33a/scheduler",
-			"request.count": 1,
-			"request.resource": "statefulsets",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 7286,
-					"1000000": 7285,
-					"125000": 7259,
-					"2000000": 7285,
-					"250000": 7275,
-					"4000000": 7285,
-					"500000": 7284,
-					"8000000": 7285
-				},
-				"count": 7286,
-				"sum": 79006880
-			},
-			"request.resource": "pods",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
-			"request.count": 1459,
-			"request.resource": "horizontalpodautoscalers",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:attachdetach-controller",
-			"request.count": 5,
-			"request.resource": "nodes",
-			"request.scope": "cluster",
-			"request.subresource": "status",
-			"request.verb": "PATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:replicaset-controller",
-			"request.count": 22,
-			"request.resource": "replicasets",
-			"request.scope": "namespace",
-			"request.subresource": "status",
-			"request.verb": "PUT"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-scheduler/v1.8.8 (linux/amd64) kubernetes/6e5b33a/scheduler",
-			"request.count": 1,
-			"request.resource": "replicasets",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "pod_nanny/v0.0.0 (linux/amd64) kubernetes/$Format",
-			"request.count": 65696,
-			"request.resource": "pods",
-			"request.scope": "namespace",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 656937,
-					"1000000": 656930,
-					"125000": 656912,
-					"2000000": 656937,
-					"250000": 656919,
-					"4000000": 656937,
-					"500000": 656926,
-					"8000000": 656937
-				},
-				"count": 656937,
-				"sum": 1660247858
-			},
-			"request.resource": "endpoints",
-			"request.scope": "namespace",
-			"request.verb": "PUT"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 19,
-					"1000000": 18,
-					"125000": 18,
-					"2000000": 19,
-					"250000": 18,
-					"4000000": 19,
-					"500000": 18,
-					"8000000": 19
-				},
-				"count": 19,
-				"sum": 1525720
-			},
-			"request.resource": "jobs",
-			"request.scope": "namespace",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
-			"request.count": 1469,
-			"request.resource": "jobs",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-state-metrics/v0.0.0 (linux/amd64) kubernetes/$Format",
-			"request.count": 1468,
-			"request.resource": "replicationcontrollers",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "glbc/v0.0.0 (linux/amd64) kubernetes/$Format",
-			"request.count": 2,
-			"request.resource": "ingresses",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
-			"request.count": 1,
-			"request.resource": "certificatesigningrequests",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:endpoint-controller",
-			"request.count": 2,
-			"request.resource": "endpoints",
-			"request.scope": "namespace",
-			"request.verb": "PUT"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:replicaset-controller",
-			"request.count": 30,
-			"request.resource": "events",
-			"request.scope": "namespace",
-			"request.verb": "PATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-scheduler/v1.8.8 (linux/amd64) kubernetes/6e5b33a/scheduler",
-			"request.count": 1471,
-			"request.resource": "persistentvolumeclaims",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-scheduler/v1.8.8 (linux/amd64) kubernetes/6e5b33a/scheduler",
-			"request.count": 1476,
-			"request.resource": "replicationcontrollers",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
-			"request.count": 21997,
-			"request.resource": "persistentvolumeclaims",
-			"request.scope": "namespace",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 21997,
-					"1000000": 21997,
-					"125000": 21997,
-					"2000000": 21997,
-					"250000": 21997,
-					"4000000": 21997,
-					"500000": 21997,
-					"8000000": 21997
-				},
-				"count": 21997,
-				"sum": 31133138
-			},
-			"request.resource": "replicationcontrollers",
-			"request.scope": "namespace",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
-			"request.count": 1,
-			"request.resource": "networkpolicies",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "glbc/v0.0.0 (linux/amd64) kubernetes/$Format",
-			"request.count": 1,
-			"request.resource": "pods",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/leader-election",
-			"request.count": 328381,
-			"request.resource": "endpoints",
-			"request.scope": "namespace",
-			"request.verb": "PUT"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:persistent-volume-binder",
-			"request.count": 1,
-			"request.resource": "persistentvolumes",
-			"request.scope": "cluster",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-scheduler/v1.8.8 (linux/amd64) kubernetes/6e5b33a/scheduler",
-			"request.count": 1,
-			"request.resource": "pods",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
-			"request.count": 21997,
-			"request.resource": "configmaps",
-			"request.scope": "namespace",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
-			"request.count": 21997,
-			"request.resource": "secrets",
-			"request.scope": "namespace",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 3,
-					"1000000": 2,
-					"125000": 2,
-					"2000000": 3,
-					"250000": 2,
-					"4000000": 3,
-					"500000": 2,
-					"8000000": 3
-				},
-				"count": 3,
-				"sum": 1678278
-			},
-			"request.resource": "clusterrolebindings",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 1,
-					"1000000": 0,
-					"125000": 0,
-					"2000000": 0,
-					"250000": 0,
-					"4000000": 0,
-					"500000": 0,
-					"8000000": 0
-				},
-				"count": 1,
-				"sum": 60000198
-			},
-			"request.resource": "configmaps",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 66815,
-					"1000000": 66815,
-					"125000": 66815,
-					"2000000": 66815,
-					"250000": 66815,
-					"4000000": 66815,
-					"500000": 66815,
-					"8000000": 66815
-				},
-				"count": 66815,
-				"sum": 93487208
-			},
-			"request.resource": "pods",
-			"request.scope": "namespace",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "GoogleContainerEngine",
-			"request.count": 709,
-			"request.resource": "deployments",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:service-controller",
-			"request.count": 1,
-			"request.resource": "services",
-			"request.scope": "namespace",
-			"request.subresource": "status",
-			"request.verb": "PUT"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubelet/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 4408,
-			"request.resource": "services",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 1469,
-					"1000000": 0,
-					"125000": 0,
-					"2000000": 0,
-					"250000": 0,
-					"4000000": 0,
-					"500000": 0,
-					"8000000": 0
-				},
-				"count": 1469,
-				"sum": 659704930318
-			},
-			"request.resource": "jobs",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 8712,
-					"1000000": 8712,
-					"125000": 8712,
-					"2000000": 8712,
-					"250000": 8712,
-					"4000000": 8712,
-					"500000": 8712,
-					"8000000": 8712
-				},
-				"count": 8712,
-				"sum": 16083150
-			},
-			"request.resource": "persistentvolumeclaims",
-			"request.scope": "namespace",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 7,
-			"request.resource": "roles",
-			"request.scope": "namespace",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
-			"request.count": 1,
-			"request.resource": "pods",
-			"request.scope": "namespace",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
-			"request.count": 14,
-			"request.resource": "replicasets",
-			"request.scope": "namespace",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
-			"request.count": 5,
-			"request.resource": "daemonsets",
-			"request.scope": "namespace",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
-			"request.count": 2,
-			"request.resource": "roles",
-			"request.scope": "namespace",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 202551,
-					"1000000": 202551,
-					"125000": 202550,
-					"2000000": 202551,
-					"250000": 202551,
-					"4000000": 202551,
-					"500000": 202551,
-					"8000000": 202551
-				},
-				"count": 202551,
-				"sum": 56134705
-			},
-			"request.resource": "secrets",
-			"request.scope": "namespace",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "GoogleContainerEngine",
-			"request.count": 709,
-			"request.resource": "poddisruptionbudgets",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 230098,
-					"1000000": 230094,
-					"125000": 230033,
-					"2000000": 230098,
-					"250000": 230085,
-					"4000000": 230098,
-					"500000": 230091,
-					"8000000": 230098
-				},
-				"count": 230098,
-				"sum": 2438676783
-			},
-			"request.resource": "nodes",
-			"request.scope": "cluster",
-			"request.subresource": "status",
-			"request.verb": "PATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 2,
-					"1000000": 1,
-					"125000": 1,
-					"2000000": 1,
-					"250000": 1,
-					"4000000": 2,
-					"500000": 1,
-					"8000000": 2
-				},
-				"count": 2,
-				"sum": 2306787
-			},
-			"request.resource": "roles",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 711,
-					"1000000": 711,
-					"125000": 711,
-					"2000000": 711,
-					"250000": 711,
-					"4000000": 711,
-					"500000": 711,
-					"8000000": 711
-				},
-				"count": 711,
-				"sum": 1029136
-			},
-			"request.resource": "statefulsets",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 1,
-			"request.resource": "endpoints",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/controller-manager",
-			"request.count": 27,
-			"request.resource": "tokenreviews",
-			"request.scope": "cluster",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
-			"request.count": 1,
-			"request.resource": "configmaps",
-			"request.scope": "namespace",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 10319,
-					"1000000": 0,
-					"125000": 0,
-					"2000000": 0,
-					"250000": 0,
-					"4000000": 0,
-					"500000": 0,
-					"8000000": 0
-				},
-				"count": 10319,
-				"sum": 4618957403529
-			},
-			"request.resource": "endpoints",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 2941,
-					"1000000": 0,
-					"125000": 0,
-					"2000000": 0,
-					"250000": 0,
-					"4000000": 0,
-					"500000": 0,
-					"8000000": 0
-				},
-				"count": 2941,
-				"sum": 1319639948582
-			},
-			"request.resource": "ingresses",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 1,
-			"request.resource": "pods",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/tokens-controller",
-			"request.count": 38,
-			"request.resource": "secrets",
-			"request.scope": "namespace",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 1,
-					"1000000": 1,
-					"125000": 1,
-					"2000000": 1,
-					"250000": 1,
-					"4000000": 1,
-					"500000": 1,
-					"8000000": 1
-				},
-				"count": 1,
-				"sum": 2145
-			},
-			"request.resource": "configmaps",
-			"request.scope": "namespace",
-			"request.verb": "PUT"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "glbc/v0.0.0 (linux/amd64) kubernetes/$Format",
-			"request.count": 1,
-			"request.resource": "configmaps",
-			"request.scope": "namespace",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "glbc/v0.0.0 (linux/amd64) kubernetes/$Format",
-			"request.count": 1,
-			"request.resource": "services",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 1,
-			"request.resource": "customresourcedefinitions",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
-			"request.count": 1,
-			"request.resource": "jobs",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
-			"request.count": 2,
-			"request.resource": "daemonsets",
-			"request.scope": "namespace",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
-			"request.count": 21997,
-			"request.resource": "statefulsets",
-			"request.scope": "namespace",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 713,
-					"1000000": 713,
-					"125000": 713,
-					"2000000": 713,
-					"250000": 713,
-					"4000000": 713,
-					"500000": 713,
-					"8000000": 713
-				},
-				"count": 713,
-				"sum": 1104285
-			},
-			"request.resource": "replicationcontrollers",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "GoogleContainerEngine",
-			"request.count": 7195,
-			"request.resource": "componentstatuses",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 11023,
-					"1000000": 11023,
-					"125000": 11023,
-					"2000000": 11023,
-					"250000": 11023,
-					"4000000": 11023,
-					"500000": 11023,
-					"8000000": 11023
-				},
-				"count": 11023,
-				"sum": 15416410
-			},
-			"request.resource": "resourcequotas",
-			"request.scope": "namespace",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 1,
-			"request.resource": "apiservices",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 22009,
-					"1000000": 22009,
-					"125000": 22009,
-					"2000000": 22009,
-					"250000": 22009,
-					"4000000": 22009,
-					"500000": 22009,
-					"8000000": 22009
-				},
-				"count": 22009,
-				"sum": 91312572
-			},
-			"request.resource": "configmaps",
-			"request.scope": "namespace",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 713,
-					"1000000": 713,
-					"125000": 713,
-					"2000000": 713,
-					"250000": 713,
-					"4000000": 713,
-					"500000": 713,
-					"8000000": 713
-				},
-				"count": 713,
-				"sum": 1783238
-			},
-			"request.resource": "daemonsets",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 21965,
-					"1000000": 21960,
-					"125000": 21957,
-					"2000000": 21960,
-					"250000": 21960,
-					"4000000": 21960,
-					"500000": 21960,
-					"8000000": 21960
-				},
-				"count": 21965,
-				"sum": 465256128
-			},
-			"request.resource": "services",
-			"request.scope": "resource",
-			"request.verb": "PROXY"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "GoogleContainerEngine",
-			"request.count": 709,
-			"request.resource": "ingresses",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/controller-manager",
-			"request.count": 15,
-			"request.resource": "secrets",
-			"request.scope": "namespace",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
-			"request.count": 1,
-			"request.resource": "clusterroles",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
-			"request.count": 21996,
-			"request.resource": "configmaps",
-			"request.scope": "namespace",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 22004,
-					"1000000": 22004,
-					"125000": 22004,
-					"2000000": 22004,
-					"250000": 22004,
-					"4000000": 22004,
-					"500000": 22004,
-					"8000000": 22004
-				},
-				"count": 22004,
-				"sum": 23746483
-			},
-			"request.resource": "roles",
-			"request.scope": "namespace",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 2,
-					"1000000": 1,
-					"125000": 1,
-					"2000000": 2,
-					"250000": 1,
-					"4000000": 2,
-					"500000": 1,
-					"8000000": 2
-				},
-				"count": 2,
-				"sum": 1806364
-			},
-			"request.resource": "secrets",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 2,
-			"request.resource": "clusterrolebindings",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 7,
-					"1000000": 7,
-					"125000": 7,
-					"2000000": 7,
-					"250000": 7,
-					"4000000": 7,
-					"500000": 7,
-					"8000000": 7
-				},
-				"count": 7,
-				"sum": 88537
-			},
-			"request.resource": "nodes",
-			"request.scope": "cluster",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
-			"request.count": 1470,
-			"request.resource": "pods",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
-			"request.count": 1465,
-			"request.resource": "resourcequotas",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-state-metrics/v0.0.0 (linux/amd64) kubernetes/$Format",
-			"request.count": 1456,
-			"request.resource": "deployments",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
-			"request.count": 21997,
-			"request.resource": "jobs",
-			"request.scope": "namespace",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 2944,
-					"1000000": 7,
-					"125000": 7,
-					"2000000": 7,
-					"250000": 7,
-					"4000000": 7,
-					"500000": 7,
-					"8000000": 7
-				},
-				"count": 2944,
-				"sum": 1319072288505
-			},
-			"request.resource": "certificatesigningrequests",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 2599,
-					"1000000": 1129,
-					"125000": 1128,
-					"2000000": 1129,
-					"250000": 1129,
-					"4000000": 1129,
-					"500000": 1129,
-					"8000000": 1129
-				},
-				"count": 2599,
-				"sum": 658396349345
-			},
-			"request.resource": "events",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 1,
-			"request.resource": "namespaces",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
-			"request.count": 1,
-			"request.resource": "pods",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
-			"request.count": 3,
-			"request.resource": "clusterroles",
-			"request.scope": "cluster",
-			"request.verb": "DELETE"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 36425,
-					"1000000": 36425,
-					"125000": 36411,
-					"2000000": 36425,
-					"250000": 36412,
-					"4000000": 36425,
-					"500000": 36421,
-					"8000000": 36425
-				},
-				"count": 36425,
-				"sum": 153386026
-			},
-			"request.resource": "pods",
-			"request.scope": "namespace",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 10999,
-					"1000000": 10999,
-					"125000": 10999,
-					"2000000": 10999,
-					"250000": 10999,
-					"4000000": 10999,
-					"500000": 10999,
-					"8000000": 10999
-				},
-				"count": 10999,
-				"sum": 28899398
-			},
-			"request.resource": "storageclasses",
-			"request.scope": "cluster",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:persistent-volume-binder",
-			"request.count": 1,
-			"request.resource": "persistentvolumeclaims",
-			"request.scope": "namespace",
-			"request.subresource": "status",
-			"request.verb": "PUT"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 116,
-					"1000000": 116,
-					"125000": 116,
-					"2000000": 116,
-					"250000": 116,
-					"4000000": 116,
-					"500000": 116,
-					"8000000": 116
-				},
-				"count": 116,
-				"sum": 1336329
-			},
-			"request.resource": "daemonsets",
-			"request.scope": "namespace",
-			"request.subresource": "status",
-			"request.verb": "PUT"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "dashboard/v1.8.0",
-			"request.count": 10,
-			"request.resource": "services",
-			"request.scope": "resource",
-			"request.verb": "PROXY"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 109953,
-					"1000000": 109952,
-					"125000": 109950,
-					"2000000": 109953,
-					"250000": 109950,
-					"4000000": 109953,
-					"500000": 109951,
-					"8000000": 109953
-				},
-				"count": 109953,
-				"sum": 142476285
-			},
-			"request.resource": "services",
-			"request.scope": "namespace",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "event-exporter/v0.0.0 (linux/amd64) kubernetes/$Format",
-			"request.count": 2599,
-			"request.resource": "events",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "glbc/v0.0.0 (linux/amd64) kubernetes/$Format",
-			"request.count": 15,
-			"request.resource": "services",
-			"request.scope": "namespace",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
-			"request.count": 90,
-			"request.resource": "daemonsets",
-			"request.scope": "namespace",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
-			"request.count": 3,
-			"request.resource": "pods",
-			"request.scope": "namespace",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 44000,
-					"1000000": 44000,
-					"125000": 44000,
-					"2000000": 44000,
-					"250000": 44000,
-					"4000000": 44000,
-					"500000": 44000,
-					"8000000": 44000
-				},
-				"count": 44000,
-				"sum": 69726863
-			},
-			"request.resource": "apiservices",
-			"request.scope": "cluster",
-			"request.subresource": "status",
-			"request.verb": "PUT"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 6,
-					"1000000": 6,
-					"125000": 6,
-					"2000000": 6,
-					"250000": 6,
-					"4000000": 6,
-					"500000": 6,
-					"8000000": 6
-				},
-				"count": 6,
-				"sum": 10013
-			},
-			"request.resource": "controllerrevisions",
-			"request.scope": "namespace",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:generic-garbage-collector",
-			"request.count": 1,
-			"request.resource": "replicasets",
-			"request.scope": "namespace",
-			"request.verb": "PUT"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-proxy/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 7,
-			"request.resource": "endpoints",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-scheduler/v1.8.8 (linux/amd64) kubernetes/6e5b33a/scheduler",
-			"request.count": 1482,
-			"request.resource": "services",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
-			"request.count": 3,
-			"request.resource": "daemonsets",
-			"request.scope": "namespace",
-			"request.verb": "DELETE"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
-			"request.count": 16,
-			"request.resource": "jobs",
-			"request.scope": "namespace",
-			"request.verb": "DELETE"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubelet/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 7,
-			"request.resource": "nodes",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 21998,
-					"1000000": 21998,
-					"125000": 21998,
-					"2000000": 21998,
-					"250000": 21998,
-					"4000000": 21998,
-					"500000": 21998,
-					"8000000": 21998
-				},
-				"count": 21998,
-				"sum": 54318333
-			},
-			"request.resource": "configmaps",
-			"request.scope": "namespace",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
-			"request.count": 1461,
-			"request.resource": "serviceaccounts",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubelet/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 1,
-			"request.resource": "configmaps",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
-			"request.count": 1470,
-			"request.resource": "replicationcontrollers",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:generic-garbage-collector",
-			"request.count": 6,
-			"request.resource": "controllerrevisions",
-			"request.scope": "namespace",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
-			"request.count": 21997,
-			"request.resource": "endpoints",
-			"request.scope": "namespace",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 9,
-					"1000000": 9,
-					"125000": 9,
-					"2000000": 9,
-					"250000": 9,
-					"4000000": 9,
-					"500000": 9,
-					"8000000": 9
-				},
-				"count": 9,
-				"sum": 24784
-			},
-			"request.resource": "certificatesigningrequests",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 1,
-					"1000000": 1,
-					"125000": 1,
-					"2000000": 1,
-					"250000": 1,
-					"4000000": 1,
-					"500000": 1,
-					"8000000": 1
-				},
-				"count": 1,
-				"sum": 25903
-			},
-			"request.resource": "deployments",
-			"request.scope": "namespace",
-			"request.subresource": "scale",
-			"request.verb": "PUT"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 157377,
-					"1000000": 157373,
-					"125000": 157353,
-					"2000000": 157377,
-					"250000": 157363,
-					"4000000": 157377,
-					"500000": 157370,
-					"8000000": 157377
-				},
-				"count": 157377,
-				"sum": 478451230
-			},
-			"request.resource": "nodes",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "GoogleCloudConsole",
-			"request.count": 7,
-			"request.resource": "persistentvolumes",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:attachdetach-controller",
-			"request.count": 50,
-			"request.resource": "events",
-			"request.scope": "namespace",
-			"request.verb": "PATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:route-controller",
-			"request.count": 7,
-			"request.resource": "nodes",
-			"request.scope": "cluster",
-			"request.subresource": "status",
-			"request.verb": "PATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
-			"request.count": 1,
-			"request.resource": "limitranges",
-			"request.scope": "namespace",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 7,
-					"1000000": 7,
-					"125000": 7,
-					"2000000": 7,
-					"250000": 7,
-					"4000000": 7,
-					"500000": 7,
-					"8000000": 7
-				},
-				"count": 7,
-				"sum": 37113
-			},
-			"request.resource": "certificatesigningrequests",
-			"request.scope": "cluster",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 1,
-					"1000000": 0,
-					"125000": 0,
-					"2000000": 0,
-					"250000": 0,
-					"4000000": 0,
-					"500000": 0,
-					"8000000": 0
-				},
-				"count": 1,
-				"sum": 60000155
-			},
-			"request.resource": "nodes",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
-			"request.count": 2,
-			"request.resource": "deployments",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:daemon-set-controller",
-			"request.count": 10,
-			"request.resource": "daemonsets",
-			"request.scope": "namespace",
-			"request.subresource": "status",
-			"request.verb": "PUT"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "cluster-proportional-autoscaler/v1.6.5 (linux/amd64) kubernetes/$Format",
-			"request.count": 65893,
-			"request.resource": "deployments",
-			"request.scope": "namespace",
-			"request.subresource": "scale",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 43979,
-			"request.resource": "nodes",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:cloud-provider",
-			"request.count": 1462,
-			"request.resource": "configmaps",
-			"request.scope": "namespace",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-state-metrics/v0.0.0 (linux/amd64) kubernetes/$Format",
-			"request.count": 2,
-			"request.resource": "daemonsets",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
-			"request.count": 15,
-			"request.resource": "pods",
-			"request.scope": "namespace",
-			"request.verb": "DELETE"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 16,
-					"1000000": 15,
-					"125000": 15,
-					"2000000": 16,
-					"250000": 15,
-					"4000000": 16,
-					"500000": 15,
-					"8000000": 16
-				},
-				"count": 16,
-				"sum": 1437944
-			},
-			"request.resource": "jobs",
-			"request.scope": "namespace",
-			"request.verb": "DELETE"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 1482,
-			"request.resource": "roles",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
-			"request.count": 1478,
-			"request.resource": "persistentvolumeclaims",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 18,
-					"1000000": 18,
-					"125000": 18,
-					"2000000": 18,
-					"250000": 18,
-					"4000000": 18,
-					"500000": 18,
-					"8000000": 18
-				},
-				"count": 18,
-				"sum": 134182
-			},
-			"request.resource": "limitranges",
-			"request.scope": "namespace",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 1,
-			"request.resource": "limitranges",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "GoogleContainerEngine",
-			"request.count": 709,
-			"request.resource": "services",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:node-controller",
-			"request.count": 70,
-			"request.resource": "pods",
-			"request.scope": "namespace",
-			"request.subresource": "status",
-			"request.verb": "PUT"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 1496,
-			"request.resource": "resourcequotas",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:cloud-provider",
-			"request.count": 1,
-			"request.resource": "configmaps",
-			"request.scope": "namespace",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
-			"request.count": 21995,
-			"request.resource": "roles",
-			"request.scope": "namespace",
-			"request.verb": "PATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 15,
-					"1000000": 15,
-					"125000": 15,
-					"2000000": 15,
-					"250000": 15,
-					"4000000": 15,
-					"500000": 15,
-					"8000000": 15
-				},
-				"count": 15,
-				"sum": 171645
-			},
-			"request.resource": "replicasets",
-			"request.scope": "namespace",
-			"request.verb": "DELETE"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 1,
-			"request.resource": "roles",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 2928,
-					"1000000": 0,
-					"125000": 0,
-					"2000000": 0,
-					"250000": 0,
-					"4000000": 0,
-					"500000": 0,
-					"8000000": 0
-				},
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
 				"count": 2928,
-				"sum": 1319357064565
-			},
-			"request.resource": "statefulsets",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
+				"resource": "deployments",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
 		},
 		"Index": "",
 		"Namespace": "",
@@ -3860,569 +187,13 @@
 		"RootFields": null,
 		"ModuleFields": null,
 		"MetricSetFields": {
-			"request.client": "glbc/v0.0.0 (linux/amd64) kubernetes/$Format",
-			"request.count": 1465,
-			"request.resource": "pods",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 1,
-			"request.resource": "configmaps",
-			"request.scope": "namespace",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:certificate-controller",
-			"request.count": 7,
-			"request.resource": "subjectaccessreviews",
-			"request.scope": "cluster",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 1,
-					"1000000": 1,
-					"125000": 1,
-					"2000000": 1,
-					"250000": 1,
-					"4000000": 1,
-					"500000": 1,
-					"8000000": 1
-				},
-				"count": 1,
-				"sum": 5655
-			},
-			"request.resource": "jobs",
-			"request.scope": "namespace",
-			"request.verb": "PATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 38,
-					"1000000": 38,
-					"125000": 38,
-					"2000000": 38,
-					"250000": 38,
-					"4000000": 38,
-					"500000": 38,
-					"8000000": 38
-				},
-				"count": 38,
-				"sum": 137225
-			},
-			"request.resource": "serviceaccounts",
-			"request.scope": "namespace",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
-			"request.count": 1478,
-			"request.resource": "storageclasses",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:persistent-volume-binder",
-			"request.count": 1,
-			"request.resource": "persistentvolumes",
-			"request.scope": "cluster",
-			"request.subresource": "status",
-			"request.verb": "PUT"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
-			"request.count": 1,
-			"request.resource": "jobs",
-			"request.scope": "namespace",
-			"request.verb": "PUT"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "GoogleCloudConsole",
-			"request.count": 20,
-			"request.resource": "pods",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 41,
-			"request.resource": "clusterroles",
-			"request.scope": "cluster",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 2939,
-					"1000000": 0,
-					"125000": 0,
-					"2000000": 0,
-					"250000": 0,
-					"4000000": 0,
-					"500000": 0,
-					"8000000": 0
-				},
-				"count": 2939,
-				"sum": 1319265103606
-			},
-			"request.resource": "storageclasses",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 17,
-					"1000000": 17,
-					"125000": 17,
-					"2000000": 17,
-					"250000": 17,
-					"4000000": 17,
-					"500000": 17,
-					"8000000": 17
-				},
-				"count": 17,
-				"sum": 12218
-			},
-			"request.resource": "subjectaccessreviews",
-			"request.scope": "cluster",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
-			"request.count": 1,
-			"request.resource": "persistentvolumes",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:deployment-controller",
-			"request.count": 2,
-			"request.resource": "replicasets",
-			"request.scope": "namespace",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 21999,
-					"1000000": 21999,
-					"125000": 21999,
-					"2000000": 21999,
-					"250000": 21999,
-					"4000000": 21999,
-					"500000": 21999,
-					"8000000": 21999
-				},
-				"count": 21999,
-				"sum": 42542811
-			},
-			"request.resource": "daemonsets",
-			"request.scope": "namespace",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 91,
-					"1000000": 91,
-					"125000": 90,
-					"2000000": 91,
-					"250000": 91,
-					"4000000": 91,
-					"500000": 91,
-					"8000000": 91
-				},
-				"count": 91,
-				"sum": 1467975
-			},
-			"request.resource": "pods",
-			"request.scope": "namespace",
-			"request.subresource": "binding",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 65986,
-					"1000000": 65986,
-					"125000": 65986,
-					"2000000": 65986,
-					"250000": 65986,
-					"4000000": 65986,
-					"500000": 65986,
-					"8000000": 65986
-				},
-				"count": 65986,
-				"sum": 112424509
-			},
-			"request.resource": "serviceaccounts",
-			"request.scope": "namespace",
-			"request.verb": "PATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:node-controller",
-			"request.count": 5,
-			"request.resource": "pods",
-			"request.scope": "namespace",
-			"request.verb": "DELETE"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 22024,
-					"1000000": 22024,
-					"125000": 22023,
-					"2000000": 22024,
-					"250000": 22024,
-					"4000000": 22024,
-					"500000": 22024,
-					"8000000": 22024
-				},
-				"count": 22024,
-				"sum": 72887687
-			},
-			"request.resource": "secrets",
-			"request.scope": "namespace",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 8067,
-					"1000000": 8067,
-					"125000": 8066,
-					"2000000": 8067,
-					"250000": 8066,
-					"4000000": 8067,
-					"500000": 8067,
-					"8000000": 8067
-				},
-				"count": 8067,
-				"sum": 16999211
-			},
-			"request.resource": "services",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "event-exporter/v0.0.0 (linux/amd64) kubernetes/$Format",
-			"request.count": 1131,
-			"request.resource": "events",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 1472,
-			"request.resource": "limitranges",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:replicaset-controller",
-			"request.count": 34,
-			"request.resource": "pods",
-			"request.scope": "namespace",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "rescheduler/v0.0.0 (linux/amd64) kubernetes/$Format",
-			"request.count": 2,
-			"request.resource": "pods",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 1,
-					"1000000": 0,
-					"125000": 0,
-					"2000000": 0,
-					"250000": 0,
-					"4000000": 0,
-					"500000": 0,
-					"8000000": 0
-				},
-				"count": 1,
-				"sum": 60000399
-			},
-			"request.resource": "jobs",
-			"request.verb": "UPDATE"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 2,
-					"1000000": 2,
-					"125000": 2,
-					"2000000": 2,
-					"250000": 2,
-					"4000000": 2,
-					"500000": 2,
-					"8000000": 2
-				},
+			"request": {
+				"client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
 				"count": 2,
-				"sum": 6185
-			},
-			"request.resource": "persistentvolumeclaims",
-			"request.scope": "namespace",
-			"request.verb": "PUT"
+				"resource": "events",
+				"scope": "namespace",
+				"verb": "LIST"
+			}
 		},
 		"Index": "",
 		"Namespace": "",
@@ -4435,11 +206,13 @@
 		"RootFields": null,
 		"ModuleFields": null,
 		"MetricSetFields": {
-			"request.client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 1465,
-			"request.resource": "apiservices",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
+			"request": {
+				"client": "rescheduler/v0.0.0 (linux/amd64) kubernetes/$Format",
+				"count": 2936,
+				"resource": "pods",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
 		},
 		"Index": "",
 		"Namespace": "",
@@ -4452,1187 +225,14 @@
 		"RootFields": null,
 		"ModuleFields": null,
 		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:node-controller",
-			"request.count": 4,
-			"request.resource": "nodes",
-			"request.scope": "cluster",
-			"request.verb": "DELETE"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:ttl-controller",
-			"request.count": 7,
-			"request.resource": "nodes",
-			"request.scope": "cluster",
-			"request.verb": "PATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 5876,
-					"1000000": 0,
-					"125000": 0,
-					"2000000": 0,
-					"250000": 0,
-					"4000000": 0,
-					"500000": 0,
-					"8000000": 0
-				},
-				"count": 5876,
-				"sum": 2637626661333
-			},
-			"request.resource": "replicasets",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 1,
-					"1000000": 1,
-					"125000": 1,
-					"2000000": 1,
-					"250000": 1,
-					"4000000": 1,
-					"500000": 1,
-					"8000000": 1
-				},
-				"count": 1,
-				"sum": 4441
-			},
-			"request.resource": "services",
-			"request.scope": "namespace",
-			"request.subresource": "status",
-			"request.verb": "PUT"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
-			"request.count": 10998,
-			"request.resource": "storageclasses",
-			"request.scope": "cluster",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 1463,
-					"1000000": 0,
-					"125000": 0,
-					"2000000": 0,
-					"250000": 0,
-					"4000000": 0,
-					"500000": 0,
-					"8000000": 0
-				},
-				"count": 1463,
-				"sum": 659457907105
-			},
-			"request.resource": "controllerrevisions",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 2,
-			"request.resource": "persistentvolumes",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "GoogleContainerEngine",
-			"request.count": 4,
-			"request.resource": "nodes",
-			"request.scope": "cluster",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 1478,
-			"request.resource": "clusterrolebindings",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 1461,
-			"request.resource": "storageclasses",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:generic-garbage-collector",
-			"request.count": 1468,
-			"request.resource": "networkpolicies",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/tokens-controller",
-			"request.count": 38,
-			"request.resource": "serviceaccounts",
-			"request.scope": "namespace",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
-			"request.count": 3,
-			"request.resource": "services",
-			"request.scope": "namespace",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 1,
-					"1000000": 1,
-					"125000": 1,
-					"2000000": 1,
-					"250000": 1,
-					"4000000": 1,
-					"500000": 1,
-					"8000000": 1
-				},
-				"count": 1,
-				"sum": 298
-			},
-			"request.resource": "controllerrevisions",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 1459,
-					"1000000": 0,
-					"125000": 0,
-					"2000000": 0,
-					"250000": 0,
-					"4000000": 0,
-					"500000": 0,
-					"8000000": 0
-				},
-				"count": 1459,
-				"sum": 659831109566
-			},
-			"request.resource": "horizontalpodautoscalers",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubelet/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 10,
-			"request.resource": "subjectaccessreviews",
-			"request.scope": "cluster",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 38,
-					"1000000": 38,
-					"125000": 38,
-					"2000000": 38,
-					"250000": 38,
-					"4000000": 38,
-					"500000": 38,
-					"8000000": 38
-				},
-				"count": 38,
-				"sum": 137375
-			},
-			"request.resource": "serviceaccounts",
-			"request.scope": "namespace",
-			"request.verb": "PUT"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
-			"request.count": 1,
-			"request.resource": "deployments",
-			"request.scope": "namespace",
-			"request.verb": "PATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:deployment-controller",
-			"request.count": 27,
-			"request.resource": "replicasets",
-			"request.scope": "namespace",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubelet/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 11,
-			"request.resource": "nodes",
-			"request.scope": "cluster",
-			"request.subresource": "status",
-			"request.verb": "PATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 16,
-					"1000000": 16,
-					"125000": 15,
-					"2000000": 16,
-					"250000": 15,
-					"4000000": 16,
-					"500000": 15,
-					"8000000": 16
-				},
-				"count": 16,
-				"sum": 793020
-			},
-			"request.resource": "namespaces",
-			"request.scope": "cluster",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
-			"request.count": 1,
-			"request.resource": "replicationcontrollers",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/leader-election",
-			"request.count": 1,
-			"request.resource": "endpoints",
-			"request.scope": "namespace",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 17682,
-					"1000000": 0,
-					"125000": 0,
-					"2000000": 0,
-					"250000": 0,
-					"4000000": 0,
-					"500000": 0,
-					"8000000": 0
-				},
-				"count": 17682,
-				"sum": 7916402902308
-			},
-			"request.resource": "services",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "Go-http-client/2.0",
-			"request.count": 20,
-			"request.resource": "pods",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
-			"request.count": 1,
-			"request.resource": "secrets",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
-			"request.count": 1463,
-			"request.resource": "controllerrevisions",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
-			"request.count": 1476,
-			"request.resource": "rolebindings",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:generic-garbage-collector",
-			"request.count": 36,
-			"request.resource": "pods",
-			"request.scope": "namespace",
-			"request.verb": "PATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
-			"request.count": 14,
-			"request.resource": "deployments",
-			"request.scope": "namespace",
-			"request.verb": "DELETE"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "Go-http-client/2.0",
-			"request.count": 14,
-			"request.resource": "pods",
-			"request.scope": "namespace",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 1471,
-			"request.resource": "persistentvolumes",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:deployment-controller",
-			"request.count": 14,
-			"request.resource": "replicasets",
-			"request.scope": "namespace",
-			"request.verb": "DELETE"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-state-metrics/v0.0.0 (linux/amd64) kubernetes/$Format",
-			"request.count": 2,
-			"request.resource": "replicasets",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-state-metrics/v0.0.0 (linux/amd64) kubernetes/$Format",
-			"request.count": 2,
-			"request.resource": "replicationcontrollers",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 2,
-					"1000000": 1,
-					"125000": 1,
-					"2000000": 2,
-					"250000": 1,
-					"4000000": 2,
-					"500000": 1,
-					"8000000": 2
-				},
-				"count": 2,
-				"sum": 1654312
-			},
-			"request.resource": "limitranges",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "GoogleContainerEngine",
-			"request.count": 709,
-			"request.resource": "horizontalpodautoscalers",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 13,
-					"1000000": 13,
-					"125000": 12,
-					"2000000": 13,
-					"250000": 13,
-					"4000000": 13,
-					"500000": 13,
-					"8000000": 13
-				},
-				"count": 13,
-				"sum": 133887
-			},
-			"request.resource": "endpoints",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 4,
-					"1000000": 4,
-					"125000": 3,
-					"2000000": 4,
-					"250000": 3,
-					"4000000": 4,
-					"500000": 3,
-					"8000000": 4
-				},
-				"count": 4,
-				"sum": 695137
-			},
-			"request.resource": "resourcequotas",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
-			"request.count": 1,
-			"request.resource": "serviceaccounts",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-proxy/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 4420,
-			"request.resource": "endpoints",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-state-metrics/v0.0.0 (linux/amd64) kubernetes/$Format",
-			"request.count": 2,
-			"request.resource": "deployments",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
-			"request.count": 2,
-			"request.resource": "secrets",
-			"request.scope": "namespace",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 51,
-					"1000000": 51,
-					"125000": 50,
-					"2000000": 51,
-					"250000": 51,
-					"4000000": 51,
-					"500000": 51,
-					"8000000": 51
-				},
-				"count": 51,
-				"sum": 453911
-			},
-			"request.resource": "clusterroles",
-			"request.scope": "cluster",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 65893,
-					"1000000": 65893,
-					"125000": 65893,
-					"2000000": 65893,
-					"250000": 65893,
-					"4000000": 65893,
-					"500000": 65893,
-					"8000000": 65893
-				},
-				"count": 65893,
-				"sum": 82149159
-			},
-			"request.resource": "deployments",
-			"request.scope": "namespace",
-			"request.subresource": "scale",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
-			"request.count": 1,
-			"request.resource": "namespaces",
-			"request.scope": "cluster",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 3,
-					"1000000": 3,
-					"125000": 3,
-					"2000000": 3,
-					"250000": 3,
-					"4000000": 3,
-					"500000": 3,
-					"8000000": 3
-				},
-				"count": 3,
-				"sum": 19136
-			},
-			"request.resource": "secrets",
-			"request.scope": "namespace",
-			"request.verb": "DELETE"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 73,
-			"request.resource": "serviceaccounts",
-			"request.scope": "namespace",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
-			"request.count": 1464,
-			"request.resource": "statefulsets",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-proxy/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 7,
-			"request.resource": "events",
-			"request.scope": "namespace",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
-			"request.count": 65988,
-			"request.resource": "deployments",
-			"request.scope": "namespace",
-			"request.verb": "PATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubelet/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 8712,
-			"request.resource": "persistentvolumeclaims",
-			"request.scope": "namespace",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 45,
-					"1000000": 45,
-					"125000": 45,
-					"2000000": 45,
-					"250000": 45,
-					"4000000": 45,
-					"500000": 45,
-					"8000000": 45
-				},
-				"count": 45,
-				"sum": 242600
-			},
-			"request.resource": "clusterrolebindings",
-			"request.scope": "cluster",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 1459,
-			"request.resource": "clusterroles",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 21997,
-					"1000000": 21997,
-					"125000": 21997,
-					"2000000": 21997,
-					"250000": 21997,
-					"4000000": 21997,
-					"500000": 21997,
-					"8000000": 21997
-				},
-				"count": 21997,
-				"sum": 28334415
-			},
-			"request.resource": "statefulsets",
-			"request.scope": "namespace",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-state-metrics/v0.0.0 (linux/amd64) kubernetes/$Format",
-			"request.count": 1473,
-			"request.resource": "replicasets",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
-			"request.count": 21995,
-			"request.resource": "rolebindings",
-			"request.scope": "namespace",
-			"request.verb": "PATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 15,
-					"1000000": 14,
-					"125000": 14,
-					"2000000": 15,
-					"250000": 14,
-					"4000000": 15,
-					"500000": 14,
-					"8000000": 15
-				},
+			"request": {
+				"client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
 				"count": 15,
-				"sum": 1450354
-			},
-			"request.resource": "deployments",
-			"request.scope": "namespace",
-			"request.verb": "PUT"
+				"resource": "pods",
+				"scope": "namespace",
+				"subresource": "log",
+				"verb": "CONNECT"
+			}
 		},
 		"Index": "",
 		"Namespace": "",
@@ -5645,150 +245,13 @@
 		"RootFields": null,
 		"ModuleFields": null,
 		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 203,
-					"1000000": 203,
-					"125000": 202,
-					"2000000": 203,
-					"250000": 203,
-					"4000000": 203,
-					"500000": 203,
-					"8000000": 203
-				},
-				"count": 203,
-				"sum": 2941687
-			},
-			"request.resource": "pods",
-			"request.scope": "namespace",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 1,
-			"request.resource": "resourcequotas",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:node-controller",
-			"request.count": 9,
-			"request.resource": "nodes",
-			"request.scope": "cluster",
-			"request.subresource": "status",
-			"request.verb": "PUT"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
-			"request.count": 43992,
-			"request.resource": "services",
-			"request.scope": "namespace",
-			"request.verb": "PATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubelet/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 56,
-			"request.resource": "nodes",
-			"request.scope": "cluster",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 2947,
-					"1000000": 0,
-					"125000": 0,
-					"2000000": 0,
-					"250000": 0,
-					"4000000": 0,
-					"500000": 0,
-					"8000000": 0
-				},
-				"count": 2947,
-				"sum": 1319410001462
-			},
-			"request.resource": "networkpolicies",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 2,
-					"1000000": 1,
-					"125000": 1,
-					"2000000": 2,
-					"250000": 1,
-					"4000000": 2,
-					"500000": 1,
-					"8000000": 2
-				},
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:persistent-volume-binder",
 				"count": 2,
-				"sum": 1761331
-			},
-			"request.resource": "rolebindings",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
+				"resource": "persistentvolumeclaims",
+				"scope": "namespace",
+				"verb": "PUT"
+			}
 		},
 		"Index": "",
 		"Namespace": "",
@@ -5801,4790 +264,25 @@
 		"RootFields": null,
 		"ModuleFields": null,
 		"MetricSetFields": {
-			"request.client": "kube-scheduler/v1.8.8 (linux/amd64) kubernetes/6e5b33a/scheduler",
-			"request.count": 1471,
-			"request.resource": "persistentvolumes",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 3,
-					"1000000": 3,
-					"125000": 2,
-					"2000000": 3,
-					"250000": 2,
-					"4000000": 3,
-					"500000": 2,
-					"8000000": 3
-				},
-				"count": 3,
-				"sum": 751587
-			},
-			"request.resource": "clusterroles",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
-			"request.count": 1472,
-			"request.resource": "podsecuritypolicies",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 1466,
-			"request.resource": "services",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
-			"request.count": 1,
-			"request.resource": "persistentvolumeclaims",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "pod_nanny/v0.0.0 (linux/amd64) kubernetes/$Format",
-			"request.count": 1482,
-			"request.resource": "nodes",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "dashboard/v1.8.0",
-			"request.count": 10,
-			"request.resource": "services",
-			"request.scope": "resource",
-			"request.verb": "proxy"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubelet/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 4428,
-			"request.resource": "pods",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:daemon-set-controller",
-			"request.count": 9,
-			"request.resource": "controllerrevisions",
-			"request.scope": "namespace",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:node-controller",
-			"request.count": 1,
-			"request.resource": "nodes",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
-			"request.count": 21997,
-			"request.resource": "replicasets",
-			"request.scope": "namespace",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
-			"request.count": 21997,
-			"request.resource": "replicationcontrollers",
-			"request.scope": "namespace",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 44036,
-					"1000000": 44036,
-					"125000": 44036,
-					"2000000": 44036,
-					"250000": 44036,
-					"4000000": 44036,
-					"500000": 44036,
-					"8000000": 44036
-				},
-				"count": 44036,
-				"sum": 46748890
-			},
-			"request.resource": "clusterroles",
-			"request.scope": "cluster",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 24,
-					"1000000": 24,
-					"125000": 23,
-					"2000000": 24,
-					"250000": 24,
-					"4000000": 24,
-					"500000": 24,
-					"8000000": 24
-				},
-				"count": 24,
-				"sum": 410336
-			},
-			"request.resource": "deployments",
-			"request.scope": "namespace",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 168,
-					"1000000": 168,
-					"125000": 167,
-					"2000000": 168,
-					"250000": 168,
-					"4000000": 168,
-					"500000": 168,
-					"8000000": 168
-				},
-				"count": 168,
-				"sum": 3433972
-			},
-			"request.resource": "pods",
-			"request.scope": "namespace",
-			"request.verb": "DELETE"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "glbc/v0.0.0 (linux/amd64) kubernetes/$Format",
-			"request.count": 2,
-			"request.resource": "configmaps",
-			"request.scope": "namespace",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
-			"request.count": 1478,
-			"request.resource": "endpoints",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
-			"request.count": 2938,
-			"request.resource": "replicasets",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "node-problem-detector/v1.4.0 (linux/amd64) kubernetes/$Format",
-			"request.count": 1,
-			"request.resource": "events",
-			"request.scope": "namespace",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 1,
-					"1000000": 1,
-					"125000": 1,
-					"2000000": 1,
-					"250000": 1,
-					"4000000": 1,
-					"500000": 1,
-					"8000000": 1
-				},
-				"count": 1,
-				"sum": 1192
-			},
-			"request.resource": "configmaps",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 444870,
-					"1000000": 444869,
-					"125000": 444861,
-					"2000000": 444869,
-					"250000": 444863,
-					"4000000": 444869,
-					"500000": 444866,
-					"8000000": 444869
-				},
-				"count": 444870,
-				"sum": 1016382203
-			},
-			"request.resource": "configmaps",
-			"request.scope": "namespace",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
-			"request.count": 1483,
-			"request.resource": "services",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:daemon-set-controller",
-			"request.count": 58,
-			"request.resource": "events",
-			"request.scope": "namespace",
-			"request.verb": "PATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:daemon-set-controller",
-			"request.count": 41,
-			"request.resource": "events",
-			"request.scope": "namespace",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
-			"request.count": 3,
-			"request.resource": "clusterrolebindings",
-			"request.scope": "cluster",
-			"request.verb": "DELETE"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
-			"request.count": 6,
-			"request.resource": "serviceaccounts",
-			"request.scope": "namespace",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 4384,
-					"1000000": 0,
-					"125000": 0,
-					"2000000": 0,
-					"250000": 0,
-					"4000000": 0,
-					"500000": 0,
-					"8000000": 0
-				},
-				"count": 4384,
-				"sum": 1978039440788
-			},
-			"request.resource": "deployments",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 1,
-			"request.resource": "serviceaccounts",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
-			"request.count": 1,
-			"request.resource": "namespaces",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
-			"request.count": 6,
-			"request.resource": "deployments",
-			"request.scope": "namespace",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
-			"request.count": 4,
-			"request.resource": "clusterroles",
-			"request.scope": "cluster",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 1483,
-					"1000000": 0,
-					"125000": 0,
-					"2000000": 0,
-					"250000": 0,
-					"4000000": 0,
-					"500000": 0,
-					"8000000": 0
-				},
-				"count": 1483,
-				"sum": 659897025212
-			},
-			"request.resource": "configmaps",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
-			"request.count": 1,
-			"request.resource": "clusterrolebindings",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
-			"request.count": 1464,
-			"request.resource": "secrets",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-scheduler/v1.8.8 (linux/amd64) kubernetes/6e5b33a/scheduler",
-			"request.count": 1469,
-			"request.resource": "nodes",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-state-metrics/v0.0.0 (linux/amd64) kubernetes/$Format",
-			"request.count": 1464,
-			"request.resource": "nodes",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 1,
-					"1000000": 1,
-					"125000": 1,
-					"2000000": 1,
-					"250000": 1,
-					"4000000": 1,
-					"500000": 1,
-					"8000000": 1
-				},
-				"count": 1,
-				"sum": 4186
-			},
-			"request.resource": "namespaces",
-			"request.scope": "cluster",
-			"request.verb": "PATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
-			"request.count": 1,
-			"request.resource": "services",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 2940,
-					"1000000": 0,
-					"125000": 0,
-					"2000000": 0,
-					"250000": 0,
-					"4000000": 0,
-					"500000": 0,
-					"8000000": 0
-				},
-				"count": 2940,
-				"sum": 1319158063084
-			},
-			"request.resource": "limitranges",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 38,
-					"1000000": 38,
-					"125000": 38,
-					"2000000": 38,
-					"250000": 38,
-					"4000000": 38,
-					"500000": 38,
-					"8000000": 38
-				},
-				"count": 38,
-				"sum": 390430
-			},
-			"request.resource": "replicasets",
-			"request.scope": "namespace",
-			"request.verb": "PUT"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 21995,
-					"1000000": 21995,
-					"125000": 21995,
-					"2000000": 21995,
-					"250000": 21995,
-					"4000000": 21995,
-					"500000": 21995,
-					"8000000": 21995
-				},
-				"count": 21995,
-				"sum": 42319790
-			},
-			"request.resource": "roles",
-			"request.scope": "namespace",
-			"request.verb": "PATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 4,
-					"1000000": 4,
-					"125000": 4,
-					"2000000": 4,
-					"250000": 4,
-					"4000000": 4,
-					"500000": 4,
-					"8000000": 4
-				},
-				"count": 4,
-				"sum": 19435
-			},
-			"request.resource": "configmaps",
-			"request.scope": "namespace",
-			"request.verb": "DELETE"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 21997,
-					"1000000": 21997,
-					"125000": 21997,
-					"2000000": 21997,
-					"250000": 21997,
-					"4000000": 21997,
-					"500000": 21997,
-					"8000000": 21997
-				},
-				"count": 21997,
-				"sum": 33805681
-			},
-			"request.resource": "jobs",
-			"request.scope": "namespace",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 27,
-					"1000000": 27,
-					"125000": 27,
-					"2000000": 27,
-					"250000": 27,
-					"4000000": 27,
-					"500000": 27,
-					"8000000": 27
-				},
-				"count": 27,
-				"sum": 149618
-			},
-			"request.resource": "replicasets",
-			"request.scope": "namespace",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 66139,
-					"1000000": 66138,
-					"125000": 66138,
-					"2000000": 66139,
-					"250000": 66138,
-					"4000000": 66139,
-					"500000": 66138,
-					"8000000": 66139
-				},
-				"count": 66139,
-				"sum": 78537675
-			},
-			"request.resource": "serviceaccounts",
-			"request.scope": "namespace",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "GoogleContainerEngine",
-			"request.count": 709,
-			"request.resource": "persistentvolumes",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
-			"request.count": 1,
-			"request.resource": "roles",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
-			"request.count": 14,
-			"request.resource": "serviceaccounts",
-			"request.scope": "namespace",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 7195,
-					"1000000": 7195,
-					"125000": 0,
-					"2000000": 7195,
-					"250000": 0,
-					"4000000": 7195,
-					"500000": 1419,
-					"8000000": 7195
-				},
-				"count": 7195,
-				"sum": 3270551868
-			},
-			"request.resource": "componentstatuses",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 10998,
-					"1000000": 10998,
-					"125000": 10998,
-					"2000000": 10998,
-					"250000": 10998,
-					"4000000": 10998,
-					"500000": 10998,
-					"8000000": 10998
-				},
-				"count": 10998,
-				"sum": 46349882
-			},
-			"request.resource": "daemonsets",
-			"request.scope": "namespace",
-			"request.verb": "PATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
-			"request.count": 1,
-			"request.resource": "rolebindings",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-state-metrics/v0.0.0 (linux/amd64) kubernetes/$Format",
-			"request.count": 2,
-			"request.resource": "nodes",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
-			"request.count": 19,
-			"request.resource": "jobs",
-			"request.scope": "namespace",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 11,
-					"1000000": 11,
-					"125000": 11,
-					"2000000": 11,
-					"250000": 11,
-					"4000000": 11,
-					"500000": 11,
-					"8000000": 11
-				},
-				"count": 11,
-				"sum": 56853
-			},
-			"request.resource": "endpoints",
-			"request.scope": "namespace",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 1,
-			"request.resource": "secrets",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
-			"request.count": 1483,
-			"request.resource": "configmaps",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:node-controller",
-			"request.count": 17,
-			"request.resource": "pods",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:service-account-controller",
-			"request.count": 3,
-			"request.resource": "serviceaccounts",
-			"request.scope": "namespace",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-state-metrics/v0.0.0 (linux/amd64) kubernetes/$Format",
-			"request.count": 2,
-			"request.resource": "resourcequotas",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
-			"request.count": 2,
-			"request.resource": "roles",
-			"request.scope": "namespace",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 6,
-					"1000000": 6,
-					"125000": 6,
-					"2000000": 6,
-					"250000": 6,
-					"4000000": 6,
-					"500000": 6,
-					"8000000": 6
-				},
-				"count": 6,
-				"sum": 81365
-			},
-			"request.resource": "daemonsets",
-			"request.scope": "namespace",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 1,
-					"1000000": 1,
-					"125000": 1,
-					"2000000": 1,
-					"250000": 1,
-					"4000000": 1,
-					"500000": 1,
-					"8000000": 1
-				},
-				"count": 1,
-				"sum": 15199
-			},
-			"request.resource": "persistentvolumeclaims",
-			"request.scope": "namespace",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubelet/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 7,
-			"request.resource": "certificatesigningrequests",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:job-controller",
-			"request.count": 1,
-			"request.resource": "jobs",
-			"request.scope": "namespace",
-			"request.subresource": "status",
-			"request.verb": "PUT"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
-			"request.count": 1,
-			"request.resource": "services",
-			"request.scope": "namespace",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "heapster/v0.0.0 (linux/amd64) kubernetes/$Format",
-			"request.count": 5,
-			"request.resource": "namespaces",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 1474,
-			"request.resource": "endpoints",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
-			"request.count": 1,
-			"request.resource": "poddisruptionbudgets",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 87983,
-					"1000000": 87983,
-					"125000": 87983,
-					"2000000": 87983,
-					"250000": 87983,
-					"4000000": 87983,
-					"500000": 87983,
-					"8000000": 87983
-				},
-				"count": 87983,
-				"sum": 161403153
-			},
-			"request.resource": "clusterrolebindings",
-			"request.scope": "cluster",
-			"request.verb": "PATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 2940,
-					"1000000": 0,
-					"125000": 0,
-					"2000000": 0,
-					"250000": 0,
-					"4000000": 0,
-					"500000": 0,
-					"8000000": 0
-				},
-				"count": 2940,
-				"sum": 1319248184423
-			},
-			"request.resource": "secrets",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:certificate-controller",
-			"request.count": 7,
-			"request.resource": "certificatesigningrequests",
-			"request.scope": "cluster",
-			"request.subresource": "approval",
-			"request.verb": "PUT"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 4392,
-					"1000000": 0,
-					"125000": 0,
-					"2000000": 0,
-					"250000": 0,
-					"4000000": 0,
-					"500000": 0,
-					"8000000": 0
-				},
-				"count": 4392,
-				"sum": 1979690652276
-			},
-			"request.resource": "namespaces",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
-			"request.count": 1472,
-			"request.resource": "poddisruptionbudgets",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 21997,
-					"1000000": 21997,
-					"125000": 21997,
-					"2000000": 21997,
-					"250000": 21997,
-					"4000000": 21997,
-					"500000": 21997,
-					"8000000": 21997
-				},
-				"count": 21997,
-				"sum": 38610514
-			},
-			"request.resource": "endpoints",
-			"request.scope": "namespace",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 17,
-					"1000000": 15,
-					"125000": 15,
-					"2000000": 15,
-					"250000": 15,
-					"4000000": 16,
-					"500000": 15,
-					"8000000": 16
-				},
-				"count": 17,
-				"sum": 62613720
-			},
-			"request.resource": "jobs",
-			"request.scope": "namespace",
-			"request.verb": "PUT"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 2934,
-					"1000000": 0,
-					"125000": 0,
-					"2000000": 0,
-					"250000": 0,
-					"4000000": 0,
-					"500000": 0,
-					"8000000": 0
-				},
-				"count": 2934,
-				"sum": 1319449062336
-			},
-			"request.resource": "serviceaccounts",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 21998,
-					"1000000": 21998,
-					"125000": 21998,
-					"2000000": 21998,
-					"250000": 21998,
-					"4000000": 21998,
-					"500000": 21998,
-					"8000000": 21998
-				},
-				"count": 21998,
-				"sum": 37531190
-			},
-			"request.resource": "services",
-			"request.scope": "namespace",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 44000,
-			"request.resource": "apiservices",
-			"request.scope": "cluster",
-			"request.subresource": "status",
-			"request.verb": "PUT"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
-			"request.count": 1464,
-			"request.resource": "persistentvolumes",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 7,
-					"1000000": 7,
-					"125000": 7,
-					"2000000": 7,
-					"250000": 7,
-					"4000000": 7,
-					"500000": 7,
-					"8000000": 7
-				},
-				"count": 7,
-				"sum": 24266
-			},
-			"request.resource": "certificatesigningrequests",
-			"request.scope": "cluster",
-			"request.subresource": "status",
-			"request.verb": "PUT"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 733671,
-					"1000000": 733664,
-					"125000": 733634,
-					"2000000": 733671,
-					"250000": 733639,
-					"4000000": 733671,
-					"500000": 733649,
-					"8000000": 733671
-				},
-				"count": 733671,
-				"sum": 834805253
-			},
-			"request.resource": "endpoints",
-			"request.scope": "namespace",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
-			"request.count": 7,
-			"request.resource": "clusterrolebindings",
-			"request.scope": "cluster",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
-			"request.count": 21997,
-			"request.resource": "persistentvolumes",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
-			"request.count": 1,
-			"request.resource": "podsecuritypolicies",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
-			"request.count": 14,
-			"request.resource": "deployments",
-			"request.scope": "namespace",
-			"request.verb": "PUT"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
-			"request.count": 1,
-			"request.resource": "jobs",
-			"request.verb": "UPDATE"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "GoogleCloudConsole",
-			"request.count": 7,
-			"request.resource": "storageclasses",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 1467,
-			"request.resource": "customresourcedefinitions",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 8712,
-					"1000000": 8712,
-					"125000": 8712,
-					"2000000": 8712,
-					"250000": 8712,
-					"4000000": 8712,
-					"500000": 8712,
-					"8000000": 8712
-				},
-				"count": 8712,
-				"sum": 9535813
-			},
-			"request.resource": "persistentvolumes",
-			"request.scope": "cluster",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 1472,
-					"1000000": 0,
-					"125000": 0,
-					"2000000": 0,
-					"250000": 0,
-					"4000000": 0,
-					"500000": 0,
-					"8000000": 0
-				},
-				"count": 1472,
-				"sum": 659545988637
-			},
-			"request.resource": "podsecuritypolicies",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 4414,
-					"1000000": 0,
-					"125000": 0,
-					"2000000": 0,
-					"250000": 0,
-					"4000000": 0,
-					"500000": 0,
-					"8000000": 0
-				},
-				"count": 4414,
-				"sum": 1978079922988
-			},
-			"request.resource": "replicationcontrollers",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "pod_nanny/v0.0.0 (linux/amd64) kubernetes/$Format",
-			"request.count": 5,
-			"request.resource": "nodes",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 20,
-					"1000000": 20,
-					"125000": 20,
-					"2000000": 20,
-					"250000": 20,
-					"4000000": 20,
-					"500000": 20,
-					"8000000": 20
-				},
-				"count": 20,
-				"sum": 518921
-			},
-			"request.resource": "apiservices",
-			"request.scope": "cluster",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 712,
-					"1000000": 712,
-					"125000": 712,
-					"2000000": 712,
-					"250000": 712,
-					"4000000": 712,
-					"500000": 712,
-					"8000000": 712
-				},
-				"count": 712,
-				"sum": 1102127
-			},
-			"request.resource": "ingresses",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
-			"request.count": 1468,
-			"request.resource": "ingresses",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-scheduler/v1.8.8 (linux/amd64) kubernetes/6e5b33a/scheduler",
-			"request.count": 91,
-			"request.resource": "pods",
-			"request.scope": "namespace",
-			"request.subresource": "binding",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubelet/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 16,
-			"request.resource": "secrets",
-			"request.scope": "namespace",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "pod_nanny/v0.0.0 (linux/amd64) kubernetes/$Format",
-			"request.count": 1,
-			"request.resource": "deployments",
-			"request.scope": "namespace",
-			"request.verb": "PUT"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 27,
-					"1000000": 27,
-					"125000": 27,
-					"2000000": 27,
-					"250000": 27,
-					"4000000": 27,
-					"500000": 27,
-					"8000000": 27
-				},
-				"count": 27,
-				"sum": 108241
-			},
-			"request.resource": "tokenreviews",
-			"request.scope": "cluster",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 18,
-			"request.resource": "limitranges",
-			"request.scope": "namespace",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
-			"request.count": 1,
-			"request.resource": "jobs",
-			"request.scope": "namespace",
-			"request.verb": "PATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 2927,
-					"1000000": 0,
-					"125000": 0,
-					"2000000": 0,
-					"250000": 0,
-					"4000000": 0,
-					"500000": 0,
-					"8000000": 0
-				},
-				"count": 2927,
-				"sum": 1319595133369
-			},
-			"request.resource": "clusterroles",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 1467,
-					"1000000": 0,
-					"125000": 0,
-					"2000000": 0,
-					"250000": 0,
-					"4000000": 0,
-					"500000": 0,
-					"8000000": 0
-				},
-				"count": 1467,
-				"sum": 659897009038
-			},
-			"request.resource": "customresourcedefinitions",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/controller-manager",
-			"request.count": 23,
-			"request.resource": "namespaces",
-			"request.scope": "cluster",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
-			"request.count": 1,
-			"request.resource": "cronjobs",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
-			"request.count": 1,
-			"request.resource": "ingresses",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
-			"request.count": 1,
-			"request.resource": "resourcequotas",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.8.7 (linux/amd64) kubernetes/b30876a",
-			"request.count": 1,
-			"request.resource": "nodes",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 1,
-					"1000000": 1,
-					"125000": 1,
-					"2000000": 1,
-					"250000": 1,
-					"4000000": 1,
-					"500000": 1,
-					"8000000": 1
-				},
-				"count": 1,
-				"sum": 104
-			},
-			"request.resource": "apiservices",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 4406,
-					"1000000": 1,
-					"125000": 1,
-					"2000000": 1,
-					"250000": 1,
-					"4000000": 1,
-					"500000": 1,
-					"8000000": 1
-				},
-				"count": 4406,
-				"sum": 1979024165553
-			},
-			"request.resource": "persistentvolumes",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
-			"request.count": 1,
-			"request.resource": "namespaces",
-			"request.scope": "cluster",
-			"request.verb": "PATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "glbc/v0.0.0 (linux/amd64) kubernetes/$Format",
-			"request.count": 1,
-			"request.resource": "nodes",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
-			"request.count": 1,
-			"request.resource": "endpoints",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 87994,
-					"1000000": 87994,
-					"125000": 87991,
-					"2000000": 87994,
-					"250000": 87993,
-					"4000000": 87994,
-					"500000": 87994,
-					"8000000": 87994
-				},
-				"count": 87994,
-				"sum": 95827906
-			},
-			"request.resource": "namespaces",
-			"request.scope": "cluster",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "cluster-proportional-autoscaler/v1.6.5 (linux/amd64) kubernetes/$Format",
-			"request.count": 1,
-			"request.resource": "configmaps",
-			"request.scope": "namespace",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:generic-garbage-collector",
-			"request.count": 14,
-			"request.resource": "replicasets",
-			"request.scope": "namespace",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
-			"request.count": 2,
-			"request.resource": "deployments",
-			"request.scope": "namespace",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
-			"request.count": 1,
-			"request.resource": "replicasets",
-			"request.scope": "namespace",
-			"request.verb": "DELETE"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
-			"request.count": 6,
-			"request.resource": "clusterroles",
-			"request.scope": "cluster",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 9,
-					"1000000": 9,
-					"125000": 9,
-					"2000000": 9,
-					"250000": 9,
-					"4000000": 9,
-					"500000": 9,
-					"8000000": 9
-				},
-				"count": 9,
-				"sum": 30051
-			},
-			"request.resource": "controllerrevisions",
-			"request.scope": "namespace",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 11023,
-			"request.resource": "resourcequotas",
-			"request.scope": "namespace",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/tokens-controller",
-			"request.count": 3,
-			"request.resource": "secrets",
-			"request.scope": "namespace",
-			"request.verb": "DELETE"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubelet/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 1,
-			"request.resource": "pods",
-			"request.scope": "namespace",
-			"request.subresource": "status",
-			"request.verb": "PUT"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 9,
-					"1000000": 9,
-					"125000": 9,
-					"2000000": 9,
-					"250000": 9,
-					"4000000": 9,
-					"500000": 9,
-					"8000000": 9
-				},
-				"count": 9,
-				"sum": 27124
-			},
-			"request.resource": "roles",
-			"request.scope": "namespace",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 1463,
-			"request.resource": "namespaces",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 2,
-					"1000000": 2,
-					"125000": 2,
-					"2000000": 2,
-					"250000": 2,
-					"4000000": 2,
-					"500000": 2,
-					"8000000": 2
-				},
-				"count": 2,
-				"sum": 770
-			},
-			"request.resource": "networkpolicies",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/controller-manager",
-			"request.count": 23,
-			"request.resource": "serviceaccounts",
-			"request.scope": "namespace",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/controller-manager",
-			"request.count": 23,
-			"request.resource": "serviceaccounts",
-			"request.scope": "namespace",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:replicaset-controller",
-			"request.count": 22,
-			"request.resource": "replicasets",
-			"request.scope": "namespace",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-scheduler/v1.8.8 (linux/amd64) kubernetes/6e5b33a/leader-election",
-			"request.count": 328348,
-			"request.resource": "endpoints",
-			"request.scope": "namespace",
-			"request.verb": "PUT"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 66639,
-					"1000000": 66637,
-					"125000": 66635,
-					"2000000": 66639,
-					"250000": 66636,
-					"4000000": 66639,
-					"500000": 66636,
-					"8000000": 66639
-				},
-				"count": 66639,
-				"sum": 120279290
-			},
-			"request.resource": "jobs",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 1,
-					"1000000": 1,
-					"125000": 1,
-					"2000000": 1,
-					"250000": 1,
-					"4000000": 1,
-					"500000": 1,
-					"8000000": 1
-				},
-				"count": 1,
-				"sum": 8582
-			},
-			"request.resource": "limitranges",
-			"request.scope": "namespace",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 21995,
-					"1000000": 21995,
-					"125000": 21995,
-					"2000000": 21995,
-					"250000": 21995,
-					"4000000": 21995,
-					"500000": 21995,
-					"8000000": 21995
-				},
-				"count": 21995,
-				"sum": 41165835
-			},
-			"request.resource": "rolebindings",
-			"request.scope": "namespace",
-			"request.verb": "PATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "GoogleContainerEngine",
-			"request.count": 4,
-			"request.resource": "nodes",
-			"request.scope": "cluster",
-			"request.verb": "PUT"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "gke-certificates-controller/v1.7.0 (linux/amd64) kubernetes/6b9ded1/certificate-controller",
-			"request.count": 1,
-			"request.resource": "certificatesigningrequests",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "glbc/v0.0.0 (linux/amd64) kubernetes/$Format",
-			"request.count": 1485,
-			"request.resource": "services",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "heapster/v0.0.0 (linux/amd64) kubernetes/$Format",
-			"request.count": 1473,
-			"request.resource": "namespaces",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
-			"request.count": 2,
-			"request.resource": "daemonsets",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 36,
-					"1000000": 36,
-					"125000": 36,
-					"2000000": 36,
-					"250000": 36,
-					"4000000": 36,
-					"500000": 36,
-					"8000000": 36
-				},
-				"count": 36,
-				"sum": 900579
-			},
-			"request.resource": "pods",
-			"request.scope": "namespace",
-			"request.verb": "PATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 1,
-					"1000000": 0,
-					"125000": 0,
-					"2000000": 0,
-					"250000": 0,
-					"4000000": 0,
-					"500000": 0,
-					"8000000": 0
-				},
-				"count": 1,
-				"sum": 61438916
-			},
-			"request.resource": "pods",
-			"request.scope": "namespace",
-			"request.subresource": "exec",
-			"request.verb": "CONNECT"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
-			"request.count": 2,
-			"request.resource": "rolebindings",
-			"request.scope": "namespace",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:cronjob-controller",
-			"request.count": 65929,
-			"request.resource": "jobs",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-proxy/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 7,
-			"request.resource": "nodes",
-			"request.scope": "cluster",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
-			"request.count": 87983,
-			"request.resource": "clusterrolebindings",
-			"request.scope": "cluster",
-			"request.verb": "PATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:pod-garbage-collector",
-			"request.count": 12,
-			"request.resource": "pods",
-			"request.scope": "namespace",
-			"request.verb": "DELETE"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-state-metrics/v0.0.0 (linux/amd64) kubernetes/$Format",
-			"request.count": 1478,
-			"request.resource": "daemonsets",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 4,
-					"1000000": 4,
-					"125000": 4,
-					"2000000": 4,
-					"250000": 4,
-					"4000000": 4,
-					"500000": 4,
-					"8000000": 4
-				},
-				"count": 4,
-				"sum": 32628
-			},
-			"request.resource": "nodes",
-			"request.scope": "cluster",
-			"request.verb": "DELETE"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 4436,
-					"1000000": 0,
-					"125000": 0,
-					"2000000": 0,
-					"250000": 0,
-					"4000000": 0,
-					"500000": 0,
-					"8000000": 0
-				},
-				"count": 4436,
-				"sum": 1978507486290
-			},
-			"request.resource": "resourcequotas",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "GoogleContainerEngine",
-			"request.count": 14,
-			"request.resource": "pods",
-			"request.scope": "namespace",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 1,
-			"request.resource": "storageclasses",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 30,
-			"request.resource": "clusterrolebindings",
-			"request.scope": "cluster",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-scheduler/v1.8.8 (linux/amd64) kubernetes/6e5b33a/scheduler",
-			"request.count": 31,
-			"request.resource": "pods",
-			"request.scope": "namespace",
-			"request.subresource": "status",
-			"request.verb": "PUT"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 65930,
-					"1000000": 65930,
-					"125000": 65929,
-					"2000000": 65930,
-					"250000": 65930,
-					"4000000": 65930,
-					"500000": 65930,
-					"8000000": 65930
-				},
-				"count": 65930,
-				"sum": 88828794
-			},
-			"request.resource": "cronjobs",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 11099,
-					"1000000": 11099,
-					"125000": 11099,
-					"2000000": 11099,
-					"250000": 11099,
-					"4000000": 11099,
-					"500000": 11099,
-					"8000000": 11099
-				},
-				"count": 11099,
-				"sum": 17674492
-			},
-			"request.resource": "daemonsets",
-			"request.scope": "namespace",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
-			"request.count": 3,
-			"request.resource": "daemonsets",
-			"request.scope": "namespace",
-			"request.verb": "PUT"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
-			"request.count": 1,
-			"request.resource": "limitranges",
-			"request.scope": "namespace",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "GoogleContainerEngine",
-			"request.count": 709,
-			"request.resource": "statefulsets",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-state-metrics/v0.0.0 (linux/amd64) kubernetes/$Format",
-			"request.count": 1475,
-			"request.resource": "resourcequotas",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 22003,
-					"1000000": 22003,
-					"125000": 22003,
-					"2000000": 22003,
-					"250000": 22003,
-					"4000000": 22003,
-					"500000": 22003,
-					"8000000": 22003
-				},
-				"count": 22003,
-				"sum": 23608438
-			},
-			"request.resource": "rolebindings",
-			"request.scope": "namespace",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "GoogleContainerEngine",
-			"request.count": 14465,
-			"request.resource": "nodes",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
-			"request.count": 1,
-			"request.resource": "statefulsets",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 10997,
-					"1000000": 10997,
-					"125000": 10997,
-					"2000000": 10997,
-					"250000": 10997,
-					"4000000": 10997,
-					"500000": 10997,
-					"8000000": 10997
-				},
-				"count": 10997,
-				"sum": 27035169
-			},
-			"request.resource": "configmaps",
-			"request.scope": "namespace",
-			"request.verb": "PATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 4412,
-					"1000000": 0,
-					"125000": 0,
-					"2000000": 0,
-					"250000": 0,
-					"4000000": 0,
-					"500000": 0,
-					"8000000": 0
-				},
-				"count": 4412,
-				"sum": 1978402804959
-			},
-			"request.resource": "daemonsets",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
-			"request.count": 1483,
-			"request.resource": "clusterrolebindings",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:node-controller",
-			"request.count": 4,
-			"request.resource": "nodes",
-			"request.scope": "cluster",
-			"request.verb": "PUT"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
-			"request.count": 4,
-			"request.resource": "configmaps",
-			"request.scope": "namespace",
-			"request.verb": "DELETE"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 15,
-					"1000000": 15,
-					"125000": 15,
-					"2000000": 15,
-					"250000": 15,
-					"4000000": 15,
-					"500000": 15,
-					"8000000": 15
-				},
-				"count": 15,
-				"sum": 213078
-			},
-			"request.resource": "nodes",
-			"request.scope": "cluster",
-			"request.verb": "PUT"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 710,
-					"1000000": 710,
-					"125000": 710,
-					"2000000": 710,
-					"250000": 710,
-					"4000000": 710,
-					"500000": 710,
-					"8000000": 710
-				},
-				"count": 710,
-				"sum": 1012232
-			},
-			"request.resource": "poddisruptionbudgets",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-scheduler/v1.8.8 (linux/amd64) kubernetes/6e5b33a/scheduler",
-			"request.count": 1465,
-			"request.resource": "replicasets",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 1,
-					"1000000": 1,
-					"125000": 1,
-					"2000000": 1,
-					"250000": 1,
-					"4000000": 1,
-					"500000": 1,
-					"8000000": 1
-				},
-				"count": 1,
-				"sum": 242
-			},
-			"request.resource": "podsecuritypolicies",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 21965,
-					"1000000": 21960,
-					"125000": 21957,
-					"2000000": 21960,
-					"250000": 21960,
-					"4000000": 21960,
-					"500000": 21960,
-					"8000000": 21960
-				},
-				"count": 21965,
-				"sum": 464443049
-			},
-			"request.resource": "services",
-			"request.scope": "resource",
-			"request.verb": "proxy"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
-			"request.count": 1,
-			"request.resource": "horizontalpodautoscalers",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-scheduler/v1.8.8 (linux/amd64) kubernetes/6e5b33a/scheduler",
-			"request.count": 1,
-			"request.resource": "persistentvolumes",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubelet/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 8711,
-			"request.resource": "persistentvolumes",
-			"request.scope": "cluster",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "GoogleContainerEngine",
-			"request.count": 14380,
-			"request.resource": "pods",
-			"request.scope": "namespace",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "heapster/v0.0.0 (linux/amd64) kubernetes/$Format",
-			"request.count": 15,
-			"request.resource": "nodes",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:job-controller",
-			"request.count": 21,
-			"request.resource": "events",
-			"request.scope": "namespace",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 711,
-					"1000000": 711,
-					"125000": 711,
-					"2000000": 711,
-					"250000": 711,
-					"4000000": 711,
-					"500000": 711,
-					"8000000": 711
-				},
-				"count": 711,
-				"sum": 1286718
-			},
-			"request.resource": "persistentvolumeclaims",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
-			"request.count": 1,
-			"request.resource": "limitranges",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-scheduler/v1.8.8 (linux/amd64) kubernetes/6e5b33a/scheduler",
-			"request.count": 1,
-			"request.resource": "persistentvolumeclaims",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-scheduler/v1.8.8 (linux/amd64) kubernetes/6e5b33a/scheduler",
-			"request.count": 1,
-			"request.resource": "services",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "GoogleContainerEngine",
-			"request.count": 709,
-			"request.resource": "serviceaccounts",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/leader-election",
-			"request.count": 1,
-			"request.resource": "endpoints",
-			"request.scope": "namespace",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 711,
-					"1000000": 710,
-					"125000": 710,
-					"2000000": 711,
-					"250000": 710,
-					"4000000": 711,
-					"500000": 710,
-					"8000000": 711
-				},
-				"count": 711,
-				"sum": 3695657
-			},
-			"request.resource": "serviceaccounts",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "GoogleContainerEngine",
-			"request.count": 14,
-			"request.resource": "pods",
-			"request.scope": "namespace",
-			"request.verb": "DELETE"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
-			"request.count": 2928,
-			"request.resource": "deployments",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
-			"request.count": 1456,
-			"request.resource": "namespaces",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-scheduler/v1.8.8 (linux/amd64) kubernetes/6e5b33a/scheduler",
-			"request.count": 123,
-			"request.resource": "events",
-			"request.scope": "namespace",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 1,
-					"1000000": 1,
-					"125000": 0,
-					"2000000": 1,
-					"250000": 1,
-					"4000000": 1,
-					"500000": 1,
-					"8000000": 1
-				},
-				"count": 1,
-				"sum": 148703
-			},
-			"request.resource": "customresourcedefinitions",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 21997,
-					"1000000": 21997,
-					"125000": 21997,
-					"2000000": 21997,
-					"250000": 21997,
-					"4000000": 21997,
-					"500000": 21997,
-					"8000000": 21997
-				},
-				"count": 21997,
-				"sum": 29407747
-			},
-			"request.resource": "ingresses",
-			"request.scope": "namespace",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "cluster-proportional-autoscaler/v1.6.5 (linux/amd64) kubernetes/$Format",
-			"request.count": 1,
-			"request.resource": "deployments",
-			"request.scope": "namespace",
-			"request.subresource": "scale",
-			"request.verb": "PUT"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 30,
-			"request.resource": "clusterrolebindings",
-			"request.scope": "cluster",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:deployment-controller",
-			"request.count": 22,
-			"request.resource": "replicasets",
-			"request.scope": "namespace",
-			"request.verb": "PUT"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:service-controller",
-			"request.count": 4,
-			"request.resource": "events",
-			"request.scope": "namespace",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 11041,
-					"1000000": 11041,
-					"125000": 11041,
-					"2000000": 11041,
-					"250000": 11041,
-					"4000000": 11041,
-					"500000": 11041,
-					"8000000": 11041
-				},
-				"count": 11041,
-				"sum": 26980827
-			},
-			"request.resource": "secrets",
-			"request.scope": "namespace",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
-			"request.count": 1,
-			"request.resource": "controllerrevisions",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 2,
-			"request.resource": "namespaces",
-			"request.scope": "cluster",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:daemon-set-controller",
-			"request.count": 9,
-			"request.resource": "pods",
-			"request.scope": "namespace",
-			"request.verb": "DELETE"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:job-controller",
-			"request.count": 20,
-			"request.resource": "pods",
-			"request.scope": "namespace",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
-			"request.count": 6,
-			"request.resource": "serviceaccounts",
-			"request.scope": "namespace",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubelet/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 4409,
-			"request.resource": "nodes",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 17686,
-					"1000000": 0,
-					"125000": 0,
-					"2000000": 1,
-					"250000": 0,
-					"4000000": 1,
-					"500000": 0,
-					"8000000": 2
-				},
-				"count": 17686,
-				"sum": 7918564532837
-			},
-			"request.resource": "nodes",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "dashboard/v1.8.0",
-			"request.count": 4,
-			"request.resource": "secrets",
-			"request.scope": "namespace",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "cluster-proportional-autoscaler/v1.6.5 (linux/amd64) kubernetes/$Format",
-			"request.count": 1,
-			"request.resource": "configmaps",
-			"request.scope": "namespace",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
-			"request.count": 1479,
-			"request.resource": "networkpolicies",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:attachdetach-controller",
-			"request.count": 2,
-			"request.resource": "nodes",
-			"request.scope": "cluster",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubelet/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 13,
-			"request.resource": "events",
-			"request.scope": "namespace",
-			"request.verb": "PATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubelet/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 68,
-			"request.resource": "pods",
-			"request.scope": "namespace",
-			"request.verb": "DELETE"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubelet/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 80,
-			"request.resource": "pods",
-			"request.scope": "namespace",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 14,
-					"1000000": 14,
-					"125000": 14,
-					"2000000": 14,
-					"250000": 14,
-					"4000000": 14,
-					"500000": 14,
-					"8000000": 14
-				},
-				"count": 14,
-				"sum": 139646
-			},
-			"request.resource": "deployments",
-			"request.scope": "namespace",
-			"request.verb": "DELETE"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 1,
-					"1000000": 1,
-					"125000": 1,
-					"2000000": 1,
-					"250000": 1,
-					"4000000": 1,
-					"500000": 1,
-					"8000000": 1
-				},
-				"count": 1,
-				"sum": 3500
-			},
-			"request.resource": "persistentvolumes",
-			"request.scope": "cluster",
-			"request.subresource": "status",
-			"request.verb": "PUT"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubelet/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 7,
-			"request.resource": "certificatesigningrequests",
-			"request.scope": "cluster",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 197492,
-					"1000000": 197485,
-					"125000": 197485,
-					"2000000": 197485,
-					"250000": 197485,
-					"4000000": 197485,
-					"500000": 197485,
-					"8000000": 197485
-				},
-				"count": 197492,
-				"sum": 668178451
-			},
-			"request.resource": "nodes",
-			"request.scope": "cluster",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 1,
-			"request.resource": "services",
-			"request.scope": "namespace",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 41,
-			"request.resource": "clusterroles",
-			"request.scope": "cluster",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-scheduler/v1.8.8 (linux/amd64) kubernetes/6e5b33a/scheduler",
-			"request.count": 1464,
-			"request.resource": "statefulsets",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 6,
-					"1000000": 6,
-					"125000": 6,
-					"2000000": 6,
-					"250000": 6,
-					"4000000": 6,
-					"500000": 6,
-					"8000000": 6
-				},
-				"count": 6,
-				"sum": 40480
-			},
-			"request.resource": "controllerrevisions",
-			"request.scope": "namespace",
-			"request.verb": "DELETE"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 713,
-					"1000000": 713,
-					"125000": 713,
-					"2000000": 713,
-					"250000": 713,
-					"4000000": 713,
-					"500000": 713,
-					"8000000": 713
-				},
-				"count": 713,
-				"sum": 2461062
-			},
-			"request.resource": "deployments",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
-			"request.count": 2,
-			"request.resource": "events",
-			"request.scope": "namespace",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
-			"request.count": 18,
-			"request.resource": "deployments",
-			"request.scope": "namespace",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubelet/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 7,
-			"request.resource": "certificatesigningrequests",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 388,
-					"1000000": 388,
-					"125000": 386,
-					"2000000": 388,
-					"250000": 388,
-					"4000000": 388,
-					"500000": 388,
-					"8000000": 388
-				},
-				"count": 388,
-				"sum": 4031187
-			},
-			"request.resource": "events",
-			"request.scope": "namespace",
-			"request.verb": "PATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/tokens-controller",
-			"request.count": 38,
-			"request.resource": "serviceaccounts",
-			"request.scope": "namespace",
-			"request.verb": "PUT"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 40,
-					"1000000": 40,
-					"125000": 40,
-					"2000000": 40,
-					"250000": 40,
-					"4000000": 40,
-					"500000": 40,
-					"8000000": 40
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 3,
+						"1000000": 2,
+						"125000": 2,
+						"2000000": 3,
+						"250000": 2,
+						"4000000": 3,
+						"500000": 2,
+						"8000000": 3
+					},
+					"count": 3,
+					"sum": 1678278
 				},
-				"count": 40,
-				"sum": 408553
-			},
-			"request.resource": "jobs",
-			"request.scope": "namespace",
-			"request.subresource": "status",
-			"request.verb": "PUT"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
-			"request.count": 1467,
-			"request.resource": "cronjobs",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "heapster/v0.0.0 (linux/amd64) kubernetes/$Format",
-			"request.count": 1460,
-			"request.resource": "pods",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
-			"request.count": 3,
-			"request.resource": "serviceaccounts",
-			"request.scope": "namespace",
-			"request.verb": "DELETE"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubelet/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 7,
-			"request.resource": "nodes",
-			"request.scope": "cluster",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "GoogleContainerEngine",
-			"request.count": 709,
-			"request.resource": "daemonsets",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/controller-manager",
-			"request.count": 27,
-			"request.resource": "secrets",
-			"request.scope": "namespace",
-			"request.verb": "LIST"
+				"resource": "clusterrolebindings",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
 		},
 		"Index": "",
 		"Namespace": "",
@@ -10597,11 +295,13 @@
 		"RootFields": null,
 		"ModuleFields": null,
 		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
-			"request.count": 4,
-			"request.resource": "clusterroles",
-			"request.scope": "cluster",
-			"request.verb": "GET"
+			"request": {
+				"client": "dashboard/v1.8.0",
+				"count": 10,
+				"resource": "services",
+				"scope": "resource",
+				"verb": "proxy"
+			}
 		},
 		"Index": "",
 		"Namespace": "",
@@ -10614,23 +314,13 @@
 		"RootFields": null,
 		"ModuleFields": null,
 		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 1464,
-					"1000000": 0,
-					"125000": 0,
-					"2000000": 0,
-					"250000": 0,
-					"4000000": 0,
-					"500000": 0,
-					"8000000": 0
-				},
+			"request": {
+				"client": "kube-scheduler/v1.8.8 (linux/amd64) kubernetes/6e5b33a/scheduler",
 				"count": 1464,
-				"sum": 659859975068
-			},
-			"request.resource": "podtemplates",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
+				"resource": "statefulsets",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
 		},
 		"Index": "",
 		"Namespace": "",
@@ -10643,11 +333,13 @@
 		"RootFields": null,
 		"ModuleFields": null,
 		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:node-controller",
-			"request.count": 11,
-			"request.resource": "nodes",
-			"request.scope": "cluster",
-			"request.verb": "GET"
+			"request": {
+				"client": "GoogleContainerEngine",
+				"count": 709,
+				"resource": "replicationcontrollers",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
 		},
 		"Index": "",
 		"Namespace": "",
@@ -10660,23 +352,44 @@
 		"RootFields": null,
 		"ModuleFields": null,
 		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 1659,
-					"1000000": 1657,
-					"125000": 1652,
-					"2000000": 1657,
-					"250000": 1654,
-					"4000000": 1657,
-					"500000": 1657,
-					"8000000": 1659
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:node-controller",
+				"count": 4,
+				"resource": "nodes",
+				"scope": "cluster",
+				"verb": "DELETE"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 15,
+						"1000000": 14,
+						"125000": 14,
+						"2000000": 15,
+						"250000": 14,
+						"4000000": 15,
+						"500000": 14,
+						"8000000": 15
+					},
+					"count": 15,
+					"sum": 1450354
 				},
-				"count": 1659,
-				"sum": 31122339
-			},
-			"request.resource": "events",
-			"request.scope": "namespace",
-			"request.verb": "POST"
+				"resource": "deployments",
+				"scope": "namespace",
+				"verb": "PUT"
+			}
 		},
 		"Index": "",
 		"Namespace": "",
@@ -10689,2141 +402,13 @@
 		"RootFields": null,
 		"ModuleFields": null,
 		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 7,
-					"1000000": 7,
-					"125000": 7,
-					"2000000": 7,
-					"250000": 7,
-					"4000000": 7,
-					"500000": 7,
-					"8000000": 7
-				},
-				"count": 7,
-				"sum": 192618
-			},
-			"request.resource": "nodes",
-			"request.scope": "cluster",
-			"request.verb": "PATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 2961,
-					"1000000": 0,
-					"125000": 0,
-					"2000000": 0,
-					"250000": 0,
-					"4000000": 0,
-					"500000": 0,
-					"8000000": 0
-				},
-				"count": 2961,
-				"sum": 1319737924064
-			},
-			"request.resource": "clusterrolebindings",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 43991,
-					"1000000": 43991,
-					"125000": 43991,
-					"2000000": 43991,
-					"250000": 43991,
-					"4000000": 43991,
-					"500000": 43991,
-					"8000000": 43991
-				},
-				"count": 43991,
-				"sum": 79881493
-			},
-			"request.resource": "clusterroles",
-			"request.scope": "cluster",
-			"request.verb": "PATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 55,
-					"1000000": 55,
-					"125000": 54,
-					"2000000": 55,
-					"250000": 55,
-					"4000000": 55,
-					"500000": 55,
-					"8000000": 55
-				},
-				"count": 55,
-				"sum": 744329
-			},
-			"request.resource": "replicasets",
-			"request.scope": "namespace",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 68,
-			"request.resource": "pods",
-			"request.scope": "namespace",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
-			"request.count": 2,
-			"request.resource": "replicasets",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:pod-garbage-collector",
-			"request.count": 32985,
-			"request.resource": "nodes",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "rescheduler/v0.0.0 (linux/amd64) kubernetes/$Format",
-			"request.count": 2936,
-			"request.resource": "pods",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 7,
-					"1000000": 7,
-					"125000": 7,
-					"2000000": 7,
-					"250000": 7,
-					"4000000": 7,
-					"500000": 7,
-					"8000000": 7
-				},
-				"count": 7,
-				"sum": 41871
-			},
-			"request.resource": "certificatesigningrequests",
-			"request.scope": "cluster",
-			"request.subresource": "approval",
-			"request.verb": "PUT"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 43994,
-					"1000000": 43994,
-					"125000": 43994,
-					"2000000": 43994,
-					"250000": 43994,
-					"4000000": 43994,
-					"500000": 43994,
-					"8000000": 43994
-				},
-				"count": 43994,
-				"sum": 116859281
-			},
-			"request.resource": "deployments",
-			"request.scope": "namespace",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-scheduler/v1.8.8 (linux/amd64) kubernetes/6e5b33a/scheduler",
-			"request.count": 1,
-			"request.resource": "replicationcontrollers",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
-			"request.count": 6,
-			"request.resource": "deployments",
-			"request.scope": "namespace",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "rescheduler/v0.0.0 (linux/amd64) kubernetes/$Format",
-			"request.count": 1,
-			"request.resource": "pods",
-			"request.scope": "namespace",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 1472,
-					"1000000": 0,
-					"125000": 0,
-					"2000000": 0,
-					"250000": 0,
-					"4000000": 0,
-					"500000": 0,
-					"8000000": 0
-				},
-				"count": 1472,
-				"sum": 659755004696
-			},
-			"request.resource": "poddisruptionbudgets",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-scheduler/v1.8.8 (linux/amd64) kubernetes/6e5b33a/scheduler",
-			"request.count": 1,
-			"request.resource": "nodes",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "heapster/v0.0.0 (linux/amd64) kubernetes/$Format",
-			"request.count": 5,
-			"request.resource": "pods",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:generic-garbage-collector",
-			"request.count": 6,
-			"request.resource": "controllerrevisions",
-			"request.scope": "namespace",
-			"request.verb": "DELETE"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-proxy/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 4417,
-			"request.resource": "services",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 1131,
-					"1000000": 1131,
-					"125000": 1131,
-					"2000000": 1131,
-					"250000": 1131,
-					"4000000": 1131,
-					"500000": 1131,
-					"8000000": 1131
-				},
-				"count": 1131,
-				"sum": 2194490
-			},
-			"request.resource": "events",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 15,
-					"1000000": 15,
-					"125000": 15,
-					"2000000": 15,
-					"250000": 15,
-					"4000000": 15,
-					"500000": 15,
-					"8000000": 15
-				},
-				"count": 15,
-				"sum": 337373
-			},
-			"request.resource": "secrets",
-			"request.scope": "namespace",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "GoogleContainerEngine",
-			"request.count": 709,
-			"request.resource": "replicasets",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "glbc/v0.0.0 (linux/amd64) kubernetes/$Format",
-			"request.count": 1473,
-			"request.resource": "ingresses",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 1450,
-			"request.resource": "rolebindings",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:node-controller",
-			"request.count": 2,
-			"request.resource": "events",
-			"request.scope": "namespace",
-			"request.verb": "PATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
-			"request.count": 8,
-			"request.resource": "clusterrolebindings",
-			"request.scope": "cluster",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubelet/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 1,
-			"request.resource": "nodes",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 3,
-					"1000000": 3,
-					"125000": 3,
-					"2000000": 3,
-					"250000": 3,
-					"4000000": 3,
-					"500000": 3,
-					"8000000": 3
-				},
-				"count": 3,
-				"sum": 21094
-			},
-			"request.resource": "daemonsets",
-			"request.scope": "namespace",
-			"request.verb": "DELETE"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 347,
-					"1000000": 347,
-					"125000": 343,
-					"2000000": 347,
-					"250000": 346,
-					"4000000": 347,
-					"500000": 347,
-					"8000000": 347
-				},
-				"count": 347,
-				"sum": 5307111
-			},
-			"request.resource": "deployments",
-			"request.scope": "namespace",
-			"request.subresource": "status",
-			"request.verb": "PUT"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
-			"request.count": 10997,
-			"request.resource": "configmaps",
-			"request.scope": "namespace",
-			"request.verb": "PATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:generic-garbage-collector",
-			"request.count": 1,
-			"request.resource": "networkpolicies",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-scheduler/v1.8.8 (linux/amd64) kubernetes/6e5b33a/scheduler",
-			"request.count": 1460,
-			"request.resource": "pods",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:deployment-controller",
-			"request.count": 60,
-			"request.resource": "deployments",
-			"request.scope": "namespace",
-			"request.subresource": "status",
-			"request.verb": "PUT"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
-			"request.count": 1,
-			"request.resource": "jobs",
-			"request.scope": "namespace",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
-			"request.count": 4,
-			"request.resource": "services",
-			"request.scope": "namespace",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubelet/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 1258,
-			"request.resource": "events",
-			"request.scope": "namespace",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 22717,
-					"1000000": 22716,
-					"125000": 22716,
-					"2000000": 22716,
-					"250000": 22716,
-					"4000000": 22717,
-					"500000": 22716,
-					"8000000": 22717
-				},
-				"count": 22717,
-				"sum": 33164863
-			},
-			"request.resource": "persistentvolumes",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "glbc/v0.0.0 (linux/amd64) kubernetes/$Format",
-			"request.count": 1464,
-			"request.resource": "nodes",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 8,
-					"1000000": 8,
-					"125000": 8,
-					"2000000": 8,
-					"250000": 8,
-					"4000000": 8,
-					"500000": 8,
-					"8000000": 8
-				},
-				"count": 8,
-				"sum": 27618
-			},
-			"request.resource": "rolebindings",
-			"request.scope": "namespace",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "dashboard/v1.8.0",
-			"request.count": 1,
-			"request.resource": "secrets",
-			"request.scope": "namespace",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 2,
-			"request.resource": "clusterroles",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
-			"request.count": 21997,
-			"request.resource": "ingresses",
-			"request.scope": "namespace",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "GoogleContainerEngine",
-			"request.count": 709,
-			"request.resource": "replicationcontrollers",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:daemon-set-controller",
-			"request.count": 39,
-			"request.resource": "pods",
-			"request.scope": "namespace",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:attachdetach-controller",
-			"request.count": 2,
-			"request.resource": "events",
-			"request.scope": "namespace",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-dns/v0.0.0 (linux/amd64) kubernetes/$Format",
-			"request.count": 2947,
-			"request.resource": "endpoints",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
-			"request.count": 2934,
-			"request.resource": "daemonsets",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 29194,
-					"1000000": 29194,
-					"125000": 29194,
-					"2000000": 29194,
-					"250000": 29194,
-					"4000000": 29194,
-					"500000": 29194,
-					"8000000": 29194
-				},
-				"count": 29194,
-				"sum": 44608509
-			},
-			"request.resource": "namespaces",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 22013,
-					"1000000": 22013,
-					"125000": 22013,
-					"2000000": 22013,
-					"250000": 22013,
-					"4000000": 22013,
-					"500000": 22013,
-					"8000000": 22013
-				},
-				"count": 22013,
-				"sum": 49092249
-			},
-			"request.resource": "replicasets",
-			"request.scope": "namespace",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 9,
-					"1000000": 9,
-					"125000": 8,
-					"2000000": 9,
-					"250000": 9,
-					"4000000": 9,
-					"500000": 9,
-					"8000000": 9
-				},
-				"count": 9,
-				"sum": 218590
-			},
-			"request.resource": "storageclasses",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/controller-manager",
-			"request.count": 1,
-			"request.resource": "events",
-			"request.scope": "namespace",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
-			"request.count": 1,
-			"request.resource": "nodes",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:node-controller",
-			"request.count": 28,
-			"request.resource": "events",
-			"request.scope": "namespace",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-dns/v0.0.0 (linux/amd64) kubernetes/$Format",
-			"request.count": 2941,
-			"request.resource": "services",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 65989,
-					"1000000": 65989,
-					"125000": 65989,
-					"2000000": 65989,
-					"250000": 65989,
-					"4000000": 65989,
-					"500000": 65989,
-					"8000000": 65989
-				},
-				"count": 65989,
-				"sum": 227196113
-			},
-			"request.resource": "deployments",
-			"request.scope": "namespace",
-			"request.verb": "PATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 43992,
-					"1000000": 43992,
-					"125000": 43992,
-					"2000000": 43992,
-					"250000": 43992,
-					"4000000": 43992,
-					"500000": 43992,
-					"8000000": 43992
-				},
-				"count": 43992,
-				"sum": 112112515
-			},
-			"request.resource": "services",
-			"request.scope": "namespace",
-			"request.verb": "PATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:replicaset-controller",
-			"request.count": 123,
-			"request.resource": "events",
-			"request.scope": "namespace",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 1462,
-					"1000000": 0,
-					"125000": 0,
-					"2000000": 0,
-					"250000": 0,
-					"4000000": 0,
-					"500000": 0,
-					"8000000": 0
-				},
-				"count": 1462,
-				"sum": 659801007214
-			},
-			"request.resource": "configmaps",
-			"request.scope": "namespace",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "gke-certificates-controller/v1.7.0 (linux/amd64) kubernetes/6b9ded1/certificate-controller",
-			"request.count": 7,
-			"request.resource": "certificatesigningrequests",
-			"request.scope": "cluster",
-			"request.subresource": "status",
-			"request.verb": "PUT"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "rescheduler/v0.0.0 (linux/amd64) kubernetes/$Format",
-			"request.count": 1,
-			"request.resource": "nodes",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 1465,
-					"1000000": 0,
-					"125000": 0,
-					"2000000": 0,
-					"250000": 0,
-					"4000000": 0,
-					"500000": 0,
-					"8000000": 0
-				},
-				"count": 1465,
-				"sum": 659555023618
-			},
-			"request.resource": "apiservices",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 714,
-					"1000000": 714,
-					"125000": 714,
-					"2000000": 714,
-					"250000": 714,
-					"4000000": 714,
-					"500000": 714,
-					"8000000": 714
-				},
-				"count": 714,
-				"sum": 2514414
-			},
-			"request.resource": "replicasets",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
-			"request.count": 1468,
-			"request.resource": "limitranges",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-scheduler/v1.8.8 (linux/amd64) kubernetes/6e5b33a/leader-election",
-			"request.count": 1,
-			"request.resource": "endpoints",
-			"request.scope": "namespace",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "rescheduler/v0.0.0 (linux/amd64) kubernetes/$Format",
-			"request.count": 1467,
-			"request.resource": "pods",
-			"request.scope": "namespace",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 3,
-					"1000000": 3,
-					"125000": 3,
-					"2000000": 3,
-					"250000": 3,
-					"4000000": 3,
-					"500000": 3,
-					"8000000": 3
-				},
-				"count": 3,
-				"sum": 19942
-			},
-			"request.resource": "clusterrolebindings",
-			"request.scope": "cluster",
-			"request.verb": "DELETE"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 2949,
-					"1000000": 0,
-					"125000": 0,
-					"2000000": 0,
-					"250000": 0,
-					"4000000": 0,
-					"500000": 0,
-					"8000000": 0
-				},
-				"count": 2949,
-				"sum": 1319045104600
-			},
-			"request.resource": "persistentvolumeclaims",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
-			"request.count": 1468,
-			"request.resource": "roles",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
-			"request.count": 11,
-			"request.resource": "pods",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 1467,
-					"1000000": 0,
-					"125000": 0,
-					"2000000": 0,
-					"250000": 0,
-					"4000000": 0,
-					"500000": 0,
-					"8000000": 0
-				},
-				"count": 1467,
-				"sum": 659673062825
-			},
-			"request.resource": "cronjobs",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 1476,
-			"request.resource": "pods",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 717,
-					"1000000": 717,
-					"125000": 715,
-					"2000000": 717,
-					"250000": 717,
-					"4000000": 717,
-					"500000": 717,
-					"8000000": 717
-				},
-				"count": 717,
-				"sum": 6031823
-			},
-			"request.resource": "pods",
-			"request.scope": "namespace",
-			"request.subresource": "status",
-			"request.verb": "PUT"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 2950,
-					"1000000": 0,
-					"125000": 0,
-					"2000000": 0,
-					"250000": 0,
-					"4000000": 0,
-					"500000": 0,
-					"8000000": 0
-				},
-				"count": 2950,
-				"sum": 1319502090736
-			},
-			"request.resource": "roles",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "glbc/v0.0.0 (linux/amd64) kubernetes/$Format",
-			"request.count": 1,
-			"request.resource": "configmaps",
-			"request.scope": "namespace",
-			"request.verb": "PUT"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:deployment-controller",
-			"request.count": 49,
-			"request.resource": "events",
-			"request.scope": "namespace",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 88021,
-					"1000000": 88021,
-					"125000": 88021,
-					"2000000": 88021,
-					"250000": 88021,
-					"4000000": 88021,
-					"500000": 88021,
-					"8000000": 88021
-				},
-				"count": 88021,
-				"sum": 94043104
-			},
-			"request.resource": "clusterrolebindings",
-			"request.scope": "cluster",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 1468,
-					"1000000": 0,
-					"125000": 0,
-					"2000000": 0,
-					"250000": 0,
-					"4000000": 0,
-					"500000": 0,
-					"8000000": 0
-				},
-				"count": 1468,
-				"sum": 660607341894
-			},
-			"request.resource": "pods",
-			"request.scope": "namespace",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 20,
-			"request.resource": "apiservices",
-			"request.scope": "cluster",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 7,
-			"request.resource": "roles",
-			"request.scope": "namespace",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
-			"request.count": 1478,
-			"request.resource": "nodes",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "Go-http-client/2.0",
-			"request.count": 1165,
-			"request.resource": "pods",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "GoogleContainerEngine",
-			"request.count": 709,
-			"request.resource": "podtemplates",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-dns/v0.0.0 (linux/amd64) kubernetes/$Format",
-			"request.count": 4,
-			"request.resource": "endpoints",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 8,
-					"1000000": 8,
-					"125000": 8,
-					"2000000": 8,
-					"250000": 8,
-					"4000000": 8,
-					"500000": 8,
-					"8000000": 8
-				},
-				"count": 8,
-				"sum": 80513
-			},
-			"request.resource": "services",
-			"request.scope": "namespace",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 6,
-			"request.resource": "rolebindings",
-			"request.scope": "namespace",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:service-controller",
-			"request.count": 1,
-			"request.resource": "events",
-			"request.scope": "namespace",
-			"request.verb": "PATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-proxy/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 7,
-			"request.resource": "services",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
-			"request.count": 1,
-			"request.resource": "pods",
-			"request.scope": "namespace",
-			"request.subresource": "exec",
-			"request.verb": "CONNECT"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
-			"request.count": 47,
-			"request.resource": "pods",
-			"request.scope": "namespace",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubelet/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 7,
-			"request.resource": "pods",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 3,
-					"1000000": 3,
-					"125000": 3,
-					"2000000": 3,
-					"250000": 3,
-					"4000000": 3,
-					"500000": 3,
-					"8000000": 3
-				},
-				"count": 3,
-				"sum": 29952
-			},
-			"request.resource": "daemonsets",
-			"request.scope": "namespace",
-			"request.verb": "PUT"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 710,
-					"1000000": 710,
-					"125000": 710,
-					"2000000": 710,
-					"250000": 710,
-					"4000000": 710,
-					"500000": 710,
-					"8000000": 710
-				},
-				"count": 710,
-				"sum": 1024073
-			},
-			"request.resource": "horizontalpodautoscalers",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 1476,
-			"request.resource": "secrets",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 13,
-			"request.resource": "namespaces",
-			"request.scope": "cluster",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubelet/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 2,
-			"request.resource": "pods",
-			"request.scope": "namespace",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "pod_nanny/v0.0.0 (linux/amd64) kubernetes/$Format",
-			"request.count": 1,
-			"request.resource": "deployments",
-			"request.scope": "namespace",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 21997,
-					"1000000": 21997,
-					"125000": 21997,
-					"2000000": 21997,
-					"250000": 21997,
-					"4000000": 21997,
-					"500000": 21997,
-					"8000000": 21997
-				},
-				"count": 21997,
-				"sum": 29995607
-			},
-			"request.resource": "persistentvolumeclaims",
-			"request.scope": "namespace",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 3,
-					"1000000": 3,
-					"125000": 3,
-					"2000000": 3,
-					"250000": 3,
-					"4000000": 3,
-					"500000": 3,
-					"8000000": 3
-				},
-				"count": 3,
-				"sum": 14251
-			},
-			"request.resource": "serviceaccounts",
-			"request.scope": "namespace",
-			"request.verb": "DELETE"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-state-metrics/v0.0.0 (linux/amd64) kubernetes/$Format",
-			"request.count": 2,
-			"request.resource": "pods",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-state-metrics/v0.0.0 (linux/amd64) kubernetes/$Format",
-			"request.count": 1472,
-			"request.resource": "pods",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
-			"request.count": 1,
-			"request.resource": "daemonsets",
-			"request.scope": "namespace",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
-			"request.count": 10999,
-			"request.resource": "endpoints",
-			"request.scope": "namespace",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 2,
-					"1000000": 2,
-					"125000": 2,
-					"2000000": 2,
-					"250000": 2,
-					"4000000": 2,
-					"500000": 2,
-					"8000000": 2
-				},
+			"request": {
+				"client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
 				"count": 2,
-				"sum": 10407
-			},
-			"request.resource": "events",
-			"request.scope": "namespace",
-			"request.verb": "LIST"
+				"resource": "daemonsets",
+				"scope": "namespace",
+				"verb": "LIST"
+			}
 		},
 		"Index": "",
 		"Namespace": "",
@@ -12836,74 +421,25 @@
 		"RootFields": null,
 		"ModuleFields": null,
 		"MetricSetFields": {
-			"request.client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 1,
-			"request.resource": "services",
-			"request.scope": "namespace",
-			"request.verb": "POST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:persistent-volume-binder",
-			"request.count": 1,
-			"request.resource": "persistentvolumes",
-			"request.scope": "cluster",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
-			"request.count": 21997,
-			"request.resource": "namespaces",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 66026,
-					"1000000": 66025,
-					"125000": 66025,
-					"2000000": 66026,
-					"250000": 66025,
-					"4000000": 66026,
-					"500000": 66025,
-					"8000000": 66026
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 7,
+						"1000000": 7,
+						"125000": 7,
+						"2000000": 7,
+						"250000": 7,
+						"4000000": 7,
+						"500000": 7,
+						"8000000": 7
+					},
+					"count": 7,
+					"sum": 192618
 				},
-				"count": 66026,
-				"sum": 98827970
-			},
-			"request.resource": "deployments",
-			"request.scope": "namespace",
-			"request.verb": "GET"
+				"resource": "nodes",
+				"scope": "cluster",
+				"verb": "PATCH"
+			}
 		},
 		"Index": "",
 		"Namespace": "",
@@ -12916,142 +452,3888 @@
 		"RootFields": null,
 		"ModuleFields": null,
 		"MetricSetFields": {
-			"request.client": "GoogleContainerEngine",
-			"request.count": 7190,
-			"request.resource": "namespaces",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 7337,
-			"request.resource": "services",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
-			"request.count": 1,
-			"request.resource": "configmaps",
-			"request.scope": "namespace",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
-			"request.count": 1,
-			"request.resource": "configmaps",
-			"request.scope": "cluster",
-			"request.verb": "LIST"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
-			"request.count": 1470,
-			"request.resource": "certificatesigningrequests",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
-			"request.count": 1464,
-			"request.resource": "podtemplates",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
-			"request.count": 4,
-			"request.resource": "replicasets",
-			"request.scope": "namespace",
-			"request.verb": "GET"
-		},
-		"Index": "",
-		"Namespace": "",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 68,
-					"1000000": 68,
-					"125000": 68,
-					"2000000": 68,
-					"250000": 68,
-					"4000000": 68,
-					"500000": 68,
-					"8000000": 68
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 2939,
+						"1000000": 0,
+						"125000": 0,
+						"2000000": 0,
+						"250000": 0,
+						"4000000": 0,
+						"500000": 0,
+						"8000000": 0
+					},
+					"count": 2939,
+					"sum": 1319265103606
 				},
+				"resource": "storageclasses",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-scheduler/v1.8.8 (linux/amd64) kubernetes/6e5b33a/scheduler",
+				"count": 1,
+				"resource": "replicasets",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:daemon-set-controller",
+				"count": 39,
+				"resource": "pods",
+				"scope": "namespace",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:node-controller",
+				"count": 28,
+				"resource": "events",
+				"scope": "namespace",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 1,
+						"1000000": 1,
+						"125000": 1,
+						"2000000": 1,
+						"250000": 1,
+						"4000000": 1,
+						"500000": 1,
+						"8000000": 1
+					},
+					"count": 1,
+					"sum": 25903
+				},
+				"resource": "deployments",
+				"scope": "namespace",
+				"subresource": "scale",
+				"verb": "PUT"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
+				"count": 14,
+				"resource": "deployments",
+				"scope": "namespace",
+				"verb": "DELETE"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "heapster/v0.0.0 (linux/amd64) kubernetes/$Format",
+				"count": 4446,
+				"resource": "nodes",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 43992,
+						"1000000": 43992,
+						"125000": 43992,
+						"2000000": 43992,
+						"250000": 43992,
+						"4000000": 43992,
+						"500000": 43992,
+						"8000000": 43992
+					},
+					"count": 43992,
+					"sum": 112112515
+				},
+				"resource": "services",
+				"scope": "namespace",
+				"verb": "PATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 7,
+						"1000000": 7,
+						"125000": 7,
+						"2000000": 7,
+						"250000": 7,
+						"4000000": 7,
+						"500000": 7,
+						"8000000": 7
+					},
+					"count": 7,
+					"sum": 41871
+				},
+				"resource": "certificatesigningrequests",
+				"scope": "cluster",
+				"subresource": "approval",
+				"verb": "PUT"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubelet/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 13,
+				"resource": "events",
+				"scope": "namespace",
+				"verb": "PATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 21998,
+						"1000000": 21998,
+						"125000": 21998,
+						"2000000": 21998,
+						"250000": 21998,
+						"4000000": 21998,
+						"500000": 21998,
+						"8000000": 21998
+					},
+					"count": 21998,
+					"sum": 37531190
+				},
+				"resource": "services",
+				"scope": "namespace",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
+				"count": 1469,
+				"resource": "jobs",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 711,
+						"1000000": 710,
+						"125000": 710,
+						"2000000": 711,
+						"250000": 710,
+						"4000000": 711,
+						"500000": 710,
+						"8000000": 711
+					},
+					"count": 711,
+					"sum": 3695657
+				},
+				"resource": "serviceaccounts",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 3,
+						"1000000": 3,
+						"125000": 3,
+						"2000000": 3,
+						"250000": 3,
+						"4000000": 3,
+						"500000": 3,
+						"8000000": 3
+					},
+					"count": 3,
+					"sum": 16257
+				},
+				"resource": "clusterroles",
+				"scope": "cluster",
+				"verb": "DELETE"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
+				"count": 21996,
+				"resource": "configmaps",
+				"scope": "namespace",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
+				"count": 3,
+				"resource": "services",
+				"scope": "namespace",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "GoogleContainerEngine",
+				"count": 14,
+				"resource": "pods",
+				"scope": "namespace",
+				"verb": "DELETE"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 203,
+						"1000000": 203,
+						"125000": 202,
+						"2000000": 203,
+						"250000": 203,
+						"4000000": 203,
+						"500000": 203,
+						"8000000": 203
+					},
+					"count": 203,
+					"sum": 2941687
+				},
+				"resource": "pods",
+				"scope": "namespace",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 9,
+						"1000000": 9,
+						"125000": 9,
+						"2000000": 9,
+						"250000": 9,
+						"4000000": 9,
+						"500000": 9,
+						"8000000": 9
+					},
+					"count": 9,
+					"sum": 24784
+				},
+				"resource": "certificatesigningrequests",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
+				"count": 1,
+				"resource": "secrets",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "cluster-proportional-autoscaler/v1.6.5 (linux/amd64) kubernetes/$Format",
+				"count": 1,
+				"resource": "configmaps",
+				"scope": "namespace",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 18,
+				"resource": "limitranges",
+				"scope": "namespace",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-scheduler/v1.8.8 (linux/amd64) kubernetes/6e5b33a/scheduler",
+				"count": 1469,
+				"resource": "nodes",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-scheduler/v1.8.8 (linux/amd64) kubernetes/6e5b33a/scheduler",
+				"count": 1,
+				"resource": "services",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
+				"count": 1478,
+				"resource": "nodes",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 4,
+						"1000000": 4,
+						"125000": 3,
+						"2000000": 4,
+						"250000": 3,
+						"4000000": 4,
+						"500000": 3,
+						"8000000": 4
+					},
+					"count": 4,
+					"sum": 695137
+				},
+				"resource": "resourcequotas",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 1,
+				"resource": "resourcequotas",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
+				"count": 15,
+				"resource": "pods",
+				"scope": "namespace",
+				"verb": "DELETE"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
+				"count": 1,
+				"resource": "persistentvolumeclaims",
+				"scope": "namespace",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
+				"count": 8,
+				"resource": "clusterrolebindings",
+				"scope": "cluster",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 1,
+						"1000000": 1,
+						"125000": 1,
+						"2000000": 1,
+						"250000": 1,
+						"4000000": 1,
+						"500000": 1,
+						"8000000": 1
+					},
+					"count": 1,
+					"sum": 8582
+				},
+				"resource": "limitranges",
+				"scope": "namespace",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/controller-manager",
+				"count": 1,
+				"resource": "events",
+				"scope": "namespace",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 87983,
+						"1000000": 87983,
+						"125000": 87983,
+						"2000000": 87983,
+						"250000": 87983,
+						"4000000": 87983,
+						"500000": 87983,
+						"8000000": 87983
+					},
+					"count": 87983,
+					"sum": 161403153
+				},
+				"resource": "clusterrolebindings",
+				"scope": "cluster",
+				"verb": "PATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 11041,
+						"1000000": 11041,
+						"125000": 11041,
+						"2000000": 11041,
+						"250000": 11041,
+						"4000000": 11041,
+						"500000": 11041,
+						"8000000": 11041
+					},
+					"count": 11041,
+					"sum": 26980827
+				},
+				"resource": "secrets",
+				"scope": "namespace",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
+				"count": 19,
+				"resource": "jobs",
+				"scope": "namespace",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
+				"count": 2,
+				"resource": "secrets",
+				"scope": "namespace",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
+				"count": 21997,
+				"resource": "jobs",
+				"scope": "namespace",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "pod_nanny/v0.0.0 (linux/amd64) kubernetes/$Format",
+				"count": 5,
+				"resource": "nodes",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "glbc/v0.0.0 (linux/amd64) kubernetes/$Format",
+				"count": 1464,
+				"resource": "nodes",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 2950,
+						"1000000": 0,
+						"125000": 0,
+						"2000000": 0,
+						"250000": 0,
+						"4000000": 0,
+						"500000": 0,
+						"8000000": 0
+					},
+					"count": 2950,
+					"sum": 1319502090736
+				},
+				"resource": "roles",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-scheduler/v1.8.8 (linux/amd64) kubernetes/6e5b33a/leader-election",
+				"count": 328348,
+				"resource": "endpoints",
+				"scope": "namespace",
+				"verb": "PUT"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:replicaset-controller",
+				"count": 34,
+				"resource": "pods",
+				"scope": "namespace",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 711,
+						"1000000": 711,
+						"125000": 711,
+						"2000000": 711,
+						"250000": 711,
+						"4000000": 711,
+						"500000": 711,
+						"8000000": 711
+					},
+					"count": 711,
+					"sum": 1286718
+				},
+				"resource": "persistentvolumeclaims",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
+				"count": 18,
+				"resource": "deployments",
+				"scope": "namespace",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubelet/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 80,
+				"resource": "pods",
+				"scope": "namespace",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "gke-certificates-controller/v1.7.0 (linux/amd64) kubernetes/6b9ded1/certificate-controller",
+				"count": 7,
+				"resource": "certificatesigningrequests",
+				"scope": "cluster",
+				"subresource": "status",
+				"verb": "PUT"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "glbc/v0.0.0 (linux/amd64) kubernetes/$Format",
+				"count": 1,
+				"resource": "configmaps",
+				"scope": "namespace",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 10998,
+						"1000000": 10998,
+						"125000": 10998,
+						"2000000": 10998,
+						"250000": 10998,
+						"4000000": 10998,
+						"500000": 10998,
+						"8000000": 10998
+					},
+					"count": 10998,
+					"sum": 46349882
+				},
+				"resource": "daemonsets",
+				"scope": "namespace",
+				"verb": "PATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 41,
+				"resource": "clusterroles",
+				"scope": "cluster",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 202551,
+						"1000000": 202551,
+						"125000": 202550,
+						"2000000": 202551,
+						"250000": 202551,
+						"4000000": 202551,
+						"500000": 202551,
+						"8000000": 202551
+					},
+					"count": 202551,
+					"sum": 56134705
+				},
+				"resource": "secrets",
+				"scope": "namespace",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "dashboard/v1.8.0",
+				"count": 4,
+				"resource": "secrets",
+				"scope": "namespace",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 21997,
+						"1000000": 21997,
+						"125000": 21997,
+						"2000000": 21997,
+						"250000": 21997,
+						"4000000": 21997,
+						"500000": 21997,
+						"8000000": 21997
+					},
+					"count": 21997,
+					"sum": 29407747
+				},
+				"resource": "ingresses",
+				"scope": "namespace",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 1482,
+				"resource": "roles",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
+				"count": 3,
+				"resource": "daemonsets",
+				"scope": "namespace",
+				"verb": "PUT"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:pod-garbage-collector",
+				"count": 12,
+				"resource": "pods",
+				"scope": "namespace",
+				"verb": "DELETE"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
+				"count": 4,
+				"resource": "clusterroles",
+				"scope": "cluster",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:deployment-controller",
+				"count": 27,
+				"resource": "replicasets",
+				"scope": "namespace",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubelet/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 4408,
+				"resource": "services",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:cronjob-controller",
+				"count": 65929,
+				"resource": "jobs",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
+				"count": 31,
+				"resource": "namespaces",
+				"scope": "cluster",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
+				"count": 1,
+				"resource": "persistentvolumes",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:cloud-provider",
+				"count": 1462,
+				"resource": "configmaps",
+				"scope": "namespace",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 7286,
+						"1000000": 7285,
+						"125000": 7259,
+						"2000000": 7285,
+						"250000": 7275,
+						"4000000": 7285,
+						"500000": 7284,
+						"8000000": 7285
+					},
+					"count": 7286,
+					"sum": 79006880
+				},
+				"resource": "pods",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
+				"count": 10998,
+				"resource": "daemonsets",
+				"scope": "namespace",
+				"verb": "PATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
+				"count": 10998,
+				"resource": "secrets",
+				"scope": "namespace",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 2,
+				"resource": "namespaces",
+				"scope": "cluster",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:node-controller",
+				"count": 70,
+				"resource": "pods",
+				"scope": "namespace",
+				"subresource": "status",
+				"verb": "PUT"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:generic-garbage-collector",
+				"count": 1468,
+				"resource": "networkpolicies",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 17682,
+						"1000000": 0,
+						"125000": 0,
+						"2000000": 0,
+						"250000": 0,
+						"4000000": 0,
+						"500000": 0,
+						"8000000": 0
+					},
+					"count": 17682,
+					"sum": 7916402902308
+				},
+				"resource": "services",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 68,
+						"1000000": 68,
+						"125000": 68,
+						"2000000": 68,
+						"250000": 68,
+						"4000000": 68,
+						"500000": 68,
+						"8000000": 68
+					},
+					"count": 68,
+					"sum": 117705
+				},
+				"resource": "jobs",
+				"scope": "namespace",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:node-controller",
+				"count": 9,
+				"resource": "nodes",
+				"scope": "cluster",
+				"subresource": "status",
+				"verb": "PUT"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
+				"count": 10997,
+				"resource": "configmaps",
+				"scope": "namespace",
+				"verb": "PATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 1462,
+						"1000000": 0,
+						"125000": 0,
+						"2000000": 0,
+						"250000": 0,
+						"4000000": 0,
+						"500000": 0,
+						"8000000": 0
+					},
+					"count": 1462,
+					"sum": 659801007214
+				},
+				"resource": "configmaps",
+				"scope": "namespace",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 65930,
+						"1000000": 65930,
+						"125000": 65929,
+						"2000000": 65930,
+						"250000": 65930,
+						"4000000": 65930,
+						"500000": 65930,
+						"8000000": 65930
+					},
+					"count": 65930,
+					"sum": 88828794
+				},
+				"resource": "cronjobs",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 1,
+						"1000000": 0,
+						"125000": 0,
+						"2000000": 0,
+						"250000": 0,
+						"4000000": 0,
+						"500000": 0,
+						"8000000": 0
+					},
+					"count": 1,
+					"sum": 60000198
+				},
+				"resource": "configmaps",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
+				"count": 1,
+				"resource": "endpoints",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
+				"count": 1,
+				"resource": "clusterroles",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:daemon-set-controller",
+				"count": 9,
+				"resource": "controllerrevisions",
+				"scope": "namespace",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
+				"count": 1467,
+				"resource": "cronjobs",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
+				"count": 1,
+				"resource": "replicationcontrollers",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
+				"count": 1468,
+				"resource": "roles",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 197492,
+						"1000000": 197485,
+						"125000": 197485,
+						"2000000": 197485,
+						"250000": 197485,
+						"4000000": 197485,
+						"500000": 197485,
+						"8000000": 197485
+					},
+					"count": 197492,
+					"sum": 668178451
+				},
+				"resource": "nodes",
+				"scope": "cluster",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 16,
+						"1000000": 16,
+						"125000": 15,
+						"2000000": 16,
+						"250000": 15,
+						"4000000": 16,
+						"500000": 15,
+						"8000000": 16
+					},
+					"count": 16,
+					"sum": 793020
+				},
+				"resource": "namespaces",
+				"scope": "cluster",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 4414,
+						"1000000": 0,
+						"125000": 0,
+						"2000000": 0,
+						"250000": 0,
+						"4000000": 0,
+						"500000": 0,
+						"8000000": 0
+					},
+					"count": 4414,
+					"sum": 1978079922988
+				},
+				"resource": "replicationcontrollers",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 293,
+						"1000000": 293,
+						"125000": 291,
+						"2000000": 293,
+						"250000": 293,
+						"4000000": 293,
+						"500000": 293,
+						"8000000": 293
+					},
+					"count": 293,
+					"sum": 4833955
+				},
+				"resource": "replicasets",
+				"scope": "namespace",
+				"subresource": "status",
+				"verb": "PUT"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 22004,
+						"1000000": 22004,
+						"125000": 22004,
+						"2000000": 22004,
+						"250000": 22004,
+						"4000000": 22004,
+						"500000": 22004,
+						"8000000": 22004
+					},
+					"count": 22004,
+					"sum": 23746483
+				},
+				"resource": "roles",
+				"scope": "namespace",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
+				"count": 1,
+				"resource": "limitranges",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
+				"count": 1,
+				"resource": "daemonsets",
+				"scope": "namespace",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 15,
+						"1000000": 0,
+						"125000": 0,
+						"2000000": 0,
+						"250000": 0,
+						"4000000": 0,
+						"500000": 0,
+						"8000000": 1
+					},
+					"count": 15,
+					"sum": 9995258313
+				},
+				"resource": "pods",
+				"scope": "namespace",
+				"subresource": "log",
+				"verb": "CONNECT"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 2944,
+						"1000000": 7,
+						"125000": 7,
+						"2000000": 7,
+						"250000": 7,
+						"4000000": 7,
+						"500000": 7,
+						"8000000": 7
+					},
+					"count": 2944,
+					"sum": 1319072288505
+				},
+				"resource": "certificatesigningrequests",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
+				"count": 1,
+				"resource": "persistentvolumeclaims",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 21997,
+						"1000000": 21997,
+						"125000": 21997,
+						"2000000": 21997,
+						"250000": 21997,
+						"4000000": 21997,
+						"500000": 21997,
+						"8000000": 21997
+					},
+					"count": 21997,
+					"sum": 38610514
+				},
+				"resource": "endpoints",
+				"scope": "namespace",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
+				"count": 1468,
+				"resource": "ingresses",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "GoogleContainerEngine",
+				"count": 709,
+				"resource": "daemonsets",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:service-controller",
+				"count": 1,
+				"resource": "events",
+				"scope": "namespace",
+				"verb": "PATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 1467,
+						"1000000": 0,
+						"125000": 0,
+						"2000000": 0,
+						"250000": 0,
+						"4000000": 0,
+						"500000": 0,
+						"8000000": 0
+					},
+					"count": 1467,
+					"sum": 659897009038
+				},
+				"resource": "customresourcedefinitions",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 1,
+				"resource": "serviceaccounts",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 1468,
+						"1000000": 0,
+						"125000": 0,
+						"2000000": 0,
+						"250000": 0,
+						"4000000": 0,
+						"500000": 0,
+						"8000000": 0
+					},
+					"count": 1468,
+					"sum": 660607341894
+				},
+				"resource": "pods",
+				"scope": "namespace",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 116,
+						"1000000": 116,
+						"125000": 116,
+						"2000000": 116,
+						"250000": 116,
+						"4000000": 116,
+						"500000": 116,
+						"8000000": 116
+					},
+					"count": 116,
+					"sum": 1336329
+				},
+				"resource": "daemonsets",
+				"scope": "namespace",
+				"subresource": "status",
+				"verb": "PUT"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 1465,
+						"1000000": 0,
+						"125000": 0,
+						"2000000": 0,
+						"250000": 0,
+						"4000000": 0,
+						"500000": 0,
+						"8000000": 0
+					},
+					"count": 1465,
+					"sum": 659555023618
+				},
+				"resource": "apiservices",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-state-metrics/v0.0.0 (linux/amd64) kubernetes/$Format",
+				"count": 2,
+				"resource": "nodes",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubelet/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 10,
+				"resource": "subjectaccessreviews",
+				"scope": "cluster",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:persistent-volume-binder",
+				"count": 1,
+				"resource": "persistentvolumeclaims",
+				"scope": "namespace",
+				"subresource": "status",
+				"verb": "PUT"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:certificate-controller",
+				"count": 7,
+				"resource": "subjectaccessreviews",
+				"scope": "cluster",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
+				"count": 21997,
+				"resource": "endpoints",
+				"scope": "namespace",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubelet/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 2,
+				"resource": "pods",
+				"scope": "namespace",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:cronjob-controller",
+				"count": 65929,
+				"resource": "cronjobs",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-scheduler/v1.8.8 (linux/amd64) kubernetes/6e5b33a/scheduler",
+				"count": 3,
+				"resource": "pods",
+				"scope": "namespace",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 1461,
+				"resource": "storageclasses",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "glbc/v0.0.0 (linux/amd64) kubernetes/$Format",
+				"count": 1,
+				"resource": "pods",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
+				"count": 21997,
+				"resource": "replicationcontrollers",
+				"scope": "namespace",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/controller-manager",
+				"count": 23,
+				"resource": "serviceaccounts",
+				"scope": "namespace",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/tokens-controller",
+				"count": 38,
+				"resource": "serviceaccounts",
+				"scope": "namespace",
+				"verb": "PUT"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:generic-garbage-collector",
+				"count": 36,
+				"resource": "pods",
+				"scope": "namespace",
+				"verb": "PATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
+				"count": 1,
+				"resource": "clusterrolebindings",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 21995,
+						"1000000": 21995,
+						"125000": 21995,
+						"2000000": 21995,
+						"250000": 21995,
+						"4000000": 21995,
+						"500000": 21995,
+						"8000000": 21995
+					},
+					"count": 21995,
+					"sum": 42319790
+				},
+				"resource": "roles",
+				"scope": "namespace",
+				"verb": "PATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 2,
+						"1000000": 1,
+						"125000": 1,
+						"2000000": 1,
+						"250000": 1,
+						"4000000": 2,
+						"500000": 1,
+						"8000000": 2
+					},
+					"count": 2,
+					"sum": 2306787
+				},
+				"resource": "roles",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
+				"count": 1,
+				"resource": "jobs",
+				"verb": "UPDATE"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
+				"count": 1,
+				"resource": "pods",
+				"scope": "namespace",
+				"subresource": "exec",
+				"verb": "CONNECT"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 38,
+						"1000000": 38,
+						"125000": 38,
+						"2000000": 38,
+						"250000": 38,
+						"4000000": 38,
+						"500000": 38,
+						"8000000": 38
+					},
+					"count": 38,
+					"sum": 390430
+				},
+				"resource": "replicasets",
+				"scope": "namespace",
+				"verb": "PUT"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 21997,
+						"1000000": 21997,
+						"125000": 21997,
+						"2000000": 21997,
+						"250000": 21997,
+						"4000000": 21997,
+						"500000": 21997,
+						"8000000": 21997
+					},
+					"count": 21997,
+					"sum": 33805681
+				},
+				"resource": "jobs",
+				"scope": "namespace",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
+				"count": 1,
+				"resource": "certificatesigningrequests",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
+				"count": 1,
+				"resource": "controllerrevisions",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:node-controller",
+				"count": 1,
+				"resource": "nodes",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-state-metrics/v0.0.0 (linux/amd64) kubernetes/$Format",
+				"count": 1464,
+				"resource": "nodes",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "node-problem-detector/v1.4.0 (linux/amd64) kubernetes/$Format",
+				"count": 1,
+				"resource": "events",
+				"scope": "namespace",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 11,
+						"1000000": 11,
+						"125000": 11,
+						"2000000": 11,
+						"250000": 11,
+						"4000000": 11,
+						"500000": 11,
+						"8000000": 11
+					},
+					"count": 11,
+					"sum": 56853
+				},
+				"resource": "endpoints",
+				"scope": "namespace",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
+				"count": 1,
+				"resource": "configmaps",
+				"scope": "namespace",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubelet/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 1258,
+				"resource": "events",
+				"scope": "namespace",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-proxy/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 7,
+				"resource": "events",
+				"scope": "namespace",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 21965,
+						"1000000": 21960,
+						"125000": 21957,
+						"2000000": 21960,
+						"250000": 21960,
+						"4000000": 21960,
+						"500000": 21960,
+						"8000000": 21960
+					},
+					"count": 21965,
+					"sum": 464443049
+				},
+				"resource": "services",
+				"scope": "resource",
+				"verb": "proxy"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "glbc/v0.0.0 (linux/amd64) kubernetes/$Format",
+				"count": 2,
+				"resource": "configmaps",
+				"scope": "namespace",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 22003,
+						"1000000": 22003,
+						"125000": 22003,
+						"2000000": 22003,
+						"250000": 22003,
+						"4000000": 22003,
+						"500000": 22003,
+						"8000000": 22003
+					},
+					"count": 22003,
+					"sum": 23608438
+				},
+				"resource": "rolebindings",
+				"scope": "namespace",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 1463,
+						"1000000": 0,
+						"125000": 0,
+						"2000000": 0,
+						"250000": 0,
+						"4000000": 0,
+						"500000": 0,
+						"8000000": 0
+					},
+					"count": 1463,
+					"sum": 659457907105
+				},
+				"resource": "controllerrevisions",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:endpoint-controller",
+				"count": 2,
+				"resource": "endpoints",
+				"scope": "namespace",
+				"verb": "PUT"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 30,
+				"resource": "clusterrolebindings",
+				"scope": "cluster",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
+				"count": 1479,
+				"resource": "networkpolicies",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 6,
+						"1000000": 6,
+						"125000": 6,
+						"2000000": 6,
+						"250000": 6,
+						"4000000": 6,
+						"500000": 6,
+						"8000000": 6
+					},
+					"count": 6,
+					"sum": 10013
+				},
+				"resource": "controllerrevisions",
+				"scope": "namespace",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 1,
+				"resource": "limitranges",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 1,
+				"resource": "rolebindings",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/controller-manager",
+				"count": 27,
+				"resource": "secrets",
+				"scope": "namespace",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 1,
+				"resource": "configmaps",
+				"scope": "namespace",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
+				"count": 21997,
+				"resource": "daemonsets",
+				"scope": "namespace",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-dns/v0.0.0 (linux/amd64) kubernetes/$Format",
+				"count": 2947,
+				"resource": "endpoints",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-state-metrics/v0.0.0 (linux/amd64) kubernetes/$Format",
+				"count": 1475,
+				"resource": "resourcequotas",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
+				"count": 2938,
+				"resource": "replicasets",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:service-controller",
+				"count": 4,
+				"resource": "events",
+				"scope": "namespace",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
+				"count": 1,
+				"resource": "jobs",
+				"scope": "namespace",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 24,
+						"1000000": 24,
+						"125000": 23,
+						"2000000": 24,
+						"250000": 24,
+						"4000000": 24,
+						"500000": 24,
+						"8000000": 24
+					},
+					"count": 24,
+					"sum": 410336
+				},
+				"resource": "deployments",
+				"scope": "namespace",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
+				"count": 2,
+				"resource": "replicasets",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:node-controller",
+				"count": 5,
+				"resource": "pods",
+				"scope": "namespace",
+				"verb": "DELETE"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 1,
+						"1000000": 0,
+						"125000": 0,
+						"2000000": 0,
+						"250000": 0,
+						"4000000": 0,
+						"500000": 0,
+						"8000000": 0
+					},
+					"count": 1,
+					"sum": 60000155
+				},
+				"resource": "nodes",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 8,
+						"1000000": 8,
+						"125000": 8,
+						"2000000": 8,
+						"250000": 8,
+						"4000000": 8,
+						"500000": 8,
+						"8000000": 8
+					},
+					"count": 8,
+					"sum": 27618
+				},
+				"resource": "rolebindings",
+				"scope": "namespace",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 347,
+						"1000000": 347,
+						"125000": 343,
+						"2000000": 347,
+						"250000": 346,
+						"4000000": 347,
+						"500000": 347,
+						"8000000": 347
+					},
+					"count": 347,
+					"sum": 5307111
+				},
+				"resource": "deployments",
+				"scope": "namespace",
+				"subresource": "status",
+				"verb": "PUT"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
+				"count": 1,
+				"resource": "services",
+				"scope": "namespace",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 8712,
+						"1000000": 8712,
+						"125000": 8712,
+						"2000000": 8712,
+						"250000": 8712,
+						"4000000": 8712,
+						"500000": 8712,
+						"8000000": 8712
+					},
+					"count": 8712,
+					"sum": 16083150
+				},
+				"resource": "persistentvolumeclaims",
+				"scope": "namespace",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/leader-election",
+				"count": 328381,
+				"resource": "endpoints",
+				"scope": "namespace",
+				"verb": "PUT"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubelet/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 7,
+				"resource": "certificatesigningrequests",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/controller-manager",
+				"count": 23,
+				"resource": "serviceaccounts",
+				"scope": "namespace",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 2,
+						"1000000": 1,
+						"125000": 1,
+						"2000000": 2,
+						"250000": 1,
+						"4000000": 2,
+						"500000": 1,
+						"8000000": 2
+					},
+					"count": 2,
+					"sum": 1654312
+				},
+				"resource": "limitranges",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
+				"count": 1478,
+				"resource": "persistentvolumeclaims",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 2941,
+						"1000000": 0,
+						"125000": 0,
+						"2000000": 0,
+						"250000": 0,
+						"4000000": 0,
+						"500000": 0,
+						"8000000": 0
+					},
+					"count": 2941,
+					"sum": 1319639948582
+				},
+				"resource": "ingresses",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
+				"count": 1,
+				"resource": "jobs",
+				"scope": "namespace",
+				"verb": "PUT"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
+				"count": 2,
+				"resource": "roles",
+				"scope": "namespace",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
+				"count": 90,
+				"resource": "daemonsets",
+				"scope": "namespace",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:endpoint-controller",
+				"count": 1,
+				"resource": "endpoints",
+				"scope": "namespace",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
+				"count": 1464,
+				"resource": "podtemplates",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
+				"count": 1,
+				"resource": "namespaces",
+				"scope": "cluster",
+				"verb": "PATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
+				"count": 3,
+				"resource": "clusterroles",
+				"scope": "cluster",
+				"verb": "DELETE"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 7,
+						"1000000": 7,
+						"125000": 7,
+						"2000000": 7,
+						"250000": 7,
+						"4000000": 7,
+						"500000": 7,
+						"8000000": 7
+					},
+					"count": 7,
+					"sum": 24266
+				},
+				"resource": "certificatesigningrequests",
+				"scope": "cluster",
+				"subresource": "status",
+				"verb": "PUT"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubelet/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
 				"count": 68,
-				"sum": 117705
-			},
-			"request.resource": "jobs",
-			"request.scope": "namespace",
-			"request.verb": "GET"
+				"resource": "pods",
+				"scope": "namespace",
+				"verb": "DELETE"
+			}
 		},
 		"Index": "",
 		"Namespace": "",
@@ -13064,23 +4346,10003 @@
 		"RootFields": null,
 		"ModuleFields": null,
 		"MetricSetFields": {
-			"request.latency": {
-				"bucket": {
-					"+Inf": 17332,
-					"1000000": 0,
-					"125000": 0,
-					"2000000": 0,
-					"250000": 0,
-					"4000000": 0,
-					"500000": 0,
-					"8000000": 0
+			"request": {
+				"client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
+				"count": 5,
+				"resource": "daemonsets",
+				"scope": "namespace",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 1466,
+				"resource": "services",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "heapster/v0.0.0 (linux/amd64) kubernetes/$Format",
+				"count": 5,
+				"resource": "namespaces",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-proxy/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 4417,
+				"resource": "services",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 1464,
+						"1000000": 0,
+						"125000": 0,
+						"2000000": 0,
+						"250000": 0,
+						"4000000": 0,
+						"500000": 0,
+						"8000000": 0
+					},
+					"count": 1464,
+					"sum": 659859975068
 				},
-				"count": 17332,
-				"sum": 10380663647634
-			},
-			"request.resource": "pods",
-			"request.scope": "cluster",
-			"request.verb": "WATCH"
+				"resource": "podtemplates",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:generic-garbage-collector",
+				"count": 6,
+				"resource": "controllerrevisions",
+				"scope": "namespace",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/tokens-controller",
+				"count": 38,
+				"resource": "secrets",
+				"scope": "namespace",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 17332,
+						"1000000": 0,
+						"125000": 0,
+						"2000000": 0,
+						"250000": 0,
+						"4000000": 0,
+						"500000": 0,
+						"8000000": 0
+					},
+					"count": 17332,
+					"sum": 10380663647634
+				},
+				"resource": "pods",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "GoogleContainerEngine",
+				"count": 709,
+				"resource": "replicasets",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "cluster-proportional-autoscaler/v1.6.5 (linux/amd64) kubernetes/$Format",
+				"count": 1,
+				"resource": "configmaps",
+				"scope": "namespace",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 22717,
+						"1000000": 22716,
+						"125000": 22716,
+						"2000000": 22716,
+						"250000": 22716,
+						"4000000": 22717,
+						"500000": 22716,
+						"8000000": 22717
+					},
+					"count": 22717,
+					"sum": 33164863
+				},
+				"resource": "persistentvolumes",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 7,
+						"1000000": 7,
+						"125000": 7,
+						"2000000": 7,
+						"250000": 7,
+						"4000000": 7,
+						"500000": 7,
+						"8000000": 7
+					},
+					"count": 7,
+					"sum": 88537
+				},
+				"resource": "nodes",
+				"scope": "cluster",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-scheduler/v1.8.8 (linux/amd64) kubernetes/6e5b33a/scheduler",
+				"count": 91,
+				"resource": "pods",
+				"scope": "namespace",
+				"subresource": "binding",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
+				"count": 10999,
+				"resource": "endpoints",
+				"scope": "namespace",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 1,
+						"1000000": 1,
+						"125000": 1,
+						"2000000": 1,
+						"250000": 1,
+						"4000000": 1,
+						"500000": 1,
+						"8000000": 1
+					},
+					"count": 1,
+					"sum": 242
+				},
+				"resource": "podsecuritypolicies",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 66026,
+						"1000000": 66025,
+						"125000": 66025,
+						"2000000": 66026,
+						"250000": 66025,
+						"4000000": 66026,
+						"500000": 66025,
+						"8000000": 66026
+					},
+					"count": 66026,
+					"sum": 98827970
+				},
+				"resource": "deployments",
+				"scope": "namespace",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:persistent-volume-binder",
+				"count": 1,
+				"resource": "persistentvolumes",
+				"scope": "cluster",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 38,
+						"1000000": 38,
+						"125000": 38,
+						"2000000": 38,
+						"250000": 38,
+						"4000000": 38,
+						"500000": 38,
+						"8000000": 38
+					},
+					"count": 38,
+					"sum": 137225
+				},
+				"resource": "serviceaccounts",
+				"scope": "namespace",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 21995,
+						"1000000": 21995,
+						"125000": 21995,
+						"2000000": 21995,
+						"250000": 21995,
+						"4000000": 21995,
+						"500000": 21995,
+						"8000000": 21995
+					},
+					"count": 21995,
+					"sum": 41165835
+				},
+				"resource": "rolebindings",
+				"scope": "namespace",
+				"verb": "PATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-scheduler/v1.8.8 (linux/amd64) kubernetes/6e5b33a/scheduler",
+				"count": 1476,
+				"resource": "replicationcontrollers",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 1471,
+				"resource": "persistentvolumes",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 2961,
+						"1000000": 0,
+						"125000": 0,
+						"2000000": 0,
+						"250000": 0,
+						"4000000": 0,
+						"500000": 0,
+						"8000000": 0
+					},
+					"count": 2961,
+					"sum": 1319737924064
+				},
+				"resource": "clusterrolebindings",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 10319,
+						"1000000": 0,
+						"125000": 0,
+						"2000000": 0,
+						"250000": 0,
+						"4000000": 0,
+						"500000": 0,
+						"8000000": 0
+					},
+					"count": 10319,
+					"sum": 4618957403529
+				},
+				"resource": "endpoints",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 2,
+				"resource": "clusterroles",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 11099,
+						"1000000": 11099,
+						"125000": 11099,
+						"2000000": 11099,
+						"250000": 11099,
+						"4000000": 11099,
+						"500000": 11099,
+						"8000000": 11099
+					},
+					"count": 11099,
+					"sum": 17674492
+				},
+				"resource": "daemonsets",
+				"scope": "namespace",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
+				"count": 14,
+				"resource": "serviceaccounts",
+				"scope": "namespace",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
+				"count": 8,
+				"resource": "clusterrolebindings",
+				"scope": "cluster",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 2,
+				"resource": "clusterrolebindings",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "GoogleContainerEngine",
+				"count": 4,
+				"resource": "nodes",
+				"scope": "cluster",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 18,
+						"1000000": 18,
+						"125000": 18,
+						"2000000": 18,
+						"250000": 18,
+						"4000000": 18,
+						"500000": 18,
+						"8000000": 18
+					},
+					"count": 18,
+					"sum": 134182
+				},
+				"resource": "limitranges",
+				"scope": "namespace",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
+				"count": 1470,
+				"resource": "pods",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-scheduler/v1.8.8 (linux/amd64) kubernetes/6e5b33a/scheduler",
+				"count": 1,
+				"resource": "replicationcontrollers",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:deployment-controller",
+				"count": 60,
+				"resource": "deployments",
+				"scope": "namespace",
+				"subresource": "status",
+				"verb": "PUT"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
+				"count": 43992,
+				"resource": "services",
+				"scope": "namespace",
+				"verb": "PATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:replicaset-controller",
+				"count": 123,
+				"resource": "events",
+				"scope": "namespace",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-scheduler/v1.8.8 (linux/amd64) kubernetes/6e5b33a/scheduler",
+				"count": 1,
+				"resource": "statefulsets",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 1469,
+						"1000000": 0,
+						"125000": 0,
+						"2000000": 0,
+						"250000": 0,
+						"4000000": 0,
+						"500000": 0,
+						"8000000": 0
+					},
+					"count": 1469,
+					"sum": 659704930318
+				},
+				"resource": "jobs",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "GoogleContainerEngine",
+				"count": 709,
+				"resource": "poddisruptionbudgets",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
+				"count": 1470,
+				"resource": "certificatesigningrequests",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 157377,
+						"1000000": 157373,
+						"125000": 157353,
+						"2000000": 157377,
+						"250000": 157363,
+						"4000000": 157377,
+						"500000": 157370,
+						"8000000": 157377
+					},
+					"count": 157377,
+					"sum": 478451230
+				},
+				"resource": "nodes",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "Go-http-client/2.0",
+				"count": 14,
+				"resource": "pods",
+				"scope": "namespace",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/leader-election",
+				"count": 1,
+				"resource": "endpoints",
+				"scope": "namespace",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "glbc/v0.0.0 (linux/amd64) kubernetes/$Format",
+				"count": 15,
+				"resource": "services",
+				"scope": "namespace",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 714,
+						"1000000": 714,
+						"125000": 714,
+						"2000000": 714,
+						"250000": 714,
+						"4000000": 714,
+						"500000": 714,
+						"8000000": 714
+					},
+					"count": 714,
+					"sum": 2514414
+				},
+				"resource": "replicasets",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 3,
+						"1000000": 3,
+						"125000": 3,
+						"2000000": 3,
+						"250000": 3,
+						"4000000": 3,
+						"500000": 3,
+						"8000000": 3
+					},
+					"count": 3,
+					"sum": 14251
+				},
+				"resource": "serviceaccounts",
+				"scope": "namespace",
+				"verb": "DELETE"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 22024,
+						"1000000": 22024,
+						"125000": 22023,
+						"2000000": 22024,
+						"250000": 22024,
+						"4000000": 22024,
+						"500000": 22024,
+						"8000000": 22024
+					},
+					"count": 22024,
+					"sum": 72887687
+				},
+				"resource": "secrets",
+				"scope": "namespace",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubelet/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 1,
+				"resource": "configmaps",
+				"scope": "namespace",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 109953,
+						"1000000": 109952,
+						"125000": 109950,
+						"2000000": 109953,
+						"250000": 109950,
+						"4000000": 109953,
+						"500000": 109951,
+						"8000000": 109953
+					},
+					"count": 109953,
+					"sum": 142476285
+				},
+				"resource": "services",
+				"scope": "namespace",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 43994,
+						"1000000": 43994,
+						"125000": 43994,
+						"2000000": 43994,
+						"250000": 43994,
+						"4000000": 43994,
+						"500000": 43994,
+						"8000000": 43994
+					},
+					"count": 43994,
+					"sum": 116859281
+				},
+				"resource": "deployments",
+				"scope": "namespace",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "GoogleContainerEngine",
+				"count": 709,
+				"resource": "horizontalpodautoscalers",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 4412,
+						"1000000": 0,
+						"125000": 0,
+						"2000000": 0,
+						"250000": 0,
+						"4000000": 0,
+						"500000": 0,
+						"8000000": 0
+					},
+					"count": 4412,
+					"sum": 1978402804959
+				},
+				"resource": "daemonsets",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
+				"count": 1483,
+				"resource": "clusterrolebindings",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
+				"count": 1456,
+				"resource": "namespaces",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 1,
+				"resource": "services",
+				"scope": "namespace",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:deployment-controller",
+				"count": 49,
+				"resource": "events",
+				"scope": "namespace",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
+				"count": 6,
+				"resource": "serviceaccounts",
+				"scope": "namespace",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "dashboard/v1.8.0",
+				"count": 10,
+				"resource": "services",
+				"scope": "resource",
+				"verb": "PROXY"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-state-metrics/v0.0.0 (linux/amd64) kubernetes/$Format",
+				"count": 2,
+				"resource": "daemonsets",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubelet/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 7,
+				"resource": "certificatesigningrequests",
+				"scope": "cluster",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:job-controller",
+				"count": 1,
+				"resource": "jobs",
+				"scope": "namespace",
+				"subresource": "status",
+				"verb": "PUT"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 3,
+						"1000000": 3,
+						"125000": 3,
+						"2000000": 3,
+						"250000": 3,
+						"4000000": 3,
+						"500000": 3,
+						"8000000": 3
+					},
+					"count": 3,
+					"sum": 19136
+				},
+				"resource": "secrets",
+				"scope": "namespace",
+				"verb": "DELETE"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 88021,
+						"1000000": 88021,
+						"125000": 88021,
+						"2000000": 88021,
+						"250000": 88021,
+						"4000000": 88021,
+						"500000": 88021,
+						"8000000": 88021
+					},
+					"count": 88021,
+					"sum": 94043104
+				},
+				"resource": "clusterrolebindings",
+				"scope": "cluster",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-proxy/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 7,
+				"resource": "endpoints",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 8067,
+						"1000000": 8067,
+						"125000": 8066,
+						"2000000": 8067,
+						"250000": 8066,
+						"4000000": 8067,
+						"500000": 8067,
+						"8000000": 8067
+					},
+					"count": 8067,
+					"sum": 16999211
+				},
+				"resource": "services",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 87994,
+						"1000000": 87994,
+						"125000": 87991,
+						"2000000": 87994,
+						"250000": 87993,
+						"4000000": 87994,
+						"500000": 87994,
+						"8000000": 87994
+					},
+					"count": 87994,
+					"sum": 95827906
+				},
+				"resource": "namespaces",
+				"scope": "cluster",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
+				"count": 14,
+				"resource": "replicasets",
+				"scope": "namespace",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "GoogleContainerEngine",
+				"count": 709,
+				"resource": "statefulsets",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "pod_nanny/v0.0.0 (linux/amd64) kubernetes/$Format",
+				"count": 1,
+				"resource": "deployments",
+				"scope": "namespace",
+				"verb": "PUT"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "GoogleContainerEngine",
+				"count": 7190,
+				"resource": "namespaces",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
+				"count": 4,
+				"resource": "services",
+				"scope": "namespace",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:cloud-provider",
+				"count": 1,
+				"resource": "configmaps",
+				"scope": "namespace",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 1,
+				"resource": "endpoints",
+				"scope": "namespace",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 66815,
+						"1000000": 66815,
+						"125000": 66815,
+						"2000000": 66815,
+						"250000": 66815,
+						"4000000": 66815,
+						"500000": 66815,
+						"8000000": 66815
+					},
+					"count": 66815,
+					"sum": 93487208
+				},
+				"resource": "pods",
+				"scope": "namespace",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubelet/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 1,
+				"resource": "configmaps",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
+				"count": 1,
+				"resource": "serviceaccounts",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 9,
+						"1000000": 9,
+						"125000": 9,
+						"2000000": 9,
+						"250000": 9,
+						"4000000": 9,
+						"500000": 9,
+						"8000000": 9
+					},
+					"count": 9,
+					"sum": 27124
+				},
+				"resource": "roles",
+				"scope": "namespace",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:job-controller",
+				"count": 20,
+				"resource": "pods",
+				"scope": "namespace",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-proxy/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 7,
+				"resource": "services",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "event-exporter/v0.0.0 (linux/amd64) kubernetes/$Format",
+				"count": 1131,
+				"resource": "events",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/leader-election",
+				"count": 1,
+				"resource": "endpoints",
+				"scope": "namespace",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
+				"count": 1,
+				"resource": "ingresses",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
+				"count": 4,
+				"resource": "clusterroles",
+				"scope": "cluster",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
+				"count": 2,
+				"resource": "deployments",
+				"scope": "namespace",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-scheduler/v1.8.8 (linux/amd64) kubernetes/6e5b33a/scheduler",
+				"count": 1460,
+				"resource": "pods",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:persistent-volume-binder",
+				"count": 1,
+				"resource": "persistentvolumes",
+				"scope": "cluster",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 7,
+				"resource": "roles",
+				"scope": "namespace",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "GoogleContainerEngine",
+				"count": 709,
+				"resource": "ingresses",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 710,
+						"1000000": 710,
+						"125000": 710,
+						"2000000": 710,
+						"250000": 710,
+						"4000000": 710,
+						"500000": 710,
+						"8000000": 710
+					},
+					"count": 710,
+					"sum": 1024073
+				},
+				"resource": "horizontalpodautoscalers",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "GoogleCloudConsole",
+				"count": 7,
+				"resource": "storageclasses",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 710,
+						"1000000": 710,
+						"125000": 710,
+						"2000000": 710,
+						"250000": 710,
+						"4000000": 710,
+						"500000": 710,
+						"8000000": 710
+					},
+					"count": 710,
+					"sum": 1057701
+				},
+				"resource": "podtemplates",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 1476,
+				"resource": "secrets",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "rescheduler/v0.0.0 (linux/amd64) kubernetes/$Format",
+				"count": 2,
+				"resource": "pods",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
+				"count": 1468,
+				"resource": "limitranges",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 21999,
+						"1000000": 21999,
+						"125000": 21999,
+						"2000000": 21999,
+						"250000": 21999,
+						"4000000": 21999,
+						"500000": 21999,
+						"8000000": 21999
+					},
+					"count": 21999,
+					"sum": 42542811
+				},
+				"resource": "daemonsets",
+				"scope": "namespace",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 43991,
+						"1000000": 43991,
+						"125000": 43991,
+						"2000000": 43991,
+						"250000": 43991,
+						"4000000": 43991,
+						"500000": 43991,
+						"8000000": 43991
+					},
+					"count": 43991,
+					"sum": 79881493
+				},
+				"resource": "clusterroles",
+				"scope": "cluster",
+				"verb": "PATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
+				"count": 21997,
+				"resource": "services",
+				"scope": "namespace",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 38,
+						"1000000": 38,
+						"125000": 38,
+						"2000000": 38,
+						"250000": 38,
+						"4000000": 38,
+						"500000": 38,
+						"8000000": 38
+					},
+					"count": 38,
+					"sum": 137375
+				},
+				"resource": "serviceaccounts",
+				"scope": "namespace",
+				"verb": "PUT"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "glbc/v0.0.0 (linux/amd64) kubernetes/$Format",
+				"count": 1485,
+				"resource": "services",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 21965,
+						"1000000": 21960,
+						"125000": 21957,
+						"2000000": 21960,
+						"250000": 21960,
+						"4000000": 21960,
+						"500000": 21960,
+						"8000000": 21960
+					},
+					"count": 21965,
+					"sum": 465256128
+				},
+				"resource": "services",
+				"scope": "resource",
+				"verb": "PROXY"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 1,
+				"resource": "customresourcedefinitions",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 388,
+						"1000000": 388,
+						"125000": 386,
+						"2000000": 388,
+						"250000": 388,
+						"4000000": 388,
+						"500000": 388,
+						"8000000": 388
+					},
+					"count": 388,
+					"sum": 4031187
+				},
+				"resource": "events",
+				"scope": "namespace",
+				"verb": "PATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-scheduler/v1.8.8 (linux/amd64) kubernetes/6e5b33a/scheduler",
+				"count": 123,
+				"resource": "events",
+				"scope": "namespace",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubelet/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 1,
+				"resource": "pods",
+				"scope": "namespace",
+				"subresource": "status",
+				"verb": "PUT"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "gke-certificates-controller/v1.7.0 (linux/amd64) kubernetes/6b9ded1/certificate-controller",
+				"count": 1,
+				"resource": "certificatesigningrequests",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
+				"count": 1,
+				"resource": "poddisruptionbudgets",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 2,
+						"1000000": 2,
+						"125000": 2,
+						"2000000": 2,
+						"250000": 2,
+						"4000000": 2,
+						"500000": 2,
+						"8000000": 2
+					},
+					"count": 2,
+					"sum": 770
+				},
+				"resource": "networkpolicies",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
+				"count": 21995,
+				"resource": "roles",
+				"scope": "namespace",
+				"verb": "PATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubelet/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 7,
+				"resource": "pods",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
+				"count": 1,
+				"resource": "cronjobs",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 1,
+						"1000000": 1,
+						"125000": 1,
+						"2000000": 1,
+						"250000": 1,
+						"4000000": 1,
+						"500000": 1,
+						"8000000": 1
+					},
+					"count": 1,
+					"sum": 3500
+				},
+				"resource": "persistentvolumes",
+				"scope": "cluster",
+				"subresource": "status",
+				"verb": "PUT"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "pod_nanny/v0.0.0 (linux/amd64) kubernetes/$Format",
+				"count": 1482,
+				"resource": "nodes",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
+				"count": 1,
+				"resource": "networkpolicies",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-state-metrics/v0.0.0 (linux/amd64) kubernetes/$Format",
+				"count": 2,
+				"resource": "resourcequotas",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:replicaset-controller",
+				"count": 22,
+				"resource": "replicasets",
+				"scope": "namespace",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 66639,
+						"1000000": 66637,
+						"125000": 66635,
+						"2000000": 66639,
+						"250000": 66636,
+						"4000000": 66639,
+						"500000": 66636,
+						"8000000": 66639
+					},
+					"count": 66639,
+					"sum": 120279290
+				},
+				"resource": "jobs",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:ttl-controller",
+				"count": 7,
+				"resource": "nodes",
+				"scope": "cluster",
+				"verb": "PATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 1,
+				"resource": "pods",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 2,
+						"1000000": 1,
+						"125000": 1,
+						"2000000": 2,
+						"250000": 1,
+						"4000000": 2,
+						"500000": 1,
+						"8000000": 2
+					},
+					"count": 2,
+					"sum": 1761331
+				},
+				"resource": "rolebindings",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 10999,
+						"1000000": 10999,
+						"125000": 10999,
+						"2000000": 10999,
+						"250000": 10999,
+						"4000000": 10999,
+						"500000": 10999,
+						"8000000": 10999
+					},
+					"count": 10999,
+					"sum": 28899398
+				},
+				"resource": "storageclasses",
+				"scope": "cluster",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 1472,
+				"resource": "limitranges",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 1,
+				"resource": "configmaps",
+				"scope": "namespace",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 1,
+						"1000000": 1,
+						"125000": 0,
+						"2000000": 1,
+						"250000": 1,
+						"4000000": 1,
+						"500000": 1,
+						"8000000": 1
+					},
+					"count": 1,
+					"sum": 148703
+				},
+				"resource": "customresourcedefinitions",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 2,
+				"resource": "persistentvolumes",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
+				"count": 21997,
+				"resource": "ingresses",
+				"scope": "namespace",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 30,
+				"resource": "clusterrolebindings",
+				"scope": "cluster",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 1459,
+				"resource": "clusterroles",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 1,
+				"resource": "endpoints",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 1450,
+				"resource": "rolebindings",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 21998,
+						"1000000": 21998,
+						"125000": 21998,
+						"2000000": 21998,
+						"250000": 21998,
+						"4000000": 21998,
+						"500000": 21998,
+						"8000000": 21998
+					},
+					"count": 21998,
+					"sum": 54318333
+				},
+				"resource": "configmaps",
+				"scope": "namespace",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
+				"count": 10998,
+				"resource": "storageclasses",
+				"scope": "cluster",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
+				"count": 1461,
+				"resource": "serviceaccounts",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 1,
+						"1000000": 1,
+						"125000": 1,
+						"2000000": 1,
+						"250000": 1,
+						"4000000": 1,
+						"500000": 1,
+						"8000000": 1
+					},
+					"count": 1,
+					"sum": 1192
+				},
+				"resource": "configmaps",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "heapster/v0.0.0 (linux/amd64) kubernetes/$Format",
+				"count": 1460,
+				"resource": "pods",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 1,
+						"1000000": 1,
+						"125000": 1,
+						"2000000": 1,
+						"250000": 1,
+						"4000000": 1,
+						"500000": 1,
+						"8000000": 1
+					},
+					"count": 1,
+					"sum": 15199
+				},
+				"resource": "persistentvolumeclaims",
+				"scope": "namespace",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 712,
+						"1000000": 712,
+						"125000": 712,
+						"2000000": 712,
+						"250000": 712,
+						"4000000": 712,
+						"500000": 712,
+						"8000000": 712
+					},
+					"count": 712,
+					"sum": 1102127
+				},
+				"resource": "ingresses",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "GoogleContainerEngine",
+				"count": 709,
+				"resource": "deployments",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
+				"count": 21997,
+				"resource": "replicasets",
+				"scope": "namespace",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 1,
+						"1000000": 1,
+						"125000": 0,
+						"2000000": 1,
+						"250000": 1,
+						"4000000": 1,
+						"500000": 1,
+						"8000000": 1
+					},
+					"count": 1,
+					"sum": 138053
+				},
+				"resource": "persistentvolumes",
+				"scope": "cluster",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 2927,
+						"1000000": 0,
+						"125000": 0,
+						"2000000": 0,
+						"250000": 0,
+						"4000000": 0,
+						"500000": 0,
+						"8000000": 0
+					},
+					"count": 2927,
+					"sum": 1319595133369
+				},
+				"resource": "clusterroles",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 36,
+						"1000000": 36,
+						"125000": 36,
+						"2000000": 36,
+						"250000": 36,
+						"4000000": 36,
+						"500000": 36,
+						"8000000": 36
+					},
+					"count": 36,
+					"sum": 900579
+				},
+				"resource": "pods",
+				"scope": "namespace",
+				"verb": "PATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "glbc/v0.0.0 (linux/amd64) kubernetes/$Format",
+				"count": 2,
+				"resource": "ingresses",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "glbc/v0.0.0 (linux/amd64) kubernetes/$Format",
+				"count": 1465,
+				"resource": "pods",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 6,
+						"1000000": 6,
+						"125000": 6,
+						"2000000": 6,
+						"250000": 6,
+						"4000000": 6,
+						"500000": 6,
+						"8000000": 6
+					},
+					"count": 6,
+					"sum": 81365
+				},
+				"resource": "daemonsets",
+				"scope": "namespace",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
+				"count": 1478,
+				"resource": "endpoints",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
+				"count": 1,
+				"resource": "namespaces",
+				"scope": "cluster",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "GoogleContainerEngine",
+				"count": 709,
+				"resource": "jobs",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 4436,
+						"1000000": 0,
+						"125000": 0,
+						"2000000": 0,
+						"250000": 0,
+						"4000000": 0,
+						"500000": 0,
+						"8000000": 0
+					},
+					"count": 4436,
+					"sum": 1978507486290
+				},
+				"resource": "resourcequotas",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 7337,
+				"resource": "services",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
+				"count": 21997,
+				"resource": "persistentvolumeclaims",
+				"scope": "namespace",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
+				"count": 1,
+				"resource": "limitranges",
+				"scope": "namespace",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 45,
+						"1000000": 45,
+						"125000": 45,
+						"2000000": 45,
+						"250000": 45,
+						"4000000": 45,
+						"500000": 45,
+						"8000000": 45
+					},
+					"count": 45,
+					"sum": 242600
+				},
+				"resource": "clusterrolebindings",
+				"scope": "cluster",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
+				"count": 1476,
+				"resource": "rolebindings",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-state-metrics/v0.0.0 (linux/amd64) kubernetes/$Format",
+				"count": 1468,
+				"resource": "replicationcontrollers",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
+				"count": 43994,
+				"resource": "deployments",
+				"scope": "namespace",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 4,
+						"1000000": 4,
+						"125000": 4,
+						"2000000": 4,
+						"250000": 4,
+						"4000000": 4,
+						"500000": 4,
+						"8000000": 4
+					},
+					"count": 4,
+					"sum": 19435
+				},
+				"resource": "configmaps",
+				"scope": "namespace",
+				"verb": "DELETE"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/controller-manager",
+				"count": 23,
+				"resource": "namespaces",
+				"scope": "cluster",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
+				"count": 2,
+				"resource": "rolebindings",
+				"scope": "namespace",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 2928,
+						"1000000": 0,
+						"125000": 0,
+						"2000000": 0,
+						"250000": 0,
+						"4000000": 0,
+						"500000": 0,
+						"8000000": 0
+					},
+					"count": 2928,
+					"sum": 1319357064565
+				},
+				"resource": "statefulsets",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 4384,
+						"1000000": 0,
+						"125000": 0,
+						"2000000": 0,
+						"250000": 0,
+						"4000000": 0,
+						"500000": 0,
+						"8000000": 0
+					},
+					"count": 4384,
+					"sum": 1978039440788
+				},
+				"resource": "deployments",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "glbc/v0.0.0 (linux/amd64) kubernetes/$Format",
+				"count": 1,
+				"resource": "services",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 44036,
+						"1000000": 44036,
+						"125000": 44036,
+						"2000000": 44036,
+						"250000": 44036,
+						"4000000": 44036,
+						"500000": 44036,
+						"8000000": 44036
+					},
+					"count": 44036,
+					"sum": 46748890
+				},
+				"resource": "clusterroles",
+				"scope": "cluster",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
+				"count": 1472,
+				"resource": "podsecuritypolicies",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
+				"count": 1,
+				"resource": "configmaps",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 51,
+						"1000000": 51,
+						"125000": 50,
+						"2000000": 51,
+						"250000": 51,
+						"4000000": 51,
+						"500000": 51,
+						"8000000": 51
+					},
+					"count": 51,
+					"sum": 453911
+				},
+				"resource": "clusterroles",
+				"scope": "cluster",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 3,
+						"1000000": 3,
+						"125000": 3,
+						"2000000": 3,
+						"250000": 3,
+						"4000000": 3,
+						"500000": 3,
+						"8000000": 3
+					},
+					"count": 3,
+					"sum": 29952
+				},
+				"resource": "daemonsets",
+				"scope": "namespace",
+				"verb": "PUT"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
+				"count": 1,
+				"resource": "nodes",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 4406,
+						"1000000": 1,
+						"125000": 1,
+						"2000000": 1,
+						"250000": 1,
+						"4000000": 1,
+						"500000": 1,
+						"8000000": 1
+					},
+					"count": 4406,
+					"sum": 1979024165553
+				},
+				"resource": "persistentvolumes",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
+				"count": 3,
+				"resource": "daemonsets",
+				"scope": "namespace",
+				"verb": "DELETE"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 22009,
+						"1000000": 22009,
+						"125000": 22009,
+						"2000000": 22009,
+						"250000": 22009,
+						"4000000": 22009,
+						"500000": 22009,
+						"8000000": 22009
+					},
+					"count": 22009,
+					"sum": 91312572
+				},
+				"resource": "configmaps",
+				"scope": "namespace",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubelet/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 8712,
+				"resource": "persistentvolumeclaims",
+				"scope": "namespace",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 66139,
+						"1000000": 66138,
+						"125000": 66138,
+						"2000000": 66139,
+						"250000": 66138,
+						"4000000": 66139,
+						"500000": 66138,
+						"8000000": 66139
+					},
+					"count": 66139,
+					"sum": 78537675
+				},
+				"resource": "serviceaccounts",
+				"scope": "namespace",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "event-exporter/v0.0.0 (linux/amd64) kubernetes/$Format",
+				"count": 2599,
+				"resource": "events",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 20,
+						"1000000": 20,
+						"125000": 20,
+						"2000000": 20,
+						"250000": 20,
+						"4000000": 20,
+						"500000": 20,
+						"8000000": 20
+					},
+					"count": 20,
+					"sum": 518921
+				},
+				"resource": "apiservices",
+				"scope": "cluster",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
+				"count": 6,
+				"resource": "deployments",
+				"scope": "namespace",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 1473,
+				"resource": "serviceaccounts",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
+				"count": 3,
+				"resource": "clusterrolebindings",
+				"scope": "cluster",
+				"verb": "DELETE"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
+				"count": 2,
+				"resource": "daemonsets",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:node-controller",
+				"count": 2,
+				"resource": "events",
+				"scope": "namespace",
+				"verb": "PATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-scheduler/v1.8.8 (linux/amd64) kubernetes/6e5b33a/leader-election",
+				"count": 1,
+				"resource": "endpoints",
+				"scope": "namespace",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 5876,
+						"1000000": 0,
+						"125000": 0,
+						"2000000": 0,
+						"250000": 0,
+						"4000000": 0,
+						"500000": 0,
+						"8000000": 0
+					},
+					"count": 5876,
+					"sum": 2637626661333
+				},
+				"resource": "replicasets",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 1,
+				"resource": "services",
+				"scope": "namespace",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
+				"count": 1483,
+				"resource": "configmaps",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "pod_nanny/v0.0.0 (linux/amd64) kubernetes/$Format",
+				"count": 1,
+				"resource": "deployments",
+				"scope": "namespace",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
+				"count": 1,
+				"resource": "podsecuritypolicies",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 4,
+						"1000000": 4,
+						"125000": 4,
+						"2000000": 4,
+						"250000": 4,
+						"4000000": 4,
+						"500000": 4,
+						"8000000": 4
+					},
+					"count": 4,
+					"sum": 32628
+				},
+				"resource": "nodes",
+				"scope": "cluster",
+				"verb": "DELETE"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
+				"count": 21995,
+				"resource": "rolebindings",
+				"scope": "namespace",
+				"verb": "PATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
+				"count": 21997,
+				"resource": "secrets",
+				"scope": "namespace",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "GoogleContainerEngine",
+				"count": 7198,
+				"resource": "pods",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 11023,
+				"resource": "resourcequotas",
+				"scope": "namespace",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
+				"count": 2934,
+				"resource": "daemonsets",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 2,
+						"1000000": 2,
+						"125000": 2,
+						"2000000": 2,
+						"250000": 2,
+						"4000000": 2,
+						"500000": 2,
+						"8000000": 2
+					},
+					"count": 2,
+					"sum": 10407
+				},
+				"resource": "events",
+				"scope": "namespace",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:replicaset-controller",
+				"count": 30,
+				"resource": "events",
+				"scope": "namespace",
+				"verb": "PATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 168,
+						"1000000": 168,
+						"125000": 167,
+						"2000000": 168,
+						"250000": 168,
+						"4000000": 168,
+						"500000": 168,
+						"8000000": 168
+					},
+					"count": 168,
+					"sum": 3433972
+				},
+				"resource": "pods",
+				"scope": "namespace",
+				"verb": "DELETE"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 44000,
+						"1000000": 44000,
+						"125000": 44000,
+						"2000000": 44000,
+						"250000": 44000,
+						"4000000": 44000,
+						"500000": 44000,
+						"8000000": 44000
+					},
+					"count": 44000,
+					"sum": 69726863
+				},
+				"resource": "apiservices",
+				"scope": "cluster",
+				"subresource": "status",
+				"verb": "PUT"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 1131,
+						"1000000": 1131,
+						"125000": 1131,
+						"2000000": 1131,
+						"250000": 1131,
+						"4000000": 1131,
+						"500000": 1131,
+						"8000000": 1131
+					},
+					"count": 1131,
+					"sum": 2194490
+				},
+				"resource": "events",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
+				"count": 1,
+				"resource": "pods",
+				"scope": "namespace",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
+				"count": 3,
+				"resource": "serviceaccounts",
+				"scope": "namespace",
+				"verb": "DELETE"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 1,
+						"1000000": 1,
+						"125000": 1,
+						"2000000": 1,
+						"250000": 1,
+						"4000000": 1,
+						"500000": 1,
+						"8000000": 1
+					},
+					"count": 1,
+					"sum": 5655
+				},
+				"resource": "jobs",
+				"scope": "namespace",
+				"verb": "PATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-scheduler/v1.8.8 (linux/amd64) kubernetes/6e5b33a/scheduler",
+				"count": 1,
+				"resource": "persistentvolumes",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-scheduler/v1.8.8 (linux/amd64) kubernetes/6e5b33a/scheduler",
+				"count": 1,
+				"resource": "pods",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 4392,
+						"1000000": 0,
+						"125000": 0,
+						"2000000": 0,
+						"250000": 0,
+						"4000000": 0,
+						"500000": 0,
+						"8000000": 0
+					},
+					"count": 4392,
+					"sum": 1979690652276
+				},
+				"resource": "namespaces",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 444870,
+						"1000000": 444869,
+						"125000": 444861,
+						"2000000": 444869,
+						"250000": 444863,
+						"4000000": 444869,
+						"500000": 444866,
+						"8000000": 444869
+					},
+					"count": 444870,
+					"sum": 1016382203
+				},
+				"resource": "configmaps",
+				"scope": "namespace",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
+				"count": 7,
+				"resource": "clusterrolebindings",
+				"scope": "cluster",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubelet/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 7,
+				"resource": "nodes",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "cluster-proportional-autoscaler/v1.6.5 (linux/amd64) kubernetes/$Format",
+				"count": 65893,
+				"resource": "deployments",
+				"scope": "namespace",
+				"subresource": "scale",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/tokens-controller",
+				"count": 38,
+				"resource": "serviceaccounts",
+				"scope": "namespace",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
+				"count": 7,
+				"resource": "configmaps",
+				"scope": "namespace",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubelet/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 4409,
+				"resource": "nodes",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 1463,
+				"resource": "namespaces",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 68,
+				"resource": "pods",
+				"scope": "namespace",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 733671,
+						"1000000": 733664,
+						"125000": 733634,
+						"2000000": 733671,
+						"250000": 733639,
+						"4000000": 733671,
+						"500000": 733649,
+						"8000000": 733671
+					},
+					"count": 733671,
+					"sum": 834805253
+				},
+				"resource": "endpoints",
+				"scope": "namespace",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 13,
+						"1000000": 13,
+						"125000": 12,
+						"2000000": 13,
+						"250000": 13,
+						"4000000": 13,
+						"500000": 13,
+						"8000000": 13
+					},
+					"count": 13,
+					"sum": 133887
+				},
+				"resource": "endpoints",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:daemon-set-controller",
+				"count": 10,
+				"resource": "daemonsets",
+				"scope": "namespace",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 711,
+						"1000000": 711,
+						"125000": 711,
+						"2000000": 711,
+						"250000": 711,
+						"4000000": 711,
+						"500000": 711,
+						"8000000": 711
+					},
+					"count": 711,
+					"sum": 1029136
+				},
+				"resource": "statefulsets",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/tokens-controller",
+				"count": 3,
+				"resource": "secrets",
+				"scope": "namespace",
+				"verb": "DELETE"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
+				"count": 1478,
+				"resource": "storageclasses",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 1465,
+				"resource": "apiservices",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:replicaset-controller",
+				"count": 22,
+				"resource": "replicasets",
+				"scope": "namespace",
+				"subresource": "status",
+				"verb": "PUT"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "GoogleContainerEngine",
+				"count": 709,
+				"resource": "persistentvolumes",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 2949,
+						"1000000": 0,
+						"125000": 0,
+						"2000000": 0,
+						"250000": 0,
+						"4000000": 0,
+						"500000": 0,
+						"8000000": 0
+					},
+					"count": 2949,
+					"sum": 1319045104600
+				},
+				"resource": "persistentvolumeclaims",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 2,
+						"1000000": 1,
+						"125000": 1,
+						"2000000": 2,
+						"250000": 1,
+						"4000000": 2,
+						"500000": 1,
+						"8000000": 2
+					},
+					"count": 2,
+					"sum": 1806364
+				},
+				"resource": "secrets",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 230098,
+						"1000000": 230094,
+						"125000": 230033,
+						"2000000": 230098,
+						"250000": 230085,
+						"4000000": 230098,
+						"500000": 230091,
+						"8000000": 230098
+					},
+					"count": 230098,
+					"sum": 2438676783
+				},
+				"resource": "nodes",
+				"scope": "cluster",
+				"subresource": "status",
+				"verb": "PATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
+				"count": 1464,
+				"resource": "persistentvolumes",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 7,
+						"1000000": 7,
+						"125000": 7,
+						"2000000": 7,
+						"250000": 7,
+						"4000000": 7,
+						"500000": 7,
+						"8000000": 7
+					},
+					"count": 7,
+					"sum": 37113
+				},
+				"resource": "certificatesigningrequests",
+				"scope": "cluster",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 15,
+						"1000000": 15,
+						"125000": 15,
+						"2000000": 15,
+						"250000": 15,
+						"4000000": 15,
+						"500000": 15,
+						"8000000": 15
+					},
+					"count": 15,
+					"sum": 213078
+				},
+				"resource": "nodes",
+				"scope": "cluster",
+				"verb": "PUT"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubelet/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 8711,
+				"resource": "persistentvolumes",
+				"scope": "cluster",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "GoogleContainerEngine",
+				"count": 14465,
+				"resource": "nodes",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "heapster/v0.0.0 (linux/amd64) kubernetes/$Format",
+				"count": 5,
+				"resource": "pods",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 710,
+						"1000000": 710,
+						"125000": 710,
+						"2000000": 710,
+						"250000": 710,
+						"4000000": 710,
+						"500000": 710,
+						"8000000": 710
+					},
+					"count": 710,
+					"sum": 1012232
+				},
+				"resource": "poddisruptionbudgets",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
+				"count": 1,
+				"resource": "limitranges",
+				"scope": "namespace",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 65989,
+						"1000000": 65989,
+						"125000": 65989,
+						"2000000": 65989,
+						"250000": 65989,
+						"4000000": 65989,
+						"500000": 65989,
+						"8000000": 65989
+					},
+					"count": 65989,
+					"sum": 227196113
+				},
+				"resource": "deployments",
+				"scope": "namespace",
+				"verb": "PATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "GoogleCloudConsole",
+				"count": 7,
+				"resource": "persistentvolumes",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:daemon-set-controller",
+				"count": 9,
+				"resource": "pods",
+				"scope": "namespace",
+				"verb": "DELETE"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubelet/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 16,
+				"resource": "secrets",
+				"scope": "namespace",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:deployment-controller",
+				"count": 22,
+				"resource": "replicasets",
+				"scope": "namespace",
+				"verb": "PUT"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 1,
+						"1000000": 1,
+						"125000": 1,
+						"2000000": 1,
+						"250000": 1,
+						"4000000": 1,
+						"500000": 1,
+						"8000000": 1
+					},
+					"count": 1,
+					"sum": 298
+				},
+				"resource": "controllerrevisions",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
+				"count": 1,
+				"resource": "statefulsets",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:persistent-volume-binder",
+				"count": 1,
+				"resource": "events",
+				"scope": "namespace",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
+				"count": 4,
+				"resource": "replicasets",
+				"scope": "namespace",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 1,
+						"1000000": 1,
+						"125000": 1,
+						"2000000": 1,
+						"250000": 1,
+						"4000000": 1,
+						"500000": 1,
+						"8000000": 1
+					},
+					"count": 1,
+					"sum": 4186
+				},
+				"resource": "namespaces",
+				"scope": "cluster",
+				"verb": "PATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 2926,
+						"1000000": 0,
+						"125000": 0,
+						"2000000": 0,
+						"250000": 0,
+						"4000000": 0,
+						"500000": 0,
+						"8000000": 0
+					},
+					"count": 2926,
+					"sum": 1319580992038
+				},
+				"resource": "rolebindings",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "dashboard/v1.8.0",
+				"count": 1,
+				"resource": "secrets",
+				"scope": "namespace",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 65893,
+						"1000000": 65893,
+						"125000": 65893,
+						"2000000": 65893,
+						"250000": 65893,
+						"4000000": 65893,
+						"500000": 65893,
+						"8000000": 65893
+					},
+					"count": 65893,
+					"sum": 82149159
+				},
+				"resource": "deployments",
+				"scope": "namespace",
+				"subresource": "scale",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.8.7 (linux/amd64) kubernetes/b30876a",
+				"count": 1,
+				"resource": "nodes",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 1,
+						"1000000": 1,
+						"125000": 1,
+						"2000000": 1,
+						"250000": 1,
+						"4000000": 1,
+						"500000": 1,
+						"8000000": 1
+					},
+					"count": 1,
+					"sum": 3552
+				},
+				"resource": "limitranges",
+				"scope": "namespace",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubelet/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 1,
+				"resource": "nodes",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "glbc/v0.0.0 (linux/amd64) kubernetes/$Format",
+				"count": 1,
+				"resource": "nodes",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-dns/v0.0.0 (linux/amd64) kubernetes/$Format",
+				"count": 4,
+				"resource": "endpoints",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 73,
+				"resource": "serviceaccounts",
+				"scope": "namespace",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 6,
+				"resource": "rolebindings",
+				"scope": "namespace",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 55,
+						"1000000": 55,
+						"125000": 54,
+						"2000000": 55,
+						"250000": 55,
+						"4000000": 55,
+						"500000": 55,
+						"8000000": 55
+					},
+					"count": 55,
+					"sum": 744329
+				},
+				"resource": "replicasets",
+				"scope": "namespace",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 22013,
+						"1000000": 22013,
+						"125000": 22013,
+						"2000000": 22013,
+						"250000": 22013,
+						"4000000": 22013,
+						"500000": 22013,
+						"8000000": 22013
+					},
+					"count": 22013,
+					"sum": 49092249
+				},
+				"resource": "replicasets",
+				"scope": "namespace",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubelet/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 7,
+				"resource": "certificatesigningrequests",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 2947,
+						"1000000": 0,
+						"125000": 0,
+						"2000000": 0,
+						"250000": 0,
+						"4000000": 0,
+						"500000": 0,
+						"8000000": 0
+					},
+					"count": 2947,
+					"sum": 1319410001462
+				},
+				"resource": "networkpolicies",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 27,
+						"1000000": 27,
+						"125000": 27,
+						"2000000": 27,
+						"250000": 27,
+						"4000000": 27,
+						"500000": 27,
+						"8000000": 27
+					},
+					"count": 27,
+					"sum": 149618
+				},
+				"resource": "replicasets",
+				"scope": "namespace",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
+				"count": 1,
+				"resource": "services",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
+				"count": 1464,
+				"resource": "secrets",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
+				"count": 1470,
+				"resource": "replicationcontrollers",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 1,
+						"1000000": 1,
+						"125000": 1,
+						"2000000": 1,
+						"250000": 1,
+						"4000000": 1,
+						"500000": 1,
+						"8000000": 1
+					},
+					"count": 1,
+					"sum": 2419
+				},
+				"resource": "persistentvolumeclaims",
+				"scope": "namespace",
+				"subresource": "status",
+				"verb": "PUT"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 1496,
+				"resource": "resourcequotas",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
+				"count": 2,
+				"resource": "roles",
+				"scope": "namespace",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-scheduler/v1.8.8 (linux/amd64) kubernetes/6e5b33a/leader-election",
+				"count": 1,
+				"resource": "endpoints",
+				"scope": "namespace",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:job-controller",
+				"count": 21,
+				"resource": "events",
+				"scope": "namespace",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
+				"count": 1,
+				"resource": "jobs",
+				"scope": "namespace",
+				"verb": "PATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 21997,
+						"1000000": 21997,
+						"125000": 21997,
+						"2000000": 21997,
+						"250000": 21997,
+						"4000000": 21997,
+						"500000": 21997,
+						"8000000": 21997
+					},
+					"count": 21997,
+					"sum": 29995607
+				},
+				"resource": "persistentvolumeclaims",
+				"scope": "namespace",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:service-controller",
+				"count": 1,
+				"resource": "services",
+				"scope": "namespace",
+				"subresource": "status",
+				"verb": "PUT"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 2940,
+						"1000000": 0,
+						"125000": 0,
+						"2000000": 0,
+						"250000": 0,
+						"4000000": 0,
+						"500000": 0,
+						"8000000": 0
+					},
+					"count": 2940,
+					"sum": 1319248184423
+				},
+				"resource": "secrets",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 27,
+						"1000000": 27,
+						"125000": 27,
+						"2000000": 27,
+						"250000": 27,
+						"4000000": 27,
+						"500000": 27,
+						"8000000": 27
+					},
+					"count": 27,
+					"sum": 108241
+				},
+				"resource": "tokenreviews",
+				"scope": "cluster",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
+				"count": 65986,
+				"resource": "serviceaccounts",
+				"scope": "namespace",
+				"verb": "PATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubelet/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 7,
+				"resource": "services",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "rescheduler/v0.0.0 (linux/amd64) kubernetes/$Format",
+				"count": 1,
+				"resource": "pods",
+				"scope": "namespace",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:generic-garbage-collector",
+				"count": 1,
+				"resource": "replicasets",
+				"scope": "namespace",
+				"verb": "PUT"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 9,
+						"1000000": 9,
+						"125000": 9,
+						"2000000": 9,
+						"250000": 9,
+						"4000000": 9,
+						"500000": 9,
+						"8000000": 9
+					},
+					"count": 9,
+					"sum": 30051
+				},
+				"resource": "controllerrevisions",
+				"scope": "namespace",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 36425,
+						"1000000": 36425,
+						"125000": 36411,
+						"2000000": 36425,
+						"250000": 36412,
+						"4000000": 36425,
+						"500000": 36421,
+						"8000000": 36425
+					},
+					"count": 36425,
+					"sum": 153386026
+				},
+				"resource": "pods",
+				"scope": "namespace",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "glbc/v0.0.0 (linux/amd64) kubernetes/$Format",
+				"count": 1,
+				"resource": "configmaps",
+				"scope": "namespace",
+				"verb": "PUT"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "glbc/v0.0.0 (linux/amd64) kubernetes/$Format",
+				"count": 1473,
+				"resource": "ingresses",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 1,
+				"resource": "endpoints",
+				"scope": "namespace",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
+				"count": 21997,
+				"resource": "pods",
+				"scope": "namespace",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
+				"count": 21997,
+				"resource": "persistentvolumes",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 713,
+						"1000000": 713,
+						"125000": 713,
+						"2000000": 713,
+						"250000": 713,
+						"4000000": 713,
+						"500000": 713,
+						"8000000": 713
+					},
+					"count": 713,
+					"sum": 1104285
+				},
+				"resource": "replicationcontrollers",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:attachdetach-controller",
+				"count": 2,
+				"resource": "events",
+				"scope": "namespace",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 656937,
+						"1000000": 656930,
+						"125000": 656912,
+						"2000000": 656937,
+						"250000": 656919,
+						"4000000": 656937,
+						"500000": 656926,
+						"8000000": 656937
+					},
+					"count": 656937,
+					"sum": 1660247858
+				},
+				"resource": "endpoints",
+				"scope": "namespace",
+				"verb": "PUT"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:pod-garbage-collector",
+				"count": 32985,
+				"resource": "nodes",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
+				"count": 6,
+				"resource": "deployments",
+				"scope": "namespace",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "GoogleContainerEngine",
+				"count": 4,
+				"resource": "nodes",
+				"scope": "cluster",
+				"verb": "PUT"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
+				"count": 21997,
+				"resource": "statefulsets",
+				"scope": "namespace",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-state-metrics/v0.0.0 (linux/amd64) kubernetes/$Format",
+				"count": 2,
+				"resource": "pods",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 713,
+						"1000000": 713,
+						"125000": 713,
+						"2000000": 713,
+						"250000": 713,
+						"4000000": 713,
+						"500000": 713,
+						"8000000": 713
+					},
+					"count": 713,
+					"sum": 1783238
+				},
+				"resource": "daemonsets",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
+				"count": 2,
+				"resource": "rolebindings",
+				"scope": "namespace",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "rescheduler/v0.0.0 (linux/amd64) kubernetes/$Format",
+				"count": 1,
+				"resource": "nodes",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-state-metrics/v0.0.0 (linux/amd64) kubernetes/$Format",
+				"count": 1456,
+				"resource": "deployments",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 1474,
+				"resource": "endpoints",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 21997,
+						"1000000": 21997,
+						"125000": 21997,
+						"2000000": 21997,
+						"250000": 21997,
+						"4000000": 21997,
+						"500000": 21997,
+						"8000000": 21997
+					},
+					"count": 21997,
+					"sum": 28334415
+				},
+				"resource": "statefulsets",
+				"scope": "namespace",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 8712,
+						"1000000": 8712,
+						"125000": 8712,
+						"2000000": 8712,
+						"250000": 8712,
+						"4000000": 8712,
+						"500000": 8712,
+						"8000000": 8712
+					},
+					"count": 8712,
+					"sum": 9535813
+				},
+				"resource": "persistentvolumes",
+				"scope": "cluster",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
+				"count": 21997,
+				"resource": "namespaces",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:daemon-set-controller",
+				"count": 41,
+				"resource": "events",
+				"scope": "namespace",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 20,
+				"resource": "apiservices",
+				"scope": "cluster",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 16,
+						"1000000": 15,
+						"125000": 15,
+						"2000000": 16,
+						"250000": 15,
+						"4000000": 16,
+						"500000": 15,
+						"8000000": 16
+					},
+					"count": 16,
+					"sum": 1437944
+				},
+				"resource": "jobs",
+				"scope": "namespace",
+				"verb": "DELETE"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-state-metrics/v0.0.0 (linux/amd64) kubernetes/$Format",
+				"count": 2,
+				"resource": "replicasets",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-scheduler/v1.8.8 (linux/amd64) kubernetes/6e5b33a/scheduler",
+				"count": 1471,
+				"resource": "persistentvolumes",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 1,
+						"1000000": 1,
+						"125000": 1,
+						"2000000": 1,
+						"250000": 1,
+						"4000000": 1,
+						"500000": 1,
+						"8000000": 1
+					},
+					"count": 1,
+					"sum": 4441
+				},
+				"resource": "services",
+				"scope": "namespace",
+				"subresource": "status",
+				"verb": "PUT"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 43979,
+				"resource": "nodes",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "Go-http-client/2.0",
+				"count": 20,
+				"resource": "pods",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
+				"count": 1,
+				"resource": "replicasets",
+				"scope": "namespace",
+				"verb": "PUT"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
+				"count": 1,
+				"resource": "deployments",
+				"scope": "namespace",
+				"verb": "PATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 6,
+						"1000000": 6,
+						"125000": 6,
+						"2000000": 6,
+						"250000": 6,
+						"4000000": 6,
+						"500000": 6,
+						"8000000": 6
+					},
+					"count": 6,
+					"sum": 40480
+				},
+				"resource": "controllerrevisions",
+				"scope": "namespace",
+				"verb": "DELETE"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:generic-garbage-collector",
+				"count": 6,
+				"resource": "controllerrevisions",
+				"scope": "namespace",
+				"verb": "DELETE"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 1478,
+				"resource": "clusterrolebindings",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:attachdetach-controller",
+				"count": 50,
+				"resource": "events",
+				"scope": "namespace",
+				"verb": "PATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-scheduler/v1.8.8 (linux/amd64) kubernetes/6e5b33a/scheduler",
+				"count": 1,
+				"resource": "nodes",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 1483,
+						"1000000": 0,
+						"125000": 0,
+						"2000000": 0,
+						"250000": 0,
+						"4000000": 0,
+						"500000": 0,
+						"8000000": 0
+					},
+					"count": 1483,
+					"sum": 659897025212
+				},
+				"resource": "configmaps",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubelet/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 4428,
+				"resource": "pods",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 91,
+						"1000000": 91,
+						"125000": 90,
+						"2000000": 91,
+						"250000": 91,
+						"4000000": 91,
+						"500000": 91,
+						"8000000": 91
+					},
+					"count": 91,
+					"sum": 1467975
+				},
+				"resource": "pods",
+				"scope": "namespace",
+				"subresource": "binding",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 717,
+						"1000000": 717,
+						"125000": 715,
+						"2000000": 717,
+						"250000": 717,
+						"4000000": 717,
+						"500000": 717,
+						"8000000": 717
+					},
+					"count": 717,
+					"sum": 6031823
+				},
+				"resource": "pods",
+				"scope": "namespace",
+				"subresource": "status",
+				"verb": "PUT"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 17686,
+						"1000000": 0,
+						"125000": 0,
+						"2000000": 1,
+						"250000": 0,
+						"4000000": 1,
+						"500000": 0,
+						"8000000": 2
+					},
+					"count": 17686,
+					"sum": 7918564532837
+				},
+				"resource": "nodes",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-proxy/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 4420,
+				"resource": "endpoints",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "cluster-proportional-autoscaler/v1.6.5 (linux/amd64) kubernetes/$Format",
+				"count": 1,
+				"resource": "deployments",
+				"scope": "namespace",
+				"subresource": "scale",
+				"verb": "PUT"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 15,
+						"1000000": 15,
+						"125000": 15,
+						"2000000": 15,
+						"250000": 15,
+						"4000000": 15,
+						"500000": 15,
+						"8000000": 15
+					},
+					"count": 15,
+					"sum": 337373
+				},
+				"resource": "secrets",
+				"scope": "namespace",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-dns/v0.0.0 (linux/amd64) kubernetes/$Format",
+				"count": 2941,
+				"resource": "services",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:deployment-controller",
+				"count": 14,
+				"resource": "replicasets",
+				"scope": "namespace",
+				"verb": "DELETE"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 65986,
+						"1000000": 65986,
+						"125000": 65986,
+						"2000000": 65986,
+						"250000": 65986,
+						"4000000": 65986,
+						"500000": 65986,
+						"8000000": 65986
+					},
+					"count": 65986,
+					"sum": 112424509
+				},
+				"resource": "serviceaccounts",
+				"scope": "namespace",
+				"verb": "PATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 7,
+				"resource": "roles",
+				"scope": "namespace",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "GoogleContainerEngine",
+				"count": 7195,
+				"resource": "componentstatuses",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
+				"count": 65988,
+				"resource": "deployments",
+				"scope": "namespace",
+				"verb": "PATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "heapster/v0.0.0 (linux/amd64) kubernetes/$Format",
+				"count": 1473,
+				"resource": "namespaces",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:generic-garbage-collector",
+				"count": 1,
+				"resource": "networkpolicies",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
+				"count": 21997,
+				"resource": "configmaps",
+				"scope": "namespace",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "GoogleContainerEngine",
+				"count": 709,
+				"resource": "podtemplates",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 1,
+				"resource": "secrets",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 2599,
+						"1000000": 1129,
+						"125000": 1128,
+						"2000000": 1129,
+						"250000": 1129,
+						"4000000": 1129,
+						"500000": 1129,
+						"8000000": 1129
+					},
+					"count": 2599,
+					"sum": 658396349345
+				},
+				"resource": "events",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 1,
+						"1000000": 0,
+						"125000": 0,
+						"2000000": 0,
+						"250000": 0,
+						"4000000": 0,
+						"500000": 0,
+						"8000000": 0
+					},
+					"count": 1,
+					"sum": 61438916
+				},
+				"resource": "pods",
+				"scope": "namespace",
+				"subresource": "exec",
+				"verb": "CONNECT"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:persistent-volume-binder",
+				"count": 1,
+				"resource": "persistentvolumes",
+				"scope": "cluster",
+				"subresource": "status",
+				"verb": "PUT"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 8,
+						"1000000": 8,
+						"125000": 8,
+						"2000000": 8,
+						"250000": 8,
+						"4000000": 8,
+						"500000": 8,
+						"8000000": 8
+					},
+					"count": 8,
+					"sum": 80513
+				},
+				"resource": "services",
+				"scope": "namespace",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "GoogleCloudConsole",
+				"count": 20,
+				"resource": "pods",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:node-controller",
+				"count": 17,
+				"resource": "pods",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
+				"count": 1,
+				"resource": "pods",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
+				"count": 1,
+				"resource": "storageclasses",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 1,
+				"resource": "namespaces",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 29194,
+						"1000000": 29194,
+						"125000": 29194,
+						"2000000": 29194,
+						"250000": 29194,
+						"4000000": 29194,
+						"500000": 29194,
+						"8000000": 29194
+					},
+					"count": 29194,
+					"sum": 44608509
+				},
+				"resource": "namespaces",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
+				"count": 16,
+				"resource": "jobs",
+				"scope": "namespace",
+				"verb": "DELETE"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 1472,
+						"1000000": 0,
+						"125000": 0,
+						"2000000": 0,
+						"250000": 0,
+						"4000000": 0,
+						"500000": 0,
+						"8000000": 0
+					},
+					"count": 1472,
+					"sum": 659545988637
+				},
+				"resource": "podsecuritypolicies",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-scheduler/v1.8.8 (linux/amd64) kubernetes/6e5b33a/scheduler",
+				"count": 1471,
+				"resource": "persistentvolumeclaims",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:service-account-controller",
+				"count": 3,
+				"resource": "serviceaccounts",
+				"scope": "namespace",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 1,
+						"1000000": 1,
+						"125000": 1,
+						"2000000": 1,
+						"250000": 1,
+						"4000000": 1,
+						"500000": 1,
+						"8000000": 1
+					},
+					"count": 1,
+					"sum": 104
+				},
+				"resource": "apiservices",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "GoogleContainerEngine",
+				"count": 709,
+				"resource": "serviceaccounts",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "GoogleContainerEngine",
+				"count": 14380,
+				"resource": "pods",
+				"scope": "namespace",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:daemon-set-controller",
+				"count": 58,
+				"resource": "events",
+				"scope": "namespace",
+				"verb": "PATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
+				"count": 1,
+				"resource": "jobs",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 1459,
+						"1000000": 0,
+						"125000": 0,
+						"2000000": 0,
+						"250000": 0,
+						"4000000": 0,
+						"500000": 0,
+						"8000000": 0
+					},
+					"count": 1459,
+					"sum": 659831109566
+				},
+				"resource": "horizontalpodautoscalers",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
+				"count": 4,
+				"resource": "services",
+				"scope": "namespace",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
+				"count": 3,
+				"resource": "pods",
+				"scope": "namespace",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:node-controller",
+				"count": 4,
+				"resource": "nodes",
+				"scope": "cluster",
+				"verb": "PUT"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:deployment-controller",
+				"count": 2,
+				"resource": "replicasets",
+				"scope": "namespace",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-state-metrics/v0.0.0 (linux/amd64) kubernetes/$Format",
+				"count": 1472,
+				"resource": "pods",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 40,
+						"1000000": 40,
+						"125000": 40,
+						"2000000": 40,
+						"250000": 40,
+						"4000000": 40,
+						"500000": 40,
+						"8000000": 40
+					},
+					"count": 40,
+					"sum": 408553
+				},
+				"resource": "jobs",
+				"scope": "namespace",
+				"subresource": "status",
+				"verb": "PUT"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
+				"count": 1,
+				"resource": "roles",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 3,
+						"1000000": 3,
+						"125000": 3,
+						"2000000": 3,
+						"250000": 3,
+						"4000000": 3,
+						"500000": 3,
+						"8000000": 3
+					},
+					"count": 3,
+					"sum": 21094
+				},
+				"resource": "daemonsets",
+				"scope": "namespace",
+				"verb": "DELETE"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
+				"count": 1463,
+				"resource": "controllerrevisions",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-state-metrics/v0.0.0 (linux/amd64) kubernetes/$Format",
+				"count": 2,
+				"resource": "deployments",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 13,
+				"resource": "namespaces",
+				"scope": "cluster",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 1467,
+						"1000000": 0,
+						"125000": 0,
+						"2000000": 0,
+						"250000": 0,
+						"4000000": 0,
+						"500000": 0,
+						"8000000": 0
+					},
+					"count": 1467,
+					"sum": 659673062825
+				},
+				"resource": "cronjobs",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 21997,
+						"1000000": 21997,
+						"125000": 21997,
+						"2000000": 21997,
+						"250000": 21997,
+						"4000000": 21997,
+						"500000": 21997,
+						"8000000": 21997
+					},
+					"count": 21997,
+					"sum": 31133138
+				},
+				"resource": "replicationcontrollers",
+				"scope": "namespace",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-scheduler/v1.8.8 (linux/amd64) kubernetes/6e5b33a/scheduler",
+				"count": 1465,
+				"resource": "replicasets",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
+				"count": 1,
+				"resource": "podtemplates",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "node-problem-detector/v1.4.0 (linux/amd64) kubernetes/$Format",
+				"count": 8,
+				"resource": "nodes",
+				"scope": "cluster",
+				"subresource": "status",
+				"verb": "PATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
+				"count": 2,
+				"resource": "deployments",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 1,
+				"resource": "storageclasses",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/controller-manager",
+				"count": 15,
+				"resource": "secrets",
+				"scope": "namespace",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "rescheduler/v0.0.0 (linux/amd64) kubernetes/$Format",
+				"count": 1474,
+				"resource": "nodes",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
+				"count": 1,
+				"resource": "horizontalpodautoscalers",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 1,
+						"1000000": 0,
+						"125000": 0,
+						"2000000": 0,
+						"250000": 0,
+						"4000000": 0,
+						"500000": 0,
+						"8000000": 0
+					},
+					"count": 1,
+					"sum": 60000399
+				},
+				"resource": "jobs",
+				"verb": "UPDATE"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
+				"count": 1472,
+				"resource": "poddisruptionbudgets",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 9,
+						"1000000": 9,
+						"125000": 8,
+						"2000000": 9,
+						"250000": 9,
+						"4000000": 9,
+						"500000": 9,
+						"8000000": 9
+					},
+					"count": 9,
+					"sum": 218590
+				},
+				"resource": "storageclasses",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
+				"count": 11,
+				"resource": "pods",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubelet/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 7,
+				"resource": "nodes",
+				"scope": "cluster",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:attachdetach-controller",
+				"count": 5,
+				"resource": "nodes",
+				"scope": "cluster",
+				"subresource": "status",
+				"verb": "PATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
+				"count": 14,
+				"resource": "deployments",
+				"scope": "namespace",
+				"verb": "PUT"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
+				"count": 1468,
+				"resource": "clusterroles",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 9,
+						"1000000": 9,
+						"125000": 9,
+						"2000000": 9,
+						"250000": 9,
+						"4000000": 9,
+						"500000": 9,
+						"8000000": 9
+					},
+					"count": 9,
+					"sum": 99447
+				},
+				"resource": "nodes",
+				"scope": "cluster",
+				"subresource": "status",
+				"verb": "PUT"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:attachdetach-controller",
+				"count": 2,
+				"resource": "nodes",
+				"scope": "cluster",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:replicaset-controller",
+				"count": 45,
+				"resource": "pods",
+				"scope": "namespace",
+				"verb": "DELETE"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 41,
+				"resource": "clusterroles",
+				"scope": "cluster",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:node-controller",
+				"count": 11,
+				"resource": "nodes",
+				"scope": "cluster",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 17,
+						"1000000": 17,
+						"125000": 17,
+						"2000000": 17,
+						"250000": 17,
+						"4000000": 17,
+						"500000": 17,
+						"8000000": 17
+					},
+					"count": 17,
+					"sum": 12218
+				},
+				"resource": "subjectaccessreviews",
+				"scope": "cluster",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-scheduler/v1.8.8 (linux/amd64) kubernetes/6e5b33a/scheduler",
+				"count": 1,
+				"resource": "persistentvolumeclaims",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 1,
+				"resource": "apiservices",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "heapster/v0.0.0 (linux/amd64) kubernetes/$Format",
+				"count": 15,
+				"resource": "nodes",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
+				"count": 1,
+				"resource": "replicasets",
+				"scope": "namespace",
+				"verb": "DELETE"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "pod_nanny/v0.0.0 (linux/amd64) kubernetes/$Format",
+				"count": 65696,
+				"resource": "pods",
+				"scope": "namespace",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-state-metrics/v0.0.0 (linux/amd64) kubernetes/$Format",
+				"count": 1473,
+				"resource": "replicasets",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
+				"count": 6,
+				"resource": "clusterroles",
+				"scope": "cluster",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
+				"count": 1464,
+				"resource": "statefulsets",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 2940,
+						"1000000": 0,
+						"125000": 0,
+						"2000000": 0,
+						"250000": 0,
+						"4000000": 0,
+						"500000": 0,
+						"8000000": 0
+					},
+					"count": 2940,
+					"sum": 1319158063084
+				},
+				"resource": "limitranges",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 713,
+						"1000000": 713,
+						"125000": 713,
+						"2000000": 713,
+						"250000": 713,
+						"4000000": 713,
+						"500000": 713,
+						"8000000": 713
+					},
+					"count": 713,
+					"sum": 2461062
+				},
+				"resource": "deployments",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 14,
+						"1000000": 14,
+						"125000": 14,
+						"2000000": 14,
+						"250000": 14,
+						"4000000": 14,
+						"500000": 14,
+						"8000000": 14
+					},
+					"count": 14,
+					"sum": 139646
+				},
+				"resource": "deployments",
+				"scope": "namespace",
+				"verb": "DELETE"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-scheduler/v1.8.8 (linux/amd64) kubernetes/6e5b33a/scheduler",
+				"count": 160,
+				"resource": "events",
+				"scope": "namespace",
+				"verb": "PATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 17,
+						"1000000": 15,
+						"125000": 15,
+						"2000000": 15,
+						"250000": 15,
+						"4000000": 16,
+						"500000": 15,
+						"8000000": 16
+					},
+					"count": 17,
+					"sum": 62613720
+				},
+				"resource": "jobs",
+				"scope": "namespace",
+				"verb": "PUT"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 3,
+						"1000000": 3,
+						"125000": 2,
+						"2000000": 3,
+						"250000": 2,
+						"4000000": 3,
+						"500000": 2,
+						"8000000": 3
+					},
+					"count": 3,
+					"sum": 751587
+				},
+				"resource": "clusterroles",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
+				"count": 87983,
+				"resource": "clusterrolebindings",
+				"scope": "cluster",
+				"verb": "PATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:daemon-set-controller",
+				"count": 10,
+				"resource": "daemonsets",
+				"scope": "namespace",
+				"subresource": "status",
+				"verb": "PUT"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/controller-manager",
+				"count": 27,
+				"resource": "tokenreviews",
+				"scope": "cluster",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 11023,
+						"1000000": 11023,
+						"125000": 11023,
+						"2000000": 11023,
+						"250000": 11023,
+						"4000000": 11023,
+						"500000": 11023,
+						"8000000": 11023
+					},
+					"count": 11023,
+					"sum": 15416410
+				},
+				"resource": "resourcequotas",
+				"scope": "namespace",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 6,
+				"resource": "rolebindings",
+				"scope": "namespace",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubelet/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 56,
+				"resource": "nodes",
+				"scope": "cluster",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 10997,
+						"1000000": 10997,
+						"125000": 10997,
+						"2000000": 10997,
+						"250000": 10997,
+						"4000000": 10997,
+						"500000": 10997,
+						"8000000": 10997
+					},
+					"count": 10997,
+					"sum": 27035169
+				},
+				"resource": "configmaps",
+				"scope": "namespace",
+				"verb": "PATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "gke-certificates-controller/v1.7.0 (linux/amd64) kubernetes/6b9ded1/certificate-controller",
+				"count": 1467,
+				"resource": "certificatesigningrequests",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
+				"count": 4,
+				"resource": "configmaps",
+				"scope": "namespace",
+				"verb": "DELETE"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-proxy/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 7,
+				"resource": "nodes",
+				"scope": "cluster",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:generic-garbage-collector",
+				"count": 14,
+				"resource": "replicasets",
+				"scope": "namespace",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "GoogleContainerEngine",
+				"count": 709,
+				"resource": "services",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "GoogleContainerEngine",
+				"count": 709,
+				"resource": "persistentvolumeclaims",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
+				"count": 1,
+				"resource": "rolebindings",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
+				"count": 1483,
+				"resource": "services",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-dns/v0.0.0 (linux/amd64) kubernetes/$Format",
+				"count": 4,
+				"resource": "services",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
+				"count": 1,
+				"resource": "resourcequotas",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 3,
+						"1000000": 3,
+						"125000": 3,
+						"2000000": 3,
+						"250000": 3,
+						"4000000": 3,
+						"500000": 3,
+						"8000000": 3
+					},
+					"count": 3,
+					"sum": 19942
+				},
+				"resource": "clusterrolebindings",
+				"scope": "cluster",
+				"verb": "DELETE"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 19,
+						"1000000": 18,
+						"125000": 18,
+						"2000000": 19,
+						"250000": 18,
+						"4000000": 19,
+						"500000": 18,
+						"8000000": 19
+					},
+					"count": 19,
+					"sum": 1525720
+				},
+				"resource": "jobs",
+				"scope": "namespace",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-state-metrics/v0.0.0 (linux/amd64) kubernetes/$Format",
+				"count": 2,
+				"resource": "replicationcontrollers",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
+				"count": 6,
+				"resource": "serviceaccounts",
+				"scope": "namespace",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 7195,
+						"1000000": 7195,
+						"125000": 0,
+						"2000000": 7195,
+						"250000": 0,
+						"4000000": 7195,
+						"500000": 1419,
+						"8000000": 7195
+					},
+					"count": 7195,
+					"sum": 3270551868
+				},
+				"resource": "componentstatuses",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "Go-http-client/2.0",
+				"count": 1165,
+				"resource": "pods",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:route-controller",
+				"count": 7,
+				"resource": "nodes",
+				"scope": "cluster",
+				"subresource": "status",
+				"verb": "PATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
+				"count": 1,
+				"resource": "daemonsets",
+				"scope": "namespace",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "cluster-proportional-autoscaler/v1.6.5 (linux/amd64) kubernetes/$Format",
+				"count": 65893,
+				"resource": "nodes",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
+				"count": 1465,
+				"resource": "resourcequotas",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/system:serviceaccount:kube-system:certificate-controller",
+				"count": 7,
+				"resource": "certificatesigningrequests",
+				"scope": "cluster",
+				"subresource": "approval",
+				"verb": "PUT"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 1659,
+						"1000000": 1657,
+						"125000": 1652,
+						"2000000": 1657,
+						"250000": 1654,
+						"4000000": 1657,
+						"500000": 1657,
+						"8000000": 1659
+					},
+					"count": 1659,
+					"sum": 31122339
+				},
+				"resource": "events",
+				"scope": "namespace",
+				"verb": "POST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "GoogleCloudConsole",
+				"count": 20,
+				"resource": "nodes",
+				"scope": "cluster",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubelet/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 11,
+				"resource": "nodes",
+				"scope": "cluster",
+				"subresource": "status",
+				"verb": "PATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 15,
+						"1000000": 15,
+						"125000": 15,
+						"2000000": 15,
+						"250000": 15,
+						"4000000": 15,
+						"500000": 15,
+						"8000000": 15
+					},
+					"count": 15,
+					"sum": 171645
+				},
+				"resource": "replicasets",
+				"scope": "namespace",
+				"verb": "DELETE"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 1476,
+				"resource": "pods",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-apiserver/v1.8.8 (linux/amd64) kubernetes/6e5b33a",
+				"count": 44000,
+				"resource": "apiservices",
+				"scope": "cluster",
+				"subresource": "status",
+				"verb": "PUT"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.1 (linux/amd64) kubernetes/b0b7a32",
+				"count": 47,
+				"resource": "pods",
+				"scope": "namespace",
+				"verb": "LIST"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "GoogleContainerEngine",
+				"count": 14,
+				"resource": "pods",
+				"scope": "namespace",
+				"verb": "GET"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 2,
+						"1000000": 2,
+						"125000": 2,
+						"2000000": 2,
+						"250000": 2,
+						"4000000": 2,
+						"500000": 2,
+						"8000000": 2
+					},
+					"count": 2,
+					"sum": 6185
+				},
+				"resource": "persistentvolumeclaims",
+				"scope": "namespace",
+				"verb": "PUT"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 1,
+						"1000000": 1,
+						"125000": 1,
+						"2000000": 1,
+						"250000": 1,
+						"4000000": 1,
+						"500000": 1,
+						"8000000": 1
+					},
+					"count": 1,
+					"sum": 2145
+				},
+				"resource": "configmaps",
+				"scope": "namespace",
+				"verb": "PUT"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"latency": {
+					"bucket": {
+						"+Inf": 2934,
+						"1000000": 0,
+						"125000": 0,
+						"2000000": 0,
+						"250000": 0,
+						"4000000": 0,
+						"500000": 0,
+						"8000000": 0
+					},
+					"count": 2934,
+					"sum": 1319449062336
+				},
+				"resource": "serviceaccounts",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kube-controller-manager/v1.8.8 (linux/amd64) kubernetes/6e5b33a/shared-informers",
+				"count": 1459,
+				"resource": "horizontalpodautoscalers",
+				"scope": "cluster",
+				"verb": "WATCH"
+			}
+		},
+		"Index": "",
+		"Namespace": "",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"request": {
+				"client": "kubectl/v1.6.4 (linux/amd64) kubernetes/d6f4332",
+				"count": 43991,
+				"resource": "clusterroles",
+				"scope": "cluster",
+				"verb": "PATCH"
+			}
 		},
 		"Index": "",
 		"Namespace": "",

--- a/metricbeat/module/kubernetes/state_container/_meta/test/kube-state-metrics.expected
+++ b/metricbeat/module/kubernetes/state_container/_meta/test/kube-state-metrics.expected
@@ -1,158 +1,304 @@
 [
 	{
-		"_module.namespace": "kube-system",
-		"_module.node.name": "minikube",
-		"_module.pod.name": "kube-dns-v20-5g5cb",
+		"_module": {
+			"namespace": "jenkins",
+			"node": {
+				"name": "minikube"
+			},
+			"pod": {
+				"name": "wise-lynx-jenkins-1616735317-svn6k"
+			}
+		},
 		"_namespace": "container",
-		"cpu.request.cores": 0.1,
-		"cpu.request.nanocores": 100000000,
-		"id": "docker://fa3d83f648de42492b38fa3e8501d109376f391c50f2bd210c895c8477ae4b62",
-		"image": "gcr.io/google_containers/kubedns-amd64:1.9",
-		"memory.limit.bytes": 178257920,
-		"memory.request.bytes": 73400320,
-		"name": "kubedns",
-		"status.phase": "running",
-		"status.ready": true,
-		"status.restarts": 2
-	},
-	{
-		"_module.namespace": "kube-system",
-		"_module.pod.name": "tiller-deploy-3067024529-9lpmb",
-		"_namespace": "container",
-		"id": "docker://469f5d2b7854eb52e5d13dc0cd3e664c1b682b157aabaf596ffe4984f1516902",
-		"image": "gcr.io/kubernetes-helm/tiller:v2.3.1",
-		"name": "tiller",
-		"status.phase": "running",
-		"status.ready": true,
-		"status.restarts": 1
-	},
-	{
-		"_module.namespace": "jenkins",
-		"_module.node.name": "minikube",
-		"_module.pod.name": "wise-lynx-jenkins-1616735317-svn6k",
-		"_namespace": "container",
-		"cpu.request.cores": 0.2,
-		"cpu.request.nanocores": 200000000,
+		"cpu": {
+			"request": {
+				"cores": 0.2
+			}
+		},
 		"id": "docker://e2ee1c2c7b8d4e5fd8c834b83cba8377d6b0e39da18157688ccc1a06b7c53117",
 		"image": "jenkinsci/jenkins:2.46.1",
-		"memory.request.bytes": 268435456,
+		"memory": {
+			"request": {
+				"bytes": 268435456
+			}
+		},
 		"name": "wise-lynx-jenkins",
-		"status.phase": "running",
-		"status.ready": true,
-		"status.restarts": 1
+		"status": {
+			"phase": "running",
+			"ready": true,
+			"restarts": 1
+		}
 	},
 	{
-		"_module.namespace": "test",
-		"_module.node.name": "minikube-test",
-		"_module.pod.name": "kube-dns-v20-5g5cb-test",
-		"_namespace": "container",
-		"cpu.request.cores": 0.2,
-		"cpu.request.nanocores": 200000000,
-		"id": "docker://fa3d83f648de42492b38fa3e8501d109376f391c50f2bd210c895c8477ae4b62-test",
-		"image": "gcr.io/google_containers/kubedns-amd64:1.9-test",
-		"memory.limit.bytes": 278257920,
-		"memory.request.bytes": 83400320,
-		"name": "kubedns",
-		"status.phase": "terminated",
-		"status.ready": false,
-		"status.restarts": 3
-	},
-	{
-		"_module.namespace": "kube-system",
-		"_module.pod.name": "kube-state-metrics-1303537707-mnzbp",
-		"_namespace": "container",
-		"cpu.limit.cores": 0.2,
-		"cpu.limit.nanocores": 200000000,
-		"cpu.request.cores": 0.1,
-		"cpu.request.nanocores": 100000000,
-		"memory.limit.bytes": 52428800,
-		"memory.request.bytes": 31457280,
-		"name": "kube-state-metrics"
-	},
-	{
-		"_module.namespace": "kube-system",
-		"_module.pod.name": "kube-dns-v20-5g5cb",
+		"_module": {
+			"namespace": "kube-system",
+			"pod": {
+				"name": "kube-dns-v20-5g5cb"
+			}
+		},
 		"_namespace": "container",
 		"id": "docker://9a4c9462cd078d7be4f0a9b94bcfeb69d5fdd76bff67142df3f58367ac7e8d61",
 		"image": "gcr.io/google_containers/kube-dnsmasq-amd64:1.4",
 		"name": "dnsmasq",
-		"status.phase": "running",
-		"status.ready": true,
-		"status.restarts": 2
+		"status": {
+			"phase": "running",
+			"ready": true,
+			"restarts": 2
+		}
 	},
 	{
-		"_module.namespace": "kube-system",
-		"_module.node.name": "minikube",
-		"_module.pod.name": "kube-dns-v20-5g5cb",
+		"_module": {
+			"namespace": "default",
+			"node": {
+				"name": "minikube"
+			},
+			"pod": {
+				"name": "jumpy-owl-redis-3481028193-s78x9"
+			}
+		},
 		"_namespace": "container",
-		"cpu.request.cores": 0.01,
-		"cpu.request.nanocores": 10000000,
-		"id": "docker://52fa55e051dc5b68e44c027588685b7edd85aaa03b07f7216d399249ff4fc821",
-		"image": "gcr.io/google_containers/exechealthz-amd64:1.2",
-		"memory.limit.bytes": 52428800,
-		"memory.request.bytes": 52428800,
-		"name": "healthz",
-		"status.phase": "running",
-		"status.ready": true,
-		"status.restarts": 2
+		"cpu": {
+			"request": {
+				"cores": 0.1
+			}
+		},
+		"id": "docker://4fa227874ee68536bf902394fb662f07b99099798ca9cd5c1506b79075acc065",
+		"image": "bitnami/redis:3.2.8-r2",
+		"memory": {
+			"request": {
+				"bytes": 268435456
+			}
+		},
+		"name": "jumpy-owl-redis",
+		"status": {
+			"phase": "waiting",
+			"ready": false,
+			"restarts": 270
+		}
 	},
 	{
-		"_module.namespace": "kube-system",
-		"_module.node.name": "minikube",
-		"_module.pod.name": "kube-addon-manager-minikube",
+		"_module": {
+			"namespace": "kube-system",
+			"node": {
+				"name": "minikube"
+			},
+			"pod": {
+				"name": "kube-state-metrics-1303537707-7ncd1"
+			}
+		},
 		"_namespace": "container",
-		"cpu.request.cores": 0.005,
-		"cpu.request.nanocores": 5000000,
-		"id": "docker://91fdd43f6b1b4c3dd133cfca53e0b1210bc557c2ae56006026b5ccdb5f52826f",
-		"image": "gcr.io/google-containers/kube-addon-manager:v6.3",
-		"memory.request.bytes": 52428800,
-		"name": "kube-addon-manager",
-		"status.phase": "running",
-		"status.ready": true,
-		"status.restarts": 2
-	},
-	{
-		"_module.namespace": "kube-system",
-		"_module.node.name": "minikube",
-		"_module.pod.name": "kube-state-metrics-1303537707-7ncd1",
-		"_namespace": "container",
-		"cpu.limit.cores": 0.2,
-		"cpu.limit.nanocores": 200000000,
-		"cpu.request.cores": 0.1,
-		"cpu.request.nanocores": 100000000,
+		"cpu": {
+			"limit": {
+				"cores": 0.2
+			},
+			"request": {
+				"cores": 0.1
+			}
+		},
 		"id": "docker://973cbe45982c5126a5caf8c58d964c0ab1d5bb2c165ccc59715fcc1ebd58ab3d",
 		"image": "gcr.io/google_containers/kube-state-metrics:v0.4.1",
-		"memory.limit.bytes": 52428800,
-		"memory.request.bytes": 31457280,
+		"memory": {
+			"limit": {
+				"bytes": 52428800
+			},
+			"request": {
+				"bytes": 31457280
+			}
+		},
 		"name": "kube-state-metrics",
-		"status.phase": "running",
-		"status.ready": true,
-		"status.restarts": 1
+		"status": {
+			"phase": "running",
+			"ready": true,
+			"restarts": 1
+		}
 	},
 	{
-		"_module.namespace": "kube-system",
-		"_module.pod.name": "kubernetes-dashboard-vw0l6",
+		"_module": {
+			"namespace": "kube-system",
+			"node": {
+				"name": "minikube"
+			},
+			"pod": {
+				"name": "kube-dns-v20-5g5cb"
+			}
+		},
+		"_namespace": "container",
+		"cpu": {
+			"request": {
+				"cores": 0.1
+			}
+		},
+		"id": "docker://fa3d83f648de42492b38fa3e8501d109376f391c50f2bd210c895c8477ae4b62",
+		"image": "gcr.io/google_containers/kubedns-amd64:1.9",
+		"memory": {
+			"limit": {
+				"bytes": 178257920
+			},
+			"request": {
+				"bytes": 73400320
+			}
+		},
+		"name": "kubedns",
+		"status": {
+			"phase": "running",
+			"ready": true,
+			"restarts": 2
+		}
+	},
+	{
+		"_module": {
+			"namespace": "kube-system",
+			"node": {
+				"name": "minikube"
+			},
+			"pod": {
+				"name": "kube-dns-v20-5g5cb"
+			}
+		},
+		"_namespace": "container",
+		"cpu": {
+			"request": {
+				"cores": 0.01
+			}
+		},
+		"id": "docker://52fa55e051dc5b68e44c027588685b7edd85aaa03b07f7216d399249ff4fc821",
+		"image": "gcr.io/google_containers/exechealthz-amd64:1.2",
+		"memory": {
+			"limit": {
+				"bytes": 52428800
+			},
+			"request": {
+				"bytes": 52428800
+			}
+		},
+		"name": "healthz",
+		"status": {
+			"phase": "running",
+			"ready": true,
+			"restarts": 2
+		}
+	},
+	{
+		"_module": {
+			"namespace": "kube-system",
+			"pod": {
+				"name": "tiller-deploy-3067024529-9lpmb"
+			}
+		},
+		"_namespace": "container",
+		"id": "docker://469f5d2b7854eb52e5d13dc0cd3e664c1b682b157aabaf596ffe4984f1516902",
+		"image": "gcr.io/kubernetes-helm/tiller:v2.3.1",
+		"name": "tiller",
+		"status": {
+			"phase": "running",
+			"ready": true,
+			"restarts": 1
+		}
+	},
+	{
+		"_module": {
+			"namespace": "kube-system",
+			"node": {
+				"name": "minikube"
+			},
+			"pod": {
+				"name": "kube-addon-manager-minikube"
+			}
+		},
+		"_namespace": "container",
+		"cpu": {
+			"request": {
+				"cores": 0.005
+			}
+		},
+		"id": "docker://91fdd43f6b1b4c3dd133cfca53e0b1210bc557c2ae56006026b5ccdb5f52826f",
+		"image": "gcr.io/google-containers/kube-addon-manager:v6.3",
+		"memory": {
+			"request": {
+				"bytes": 52428800
+			}
+		},
+		"name": "kube-addon-manager",
+		"status": {
+			"phase": "running",
+			"ready": true,
+			"restarts": 2
+		}
+	},
+	{
+		"_module": {
+			"namespace": "kube-system",
+			"pod": {
+				"name": "kube-state-metrics-1303537707-mnzbp"
+			}
+		},
+		"_namespace": "container",
+		"cpu": {
+			"limit": {
+				"cores": 0.2
+			},
+			"request": {
+				"cores": 0.1
+			}
+		},
+		"memory": {
+			"limit": {
+				"bytes": 52428800
+			},
+			"request": {
+				"bytes": 31457280
+			}
+		},
+		"name": "kube-state-metrics"
+	},
+	{
+		"_module": {
+			"namespace": "kube-system",
+			"pod": {
+				"name": "kubernetes-dashboard-vw0l6"
+			}
+		},
 		"_namespace": "container",
 		"id": "docker://3aaee8bdd311c015240e99fa2a5a5f2f26b11b51236a683b39d8c1902e423978",
 		"image": "gcr.io/google_containers/kubernetes-dashboard-amd64:v1.5.1",
 		"name": "kubernetes-dashboard",
-		"status.phase": "running",
-		"status.ready": true,
-		"status.restarts": 2
+		"status": {
+			"phase": "running",
+			"ready": true,
+			"restarts": 2
+		}
 	},
 	{
-		"_module.namespace": "default",
-		"_module.node.name": "minikube",
-		"_module.pod.name": "jumpy-owl-redis-3481028193-s78x9",
+		"_module": {
+			"namespace": "test",
+			"node": {
+				"name": "minikube-test"
+			},
+			"pod": {
+				"name": "kube-dns-v20-5g5cb-test"
+			}
+		},
 		"_namespace": "container",
-		"cpu.request.cores": 0.1,
-		"cpu.request.nanocores": 100000000,
-		"id": "docker://4fa227874ee68536bf902394fb662f07b99099798ca9cd5c1506b79075acc065",
-		"image": "bitnami/redis:3.2.8-r2",
-		"memory.request.bytes": 268435456,
-		"name": "jumpy-owl-redis",
-		"status.phase": "waiting",
-		"status.ready": false,
-		"status.restarts": 270
+		"cpu": {
+			"request": {
+				"cores": 0.2
+			}
+		},
+		"id": "docker://fa3d83f648de42492b38fa3e8501d109376f391c50f2bd210c895c8477ae4b62-test",
+		"image": "gcr.io/google_containers/kubedns-amd64:1.9-test",
+		"memory": {
+			"limit": {
+				"bytes": 278257920
+			},
+			"request": {
+				"bytes": 83400320
+			}
+		},
+		"name": "kubedns",
+		"status": {
+			"phase": "terminated",
+			"ready": false,
+			"restarts": 3
+		}
 	}
 ]

--- a/metricbeat/module/kubernetes/state_container/_meta/test/kube-state-metrics.expected
+++ b/metricbeat/module/kubernetes/state_container/_meta/test/kube-state-metrics.expected
@@ -1,6 +1,26 @@
 [
 	{
 		"_module": {
+			"namespace": "kube-system",
+			"node": {
+				"name": "minikube"
+			},
+			"pod": {
+				"name": "kubernetes-dashboard-vw0l6"
+			}
+		},
+		"_namespace": "container",
+		"id": "docker://3aaee8bdd311c015240e99fa2a5a5f2f26b11b51236a683b39d8c1902e423978",
+		"image": "gcr.io/google_containers/kubernetes-dashboard-amd64:v1.5.1",
+		"name": "kubernetes-dashboard",
+		"status": {
+			"phase": "running",
+			"ready": true,
+			"restarts": 2
+		}
+	},
+	{
+		"_module": {
 			"namespace": "jenkins",
 			"node": {
 				"name": "minikube"
@@ -27,23 +47,6 @@
 			"phase": "running",
 			"ready": true,
 			"restarts": 1
-		}
-	},
-	{
-		"_module": {
-			"namespace": "kube-system",
-			"pod": {
-				"name": "kube-dns-v20-5g5cb"
-			}
-		},
-		"_namespace": "container",
-		"id": "docker://9a4c9462cd078d7be4f0a9b94bcfeb69d5fdd76bff67142df3f58367ac7e8d61",
-		"image": "gcr.io/google_containers/kube-dnsmasq-amd64:1.4",
-		"name": "dnsmasq",
-		"status": {
-			"phase": "running",
-			"ready": true,
-			"restarts": 2
 		}
 	},
 	{
@@ -156,6 +159,26 @@
 			}
 		},
 		"_namespace": "container",
+		"id": "docker://9a4c9462cd078d7be4f0a9b94bcfeb69d5fdd76bff67142df3f58367ac7e8d61",
+		"image": "gcr.io/google_containers/kube-dnsmasq-amd64:1.4",
+		"name": "dnsmasq",
+		"status": {
+			"phase": "running",
+			"ready": true,
+			"restarts": 2
+		}
+	},
+	{
+		"_module": {
+			"namespace": "kube-system",
+			"node": {
+				"name": "minikube"
+			},
+			"pod": {
+				"name": "kube-dns-v20-5g5cb"
+			}
+		},
+		"_namespace": "container",
 		"cpu": {
 			"request": {
 				"cores": 0.01
@@ -181,6 +204,9 @@
 	{
 		"_module": {
 			"namespace": "kube-system",
+			"node": {
+				"name": "minikube"
+			},
 			"pod": {
 				"name": "tiller-deploy-3067024529-9lpmb"
 			}
@@ -250,23 +276,6 @@
 			}
 		},
 		"name": "kube-state-metrics"
-	},
-	{
-		"_module": {
-			"namespace": "kube-system",
-			"pod": {
-				"name": "kubernetes-dashboard-vw0l6"
-			}
-		},
-		"_namespace": "container",
-		"id": "docker://3aaee8bdd311c015240e99fa2a5a5f2f26b11b51236a683b39d8c1902e423978",
-		"image": "gcr.io/google_containers/kubernetes-dashboard-amd64:v1.5.1",
-		"name": "kubernetes-dashboard",
-		"status": {
-			"phase": "running",
-			"ready": true,
-			"restarts": 2
-		}
 	},
 	{
 		"_module": {

--- a/metricbeat/module/kubernetes/state_container/_meta/test/kube-state-metrics.v1.3.0.expected
+++ b/metricbeat/module/kubernetes/state_container/_meta/test/kube-state-metrics.v1.3.0.expected
@@ -156,23 +156,9 @@
 	{
 		"_module": {
 			"namespace": "kube-system",
-			"pod": {
-				"name": "kube-proxy-znhg6"
-			}
-		},
-		"_namespace": "container",
-		"id": "docker://76c260259ddfd0267b5acb4e514465215ef1ebfa93a4057d592828772e6b39f5",
-		"image": "gcr.io/google_containers/kube-proxy-amd64:v1.9.7",
-		"name": "kube-proxy",
-		"status": {
-			"phase": "running",
-			"ready": true,
-			"restarts": 0
-		}
-	},
-	{
-		"_module": {
-			"namespace": "kube-system",
+			"node": {
+				"name": "minikube"
+			},
 			"pod": {
 				"name": "etcd-minikube"
 			}
@@ -190,6 +176,30 @@
 	{
 		"_module": {
 			"namespace": "kube-system",
+			"node": {
+				"name": "minikube"
+			},
+			"pod": {
+				"name": "storage-provisioner"
+			}
+		},
+		"_namespace": "container",
+		"id": "docker://f4cc07b8e7ee5952738c69a0bff0c7b331c10af66faa541197684127d393b760",
+		"image": "gcr.io/k8s-minikube/storage-provisioner:v1.8.1",
+		"name": "storage-provisioner",
+		"status": {
+			"phase": "running",
+			"ready": true,
+			"reason": "ImagePullBackOff",
+			"restarts": 0
+		}
+	},
+	{
+		"_module": {
+			"namespace": "kube-system",
+			"node": {
+				"name": "minikube"
+			},
 			"pod": {
 				"name": "kubernetes-dashboard-77d8b98585-vqtzm"
 			}
@@ -243,18 +253,20 @@
 	{
 		"_module": {
 			"namespace": "kube-system",
+			"node": {
+				"name": "minikube"
+			},
 			"pod": {
-				"name": "storage-provisioner"
+				"name": "kube-proxy-znhg6"
 			}
 		},
 		"_namespace": "container",
-		"id": "docker://f4cc07b8e7ee5952738c69a0bff0c7b331c10af66faa541197684127d393b760",
-		"image": "gcr.io/k8s-minikube/storage-provisioner:v1.8.1",
-		"name": "storage-provisioner",
+		"id": "docker://76c260259ddfd0267b5acb4e514465215ef1ebfa93a4057d592828772e6b39f5",
+		"image": "gcr.io/google_containers/kube-proxy-amd64:v1.9.7",
+		"name": "kube-proxy",
 		"status": {
 			"phase": "running",
 			"ready": true,
-			"reason": "ImagePullBackOff",
 			"restarts": 0
 		}
 	},

--- a/metricbeat/module/kubernetes/state_container/_meta/test/kube-state-metrics.v1.3.0.expected
+++ b/metricbeat/module/kubernetes/state_container/_meta/test/kube-state-metrics.v1.3.0.expected
@@ -1,187 +1,342 @@
 [
 	{
-		"_module.namespace": "kube-system",
-		"_module.node.name": "minikube",
-		"_module.pod.name": "kube-apiserver-minikube",
+		"_module": {
+			"namespace": "kube-system",
+			"node": {
+				"name": "minikube"
+			},
+			"pod": {
+				"name": "kube-dns-6f4fd4bdf-wlmht"
+			}
+		},
 		"_namespace": "container",
-		"cpu.request.cores": 0.25,
-		"cpu.request.nanocores": 250000000,
-		"id": "docker://e9568dfef1dd249cabac4bf09e6bf4a239fe738ae20eba072b6516676fce4bf6",
-		"image": "gcr.io/google_containers/kube-apiserver-amd64:v1.9.7",
-		"name": "kube-apiserver",
-		"status.phase": "running",
-		"status.ready": true,
-		"status.restarts": 0
+		"cpu": {
+			"request": {
+				"cores": 0.1
+			}
+		},
+		"id": "docker://1958e71d048065d38ce83dafda567c5fa9d0c1278cd7292d55b9f1d80b0a67f9",
+		"image": "gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.7",
+		"memory": {
+			"limit": {
+				"bytes": 178257920
+			},
+			"request": {
+				"bytes": 73400320
+			}
+		},
+		"name": "kubedns",
+		"status": {
+			"phase": "running",
+			"ready": true,
+			"restarts": 0
+		}
 	},
 	{
-		"_module.namespace": "kube-system",
-		"_module.node.name": "minikube",
-		"_module.pod.name": "kube-controller-manager-minikube",
+		"_module": {
+			"namespace": "kube-system",
+			"node": {
+				"name": "minikube"
+			},
+			"pod": {
+				"name": "kube-controller-manager-minikube"
+			}
+		},
 		"_namespace": "container",
-		"cpu.request.cores": 0.2,
-		"cpu.request.nanocores": 200000000,
+		"cpu": {
+			"request": {
+				"cores": 0.2
+			}
+		},
 		"id": "docker://4beb9aab887ca162c9cb3534c4826156636241052cd548153eaa2a170b6d102f",
 		"image": "gcr.io/google_containers/kube-controller-manager-amd64:v1.9.7",
 		"name": "kube-controller-manager",
-		"status.phase": "running",
-		"status.ready": true,
-		"status.restarts": 0
+		"status": {
+			"phase": "running",
+			"ready": true,
+			"restarts": 0
+		}
 	},
 	{
-		"_module.namespace": "kube-system",
-		"_module.node.name": "minikube",
-		"_module.pod.name": "kube-dns-6f4fd4bdf-wlmht",
+		"_module": {
+			"namespace": "kube-system",
+			"node": {
+				"name": "minikube"
+			},
+			"pod": {
+				"name": "kube-state-metrics-6479d88c5c-5b6cl"
+			}
+		},
 		"_namespace": "container",
-		"cpu.request.cores": 0.01,
-		"cpu.request.nanocores": 10000000,
-		"id": "docker://aad0addd205dc72dc7abc8f9d02a1b429a2f2e1df3acc60431ca6b79746c093b",
-		"image": "gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.7",
-		"memory.request.bytes": 20971520,
-		"name": "sidecar",
-		"status.phase": "running",
-		"status.ready": true,
-		"status.reason": "OOMKilled",
-		"status.restarts": 0
+		"cpu": {
+			"limit": {
+				"cores": 0.1
+			},
+			"request": {
+				"cores": 0.1
+			}
+		},
+		"id": "docker://948c4ebd8ca4fdf352e7fbf7f5c5d381af7e615ced435dc42fde0c1d25851320",
+		"image": "k8s.gcr.io/addon-resizer:1.7",
+		"memory": {
+			"limit": {
+				"bytes": 31457280
+			},
+			"request": {
+				"bytes": 31457280
+			}
+		},
+		"name": "addon-resizer",
+		"status": {
+			"phase": "running",
+			"ready": true,
+			"restarts": 0
+		}
 	},
 	{
-		"_module.namespace": "kube-system",
-		"_module.pod.name": "storage-provisioner",
+		"_module": {
+			"namespace": "kube-system",
+			"node": {
+				"name": "minikube"
+			},
+			"pod": {
+				"name": "kube-addon-manager-minikube"
+			}
+		},
 		"_namespace": "container",
-		"id": "docker://f4cc07b8e7ee5952738c69a0bff0c7b331c10af66faa541197684127d393b760",
-		"image": "gcr.io/k8s-minikube/storage-provisioner:v1.8.1",
-		"name": "storage-provisioner",
-		"status.phase": "running",
-		"status.ready": true,
-		"status.reason": "ImagePullBackOff",
-		"status.restarts": 0
-	},
-	{
-		"_module.namespace": "kube-system",
-		"_module.pod.name": "etcd-minikube",
-		"_namespace": "container",
-		"id": "docker://6e96fd8a687409b2314dcc01f209bb0c813c2fb08b8f75ad1695e120d41e1a2a",
-		"image": "gcr.io/google_containers/etcd-amd64:3.1.11",
-		"name": "etcd",
-		"status.phase": "running",
-		"status.ready": true,
-		"status.restarts": 0
-	},
-	{
-		"_module.namespace": "kube-system",
-		"_module.node.name": "minikube",
-		"_module.pod.name": "kube-addon-manager-minikube",
-		"_namespace": "container",
-		"cpu.request.cores": 0.005,
-		"cpu.request.nanocores": 5000000,
+		"cpu": {
+			"request": {
+				"cores": 0.005
+			}
+		},
 		"id": "docker://ab382dbe8f8265f88ee9fec7de142f778da4a5fd9fe0334e3bdb6fe851124c08",
 		"image": "k8s.gcr.io/kube-addon-manager:v8.6",
-		"memory.request.bytes": 52428800,
+		"memory": {
+			"request": {
+				"bytes": 52428800
+			}
+		},
 		"name": "kube-addon-manager",
-		"status.phase": "running",
-		"status.ready": true,
-		"status.restarts": 0
+		"status": {
+			"phase": "running",
+			"ready": true,
+			"restarts": 0
+		}
 	},
 	{
-		"_module.namespace": "kube-system",
-		"_module.pod.name": "kube-proxy-znhg6",
+		"_module": {
+			"namespace": "kube-system",
+			"node": {
+				"name": "minikube"
+			},
+			"pod": {
+				"name": "kube-dns-6f4fd4bdf-wlmht"
+			}
+		},
+		"_namespace": "container",
+		"cpu": {
+			"request": {
+				"cores": 0.15
+			}
+		},
+		"id": "docker://e9560bbace13ca19de4b3771023198e8568f6b5ed6af3a949f10a5b8137b5be9",
+		"image": "gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.7",
+		"memory": {
+			"request": {
+				"bytes": 20971520
+			}
+		},
+		"name": "dnsmasq",
+		"status": {
+			"phase": "running",
+			"ready": true,
+			"restarts": 0
+		}
+	},
+	{
+		"_module": {
+			"namespace": "kube-system",
+			"pod": {
+				"name": "kube-proxy-znhg6"
+			}
+		},
 		"_namespace": "container",
 		"id": "docker://76c260259ddfd0267b5acb4e514465215ef1ebfa93a4057d592828772e6b39f5",
 		"image": "gcr.io/google_containers/kube-proxy-amd64:v1.9.7",
 		"name": "kube-proxy",
-		"status.phase": "running",
-		"status.ready": true,
-		"status.restarts": 0
+		"status": {
+			"phase": "running",
+			"ready": true,
+			"restarts": 0
+		}
 	},
 	{
-		"_module.namespace": "kube-system",
-		"_module.node.name": "minikube",
-		"_module.pod.name": "kube-scheduler-minikube",
+		"_module": {
+			"namespace": "kube-system",
+			"pod": {
+				"name": "etcd-minikube"
+			}
+		},
 		"_namespace": "container",
-		"cpu.request.cores": 0.1,
-		"cpu.request.nanocores": 100000000,
-		"id": "docker://eadcbd54ba914dff6475ae64805887967cfb973aeb9b07364c94372658a71d11",
-		"image": "gcr.io/google_containers/kube-scheduler-amd64:v1.9.7",
-		"name": "kube-scheduler",
-		"status.phase": "running",
-		"status.ready": true,
-		"status.restarts": 0
+		"id": "docker://6e96fd8a687409b2314dcc01f209bb0c813c2fb08b8f75ad1695e120d41e1a2a",
+		"image": "gcr.io/google_containers/etcd-amd64:3.1.11",
+		"name": "etcd",
+		"status": {
+			"phase": "running",
+			"ready": true,
+			"restarts": 0
+		}
 	},
 	{
-		"_module.namespace": "kube-system",
-		"_module.node.name": "minikube",
-		"_module.pod.name": "kube-state-metrics-6479d88c5c-5b6cl",
-		"_namespace": "container",
-		"cpu.limit.cores": 0.101,
-		"cpu.limit.nanocores": 101000000,
-		"cpu.request.cores": 0.101,
-		"cpu.request.nanocores": 101000000,
-		"id": "docker://88951e0178ea5131fa3e2d7cafacb3a7e63700795dd6fa0d40ed2e4ac1f52f9c",
-		"image": "quay.io/coreos/kube-state-metrics:v1.3.0",
-		"memory.limit.bytes": 106954752,
-		"memory.request.bytes": 106954752,
-		"name": "kube-state-metrics",
-		"status.phase": "running",
-		"status.ready": true,
-		"status.restarts": 0
-	},
-	{
-		"_module.namespace": "kube-system",
-		"_module.node.name": "minikube",
-		"_module.pod.name": "kube-dns-6f4fd4bdf-wlmht",
-		"_namespace": "container",
-		"cpu.request.cores": 0.1,
-		"cpu.request.nanocores": 100000000,
-		"id": "docker://1958e71d048065d38ce83dafda567c5fa9d0c1278cd7292d55b9f1d80b0a67f9",
-		"image": "gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.7",
-		"memory.limit.bytes": 178257920,
-		"memory.request.bytes": 73400320,
-		"name": "kubedns",
-		"status.phase": "running",
-		"status.ready": true,
-		"status.restarts": 0
-	},
-	{
-		"_module.namespace": "kube-system",
-		"_module.pod.name": "kubernetes-dashboard-77d8b98585-vqtzm",
+		"_module": {
+			"namespace": "kube-system",
+			"pod": {
+				"name": "kubernetes-dashboard-77d8b98585-vqtzm"
+			}
+		},
 		"_namespace": "container",
 		"id": "docker://c46bc2164edcb5972be6fc9174155e61179cb04314c4f6da5d25d3a76acadee6",
 		"image": "k8s.gcr.io/kubernetes-dashboard-amd64:v1.8.1",
 		"name": "kubernetes-dashboard",
-		"status.phase": "running",
-		"status.ready": true,
-		"status.restarts": 0
+		"status": {
+			"phase": "running",
+			"ready": true,
+			"restarts": 0
+		}
 	},
 	{
-		"_module.namespace": "kube-system",
-		"_module.node.name": "minikube",
-		"_module.pod.name": "kube-state-metrics-6479d88c5c-5b6cl",
+		"_module": {
+			"namespace": "kube-system",
+			"node": {
+				"name": "minikube"
+			},
+			"pod": {
+				"name": "kube-state-metrics-6479d88c5c-5b6cl"
+			}
+		},
 		"_namespace": "container",
-		"cpu.limit.cores": 0.1,
-		"cpu.limit.nanocores": 100000000,
-		"cpu.request.cores": 0.1,
-		"cpu.request.nanocores": 100000000,
-		"id": "docker://948c4ebd8ca4fdf352e7fbf7f5c5d381af7e615ced435dc42fde0c1d25851320",
-		"image": "k8s.gcr.io/addon-resizer:1.7",
-		"memory.limit.bytes": 31457280,
-		"memory.request.bytes": 31457280,
-		"name": "addon-resizer",
-		"status.phase": "running",
-		"status.ready": true,
-		"status.restarts": 0
+		"cpu": {
+			"limit": {
+				"cores": 0.101
+			},
+			"request": {
+				"cores": 0.101
+			}
+		},
+		"id": "docker://88951e0178ea5131fa3e2d7cafacb3a7e63700795dd6fa0d40ed2e4ac1f52f9c",
+		"image": "quay.io/coreos/kube-state-metrics:v1.3.0",
+		"memory": {
+			"limit": {
+				"bytes": 106954752
+			},
+			"request": {
+				"bytes": 106954752
+			}
+		},
+		"name": "kube-state-metrics",
+		"status": {
+			"phase": "running",
+			"ready": true,
+			"restarts": 0
+		}
 	},
 	{
-		"_module.namespace": "kube-system",
-		"_module.node.name": "minikube",
-		"_module.pod.name": "kube-dns-6f4fd4bdf-wlmht",
+		"_module": {
+			"namespace": "kube-system",
+			"pod": {
+				"name": "storage-provisioner"
+			}
+		},
 		"_namespace": "container",
-		"cpu.request.cores": 0.15,
-		"cpu.request.nanocores": 150000000,
-		"id": "docker://e9560bbace13ca19de4b3771023198e8568f6b5ed6af3a949f10a5b8137b5be9",
-		"image": "gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.7",
-		"memory.request.bytes": 20971520,
-		"name": "dnsmasq",
-		"status.phase": "running",
-		"status.ready": true,
-		"status.restarts": 0
+		"id": "docker://f4cc07b8e7ee5952738c69a0bff0c7b331c10af66faa541197684127d393b760",
+		"image": "gcr.io/k8s-minikube/storage-provisioner:v1.8.1",
+		"name": "storage-provisioner",
+		"status": {
+			"phase": "running",
+			"ready": true,
+			"reason": "ImagePullBackOff",
+			"restarts": 0
+		}
+	},
+	{
+		"_module": {
+			"namespace": "kube-system",
+			"node": {
+				"name": "minikube"
+			},
+			"pod": {
+				"name": "kube-apiserver-minikube"
+			}
+		},
+		"_namespace": "container",
+		"cpu": {
+			"request": {
+				"cores": 0.25
+			}
+		},
+		"id": "docker://e9568dfef1dd249cabac4bf09e6bf4a239fe738ae20eba072b6516676fce4bf6",
+		"image": "gcr.io/google_containers/kube-apiserver-amd64:v1.9.7",
+		"name": "kube-apiserver",
+		"status": {
+			"phase": "running",
+			"ready": true,
+			"restarts": 0
+		}
+	},
+	{
+		"_module": {
+			"namespace": "kube-system",
+			"node": {
+				"name": "minikube"
+			},
+			"pod": {
+				"name": "kube-dns-6f4fd4bdf-wlmht"
+			}
+		},
+		"_namespace": "container",
+		"cpu": {
+			"request": {
+				"cores": 0.01
+			}
+		},
+		"id": "docker://aad0addd205dc72dc7abc8f9d02a1b429a2f2e1df3acc60431ca6b79746c093b",
+		"image": "gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.7",
+		"memory": {
+			"request": {
+				"bytes": 20971520
+			}
+		},
+		"name": "sidecar",
+		"status": {
+			"phase": "running",
+			"ready": true,
+			"reason": "OOMKilled",
+			"restarts": 0
+		}
+	},
+	{
+		"_module": {
+			"namespace": "kube-system",
+			"node": {
+				"name": "minikube"
+			},
+			"pod": {
+				"name": "kube-scheduler-minikube"
+			}
+		},
+		"_namespace": "container",
+		"cpu": {
+			"request": {
+				"cores": 0.1
+			}
+		},
+		"id": "docker://eadcbd54ba914dff6475ae64805887967cfb973aeb9b07364c94372658a71d11",
+		"image": "gcr.io/google_containers/kube-scheduler-amd64:v1.9.7",
+		"name": "kube-scheduler",
+		"status": {
+			"phase": "running",
+			"ready": true,
+			"restarts": 0
+		}
 	}
 ]

--- a/metricbeat/module/kubernetes/state_container/state_container.go
+++ b/metricbeat/module/kubernetes/state_container/state_container.go
@@ -20,9 +20,11 @@ var (
 		DefaultPath:   defaultPath,
 	}.Build()
 
+	// Mapping of state metrics
 	mapping = &p.MetricsMapping{
 		Metrics: map[string]p.MetricMap{
-			"kube_pod_container_info":                           p.Metric(""),
+			"kube_pod_info":                                     p.InfoMetric(),
+			"kube_pod_container_info":                           p.InfoMetric(),
 			"kube_pod_container_resource_limits_cpu_cores":      p.Metric("cpu.limit.cores"),
 			"kube_pod_container_resource_requests_cpu_cores":    p.Metric("cpu.request.cores"),
 			"kube_pod_container_resource_limits_memory_bytes":   p.Metric("memory.limit.bytes"),

--- a/metricbeat/module/kubernetes/state_deployment/state_deployment.go
+++ b/metricbeat/module/kubernetes/state_deployment/state_deployment.go
@@ -21,7 +21,7 @@ var (
 
 	mapping = &p.MetricsMapping{
 		Metrics: map[string]p.MetricMap{
-			"kube_deployment_metadata_generation":         p.Metric(""),
+			"kube_deployment_metadata_generation":         p.InfoMetric(),
 			"kube_deployment_status_replicas_updated":     p.Metric("replicas.updated"),
 			"kube_deployment_status_replicas_unavailable": p.Metric("replicas.unavailable"),
 			"kube_deployment_status_replicas_available":   p.Metric("replicas.available"),

--- a/metricbeat/module/kubernetes/state_node/state_node.go
+++ b/metricbeat/module/kubernetes/state_node/state_node.go
@@ -20,7 +20,7 @@ var (
 
 	mapping = &p.MetricsMapping{
 		Metrics: map[string]p.MetricMap{
-			"kube_node_info":                            p.Metric(""),
+			"kube_node_info":                            p.InfoMetric(),
 			"kube_node_status_allocatable_pods":         p.Metric("pod.allocatable.total"),
 			"kube_node_status_capacity_pods":            p.Metric("pod.capacity.total"),
 			"kube_node_status_capacity_memory_bytes":    p.Metric("memory.capacity.bytes"),

--- a/metricbeat/module/kubernetes/state_pod/state_pod.go
+++ b/metricbeat/module/kubernetes/state_pod/state_pod.go
@@ -20,7 +20,7 @@ var (
 
 	mapping = &p.MetricsMapping{
 		Metrics: map[string]p.MetricMap{
-			"kube_pod_info":             p.Metric(""),
+			"kube_pod_info":             p.InfoMetric(),
 			"kube_pod_status_phase":     p.LabelMetric("status.phase", "phase", true),
 			"kube_pod_status_ready":     p.LabelMetric("status.ready", "condition", true),
 			"kube_pod_status_scheduled": p.LabelMetric("status.scheduled", "condition", true),

--- a/metricbeat/module/kubernetes/state_replicaset/state_replicaset.go
+++ b/metricbeat/module/kubernetes/state_replicaset/state_replicaset.go
@@ -20,7 +20,7 @@ var (
 
 	mapping = &p.MetricsMapping{
 		Metrics: map[string]p.MetricMap{
-			"kube_replicaset_metadata_generation":           p.Metric(""),
+			"kube_replicaset_metadata_generation":           p.InfoMetric(),
 			"kube_replicaset_status_fully_labeled_replicas": p.Metric("replicas.labeled"),
 			"kube_replicaset_status_observed_generation":    p.Metric("replicas.observed"),
 			"kube_replicaset_status_ready_replicas":         p.Metric("replicas.ready"),


### PR DESCRIPTION
This PR fixes info retrieval for state_container after latest Prometheus helper changes.

I've added code to create repeatable expected files (sorted), this should avoid big diffs in the future when we regenerate them.