### PR TITLE
Enforce normalization on Namespace and Name and check for nil factory

### DIFF
--- a/libbeat/feature/registry.go
+++ b/libbeat/feature/registry.go
@@ -54,6 +54,10 @@ func (r *registry) Register(feature Featurable) error {
 	ns := normalize(feature.Namespace())
 	name := normalize(feature.Name())
 
+	if feature.Factory() == nil {
+		return fmt.Errorf("feature '%s' cannot be registered with a nil factory", name)
+	}
+
 	// Lazy create namespaces
 	_, found := r.namespaces[ns]
 	if !found {

--- a/libbeat/feature/registry.go
+++ b/libbeat/feature/registry.go
@@ -20,6 +20,7 @@ package feature
 import (
 	"fmt"
 	"reflect"
+	"strings"
 	"sync"
 
 	"github.com/elastic/beats/libbeat/logp"
@@ -50,8 +51,8 @@ func (r *registry) Register(feature Featurable) error {
 	r.Lock()
 	defer r.Unlock()
 
-	ns := feature.Namespace()
-	name := feature.Name()
+	ns := normalize(feature.Namespace())
+	name := normalize(feature.Name())
 
 	// Lazy create namespaces
 	_, found := r.namespaces[ns]
@@ -95,18 +96,19 @@ func (r *registry) Register(feature Featurable) error {
 func (r *registry) Unregister(namespace, name string) error {
 	r.Lock()
 	defer r.Unlock()
+	ns := normalize(namespace)
 
-	v, found := r.namespaces[namespace]
+	v, found := r.namespaces[ns]
 	if !found {
-		return fmt.Errorf("unknown namespace named '%s'", namespace)
+		return fmt.Errorf("unknown namespace named '%s'", ns)
 	}
 
 	_, found = v[name]
 	if !found {
-		return fmt.Errorf("unknown feature '%s' in namespace '%s'", name, namespace)
+		return fmt.Errorf("unknown feature '%s' in namespace '%s'", name, ns)
 	}
 
-	delete(r.namespaces[namespace], name)
+	delete(r.namespaces[ns], name)
 	return nil
 }
 
@@ -115,14 +117,17 @@ func (r *registry) Lookup(namespace, name string) (Featurable, error) {
 	r.RLock()
 	defer r.RUnlock()
 
-	v, found := r.namespaces[namespace]
+	ns := normalize(namespace)
+	n := normalize(name)
+
+	v, found := r.namespaces[ns]
 	if !found {
-		return nil, fmt.Errorf("unknown namespace named '%s'", namespace)
+		return nil, fmt.Errorf("unknown namespace named '%s'", ns)
 	}
 
-	m, found := v[name]
+	m, found := v[n]
 	if !found {
-		return nil, fmt.Errorf("unknown feature '%s' in namespace '%s'", name, namespace)
+		return nil, fmt.Errorf("unknown feature '%s' in namespace '%s'", n, ns)
 	}
 
 	return m, nil
@@ -133,9 +138,11 @@ func (r *registry) LookupAll(namespace string) ([]Featurable, error) {
 	r.RLock()
 	defer r.RUnlock()
 
-	v, found := r.namespaces[namespace]
+	ns := normalize(namespace)
+
+	v, found := r.namespaces[ns]
 	if !found {
-		return nil, fmt.Errorf("unknown namespace named '%s'", namespace)
+		return nil, fmt.Errorf("unknown namespace named '%s'", ns)
 	}
 
 	list := make([]Featurable, len(v))
@@ -171,4 +178,8 @@ func featuresEqual(f1, f2 Featurable) bool {
 	}
 
 	return false
+}
+
+func normalize(s string) string {
+	return strings.ToLower(s)
 }

--- a/libbeat/feature/registry_test.go
+++ b/libbeat/feature/registry_test.go
@@ -26,6 +26,14 @@ import (
 func TestRegister(t *testing.T) {
 	f := func() {}
 
+	t.Run("when the factory is nil", func(t *testing.T) {
+		r := newRegistry()
+		err := r.Register(New("outputs", "null", nil, Stable))
+		if !assert.Error(t, err) {
+			return
+		}
+	})
+
 	t.Run("namespace and feature doesn't exist", func(t *testing.T) {
 		r := newRegistry()
 		err := r.Register(New("outputs", "null", f, Stable))

--- a/libbeat/feature/registry_test.go
+++ b/libbeat/feature/registry_test.go
@@ -74,6 +74,7 @@ func TestFeature(t *testing.T) {
 
 	r := newRegistry()
 	r.Register(New("processor", "foo", f, Stable))
+	r.Register(New("HOLA", "fOO", f, Stable))
 
 	t.Run("when namespace and feature are present", func(t *testing.T) {
 		feature, err := r.Lookup("processor", "foo")
@@ -89,14 +90,22 @@ func TestFeature(t *testing.T) {
 			return
 		}
 	})
+
+	t.Run("when namespace and key are normalized", func(t *testing.T) {
+		_, err := r.Lookup("HOLA", "foo")
+		if !assert.NoError(t, err) {
+			return
+		}
+	})
 }
 
-func TestFeatures(t *testing.T) {
+func TestLookup(t *testing.T) {
 	f := func() {}
 
 	r := newRegistry()
 	r.Register(New("processor", "foo", f, Stable))
 	r.Register(New("processor", "foo2", f, Stable))
+	r.Register(New("HELLO", "fOO", f, Stable))
 
 	t.Run("when namespace and feature are present", func(t *testing.T) {
 		features, err := r.LookupAll("processor")
@@ -111,6 +120,15 @@ func TestFeatures(t *testing.T) {
 		if !assert.Error(t, err) {
 			return
 		}
+	})
+
+	t.Run("when namespace and name are normalized", func(t *testing.T) {
+		features, err := r.LookupAll("hello")
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		assert.Equal(t, 1, len(features))
 	})
 }
 


### PR DESCRIPTION
Most of the registries implementation in libbeat were not doing
normalization on the string, except for the 'Autodiscover' feature.
Since all code will now use the same registry, I've opted to lowercase
the namespace and the feature name before registering or doing any lookup this will
make sure we don't introduce any breaking changes.