### PR TITLE
Cherry-pick #7047 to 6.3: Metricbeat: Ensure canonical naming for JMX beans is disabled

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -176,6 +176,10 @@ https://github.com/elastic/beats/compare/v6.2.3...v6.3.0[View commits]
 - Add mapping for docker metrics per cpu. {pull}6843[6843]
 - Ensure canonical naming for JMX beans is disabled in Jolokia module. {pull}7047[7047]
 
+*Packetbeat*
+
+- Fix an out of bounds access in HTTP parser caused by malformed request. {pull}6997[6997]
+
 *Winlogbeat*
 
 - Fixed a crash under Windows 2003 and XP when an event had less insert strings than required by its format string. {pull}6247[6247]


### PR DESCRIPTION
Cherry-pick of PR #7047 to 6.3 branch. Original message: 

Canonical naming for JMX beans in Jolokia is enabled by default, this
orders mbean fields, what breaks metricbeat internal mapping.

We were already setting these options in the url, but url parameters are
ignored in POST requests. This change adds these parameters as part of
the body.