### PR TITLE
Add host reporting to state API endpoint

### DIFF
--- a/auditbeat/module/auditd/show_linux.go
+++ b/auditbeat/module/auditd/show_linux.go
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package auditd
 
 import (

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -48,6 +48,7 @@ import (
 	"github.com/elastic/beats/libbeat/keystore"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/logp/configure"
+	"github.com/elastic/beats/libbeat/metric/system/host"
 	"github.com/elastic/beats/libbeat/monitoring"
 	"github.com/elastic/beats/libbeat/monitoring/report"
 	"github.com/elastic/beats/libbeat/monitoring/report/log"
@@ -166,12 +167,23 @@ func Run(name, idxPrefix, version string, bt beat.Creator) error {
 			return err
 		}
 
+		// Add basic info
 		registry := monitoring.GetNamespace("info").GetRegistry()
 		monitoring.NewString(registry, "version").Set(b.Info.Version)
 		monitoring.NewString(registry, "beat").Set(b.Info.Beat)
 		monitoring.NewString(registry, "name").Set(b.Info.Name)
 		monitoring.NewString(registry, "uuid").Set(b.Info.UUID.String())
 		monitoring.NewString(registry, "hostname").Set(b.Info.Hostname)
+
+		// Add additional info to state registry. This is also reported to monitoring
+		stateRegistry := monitoring.GetNamespace("state").GetRegistry()
+		serviceRegistry := stateRegistry.NewRegistry("service")
+		monitoring.NewString(serviceRegistry, "version").Set(b.Info.Version)
+		monitoring.NewString(serviceRegistry, "name").Set(b.Info.Beat)
+		monitoring.NewString(serviceRegistry, "id").Set(b.Info.UUID.String())
+		beatRegistry := stateRegistry.NewRegistry("beat")
+		monitoring.NewString(beatRegistry, "name").Set(b.Info.Name)
+		monitoring.NewFunc(stateRegistry, "host", host.ReportInfo, monitoring.Report)
 
 		return b.launch(bt)
 	}())

--- a/libbeat/metric/system/host/host.go
+++ b/libbeat/metric/system/host/host.go
@@ -1,0 +1,90 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package host
+
+import (
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/monitoring"
+	"github.com/elastic/go-sysinfo"
+	"github.com/elastic/go-sysinfo/types"
+)
+
+// MapHostInfo converts the HostInfo to a MapStr based on ECS.
+func MapHostInfo(info types.HostInfo) common.MapStr {
+	data := common.MapStr{
+		"host": common.MapStr{
+			"name":         info.Hostname,
+			"architecture": info.Architecture,
+			"os": common.MapStr{
+				"platform": info.OS.Platform,
+				"version":  info.OS.Version,
+				"family":   info.OS.Family,
+			},
+		},
+	}
+
+	// Optional params
+	if info.UniqueID != "" {
+		data.Put("host.id", info.UniqueID)
+	}
+	if info.Containerized != nil {
+		data.Put("host.containerized", *info.Containerized)
+	}
+	if info.OS.Codename != "" {
+		data.Put("host.os.codename", info.OS.Codename)
+	}
+	if info.OS.Build != "" {
+		data.Put("host.os.build", info.OS.Build)
+	}
+
+	return data
+}
+
+// ReportInfo reports the HostInfo to monitoring.
+func ReportInfo(_ monitoring.Mode, V monitoring.Visitor) {
+	V.OnRegistryStart()
+	defer V.OnRegistryFinished()
+
+	h, err := sysinfo.Host()
+	if err != nil {
+		return
+	}
+	info := h.Info()
+
+	monitoring.ReportString(V, "name", info.Hostname)
+	monitoring.ReportString(V, "architecture", info.Architecture)
+	monitoring.ReportNamespace(V, "os", func() {
+		monitoring.ReportString(V, "platform", info.OS.Platform)
+		monitoring.ReportString(V, "version", info.OS.Version)
+		monitoring.ReportString(V, "family", info.OS.Family)
+
+		if info.OS.Codename != "" {
+			monitoring.ReportString(V, "codename", info.OS.Codename)
+		}
+		if info.OS.Build != "" {
+			monitoring.ReportString(V, "build", info.OS.Build)
+		}
+	})
+
+	if info.UniqueID != "" {
+		monitoring.ReportString(V, "id", info.UniqueID)
+	}
+	if info.Containerized != nil {
+		monitoring.ReportBool(V, "containerized", *info.Containerized)
+	}
+}

--- a/libbeat/processors/add_host_metadata/add_host_metadata.go
+++ b/libbeat/processors/add_host_metadata/add_host_metadata.go
@@ -28,6 +28,7 @@ import (
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/metric/system/host"
 	"github.com/elastic/beats/libbeat/processors"
 	"github.com/elastic/go-sysinfo"
 	"github.com/elastic/go-sysinfo/types"
@@ -77,31 +78,7 @@ func (p *addHostMetadata) loadData() {
 
 	// Check if cache is expired
 	if p.lastUpdate.Add(cacheExpiration).Before(time.Now()) {
-		p.data = common.MapStr{
-			"host": common.MapStr{
-				"name":         p.info.Hostname,
-				"architecture": p.info.Architecture,
-				"os": common.MapStr{
-					"platform": p.info.OS.Platform,
-					"version":  p.info.OS.Version,
-					"family":   p.info.OS.Family,
-				},
-			},
-		}
-
-		// Optional params
-		if p.info.UniqueID != "" {
-			p.data.Put("host.id", p.info.UniqueID)
-		}
-		if p.info.Containerized != nil {
-			p.data.Put("host.containerized", *p.info.Containerized)
-		}
-		if p.info.OS.Codename != "" {
-			p.data.Put("host.os.codename", p.info.OS.Codename)
-		}
-		if p.info.OS.Build != "" {
-			p.data.Put("host.os.build", p.info.OS.Build)
-		}
+		p.data = host.MapHostInfo(p.info)
 
 		if p.config.NetInfoEnabled {
 			// IP-address and MAC-address
@@ -117,7 +94,6 @@ func (p *addHostMetadata) loadData() {
 				p.data.Put("host.mac", hwList)
 			}
 		}
-
 		p.lastUpdate = time.Now()
 	}
 }


### PR DESCRIPTION
Calling the `/state` API endpoint the data returned looks as following:

```
{
  "beat": {
    "name": "ruflin"
  },
  "host": {
    "architecture": "x86_64",
    "name": "ruflin",
    "os": {
      "build": "17E202",
      "family": "darwin",
      "platform": "darwin",
      "version": "10.13.4"
    }
  },
  "module": {
    "count": 3,
    "names": [
      "system"
    ]
  },
  "service": {
    "id": "ac7c8804-42da-4aa3-911c-eea5dd9a460b",
    "name": "metricbeat",
    "version": "7.0.0-alpha1"
  }
}
```

This is the same data as is added by the add_host_metadata processor. It is also reported as part of the monitoring endpoint and means it has to be added to the Elasticsearch monitoring template after merging.

The code for the reporter generation and MapStr was moved into the same file to simplify to keep them in sync. An idea would be to have a Visitor for MapStr which would make the additional code obsolete.