### PR TITLE
Cherry-pick #7285 to 6.3: permit index-pattern only setup

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -13,6 +13,8 @@ https://github.com/elastic/beats/compare/v6.3.0...6.3[Check the HEAD diff]
 
 *Affecting all Beats*
 
+- Allow index-pattern only setup when setup.dashboards.only_index=true. {pull}7285[7285]
+
 *Auditbeat*
 
 *Filebeat*

--- a/libbeat/dashboards/importer.go
+++ b/libbeat/dashboards/importer.go
@@ -278,8 +278,10 @@ func (imp Importer) ImportKibanaDir(dir string) error {
 	if !imp.cfg.OnlyDashboards {
 		check = append(check, "index-pattern")
 	}
+	wantDashboards := false
 	if !imp.cfg.OnlyIndex {
 		check = append(check, "dashboard")
+		wantDashboards = true
 	}
 
 	types := []string{}
@@ -306,7 +308,7 @@ func (imp Importer) ImportKibanaDir(dir string) error {
 		}
 	}
 
-	if !importDashboards {
+	if wantDashboards && !importDashboards {
 		return fmt.Errorf("No dashboards to import. Please make sure the %s directory contains a dashboard directory.",
 			dir)
 	}

--- a/libbeat/tests/system/test_dashboard.py
+++ b/libbeat/tests/system/test_dashboard.py
@@ -38,6 +38,32 @@ class Test(BaseTest):
 
     @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     @attr('integration')
+    def test_load_only_index_patterns(self):
+        """
+        Test loading dashboards
+        """
+        self.render_config_template()
+        beat = self.start_beat(
+            logging_args=["-e", "-d", "*"],
+            extra_args=["setup",
+                        "--dashboards",
+                        "-E", "setup.dashboards.file=" +
+                        os.path.join(self.beat_path, "tests", "files", "testbeat-dashboards.zip"),
+                        "-E", "setup.dashboards.beat=testbeat",
+                        "-E", "setup.dashboards.only_index=true",
+                        "-E", "setup.kibana.protocol=http",
+                        "-E", "setup.kibana.host=" + self.get_kibana_host(),
+                        "-E", "setup.kibana.port=" + self.get_kibana_port(),
+                        "-E", "output.elasticsearch.hosts=['" + self.get_host() + "']",
+                        "-E", "output.file.enabled=false"]
+        )
+
+        beat.check_wait(exit_code=0)
+
+        assert self.log_contains("Kibana dashboards successfully loaded") is True
+
+    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
+    @attr('integration')
     def test_export_dashboard(self):
         """
         Test export dashboards and remove unsupported characters


### PR DESCRIPTION
Cherry-pick of PR #7285 to 6.3 branch. Original message: 

with `setup.dashboards.enabled=true`, `setup.dashboards.only_index=true` always throws
"Error importing Kibana dashboards: fail to import the dashboards in Kibana"