### PR TITLE
X-Pack binaries

### DIFF
--- a/CHANGELOG-developer.asciidoc
+++ b/CHANGELOG-developer.asciidoc
@@ -44,3 +44,4 @@ The list below covers the major changes between 6.3.0 and master only.
   'go test'. This captures the log to a file, summarizes the result, produces a
   coverage profile (.cov), and produces an HTML coverage report. See
   `mage -h goTestUnit`. {pull}7766[7766]
+- Beats packaging now build non-oss binaries from code located in the x-pack folder. {issue}7783[7783]

--- a/Makefile
+++ b/Makefile
@@ -84,12 +84,14 @@ check: python-env
 .PHONY: check-headers
 check-headers:
 	@go get github.com/elastic/go-licenser
-	@go-licenser -d
+	@go-licenser -d -exclude x-pack
+	@go-licenser -d -license Elastic x-pack
 
 .PHONY: add-headers
 add-headers:
 	@go get github.com/elastic/go-licenser
-	@go-licenser
+	@go-licenser -exclude x-pack
+	@go-licenser -license Elastic x-pack
 
 # Corrects spelling errors
 .PHONY: misspell

--- a/auditbeat/magefile.go
+++ b/auditbeat/magefile.go
@@ -57,6 +57,11 @@ func CrossBuild() error {
 	return mage.CrossBuild()
 }
 
+// CrossBuildXPack cross-builds the beat with XPack for all target platforms.
+func CrossBuildXPack() error {
+	return mage.CrossBuildXPack()
+}
+
 // CrossBuildGoDaemon cross-builds the go-daemon binary using Docker.
 func CrossBuildGoDaemon() error {
 	return mage.CrossBuildGoDaemon()
@@ -78,7 +83,7 @@ func Package() {
 	customizePackaging()
 
 	mg.Deps(Update)
-	mg.Deps(makeConfigTemplates, CrossBuild, CrossBuildGoDaemon)
+	mg.Deps(makeConfigTemplates, CrossBuild, CrossBuildXPack, CrossBuildGoDaemon)
 	mg.SerialDeps(mage.Package, TestPackages)
 }
 

--- a/dev-tools/mage/clean.go
+++ b/dev-tools/mage/clean.go
@@ -35,6 +35,10 @@ var DefaultCleanPaths = []string{
 	"_meta/kibana.generated",
 	"_meta/kibana/5/index-pattern/{{.BeatName}}.json",
 	"_meta/kibana/6/index-pattern/{{.BeatName}}.json",
+
+	"../x-pack/{{.BeatName}}/build",
+	"../x-pack/{{.BeatName}}/{{.BeatName}}",
+	"../x-pack/{{.BeatName}}/{{.BeatName}}.exe",
 }
 
 // Clean clean generated build artifacts.

--- a/dev-tools/mage/pkg.go
+++ b/dev-tools/mage/pkg.go
@@ -37,7 +37,7 @@ func Package() error {
 
 	if len(Packages) == 0 {
 		return errors.New("no package specs are registered. Call " +
-			"UseCommunityBeatPackaging or UseElasticBeatPackaging first.")
+			"UseCommunityBeatPackaging, UseElasticBeatPackaging or USeElasticBeatWithoutXPackPackaging first.")
 	}
 
 	var tasks []interface{}

--- a/dev-tools/mage/pkgspecs.go
+++ b/dev-tools/mage/pkgspecs.go
@@ -62,6 +62,26 @@ func UseElasticBeatPackaging() {
 	}
 }
 
