### PR TITLE
[DOCS] Backport: Adds shutdown pages for Beats

### DIFF
--- a/auditbeat/docs/setting-up-running.asciidoc
+++ b/auditbeat/docs/setting-up-running.asciidoc
@@ -30,3 +30,5 @@ include::../../libbeat/docs/keystore.asciidoc[]
 include::../../libbeat/docs/command-reference.asciidoc[]
 
 include::./running-on-docker.asciidoc[]
+
+include::../../libbeat/docs/shared-shutdown.asciidoc[]

--- a/filebeat/docs/setting-up-running.asciidoc
+++ b/filebeat/docs/setting-up-running.asciidoc
@@ -34,3 +34,5 @@ include::../../libbeat/docs/command-reference.asciidoc[]
 include::./running-on-docker.asciidoc[]
 
 include::./running-on-kubernetes.asciidoc[]
+
+include::../../libbeat/docs/shared-shutdown.asciidoc[]

--- a/heartbeat/docs/setting-up-running.asciidoc
+++ b/heartbeat/docs/setting-up-running.asciidoc
@@ -29,3 +29,5 @@ include::../../libbeat/docs/keystore.asciidoc[]
 include::../../libbeat/docs/command-reference.asciidoc[]
 
 include::./running-on-docker.asciidoc[]
+
+include::../../libbeat/docs/shared-shutdown.asciidoc[]

--- a/libbeat/docs/shared-shutdown.asciidoc
+++ b/libbeat/docs/shared-shutdown.asciidoc
@@ -6,7 +6,7 @@
 //// Use the appropriate variables defined in the index.asciidoc file to
 //// resolve Beat names: beatname_uc and beatname_lc.
 //// Use the following include to pull this content into a doc file:
-//// include::../../libbeat/docs/shared-directory-layout.asciidoc[]
+//// include::../../libbeat/docs/shared-shutdown.asciidoc[]
 //////////////////////////////////////////////////////////////////////////
 
 [[shutdown]]

--- a/libbeat/docs/shared-shutdown.asciidoc
+++ b/libbeat/docs/shared-shutdown.asciidoc
@@ -1,0 +1,24 @@
+//////////////////////////////////////////////////////////////////////////
+//// This content is shared by all Elastic Beats. Make sure you keep the
+//// descriptions here generic enough to work for all Beats that include
+//// this file. When using cross references, make sure that the cross
+//// references resolve correctly for any files that include this one.
+//// Use the appropriate variables defined in the index.asciidoc file to
+//// resolve Beat names: beatname_uc and beatname_lc.
+//// Use the following include to pull this content into a doc file:
+//// include::../../libbeat/docs/shared-directory-layout.asciidoc[]
+//////////////////////////////////////////////////////////////////////////
+
+[[shutdown]]
+=== Stopping {beatname_uc}
+
+An orderly shutdown of {beatname_uc} ensures that it has a chance to clean up 
+and close outstanding resources. You can help ensure an orderly shutdown by 
+stopping {beatname_uc} properly. 
+
+If you’re running {beatname_uc} as a service, you can stop it via the service 
+management functionality provided by your installation. 
+
+If you’re running {beatname_uc} directly in the console, you can stop it by 
+entering *Ctrl-C*. Alternatively, send SIGTERM to the {beatname_uc} process on a 
+POSIX system.

--- a/metricbeat/docs/setting-up-running.asciidoc
+++ b/metricbeat/docs/setting-up-running.asciidoc
@@ -33,3 +33,5 @@ include::../../libbeat/docs/command-reference.asciidoc[]
 include::./running-on-docker.asciidoc[]
 
 include::./running-on-kubernetes.asciidoc[]
+
+include::../../libbeat/docs/shared-shutdown.asciidoc[]

--- a/packetbeat/docs/setting-up-running.asciidoc
+++ b/packetbeat/docs/setting-up-running.asciidoc
@@ -29,3 +29,5 @@ include::../../libbeat/docs/keystore.asciidoc[]
 include::../../libbeat/docs/command-reference.asciidoc[]
 
 include::./running-on-docker.asciidoc[]
+
+include::../../libbeat/docs/shared-shutdown.asciidoc[]

--- a/winlogbeat/docs/setting-up-running.asciidoc
+++ b/winlogbeat/docs/setting-up-running.asciidoc
@@ -25,3 +25,5 @@ include::../../libbeat/docs/shared-directory-layout.asciidoc[]
 include::../../libbeat/docs/keystore.asciidoc[]
 
 include::../../libbeat/docs/command-reference.asciidoc[]
+
+include::../../libbeat/docs/shared-shutdown.asciidoc[]


### PR DESCRIPTION
Backports https://github.com/elastic/beats/pull/7547 to the 6.3 branch