### PR TITLE
Fix beats-dashboards package naming

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -46,7 +46,7 @@ func PackageBeatDashboards() error {
 	}
 
 	spec := mage.PackageSpec{
-		Name:     "beat-dashboards",
+		Name:     "beats-dashboards",
 		Version:  version,
 		Snapshot: mage.Snapshot,
 		Files: map[string]mage.PackageFile{


### PR DESCRIPTION
I had it as beat-dashboards rather than beats-dashboards.