### PR TITLE
Disable labels dedotting in default docker module configuration

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -47,6 +47,7 @@ https://github.com/elastic/beats/compare/v6.2.3...master[Check the HEAD diff]
 - RabbitMQ management plugin path is now configured at the module level instead of having to do it in each of the metricsets. New `management_path_prefix` option should be used now {pull}7074[7074]
 - RabbitMQ node metricset only collects metrics of the instance it connects to, `node.collect: cluster` can be used to collect all nodes as before. {issue}6556[6556] {pull}6971[6971]
 - Change http/server metricset to put events by default under http.server and prefix config options with server.. {pull}7100[7100]
+- Disable dedotting in docker module configuration. This will change the out-of-the-box behaviour, but not the one of already configured instances. {pull}7485[7485]
 
 *Packetbeat*
 

--- a/metricbeat/docs/modules/docker.asciidoc
+++ b/metricbeat/docs/modules/docker.asciidoc
@@ -42,8 +42,8 @@ metricbeat.modules:
   period: 10s
   enabled: true
 
-  # Replace dots in labels with `_`. Set to false to keep dots
-  labels.dedot: true
+  # If set to true, replace dots in labels with `_`.
+  #labels.dedot: false
 
   # To connect to Docker over TLS you must specify a client and CA certificate.
   #ssl:

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -175,8 +175,8 @@ metricbeat.modules:
   period: 10s
   enabled: true
 
-  # Replace dots in labels with `_`. Set to false to keep dots
-  labels.dedot: true
+  # If set to true, replace dots in labels with `_`.
+  #labels.dedot: false
 
   # To connect to Docker over TLS you must specify a client and CA certificate.
   #ssl:

--- a/metricbeat/module/docker/_meta/config.reference.yml
+++ b/metricbeat/module/docker/_meta/config.reference.yml
@@ -12,8 +12,8 @@
   period: 10s
   enabled: true
 
-  # Replace dots in labels with `_`. Set to false to keep dots
-  labels.dedot: true
+  # If set to true, replace dots in labels with `_`.
+  #labels.dedot: false
 
   # To connect to Docker over TLS you must specify a client and CA certificate.
   #ssl:

--- a/metricbeat/module/docker/_meta/config.yml
+++ b/metricbeat/module/docker/_meta/config.yml
@@ -10,8 +10,8 @@
   period: 10s
   hosts: ["unix:///var/run/docker.sock"]
 
-  # Replace dots in labels with `_`. Set to false to keep dots
-  labels.dedot: true
+  # If set to true, replace dots in labels with `_`.
+  #labels.dedot: false
 
   # To connect to Docker over TLS you must specify a client and CA certificate.
   #ssl:

--- a/metricbeat/modules.d/docker.yml.disabled
+++ b/metricbeat/modules.d/docker.yml.disabled
@@ -13,8 +13,8 @@
   period: 10s
   hosts: ["unix:///var/run/docker.sock"]
 
-  # Replace dots in labels with `_`. Set to false to keep dots
-  labels.dedot: true
+  # If set to true, replace dots in labels with `_`.
+  #labels.dedot: false
 
   # To connect to Docker over TLS you must specify a client and CA certificate.
   #ssl:


### PR DESCRIPTION
Default docker module configuration made metricbeat to replace dots
with underscores in labels. This conflicted with `add_docker_metadata`
that also adds labels, but without replacing dots.

This makes docker module and `add_docker_metadata` processor to have a
consistent behaviour, but there can be still cases where type mapping
conflicts appear. For these cases there are some options using the
`rename` or `drop_fields` processors.