### PR TITLE
Html escaping

### DIFF
--- a/CHANGELOG-developer.asciidoc
+++ b/CHANGELOG-developer.asciidoc
@@ -23,6 +23,7 @@ The list below covers the major changes between 6.3.0 and master only.
 - Moving of TLS helper functions and structs from `output/tls` to `tlscommon`. {pull}7054[7054]
 - Port fields.yml collector to Golang {pull}6911[6911]
 - Dashboards under _meta/kibana are expected to be decoded. See https://github.com/elastic/beats/pull/7224 for a conversion script. {pull}7265[7265]
+- Constructor `(github.com/elastic/beats/libbeat/output/codec/json).New` expects a new `escapeHTML` parameter. {pull}7445[7445]
 
 ==== Bugfixes
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -166,6 +166,7 @@ https://github.com/elastic/beats/compare/v6.2.3...master[Check the HEAD diff]
 - Add support for docker autodiscover to monitor containers on host network {pull}6708[6708]
 - Add ability to define input configuration as stringified JSON for autodiscover. {pull}7372[7372]
 - Add processor definition support for hints builder {pull}7386[7386]
+- Add support to disable html escaping in outputs. {pull}7445[7445]
 
 *Auditbeat*
 

--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -335,6 +335,9 @@ output.elasticsearch:
   # Set gzip compression level.
   #compression_level: 0
 
+  # Configure escaping html symbols in strings.
+  #escape_html: true
+
   # Optional protocol and basic auth credentials.
   #protocol: "https"
   #username: "elastic"
@@ -439,6 +442,9 @@ output.elasticsearch:
 
   # Set gzip compression level.
   #compression_level: 3
+
+  # Configure escaping html symbols in strings.
+  #escape_html: true
 
   # Optional maximum time to live for a connection to Logstash, after which the
   # connection will be re-established.  A value of `0s` (the default) will
@@ -554,6 +560,14 @@ output.elasticsearch:
   # Kafka version auditbeat is assumed to run against. Defaults to the "1.0.0".
   #version: '1.0.0'
 
+  # Configure JSON encoding
+  #codec.json:
+    # Pretty print json event
+    #pretty: false
+
+    # Configure escaping html symbols in strings.
+    #escape_html: true
+
   # Metadata update configuration. Metadata do contain leader information
   # deciding which broker to use when publishing.
   #metadata:
@@ -656,6 +670,14 @@ output.elasticsearch:
   # Boolean flag to enable or disable the output module.
   #enabled: true
 
+  # Configure JSON encoding
+  #codec.json:
+    # Pretty print json event
+    #pretty: false
+
+    # Configure escaping html symbols in strings.
+    #escape_html: true
+
   # The list of Redis servers to connect to. If load balancing is enabled, the
   # events are distributed to the servers in the list. If one server becomes
   # unreachable, the events are distributed to the reachable servers only.
@@ -757,6 +779,14 @@ output.elasticsearch:
   # Boolean flag to enable or disable the output module.
   #enabled: true
 
+  # Configure JSON encoding
+  #codec.json:
+    # Pretty print json event
+    #pretty: false
+
+    # Configure escaping html symbols in strings.
+    #escape_html: true
+
   # Path to the directory where to save the generated files. The option is
   # mandatory.
   #path: "/tmp/auditbeat"
@@ -784,8 +814,13 @@ output.elasticsearch:
   # Boolean flag to enable or disable the output module.
   #enabled: true
 
-  # Pretty print json event
-  #pretty: false
+  # Configure JSON encoding
+  #codec.json:
+    # Pretty print json event
+    #pretty: false
+
+    # Configure escaping html symbols in strings.
+    #escape_html: true
 
 #================================= Paths ======================================
 

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -977,6 +977,9 @@ output.elasticsearch:
   # Set gzip compression level.
   #compression_level: 0
 
+  # Configure escaping html symbols in strings.
+  #escape_html: true
+
   # Optional protocol and basic auth credentials.
   #protocol: "https"
   #username: "elastic"
