### PR TITLE
Add custom unpack to log hints config to avoid env resolution

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -54,6 +54,8 @@ https://github.com/elastic/beats/compare/v6.4.0...master[Check the HEAD diff]
 
 *Filebeat*
 
+- Add custom unpack to log hints config to avoid env resolution {pull}7710[7710]
+
 *Heartbeat*
 
 *Metricbeat*

--- a/filebeat/autodiscover/builder/hints/config.go
+++ b/filebeat/autodiscover/builder/hints/config.go
@@ -39,3 +39,21 @@ func defaultConfig() config {
 		Config: cfg,
 	}
 }
+
+func (c *config) Unpack(from *common.Config) error {
+	tmpConfig := struct {
+		Key string `config:"key"`
+	}{
+		Key: c.Key,
+	}
+	if err := from.Unpack(&tmpConfig); err != nil {
+		return err
+	}
+
+	if config, err := from.Child("config", -1); err == nil {
+		c.Config = config
+	}
+
+	c.Key = tmpConfig.Key
+	return nil
+}


### PR DESCRIPTION
Raising this as per @exekias. After numerous attempts, using a hints builder in a custom builder was not possible due to template variable being resolved when passing them to the log hints builder.