### PR TITLE
Add queue name to state reporting

### DIFF
--- a/libbeat/publisher/pipeline/module.go
+++ b/libbeat/publisher/pipeline/module.go
@@ -157,6 +157,10 @@ func createQueueBuilder(config common.ConfigNamespace) (func(queue.Eventer) (que
 		queueConfig = common.NewConfig()
 	}
 
+	stateRegistry := monitoring.GetNamespace("state").GetRegistry()
+	queueRegistry := stateRegistry.NewRegistry("queue")
+	monitoring.NewString(queueRegistry, "name").Set(queueType)
+
 	return func(eventer queue.Eventer) (queue.Queue, error) {
 		return queueFactory(eventer, queueConfig)
 	}, nil


### PR DESCRIPTION
The queue name is reported as part of the state event. An event looks as following:

```
{
  "beat": {
    "name": "ruflin"
  },
  "host": {
    "architecture": "x86_64",
    "name": "ruflin",
    "os": {
      "build": "17E202",
      "family": "darwin",
      "platform": "darwin",
      "version": "10.13.4"
    }
  },
  "module": {
    "count": 3,
    "names": [
      "system"
    ]
  },
  "output": {
    "name": "elasticsearch"
  },
  "queue": {
    "name": "mem"
  },
  "service": {
    "id": "0e1b1913-73db-4512-b17a-8209fa45eaa4",
    "name": "metricbeat",
    "version": "7.0.0-alpha1"
  }
}
```