### PR TITLE
Update log builder settings unpack testing

### DIFF
--- a/filebeat/autodiscover/builder/hints/config.go
+++ b/filebeat/autodiscover/builder/hints/config.go
@@ -39,3 +39,22 @@ func defaultConfig() config {
 		Config: cfg,
 	}
 }
+
+// Unpack is needed here as go-ucfg fails to unpack the Config object by default
+func (c *config) Unpack(from *common.Config) error {
+	tmpConfig := struct {
+		Key string `config:"key"`
+	}{
+		Key: c.Key,
+	}
+	if err := from.Unpack(&tmpConfig); err != nil {
+		return err
+	}
+
+	if config, err := from.Child("config", -1); err == nil {
+		c.Config = config
+	}
+
+	c.Key = tmpConfig.Key
+	return nil
+}

--- a/filebeat/autodiscover/builder/hints/config.go
+++ b/filebeat/autodiscover/builder/hints/config.go
@@ -39,22 +39,3 @@ func defaultConfig() config {
 		Config: cfg,
 	}
 }
-
-// Unpack is needed here as go-ucfg fails to unpack the Config object by default
-func (c *config) Unpack(from *common.Config) error {
-	tmpConfig := struct {
-		Key string `config:"key"`
-	}{
-		Key: c.Key,
-	}
-	if err := from.Unpack(&tmpConfig); err != nil {
-		return err
-	}
-
-	if config, err := from.Child("config", -1); err == nil {
-		c.Config = config
-	}
-
-	c.Key = tmpConfig.Key
-	return nil
-}

--- a/filebeat/autodiscover/builder/hints/logs_test.go
+++ b/filebeat/autodiscover/builder/hints/logs_test.go
@@ -68,6 +68,7 @@ func TestGenerateHints(t *testing.T) {
 				"containers": map[string]interface{}{
 					"ids": []interface{}{"abc"},
 				},
+				"close_timeout": "true",
 			},
 		},
 		{
@@ -99,6 +100,7 @@ func TestGenerateHints(t *testing.T) {
 				},
 				"include_lines": []interface{}{"^test", "^test1"},
 				"exclude_lines": []interface{}{"^test2", "^test3"},
+				"close_timeout": "true",
 			},
 		},
 		{
@@ -134,6 +136,7 @@ func TestGenerateHints(t *testing.T) {
 					"pattern": "^test",
 					"negate":  "true",
 				},
+				"close_timeout": "true",
 			},
 		},
 		{
@@ -201,6 +204,7 @@ func TestGenerateHints(t *testing.T) {
 				"containers": map[string]interface{}{
 					"ids": []interface{}{"abc"},
 				},
+				"close_timeout": "true",
 				"processors": []interface{}{
 					map[string]interface{}{
 						"dissect": map[string]interface{}{
@@ -244,6 +248,7 @@ func TestGenerateHints(t *testing.T) {
 							"stream": "all",
 							"ids":    []interface{}{"abc"},
 						},
+						"close_timeout": "true",
 					},
 				},
 				"access": map[string]interface{}{
@@ -254,6 +259,7 @@ func TestGenerateHints(t *testing.T) {
 							"stream": "all",
 							"ids":    []interface{}{"abc"},
 						},
+						"close_timeout": "true",
 					},
 				},
 			},
@@ -290,6 +296,7 @@ func TestGenerateHints(t *testing.T) {
 							"stream": "all",
 							"ids":    []interface{}{"abc"},
 						},
+						"close_timeout": "true",
 					},
 				},
 				"error": map[string]interface{}{
@@ -300,6 +307,7 @@ func TestGenerateHints(t *testing.T) {
 							"stream": "all",
 							"ids":    []interface{}{"abc"},
 						},
+						"close_timeout": "true",
 					},
 				},
 			},
@@ -337,6 +345,7 @@ func TestGenerateHints(t *testing.T) {
 							"stream": "stdout",
 							"ids":    []interface{}{"abc"},
 						},
+						"close_timeout": "true",
 					},
 				},
 				"error": map[string]interface{}{
@@ -347,6 +356,7 @@ func TestGenerateHints(t *testing.T) {
 							"stream": "stderr",
 							"ids":    []interface{}{"abc"},
 						},
+						"close_timeout": "true",
 					},
 				},
 			},
@@ -355,11 +365,14 @@ func TestGenerateHints(t *testing.T) {
 
 	for _, test := range tests {
 		cfg, _ := common.NewConfigFrom(map[string]interface{}{
-			"type": "docker",
-			"containers": map[string]interface{}{
-				"ids": []string{
-					"${data.container.id}",
+			"config": map[string]interface{}{
+				"type": "docker",
+				"containers": map[string]interface{}{
+					"ids": []string{
+						"${data.container.id}",
+					},
 				},
+				"close_timeout": "true",
 			},
 		})
 


### PR DESCRIPTION
https://github.com/elastic/beats/pull/7510 has fixed a bug when unpacking into `*common.Config`, this PR updates a test in autodiscover logs builder to make sure that's working