### PR TITLE
Fix incorrect heading level to fix book structure

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -123,7 +123,7 @@ https://github.com/elastic/beats/compare/v6.3.0...v6.3.1[View commits]
 - Fix an out of bounds access in HTTP parser caused by malformed request. {pull}6997[6997]
 - Fix missing type for `http.response.body` field. {pull}7169[7169]
 
-== Added ==
+==== Added
 
 *Auditbeat*
 


### PR DESCRIPTION
Fixes a typo (incorrect heading format) that is breaking the book structure in the published docs:

![image](https://user-images.githubusercontent.com/14206422/42912205-feb09436-8aa2-11e8-94c6-da7f8743af1e.png)

I don't think I need to back or forward port this, right?