### PR TITLE
Adding more flexibility to describe a feature

### DIFF
--- a/libbeat/feature/bundle.go
+++ b/libbeat/feature/bundle.go
@@ -38,7 +38,7 @@ func (b *Bundle) Filter(stabilities ...Stability) *Bundle {
 
 	for _, feature := range b.features {
 		for _, stability := range stabilities {
-			if feature.Stability() == stability {
+			if feature.Description().Stability() == stability {
 				filtered = append(filtered, feature)
 				break
 			}

--- a/libbeat/feature/bundle.go
+++ b/libbeat/feature/bundle.go
@@ -17,6 +17,9 @@
 
 package feature
 
+// FilterFunc is the function use to filter elements from a bundle.
+type FilterFunc = func(Featurable) bool
+
 // Bundleable merges featurable and bundle interface together.
 type bundleable interface {
 	Features() []Featurable
@@ -32,19 +35,21 @@ func NewBundle(features ...Featurable) *Bundle {
 	return &Bundle{features: features}
 }
 
-// Filter creates a new bundle with only the feature matching the requested stability.
-func (b *Bundle) Filter(stabilities ...Stability) *Bundle {
+// FilterWith takes a predicate and return a list of filtered bundle matching the predicate.
+func (b *Bundle) FilterWith(pred FilterFunc) *Bundle {
 	var filtered []Featurable
 
 	for _, feature := range b.features {
-		for _, stability := range stabilities {
-			if feature.Description().Stability() == stability {
-				filtered = append(filtered, feature)
-				break
-			}
+		if pred(feature) {
+			filtered = append(filtered, feature)
 		}
 	}
 	return NewBundle(filtered...)
+}
+
+// Filter creates a new bundle with only the feature matching the requested stability.
+func (b *Bundle) Filter(stabilities ...Stability) *Bundle {
+	return b.FilterWith(HasStabilityPred(stabilities...))
 }
 
 // Features returns the interface features slice so
@@ -59,4 +64,16 @@ func MustBundle(bundle ...bundleable) *Bundle {
 		merged = append(merged, feature.Features()...)
 	}
 	return NewBundle(merged...)
+}
+
+// HasStabilityPred returns true if the feature match any of the provided stabilities.
+func HasStabilityPred(stabilities ...Stability) FilterFunc {
+	return func(f Featurable) bool {
+		for _, s := range stabilities {
+			if s == f.Description().Stability() {
+				return true
+			}
+		}
+		return false
+	}
 }

--- a/libbeat/feature/bundle_test.go
+++ b/libbeat/feature/bundle_test.go
@@ -26,9 +26,9 @@ import (
 func TestBundle(t *testing.T) {
 	factory := func() {}
 	features := []Featurable{
-		New("libbeat.outputs", "elasticsearch", factory, Stable),
-		New("libbeat.outputs", "edge", factory, Experimental),
-		New("libbeat.input", "tcp", factory, Beta),
+		New("libbeat.outputs", "elasticsearch", factory, &Details{stability: Stable}),
+		New("libbeat.outputs", "edge", factory, &Details{stability: Experimental}),
+		New("libbeat.input", "tcp", factory, &Details{stability: Beta}),
 	}
 
 	t.Run("Creates a new Bundle", func(t *testing.T) {
@@ -49,16 +49,16 @@ func TestBundle(t *testing.T) {
 	})
 
 	t.Run("Creates a new Bundle from specified feature", func(t *testing.T) {
-		f1 := New("libbeat.outputs", "elasticsearch", factory, Stable)
+		f1 := New("libbeat.outputs", "elasticsearch", factory, &Details{stability: Stable})
 		b := MustBundle(f1)
 		assert.Equal(t, 1, len(b.Features()))
 	})
 
 	t.Run("Creates a new Bundle with grouped features", func(t *testing.T) {
-		f1 := New("libbeat.outputs", "elasticsearch", factory, Stable)
-		f2 := New("libbeat.outputs", "edge", factory, Experimental)
-		f3 := New("libbeat.input", "tcp", factory, Beta)
-		f4 := New("libbeat.input", "udp", factory, Beta)
+		f1 := New("libbeat.outputs", "elasticsearch", factory, &Details{stability: Stable})
+		f2 := New("libbeat.outputs", "edge", factory, &Details{stability: Experimental})
+		f3 := New("libbeat.input", "tcp", factory, &Details{stability: Beta})
+		f4 := New("libbeat.input", "udp", factory, &Details{stability: Beta})
 
 		b := MustBundle(
 			MustBundle(f1),

--- a/libbeat/feature/details.go
+++ b/libbeat/feature/details.go
@@ -1,0 +1,79 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package feature
+
+import "fmt"
+
+// Describable contains general information for a specific feature, the fields will be used to report
+// useful information by the factories or any future CLI.
+type Describable interface {
+	// Stability is the stability of the Feature, this allow the user to filter embedded functionality
+	// by their maturity at runtime.
+	// Example: Beta, Experimental, Stable or Undefined.
+	Stability() Stability
+
+	// Doc is a one liner describing the current feature.
+	// Example: Dissect allows to define patterns to extract useful information from a string.
+	Doc() string
+
+	// FullName is the human readable name of the feature.
+	// Example: Jolokia Discovery
+	FullName() string
+
+	String() string
+}
+
+// Details minimal information that you must provide when creating a feature.
+type Details struct {
+	stability Stability
+	doc       string
+	fullName  string
+}
+
+// Stability is the stability of the Feature, this allow the user to filter embedded functionality
+// by their maturity at runtime.
+// Example: Beta, Experimental, Stable or Undefined.
+func (d *Details) Stability() Stability {
+	return d.stability
+}
+
+// Doc is a one liner describing the current feature.
+// Example: Dissect allows to define patterns to extract useful information from a string.
+func (d *Details) Doc() string {
+	return d.doc
+}
+
+// FullName is the human readable name of the feature.
+// Example: Jolokia Discovery
+func (d *Details) FullName() string {
+	return d.fullName
+}
+
+func (d *Details) String() string {
+	return fmt.Sprintf(
+		"name: %s, description: %s (stability: %s)",
+		d.fullName,
+		d.doc,
+		d.stability,
+	)
+}
+
+// NewDetails return the minimal information a new feature must provide.
+func NewDetails(fullName string, doc string, stability Stability) *Details {
+	return &Details{fullName: fullName, doc: doc, stability: stability}
+}

--- a/libbeat/feature/details.go
+++ b/libbeat/feature/details.go
@@ -34,8 +34,6 @@ type Describable interface {
 	// FullName is the human readable name of the feature.
 	// Example: Jolokia Discovery
 	FullName() string
-
-	String() string
 }
 
 // Details minimal information that you must provide when creating a feature.

--- a/libbeat/feature/details.go
+++ b/libbeat/feature/details.go
@@ -19,9 +19,9 @@ package feature
 
 import "fmt"
 
-// Describable contains general information for a specific feature, the fields will be used to report
+// Describer contains general information for a specific feature, the fields will be used to report
 // useful information by the factories or any future CLI.
-type Describable interface {
+type Describer interface {
 	// Stability is the stability of the Feature, this allow the user to filter embedded functionality
 	// by their maturity at runtime.
 	// Example: Beta, Experimental, Stable or Undefined.

--- a/libbeat/feature/feature.go
+++ b/libbeat/feature/feature.go
@@ -42,20 +42,18 @@ type Featurable interface {
 	// of the method is type checked by the 'FindFactory' of each namespace.
 	Factory() interface{}
 
-	// Stability is the stability of the Feature, this allow the user to filter embedded functionality
-	// by their maturity at runtime.
-	// Example: Beta, Experimental, Stable or Undefined.
-	Stability() Stability
+	// Description return the avaiable information for a specific feature.
+	Description() Describable
 
 	String() string
 }
 
 // Feature contains the information for a specific feature
 type Feature struct {
-	namespace string
-	name      string
-	factory   interface{}
-	stability Stability
+	namespace   string
+	name        string
+	factory     interface{}
+	description Describable
 }
 
 // Namespace return the namespace of the feature.
@@ -73,9 +71,9 @@ func (f *Feature) Factory() interface{} {
 	return f.factory
 }
 
-// Stability returns the stability level of the feature, current: stable, beta, experimental.
-func (f *Feature) Stability() Stability {
-	return f.stability
+// Description return the avaiable information for a specific feature.
+func (f *Feature) Description() Describable {
+	return f.description
 }
 
 // Features return the current feature as a slice to be compatible with Bundle merging and filtering.
@@ -85,16 +83,16 @@ func (f *Feature) Features() []Featurable {
 
 // String return the debug information
 func (f *Feature) String() string {
-	return fmt.Sprintf("%s/%s (stability: %s)", f.namespace, f.name, f.stability)
+	return fmt.Sprintf("%s/%s (description: %s)", f.namespace, f.name, f.description)
 }
 
 // New returns a new Feature.
-func New(namespace, name string, factory interface{}, stability Stability) *Feature {
+func New(namespace, name string, factory interface{}, description Describable) *Feature {
 	return &Feature{
-		namespace: namespace,
-		name:      name,
-		factory:   factory,
-		stability: stability,
+		namespace:   namespace,
+		name:        name,
+		factory:     factory,
+		description: description,
 	}
 }
 

--- a/libbeat/feature/feature.go
+++ b/libbeat/feature/feature.go
@@ -43,7 +43,7 @@ type Featurable interface {
 	Factory() interface{}
 
 	// Description return the avaiable information for a specific feature.
-	Description() Describable
+	Description() Describer
 
 	String() string
 }
@@ -53,7 +53,7 @@ type Feature struct {
 	namespace   string
 	name        string
 	factory     interface{}
-	description Describable
+	description Describer
 }
 
 // Namespace return the namespace of the feature.
@@ -72,7 +72,7 @@ func (f *Feature) Factory() interface{} {
 }
 
 // Description return the avaiable information for a specific feature.
-func (f *Feature) Description() Describable {
+func (f *Feature) Description() Describer {
 	return f.description
 }
 
@@ -87,7 +87,7 @@ func (f *Feature) String() string {
 }
 
 // New returns a new Feature.
-func New(namespace, name string, factory interface{}, description Describable) *Feature {
+func New(namespace, name string, factory interface{}, description Describer) *Feature {
 	return &Feature{
 		namespace:   namespace,
 		name:        name,

--- a/libbeat/feature/registry_test.go
+++ b/libbeat/feature/registry_test.go
@@ -184,18 +184,18 @@ func TestOverwrite(t *testing.T) {
 		f := func() {}
 		r := newRegistry()
 		assert.Equal(t, 0, r.Size())
-		r.Overwrite(New("processor", "foo", f, Stable))
+		r.Overwrite(New("processor", "foo", f, defaultDetails))
 		assert.Equal(t, 1, r.Size())
 	})
 
 	t.Run("overwrite when the feature exists", func(t *testing.T) {
 		f := func() {}
 		r := newRegistry()
-		r.Register(New("processor", "foo", f, Stable))
+		r.Register(New("processor", "foo", f, defaultDetails))
 		assert.Equal(t, 1, r.Size())
 
 		check := 42
-		r.Overwrite(New("processor", "foo", check, Stable))
+		r.Overwrite(New("processor", "foo", check, defaultDetails))
 		assert.Equal(t, 1, r.Size())
 
 		feature, err := r.Lookup("processor", "foo")

--- a/libbeat/feature/registry_test.go
+++ b/libbeat/feature/registry_test.go
@@ -23,12 +23,14 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var defaultDetails = &Details{stability: Stable}
+
 func TestRegister(t *testing.T) {
 	f := func() {}
 
 	t.Run("when the factory is nil", func(t *testing.T) {
 		r := newRegistry()
-		err := r.Register(New("outputs", "null", nil, Stable))
+		err := r.Register(New("outputs", "null", nil, defaultDetails))
 		if !assert.Error(t, err) {
 			return
 		}
@@ -36,7 +38,7 @@ func TestRegister(t *testing.T) {
 
 	t.Run("namespace and feature doesn't exist", func(t *testing.T) {
 		r := newRegistry()
-		err := r.Register(New("outputs", "null", f, Stable))
+		err := r.Register(New("outputs", "null", f, defaultDetails))
 		if !assert.NoError(t, err) {
 			return
 		}
@@ -46,8 +48,8 @@ func TestRegister(t *testing.T) {
 
 	t.Run("namespace exists and feature doesn't exist", func(t *testing.T) {
 		r := newRegistry()
-		r.Register(New("processor", "bar", f, Stable))
-		err := r.Register(New("processor", "foo", f, Stable))
+		r.Register(New("processor", "bar", f, defaultDetails))
+		err := r.Register(New("processor", "foo", f, defaultDetails))
 		if !assert.NoError(t, err) {
 			return
 		}
@@ -57,8 +59,8 @@ func TestRegister(t *testing.T) {
 
 	t.Run("namespace exists and feature exists and not the same factory", func(t *testing.T) {
 		r := newRegistry()
-		r.Register(New("processor", "foo", func() {}, Stable))
-		err := r.Register(New("processor", "foo", f, Stable))
+		r.Register(New("processor", "foo", func() {}, defaultDetails))
+		err := r.Register(New("processor", "foo", f, defaultDetails))
 		if !assert.Error(t, err) {
 			return
 		}
@@ -66,7 +68,7 @@ func TestRegister(t *testing.T) {
 	})
 
 	t.Run("when the exact feature is already registered", func(t *testing.T) {
-		feature := New("processor", "foo", f, Stable)
+		feature := New("processor", "foo", f, defaultDetails)
 		r := newRegistry()
 		r.Register(feature)
 		err := r.Register(feature)
@@ -81,8 +83,8 @@ func TestFeature(t *testing.T) {
 	f := func() {}
 
 	r := newRegistry()
-	r.Register(New("processor", "foo", f, Stable))
-	r.Register(New("HOLA", "fOO", f, Stable))
+	r.Register(New("processor", "foo", f, defaultDetails))
+	r.Register(New("HOLA", "fOO", f, defaultDetails))
 
 	t.Run("when namespace and feature are present", func(t *testing.T) {
 		feature, err := r.Lookup("processor", "foo")
@@ -111,9 +113,9 @@ func TestLookup(t *testing.T) {
 	f := func() {}
 
 	r := newRegistry()
-	r.Register(New("processor", "foo", f, Stable))
-	r.Register(New("processor", "foo2", f, Stable))
-	r.Register(New("HELLO", "fOO", f, Stable))
+	r.Register(New("processor", "foo", f, defaultDetails))
+	r.Register(New("processor", "foo2", f, defaultDetails))
+	r.Register(New("HELLO", "fOO", f, defaultDetails))
 
 	t.Run("when namespace and feature are present", func(t *testing.T) {
 		features, err := r.LookupAll("processor")
@@ -145,7 +147,7 @@ func TestUnregister(t *testing.T) {
 
 	t.Run("when the namespace and the feature exists", func(t *testing.T) {
 		r := newRegistry()
-		r.Register(New("processor", "foo", f, Stable))
+		r.Register(New("processor", "foo", f, defaultDetails))
 		assert.Equal(t, 1, r.Size())
 		err := r.Unregister("processor", "foo")
 		if !assert.NoError(t, err) {
@@ -156,7 +158,7 @@ func TestUnregister(t *testing.T) {
 
 	t.Run("when the namespace exist and the feature doesn't", func(t *testing.T) {
 		r := newRegistry()
-		r.Register(New("processor", "foo", f, Stable))
+		r.Register(New("processor", "foo", f, defaultDetails))
 		assert.Equal(t, 1, r.Size())
 		err := r.Unregister("processor", "bar")
 		if assert.Error(t, err) {
@@ -167,7 +169,7 @@ func TestUnregister(t *testing.T) {
 
 	t.Run("when the namespace doesn't exists", func(t *testing.T) {
 		r := newRegistry()
-		r.Register(New("processor", "foo", f, Stable))
+		r.Register(New("processor", "foo", f, defaultDetails))
 		assert.Equal(t, 1, r.Size())
 		err := r.Unregister("outputs", "bar")
 		if assert.Error(t, err) {

--- a/libbeat/publisher/queue/memqueue/broker.go
+++ b/libbeat/publisher/queue/memqueue/broker.go
@@ -28,7 +28,13 @@ import (
 )
 
 // Feature exposes a memory queue.
-var Feature = queue.Feature("mem", create, feature.Stable)
+var Feature = queue.Feature("mem",
+	create,
+	feature.NewDetails(
+		"Memory queue",
+		"Buffer events in memory before sending to the output.",
+		feature.Stable),
+)
 
 type Broker struct {
 	done chan struct{}

--- a/libbeat/publisher/queue/queue_reg.go
+++ b/libbeat/publisher/queue/queue_reg.go
@@ -45,6 +45,6 @@ func FindFactory(name string) Factory {
 }
 
 // Feature creates a new type of queue.
-func Feature(name string, factory Factory, description feature.Describable) *feature.Feature {
+func Feature(name string, factory Factory, description feature.Describer) *feature.Feature {
 	return feature.New(Namespace, name, factory, description)
 }

--- a/libbeat/publisher/queue/queue_reg.go
+++ b/libbeat/publisher/queue/queue_reg.go
@@ -24,13 +24,9 @@ import (
 // Namespace is the feature namespace for queue definition.
 var Namespace = "libbeat.queue"
 
-// Global queue type registry for configuring and loading a queue instance
-// via common.Config
-var queueReg = map[string]Factory{}
-
 // RegisterType registers a new queue type.
 func RegisterType(name string, fn Factory) {
-	f := feature.New(Namespace, name, fn, feature.Undefined)
+	f := Feature(name, fn, feature.NewDetails(name, "", feature.Undefined))
 	feature.MustRegister(f)
 }
 
@@ -49,6 +45,6 @@ func FindFactory(name string) Factory {
 }
 
 // Feature creates a new type of queue.
-func Feature(name string, factory Factory, stability feature.Stability) *feature.Feature {
-	return feature.New(Namespace, name, factory, stability)
+func Feature(name string, factory Factory, description feature.Describable) *feature.Feature {
+	return feature.New(Namespace, name, factory, description)
 }

--- a/libbeat/publisher/queue/spool/module.go
+++ b/libbeat/publisher/queue/spool/module.go
@@ -27,7 +27,12 @@ import (
 )
 
 // Feature exposes a spooling to disk queue.
-var Feature = queue.Feature("spool", create, feature.Beta)
+var Feature = queue.Feature("spool", create,
+	feature.NewDetails(
+		"Memory queue",
+		"Buffer events in memory before sending to the output.",
+		feature.Beta),
+)
 
 func init() {
 	queue.RegisterType("spool", create)


### PR DESCRIPTION
**Motivation:**

Only adding a stability to describe a feature is often not enough,
instead we now allow to add the following information.

**Fullname:**
This is a more human readable version of the feature.
Example: Jolokia autodiscovery

**Doc:**
This is a one liner describing what you can do with the feature.
Example: The dissect processor allows to extract useful parts of the
original string.

**Stability:**
Describe how stable is the current feature.

From the conversation in https://github.com/elastic/beats/pull/7443#discussion_r199139263 to make the feature concept a bit more future proof.

**Note:** I've decided to use an interface in that case because it will be easier to give an upgrade path for feature developers.