### PR TITLE
Add ability to configure autodiscover with JSON hints

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -162,6 +162,7 @@ https://github.com/elastic/beats/compare/v6.2.3...master[Check the HEAD diff]
 - Add owner object info to Kubernetes metadata. {pull}7231[7231]
 - Add beat export dashboard command. {pull}7239[7239]
 - Add support for docker autodiscover to monitor containers on host network {pull}6708[6708]
+- Add ability to define input configuration as stringified JSON for autodiscover. {pull}7372[7372]
 
 *Auditbeat*
 

--- a/filebeat/autodiscover/builder/hints/logs.go
+++ b/filebeat/autodiscover/builder/hints/logs.go
@@ -22,6 +22,7 @@ const (
 	multiline    = "multiline"
 	includeLines = "include_lines"
 	excludeLines = "exclude_lines"
+	inputs       = "inputs"
 )
 
 // validModuleNames to sanitize user input
@@ -107,6 +108,20 @@ func (l *logHints) CreateConfig(event bus.Event) []*common.Config {
 		config, _ = common.NewConfigFrom(moduleConf)
 	}
 
+	inputConfig := l.getInputs(hints)
+	if inputConfig != nil {
+		configs := []*common.Config{}
+		for _, cfg := range inputConfig {
+			if config, err := common.NewConfigFrom(cfg); err == nil {
+				configs = append(configs, config)
+			}
+		}
+		logp.Debug("hints.builder", "generated config %+v", configs)
+		// Apply information in event to the template to generate the final config
+		return template.ApplyConfigTemplate(event, configs)
+
+	}
+
 	logp.Debug("hints.builder", "generated config %+v", config)
 
 	// Apply information in event to the template to generate the final config
