### PR TITLE
Cherry-pick #7315 to 6.3: Add warning about autodiscover and template scoping

### DIFF
--- a/libbeat/docs/shared-autodiscover.asciidoc
+++ b/libbeat/docs/shared-autodiscover.asciidoc
@@ -62,6 +62,51 @@ For example, with the example event, "`${data.port}`" resolves to `6379`.
 
 include::../../{beatname_lc}/docs/autodiscover-docker-config.asciidoc[]
 
+
+ifeval::["{beatname_lc}"=="filebeat"]
+[WARNING]
+=======================================
+When using autodiscover, you have to be careful when defining config templates, especially if they are
+reading from places holding information for several containers. For instance, under this file structure:
+
+`/mnt/logs/<container_id>/*.log`
+
+You can define a config template like this:
+
+**Wrong settings**:
+
+[source,yaml]
+-------------------------------------------------------------------------------------
+autodiscover.providers:
+  - type: docker
+    templates:
+      - condition.contains:
+          docker.container.image: nginx
+        config:
+          - type: log
+            paths:
+              - "/mnt/logs/*/*.log"
+-------------------------------------------------------------------------------------
+
+That would read all the files under the given path several times (one per nginx container). What you really
+want is to scope your template to the container that matched the autodiscover condition. Good settings:
+
+[source,yaml]
+-------------------------------------------------------------------------------------
+autodiscover.providers:
+  - type: docker
+    templates:
+      - condition.contains:
+          docker.container.image: nginx
+        config:
+          - type: log
+            paths:
+              - "/mnt/logs/${data.docker.container.id}/*.log"
+-------------------------------------------------------------------------------------
+
+=======================================
+endif::[]
+
 [float]
 ===== Kubernetes
 


### PR DESCRIPTION
Cherry-pick of PR #7315 to 6.3 branch. Original message: 

When using autodiscover, you have to be careful when defining config templates, especially if they are
reading from places holding information for several containers. For instance, under this file structure:

```
/mnt/logs/<container_id>/*.log
```

You can define a config template like this:

:warning: Wrong settings:
```
autodiscover.providers:
  - type: docker
    templates:
      - condition.contains:
          docker.container.image: nginx
        config:
          - type: log
            paths:
              - "/mnt/logs/*/*.log"
```

That would read all the files under the given path several times (one per nginx container). What you really want is to scope your template to the container that matched the autodiscover condition:

:green_heart: Good settings:
```
autodiscover.providers:
  - type: docker
    templates:
      - condition.contains:
          docker.container.image: nginx
        config:
          - type: log
            paths:
              - "/mnt/logs/${data.docker.container.id}/*.log"
```

I'm not sure if I explained this well in the text, so any input is welcomed :)

Closes #7312