### PR TITLE
Add docs for the show command and backpressure_strategy options

### DIFF
--- a/auditbeat/docs/modules/auditd.asciidoc
+++ b/auditbeat/docs/modules/auditd.asciidoc
@@ -79,10 +79,11 @@ following example shows all configuration options with their default values.
 - module: auditd
   resolve_ids: true
   failure_mode: silent
-  backlog_limit: 8196
+  backlog_limit: 8192
   rate_limit: 0
   include_raw_message: false
   include_warnings: false
+  backpressure_strategy: auto
 ----
 
 *`socket_type`*:: This optional setting controls the type of
@@ -145,6 +146,28 @@ used by the Linux `auditctl` utility. {beatname_uc} supports adding file watches
 loaded after the rules declared in `audit_rules` are loaded. Wildcards are
 supported and will expand in lexicographical order. The format is the same as
 that of the `audit_rules` field.
+
+*`backpressure_strategy`*:: Specifies the strategy that {beatname_uc} uses to
+prevent backpressure from propagating to the kernel and impacting audited
+processes.
++
+--
+The possible values are:
+
+- `auto` (default): {beatname_uc} uses the `kernel` strategy, if supported, or
+falls back to the `userspace` strategy.
+- `kernel`: {beatname_uc} sets the `backlog_wait_time` in the kernel's
+audit framework to 0. This causes events to be discarded in the kernel if
+the audit backlog queue fills to capacity. Requires a 3.14 kernel or
+newer.
+- `userspace`: {beatname_uc} drops events when there is backpressure
+from the publishing pipeline. If no `rate_limit` is set, {beatname_uc} sets a rate
+limit of 5000. Users should test their setup and adjust the `rate_limit`
+option accordingly.
+- `both`: {beatname_uc} uses the `kernel` and `userspace` strategies at the same
+time.
+- `none`: No backpressure mitigation measures are enabled.
+--
 
 [float]
 === Audit rules

--- a/auditbeat/docs/modules/auditd.asciidoc
+++ b/auditbeat/docs/modules/auditd.asciidoc
@@ -67,6 +67,55 @@ from listening to audit messages:
 systemctl mask systemd-journald-audit.socket
 -----
 
+[float]
+=== Inspect the kernel audit system status
+
+{beatname_uc} provides useful commands to query the state of the audit system
+in the Linux kernel.
+
+* See the list of installed audit rules:
++
+[source,shell]
+-----
+auditbeat show auditd-rules
+-----
++
+Prints the list of loaded rules, similar to `auditctl -l`:
++
+[source,shell]
+-----
+-a never,exit -S all -F pid=26253
+-a always,exit -F arch=b32 -S all -F key=32bit-abi
+-a always,exit -F arch=b64 -S execve,execveat -F key=exec
+-a always,exit -F arch=b64 -S connect,accept,bind -F key=external-access
+-w /etc/group -p wa -k identity
+-w /etc/passwd -p wa -k identity
+-w /etc/gshadow -p wa -k identity
+-a always,exit -F arch=b64 -S open,truncate,ftruncate,creat,openat,open_by_handle_at -F exit=-EACCES -F key=access
+-a always,exit -F arch=b64 -S open,truncate,ftruncate,creat,openat,open_by_handle_at -F exit=-EPERM -F key=access
+-----
+
+* See the status of the audit system:
++
+[source,shell]
+-----
+auditbeat show auditd-status
+-----
++
+Prints the status of the kernel audit system, similar to `auditctl -s`:
++
+[source,shell]
+-----
+enabled 1
+failure 0
+pid 0
+rate_limit 0
+backlog_limit 8192
+lost 14407
+backlog 0
+backlog_wait_time 0
+features 0xf
+-----
 
 [float]
 === Configuration options

--- a/auditbeat/module/auditd/_meta/docs.asciidoc
+++ b/auditbeat/module/auditd/_meta/docs.asciidoc
@@ -74,10 +74,11 @@ following example shows all configuration options with their default values.
 - module: auditd
   resolve_ids: true
   failure_mode: silent
-  backlog_limit: 8196
+  backlog_limit: 8192
   rate_limit: 0
   include_raw_message: false
   include_warnings: false
+  backpressure_strategy: auto
 ----
 
 *`socket_type`*:: This optional setting controls the type of
@@ -140,6 +141,28 @@ used by the Linux `auditctl` utility. {beatname_uc} supports adding file watches
 loaded after the rules declared in `audit_rules` are loaded. Wildcards are
 supported and will expand in lexicographical order. The format is the same as
 that of the `audit_rules` field.
+
+*`backpressure_strategy`*:: Specifies the strategy that {beatname_uc} uses to
+prevent backpressure from propagating to the kernel and impacting audited
+processes.
++
+--
+The possible values are:
+
+- `auto` (default): {beatname_uc} uses the `kernel` strategy, if supported, or
+falls back to the `userspace` strategy.
+- `kernel`: {beatname_uc} sets the `backlog_wait_time` in the kernel's
+audit framework to 0. This causes events to be discarded in the kernel if
+the audit backlog queue fills to capacity. Requires a 3.14 kernel or
+newer.
+- `userspace`: {beatname_uc} drops events when there is backpressure
+from the publishing pipeline. If no `rate_limit` is set, {beatname_uc} sets a rate
+limit of 5000. Users should test their setup and adjust the `rate_limit`
+option accordingly.
+- `both`: {beatname_uc} uses the `kernel` and `userspace` strategies at the same
+time.
+- `none`: No backpressure mitigation measures are enabled.
+--
 
 [float]
 === Audit rules

--- a/auditbeat/module/auditd/_meta/docs.asciidoc
+++ b/auditbeat/module/auditd/_meta/docs.asciidoc
@@ -62,6 +62,55 @@ from listening to audit messages:
 systemctl mask systemd-journald-audit.socket
 -----
 
+[float]
+=== Inspect the kernel audit system status
+
+{beatname_uc} provides useful commands to query the state of the audit system
+in the Linux kernel.
+
+* See the list of installed audit rules:
++
+[source,shell]
+-----
+auditbeat show auditd-rules
+-----
++
+Prints the list of loaded rules, similar to `auditctl -l`:
++
+[source,shell]
+-----
+-a never,exit -S all -F pid=26253
+-a always,exit -F arch=b32 -S all -F key=32bit-abi
+-a always,exit -F arch=b64 -S execve,execveat -F key=exec
+-a always,exit -F arch=b64 -S connect,accept,bind -F key=external-access
+-w /etc/group -p wa -k identity
+-w /etc/passwd -p wa -k identity
+-w /etc/gshadow -p wa -k identity
+-a always,exit -F arch=b64 -S open,truncate,ftruncate,creat,openat,open_by_handle_at -F exit=-EACCES -F key=access
+-a always,exit -F arch=b64 -S open,truncate,ftruncate,creat,openat,open_by_handle_at -F exit=-EPERM -F key=access
+-----
+
+* See the status of the audit system:
++
+[source,shell]
+-----
+auditbeat show auditd-status
+-----
++
+Prints the status of the kernel audit system, similar to `auditctl -s`:
++
+[source,shell]
+-----
+enabled 1
+failure 0
+pid 0
+rate_limit 0
+backlog_limit 8192
+lost 14407
+backlog 0
+backlog_wait_time 0
+features 0xf
+-----
 
 [float]
 === Configuration options


### PR DESCRIPTION
Document the following features of Auditbeat's auditd module:

* `backpressure_strategy` option.
* `show auditd-status` and `show auditd-rules`.