### PR TITLE
Updating docs to use new `Fetch` method signature

### DIFF
--- a/docs/devguide/create-metricset.asciidoc
+++ b/docs/devguide/create-metricset.asciidoc
@@ -144,30 +144,29 @@ time new data is retrieved. If more than one host is defined, `Fetch` is
 called once for each host. The frequency of calling `Fetch` is based on the `period`
 defined in the configuration file.
 
-`Fetch` must return a `common.MapStr` object, which is then sent to Elasticsearch.
-If an error happens, the error must be returned and then is sent instead
-to Elasticsearch. This means that Metricbeat always sends an event, even on failure.
-You must make sure that the error message helps to identify the actual error.
+`Fetch` must publish the event using the `mb.ReporterV2.Event` method. If an error
+happens, the error must be published using the `mb.ReporterV2.Error` method. This means
+that Metricbeat always sends an event, even on failure. You must make sure that the
+error message helps to identify the actual error.
 
 The following example shows a metricset `Fetch` method with a counter that is
 incremented for each `Fetch` call:
 
 [source,go]
 ----
-func (m *MetricSet) Fetch() (common.MapStr, error) {
+func (m *MetricSet) Fetch(report mb.ReporterV2) {
 
-	event := common.MapStr{
-		"counter": m.counter,
-	}
+	report.Event(mb.Event{
+		MetricSetFields: common.MapStr{
+			"counter": m.counter,
+		}
+	})
 	m.counter++
-
-	return event, nil
 }
 ----
 
-`Fetch` must return a `common.MapStr`, which will be translated to the JSON content.
-The JSON output will be identical to the naming and structure you use in
-`common.MapStr`. For more details about `MapStr` and its functions, see the
+The JSON output derived from the reported event will be identical to the naming and
+structure you use in `common.MapStr`. For more details about `MapStr` and its functions, see the
 https://godoc.org/github.com/elastic/beats/libbeat/common#MapStr[MapStr API docs].
 
 


### PR DESCRIPTION
Previously, the `Fetch` method for `MetricSet`s would accept no arguments and return `(common.MapStr, error)`, which would be used to publish the event or error.

Now the preferred way is to use the `Fetch` method which accepts `mb.ReporterV2` as its argument and returns nothing. Inside the method, the `mb.ReporterV2` object is used to publish the event or error.

This PR updates the developer guide to consistently use the preferred way in all places.