@@ -1081,6 +1084,9 @@ output.elasticsearch:
 
   # Set gzip compression level.
   #compression_level: 3
+
+  # Configure escaping html symbols in strings.
+  #escape_html: true
 
   # Optional maximum time to live for a connection to Logstash, after which the
   # connection will be re-established.  A value of `0s` (the default) will
@@ -1196,6 +1202,14 @@ output.elasticsearch:
   # Kafka version filebeat is assumed to run against. Defaults to the "1.0.0".
   #version: '1.0.0'
 
+  # Configure JSON encoding
+  #codec.json:
+    # Pretty print json event
+    #pretty: false
+
+    # Configure escaping html symbols in strings.
+    #escape_html: true
+
   # Metadata update configuration. Metadata do contain leader information
   # deciding which broker to use when publishing.
   #metadata:
@@ -1298,6 +1312,14 @@ output.elasticsearch:
   # Boolean flag to enable or disable the output module.
   #enabled: true
 
+  # Configure JSON encoding
+  #codec.json:
+    # Pretty print json event
+    #pretty: false
+
+    # Configure escaping html symbols in strings.
+    #escape_html: true
+
   # The list of Redis servers to connect to. If load balancing is enabled, the
   # events are distributed to the servers in the list. If one server becomes
   # unreachable, the events are distributed to the reachable servers only.
@@ -1399,6 +1421,14 @@ output.elasticsearch:
   # Boolean flag to enable or disable the output module.
   #enabled: true
 
+  # Configure JSON encoding
+  #codec.json:
+    # Pretty print json event
+    #pretty: false
+
+    # Configure escaping html symbols in strings.
+    #escape_html: true
+
   # Path to the directory where to save the generated files. The option is
   # mandatory.
   #path: "/tmp/filebeat"
@@ -1426,8 +1456,13 @@ output.elasticsearch:
   # Boolean flag to enable or disable the output module.
   #enabled: true
 
-  # Pretty print json event
-  #pretty: false
+  # Configure JSON encoding
+  #codec.json:
+    # Pretty print json event
+    #pretty: false
+
+    # Configure escaping html symbols in strings.
+    #escape_html: true
 
 #================================= Paths ======================================
 

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -444,6 +444,9 @@ output.elasticsearch:
   # Set gzip compression level.
   #compression_level: 0
 
+  # Configure escaping html symbols in strings.
+  #escape_html: true
+
   # Optional protocol and basic auth credentials.
   #protocol: "https"
   #username: "elastic"
@@ -548,6 +551,9 @@ output.elasticsearch:
 
   # Set gzip compression level.
   #compression_level: 3
+
+  # Configure escaping html symbols in strings.
+  #escape_html: true
 
   # Optional maximum time to live for a connection to Logstash, after which the
   # connection will be re-established.  A value of `0s` (the default) will
@@ -663,6 +669,14 @@ output.elasticsearch:
   # Kafka version heartbeat is assumed to run against. Defaults to the "1.0.0".
   #version: '1.0.0'
 
+  # Configure JSON encoding
+  #codec.json:
+    # Pretty print json event
+    #pretty: false
+
+    # Configure escaping html symbols in strings.
+    #escape_html: true
+
   # Metadata update configuration. Metadata do contain leader information
   # deciding which broker to use when publishing.
   #metadata:
@@ -765,6 +779,14 @@ output.elasticsearch:
   # Boolean flag to enable or disable the output module.
   #enabled: true
 
+  # Configure JSON encoding
+  #codec.json:
+    # Pretty print json event
+    #pretty: false
+
+    # Configure escaping html symbols in strings.
+    #escape_html: true
+
   # The list of Redis servers to connect to. If load balancing is enabled, the
   # events are distributed to the servers in the list. If one server becomes
   # unreachable, the events are distributed to the reachable servers only.
@@ -866,6 +888,14 @@ output.elasticsearch:
   # Boolean flag to enable or disable the output module.
   #enabled: true
 
