### PR TITLE
Cherry-pick #7346 to 6.3: Fix autodiscover hint names

### DIFF
--- a/filebeat/docs/autodiscover-hints.asciidoc
+++ b/filebeat/docs/autodiscover-hints.asciidoc
@@ -6,30 +6,30 @@ from the container using the `docker` input. You can use hints to modify this be
 list of supported hints:
 
 [float]
-===== `co.elastic.logs.multiline.*`
+===== `co.elastic.logs/multiline.*`
 
 Multiline settings. See <<multiline-examples>> for a full list of all supported options.
 
 [float]
-===== `co.elastic.logs.include_lines`
+===== `co.elastic.logs/include_lines`
 
 A list of regular expressions to match the lines that you want {beatname_uc} to include.
 See <<configuration-filebeat-options>> for more info.
 
 [float]
-===== `co.elastic.logs.exclude_lines`
+===== `co.elastic.logs/exclude_lines`
 
 A list of regular expressions to match the lines that you want {beatname_uc} to exclude.
 See <<configuration-filebeat-options>> for more info.
 
 [float]
-===== `co.elastic.logs.module`
+===== `co.elastic.logs/module`
 
 Instead of using raw `docker` input, specifies the module to use to parse logs from the container. See
 <<filebeat-modules>> for the list of supported modules.
 
 [float]
-===== `co.elastic.logs.fileset`
+===== `co.elastic.logs/fileset`
 
 When module is configured, map container logs to module filesets. You can either configure
 a single fileset like this:

--- a/metricbeat/docs/autodiscover-hints.asciidoc
+++ b/metricbeat/docs/autodiscover-hints.asciidoc
@@ -4,34 +4,34 @@ the container starts, {beatname_uc} will check if it contains any hints and laun
 it. Hints tell {beatname_uc} how to get metrics for the given container. This is the full list of supported hints:
 
 [float]
-===== `co.elastic.metrics.module`
+===== `co.elastic.metrics/module`
 
 {beatname_uc} module to use to fetch metrics. See <<metricbeat-modules>> for the list of supported modules.
 
 [float]
-===== `co.elastic.metrics.hosts`
+===== `co.elastic.metrics/hosts`
 
 Hosts setting to use with the given module. Hosts can include `${data.host}` and `${data.port}`
 values from the autodiscover event, ie: `${data.host}:80`.
 
 [float]
-===== `co.elastic.metrics.metricsets`
+===== `co.elastic.metrics/metricsets`
 
 List of metricsets to use, comma separated. If no metricsets are provided, default metricsets for the module
 are used.
 
 [float]
-===== `co.elastic.metrics.period`
+===== `co.elastic.metrics/period`
 
 The time interval for metrics retrieval, ie: 10s
 
 [float]
-===== `co.elastic.metrics.timeout`
+===== `co.elastic.metrics/timeout`
 
 Metrics retrieval timeout, default: 3s
 
 [float]
-===== `co.elastic.metrics.ssl.*`
+===== `co.elastic.metrics/ssl.*`
 
 SSL parameters, as seen in <<configuration-ssl>>.
 


### PR DESCRIPTION
Cherry-pick of PR #7346 to 6.3 branch. Original message: 

I misspelled hint names in my previous PR :man_facepalming: 