### PR TITLE
Update compatibility statement in Kafka docs

### DIFF
--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -667,7 +667,8 @@ NOTE: Events bigger than <<kafka-max_message_bytes,`max_message_bytes`>> will be
 
 ==== Compatibility
 
-This output works with Kafka 0.8, 0.9, and 0.10.
+This output works with Kafka 0.8.2.0 through 1.0.0. The default is Kafka 1.0.0.
+To specify a different version, set the <<kafka-version>> option.
 
 ==== Configuration options
 
@@ -685,13 +686,14 @@ The default value is true.
 The list of Kafka broker addresses from where to fetch the cluster metadata.
 The cluster metadata contain the actual Kafka brokers events are published to.
 
+[[kafka-version]]
 ===== `version`
 
-Kafka version ${beatname_lc} is assumed to run against. Defaults to 1.0.0.
+Kafka version {beatname_lc} is assumed to run against. Defaults to `1.0.0`.
 
 Event timestamps will be added, if version 0.10.0.0+ is enabled.
 
-Valid values are all kafka releases in between `0.8.2.0` and `1.1.0`.
+Valid values are all Kafka releases in between `0.8.2.0` and `1.1.0`.
 
 ===== `username`
 


### PR DESCRIPTION
@urso Should this say, "This output works with Kafka 0.8.2.0 through 1.1.0" (instead of 1.0.0). It wasn't clear to me whether we are saying that we support (and have tested) against 1.1.0. I think it looks a little weird to have 1.1.0 as a valid setting if we don't test against it. WDYT?

Closes https://github.com/elastic/beats/issues/6215