### PR TITLE
 Fix a panic when dealing with remaining at the end of a delimiter

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -72,6 +72,7 @@ https://github.com/elastic/beats/compare/v6.2.3...master[Check the HEAD diff]
 - Allow to override the `ignore_above` option when defining new field with the type keyword. {pull}7238[7238]
 - Allow index-pattern only setup when setup.dashboards.only_index=true. {pull}7285[7285]
 - Fix duplicating dynamic_fields in template when overwriting the template. {pull}7352[7352]
+- Fix a panic on the Dissect processor when we have data remaining after the last delimiter. {pull}7449[7449]
 
 *Auditbeat*
 

--- a/libbeat/processors/dissect/dissect.go
+++ b/libbeat/processors/dissect/dissect.go
@@ -118,7 +118,8 @@ func (d *Dissector) extract(s string) (positions, error) {
 		dl = dl.Next()
 	}
 
-	if offset < len(s) {
+	// If we have remaining contents and have not captured all the requested fields
+	if offset < len(s) && i < len(d.parser.fields) {
 		positions[i] = position{start: offset, end: len(s)}
 	}
 	return positions, nil

--- a/libbeat/processors/dissect/dissect_test.go
+++ b/libbeat/processors/dissect/dissect_test.go
@@ -53,6 +53,17 @@ type dissectTest struct {
 
 var tests = []dissectTest{
 	{
+		Name: "When all the defined fields are captured by we have remaining data",
+		Tok:  "level=%{level} ts=%{timestamp} caller=%{caller} msg=\"%{message}\"",
+		Msg:  "level=info ts=2018-06-27T17:19:13.036579993Z caller=main.go:222 msg=\"Starting OK\" version=\"(version=2.3.1, branch=HEAD, revision=188ca45bd85ce843071e768d855722a9d9dabe03)\"}",
+		Expected: Map{
+			"level":     "info",
+			"timestamp": "2018-06-27T17:19:13.036579993Z",
+			"caller":    "main.go:222",
+			"message":   "Starting OK",
+		},
+	},
+	{
 		Name: "Complex stack trace",
 		Tok:  "%{day}-%{month}-%{year} %{hour} %{severity} [%{thread_id}] %{origin} %{message}",
 		Msg: `18-Apr-2018 06:53:20.411 INFO [http-nio-8080-exec-1] org.apache.coyote.http11.Http11Processor.service Error parsing HTTP request header


### PR DESCRIPTION
When the last delimiter is not greedy, and we have captured all the data
for the defined fields in the Tokenizer string, we should ignore the
remaining of the string.