### PR TITLE
Add support for alias field type to fields.yml

### DIFF
--- a/libbeat/common/field.go
+++ b/libbeat/common/field.go
@@ -52,6 +52,7 @@ type Field struct {
 	DocValues             *bool       `config:"doc_values"`
 	CopyTo                string      `config:"copy_to"`
 	IgnoreAbove           int         `config:"ignore_above"`
+	AliasPath             string      `config:"path"`
 
 	// Kibana specific
 	Analyzed     *bool  `config:"analyzed"`

--- a/libbeat/template/processor.go
+++ b/libbeat/template/processor.go
@@ -62,6 +62,8 @@ func (p *Processor) Process(fields common.Fields, path string, output common.Map
 			mapping = p.object(&field)
 		case "array":
 			mapping = p.array(&field)
+		case "alias":
+			mapping = p.alias(&field)
 		case "group":
 			var newPath string
 			if path == "" {
@@ -239,6 +241,13 @@ func (p *Processor) array(f *common.Field) common.MapStr {
 	if f.ObjectType != "" {
 		properties["type"] = f.ObjectType
 	}
+	return properties
+}
+
+func (p *Processor) alias(f *common.Field) common.MapStr {
+	properties := getDefaultProperties(f)
+	properties["type"] = "alias"
+	properties["path"] = f.AliasPath
 	return properties
 }
 

--- a/libbeat/template/processor_test.go
+++ b/libbeat/template/processor_test.go
@@ -87,6 +87,10 @@ func TestProcessor(t *testing.T) {
 			expected: common.MapStr{"index": false, "type": "keyword"},
 		},
 		{
+			output:   p.alias(&common.Field{Type: "alias", AliasPath: "a.b"}),
+			expected: common.MapStr{"path": "a.b", "type": "alias"},
+		},
+		{
 			output: p.object(&common.Field{Type: "object", Enabled: &falseVar}),
 			expected: common.MapStr{
 				"type":    "object",

--- a/libbeat/template/testdata/fields.yml
+++ b/libbeat/template/testdata/fields.yml
@@ -20,3 +20,7 @@
     - name: array_disabled
       type: array
       enabled: false
+
+    - name: alias
+      type: alias
+      path: keyword


### PR DESCRIPTION
In https://github.com/elastic/elasticsearch/issues/23714 Elasticsearch implemented the alias field type. This can be used in fields.yml as following:

```
- name: a.b
  type: alias
  path: a.c
```

`a.b` will be the alias for `a.c`.