### PR TITLE
Update Logstash to 6.3 for Metricbeat module testing

### DIFF
--- a/metricbeat/module/logstash/_meta/Dockerfile
+++ b/metricbeat/module/logstash/_meta/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/logstash/logstash:6.2.4
+FROM docker.elastic.co/logstash/logstash:6.3.0
 
 COPY healthcheck.sh /
 ENV XPACK_MONITORING_ENABLED=FALSE


### PR DESCRIPTION
This means from now on all tests are run against Logstash with x-pack basic.