### PR TITLE
fix log suffix can only be .log in kubernetes

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -104,6 +104,7 @@ https://github.com/elastic/beats/compare/v6.2.3...master[Check the HEAD diff]
 - Fix an issue when parsing ISO8601 dates with timezone definition {issue}7367[7367]
 - Fix Grok pattern of MongoDB module. {pull}7568[7568]
 - Fix registry duplicates and log resending on upgrade. {issue}7634[7634]
+- Fix log suffix can only be .log in kubernetes. {pull}7672[7672]
 
 *Heartbeat*
 - Fix race due to updates of shared a map, that was not supposed to be shared between multiple go-routines. {issue}6616[6616]

--- a/filebeat/processor/add_kubernetes_metadata/matchers.go
+++ b/filebeat/processor/add_kubernetes_metadata/matchers.go
@@ -92,7 +92,7 @@ func (f *LogPathMatcher) MetadataIndex(event common.MapStr) string {
 		if f.ResourceType == "pod" {
 			// Specify a pod resource type when manually mounting log volumes and they end up under "/var/lib/kubelet/pods/"
 			// This will extract only the pod UID, which offers less granularity of metadata when compared to the container ID
-			if strings.HasPrefix(f.LogsPath, "/var/lib/kubelet/pods/") && strings.HasSuffix(source, ".log") {
+			if strings.HasPrefix(f.LogsPath, "/var/lib/kubelet/pods/") {
 				pathDirs := strings.Split(source, "/")
 				if len(pathDirs) > podUIDPos {
 					podUID := strings.Split(source, "/")[podUIDPos]


### PR DESCRIPTION
Since the kubernetes emptyDir log can only have suffix with `.log`, then we can not collect other log formats in the filebeat `type` log. So this piece of code should be removed.