### PR TITLE
Add missing host config in Ceph module

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -40,7 +40,7 @@ https://github.com/elastic/beats/compare/v6.3.1...6.3[Check the HEAD diff]
 *Heartbeat*
 
 *Metricbeat*
-- Fix missing hosts config option in Ceph module.
+- Fix missing hosts config option in Ceph module. {pull}7596[7596]
 
 *Packetbeat*
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -40,6 +40,7 @@ https://github.com/elastic/beats/compare/v6.3.1...6.3[Check the HEAD diff]
 *Heartbeat*
 
 *Metricbeat*
+- Fix missing hosts config option in Ceph module.
 
 *Packetbeat*
 

--- a/metricbeat/module/ceph/_meta/config.yml
+++ b/metricbeat/module/ceph/_meta/config.yml
@@ -1,9 +1,11 @@
 - module: ceph
   metricsets: ["cluster_health", "cluster_status", "monitor_health"]
   period: 10s
+  hosts: ["localhost:5000"]
   #username: "user"
   #password: "secret"
 
 - module: ceph
   metricsets: ["cluster_disk", "osd_tree", "pool_disk"]
   period: 1m
+  hosts: ["localhost:5000"]

--- a/metricbeat/modules.d/ceph.yml.disabled
+++ b/metricbeat/modules.d/ceph.yml.disabled
@@ -1,9 +1,11 @@
 - module: ceph
   metricsets: ["cluster_health", "cluster_status", "monitor_health"]
   period: 10s
+  hosts: ["localhost:5000"]
   #username: "user"
   #password: "secret"
 
 - module: ceph
   metricsets: ["cluster_disk", "osd_tree", "pool_disk"]
   period: 1m
+  hosts: ["localhost:5000"]


### PR DESCRIPTION
The hosts part of the config was missing for the Ceph module. It is already fixed in master.