### PR TITLE
[Kibana metricset] Make integration test conditional on Kibana version

### DIFF
--- a/metricbeat/module/kibana/kibana.go
+++ b/metricbeat/module/kibana/kibana.go
@@ -26,7 +26,19 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 
 	"github.com/elastic/beats/metricbeat/helper"
+	"github.com/elastic/beats/metricbeat/mb"
 )
+
+// StatsAPIAvailableVersion is the version of Kibana since when the stats API is available
+const StatsAPIAvailableVersion = "6.4.0"
+
+// ReportErrorForMissingField reports and returns an error message for the given
+// field being missing in API response received from Kibana
+func ReportErrorForMissingField(field string, r mb.ReporterV2) error {
+	err := fmt.Errorf("Could not find field '%v' in Kibana stats API response", field)
+	r.Error(err)
+	return err
+}
 
 // GetVersion returns the version of the Kibana instance
 func GetVersion(http *helper.HTTP, currentPath string) (string, error) {
@@ -53,6 +65,21 @@ func GetVersion(http *helper.HTTP, currentPath string) (string, error) {
 	}
 
 	return versionStr, nil
+}
+
+// IsStatsAPIAvailable returns whether the stats API is available in the given version of Kibana
+func IsStatsAPIAvailable(kibanaVersion string) (bool, error) {
+	currentVersion, err := common.NewVersion(kibanaVersion)
+	if err != nil {
+		return false, err
+	}
+
+	wantVersion, err := common.NewVersion(StatsAPIAvailableVersion)
+	if err != nil {
+		return false, err
+	}
+
+	return !currentVersion.LessThan(wantVersion), nil
 }
 
 func fetchPath(http *helper.HTTP, currentPath, newPath string) ([]byte, error) {

--- a/metricbeat/module/kibana/kibana_test.go
+++ b/metricbeat/module/kibana/kibana_test.go
@@ -1,0 +1,42 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package kibana
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsStatsAPIAvailable(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected bool
+	}{
+		{"6.3.1", false},
+		{"6.4.0", true},
+		{"6.5.0", true},
+		{"7.0.0-alpha1", true},
+	}
+
+	for _, test := range tests {
+		actual, err := IsStatsAPIAvailable(test.input)
+		assert.NoError(t, err)
+		assert.Equal(t, test.expected, actual)
+	}
+}

--- a/metricbeat/module/kibana/stats/stats.go
+++ b/metricbeat/module/kibana/stats/stats.go
@@ -20,7 +20,6 @@ package stats
 import (
 	"fmt"
 
-	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/metricbeat/helper"
 	"github.com/elastic/beats/metricbeat/mb"
@@ -37,8 +36,7 @@ func init() {
 }
 
 const (
-	statsPath                      = "api/stats"
-	kibanaStatsAPIAvailableVersion = "6.4.0"
+	statsPath = "api/stats"
 )
 
 var (
@@ -54,20 +52,6 @@ type MetricSet struct {
 	mb.BaseMetricSet
 	http         *helper.HTTP
 	xPackEnabled bool
-}
-
-func isKibanaStatsAPIAvailable(kibanaVersion string) (bool, error) {
-	currentVersion, err := common.NewVersion(kibanaVersion)
-	if err != nil {
-		return false, err
-	}
-
-	wantVersion, err := common.NewVersion(kibanaStatsAPIAvailableVersion)
-	if err != nil {
-		return false, err
-	}
-
-	return !currentVersion.LessThan(wantVersion), nil
 }
 
 // New create a new instance of the MetricSet
@@ -93,14 +77,14 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 		return nil, err
 	}
 
-	isAPIAvailable, err := isKibanaStatsAPIAvailable(kibanaVersion)
+	isAPIAvailable, err := kibana.IsStatsAPIAvailable(kibanaVersion)
 	if err != nil {
 		return nil, err
 	}
 
 	if !isAPIAvailable {
 		const errorMsg = "The kibana stats metricset is only supported with Kibana >= %v. You are currently running Kibana %v"
-		return nil, fmt.Errorf(errorMsg, kibanaStatsAPIAvailableVersion, kibanaVersion)
+		return nil, fmt.Errorf(errorMsg, kibana.StatsAPIAvailableVersion, kibanaVersion)
 	}
 
 	return &MetricSet{

--- a/metricbeat/module/kibana/stats/stats_integration_test.go
+++ b/metricbeat/module/kibana/stats/stats_integration_test.go
@@ -20,34 +20,66 @@
 package stats
 
 import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
 	"testing"
 
+	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/tests/compose"
+
 	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
+	"github.com/elastic/beats/metricbeat/module/kibana"
 	"github.com/elastic/beats/metricbeat/module/kibana/mtest"
 )
 
 func TestData(t *testing.T) {
-	t.Skip("Skipping until we find a way to conditionally skip this for Kibana < 6.4.0") // FIXME
 	compose.EnsureUp(t, "kibana")
 
-	f := mbtest.NewReportingMetricSetV2(t, mtest.GetConfig("stats"))
+	config := mtest.GetConfig("stats")
+	host := config["hosts"].([]string)[0]
+	version, err := getKibanaVersion(host)
+	if err != nil {
+		t.Fatal("getting kibana version", err)
+	}
 
-	// FIXME! See skip above
-	// version, err := kibana.GetVersion(f.http, "api/stats")
-	// if err != nil {
-	// 	t.Fatal("getting kibana version", err)
-	// }
+	isStatsAPIAvailable, err := kibana.IsStatsAPIAvailable(version)
+	if err != nil {
+		t.Fatal("checking if kibana stats API is available", err)
+	}
 
-	// isStatsAPIAvailable, err := kibana.IsStatsAPIAvailable(version)
-	// if err != nil {
-	// 	t.Fatal("checking if kibana stats API is available", err)
-	// }
+	if !isStatsAPIAvailable {
+		t.Skip("Kibana stats API is not available until 6.4.0")
+	}
 
-	// t.Skip("Kibana stats API is not available until 6.4.0")
-
-	err := mbtest.WriteEventsReporterV2(f, t, "")
+	f := mbtest.NewReportingMetricSetV2(t, config)
+	err = mbtest.WriteEventsReporterV2(f, t, "")
 	if err != nil {
 		t.Fatal("write", err)
 	}
+}
+
+func getKibanaVersion(kibanaHostPort string) (string, error) {
+	resp, err := http.Get("http://" + kibanaHostPort + "/api/status")
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	var data common.MapStr
+	err = json.Unmarshal(body, &data)
+	if err != nil {
+		return "", err
+	}
+
+	version, err := data.GetValue("version.number")
+	if err != nil {
+		return "", err
+	}
+	return version.(string), nil
 }


### PR DESCRIPTION
Resolves #7732.

This PR removes the `FIXME` from the Kibana metricset's integration test. It skips the test if the version of Kibana used for the test doesn't implement the API the test will need to exercise.