### PR TITLE
Documenting HTTP `headers` setting (#7752)

### DIFF
--- a/metricbeat/docs/metricbeat-options.asciidoc
+++ b/metricbeat/docs/metricbeat-options.asciidoc
@@ -218,6 +218,18 @@ The username to use for basic authentication.
 The password to use for basic authentication.
 
 [float]
+==== `headers`
+
+A list of headers to use with the HTTP request. For example:
+
+[source,yaml]
+----
+headers:
+  Cookie: abcdef=123456
+  My-Custom-Header: my-custom-value
+----
+
+[float]
 ==== `bearer_token_file`
 
 If defined, Metricbeat will read the contents of the file once at initialization


### PR DESCRIPTION
* Documenting HTTP `headers` setting

* Moving headers section below username and password sections

(cherry picked from commit 6071772d153cf812095a2181cfe10033c213d41d)