### PR TITLE
Cherry-pick #7336 to 6.3: [Filebeat] Fix offset field pointing at end of line for #6514

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -147,6 +147,7 @@ https://github.com/elastic/beats/compare/v6.2.3...v6.3.0[View commits]
 - Fix a parsing issue in the syslog input for RFC3339 timestamp and time with nanoseconds. {pull}7046[7046]
 - Fix an issue with an overflowing wait group when using the TCP input. {issue}7202[7202]
 - Keep different registry entry per container stream to avoid wrong offsets. {issue}7281[7281]
+- Fix offset field pointing at end of a line. {issue}6514[6514]
 
 *Heartbeat*
 

--- a/filebeat/input/log/harvester.go
+++ b/filebeat/input/log/harvester.go
@@ -267,6 +267,7 @@ func (h *Harvester) Run() error {
 		// This is important in case sending is not successful so on shutdown
 		// the old offset is reported
 		state := h.getState()
+		startingOffset := state.Offset
 		state.Offset += int64(message.Bytes)
 
 		// Create state event
@@ -281,7 +282,7 @@ func (h *Harvester) Run() error {
 		if !message.IsEmpty() && h.shouldExportLine(text) {
 			fields := common.MapStr{
 				"source": state.Source,
-				"offset": state.Offset, // Offset here is the offset before the starting char.
+				"offset": startingOffset, // Offset here is the offset before the starting char.
 			}
 			fields.DeepUpdate(message.Fields)
 

--- a/filebeat/tests/system/test_shutdown.py
+++ b/filebeat/tests/system/test_shutdown.py
@@ -64,8 +64,13 @@ class Test(BaseTest):
 
         # we allow for a potential race in the harvester shutdown here.
         # In some cases the registry offset might match the penultimate offset.
-        assert (offset == outputs[-1]["offset"] or
-                offset == outputs[-2]["offset"])
+
+        eol_offset = 1
+        if os.name == "nt":
+            eol_offset += 1
+
+        assert (offset == (outputs[-1]["offset"] + eol_offset + len(outputs[-1]["message"])) or
+                offset == (outputs[-2]["offset"] + eol_offset + len(outputs[-2]["message"])))
 
     def test_shutdown_wait_timeout(self):
         """


### PR DESCRIPTION
Cherry-pick of PR #7336 to 6.3 branch. Original message: 

Fixes #6514. Didn't add a new test because I had to adjust that one test to reflect the change by adding EOL + message length before comparing to the stored file offset.