### PR TITLE
Add symlink to imports_generator_helper in generated Metricbeat Makefile

### DIFF
--- a/generator/metricbeat/{beat}/Makefile
+++ b/generator/metricbeat/{beat}/Makefile
@@ -22,6 +22,7 @@ setup: copy-vendor
 copy-vendor:
 	mkdir -p vendor/github.com/elastic/
 	cp -R ${GOPATH}/src/github.com/elastic/beats vendor/github.com/elastic/
+	ln -s ${PWD}/vendor/github.com/elastic/beats/metricbeat/scripts/generate_imports_helper.py ${PWD}/vendor/github.com/elastic/beats/script/generate_imports_helper.py
 	rm -rf vendor/github.com/elastic/beats/.git vendor/github.com/elastic/beats/x-pack
 
 # This is called by the beats packer before building starts


### PR DESCRIPTION
Generating imports requires Beat dependent helper functions. In case of normal Beats where a `generate_imports_helper` is available under the proper folder importing helper functions works without any problem. However, if someone generated a Beat based on Metricbeat, import paths in Python are incorrect. I added a symlink to the generate_imports_helper of Metricbeat, so functions can be imported.

This is not the cleanest solution. But I opted for this, because I am porting generator codes to Golang anyways, so I do not want to spend too much time fixing something that is going to be removed.

Closes #7366