### PR TITLE
Cherry-pick #7754 to 6.x: file_integrity module: Protect against nil errors from inotify

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -31,6 +31,8 @@ https://github.com/elastic/beats/compare/v6.4.0...6.x[Check the HEAD diff]
 
 *Auditbeat*
 
+- Fixed a crash in the file_integrity module under Linux. {issue}7753[7753]
+
 *Filebeat*
 
 *Heartbeat*

--- a/auditbeat/module/file_integrity/eventreader_fsnotify.go
+++ b/auditbeat/module/file_integrity/eventreader_fsnotify.go
@@ -103,7 +103,11 @@ func (r *reader) consumeEvents(done <-chan struct{}) {
 
 			r.eventC <- e
 		case err := <-r.watcher.ErrorChannel():
-			r.log.Warnw("fsnotify watcher error", "error", err)
+			// a bug in fsnotify can cause spurious nil errors to be sent
+			// on the error channel.
+			if err != nil {
+				r.log.Warnw("fsnotify watcher error", "error", err)
+			}
 		}
 	}
 }


### PR DESCRIPTION
Cherry-pick of PR #7754 to 6.x branch. Original message: 

Users are experiencing occasional crashes in auditbeat that are caused by a nil error being printed to the logs. Adding some defensive code to prevent auditbeat from panicking.

Fixes #7753