### PR TITLE
Add more detail topic about downloading docker images

### DIFF
--- a/libbeat/docs/shared-docker.asciidoc
+++ b/libbeat/docs/shared-docker.asciidoc
@@ -2,7 +2,23 @@
 === Running {beatname_uc} on Docker
 
 Docker images for {beatname_uc} are available from the Elastic Docker
-registry. You can retrieve an image with a `docker pull` command.
+registry. The base image is https://hub.docker.com/_/centos/[centos:7].
+
+A list of all published Docker images and tags is available at
+https://www.docker.elastic.co[www.docker.elastic.co]. The source code is in
+{dockergithub}[GitHub].
+
+These images are free to use under the Elastic license. They contain open source 
+and free commercial features and access to paid commercial features.  
+{xpack-ref}/license-management.html[Start a 30-day trial] to try out all of the 
+paid commercial features. See the 
+https://www.elastic.co/subscriptions[Subscriptions] page for information about 
+Elastic license levels.
+
+==== Pulling the image
+
+Obtaining Beats for Docker is as simple as issuing a +docker pull+ command
+against the Elastic Docker registry.
 
 ifeval::["{release-state}"=="unreleased"]
 
@@ -18,11 +34,11 @@ ifeval::["{release-state}"!="unreleased"]
 docker pull {dockerimage}
 ------------------------------------------------
 
-endif::[]
+Alternatively, you can download other Docker images that contain only features
+available under the Apache 2.0 license. To download the images, go to 
+https://www.docker.elastic.co[www.docker.elastic.co]. 
 
-The base image is https://hub.docker.com/_/centos/[centos:7] and the source
-code can be found on
-{dockergithub}[GitHub].
+endif::[]
 
 [float]
 ==== Configure {beatname_uc} on Docker


### PR DESCRIPTION
I wasn't completely satisfied with the language that we added in https://github.com/elastic/logstash/pull/9831, so I've made some changes. The original text was a bit verbose, overly passive, and  ambiguous in places. If you like the changes, we can get them into the other repos. 

* Removed the passive voice from the second paragraph and tightened up the language just a little.
* Removed the following sentence because I don't think it adds anything new: "For example, the Docker image can be retrieved with the following command."  If you think this is necessary, I can add it back in...but IMO, it is redundant.
* Broke the sentence that begins with "Alternatively, you can download..." into two sentences. The original sentence has a dangling modifier. Grammatically, it's saying that the Apache license is available from the docker page. Passed it by Gail, and she agreed that it was hard to parse.

I've also added the license content that wasn't in the Beats topic originally. Let me know if it's not completely accurate for Beats.