### PR TITLE
Additional HB Tests + Improved mapval

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1639,6 +1639,28 @@ For more information, please see http://www.bis.doc.gov
 See also http://www.apache.org/dev/crypto.html and/or seek legal counsel.
 
 --------------------------------------------------------------------
+Dependency: github.com/phayes/freeport
+Revision: e27662a4a9d6b2083dfd7e7b5d0e30985daca925
+License type (autodetected): BSD-3-Clause
+./vendor/github.com/phayes/freeport/LICENSE.md:
+--------------------------------------------------------------------
+Open Source License (BSD 3-Clause)
+----------------------------------
+
+Copyright (c) 2014, Patrick Hayes / HighWire Press
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+--------------------------------------------------------------------
 Dependency: github.com/pierrec/lz4
 Revision: 90290f74b1b4d9c097f0a3b3c7eba2ef3875c699
 License type (autodetected): BSD-3-Clause

--- a/heartbeat/hbtest/hbtestutil.go
+++ b/heartbeat/hbtest/hbtestutil.go
@@ -33,20 +33,17 @@ const HelloWorldBody = "hello, world!"
 
 // HelloWorldHandler is a handler for an http server that returns
 // HelloWorldBody and a 200 OK status.
-var HelloWorldHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-	w.WriteHeader(http.StatusOK)
-	io.WriteString(w, HelloWorldBody)
-})
-
-// BadGatewayBody is the body of the BadGatewayHandler.
-const BadGatewayBody = "Bad Gateway"
-
-// BadGatewayHandler is a handler for an http server that returns
-// BadGatewayBody and a 200 OK status.
-var BadGatewayHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-	w.WriteHeader(http.StatusBadGateway)
-	io.WriteString(w, BadGatewayBody)
-})
+func HelloWorldHandler(status int) http.HandlerFunc {
+	return http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			if status >= 301 && status <= 303 {
+				w.Header().Set("Location", "/somewhere")
+			}
+			w.WriteHeader(status)
+			io.WriteString(w, HelloWorldBody)
+		},
+	)
+}
 
 // ServerPort takes an httptest.Server and returns its port as a uint16.
 func ServerPort(server *httptest.Server) (uint16, error) {
@@ -85,8 +82,8 @@ func TCPBaseChecks(port uint16) mapval.Validator {
 }
 
 // ErrorChecks checks the standard heartbeat error hierarchy, which should
-// consist of a message and a type under the error key.
-func ErrorChecks(msg string, errType string) mapval.Validator {
+// consist of a message (or a mapval isdef that can match the message) and a type under the error key.
+func ErrorChecks(msg interface{}, errType string) mapval.Validator {
 	return mapval.Schema(mapval.Map{
 		"error": mapval.Map{
 			"message": msg,

--- a/heartbeat/monitors/active/http/http_test.go
+++ b/heartbeat/monitors/active/http/http_test.go
@@ -224,6 +224,7 @@ func TestUnreachableJob(t *testing.T) {
 	// 203.0.113.0/24 is reserved for documentation so should not be routable
 	// See: https://tools.ietf.org/html/rfc6890
 	ip := "203.0.113.1"
+	port := 80
 	url := "http://" + ip
 
 	event := testRequest(t, url)
@@ -232,10 +233,10 @@ func TestUnreachableJob(t *testing.T) {
 		t,
 		mapval.Strict(mapval.Compose(
 			hbtest.MonitorChecks("http@"+url, url, ip, "http", "down"),
-			hbtest.TCPBaseChecks(80),
+			hbtest.TCPBaseChecks(uint16(port)),
 			hbtest.ErrorChecks(
 				mapval.IsStringContaining(fmt.Sprintf(
-					"Get http://%s: dial tcp %s:80: i/o timeout", ip, ip)),
+					"Get http://%s:%d dial tcp %s:%d: i/o timeout", ip, port, ip, port)),
 				"io"),
 			httpBaseChecks(url),
 		)),

--- a/heartbeat/monitors/active/http/http_test.go
+++ b/heartbeat/monitors/active/http/http_test.go
@@ -234,8 +234,8 @@ func TestUnreachableJob(t *testing.T) {
 			hbtest.MonitorChecks("http@"+url, url, ip, "http", "down"),
 			hbtest.TCPBaseChecks(80),
 			hbtest.ErrorChecks(
-				fmt.Sprintf(
-					"Get http://%s: dial tcp %s:80: i/o timeout (Client.Timeout exceeded while awaiting headers)", ip, ip),
+				mapval.IsStringContaining(fmt.Sprintf(
+					"Get http://%s: dial tcp %s:80: i/o timeout", ip, ip)),
 				"io"),
 			httpBaseChecks(url),
 		)),

--- a/heartbeat/monitors/active/http/http_test.go
+++ b/heartbeat/monitors/active/http/http_test.go
@@ -235,8 +235,17 @@ func TestUnreachableJob(t *testing.T) {
 			hbtest.MonitorChecks("http@"+url, url, ip, "http", "down"),
 			hbtest.TCPBaseChecks(uint16(port)),
 			hbtest.ErrorChecks(
-				mapval.IsStringContaining(fmt.Sprintf(
-					"Get http://%s:%d dial tcp %s:%d: i/o timeout", ip, port, ip, port)),
+				mapval.IsAny(
+					mapval.IsStringContaining(
+						fmt.Sprintf(
+							"Get http://%s: dial tcp %s:%d: i/o timeout", ip, ip, port),
+					),
+					mapval.IsStringContaining(
+						fmt.Sprintf(
+							"Get http://%s: dial tcp %s:%d: connect: network is unreachable", ip, ip, port),
+					),
+				),
+
 				"io"),
 			httpBaseChecks(url),
 		)),

--- a/heartbeat/monitors/active/http/http_test.go
+++ b/heartbeat/monitors/active/http/http_test.go
@@ -18,13 +18,12 @@
 package http
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
-	"fmt"
 
 	"github.com/phayes/freeport"
 

--- a/heartbeat/monitors/active/http/http_test.go
+++ b/heartbeat/monitors/active/http/http_test.go
@@ -36,7 +36,6 @@ import (
 
 func testRequest(t *testing.T, url string) beat.Event {
 	config := common.NewConfig()
-	config.SetString("timeout", 0, "1")
 	config.SetString("urls", 0, url)
 
 	jobs, err := create(monitors.Info{}, config)
@@ -94,7 +93,8 @@ func TestOKJob(t *testing.T) {
 			hbtest.MonitorChecks("http@"+server.URL, server.URL, "127.0.0.1", "http", "up"),
 			hbtest.RespondingTCPChecks(port),
 			respondingHTTPChecks(server.URL, http.StatusOK),
-		))(event.Fields),
+		)),
+		(event.Fields),
 	)
 }
 
@@ -110,7 +110,8 @@ func TestBadGatewayJob(t *testing.T) {
 			hbtest.RespondingTCPChecks(port),
 			respondingHTTPChecks(server.URL, http.StatusBadGateway),
 			hbtest.ErrorChecks("502 Bad Gateway", "validate"),
-		))(event.Fields),
+		)),
+		(event.Fields),
 	)
 }
 
