### PR TITLE
Fix beats-dashboard make command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ lint:
 .PHONY: beats-dashboards
 beats-dashboards:
 	@mkdir -p build/dashboards
-	@$(foreach var,$(BEATS),cp -r $(var)/_meta/kibana/ build/dashboards/$(var)  || exit 1;)
+	@$(foreach var,$(BEATS),cp -r $(var)/_meta/kibana.generated/ build/dashboards/$(var)  || exit 1;)
 
 # Builds the documents for each beat
 .PHONY: docs


### PR DESCRIPTION
This was broken because of the change to kibana.generated directory.