### PR TITLE
Update state_node metricset

### DIFF
--- a/metricbeat/helper/prometheus/metric.go
+++ b/metricbeat/helper/prometheus/metric.go
@@ -41,7 +41,7 @@ type MetricMap interface {
 
 // MetricOption adds settings to Metric objects behavior
 type MetricOption interface {
-	Process(field string, value interface{}, labels, keyLabels common.MapStr) (string, interface{}, common.MapStr, common.MapStr)
+	Process(field string, value interface{}, labels common.MapStr) (string, interface{}, common.MapStr)
 }
 
 // OpFilter only processes metrics matching the given filter
@@ -247,20 +247,20 @@ type opFilter struct {
 	labels map[string]string
 }
 
-func (o opFilter) Process(field string, value interface{}, labels, keyLabels common.MapStr) (string, interface{}, common.MapStr, common.MapStr) {
+func (o opFilter) Process(field string, value interface{}, labels common.MapStr) (string, interface{}, common.MapStr) {
 	for k, v := range o.labels {
-		if labels[k] != v && keyLabels[k] != v {
-			return "", nil, nil, nil
+		if labels[k] != v {
+			return "", nil, nil
 		}
 	}
-	return field, value, labels, keyLabels
+	return field, value, labels
 }
 
 type opLowercaseValue struct{}
 
-func (o opLowercaseValue) Process(field string, value interface{}, labels, keyLabels common.MapStr) (string, interface{}, common.MapStr, common.MapStr) {
+func (o opLowercaseValue) Process(field string, value interface{}, labels common.MapStr) (string, interface{}, common.MapStr) {
 	if val, ok := value.(string); ok {
 		value = strings.ToLower(val)
 	}
-	return field, value, labels, keyLabels
+	return field, value, labels
 }

--- a/metricbeat/helper/prometheus/prometheus.go
+++ b/metricbeat/helper/prometheus/prometheus.go
@@ -128,10 +128,16 @@ func (p *prometheus) GetProcessedMetrics(mapping *MetricsMapping) ([]common.MapS
 				continue
 			}
 
+			// Apply extra options
+			allLabels := getLabels(metric)
+			for _, option := range m.GetOptions() {
+				field, value, allLabels = option.Process(field, value, allLabels)
+			}
+
 			// Convert labels
 			labels := common.MapStr{}
 			keyLabels := common.MapStr{}
-			for k, v := range getLabels(metric) {
+			for k, v := range allLabels {
 				if l, ok := mapping.Labels[k]; ok {
 					if l.IsKey() {
 						keyLabels.Put(l.GetField(), v)
@@ -139,11 +145,6 @@ func (p *prometheus) GetProcessedMetrics(mapping *MetricsMapping) ([]common.MapS
 						labels.Put(l.GetField(), v)
 					}
 				}
-			}
-
-			// Apply extra options
-			for _, option := range m.GetOptions() {
-				field, value, labels, keyLabels = option.Process(field, value, labels, keyLabels)
 			}
 
 			// Keep a info document if it's an infoMetric

--- a/metricbeat/helper/prometheus/prometheus.go
+++ b/metricbeat/helper/prometheus/prometheus.go
@@ -141,6 +141,11 @@ func (p *prometheus) GetProcessedMetrics(mapping *MetricsMapping) ([]common.MapS
 				}
 			}
 
+			// Apply extra options
+			for _, option := range m.GetOptions() {
+				field, value, labels, keyLabels = option.Process(field, value, labels, keyLabels)
+			}
+
 			// Keep a info document if it's an infoMetric
 			if _, ok = m.(*infoMetric); ok {
 				labels.DeepUpdate(keyLabels)
@@ -151,10 +156,12 @@ func (p *prometheus) GetProcessedMetrics(mapping *MetricsMapping) ([]common.MapS
 				continue
 			}
 
-			// Put it in the event if it's a common metric
-			event := getEvent(eventsMap, keyLabels)
-			event.Put(field, value)
-			event.DeepUpdate(labels)
+			if field != "" {
+				// Put it in the event if it's a common metric
+				event := getEvent(eventsMap, keyLabels)
+				event.Put(field, value)
+				event.DeepUpdate(labels)
+			}
 		}
 	}
 

--- a/metricbeat/helper/prometheus/prometheus_test.go
+++ b/metricbeat/helper/prometheus/prometheus_test.go
@@ -266,6 +266,20 @@ func TestPrometheus(t *testing.T) {
 			},
 		},
 		{
+			msg: "Label metrics, filter",
+			mapping: &MetricsMapping{
+				Metrics: map[string]MetricMap{
+					"first_metric": LabelMetric("first.metric", "label4", false, OpFilter(map[string]string{
+						"foo": "filtered",
+					})),
+				},
+				Labels: map[string]LabelMap{
+					"label1": Label("labels.label1"),
+				},
+			},
+			expected: []common.MapStr{},
+		},
+		{
 			msg: "Summary metric",
 			mapping: &MetricsMapping{
 				Metrics: map[string]MetricMap{
@@ -326,6 +340,7 @@ func TestPrometheus(t *testing.T) {
 		sort.Slice(res, func(i, j int) bool {
 			return res[i].MetricSetFields.String() < res[j].MetricSetFields.String()
 		})
+		assert.Equal(t, len(test.expected), len(res))
 		for j, ev := range res {
 			assert.Equal(t, test.expected[j], ev.MetricSetFields, test.msg)
 		}

--- a/metricbeat/module/kubernetes/state_container/state_container.go
+++ b/metricbeat/module/kubernetes/state_container/state_container.go
@@ -53,8 +53,8 @@ var (
 			"kube_pod_container_status_running":                 p.KeywordMetric("status.phase", "running"),
 			"kube_pod_container_status_terminated":              p.KeywordMetric("status.phase", "terminated"),
 			"kube_pod_container_status_waiting":                 p.KeywordMetric("status.phase", "waiting"),
-			"kube_pod_container_status_terminated_reason":       p.LabelMetric("status.reason", "reason", false),
-			"kube_pod_container_status_waiting_reason":          p.LabelMetric("status.reason", "reason", false),
+			"kube_pod_container_status_terminated_reason":       p.LabelMetric("status.reason", "reason"),
+			"kube_pod_container_status_waiting_reason":          p.LabelMetric("status.reason", "reason"),
 		},
 
 		Labels: map[string]p.LabelMap{

--- a/metricbeat/module/kubernetes/state_node/_meta/test/kube-state-metrics.expected
+++ b/metricbeat/module/kubernetes/state_node/_meta/test/kube-state-metrics.expected
@@ -1,0 +1,66 @@
+[
+	{
+		"_namespace": "node",
+		"cpu": {
+			"allocatable": {
+				"cores": 3
+			},
+			"capacity": {
+				"cores": 4
+			}
+		},
+		"memory": {
+			"allocatable": {
+				"bytes": 3097786880
+			},
+			"capacity": {
+				"bytes": 4097786880
+			}
+		},
+		"name": "minikube-test",
+		"pod": {
+			"allocatable": {
+				"total": 210
+			},
+			"capacity": {
+				"total": 310
+			}
+		},
+		"status": {
+			"ready": "true",
+			"unschedulable": true
+		}
+	},
+	{
+		"_namespace": "node",
+		"cpu": {
+			"allocatable": {
+				"cores": 2
+			},
+			"capacity": {
+				"cores": 2
+			}
+		},
+		"memory": {
+			"allocatable": {
+				"bytes": 2097786880
+			},
+			"capacity": {
+				"bytes": 2097786880
+			}
+		},
+		"name": "minikube",
+		"pod": {
+			"allocatable": {
+				"total": 110
+			},
+			"capacity": {
+				"total": 110
+			}
+		},
+		"status": {
+			"ready": "true",
+			"unschedulable": false
+		}
+	}
+]

--- a/metricbeat/module/kubernetes/state_node/_meta/test/kube-state-metrics.v1.3.0.expected
+++ b/metricbeat/module/kubernetes/state_node/_meta/test/kube-state-metrics.v1.3.0.expected
@@ -1,0 +1,34 @@
+[
+	{
+		"_namespace": "node",
+		"cpu": {
+			"allocatable": {
+				"cores": 2
+			},
+			"capacity": {
+				"cores": 2
+			}
+		},
+		"memory": {
+			"allocatable": {
+				"bytes": 1992347648
+			},
+			"capacity": {
+				"bytes": 2097205248
+			}
+		},
+		"name": "minikube",
+		"pod": {
+			"allocatable": {
+				"total": 110
+			},
+			"capacity": {
+				"total": 110
+			}
+		},
+		"status": {
+			"ready": "true",
+			"unschedulable": false
+		}
+	}
+]

--- a/metricbeat/module/kubernetes/state_node/state_node.go
+++ b/metricbeat/module/kubernetes/state_node/state_node.go
@@ -48,6 +48,10 @@ var (
 			"kube_node_status_allocatable_cpu_cores":    p.Metric("cpu.allocatable.cores"),
 			"kube_node_spec_unschedulable":              p.BooleanMetric("status.unschedulable"),
 			"kube_node_status_ready":                    p.LabelMetric("status.ready", "condition"),
+			"kube_node_status_condition": p.LabelMetric("status.ready", "status",
+				p.OpFilter(map[string]string{
+					"condition": "Ready",
+				})),
 		},
 
 		Labels: map[string]p.LabelMap{

--- a/metricbeat/module/kubernetes/state_node/state_node.go
+++ b/metricbeat/module/kubernetes/state_node/state_node.go
@@ -47,7 +47,7 @@ var (
 			"kube_node_status_capacity_cpu_cores":       p.Metric("cpu.capacity.cores"),
 			"kube_node_status_allocatable_cpu_cores":    p.Metric("cpu.allocatable.cores"),
 			"kube_node_spec_unschedulable":              p.BooleanMetric("status.unschedulable"),
-			"kube_node_status_ready":                    p.LabelMetric("status.ready", "condition", false),
+			"kube_node_status_ready":                    p.LabelMetric("status.ready", "condition"),
 		},
 
 		Labels: map[string]p.LabelMap{

--- a/metricbeat/module/kubernetes/state_node/state_node_test.go
+++ b/metricbeat/module/kubernetes/state_node/state_node_test.go
@@ -20,108 +20,22 @@
 package state_node
 
 import (
-	"io/ioutil"
-	"net/http"
-	"net/http/httptest"
-	"os"
 	"testing"
 
-	"github.com/elastic/beats/libbeat/common"
-	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
-
-	"github.com/stretchr/testify/assert"
+	"github.com/elastic/beats/metricbeat/helper/prometheus/ptest"
 )
 
-const testFile = "../_meta/test/kube-state-metrics"
-
 func TestEventMapping(t *testing.T) {
-	file, err := os.Open(testFile)
-	assert.NoError(t, err, "cannot open test file "+testFile)
-
-	body, err := ioutil.ReadAll(file)
-	assert.NoError(t, err, "cannot read test file "+testFile)
-
-	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(200)
-		w.Header().Set("Content-Type", "text/plain; charset=ISO-8859-1")
-		w.Write([]byte(body))
-	}))
-
-	server.Start()
-	defer server.Close()
-
-	config := map[string]interface{}{
-		"module":     "kubernetes",
-		"metricsets": []string{"state_node"},
-		"hosts":      []string{server.URL},
-	}
-
-	f := mbtest.NewEventsFetcher(t, config)
-
-	events, err := f.Fetch()
-	assert.NoError(t, err)
-
-	assert.Equal(t, 2, len(events), "Wrong number of returned events")
-
-	testCases := testCases()
-	for _, event := range events {
-		name, err := event.GetValue("name")
-		if err == nil {
-			eventKey := name.(string)
-			oneTestCase, oneTestCaseFound := testCases[eventKey]
-			if oneTestCaseFound {
-				for k, v := range oneTestCase {
-					testValue(eventKey, t, event, k, v)
-				}
-				delete(testCases, eventKey)
-			}
-		}
-	}
-
-	if len(testCases) > 0 {
-		t.Errorf("Test reference events not found: %v, \n\ngot: %v", testCases, events)
-	}
-}
-
-func testValue(eventKey string, t *testing.T, event common.MapStr, field string, expected interface{}) {
-	data, err := event.GetValue(field)
-	assert.NoError(t, err, eventKey+": Could not read field "+field)
-	assert.EqualValues(t, expected, data, eventKey+": Wrong value for field "+field)
-}
-
-func testCases() map[string]map[string]interface{} {
-	return map[string]map[string]interface{}{
-		"minikube": {
-			"_namespace": "node",
-			"name":       "minikube",
-
-			"status.ready":         "true",
-			"status.unschedulable": false,
-
-			"cpu.allocatable.cores": 2,
-			"cpu.capacity.cores":    2,
-
-			"memory.allocatable.bytes": 2097786880,
-			"memory.capacity.bytes":    2097786880,
-
-			"pod.allocatable.total": 110,
-			"pod.capacity.total":    110,
+	ptest.TestMetricSetEventsFetcher(t, "kubernetes", "state_node",
+		ptest.TestCases{
+			{
+				MetricsFile:  "../_meta/test/kube-state-metrics",
+				ExpectedFile: "./_meta/test/kube-state-metrics.expected",
+			},
+			{
+				MetricsFile:  "../_meta/test/kube-state-metrics.v1.3.0",
+				ExpectedFile: "./_meta/test/kube-state-metrics.v1.3.0.expected",
+			},
 		},
-		"minikube-test": {
-			"_namespace": "node",
-			"name":       "minikube-test",
-
-			"status.ready":         "true",
-			"status.unschedulable": true,
-
-			"cpu.allocatable.cores": 3,
-			"cpu.capacity.cores":    4,
-
-			"memory.allocatable.bytes": 3097786880,
-			"memory.capacity.bytes":    4097786880,
-
-			"pod.allocatable.total": 210,
-			"pod.capacity.total":    310,
-		},
-	}
+	)
 }

--- a/metricbeat/module/kubernetes/state_pod/state_pod.go
+++ b/metricbeat/module/kubernetes/state_pod/state_pod.go
@@ -40,9 +40,9 @@ var (
 	mapping = &p.MetricsMapping{
 		Metrics: map[string]p.MetricMap{
 			"kube_pod_info":             p.InfoMetric(),
-			"kube_pod_status_phase":     p.LabelMetric("status.phase", "phase", true),
-			"kube_pod_status_ready":     p.LabelMetric("status.ready", "condition", true),
-			"kube_pod_status_scheduled": p.LabelMetric("status.scheduled", "condition", true),
+			"kube_pod_status_phase":     p.LabelMetric("status.phase", "phase", p.OpLowercaseValue()),
+			"kube_pod_status_ready":     p.LabelMetric("status.ready", "condition", p.OpLowercaseValue()),
+			"kube_pod_status_scheduled": p.LabelMetric("status.scheduled", "condition", p.OpLowercaseValue()),
 		},
 
 		Labels: map[string]p.LabelMap{


### PR DESCRIPTION
`kube_node_status_ready` was deprecated in favor of `kube_node_status_condition`. This PR updates `state_node` metricset to support both old and new fields.

More details in: closes #6499