@@ -132,6 +133,7 @@ func TestUnreachableJob(t *testing.T) {
 					"Get http://%s: dial tcp %s:80: i/o timeout (Client.Timeout exceeded while awaiting headers)", ip, ip),
 				"io"),
 			httpBaseChecks(url),
-		))(event.Fields),
+		)),
+		(event.Fields),
 	)
 }

--- a/heartbeat/monitors/active/icmp/icmp_test.go
+++ b/heartbeat/monitors/active/icmp/icmp_test.go
@@ -1,0 +1,1 @@
+package icmp

--- a/heartbeat/monitors/active/icmp/icmp_test.go
+++ b/heartbeat/monitors/active/icmp/icmp_test.go
@@ -1,1 +1,0 @@
-package icmp

--- a/heartbeat/monitors/active/tcp/tcp_test.go
+++ b/heartbeat/monitors/active/tcp/tcp_test.go
@@ -117,7 +117,7 @@ func TestUnreachableEndpointJob(t *testing.T) {
 			hbtest.ErrorChecks(
 				mapval.IsAny(
 					mapval.IsEqual(fmt.Sprintf("dial tcp %s:%d: i/o timeout", ip, port)),
-					mapval.IsEqual(fmt.Sprintf("dial tcp 203.0.113.1:1234: connect: network is unreachable", ip, port)),
+					mapval.IsEqual(fmt.Sprintf("dial tcp %s:%d: connect: network is unreachable", ip, port)),
 				),
 				"io"),
 			hbtest.TCPBaseChecks(port),

--- a/heartbeat/monitors/active/tcp/tcp_test.go
+++ b/heartbeat/monitors/active/tcp/tcp_test.go
@@ -114,7 +114,12 @@ func TestUnreachableEndpointJob(t *testing.T) {
 		t,
 		mapval.Strict(mapval.Compose(
 			tcpMonitorChecks(ip, ip, port, "down"),
-			hbtest.ErrorChecks(fmt.Sprintf("dial tcp %s:%d: i/o timeout", ip, port), "io"),
+			hbtest.ErrorChecks(
+				mapval.IsAny(
+					mapval.IsEqual(fmt.Sprintf("dial tcp %s:%d: i/o timeout", ip, port)),
+					mapval.IsEqual(fmt.Sprintf("dial tcp 203.0.113.1:1234: connect: network is unreachable", ip, port)),
+				),
+				"io"),
 			hbtest.TCPBaseChecks(port),
 		)),
 		event.Fields,

--- a/heartbeat/monitors/active/tcp/tcp_test.go
+++ b/heartbeat/monitors/active/tcp/tcp_test.go
@@ -26,6 +26,8 @@ import (
 
 	"github.com/phayes/freeport"
 
+	"net/http"
+
 	"github.com/elastic/beats/heartbeat/hbtest"
 	"github.com/elastic/beats/heartbeat/monitors"
 	"github.com/elastic/beats/libbeat/beat"
@@ -56,7 +58,7 @@ func tcpMonitorChecks(host string, ip string, port uint16, status string) mapval
 }
 
 func TestUpEndpointJob(t *testing.T) {
-	server := httptest.NewServer(hbtest.HelloWorldHandler)
+	server := httptest.NewServer(hbtest.HelloWorldHandler(http.StatusOK))
 	defer server.Close()
 
 	port, err := hbtest.ServerPort(server)

--- a/heartbeat/monitors/active/tcp/tcp_test.go
+++ b/heartbeat/monitors/active/tcp/tcp_test.go
@@ -80,7 +80,8 @@ func TestUpEndpoint(t *testing.T) {
 					"rtt.us": mapval.IsDuration,
 				},
 			}),
-		))(event.Fields),
+		)),
+		event.Fields,
 	)
 }
 
