### PR TITLE
Add correct license file name

### DIFF
--- a/generator/beat/{beat}/Makefile
+++ b/generator/beat/{beat}/Makefile
@@ -29,7 +29,7 @@ git-init:
 	git init
 	git add README.md CONTRIBUTING.md
 	git commit -m "Initial commit"
-	git add LICENSE
+	git add LICENSE.txt
 	git commit -m "Add the LICENSE"
 	git add .gitignore
 	git commit -m "Add git settings"


### PR DESCRIPTION
After running the generator, a file "LICENSE.txt" exists in the repo.

During `make setup`, the target `git-init` runs and tries to `git add LICENCE`. This fails and interrupts the setup.


The error you get is:

```
git add LICENSE
fatal: pathspec 'LICENSE' did not match any files
Makefile:29: recipe for target 'git-init' failed
```

This patch resolves the error.