### PR TITLE
Add Filebeat modules to packages

### DIFF
--- a/dev-tools/mage/copy.go
+++ b/dev-tools/mage/copy.go
@@ -1,0 +1,130 @@
+package mage
+
+import (
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"regexp"
+
+	"github.com/pkg/errors"
+)
+
+// Copy copies a file or a directory (recursively) and preserves the permissions.
+func Copy(src, dest string) error {
+	copy := &CopyTask{Source: src, Dest: dest}
+	return copy.Execute()
+}
+
+// CopyTask copies a file or directory (recursively) and preserves the permissions.
+type CopyTask struct {
+	Source   string           // Source directory or file.
+	Dest     string           // Destination directory or file.
+	Mode     os.FileMode      // Mode to use for copied files. Defaults to preserve permissions.
+	DirMode  os.FileMode      // Mode to use for copied dirs. Defaults to preserve permissions.
+	Exclude  []string         // Exclude paths that match these regular expressions.
+	excludes []*regexp.Regexp // Compiled exclude regexes.
+}
+
+// Execute executes the copy and returns an error of there is a failure.
+func (t *CopyTask) Execute() error {
+	if err := t.init(); err != nil {
+		return errors.Wrap(err, "copy failed")
+	}
+
+	info, err := os.Stat(t.Source)
+	if err != nil {
+		return errors.Wrapf(err, "copy failed: cannot stat source file %v", t.Source)
+	}
+
+	return errors.Wrap(t.recursiveCopy(t.Source, t.Dest, info), "copy failed")
+}
+
+func (t *CopyTask) init() error {
+	for _, excl := range t.Exclude {
+		re, err := regexp.Compile(excl)
+		if err != nil {
+			return errors.Wrapf(err, "bad exclude pattern %v", excl)
+		}
+		t.excludes = append(t.excludes, re)
+	}
+	return nil
+}
+
+func (t *CopyTask) isExcluded(src string) bool {
+	for _, excl := range t.excludes {
+		if match := excl.MatchString(filepath.ToSlash(src)); match {
+			return true
+		}
+	}
+	return false
+}
+
+func (t *CopyTask) recursiveCopy(src, dest string, info os.FileInfo) error {
+	if info.IsDir() {
+		return t.dirCopy(src, dest, info)
+	}
+	return t.fileCopy(src, dest, info)
+}
+
+func (t *CopyTask) fileCopy(src, dest string, info os.FileInfo) error {
+	if t.isExcluded(src) {
+		return nil
+	}
+
+	srcFile, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer srcFile.Close()
+
+	if !info.Mode().IsRegular() {
+		return errors.Errorf("failed to copy source file because it is not a " +
+			"regular file")
+	}
+
+	mode := t.Mode
+	if mode == 0 {
+		mode = info.Mode()
+	}
+	destFile, err := os.OpenFile(createDir(dest),
+		os.O_CREATE|os.O_TRUNC|os.O_WRONLY, mode&os.ModePerm)
+	if err != nil {
+		return err
+	}
+	defer destFile.Close()
+
+	if _, err = io.Copy(destFile, srcFile); err != nil {
+		return err
+	}
+	return destFile.Close()
+}
+
+func (t *CopyTask) dirCopy(src, dest string, info os.FileInfo) error {
+	if t.isExcluded(src) {
+		return nil
+	}
+
+	mode := t.DirMode
+	if mode == 0 {
+		mode = info.Mode()
+	}
+	if err := os.MkdirAll(dest, mode&os.ModePerm); err != nil {
+		return errors.Wrap(err, "failed creating dirs")
+	}
+
+	contents, err := ioutil.ReadDir(src)
+	if err != nil {
+		return errors.Wrapf(err, "failed to read dir %v", src)
+	}
+
+	for _, info := range contents {
+		srcFile := filepath.Join(src, info.Name())
+		destFile := filepath.Join(dest, info.Name())
+		if err = t.recursiveCopy(srcFile, destFile, info); err != nil {
+			return errors.Wrapf(err, "failed to copy %v to %v", srcFile, destFile)
+		}
+	}
+
+	return nil
+}

--- a/dev-tools/mage/pkgtypes.go
+++ b/dev-tools/mage/pkgtypes.go
@@ -608,6 +608,11 @@ func runFPM(spec PackageSpec, packageType PackageType) error {
 	if spec.localPostInstallScript != "" {
 		args = append(args, "--after-install", spec.localPostInstallScript)
 	}
+	for _, pf := range spec.Files {
+		if pf.Config {
+			args = append(args, "--config-files", pf.Target)
+		}
+	}
 	args = append(args,
 		"-p", spec.OutputFile,
 		inputTar,

--- a/filebeat/Makefile
+++ b/filebeat/Makefile
@@ -15,13 +15,6 @@ kibana:
 	@mkdir -p _meta/kibana.generated
 	@-cp -pr module/*/_meta/kibana/* _meta/kibana.generated
 
-# Collects all modules files to be packaged in a temporary folder
-.PHONY: modules
-modules:
-	@mkdir -p _meta/
-	@rm -rf _meta/module.generated
-	@rsync -q -av module/ _meta/module.generated --exclude "_meta" --exclude "*/*/test"
-
 # Collects all module configs
 .PHONY: configs
 configs: python-env
@@ -49,7 +42,7 @@ imports: python-env
 
 # Runs all collection steps and updates afterwards
 .PHONY: collect
-collect: fields kibana modules configs collect-docs imports
+collect: fields kibana configs collect-docs imports
 
 # Creates a new module. Requires the params MODULE
 .PHONY: create-module


### PR DESCRIPTION
This adds the Filebeat modules files to packages. They were missed during the refactor.

It also fixes a minor issue where files were not marked as config within .rpm files.

I opened https://github.com/elastic/beats/issues/7488 because this wasn't caught by any of the testing we do post packaging including beats-tester.