### PR TITLE
Bugfix: default dir for dashboard `kibana.generated`

### DIFF
--- a/libbeat/_meta/config.reference.yml
+++ b/libbeat/_meta/config.reference.yml
@@ -757,9 +757,9 @@ output.elasticsearch:
 # options here, or by using the `-setup` CLI flag or the `setup` command.
 #setup.dashboards.enabled: false
 
-# The directory from where to read the dashboards. The default is the `kibana`
+# The directory from where to read the dashboards. The default is the `kibana.generated`
 # folder in the home path.
-#setup.dashboards.directory: ${path.home}/kibana
+#setup.dashboards.directory: ${path.home}/kibana.generated
 
 # The URL from where to download the dashboards archive. It is used instead of
 # the directory if it has a value.

--- a/libbeat/dashboards/config.go
+++ b/libbeat/dashboards/config.go
@@ -49,5 +49,5 @@ var defaultConfig = Config{
 	},
 }
 var (
-	defaultDirectory = "kibana"
+	defaultDirectory = "kibana.generated"
 )


### PR DESCRIPTION
Change default dir for loading dashboards from `kibana` to
`kibana.generated`.