### PR TITLE
Update go-ucfg to 0.6.1

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -79,6 +79,7 @@ https://github.com/elastic/beats/compare/v6.2.3...master[Check the HEAD diff]
 - Fix default value for logging.files.keepfiles. It was being set to 0 and now
   it's set to the documented value of 7. {issue}7494[7494]
 - Retain compatibility with older Docker server versions. {issue}7542[7542]
+- Fix errors unpacking configs modified via CLI by ignoring `-E key=value` pairs with missing value. {pull}7599[7599]
 
 *Auditbeat*
 

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -447,8 +447,8 @@ Apache License 2.0
 
 --------------------------------------------------------------------
 Dependency: github.com/elastic/go-ucfg
-Version: v0.6.0
-Revision: 9c66f5c432b1d25bdb449a1e588d58b5d0cd7268
+Version: v0.6.1
+Revision: 581f7b1fe9d84f4c18ef0694d6e0eb944a925dae
 License type (autodetected): Apache-2.0
 ./vendor/github.com/elastic/go-ucfg/LICENSE:
 --------------------------------------------------------------------

--- a/vendor/github.com/elastic/go-ucfg/CHANGELOG.md
+++ b/vendor/github.com/elastic/go-ucfg/CHANGELOG.md
@@ -14,6 +14,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+## [0.6.1]
+
+### Fixed
+- Ignore flag keys with missing values. #111
+
 ## [0.6.0]
 
 ### Added
@@ -197,7 +202,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Introduced CHANGELOG.md for documenting changes to ucfg.
 
 
-[Unreleased]: https://github.com/elastic/go-ucfg/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/elastic/go-ucfg/compare/v0.6.1...HEAD
+[0.6.1]: https://github.com/elastic/go-ucfg/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/elastic/go-ucfg/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/elastic/go-ucfg/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/elastic/go-ucfg/compare/v0.4.6...v0.5.0

