### PR TITLE
Cherry-pick #7140 to 6.3: Fix permissions of generated Filebeat filesets

### DIFF
--- a/CHANGELOG-developer.asciidoc
+++ b/CHANGELOG-developer.asciidoc
@@ -19,5 +19,11 @@ The list below covers the major changes between 6.3.0 and master only.
 
 ==== Breaking changes
 
+- The beat.Pipeline is now passed to cfgfile.RunnerFactory. Beats using libbeat for module reloading or autodiscovery need to be adapted. {pull}7018[7017]
+- Moving of TLS helper functions and structs from `output/tls` to `tlscommon`. {pull}7054[7054]
+
+==== Bugfixes
+
+- Fix permissions of generated Filebeat filesets. {pull}7140[7140]
 
 ==== Added

--- a/filebeat/scripts/generator/generator.go
+++ b/filebeat/scripts/generator/generator.go
@@ -49,7 +49,7 @@ func AppendTemplate(template, dest string, replace map[string]string) error {
 		return err
 	}
 
-	f, err := os.OpenFile(dest, os.O_WRONLY|os.O_APPEND, os.ModePerm)
+	f, err := os.OpenFile(dest, os.O_WRONLY|os.O_APPEND, 0644)
 	if err == nil {
 		_, err = f.Write(c)
 	}
@@ -66,10 +66,11 @@ func copyTemplate(template, dest string, replace map[string]string) error {
 		return err
 	}
 
-	err = ioutil.WriteFile(dest, c, os.ModePerm)
+	err = ioutil.WriteFile(dest, c, 0644)
 	if err != nil {
 		return fmt.Errorf("cannot copy template: %v", err)
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
* fix generated files' permission

Closes #6856

(cherry picked from commit 89178c395b4b77cd3e3820dfe6d11955ccc5a327)