### PR TITLE
Add Openstack Nova cloud_metadata Processor (#7649)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -182,6 +182,7 @@ https://github.com/elastic/beats/compare/v6.2.3...master[Check the HEAD diff]
 - Add additional types to kubernetes metadata {pull}7457[7457]
 - Add module state reporting for X-Pack Monitoring. {pull}7075[7075]
 - Release the rename processor as GA. {pull}7656[7656]
+- Add support for Openstack Nova in add_cloud_metadata processor. {pull}7663[7663]
 
 *Auditbeat*
 

--- a/libbeat/docs/processors-using.asciidoc
+++ b/libbeat/docs/processors-using.asciidoc
@@ -404,6 +404,7 @@ The following cloud providers are supported:
 - https://www.qcloud.com/?lang=en[Tencent Cloud] (QCloud)
 - Alibaba Cloud (ECS)
 - Azure Virtual Machine
+- Openstack Nova
 
 The simple configuration below enables the processor.
 
@@ -521,6 +522,23 @@ _Azure Virtual Machine_
       "instance_name": "test-az-vm",
       "machine_type": "Standard_D3_v2",
       "region": "eastus2"
+    }
+  }
+}
+-------------------------------------------------------------------------------
+
+_Openstack Nova_
+
+[source,json]
+-------------------------------------------------------------------------------
+{
+  "meta": {
+    "cloud": {
+      "provider": "openstack",
+      "instance_name": "test-998d932195.mycloud.tld",
+      "availability_zone": "xxxx-az-c",
+      "instance_id": "i-00011a84",
+      "machine_type": "m2.large"
     }
   }
 }

--- a/libbeat/processors/add_cloud_metadata/add_cloud_metadata.go
+++ b/libbeat/processors/add_cloud_metadata/add_cloud_metadata.go
@@ -281,6 +281,10 @@ func setupFetchers(c *common.Config) ([]*metadataFetcher, error) {
 	if err != nil {
 		return fetchers, err
 	}
+	osFetcher, err := newOpenstackNovaMetadataFetcher(c)
+	if err != nil {
+		return fetchers, err
+	}
 
 	fetchers = []*metadataFetcher{
 		doFetcher,
@@ -289,6 +293,7 @@ func setupFetchers(c *common.Config) ([]*metadataFetcher, error) {
 		qcloudFetcher,
 		ecsFetcher,
 		azFetcher,
+		osFetcher,
 	}
 	return fetchers, nil
 }

--- a/libbeat/processors/add_cloud_metadata/provider_openstack_nova.go
+++ b/libbeat/processors/add_cloud_metadata/provider_openstack_nova.go
@@ -1,0 +1,70 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package add_cloud_metadata
+
+import (
+	"github.com/elastic/beats/libbeat/common"
+)
+
+const (
+	osMetadataInstanceIDURI   = "/2009-04-04/meta-data/instance-id"
+	osMetadataInstanceTypeURI = "/2009-04-04/meta-data/instance-type"
+	osMetadataHostnameURI     = "/2009-04-04/meta-data/hostname"
+	osMetadataZoneURI         = "/2009-04-04/meta-data/placement/availability-zone"
+)
+
+// newOpenstackNovaMetadataFetcher returns a metadataFetcher for the
+// OpenStack Nova Metadata Service
+// Document https://docs.openstack.org/nova/latest/user/metadata-service.html
+func newOpenstackNovaMetadataFetcher(c *common.Config) (*metadataFetcher, error) {
+
+	osSchema := func(m map[string]interface{}) common.MapStr {
+		return common.MapStr(m)
+	}
+
+	urls, err := getMetadataURLs(c, metadataHost, []string{
+		osMetadataInstanceIDURI,
+		osMetadataInstanceTypeURI,
+		osMetadataHostnameURI,
+		osMetadataZoneURI,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	responseHandlers := map[string]responseHandler{
+		urls[0]: func(all []byte, result *result) error {
+			result.metadata["instance_id"] = string(all)
+			return nil
+		},
+		urls[1]: func(all []byte, result *result) error {
+			result.metadata["machine_type"] = string(all)
+			return nil
+		},
+		urls[2]: func(all []byte, result *result) error {
+			result.metadata["instance_name"] = string(all)
+			return nil
+		},
+		urls[3]: func(all []byte, result *result) error {
+			result.metadata["availability_zone"] = string(all)
+			return nil
+		},
+	}
+	fetcher := &metadataFetcher{"openstack", nil, responseHandlers, osSchema}
+	return fetcher, nil
+}

--- a/libbeat/processors/add_cloud_metadata/provider_openstack_nova_test.go
+++ b/libbeat/processors/add_cloud_metadata/provider_openstack_nova_test.go
@@ -1,0 +1,91 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package add_cloud_metadata
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
+)
+
+func initOpenstackNovaTestServer() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.RequestURI == osMetadataInstanceIDURI {
+			w.Write([]byte("i-0000ffac"))
+			return
+		}
+		if r.RequestURI == osMetadataInstanceTypeURI {
+			w.Write([]byte("m1.xlarge"))
+			return
+		}
+		if r.RequestURI == osMetadataHostnameURI {
+			w.Write([]byte("testvm01.stack.cloud"))
+			return
+		}
+		if r.RequestURI == osMetadataZoneURI {
+			w.Write([]byte("az-test-2"))
+			return
+		}
+
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+}
+
+func TestRetrieveOpenstackNovaMetadata(t *testing.T) {
+	logp.TestingSetup()
+
+	server := initOpenstackNovaTestServer()
+	defer server.Close()
+
+	config, err := common.NewConfigFrom(map[string]interface{}{
+		"host": server.Listener.Addr().String(),
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p, err := newCloudMetadata(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	actual, err := p.Run(&beat.Event{Fields: common.MapStr{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := common.MapStr{
+		"meta": common.MapStr{
+			"cloud": common.MapStr{
+				"provider":          "openstack",
+				"instance_id":       "i-0000ffac",
+				"instance_name":     "testvm01.stack.cloud",
+				"machine_type":      "m1.xlarge",
+				"availability_zone": "az-test-2",
+			},
+		},
+	}
+	assert.Equal(t, expected, actual.Fields)
+}


### PR DESCRIPTION
Using the EC2 compatible metadata endpoint because it exposes more useful information that the native "openstack" endpoint.