### PR TITLE
Fix missing metadata in redis output

### DIFF
--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -885,15 +885,12 @@ The Redis port to use if `hosts` does not contain a port number. The default is 
 
 ===== `index`
 
-deprecated[5.0.0,The `index` setting is renamed to `key`]
-
-The name of the Redis list or channel the events are published to. The default is
-"{beatname_lc}".
+The index name added to the events metadata for use by Logstash. The default is "{beatname_lc}".
 
 ===== `key`
 
-The name of the Redis list or channel the events are published to. The default is
-"{beatname_lc}".
+The name of the Redis list or channel the events are published to. If not
+configured, the value of the `index` setting is used.
 
 The redis key can be set dynamically using a format string accessing any
 fields in the event to be published.

--- a/libbeat/outputs/redis/config.go
+++ b/libbeat/outputs/redis/config.go
@@ -18,12 +18,10 @@
 package redis
 
 import (
-	"errors"
 	"fmt"
 	"time"
 
 	"github.com/elastic/beats/libbeat/common/transport/tlscommon"
-	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/outputs/codec"
 	"github.com/elastic/beats/libbeat/outputs/transport"
 )
@@ -62,16 +60,6 @@ func (c *redisConfig) Validate() error {
 	case "", "list", "channel":
 	default:
 		return fmt.Errorf("redis data type %v not supported", c.DataType)
-	}
-
-	if c.Key != "" && c.Index != "" {
-		return errors.New("Cannot use both `output.redis.key` and `output.redis.index` configuration options." +
-			" Set only `output.redis.key`")
-	}
-
-	if c.Key == "" && c.Index != "" {
-		c.Key = c.Index
-		logp.Warn("The `output.redis.index` configuration setting is deprecated. Use `output.redis.key` instead.")
 	}
 
 	return nil

