### PR TITLE
Fix wrong param in Metricbeat Kibana module reference config

### DIFF
--- a/metricbeat/docs/modules/kibana.asciidoc
+++ b/metricbeat/docs/modules/kibana.asciidoc
@@ -25,7 +25,7 @@ metricbeat.modules:
   metricsets: ["status"]
   period: 10s
   hosts: ["localhost:5601"]
-  enabled: default
+  enabled: true
 ----
 
 This module supports TLS connection when using `ssl` config field, as described in <<configuration-ssl>>. It also supports the options described in <<module-http-config-options>>.

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -346,7 +346,7 @@ metricbeat.modules:
   metricsets: ["status"]
   period: 10s
   hosts: ["localhost:5601"]
-  enabled: default
+  enabled: true
 
 #----------------------------- Kubernetes Module -----------------------------
 # Node metrics, from kubelet:

--- a/metricbeat/module/kibana/_meta/config.reference.yml
+++ b/metricbeat/module/kibana/_meta/config.reference.yml
@@ -2,4 +2,4 @@
   metricsets: ["status"]
   period: 10s
   hosts: ["localhost:5601"]
-  enabled: default
+  enabled: true


### PR DESCRIPTION
`enabled` was set to `default` instead of `true`.

Closes https://github.com/elastic/beats/issues/7364