### PR TITLE
Add kubernetes to services which are kept running

### DIFF
--- a/heartbeat/tests/system/test_monitor.py
+++ b/heartbeat/tests/system/test_monitor.py
@@ -21,7 +21,7 @@ class Test(BaseTest):
         self.render_config_template(
             monitors=[{
                 "type": "http",
-                "urls": ["http://localhost:8181"],
+                "urls": ["http://localhost:8185"],
             }],
         )
 
@@ -43,8 +43,8 @@ class Test(BaseTest):
         self.assert_fields_are_documented(output[0])
 
     @parameterized.expand([
-        ("8181", "up"),
-        ("8182", "down"),
+        ("8185", "up"),
+        ("8186", "down"),
     ])
     def test_tcp(self, port, status):
         """
@@ -83,7 +83,7 @@ class Test(BaseTest):
                 self.end_headers()
                 self.wfile.write(content)
 
-        server = BaseHTTPServer.HTTPServer(('localhost', 8181), HTTPHandler)
+        server = BaseHTTPServer.HTTPServer(('localhost', 8185), HTTPHandler)
 
         thread = threading.Thread(target=server.serve_forever)
         thread.start()

--- a/libbeat/tests/compose/compose.go
+++ b/libbeat/tests/compose/compose.go
@@ -160,7 +160,7 @@ func (c *composeProject) KillOld(except []string) error {
 	// it can happen that an other package tries to start them at the same time
 	// which leads to a conflict. We need a better solution long term but that should
 	// solve the problem for now.
-	except = append(except, "elasticsearch", "kibana", "logstash")
+	except = append(except, "elasticsearch", "kibana", "logstash", "kubernetes")
 
 	servicesStatus, err := c.getServices()
 	if err != nil {


### PR DESCRIPTION
Our metricbeat tests on Jenkins are flaky because of Kubernetes. My current assumption is that there are some overlaps when starting / stopping kuberenetes. Reason for this is that we do not see the same issue on Travis. The different between Travis and Jenkis is probably the number of processes which run in parallel. So either we could reduce the number of processes for the tests to 1 or add kubernetes to the services that keep running. I decided to keep it running for now to see what the outcome is.

* Changing heartbeat testing ports as sometimes they conflicted with other services running.