### PR TITLE
Cherry-pick #7169 to 6.3: Add missing type to http.response.body field

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -47,6 +47,7 @@ https://github.com/elastic/beats/compare/v6.3.0...6.3[Check the HEAD diff]
 *Packetbeat*
 
 - Fix an out of bounds access in HTTP parser caused by malformed request. {pull}6997[6997]
+- Fix missing type for `http.response.body` field. {pull}7169[7169]
 
 *Winlogbeat*
 

--- a/packetbeat/_meta/fields.yml
+++ b/packetbeat/_meta/fields.yml
@@ -1200,6 +1200,7 @@
                 same header name are present in the message, they will be separated
                 by commas.
             - name: body
+              type: text
               description: The body of the HTTP response.
 
 - key: icmp

--- a/packetbeat/docs/fields.asciidoc
+++ b/packetbeat/docs/fields.asciidoc
@@ -2400,6 +2400,8 @@ A map containing the captured header fields from the response. Which headers to 
 *`http.response.body`*::
 +
 --
+type: text
+
 The body of the HTTP response.
 
 --

--- a/packetbeat/protos/http/_meta/fields.yml
+++ b/packetbeat/protos/http/_meta/fields.yml
@@ -47,5 +47,6 @@
                 same header name are present in the message, they will be separated
                 by commas.
             - name: body
+              type: text
               description: The body of the HTTP response.
 


### PR DESCRIPTION
Cherry-pick of PR #7169 to 6.3 branch. Original message: 

The field `http.response.body` was missing its `text` type, thus defaulting to `keyword`.