### PR TITLE
Cherry-pick #7178 to 6.3: spool to disk: more descriptive error message

### DIFF
--- a/libbeat/publisher/queue/spool/spool.go
+++ b/libbeat/publisher/queue/spool/spool.go
@@ -6,6 +6,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/elastic/beats/libbeat/common/atomic"
 	"github.com/elastic/beats/libbeat/publisher/queue"
 	"github.com/elastic/go-txfile"
@@ -86,7 +88,7 @@ func NewSpool(logger logger, path string, settings Settings) (*Spool, error) {
 
 	f, err := txfile.Open(path, mode, settings.File)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "spool queue: failed to open file at path '%s'", path)
 	}
 	defer ifNotOK(&ok, ignoreErr(f.Close))
 


### PR DESCRIPTION
Cherry-pick of PR #7178 to 6.3 branch. Original message: 

When the file backing the queue.spool cannot be open or created, beats fail with a rather vague error message:

```
  Exiting: error initializing publisher: invalid argument
```

This happens when the file resides in a filesystem that doesn't support mmap, like a shared virtualbox directory.

Now it will output something a little bit more descriptive:

```
Exiting: error initializing publisher: spool queue: failed to open file
at path '/vagrant/src/github.com/elastic/beats/auditbeat/data/spool.dat':
invalid argument
```
