### PR TITLE
Add additional types to kubernetes metadata

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -167,6 +167,7 @@ https://github.com/elastic/beats/compare/v6.2.3...master[Check the HEAD diff]
 - Add ability to define input configuration as stringified JSON for autodiscover. {pull}7372[7372]
 - Add processor definition support for hints builder {pull}7386[7386]
 - Add support to disable html escaping in outputs. {pull}7445[7445]
+- Add additional types to kubernetes metadata {pull}7457[7457]
 
 *Auditbeat*
 

--- a/libbeat/common/kubernetes/types.go
+++ b/libbeat/common/kubernetes/types.go
@@ -34,11 +34,23 @@ func init() {
 // Resource data
 type Resource = k8s.Resource
 
+// ObjectMeta data
+type ObjectMeta = metav1.ObjectMeta
+
 // Pod data
 type Pod = v1.Pod
 
+// PodSpec data
+type PodSpec = v1.PodSpec
+
+// PodStatus data
+type PodStatus = v1.PodStatus
+
 // Container data
 type Container = v1.Container
+
+// ContainerPort data
+type ContainerPort = v1.ContainerPort
 
 // Event data
 type Event = v1.Event


### PR DESCRIPTION
The lack of the below type definitions is impacting testing custom indexers that are loaded in as go-plugins. It would be nice to have them defined as well.