### PR TITLE
Allow user to rely on Elasticsearch default ignore above for keyword

### DIFF
--- a/libbeat/template/processor.go
+++ b/libbeat/template/processor.go
@@ -151,9 +151,12 @@ func (p *Processor) keyword(f *common.Field) common.MapStr {
 	defaultFields = append(defaultFields, fullName)
 
 	property["type"] = "keyword"
-	if f.IgnoreAbove == 0 {
+
+	switch f.IgnoreAbove {
+	case 0: // Use libbeat default
 		property["ignore_above"] = defaultIgnoreAbove
-	} else {
+	case -1: // Use ES default
+	default: // Use user value
 		property["ignore_above"] = f.IgnoreAbove
 	}
 

--- a/libbeat/template/processor_test.go
+++ b/libbeat/template/processor_test.go
@@ -138,6 +138,12 @@ func TestProcessor(t *testing.T) {
 			},
 		},
 		{
+			output: p.keyword(&common.Field{Type: "keyword", IgnoreAbove: -1}),
+			expected: common.MapStr{
+				"type": "keyword",
+			},
+		},
+		{
 			output: p.keyword(&common.Field{Type: "keyword"}),
 			expected: common.MapStr{
 				"type":         "keyword",


### PR DESCRIPTION
value.

Allow users to rely on Elasticsearch ignore_above default for the keyword
data type, sometimes we want to have a large keyword to hold
certificates.

Behavior:

- Not specifying a value will use 1024.
- Will use the specified value.
- Using -1 will fallback to ES default.