### PR TITLE
Improve and separate Filebeat module testing

### DIFF
--- a/filebeat/tests/system/test_ml.py
+++ b/filebeat/tests/system/test_ml.py
@@ -1,0 +1,130 @@
+from filebeat import BaseTest
+from beat.beat import INTEGRATION_TESTS
+import os
+import unittest
+import shutil
+import subprocess
+from elasticsearch import Elasticsearch
+import logging
+from parameterized import parameterized
+
+
+class Test(BaseTest):
+
+    def init(self):
+        self.elasticsearch_url = self.get_elasticsearch_url()
+        self.kibana_url = self.get_kibana_url()
+        print("Using elasticsearch: {}".format(self.elasticsearch_url))
+        self.es = Elasticsearch([self.elasticsearch_url])
+        logging.getLogger("urllib3").setLevel(logging.WARNING)
+        logging.getLogger("elasticsearch").setLevel(logging.ERROR)
+
+        self.modules_path = os.path.abspath(self.working_dir +
+                                            "/../../../../module")
+
+        self.kibana_path = os.path.abspath(self.working_dir +
+                                           "/../../../../_meta/kibana.generated")
+
+        self.filebeat = os.path.abspath(self.working_dir +
+                                        "/../../../../filebeat.test")
+
+        self.index_name = "test-filebeat-ml"
+
+    @parameterized.expand([
+        (True, False),
+        (True, True),
+        (False, False),
+        (False, True),
+    ])
+    @unittest.skipIf(not INTEGRATION_TESTS,
+                     "integration tests are disabled, run with INTEGRATION_TESTS=1 to enable them.")
+    @unittest.skipIf(os.getenv("TESTING_ENVIRONMENT") == "2x",
+                     "integration test not available on 2.x")
+    def test_ml_setup(self, setup_flag, modules_flag):
+        """ Test ML are installed in all possible ways """
+        self._run_ml_test(setup_flag, modules_flag)
+
+    def _run_ml_test(self, setup_flag, modules_flag):
+        self.init()
+
+        print("Test setup_flag: {}, modules_flag: {}".format(setup_flag, modules_flag))
+
+        # Clean any previous state
+        for df in self.es.transport.perform_request("GET", "/_xpack/ml/datafeeds/")["datafeeds"]:
+            if df["datafeed_id"] == 'filebeat-nginx-access-response_code':
+                self.es.transport.perform_request(
+                    "DELETE", "/_xpack/ml/datafeeds/" + df["datafeed_id"])
+
+        for df in self.es.transport.perform_request("GET", "/_xpack/ml/anomaly_detectors/")["jobs"]:
+            if df["job_id"] == 'datafeed-filebeat-nginx-access-response_code':
+                self.es.transport.perform_request(
+                    "DELETE", "/_xpack/ml/anomaly_detectors/" + df["job_id"])
+
+        shutil.rmtree(os.path.join(self.working_dir,
+                                   "modules.d"), ignore_errors=True)
+
+        # generate a minimal configuration
+        cfgfile = os.path.join(self.working_dir, "filebeat.yml")
+        self.render_config_template(
+            template_name="filebeat_modules",
+            output=cfgfile,
+            index_name=self.index_name,
+            elasticsearch_url=self.elasticsearch_url,
+            kibana_url=self.kibana_url,
+            kibana_path=self.kibana_path)
+
+        if not modules_flag:
+            # Enable nginx
+            os.mkdir(os.path.join(self.working_dir, "modules.d"))
+            with open(os.path.join(self.working_dir, "modules.d/nginx.yml"), "wb") as nginx:
+                nginx.write("- module: nginx")
+
+        cmd = [
+            self.filebeat, "-systemTest",
+            "-e", "-d", "*",
+            "-c", cfgfile
+        ]
+
+        if setup_flag:
+            cmd += ["--setup"]
+        else:
+            cmd += ["setup", "--machine-learning"]
+
+        if modules_flag:
+            cmd += ["--modules=nginx"]
+
+        output_path = os.path.join(self.working_dir, "output.log")
+        output = open(output_path, "ab")
+        output.write(" ".join(cmd) + "\n")
+        beat = subprocess.Popen(cmd,
+                                stdin=None,
+                                stdout=output,
+                                stderr=output,
+                                bufsize=0)
+
+        # Check result
+        self.wait_until(lambda: "filebeat-nginx-access-response_code" in
+                                (df["job_id"] for df in self.es.transport.perform_request(
+                                    "GET", "/_xpack/ml/anomaly_detectors/")["jobs"]),
+                        max_timeout=60)
+        self.wait_until(lambda: "datafeed-filebeat-nginx-access-response_code" in
+                                (df["datafeed_id"] for df in self.es.transport.perform_request("GET", "/_xpack/ml/datafeeds/")["datafeeds"]))
+
+        beat.kill()
+
+        # check if fails during trying to setting it up again
+        output = open(output_path, "ab")
+        output.write(" ".join(cmd) + "\n")
+        beat = subprocess.Popen(cmd,
+                                stdin=None,
+                                stdout=output,
+                                stderr=output,
+                                bufsize=0)
+
+        output = open(output_path, "r")
+        for obj in ["Datafeed", "Job", "Dashboard", "Search", "Visualization"]:
+            self.wait_log_contains("{obj} already exists".format(obj=obj),
+                                   logfile=output_path,
+                                   max_timeout=30)
+
+        beat.kill()

