### PR TITLE
[6.x] Add jsondiff to test requirements. (#7694)

### DIFF
--- a/libbeat/tests/system/requirements.txt
+++ b/libbeat/tests/system/requirements.txt
@@ -28,3 +28,4 @@ texttable==0.9.1
 urllib3==1.22
 websocket-client==0.47.0
 parameterized==0.6.1
+jsondiff==1.1.2


### PR DESCRIPTION
Backports the following commits to 6.x:
 - Add jsondiff to test requirements.  (#7694)