### PR TITLE
Make heartbeat test error checks handle platform differences better

### DIFF
--- a/heartbeat/hbtest/hbtestutil.go
+++ b/heartbeat/hbtest/hbtestutil.go
@@ -83,10 +83,11 @@ func TCPBaseChecks(port uint16) mapval.Validator {
 
 // ErrorChecks checks the standard heartbeat error hierarchy, which should
 // consist of a message (or a mapval isdef that can match the message) and a type under the error key.
-func ErrorChecks(msg interface{}, errType string) mapval.Validator {
+// The message is checked only as a substring since exact string matches can be fragile due to platform differences.
+func ErrorChecks(msgSubstr string, errType string) mapval.Validator {
 	return mapval.Schema(mapval.Map{
 		"error": mapval.Map{
-			"message": msg,
+			"message": mapval.IsStringContaining(msgSubstr),
 			"type":    errType,
 		},
 	})

--- a/heartbeat/monitors/active/tcp/tcp_test.go
+++ b/heartbeat/monitors/active/tcp/tcp_test.go
@@ -94,11 +94,12 @@ func TestConnectionRefusedEndpointJob(t *testing.T) {
 	port := uint16(freeport.GetPort())
 	event := testTCPCheck(t, ip, port)
 
+	dialErr := fmt.Sprintf("dial tcp %s:%d", ip, port)
 	mapvaltest.Test(
 		t,
 		mapval.Strict(mapval.Compose(
 			tcpMonitorChecks(ip, ip, port, "down"),
-			hbtest.ErrorChecks(fmt.Sprintf("dial tcp %s:%d: connect: connection refused", ip, port), "io"),
+			hbtest.ErrorChecks(dialErr, "io"),
 			hbtest.TCPBaseChecks(port),
 		)),
 		event.Fields,
@@ -110,16 +111,12 @@ func TestUnreachableEndpointJob(t *testing.T) {
 	port := uint16(1234)
 	event := testTCPCheck(t, ip, port)
 
+	dialErr := fmt.Sprintf("dial tcp %s:%d", ip, port)
 	mapvaltest.Test(
 		t,
 		mapval.Strict(mapval.Compose(
 			tcpMonitorChecks(ip, ip, port, "down"),
-			hbtest.ErrorChecks(
-				mapval.IsAny(
-					mapval.IsEqual(fmt.Sprintf("dial tcp %s:%d: i/o timeout", ip, port)),
-					mapval.IsEqual(fmt.Sprintf("dial tcp %s:%d: connect: network is unreachable", ip, port)),
-				),
-				"io"),
+			hbtest.ErrorChecks(dialErr, "io"),
 			hbtest.TCPBaseChecks(port),
 		)),
 		event.Fields,


### PR DESCRIPTION
Different platforms commonly report different error messages. The good news is that the key substrings of errors remain the same. This refactor makes error checks substring based instead of exact matches. This should be just as good practically, and more robust to boot.