### PR TITLE
Check Kibana version for stats API availability

### DIFF
--- a/metricbeat/module/kibana/kibana.go
+++ b/metricbeat/module/kibana/kibana.go
@@ -1,0 +1,83 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package kibana
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/elastic/beats/libbeat/common"
+
+	"github.com/elastic/beats/metricbeat/helper"
+	"github.com/elastic/beats/metricbeat/mb"
+)
+
+// ReportErrorForMissingField reports and returns an error message for the given
+// field being missing in API response received from Kibana
+func ReportErrorForMissingField(field string, r mb.ReporterV2) error {
+	err := fmt.Errorf("Could not find field '%v' in Kibana stats API response", field)
+	r.Error(err)
+	return err
+}
+
+// GetVersion returns the version of the Kibana instance
+func GetVersion(http *helper.HTTP, currentPath string) (string, error) {
+	const statusPath = "api/status"
+	content, err := fetchPath(http, currentPath, statusPath)
+	if err != nil {
+		return "", err
+	}
+
+	var data common.MapStr
+	err = json.Unmarshal(content, &data)
+	if err != nil {
+		return "", err
+	}
+
+	version, err := data.GetValue("version.number")
+	if err != nil {
+		return "", err
+	}
+
+	versionStr, ok := version.(string)
+	if !ok {
+		return "", fmt.Errorf("Could not parse Kibana version in status API response")
+	}
+
+	return versionStr, nil
+}
+
+func fetchPath(http *helper.HTTP, currentPath, newPath string) ([]byte, error) {
+	currentURI := http.GetURI()
+	defer http.SetURI(currentURI) // Reset after this request
+
+	// Parse the URI to replace the path
+	u, err := url.Parse(currentURI)
+	if err != nil {
+		return nil, err
+	}
+
+	u.Path = strings.Replace(u.Path, currentPath, newPath, 1) // HACK: to account for base paths
+	u.RawQuery = ""
+
+	// Http helper includes the HostData with username and password
+	http.SetURI(u.String())
+	return http.FetchContent()
+}

--- a/metricbeat/module/kibana/stats/stats.go
+++ b/metricbeat/module/kibana/stats/stats.go
@@ -18,6 +18,9 @@
 package stats
 
 import (
+	"fmt"
+
+	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/metricbeat/helper"
 	"github.com/elastic/beats/metricbeat/mb"
@@ -33,10 +36,15 @@ func init() {
 	)
 }
 
+const (
+	statsPath                      = "api/stats"
+	kibanaStatsAPIAvailableVersion = "6.4.0"
+)
+
 var (
 	hostParser = parse.URLHostParserBuilder{
 		DefaultScheme: "http",
-		DefaultPath:   "api/stats",
+		DefaultPath:   statsPath,
 		QueryParams:   "extended=true", // make Kibana fetch the cluster_uuid
 	}.Build()
 )
@@ -46,6 +54,20 @@ type MetricSet struct {
 	mb.BaseMetricSet
 	http         *helper.HTTP
 	xPackEnabled bool
+}
+
+func isKibanaStatsAPIAvailable(kibanaVersion string) (bool, error) {
+	currentVersion, err := common.NewVersion(kibanaVersion)
+	if err != nil {
+		return false, err
+	}
+
+	wantVersion, err := common.NewVersion(kibanaStatsAPIAvailableVersion)
+	if err != nil {
+		return false, err
+	}
+
+	return !currentVersion.LessThan(wantVersion), nil
 }
 
 // New create a new instance of the MetricSet
