### PR TITLE
[WIP] Global plugin registry

### DIFF
--- a/libbeat/registry/ordered_set.go
+++ b/libbeat/registry/ordered_set.go
@@ -56,6 +56,9 @@ func (o *orderedSet) list() []Plugin {
 }
 
 func (o *orderedSet) insert(order order, target, id PluginID, newPlugin Plugin) error {
+	if o.len() == 0 {
+		return fmt.Errorf("could not insert at a specific position no plugin found")
+	}
 	_, found := o.mapped[id]
 	if found {
 		return fmt.Errorf("could not add plugin: '%s', the plugin is already registered", id)
@@ -88,4 +91,8 @@ func (o *orderedSet) assertPos(pos int) {
 	if pos == -1 {
 		panic("inconsistent state in the plugin list")
 	}
+}
+
+func (o *orderedSet) len() int {
+	return len(o.mapped)
 }

--- a/libbeat/registry/ordered_set.go
+++ b/libbeat/registry/ordered_set.go
@@ -1,0 +1,87 @@
+package registry
+
+import "fmt"
+
+// orderedSet allow to uniquely register plugins and allow to specify their order, by default
+// plugins will be appended as they are defined.
+type orderedSet struct {
+	mapped  map[PluginID]Plugin
+	ordered []Plugin
+}
+
+func newOrderedSet() *orderedSet {
+	return &orderedSet{mapped: make(map[PluginID]Plugin)}
+}
+
+func (o *orderedSet) get(id PluginID) (Plugin, error) {
+	plugin, found := o.mapped[id]
+	if !found {
+		return nil, fmt.Errorf("could not find plugin: '%s'", id)
+	}
+	return plugin, nil
+}
+
+func (o *orderedSet) add(id PluginID, plugin Plugin) error {
+	_, found := o.mapped[id]
+	if found {
+		return fmt.Errorf("could not add plugin: '%s', the plugin is already registered", id)
+	}
+
+	o.mapped[id] = plugin
+	o.ordered = append(o.ordered, plugin)
+	return nil
+}
+
+func (o *orderedSet) remove(id PluginID) error {
+	plugin, found := o.mapped[id]
+	if !found {
+		return fmt.Errorf("could not find plugin: '%s'", id)
+	}
+
+	pos := -1
+	for idx, p := range o.ordered {
+		if p == plugin {
+			pos = idx
+			break
+		}
+	}
+
+	if pos == -1 {
+		panic("inconsistent state in the plugin list")
+	}
+
+	o.ordered = append(o.ordered[:pos], o.ordered[pos+1:]...)
+	return nil
+}
+
+func (o *orderedSet) list() []Plugin {
+	return o.ordered
+}
+
+func (o *orderedSet) insert(order order, target, id PluginID, newPlugin Plugin) error {
+	_, found := o.mapped[id]
+	if found {
+		return fmt.Errorf("could not add plugin: '%s', the plugin is already registered", id)
+	}
+
+	// lets find the target plugin
+	plugin, found := o.mapped[target]
+	if !found {
+		return fmt.Errorf("could not find the target plugin: '%s'", target)
+	}
+
+	pos := -1
+	for idx, p := range o.ordered {
+		if p == plugin {
+			pos = idx
+			break
+		}
+	}
+
+	if pos == -1 {
+		panic("inconsistent state in the plugin list")
+	}
+
+	o.ordered = append(o.ordered[:pos+int(order)], newPlugin, o.ordered[pos+-1*int(order):])
+	return nil
+}

--- a/libbeat/registry/ordered_set.go
+++ b/libbeat/registry/ordered_set.go
@@ -46,10 +46,7 @@ func (o *orderedSet) remove(id PluginID) error {
 		}
 	}
 
-	if pos == -1 {
-		panic("inconsistent state in the plugin list")
-	}
-
+	o.assertPos(pos)
 	o.ordered = append(o.ordered[:pos], o.ordered[pos+1:]...)
 	return nil
 }
@@ -78,10 +75,17 @@ func (o *orderedSet) insert(order order, target, id PluginID, newPlugin Plugin) 
 		}
 	}
 
+	o.assertPos(pos)
+	if order == After {
+		pos++
+
+	}
+	o.ordered = append(o.ordered[:pos], append([]Plugin{newPlugin}, o.ordered[pos:]...)...)
+	return nil
+}
+
+func (o *orderedSet) assertPos(pos int) {
 	if pos == -1 {
 		panic("inconsistent state in the plugin list")
 	}
-
-	o.ordered = append(o.ordered[:pos+int(order)], newPlugin, o.ordered[pos+-1*int(order):])
-	return nil
 }

