### PR TITLE
Remove outdated vendor information.

### DIFF
--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -496,22 +496,10 @@
 			"versionExact": "v0.0.4"
 		},
 		{
-			"path": "github.com/elastic/go-structform/internal/ubjson",
-			"revision": "v0.0.4",
-			"version": "v0.0.4",
-			"versionExact": "v0.0.4"
-		},
-		{
 			"checksumSHA1": "s7k0vEuuqkoPXU0FtrD6Y0jxd7U=",
 			"path": "github.com/elastic/go-structform/internal/unsafe",
 			"revision": "0ea09ff9b43c387dd183a4088f6d573bf823e4ed",
 			"revisionTime": "2018-06-27T12:43:37Z",
-			"version": "v0.0.4",
-			"versionExact": "v0.0.4"
-		},
-		{
-			"path": "github.com/elastic/go-structform/internal/visitors",
-			"revision": "v0.0.4",
 			"version": "v0.0.4",
 			"versionExact": "v0.0.4"
 		},


### PR DESCRIPTION
There seems to be an outdated information in the vendor.json file for `go-structform`. 