### PR TITLE
Set logp default for keepfiles to 7

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -74,6 +74,8 @@ https://github.com/elastic/beats/compare/v6.2.3...master[Check the HEAD diff]
 - Fix duplicating dynamic_fields in template when overwriting the template. {pull}7352[7352]
 - Fix a panic on the Dissect processor when we have data remaining after the last delimiter. {pull}7449[7449]
 - When we fail to build a Kubernetes' indexer or matcher we produce a warning but we don't add them to the execution. {pull}7466[7466]
+- Fix default value for logging.files.keepfiles. It was being set to 0 and now
+  it's set to the documented value of 7. {issue}7494[7494]
 
 *Auditbeat*
 

--- a/libbeat/logp/config.go
+++ b/libbeat/logp/config.go
@@ -52,6 +52,7 @@ var defaultConfig = Config{
 	ToFiles: true,
 	Files: FileConfig{
 		MaxSize:     10 * 1024 * 1024,
+		MaxBackups:  7,
 		Permissions: 0600,
 	},
 	addCaller: true,


### PR DESCRIPTION
The config files and docs state that the default number of backups to keep is 7. This default value in the code was lost during the logging refactor.

Fixes #7494