### PR TITLE
Fixes common.bash directory for Apm Server

### DIFF
--- a/dev-tools/jenkins_release.sh
+++ b/dev-tools/jenkins_release.sh
@@ -4,7 +4,7 @@ set -euox pipefail
 : "${HOME:?Need to set HOME to a non-empty value.}"
 : "${WORKSPACE:?Need to set WORKSPACE to a non-empty value.}"
 
-source ./dev-tools/common.bash
+source $(dirname "$0")/common.bash
 
 jenkins_setup
 


### PR DESCRIPTION
For Apm Server, the dev-tools are under a `_beats` directory.
This has been tested in Apm Server already here https://apm-ci.elastic.co/job/elastic+apm-server+master+package/165/