### PR TITLE
Adding xpack code for ES cluster stats metricset

### DIFF
--- a/metricbeat/helper/elastic/elastic.go
+++ b/metricbeat/helper/elastic/elastic.go
@@ -82,7 +82,13 @@ func MakeXPackMonitoringIndexName(product Product) string {
 // ReportErrorForMissingField reports and returns an error message for the given
 // field being missing in API response received from a given product
 func ReportErrorForMissingField(field string, product Product, r mb.ReporterV2) error {
-	err := fmt.Errorf("Could not find field '%v' in %v stats API response", field, strings.Title(product.String()))
+	err := MakeErrorForMissingField(field, product)
 	r.Error(err)
 	return err
+}
+
+// MakeErrorForMissingField returns an error message for the given field being missing in an API
+// response received from a given product
+func MakeErrorForMissingField(field string, product Product) error {
+	return fmt.Errorf("Could not find field '%v' in %v stats API response", field, strings.Title(product.String()))
 }

--- a/metricbeat/module/elasticsearch/cluster_stats/cluster_stats.go
+++ b/metricbeat/module/elasticsearch/cluster_stats/cluster_stats.go
@@ -63,7 +63,7 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 
 	// Not master, no event sent
 	if !isMaster {
-		logp.Debug("elasticsearch", "Trying to fetch index recovery stats from a non master node.")
+		logp.Debug("elasticsearch", "Trying to fetch cluster stats from a non master node.")
 		return
 	}
 

--- a/metricbeat/module/elasticsearch/cluster_stats/cluster_stats.go
+++ b/metricbeat/module/elasticsearch/cluster_stats/cluster_stats.go
@@ -73,5 +73,9 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 		return
 	}
 
-	eventMapping(r, content)
+	if m.MetricSet.XPack {
+		eventMappingXPack(r, m, content)
+	} else {
+		eventMapping(r, content)
+	}
 }