--- a/vendor/github.com/elastic/go-ucfg/README.md
+++ b/vendor/github.com/elastic/go-ucfg/README.md
@@ -17,26 +17,25 @@ The full API Documentation can be found [here](https://godoc.org/github.com/elas
 
 A few examples on how ucfg can be used. All examples below assume, that the following packages are imported:
 
-```
+```golang
 import (
 	"github.com/elastic/go-ucfg"
 	"github.com/elastic/go-ucfg/yaml"
 )
 ```
 
-
-### Dot notations
+### Dot notations
 
 ufcg allows you to load yaml configuration files using dots instead of indentation. For example instead of having:
 
-```
+```yaml
 config:
   user: name
 ```
 
 with ucfg you can write:
 
-```
+```yaml
 config.user: name
 ```
 
@@ -44,7 +43,7 @@ This makes configurations easier and simpler.
 
 To load such a config file in Golang, use the following command:
 
-```
+```golang
 config, err := yaml.NewConfigWithFile(path, ucfg.PathSep("."))
 ```
 
@@ -55,7 +54,7 @@ config, err := yaml.NewConfigWithFile(path, ucfg.PathSep("."))
 ucfg allows to automatically validate fields and set defaults for fields in case they are not defined.
 
 
-```
+```golang
 // Defines struct to read config from
 type ExampleConfig struct {
     Counter  string 	`config:"counter" validate:"min=0, max=9"`
@@ -90,4 +89,4 @@ The above uses `Counter` as the config variable. ucfg assures that the value is 
 
 ucfg has the following requirements:
 
-* Golang 1.5+
+* Golang 1.7+

--- a/vendor/github.com/elastic/go-ucfg/flag/value.go
+++ b/vendor/github.com/elastic/go-ucfg/flag/value.go
@@ -62,6 +62,10 @@ func NewFlagKeyValue(cfg *ucfg.Config, autoBool bool, opts ...ucfg.Option) *Flag
 			val = true
 		} else {
 			key = args[0]
+			if args[1] == "" {
+				return nil, nil, nil
+			}
+
 			val, err = parse.Value(args[1])
 			if err != nil {
 				return nil, err, err

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -638,52 +638,52 @@
 			"versionExact": "v0.0.1"
 		},
 		{
-			"checksumSHA1": "d0qibYdQy5G1YqI5H+xNC0QJ66g=",
+			"checksumSHA1": "MK8/w0Idj7kRBUiBabARPdm9hOo=",
 			"path": "github.com/elastic/go-ucfg",
-			"revision": "9c66f5c432b1d25bdb449a1e588d58b5d0cd7268",
-			"revisionTime": "2018-07-04T14:42:58Z",
-			"version": "v0.6.0",
-			"versionExact": "v0.6.0"
+			"revision": "581f7b1fe9d84f4c18ef0694d6e0eb944a925dae",
+			"revisionTime": "2018-07-13T14:04:29Z",
+			"version": "v0.6.1",
+			"versionExact": "v0.6.1"
 		},
 		{
 			"checksumSHA1": "X+R/CD8SokJrmlxFTx2nSevRDhQ=",
 			"path": "github.com/elastic/go-ucfg/cfgutil",
-			"revision": "9c66f5c432b1d25bdb449a1e588d58b5d0cd7268",
-			"revisionTime": "2018-07-04T14:42:58Z",
-			"version": "v0.6.0",
-			"versionExact": "v0.6.0"
+			"revision": "581f7b1fe9d84f4c18ef0694d6e0eb944a925dae",
+			"revisionTime": "2018-07-13T14:04:29Z",
+			"version": "v0.6.1",
+			"versionExact": "v0.6.1"
 		},
 		{
-			"checksumSHA1": "dShGF53hLUufO70RAjju+RT0fHY=",
+			"checksumSHA1": "zC8mCPW/pPPNcuHQOc/B/Ej1W1U=",
 			"path": "github.com/elastic/go-ucfg/flag",
-			"revision": "9c66f5c432b1d25bdb449a1e588d58b5d0cd7268",
-			"revisionTime": "2018-07-04T14:42:58Z",
-			"version": "v0.6.0",
-			"versionExact": "v0.6.0"
+			"revision": "581f7b1fe9d84f4c18ef0694d6e0eb944a925dae",
+			"revisionTime": "2018-07-13T14:04:29Z",
+			"version": "v0.6.1",
+			"versionExact": "v0.6.1"
 		},
 		{
 			"checksumSHA1": "esXpiQlEvTOUwsE0nNesso8albo=",
 			"path": "github.com/elastic/go-ucfg/internal/parse",
-			"revision": "9c66f5c432b1d25bdb449a1e588d58b5d0cd7268",
-			"revisionTime": "2018-07-04T14:42:58Z",
-			"version": "v0.6.0",
-			"versionExact": "v0.6.0"
+			"revision": "581f7b1fe9d84f4c18ef0694d6e0eb944a925dae",
+			"revisionTime": "2018-07-13T14:04:29Z",
+			"version": "v0.6.1",
+			"versionExact": "v0.6.1"
 		},
 		{
 			"checksumSHA1": "5mXUhhlPdvcAFKiQENInTJWrtQM=",
 			"path": "github.com/elastic/go-ucfg/json",
-			"revision": "9c66f5c432b1d25bdb449a1e588d58b5d0cd7268",
-			"revisionTime": "2018-07-04T14:42:58Z",
-			"version": "v0.6.0",
-			"versionExact": "v0.6.0"
+			"revision": "581f7b1fe9d84f4c18ef0694d6e0eb944a925dae",
+			"revisionTime": "2018-07-13T14:04:29Z",
+			"version": "v0.6.1",
+			"versionExact": "v0.6.1"
 		},
 		{
 			"checksumSHA1": "Bg6vistPQLftv2fEYB7GWwSExv8=",
 			"path": "github.com/elastic/go-ucfg/yaml",
-			"revision": "9c66f5c432b1d25bdb449a1e588d58b5d0cd7268",
-			"revisionTime": "2018-07-04T14:42:58Z",
-			"version": "v0.6.0",
-			"versionExact": "v0.6.0"
+			"revision": "581f7b1fe9d84f4c18ef0694d6e0eb944a925dae",
+			"revisionTime": "2018-07-13T14:04:29Z",
+			"version": "v0.6.1",
+			"versionExact": "v0.6.1"
 		},
 		{
 			"checksumSHA1": "yu/X+qHftvfQlAnjPdYLwrDn2nI=",


### PR DESCRIPTION
Update fixes config unpacking if users overwrite settings from CLI, with
missing values. When using `-E key=` (e.g. in scripts defining potential
empty defaults via env variables like `-E key=${MYVALUE}`), an untyped
`nil`-values was inserted into the config. This untyped value will make
Unpack fail for most typed settings.