@@ -129,6 +144,10 @@ func (l *logHints) getModule(hints common.MapStr) string {
 	module := builder.GetHintString(hints, l.Key, "module")
 	// for security, strip module name
 	return validModuleNames.ReplaceAllString(module, "")
+}
+
+func (l *logHints) getInputs(hints common.MapStr) []common.MapStr {
+	return builder.GetHintAsConfig(hints, l.Key, inputs)
 }
 
 type filesetConfig struct {

--- a/filebeat/autodiscover/builder/hints/logs_test.go
+++ b/filebeat/autodiscover/builder/hints/logs_test.go
@@ -120,6 +120,38 @@ func TestGenerateHints(t *testing.T) {
 			},
 		},
 		{
+			msg: "Hint with inputs config as json must be accepted",
+			event: bus.Event{
+				"host": "1.2.3.4",
+				"kubernetes": common.MapStr{
+					"container": common.MapStr{
+						"name": "foobar",
+						"id":   "abc",
+					},
+				},
+				"container": common.MapStr{
+					"name": "foobar",
+					"id":   "abc",
+				},
+				"hints": common.MapStr{
+					"logs": common.MapStr{
+						"inputs": "[{\"containers\":{\"ids\":[\"${data.container.id}\"]},\"multiline\":{\"negate\":\"true\",\"pattern\":\"^test\"},\"type\":\"docker\"}]",
+					},
+				},
+			},
+			len: 1,
+			result: common.MapStr{
+				"type": "docker",
+				"containers": map[string]interface{}{
+					"ids": []interface{}{"abc"},
+				},
+				"multiline": map[string]interface{}{
+					"pattern": "^test",
+					"negate":  "true",
+				},
+			},
+		},
+		{
 			msg: "Hint with module should attach input to its filesets",
 			event: bus.Event{
 				"host": "1.2.3.4",
@@ -282,7 +314,6 @@ func TestGenerateHints(t *testing.T) {
 
 		cfgs := l.CreateConfig(test.event)
 		assert.Equal(t, len(cfgs), test.len, test.msg)
-
 		if test.len != 0 {
 			config := common.MapStr{}
 			err := cfgs[0].Unpack(&config)

--- a/filebeat/autodiscover/builder/hints/logs_test.go
+++ b/filebeat/autodiscover/builder/hints/logs_test.go
@@ -135,7 +135,7 @@ func TestGenerateHints(t *testing.T) {
 				},
 				"hints": common.MapStr{
 					"logs": common.MapStr{
-						"inputs": "[{\"containers\":{\"ids\":[\"${data.container.id}\"]},\"multiline\":{\"negate\":\"true\",\"pattern\":\"^test\"},\"type\":\"docker\"}]",
+						"raw": "[{\"containers\":{\"ids\":[\"${data.container.id}\"]},\"multiline\":{\"negate\":\"true\",\"pattern\":\"^test\"},\"type\":\"docker\"}]",
 					},
 				},
 			},

--- a/filebeat/docs/autodiscover-hints.asciidoc
+++ b/filebeat/docs/autodiscover-hints.asciidoc
@@ -48,6 +48,17 @@ co.elastic.logs/fileset.stderr: error
 -------------------------------------------------------------------------------------
 
 [float]
+===== `co.elastic.logs/raw`
+When an entire input/module configuration needs to be completely set the `raw` hint can be used. You can provide a
+stringified JSON of the input configuration. `raw` overrides every other hint and can be used to create bot a single or
+a list of configurations.
+
+["source","yaml",subs="attributes"]
+-------------------------------------------------------------------------------------
+co.elastic.logs/raw: "[{\"containers\":{\"ids\":[\"${data.container.id}\"]},\"multiline\":{\"negate\":\"true\",\"pattern\":\"^test\"},\"type\":\"docker\"}]"
+-------------------------------------------------------------------------------------
+
+[float]
 ==== Kubernetes
 
 Kubernetes autodiscover provider supports hints in Pod annotations. To enable it just set `hints.enabled`:

--- a/libbeat/autodiscover/builder/helper.go
+++ b/libbeat/autodiscover/builder/helper.go
@@ -1,11 +1,13 @@
 package builder
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
 
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
 )
 
 // GetContainerID returns the id of a container
@@ -62,6 +64,19 @@ func getStringAsList(input string) []string {
 	}
 
 	return list
+}
+
+// GetHintAsConfig can read a hint in the form of a stringified JSON and return a common.MapStr
+func GetHintAsConfig(hints common.MapStr, key, config string) []common.MapStr {
+	if str := GetHintString(hints, key, config); str != "" {
+		cfg := []common.MapStr{}
+		if err := json.Unmarshal([]byte(str), &cfg); err != nil {
+			logp.Debug("autodiscover.builder", "unable to unmarshall json due to error: %v", err)
+			return nil
+		}
+		return cfg
+	}
+	return nil
 }
 
 // IsNoOp is a big red button to prevent spinning up Runners in case of issues.

--- a/libbeat/autodiscover/builder/helper.go
+++ b/libbeat/autodiscover/builder/helper.go
@@ -66,12 +66,22 @@ func getStringAsList(input string) []string {
 	return list
 }
 
-// GetHintAsConfig can read a hint in the form of a stringified JSON and return a common.MapStr
-func GetHintAsConfig(hints common.MapStr, key, config string) []common.MapStr {
-	if str := GetHintString(hints, key, config); str != "" {
+// GetHintAsConfigs can read a hint in the form of a stringified JSON and return a common.MapStr
+func GetHintAsConfigs(hints common.MapStr, key string) []common.MapStr {
+	if str := GetHintString(hints, key, "raw"); str != "" {
+		// check if it is a single config
+		if str[0] != '[' {
+			cfg := common.MapStr{}
+			if err := json.Unmarshal([]byte(str), &cfg); err != nil {
+				logp.Debug("autodiscover.builder", "unable to unmarshal json due to error: %v", err)
+				return nil
+			}
+			return []common.MapStr{cfg}
+		}
+
 		cfg := []common.MapStr{}
 		if err := json.Unmarshal([]byte(str), &cfg); err != nil {
-			logp.Debug("autodiscover.builder", "unable to unmarshall json due to error: %v", err)
+			logp.Debug("autodiscover.builder", "unable to unmarshal json due to error: %v", err)
 			return nil
 		}
 		return cfg

--- a/metricbeat/autodiscover/builder/hints/metrics.go
+++ b/metricbeat/autodiscover/builder/hints/metrics.go
@@ -27,6 +27,7 @@ const (
 	period     = "period"
 	timeout    = "timeout"
 	ssl        = "ssl"
+	modules    = "modules"
 
 	defaultTimeout = "3s"
 	defaultPeriod  = "1m"
@@ -65,6 +66,20 @@ func (m *metricHints) CreateConfig(event bus.Event) []*common.Config {
 		return config
 	}
 
+	modulesConfig := m.getModules(hints)
+	if modulesConfig != nil {
+		configs := []*common.Config{}
+		for _, cfg := range modulesConfig {
+			if config, err := common.NewConfigFrom(cfg); err == nil {
+				configs = append(configs, config)
+			}
+		}
+		logp.Debug("hints.builder", "generated config %+v", configs)
+		// Apply information in event to the template to generate the final config
+		return template.ApplyConfigTemplate(event, configs)
+
+	}
+
 	mod := m.getModule(hints)
 	if mod == "" {
 		return config
@@ -98,14 +113,13 @@ func (m *metricHints) CreateConfig(event bus.Event) []*common.Config {
 	if err != nil {
 		logp.Debug("hints.builder", "config merge failed with error: %v", err)
 	}
-	logp.Debug("hints.builder", "generated config: %v", *cfg)
+	logp.Debug("hints.builder", "generated config: +%v", *cfg)
 	config = append(config, cfg)
 
 	// Apply information in event to the template to generate the final config
 	// This especially helps in a scenario where endpoints are configured as:
 	// co.elastic.metrics/hosts= "${data.host}:9090"
-	config = template.ApplyConfigTemplate(event, config)
-	return config
+	return template.ApplyConfigTemplate(event, config)
 }
 
 func (m *metricHints) getModule(hints common.MapStr) string {
@@ -167,4 +181,8 @@ func (m *metricHints) getTimeout(hints common.MapStr) string {
 
 func (m *metricHints) getSSLConfig(hints common.MapStr) common.MapStr {
 	return builder.GetHintMapStr(hints, m.Key, ssl)
+}
+
+func (m *metricHints) getModules(hints common.MapStr) []common.MapStr {
+	return builder.GetHintAsConfig(hints, m.Key, modules)
 }

--- a/metricbeat/autodiscover/builder/hints/metrics.go
+++ b/metricbeat/autodiscover/builder/hints/metrics.go
@@ -27,7 +27,6 @@ const (
 	period     = "period"
 	timeout    = "timeout"
 	ssl        = "ssl"
-	modules    = "modules"
 
 	defaultTimeout = "3s"
 	defaultPeriod  = "1m"
@@ -184,5 +183,5 @@ func (m *metricHints) getSSLConfig(hints common.MapStr) common.MapStr {
 }
 
 func (m *metricHints) getModules(hints common.MapStr) []common.MapStr {
-	return builder.GetHintAsConfig(hints, m.Key, modules)
+	return builder.GetHintAsConfigs(hints, m.Key)
 }

--- a/metricbeat/autodiscover/builder/hints/metrics_test.go
+++ b/metricbeat/autodiscover/builder/hints/metrics_test.go
@@ -109,6 +109,25 @@ func TestGenerateHints(t *testing.T) {
 			},
 		},
 		{
+			message: "Module defined in modules as a JSON string should return a config",
+			event: bus.Event{
+				"host": "1.2.3.4",
+				"hints": common.MapStr{
+					"metrics": common.MapStr{
+						"modules": "[{\"enabled\":true,\"metricsets\":[\"default\"],\"module\":\"mockmoduledefaults\",\"period\":\"1m\",\"timeout\":\"3s\"}]",
+					},
+				},
+			},
+			len: 1,
+			result: common.MapStr{
+				"module":     "mockmoduledefaults",
+				"metricsets": []string{"default"},
+				"timeout":    "3s",
+				"period":     "1m",
+				"enabled":    true,
+			},
+		},
+		{
 			message: "Module, namespace, host hint should return valid config with port should return hosts for " +
 				"docker host network scenario",
 			event: bus.Event{
@@ -171,7 +190,7 @@ func TestGenerateHints(t *testing.T) {
 		cfgs := m.CreateConfig(test.event)
 		assert.Equal(t, len(cfgs), test.len)
 
-		if test.len != 0 {
+		if len(cfgs) != 0 {
 			config := common.MapStr{}
 			err := cfgs[0].Unpack(&config)
 			assert.Nil(t, err, test.message)

--- a/metricbeat/autodiscover/builder/hints/metrics_test.go
+++ b/metricbeat/autodiscover/builder/hints/metrics_test.go
@@ -114,7 +114,7 @@ func TestGenerateHints(t *testing.T) {
 				"host": "1.2.3.4",
 				"hints": common.MapStr{
 					"metrics": common.MapStr{
-						"modules": "[{\"enabled\":true,\"metricsets\":[\"default\"],\"module\":\"mockmoduledefaults\",\"period\":\"1m\",\"timeout\":\"3s\"}]",
+						"raw": "{\"enabled\":true,\"metricsets\":[\"default\"],\"module\":\"mockmoduledefaults\",\"period\":\"1m\",\"timeout\":\"3s\"}",
 					},
 				},
 			},

--- a/metricbeat/docs/autodiscover-hints.asciidoc
+++ b/metricbeat/docs/autodiscover-hints.asciidoc
@@ -35,7 +35,16 @@ Metrics retrieval timeout, default: 3s
 
 SSL parameters, as seen in <<configuration-ssl>>.
 
+[float]
+===== `co.elastic.logs/raw`
+When an entire module configuration needs to be completely set the `raw` hint can be used. You can provide a
+stringified JSON of the input configuration. `raw` overrides every other hint and can be used to create bot a single or
+a list of configurations.
 
+["source","yaml",subs="attributes"]
+-------------------------------------------------------------------------------------
+co.elastic.metrics/raw: "[{\"enabled\":true,\"metricsets\":[\"default\"],\"module\":\"mockmoduledefaults\",\"period\":\"1m\",\"timeout\":\"3s\"}]"
+-------------------------------------------------------------------------------------
 
 [float]
 === Kubernetes


### PR DESCRIPTION
Allow filebeat to configure an array of inputs using `co.elastic.logs/inputs: [stringified json]` and `co.elastic.metrics/modules` to do the same for metricbeat.