### PR TITLE
Note that python 2 is required for `generate.py`

### DIFF
--- a/docs/devguide/newbeat.asciidoc
+++ b/docs/devguide/newbeat.asciidoc
@@ -137,6 +137,8 @@ cd ${GOPATH}/src/github.com/{user}
 
 Run python and specify the path to the Beat generator:
 
+NOTE: Python 2 is required (Python 3 will not work).
+
 [source,shell]
 --------------------
 python $GOPATH/src/github.com/elastic/beats/script/generate.py


### PR DESCRIPTION
The `generate.py` script uses `raw_input` which is not available in Python 3 and fails if you try to run it. It works in Python 2 :)