+  # Configure JSON encoding
+  #codec.json:
+    # Pretty print json event
+    #pretty: false
+
+    # Configure escaping html symbols in strings.
+    #escape_html: true
+
   # Path to the directory where to save the generated files. The option is
   # mandatory.
   #path: "/tmp/heartbeat"
@@ -893,8 +923,13 @@ output.elasticsearch:
   # Boolean flag to enable or disable the output module.
   #enabled: true
 
-  # Pretty print json event
-  #pretty: false
+  # Configure JSON encoding
+  #codec.json:
+    # Pretty print json event
+    #pretty: false
+
+    # Configure escaping html symbols in strings.
+    #escape_html: true
 
 #================================= Paths ======================================
 

--- a/libbeat/_meta/config.reference.yml
+++ b/libbeat/_meta/config.reference.yml
@@ -230,6 +230,9 @@ output.elasticsearch:
   # Set gzip compression level.
   #compression_level: 0
 
+  # Configure escaping html symbols in strings.
+  #escape_html: true
+
   # Optional protocol and basic auth credentials.
   #protocol: "https"
   #username: "elastic"
@@ -334,6 +337,9 @@ output.elasticsearch:
 
   # Set gzip compression level.
   #compression_level: 3
+
+  # Configure escaping html symbols in strings.
+  #escape_html: true
 
   # Optional maximum time to live for a connection to Logstash, after which the
   # connection will be re-established.  A value of `0s` (the default) will
@@ -449,6 +455,14 @@ output.elasticsearch:
   # Kafka version beatname is assumed to run against. Defaults to the "1.0.0".
   #version: '1.0.0'
 
+  # Configure JSON encoding
+  #codec.json:
+    # Pretty print json event
+    #pretty: false
+
+    # Configure escaping html symbols in strings.
+    #escape_html: true
+
   # Metadata update configuration. Metadata do contain leader information
   # deciding which broker to use when publishing.
   #metadata:
@@ -551,6 +565,14 @@ output.elasticsearch:
   # Boolean flag to enable or disable the output module.
   #enabled: true
 
+  # Configure JSON encoding
+  #codec.json:
+    # Pretty print json event
+    #pretty: false
+
+    # Configure escaping html symbols in strings.
+    #escape_html: true
+
   # The list of Redis servers to connect to. If load balancing is enabled, the
   # events are distributed to the servers in the list. If one server becomes
   # unreachable, the events are distributed to the reachable servers only.
@@ -652,6 +674,14 @@ output.elasticsearch:
   # Boolean flag to enable or disable the output module.
   #enabled: true
 
+  # Configure JSON encoding
+  #codec.json:
+    # Pretty print json event
+    #pretty: false
+
+    # Configure escaping html symbols in strings.
+    #escape_html: true
+
   # Path to the directory where to save the generated files. The option is
   # mandatory.
   #path: "/tmp/beatname"
@@ -679,8 +709,13 @@ output.elasticsearch:
   # Boolean flag to enable or disable the output module.
   #enabled: true
 
-  # Pretty print json event
-  #pretty: false
+  # Configure JSON encoding
+  #codec.json:
+    # Pretty print json event
+    #pretty: false
+
+    # Configure escaping html symbols in strings.
+    #escape_html: true
 
 #================================= Paths ======================================
 

--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -138,6 +138,13 @@ Increasing the compression level will reduce the network usage but will increase
 
 The default value is 0.
 
+===== `escape_html`
+
+Configure escaping of HTML in strings. Set to `false` to disable escaping.
+
+The default value is `true`.
+
+
 ===== `worker`
 
 The number of workers per configured host publishing events to Elasticsearch. This
