### PR TITLE
Enhance mapval to handle slices

### DIFF
--- a/heartbeat/hbtest/hbtestutil.go
+++ b/heartbeat/hbtest/hbtestutil.go
@@ -61,7 +61,7 @@ func ServerPort(server *httptest.Server) (uint16, error) {
 // MonitorChecks creates a skima.Validator that represents the "monitor" field present
 // in all heartbeat events.
 func MonitorChecks(id string, host string, ip string, scheme string, status string) mapval.Validator {
-	return mapval.Schema(mapval.Map{
+	return mapval.MustCompile(mapval.Map{
 		"monitor": mapval.Map{
 			// TODO: This is only optional because, for some reason, TCP returns
 			// this value, but HTTP does not. We should fix this
@@ -78,14 +78,14 @@ func MonitorChecks(id string, host string, ip string, scheme string, status stri
 // TCPBaseChecks checks the minimum TCP response, which is only issued
 // without further fields when the endpoint does not respond.
 func TCPBaseChecks(port uint16) mapval.Validator {
-	return mapval.Schema(mapval.Map{"tcp.port": port})
+	return mapval.MustCompile(mapval.Map{"tcp.port": port})
 }
 
 // ErrorChecks checks the standard heartbeat error hierarchy, which should
 // consist of a message (or a mapval isdef that can match the message) and a type under the error key.
 // The message is checked only as a substring since exact string matches can be fragile due to platform differences.
 func ErrorChecks(msgSubstr string, errType string) mapval.Validator {
-	return mapval.Schema(mapval.Map{
+	return mapval.MustCompile(mapval.Map{
 		"error": mapval.Map{
 			"message": mapval.IsStringContaining(msgSubstr),
 			"type":    errType,
@@ -98,6 +98,6 @@ func ErrorChecks(msgSubstr string, errType string) mapval.Validator {
 func RespondingTCPChecks(port uint16) mapval.Validator {
 	return mapval.Compose(
 		TCPBaseChecks(port),
-		mapval.Schema(mapval.Map{"tcp.rtt.connect.us": mapval.IsDuration}),
+		mapval.MustCompile(mapval.Map{"tcp.rtt.connect.us": mapval.IsDuration}),
 	)
 }

--- a/heartbeat/monitors/active/http/http_test.go
+++ b/heartbeat/monitors/active/http/http_test.go
@@ -62,7 +62,7 @@ func checkServer(t *testing.T, handlerFunc http.HandlerFunc) (*httptest.Server, 
 // The minimum response is just the URL. Only to be used for unreachable server
 // tests.
 func httpBaseChecks(url string) mapval.Validator {
-	return mapval.Schema(mapval.Map{
+	return mapval.MustCompile(mapval.Map{
 		"http.url": url,
 	})
 }
@@ -70,7 +70,7 @@ func httpBaseChecks(url string) mapval.Validator {
 func respondingHTTPChecks(url string, statusCode int) mapval.Validator {
 	return mapval.Compose(
 		httpBaseChecks(url),
-		mapval.Schema(mapval.Map{
+		mapval.MustCompile(mapval.Map{
 			"http": mapval.Map{
 				"response.status_code":   statusCode,
 				"rtt.content.us":         mapval.IsDuration,

--- a/heartbeat/monitors/active/tcp/tcp_test.go
+++ b/heartbeat/monitors/active/tcp/tcp_test.go
@@ -77,7 +77,7 @@ func TestUpEndpointJob(t *testing.T) {
 				"up",
 			),
 			hbtest.RespondingTCPChecks(port),
-			mapval.Schema(mapval.Map{
+			mapval.MustCompile(mapval.Map{
 				"resolve": mapval.Map{
 					"host":   "localhost",
 					"ip":     "127.0.0.1",

--- a/libbeat/common/mapval/is_defs.go
+++ b/libbeat/common/mapval/is_defs.go
@@ -35,22 +35,21 @@ var KeyMissing = IsDef{name: "check key not present", checkKeyMissing: true}
 // IsArrayOf validates that the array at the given key is an array of objects all validatable
 // via the given Validator.
 func IsArrayOf(validator Validator) IsDef {
-	return Is("array of maps", func(path Path, v interface{}) (*Results, error) {
+	return Is("array of maps", func(path Path, v interface{}) *Results {
 		vArr, isArr := v.([]common.MapStr)
 		if !isArr {
-			return SimpleResult(path, false, "Expected array at given path"), nil
+			return SimpleResult(path, false, "Expected array at given path")
 		}
 
 		results := NewResults()
 
-		var err error
 		for idx, curMap := range vArr {
 			var validatorRes *Results
-			validatorRes, err = validator(curMap)
+			validatorRes = validator(curMap)
 			results.mergeUnderPrefix(path.ExtendSlice(idx), validatorRes)
 		}
 
-		return results, err
+		return results
 	})
 }
 
@@ -63,12 +62,11 @@ func IsAny(of ...IsDef) IsDef {
 	}
 	isName := fmt.Sprintf("either %#v", names)
 
-	return Is(isName, func(path Path, v interface{}) (*Results, error) {
+	return Is(isName, func(path Path, v interface{}) *Results {
 		for _, def := range of {
-			var err error
-			vr, err := def.check(path, v, true)
+			vr := def.check(path, v, true)
 			if vr.Valid {
-				return vr, err
+				return vr
 			}
 		}
 
@@ -76,13 +74,13 @@ func IsAny(of ...IsDef) IsDef {
 			path,
 			false,
 			fmt.Sprintf("Value was none of %#v, actual value was %#v", names, v),
-		), nil
+		)
 	})
 }
 
 // IsStringContaining validates that the the actual value contains the specified substring.
 func IsStringContaining(needle string) IsDef {
-	return Is("is string containing", func(path Path, v interface{}) (*Results, error) {
+	return Is("is string containing", func(path Path, v interface{}) *Results {
 		strV, ok := v.(string)
 
 		if !ok {
@@ -90,7 +88,7 @@ func IsStringContaining(needle string) IsDef {
 				path,
 				false,
 				fmt.Sprintf("Unable to convert '%v' to string", v),
-			), nil
+			)
 		}
 
 		if !strings.Contains(strV, needle) {
@@ -98,68 +96,68 @@ func IsStringContaining(needle string) IsDef {
 				path,
 				false,
 				fmt.Sprintf("String '%s' did not contain substring '%s'", strV, needle),
-			), nil
+			)
 		}
 
-		return ValidResult(path), nil
+		return ValidResult(path)
 	})
 }
 
 // IsDuration tests that the given value is a duration.
-var IsDuration = Is("is a duration", func(path Path, v interface{}) (*Results, error) {
+var IsDuration = Is("is a duration", func(path Path, v interface{}) *Results {
 	if _, ok := v.(time.Duration); ok {
-		return ValidResult(path), nil
+		return ValidResult(path)
 	}
 	return SimpleResult(
 		path,
 		false,
 		fmt.Sprintf("Expected a time.duration, got '%v' which is a %T", v, v),
-	), nil
+	)
 })
 
 // IsEqual tests that the given object is equal to the actual object.
 func IsEqual(to interface{}) IsDef {
-	return Is("equals", func(path Path, v interface{}) (*Results, error) {
+	return Is("equals", func(path Path, v interface{}) *Results {
 		if reflect.DeepEqual(v, to) {
-			return ValidResult(path), nil
+			return ValidResult(path)
 		}
 		return SimpleResult(
 			path,
 			false,
 			fmt.Sprintf("objects not equal: actual(%v) != expected(%v)", v, to),
-		), nil
+		)
 	})
 }
 
 // IsNil tests that a value is nil.
-var IsNil = Is("is nil", func(path Path, v interface{}) (*Results, error) {
+var IsNil = Is("is nil", func(path Path, v interface{}) *Results {
 	if v == nil {
-		return ValidResult(path), nil
+		return ValidResult(path)
 	}
 	return SimpleResult(
 		path,
 		false,
 		fmt.Sprintf("Value %v is not nil", v),
-	), nil
+	)
 })
 
 func intGtChecker(than int) ValueValidator {
-	return func(path Path, v interface{}) (*Results, error) {
+	return func(path Path, v interface{}) *Results {
 		n, ok := v.(int)
 		if !ok {
 			msg := fmt.Sprintf("%v is a %T, but was expecting an int!", v, v)
-			return SimpleResult(path, false, msg), nil
+			return SimpleResult(path, false, msg)
 		}
 
 		if n > than {
-			return ValidResult(path), nil
+			return ValidResult(path)
 		}
 
 		return SimpleResult(
 			path,
 			false,
 			fmt.Sprintf("%v is not greater than %v", n, than),
-		), nil
+		)
 	}
 }
 

--- a/libbeat/common/mapval/is_defs.go
+++ b/libbeat/common/mapval/is_defs.go
@@ -19,10 +19,11 @@ package mapval
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 	"time"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/elastic/beats/libbeat/common"
 )
 
 // KeyPresent checks that the given key is in the map, even if it has a nil value.
@@ -30,6 +31,28 @@ var KeyPresent = IsDef{name: "check key present"}
 
 // KeyMissing checks that the given key is not present defined.
 var KeyMissing = IsDef{name: "check key not present", checkKeyMissing: true}
+
+// IsArrayOf validates that the array at the given key is an array of objects all validatable
+// via the given Validator.
+func IsArrayOf(validator Validator) IsDef {
+	return Is("array of maps", func(path Path, v interface{}) (*Results, error) {
+		vArr, isArr := v.([]common.MapStr)
+		if !isArr {
+			return SimpleResult(path, false, "Expected array at given path"), nil
+		}
+
+		results := NewResults()
+
+		var err error
+		for idx, curMap := range vArr {
+			var validatorRes *Results
+			validatorRes, err = validator(curMap)
+			results.mergeUnderPrefix(path.ExtendSlice(idx), validatorRes)
+		}
+
+		return results, err
+	})
+}
 
 // IsAny takes a variable number of IsDef's and combines them with a logical OR. If any single definition
 // matches the key will be marked as valid.
@@ -40,108 +63,103 @@ func IsAny(of ...IsDef) IsDef {
 	}
 	isName := fmt.Sprintf("either %#v", names)
 
-	return Is(isName, func(v interface{}) ValueResult {
+	return Is(isName, func(path Path, v interface{}) (*Results, error) {
 		for _, def := range of {
-			vr := def.check(v, true)
+			var err error
+			vr, err := def.check(path, v, true)
 			if vr.Valid {
-				return vr
+				return vr, err
 			}
 		}
 
-		return ValueResult{
+		return SimpleResult(
+			path,
 			false,
 			fmt.Sprintf("Value was none of %#v, actual value was %#v", names, v),
-		}
+		), nil
 	})
 }
 
 // IsStringContaining validates that the the actual value contains the specified substring.
 func IsStringContaining(needle string) IsDef {
-	return Is("is string containing", func(v interface{}) ValueResult {
+	return Is("is string containing", func(path Path, v interface{}) (*Results, error) {
 		strV, ok := v.(string)
 
 		if !ok {
-			return ValueResult{
+			return SimpleResult(
+				path,
 				false,
 				fmt.Sprintf("Unable to convert '%v' to string", v),
-			}
+			), nil
 		}
 
 		if !strings.Contains(strV, needle) {
-			return ValueResult{
+			return SimpleResult(
+				path,
 				false,
 				fmt.Sprintf("String '%s' did not contain substring '%s'", strV, needle),
-			}
+			), nil
 		}
 
-		return ValidVR
+		return ValidResult(path), nil
 	})
 }
 
 // IsDuration tests that the given value is a duration.
-var IsDuration = Is("is a duration", func(v interface{}) ValueResult {
+var IsDuration = Is("is a duration", func(path Path, v interface{}) (*Results, error) {
 	if _, ok := v.(time.Duration); ok {
-		return ValidVR
+		return ValidResult(path), nil
 	}
-	return ValueResult{
+	return SimpleResult(
+		path,
 		false,
 		fmt.Sprintf("Expected a time.duration, got '%v' which is a %T", v, v),
-	}
+	), nil
 })
 
 // IsEqual tests that the given object is equal to the actual object.
 func IsEqual(to interface{}) IsDef {
-	return Is("equals", func(v interface{}) ValueResult {
-		if assert.ObjectsAreEqual(v, to) {
-			return ValidVR
+	return Is("equals", func(path Path, v interface{}) (*Results, error) {
+		if reflect.DeepEqual(v, to) {
+			return ValidResult(path), nil
 		}
-		return ValueResult{
+		return SimpleResult(
+			path,
 			false,
 			fmt.Sprintf("objects not equal: actual(%v) != expected(%v)", v, to),
-		}
-	})
-}
-
-// IsEqualToValue tests that the given value is equal to the actual value.
-func IsEqualToValue(to interface{}) IsDef {
-	return Is("equals", func(v interface{}) ValueResult {
-		if assert.ObjectsAreEqualValues(v, to) {
-			return ValidVR
-		}
-		return ValueResult{
-			false,
-			fmt.Sprintf("values not equal: actual(%v) != expected(%v)", v, to),
-		}
+		), nil
 	})
 }
 
 // IsNil tests that a value is nil.
-var IsNil = Is("is nil", func(v interface{}) ValueResult {
+var IsNil = Is("is nil", func(path Path, v interface{}) (*Results, error) {
 	if v == nil {
-		return ValidVR
+		return ValidResult(path), nil
 	}
-	return ValueResult{
+	return SimpleResult(
+		path,
 		false,
 		fmt.Sprintf("Value %v is not nil", v),
-	}
+	), nil
 })
 
 func intGtChecker(than int) ValueValidator {
-	return func(v interface{}) ValueResult {
+	return func(path Path, v interface{}) (*Results, error) {
 		n, ok := v.(int)
 		if !ok {
 			msg := fmt.Sprintf("%v is a %T, but was expecting an int!", v, v)
-			return ValueResult{false, msg}
+			return SimpleResult(path, false, msg), nil
 		}
 
 		if n > than {
-			return ValidVR
+			return ValidResult(path), nil
 		}
 
-		return ValueResult{
+		return SimpleResult(
+			path,
 			false,
 			fmt.Sprintf("%v is not greater than %v", n, than),
-		}
+		), nil
 	}
 }
 

--- a/libbeat/common/mapval/is_defs_test.go
+++ b/libbeat/common/mapval/is_defs_test.go
@@ -19,11 +19,9 @@ package mapval
 
 import (
 	"testing"
-
 	"time"
 
 	"github.com/stretchr/testify/assert"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/libbeat/common"

--- a/libbeat/common/mapval/is_defs_test.go
+++ b/libbeat/common/mapval/is_defs_test.go
@@ -23,21 +23,30 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/libbeat/common"
 )
 
-func assertIsDefValid(t *testing.T, id IsDef, value interface{}) {
-	res := id.check(value, true)
+func assertIsDefValid(t *testing.T, id IsDef, value interface{}) *Results {
+	res, err := id.check(MustParsePath("p"), value, true)
+	require.NoError(t, err)
+
 	if !res.Valid {
 		assert.Fail(
 			t,
 			"Expected Valid IsDef",
-			"Isdef %#v was not valid for value %#v with error: ", id, value, res.Message,
+			"Isdef %#v was not valid for value %#v with error: ", id, value, res.Errors(),
 		)
 	}
+	return res
 }
 
-func assertIsDefInvalid(t *testing.T, id IsDef, value interface{}) {
-	res := id.check(value, true)
+func assertIsDefInvalid(t *testing.T, id IsDef, value interface{}) *Results {
+	res, err := id.check(MustParsePath("p"), value, true)
+	require.NoError(t, err)
+
 	if res.Valid {
 		assert.Fail(
 			t,
@@ -47,6 +56,30 @@ func assertIsDefInvalid(t *testing.T, id IsDef, value interface{}) {
 			value,
 		)
 	}
+	return res
+}
+
+func TestIsArrayOf(t *testing.T) {
+	validator := Schema(Map{"foo": "bar"})
+
+	id := IsArrayOf(validator)
+
+	goodMap := common.MapStr{"foo": "bar"}
+	goodMapArr := []common.MapStr{goodMap, goodMap}
+
+	goodRes := assertIsDefValid(t, id, goodMapArr)
+	goodFields := goodRes.Fields
+	assert.Len(t, goodFields, 2)
+	assert.Contains(t, goodFields, "p.[0].foo")
+	assert.Contains(t, goodFields, "p.[1].foo")
+
+	badMap := common.MapStr{"foo": "bot"}
+	badMapArr := []common.MapStr{badMap}
+
+	badRes := assertIsDefInvalid(t, id, badMapArr)
+	badFields := badRes.Fields
+	assert.Len(t, badFields, 1)
+	assert.Contains(t, badFields, "p.[0].foo")
 }
 
 func TestIsAny(t *testing.T) {

--- a/libbeat/common/mapval/is_defs_test.go
+++ b/libbeat/common/mapval/is_defs_test.go
@@ -22,14 +22,12 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/libbeat/common"
 )
 
 func assertIsDefValid(t *testing.T, id IsDef, value interface{}) *Results {
-	res, err := id.check(MustParsePath("p"), value, true)
-	require.NoError(t, err)
+	res := id.check(MustParsePath("p"), value, true)
 
 	if !res.Valid {
 		assert.Fail(
@@ -42,8 +40,7 @@ func assertIsDefValid(t *testing.T, id IsDef, value interface{}) *Results {
 }
 
 func assertIsDefInvalid(t *testing.T, id IsDef, value interface{}) *Results {
-	res, err := id.check(MustParsePath("p"), value, true)
-	require.NoError(t, err)
+	res := id.check(MustParsePath("p"), value, true)
 
 	if res.Valid {
 		assert.Fail(
@@ -58,7 +55,7 @@ func assertIsDefInvalid(t *testing.T, id IsDef, value interface{}) *Results {
 }
 
 func TestIsArrayOf(t *testing.T) {
-	validator := Schema(Map{"foo": "bar"})
+	validator := MustCompile(Map{"foo": "bar"})
 
 	id := IsArrayOf(validator)
 

--- a/libbeat/common/mapval/path.go
+++ b/libbeat/common/mapval/path.go
@@ -1,0 +1,172 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package mapval
+
+import (
+	"fmt"
+	"reflect"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/elastic/beats/libbeat/common"
+)
+
+// PathComponentType indicates the type of PathComponent.
+type PathComponentType int
+
+const (
+	// PCMapKey is the Type for map keys.
+	PCMapKey = iota
+	// PCSliceIdx is the Type for slice indices.
+	PCSliceIdx
+)
+
+// PathComponent structs represent one breadcrumb in a Path.
+type PathComponent struct {
+	Type  PathComponentType // One of PCMapKey or PCSliceIdx
+	Key   string            // Populated for maps
+	Index int               // Populated for slices
+}
+
+func (pc PathComponent) String() string {
+	if pc.Type == PCSliceIdx {
+		return fmt.Sprintf("[%d]", pc.Index)
+	}
+	return pc.Key
+}
+
+// Path represents the path within a nested set of maps.
+type Path []PathComponent
+
+// ExtendSlice is used to add a new PathComponent of the PCSliceIdx type.
+func (p Path) ExtendSlice(index int) Path {
+	return p.extend(
+		PathComponent{PCSliceIdx, "", index},
+	)
+}
+
+// ExtendMap adds a new PathComponent of the PCMapKey type.
+func (p Path) ExtendMap(key string) Path {
+	return p.extend(
+		PathComponent{PCMapKey, key, -1},
+	)
+}
+
+func (p Path) extend(pc PathComponent) Path {
+	out := make(Path, len(p)+1)
+	copy(out, p)
+	out[len(p)] = pc
+	return out
+}
+
+// Concat combines two paths into a new path without modifying any existing paths.
+func (p Path) Concat(other Path) Path {
+	out := make(Path, 0, len(p)+len(other))
+	out = append(out, p...)
+	return append(out, other...)
+}
+
+func (p Path) String() string {
+	out := make([]string, len(p))
+	for idx, pc := range p {
+		out[idx] = pc.String()
+	}
+	return strings.Join(out, ".")
+}
+
+// Last returns the last PathComponent in this Path.
+func (p Path) Last() PathComponent {
+	return p[len(p)-1]
+}
+
+// GetFrom takes a map and fetches the given path from it.
+func (p Path) GetFrom(m common.MapStr) (exists bool, value interface{}) {
+	value = m
+	exists = true
+	for _, pc := range p {
+		switch reflect.TypeOf(value).Kind() {
+		case reflect.Map:
+			converted := interfaceToMapStr(value)
+			value, exists = converted[pc.Key]
+		case reflect.Slice:
+			converted := sliceToSliceOfInterfaces(value)
+			if pc.Index < len(converted) {
+				exists = true
+				value = converted[pc.Index]
+			} else {
+				exists = false
+				value = nil
+			}
+		default:
+			panic("Unexpected type")
+		}
+
+		if exists == false {
+			return exists, nil
+		}
+	}
+
+	return exists, value
+}
+
+var arrMatcher = regexp.MustCompile("\\[(\\d+)\\]")
+
+// InvalidPathString is the error type returned from unparseable paths.
+type InvalidPathString string
+
+func (ps InvalidPathString) Error() string {
+	return fmt.Sprintf("Invalid path Path: %#v", ps)
+}
+
+// ParsePath parses a path of form key.[0].otherKey.[1] into a Path object.
+func ParsePath(in string) (p Path, err error) {
+	keyParts := strings.Split(in, ".")
+
+	p = make(Path, len(keyParts))
+	for idx, part := range keyParts {
+		r := arrMatcher.FindStringSubmatch(part)
+		pc := PathComponent{}
+		if len(r) > 0 {
+			pc.Type = PCSliceIdx
+			// Cannot fail, validated by regexp already
+			pc.Index, err = strconv.Atoi(r[1])
+			if err != nil {
+				return p, err
+			}
+		} else if len(part) > 0 {
+			pc.Type = PCMapKey
+			pc.Key = part
+		} else {
+			return p, InvalidPathString(in)
+		}
+
+		p[idx] = pc
+	}
+
+	return p, nil
+}
+
+// MustParsePath is a convenience method for parsing paths that have been previously validated
+func MustParsePath(in string) Path {
+	out, err := ParsePath(in)
+	if err != nil {
+		panic(err)
+	}
+	return out
+}

--- a/libbeat/common/mapval/path.go
+++ b/libbeat/common/mapval/path.go
@@ -96,7 +96,7 @@ func (p Path) Last() PathComponent {
 }
 
 // GetFrom takes a map and fetches the given path from it.
-func (p Path) GetFrom(m common.MapStr) (exists bool, value interface{}) {
+func (p Path) GetFrom(m common.MapStr) (value interface{}, exists bool) {
 	value = m
 	exists = true
 	for _, pc := range p {
@@ -118,11 +118,11 @@ func (p Path) GetFrom(m common.MapStr) (exists bool, value interface{}) {
 		}
 
 		if exists == false {
-			return exists, nil
+			return nil, exists
 		}
 	}
 
-	return exists, value
+	return value, exists
 }
 
 var arrMatcher = regexp.MustCompile("\\[(\\d+)\\]")

--- a/libbeat/common/mapval/reflect_tools.go
+++ b/libbeat/common/mapval/reflect_tools.go
@@ -1,0 +1,62 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package mapval
+
+import (
+	"reflect"
+
+	"github.com/elastic/beats/libbeat/common"
+)
+
+func interfaceToMapStr(o interface{}) common.MapStr {
+	newMap := common.MapStr{}
+	rv := reflect.ValueOf(o)
+
+	for _, key := range rv.MapKeys() {
+		mapV := rv.MapIndex(key)
+		keyStr := key.Interface().(string)
+		var value interface{}
+
+		if !mapV.IsNil() {
+			value = mapV.Interface().(interface{})
+		}
+
+		newMap[keyStr] = value
+	}
+	return newMap
+}
+
+func sliceToSliceOfInterfaces(o interface{}) []interface{} {
+	rv := reflect.ValueOf(o)
+	converted := make([]interface{}, rv.Len())
+	for i := 0; i < rv.Len(); i++ {
+		var indexV = rv.Index(i)
+		var convertedValue interface{}
+		if indexV.Type().Kind() == reflect.Interface {
+			if !indexV.IsNil() {
+				convertedValue = indexV.Interface().(interface{})
+			} else {
+				convertedValue = nil
+			}
+		} else {
+			convertedValue = indexV.Interface().(interface{})
+		}
+		converted[i] = convertedValue
+	}
+	return converted
+}

--- a/libbeat/common/mapval/results_test.go
+++ b/libbeat/common/mapval/results_test.go
@@ -32,8 +32,8 @@ func TestEmpty(t *testing.T) {
 
 func TestWithError(t *testing.T) {
 	r := NewResults()
-	r.record("foo", KeyMissingVR)
-	r.record("bar", ValidVR)
+	r.record(MustParsePath("foo"), KeyMissingVR)
+	r.record(MustParsePath("bar"), ValidVR)
 
 	assert.False(t, r.Valid)
 

--- a/libbeat/common/mapval/value.go
+++ b/libbeat/common/mapval/value.go
@@ -24,7 +24,7 @@ type ValueResult struct {
 }
 
 // A ValueValidator is used to validate a value in a Map.
-type ValueValidator func(path Path, v interface{}) (*Results, error)
+type ValueValidator func(path Path, v interface{}) *Results
 
 // An IsDef defines the type of check to do.
 // Generally only name and checker are set. optional and checkKeyMissing are
@@ -36,24 +36,24 @@ type IsDef struct {
 	checkKeyMissing bool
 }
 
-func (id IsDef) check(path Path, v interface{}, keyExists bool) (*Results, error) {
+func (id IsDef) check(path Path, v interface{}, keyExists bool) *Results {
 	if id.checkKeyMissing {
 		if !keyExists {
-			return ValidResult(path), nil
+			return ValidResult(path)
 		}
 
-		return SimpleResult(path, false, "this key should not exist"), nil
+		return SimpleResult(path, false, "this key should not exist")
 	}
 
 	if !id.optional && !keyExists {
-		return KeyMissingResult(path), nil
+		return KeyMissingResult(path)
 	}
 
 	if id.checker != nil {
 		return id.checker(path, v)
 	}
 
-	return ValidResult(path), nil
+	return ValidResult(path)
 }
 
 // ValidResult is a convenience value for Valid results.

--- a/libbeat/common/mapval/value.go
+++ b/libbeat/common/mapval/value.go
@@ -24,7 +24,7 @@ type ValueResult struct {
 }
 
 // A ValueValidator is used to validate a value in a Map.
-type ValueValidator func(v interface{}) ValueResult
+type ValueValidator func(path Path, v interface{}) (*Results, error)
 
 // An IsDef defines the type of check to do.
 // Generally only name and checker are set. optional and checkKeyMissing are
@@ -36,28 +36,38 @@ type IsDef struct {
 	checkKeyMissing bool
 }
 
-func (id IsDef) check(v interface{}, keyExists bool) ValueResult {
+func (id IsDef) check(path Path, v interface{}, keyExists bool) (*Results, error) {
 	if id.checkKeyMissing {
 		if !keyExists {
-			return ValidVR
+			return ValidResult(path), nil
 		}
 
-		return ValueResult{false, "key should not exist!"}
+		return SimpleResult(path, false, "this key should not exist"), nil
 	}
 
 	if !id.optional && !keyExists {
-		return KeyMissingVR
+		return KeyMissingResult(path), nil
 	}
 
 	if id.checker != nil {
-		return id.checker(v)
+		return id.checker(path, v)
 	}
 
-	return ValidVR
+	return ValidResult(path), nil
+}
+
+// ValidResult is a convenience value for Valid results.
+func ValidResult(path Path) *Results {
+	return SimpleResult(path, true, "is valid")
 }
 
 // ValidVR is a convenience value for Valid results.
-var ValidVR = ValueResult{true, ""}
+var ValidVR = ValueResult{true, "is valid"}
+
+// KeyMissingResult is emitted when a key was expected, but was not present.
+func KeyMissingResult(path Path) *Results {
+	return SingleResult(path, KeyMissingVR)
+}
 
 // KeyMissingVR is emitted when a key was expected, but was not present.
 var KeyMissingVR = ValueResult{
@@ -65,5 +75,13 @@ var KeyMissingVR = ValueResult{
 	"expected this key to be present",
 }
 
+// StrictFailureResult is emitted when Strict() is used, and an unexpected field is found.
+func StrictFailureResult(path Path) *Results {
+	return SingleResult(path, StrictFailureVR)
+}
+
 // StrictFailureVR is emitted when Strict() is used, and an unexpected field is found.
-var StrictFailureVR = ValueResult{false, "unexpected field encountered during strict validation"}
+var StrictFailureVR = ValueResult{
+	false,
+	"unexpected field encountered during strict validation",
+}

--- a/libbeat/common/mapval/walk.go
+++ b/libbeat/common/mapval/walk.go
@@ -18,56 +18,63 @@
 package mapval
 
 import (
-	"strings"
+	"reflect"
 
 	"github.com/elastic/beats/libbeat/common"
 )
 
 type walkObserverInfo struct {
-	key        string
-	value      interface{}
-	currentMap common.MapStr
-	rootMap    common.MapStr
-	path       []string
-	dottedPath string
+	key     PathComponent
+	value   interface{}
+	rootMap common.MapStr
+	path    Path
 }
 
 // walkObserver functions run once per object in the tree.
 type walkObserver func(info walkObserverInfo)
 
 // walk is a shorthand way to walk a tree.
-func walk(m common.MapStr, wo walkObserver) {
-	walkFull(m, m, []string{}, wo)
+func walk(m common.MapStr, wo walkObserver) error {
+	return walkFullMap(m, m, Path{}, wo)
 }
 
-// walkFull walks the given MapStr tree.
-// TODO: Handle slices/arrays. We intentionally don't handle list types now because we don't need it (yet)
-// and it isn't clear in the context of validation what the right thing is to do there beyond letting the user
-// perform a custom validation
-func walkFull(m common.MapStr, root common.MapStr, path []string, wo walkObserver) {
-	for k, v := range m {
-		splitK := strings.Split(k, ".")
-		newPath := make([]string, len(path)+len(splitK))
-		copy(newPath, path)
-		copy(newPath[len(path):], splitK)
+func walkFull(o interface{}, root common.MapStr, path Path, wo walkObserver) error {
+	wo(walkObserverInfo{path.Last(), o, root, path})
 
-		dottedPath := strings.Join(newPath, ".")
-
-		wo(walkObserverInfo{k, v, m, root, newPath, dottedPath})
-
-		// Walk nested maps
-		vIsMap := false
-		var mapV common.MapStr
-		if convertedMS, ok := v.(common.MapStr); ok {
-			mapV = convertedMS
-			vIsMap = true
-		} else if convertedM, ok := v.(Map); ok {
-			mapV = common.MapStr(convertedM)
-			vIsMap = true
+	switch reflect.TypeOf(o).Kind() {
+	case reflect.Map:
+		converted := interfaceToMapStr(o)
+		err := walkFullMap(converted, root, path, wo)
+		if err != nil {
+			return err
 		}
+	case reflect.Slice:
+		converted := sliceToSliceOfInterfaces(o)
 
-		if vIsMap {
-			walkFull(mapV, root, newPath, wo)
+		for idx, v := range converted {
+			newPath := path.ExtendSlice(idx)
+			err := walkFull(v, root, newPath, wo)
+			if err != nil {
+				return err
+			}
 		}
 	}
+
+	return nil
+}
+
+// walkFullMap walks the given MapStr tree.
+func walkFullMap(m common.MapStr, root common.MapStr, path Path, wo walkObserver) error {
+	for k, v := range m {
+		//TODO: Handle this error
+		additionalPath, err := ParsePath(k)
+		if err != nil {
+			return err
+		}
+		newPath := path.Concat(additionalPath)
+
+		walkFull(v, root, newPath, wo)
+	}
+
+	return nil
 }

--- a/libbeat/testing/mapvaltest/mapvaltest.go
+++ b/libbeat/testing/mapvaltest/mapvaltest.go
@@ -28,6 +28,8 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/mapval"
 )
@@ -35,7 +37,8 @@ import (
 // Test takes the output from a Validator invocation and runs test assertions on the result.
 // If you are using this library for testing you will probably want to run Test(t, Schema(Map{...}), actual) as a pattern.
 func Test(t *testing.T, v mapval.Validator, m common.MapStr) *mapval.Results {
-	r := v(m)
+	r, err := v(m)
+	require.NoError(t, err)
 
 	if !r.Valid {
 		assert.Fail(

--- a/libbeat/testing/mapvaltest/mapvaltest.go
+++ b/libbeat/testing/mapvaltest/mapvaltest.go
@@ -28,17 +28,14 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/mapval"
 )
 
 // Test takes the output from a Validator invocation and runs test assertions on the result.
-// If you are using this library for testing you will probably want to run Test(t, Schema(Map{...}), actual) as a pattern.
+// If you are using this library for testing you will probably want to run Test(t, Compile(Map{...}), actual) as a pattern.
 func Test(t *testing.T, v mapval.Validator, m common.MapStr) *mapval.Results {
-	r, err := v(m)
-	require.NoError(t, err)
+	r := v(m)
 
 	if !r.Valid {
 		assert.Fail(


### PR DESCRIPTION
Introduces initial support for slices into mapval. There are lots of good refactor opportunities this opens up, but I want to draw the line somewhere close. 

I came across a case where I needed array support in #7545 which I'll be rebasing on this PR.

This required a lot of internals refactoring. The highlights are:

* While the code is more complex, there are fewer special cases, and the control flow is less complicated
* Making value validation less of a special case
* Redesigning the walk function to work correctly with slices. This required using `reflect` extensively.
* Validating a value involves returning a full mapval.Results map which gets merged into the main Validator results. This is a better internal design and allows for more flexibility. It does mean that custom `IsDef` validations have a slightly more complicated signature since they need to know the path of the thing they're validating, but that's a good thing in terms of power.
* Introducing a `Path` type instead of using simple strings for paths.
* Moved away from using the `MapStr` `Get` method to fetch subkeys. This was required to allow users to specify slice subscript.

Tests was added for comparing slices in various ways. As literals, with nested matchers, etc.