### PR TITLE
Clarify autodiscover docs in relation to startup process

### DIFF
--- a/libbeat/docs/shared-autodiscover.asciidoc
+++ b/libbeat/docs/shared-autodiscover.asciidoc
@@ -15,9 +15,8 @@ Autodiscover providers work by watching for events on the system and translating
 events with a common format. When you configure the provider, you can use fields from the autodiscover event to set
 conditions that, when met, launch specific configurations.
 
-On start, {beatname_uc} will scan all the already existing containers and launch the proper configs for them. Then
-it will watch for new start/stop events. This ensures you don't need to worry about state, but only define your desired
-configs.
+On start, {beatname_uc} will scan existing containers and launch the proper configs for them. Then it will watch for new
+start/stop events. This ensures you don't need to worry about state, but only define your desired configs.
 
 [float]
 ===== Docker

--- a/libbeat/docs/shared-autodiscover.asciidoc
+++ b/libbeat/docs/shared-autodiscover.asciidoc
@@ -15,6 +15,10 @@ Autodiscover providers work by watching for events on the system and translating
 events with a common format. When you configure the provider, you can use fields from the autodiscover event to set
 conditions that, when met, launch specific configurations.
 
+On start, {beatname_uc} will scan all the already existing containers and launch the proper configs for them. Then
+it will watch for new start/stop events. This ensures you don't need to worry about state, but only define your desired
+configs.
+
 [float]
 ===== Docker
 


### PR DESCRIPTION
Autodiscover reacts to already existing containers first, then it
starts listening for changes of that initial state.