### PR TITLE
more dynamic mappings for numeric object types

### DIFF
--- a/libbeat/template/processor.go
+++ b/libbeat/template/processor.go
@@ -250,7 +250,7 @@ func (p *Processor) object(f *common.Field) common.MapStr {
 	case "keyword":
 		dynProperties["type"] = f.ObjectType
 		addDynamicTemplate(f, dynProperties, matchType("string"))
-	case "long", "double":
+	case "byte", "double", "float", "long", "short":
 		dynProperties["type"] = f.ObjectType
 		addDynamicTemplate(f, dynProperties, matchType(f.ObjectType))
 	}

--- a/libbeat/template/processor_test.go
+++ b/libbeat/template/processor_test.go
@@ -348,6 +348,28 @@ func TestDynamicTemplate(t *testing.T) {
 		},
 	}
 
+	for _, numericType := range []string{"byte", "double", "float", "long", "short"} {
+		gen := struct {
+			field    common.Field
+			expected common.MapStr
+		}{
+			field: common.Field{
+				Type: "object", ObjectType: numericType,
+				Name: "somefield", ObjectTypeMappingType: "long",
+			},
+			expected: common.MapStr{
+				"somefield": common.MapStr{
+					"mapping": common.MapStr{
+						"type": numericType,
+					},
+					"match_mapping_type": "long",
+					"path_match":         "somefield.*",
+				},
+			},
+		}
+		tests = append(tests, gen)
+	}
+
 	for _, test := range tests {
 		dynamicTemplates = nil
 		p.object(&test.field)


### PR DESCRIPTION
This change adds support for generating dynamic templates with field mapping types for `byte, float, short`.

Given `fields.yml` with:
```
    - name: foo
      type: object
      object_type: float
      object_type_mapping_type: long
      dynamic: true
```

Current code will ignore this definition.  This update generates this dynamic template:

```
{
  "foo": {
    "mapping": {
      "type": "float"
    },
    "match_mapping_type": "long",
    "path_match": "foo.*"
  }
}
```