### PR TITLE
Add missing libbeat fields to imports in Metricbeat

### DIFF
--- a/metricbeat/cmd/root.go
+++ b/metricbeat/cmd/root.go
@@ -28,6 +28,7 @@ import (
 
 	// import modules
 	_ "github.com/elastic/beats/metricbeat/include"
+	_ "github.com/elastic/beats/metricbeat/include/fields"
 )
 
 // Name of this beat


### PR DESCRIPTION
Even though the fields from libbeat were loaded into Golang code, the code was never added to the binary as the import was missing. This meant the libbeat fields did not end up in the template.

This was never released so far, so no changelog.