### PR TITLE
Additional error checking for fields.yml generator

### DIFF
--- a/libbeat/generator/fields/fields.go
+++ b/libbeat/generator/fields/fields.go
@@ -81,7 +81,10 @@ func writeGeneratedFieldsYml(beatPath string, fieldFiles []*YmlFile, output stri
 
 	if output == "-" {
 		fw := bufio.NewWriter(os.Stdout)
-		fw.Write(data)
+		_, err = fw.Write(data)
+		if err != nil {
+			return err
+		}
 		return fw.Flush()
 	}
 
@@ -93,7 +96,10 @@ func writeGeneratedFieldsYml(beatPath string, fieldFiles []*YmlFile, output stri
 	defer f.Close()
 
 	fw := bufio.NewWriter(f)
-	fw.Write(data)
+	_, err = fw.Write(data)
+	if err != nil {
+		return err
+	}
 	return fw.Flush()
 }
 

--- a/libbeat/scripts/cmd/global_fields/main.go
+++ b/libbeat/scripts/cmd/global_fields/main.go
@@ -71,7 +71,7 @@ func main() {
 	// it's not a problem because all of them has unique fields.yml files somewhere.
 	if len(beatFieldsPaths) == 0 && os.SameFile(esBeatsInfo, beatInfo) {
 		if output != "-" {
-			fmt.Println("No field files to collect")
+			fmt.Fprintln(os.Stderr, "No field files to collect")
 		}
 		return
 	}
@@ -95,7 +95,5 @@ func main() {
 		os.Exit(3)
 	}
 
-	if output != "-" {
-		fmt.Printf("Generated fields.yml for %s\n", name)
-	}
+	fmt.Fprintf(os.Stderr, "Generated fields.yml for %s to %s\n", name, filepath.Join(beatPath, output))
 }


### PR DESCRIPTION
* add missing error checking for writing output buffer
* print log messages to stderr

This provides more information why the release-manager fails during `make update` if it does again.