### PR TITLE
Cherry-pick #7495 to 6.3: Set logp default for keepfiles to 7

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -29,6 +29,9 @@ https://github.com/elastic/beats/compare/v6.3.0...6.3[Check the HEAD diff]
 
 *Affecting all Beats*
 
+- Fix default value for logging.files.keepfiles. It was being set to 0 and now
+  it's set to the documented value of 7. {issue}7494[7494]
+
 *Auditbeat*
 
 *Filebeat*

--- a/libbeat/logp/config.go
+++ b/libbeat/logp/config.go
@@ -35,6 +35,7 @@ var defaultConfig = Config{
 	ToFiles: true,
 	Files: FileConfig{
 		MaxSize:     10 * 1024 * 1024,
+		MaxBackups:  7,
 		Permissions: 0600,
 	},
 	addCaller: true,


### PR DESCRIPTION
Cherry-pick of PR #7495 to 6.3 branch. Original message: 

The config files and docs state that the default number of backups to keep is 7. This default value in the code was lost during the logging refactor.

Fixes #7494