### PR TITLE
Allow to specify auditd rules in separate files

### DIFF
--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -38,6 +38,8 @@ auditbeat.modules:
   rate_limit: 0
   include_raw_message: false
   include_warnings: false
+  # Load audit rules from separate files. Same format as audit.rules(7).
+  audit_rule_files: [ '${path.config}/audit.rules.d/*.conf' ]
   audit_rules: |
     ## Define audit rules here.
     ## Create file watches (-w) or syscall audits (-a or -A). Uncomment these

--- a/auditbeat/auditbeat.yml
+++ b/auditbeat/auditbeat.yml
@@ -11,6 +11,8 @@
 auditbeat.modules:
 
 - module: auditd
+  # Load audit rules from separate files. Same format as audit.rules(7).
+  audit_rule_files: [ '${path.config}/audit.rules.d/*.conf' ]
   audit_rules: |
     ## Define audit rules here.
     ## Create file watches (-w) or syscall audits (-a or -A). Uncomment these

--- a/auditbeat/docs/modules/auditd.asciidoc
+++ b/auditbeat/docs/modules/auditd.asciidoc
@@ -141,6 +141,11 @@ embedded in the string using `#` as a prefix. The format for rules is the same
 used by the Linux `auditctl` utility. {beatname_uc} supports adding file watches
 (`-w`) and syscall rules (`-a` or `-A`).
 
+*`audit_rule_files`*:: A list of files to load audit rules from. This files are
+loaded after the rules declared in `audit_rules` are loaded. Wildcards are
+supported and will expand in lexicographical order. The format is the same as
+that of the `audit_rules` field.
+
 [float]
 === Audit rules
 
@@ -193,6 +198,8 @@ is an example configuration:
 ----
 auditbeat.modules:
 - module: auditd
+  # Load audit rules from separate files. Same format as audit.rules(7).
+  audit_rule_files: [ '${path.config}/audit.rules.d/*.conf' ]
   audit_rules: |
     ## Define audit rules here.
     ## Create file watches (-w) or syscall audits (-a or -A). Uncomment these

--- a/auditbeat/module/auditd/_meta/audit.rules.d/sample-rules-linux-32bit.conf
+++ b/auditbeat/module/auditd/_meta/audit.rules.d/sample-rules-linux-32bit.conf
@@ -1,0 +1,14 @@
+## Executions.
+-a always,exit -F arch=b32 -S execve,execveat -k exec
+
+## External access (warning: these can be expensive to audit).
+-a always,exit -F arch=b32 -S accept,bind,connect -F key=external-access
+
+## Identity changes.
+-w /etc/group -p wa -k identity
+-w /etc/passwd -p wa -k identity
+-w /etc/gshadow -p wa -k identity
+
+## Unauthorized access attempts.
+-a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -k access
+-a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -k access

--- a/auditbeat/module/auditd/_meta/audit.rules.d/sample-rules-linux-64bit.conf
+++ b/auditbeat/module/auditd/_meta/audit.rules.d/sample-rules-linux-64bit.conf
@@ -1,0 +1,20 @@
+## If you are on a 64 bit platform, everything should be running
+## in 64 bit mode. This rule will detect any use of the 32 bit syscalls
+## because this might be a sign of someone exploiting a hole in the 32
+## bit API.
+-a always,exit -F arch=b32 -S all -F key=32bit-abi
+
+## Executions.
+-a always,exit -F arch=b64 -S execve,execveat -k exec
+
+## External access (warning: these can be expensive to audit).
+-a always,exit -F arch=b64 -S accept,bind,connect -F key=external-access
+
+## Identity changes.
+-w /etc/group -p wa -k identity
+-w /etc/passwd -p wa -k identity
+-w /etc/gshadow -p wa -k identity
+
+## Unauthorized access attempts.
+-a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -k access
+-a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -k access

--- a/auditbeat/module/auditd/_meta/config.yml.tmpl
+++ b/auditbeat/module/auditd/_meta/config.yml.tmpl
@@ -12,6 +12,8 @@
   include_raw_message: false
   include_warnings: false
   {{ end -}}
+  # Load audit rules from separate files. Same format as audit.rules(7).
+  audit_rule_files: [ '${path.config}/audit.rules.d/*.conf' ]
   audit_rules: |
     ## Define audit rules here.
     ## Create file watches (-w) or syscall audits (-a or -A). Uncomment these

--- a/auditbeat/module/auditd/_meta/docs.asciidoc
+++ b/auditbeat/module/auditd/_meta/docs.asciidoc
@@ -136,6 +136,11 @@ embedded in the string using `#` as a prefix. The format for rules is the same
 used by the Linux `auditctl` utility. {beatname_uc} supports adding file watches
 (`-w`) and syscall rules (`-a` or `-A`).
 