@@ -465,6 +472,12 @@ The compression level must be in the range of 1 (best speed) to 9 (best compress
 Increasing the compression level will reduce the network usage but will increase the cpu usage.
 
 The default value is 3.
+
+===== `escape_html`
+
+Configure escaping of HTML in strings. Set to `false` to disable escaping.
+
+The default value is `true`.
 
 ===== `worker`
 
@@ -1187,6 +1200,8 @@ codec. By default the `json` codec is used.
 
 *`json.pretty`*: If `pretty` is set to true, events will be nicely formatted. The default is false.
 
+*`json.escape_html`*: If `escape_html` is set to false, html symbols will not be escaped in strings. The default is true.
+
 Example configuration that uses the `json` codec with pretty printing enabled to write events to the console:
 
 [source,yaml]
@@ -1194,6 +1209,7 @@ Example configuration that uses the `json` codec with pretty printing enabled to
 output.console:
   codec.json:
     pretty: true
+    escape_html: false
 ------------------------------------------------------------------------------
 
 *`format.string`*: Configurable format string used to create a custom formatted message.

--- a/libbeat/outputs/codec/json/json_test.go
+++ b/libbeat/outputs/codec/json/json_test.go
@@ -25,22 +25,22 @@ import (
 )
 
 func TestJsonCodec(t *testing.T) {
-	expectedValue := `{"@timestamp":"0001-01-01T00:00:00.000Z","@metadata":{"beat":"test","type":"doc","version":"1.2.3"},"msg":"message"}`
-
-	codec := New(false, "1.2.3")
-	output, err := codec.Encode("test", &beat.Event{Fields: common.MapStr{"msg": "message"}})
-
-	if err != nil {
-		t.Errorf("Error during event write %v", err)
-	} else {
-		if string(output) != expectedValue {
-			t.Errorf("Expected value (%s) does not equal with output (%s)", expectedValue, output)
-		}
+	type testCase struct {
+		config   config
+		in       common.MapStr
+		expected string
 	}
-}
 
-func TestJsonWriterPrettyPrint(t *testing.T) {
-	expectedValue := `{
+	cases := map[string]testCase{
+		"default json": testCase{
+			config:   defaultConfig,
+			in:       common.MapStr{"msg": "message"},
+			expected: `{"@timestamp":"0001-01-01T00:00:00.000Z","@metadata":{"beat":"test","type":"doc","version":"1.2.3"},"msg":"message"}`,
+		},
+		"pretty enabled": testCase{
+			config: config{Pretty: true},
+			in:     common.MapStr{"msg": "message"},
+			expected: `{
   "@timestamp": "0001-01-01T00:00:00.000Z",
   "@metadata": {
     "beat": "test",
@@ -48,16 +48,32 @@ func TestJsonWriterPrettyPrint(t *testing.T) {
     "version": "1.2.3"
   },
   "msg": "message"
-}`
+}`,
+		},
+		"html escaping enabled": testCase{
+			config:   config{EscapeHTML: true},
+			in:       common.MapStr{"msg": "<hello>world</hello>"},
+			expected: `{"@timestamp":"0001-01-01T00:00:00.000Z","@metadata":{"beat":"test","type":"doc","version":"1.2.3"},"msg":"\u003chello\u003eworld\u003c/hello\u003e"}`,
+		},
+		"html escaping disabled": testCase{
+			config:   config{EscapeHTML: false},
+			in:       common.MapStr{"msg": "<hello>world</hello>"},
+			expected: `{"@timestamp":"0001-01-01T00:00:00.000Z","@metadata":{"beat":"test","type":"doc","version":"1.2.3"},"msg":"<hello>world</hello>"}`,
+		},
+	}
 
-	codec := New(true, "1.2.3")
-	output, err := codec.Encode("test", &beat.Event{Fields: common.MapStr{"msg": "message"}})
+	for name, test := range cases {
+		cfg, fields, expected := test.config, test.in, test.expected
 
-	if err != nil {
-		t.Errorf("Error during event write %v", err)
-	} else {
-		if string(output) != expectedValue {
-			t.Errorf("Expected value (%s) does not equal with output (%s)", expectedValue, output)
-		}
+		t.Run(name, func(t *testing.T) {
+			codec := New(cfg.Pretty, cfg.EscapeHTML, "1.2.3")
+			actual, err := codec.Encode("test", &beat.Event{Fields: fields})
+
+			if err != nil {
+				t.Errorf("Error during event write %v", err)
+			} else if string(actual) != expected {
+				t.Errorf("Expected value (%s) does not equal with output (%s)", expected, actual)
+			}
+		})
 	}
 }

--- a/libbeat/outputs/console/console.go
+++ b/libbeat/outputs/console/console.go
@@ -70,7 +70,7 @@ func makeConsole(
 			return outputs.Fail(err)
 		}
 	} else {
-		enc = json.New(config.Pretty, beat.Version)
+		enc = json.New(config.Pretty, true, beat.Version)
 	}
 
 	index := beat.Beat

--- a/libbeat/outputs/console/console_test.go
+++ b/libbeat/outputs/console/console_test.go
@@ -78,7 +78,7 @@ func TestConsoleOutput(t *testing.T) {
 	}{
 		{
 			"single json event (pretty=false)",
-			json.New(false, "1.2.3"),
+			json.New(false, true, "1.2.3"),
 			[]beat.Event{
 				{Fields: event("field", "value")},
 			},
@@ -86,7 +86,7 @@ func TestConsoleOutput(t *testing.T) {
 		},
 		{
 			"single json event (pretty=true)",
-			json.New(true, "1.2.3"),
+			json.New(true, true, "1.2.3"),
 			[]beat.Event{
 				{Fields: event("field", "value")},
 			},

--- a/libbeat/outputs/elasticsearch/client.go
+++ b/libbeat/outputs/elasticsearch/client.go
@@ -66,6 +66,7 @@ type ClientSettings struct {
 	Proxy              *url.URL
 	TLS                *transport.TLSConfig
 	Username, Password string
+	EscapeHTML         bool
 	Parameters         map[string]string
 	Headers            map[string]string
 	Index              outil.Selector
@@ -184,9 +185,9 @@ func NewClient(
 	var encoder bodyEncoder
 	compression := s.CompressionLevel
 	if compression == 0 {
-		encoder = newJSONEncoder(nil)
+		encoder = newJSONEncoder(nil, s.EscapeHTML)
 	} else {
-		encoder, err = newGzipEncoder(compression, nil)
+		encoder, err = newGzipEncoder(compression, nil, s.EscapeHTML)
 		if err != nil {
 			return nil, err
 		}

--- a/libbeat/outputs/elasticsearch/config.go
+++ b/libbeat/outputs/elasticsearch/config.go
@@ -33,6 +33,7 @@ type elasticsearchConfig struct {
 	ProxyURL         string            `config:"proxy_url"`
 	LoadBalance      bool              `config:"loadbalance"`
 	CompressionLevel int               `config:"compression_level" validate:"min=0, max=9"`
+	EscapeHTML       bool              `config:"escape_html"`
 	TLS              *tlscommon.Config `config:"ssl"`
 	BulkMaxSize      int               `config:"bulk_max_size"`
 	MaxRetries       int               `config:"max_retries"`
@@ -60,6 +61,7 @@ var (
 		Timeout:          90 * time.Second,
 		MaxRetries:       3,
 		CompressionLevel: 0,
+		EscapeHTML:       true,
 		TLS:              nil,
 		LoadBalance:      true,
 		Backoff: Backoff{

--- a/libbeat/outputs/elasticsearch/elasticsearch.go
+++ b/libbeat/outputs/elasticsearch/elasticsearch.go
@@ -154,6 +154,7 @@ func makeES(
 			Timeout:          config.Timeout,
 			CompressionLevel: config.CompressionLevel,
 			Observer:         observer,
+			EscapeHTML:       config.EscapeHTML,
 		}, &connectCallbackRegistry)
 		if err != nil {
 			return outputs.Fail(err)

--- a/libbeat/outputs/elasticsearch/enc_test.go
+++ b/libbeat/outputs/elasticsearch/enc_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func TestJSONEncoderMarshalBeatEvent(t *testing.T) {
-	encoder := newJSONEncoder(nil)
+	encoder := newJSONEncoder(nil, true)
 	event := beat.Event{
 		Timestamp: time.Date(2017, time.November, 7, 12, 0, 0, 0, time.UTC),
 		Fields: common.MapStr{
@@ -46,7 +46,7 @@ func TestJSONEncoderMarshalBeatEvent(t *testing.T) {
 }
 
 func TestJSONEncoderMarshalMonitoringEvent(t *testing.T) {
-	encoder := newJSONEncoder(nil)
+	encoder := newJSONEncoder(nil, true)
 	event := report.Event{
 		Timestamp: time.Date(2017, time.November, 7, 12, 0, 0, 0, time.UTC),
 		Fields: common.MapStr{

--- a/libbeat/outputs/logstash/async.go
+++ b/libbeat/outputs/logstash/async.go
@@ -68,7 +68,7 @@ func newAsyncClient(
 		logp.Warn(`The async Logstash client does not support the "ttl" option`)
 	}
 
-	enc := makeLogstashEventEncoder(beat, config.Index)
+	enc := makeLogstashEventEncoder(beat, config.EscapeHTML, config.Index)
 
 	queueSize := config.Pipelining - 1
 	timeout := config.Timeout

--- a/libbeat/outputs/logstash/config.go
+++ b/libbeat/outputs/logstash/config.go
@@ -38,6 +38,7 @@ type Config struct {
 	TLS              *tlscommon.Config     `config:"ssl"`
 	Proxy            transport.ProxyConfig `config:",inline"`
 	Backoff          Backoff               `config:"backoff"`
+	EscapeHTML       bool                  `config:"escape_html"`
 }
 
 type Backoff struct {
@@ -59,6 +60,7 @@ var defaultConfig = Config{
 		Init: 1 * time.Second,
 		Max:  60 * time.Second,
 	},
+	EscapeHTML: true,
 }
 
 func newConfig() *Config {

--- a/libbeat/outputs/logstash/enc.go
+++ b/libbeat/outputs/logstash/enc.go
@@ -22,8 +22,8 @@ import (
 	"github.com/elastic/beats/libbeat/outputs/codec/json"
 )
 
-func makeLogstashEventEncoder(info beat.Info, index string) func(interface{}) ([]byte, error) {
-	enc := json.New(false, info.Version)
+func makeLogstashEventEncoder(info beat.Info, escapeHTML bool, index string) func(interface{}) ([]byte, error) {
+	enc := json.New(false, escapeHTML, info.Version)
 	return func(event interface{}) ([]byte, error) {
 		return enc.Encode(index, event.(*beat.Event))
 	}

--- a/libbeat/outputs/logstash/sync.go
+++ b/libbeat/outputs/logstash/sync.go
@@ -57,7 +57,7 @@ func newSyncClient(
 	}
 
 	var err error
-	enc := makeLogstashEventEncoder(beat, config.Index)
+	enc := makeLogstashEventEncoder(beat, config.EscapeHTML, config.Index)
 	c.client, err = v2.NewSyncClientWithConn(conn,
 		v2.JSONEncoder(enc),
 		v2.Timeout(config.Timeout),

--- a/libbeat/publisher/pipeline/processor.go
+++ b/libbeat/publisher/pipeline/processor.go
@@ -295,7 +295,7 @@ func debugPrintProcessor(info beat.Info) *processorFn {
 	// beat.Client is shared between multiple go-routines by accident)
 	var mux sync.Mutex
 
-	encoder := json.New(true, info.Version)
+	encoder := json.New(true, false, info.Version)
 	return newProcessor("debugPrint", func(event *beat.Event) (*beat.Event, error) {
 		mux.Lock()
 		defer mux.Unlock()

--- a/metricbeat/mb/module/example_test.go
+++ b/metricbeat/mb/module/example_test.go
@@ -147,7 +147,7 @@ func ExampleRunner() {
 }
 
 func encodeEvent(event beat.Event) (string, error) {
-	output, err := json.New(false, "1.2.3").Encode("noindex", &event)
+	output, err := json.New(false, true, "1.2.3").Encode("noindex", &event)
 	if err != nil {
 		return "", nil
 	}

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -850,6 +850,9 @@ output.elasticsearch:
   # Set gzip compression level.
   #compression_level: 0
 
+  # Configure escaping html symbols in strings.
+  #escape_html: true
+
   # Optional protocol and basic auth credentials.
   #protocol: "https"
   #username: "elastic"
@@ -954,6 +957,9 @@ output.elasticsearch:
 
   # Set gzip compression level.
   #compression_level: 3
+
+  # Configure escaping html symbols in strings.
+  #escape_html: true
 
   # Optional maximum time to live for a connection to Logstash, after which the
   # connection will be re-established.  A value of `0s` (the default) will
@@ -1069,6 +1075,14 @@ output.elasticsearch:
   # Kafka version metricbeat is assumed to run against. Defaults to the "1.0.0".
   #version: '1.0.0'
 
+  # Configure JSON encoding
+  #codec.json:
+    # Pretty print json event
+    #pretty: false
+
+    # Configure escaping html symbols in strings.
+    #escape_html: true
+
   # Metadata update configuration. Metadata do contain leader information
   # deciding which broker to use when publishing.
   #metadata:
@@ -1171,6 +1185,14 @@ output.elasticsearch:
   # Boolean flag to enable or disable the output module.
   #enabled: true
 
+  # Configure JSON encoding
+  #codec.json:
+    # Pretty print json event
+    #pretty: false
+
+    # Configure escaping html symbols in strings.
+    #escape_html: true
+
   # The list of Redis servers to connect to. If load balancing is enabled, the
   # events are distributed to the servers in the list. If one server becomes
   # unreachable, the events are distributed to the reachable servers only.
@@ -1272,6 +1294,14 @@ output.elasticsearch:
   # Boolean flag to enable or disable the output module.
   #enabled: true
 
+  # Configure JSON encoding
+  #codec.json:
+    # Pretty print json event
+    #pretty: false
+
+    # Configure escaping html symbols in strings.
+    #escape_html: true
+
   # Path to the directory where to save the generated files. The option is
   # mandatory.
   #path: "/tmp/metricbeat"
@@ -1299,8 +1329,13 @@ output.elasticsearch:
   # Boolean flag to enable or disable the output module.
   #enabled: true
 
-  # Pretty print json event
-  #pretty: false
+  # Configure JSON encoding
+  #codec.json:
+    # Pretty print json event
+    #pretty: false
+
+    # Configure escaping html symbols in strings.
+    #escape_html: true
 
 #================================= Paths ======================================
 

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -707,6 +707,9 @@ output.elasticsearch:
   # Set gzip compression level.
   #compression_level: 0
 
+  # Configure escaping html symbols in strings.
+  #escape_html: true
+
   # Optional protocol and basic auth credentials.
   #protocol: "https"
   #username: "elastic"
@@ -811,6 +814,9 @@ output.elasticsearch:
 
   # Set gzip compression level.
   #compression_level: 3
+
+  # Configure escaping html symbols in strings.
+  #escape_html: true
 
   # Optional maximum time to live for a connection to Logstash, after which the
   # connection will be re-established.  A value of `0s` (the default) will
@@ -926,6 +932,14 @@ output.elasticsearch:
   # Kafka version packetbeat is assumed to run against. Defaults to the "1.0.0".
   #version: '1.0.0'
 
+  # Configure JSON encoding
+  #codec.json:
+    # Pretty print json event
+    #pretty: false
+
+    # Configure escaping html symbols in strings.
+    #escape_html: true
+
   # Metadata update configuration. Metadata do contain leader information
   # deciding which broker to use when publishing.
   #metadata:
@@ -1028,6 +1042,14 @@ output.elasticsearch:
   # Boolean flag to enable or disable the output module.
   #enabled: true
 
+  # Configure JSON encoding
+  #codec.json:
+    # Pretty print json event
+    #pretty: false
+
+    # Configure escaping html symbols in strings.
+    #escape_html: true
+
   # The list of Redis servers to connect to. If load balancing is enabled, the
   # events are distributed to the servers in the list. If one server becomes
   # unreachable, the events are distributed to the reachable servers only.
@@ -1129,6 +1151,14 @@ output.elasticsearch:
   # Boolean flag to enable or disable the output module.
   #enabled: true
 
+  # Configure JSON encoding
+  #codec.json:
+    # Pretty print json event
+    #pretty: false
+
+    # Configure escaping html symbols in strings.
+    #escape_html: true
+
   # Path to the directory where to save the generated files. The option is
   # mandatory.
   #path: "/tmp/packetbeat"
@@ -1156,8 +1186,13 @@ output.elasticsearch:
   # Boolean flag to enable or disable the output module.
   #enabled: true
 
-  # Pretty print json event
-  #pretty: false
+  # Configure JSON encoding
+  #codec.json:
+    # Pretty print json event
+    #pretty: false
+
+    # Configure escaping html symbols in strings.
+    #escape_html: true
 
 #================================= Paths ======================================
 

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -259,6 +259,9 @@ output.elasticsearch:
   # Set gzip compression level.
   #compression_level: 0
 
+  # Configure escaping html symbols in strings.
+  #escape_html: true
+
   # Optional protocol and basic auth credentials.
   #protocol: "https"
   #username: "elastic"
@@ -363,6 +366,9 @@ output.elasticsearch:
 
   # Set gzip compression level.
   #compression_level: 3
+
+  # Configure escaping html symbols in strings.
+  #escape_html: true
 
   # Optional maximum time to live for a connection to Logstash, after which the
   # connection will be re-established.  A value of `0s` (the default) will
@@ -478,6 +484,14 @@ output.elasticsearch:
   # Kafka version winlogbeat is assumed to run against. Defaults to the "1.0.0".
   #version: '1.0.0'
 
+  # Configure JSON encoding
+  #codec.json:
+    # Pretty print json event
+    #pretty: false
+
+    # Configure escaping html symbols in strings.
+    #escape_html: true
+
   # Metadata update configuration. Metadata do contain leader information
   # deciding which broker to use when publishing.
   #metadata:
@@ -580,6 +594,14 @@ output.elasticsearch:
   # Boolean flag to enable or disable the output module.
   #enabled: true
 
+  # Configure JSON encoding
+  #codec.json:
+    # Pretty print json event
+    #pretty: false
+
+    # Configure escaping html symbols in strings.
+    #escape_html: true
+
   # The list of Redis servers to connect to. If load balancing is enabled, the
   # events are distributed to the servers in the list. If one server becomes
   # unreachable, the events are distributed to the reachable servers only.
@@ -681,6 +703,14 @@ output.elasticsearch:
   # Boolean flag to enable or disable the output module.
   #enabled: true
 
+  # Configure JSON encoding
+  #codec.json:
+    # Pretty print json event
+    #pretty: false
+
+    # Configure escaping html symbols in strings.
+    #escape_html: true
+
   # Path to the directory where to save the generated files. The option is
   # mandatory.
   #path: "/tmp/winlogbeat"
@@ -708,8 +738,13 @@ output.elasticsearch:
   # Boolean flag to enable or disable the output module.
   #enabled: true
 
-  # Pretty print json event
-  #pretty: false
+  # Configure JSON encoding
+  #codec.json:
+    # Pretty print json event
+    #pretty: false
+
+    # Configure escaping html symbols in strings.
+    #escape_html: true
 
 #================================= Paths ======================================
 


### PR DESCRIPTION
Requires: #7444 
Closes: #2581 

Add support to codecs and outputs to enable/disable escaping of html symbols in JSON strings.

By default html escaping is enabled.

- Add new setting `escape_html` to `codec.json`
- Add new setting `output.elasticsearch.escape_html`
- Add new setting `output.logstash.escape_html`
- Add settings to reference config files and output documentation