### PR TITLE
Disable colors on tests

### DIFF
--- a/libbeat/testing/console_test.go
+++ b/libbeat/testing/console_test.go
@@ -23,8 +23,13 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/fatih/color"
 	"github.com/stretchr/testify/assert"
 )
+
+func init() {
+	color.NoColor = true
+}
 
 func TestConsoleDriverInfo(t *testing.T) {
 	buffer, output, driver := createDriver(nil)


### PR DESCRIPTION
It seems this is given problems on some terminals, this change
disables any kind of colors on tests