### PR TITLE
Fix duplication of dynamic fields on reconnect

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -71,6 +71,7 @@ https://github.com/elastic/beats/compare/v6.2.3...master[Check the HEAD diff]
 - Do not emit Kubernetes autodiscover events for Pods without IP address. {pull}7235[7235]
 - Allow to override the `ignore_above` option when defining new field with the type keyword. {pull}7238[7238]
 - Allow index-pattern only setup when setup.dashboards.only_index=true. {pull}7285[7285]
+- Fix duplicating dynamic_fields in template when overwriting the template. {pull}7352[7352]
 
 *Auditbeat*
 

--- a/libbeat/template/template.go
+++ b/libbeat/template/template.go
@@ -97,6 +97,9 @@ func New(beatVersion string, beatName string, esVersion string, config TemplateC
 
 func (t *Template) load(fields common.Fields) (common.MapStr, error) {
 
+	dynamicTemplates = nil
+	defaultFields = nil
+
 	var err error
 	if len(t.config.AppendFields) > 0 {
 		cfgwarn.Experimental("append_fields is used.")

--- a/libbeat/template/template.go
+++ b/libbeat/template/template.go
@@ -2,6 +2,7 @@ package template
 
 import (
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/elastic/beats/libbeat/beat"
@@ -24,6 +25,7 @@ var (
 )
 
 type Template struct {
+	sync.Mutex
 	name        string
 	pattern     string
 	beatVersion common.Version
@@ -96,6 +98,10 @@ func New(beatVersion string, beatName string, esVersion string, config TemplateC
 }
 
 func (t *Template) load(fields common.Fields) (common.MapStr, error) {
+
+	// Locking to make sure dynamicTemplates and defaultFields is not accessed in parallel
+	t.Lock()
+	defer t.Unlock()
 
 	dynamicTemplates = nil
 	defaultFields = nil


### PR DESCRIPTION
If `setup.template.overwrite: true` is set the template is overwritten each time the Beat reconnects. The `dynamicTemplates` are a global variable that keeps state. This had the side effect that each time the template was generated for loading, the dynamic fields were append again. The logic in the code is changed now that each time when the template is generated first the dynamicFields array is reset.

This also works with the new `append_fields` config option because it is read during the load process to also potentially add dynamic fields.

The same applies to the default fields which are global. Also this array is reset. As default_fields were only used for Elasticsearch 7.0 is does not need an entry in the changelog.

If possible in the future both variables should be part of the template object instead of being global. Unfortunately this would required major changes.