### PR TITLE
Separate Line reader into a reader and a scanner

### DIFF
--- a/filebeat/input/log/harvester.go
+++ b/filebeat/input/log/harvester.go
@@ -549,10 +549,7 @@ func (h *Harvester) newLogFileReader() (reader.Reader, error) {
 		return nil, err
 	}
 
-	r, err = readfile.NewEncodeReader(h.log, h.encoding, h.config.BufferSize)
-	if err != nil {
-		return nil, err
-	}
+	r = readfile.NewEncodeReader(h.log, h.encoding, h.config.BufferSize)
 
 	if h.config.DockerJSON != nil {
 		// Docker json-file format, add custom parsing to the pipeline

--- a/filebeat/reader/multiline/multiline_test.go
+++ b/filebeat/reader/multiline/multiline_test.go
@@ -189,10 +189,7 @@ func createMultilineTestReader(t *testing.T, in *bytes.Buffer, cfg Config) reade
 	}
 
 	var r reader.Reader
-	r, err = readfile.NewEncodeReader(in, enc, 4096)
-	if err != nil {
-		t.Fatalf("Failed to initialize line reader: %v", err)
-	}
+	r = readfile.NewEncodeReader(in, enc, 4096)
 
 	r, err = New(readfile.NewStripNewline(r), "\n", 1<<20, &cfg)
 	if err != nil {

--- a/filebeat/reader/readfile/decoder.go
+++ b/filebeat/reader/readfile/decoder.go
@@ -1,0 +1,166 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package readfile
+
+import (
+	"fmt"
+	"io"
+
+	"golang.org/x/text/encoding"
+	"golang.org/x/text/transform"
+
+	"github.com/elastic/beats/libbeat/common/streambuf"
+)
+
+type decoderReader struct {
+	in         io.Reader
+	decoder    transform.Transformer
+	buf        *streambuf.Buffer
+	encodedBuf *streambuf.Buffer
+	bufferSize int
+	symlen     []uint8
+}
+
+func newDecoderReader(in io.Reader, codec encoding.Encoding, bufferSize int) *decoderReader {
+	return &decoderReader{
+		in:         in,
+		decoder:    codec.NewDecoder(),
+		buf:        streambuf.New(nil),
+		encodedBuf: streambuf.New(nil),
+		bufferSize: bufferSize,
+	}
+}
+
+func (r *decoderReader) read(buf []byte) (int, error) {
+	b := make([]byte, r.bufferSize)
+
+	if r.buf.Len() != 0 {
+		return r.copyToOut(buf)
+	}
+
+	for {
+		start := r.encodedBuf.Len()
+		n, err := r.in.Read(b[start:])
+		if err != nil {
+			return len(buf[:n]), err
+		}
+
+		if start > 0 {
+			enc, err := r.encodedBuf.Collect(start)
+			if err != nil {
+				return 0, err
+			}
+			r.encodedBuf.Reset()
+			b = append(enc, b[start:]...)
+		}
+
+		nBytes, nProcessed, err := r.conv(b[:start+n], buf)
+		if err != nil {
+			if err == transform.ErrShortSrc {
+				r.encodedBuf.Append(b[nProcessed:])
+				return nBytes, nil
+			}
+			return 0, err
+		}
+		return nBytes, nil
+	}
+}
+
+// msgSize returns the size of the encoded message on the disk
+func (r *decoderReader) msgSize(symlen []uint8, size int) (int, []uint8, error) {
+	n := 0
+	for size > 0 {
+		if len(symlen) <= n {
+			return 0, symlen, fmt.Errorf("error calculating size: too short symlen")
+		}
+
+		size -= int(symlen[n])
+		n++
+	}
+
+	symlen = symlen[n:]
+
+	return n, symlen, nil
+}
+
+func (r *decoderReader) symbolsLen() []uint8 {
+	s := r.symlen
+	r.symlen = []uint8{}
+	return s
+}
+
+// conv converts encoded bytes into UTF-8 and produces a symlen array which
+// records the size of the encoded bytes and its converted size
+func (r *decoderReader) conv(in []byte, out []byte) (int, int, error) {
+	var err error
+	nProcessed := 0
+	decodedChar := make([]byte, 64)
+	r.symlen = make([]uint8, len(in))
+
+	i := 0
+	srcLen := len(in)
+	for i < srcLen {
+		j := i + 1
+
+		for j <= srcLen {
+			nDst, nSrc, err := r.decoder.Transform(decodedChar, in[i:j], false)
+			if err != nil {
+				// if no char is decoded, try increasing the input buffer
+				if err == transform.ErrShortSrc {
+					j++
+
+					// if the buffer size cannot be increased, return what's been decoded and an error
+					if srcLen < j {
+						n, _ := r.copyToOut(out)
+						r.symlen = r.symlen[:nProcessed]
+						return n, nProcessed, err
+					}
+				}
+				err = nil
+			}
+
+			// move in the symlen buffer if no char is decoded
+			if nDst == 0 && nSrc == 0 {
+				nProcessed++
+				continue
+			}
+
+			r.symlen[nProcessed] = uint8(nDst)
+			r.buf.Write(decodedChar[:nDst])
+			nProcessed++
+			break
+		}
+		i = j
+	}
+
+	n, err := r.copyToOut(out)
+	return n, nProcessed, err
+}
+
+func (r *decoderReader) copyToOut(out []byte) (int, error) {
+	until := len(out)
+	if r.buf.Len() < until {
+		until = r.buf.Len()
+	}
+	b, err := r.buf.Collect(until)
+	if err != nil {
+		return 0, err
+	}
+	r.buf.Reset()
+	return copy(out, b), nil
+}

--- a/filebeat/reader/readfile/encode.go
+++ b/filebeat/reader/readfile/encode.go
@@ -37,9 +37,9 @@ func NewEncodeReader(
 	r io.Reader,
 	codec encoding.Encoding,
 	bufferSize int,
-) (EncoderReader, error) {
-	eReader, err := NewLineReader(r, codec, bufferSize)
-	return EncoderReader{eReader}, err
+) EncoderReader {
+	eReader := NewLineReader(r, codec, []byte("\n"), bufferSize)
+	return EncoderReader{eReader}
 }
 
 // Next reads the next line from it's initial io.Reader

--- a/filebeat/reader/readfile/line.go
+++ b/filebeat/reader/readfile/line.go
@@ -21,174 +21,26 @@ import (
 	"io"
 
 	"golang.org/x/text/encoding"
-	"golang.org/x/text/transform"
-
-	"github.com/elastic/beats/libbeat/common/streambuf"
-	"github.com/elastic/beats/libbeat/logp"
 )
 
 // lineReader reads lines from underlying reader, decoding the input stream
 // using the configured codec. The reader keeps track of bytes consumed
 // from raw input stream for every decoded line.
 type LineReader struct {
-	reader     io.Reader
-	codec      encoding.Encoding
-	bufferSize int
-	nl         []byte
-	inBuffer   *streambuf.Buffer
-	outBuffer  *streambuf.Buffer
-	inOffset   int // input buffer read offset
-	byteCount  int // number of bytes decoded from input buffer into output buffer
-	decoder    transform.Transformer
+	lineScanner *lineScanner
 }
 
 // New creates a new reader object
-func NewLineReader(input io.Reader, codec encoding.Encoding, bufferSize int) (*LineReader, error) {
-	encoder := codec.NewEncoder()
-
-	// Create newline char based on encoding
-	nl, _, err := transform.Bytes(encoder, []byte{'\n'})
-	if err != nil {
-		return nil, err
-	}
+func NewLineReader(input io.Reader, codec encoding.Encoding, separator []byte, bufferSize int) *LineReader {
+	decReader := newDecoderReader(input, codec, bufferSize)
+	lineScanner := newLineScanner(decReader, separator, bufferSize)
 
 	return &LineReader{
-		reader:     input,
-		codec:      codec,
-		bufferSize: bufferSize,
-		nl:         nl,
-		decoder:    codec.NewDecoder(),
-		inBuffer:   streambuf.New(nil),
-		outBuffer:  streambuf.New(nil),
-	}, nil
+		lineScanner: lineScanner,
+	}
 }
 
 // Next reads the next line until the new line character
 func (r *LineReader) Next() ([]byte, int, error) {
-	// This loop is need in case advance detects an line ending which turns out
-	// not to be one when decoded. If that is the case, reading continues.
-	for {
-		// read next 'potential' line from input buffer/reader
-		err := r.advance()
-		if err != nil {
-			return nil, 0, err
-		}
-
-		// Check last decoded byte really being '\n' also unencoded
-		// if not, continue reading
-		buf := r.outBuffer.Bytes()
-
-		// This can happen if something goes wrong during decoding
-		if len(buf) == 0 {
-			logp.Err("Empty buffer returned by advance")
-			continue
-		}
-
-		if buf[len(buf)-1] == '\n' {
-			break
-		} else {
-			logp.Debug("line", "Line ending char found which wasn't one: %s", buf[len(buf)-1])
-		}
-	}
-
-	// output buffer contains complete line ending with '\n'. Extract
-	// byte slice from buffer and reset output buffer.
-	bytes, err := r.outBuffer.Collect(r.outBuffer.Len())
-	r.outBuffer.Reset()
-	if err != nil {
-		// This should never happen as otherwise we have a broken state
-		panic(err)
-	}
-
-	// return and reset consumed bytes count
-	sz := r.byteCount
-	r.byteCount = 0
-	return bytes, sz, nil
-}
-
-// Reads from the buffer until a new line character is detected
-// Returns an error otherwise
-func (r *LineReader) advance() error {
-	// Initial check if buffer has already a newLine character
-	idx := r.inBuffer.IndexFrom(r.inOffset, r.nl)
-
-	// fill inBuffer until '\n' sequence has been found in input buffer
-	for idx == -1 {
-		// increase search offset to reduce iterations on buffer when looping
-		newOffset := r.inBuffer.Len() - len(r.nl)
-		if newOffset > r.inOffset {
-			r.inOffset = newOffset
-		}
-
-		buf := make([]byte, r.bufferSize)
-
-		// try to read more bytes into buffer
-		n, err := r.reader.Read(buf)
-
-		// Appends buffer also in case of err
-		r.inBuffer.Append(buf[:n])
-		if err != nil {
-			return err
-		}
-
-		// empty read => return buffer error (more bytes required error)
-		if n == 0 {
-			return streambuf.ErrNoMoreBytes
-		}
-
-		// Check if buffer has newLine character
-		idx = r.inBuffer.IndexFrom(r.inOffset, r.nl)
-	}
-
-	// found encoded byte sequence for '\n' in buffer
-	// -> decode input sequence into outBuffer
-	sz, err := r.decode(idx + len(r.nl))
-	if err != nil {
-		logp.Err("Error decoding line: %s", err)
-		// In case of error increase size by unencoded length
-		sz = idx + len(r.nl)
-	}
-
-	// consume transformed bytes from input buffer
-	err = r.inBuffer.Advance(sz)
-	r.inBuffer.Reset()
-
-	// continue scanning input buffer from last position + 1
-	r.inOffset = idx + 1 - sz
-	if r.inOffset < 0 {
-		// fix inOffset if '\n' has encoding > 8bits + firl line has been decoded
-		r.inOffset = 0
-	}
-
-	return err
-}
-
-func (r *LineReader) decode(end int) (int, error) {
-	var err error
-	buffer := make([]byte, 1024)
-	inBytes := r.inBuffer.Bytes()
-	start := 0
-
-	for start < end {
-		var nDst, nSrc int
-
-		nDst, nSrc, err = r.decoder.Transform(buffer, inBytes[start:end], false)
-		if err != nil {
-			// Check if error is different from destination buffer too short
-			if err != transform.ErrShortDst {
-				r.outBuffer.Write(inBytes[0:end])
-				start = end
-				break
-			}
-
-			// Reset error as decoding continues
-			err = nil
-		}
-
-		start += nSrc
-		r.outBuffer.Write(buffer[:nDst])
-	}
-
-	r.byteCount += start
-	return start, err
+	return r.lineScanner.scan()
 }

--- a/filebeat/reader/readfile/line_test.go
+++ b/filebeat/reader/readfile/line_test.go
@@ -35,10 +35,40 @@ var tests = []struct {
 	encoding string
 	strings  []string
 }{
+	{"plain", []string{""}},
+	{"plain", []string{"", ""}},
+	{"plain", []string{"I can"}},
 	{"plain", []string{"I can", "eat glass"}},
+
+	{"latin1", []string{""}},
+	{"latin1", []string{"I can"}},
+	{"latin1", []string{"I kå Glas frässa"}},
 	{"latin1", []string{"I kå Glas frässa", "ond des macht mr nix!"}},
+
+	{"utf-8", []string{""}},
+	{"utf-8", []string{"I can"}},
+	{"utf-8", []string{"árvíztűrő tükörfúrógép"}},
+	{"utf-8", []string{"A nap tüze, látod,", "a fürge diákot", "a hegyre kicsalta: a csúcsra kiállt."}},
+
+	{"utf-16", []string{""}},
+	{"utf-16", []string{"I can"}},
+	{"utf-16", []string{"I can", "eat glass"}},
+	{"utf-16", []string{"Pot să mănânc sticlă"}},
+	{"utf-16", []string{"Pot să mănânc sticlă", "și ea nu mă rănește."}},
+	{"utf-16", []string{"\u0001234", "\u0000", "\u3453"}},
+
+	{"utf-16be", []string{""}},
+	{"utf-16be", []string{"I can"}},
+	{"utf-16be", []string{"I can", "eat glass"}},
+	{"utf-16be", []string{"Pot să mănânc sticlă"}},
 	{"utf-16be", []string{"Pot să mănânc sticlă", "și ea nu mă rănește."}},
+
+	{"utf-16le", []string{""}},
+	{"utf-16le", []string{"I can"}},
+	{"utf-16le", []string{"I can", "eat glass"}},
+	{"utf-16le", []string{"काचं शक्नोम्यत्तुम् ।"}},
 	{"utf-16le", []string{"काचं शक्नोम्यत्तुम् ।", "नोपहिनस्ति माम् ॥"}},
+
 	{"big5", []string{"我能吞下玻", "璃而不傷身體。"}},
 	{"gb18030", []string{"我能吞下玻璃", "而不傷身。體"}},
 	{"euc-kr", []string{" 나는 유리를 먹을 수 있어요.", " 그래도 아프지 않아요"}},
@@ -46,6 +76,14 @@ var tests = []struct {
 }
 
 func TestReaderEncodings(t *testing.T) {
+	testReaderWithEncodings(t, 1024)
+}
+
+func TestReaderEncodingsWithSmallBuffer(t *testing.T) {
+	testReaderWithEncodings(t, 3)
+}
+
+func testReaderWithEncodings(t *testing.T, bufferSize int) {
 	for _, test := range tests {
 		t.Logf("test codec: %v", test.encoding)
 
@@ -68,11 +106,7 @@ func TestReaderEncodings(t *testing.T) {
 		}
 
 		// create line reader
-		reader, err := NewLineReader(buffer, codec, 1024)
-		if err != nil {
-			t.Errorf("failed to initialize reader: %v", err)
-			continue
-		}
+		reader := NewLineReader(buffer, codec, []byte("\n"), 1024)
 
 		// read decodec lines from buffer
 		var readLines []string
@@ -159,10 +193,7 @@ func testReadLines(t *testing.T, inputLines [][]byte) {
 	// initialize reader
 	buffer := bytes.NewBuffer(inputStream)
 	codec, _ := encoding.Plain(buffer)
-	reader, err := NewLineReader(buffer, codec, buffer.Len())
-	if err != nil {
-		t.Fatalf("Error initializing reader: %v", err)
-	}
+	reader := NewLineReader(buffer, codec, []byte("\n"), buffer.Len())
 
 	// read lines
 	var lines [][]byte

--- a/filebeat/reader/readfile/scanner.go
+++ b/filebeat/reader/readfile/scanner.go
@@ -44,12 +44,12 @@ func (s *lineScanner) scan() ([]byte, int, error) {
 	for !separatorFound(idx) {
 		b := make([]byte, s.bufferSize)
 		n, err := s.in.read(b)
+		s.buf.Append(b[:n])
+		s.symlen = append(s.symlen, s.in.symbolsLen()...)
 		if err != nil {
 			return nil, 0, err
 		}
 
-		s.buf.Append(b[:n])
-		s.symlen = append(s.symlen, s.in.symbolsLen()...)
 		idx = s.buf.Index(s.separator)
 	}
 
@@ -69,7 +69,7 @@ func (s *lineScanner) line(i int) ([]byte, int, error) {
 	}
 
 	var msgSymbols int
-	msgSymbols, s.symlen, err = s.in.msgSize(s.symlen, len(line))
+	msgSymbols, s.symlen, err = s.in.msgSize(s.symlen, uint(len(line)))
 	if err != nil {
 		return nil, 0, err
 	}

--- a/filebeat/reader/readfile/scanner.go
+++ b/filebeat/reader/readfile/scanner.go
@@ -1,0 +1,80 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package readfile
+
+import "github.com/elastic/beats/libbeat/common/streambuf"
+
+type lineScanner struct {
+	in         *decoderReader
+	separator  []byte
+	bufferSize int
+
+	symlen []uint8
+	buf    *streambuf.Buffer
+}
+
+func newLineScanner(in *decoderReader, separator []byte, bufferSize int) *lineScanner {
+	return &lineScanner{
+		in:         in,
+		separator:  separator,
+		bufferSize: bufferSize,
+		buf:        streambuf.New(nil),
+		symlen:     []uint8{},
+	}
+}
+
+// Scan reads from the underlying decoder reader and returns decoded lines.
+func (s *lineScanner) scan() ([]byte, int, error) {
+	idx := s.buf.Index(s.separator)
+	for !separatorFound(idx) {
+		b := make([]byte, s.bufferSize)
+		n, err := s.in.read(b)
+		if err != nil {
+			return nil, 0, err
+		}
+
+		s.buf.Append(b[:n])
+		s.symlen = append(s.symlen, s.in.symbolsLen()...)
+		idx = s.buf.Index(s.separator)
+	}
+
+	return s.line(idx)
+}
+
+// separatorFound checks if a new separator was found.
+func separatorFound(i int) bool {
+	return i != -1
+}
+
+// line sets the offset of the scanner and returns a line.
+func (s *lineScanner) line(i int) ([]byte, int, error) {
+	line, err := s.buf.CollectUntil(s.separator)
+	if err != nil {
+		panic(err)
+	}
+
+	var msgSymbols int
+	msgSymbols, s.symlen, err = s.in.msgSize(s.symlen, len(line))
+	if err != nil {
+		return nil, 0, err
+	}
+
+	s.buf.Reset()
+
+	return line, msgSymbols, nil
+}

--- a/filebeat/scripts/tester/main.go
+++ b/filebeat/scripts/tester/main.go
@@ -133,11 +133,7 @@ func getLogsFromFile(logfile string, conf *logReaderConfig) ([]string, error) {
 	}
 
 	var r reader.Reader
-	r, err = readfile.NewEncodeReader(f, enc, 4096)
-	if err != nil {
-		return nil, err
-	}
-
+	r = readfile.NewEncodeReader(f, enc, 4096)
 	r = readfile.NewStripNewline(r)
 
 	if conf.multiPattern != "" {


### PR DESCRIPTION
### Architecture
The existing `Line` reader is separated into two smaller units: a reader and a scanner. The reader decodes and converts the input bytes into UTF-8. Then the scanner looks for new lines in the output of the decoder. If it finds one, returns the new line along with its size.

### Challenges
1. Size of the encoded line to store the correct state
    As the scanner is encoding-agnostic, the length of the encoded bytes is unknown when scanning for new lines. However, it's required otherwise the state becomes corrupt. To eliminate this problem I added a helper slice to track bytes sizes. See more in the section "Size calculation".
2. Error handling
    Error detection during converting bytes is hard. Our previous solution was incorrect and hadn't caught every error. No error is reported if a users misconfigures the `encoding` of an `input`. We could use external libraries which guess the correct encoding, but it would not add as much value as it complicates the code and degrades performance. Also, we haven't heard about many problems related to selecting the correct encoding for an input file, so I think we can live without it.
3. Performance
    See more in the dedicated section.

### Size calculation
To calculate the original size of the encoded string I introduced an array. The length of the array equals the number of bytes of the converted string. The i-th element of the array shows how many bytes long in UTF-8 is the original i-th byte. In order to calculate the length of an n bytes long converted string, sum the numbers in the array from the left to right until it equals the `len` of the converted string. The original size is the number of elements that have to be added.
#### Example
String: `"tél"` (It means winter in Hungarian. Congrats, you've just learnt something new!)
Len in UTF-8: 5
```
len("tél") # equals 5
```
Latin1
```
[1 2 1 1]
count: 4
```
Original length of the encoded string: 4 bytes

UTF-8
```
[1 0 2 1 1]
count: 5
```
Original length of the encoded string: 5 bytes

UTF-16
```
[0 1 0 2 0 1 0 1]
count: 8
```
Original length of the encoded string: 8 bytes

### Possible optimizations
This is a general converter which transforms everything byte-by-byte. This could add a significant performance penalty. To avoid bad performance, specialized decoders could be introduced in later PRs.
1. No conversion and skip size calculation when encoding is UTF-8.
2. Convert the whole byte slice and skip size calculation when encoding is ASCII.
3. Convert two bytes at a time when encoding is UTF-16