--- a/metricbeat/module/elasticsearch/cluster_stats/data_xpack.go
+++ b/metricbeat/module/elasticsearch/cluster_stats/data_xpack.go
@@ -170,11 +170,11 @@ func eventMappingXPack(r mb.ReporterV2, m *MetricSet, content []byte) error {
 
 	passthruFields := []string{
 		"indices.segments.file_sizes", // object with dynamic keys
-		"nodes.versions", // array of strings
-		"nodes.os.names", // array of objects
-		"nodes.jvm.versions", // array of objects
-		"nodes.plugins", // array of objects
-		"nodes.network_types", // object with dynamic keys
+		"nodes.versions",              // array of strings
+		"nodes.os.names",              // array of objects
+		"nodes.jvm.versions",          // array of objects
+		"nodes.plugins",               // array of objects
+		"nodes.network_types",         // object with dynamic keys
 	}
 	for _, fieldPath := range passthruFields {
 		if err = passthruField(fieldPath, dataMS, clusterStats); err != nil {

--- a/metricbeat/module/elasticsearch/cluster_stats/data_xpack.go
+++ b/metricbeat/module/elasticsearch/cluster_stats/data_xpack.go
@@ -1,0 +1,168 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cluster_stats
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/elastic/beats/metricbeat/helper/elastic"
+
+	"github.com/elastic/beats/libbeat/common"
+	s "github.com/elastic/beats/libbeat/common/schema"
+	c "github.com/elastic/beats/libbeat/common/schema/mapstriface"
+	"github.com/elastic/beats/metricbeat/mb"
+	"github.com/elastic/beats/metricbeat/module/elasticsearch"
+)
+
+var (
+	clusterStatsSchema = s.Schema{
+		"status": c.Str("status"),
+		"indices": c.Dict("indices", s.Schema{
+			"count": c.Int("count"),
+			"shards": c.Dict("shards", s.Schema{
+				"total":       c.Int("total"),
+				"primaries":   c.Int("primaries"),
+				"replication": c.Int("replication"),
+				"index": c.Dict("index", s.Schema{
+					"shards": c.Dict("shards", s.Schema{
+						"min": c.Int("min"),
+						"max": c.Int("max"),
+						"avg": c.Int("avg"),
+					}),
+					"primaries": c.Dict("primaries", s.Schema{
+						"min": c.Int("min"),
+						"max": c.Int("max"),
+						"avg": c.Int("avg"),
+					}),
+					"replication": c.Dict("replication", s.Schema{
+						"min": c.Int("min"),
+						"max": c.Int("max"),
+						"avg": c.Int("avg"),
+					}),
+				}),
+			}),
+			"docs": c.Dict("docs", s.Schema{
+				"count":   c.Int("count"),
+				"deleted": c.Int("deleted"),
+			}),
+			"store": c.Dict("store", s.Schema{
+				"size_in_bytes": c.Int("size_in_bytes"),
+			}),
+			"fielddata": c.Dict("fielddata", s.Schema{
+				"memory_size_in_bytes": c.Int("memory_size_in_bytes"),
+				"evictions":            c.Int("evictions"),
+			}),
+			"query_cache": c.Dict("query_cache", s.Schema{
+				"memory_size_in_bytes": c.Int("memory_size_in_bytes"),
+				"total_count":          c.Int("total_count"),
+				"hit_count":            c.Int("hit_count"),
+				"miss_count":           c.Int("miss_count"),
+				"cache_size":           c.Int("cache_size"),
+				"cache_count":          c.Int("cache_count"),
+			}),
+			"completion": c.Dict("completion", s.Schema{
+				"size_in_bytes": c.Int("size_in_bytes"),
+			}),
+			"segments": c.Dict("segments", s.Schema{
+				"count":                         c.Int("count"),
+				"memory_in_bytes":               c.Int("memory_in_bytes"),
+				"terms_memory_in_bytes":         c.Int("terms_memory_in_bytes"),
+				"stored_fields_memory_in_bytes": c.Int("stored_fields_memory_in_bytes"),
+				"term_vectors_memory_in_bytes":  c.Int("term_vectors_memory_in_bytes"),
+				"norms_memory_in_bytes":         c.Int("norms_memory_in_bytes"),
+				"points_memory_in_bytes":        c.Int("points_memory_in_bytes"),
+				"doc_values_memory_in_bytes":    c.Int("doc_values_memory_in_bytes"),
+
+				"index_writer_memory_in_bytes":  c.Int("index_writer_memory_in_bytes"),
+				"version_map_memory_in_bytes":   c.Int("version_map_memory_in_bytes"),
+				"fixed_bit_set_memory_in_bytes": c.Int("fixed_bit_set_memory_in_bytes"),
+				"max_unsafe_auto_id_timestamp":  c.Int("max_unsafe_auto_id_timestamp"),
+			}),
+		}),
+		"nodes": c.Dict("nodes", s.Schema{
+			"count": c.Dict("count", s.Schema{
+				"total":             c.Int("total"),
+				"data":              c.Int("data"),
+				"coordinating_only": c.Int("coordinating_only"),
+				"master":            c.Int("master"),
+				"ingest":            c.Int("ingest"),
+			}),
+			// TODO: os
+			// TODO: process
+			// TODO: jvm
+			// TODO: fs
+			// TODO: network_types
+		}),
+	}
+)
+
+func eventMappingXPack(r mb.ReporterV2, m *MetricSet, info elasticsearch.Info, content []byte) error {
+	var data map[string]interface{}
+	err := json.Unmarshal(content, &data)
+	if err != nil {
+		r.Error(err)
+		return err
+	}
+
+	clusterStatsFields, err := clusterStatsSchema.Apply(data)
+	if err != nil {
+		r.Error(err)
+		return err
+	}
+
+	// TODO: handle cluster stats fields:
+	// - nodes.versions (array of strings)
+	// - nodes.os.names (array of objects)
+	// - nodes.jvm.versions (array of objects)
+	// - nodes.plugins (array of ??)
+	// - nodes.network_types.transport_types (is this an object with dynamic keys?)
+	// - nodes.network_types.http_types (is this an object with dynamic keys?)
+
+	clusterUUID, ok := data["cluster_uuid"].(string)
+	if !ok {
+		return elastic.ReportErrorForMissingField("cluster_uuid", elastic.Elasticsearch, r)
+	}
+
+	clusterName, ok := data["cluster_name"].(string)
+	if !ok {
+		return elastic.ReportErrorForMissingField("cluster_name", elastic.Elasticsearch, r)
+	}
+
+	nodesFields := "TODO: Fetch from ES (where?) and parse"
+	clusterStateFields := "TODO: Fetch from ES and parse"
+	stackStatsFields := "TODO: Fetch from ES and parse"
+
+	event := mb.Event{}
+	event.RootFields = common.MapStr{
+		"cluster_uuid":  clusterUUID, // TODO: In New(), error out if ES version < 6.5.0 and xpack.enabled = true
+		"cluster_name":  clusterName,
+		"timestamp":     common.Time(time.Now()),
+		"interval_ms":   m.Module().Config().Period / time.Millisecond,
+		"type":          "cluster_stats",
+		"cluster_stats": clusterStatsFields,
+		"nodes":         nodesFields,
+		"cluster_state": clusterStateFields,
+		"stack_stats":   stackStatsFields,
+	}
+
+	event.Index = elastic.MakeXPackMonitoringIndexName(elastic.Elasticsearch)
+	r.Event(event)
+
+	return nil
+}

--- a/metricbeat/module/elasticsearch/cluster_stats/data_xpack.go
+++ b/metricbeat/module/elasticsearch/cluster_stats/data_xpack.go
@@ -144,11 +144,10 @@ func eventMappingXPack(r mb.ReporterV2, m *MetricSet, info elasticsearch.Info, c
 		return elastic.ReportErrorForMissingField("cluster_name", elastic.Elasticsearch, r)
 	}
 
-	version := "TODO: Fetch from ES (where?) and parse"
-	licenseFields := "TODO: Fetch from ES (where?) and parse"
-	nodesFields := "TODO: Fetch from ES (where?) and parse"
-	clusterStateFields := "TODO: Fetch from ES (where?) and parse"
-	stackStatsFields := "TODO: Fetch from ES (where?) and parse"
+	version := "TODO: Fetch from http://localhost:9200/ and parse"
+	licenseFields := "TODO: Fetch from http://localhost:9200/_xpack/license and parse"
+	clusterStateFields := "TODO: Fetch from http://localhost:9200/_cluster/state (with response filtering) + http://localhost:9200/_cluster/health (for status field) and parse"
+	stackStatsFields := "TODO: Fetch from http://localhost:9200/_xpack/usage + apm (from cluster state if apm-* indices exist) + and parse"
 
 	event := mb.Event{}
 	event.RootFields = common.MapStr{
@@ -160,7 +159,6 @@ func eventMappingXPack(r mb.ReporterV2, m *MetricSet, info elasticsearch.Info, c
 		"license":       licenseFields,
 		"version":       version,
 		"cluster_stats": clusterStatsFields,
-		"nodes":         nodesFields,
 		"cluster_state": clusterStateFields,
 		"stack_stats":   stackStatsFields,
 	}

--- a/metricbeat/module/elasticsearch/cluster_stats/data_xpack.go
+++ b/metricbeat/module/elasticsearch/cluster_stats/data_xpack.go
@@ -258,7 +258,7 @@ func apmIndicesExist(clusterState common.MapStr) (bool, error) {
 		return false, fmt.Errorf("Routing table indices is not a map")
 	}
 
-	for name, _ := range indices {
+	for name := range indices {
 		if strings.HasPrefix(name, "apm-") {
 			return true, nil
 		}

--- a/metricbeat/module/elasticsearch/cluster_stats/data_xpack.go
+++ b/metricbeat/module/elasticsearch/cluster_stats/data_xpack.go
@@ -144,9 +144,11 @@ func eventMappingXPack(r mb.ReporterV2, m *MetricSet, info elasticsearch.Info, c
 		return elastic.ReportErrorForMissingField("cluster_name", elastic.Elasticsearch, r)
 	}
 
+	version := "TODO: Fetch from ES (where?) and parse"
+	licenseFields := "TODO: Fetch from ES (where?) and parse"
 	nodesFields := "TODO: Fetch from ES (where?) and parse"
-	clusterStateFields := "TODO: Fetch from ES and parse"
-	stackStatsFields := "TODO: Fetch from ES and parse"
+	clusterStateFields := "TODO: Fetch from ES (where?) and parse"
+	stackStatsFields := "TODO: Fetch from ES (where?) and parse"
 
 	event := mb.Event{}
 	event.RootFields = common.MapStr{
@@ -155,6 +157,8 @@ func eventMappingXPack(r mb.ReporterV2, m *MetricSet, info elasticsearch.Info, c
 		"timestamp":     common.Time(time.Now()),
 		"interval_ms":   m.Module().Config().Period / time.Millisecond,
 		"type":          "cluster_stats",
+		"license":       licenseFields,
+		"version":       version,
 		"cluster_stats": clusterStatsFields,
 		"nodes":         nodesFields,
 		"cluster_state": clusterStateFields,

--- a/metricbeat/module/elasticsearch/cluster_stats/data_xpack.go
+++ b/metricbeat/module/elasticsearch/cluster_stats/data_xpack.go
@@ -162,7 +162,7 @@ func clusterNeedsTLSEnabled(license, stackStats common.MapStr) (bool, error) {
 	// TLS does not need to be enabled if license type is something other than trial
 	value, err := license.GetValue("license.type")
 	if err != nil {
-		return false, err
+		return false, elastic.MakeErrorForMissingField("license.type", elastic.Elasticsearch)
 	}
 
 	licenseType, ok := value.(string)
@@ -177,7 +177,7 @@ func clusterNeedsTLSEnabled(license, stackStats common.MapStr) (bool, error) {
 	// TLS does not need to be enabled if security is not enabled
 	value, err = stackStats.GetValue("security.enabled")
 	if err != nil {
-		return false, err
+		return false, elastic.MakeErrorForMissingField("security.enabled", elastic.Elasticsearch)
 	}
 
 	isSecurityEnabled, ok := value.(bool)
@@ -192,7 +192,7 @@ func clusterNeedsTLSEnabled(license, stackStats common.MapStr) (bool, error) {
 	// TLS does not need to be enabled if TLS is already enabled on the transport protocol
 	value, err = stackStats.GetValue("security.ssl.transport.enabled")
 	if err != nil {
-		return false, err
+		return false, elastic.MakeErrorForMissingField("security.ssl.transport.enabled", elastic.Elasticsearch)
 	}
 
 	isTLSAlreadyEnabled, ok := value.(bool)
@@ -207,7 +207,7 @@ func clusterNeedsTLSEnabled(license, stackStats common.MapStr) (bool, error) {
 func computeNodesHash(clusterState common.MapStr) (int32, error) {
 	value, err := clusterState.GetValue("nodes")
 	if err != nil {
-		return 0, err
+		return 0, elastic.MakeErrorForMissingField("nodes", elastic.Elasticsearch)
 	}
 
 	nodes, ok := value.(map[string]interface{})
@@ -250,7 +250,7 @@ func hash(s string) int32 {
 func apmIndicesExist(clusterState common.MapStr) (bool, error) {
 	value, err := clusterState.GetValue("routing_table.indices")
 	if err != nil {
-		return false, err
+		return false, elastic.MakeErrorForMissingField("routing_table.indices", elastic.Elasticsearch)
 	}
 
 	indices, ok := value.(map[string]interface{})

--- a/metricbeat/module/elasticsearch/cluster_stats/data_xpack.go
+++ b/metricbeat/module/elasticsearch/cluster_stats/data_xpack.go
@@ -169,12 +169,12 @@ func eventMappingXPack(r mb.ReporterV2, m *MetricSet, content []byte) error {
 	dataMS := common.MapStr(data)
 
 	passthruFields := []string{
-		"indices.segments.file_sizes",
-		"nodes.versions",
-		"nodes.os.names",
-		"nodes.jvm.versions",
-		"nodes.plugins",
-		"nodes.network_types",
+		"indices.segments.file_sizes", // object with dynamic keys
+		"nodes.versions", // array of strings
+		"nodes.os.names", // array of objects
+		"nodes.jvm.versions", // array of objects
+		"nodes.plugins", // array of objects
+		"nodes.network_types", // object with dynamic keys
 	}
 	for _, fieldPath := range passthruFields {
 		if err = passthruField(fieldPath, dataMS, clusterStats); err != nil {

--- a/metricbeat/module/elasticsearch/cluster_stats/data_xpack.go
+++ b/metricbeat/module/elasticsearch/cluster_stats/data_xpack.go
@@ -167,7 +167,7 @@ func clusterNeedsTLSEnabled(license, stackStats common.MapStr) (bool, error) {
 
 	licenseType, ok := value.(string)
 	if !ok {
-		return false, fmt.Errorf("License type is not a string")
+		return false, fmt.Errorf("license type is not a string")
 	}
 
 	if licenseType != "trial" {
@@ -182,7 +182,7 @@ func clusterNeedsTLSEnabled(license, stackStats common.MapStr) (bool, error) {
 
 	isSecurityEnabled, ok := value.(bool)
 	if !ok {
-		return false, fmt.Errorf("Security enabled flag is not a boolean")
+		return false, fmt.Errorf("security enabled flag is not a boolean")
 	}
 
 	if !isSecurityEnabled {
@@ -197,7 +197,7 @@ func clusterNeedsTLSEnabled(license, stackStats common.MapStr) (bool, error) {
 
 	isTLSAlreadyEnabled, ok := value.(bool)
 	if !ok {
-		return false, fmt.Errorf("Transport protocol SSL enabled flag is not a boolean")
+		return false, fmt.Errorf("transport protocol SSL enabled flag is not a boolean")
 	}
 
 	return !isTLSAlreadyEnabled, nil
@@ -212,24 +212,24 @@ func computeNodesHash(clusterState common.MapStr) (int32, error) {
 
 	nodes, ok := value.(map[string]interface{})
 	if !ok {
-		return 0, fmt.Errorf("Nodes is not a map")
+		return 0, fmt.Errorf("nodes is not a map")
 	}
 
 	var nodeEphemeralIDs []string
 	for _, value := range nodes {
 		nodeData, ok := value.(map[string]interface{})
 		if !ok {
-			return 0, fmt.Errorf("Node data is not a map")
+			return 0, fmt.Errorf("node data is not a map")
 		}
 
 		value, ok := nodeData["ephemeral_id"]
 		if !ok {
-			return 0, fmt.Errorf("Node data does not contain ephemeral ID")
+			return 0, fmt.Errorf("node data does not contain ephemeral ID")
 		}
 
 		ephemeralID, ok := value.(string)
 		if !ok {
-			return 0, fmt.Errorf("Node ephemeral ID is not a string")
+			return 0, fmt.Errorf("node ephemeral ID is not a string")
 		}
 
 		nodeEphemeralIDs = append(nodeEphemeralIDs, ephemeralID)
@@ -255,7 +255,7 @@ func apmIndicesExist(clusterState common.MapStr) (bool, error) {
 
 	indices, ok := value.(map[string]interface{})
 	if !ok {
-		return false, fmt.Errorf("Routing table indices is not a map")
+		return false, fmt.Errorf("routing table indices is not a map")
 	}
 
 	for name := range indices {

--- a/metricbeat/module/elasticsearch/cluster_stats/data_xpack.go
+++ b/metricbeat/module/elasticsearch/cluster_stats/data_xpack.go
@@ -103,11 +103,41 @@ var (
 				"master":            c.Int("master"),
 				"ingest":            c.Int("ingest"),
 			}),
-			// TODO: os
-			// TODO: process
-			// TODO: jvm
-			// TODO: fs
-			// TODO: network_types
+			"os": c.Dict("os", s.Schema{
+				"available_processors": c.Int("available_processors"),
+				"allocated_processors": c.Int("allocated_processors"),
+				"mem": c.Dict("mem", s.Schema{
+					"total_in_bytes": c.Int("total_in_bytes"),
+					"free_in_bytes":  c.Int("free_in_bytes"),
+					"used_in_bytes":  c.Int("used_in_bytes"),
+					"free_percent":   c.Int("free_percent"),
+					"used_percent":   c.Int("used_percent"),
+				}),
+			}),
+			"process": c.Dict("process", s.Schema{
+				"cpu": c.Dict("cpu", s.Schema{
+					"percent": c.Int("percent"),
+				}),
+				"open_file_descriptors": c.Dict("open_file_descriptors", s.Schema{
+					"min": c.Int("min"),
+					"max": c.Int("max"),
+					"avg": c.Int("avg"),
+				}),
+			}),
+			"jvm": c.Dict("jvm", s.Schema{
+				"max_uptime_in_millis": c.Int("max_uptime_in_millis"),
+				"mem": c.Dict("mem", s.Schema{
+					"heap_used_in_bytes": c.Int("heap_used_in_bytes"),
+					"heap_max_in_bytes":  c.Int("heap_max_in_bytes"),
+				}),
+				"threads": c.Int("threads"),
+			}),
+			"fs": c.Dict("fs", s.Schema{
+				"total_in_bytes":     c.Int("total_in_bytes"),
+				"free_in_bytes":      c.Int("free_in_bytes"),
+				"available_in_bytes": c.Int("available_in_bytes"),
+			}),
+			// TODO: "network_types"
 		}),
 	}
 )

--- a/metricbeat/module/elasticsearch/elasticsearch.go
+++ b/metricbeat/module/elasticsearch/elasticsearch.go
@@ -231,7 +231,7 @@ func GetLicense(http *helper.HTTP, resetURI string) (common.MapStr, error) {
 
 // GetClusterState returns cluster state information
 func GetClusterState(http *helper.HTTP, resetURI string) (common.MapStr, error) {
-	content, err := fetchPath(http, resetURI, "_cluster/state/version,master_node,nodes")
+	content, err := fetchPath(http, resetURI, "_cluster/state/version,master_node,nodes,routing_table")
 	if err != nil {
 		return nil, err
 	}

--- a/metricbeat/module/elasticsearch/elasticsearch.go
+++ b/metricbeat/module/elasticsearch/elasticsearch.go
@@ -241,14 +241,14 @@ func GetClusterState(http *helper.HTTP, resetURI string) (common.MapStr, error) 
 	return clusterState, err
 }
 
-// GetStackStats returns stack stats (usage) information
-func GetStackStats(http *helper.HTTP, resetURI string) (common.MapStr, error) {
+// GetStackUsage returns stack usage information
+func GetStackUsage(http *helper.HTTP, resetURI string) (common.MapStr, error) {
 	content, err := fetchPath(http, resetURI, "_xpack/usage")
 	if err != nil {
 		return nil, err
 	}
 
-	var stackStats map[string]interface{}
-	err = json.Unmarshal(content, &stackStats)
-	return stackStats, err
+	var stackUsage map[string]interface{}
+	err = json.Unmarshal(content, &stackUsage)
+	return stackUsage, err
 }

--- a/metricbeat/module/elasticsearch/elasticsearch.go
+++ b/metricbeat/module/elasticsearch/elasticsearch.go
@@ -32,6 +32,9 @@ var clusterIDCache = map[string]string{}
 type Info struct {
 	ClusterName string `json:"cluster_name"`
 	ClusterID   string `json:"cluster_uuid"`
+	Version     struct {
+		Number string `json:"number"`
+	} `json:"version"`
 }
 
 // NodeInfo struct cotains data about the node
@@ -166,4 +169,28 @@ func GetNodeInfo(http *helper.HTTP, uri string, nodeID string) (*NodeInfo, error
 		}
 	}
 	return nil, fmt.Errorf("no node matched id %s", nodeID)
+}
+
+// GetLicense returns license information
+func GetLicense(http *helper.HTTP, resetURI string) (map[string]interface{}, error) {
+	content, err := fetchPath(http, resetURI, "_xpack/license")
+	if err != nil {
+		return nil, err
+	}
+
+	var license map[string]interface{}
+	err = json.Unmarshal(content, &license)
+	return license, err
+}
+
+// GetClusterState returns cluster state information
+func GetClusterState(http *helper.HTTP, resetURI string) (map[string]interface{}, error) {
+	content, err := fetchPath(http, resetURI, "_cluster/state")
+	if err != nil {
+		return nil, err
+	}
+
+	var clusterState map[string]interface{}
+	err = json.Unmarshal(content, &clusterState)
+	return clusterState, err
 }

--- a/metricbeat/module/elasticsearch/elasticsearch.go
+++ b/metricbeat/module/elasticsearch/elasticsearch.go
@@ -185,7 +185,7 @@ func GetLicense(http *helper.HTTP, resetURI string) (map[string]interface{}, err
 
 // GetClusterState returns cluster state information
 func GetClusterState(http *helper.HTTP, resetURI string) (map[string]interface{}, error) {
-	content, err := fetchPath(http, resetURI, "_cluster/state")
+	content, err := fetchPath(http, resetURI, "_cluster/state/version,master_node,nodes")
 	if err != nil {
 		return nil, err
 	}
@@ -193,4 +193,16 @@ func GetClusterState(http *helper.HTTP, resetURI string) (map[string]interface{}
 	var clusterState map[string]interface{}
 	err = json.Unmarshal(content, &clusterState)
 	return clusterState, err
+}
+
+// GetStackStats returns stack stats (usage) information
+func GetStackStats(http *helper.HTTP, resetURI string) (map[string]interface{}, error) {
+	content, err := fetchPath(http, resetURI, "_xpack/usage")
+	if err != nil {
+		return nil, err
+	}
+
+	var stackStats map[string]interface{}
+	err = json.Unmarshal(content, &stackStats)
+	return stackStats, err
 }

--- a/metricbeat/module/elasticsearch/elasticsearch.go
+++ b/metricbeat/module/elasticsearch/elasticsearch.go
@@ -31,37 +31,6 @@ import (
 // Global clusterIdCache. Assumption is that the same node id never can belong to a different cluster id
 var clusterIDCache = map[string]string{}
 
-// Global cache for license information. Assumption is that license information changes infrequently
-type _licenseCache struct {
-	sync.RWMutex
-	license  common.MapStr
-	cachedOn time.Time
-	ttl      time.Duration
-}
-
-var licenseCache = &_licenseCache{}
-
-func (c *_licenseCache) get() common.MapStr {
-	c.Lock()
-	defer c.Unlock()
-
-	if time.Since(c.cachedOn) > c.ttl {
-		// We are past the TTL, so invalidate cache
-		c.license = nil
-	}
-
-	return c.license
-}
-
-func (c *_licenseCache) set(license common.MapStr, ttl time.Duration) {
-	c.Lock()
-	defer c.Unlock()
-
-	c.license = license
-	c.ttl = ttl
-	c.cachedOn = time.Now()
-}
-
 // Info construct contains the data from the Elasticsearch / endpoint
 type Info struct {
 	ClusterName string `json:"cluster_name"`
@@ -253,4 +222,35 @@ func GetStackUsage(http *helper.HTTP, resetURI string) (common.MapStr, error) {
 	var stackUsage map[string]interface{}
 	err = json.Unmarshal(content, &stackUsage)
 	return stackUsage, err
+}
+
+// Global cache for license information. Assumption is that license information changes infrequently
+var licenseCache = &_licenseCache{}
+
+type _licenseCache struct {
+	sync.RWMutex
+	license  common.MapStr
+	cachedOn time.Time
+	ttl      time.Duration
+}
+
+func (c *_licenseCache) get() common.MapStr {
+	c.Lock()
+	defer c.Unlock()
+
+	if time.Since(c.cachedOn) > c.ttl {
+		// We are past the TTL, so invalidate cache
+		c.license = nil
+	}
+
+	return c.license
+}
+
+func (c *_licenseCache) set(license common.MapStr, ttl time.Duration) {
+	c.Lock()
+	defer c.Unlock()
+
+	c.license = license
+	c.ttl = ttl
+	c.cachedOn = time.Now()
 }

--- a/metricbeat/module/elasticsearch/elasticsearch.go
+++ b/metricbeat/module/elasticsearch/elasticsearch.go
@@ -206,7 +206,7 @@ func GetNodeInfo(http *helper.HTTP, uri string, nodeID string) (*NodeInfo, error
 }
 
 // GetLicense returns license information
-func GetLicense(http *helper.HTTP, resetURI string) (map[string]interface{}, error) {
+func GetLicense(http *helper.HTTP, resetURI string) (common.MapStr, error) {
 	// First, check the cache
 	license := licenseCache.get()
 
@@ -230,7 +230,7 @@ func GetLicense(http *helper.HTTP, resetURI string) (map[string]interface{}, err
 }
 
 // GetClusterState returns cluster state information
-func GetClusterState(http *helper.HTTP, resetURI string) (map[string]interface{}, error) {
+func GetClusterState(http *helper.HTTP, resetURI string) (common.MapStr, error) {
 	content, err := fetchPath(http, resetURI, "_cluster/state/version,master_node,nodes")
 	if err != nil {
 		return nil, err
@@ -242,7 +242,7 @@ func GetClusterState(http *helper.HTTP, resetURI string) (map[string]interface{}
 }
 
 // GetStackStats returns stack stats (usage) information
-func GetStackStats(http *helper.HTTP, resetURI string) (map[string]interface{}, error) {
+func GetStackStats(http *helper.HTTP, resetURI string) (common.MapStr, error) {
 	content, err := fetchPath(http, resetURI, "_xpack/usage")
 	if err != nil {
 		return nil, err

--- a/metricbeat/module/elasticsearch/elasticsearch.go
+++ b/metricbeat/module/elasticsearch/elasticsearch.go
@@ -205,7 +205,9 @@ func GetNodeInfo(http *helper.HTTP, uri string, nodeID string) (*NodeInfo, error
 	return nil, fmt.Errorf("no node matched id %s", nodeID)
 }
 
-// GetLicense returns license information
+// GetLicense returns license information. Since we don't expect license information
+// to change frequently, the information is cached for 1 minute to avoid
+// hitting Elasticsearch frequently
 func GetLicense(http *helper.HTTP, resetURI string) (common.MapStr, error) {
 	// First, check the cache
 	license := licenseCache.get()


### PR DESCRIPTION
This PR teaches the `elasticsearch/cluster_stats` metricset to query the appropriate Elasticsearch HTTP APIs and index `cluster_stats` documents into `.monitoring-es-6-mb-*` indices. These documents should be compatible in structure to `cluster_stats` documents in the current `.monitoring-es-6-*` indices indexed via the internal monitoring method.
