### PR TITLE
Use KEY_WOW64_64KEY to access MachineGuid

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -110,6 +110,7 @@ https://github.com/elastic/beats/compare/v6.2.3...master[Check the HEAD diff]
 - Add mapping for docker metrics per cpu. {pull}6843[6843]
 - Ensure canonical naming for JMX beans is disabled in Jolokia module. {pull}7047[7047]
 - Fix field mapping for the system process CPU ticks fields. {pull}7230[7230]
+- Fix Windows service metricset when using a 32-bit binary on a 64-bit OS. {pull}7294[7294]
 
 *Packetbeat*
 

--- a/metricbeat/module/windows/service/service_windows.go
+++ b/metricbeat/module/windows/service/service_windows.go
@@ -528,7 +528,7 @@ func getMachineGUID() (string, error) {
 	const path = `SOFTWARE\Microsoft\Cryptography`
 	const name = "MachineGuid"
 
-	k, err := registry.OpenKey(key, path, registry.READ)
+	k, err := registry.OpenKey(key, path, registry.READ|registry.WOW64_64KEY)
 	if err != nil {
 		return "", errors.Wrapf(err, `failed to open HKLM\%v`, path)
 	}


### PR DESCRIPTION
KEY_WOW64_64KEY on a 64-bit OS means that the registry access, no matter if it's a 32 or 64 bit process, will access the 64 bit registry view.

This fixes an issue where the Metricbeat windows-service metricset would not start if the 32-bit binary was used on a 64-bit machine. The flag will have no effect on 32-bit machines.