### PR TITLE
Update Elasticsearch for Metricbeat tests to 6.3

### DIFF
--- a/metricbeat/module/elasticsearch/_meta/Dockerfile
+++ b/metricbeat/module/elasticsearch/_meta/Dockerfile
@@ -1,2 +1,2 @@
-FROM docker.elastic.co/elasticsearch/elasticsearch:6.2.4
+FROM docker.elastic.co/elasticsearch/elasticsearch:6.3.0
 HEALTHCHECK --interval=1s --retries=300 CMD curl -f http://localhost:9200


### PR DESCRIPTION
This means from now on all tests are run against Elasticsearch with x-pack basic.