--- a/filebeat/tests/system/test_modules.py
+++ b/filebeat/tests/system/test_modules.py
@@ -53,7 +53,6 @@ class Test(BaseTest):
 
     def init(self):
         self.elasticsearch_url = self.get_elasticsearch_url()
-        self.kibana_url = self.get_kibana_url()
         print("Using elasticsearch: {}".format(self.elasticsearch_url))
         self.es = Elasticsearch([self.elasticsearch_url])
         logging.getLogger("urllib3").setLevel(logging.WARNING)
@@ -61,9 +60,6 @@ class Test(BaseTest):
 
         self.modules_path = os.path.abspath(self.working_dir +
                                             "/../../../../module")
-
-        self.kibana_path = os.path.abspath(self.working_dir +
-                                           "/../../../../_meta/kibana.generated")
 
         self.filebeat = os.path.abspath(self.working_dir +
                                         "/../../../../filebeat.test")
@@ -171,164 +167,6 @@ class Test(BaseTest):
 
         if os.path.exists(test_file + "-expected.json"):
             self._test_expected_events(module, test_file, res, objects)
-
-    @unittest.skipIf(not INTEGRATION_TESTS,
-                     "integration tests are disabled, run with INTEGRATION_TESTS=1 to enable them.")
-    @unittest.skipIf(os.getenv("TESTING_ENVIRONMENT") == "2x",
-                     "integration test not available on 2.x")
-    def test_input_pipeline_config(self):
-        """
-        Tests that the pipeline configured in the input overwrites
-        the one from the output.
-        """
-        self.init()
-        index_name = "filebeat-test-input"
-        try:
-            self.es.indices.delete(index=index_name)
-        except:
-            pass
-        self.wait_until(lambda: not self.es.indices.exists(index_name))
-
-        self.render_config_template(
-            path=os.path.abspath(self.working_dir) + "/log/*",
-            elasticsearch=dict(
-                host=self.elasticsearch_url,
-                pipeline="estest",
-                index=index_name),
-            pipeline="test",
-            setup_template_name=index_name,
-            setup_template_pattern=index_name + "*",
-        )
-
-        os.mkdir(self.working_dir + "/log/")
-        testfile = self.working_dir + "/log/test.log"
-        with open(testfile, 'a') as file:
-            file.write("Hello World1\n")
-
-        # put pipeline
-        self.es.transport.perform_request("PUT", "/_ingest/pipeline/test",
-                                          body={
-                                              "processors": [{
-                                                  "set": {
-                                                      "field": "x-pipeline",
-                                                      "value": "test-pipeline",
-                                                  }
-                                              }]})
-
-        filebeat = self.start_beat()
-
-        # Wait until the event is in ES
-        self.wait_until(lambda: self.es.indices.exists(index_name))
-
-        def search_objects():
-            try:
-                self.es.indices.refresh(index=index_name)
-                res = self.es.search(index=index_name,
-                                     body={"query": {"match_all": {}}})
-                return [o["_source"] for o in res["hits"]["hits"]]
-            except:
-                return []
-
-        self.wait_until(lambda: len(search_objects()) > 0, max_timeout=20)
-        filebeat.check_kill_and_wait()
-
-        objects = search_objects()
-        assert len(objects) == 1
-        o = objects[0]
-        assert o["x-pipeline"] == "test-pipeline"
-
-    @unittest.skipIf(not INTEGRATION_TESTS,
-                     "integration tests are disabled, run with INTEGRATION_TESTS=1 to enable them.")
-    @unittest.skipIf(os.getenv("TESTING_ENVIRONMENT") == "2x",
-                     "integration test not available on 2.x")
-    def test_ml_setup(self):
-        """ Test ML are installed in all possible ways """
-        for setup_flag in (True, False):
-            for modules_flag in (True, False):
-                self._run_ml_test(setup_flag, modules_flag)
-
-    def _run_ml_test(self, setup_flag, modules_flag):
-        self.init()
-
-        # Clean any previous state
-        for df in self.es.transport.perform_request("GET", "/_xpack/ml/datafeeds/")["datafeeds"]:
-            if df["datafeed_id"] == 'filebeat-nginx-access-response_code':
-                self.es.transport.perform_request(
-                    "DELETE", "/_xpack/ml/datafeeds/" + df["datafeed_id"])
-
-        for df in self.es.transport.perform_request("GET", "/_xpack/ml/anomaly_detectors/")["jobs"]:
-            if df["job_id"] == 'datafeed-filebeat-nginx-access-response_code':
-                self.es.transport.perform_request(
-                    "DELETE", "/_xpack/ml/anomaly_detectors/" + df["job_id"])
-
-        shutil.rmtree(os.path.join(self.working_dir,
-                                   "modules.d"), ignore_errors=True)
-
-        # generate a minimal configuration
-        cfgfile = os.path.join(self.working_dir, "filebeat.yml")
-        self.render_config_template(
-            template_name="filebeat_modules",
-            output=cfgfile,
-            index_name=self.index_name,
-            elasticsearch_url=self.elasticsearch_url,
-            kibana_url=self.kibana_url,
-            kibana_path=self.kibana_path)
-
-        if not modules_flag:
-            # Enable nginx
-            os.mkdir(os.path.join(self.working_dir, "modules.d"))
-            with open(os.path.join(self.working_dir, "modules.d/nginx.yml"), "wb") as nginx:
-                nginx.write("- module: nginx")
-
-        cmd = [
-            self.filebeat, "-systemTest",
-            "-e", "-d", "*",
-            "-c", cfgfile
-        ]
-
-        if setup_flag:
-            cmd += ["--setup"]
-        else:
-            cmd += ["setup", "--machine-learning"]
-
-        if modules_flag:
-            cmd += ["--modules=nginx"]
-
-        output_path = os.path.join(self.working_dir, "output.log")
-        output = open(output_path, "ab")
-        output.write(" ".join(cmd) + "\n")
-        beat = subprocess.Popen(cmd,
-                                stdin=None,
-                                stdout=output,
-                                stderr=output,
-                                bufsize=0)
-
-        # Check result
-        self.wait_until(lambda: "filebeat-nginx-access-response_code" in
-                        (df["job_id"] for df in self.es.transport.perform_request(
-                            "GET", "/_xpack/ml/anomaly_detectors/")["jobs"]),
-                        max_timeout=30)
-        self.wait_until(lambda: "datafeed-filebeat-nginx-access-response_code" in
-                        (df["datafeed_id"] for df in self.es.transport.perform_request("GET", "/_xpack/ml/datafeeds/")["datafeeds"]))
-
-        beat.kill()
-
-        # check if fails during trying to setting it up again
-        output = open(output_path, "ab")
-        output.write(" ".join(cmd) + "\n")
-        beat = subprocess.Popen(cmd,
-                                stdin=None,
-                                stdout=output,
-                                stderr=output,
-                                bufsize=0)
-
-        output = open(output_path, "r")
-        for obj in ["Datafeed", "Job", "Dashboard", "Search", "Visualization"]:
-            self.wait_log_contains("{obj} already exists".format(obj=obj),
-                                   logfile=output_path,
-                                   max_timeout=30)
-
-        beat.kill()
 
 
 def pretty_json(obj):

