### PR TITLE
Update Kibana to 6.3 for Metricbeat testing

### DIFF
--- a/metricbeat/module/kibana/_meta/Dockerfile
+++ b/metricbeat/module/kibana/_meta/Dockerfile
@@ -1,2 +1,2 @@
-FROM docker.elastic.co/kibana/kibana:6.2.4
+FROM docker.elastic.co/kibana/kibana:6.3.0
 HEALTHCHECK --interval=1s --retries=300 CMD curl -f http://localhost:5601/api/status | grep '"disconnects"'


### PR DESCRIPTION
This means from now on all tests are run against Kibana with x-pack basic.