### PR TITLE
Refactor: Move the plugin.Bundle to use feature.Bundle

### DIFF
--- a/libbeat/feature/bundle.go
+++ b/libbeat/feature/bundle.go
@@ -18,7 +18,7 @@
 package feature
 
 // Bundleable merges featurable and bundle interface together.
-type bundleable interface {
+type Bundleable interface {
 	Features() []Featurable
 }
 
@@ -53,7 +53,7 @@ func (b *Bundle) Features() []Featurable {
 }
 
 // MustBundle takes existing bundle or features and create a new Bundle with all the merged Features.
-func MustBundle(bundle ...bundleable) *Bundle {
+func MustBundle(bundle ...Bundleable) *Bundle {
 	var merged []Featurable
 	for _, feature := range bundle {
 		merged = append(merged, feature.Features()...)

--- a/libbeat/feature/feature.go
+++ b/libbeat/feature/feature.go
@@ -27,7 +27,7 @@ var Registry = newRegistry()
 
 // Featurable implements the description of a feature.
 type Featurable interface {
-	bundleable
+	Bundleable
 
 	// Namespace is the kind of plugin or functionality we want to expose as a feature.
 	// Examples: Autodiscover's provider, processors, outputs.

--- a/libbeat/plugin/load.go
+++ b/libbeat/plugin/load.go
@@ -21,8 +21,10 @@
 package plugin
 
 import (
-	"errors"
+	"fmt"
 	goplugin "plugin"
+
+	"github.com/elastic/beats/libbeat/feature"
 )
 
 func loadPlugins(path string) error {
@@ -36,24 +38,10 @@ func loadPlugins(path string) error {
 		return err
 	}
 
-	ptr, ok := sym.(*map[string][]interface{})
+	bundle, ok := sym.(*feature.Bundle)
 	if !ok {
-		return errors.New("invalid bundle type")
+		return fmt.Errorf("invalid bundle type, received '%T'", bundle)
 	}
 
-	bundle := *ptr
-	for name, plugins := range bundle {
-		loader := registry[name]
-		if loader == nil {
-			continue
-		}
-
-		for _, plugin := range plugins {
-			if err := loader(plugin); err != nil {
-				return err
-			}
-		}
-	}
-
-	return nil
+	return feature.RegisterBundle(bundle)
 }

--- a/libbeat/plugin/load.go
+++ b/libbeat/plugin/load.go
@@ -38,10 +38,10 @@ func loadPlugins(path string) error {
 		return err
 	}
 
-	bundle, ok := sym.(*feature.Bundle)
+	bundle, ok := sym.(**feature.Bundle)
 	if !ok {
-		return fmt.Errorf("invalid bundle type, received '%T'", bundle)
+		return fmt.Errorf("invalid bundle type, received '%T'", sym)
 	}
 
-	return feature.RegisterBundle(bundle)
+	return feature.RegisterBundle(*bundle)
 }

--- a/libbeat/plugin/plugin.go
+++ b/libbeat/plugin/plugin.go
@@ -19,8 +19,8 @@ package plugin
 
 import "github.com/elastic/beats/libbeat/feature"
 
-// Bundle takes a an existing bundle or a set of feature and will merge the into a new Bundle that
-// can be registered.
+// Bundle takes a an existing bundle or a set of features and will merge them the into a new Bundle
+// that can be registered.
 func Bundle(bundle ...feature.Bundleable) *feature.Bundle {
 	return feature.MustBundle(bundle...)
 }

--- a/libbeat/plugin/plugin.go
+++ b/libbeat/plugin/plugin.go
@@ -17,46 +17,12 @@
 
 package plugin
 
-import "fmt"
+import "github.com/elastic/beats/libbeat/feature"
 
-type PluginLoader func(p interface{}) error
-
-var registry = map[string]PluginLoader{}
-
-func Bundle(
-	bundles ...map[string][]interface{},
-) map[string][]interface{} {
-	ret := map[string][]interface{}{}
-
-	for _, bundle := range bundles {
-		for name, plugins := range bundle {
-			ret[name] = append(ret[name], plugins...)
-		}
-	}
-
-	return ret
-}
-
-func MakePlugin(key string, ifc interface{}) map[string][]interface{} {
-	return map[string][]interface{}{
-		key: {ifc},
-	}
-}
-
-func MustRegisterLoader(name string, l PluginLoader) {
-	err := RegisterLoader(name, l)
-	if err != nil {
-		panic(err)
-	}
-}
-
-func RegisterLoader(name string, l PluginLoader) error {
-	if l := registry[name]; l != nil {
-		return fmt.Errorf("plugin loader '%v' already registered", name)
-	}
-
-	registry[name] = l
-	return nil
+// Bundle takes a an existing bundle or a set of feature and will merge the into a new Bundle that
+// can be registered.
+func Bundle(bundle ...feature.Bundleable) *feature.Bundle {
+	return feature.MustBundle(bundle...)
 }
 
 func LoadPlugins(path string) error {


### PR DESCRIPTION
Since a go plugin only works with a specific of golang and beats we
can change the return value without changing the signature. The plugin function for each feature will now return a Feature instead of returning a hash. Meaning the following code should work unchanged.
```golang
var Bundle = plugin.Bundle(
	// bundle of processor plugins
	plugin.Bundle(
		processors.Plugin("lookup.exec", exec.New),
		processors.Plugin("my_drop_fields", my_drop_fields.New),
	),

	// bundle of output plugins
	plugin.Bundle(
		outputs.Plugin("myconsole", myconsole.New),
	),
)
```

**Notes:** Since this is a big refactoring we target a feature branch and this PR will fails the tests because the plugin is not returning a _feature_. It should be merged last. Also _goplugins_ supports is experimental and we could break the API.