### PR TITLE
add kafkabeat2

### DIFF
--- a/libbeat/docs/communitybeats.asciidoc
+++ b/libbeat/docs/communitybeats.asciidoc
@@ -60,6 +60,7 @@ https://github.com/devopsmakers/iobeat[iobeat]:: Reads IO stats from /proc/disks
 https://github.com/radoondas/jmxproxybeat[jmxproxybeat]:: Reads Tomcat JMX metrics exposed over 'JMX Proxy Servlet' to HTTP.
 https://github.com/mheese/journalbeat[journalbeat]:: Used for log shipping from systemd/journald based Linux systems.
 https://github.com/justsocialapps/kafkabeat[kafkabeat]:: Reads data from Kafka topics.
+https://github.com/arkady-emelyanov/kafkabeat[kafkabeat2]:: Reads data (json or plain) from Kafka topics.
 https://github.com/PPACI/krakenbeat[krakenbeat]:: Collect information on each transaction on the Kraken crypto platform.
 https://github.com/eskibars/lmsensorsbeat[lmsensorsbeat]:: Collects data from lm-sensors (such as CPU temperatures, fan speeds, and voltages from i2c and smbus).
 https://github.com/consulthys/logstashbeat[logstashbeat]:: Collects data from Logstash monitoring API (v5 onwards) and indexes them in Elasticsearch.


### PR DESCRIPTION
justsocialapps/kafkabeat is generally ok, here is [updated version of kafkabeat](https://github.com/arkady-emelyanov/kafkabeat) which supports two ways of handling Kafka messages: json and plain.

Published documentation describes both ways to deal with messages. Beat build on top of stable `6.3.1` release.