### PR TITLE
Fix configuration-ssl docs for key param

### DIFF
--- a/libbeat/docs/shared-ssl-config.asciidoc
+++ b/libbeat/docs/shared-ssl-config.asciidoc
@@ -82,10 +82,10 @@ might fail if the server requests client authentication. If the SSL server does 
 require client authentication, the certificate will be loaded, but not requested or used
 by the server.
 
-When this option is configured, the <<certificate_key,`certificate_key`>> option is also required.
+When this option is configured, the <<key,`key`>> option is also required.
 
 [float]
-[[certificate_key]]
+[[key]]
 ==== `key: "/etc/pki/client/cert.key"`
 
 The client certificate key used for client authentication. This option is required if <<certificate,`certificate`>> is specified.


### PR DESCRIPTION
The documentation was referring to the `key` parameter by its old name, `certificate_key`. It was renamed to `key` in 5.0.0.