### PR TITLE
Backport to 6.3: Cherrypick multiple doc changes (#7128 #7174 #7282 #7284)

### DIFF
--- a/deploy/kubernetes/filebeat-kubernetes.yaml
+++ b/deploy/kubernetes/filebeat-kubernetes.yaml
@@ -6,7 +6,6 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: filebeat
-    kubernetes.io/cluster-service: "true"
 data:
   filebeat.yml: |-
     filebeat.config:
@@ -38,7 +37,6 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: filebeat
-    kubernetes.io/cluster-service: "true"
 data:
   kubernetes.yml: |-
     - type: docker
@@ -55,13 +53,11 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: filebeat
-    kubernetes.io/cluster-service: "true"
 spec:
   template:
     metadata:
       labels:
         k8s-app: filebeat
-        kubernetes.io/cluster-service: "true"
     spec:
       serviceAccountName: filebeat
       terminationGracePeriodSeconds: 30

--- a/deploy/kubernetes/filebeat/filebeat-configmap.yaml
+++ b/deploy/kubernetes/filebeat/filebeat-configmap.yaml
@@ -6,7 +6,6 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: filebeat
-    kubernetes.io/cluster-service: "true"
 data:
   filebeat.yml: |-
     filebeat.config:
@@ -38,7 +37,6 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: filebeat
-    kubernetes.io/cluster-service: "true"
 data:
   kubernetes.yml: |-
     - type: docker

--- a/deploy/kubernetes/filebeat/filebeat-daemonset.yaml
+++ b/deploy/kubernetes/filebeat/filebeat-daemonset.yaml
@@ -5,13 +5,11 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: filebeat
-    kubernetes.io/cluster-service: "true"
 spec:
   template:
     metadata:
       labels:
         k8s-app: filebeat
-        kubernetes.io/cluster-service: "true"
     spec:
       serviceAccountName: filebeat
       terminationGracePeriodSeconds: 30

--- a/deploy/kubernetes/metricbeat-kubernetes.yaml
+++ b/deploy/kubernetes/metricbeat-kubernetes.yaml
@@ -6,7 +6,6 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: metricbeat
-    kubernetes.io/cluster-service: "true"
 data:
   metricbeat.yml: |-
     metricbeat.config.modules:
@@ -33,7 +32,6 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: metricbeat
-    kubernetes.io/cluster-service: "true"
 data:
   system.yml: |-
     - module: system
@@ -80,13 +78,11 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: metricbeat
-    kubernetes.io/cluster-service: "true"
 spec:
   template:
     metadata:
       labels:
         k8s-app: metricbeat
-        kubernetes.io/cluster-service: "true"
     spec:
       serviceAccountName: metricbeat
       terminationGracePeriodSeconds: 30
@@ -172,7 +168,6 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: metricbeat
-    kubernetes.io/cluster-service: "true"
 data:
   # This module requires `kube-state-metrics` up and running under `kube-system` namespace
   kubernetes.yml: |-
@@ -196,13 +191,11 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: metricbeat
-    kubernetes.io/cluster-service: "true"
 spec:
   template:
     metadata:
       labels:
         k8s-app: metricbeat
-        kubernetes.io/cluster-service: "true"
     spec:
       serviceAccountName: metricbeat
       containers:

--- a/deploy/kubernetes/metricbeat/metricbeat-daemonset-configmap.yaml
+++ b/deploy/kubernetes/metricbeat/metricbeat-daemonset-configmap.yaml
@@ -6,7 +6,6 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: metricbeat
-    kubernetes.io/cluster-service: "true"
 data:
   metricbeat.yml: |-
     metricbeat.config.modules:
@@ -33,7 +32,6 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: metricbeat
-    kubernetes.io/cluster-service: "true"
 data:
   system.yml: |-
     - module: system

--- a/deploy/kubernetes/metricbeat/metricbeat-daemonset.yaml
+++ b/deploy/kubernetes/metricbeat/metricbeat-daemonset.yaml
@@ -6,13 +6,11 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: metricbeat
-    kubernetes.io/cluster-service: "true"
 spec:
   template:
     metadata:
       labels:
         k8s-app: metricbeat
-        kubernetes.io/cluster-service: "true"
     spec:
       serviceAccountName: metricbeat
       terminationGracePeriodSeconds: 30

--- a/deploy/kubernetes/metricbeat/metricbeat-deployment-configmap.yaml
+++ b/deploy/kubernetes/metricbeat/metricbeat-deployment-configmap.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: metricbeat
-    kubernetes.io/cluster-service: "true"
 data:
   # This module requires `kube-state-metrics` up and running under `kube-system` namespace
   kubernetes.yml: |-

--- a/deploy/kubernetes/metricbeat/metricbeat-deployment.yaml
+++ b/deploy/kubernetes/metricbeat/metricbeat-deployment.yaml
@@ -6,13 +6,11 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: metricbeat
-    kubernetes.io/cluster-service: "true"
 spec:
   template:
     metadata:
       labels:
         k8s-app: metricbeat
-        kubernetes.io/cluster-service: "true"
     spec:
       serviceAccountName: metricbeat
       containers:

--- a/filebeat/docs/autodiscover-docker-config.asciidoc
+++ b/filebeat/docs/autodiscover-docker-config.asciidoc
@@ -7,7 +7,7 @@ filebeat.autodiscover:
     - type: docker
       templates:
         - condition:
-            equals:
+            contains:
               docker.container.image: redis
           config:
             - type: docker
@@ -27,8 +27,8 @@ filebeat.autodiscover:
     - type: docker
       templates:
         - condition:
-            equals:
-              docker.container.image: "redis"
+            contains:
+              docker.container.image: redis
           config:
             - module: redis
               log:

--- a/libbeat/docs/dashboards.asciidoc
+++ b/libbeat/docs/dashboards.asciidoc
@@ -29,6 +29,10 @@ for your system. The command shown here loads the dashboards from the {beatname_
 package. For more options, such as loading customized dashboards, see
 {beatsdevguide}/import-dashboards.html[Importing Existing Beat Dashboards] in
 the _Beats Developer Guide_.
+ifndef::only-elasticsearch[]
+If you've configured the Logstash output, see
+<<load-dashboards-logstash>>.
+endif::[]
 
 ifdef::allplatforms[]
 
@@ -54,16 +58,12 @@ endif::[]
 ----------------------------------------------------------------------
 
 
-ifeval::["{beatname_lc}"!="auditbeat"]
-
 *docker:*
 
 ["source","sh",subs="attributes"]
 ----------------------------------------------------------------------
 docker run {dockerimage} setup --dashboards
 ----------------------------------------------------------------------
-
-endif::[]
 
 *win:*
 
@@ -79,3 +79,81 @@ and run:
 ----------------------------------------------------------------------
 PS > {beatname_lc} setup --dashboards
 ----------------------------------------------------------------------
+
+ifndef::only-elasticsearch[]
+[[load-dashboards-logstash]]
+==== Set up dashboards for Logstash output
+
+During dashboard loading, {beatname_uc} connects to Elasticsearch to check
+version information. To load dashboards when the Logstash output is enabled, you
+need to temporarily disable the Logstash output and enable Elasticsearch. To
+connect to a secured Elasticsearch cluster, you also need to pass Elasticsearch
+credentials.
+
+TIP: The example shows a hard-coded password, but you should store sensitive
+values in the <<keystore,secrets keystore>>.
+
+ifdef::allplatforms[]
+
+*deb and rpm:*
+
+["source","sh",subs="attributes"]
+----
+{beatname_lc} setup -e \
+  -E output.logstash.enabled=false \
+  -E output.elasticsearch.hosts=['localhost:9200'] \
+  -E output.elasticsearch.username={beat_default_index_prefix}_internal \
+  -E output.elasticsearch.password={pwd} \
+  -E setup.kibana.host=localhost:5601
+----
+
+
+*mac:*
+
+["source","sh",subs="attributes"]
+----
+./{beatname_lc} setup -e \
+  -E output.logstash.enabled=false \
+  -E output.elasticsearch.hosts=['localhost:9200'] \
+  -E output.elasticsearch.username={beat_default_index_prefix}_internal \
+  -E output.elasticsearch.password={pwd} \
+  -E setup.kibana.host=localhost:5601 
+----
+
+
+*docker:*
+
+["source","sh",subs="attributes"]
+----
+docker run {dockerimage} setup -e \
+  -E output.logstash.enabled=false \
+  -E output.elasticsearch.hosts=['localhost:9200'] \
+  -E output.elasticsearch.username={beat_default_index_prefix}_internal \
+  -E output.elasticsearch.password={pwd} \
+  -E setup.kibana.host=localhost:5601
+----
+
+
+*win:*
+
+endif::allplatforms[]
+
+Open a PowerShell prompt as an Administrator (right-click the PowerShell icon
+and select *Run As Administrator*).
+
+From the PowerShell prompt, change to the directory where you installed {beatname_uc},
+and run:
+
+["source","sh",subs="attributes"]
+----
+PS > .{backslash}{beatname_lc}.exe setup -e `
+  -E output.logstash.enabled=false `
+  -E output.elasticsearch.hosts=['localhost:9200'] `
+  -E output.elasticsearch.username={beat_default_index_prefix}_internal `
+  -E output.elasticsearch.password={pwd} `
+  -E setup.kibana.host=localhost:5601 
+----
+
+
+endif::only-elasticsearch[]
+

--- a/libbeat/docs/https.asciidoc
+++ b/libbeat/docs/https.asciidoc
@@ -10,8 +10,13 @@
 //// This content is structured to be included as a whole file.
 //////////////////////////////////////////////////////////////////////////
 
-To secure the communication between {beatname_uc} and Elasticsearch, you can use HTTPS
-and basic authentication. Here is a sample configuration:
+To secure the communication between {beatname_uc} and Elasticsearch, you can use
+HTTPS and basic authentication. Basic authentication for Elasticsearch is
+available when you enable {security} (see
+{securitydoc}/xpack-security.html[Securing the {stack}] and <<securing-beats>>).
+If you aren't using {security}, you can use a web proxy instead.
+
+Here is a sample configuration:
 
 ["source","yaml",subs="attributes,callouts"]
 ----------------------------------------------------------------------
@@ -28,11 +33,6 @@ output.elasticsearch:
 
 TIP: To obfuscate passwords and other sensitive settings, use the
 <<keystore,secrets keystore>>.
-
-Elasticsearch doesn't have built-in basic authentication, but you can achieve it
-either by using a web proxy or by using {xpack} to secure Elasticsearch. For more
-information, see the documentation about
-{securitydoc}/xpack-security.html[securing Elasticsearch] and <<securing-beats>>. 
 
 {beatname_uc} verifies the validity of the server certificates and only accepts trusted
 certificates. Creating a correct SSL/TLS infrastructure is outside the scope of

--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -32,6 +32,9 @@ The following topics describe how to configure each supported output:
 * <<file-output>>
 * <<console-output>>
 
+If you've secured the {stack}, also read <<securing-{beatname_lc}>> for more about
+security-related configuration options.
+
 endif::[]
 
 [[elasticsearch-output]]
@@ -49,12 +52,14 @@ Example configuration:
 ------------------------------------------------------------------------------
 
 output.elasticsearch:
-  hosts: ["http://localhost:9200"]
+  hosts: ["https://localhost:9200"]
   index: "{beatname_lc}-%{[beat.version]}-%{+yyyy.MM.dd}"
   ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
   ssl.certificate: "/etc/pki/client/cert.pem"
   ssl.key: "/etc/pki/client/cert.key"
 ------------------------------------------------------------------------------
+
+//
 
 To enable SSL, just add `https` to all URLs defined under __hosts__.
 
@@ -63,8 +68,8 @@ To enable SSL, just add `https` to all URLs defined under __hosts__.
 
 output.elasticsearch:
   hosts: ["https://localhost:9200"]
-  username: "admin"
-  password: "s3cr3t"
+  username: "{beatname_lc}_internal"
+  password: "{pwd}"
 ------------------------------------------------------------------------------
 
 If the Elasticsearch nodes are defined by `IP:PORT`, then add `protocol: https` to the yaml file.
@@ -74,10 +79,14 @@ If the Elasticsearch nodes are defined by `IP:PORT`, then add `protocol: https` 
 output.elasticsearch:
   hosts: ["localhost"]
   protocol: "https"
-  username: "admin"
-  password: "s3cr3t"
+  username: "{beatname_lc}_internal"
+  password: "{pwd}"
 
 ------------------------------------------------------------------------------
+
+
+For more information about securing {beatname_uc}, see
+<<securing-{beatname_lc}>>.
 
 ==== Compatibility
 

--- a/libbeat/docs/reference-yml.asciidoc
+++ b/libbeat/docs/reference-yml.asciidoc
@@ -5,21 +5,9 @@ The following reference file is available with your {beatname_uc} installation. 
 shows all non-deprecated {beatname_uc} options. You can copy from this file and paste
 configurations into the +{beatname_lc}.yml+ file to customize it.
 
-ifeval::["{beatname_lc}"!="auditbeat"]
-
 TIP: For rpm and deb, you'll find the reference configuration file at +/etc/{beatname_lc}/{beatname_lc}.reference.yml+. Under
 Docker, it's located at +/usr/share/{beatname_lc}/{beatname_lc}.reference.yml+. For mac and win,
 look in the archive that you just extracted.
-
-endif::[]
-
-ifeval::["{beatname_lc}"=="auditbeat"]
-
-TIP: For rpm and deb, you'll find the reference configuration file at +/etc/{beatname_lc}/{beatname_lc}.reference.yml+. Under
-Docker, it's located at +/usr/share/{beatname_lc}/{beatname_lc}.reference.yml+. For mac and win,
-look in the archive that you just extracted.
-
-endif::[]
 
 The contents of the file are included here for your convenience.
 

--- a/libbeat/docs/security/basic-auth.asciidoc
+++ b/libbeat/docs/security/basic-auth.asciidoc
@@ -1,6 +1,6 @@
 [role="xpack"]
 [[beats-basic-auth]]
-=== Configuring authentication credentials for {beatname_uc}
+=== Configure authentication credentials
 
 When sending data to a secured cluster through the `elasticsearch`
 output, {beatname_uc} must either provide basic authentication credentials
@@ -8,17 +8,30 @@ or present a client certificate.
 
 To configure authentication credentials for {beatname_uc}:
 
-. Create a role that has the `manage_index_templates` and
-`monitor` cluster privileges, and `read`, `write`, and `create_index`
-privileges for the indices that {beatname_uc} creates. You can create roles from the
-**Management / Roles** UI in {kib} or through the `role` API.
-For example, the following request creates a ++{beat_default_index_prefix}_writer++ role:
+. Create a writer role that has the following privileges:
 +
+--
+ifeval::["{beatname_lc}"!="filebeat"]
+* *Cluster*: `manage_index_templates` and `monitor`
+endif::[]
+ifeval::["{beatname_lc}"=="filebeat"]
+* *Cluster*: `manage_index_templates`, `monitor`, and
+`manage_ingest_pipelines`
+endif::[]
+* *Index*: `write` and `create_index` on the {beatname_uc} indices 
+--
++
+You can create roles from the **Management / Roles** UI in {kib} or through the
+`role` API. For example, the following request creates a role named
+++{beat_default_index_prefix}_writer++:
++
+--
+ifeval::["{beatname_lc}"!="filebeat"]
 ["source","sh",subs="attributes,callouts"]
 ---------------------------------------------------------------
 POST _xpack/security/role/{beat_default_index_prefix}_writer
 {
-  "cluster": ["manage_index_templates", "monitor"],
+  "cluster": ["manage_index_templates","monitor"],
   "indices": [
     {
       "names": [ "{beat_default_index_prefix}-*" ], <1>
@@ -29,67 +42,107 @@ POST _xpack/security/role/{beat_default_index_prefix}_writer
 ---------------------------------------------------------------
 <1> If you use a custom {beatname_uc} index pattern, specify that pattern
 instead of the default ++{beat_default_index_prefix}-*++ pattern.
+endif::[]
+ifeval::["{beatname_lc}"=="filebeat"]
+["source","sh",subs="attributes,callouts"]
+---------------------------------------------------------------
+POST _xpack/security/role/{beat_default_index_prefix}_writer
+{
+  "cluster": ["manage_index_templates","monitor","manage_ingest_pipelines"], <1>
+  "indices": [
+    {
+      "names": [ "{beat_default_index_prefix}-*" ], <2>
+      "privileges": ["write","create_index"]
+    }
+  ]
+}
+---------------------------------------------------------------
+// CONSOLE
+<1> The `manage_ingest_pipelines` cluster privilege is required to run
+{beatname_uc} modules.
+<2> If you use a custom {beatname_uc} index pattern, specify that pattern
+instead of the default ++{beat_default_index_prefix}-*++ pattern.
+endif::[]
+--
 
 . Assign the writer role to the user that {beatname_uc} will use to connect to
-{es}:
+{es}. If you plan to load the pre-built {kib} dashboards, also assign the
+`kibana_user` role. 
+ifdef::has_ml_jobs[]
+If you plan to load machine learning jobs, assign the `machine_learning_admin`
+role.
+endif::[]
 
-.. To authenticate as a native user, create a user for the {beatname_uc} to use
-internally and assign it the writer role. You can create users from the
-**Management / Users** UI in {kib} or through the `user` API. For example, the
-following request creates a ++{beat_default_index_prefix}_internal++ user that has the
-++{beat_default_index_prefix}_writer++ role:
+.. To authenticate as a native user, create a user for {beatname_uc} to use
+internally and assign it the writer role, plus any other roles that are
+needed.
 +
+You can create users from the **Management / Users** UI in {kib} or through the
+`user` API. For example, following request creates a user
+named ++{beat_default_index_prefix}_internal++ that has the
+++{beat_default_index_prefix}_writer++ and `kibana_user` roles:
++
+--
 ["source","sh",subs="attributes,callouts"]
 ---------------------------------------------------------------
 POST /_xpack/security/user/{beat_default_index_prefix}_internal
 {
-  "password" : "test-password",
-  "roles" : [ "{beat_default_index_prefix}_writer"],
+  "password" : "{pwd}",
+  "roles" : [ "{beat_default_index_prefix}_writer","kibana_user"],
   "full_name" : "Internal {beatname_uc} User"
 }
 ---------------------------------------------------------------
+// CONSOLE
 
-.. To authenticate using PKI authentication, assign the writer role
-to the internal {beatname_uc} user in the `role_mapping.yml` configuration file. Specify
-the user by the distinguished name that appears in its certificate.
+--
+
+.. To use PKI authentication, assign the writer role, plus any other roles that are
+needed, in the `role_mapping.yml` configuration file. Specify the user by the
+distinguished name that appears in its certificate:
 +
 --
 ["source","yaml",subs="attributes,callouts"]
 ---------------------------------------------------------------
 {beat_default_index_prefix}_writer:
   - "cn=Internal {beatname_uc} User,ou=example,o=com"
+kibana_user:
+  - "cn=Internal {beatname_uc} User,ou=example,o=com"
 ---------------------------------------------------------------
+
+
 For more information, see
 {xpack-ref}/mapping-roles.html#mapping-roles-file[Using Role Mapping Files].
 --
 
-. Configure authentication credentials for the `elasticsearch` output
-in the {beatname_uc} configuration file:
+. In the {beatname_uc} configuration file, specify authentication credentials
+for the `elasticsearch` output:
 
-.. To use basic authentication, configure the `username` and `password`
-settings. For example, the following {beatname_uc} output configuration
-uses the native ++{beat_default_index_prefix}_internal++ user to connect to {es}:
+
+.. To use basic authentication, configure the `username` and `password` settings.
+For example, the following {beatname_uc} output configuration uses the native
+++{beat_default_index_prefix}_internal++ user to connect to {es}: 
 +
 ["source","js",subs="attributes,callouts"]
 --------------------------------------------------
 output.elasticsearch:
-    hosts: ["localhost:9200"]
-    index: "{beat_default_index_prefix}"
-    username: "{beat_default_index_prefix}_internal"
-    password: "test-password"
+  hosts: ["localhost:9200"]
+  username: "{beat_default_index_prefix}_internal" <1>
+  password: "{pwd}" <2>
 --------------------------------------------------
+<1> You created this user earlier.
+<2> The example shows a hard-coded password, but you should store sensitive
+values in the <<keystore,secrets keystore>>.
 
-.. To use PKI authentication, configure the `certificate` and
-`key` settings:
+.. To use PKI authentication, configure the `certificate` and `key` settings:
 +
 ["source","js",subs="attributes,callouts"]
 --------------------------------------------------
 output.elasticsearch:
-    hosts: ["localhost:9200"]
-    index: "{beat_default_index_prefix}"
-    ssl.certificate: "/etc/pki/client/cert.pem" <1>
-    ssl.key: "/etc/pki/client/cert.key"
+  hosts: ["localhost:9200"]
+  ssl.certificate: "/etc/pki/client/cert.pem" <1>
+  ssl.key: "/etc/pki/client/cert.key"
 --------------------------------------------------
 <1> The distinguished name (DN) in the certificate must be mapped to
-the writer role in the `role_mapping.yml` configuration file on each
-node in the {es} cluster.
+the ++{beat_default_index_prefix}_writer++ and `kibana_user` roles in the
+`role_mapping.yml` configuration file on each node in the {es} cluster.
+

--- a/libbeat/docs/security/beats-system.asciidoc
+++ b/libbeat/docs/security/beats-system.asciidoc
@@ -1,6 +1,6 @@
 [role="xpack"]
 [[beats-system-user]]
-=== Configuring the built-in user for {beatname_uc}
+=== Set the password for the `beats_system` built-in user
 
 {security} provides built-in user credentials in {es} that have a fixed set of
 privileges. In 6.3.0 and later releases, there is a `beats_system` built-in user,

--- a/libbeat/docs/security/securing-beats.asciidoc
+++ b/libbeat/docs/security/securing-beats.asciidoc
@@ -1,33 +1,79 @@
 [role="xpack"]
 [[securing-beats]]
-== {beatname_uc} and {security}
+== Configure {beatname_uc} to use {security}
 
-If you want {beatname_uc} to connect to a cluster that has {security} enabled,
-there are extra configuration steps.
+++++
+<titleabbrev>Use {security}</titleabbrev>
+++++
 
+If you want {beatname_uc} to connect to a cluster that has
+{securitydoc}/xpack-security.html[{security}] enabled, there are extra
+configuration steps:
+
+. <<beats-basic-auth>>.
++
+ifeval::["{beatname_lc}"=="filebeat"]
 To send data to a secured cluster through the `elasticsearch` output,
 {beatname_uc} needs to authenticate as a user who can manage index templates,
-monitor the cluster, create indices, and read, and write to the indices
-it creates. See <<beats-basic-auth>>.
+monitor the cluster, create indices, read and write to the indices
+it creates, and manage ingest pipelines. 
+endif::[]
+ifeval::["{beatname_lc}"!="filebeat"]
+To send data to a secured cluster through the `elasticsearch` output,
+{beatname_uc} needs to authenticate as a user who can manage index templates,
+monitor the cluster, create indices, and read and write to the indices
+it creates. 
+endif::[]
 
-If encryption is enabled on the cluster, you also need to enable HTTPS in the
-{beatname_uc} configuration. See <<beats-tls>>.
+. <<beats-user-access>>.
++
+To search the indexed {beatname_uc} data and visualize it in {kib}, users need
+access to the indices {beatname_uc} creates.
 
-In addition to configuring authentication credentials for the {beatname_uc}
-itself, you need to grant authorized users permission to access the indices it
-creates. See <<beats-user-access>>.
+. <<beats-tls>>.
++
+If encryption is enabled on the cluster, you need to enable HTTPS in the
+{beatname_uc} configuration.
 
 ifeval::["{beatname_lc}"!="apm-server"]
-If you plan to monitor {beatname_uc} in Kibana, you must also 
-<<beats-system-user,configure the `beats_system` built-in user>>.
+. <<beats-system-user>>.
++
+{beatname_uc} uses the `beats_system` user to send monitoring data to {es}. If
+you plan to monitor {beatname_uc} in {kib} and have not yet set up the
+password, set it up now.
 endif::[]
 
 For more information about {security}, see
-{xpack-ref}/xpack-security.html[Securing {es} and {kib}].
+{xpack-ref}/xpack-security.html[Securing the {stack}].
+
+[float]
+=== {beatname_uc} features that require authorization
+
+After securing {beatname_uc}, make sure your users have the roles (or associated
+privileges) required to use these {beatname_uc} features. You must create the
+++{beat_default_index_prefix}_writer++ and
+++{beat_default_index_prefix}_reader++ roles (see <<beats-basic-auth>> and
+<<beats-user-access>>). The `machine_learning_admin` and `kibana_user` roles are
+{xpack-ref}/built-in-roles.html[built-in].
+
+[options="header"]
+|=======
+|Feature | Role
+|Send data to a secured cluster   | ++{beat_default_index_prefix}_writer++
+|Run Filebeat modules | ++{beat_default_index_prefix}_writer++
+|Load index templates | ++{beat_default_index_prefix}_writer++ and `kibana_user`
+|Load {beatname_uc} dashboards into {kib} | ++{beat_default_index_prefix}_writer++ and `kibana_user`
+|Load machine learning jobs | `machine_learning_admin`
+|Read indices created by {beatname_uc} | ++{beat_default_index_prefix}_reader++ 
+|View {beatname_uc} dashboards in {kib} | `kibana_user`
+|=======
 
 include::basic-auth.asciidoc[]
+
 include::user-access.asciidoc[]
+
 include::tls.asciidoc[]
+
 ifeval::["{beatname_lc}"!="apm-server"]
 include::beats-system.asciidoc[]
 endif::[]

--- a/libbeat/docs/security/tls.asciidoc
+++ b/libbeat/docs/security/tls.asciidoc
@@ -1,6 +1,6 @@
 [role="xpack"]
 [[beats-tls]]
-=== Configuring {beatname_uc} to use encrypted connections
+=== Configure {beatname_uc} to use encrypted connections
 
 If encryption is enabled on the {es} cluster, you need to connect to {es} via
 HTTPS. If the certificate authority (CA) that signed your node certificates
@@ -14,9 +14,9 @@ protocol to all host URLs:
 ["source","js",subs="attributes,callouts"]
 --------------------------------------------------
 output.elasticsearch:
-    hosts: ["https://localhost:9200"] <1>
-    index: "{beatname_lc}"
-    ssl.certificate_authorities: ["/etc/pki/root/ca.pem"] <2>
+  hosts: ["https://localhost:9200"] <1>
+  index: "{beatname_lc}"
+  ssl.certificate_authorities: ["/etc/pki/root/ca.pem"] <2>
 --------------------------------------------------
 <1> Specify the `https` protocol to connect the {es} cluster.
 <2> Specify the path to the local `.pem` file that contains your Certificate

--- a/libbeat/docs/security/user-access.asciidoc
+++ b/libbeat/docs/security/user-access.asciidoc
@@ -1,15 +1,17 @@
 [role="xpack"]
 [[beats-user-access]]
-=== Granting users access to {beatname_uc} indices
+=== Grant users access to {beatname_uc} indices
 
-To enable users to access the indices a {beatname_uc} creates, grant them `read`
-and `view_index_metadata` privileges on the {beatname_uc} indices:
+To enable users to access the indices {beatname_uc} creates, grant them `read`
+and `view_index_metadata` privileges on the {beatname_uc} indices. If they're
+using {kib}, they also need the `kibana_user` role.
 
-. Create a role that has the `read` and `view_index_metadata`
-privileges  for the {beatname_uc} indices. You can create roles from the
-**Management > Roles** UI in {kib} or through the `role` API.
-For example, the following request creates a ++{beat_default_index_prefix}_reader++
-role:
+. Create a reader role that has the `read` and `view_index_metadata` privileges
+on the {beatname_uc} indices.
++
+You can create roles from the **Management > Roles** UI in {kib} or through the
+`role` API. For example, the following request creates a role named
+++{beat_default_index_prefix}_reader++:
 +
 --
 ["source","sh",subs="attributes,callouts"]
@@ -24,38 +26,46 @@ POST _xpack/security/role/{beat_default_index_prefix}_reader
   ]
 }
 ---------------------------------------------------------------
+// CONSOLE
 <1> If you use a custom {beatname_uc} index pattern, specify that pattern
 instead of the default ++{beat_default_index_prefix}-*++ pattern.
 --
-. Assign your users the reader role so they can access the {beatname_uc} indices:
+
+. Assign your users the reader role so they can access the {beatname_uc}
+indices. For {kib} users who need to visualize the data, also assign the
+`kibana_user` role:
 
 .. If you're using the `native` realm, you can assign roles with the
-**Management > Users** UI in {kib} or through the `user` API. For
-example, the following request grants ++{beat_default_index_prefix}_user++ the
-++{beat_default_index_prefix}_reader++ role:
+**Management > Users** UI in {kib} or through the `user` API. For example, the
+following request grants ++{beat_default_index_prefix}_user++ the
+++{beat_default_index_prefix}_reader++ and `kibana_user` roles:
 +
 --
 ["source", "sh", subs="attributes,callouts"]
 ---------------------------------------------------------------
 POST /_xpack/security/user/{beat_default_index_prefix}_user
 {
-  "password" : "test-password",
-  "roles" : [ "{beat_default_index_prefix}_reader"],
+  "password" : "{pwd}",
+  "roles" : [ "{beat_default_index_prefix}_reader","kibana_user"],
   "full_name" : "{beatname_uc} User"
 }
 ---------------------------------------------------------------
+// CONSOLE
 --
-.. If you're using the LDAP, Active Directory, or PKI realms, you
-assign the roles in the `role_mapping.yml` configuration
-file. For example, the following snippet grants ++{beatname_uc} User++
-the ++{beat_default_index_prefix}_reader++ role:
+.. If you're using the LDAP, Active Directory, or PKI realms, you assign the
+roles in the `role_mapping.yml` configuration file. For example, the following
+snippet grants ++{beatname_uc} User++ the ++{beat_default_index_prefix}_reader++
+and `kibana_user` roles:
 +
 --
 ["source", "yaml", subs="attributes,callouts"]
 ---------------------------------------------------------------
 {beat_default_index_prefix}_reader:
   - "cn={beatname_uc} User,dc=example,dc=com"
+kibana_user:
+  - "cn={beatname_uc} User,dc=example,dc=com"
 ---------------------------------------------------------------
+
 For more information, see
 {xpack-ref}/mapping-roles.html#mapping-roles-file[Using Role Mapping Files].
 --

--- a/libbeat/docs/shared-configuring.asciidoc
+++ b/libbeat/docs/shared-configuring.asciidoc
@@ -1,24 +1,11 @@
-//Added conditional coding to support Beats that don't offer all of these install options
-
-ifeval::["{beatname_lc}"!="auditbeat"]
 
 To configure {beatname_uc}, you edit the configuration file. For rpm and deb,
 you'll find the configuration file at +/etc/{beatname_lc}/{beatname_lc}.yml+. Under
 Docker, it's located at +/usr/share/{beatname_lc}/{beatname_lc}.yml+. For mac and win,
-look in the archive that you just extracted. There’s also a full example
-configuration file called +{beatname_lc}.reference.yml+ that shows all non-deprecated
-options.
-
-endif::[]
-
-ifeval::["{beatname_lc}"=="auditbeat"]
-
-To configure {beatname_uc}, you edit the configuration file. For rpm and deb,
-you'll find the configuration file at +/etc/{beatname_lc}/{beatname_lc}.yml+.
-For mac and win, look in the archive that you just extracted. There’s also a
-full example configuration file called +{beatname_lc}.reference.yml+ that shows
-all non-deprecated options.
-
+look in the archive that you just extracted. 
+ifeval::["{beatname_lc}"!="apm-server"]
+There’s also a full example configuration file called +{beatname_lc}.reference.yml+ 
+that shows all non-deprecated options.
 endif::[]
 
 See the

--- a/libbeat/docs/shared-download-and-install.asciidoc
+++ b/libbeat/docs/shared-download-and-install.asciidoc
@@ -1,21 +1,8 @@
-//Added conditional coding to support Beats that don't offer all of these install options
-
-ifeval::["{beatname_lc}"!="auditbeat"]
 
 To download and install {beatname_uc}, use the commands that work with your system
 (<<deb, deb>> for Debian/Ubuntu, <<rpm, rpm>> for Redhat/Centos/Fedora, <<mac,
 mac>> for OS X, <<docker, docker>> for any Docker platform, and <<win, win>> for
 Windows).
-
-endif::[]
-
-ifeval::["{beatname_lc}"=="auditbeat"]
-
-To download and install {beatname_uc}, use the commands that work with your system
-(<<deb, deb>> for Debian/Ubuntu, <<rpm, rpm>> for Redhat/Centos/Fedora, <<mac,
-mac>> for OS X, and <<win, win>> for Windows).
-
-endif::[]
 
 [NOTE]
 ==================================================

--- a/libbeat/docs/shared-ssl-logstash-config.asciidoc
+++ b/libbeat/docs/shared-ssl-logstash-config.asciidoc
@@ -19,7 +19,7 @@ To use SSL mutual authentication:
 {beatname_uc} and Logstash. Creating a correct SSL/TLS infrastructure is outside the scope of this
 document. There are many online resources available that describe how to create certificates.
 +
-TIP: If you are using {xpack}, you can use the
+TIP: If you are using {security}, you can use the
 {elasticsearch}/certutil.html[elasticsearch-certutil tool] to generate certificates.
 
 . Configure {beatname_uc} to use SSL. In the +{beatname_lc}.yml+ config file, specify the following settings under

--- a/libbeat/docs/shared-template-load.asciidoc
+++ b/libbeat/docs/shared-template-load.asciidoc
@@ -159,8 +159,6 @@ endif::[]
 ----
 
 
-ifeval::["{beatname_lc}"!="auditbeat"]
-
 *docker:*
 
 ["source","sh",subs="attributes"]
@@ -168,8 +166,6 @@ ifeval::["{beatname_lc}"!="auditbeat"]
 docker run {dockerimage} setup --template{disable_logstash} -E 'output.elasticsearch.hosts=["localhost:9200"]'
 ----------------------------------------------------------------------
 
-
-endif::[]
 
 *win:*
 

--- a/libbeat/docs/step-configure-credentials.asciidoc
+++ b/libbeat/docs/step-configure-credentials.asciidoc
@@ -7,21 +7,22 @@ in the config file before you run the commands that set up and start
 ----
 output.elasticsearch:
   hosts: ["myEShost:9200"]
-  username: "elastic"
-  password: "elastic"
+  username: "filebeat_internal"
+  password: "{pwd}" <1>
 setup.kibana:
   host: "mykibanahost:5601"
-  username: "elastic" <1> <2>
-  password: "elastic"
+  username: "my_kibana_user" <2> <3>
+  password: "{pwd}"
 ----
-<1> The `username` and `password` settings for Kibana are optional. If you don't
+<1> This examples shows a hard-coded password, but you should store sensitive
+values in the <<keystore,secrets keystore>>.
+<2> The `username` and `password` settings for Kibana are optional. If you don't
 specify credentials for Kibana, {beatname_uc} uses the `username` and `password`
 specified for the Elasticsearch output.
-
-<2> If you are planning to <<load-kibana-dashboards,set up the Kibana
+<3> If you are planning to <<load-kibana-dashboards,set up the Kibana
 dashboards>>, the user must have the `kibana_user`
 {xpack-ref}/built-in-roles.html[built-in role] or equivalent privileges.
+
 --
 +
-Also see the security-related options described in <<setup-kibana-endpoint>> and
-<<elasticsearch-output,Configure the Elasticsearch output>>.
+For more information, see <<securing-{beatname_lc}>>.

--- a/metricbeat/docs/autodiscover-docker-config.asciidoc
+++ b/metricbeat/docs/autodiscover-docker-config.asciidoc
@@ -8,7 +8,7 @@ metricbeat.autodiscover:
       templates:
         - condition:
             contains:
-              docker.container.image: "redis"
+              docker.container.image: redis
           config:
             - module: redis
               metricsets: ["info", "keyspace"]

--- a/metricbeat/docs/securing-metricbeat.asciidoc
+++ b/metricbeat/docs/securing-metricbeat.asciidoc
@@ -1,4 +1,4 @@
-[[securing-meticbeat]]
+[[securing-metricbeat]]
 = Securing {beatname_uc}
 
 [partintro]

--- a/packetbeat/docs/packetbeat-options.asciidoc
+++ b/packetbeat/docs/packetbeat-options.asciidoc
@@ -570,7 +570,7 @@ If enabled Packetbeat will generate the following BPF filter: `"icmp or icmp6"`.
 <titleabbrev>DNS</titleabbrev>
 ++++
 
-The `dns` section of the +{beatname_lc}.yml+ config file specifies configuration options for the DNS protocol. The DNS protocol supports processing DNS messages on UDP. Here is a sample configuration section for DNS:
+The `dns` section of the +{beatname_lc}.yml+ config file specifies configuration options for the DNS protocol. The DNS protocol supports processing DNS messages on TCP and UDP. Here is a sample configuration section for DNS:
 
 [source,yaml]
 ------------------------------------------------------------------------------


### PR DESCRIPTION
Backports the following PRs to 6.3:

https://github.com/elastic/beats/pull/7128
https://github.com/elastic/beats/pull/7174
https://github.com/elastic/beats/pull/7282
https://github.com/elastic/beats/pull/7284

TODOs:
- [ ] After this is merged, I need to set up a redirect for the typo fixed in an anchor ID (changed securing-meticbeat to securing-metricbeat). This changes the URL of the page. 