### PR TITLE
Documenting HTTP `headers` setting

### DIFF
--- a/metricbeat/docs/metricbeat-options.asciidoc
+++ b/metricbeat/docs/metricbeat-options.asciidoc
@@ -208,6 +208,16 @@ The modules and metricsets for which the host is defined as a HTTP URL, also
 support the following options:
 
 [float]
+==== `username`
+
+The username to use for basic authentication.
+
+[float]
+==== `password`
+
+The password to use for basic authentication.
+
+[float]
 ==== `headers`
 
 A list of headers to use with the HTTP request. For example:
@@ -218,16 +228,6 @@ headers:
   Cookie: abcdef=123456
   My-Custom-Header: my-custom-value
 ----
-
-[float]
-==== `username`
-
-The username to use for basic authentication.
-
-[float]
-==== `password`
-
-The password to use for basic authentication.
 
 [float]
 ==== `bearer_token_file`

--- a/metricbeat/docs/metricbeat-options.asciidoc
+++ b/metricbeat/docs/metricbeat-options.asciidoc
@@ -208,6 +208,18 @@ The modules and metricsets for which the host is defined as a HTTP URL, also
 support the following options:
 
 [float]
+==== `headers`
+
+A list of headers to use with the HTTP request. For example:
+
+[source,yaml]
+----
+headers:
+  Cookie: abcdef=123456
+  My-Custom-Header: my-custom-value
+----
+
+[float]
 ==== `username`
 
 The username to use for basic authentication.


### PR DESCRIPTION
Resolves #7738 

Documents the previously-undocumented HTTP `headers` setting that could be used by any HTTP-based modules.

![screen shot 2018-07-26 at 6 17 23 am](https://user-images.githubusercontent.com/51061/43264674-9af7e01c-909b-11e8-8ba7-7272589b8719.png)