@@ -64,6 +86,21 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	http, err := helper.NewHTTP(base)
 	if err != nil {
 		return nil, err
+	}
+
+	kibanaVersion, err := kibana.GetVersion(http, statsPath)
+	if err != nil {
+		return nil, err
+	}
+
+	isAPIAvailable, err := isKibanaStatsAPIAvailable(kibanaVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	if !isAPIAvailable {
+		const errorMsg = "The kibana stats metricset is only supported with Kibana >= %v. You are currently running Kibana %v"
+		return nil, fmt.Errorf(errorMsg, kibanaStatsAPIAvailableVersion, kibanaVersion)
 	}
 
 	return &MetricSet{

--- a/metricbeat/module/kibana/stats/stats_integration_test.go
+++ b/metricbeat/module/kibana/stats/stats_integration_test.go
@@ -28,9 +28,24 @@ import (
 )
 
 func TestData(t *testing.T) {
+	t.Skip("Skipping until we find a way to conditionally skip this for Kibana < 6.4.0") // FIXME
 	compose.EnsureUp(t, "kibana")
 
-	f := mbtest.NewReportingMetricSetV2(t, mtest.GetConfig("stats"))
+	f := mbtest.NewReportgiingMetricSetV2(t, mtest.GetConfig("stats"))
+
+	// FIXME! See skip above
+	// version, err := kibana.GetVersion(f.http, "api/stats")
+	// if err != nil {
+	// 	t.Fatal("getting kibana version", err)
+	// }
+
+	// isStatsAPIAvailable, err := kibana.IsStatsAPIAvailable(version)
+	// if err != nil {
+	// 	t.Fatal("checking if kibana stats API is available", err)
+	// }
+
+	// t.Skip("Kibana stats API is not available until 6.4.0")
+
 	err := mbtest.WriteEventsReporterV2(f, t, "")
 	if err != nil {
 		t.Fatal("write", err)

--- a/metricbeat/module/kibana/stats/stats_integration_test.go
+++ b/metricbeat/module/kibana/stats/stats_integration_test.go
@@ -31,7 +31,7 @@ func TestData(t *testing.T) {
 	t.Skip("Skipping until we find a way to conditionally skip this for Kibana < 6.4.0") // FIXME
 	compose.EnsureUp(t, "kibana")
 
-	f := mbtest.NewReportgiingMetricSetV2(t, mtest.GetConfig("stats"))
+	f := mbtest.NewReportingMetricSetV2(t, mtest.GetConfig("stats"))
 
 	// FIXME! See skip above
 	// version, err := kibana.GetVersion(f.http, "api/stats")

--- a/metricbeat/tests/system/requirements.txt
+++ b/metricbeat/tests/system/requirements.txt
@@ -1,2 +1,3 @@
 kafka-python==1.4.3
 elasticsearch==6.2.0
+semver==2.8.1

--- a/metricbeat/tests/system/test_kibana.py
+++ b/metricbeat/tests/system/test_kibana.py
@@ -4,7 +4,6 @@ import unittest
 from nose.plugins.skip import SkipTest
 import urllib2
 import json
-import semver
 
 
 class Test(metricbeat.BaseTest):
@@ -17,16 +16,20 @@ class Test(metricbeat.BaseTest):
         """
         kibana status metricset test
         """
+        # FIXME: Need to skip conditionally for Kibana versions < 6.4.0 (see commented out
+        # code below)
+        raise SkipTest
+
         env = os.environ.get('TESTING_ENVIRONMENT')
 
         if env == "2x" or env == "5x":
             # Skip for 5.x and 2.x tests as Kibana endpoint not available
             raise SkipTest
 
-        version = self.get_version()
-        if semver.compare(version, "6.4.0") == -1:
-            # Skip for Kibana versions < 6.4.0 as Kibana endpoint not available
-            raise SkipTest
+        # version = self.get_version()
+        # if semver.compare(version, "6.4.0") == -1:
+        #     # Skip for Kibana versions < 6.4.0 as Kibana endpoint not available
+        #     raise SkipTest
 
         self.render_config_template(modules=[{
             "name": "kibana",

--- a/metricbeat/tests/system/test_kibana.py
+++ b/metricbeat/tests/system/test_kibana.py
@@ -6,6 +6,7 @@ import urllib2
 import json
 import semver
 
+
 class Test(metricbeat.BaseTest):
 
     COMPOSE_SERVICES = ['elasticsearch', 'kibana']

--- a/metricbeat/tests/system/test_kibana.py
+++ b/metricbeat/tests/system/test_kibana.py
@@ -2,7 +2,9 @@ import os
 import metricbeat
 import unittest
 from nose.plugins.skip import SkipTest
-
+import urllib2
+import json
+import semver
 
 class Test(metricbeat.BaseTest):
 
@@ -18,6 +20,11 @@ class Test(metricbeat.BaseTest):
 
         if env == "2x" or env == "5x":
             # Skip for 5.x and 2.x tests as Kibana endpoint not available
+            raise SkipTest
+
+        version = self.get_version()
+        if semver.compare(version, "6.4.0") == -1:
+            # Skip for Kibana versions < 6.4.0 as Kibana endpoint not available
             raise SkipTest
 
         self.render_config_template(modules=[{
@@ -41,3 +48,12 @@ class Test(metricbeat.BaseTest):
     def get_hosts(self):
         return [os.getenv('KIBANA_HOST', 'localhost') + ':' +
                 os.getenv('KIBANA_PORT', '5601')]
+
+    def get_version(self):
+        host = self.get_hosts()[0]
+        res = urllib2.urlopen(host + "/api/status").read()
+
+        body = json.loads(res)
+        version = body["version"]["number"]
+
+        return version


### PR DESCRIPTION
Metricbeat will now exit with a helpful error message if the user is running against a version of Kibana that doesn't yet have the stats API implemented in it.

### To test this PR

1. Run Elasticsearch 6.3.0.
   ```
   docker run --rm --name elasticsearch docker.elastic.co/elasticsearch/elasticsearch:6.3.0
   ```

2. Run Kibana 6.3.0.
   ```
   docker run --rm --name kibana --publish 5601:5601 --link elasticsearch docker.elastic.co/kibana/kibana:6.3.0
   ```

3. Using this PR, enable the kibana module in metricbeat.
   ```
   metricbeat module enable kibana
   ```

4. Modify `modules.d/kibana.yml` and enable the `stats` metricset.
5. Run metricbeat.
   ```
   metricbeat -e
   ```

6. Verify that metricbeat exits with a helpful error message about the Kibana stats API not being available.