### PR TITLE
Add a NOTE to the to_syslog option to make it clear that the option is

### DIFF
--- a/libbeat/docs/loggingconfig.asciidoc
+++ b/libbeat/docs/loggingconfig.asciidoc
@@ -44,6 +44,8 @@ You can specify the following options in the `logging` section of the
 
 When true, writes all logging output to the syslog.
 
+NOTE: This option is not supported on Windows.
+
 [float]
 ==== `logging.to_eventlog`
 


### PR DESCRIPTION
not supported on Windows.