### PR TITLE
Set doc branch to 6.x

### DIFF
--- a/libbeat/docs/version.asciidoc
+++ b/libbeat/docs/version.asciidoc
@@ -1,5 +1,5 @@
 :stack-version: 6.4.0
-:doc-branch: master
+:doc-branch: 6.x
 :go-version: 1.9.4
 :release-state: unreleased
 :python: 2.7.9


### PR DESCRIPTION
Doc branch is incorrectly set to master, which breaks some links that point to removed topics.