### PR TITLE
Add debug logging to file rotator

### DIFF
--- a/libbeat/common/file/rotator.go
+++ b/libbeat/common/file/rotator.go
@@ -30,6 +30,28 @@ import (
 // greater will result in an error.
 const MaxBackupsLimit = 1024
 
+// rotateReason is the reason why file rotation occurred.
+type rotateReason uint32
+
+const (
+	rotateReasonInitializing rotateReason = iota + 1
+	rotateReasonFileSize
+	rotateReasonManualTrigger
+)
+
+func (rr rotateReason) String() string {
+	switch rr {
+	case rotateReasonInitializing:
+		return "initializing"
+	case rotateReasonFileSize:
+		return "file size"
+	case rotateReasonManualTrigger:
+		return "manual trigger"
+	default:
+		return "unknown"
+	}
+}
+
 // Rotator is a io.WriteCloser that automatically rotates the file it is
 // writing to when it reaches a maximum size. It also purges the oldest rotated
 // files when the maximum number of backups is reached.
@@ -38,10 +60,16 @@ type Rotator struct {
 	maxSizeBytes uint
 	maxBackups   uint
 	permissions  os.FileMode
+	log          Logger // Optional Logger (may be nil).
 
 	file  *os.File
 	size  uint
 	mutex sync.Mutex
+}
+
+// Logger allows the rotator to write debug information.
+type Logger interface {
+	Debugw(msg string, keysAndValues ...interface{}) // Debug
 }
 
 // RotatorOption is a configuration option for Rotator.
@@ -72,6 +100,14 @@ func Permissions(m os.FileMode) RotatorOption {
 	}
 }
 
+// WithLogger injects a logger implementation for logging debug information.
+// If no logger is injected then the no logging will occur.
+func WithLogger(l Logger) RotatorOption {
+	return func(r *Rotator) {
+		r.log = l
+	}
+}
+
 // NewFileRotator returns a new Rotator.
 func NewFileRotator(filename string, options ...RotatorOption) (*Rotator, error) {
 	r := &Rotator{
@@ -95,6 +131,15 @@ func NewFileRotator(filename string, options ...RotatorOption) (*Rotator, error)
 		return nil, errors.Errorf("file rotator permissions mask of %o is invalid", r.permissions)
 	}
 
+	if r.log != nil {
+		r.log.Debugw("Initialized file rotator",
+			"filename", r.filename,
+			"max_size_bytes", r.maxSizeBytes,
+			"max_backups", r.maxBackups,
+			"permissions", r.permissions,
+		)
+	}
+
 	return r, nil
 }
 
@@ -116,7 +161,7 @@ func (r *Rotator) Write(data []byte) (int, error) {
 			return 0, err
 		}
 	} else if r.size+dataLen > r.maxSizeBytes {
-		if err := r.rotate(); err != nil {
+		if err := r.rotate(rotateReasonFileSize); err != nil {
 			return 0, err
 		}
 		if err := r.openFile(); err != nil {
@@ -145,7 +190,7 @@ func (r *Rotator) Sync() error {
 func (r *Rotator) Rotate() error {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
-	return r.rotate()
+	return r.rotate(rotateReasonManualTrigger)
 }
 
 // Close closes the currently open file.
@@ -185,7 +230,7 @@ func (r *Rotator) openNew() error {
 
 	_, err = os.Stat(r.filename)
 	if err == nil {
-		if err = r.rotate(); err != nil {
+		if err = r.rotate(rotateReasonInitializing); err != nil {
 			return err
 		}
 	}
@@ -237,7 +282,7 @@ func (r *Rotator) purgeOldBackups() error {
 	return nil
 }
 
-func (r *Rotator) rotate() error {
+func (r *Rotator) rotate(reason rotateReason) error {
 	if err := r.closeFile(); err != nil {
 		return errors.Wrap(err, "error file closing current file")
 	}
@@ -257,6 +302,11 @@ func (r *Rotator) rotate() error {
 		}
 		if err := os.Rename(old, older); err != nil {
 			return errors.Wrap(err, "failed to rotate backups")
+		} else if i == 1 {
+			// Log when rotation of the main file occurs.
+			if r.log != nil {
+				r.log.Debugw("Rotating file", "filename", old, "reason", reason)
+			}
 		}
 	}
 

--- a/libbeat/outputs/fileout/file.go
+++ b/libbeat/outputs/fileout/file.go
@@ -80,6 +80,7 @@ func (out *fileOutput) init(beat beat.Info, c config) error {
 		file.MaxSizeBytes(c.RotateEveryKb*1024),
 		file.MaxBackups(c.NumberOfFiles),
 		file.Permissions(os.FileMode(c.Permissions)),
+		file.WithLogger(logp.NewLogger("rotator").With(logp.Namespace("rotator"))),
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
This adds debug logging when the output file is rotated and states the reason why (size, initializing, or manual trigger).

The logger must be injectable to avoid a direct dependency on logp which uses the file rotator.