### PR TITLE
Clean up experimental and beta messages

### DIFF
--- a/heartbeat/beater/heartbeat.go
+++ b/heartbeat/beater/heartbeat.go
@@ -28,6 +28,7 @@ import (
 	"github.com/elastic/beats/heartbeat/config"
 	"github.com/elastic/beats/heartbeat/monitors"
 	"github.com/elastic/beats/heartbeat/scheduler"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 )
 
 type Heartbeat struct {
@@ -38,7 +39,7 @@ type Heartbeat struct {
 }
 
 func New(b *beat.Beat, cfg *common.Config) (beat.Beater, error) {
-	logp.Warn("Beta: Heartbeat is beta software")
+	cfgwarn.Beta("Heartbeat is beta software")
 
 	config := config.DefaultConfig
 	if err := cfg.Unpack(&config); err != nil {

--- a/libbeat/plugin/cli.go
+++ b/libbeat/plugin/cli.go
@@ -24,6 +24,7 @@ import (
 	"flag"
 	"strings"
 
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/libbeat/logp"
 )
 
@@ -54,7 +55,7 @@ func init() {
 
 func Initialize() error {
 	if len(plugins.paths) > 0 {
-		logp.Warn("EXPERIMENTAL: loadable plugin support is experimental")
+		cfgwarn.Experimental("loadable plugin support is experimental")
 	}
 
 	for _, path := range plugins.paths {

--- a/metricbeat/module/ceph/osd_df/osd_df.go
+++ b/metricbeat/module/ceph/osd_df/osd_df.go
@@ -50,7 +50,7 @@ type MetricSet struct {
 }
 
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	cfgwarn.Beta("The ceph osd_df metricset is experimental")
+	cfgwarn.Experimental("The ceph osd_df metricset is experimental")
 
 	http, err := helper.NewHTTP(base)
 	if err != nil {


### PR DESCRIPTION
Sometimes the old logging mechanism was used. If all use the new one it is easier to find all the entries. In addition some messages were inconsistent.