+// UseElasticBeatWithoutXPackPackaging configures the package target to build packages for
+// an Elastic Beat. This means it will generate two sets of packages -- one
+// that is purely OSS under Apache 2.0 and one that is licensed under the
+// Elastic License and may contain additional X-Pack features.
+//
+// NOTE: This method doesn't use binaries produced in the x-pack folder, this is
+// a temporary packaging target for projects that depends on beat but do have concrete x-pack
+// binaries.
+func UseElasticBeatWithoutXPackPackaging() {
+	beatsDir, err := ElasticBeatsDir()
+	if err != nil {
+		panic(err)
+	}
+
+	err = LoadNamedSpec("elastic_beat_without_xpack", filepath.Join(beatsDir, packageSpecFile))
+	if err != nil {
+		panic(err)
+	}
+}
+
 // LoadNamedSpec loads a packaging specification with the given name from the
 // specified YAML file. name should be a sub-key of 'specs'.
 func LoadNamedSpec(name, file string) error {

--- a/dev-tools/packaging/packages.yml
+++ b/dev-tools/packaging/packages.yml
@@ -229,8 +229,7 @@ specs:
       spec:
         <<: *deb_rpm_spec
 
-  # Official Beats
-  elastic_beat:
+  elastic_beat_without_xpack:
     ###
     # OSS Packages
     ###
@@ -301,3 +300,87 @@ specs:
       spec:
         <<: *deb_rpm_spec
         <<: *elastic_license_for_deb_rpm
+
+  # Official Beats
+  elastic_beat:
+    ###
+    # OSS Packages
+    ###
+    - os: windows
+      types: [zip]
+      spec:
+        <<: *windows_binary_spec
+        <<: *apache_license_for_binaries
+        name: '{{.BeatName}}-oss'
+
+    - os: darwin
+      types: [tgz]
+      spec:
+        <<: *binary_spec
+        <<: *apache_license_for_binaries
+        name: '{{.BeatName}}-oss'
+
+    - os: darwin
+      types: [dmg]
+      spec:
+        <<: *macos_beat_pkg_spec
+        <<: *apache_license_for_macos_pkg
+        name: '{{.BeatName}}-oss'
+
+    - os: linux
+      types: [tgz]
+      spec:
+        <<: *binary_spec
+        <<: *apache_license_for_binaries
+        name: '{{.BeatName}}-oss'
+
+    - os: linux
+      types: [deb, rpm]
+      spec:
+        <<: *deb_rpm_spec
+        <<: *apache_license_for_deb_rpm
+        name: '{{.BeatName}}-oss'
+
+    ###
+    # Elastic Licensed Packages
+    ###
+    - os: windows
+      types: [zip]
+      spec:
+        <<: *windows_binary_spec
+        <<: *elastic_license_for_binaries
+        '{{.BeatName}}{{.BinaryExt}}':
+          source: ../x-pack/{{.BeatName}}/build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
+
+    - os: darwin
+      types: [tgz]
+      spec:
+        <<: *binary_spec
+        <<: *elastic_license_for_binaries
+        files:
+          /Library/Application Support/{{.BeatVendor}}/{{.BeatName}}/bin/{{.BeatName}}{{.BinaryExt}}:
+            source: ../x-pack/{{.BeatName}}/build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
+
+    - os: darwin
+      types: [dmg]
+      spec:
+        <<: *macos_beat_pkg_spec
+        <<: *elastic_license_for_macos_pkg
+
+    - os: linux
+      types: [tgz]
+      spec:
+        <<: *binary_spec
+        <<: *elastic_license_for_binaries
+        files:
+          '{{.BeatName}}{{.BinaryExt}}':
+            source: ../x-pack/{{.BeatName}}/build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
+
+    - os: linux
+      types: [deb, rpm]
+      spec:
+        <<: *deb_rpm_spec
+        <<: *elastic_license_for_deb_rpm
+        files:
+          /usr/share/{{.BeatName}}/bin/{{.BeatName}}{{.BinaryExt}}:
+            source: ../x-pack/{{.BeatName}}/build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}

--- a/filebeat/magefile.go
+++ b/filebeat/magefile.go
@@ -57,6 +57,11 @@ func CrossBuild() error {
 	return mage.CrossBuild()
 }
 
