### PR TITLE
Fix flaky couchbase test

### DIFF
--- a/metricbeat/module/couchbase/_meta/Dockerfile
+++ b/metricbeat/module/couchbase/_meta/Dockerfile
@@ -1,6 +1,5 @@
 FROM couchbase:4.5.1
-HEALTHCHECK --interval=1s --retries=90 CMD curl -f http://localhost:8091
-
+HEALTHCHECK --interval=1s --retries=90 CMD [ "$(curl -s -o /dev/null -w ''%{http_code}'' http://localhost:8091/pools/default/buckets)" -eq "200" ]
 COPY configure-node.sh /opt/couchbase
 
 CMD ["/opt/couchbase/configure-node.sh"]


### PR DESCRIPTION
If curl is run with -f it also returns 0 in case of a 401 it seems. This change checking for 200 should fix the healthcheck.

Closes https://github.com/elastic/beats/issues/7683