+*`audit_rule_files`*:: A list of files to load audit rules from. This files are
+loaded after the rules declared in `audit_rules` are loaded. Wildcards are
+supported and will expand in lexicographical order. The format is the same as
+that of the `audit_rules` field.
+
 [float]
 === Audit rules
 

--- a/auditbeat/module/auditd/audit_linux.go
+++ b/auditbeat/module/auditd/audit_linux.go
@@ -202,10 +202,7 @@ func (ms *MetricSet) Run(reporter mb.PushReporterV2) {
 }
 
 func (ms *MetricSet) addRules(reporter mb.PushReporterV2) error {
-	rules, err := ms.config.rules()
-	if err != nil {
-		return errors.Wrap(err, "failed to add rules")
-	}
+	rules := ms.config.rules()
 
 	if len(rules) == 0 {
 		ms.log.Info("No audit_rules were specified.")
@@ -793,7 +790,7 @@ func determineSocketType(c *Config, log *logp.Logger) (string, error) {
 		}
 		return c.SocketType, nil
 	}
-	rules, _ := c.rules()
+	rules := c.rules()
 
 	isLocked := status.Enabled == auditLocked
 	hasMulticast := hasMulticastSupport()

--- a/auditbeat/module/auditd/config.go
+++ b/auditbeat/module/auditd/config.go
@@ -20,6 +20,11 @@ package auditd
 import (
 	"bufio"
 	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -31,20 +36,22 @@ import (
 )
 
 const (
-	moduleName    = "auditd"
-	metricsetName = "auditd"
+	moduleName         = "auditd"
+	metricsetName      = "auditd"
+	recursiveGlobDepth = 8
 )
 
 // Config defines the kernel metricset's possible configuration options.
 type Config struct {
-	ResolveIDs   bool   `config:"resolve_ids"`         // Resolve UID/GIDs to names.
-	FailureMode  string `config:"failure_mode"`        // Failure mode for the kernel (silent, log, panic).
-	BacklogLimit uint32 `config:"backlog_limit"`       // Max number of message to buffer in the auditd.
-	RateLimit    uint32 `config:"rate_limit"`          // Rate limit in messages/sec of messages from auditd.
-	RawMessage   bool   `config:"include_raw_message"` // Include the list of raw audit messages in the event.
-	Warnings     bool   `config:"include_warnings"`    // Include warnings in the event (for dev/debug purposes only).
-	RulesBlob    string `config:"audit_rules"`         // Audit rules. One rule per line.
-	SocketType   string `config:"socket_type"`         // Socket type to use with the kernel (unicast or multicast).
+	ResolveIDs   bool     `config:"resolve_ids"`         // Resolve UID/GIDs to names.
+	FailureMode  string   `config:"failure_mode"`        // Failure mode for the kernel (silent, log, panic).
+	BacklogLimit uint32   `config:"backlog_limit"`       // Max number of message to buffer in the auditd.
+	RateLimit    uint32   `config:"rate_limit"`          // Rate limit in messages/sec of messages from auditd.
+	RawMessage   bool     `config:"include_raw_message"` // Include the list of raw audit messages in the event.
+	Warnings     bool     `config:"include_warnings"`    // Include warnings in the event (for dev/debug purposes only).
+	RulesBlob    string   `config:"audit_rules"`         // Audit rules. One rule per line.
+	RuleFiles    []string `config:"audit_rule_files"`    // List of rule files.
+	SocketType   string   `config:"socket_type"`         // Socket type to use with the kernel (unicast or multicast).
 
 	// Tuning options (advanced, use with care)
 	ReassemblerMaxInFlight uint32        `config:"reassembler.max_in_flight"`
@@ -56,6 +63,8 @@ type Config struct {
 	// One of "user-space", "kernel", "both", "none", "auto" (default)
 	BackpressureStrategy  string `config:"backpressure_strategy"`
 	StreamBufferConsumers int    `config:"stream_buffer_consumers"`
+
+	auditRules []auditRule
 }
 
 type auditRule struct {
@@ -63,10 +72,30 @@ type auditRule struct {
 	data  []byte
 }
 
+type ruleWithSource struct {
+	rule   auditRule
+	source string
+}
+
+type ruleSet map[string]ruleWithSource
+
+var defaultConfig = Config{
+	ResolveIDs:             true,
+	FailureMode:            "silent",
+	BacklogLimit:           8192,
+	RateLimit:              0,
+	RawMessage:             false,
+	Warnings:               false,
+	ReassemblerMaxInFlight: 50,
+	ReassemblerTimeout:     2 * time.Second,
+	StreamBufferQueueSize:  8192,
+	StreamBufferConsumers:  0,
+}
+
 // Validate validates the rules specified in the config.
 func (c *Config) Validate() error {
 	var errs multierror.Errors
-	_, err := c.rules()
+	err := c.loadRules()
 	if err != nil {
 		errs = append(errs, err)
 	}
@@ -87,47 +116,46 @@ func (c *Config) Validate() error {
 }
 
 // Rules returns a list of rules specified in the config.
-func (c Config) rules() ([]auditRule, error) {
-	var errs multierror.Errors
-	var auditRules []auditRule
-	ruleSet := map[string]auditRule{}
-	s := bufio.NewScanner(bytes.NewBufferString(c.RulesBlob))
-	for s.Scan() {
-		line := strings.TrimSpace(s.Text())
-		if len(line) == 0 || line[0] == '#' {
-			continue
-		}
+func (c Config) rules() []auditRule {
+	return c.auditRules
+}
 
-		// Parse the CLI flags into an intermediate rule specification.
-		r, err := flags.Parse(line)
+func (c *Config) loadRules() error {
+	var paths []string
+	for _, pattern := range c.RuleFiles {
+		absPattern, err := filepath.Abs(pattern)
 		if err != nil {
-			errs = append(errs, errors.Wrapf(err, "failed on rule '%v'", line))
-			continue
+			return fmt.Errorf("unable to get the absolute path for %s: %v", pattern, err)
 		}
-
-		// Convert rule specification to a binary rule representation.
-		data, err := rule.Build(r)
+		files, err := filepath.Glob(absPattern)
 		if err != nil {
-			errs = append(errs, errors.Wrapf(err, "failed on rule '%v'", line))
-			continue
+			return err
 		}
-
-		// Detect duplicates based on the normalized binary rule representation.
-		existingRule, found := ruleSet[string(data)]
-		if found {
-			errs = append(errs, errors.Errorf("failed on rule '%v' because its a duplicate of '%v'", line, existingRule.flags))
-			continue
-		}
-		auditRule := auditRule{flags: line, data: []byte(data)}
-		ruleSet[string(data)] = auditRule
-
-		auditRules = append(auditRules, auditRule)
+		sort.Strings(files)
+		paths = append(paths, files...)
 	}
 
-	if len(errs) > 0 {
-		return nil, errors.Wrap(errs.Err(), "invalid audit_rules")
+	knownRules := ruleSet{}
+
+	rules, err := readRules(bytes.NewBufferString(c.RulesBlob), "(audit_rules at auditbeat.yml)", knownRules)
+	if err != nil {
+		return err
 	}
-	return auditRules, nil
+	c.auditRules = append(c.auditRules, rules...)
+
+	for _, filename := range paths {
+		fHandle, err := os.Open(filename)
+		if err != nil {
+			return fmt.Errorf("unable to open rule file '%s': %v", filename, err)
+		}
+		rules, err = readRules(fHandle, filename, knownRules)
+		if err != nil {
+			return err
+		}
+		c.auditRules = append(c.auditRules, rules...)
+	}
+
+	return nil
 }
 
 func (c Config) failureMode() (uint32, error) {
@@ -143,15 +171,45 @@ func (c Config) failureMode() (uint32, error) {
 	}
 }
 
-var defaultConfig = Config{
-	ResolveIDs:             true,
-	FailureMode:            "silent",
-	BacklogLimit:           8192,
-	RateLimit:              0,
-	RawMessage:             false,
-	Warnings:               false,
-	ReassemblerMaxInFlight: 50,
-	ReassemblerTimeout:     2 * time.Second,
-	StreamBufferQueueSize:  8192,
-	StreamBufferConsumers:  0,
+func readRules(reader io.Reader, source string, knownRules ruleSet) (rules []auditRule, err error) {
+	var errs multierror.Errors
+
+	s := bufio.NewScanner(reader)
+	for lineNum := 1; s.Scan(); lineNum++ {
+		location := fmt.Sprintf("%s:%d", source, lineNum)
+		line := strings.TrimSpace(s.Text())
+		if len(line) == 0 || line[0] == '#' {
+			continue
+		}
+
+		// Parse the CLI flags into an intermediate rule specification.
+		r, err := flags.Parse(line)
+		if err != nil {
+			errs = append(errs, errors.Wrapf(err, "at %s: failed to parse rule '%v'", location, line))
+			continue
+		}
+
+		// Convert rule specification to a binary rule representation.
+		data, err := rule.Build(r)
+		if err != nil {
+			errs = append(errs, errors.Wrapf(err, "at %s: failed to interpret rule '%v'", location, line))
+			continue
+		}
+
+		// Detect duplicates based on the normalized binary rule representation.
+		existing, found := knownRules[string(data)]
+		if found {
+			errs = append(errs, errors.Errorf("at %s: rule '%v' is a duplicate of '%v' at %s", location, line, existing.rule.flags, existing.source))
+			continue
+		}
+		rule := auditRule{flags: line, data: []byte(data)}
+		knownRules[string(data)] = ruleWithSource{rule, location}
+
+		rules = append(rules, rule)
+	}
+
+	if len(errs) > 0 {
+		return nil, errors.Wrap(errs.Err(), "failed loading rules")
+	}
+	return rules, nil
 }

--- a/auditbeat/module/auditd/config_linux_test.go
+++ b/auditbeat/module/auditd/config_linux_test.go
@@ -18,6 +18,11 @@
 package auditd
 
 import (
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -37,10 +42,8 @@ audit_rules: |
 	if err != nil {
 		t.Fatal(err)
 	}
-	rules, err := config.rules()
-	if err != nil {
-		t.Fatal()
-	}
+	rules := config.rules()
+
 	assert.EqualValues(t, []string{
 		"-w /etc/passwd -p wa -k auth",
 		"-a always,exit -S execve -k exec",
@@ -88,6 +91,107 @@ func TestConfigValidateConnectionType(t *testing.T) {
 	err := config.Validate()
 	assert.Error(t, err)
 	t.Log(err)
+}
+
+func TestConfigRuleOrdering(t *testing.T) {
+	const fileMode = 0644
+	config := defaultConfig
+	config.RulesBlob = strings.Join([]string{
+		makeRuleFlags(0, 0),
+		makeRuleFlags(0, 1),
+		makeRuleFlags(0, 2),
+	}, "\n")
+
+	dir1, err := ioutil.TempDir("", "rules1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, file := range []struct {
+		order int
+		name  string
+	}{
+		{0, "00_first.conf"},
+		{5, "99_last.conf"},
+		{2, "03_auth.conf"},
+		{4, "20_exec.conf"},
+		{3, "10_network_access.conf"},
+		{1, "01_32bit_abi.conf"},
+	} {
+		path := filepath.Join(dir1, file.name)
+		content := []byte(strings.Join([]string{
+			makeRuleFlags(1+file.order, 0),
+			makeRuleFlags(1+file.order, 1),
+			makeRuleFlags(1+file.order, 2),
+			makeRuleFlags(1+file.order, 3),
+		}, "\n"))
+		if err = ioutil.WriteFile(path, content, fileMode); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	dir2, err := ioutil.TempDir("", "rules0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, file := range []struct {
+		order int
+		name  string
+	}{
+		{3, "99_tail.conf"},
+		{0, "00_head.conf"},
+		{2, "50_mid.conf"},
+		{1, "13.conf"},
+	} {
+		path := filepath.Join(dir2, file.name)
+		content := []byte(strings.Join([]string{
+			makeRuleFlags(10+file.order, 0),
+			makeRuleFlags(10+file.order, 1),
+			makeRuleFlags(10+file.order, 2),
+			makeRuleFlags(10+file.order, 3),
+		}, "\n"))
+		if err = ioutil.WriteFile(path, content, fileMode); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	config.RuleFiles = []string{
+		fmt.Sprintf("%s/*.conf", dir1),
+		fmt.Sprintf("%s/*.conf", dir2),
+	}
+
+	if err = config.Validate(); err != nil {
+		t.Fatal(err)
+	}
+
+	rules := config.rules()
+	fileNo, ruleNo := 0, 0
+	for _, rule := range rules {
+		parts := strings.Split(rule.flags, " ")
+		assert.Len(t, parts, 6, rule.flags)
+		fields := strings.Split(parts[5], ":")
+		assert.Len(t, fields, 3, rule.flags)
+		fileID, err := strconv.Atoi(fields[1])
+		if err != nil {
+			t.Fatal(err, rule.flags)
+		}
+		ruleID, err := strconv.Atoi(fields[2])
+		if err != nil {
+			t.Fatal(err, rule.flags)
+		}
+		if fileID > fileNo {
+			fileNo = fileID
+			ruleNo = 0
+		}
+		assert.Equal(t, fileNo, fileID, rule.flags)
+		assert.Equal(t, ruleNo, ruleID, rule.flags)
+		ruleNo++
+	}
+}
+
+func makeRuleFlags(fileID, ruleID int) string {
+	return fmt.Sprintf("-w /path/%d/%d -p rwxa -k rule:%d:%d", fileID, ruleID, fileID, ruleID)
 }
 
 func parseConfig(t testing.TB, yaml string) (Config, error) {


### PR DESCRIPTION
Added a new configuration field, `audit_rule_files` to the auditd
module. It allows to specify a set of files that contain audit rules.

```
- module: auditd
  audit_rule_files: [ '${path.config}/auditd.rules.d/*.conf' ]
```

Rules will be loaded into the kernel in the following order:
1. Rules specified in the `audit_rules` field at auditbeat.yml.
2. Rules from files in the `audit_rule_files`, in the order they are
   listed.
3. If a path contains a glob, the resulting files are loaded in
   lexicographical order.

Closes #7113