+// CrossBuildXPack cross-builds the beat with XPack for all target platforms.
+func CrossBuildXPack() error {
+	return mage.CrossBuildXPack()
+}
+
 // CrossBuildGoDaemon cross-builds the go-daemon binary using Docker.
 func CrossBuildGoDaemon() error {
 	return mage.CrossBuildGoDaemon()
@@ -78,7 +83,7 @@ func Package() {
 	customizePackaging()
 
 	mg.Deps(Update, prepareModulePackaging)
-	mg.Deps(CrossBuild, CrossBuildGoDaemon)
+	mg.Deps(CrossBuild, CrossBuildXPack, CrossBuildGoDaemon)
 	mg.SerialDeps(mage.Package, TestPackages)
 }
 

--- a/heartbeat/magefile.go
+++ b/heartbeat/magefile.go
@@ -57,6 +57,11 @@ func CrossBuild() error {
 	return mage.CrossBuild()
 }
 
+// CrossBuildXPack cross-builds the beat with XPack for all target platforms.
+func CrossBuildXPack() error {
+	return mage.CrossBuildXPack()
+}
+
 // CrossBuildGoDaemon cross-builds the go-daemon binary using Docker.
 func CrossBuildGoDaemon() error {
 	return mage.CrossBuildGoDaemon()
@@ -76,7 +81,7 @@ func Package() {
 
 	mage.UseElasticBeatPackaging()
 	mg.Deps(Update)
-	mg.Deps(CrossBuild, CrossBuildGoDaemon)
+	mg.Deps(CrossBuild, CrossBuildXPack, CrossBuildGoDaemon)
 	mg.SerialDeps(mage.Package, TestPackages)
 }
 

--- a/metricbeat/magefile.go
+++ b/metricbeat/magefile.go
@@ -47,6 +47,11 @@ func GolangCrossBuild() error {
 	return mage.GolangCrossBuild(mage.DefaultGolangCrossBuildArgs())
 }
 
+// CrossBuildXPack cross-builds the beat with XPack for all target platforms.
+func CrossBuildXPack() error {
+	return mage.CrossBuildXPack()
+}
+
 // BuildGoDaemon builds the go-daemon binary (use crossBuildGoDaemon).
 func BuildGoDaemon() error {
 	return mage.BuildGoDaemon()
@@ -78,7 +83,7 @@ func Package() {
 	customizePackaging()
 
 	mg.Deps(Update)
-	mg.Deps(CrossBuild, CrossBuildGoDaemon)
+	mg.Deps(CrossBuild, CrossBuildXPack, CrossBuildGoDaemon)
 	mg.SerialDeps(mage.Package, TestPackages)
 }
 

--- a/packetbeat/magefile.go
+++ b/packetbeat/magefile.go
@@ -84,6 +84,22 @@ func CrossBuild() error {
 	return mage.CrossBuild(mage.ForPlatforms("!windows"))
 }
 
+// CrossBuildXPack cross-builds the beat with XPack for all target platforms.
+func CrossBuildXPack() error {
+	mg.Deps(patchCGODirectives)
+	defer undoPatchCGODirectives()
+
+	// These Windows builds write temporary .s and .o files into the packetbeat
+	// dir so they cannot be run in parallel. Changing to a different CWD does
+	// not change where the temp files get written so that cannot be used as a
+	// fix.
+	if err := mage.CrossBuildXPack(mage.ForPlatforms("windows"), mage.Serially()); err != nil {
+		return err
+	}
+
+	return mage.CrossBuildXPack(mage.ForPlatforms("!windows"))
+}
+
 // CrossBuildGoDaemon cross-builds the go-daemon binary using Docker.
 func CrossBuildGoDaemon() error {
 	return mage.CrossBuildGoDaemon()
@@ -105,7 +121,7 @@ func Package() {
 	customizePackaging()
 
 	mg.Deps(Update)
-	mg.Deps(CrossBuild, CrossBuildGoDaemon)
+	mg.Deps(CrossBuild, CrossBuildXPack, CrossBuildGoDaemon)
 	mg.SerialDeps(mage.Package, TestPackages)
 }
 
@@ -348,20 +364,22 @@ func installWinpcap() error {
 func generateWin64StaticWinpcap() error {
 	log.Println(">> Generating 64-bit winpcap static lib")
 
+	// Notes: We are using absolute path to make sure the files
+	// are available for x-pack build.
 	// Ref: https://github.com/elastic/beats/issues/1259
-	defer mage.DockerChown("lib/windows-64/wpcap.def")
+	defer mage.DockerChown(mage.MustExpand("{{elastic_beats_dir}}/{{.BeatName}}/lib"))
 	return mage.RunCmds(
 		// Requires mingw-w64-tools.
-		[]string{"gendef", "lib/windows-64/wpcap.dll"},
-		[]string{"mv", "wpcap.def", "lib/windows-64/wpcap.def"},
+		[]string{"gendef", mage.MustExpand("{{elastic_beats_dir}}/{{.BeatName}}/lib/windows-64/wpcap.dll")},
+		[]string{"mv", "wpcap.def", mage.MustExpand("{{ elastic_beats_dir}}/{{.BeatName}}/lib/windows-64/wpcap.def")},
 		[]string{"x86_64-w64-mingw32-dlltool", "--as-flags=--64",
 			"-m", "i386:x86-64", "-k",
 			"--output-lib", "/libpcap/win/WpdPack/Lib/x64/libwpcap.a",
-			"--input-def", "lib/windows-64/wpcap.def"},
+			"--input-def", mage.MustExpand("{{elastic_beats_dir}}/{{.BeatName}}/lib/windows-64/wpcap.def")},
 	)
 }
 
-const pcapGoFile = "../vendor/github.com/tsg/gopacket/pcap/pcap.go"
+var pcapGoFile = mage.MustExpand("{{elastic_beats_dir}}/vendor/github.com/tsg/gopacket/pcap/pcap.go")
 
 var cgoDirectiveRegex = regexp.MustCompile(`(?m)#cgo .*(?:LDFLAGS|CFLAGS).*$`)
 

--- a/winlogbeat/magefile.go
+++ b/winlogbeat/magefile.go
@@ -57,6 +57,11 @@ func CrossBuild() error {
 	return mage.CrossBuild()
 }
 
+// CrossBuildXPack cross-builds the beat with XPack for all target platforms.
+func CrossBuildXPack() error {
+	return mage.CrossBuildXPack()
+}
+
 // CrossBuildGoDaemon cross-builds the go-daemon binary using Docker.
 func CrossBuildGoDaemon() error {
 	return mage.CrossBuildGoDaemon()
@@ -76,7 +81,7 @@ func Package() {
 
 	mage.UseElasticBeatPackaging()
 	mg.Deps(Update)
-	mg.Deps(CrossBuild, CrossBuildGoDaemon)
+	mg.Deps(CrossBuild, CrossBuildXPack, CrossBuildGoDaemon)
 	mg.SerialDeps(mage.Package, TestPackages)
 }
 

--- a/x-pack/.gitignore
+++ b/x-pack/.gitignore
@@ -1,0 +1,2 @@
+# Directories
+*/build

--- a/x-pack/auditbeat/cmd/root.go
+++ b/x-pack/auditbeat/cmd/root.go
@@ -1,0 +1,14 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package cmd
+
+import "github.com/elastic/beats/auditbeat/cmd"
+
+// RootCmd to handle beats cli
+var RootCmd = cmd.RootCmd
+
+func init() {
+	// TODO inject x-pack features
+}

--- a/x-pack/auditbeat/main.go
+++ b/x-pack/auditbeat/main.go
@@ -1,0 +1,24 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package main
+
+import (
+	"os"
+
+	"github.com/elastic/beats/x-pack/auditbeat/cmd"
+
+	// Register modules.
+	_ "github.com/elastic/beats/auditbeat/module/auditd"
+	_ "github.com/elastic/beats/auditbeat/module/file_integrity"
+
+	// Register includes.
+	_ "github.com/elastic/beats/auditbeat/include"
+)
+
+func main() {
+	if err := cmd.RootCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}

--- a/x-pack/filebeat/cmd/root.go
+++ b/x-pack/filebeat/cmd/root.go
@@ -1,0 +1,14 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package cmd
+
+import "github.com/elastic/beats/filebeat/cmd"
+
+// RootCmd to handle beats cli
+var RootCmd = cmd.RootCmd
+
+func init() {
+	// TODO inject x-pack features
+}

--- a/x-pack/filebeat/main.go
+++ b/x-pack/filebeat/main.go
@@ -1,0 +1,25 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package main
+
+import (
+	"os"
+
+	"github.com/elastic/beats/x-pack/filebeat/cmd"
+)
+
+// The basic model of execution:
+// - input: finds files in paths/globs to harvest, starts harvesters
+// - harvester: reads a file, sends events to the spooler
+// - spooler: buffers events until ready to flush to the publisher
+// - publisher: writes to the network, notifies registrar
+// - registrar: records positions of files read
+// Finally, input uses the registrar information, on restart, to
+// determine where in each file to restart a harvester.
+func main() {
+	if err := cmd.RootCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}

--- a/x-pack/heartbeat/cmd/root.go
+++ b/x-pack/heartbeat/cmd/root.go
@@ -1,0 +1,14 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package cmd
+
+import "github.com/elastic/beats/heartbeat/cmd"
+
+// RootCmd to handle beats cli
+var RootCmd = cmd.RootCmd
+
+func init() {
+	// TODO inject x-pack features
+}

--- a/x-pack/heartbeat/main.go
+++ b/x-pack/heartbeat/main.go
@@ -1,0 +1,19 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package main
+
+import (
+	"os"
+
+	"github.com/elastic/beats/x-pack/heartbeat/cmd"
+
+	_ "github.com/elastic/beats/heartbeat/include"
+)
+
+func main() {
+	if err := cmd.RootCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}

--- a/x-pack/metricbeat/cmd/root.go
+++ b/x-pack/metricbeat/cmd/root.go
@@ -1,0 +1,14 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package cmd
+
+import "github.com/elastic/beats/metricbeat/cmd"
+
+// RootCmd to handle beats cli
+var RootCmd = cmd.RootCmd
+
+func init() {
+	// TODO inject x-pack features
+}

--- a/x-pack/metricbeat/main.go
+++ b/x-pack/metricbeat/main.go
@@ -1,0 +1,24 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+/*
+Package metricbeat contains the entrypoint to Metricbeat which is a lightweight
+data shipper for operating system and service metrics. It ships events directly
+to Elasticsearch or Logstash. The data can then be visualized in Kibana.
+
+Downloads: https://www.elastic.co/downloads/beats/metricbeat
+*/
+package main
+
+import (
+	"os"
+
+	"github.com/elastic/beats/x-pack/metricbeat/cmd"
+)
+
+func main() {
+	if err := cmd.RootCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}

--- a/x-pack/packetbeat/cmd/root.go
+++ b/x-pack/packetbeat/cmd/root.go
@@ -1,0 +1,14 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package cmd
+
+import "github.com/elastic/beats/packetbeat/cmd"
+
+// RootCmd to handle beats cli
+var RootCmd = cmd.RootCmd
+
+func init() {
+	// TODO inject x-pack features
+}

--- a/x-pack/packetbeat/main.go
+++ b/x-pack/packetbeat/main.go
@@ -1,0 +1,18 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package main
+
+import (
+	"os"
+
+	"github.com/elastic/beats/x-pack/packetbeat/cmd"
+)
+
+// Setups and Runs Packetbeat
+func main() {
+	if err := cmd.RootCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}

--- a/x-pack/winlogbeat/cmd/root.go
+++ b/x-pack/winlogbeat/cmd/root.go
@@ -1,0 +1,14 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package cmd
+
+import "github.com/elastic/beats/winlogbeat/cmd"
+
+// RootCmd to handle beats cli
+var RootCmd = cmd.RootCmd
+
+func init() {
+	// TODO inject x-pack features
+}

--- a/x-pack/winlogbeat/main.go
+++ b/x-pack/winlogbeat/main.go
@@ -1,0 +1,26 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+/*
+Package winlogbeat contains the entrypoint to Winlogbeat which is a lightweight
+data shipper for Windows event logs. It ships events directly to Elasticsearch
+or Logstash. The data can then be visualized in Kibana.
+
+Downloads: https://www.elastic.co/downloads/beats/winlogbeat
+*/
+package main
+
+import (
+	"os"
+
+	_ "github.com/elastic/beats/winlogbeat/include"
+
+	"github.com/elastic/beats/x-pack/winlogbeat/cmd"
+)
+
+func main() {
+	if err := cmd.RootCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
This change brings with-xpack binaries building by doing this:

Introduce `x-pack/<beatname>/main.go` and its `cmd` package. These take oss beats RootCmd and inject X-Pack features on it.

The existing `magefile.go` gains awareness of this and uses it to build and package the x-pack version.

I believe this is the minimal change we would need to just have different binaries. If modules are introduced they will require more packaging changes to take them into account.