### PR TITLE
Improve fields.yml generator of modules

### DIFF
--- a/filebeat/scripts/generator/fields/main.go
+++ b/filebeat/scripts/generator/fields/main.go
@@ -33,6 +33,10 @@ import (
 const (
 	pipelinePath  = "%s/module/%s/%s/ingest/pipeline.json"
 	fieldsYmlPath = "%s/module/%s/%s/_meta/fields.yml"
+
+	typeIdx     = 0
+	elementsIdx = 1
+	hintIdx     = 2
 )
 
 var (
@@ -96,19 +100,32 @@ func newFieldYml(name, typeName string, noDoc bool) *fieldYml {
 func newField(lp string) field {
 	lp = lp[1 : len(lp)-1]
 	ee := strings.Split(lp, ":")
-	if 2 != len(ee) && len(ee) != 3 {
+	if !isValidFormat(ee) {
 		return field{}
 	}
 
 	hint := ""
-	if len(ee) == 3 {
-		hint = ee[2]
+	if containsHint(ee) {
+		hint = ee[hintIdx]
 	}
+
 	return field{
-		Type:     ee[0],
-		Elements: strings.Split(ee[1], "."),
+		Type:     ee[typeIdx],
+		Elements: strings.Split(ee[elementsIdx], "."),
 		Hint:     hint,
 	}
+}
+
+// isValidFormat checks if the input can be split correctly
+// 1. if lenght is 2, the format is {type}:{field.elements}
+// 2. if the lenght is 3, the format is {type}:{field.elements}:{hint}
+func isValidFormat(ee []string) bool {
+	return len(ee) == 2 || len(ee) == 3
+}
+
+// the last element is the type hint
+func containsHint(ee []string) bool {
+	return len(ee) == 3
 }
 
 func readPipeline(beatsPath, module, fileset string) (*pipeline, error) {

--- a/filebeat/scripts/generator/fields/main.go
+++ b/filebeat/scripts/generator/fields/main.go
@@ -66,6 +66,7 @@ type pipeline struct {
 type field struct {
 	Type     string
 	Elements []string
+	Hint     string
 }
 
 type fieldYml struct {
@@ -95,17 +96,19 @@ func newFieldYml(name, typeName string, noDoc bool) *fieldYml {
 func newField(lp string) field {
 	lp = lp[1 : len(lp)-1]
 	ee := strings.Split(lp, ":")
-	if len(ee) != 2 {
-		return field{
-			Type:     ee[0],
-			Elements: nil,
-		}
+	if 2 < len(ee) && len(ee) < 3 {
+		return field{}
 	}
 
-	e := strings.Split(ee[1], ".")
+	hint := ""
+	if len(ee) == 3 {
+		hint = ee[2]
+		fmt.Println(hint)
+	}
 	return field{
 		Type:     ee[0],
-		Elements: e,
+		Elements: strings.Split(ee[1], "."),
+		Hint:     hint,
 	}
 }
 
@@ -275,13 +278,17 @@ func getFieldByName(f []*fieldYml, name string) *fieldYml {
 	return nil
 }
 
-func insertLastField(f []*fieldYml, name, typeName string, noDoc bool) []*fieldYml {
+func insertLastField(f []*fieldYml, name string, field field, noDoc bool) []*fieldYml {
 	ff := getFieldByName(f, name)
 	if ff != nil {
 		return f
 	}
 
-	nf := newFieldYml(name, types[typeName], noDoc)
+	fieldType := field.Hint
+	if fieldType == "" {
+		fieldType = types[field.Type]
+	}
+	nf := newFieldYml(name, fieldType, noDoc)
 	return append(f, nf)
 }
 
@@ -301,7 +308,7 @@ func insertGroup(out []*fieldYml, field field, index, count int, noDoc bool) []*
 
 func generateField(out []*fieldYml, field field, index, count int, noDoc bool) []*fieldYml {
 	if index+1 == count {
-		return insertLastField(out, field.Elements[index], field.Type, noDoc)
+		return insertLastField(out, field.Elements[index], field, noDoc)
 	}
 	return insertGroup(out, field, index, count, noDoc)
 }

--- a/filebeat/scripts/generator/fields/main.go
+++ b/filebeat/scripts/generator/fields/main.go
@@ -96,14 +96,13 @@ func newFieldYml(name, typeName string, noDoc bool) *fieldYml {
 func newField(lp string) field {
 	lp = lp[1 : len(lp)-1]
 	ee := strings.Split(lp, ":")
-	if 2 < len(ee) && len(ee) < 3 {
+	if 2 != len(ee) && len(ee) != 3 {
 		return field{}
 	}
 
 	hint := ""
 	if len(ee) == 3 {
 		hint = ee[2]
-		fmt.Println(hint)
 	}
 	return field{
 		Type:     ee[0],

--- a/filebeat/scripts/generator/fields/main.go
+++ b/filebeat/scripts/generator/fields/main.go
@@ -97,25 +97,25 @@ func newFieldYml(name, typeName string, noDoc bool) *fieldYml {
 	}
 }
 
-func newField(lp string) field {
-	if len(lp) <= 2 {
+func newField(pattern string) field {
+	if len(pattern) <= 2 {
 		return field{}
 	}
-	lp = lp[1 : len(lp)-1]
+	pattern = pattern[1 : len(pattern)-1]
 
-	ee := strings.Split(lp, ":")
-	if !isValidFormat(ee) {
+	elements := strings.Split(pattern, ":")
+	if !isValidFormat(elements) {
 		return field{}
 	}
 
 	hint := ""
-	if containsType(ee) {
-		hint = ee[hintIdx]
+	if containsType(elements) {
+		hint = elements[hintIdx]
 	}
 
 	return field{
-		Syntax:           ee[typeIdx],
-		SemanticElements: strings.Split(ee[elementsIdx], "."),
+		Syntax:           elements[typeIdx],
+		SemanticElements: strings.Split(elements[elementsIdx], "."),
 		Type:             hint,
 	}
 }

--- a/filebeat/scripts/generator/fields/main_test.go
+++ b/filebeat/scripts/generator/fields/main_test.go
@@ -126,6 +126,15 @@ func TestFieldsGenerator(t *testing.T) {
 				&fieldYml{Name: "message", Description: "Please add description", Example: "Please add example", Type: "text"},
 			},
 		},
+		FieldsGeneratorTestCase{
+			patterns: []string{
+				"\\[%{TIMESTAMP:timestamp}\\] %{NUMBER:idx:int}",
+			},
+			fields: []*fieldYml{
+				&fieldYml{Name: "timestamp", Description: "Please add description", Example: "Please add example", Type: "text"},
+				&fieldYml{Name: "idx", Description: "Please add description", Example: "Please add example", Type: "int"},
+			},
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
From now on when a user provides a type hint in an Ingest pipeline, it's added to the generated `fields.yml` instead of guessing.

Closes #7472