--- a/libbeat/registry/plugin.go
+++ b/libbeat/registry/plugin.go
@@ -1,0 +1,172 @@
+package registry
+
+import (
+	"fmt"
+
+	"github.com/elastic/beats/libbeat/logp"
+)
+
+// Goal:
+// - Unify plugin handling
+// - Keep type safety
+// - Allow external plugin
+// - different type of plugin:
+//		- processors
+//    - queue
+//    - autodiscover provider
+//    - component:
+//					- default logging configuration
+// 					- enable secomp check
+// 					- enable autodiscover
+// 					- enabled metrics
+// 					- ML
+// 					- Kibana
+// 					- keystore
+// - reduce the global variable
+// - allow scopped logger
+// - threadsafety?
+// - Add logger
+
+type order int
+
+// Control insert ordering.
+const (
+	Before order = -1
+	After  order = 1
+)
+
+// PluginTypeKey represents a unique kind of plugins and will acts as a namespace.
+// (example: Processors, autodiscover provider)
+type PluginTypeKey string
+
+// PluginID is a unique human readable identifier for a plugin.
+type PluginID string
+
+type pluginType struct {
+	builder BuilderFunc
+	plugins *orderedSet
+}
+
+func newPluginType(builder BuilderFunc) *pluginType {
+	return &pluginType{builder: builder, plugins: newOrderedSet()}
+}
+
+// Registry keeps tracks of all the registred plugins in libbeat and provides way to access them.
+type Registry struct {
+	types map[PluginTypeKey]*pluginType
+	log   *logp.Logger
+}
+
+// BuilderFunc methods user to builder the plugin.
+type BuilderFunc func(interface{}) (interface{}, error)
+
+// Plugin is the actual plugin.
+type Plugin interface{}
+
+// New creates a new plugins registry that will contains all the possible libbeat plugins.
+func New(log *logp.Logger) *Registry {
+	return &Registry{types: make(map[PluginTypeKey]*pluginType), log: log}
+}
+
+// MustRegisterType register a new plugin type in the registry and will raises a panic on failure.
+func (r *Registry) MustRegisterType(t PluginTypeKey, builder BuilderFunc) {
+	err := r.RegisterType(t, builder)
+	if err != nil {
+		panic("could not register plugin")
+	}
+}
+
+// RegisterType register a new plugin type in the registry.
+func (r *Registry) RegisterType(t PluginTypeKey, builder BuilderFunc) error {
+	_, found := r.types[t]
+	if found {
+		return fmt.Errorf("could not add plugin type %s because it already exist in the registry", t)
+	}
+	r.types[t] = newPluginType(builder)
+	return nil
+}
+
+// RemoveType removes a plugin type and all the registered plugins.
+func (r *Registry) RemoveType(t PluginTypeKey) error {
+	_, found := r.types[t]
+	if !found {
+		return fmt.Errorf("could not remove plugin type %s because it doesn't exist in the registry", t)
+	}
+	delete(r.types, t)
+	return nil
+}
+
+// MustRegisterPlugin adds a new plugin for an existing plugin type and will panic on failure.
+func (r *Registry) MustRegisterPlugin(t PluginTypeKey, id PluginID, plugin Plugin) {
+	err := r.RegisterPlugin(t, id, plugin)
+	if err != nil {
+		panic("could not registry plugin")
+	}
+}
+
+// RegisterPlugin a new plugin for an existing plugin type.
+func (r *Registry) RegisterPlugin(t PluginTypeKey, id PluginID, plugin Plugin) error {
+	pluginType, err := r.pluginType(t)
+	if err != nil {
+		return err
+	}
+
+	return pluginType.plugins.add(id, plugin)
+}
+
+// RemovePlugin removes an existing plugin
+func (r *Registry) RemovePlugin(t PluginTypeKey, id PluginID) error {
+	pluginType, err := r.pluginType(t)
+	if err != nil {
+		return err
+	}
+	return pluginType.plugins.remove(id)
+}
+
+func (r *Registry) pluginType(t PluginTypeKey) (*pluginType, error) {
+	pluginType, found := r.types[t]
+	if !found {
+		return nil, fmt.Errorf("could not find plugin type '%s'", t)
+	}
+	return pluginType, nil
+}
+
+// Plugin returns the builder and the plugin.
+func (r Registry) Plugin(t PluginTypeKey, name PluginID) (BuilderFunc, Plugin, error) {
+	pluginType, err := r.pluginType(t)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	plugin, err := pluginType.plugins.get(name)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return pluginType.builder, plugin, nil
+}
+
+// Plugins returns a list of ordered plugin
+func (r *Registry) Plugins(t PluginTypeKey) (BuilderFunc, []Plugin, error) {
+	pluginType, err := r.pluginType(t)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return pluginType.builder, pluginType.plugins.list(), nil
+}
+
+// OrderedRegisterPlugin allows to register at a relative position from another plugin.
+func (r *Registry) OrderedRegisterPlugin(
+	t PluginTypeKey,
+	o order,
+	targetID, name PluginID,
+	plugin Plugin,
+) error {
+	pluginType, err := r.pluginType(t)
+	if err != nil {
+		return err
+	}
+
+	return pluginType.plugins.insert(o, targetID, name, plugin)
+}

