### PR TITLE
Cherry-pick #7352 to 6.3: Fix duplication of dynamic fields on reconnect

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -150,6 +150,9 @@ https://github.com/elastic/beats/compare/v6.2.3...v6.3.0[View commits]
 - Fix map overwrite panics by cloning shared structs before doing the update. {pull}6947[6947]
 - Fix delays on autodiscovery events handling caused by blocking runner stops. {pull}7170[7170]
 - Do not emit Kubernetes autodiscover events for Pods without IP address. {pull}7235[7235]
+- Allow to override the `ignore_above` option when defining new field with the type keyword. {pull}7238[7238]
+- Allow index-pattern only setup when setup.dashboards.only_index=true. {pull}7285[7285]
+- Fix duplicating dynamic_fields in template when overwriting the template. {pull}7352[7352]
 
 *Auditbeat*
 


### PR DESCRIPTION
Cherry-pick of PR #7352 to 6.3 branch. Original message: 

If `setup.template.overwrite: true` is set the template is overwritten each time the Beat reconnects. The `dynamicTemplates` are a global variable that keeps state. This had the side effect that each time the template was generated for loading, the dynamic fields were append again. The logic in the code is changed now that each time when the template is generated first the dynamicFields array is reset.

This also works with the new `append_fields` config option because it is read during the load process to also potentially add dynamic fields.

The same applies to the default fields which are global. Also this array is reset. As default_fields were only used for Elasticsearch 7.0 is does not need an entry in the changelog.

If possible in the future both variables should be part of the template object instead of being global. Unfortunately this would required major changes.