### PR TITLE
Refactor: Move Autodiscovery to the new global registry

### DIFF
--- a/libbeat/autodiscover/appender.go
+++ b/libbeat/autodiscover/appender.go
@@ -18,73 +18,19 @@
 package autodiscover
 
 import (
-	"fmt"
-	"strings"
-
+	"github.com/elastic/beats/libbeat/autodiscover/appenders"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/bus"
-	"github.com/elastic/beats/libbeat/logp"
 )
 
 // Appender provides an interface by which extra configuration can be added into configs
-type Appender interface {
-	// Append takes a processed event and add extra configuration
-	Append(event bus.Event)
-}
+type Appender = appenders.Appender
+
+// AppenderBuilder is a func used to generate a Appender object
+type AppenderBuilder = appenders.Factory
 
 // Appenders is a list of Appender objects
 type Appenders []Appender
-
-// AppenderBuilder is a func used to generate a Appender object
-type AppenderBuilder func(*common.Config) (Appender, error)
-
-// AddBuilder registers a new AppenderBuilder
-func (r *registry) AddAppender(name string, appender AppenderBuilder) error {
-	r.lock.Lock()
-	defer r.lock.Unlock()
-
-	if name == "" {
-		return fmt.Errorf("appender name is required")
-	}
-
-	_, exists := r.appenders[name]
-	if exists {
-		return fmt.Errorf("appender '%s' is already registered", name)
-	}
-
-	if appender == nil {
-		return fmt.Errorf("appender '%s' cannot be registered with a nil factory", name)
-	}
-
-	r.appenders[name] = appender
-	logp.Debug(debugK, "Appender registered: %s", name)
-	return nil
-}
-
-// GetAppender returns the appender with the giving name, nil if it doesn't exist
-func (r *registry) GetAppender(name string) AppenderBuilder {
-	r.lock.RLock()
-	defer r.lock.RUnlock()
-
-	name = strings.ToLower(name)
-	return r.appenders[name]
-}
-
-// BuildAppender reads provider configuration and instantiate one
-func (r *registry) BuildAppender(c *common.Config) (Appender, error) {
-	var config AppenderConfig
-	err := c.Unpack(&config)
-	if err != nil {
-		return nil, err
-	}
-
-	appender := r.GetAppender(config.Type)
-	if appender == nil {
-		return nil, fmt.Errorf("unknown autodiscover appender %s", config.Type)
-	}
-
-	return appender(c)
-}
 
 // Append uses all initialized appenders to modify generated bus.Events.
 func (a Appenders) Append(event bus.Event) {
@@ -95,14 +41,14 @@ func (a Appenders) Append(event bus.Event) {
 
 // NewAppenders instances and returns the given list of appenders.
 func NewAppenders(aConfigs []*common.Config) (Appenders, error) {
-	var appenders Appenders
+	var list Appenders
 	for _, acfg := range aConfigs {
-		appender, err := Registry.BuildAppender(acfg)
+		appender, err := appenders.Build(acfg)
 		if err != nil {
 			return nil, err
 		}
-		appenders = append(appenders, appender)
+		list = append(list, appender)
 	}
 
-	return appenders, nil
+	return list, nil
 }

--- a/libbeat/autodiscover/appender_test.go
+++ b/libbeat/autodiscover/appender_test.go
@@ -22,8 +22,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/elastic/beats/libbeat/autodiscover/appenders"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/bus"
+	"github.com/elastic/beats/libbeat/feature"
 )
 
 type fakeAppender struct{}
@@ -37,13 +39,8 @@ func newFakeAppender(_ *common.Config) (Appender, error) {
 }
 
 func TestAppenderRegistry(t *testing.T) {
-	// Add a new builder
-	reg := NewRegistry()
-	reg.AddAppender("fake", newFakeAppender)
-
-	// Check if that appender is available in registry
-	b := reg.GetAppender("fake")
-	assert.NotNil(t, b)
+	feature.MustRegister(appenders.Feature("fake", newFakeAppender, feature.Stable))
+	defer feature.Registry.Unregister(appenders.Namespace, "fake")
 
 	// Generate a config with type fake
 	config := AppenderConfig{
@@ -54,12 +51,11 @@ func TestAppenderRegistry(t *testing.T) {
 
 	// Make sure that config building doesn't fail
 	assert.Nil(t, err)
-	appender, err := reg.BuildAppender(cfg)
+	appender, err := appenders.Build(cfg)
 	assert.Nil(t, err)
 	assert.NotNil(t, appender)
 
 	// Attempt to build using an array of configs
-	Registry.AddAppender("fake", newFakeAppender)
 	cfgs := []*common.Config{cfg}
 	appenders, err := NewAppenders(cfgs)
 	assert.Nil(t, err)

--- a/libbeat/autodiscover/appenders/config/config.go
+++ b/libbeat/autodiscover/appenders/config/config.go
@@ -21,17 +21,18 @@ import (
 	"fmt"
 
 	"github.com/elastic/beats/libbeat/autodiscover"
+	"github.com/elastic/beats/libbeat/autodiscover/appenders"
 	"github.com/elastic/beats/libbeat/autodiscover/template"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/bus"
 	"github.com/elastic/beats/libbeat/common/cfgwarn"
+	"github.com/elastic/beats/libbeat/feature"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/processors"
 )
 
-func init() {
-	autodiscover.Registry.AddAppender("config", NewConfigAppender)
-}
+// Feature exposes a config appender.
+var Feature = appenders.Feature("config", NewConfigAppender, feature.Beta)
 
 type config struct {
 	ConditionConfig *processors.ConditionConfig `config:"condition"`

--- a/libbeat/autodiscover/appenders/feature.go
+++ b/libbeat/autodiscover/appenders/feature.go
@@ -58,7 +58,7 @@ func FindFactory(name string) (Factory, error) {
 
 	factory, ok := f.Factory().(Factory)
 	if !ok {
-		return nil, fmt.Errorf("incompatible type for appender, received: '%T'", factory)
+		return nil, fmt.Errorf("incompatible type for appender, received: '%T'", f.Factory())
 	}
 
 	return factory, nil

--- a/libbeat/autodiscover/appenders/feature.go
+++ b/libbeat/autodiscover/appenders/feature.go
@@ -1,0 +1,81 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package appenders
+
+import (
+	"fmt"
+
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/bus"
+	"github.com/elastic/beats/libbeat/feature"
+	"github.com/elastic/beats/libbeat/processors"
+)
+
+// Namespace is the registry namespace for autodiscover appenders.
+var Namespace = "libbeat.autodiscover.appender"
+
+// Appender provides an interface by which extra configuration can be added into configs
+type Appender interface {
+	// Append takes a processed event and add extra configuration
+	Append(event bus.Event)
+}
+
+// Config settings
+type Config struct {
+	Type            string                      `config:"type"`
+	ConditionConfig *processors.ConditionConfig `config:"condition"`
+}
+
+// Feature defines a new appender feature.
+func Feature(name string, factory Factory, stability feature.Stability) *feature.Feature {
+	return feature.New(Namespace, name, factory, stability)
+}
+
+// Factory is a func used to generate a Appender object
+type Factory func(*common.Config) (Appender, error)
+
+// FindFactory returns the appender with the giving name or return an error.
+func FindFactory(name string) (Factory, error) {
+	f, err := feature.Registry.Lookup(Namespace, name)
+	if err != nil {
+		return nil, err
+	}
+
+	factory, ok := f.Factory().(Factory)
+	if !ok {
+		return nil, fmt.Errorf("incompatible type for appender, received: '%T'", factory)
+	}
+
+	return factory, nil
+}
+
+// Build reads provider configuration and instantiate one
+func Build(c *common.Config) (Appender, error) {
+	var config Config
+	err := c.Unpack(&config)
+	if err != nil {
+		return nil, err
+	}
+
+	appender, err := FindFactory(config.Type)
+	if err != nil {
+		return nil, err
+	}
+
+	return appender(c)
+}

--- a/libbeat/autodiscover/appenders/plugin.go
+++ b/libbeat/autodiscover/appenders/plugin.go
@@ -21,5 +21,5 @@ import "github.com/elastic/beats/libbeat/feature"
 
 // Plugin accepts a AppenderBuilder to be registered as a plugin.
 func Plugin(name string, appender Factory) *feature.Feature {
-	return Feature(name, appender, feature.Beta)
+	return Feature(name, appender, feature.Undefined)
 }

--- a/libbeat/autodiscover/appenders/plugin.go
+++ b/libbeat/autodiscover/appenders/plugin.go
@@ -17,32 +17,9 @@
 
 package appenders
 
-import (
-	"errors"
+import "github.com/elastic/beats/libbeat/feature"
 
-	"github.com/elastic/beats/libbeat/autodiscover"
-	p "github.com/elastic/beats/libbeat/plugin"
-)
-
-type appenderPlugin struct {
-	name     string
-	appender autodiscover.AppenderBuilder
-}
-
-var pluginKey = "libbeat.autodiscover.appender"
-
-// Plugin accepts a AppenderBuilder to be registered as a plugin
-func Plugin(name string, appender autodiscover.AppenderBuilder) map[string][]interface{} {
-	return p.MakePlugin(pluginKey, appenderPlugin{name, appender})
-}
-
-func init() {
-	p.MustRegisterLoader(pluginKey, func(ifc interface{}) error {
-		app, ok := ifc.(appenderPlugin)
-		if !ok {
-			return errors.New("plugin does not match appender plugin type")
-		}
-
-		return autodiscover.Registry.AddAppender(app.name, app.appender)
-	})
+// Plugin accepts a AppenderBuilder to be registered as a plugin.
+func Plugin(name string, appender Factory) *feature.Feature {
+	return Feature(name, appender, feature.Beta)
 }

--- a/libbeat/autodiscover/autodiscover.go
+++ b/libbeat/autodiscover/autodiscover.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/libbeat/autodiscover/meta"
+	"github.com/elastic/beats/libbeat/autodiscover/providers"
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/cfgfile"
 	"github.com/elastic/beats/libbeat/common"
@@ -75,14 +76,14 @@ func NewAutodiscover(name string, pipeline beat.Pipeline, adapter Adapter, confi
 	bus := bus.New(name)
 
 	// Init providers
-	var providers []Provider
+	var list []Provider
 	for _, providerCfg := range config.Providers {
-		provider, err := Registry.BuildProvider(bus, providerCfg)
+		provider, err := providers.Build(bus, providerCfg)
 		if err != nil {
 			return nil, errors.Wrap(err, "error in autodiscover provider settings")
 		}
 		logp.Debug(debugK, "Configured autodiscover provider: %s", provider)
-		providers = append(providers, provider)
+		list = append(list, provider)
 	}
 
 	return &Autodiscover{
@@ -91,7 +92,7 @@ func NewAutodiscover(name string, pipeline beat.Pipeline, adapter Adapter, confi
 		adapter:         adapter,
 		configs:         map[uint64]*cfgfile.ConfigWithMeta{},
 		runners:         cfgfile.NewRunnerList("autodiscover", adapter, pipeline),
-		providers:       providers,
+		providers:       list,
 		meta:            meta.NewMap(),
 	}, nil
 }

--- a/libbeat/autodiscover/autodiscover_test.go
+++ b/libbeat/autodiscover/autodiscover_test.go
@@ -22,10 +22,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/elastic/beats/libbeat/autodiscover/providers"
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/cfgfile"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/bus"
+	"github.com/elastic/beats/libbeat/feature"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -125,13 +127,15 @@ func TestNilAutodiscover(t *testing.T) {
 func TestAutodiscover(t *testing.T) {
 	// Register mock autodiscover provider
 	busChan := make(chan bus.Bus, 1)
-	Registry = NewRegistry()
-	Registry.AddProvider("mock", func(b bus.Bus, c *common.Config) (Provider, error) {
-		// intercept bus to mock events
-		busChan <- b
+	feature.MustRegister(
+		providers.Feature("mock", func(b bus.Bus, c *common.Config) (Provider, error) {
+			// intercept bus to mock events
+			busChan <- b
 
-		return &mockProvider{}, nil
-	})
+			return &mockProvider{}, nil
+		}, feature.Stable),
+	)
+	defer feature.Registry.Unregister(providers.Namespace, "mock")
 
 	// Create a mock adapter
 	runnerConfig, _ := common.NewConfigFrom(map[string]string{
@@ -231,14 +235,15 @@ func TestAutodiscover(t *testing.T) {
 func TestAutodiscoverHash(t *testing.T) {
 	// Register mock autodiscover provider
 	busChan := make(chan bus.Bus, 1)
+	feature.MustRegister(
+		providers.Feature("mock", func(b bus.Bus, c *common.Config) (Provider, error) {
+			// intercept bus to mock events
+			busChan <- b
 
-	Registry = NewRegistry()
-	Registry.AddProvider("mock", func(b bus.Bus, c *common.Config) (Provider, error) {
-		// intercept bus to mock events
-		busChan <- b
-
-		return &mockProvider{}, nil
-	})
+			return &mockProvider{}, nil
+		}, feature.Stable),
+	)
+	defer feature.Registry.Unregister(providers.Namespace, "mock")
 
 	// Create a mock adapter
 	runnerConfig1, _ := common.NewConfigFrom(map[string]string{

--- a/libbeat/autodiscover/builder.go
+++ b/libbeat/autodiscover/builder.go
@@ -19,73 +19,20 @@ package autodiscover
 
 import (
 	"errors"
-	"fmt"
-	"strings"
 
+	"github.com/elastic/beats/libbeat/autodiscover/builder"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/bus"
-	"github.com/elastic/beats/libbeat/logp"
 )
 
 // Builder provides an interface by which configs can be built from provider metadata
-type Builder interface {
-	// CreateConfig creates a config from hints passed from providers
-	CreateConfig(event bus.Event) []*common.Config
-}
+type Builder = builder.Builder
 
 // Builders is a list of Builder objects
 type Builders []Builder
 
 // BuilderConstructor is a func used to generate a Builder object
-type BuilderConstructor func(*common.Config) (Builder, error)
-
-// AddBuilder registers a new BuilderConstructor
-func (r *registry) AddBuilder(name string, builder BuilderConstructor) error {
-	r.lock.Lock()
-	defer r.lock.Unlock()
-
-	if name == "" {
-		return fmt.Errorf("builder name is required")
-	}
-
-	_, exists := r.builders[name]
-	if exists {
-		return fmt.Errorf("builder '%s' is already registered", name)
-	}
-
-	if builder == nil {
-		return fmt.Errorf("builder '%s' cannot be registered with a nil factory", name)
-	}
-
-	r.builders[name] = builder
-	logp.Debug(debugK, "Builder registered: %s", name)
-	return nil
-}
-
-// GetBuilder returns the provider with the giving name, nil if it doesn't exist
-func (r *registry) GetBuilder(name string) BuilderConstructor {
-	r.lock.RLock()
-	defer r.lock.RUnlock()
-
-	name = strings.ToLower(name)
-	return r.builders[name]
-}
-
-// BuildBuilder reads provider configuration and instatiate one
-func (r *registry) BuildBuilder(c *common.Config) (Builder, error) {
-	var config BuilderConfig
-	err := c.Unpack(&config)
-	if err != nil {
-		return nil, err
-	}
-
-	builder := r.GetBuilder(config.Type)
-	if builder == nil {
-		return nil, fmt.Errorf("unknown autodiscover builder %s", config.Type)
-	}
-
-	return builder(c)
-}
+type BuilderConstructor = builder.Factory
 
 // GetConfig creates configs for all builders initalized.
 func (b Builders) GetConfig(event bus.Event) []*common.Config {
@@ -118,11 +65,11 @@ func NewBuilders(bConfigs []*common.Config, hintsEnabled bool) (Builders, error)
 	}
 
 	for _, bcfg := range bConfigs {
-		builder, err := Registry.BuildBuilder(bcfg)
+		b, err := builder.Build(bcfg)
 		if err != nil {
 			return nil, err
 		}
-		builders = append(builders, builder)
+		builders = append(builders, b)
 	}
 
 	return builders, nil

--- a/libbeat/autodiscover/builder/feature.go
+++ b/libbeat/autodiscover/builder/feature.go
@@ -1,0 +1,79 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package builder
+
+import (
+	"fmt"
+
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/bus"
+	"github.com/elastic/beats/libbeat/feature"
+)
+
+// Namespace is the registry namespace for autodiscover builders.
+var Namespace = "libbeat.autodiscover.builder"
+
+// Builder provides an interface by which configs can be built from provider metadata
+type Builder interface {
+	// CreateConfig creates a config from hints passed from providers
+	CreateConfig(event bus.Event) []*common.Config
+}
+
+// Config settings
+type Config struct {
+	Type string `config:"type"`
+}
+
+// Feature defines a new builder feature.
+func Feature(name string, factory Factory, stability feature.Stability) *feature.Feature {
+	return feature.New(Namespace, name, factory, stability)
+}
+
+// Factory is a func used to generate a Builder object
+type Factory func(*common.Config) (Builder, error)
+
+// FindFactory returns the builder with the giving name or return an error.
+func FindFactory(name string) (Factory, error) {
+	f, err := feature.Registry.Lookup(Namespace, name)
+	if err != nil {
+		return nil, err
+	}
+
+	factory, ok := f.Factory().(Factory)
+	if !ok {
+		return nil, fmt.Errorf("incompatible type for builder, received: '%T'", factory)
+	}
+
+	return factory, nil
+}
+
+// Build reads provider configuration and instatiate one.
+func Build(c *common.Config) (Builder, error) {
+	var config Config
+	err := c.Unpack(&config)
+	if err != nil {
+		return nil, err
+	}
+
+	builder, err := FindFactory(config.Type)
+	if err != nil {
+		return nil, err
+	}
+
+	return builder(c)
+}

--- a/libbeat/autodiscover/builder/feature.go
+++ b/libbeat/autodiscover/builder/feature.go
@@ -56,7 +56,7 @@ func FindFactory(name string) (Factory, error) {
 
 	factory, ok := f.Factory().(Factory)
 	if !ok {
-		return nil, fmt.Errorf("incompatible type for builder, received: '%T'", factory)
+		return nil, fmt.Errorf("incompatible type for builder, received: '%T'", f.Factory())
 	}
 
 	return factory, nil

--- a/libbeat/autodiscover/builder/plugin.go
+++ b/libbeat/autodiscover/builder/plugin.go
@@ -21,5 +21,5 @@ import "github.com/elastic/beats/libbeat/feature"
 
 // Plugin accepts a builder to be registered as a plugin
 func Plugin(name string, factory Factory) *feature.Feature {
-	return Feature(name, factory, feature.Beta)
+	return Feature(name, factory, feature.Undefined)
 }

--- a/libbeat/autodiscover/builder_test.go
+++ b/libbeat/autodiscover/builder_test.go
@@ -22,8 +22,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/elastic/beats/libbeat/autodiscover/builder"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/bus"
+	"github.com/elastic/beats/libbeat/feature"
 )
 
 type fakeBuilder struct{}
@@ -37,13 +39,8 @@ func newFakeBuilder(_ *common.Config) (Builder, error) {
 }
 
 func TestBuilderRegistry(t *testing.T) {
-	// Add a new builder
-	reg := NewRegistry()
-	reg.AddBuilder("fake", newFakeBuilder)
-
-	// Check if that builder is available in registry
-	b := reg.GetBuilder("fake")
-	assert.NotNil(t, b)
+	feature.MustRegister(builder.Feature("fake", newFakeBuilder, feature.Beta))
+	defer feature.Registry.Unregister(builder.Namespace, "fake")
 
 	// Generate a config with type fake
 	config := BuilderConfig{
@@ -55,7 +52,7 @@ func TestBuilderRegistry(t *testing.T) {
 	// Make sure that config building doesn't fail
 	assert.Nil(t, err)
 
-	builder, err := reg.BuildBuilder(cfg)
+	builder, err := builder.Build(cfg)
 	assert.Nil(t, err)
 	assert.NotNil(t, builder)
 

--- a/libbeat/autodiscover/config.go
+++ b/libbeat/autodiscover/config.go
@@ -18,8 +18,10 @@
 package autodiscover
 
 import (
+	"github.com/elastic/beats/libbeat/autodiscover/appenders"
+	"github.com/elastic/beats/libbeat/autodiscover/builder"
+	"github.com/elastic/beats/libbeat/autodiscover/providers"
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/processors"
 )
 
 // Config settings for Autodiscover
@@ -28,17 +30,10 @@ type Config struct {
 }
 
 // ProviderConfig settings
-type ProviderConfig struct {
-	Type string `config:"type"`
-}
+type ProviderConfig = providers.Config
 
 // BuilderConfig settings
-type BuilderConfig struct {
-	Type string `config:"type"`
-}
+type BuilderConfig = builder.Config
 
 // AppenderConfig settings
-type AppenderConfig struct {
-	Type            string                      `config:"type"`
-	ConditionConfig *processors.ConditionConfig `config:"condition"`
-}
+type AppenderConfig = appenders.Config

--- a/libbeat/autodiscover/provider.go
+++ b/libbeat/autodiscover/provider.go
@@ -18,67 +18,11 @@
 package autodiscover
 
 import (
-	"fmt"
-	"strings"
-
-	"github.com/elastic/beats/libbeat/cfgfile"
-	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/common/bus"
-	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/autodiscover/providers"
 )
 
 // Provider for autodiscover
-type Provider interface {
-	cfgfile.Runner
-}
+type Provider = providers.Provider
 
 // ProviderBuilder creates a new provider based on the given config and returns it
-type ProviderBuilder func(bus.Bus, *common.Config) (Provider, error)
-
-// AddProvider registers a new ProviderBuilder
-func (r *registry) AddProvider(name string, provider ProviderBuilder) error {
-	r.lock.Lock()
-	defer r.lock.Unlock()
-
-	if name == "" {
-		return fmt.Errorf("provider name is required")
-	}
-
-	_, exists := r.providers[name]
-	if exists {
-		return fmt.Errorf("provider '%s' is already registered", name)
-	}
-
-	if provider == nil {
-		return fmt.Errorf("provider '%s' cannot be registered with a nil factory", name)
-	}
-
-	r.providers[name] = provider
-	logp.Debug(debugK, "Provider registered: %s", name)
-	return nil
-}
-
-// GetProvider returns the provider with the giving name, nil if it doesn't exist
-func (r *registry) GetProvider(name string) ProviderBuilder {
-	r.lock.RLock()
-	defer r.lock.RUnlock()
-
-	name = strings.ToLower(name)
-	return r.providers[name]
-}
-
-// BuildProvider reads provider configuration and instatiate one
-func (r *registry) BuildProvider(bus bus.Bus, c *common.Config) (Provider, error) {
-	var config ProviderConfig
-	err := c.Unpack(&config)
-	if err != nil {
-		return nil, err
-	}
-
-	builder := r.GetProvider(config.Type)
-	if builder == nil {
-		return nil, fmt.Errorf("Unknown autodiscover provider %s", config.Type)
-	}
-
-	return builder(bus, c)
-}
+type ProviderBuilder = providers.Factory

--- a/libbeat/autodiscover/providers/docker/docker.go
+++ b/libbeat/autodiscover/providers/docker/docker.go
@@ -20,18 +20,19 @@ package docker
 import (
 	"github.com/elastic/beats/libbeat/autodiscover"
 	"github.com/elastic/beats/libbeat/autodiscover/builder"
+	"github.com/elastic/beats/libbeat/autodiscover/providers"
 	"github.com/elastic/beats/libbeat/autodiscover/template"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/bus"
 	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/libbeat/common/docker"
 	"github.com/elastic/beats/libbeat/common/safemapstr"
+	"github.com/elastic/beats/libbeat/feature"
 	"github.com/elastic/beats/libbeat/logp"
 )
 
-func init() {
-	autodiscover.Registry.AddProvider("docker", AutodiscoverBuilder)
-}
+// Feature exposes the docker autodiscovery provider.
+var Feature = providers.Feature("docker", AutodiscoverBuilder, feature.Beta)
 
 // Provider implements autodiscover provider for docker containers
 type Provider struct {

--- a/libbeat/autodiscover/providers/feature.go
+++ b/libbeat/autodiscover/providers/feature.go
@@ -56,7 +56,7 @@ func FindFactory(name string) (Factory, error) {
 
 	factory, ok := f.Factory().(Factory)
 	if !ok {
-		return nil, fmt.Errorf("incompatible type for provider, received: '%T'", factory)
+		return nil, fmt.Errorf("incompatible type for provider, received: '%T'", f.Factory())
 	}
 
 	return factory, nil

--- a/libbeat/autodiscover/providers/feature.go
+++ b/libbeat/autodiscover/providers/feature.go
@@ -26,6 +26,7 @@ import (
 	"github.com/elastic/beats/libbeat/feature"
 )
 
+// Provider for autodiscover
 type Provider interface {
 	cfgfile.Runner
 }
@@ -46,6 +47,7 @@ func Feature(name string, factory Factory, stability feature.Stability) *feature
 	return feature.New(Namespace, name, factory, stability)
 }
 
+// FindFactory find, assert and return a provider factory.
 func FindFactory(name string) (Factory, error) {
 	f, err := feature.Registry.Lookup(Namespace, name)
 	if err != nil {
@@ -60,6 +62,7 @@ func FindFactory(name string) (Factory, error) {
 	return factory, nil
 }
 
+// Build takes the configuration and will create the appropriate provider.
 func Build(bus bus.Bus, c *common.Config) (Provider, error) {
 	var config Config
 	err := c.Unpack(&config)

--- a/libbeat/autodiscover/providers/feature.go
+++ b/libbeat/autodiscover/providers/feature.go
@@ -1,0 +1,75 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package providers
+
+import (
+	"fmt"
+
+	"github.com/elastic/beats/libbeat/cfgfile"
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/bus"
+	"github.com/elastic/beats/libbeat/feature"
+)
+
+type Provider interface {
+	cfgfile.Runner
+}
+
+// Config settings
+type Config struct {
+	Type string `config:"type"`
+}
+
+// Factory creates a new provider based on the given config and returns it
+type Factory func(bus.Bus, *common.Config) (Provider, error)
+
+// Namespace is the registry namespace for autodiscover builders.
+var Namespace = "libbeat.autodiscover.provider"
+
+// Feature defines a new provider feature.
+func Feature(name string, factory Factory, stability feature.Stability) *feature.Feature {
+	return feature.New(Namespace, name, factory, stability)
+}
+
+func FindFactory(name string) (Factory, error) {
+	f, err := feature.Registry.Lookup(Namespace, name)
+	if err != nil {
+		return nil, err
+	}
+
+	factory, ok := f.Factory().(Factory)
+	if !ok {
+		return nil, fmt.Errorf("incompatible type for provider, received: '%T'", factory)
+	}
+
+	return factory, nil
+}
+
+func Build(bus bus.Bus, c *common.Config) (Provider, error) {
+	var config Config
+	err := c.Unpack(&config)
+	if err != nil {
+		return nil, err
+	}
+
+	builder, err := FindFactory(config.Type)
+	if err != nil {
+		return nil, err
+	}
+	return builder(bus, c)
+}

--- a/libbeat/autodiscover/providers/jolokia/jolokia.go
+++ b/libbeat/autodiscover/providers/jolokia/jolokia.go
@@ -19,15 +19,16 @@ package jolokia
 
 import (
 	"github.com/elastic/beats/libbeat/autodiscover"
+	"github.com/elastic/beats/libbeat/autodiscover/providers"
 	"github.com/elastic/beats/libbeat/autodiscover/template"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/bus"
 	"github.com/elastic/beats/libbeat/common/cfgwarn"
+	"github.com/elastic/beats/libbeat/feature"
 )
 
-func init() {
-	autodiscover.Registry.AddProvider("jolokia", AutodiscoverBuilder)
-}
+// Feature exposes the Jolokia autodiscovery provider.
+var Feature = providers.Feature("jolokia", AutodiscoverBuilder, feature.Experimental)
 
 // DiscoveryProber implements discovery probes
 type DiscoveryProber interface {

--- a/libbeat/autodiscover/providers/kubernetes/kubernetes.go
+++ b/libbeat/autodiscover/providers/kubernetes/kubernetes.go
@@ -22,18 +22,19 @@ import (
 
 	"github.com/elastic/beats/libbeat/autodiscover"
 	"github.com/elastic/beats/libbeat/autodiscover/builder"
+	"github.com/elastic/beats/libbeat/autodiscover/providers"
 	"github.com/elastic/beats/libbeat/autodiscover/template"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/bus"
 	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/libbeat/common/kubernetes"
 	"github.com/elastic/beats/libbeat/common/safemapstr"
+	"github.com/elastic/beats/libbeat/feature"
 	"github.com/elastic/beats/libbeat/logp"
 )
 
-func init() {
-	autodiscover.Registry.AddProvider("kubernetes", AutodiscoverBuilder)
-}
+// Feature exposes the kubernetes autodiscovery provider.
+var Feature = providers.Feature("kubernetes", AutodiscoverBuilder, feature.Beta)
 
 // Provider implements autodiscover provider for docker containers
 type Provider struct {

--- a/libbeat/autodiscover/providers/plugin.go
+++ b/libbeat/autodiscover/providers/plugin.go
@@ -17,32 +17,9 @@
 
 package providers
 
-import (
-	"errors"
+import "github.com/elastic/beats/libbeat/feature"
 
-	"github.com/elastic/beats/libbeat/autodiscover"
-	p "github.com/elastic/beats/libbeat/plugin"
-)
-
-type providerPlugin struct {
-	name     string
-	provider autodiscover.ProviderBuilder
-}
-
-var pluginKey = "libbeat.autodiscover.provider"
-
-// Plugin accepts a ProviderBuilder to be registered as a plugin
-func Plugin(name string, provider autodiscover.ProviderBuilder) map[string][]interface{} {
-	return p.MakePlugin(pluginKey, providerPlugin{name, provider})
-}
-
-func init() {
-	p.MustRegisterLoader(pluginKey, func(ifc interface{}) error {
-		prov, ok := ifc.(providerPlugin)
-		if !ok {
-			return errors.New("plugin does not match processor plugin type")
-		}
-
-		return autodiscover.Registry.AddProvider(prov.name, prov.provider)
-	})
+// Plugin accepts a provider to be registered as a plugin.
+func Plugin(name string, provider Factory) *feature.Feature {
+	return Feature(name, provider, feature.Beta)
 }

--- a/libbeat/autodiscover/providers/plugin.go
+++ b/libbeat/autodiscover/providers/plugin.go
@@ -21,5 +21,5 @@ import "github.com/elastic/beats/libbeat/feature"
 
 // Plugin accepts a provider to be registered as a plugin.
 func Plugin(name string, provider Factory) *feature.Feature {
-	return Feature(name, provider, feature.Beta)
+	return Feature(name, provider, feature.Undefined)
 }

--- a/libbeat/autodiscover/registry.go
+++ b/libbeat/autodiscover/registry.go
@@ -17,28 +17,28 @@
 
 package autodiscover
 
-import "sync"
+import (
+	"github.com/elastic/beats/libbeat/autodiscover/appenders"
+	"github.com/elastic/beats/libbeat/autodiscover/builder"
+	"github.com/elastic/beats/libbeat/autodiscover/providers"
+	"github.com/elastic/beats/libbeat/feature"
+)
 
-// Register of autodiscover providers
-type registry struct {
-	// Lock to control concurrent read/writes
-	lock sync.RWMutex
-	// A map of provider name to ProviderBuilder.
-	providers map[string]ProviderBuilder
-	// A map of builder name to BuilderConstructor.
-	builders map[string]BuilderConstructor
-	// A map of appender name to AppenderBuilder.
-	appenders map[string]AppenderBuilder
+// Registry is a wrapper over the new global registry, this will be removed in 7.0
+var Registry = newRegistryWrapper{}
+
+// newRegistryWrapper wraps the new global registry with the old style registry that were used by
+// the autodiscover feature, this allow plugin that register at init() to still work.
+type newRegistryWrapper struct{}
+
+func (n *newRegistryWrapper) AddAppender(name string, factory appenders.Factory) {
+	feature.MustRegister(appenders.Feature(name, factory, feature.Beta))
 }
 
-// Registry holds all known autodiscover providers, they must be added to it to enable them for use
-var Registry = NewRegistry()
+func (n *newRegistryWrapper) AddBuilder(name string, factory builder.Factory) {
+	feature.MustRegister(builder.Feature(name, factory, feature.Beta))
+}
 
-// NewRegistry creates and returns a new Registry
-func NewRegistry() *registry {
-	return &registry{
-		providers: make(map[string]ProviderBuilder, 0),
-		builders:  make(map[string]BuilderConstructor, 0),
-		appenders: make(map[string]AppenderBuilder, 0),
-	}
+func (n *newRegistryWrapper) AddProvider(name string, factory providers.Factory) {
+	feature.MustRegister(providers.Feature(name, factory, feature.Beta))
 }

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -73,10 +73,8 @@ import (
 	_ "github.com/elastic/beats/libbeat/processors/add_locale"
 	_ "github.com/elastic/beats/libbeat/processors/dissect"
 
-	// Register autodiscover providers
-	_ "github.com/elastic/beats/libbeat/autodiscover/providers/docker"
-	_ "github.com/elastic/beats/libbeat/autodiscover/providers/jolokia"
-	_ "github.com/elastic/beats/libbeat/autodiscover/providers/kubernetes"
+	// Register features
+	_ "github.com/elastic/beats/libbeat/include"
 
 	// Register default monitoring reporting
 	_ "github.com/elastic/beats/libbeat/monitoring/report/elasticsearch"

--- a/libbeat/include/include.go
+++ b/libbeat/include/include.go
@@ -15,11 +15,32 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package builder
+package include
 
-import "github.com/elastic/beats/libbeat/feature"
+import (
+	"github.com/elastic/beats/libbeat/autodiscover/appenders/config"
+	"github.com/elastic/beats/libbeat/autodiscover/providers/docker"
+	"github.com/elastic/beats/libbeat/autodiscover/providers/jolokia"
+	"github.com/elastic/beats/libbeat/autodiscover/providers/kubernetes"
+	"github.com/elastic/beats/libbeat/feature"
+)
 
-// Plugin accepts a builder to be registered as a plugin
-func Plugin(name string, factory Factory) *feature.Feature {
-	return Feature(name, factory, feature.Beta)
+// Bundle expose the main features.
+var Bundle = feature.MustBundle(
+	// Autodiscovery providers
+	feature.MustBundle(
+		jolokia.Feature,
+		docker.Feature,
+		kubernetes.Feature,
+	),
+
+	// Autodiscovery appenders
+	feature.MustBundle(
+		config.Feature,
+	),
+)
+
+func init() {
+	// Register main bundle
+	feature.RegisterBundle(Bundle)
 }


### PR DESCRIPTION
The autodiscovery feature was defining 3 customs registry, this PR do
the following:

- Provider, Appender and Builder now users the feature registry.
- It move the Factory type into their right package.
- Config are now inside their own package.
- Use the same naming for finding factories and building object.
- type aliasing is in place to make the transition smoother for types.
- A shim is in place that will proxy the registry of plugin to the
global registry.
- package.Plugin methods are now returning a feature instead of a
hashmap.