@@ -95,6 +96,7 @@ func TestUnreachableEndpoint(t *testing.T) {
 			tcpMonitorChecks(ip, ip, port, "down"),
 			hbtest.ErrorChecks(fmt.Sprintf("dial tcp %s:%d: i/o timeout", ip, port), "io"),
 			hbtest.TCPBaseChecks(port),
-		))(event.Fields),
+		)),
+		event.Fields,
 	)
 }

--- a/libbeat/common/mapval/core.go
+++ b/libbeat/common/mapval/core.go
@@ -50,7 +50,7 @@ func Compose(validators ...Validator) Validator {
 			results[idx] = validator(actual)
 		}
 
-		combined := MakeResults(actual)
+		combined := MakeResults()
 		for _, r := range results {
 			r.EachResult(func(path string, vr ValueResult) bool {
 				combined.record(path, vr)
@@ -78,13 +78,13 @@ func Strict(laxValidator Validator) Validator {
 		// It's a little weird, but is fairly efficient. We could stop using the flattened map as a datastructure, but
 		// that would add complexity elsewhere. Probably a good refactor at some point, but not worth it now.
 		validatedPaths := []string{}
-		for k := range results.Validations {
+		for k := range results.Fields {
 			validatedPaths = append(validatedPaths, k)
 		}
 		sort.Strings(validatedPaths)
 
 		walk(actual, func(woi walkObserverInfo) {
-			_, validatedExactly := results.Validations[woi.dottedPath]
+			_, validatedExactly := results.Fields[woi.dottedPath]
 			if validatedExactly {
 				return // This key was tested, passes strict test
 			}
@@ -111,7 +111,7 @@ func Schema(expected Map) Validator {
 }
 
 func walkValidate(expected Map, actual common.MapStr) (results Results) {
-	results = MakeResults(actual)
+	results = MakeResults()
 	walk(
 		common.MapStr(expected),
 		func(expInfo walkObserverInfo) {

--- a/libbeat/common/mapval/core.go
+++ b/libbeat/common/mapval/core.go
@@ -40,17 +40,17 @@ func Optional(id IsDef) IsDef {
 type Map map[string]interface{}
 
 // Validator is the result of Schema and is run against the map you'd like to test.
-type Validator func(common.MapStr) Results
+type Validator func(common.MapStr) *Results
 
 // Compose combines multiple SchemaValidators into a single one.
 func Compose(validators ...Validator) Validator {
-	return func(actual common.MapStr) Results {
-		results := make([]Results, len(validators))
+	return func(actual common.MapStr) *Results {
+		results := make([]*Results, len(validators))
 		for idx, validator := range validators {
 			results[idx] = validator(actual)
 		}
 
-		combined := MakeResults()
+		combined := NewResults()
 		for _, r := range results {
 			r.EachResult(func(path string, vr ValueResult) bool {
 				combined.record(path, vr)
@@ -63,7 +63,7 @@ func Compose(validators ...Validator) Validator {
 
 // Strict is used when you want any unspecified keys that are encountered to be considered errors.
 func Strict(laxValidator Validator) Validator {
-	return func(actual common.MapStr) Results {
+	return func(actual common.MapStr) *Results {
 		results := laxValidator(actual)
 
 		// The inner workings of this are a little weird
@@ -105,13 +105,13 @@ func Strict(laxValidator Validator) Validator {
 
 // Schema takes a Map and returns an executable Validator function.
 func Schema(expected Map) Validator {
-	return func(actual common.MapStr) Results {
+	return func(actual common.MapStr) *Results {
 		return walkValidate(expected, actual)
 	}
 }
 
-func walkValidate(expected Map, actual common.MapStr) (results Results) {
-	results = MakeResults()
+func walkValidate(expected Map, actual common.MapStr) (results *Results) {
+	results = NewResults()
 	walk(
 		common.MapStr(expected),
 		func(expInfo walkObserverInfo) {

--- a/libbeat/common/mapval/core_test.go
+++ b/libbeat/common/mapval/core_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 // assertResults validates the schema passed successfully.
-func assertResults(t *testing.T, r Results) Results {
+func assertResults(t *testing.T, r *Results) *Results {
 	for _, err := range r.Errors() {
 		assert.NoError(t, err)
 	}
@@ -58,6 +58,7 @@ func TestBadFlat(t *testing.T) {
 	})(m)
 
 	assertResults(fakeT, results)
+
 	assert.True(t, fakeT.Failed())
 
 	result := results.Fields["notafield"][0]
@@ -82,7 +83,7 @@ func TestNested(t *testing.T) {
 
 	assertResults(t, results)
 
-	assert.Len(t, results, 2, "One result per matcher")
+	assert.Len(t, results.Fields, 2, "One result per matcher")
 }
 
 func TestComposition(t *testing.T) {
@@ -102,14 +103,14 @@ func TestComposition(t *testing.T) {
 	// Test that the composition of them works
 	assertResults(t, composed(m))
 
-	assert.Len(t, composed(m), 2)
+	assert.Len(t, composed(m).Fields, 2)
 
 	badValidator := Schema(Map{"notakey": "blah"})
 	badComposed := Compose(badValidator, composed)
 
 	fakeT := new(testing.T)
 	assertResults(fakeT, badComposed(m))
-	assert.Len(t, badComposed(m), 3)
+	assert.Len(t, badComposed(m).Fields, 3)
 	assert.True(t, fakeT.Failed())
 }
 
@@ -147,7 +148,7 @@ func TestStrictFunc(t *testing.T) {
 	assert.Equal(t, []ValueResult{StrictFailureVR}, res.DetailedErrors().Fields["baz"])
 	assert.Equal(t, []ValueResult{StrictFailureVR}, res.DetailedErrors().Fields["nest.very.deep"])
 	assert.Nil(t, res.DetailedErrors().Fields["bar"])
-	assert.False(t, res.Valid())
+	assert.False(t, res.Valid)
 }
 
 func TestOptional(t *testing.T) {

--- a/libbeat/common/mapval/core_test.go
+++ b/libbeat/common/mapval/core_test.go
@@ -60,7 +60,7 @@ func TestBadFlat(t *testing.T) {
 	assertResults(fakeT, results)
 	assert.True(t, fakeT.Failed())
 
-	result := results["notafield"][0]
+	result := results.Fields["notafield"][0]
 	assert.False(t, result.Valid)
 	assert.Equal(t, result.Message, KeyMissingVR.Message)
 }
@@ -144,9 +144,9 @@ func TestStrictFunc(t *testing.T) {
 	assertResults(t, partialValidator(m))
 
 	res := Strict(partialValidator)(m)
-	assert.Equal(t, []ValueResult{StrictFailureVR}, res.DetailedErrors()["baz"])
-	assert.Equal(t, []ValueResult{StrictFailureVR}, res.DetailedErrors()["nest.very.deep"])
-	assert.Nil(t, res.DetailedErrors()["bar"])
+	assert.Equal(t, []ValueResult{StrictFailureVR}, res.DetailedErrors().Fields["baz"])
+	assert.Equal(t, []ValueResult{StrictFailureVR}, res.DetailedErrors().Fields["nest.very.deep"])
+	assert.Nil(t, res.DetailedErrors().Fields["bar"])
 	assert.False(t, res.Valid())
 }
 

--- a/libbeat/common/mapval/is_defs.go
+++ b/libbeat/common/mapval/is_defs.go
@@ -32,6 +32,7 @@ var KeyPresent = IsDef{name: "check key present"}
 // KeyMissing checks that the given key is not present defined.
 var KeyMissing = IsDef{name: "check key not present", checkKeyMissing: true}
 
+// IsStringContaining validates that the the actual value contains the specified substring.
 func IsStringContaining(needle string) IsDef {
 	return Is("is string containing", func(v interface{}) ValueResult {
 		strV, ok := v.(string)

--- a/libbeat/common/mapval/is_defs.go
+++ b/libbeat/common/mapval/is_defs.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"time"
 
+	"strings"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -29,6 +31,28 @@ var KeyPresent = IsDef{name: "check key present"}
 
 // KeyMissing checks that the given key is not present defined.
 var KeyMissing = IsDef{name: "check key not present", checkKeyMissing: true}
+
+func IsStringContaining(needle string) IsDef {
+	return Is("is string containing", func(v interface{}) ValueResult {
+		strV, ok := v.(string)
+
+		if !ok {
+			return ValueResult{
+				false,
+				fmt.Sprintf("Unable to convert '%v' to string", v),
+			}
+		}
+
+		if !strings.Contains(strV, needle) {
+			return ValueResult{
+				false,
+				fmt.Sprintf("String '%s' did not contain substring '%s'", strV, needle),
+			}
+		}
+
+		return ValidVR
+	})
+}
 
 // IsDuration tests that the given value is a duration.
 var IsDuration = Is("is a duration", func(v interface{}) ValueResult {
@@ -49,7 +73,7 @@ func IsEqual(to interface{}) IsDef {
 		}
 		return ValueResult{
 			false,
-			fmt.Sprintf("objects not equal: %v != %v", v, to),
+			fmt.Sprintf("objects not equal: actual(%v) != expected(%v)", v, to),
 		}
 	})
 }
@@ -62,7 +86,7 @@ func IsEqualToValue(to interface{}) IsDef {
 		}
 		return ValueResult{
 			false,
-			fmt.Sprintf("values not equal: %v != %v", v, to),
+			fmt.Sprintf("values not equal: actual(%v) != expected(%v)", v, to),
 		}
 	})
 }

--- a/libbeat/common/mapval/is_defs.go
+++ b/libbeat/common/mapval/is_defs.go
@@ -31,6 +31,30 @@ var KeyPresent = IsDef{name: "check key present"}
 // KeyMissing checks that the given key is not present defined.
 var KeyMissing = IsDef{name: "check key not present", checkKeyMissing: true}
 
+// IsAny takes a variable number of IsDef's and combines them with a logical OR. If any single definition
+// matches the key will be marked as valid.
+func IsAny(of ...IsDef) IsDef {
+	names := make([]string, len(of))
+	for i, def := range of {
+		names[i] = def.name
+	}
+	isName := fmt.Sprintf("either %#v", names)
+
+	return Is(isName, func(v interface{}) ValueResult {
+		for _, def := range of {
+			vr := def.check(v, true)
+			if vr.Valid {
+				return vr
+			}
+		}
+
+		return ValueResult{
+			false,
+			fmt.Sprintf("Value was none of %#v, actual value was %#v", names, v),
+		}
+	})
+}
+
 // IsStringContaining validates that the the actual value contains the specified substring.
 func IsStringContaining(needle string) IsDef {
 	return Is("is string containing", func(v interface{}) ValueResult {

--- a/libbeat/common/mapval/is_defs.go
+++ b/libbeat/common/mapval/is_defs.go
@@ -19,9 +19,8 @@ package mapval
 
 import (
 	"fmt"
-	"time"
-
 	"strings"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/libbeat/common/mapval/is_defs_test.go
+++ b/libbeat/common/mapval/is_defs_test.go
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package mapval
 
 import (

--- a/libbeat/common/mapval/is_defs_test.go
+++ b/libbeat/common/mapval/is_defs_test.go
@@ -1,0 +1,76 @@
+package mapval
+
+import (
+	"testing"
+
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func assertIsDefValid(t *testing.T, id IsDef, value interface{}) {
+	res := id.check(value, true)
+	if !res.Valid {
+		assert.Fail(
+			t,
+			"Expected Valid IsDef",
+			"Isdef %#v was not valid for value %#v with error: ", id, value, res.Message,
+		)
+	}
+}
+
+func assertIsDefInvalid(t *testing.T, id IsDef, value interface{}) {
+	res := id.check(value, true)
+	if res.Valid {
+		assert.Fail(
+			t,
+			"Expected invalid IsDef",
+			"Isdef %#v was should not have been valid for value %#v",
+			id,
+			value,
+		)
+	}
+}
+
+func TestIsAny(t *testing.T) {
+	id := IsAny(IsEqual("foo"), IsEqual("bar"))
+
+	assertIsDefValid(t, id, "foo")
+	assertIsDefValid(t, id, "bar")
+	assertIsDefInvalid(t, id, "basta")
+}
+
+func TestIsEqual(t *testing.T) {
+	id := IsEqual("foo")
+
+	assertIsDefValid(t, id, "foo")
+	assertIsDefInvalid(t, id, "bar")
+}
+
+func TestIsStringContaining(t *testing.T) {
+	id := IsStringContaining("foo")
+
+	assertIsDefValid(t, id, "foo")
+	assertIsDefValid(t, id, "a foo b")
+	assertIsDefInvalid(t, id, "a bar b")
+}
+
+func TestIsDuration(t *testing.T) {
+	id := IsDuration
+
+	assertIsDefValid(t, id, time.Duration(1))
+	assertIsDefInvalid(t, id, "foo")
+}
+
+func TestIsIntGt(t *testing.T) {
+	id := IsIntGt(100)
+
+	assertIsDefValid(t, id, 101)
+	assertIsDefInvalid(t, id, 100)
+	assertIsDefInvalid(t, id, 99)
+}
+
+func TestIsNil(t *testing.T) {
+	assertIsDefValid(t, IsNil, nil)
+	assertIsDefInvalid(t, IsNil, "foo")
+}

--- a/libbeat/common/mapval/results.go
+++ b/libbeat/common/mapval/results.go
@@ -27,6 +27,7 @@ type Results struct {
 	Valid  bool
 }
 
+// NewResults creates a new Results object.
 func NewResults() *Results {
 	return &Results{
 		Fields: make(map[string][]ValueResult),

--- a/libbeat/common/mapval/results_test.go
+++ b/libbeat/common/mapval/results_test.go
@@ -1,0 +1,48 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package mapval
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEmpty(t *testing.T) {
+	r := NewResults()
+	assert.True(t, r.Valid)
+	assert.Empty(t, r.DetailedErrors().Fields)
+	assert.Empty(t, r.Errors())
+}
+
+func TestWithError(t *testing.T) {
+	r := NewResults()
+	r.record("foo", KeyMissingVR)
+	r.record("bar", ValidVR)
+
+	assert.False(t, r.Valid)
+
+	assert.Equal(t, KeyMissingVR, r.Fields["foo"][0])
+	assert.Equal(t, ValidVR, r.Fields["bar"][0])
+
+	assert.Equal(t, KeyMissingVR, r.DetailedErrors().Fields["foo"][0])
+	assert.NotContains(t, r.DetailedErrors().Fields, "bar")
+
+	assert.False(t, r.DetailedErrors().Valid)
+	assert.NotEmpty(t, r.Errors())
+}

--- a/libbeat/common/mapval/value.go
+++ b/libbeat/common/mapval/value.go
@@ -62,7 +62,7 @@ var ValidVR = ValueResult{true, ""}
 // KeyMissingVR is emitted when a key was expected, but was not present.
 var KeyMissingVR = ValueResult{
 	false,
-	"expected to see a key here",
+	"expected this key to be present",
 }
 
 // StrictFailureVR is emitted when Strict() is used, and an unexpected field is found.

--- a/libbeat/testing/mapvaltest/mapvaltest.go
+++ b/libbeat/testing/mapvaltest/mapvaltest.go
@@ -28,17 +28,20 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 
+	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/mapval"
 )
 
 // Test takes the output from a Validator invocation and runs test assertions on the result.
-// If you are using this library for testing you will probably want to run Test(t, Schema(Map{...})(actual)) as a pattern.
-func Test(t *testing.T, r mapval.Results) mapval.Results {
+// If you are using this library for testing you will probably want to run Test(t, Schema(Map{...}), actual) as a pattern.
+func Test(t *testing.T, v mapval.Validator, m common.MapStr) mapval.Results {
+	r := v(m)
+
 	if !r.Valid() {
 		assert.Fail(
 			t,
 			"mapval could not validate map",
-			"%d errors validating source: \n%s", len(r.Errors()), spew.Sdump(r.Source),
+			"%d errors validating source: \n%s", len(r.Errors()), spew.Sdump(m),
 		)
 	}
 

--- a/libbeat/testing/mapvaltest/mapvaltest.go
+++ b/libbeat/testing/mapvaltest/mapvaltest.go
@@ -34,10 +34,10 @@ import (
 
 // Test takes the output from a Validator invocation and runs test assertions on the result.
 // If you are using this library for testing you will probably want to run Test(t, Schema(Map{...}), actual) as a pattern.
-func Test(t *testing.T, v mapval.Validator, m common.MapStr) mapval.Results {
+func Test(t *testing.T, v mapval.Validator, m common.MapStr) *mapval.Results {
 	r := v(m)
 
-	if !r.Valid() {
+	if !r.Valid {
 		assert.Fail(
 			t,
 			"mapval could not validate map",

--- a/libbeat/testing/mapvaltest/mapvaltest.go
+++ b/libbeat/testing/mapvaltest/mapvaltest.go
@@ -26,12 +26,22 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/davecgh/go-spew/spew"
+
 	"github.com/elastic/beats/libbeat/common/mapval"
 )
 
 // Test takes the output from a Validator invocation and runs test assertions on the result.
 // If you are using this library for testing you will probably want to run Test(t, Schema(Map{...})(actual)) as a pattern.
 func Test(t *testing.T, r mapval.Results) mapval.Results {
+	if !r.Valid() {
+		assert.Fail(
+			t,
+			"mapval could not validate map",
+			"%d errors validating source: \n%s", len(r.Errors()), spew.Sdump(r.Source),
+		)
+	}
+
 	for _, err := range r.Errors() {
 		assert.NoError(t, err)
 	}

--- a/libbeat/testing/mapvaltest/mapvaltest_test.go
+++ b/libbeat/testing/mapvaltest/mapvaltest_test.go
@@ -22,20 +22,16 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/mapval"
 )
 
 func TestTest(t *testing.T) {
 	// Should pass
-	Test(t, mapval.Results{
-		"foo": []mapval.ValueResult{mapval.ValidVR},
-	})
+	Test(t, mapval.Schema(mapval.Map{}), common.MapStr{})
 
 	fakeT := new(testing.T)
-	Test(fakeT, mapval.Results{
-		"foo": []mapval.ValueResult{mapval.KeyMissingVR},
-	})
+	Test(fakeT, mapval.Schema(mapval.Map{"foo": "bar"}), common.MapStr{})
 
 	assert.True(t, fakeT.Failed())
-
 }

--- a/vendor/github.com/phayes/freeport/LICENSE.md
+++ b/vendor/github.com/phayes/freeport/LICENSE.md
@@ -1,0 +1,15 @@
+Open Source License (BSD 3-Clause)
+----------------------------------
+
+Copyright (c) 2014, Patrick Hayes / HighWire Press
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/phayes/freeport/README.md
+++ b/vendor/github.com/phayes/freeport/README.md
@@ -1,0 +1,58 @@
+FreePort
+========
+
+Get a free open TCP port that is ready to use.
+
+## Command Line Example:
+```bash
+# Ask the kernel to give us an open port.
+export port=$(freeport)
+
+# Start standalone httpd server for testing
+httpd -X -c "Listen $port" &
+
+# Curl local server on the selected port
+curl localhost:$port
+```
+
+## Golang example:
+```go
+package main
+
+import "github.com/phayes/freeport"
+
+func main() {
+	port, err := freeport.GetFreePort()
+	if err != nil {
+		log.Fatal(err)
+	}
+	// port is ready to listen on
+}
+
+```
+
+## Installation
+
+#### Mac OSX
+```bash
+brew install phayes/repo/freeport
+```
+
+
+#### CentOS and other RPM based systems
+```bash
+wget https://github.com/phayes/freeport/releases/download/1.0.2/freeport_1.0.2_linux_386.rpm
+rpm -Uvh freeport_1.0.2_linux_386.rpm
+```
+
+#### Ubuntu and other DEB based systems
+```bash
+wget wget https://github.com/phayes/freeport/releases/download/1.0.2/freeport_1.0.2_linux_amd64.deb
+dpkg -i freeport_1.0.2_linux_amd64.deb
+```
+
+#### Building From Source
+```bash
+sudo apt-get install golang                    # Download go. Alternativly build from source: https://golang.org/doc/install/source
+go get github.com/phayes/freeport
+```

--- a/vendor/github.com/phayes/freeport/freeport.go
+++ b/vendor/github.com/phayes/freeport/freeport.go
@@ -1,0 +1,30 @@
+package freeport
+
+import (
+	"net"
+)
+
+// GetFreePort asks the kernel for a free open port that is ready to use.
+func GetFreePort() (int, error) {
+	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
+	if err != nil {
+		return 0, err
+	}
+
+	l, err := net.ListenTCP("tcp", addr)
+	if err != nil {
+		return 0, err
+	}
+	defer l.Close()
+	return l.Addr().(*net.TCPAddr).Port, nil
+}
+
+// GetPort is deprecated, use GetFreePort instead
+// Ask the kernel for a free open port that is ready to use
+func GetPort() int {
+	port, err := GetFreePort()
+	if err != nil {
+		panic(err)
+	}
+	return port
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1223,6 +1223,12 @@
 			"revisionTime": "2017-03-27T18:58:03Z"
 		},
 		{
+			"checksumSHA1": "kZRhErakejBG0U2e8D+Ap/Djje8=",
+			"path": "github.com/phayes/freeport",
+			"revision": "e27662a4a9d6b2083dfd7e7b5d0e30985daca925",
+			"revisionTime": "2017-10-02T18:52:19Z"
+		},
+		{
 			"checksumSHA1": "WmrPO1ovmQ7t7hs9yZGbr2SAoM4=",
 			"path": "github.com/pierrec/lz4",
 			"revision": "90290f74b1b4d9c097f0a3b3c7eba2ef3875c699",


### PR DESCRIPTION
This adds a number of new tests to heartbeat

1. Testing the full range of HTTP codes
2. Testing both connection refused *and* unroutable endpoints for both TCP and HTTP
3. Makes various ergonomic and functional improvements to mapval discovered in the course of writing the above tests.
4. Adds the `freeport` dep via govendor. This nifty little lib will spit out a free local port you can use for testing.
5. Changes the signature of `mapvaltest.Test` to take `Schema` and expected `MapStr` as separate arguments. This reduces a lot of typos and makes tests easier to read.

I attempted to add some ICMP tests, but that will be a little tricky since you need escalated privileges. There's certainly a good way to add those, but I think that's deserving of its own PR. 