### PR TITLE
Add output.name to state metrics

### DIFF
--- a/libbeat/publisher/pipeline/module.go
+++ b/libbeat/publisher/pipeline/module.go
@@ -134,6 +134,10 @@ func loadOutput(
 		monitoring.NewString(outReg, "type").Set(outcfg.Name())
 	}
 
+	stateRegistry := monitoring.GetNamespace("state").GetRegistry()
+	outputRegistry := stateRegistry.NewRegistry("output")
+	monitoring.NewString(outputRegistry, "name").Set(outcfg.Name())
+
 	return out, nil
 }
 


### PR DESCRIPTION
The document looks as following:

```
{
  "output": {
    "name": "elasticsearch"
  }
}
```