### PR TITLE
file_integrity module: Protect against nil errors from inotify

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -89,6 +89,7 @@ https://github.com/elastic/beats/compare/v6.2.3...master[Check the HEAD diff]
 - Fixed parsing of AppArmor audit messages. {pull}6978[6978]
 - Allow `auditbeat setup` to run without requiring elevated privileges for the audit client. {issue}7111[7111]
 - Fix goroutine leak that occurred when the auditd module was stopped. {pull}7163[7163]
+- Fixed a crash in the file_integrity module under Linux. {issue}7753[7753]
 
 *Filebeat*
 

--- a/auditbeat/module/file_integrity/eventreader_fsnotify.go
+++ b/auditbeat/module/file_integrity/eventreader_fsnotify.go
@@ -103,7 +103,11 @@ func (r *reader) consumeEvents(done <-chan struct{}) {
 
 			r.eventC <- e
 		case err := <-r.watcher.ErrorChannel():
-			r.log.Warnw("fsnotify watcher error", "error", err)
+			// a bug in fsnotify can cause spurious nil errors to be sent
+			// on the error channel.
+			if err != nil {
+				r.log.Warnw("fsnotify watcher error", "error", err)
+			}
 		}
 	}
 }


### PR DESCRIPTION
Users are experiencing occasional crashes in auditbeat that are caused by a nil error being printed to the logs. Adding some defensive code to prevent auditbeat from panicking.

Fixes #7753