### PR TITLE
Update go ucfg

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -447,8 +447,8 @@ Apache License 2.0
 
 --------------------------------------------------------------------
 Dependency: github.com/elastic/go-ucfg
-Version: v0.5.1
-Revision: 0ba28e36add27704e6b49a7ed8557989a8f4a635
+Version: v0.6.0
+Revision: 9c66f5c432b1d25bdb449a1e588d58b5d0cd7268
 License type (autodetected): Apache-2.0
 ./vendor/github.com/elastic/go-ucfg/LICENSE:
 --------------------------------------------------------------------

--- a/libbeat/autodiscover/providers/jolokia/config.go
+++ b/libbeat/autodiscover/providers/jolokia/config.go
@@ -33,7 +33,7 @@ var (
 // Config for Jolokia Discovery autodiscover provider
 type Config struct {
 	// List of network interfaces to use for discovery probes
-	Interfaces []InterfaceConfig `config:"interfaces" validate:"nonzero"`
+	Interfaces []InterfaceConfig `config:"interfaces,replace" validate:"nonzero"`
 
 	Builders  []*common.Config        `config:"builders"`
 	Appenders []*common.Config        `config:"appenders"`

--- a/libbeat/common/config.go
+++ b/libbeat/common/config.go
@@ -87,6 +87,12 @@ func NewConfig() *Config {
 	return fromConfig(ucfg.New())
 }
 
+// NewConfigFrom creates a new Config object from the given input.
+// From can be any kind of structured data (struct, map, array, slice).
+//
+// If from is a string, the contents is treated like raw YAML input. The string
+// will be parsed and a structure config object is build from the parsed
+// result.
 func NewConfigFrom(from interface{}) (*Config, error) {
 	if str, ok := from.(string); ok {
 		c, err := yaml.NewConfig([]byte(str), configOpts...)
@@ -97,6 +103,14 @@ func NewConfigFrom(from interface{}) (*Config, error) {
 	return fromConfig(c), err
 }
 
+// MustNewConfigFrom creates a new Config object from the given input.
+// From can be any kind of structured data (struct, map, array, slice).
+//
+// If from is a string, the contents is treated like raw YAML input. The string
+// will be parsed and a structure config object is build from the parsed
+// result.
+//
+// MustNewConfigFrom panics if an error occurs.
 func MustNewConfigFrom(from interface{}) *Config {
 	cfg, err := NewConfigFrom(from)
 	if err != nil {

--- a/libbeat/common/config.go
+++ b/libbeat/common/config.go
@@ -88,8 +88,21 @@ func NewConfig() *Config {
 }
 
 func NewConfigFrom(from interface{}) (*Config, error) {
+	if str, ok := from.(string); ok {
+		c, err := yaml.NewConfig([]byte(str), configOpts...)
+		return fromConfig(c), err
+	}
+
 	c, err := ucfg.NewFrom(from, configOpts...)
 	return fromConfig(c), err
+}
+
+func MustNewConfigFrom(from interface{}) *Config {
+	cfg, err := NewConfigFrom(from)
+	if err != nil {
+		panic(err)
+	}
+	return cfg
 }
 
 func MergeConfigs(cfgs ...*Config) (*Config, error) {

--- a/vendor/github.com/elastic/go-ucfg/CHANGELOG.md
+++ b/vendor/github.com/elastic/go-ucfg/CHANGELOG.md
@@ -14,6 +14,14 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+## [0.6.0]
+
+### Added
+- Add *Config merging options merge, append, prepend, replace. #107
+
+### Fixed
+- Fix: do not treat ucfg.Config (or castable type) as Unpacker. #106
+
 ## [0.5.1]
 
 ### Fixed
@@ -189,7 +197,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Introduced CHANGELOG.md for documenting changes to ucfg.
 
 
-[Unreleased]: https://github.com/elastic/go-ucfg/compare/v0.5.1...HEAD
+[Unreleased]: https://github.com/elastic/go-ucfg/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/elastic/go-ucfg/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/elastic/go-ucfg/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/elastic/go-ucfg/compare/v0.4.6...v0.5.0
 [0.4.6]: https://github.com/elastic/go-ucfg/compare/v0.4.5...v0.4.6

--- a/vendor/github.com/elastic/go-ucfg/cfgutil/cfgutil.go
+++ b/vendor/github.com/elastic/go-ucfg/cfgutil/cfgutil.go
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package cfgutil
 
 import "github.com/elastic/go-ucfg"

--- a/vendor/github.com/elastic/go-ucfg/doc.go
+++ b/vendor/github.com/elastic/go-ucfg/doc.go
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 // Package ucfg provides a common representation for hierarchical configurations.
 //
 // The common representation provided by the Config type can be used with different

--- a/vendor/github.com/elastic/go-ucfg/error.go
+++ b/vendor/github.com/elastic/go-ucfg/error.go
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package ucfg
 
 import (

--- a/vendor/github.com/elastic/go-ucfg/errpred.go
+++ b/vendor/github.com/elastic/go-ucfg/errpred.go
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package ucfg
 
 func isCyclicError(err error) bool {

--- a/vendor/github.com/elastic/go-ucfg/fieldset.go
+++ b/vendor/github.com/elastic/go-ucfg/fieldset.go
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package ucfg
 
 type fieldSet struct {

--- a/vendor/github.com/elastic/go-ucfg/flag/file.go
+++ b/vendor/github.com/elastic/go-ucfg/flag/file.go
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package flag
 
 import (

--- a/vendor/github.com/elastic/go-ucfg/flag/flag.go
+++ b/vendor/github.com/elastic/go-ucfg/flag/flag.go
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package flag
 
 import (

--- a/vendor/github.com/elastic/go-ucfg/flag/util.go
+++ b/vendor/github.com/elastic/go-ucfg/flag/util.go
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package flag
 
 import (

--- a/vendor/github.com/elastic/go-ucfg/flag/value.go
+++ b/vendor/github.com/elastic/go-ucfg/flag/value.go
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package flag
 
 import (

--- a/vendor/github.com/elastic/go-ucfg/getset.go
+++ b/vendor/github.com/elastic/go-ucfg/getset.go
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package ucfg
 
 // ******************************************************************************

--- a/vendor/github.com/elastic/go-ucfg/internal/parse/parse.go
+++ b/vendor/github.com/elastic/go-ucfg/internal/parse/parse.go
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package parse
 
 import (

--- a/vendor/github.com/elastic/go-ucfg/json/json.go
+++ b/vendor/github.com/elastic/go-ucfg/json/json.go
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package json
 
 import (

--- a/vendor/github.com/elastic/go-ucfg/merge.go
+++ b/vendor/github.com/elastic/go-ucfg/merge.go
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package ucfg
 
 import (
@@ -14,7 +31,7 @@ import (
 // Merge traverses the value from recursively copying all values into a hierarchy
 // of Config objects plus primitives into c.
 //
-// Merge supports the options: PathSep, MetaData, StructTag, VarExp
+// Merge supports the options: PathSep, MetaData, StructTag, VarExp, ReplaceValues, AppendValues, PrependValues
 //
 // Merge uses the type-dependent default encodings:
 //  - Boolean values are encoded as booleans.
@@ -75,7 +92,23 @@ func mergeConfig(opts *options, to, from *Config) Error {
 }
 
 func mergeConfigDict(opts *options, to, from *Config) Error {
-	for k, v := range from.fields.dict() {
+	dict := from.fields.dict()
+	if len(dict) == 0 {
+		return nil
+	}
+
+	ok := false
+	if opts.configValueHandling == cfgReplaceValue {
+		old := to.fields.dict()
+		to.fields.d = nil
+		defer func() {
+			if !ok {
+				to.fields.d = old
+			}
+		}()
+	}
+
+	for k, v := range dict {
 		ctx := context{
 			parent: cfgSub{to},
 			field:  k,
@@ -89,46 +122,96 @@ func mergeConfigDict(opts *options, to, from *Config) Error {
 
 		to.fields.set(k, merged.cpy(ctx))
 	}
+
+	ok = true
 	return nil
 }
 
 func mergeConfigArr(opts *options, to, from *Config) Error {
-	l := len(to.fields.array())
-	if l > len(from.fields.array()) {
-		l = len(from.fields.array())
+	switch opts.configValueHandling {
+	case cfgReplaceValue:
+		return mergeConfigReplaceArr(opts, to, from)
+
+	case cfgArrPrepend:
+		return mergeConfigPrependArr(opts, to, from)
+
+	case cfgArrAppend:
+		return mergeConfigAppendArr(opts, to, from)
+
+	case cfgDefaultHandling, cfgMergeValues:
+		return mergeConfigMergeArr(opts, to, from)
+	default:
+		return mergeConfigMergeArr(opts, to, from)
 	}
+}
+
+func mergeConfigReplaceArr(opts *options, to, from *Config) Error {
+	a := from.fields.array()
+	if len(a) == 0 {
+		return nil
+	}
+
+	var parent value = cfgSub{to}
+	var fields = fields{
+		d: to.fields.d,
+		a: make([]value, 0, len(a)),
+	}
+	fields.append(parent, a)
+	*to.fields = fields
+	return nil
+}
+
+func mergeConfigMergeArr(opts *options, to, from *Config) Error {
+	l := len(to.fields.array())
+	arr := from.fields.array()
+	if l > len(arr) {
+		l = len(arr)
+	}
+
+	var parent value = cfgSub{to}
 
 	// merge array indexes available in to and from
 	for i := 0; i < l; i++ {
 		ctx := context{
-			parent: cfgSub{to},
+			parent: parent,
 			field:  fmt.Sprintf("%v", i),
 		}
 
 		old := to.fields.array()[i]
-		v := from.fields.array()[i]
-		merged, err := mergeValues(opts, old, v)
+		merged, err := mergeValues(opts, old, arr[i])
 		if err != nil {
 			return err
 		}
-		to.fields.setAt(i, cfgSub{to}, merged.cpy(ctx))
+		to.fields.setAt(i, parent, merged.cpy(ctx))
 	}
 
-	end := len(from.fields.array())
-	if end <= l {
+	if len(arr) > l {
+		// add additional array entries not yet in 'to'
+		to.fields.append(parent, arr[l:])
+	}
+	return nil
+}
+
+func mergeConfigPrependArr(opts *options, to, from *Config) Error {
+	a1 := to.fields.array()
+	a2 := from.fields.array()
+	if len(a2) == 0 {
 		return nil
 	}
 
-	// add additional array entries not yet in 'to'
-	for ; l < end; l++ {
-		ctx := context{
-			parent: cfgSub{to},
-			field:  fmt.Sprintf("%v", l),
-		}
-		v := from.fields.array()[l]
-		to.fields.setAt(l, cfgSub{to}, v.cpy(ctx))
+	var parent value = cfgSub{to}
+	var fields = fields{
+		d: to.fields.d,
+		a: make([]value, 0, len(a1)+len(a2)),
 	}
+	fields.append(parent, a2)
+	fields.append(parent, a1)
+	*to.fields = fields
+	return nil
+}
 
+func mergeConfigAppendArr(opts *options, to, from *Config) Error {
+	to.fields.append(cfgSub{to}, from.fields.array())
 	return nil
 }
 

--- a/vendor/github.com/elastic/go-ucfg/opts.go
+++ b/vendor/github.com/elastic/go-ucfg/opts.go
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package ucfg
 
 import (
@@ -16,6 +33,8 @@ type options struct {
 	env          []*Config
 	resolvers    []func(name string) (string, error)
 	varexp       bool
+
+	configValueHandling configHandling
 
 	// temporary cache of parsed splice values for lifetime of call to
 	// Unpack/Pack/Get/...
@@ -102,6 +121,29 @@ func doResolveEnv(o *options) {
 		}
 		return value, nil
 	})
+}
+
+var (
+	// ReplacesValues option configures all merging and unpacking operations to
+	// replace old dictionaries and arrays while merging. Value merging can be
+	// overwritten in unpack by using struct tags.
+	ReplaceValues = makeOptValueHandling(cfgReplaceValue)
+
+	// AppendValues option configures all merging and unpacking operations to
+	// merge dictionaries and append arrays to existing arrays while merging.
+	// Value merging can be overwritten in unpack by using struct tags.
+	AppendValues = makeOptValueHandling(cfgArrAppend)
+
+	// PrependValues option configures all merging and unpacking operations to
+	// merge dictionaries and prepend arrays to existing arrays while merging.
+	// Value merging can be overwritten in unpack by using struct tags.
+	PrependValues = makeOptValueHandling(cfgArrPrepend)
+)
+
+func makeOptValueHandling(h configHandling) Option {
+	return func(o *options) {
+		o.configValueHandling = h
+	}
 }
 
 // VarExp option enables support for variable expansion. Resolve and Env options will only be effective if  VarExp is set.

--- a/vendor/github.com/elastic/go-ucfg/path.go
+++ b/vendor/github.com/elastic/go-ucfg/path.go
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package ucfg
 
 import (

--- a/vendor/github.com/elastic/go-ucfg/reify.go
+++ b/vendor/github.com/elastic/go-ucfg/reify.go
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package ucfg
 
 import (
@@ -12,7 +29,7 @@ import (
 // and pointers as necessary.
 //
 // Unpack supports the options: PathSep, StructTag, ValidatorTag, Env, Resolve,
-// ResolveEnv.
+// ResolveEnv, ReplaceValues, AppendValues, PrependValues.
 //
 // When unpacking into a value, Unpack first will try to call Unpack if the
 // value implements the Unpacker interface. Otherwise, Unpack tries to convert
@@ -61,7 +78,12 @@ import (
 //  If the tag sets the `,ignore` flag, the field will not be overwritten.
 //  If the tag sets the `,inline` or `,squash` flag, Unpack will apply the current
 //  configuration namespace to the fields.
-//
+//  If the tag option `replace` is configured, arrays and *ucfg.Config
+//  convertible fields are replaced by the new values.
+//  If the tag options `append` or `prepend` is used, arrays will be merged by
+//  appending/prepending the new array contents.
+//  The struct tag options `replace`, `append`, and `prepend` overwrites the
+//  global value merging strategy (e.g. ReplaceValues, AppendValues, ...) for all sub-fields.
 //
 // Fields available in a struct or a map, but not in the Config object, will not
 // be touched. Default values should be set in the target value before calling Unpack.
@@ -217,6 +239,14 @@ func reifyStruct(opts *options, orig reflect.Value, cfg *Config) Error {
 			name, tagOpts := parseTags(stField.Tag.Get(opts.tag))
 			if tagOpts.ignore {
 				continue
+			}
+
+			// create new context, overwriting configValueHandling for all sub-operations
+			if tagOpts.cfgHandling != opts.configValueHandling {
+				tmp := &options{}
+				*tmp = *opts
+				tmp.configValueHandling = tagOpts.cfgHandling
+				opts = tmp
 			}
 
 			opts.activeFields = NewFieldSet(parentFields)
@@ -382,14 +412,6 @@ func reifyMergeValue(
 
 	baseType := chaseTypePointers(old.Type())
 
-	if v, ok := valueIsUnpacker(old); ok {
-		err := unpackWith(opts.opts, v, val)
-		if err != nil {
-			return reflect.Value{}, err
-		}
-		return old, nil
-	}
-
 	if tConfig.ConvertibleTo(baseType) {
 		sub, err := val.toConfig(opts.opts)
 		if err != nil {
@@ -420,7 +442,15 @@ func reifyMergeValue(
 		}
 
 		// old != value -> merge value into old
-		return oldValue, mergeConfig(opts.opts, subOld, sub)
+		return oldValue, mergeFieldConfig(opts, subOld, sub)
+	}
+
+	if v, ok := valueIsUnpacker(old); ok {
+		err := unpackWith(opts.opts, v, val)
+		if err != nil {
+			return reflect.Value{}, err
+		}
+		return old, nil
 	}
 
 	switch baseType.Kind() {
@@ -442,10 +472,14 @@ func reifyMergeValue(
 		return reifyArray(opts, old, baseType, val)
 
 	case reflect.Slice:
-		return reifySlice(opts, baseType, val)
+		return reifySliceMerge(opts, old, baseType, val)
 	}
 
 	return reifyPrimitive(opts, val, t, baseType)
+}
+
+func mergeFieldConfig(opts fieldOptions, to, from *Config) Error {
+	return mergeConfig(opts.opts, to, from)
 }
 
 func reifyArray(
@@ -462,11 +496,20 @@ func reifyArray(
 		ctx := val.Context()
 		return reflect.Value{}, raiseArraySize(ctx, val.meta(), len(arr), tTo.Len())
 	}
-	return reifyDoArray(opts, to, tTo.Elem(), val, arr)
+	return reifyDoArray(opts, to, tTo.Elem(), 0, val, arr)
 }
 
 func reifySlice(
 	opts fieldOptions,
+	tTo reflect.Type,
+	val value,
+) (reflect.Value, Error) {
+	return reifySliceMerge(opts, reflect.Value{}, tTo, val)
+}
+
+func reifySliceMerge(
+	opts fieldOptions,
+	old reflect.Value,
 	tTo reflect.Type,
 	val value,
 ) (reflect.Value, Error) {
@@ -475,22 +518,58 @@ func reifySlice(
 		return reflect.Value{}, err
 	}
 
-	to := reflect.MakeSlice(tTo, len(arr), len(arr))
-	return reifyDoArray(opts, to, tTo.Elem(), val, arr)
+	arrMergeCfg := opts.configHandling()
+
+	l := len(arr)
+	start := 0
+	cpyStart := 0
+
+	withOld := old.IsValid() && !old.IsNil()
+	if withOld {
+		ol := old.Len()
+
+		switch arrMergeCfg {
+		case cfgReplaceValue:
+			// do nothing
+
+		case cfgArrAppend:
+			l += ol
+			start = ol
+
+		case cfgArrPrepend:
+			cpyStart = l
+			l += ol
+
+		default:
+			if l < ol {
+				l = ol
+			}
+		}
+	}
+	tmp := reflect.MakeSlice(tTo, l, l)
+
+	if withOld {
+		reflect.Copy(tmp.Slice(cpyStart, tmp.Len()), old)
+	}
+	return reifyDoArray(opts, tmp, tTo.Elem(), start, val, arr)
 }
 
 func reifyDoArray(
 	opts fieldOptions,
 	to reflect.Value, elemT reflect.Type,
+	start int,
 	val value,
 	arr []value,
 ) (reflect.Value, Error) {
-	for i, from := range arr {
-		v, err := reifyValue(opts, elemT, from)
+	idx := start
+	for _, from := range arr {
+		to.Index(idx)
+		v, err := reifyMergeValue(opts, to.Index(idx), from)
 		if err != nil {
 			return reflect.Value{}, err
 		}
-		to.Index(i).Set(v)
+		to.Index(idx).Set(v)
+		idx++
 	}
 
 	if err := runValidators(to.Interface(), opts.validators); err != nil {

--- a/vendor/github.com/elastic/go-ucfg/types.go
+++ b/vendor/github.com/elastic/go-ucfg/types.go
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package ucfg
 
 import (

--- a/vendor/github.com/elastic/go-ucfg/ucfg.go
+++ b/vendor/github.com/elastic/go-ucfg/ucfg.go
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package ucfg
 
 import (
@@ -64,6 +81,18 @@ func New() *Config {
 	return &Config{
 		fields: &fields{nil, nil},
 	}
+}
+
+// NustNewFrom creates a new config object normalizing and copying from into the new
+// Config object. MustNewFrom uses Merge to copy from.
+//
+// MustNewFrom supports the options: PathSep, MetaData, StructTag, VarExp
+func MustNewFrom(from interface{}, opts ...Option) *Config {
+	c := New()
+	if err := c.Merge(from, opts...); err != nil {
+		panic(err)
+	}
+	return c
 }
 
 // NewFrom creates a new config object normalizing and copying from into the new
@@ -216,4 +245,28 @@ func (f *fields) setAt(idx int, parent, v value) {
 	}
 
 	f.a[idx] = v
+}
+
+func (f *fields) append(parent value, a []value) {
+	l := len(f.a)
+	count := len(a)
+	if count == 0 {
+		return
+	}
+
+	for i := 0; i < count; i, l = i+1, l+1 {
+		ctx := context{
+			parent: parent,
+			field:  fmt.Sprintf("%v", l),
+		}
+		f.setAt(l, parent, a[i].cpy(ctx))
+	}
+}
+
+func (o *fieldOptions) configHandling() configHandling {
+	h := o.tag.cfgHandling
+	if h == cfgDefaultHandling {
+		h = o.opts.configValueHandling
+	}
+	return h
 }

--- a/vendor/github.com/elastic/go-ucfg/unpack.go
+++ b/vendor/github.com/elastic/go-ucfg/unpack.go
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package ucfg
 
 import "reflect"
@@ -100,6 +117,12 @@ func typeIsUnpacker(t reflect.Type) (reflect.Value, bool) {
 }
 
 func implementsUnpacker(t reflect.Type) bool {
+	// ucfg.Config or structures that can be casted to ucfg.Config are not
+	// Unpackers.
+	if tConfig.ConvertibleTo(chaseTypePointers(t)) {
+		return false
+	}
+
 	for _, tUnpack := range tUnpackers {
 		if t.Implements(tUnpack) {
 			return true

--- a/vendor/github.com/elastic/go-ucfg/util.go
+++ b/vendor/github.com/elastic/go-ucfg/util.go
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package ucfg
 
 import (
@@ -6,9 +23,22 @@ import (
 )
 
 type tagOptions struct {
-	squash bool
-	ignore bool
+	squash      bool
+	ignore      bool
+	cfgHandling configHandling
 }
+
+// configHandling configures the operation to execute if we merge into a struct
+// field that holds an unpacked config object.
+type configHandling uint8
+
+const (
+	cfgDefaultHandling configHandling = iota
+	cfgMergeValues
+	cfgReplaceValue
+	cfgArrAppend
+	cfgArrPrepend
+)
 
 var noTagOpts = tagOptions{}
 
@@ -21,6 +51,14 @@ func parseTags(tag string) (string, tagOptions) {
 			opts.squash = true
 		case "ignore":
 			opts.ignore = true
+		case "merge":
+			opts.cfgHandling = cfgMergeValues
+		case "replace":
+			opts.cfgHandling = cfgReplaceValue
+		case "append":
+			opts.cfgHandling = cfgArrAppend
+		case "prepend":
+			opts.cfgHandling = cfgArrPrepend
 		}
 	}
 	return s[0], opts

--- a/vendor/github.com/elastic/go-ucfg/validator.go
+++ b/vendor/github.com/elastic/go-ucfg/validator.go
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package ucfg
 
 import (

--- a/vendor/github.com/elastic/go-ucfg/variables.go
+++ b/vendor/github.com/elastic/go-ucfg/variables.go
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package ucfg
 
 import (

--- a/vendor/github.com/elastic/go-ucfg/yaml/yaml.go
+++ b/vendor/github.com/elastic/go-ucfg/yaml/yaml.go
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package yaml
 
 import (

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -638,42 +638,52 @@
 			"versionExact": "v0.0.1"
 		},
 		{
-			"checksumSHA1": "61XUpyQ3zWnJ7Tlj0xLsHtnzwJY=",
+			"checksumSHA1": "d0qibYdQy5G1YqI5H+xNC0QJ66g=",
 			"path": "github.com/elastic/go-ucfg",
-			"revision": "0ba28e36add27704e6b49a7ed8557989a8f4a635",
-			"revisionTime": "2018-01-30T20:43:55Z",
-			"version": "v0.5.1",
-			"versionExact": "v0.5.1"
+			"revision": "9c66f5c432b1d25bdb449a1e588d58b5d0cd7268",
+			"revisionTime": "2018-07-04T14:42:58Z",
+			"version": "v0.6.0",
+			"versionExact": "v0.6.0"
 		},
 		{
-			"checksumSHA1": "8cr5YhslUMgpvF2JebYvKC+Ezr4=",
+			"checksumSHA1": "X+R/CD8SokJrmlxFTx2nSevRDhQ=",
 			"path": "github.com/elastic/go-ucfg/cfgutil",
-			"revision": "ec8488a52542c0c51e42e8ea204dcaff400bc644",
-			"revisionTime": "2017-02-07T06:38:51Z"
+			"revision": "9c66f5c432b1d25bdb449a1e588d58b5d0cd7268",
+			"revisionTime": "2018-07-04T14:42:58Z",
+			"version": "v0.6.0",
+			"versionExact": "v0.6.0"
 		},
 		{
-			"checksumSHA1": "Q2qrc/nI9d1tNzWTmfrkWvBNqsc=",
+			"checksumSHA1": "dShGF53hLUufO70RAjju+RT0fHY=",
 			"path": "github.com/elastic/go-ucfg/flag",
-			"revision": "ec8488a52542c0c51e42e8ea204dcaff400bc644",
-			"revisionTime": "2017-02-07T06:38:51Z"
+			"revision": "9c66f5c432b1d25bdb449a1e588d58b5d0cd7268",
+			"revisionTime": "2018-07-04T14:42:58Z",
+			"version": "v0.6.0",
+			"versionExact": "v0.6.0"
 		},
 		{
-			"checksumSHA1": "uOrhvj7stlb0foxGZ5vbC1XJeto=",
+			"checksumSHA1": "esXpiQlEvTOUwsE0nNesso8albo=",
 			"path": "github.com/elastic/go-ucfg/internal/parse",
-			"revision": "ec8488a52542c0c51e42e8ea204dcaff400bc644",
-			"revisionTime": "2017-02-07T06:38:51Z"
+			"revision": "9c66f5c432b1d25bdb449a1e588d58b5d0cd7268",
+			"revisionTime": "2018-07-04T14:42:58Z",
+			"version": "v0.6.0",
+			"versionExact": "v0.6.0"
 		},
 		{
-			"checksumSHA1": "sMBM95+VYBPhwtNVHqqN1yrvk1o=",
+			"checksumSHA1": "5mXUhhlPdvcAFKiQENInTJWrtQM=",
 			"path": "github.com/elastic/go-ucfg/json",
-			"revision": "ec8488a52542c0c51e42e8ea204dcaff400bc644",
-			"revisionTime": "2017-02-07T06:38:51Z"
+			"revision": "9c66f5c432b1d25bdb449a1e588d58b5d0cd7268",
+			"revisionTime": "2018-07-04T14:42:58Z",
+			"version": "v0.6.0",
+			"versionExact": "v0.6.0"
 		},
 		{
-			"checksumSHA1": "qvzj0KzxrWvYhHIbo+FwBxUNDFw=",
+			"checksumSHA1": "Bg6vistPQLftv2fEYB7GWwSExv8=",
 			"path": "github.com/elastic/go-ucfg/yaml",
-			"revision": "ec8488a52542c0c51e42e8ea204dcaff400bc644",
-			"revisionTime": "2017-02-07T06:38:51Z"
+			"revision": "9c66f5c432b1d25bdb449a1e588d58b5d0cd7268",
+			"revisionTime": "2018-07-04T14:42:58Z",
+			"version": "v0.6.0",
+			"versionExact": "v0.6.0"
 		},
 		{
 			"checksumSHA1": "yu/X+qHftvfQlAnjPdYLwrDn2nI=",


### PR DESCRIPTION
- Update go-ucfg to 0.6.0 
- Update NewConfigFrom to treat raw string input as YAML contents
- Introduce MustNewConfigFrom, which throws a panic on error