### PR TITLE
Improve Elasticsearch server fileset

### DIFF
--- a/filebeat/module/elasticsearch/server/config/log.yml
+++ b/filebeat/module/elasticsearch/server/config/log.yml
@@ -8,3 +8,8 @@ multiline:
   pattern: '^\[[0-9]{4}-[0-9]{2}-[0-9]{2}'
   negate: true
   match: after
+
+fields:
+  service.name: "elasticsearch"
+
+fields_under_root: true

--- a/filebeat/module/elasticsearch/server/ingest/pipeline.json
+++ b/filebeat/module/elasticsearch/server/ingest/pipeline.json
@@ -10,6 +10,12 @@
     ],
     "processors": [
         {
+            "rename": {
+                "field": "@timestamp",
+                "target_field": "event.created"
+            }
+        },
+        {
             "grok": {
                 "field": "message",
                 "pattern_definitions": {
@@ -22,29 +28,8 @@
         },
         {
             "rename": {
-                "field": "@timestamp",
-                "target_field": "read_timestamp"
-            }
-        },
-        {
-            "date": {
                 "field": "timestamp",
-                "target_field": "@timestamp",
-                "formats": [
-                    "ISO8601",
-                    "YYYY-MM-dd HH:mm:ss,SSS"
-                ]
-            }
-        },
-        {
-            "remove": {
-                "field": "timestamp"
-            }
-        },
-        {
-            "append": {
-                "field": "service.name",
-                "value": "elasticsearch"
+                "target_field": "@timestamp"
             }
         }
     ]

--- a/filebeat/module/elasticsearch/server/test/test.log-expected.json
+++ b/filebeat/module/elasticsearch/server/test/test.log-expected.json
@@ -12,7 +12,9 @@
             "prospector": {
                 "type": "log"
             },
-            "read_timestamp": "2018-05-17T06:59:59.786Z",
+            "event": {
+                "created": "2018-06-13T08:12:36.737Z"
+            },
             "source": "/Users/ruflin/Dev/gopath/src/github.com/elastic/beats/filebeat/module/elasticsearch/log/test/test.log",
             "fileset": {
                 "module": "elasticsearch",
@@ -32,6 +34,9 @@
                 "hostname": "ruflin",
                 "name": "ruflin",
                 "version": "7.0.0-alpha1"
+            },
+            "service": {
+                "name": "elasticsearch"
             }
         }
     }


### PR DESCRIPTION
* Add `service.name: elasticsearch` already on the Beats side.
* Modify ingest processor to use `event.created` for the collection timestamp instead of read_timestamp.