### PR TITLE
Filebeat: Add patterns to support Kafka 1.1 logs

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -217,6 +217,7 @@ https://github.com/elastic/beats/compare/v6.2.3...master[Check the HEAD diff]
 - Add Slow log fileset to the Elasticsearch module. {pull}7473[7473]
 - Add deprecation fileset to the Elasticsearch module. {pull}7474[7474]
 - Add `config_timezone` option to Kafka module to convert dates to UTC. {issue}7546[7546] {pull}7578[7578]
+- Add patterns for kafka 1.1 logs. {pull}7608[7608]
 
 *Heartbeat*
 

--- a/filebeat/docs/modules/kafka.asciidoc
+++ b/filebeat/docs/modules/kafka.asciidoc
@@ -15,7 +15,7 @@ include::../include/what-happens.asciidoc[]
 [float]
 === Compatibility
 
-The +{modulename}+ module was tested with logs from versions 2.11.
+The +{modulename}+ module was tested with logs from versions 0.9 and 1.11.
 
 include::../include/running-modules.asciidoc[]
 

--- a/filebeat/module/kafka/_meta/docs.asciidoc
+++ b/filebeat/module/kafka/_meta/docs.asciidoc
@@ -10,7 +10,7 @@ include::../include/what-happens.asciidoc[]
 [float]
 === Compatibility
 
-The +{modulename}+ module was tested with logs from versions 2.11.
+The +{modulename}+ module was tested with logs from versions 0.9 and 1.11.
 
 include::../include/running-modules.asciidoc[]
 

--- a/filebeat/module/kafka/log/ingest/pipeline.json
+++ b/filebeat/module/kafka/log/ingest/pipeline.json
@@ -13,8 +13,11 @@
     {
       "grok": {
         "field": "kafka.log.message",
+        "pattern_definitions": {
+          "KAFKA_COMPONENT": "[^\\]]*"
+        },
         "patterns": [
-          "\\[%{DATA:kafka.log.component}\\][,:. ] +%{JAVALOGMESSAGE:kafka.log.message}"
+          "\\[%{KAFKA_COMPONENT:kafka.log.component}\\][,:.]? +%{JAVALOGMESSAGE:kafka.log.message}"
         ],
         "on_failure": [
           {

--- a/filebeat/module/kafka/log/test/state-change-1.1.0.log
+++ b/filebeat/module/kafka/log/test/state-change-1.1.0.log
@@ -1,0 +1,1 @@
+[2018-07-16 10:17:06,489] TRACE [Broker id=30] Cached leader info PartitionState(controllerEpoch=25, leader=-1, leaderEpoch=15, isr=[10], zkVersion=15, replicas=[10], offlineReplicas=[10]) for partition __consumer_offsets-16 in response to UpdateMetadata request sent by controller 20 epoch 25 with correlation id 8 (state.change.logger)

--- a/filebeat/module/kafka/log/test/state-change-1.1.0.log-expected.json
+++ b/filebeat/module/kafka/log/test/state-change-1.1.0.log-expected.json
@@ -1,0 +1,15 @@
+[
+    {
+        "@timestamp": "2018-07-16T10:17:06.489Z",
+        "fileset.name": "log",
+        "fileset.module": "kafka",
+        "kafka.log.message": "Cached leader info PartitionState(controllerEpoch=25, leader=-1, leaderEpoch=15, isr=[10], zkVersion=15, replicas=[10], offlineReplicas=[10]) for partition __consumer_offsets-16 in response to UpdateMetadata request sent by controller 20 epoch 25 with correlation id 8",
+        "kafka.log.component": "Broker id=30",
+        "kafka.log.class": "state.change.logger",
+        "kafka.log.level": "TRACE",
+        "message": "[2018-07-16 10:17:06,489] TRACE [Broker id=30] Cached leader info PartitionState(controllerEpoch=25, leader=-1, leaderEpoch=15, isr=[10], zkVersion=15, replicas=[10], offlineReplicas=[10]) for partition __consumer_offsets-16 in response to UpdateMetadata request sent by controller 20 epoch 25 with correlation id 8 (state.change.logger)",
+        "offset": 0,
+        "input.type": "log",
+        "prospector.type": "log"
+    }
+]


### PR DESCRIPTION
Add patterns to support kafka 1.1 logs.

Existing patterns work pretty well for 1.1, but I found an issue with component parsing, closing bracket is not followed by comma, dot or colon, this causes that component is almost always set to `unknown`. It also caused in some scenarios that other bracket in the message is taken as the closing bracket of the component, incorrectly splitting the component and the log message.

This change adds a pattern for components so they cannot include a closing bracket, it also make optional the symbols after the component. Added also a test file that reproduced problems with logs in 1.1 version.

Documentation line about testing versions is fixed too.