### PR TITLE
Refactoring: use common helper function in place of old custom ones

### DIFF
--- a/metricbeat/module/elasticsearch/cluster_stats/data.go
+++ b/metricbeat/module/elasticsearch/cluster_stats/data.go
@@ -19,7 +19,8 @@ package cluster_stats
 
 import (
 	"encoding/json"
-	"fmt"
+
+	"github.com/elastic/beats/metricbeat/helper/elastic"
 
 	"github.com/elastic/beats/libbeat/common"
 
@@ -51,14 +52,6 @@ var (
 	}
 )
 
-// TODO: Remove this function and use the one implemented (currently) in the kibana
-// module, after extracting it into the metricbeat helper package
-func reportErrorForMissingField(field string, r mb.ReporterV2) error {
-	err := fmt.Errorf("Could not find field '%v' in Kibana stats API response", field)
-	r.Error(err)
-	return err
-}
-
 func eventMapping(r mb.ReporterV2, content []byte) error {
 	var data map[string]interface{}
 	err := json.Unmarshal(content, &data)
@@ -75,7 +68,7 @@ func eventMapping(r mb.ReporterV2, content []byte) error {
 
 	clusterName, ok := data["cluster_name"]
 	if !ok {
-		return reportErrorForMissingField("cluster_name", r)
+		return elastic.ReportErrorForMissingField("cluster_name", elastic.Elasticsearch, r)
 	}
 
 	var event mb.Event

--- a/metricbeat/module/kibana/kibana.go
+++ b/metricbeat/module/kibana/kibana.go
@@ -26,16 +26,7 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 
 	"github.com/elastic/beats/metricbeat/helper"
-	"github.com/elastic/beats/metricbeat/mb"
 )
-
-// ReportErrorForMissingField reports and returns an error message for the given
-// field being missing in API response received from Kibana
-func ReportErrorForMissingField(field string, r mb.ReporterV2) error {
-	err := fmt.Errorf("Could not find field '%v' in Kibana stats API response", field)
-	r.Error(err)
-	return err
-}
 
 // GetVersion returns the version of the Kibana instance
 func GetVersion(http *helper.HTTP, currentPath string) (string, error) {


### PR DESCRIPTION
This PR removes old custom helper functions in the `metricbeat/module/elasticsearch/cluster_stats` and `metricbeat/module/kibana` packages and, in their place, uses the more generic, common helper function exported from the `metricbeat/helper/elastic` package.