--- a/libbeat/outputs/redis/config_test.go
+++ b/libbeat/outputs/redis/config_test.go
@@ -32,7 +32,7 @@ func TestValidate(t *testing.T) {
 		{"No config", redisConfig{Key: "", Index: ""}, true},
 		{"Only key", redisConfig{Key: "test", Index: ""}, true},
 		{"Only index", redisConfig{Key: "", Index: "test"}, true},
-		{"Both", redisConfig{Key: "test", Index: "test"}, false},
+		{"Both", redisConfig{Key: "test", Index: "test"}, true},
 
 		{"Invalid Datatype", redisConfig{Key: "test", DataType: "something"}, false},
 		{"List Datatype", redisConfig{Key: "test", DataType: "list"}, true},

--- a/libbeat/outputs/redis/redis.go
+++ b/libbeat/outputs/redis/redis.go
@@ -51,21 +51,6 @@ func makeRedis(
 	observer outputs.Observer,
 	cfg *common.Config,
 ) (outputs.Group, error) {
-	config := defaultConfig
-	if err := cfg.Unpack(&config); err != nil {
-		return outputs.Fail(err)
-	}
-
-	var dataType redisDataType
-	switch config.DataType {
-	case "", "list":
-		dataType = redisListType
-	case "channel":
-		dataType = redisChannelType
-	default:
-		return outputs.Fail(errors.New("Bad Redis data type"))
-	}
-
 	// ensure we have a `key` field in settings
 	if cfg.HasField("index") && !cfg.HasField("key") {
 		s, err := cfg.String("index", -1)
@@ -81,6 +66,21 @@ func makeRedis(
 	}
 	if !cfg.HasField("key") {
 		cfg.SetString("key", -1, beat.Beat)
+	}
+
+	config := defaultConfig
+	if err := cfg.Unpack(&config); err != nil {
+		return outputs.Fail(err)
+	}
+
+	var dataType redisDataType
+	switch config.DataType {
+	case "", "list":
+		dataType = redisListType
+	case "channel":
+		dataType = redisChannelType
+	default:
+		return outputs.Fail(errors.New("Bad Redis data type"))
 	}
 
 	key, err := outil.BuildSelectorFromConfig(cfg, outil.Settings{

--- a/libbeat/outputs/redis/redis.go
+++ b/libbeat/outputs/redis/redis.go
@@ -51,8 +51,13 @@ func makeRedis(
 	observer outputs.Observer,
 	cfg *common.Config,
 ) (outputs.Group, error) {
+
+	if !cfg.HasField("index") {
+		cfg.SetString("index", -1, beat.Beat)
+	}
+
 	// ensure we have a `key` field in settings
-	if cfg.HasField("index") && !cfg.HasField("key") {
+	if !cfg.HasField("key") {
 		s, err := cfg.String("index", -1)
 		if err != nil {
 			return outputs.Fail(err)
@@ -60,12 +65,6 @@ func makeRedis(
 		if err := cfg.SetString("key", -1, s); err != nil {
 			return outputs.Fail(err)
 		}
-	}
-	if !cfg.HasField("index") {
-		cfg.SetString("index", -1, beat.Beat)
-	}
-	if !cfg.HasField("key") {
-		cfg.SetString("key", -1, beat.Beat)
 	}
 
 	config := defaultConfig

--- a/libbeat/outputs/redis/redis_integration_test.go
+++ b/libbeat/outputs/redis/redis_integration_test.go
@@ -48,6 +48,12 @@ const (
 	SRedisDefaultPort = "6380"
 )
 
+const (
+	testBeatname    = "libbeat"
+	testBeatversion = "1.2.3"
+	testMetaValue   = "private"
+)
+
 func TestPublishListTCP(t *testing.T) {
 	key := "test_publist_tcp"
 	db := 0
@@ -116,6 +122,10 @@ func testPublishList(t *testing.T, cfg map[string]interface{}) {
 		err = json.Unmarshal(raw, &evt)
 		assert.NoError(t, err)
 		assert.Equal(t, i+1, evt.Message)
+	}
+
+	for _, raw := range results {
+		validateMeta(t, raw)
 	}
 }
 
@@ -245,6 +255,10 @@ func testPublishChannel(t *testing.T, cfg map[string]interface{}) {
 			assert.Equal(t, i+1, evt.Message)
 		}
 	}
+
+	for _, raw := range messages {
+		validateMeta(t, raw)
+	}
 }
 
 func getEnv(name, or string) string {
@@ -277,7 +291,7 @@ func newRedisTestingOutput(t *testing.T, cfg map[string]interface{}) *client {
 		t.Fatalf("redis output module not registered")
 	}
 
-	out, err := plugin(beat.Info{Beat: "libbeat"}, outputs.NewNilObserver(), config)
+	out, err := plugin(beat.Info{Beat: testBeatname, Version: testBeatversion}, outputs.NewNilObserver(), config)
 	if err != nil {
 		t.Fatalf("Failed to initialize redis output: %v", err)
 	}
@@ -312,6 +326,31 @@ func sendTestEvents(out *client, batches, N int) error {
 func createEvent(message int) beat.Event {
 	return beat.Event{
 		Timestamp: time.Now(),
-		Fields:    common.MapStr{"message": message},
+		Meta: common.MapStr{
+			"test": testMetaValue,
+		},
+		Fields: common.MapStr{"message": message},
 	}
+}
+
+func validateMeta(t *testing.T, raw []byte) {
+	// require metadata
+	type meta struct {
+		Beat    string `struct:"beat"`
+		Version string `struct:"version"`
+		Test    string `struct:"test"`
+	}
+
+	evt := struct {
+		Meta meta `json:"@metadata"`
+	}{}
+	err := json.Unmarshal(raw, &evt)
+	if err != nil {
+		t.Errorf("failed to unmarshal meta section: ", err)
+		return
+	}
+
+	assert.Equal(t, testBeatname, evt.Meta.Beat)
+	assert.Equal(t, testBeatversion, evt.Meta.Version)
+	assert.Equal(t, testMetaValue, evt.Meta.Test)
 }

--- a/libbeat/outputs/redis/redis_integration_test.go
+++ b/libbeat/outputs/redis/redis_integration_test.go
@@ -346,7 +346,7 @@ func validateMeta(t *testing.T, raw []byte) {
 	}{}
 	err := json.Unmarshal(raw, &evt)
 	if err != nil {
-		t.Errorf("failed to unmarshal meta section: ", err)
+		t.Errorf("failed to unmarshal meta section: %v", err)
 		return
 	}
 


### PR DESCRIPTION
Resolves: #7389 

Fix ensures the `@metadata.beat` event field is not empty when sending events via redis to Logstash. By default the field is configured via output.redis.index. If not configured, the actual `(beat).Info.Beat` field is used, which contains the actual beat name (filebeat, metricbeat, ...). Setting and `@metadata.beat` usage is more similar to Logstash output now.

PR adds redis integration checks, validating the metadata output as well.

Due to the `index` setting being used again with 6.0 (used to be deprecated in 5.x), I removed the 'deprecated' notice in docs and log message.