### PR TITLE
Clarify docs around x-pack monitoring

### DIFF
--- a/libbeat/docs/monitoring/monitoring-beats.asciidoc
+++ b/libbeat/docs/monitoring/monitoring-beats.asciidoc
@@ -46,7 +46,8 @@ xpack.monitoring:
   elasticsearch:
 --------------------
 
-Otherwise, you must specify additional configuration options. For example:
+If you are using a different output then Elasticsearch, you must specify
+additional configuration options. For example:
 
 [source, yml]
 --------------------
@@ -57,6 +58,10 @@ xpack.monitoring:
     username: beats_system
     password: beatspassword
 --------------------
+
+NOTE: If the Elasticsearch output is used, no additional hosts can be
+configured. At the moment it is required that the Monitoring data is sent to the
+same cluster as all the other events.
 
 --
 

--- a/libbeat/docs/monitoring/monitoring-beats.asciidoc
+++ b/libbeat/docs/monitoring/monitoring-beats.asciidoc
@@ -33,21 +33,17 @@ information, see
 {xpack-ref}/setting-up-authentication.html[Setting Up User Authentication] and
 {xpack-ref}/built-in-roles.html[Built-in Roles].
 
-. Add the `xpack.monitoring` settings in the {beatname_uc} configuration file.
-If you configured {es} output and you want to use the same {es} production
-cluster and credentials, you can specify the following minimal configuration
-options:
+. Add the `xpack.monitoring` settings in the {beatname_uc} configuration file. If you
+configured {es} output, specify the following minimal configuration:
 +
 --
 [source, yml]
 --------------------
-xpack.monitoring:
-  enabled: true
-  elasticsearch:
+xpack.monitoring.enabled: true
 --------------------
 
-If you are using a different output then Elasticsearch, you must specify
-additional configuration options. For example:
+If you configured a different output, such as {ls}, you must specify additional
+configuration options. For example:
 
 [source, yml]
 --------------------
@@ -59,9 +55,9 @@ xpack.monitoring:
     password: beatspassword
 --------------------
 
-NOTE: If the Elasticsearch output is used, no additional hosts can be
-configured. At the moment it is required that the Monitoring data is sent to the
-same cluster as all the other events.
+NOTE: Currently you must send monitoring data to the same cluster as all other events.
+If you configured {es} output, do not specify additional hosts in the monitoring
+configuration.
 
 --
 


### PR DESCRIPTION
When the Elasticsearch output is used, no additional hosts can be configured in the X-pack configs.