### PR TITLE
Adding requests dependency

### DIFF
--- a/dev-tools/requirements.txt
+++ b/dev-tools/requirements.txt
@@ -1,1 +1,2 @@
 elasticsearch
+requests


### PR DESCRIPTION
This module dependency is required by the `dev-tools/cherrypick_pr` script.