### PR TITLE
Document tested kafka versions

### DIFF
--- a/filebeat/docs/modules/kafka.asciidoc
+++ b/filebeat/docs/modules/kafka.asciidoc
@@ -15,7 +15,7 @@ include::../include/what-happens.asciidoc[]
 [float]
 === Compatibility
 
-The +{modulename}+ module was tested with logs from versions 2.11.
+The +{modulename}+ module was tested with logs from versions 0.9.
 
 include::../include/running-modules.asciidoc[]
 

--- a/filebeat/module/kafka/_meta/docs.asciidoc
+++ b/filebeat/module/kafka/_meta/docs.asciidoc
@@ -10,7 +10,7 @@ include::../include/what-happens.asciidoc[]
 [float]
 === Compatibility
 
-The +{modulename}+ module was tested with logs from versions 2.11.
+The +{modulename}+ module was tested with logs from versions 0.9.
 
 include::../include/running-modules.asciidoc[]
 

--- a/metricbeat/docs/modules/kafka.asciidoc
+++ b/metricbeat/docs/modules/kafka.asciidoc
@@ -11,6 +11,8 @@ This is the Kafka module.
 
 The default metricsets are `consumergroup` and `partition`.
 
+This module is tested with 0.10.2.
+
 
 [float]
 === Example configuration

--- a/metricbeat/module/kafka/_meta/docs.asciidoc
+++ b/metricbeat/module/kafka/_meta/docs.asciidoc
@@ -1,3 +1,5 @@
 This is the Kafka module.
 
 The default metricsets are `consumergroup` and `partition`.
+
+This module is tested with 0.10.2.


### PR DESCRIPTION
Fix tested kafka versions in documentation for 6.x versions. This is intended to be backported to 6.4/6.3.

In master it was fixed with more changes in #7616 and #7608.