--- a/libbeat/registry/plugin_test.go
+++ b/libbeat/registry/plugin_test.go
@@ -213,3 +213,46 @@ func TestPluginsInsert(t *testing.T) {
 		})
 	}
 }
+
+func TestFailInsert(t *testing.T) {
+	builder := func(i interface{}) (interface{}, error) {
+		return i, nil
+	}
+
+	pluginA := "A"
+	pluginC := "C"
+
+	key := PluginTypeKey("hello")
+
+	t.Run("fail if no plugins are registered", func(t *testing.T) {
+		r := New(logp.NewLogger("testing"))
+		err := r.RegisterType(key, builder)
+		if !assert.NoError(t, err) {
+			return
+		}
+		err = r.OrderedRegisterPlugin(key, After, "b", "c", pluginC)
+		assert.Error(t, err)
+	})
+
+	t.Run("fail insert after if plugin doesnt exist", func(t *testing.T) {
+		r := New(logp.NewLogger("testing"))
+		err := r.RegisterType(key, builder)
+		if !assert.NoError(t, err) {
+			return
+		}
+		err = r.RegisterPlugin(key, "a", pluginA)
+		err = r.OrderedRegisterPlugin(key, After, "b", "c", pluginC)
+		assert.Error(t, err)
+	})
+
+	t.Run("fail insert before if plugin doesnt exist", func(t *testing.T) {
+		r := New(logp.NewLogger("testing"))
+		err := r.RegisterType(key, builder)
+		if !assert.NoError(t, err) {
+			return
+		}
+		err = r.RegisterPlugin(key, "a", pluginA)
+		err = r.OrderedRegisterPlugin(key, Before, "b", "c", pluginC)
+		assert.Error(t, err)
+	})
+}

--- a/libbeat/registry/plugin_test.go
+++ b/libbeat/registry/plugin_test.go
@@ -177,4 +177,22 @@ func TestPlugins(t *testing.T) {
 		}
 		assert.Equal(t, []Plugin{pluginA, pluginB, pluginC}, l)
 	})
+
+	t.Run("allow to register a plugin before another one in the ordered set if the plugin exist", func(t *testing.T) {
+		r := New(logp.NewLogger("testing"))
+		err := r.RegisterType(key, builder)
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		r.RegisterPlugin(key, "a", pluginA)
+		r.RegisterPlugin(key, "c", pluginC)
+		r.OrderedRegisterPlugin(key, Before, "c", "b", pluginB)
+
+		_, l, err := r.Plugins(key)
+		if !assert.NoError(t, err) {
+			return
+		}
+		assert.Equal(t, []Plugin{pluginA, pluginB, pluginC}, l)
+	})
 }