--- a/filebeat/tests/system/test_pipeline.py
+++ b/filebeat/tests/system/test_pipeline.py
@@ -1,0 +1,94 @@
+from filebeat import BaseTest
+from beat.beat import INTEGRATION_TESTS
+import os
+import unittest
+from elasticsearch import Elasticsearch
+import json
+import logging
+
+
+class Test(BaseTest):
+
+    def init(self):
+        self.elasticsearch_url = self.get_elasticsearch_url()
+        self.kibana_url = self.get_kibana_url()
+        print("Using elasticsearch: {}".format(self.elasticsearch_url))
+        self.es = Elasticsearch([self.elasticsearch_url])
+        logging.getLogger("urllib3").setLevel(logging.WARNING)
+        logging.getLogger("elasticsearch").setLevel(logging.ERROR)
+
+        self.modules_path = os.path.abspath(self.working_dir +
+                                            "/../../../../module")
+
+        self.kibana_path = os.path.abspath(self.working_dir +
+                                           "/../../../../_meta/kibana.generated")
+
+        self.filebeat = os.path.abspath(self.working_dir +
+                                        "/../../../../filebeat.test")
+
+        self.index_name = "test-filebeat-pipeline"
+
+    @unittest.skipIf(not INTEGRATION_TESTS,
+                     "integration tests are disabled, run with INTEGRATION_TESTS=1 to enable them.")
+    @unittest.skipIf(os.getenv("TESTING_ENVIRONMENT") == "2x",
+                     "integration test not available on 2.x")
+    def test_input_pipeline_config(self):
+        """
+        Tests that the pipeline configured in the input overwrites
+        the one from the output.
+        """
+        self.init()
+        index_name = "filebeat-test-input"
+        try:
+            self.es.indices.delete(index=index_name)
+        except:
+            pass
+        self.wait_until(lambda: not self.es.indices.exists(index_name))
+
+        self.render_config_template(
+            path=os.path.abspath(self.working_dir) + "/log/*",
+            elasticsearch=dict(
+                host=self.elasticsearch_url,
+                pipeline="estest",
+                index=index_name),
+            pipeline="test",
+            setup_template_name=index_name,
+            setup_template_pattern=index_name + "*",
+        )
+
+        os.mkdir(self.working_dir + "/log/")
+        testfile = self.working_dir + "/log/test.log"
+        with open(testfile, 'a') as file:
+            file.write("Hello World1\n")
+
+        # put pipeline
+        self.es.transport.perform_request("PUT", "/_ingest/pipeline/test",
+                                          body={
+                                              "processors": [{
+                                                  "set": {
+                                                      "field": "x-pipeline",
+                                                      "value": "test-pipeline",
+                                                  }
+                                              }]})
+
+        filebeat = self.start_beat()
+
+        # Wait until the event is in ES
+        self.wait_until(lambda: self.es.indices.exists(index_name))
+
+        def search_objects():
+            try:
+                self.es.indices.refresh(index=index_name)
+                res = self.es.search(index=index_name,
+                                     body={"query": {"match_all": {}}})
+                return [o["_source"] for o in res["hits"]["hits"]]
+            except:
+                return []
+
+        self.wait_until(lambda: len(search_objects()) > 0, max_timeout=20)
+        filebeat.check_kill_and_wait()
+
+        objects = search_objects()
+        assert len(objects) == 1
+        o = objects[0]
+        assert o["x-pipeline"] == "test-pipeline"


### PR DESCRIPTION
Currently the module, ml and pipeline tests were in the same file. When trying to run only 1 module test, pipeline and ml were always executed too. This makes separation easier. Also for the module tests only Elasticsearch is needed, for the ml also Kibana. So the setup can be simplified for each.

In addition for the ml testing parameterized tests are used to have a separate output directory for each option. This makes it easier to figure out which test failed if one failed.