### PR TITLE
XPack helper for naming monitoring indices (#7586)

### DIFF
--- a/metricbeat/helper/xpack/xpack.go
+++ b/metricbeat/helper/xpack/xpack.go
@@ -1,0 +1,64 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package xpack
+
+import (
+	"fmt"
+	"time"
+)
+
+// Product supported by X-Pack Monitoring
+type Product int
+
+const (
+	// Elasticsearch product
+	Elasticsearch Product = iota
+
+	// Kibana product
+	Kibana
+
+	// Logstash product
+	Logstash
+
+	// Beats product
+	Beats
+)
+
+func (p Product) String() string {
+	indexProductNames := []string{
+		"es",
+		"kibana",
+		"logstash",
+		"beats",
+	}
+
+	if int(p) < 0 || int(p) > len(indexProductNames) {
+		panic("Unknown product")
+	}
+
+	return indexProductNames[p]
+}
+
+// MakeMonitoringIndexName method returns the name of the monitoring index for
+// a given product { elasticsearch, kibana, logstash, beats }
+func MakeMonitoringIndexName(product Product) string {
+	today := time.Now().UTC().Format("2006.01.02")
+	const version = "6"
+
+	return fmt.Sprintf(".monitoring-%v-%v-mb-%v", product, version, today)
+}

--- a/metricbeat/helper/xpack/xpack_test.go
+++ b/metricbeat/helper/xpack/xpack_test.go
@@ -1,0 +1,65 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package xpack
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMakeMonitoringIndexName(t *testing.T) {
+	today := time.Now().UTC().Format("2006.01.02")
+
+	tests := []struct {
+		Name     string
+		Product  Product
+		Expected string
+	}{
+		{
+			"Elasticsearch monitoring index",
+			Elasticsearch,
+			fmt.Sprintf(".monitoring-es-6-mb-%v", today),
+		},
+		{
+			"Kibana monitoring index",
+			Kibana,
+			fmt.Sprintf(".monitoring-kibana-6-mb-%v", today),
+		},
+		{
+			"Logstash monitoring index",
+			Logstash,
+			fmt.Sprintf(".monitoring-logstash-6-mb-%v", today),
+		},
+		{
+			"Beats monitoring index",
+			Beats,
+			fmt.Sprintf(".monitoring-beats-6-mb-%v", today),
+		},
+	}
+
+	for _, test := range tests {
+		name := fmt.Sprintf("Test naming %v", test.Name)
+		t.Run(name, func(t *testing.T) {
+			indexName := MakeMonitoringIndexName(test.Product)
+			assert.Equal(t, test.Expected, indexName)
+		})
+	}
+}

--- a/metricbeat/module/elasticsearch/node_stats/data_xpack.go
+++ b/metricbeat/module/elasticsearch/node_stats/data_xpack.go
@@ -26,6 +26,7 @@ import (
 	s "github.com/elastic/beats/libbeat/common/schema"
 	c "github.com/elastic/beats/libbeat/common/schema/mapstriface"
 	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/metricbeat/helper/xpack"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/module/elasticsearch"
 )
@@ -229,9 +230,7 @@ func eventsMappingXPack(r mb.ReporterV2, m *MetricSet, content []byte) {
 			"node_stats":   nodeData,
 		}
 
-		// Hard coded index prefix for monitoring, no detection done for ES version at the moment
-		// It has an additonal md in the name to make it clear the data is coming from metricbeat
-		event.Index = ".monitoring-es-6-mb"
+		event.Index = xpack.MakeMonitoringIndexName(xpack.Elasticsearch)
 		r.Event(event)
 	}
 }


### PR DESCRIPTION
This PR adds a helper method for generating monitoring index names for a given product (Elasticsearch, Kibana, etc.).

Backport of #7586.