--- a/libbeat/registry/plugin_test.go
+++ b/libbeat/registry/plugin_test.go
@@ -1,0 +1,180 @@
+package registry
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/libbeat/logp"
+)
+
+func TestRegisterPluginType(t *testing.T) {
+	builder := func(i interface{}) (interface{}, error) {
+		return i, nil
+	}
+
+	t.Run("when it does not exist", func(t *testing.T) {
+		r := New(logp.NewLogger("testing"))
+		err := r.RegisterType("hello", builder)
+		assert.NoError(t, err)
+	})
+
+	t.Run("when it already exist", func(t *testing.T) {
+		r := New(logp.NewLogger("testing"))
+		err := r.RegisterType("hello", builder)
+		if !assert.NoError(t, err) {
+			return
+		}
+		err = r.RegisterType("hello", builder)
+		assert.Error(t, err)
+	})
+}
+
+func TestRemovePluginType(t *testing.T) {
+	t.Run("when it does not exist", func(t *testing.T) {
+		r := New(logp.NewLogger("testing"))
+		err := r.RemoveType("hello")
+		assert.Error(t, err)
+	})
+
+	t.Run("when it already exist", func(t *testing.T) {
+		builder := func(i interface{}) (interface{}, error) {
+			return i, nil
+		}
+
+		r := New(logp.NewLogger("testing"))
+		err := r.RegisterType("hello", builder)
+		if !assert.NoError(t, err) {
+			return
+		}
+		err = r.RemoveType("hello")
+		assert.NoError(t, err)
+	})
+}
+
+func TestAddPlugin(t *testing.T) {
+	builder := func(i interface{}) (interface{}, error) {
+		return i, nil
+	}
+
+	plugin := struct{}{}
+
+	t.Run("when the plugin type doesn't exist", func(t *testing.T) {
+		r := New(logp.NewLogger("testing"))
+		err := r.RegisterPlugin("main", "superplugin", plugin)
+		assert.Error(t, err)
+	})
+
+	t.Run("when the plugin type exists", func(t *testing.T) {
+		r := New(logp.NewLogger("testing"))
+		err := r.RegisterType("hello", builder)
+		if !assert.NoError(t, err) {
+			return
+		}
+		err = r.RegisterPlugin("hello", "superplugin", plugin)
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		b, p, err := r.Plugin("hello", "superplugin")
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		b1, _ := builder(1)
+		b2, _ := b(1)
+		if !assert.Equal(t, b1, b2) {
+			return
+		}
+
+		if !assert.Equal(t, plugin, p) {
+			return
+		}
+	})
+}
+
+func TestRemovePlugin(t *testing.T) {
+	builder := func(i interface{}) (interface{}, error) {
+		return i, nil
+	}
+
+	plugin := struct{}{}
+
+	t.Run("when the plugin type doesn't exist", func(t *testing.T) {
+		r := New(logp.NewLogger("testing"))
+		err := r.RemovePlugin("hello", "myplugin")
+		assert.Error(t, err)
+	})
+
+	t.Run("when the plugin type exists and the plugin exists", func(t *testing.T) {
+		r := New(logp.NewLogger("testing"))
+		err := r.RegisterType("hello", builder)
+		if !assert.NoError(t, err) {
+			return
+		}
+		err = r.RegisterPlugin("hello", "superplugin", plugin)
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		err = r.RemovePlugin("hello", "superplugin")
+		assert.NoError(t, err)
+	})
+
+	t.Run("when the plugin type exists and the plugin doesn't exist", func(t *testing.T) {
+		r := New(logp.NewLogger("testing"))
+		err := r.RegisterType("hello", builder)
+		if !assert.NoError(t, err) {
+			return
+		}
+		err = r.RemovePlugin("hello", "superplugin")
+		assert.Error(t, err)
+	})
+}
+
+func TestPlugins(t *testing.T) {
+	builder := func(i interface{}) (interface{}, error) {
+		return i, nil
+	}
+
+	pluginA := "A"
+	pluginB := "B"
+	pluginC := "C"
+
+	key := PluginTypeKey("hello")
+
+	t.Run("default to appending order", func(t *testing.T) {
+		r := New(logp.NewLogger("testing"))
+		err := r.RegisterType(key, builder)
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		r.RegisterPlugin(key, "a", pluginA)
+		r.RegisterPlugin(key, "b", pluginB)
+
+		_, l, err := r.Plugins(key)
+		if !assert.NoError(t, err) {
+			return
+		}
+		assert.Equal(t, []Plugin{pluginA, pluginB}, l)
+	})
+
+	t.Run("allow to register a plugin before another one in the ordered set if the plugin exist", func(t *testing.T) {
+		r := New(logp.NewLogger("testing"))
+		err := r.RegisterType(key, builder)
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		r.RegisterPlugin(key, "a", pluginA)
+		r.RegisterPlugin(key, "c", pluginC)
+		r.OrderedRegisterPlugin(key, Before, "c", "b", pluginB)
+
+		_, l, err := r.Plugins(key)
+		if !assert.NoError(t, err) {
+			return
+		}
+		assert.Equal(t, []Plugin{pluginA, pluginB, pluginC}, l)
+	})
+}


### PR DESCRIPTION
**Notes: This is not ready to get reviewed**

Motivation:

Libbeat and beats using the framework are often extended with plugins,
implementing a custom type of plugins usually mean having to create a
specific registry for the plugin type and use global variables on a
package to allow plugin to register.

This is an attempt to create a global plugin registry that can be used
internally by libbeat or consumers either directly by accessing a global
registry variable or by using the package and create a sub registry.

Notes:

The library will provide the following:
- Allow to register a new plugin type
- Provide a factory method for each plugin
- Allow to Add/Remove plugin Type
- Allow to Add/Remove plugin
- Allow to retrieve all the plugins for a specific type.
- Keep an ordered set of the plugin defined by the adding order
- Allow to register a plugin before or after another existing one.

This is an initial work to split libbeat into components.