### PR TITLE
Add info to support cloud config

### DIFF
--- a/auditbeat/docs/getting-started.asciidoc
+++ b/auditbeat/docs/getting-started.asciidoc
@@ -168,17 +168,7 @@ If you accept the default configuration without specifying additional modules,
 +
 See <<configuring-howto-{beatname_lc}>> for more details about configuring modules.
 
-. If you are sending output to Elasticsearch (and not using Logstash), set the
-IP address and port where {beatname_uc} can find the Elasticsearch installation:
-+
-[source,yaml]
-----------------------------------------------------------------------
-output.elasticsearch:
-  hosts: ["127.0.0.1:9200"]
-----------------------------------------------------------------------
-+
-If you are sending output to Logstash, make sure you
-<<logstash-output,Configure the Logstash output>> instead.
+include::../../libbeat/docs/step-configure-output.asciidoc[]
 
 include::../../libbeat/docs/step-configure-kibana-endpoint.asciidoc[]
 
@@ -189,13 +179,13 @@ include::../../libbeat/docs/step-test-config.asciidoc[]
 include::../../libbeat/docs/step-look-at-config.asciidoc[]
 
 [id="{beatname_lc}-template"]
-=== Step 3: Load the index template in Elasticsearch
+=== Step 3: Load the index template in {es}
 
 :allplatforms:
 include::../../libbeat/docs/shared-template-load.asciidoc[]
 
 [[load-kibana-dashboards]]
-=== Step 4: Set up the Kibana dashboards
+=== Step 4: Set up the {kib} dashboards
 
 :allplatforms:
 include::../../libbeat/docs/dashboards.asciidoc[]
@@ -204,8 +194,8 @@ include::../../libbeat/docs/dashboards.asciidoc[]
 === Step 5: Start {beatname_uc}
 
 Run {beatname_uc} by issuing the appropriate command for your platform. If you
-are accessing a secured Elasticsearch cluster, make sure you've configured
-credentials as described in <<{beatname_lc}-configuration>>.
+are accessing a secured {es} cluster, make sure you've configured credentials as
+described in <<{beatname_lc}-configuration>>.
 
 NOTE: If you use an init.d script to start {beatname_uc} on deb or rpm, you can't
 specify command line flags (see <<command-line-options>>). To specify flags,
@@ -234,7 +224,7 @@ sudo ./{beatname_lc} -e -c {beatname_lc}.yml -d "publish"
 ----------------------------------------------------------------------
 <1> To monitor system files, you'll be running {beatname_uc} as root, so you
 need to change ownership of the configuration file, or run {beatname_uc} with
-`-strict.perms=false` specified. See
+`--strict.perms=false` specified. See
 {libbeat}/config-file-permissions.html[Config File Ownership and Permissions]
 in the _Beats Platform Reference_.
 
@@ -252,22 +242,22 @@ By default the log files are stored in +C:{backslash}ProgramData{backslash}{beat
 
 ==== Test the {beatname_uc} installation
 
-To verify that your server's statistics are present in Elasticsearch, issue
-the following command:
+To verify that your server's statistics are present in {es}, issue the following
+command:
 
 ["source","sh",subs="attributes"]
 ----------------------------------------------------------------------
 curl -XGET 'http://localhost:9200/{beatname_lc}-*/_search?pretty'
 ----------------------------------------------------------------------
 
-Make sure that you replace `localhost:9200` with the address of your
-Elasticsearch instance.
+Make sure that you replace `localhost:9200` with the address of your {es}
+instance.
 
 On Windows, if you don't have cURL installed, simply point your browser to the
 URL.
 
 [[view-kibana-dashboards]]
-=== Step 6: View the sample Kibana dashboards
+=== Step 6: View the sample {kib} dashboards
 
 To make it easier for you to start auditing the activities of users and
 processes on your system, we have created example {beatname_uc} dashboards.

--- a/filebeat/docs/filebeat-modules-options.asciidoc
+++ b/filebeat/docs/filebeat-modules-options.asciidoc
@@ -1,3 +1,5 @@
+:modulename: apache2 mysql
+
 [id="configuration-{beatname_lc}-modules"]
 == Specify which modules to run
 
@@ -39,10 +41,7 @@ under `modules.d` by running the
 For example, to enable the `apache2` and `mysql` configs in the `modules.d`
 directory, you use:
 
-["source","sh",subs="attributes"]
-----
-./{beatname_lc} modules enable apache2 mysql
-----
+include::./include/enable-modules-command.asciidoc[]
 
 Then when you run {beatname_uc}, it loads the corresponding module configurations
 specified in the `modules.d` directory (for example, `modules.d/apache2.yml` and
@@ -50,15 +49,12 @@ specified in the `modules.d` directory (for example, `modules.d/apache2.yml` and
 
 To see a list of enabled and disabled modules, run:
 
-["source","sh",subs="attributes"]
-----
-./{beatname_lc} modules list
-----
+include::./include/list-modules-command.asciidoc[]
 
 The default module configurations assume that the logs you’re harvesting are
 in the location expected for your OS and that the behavior of the module is
 appropriate for your environment. To change the default configurations, you need
-to specify variable settings. See <<specify-variable-settings>>.
+to <<specify-variable-settings,specify variable settings>>.
 
 [float]
 [[enable-modules-cli]]
@@ -72,18 +68,34 @@ along with any modules that are enabled in the configuration file or `modules.d`
 directory. If there's a conflict, the configuration specified at the command
 line is used.
 
-The following example shows how to enable and run the `nginx`,`mysql`, and
-`system` modules.
+The following command enables and runs the `nginx`,`mysql`, and `system`
+modules.
+
+*deb and rpm:*
 
 ["source","sh",subs="attributes"]
 ----
-./{beatname_lc} -e --modules nginx,mysql,system
+{beatname_lc} --modules nginx,mysql,system
+----
+
+*mac:*
+
+["source","sh",subs="attributes"]
+----
+./{beatname_lc} --modules nginx,mysql,system
+----
+
+*win:*
+
+["source","sh",subs="attributes"]
+----
+PS > .{backslash}{beatname_lc}.exe --modules nginx,mysql,system
 ----
 
 The default module configurations assume that the logs you’re harvesting are
 in the location expected for your OS and that the behavior of the module is
 appropriate for your environment. To change the default configurations, you need
-to specify variable settings. See <<specify-variable-settings>>.
+to <<specify-variable-settings,specify variable settings>>.
 
 [float]
 [[enable-modules-config-file]]
@@ -116,45 +128,12 @@ The following example shows a configuration that runs the `nginx`,`mysql`, and
 The default module configurations assume that the logs you’re harvesting are
 in the location expected for your OS and that the behavior of the module is
 appropriate for your environment. To change the default configurations, you need
-to specify variable settings. See <<specify-variable-settings>>.
+to <<specify-variable-settings,specify variable settings>>.
 
 [[specify-variable-settings]]
 === Specify variable settings
 
-Each module and fileset has variables that you can set to change the default
-behavior of the module, including the paths where the module looks for log
-files. For example, the `var.paths` setting in the following example sets the
-path for `nginx` access log files:
-
-[source,yaml]
-----
-- module: nginx
-  access:
-    var.paths: ["/var/log/nginx/access.log*"]
-----
-
-To set the path for Nginx access log files at the command line, you use
-the `-M` flag. For example:
-
-["source","shell",subs="attributes"]
-----
-./{beatname_lc} -M "nginx.access.var.paths=[/var/log/nginx/access.log*]"
-----
-
-When you set variables at the command line, the variable name needs to include
-the module and fileset name. You can specify multiple overrides. Each override
-must start with `-M`.
-
-Here you see how to use the `-M` flag along with the `--modules` flag. This
-example shows how to set the paths to the access and error logs:
-
-["source","sh",subs="attributes"]
-----
-./{beatname_lc} --modules nginx -M "nginx.access.var.paths=[/var/log/nginx/access.log*]" -M "nginx.error.var.paths=[/var/log/nginx/error.log*]"
-----
-
-For information about specific variables that you can set for each fileset,
-see the <<{beatname_lc}-modules,documentation for the modules>>.
+include::./include/set-paths.asciidoc[]
 
 [[advanced-settings]]
 === Advanced settings
@@ -172,35 +151,28 @@ configuration:
       close_eof: true
 ----------------------------------------------------------------------
 
-Or at the command line like this:
+Or at the command line when you run {beatname_uc}:
 
 ["source","sh",subs="attributes"]
 ----------------------------------------------------------------------
-./{beatname_lc} -M "nginx.access.input.close_eof=true"
+-M "nginx.access.input.close_eof=true"
 ----------------------------------------------------------------------
-
-
-Here you see how to use the `-M` flag along with the `--modules` flag:
-
-["source","sh",subs="attributes"]
-----------------------------------------------------------------------
-./{beatname_lc} --modules nginx -M "nginx.access.input.close_eof=true"
-----------------------------------------------------------------------
-
 
 You can use wildcards to change variables or settings for multiple
-modules/filesets at once. For example, the following command enables
-`close_eof` for all the filesets in the `nginx` module:
+modules/filesets at once. For example, you can enable `close_eof` for all the
+filesets in the `nginx` module:
 
 ["source","sh",subs="attributes"]
 ----------------------------------------------------------------------
-./{beatname_lc} -M "nginx.*.input.close_eof=true"
+-M "nginx.*.input.close_eof=true"
 ----------------------------------------------------------------------
 
-The following command enables `close_eof` for all inputs created by any of
-the modules:
+You can also enable `close_eof` for all inputs created by any of the modules:
 
 ["source","sh",subs="attributes"]
 ----------------------------------------------------------------------
-./{beatname_lc} -M "*.*.input.close_eof=true"
+-M "*.*.input.close_eof=true"
 ----------------------------------------------------------------------
+
+:modulename!:
+

--- a/filebeat/docs/getting-started.asciidoc
+++ b/filebeat/docs/getting-started.asciidoc
@@ -130,11 +130,9 @@ endif::[]
 === Step 2: Configure Filebeat
 
 TIP: <<filebeat-modules-overview,Filebeat modules>> provide the fastest getting
-started experience for common log formats. See <<filebeat-modules-quickstart>>
-to learn how to get started with modules. If you use Filebeat modules to get
-started, you can skip the content in this section, including the remaining
-getting started steps, and go directly to the <<filebeat-modules-quickstart>>
-page.
+started experience for common log formats. If you want use Filebeat modules,
+skip this section, including the remaining getting started steps, and go
+directly to <<filebeat-modules-quickstart>>.
 
 include::../../libbeat/docs/shared-configuring.asciidoc[]
 
@@ -175,17 +173,7 @@ To fetch all files from a predefined level of subdirectories, the following patt
 fetch log files from the `/var/log` folder itself. Currently it is not possible to recursively
 fetch all files in all subdirectories of a directory.
 
-. If you are sending output directly to Elasticsearch (and not using Logstash),
-set the IP address and port where Filebeat can find the Elasticsearch installation:
-+
-[source,yaml]
-----------------------------------------------------------------------
-output.elasticsearch:
-  hosts: ["192.168.1.42:9200"]
-----------------------------------------------------------------------
-+
-If you are sending output to Logstash, make sure you
-configure the Logstash output in <<config-filebeat-logstash>>.
+include::../../libbeat/docs/step-configure-output.asciidoc[]
 
 include::../../libbeat/docs/step-configure-kibana-endpoint.asciidoc[]
 

--- a/filebeat/docs/include/config-option-intro.asciidoc
+++ b/filebeat/docs/include/config-option-intro.asciidoc
@@ -2,11 +2,9 @@
 [id="{modulename}-settings"]
 ==== Variable settings
 
-The +{modulename}+ module provides the following settings for configuring the
-behavior of the module. Each fileset has separate settings.
-
-If you don’t specify variable settings, the +{modulename}+ module uses the
-defaults.
+Each fileset has separate variable settings for configuring the behavior of the
+module. If you don’t specify variable settings, the +{modulename}+ module uses
+the defaults.
 
 For more information, see <<specify-variable-settings>>. Also see
 <<advanced-settings>>.

--- a/filebeat/docs/include/enable-modules-command.asciidoc
+++ b/filebeat/docs/include/enable-modules-command.asciidoc
@@ -1,0 +1,23 @@
+--
+*deb and rpm:*
+
+["source","sh",subs="attributes"]
+----
+{beatname_lc} modules enable {modulename}
+----
+
+*mac:*
+
+["source","sh",subs="attributes"]
+----
+./{beatname_lc} modules enable {modulename}
+----
+
+*win:*
+
+["source","sh",subs="attributes"]
+----
+PS > .{backslash}{beatname_lc}.exe modules enable {modulename}
+----
+
+--

--- a/filebeat/docs/include/list-modules-command.asciidoc
+++ b/filebeat/docs/include/list-modules-command.asciidoc
@@ -1,0 +1,22 @@
+--
+*deb and rpm:*
+
+["source","sh",subs="attributes"]
+----
+{beatname_lc} modules list
+----
+
+*mac:*
+
+["source","sh",subs="attributes"]
+----
+./{beatname_lc} modules list
+----
+
+*win:*
+
+["source","sh",subs="attributes"]
+----
+PS > .{backslash}{beatname_lc}.exe modules list
+----
+--

--- a/filebeat/docs/include/run-command.asciidoc
+++ b/filebeat/docs/include/run-command.asciidoc
@@ -1,0 +1,31 @@
+--
+*deb and rpm:*
+
+["source","sh",subs="attributes"]
+----
+service {beatname_lc} start
+----
+
+*mac:*
+
+["source","sh",subs="attributes"]
+----
+./{beatname_lc} -e
+----
+
+*win:*
+
+["source","sh",subs="attributes"]
+----
+PS > Start-Service {beatname_lc}
+----
+
+If the module is configured correctly, you'll see
+`INFO Harvester started` messages for each file specified in the config.
+
+NOTE: Depending on how you've installed {beatname_uc}, you might see errors
+related to file ownership or permissions when you try to run {beatname_uc}
+modules. See {libbeat}/config-file-permissions.html[Config File Ownership and
+Permissions] in the _Beats Platform Reference_ for more information.
+
+--

--- a/filebeat/docs/include/running-modules.asciidoc
+++ b/filebeat/docs/include/running-modules.asciidoc
@@ -1,143 +1,43 @@
+:has_module_steps:
+
 [float]
 [id="running-{modulename}-modules"]
 === Set up and run the module
 
-// REVIEWERS: Should we include docker commands here, too?
-
-IMPORTANT: If you’ve secured {es} and {kib}, you need to configure the
-`username` and `password` options in the {es} output before setting up
-and running the module. See
-<<elasticsearch-output,Configure the {es} output>>.
-
 Before doing these steps, verify that {es} and {kib} are running and
 that {es} is ready to receive data from {beatname_uc}.
+
+If you're running our
+https://www.elastic.co/cloud/elasticsearch-service[hosted {es} Service] on
+Elastic Cloud, or you've enabled security in {es} and {kib}, you need to specify
+additional connection information before setting up and running the module. See
+<<filebeat-modules-quickstart>> for the complete setup.
 
 To set up and run the module:
 
 . Enable the module:
 +
-*deb and rpm:*
+include::./enable-modules-command.asciidoc[]
 +
-["source","sh",subs="attributes"]
-----
-{beatname_lc} modules enable {modulename}
-----
-+
-*mac:*
-+
-["source","sh",subs="attributes"]
-----
-./{beatname_lc} modules enable {modulename}
-----
-+
-*win:*
-+
-["source","sh",subs="attributes"]
-----
-PS > .{backslash}{beatname_lc}.exe modules enable {modulename}
-----
-+
-The <<modules-command,`modules enable`>> command enables the +{modulename}+
-config defined in the `modules.d` directory. See
+This command enables the module config defined in the `modules.d` directory. See
 <<configuration-{beatname_lc}-modules>> for other ways to enable modules.
 +
 To see a list of enabled and disabled modules, run:
 +
-*deb and rpm:*
-+
-["source","sh",subs="attributes"]
-----
-{beatname_lc} modules list
-----
-+
-*mac:*
-+
-["source","sh",subs="attributes"]
-----
-./{beatname_lc} modules list
-----
-+
-*win:*
-+
-["source","sh",subs="attributes"]
-----
-PS > .{backslash}{beatname_lc}.exe modules list
-----
+include::./list-modules-command.asciidoc[]
 
 . Set up the initial environment:
 +
-*deb and rpm:*
-+
-["source","sh",subs="attributes"]
-----
-{beatname_lc} setup -e
-----
-+
-*mac:*
-+
-["source","sh",subs="attributes"]
-----
-./{beatname_lc} setup -e
-----
-+
-*win:*
-+
-["source","sh",subs="attributes"]
-----
-PS > .{backslash}{beatname_lc}.exe setup -e
-----
-+
-The <<setup-command,`setup`>> command loads the recommended index template for
-writing to {es} and deploys the sample dashboards for visualizing the
-data in {kib}. This is a one-time setup step. 
-+
-The `-e` flag is optional and sends output to standard error instead of syslog.
+include::./setup-command.asciidoc[]
 
-. Run {beatname_uc}:
-+
-*deb and rpm:*
-+
-["source","sh",subs="attributes"]
-----
-service {beatname_lc} start
-----
-+
-*mac:*
-+
-["source","sh",subs="attributes"]
-----
-./{beatname_lc} -e
-----
-+
-*win:*
-+
-["source","sh",subs="attributes"]
-----
-PS > Start-Service {beatname_lc}
-----
-+
-If the module is configured correctly, you'll see
-`INFO Harvester started` messages for each file specified in the config.
+. Run {beatname_uc}.
 +
 If your logs aren't in the default location, see
 <<configuring-{modulename}-module>>, then run {beatname_uc} after you've
-configured the module.
+set the paths variable.
 +
-NOTE: Depending on how you've installed Filebeat, you might see errors
-related to file ownership or permissions when you try to run Filebeat modules.
-See {libbeat}/config-file-permissions.html[Config File Ownership and Permissions]
-in the _Beats Platform Reference_ if you encounter errors related to file
-ownership or permissions. 
+include::./run-command.asciidoc[]
 
-. Explore your data in {kib}:
-.. Open your browser and navigate to the *Dashboard* overview in {kib}:
-http://localhost:5601/app/kibana#/dashboards[http://localhost:5601/app/kibana#/dashboards].
-Replace `localhost` with the name of the {kib} host. If you're using an
-https://cloud.elastic.co/[Elastic Cloud] instance, log in to your cloud account,
-then navigate to the {kib} endpoint in your deployment.
-.. If necessary, log in with your {kib} username and password.
-.. Enter *{modulename}* in the search box, then open a dashboard and explore
-the visualizations for your parsed logs.
-+
-TIP: If you don’t see data in {kib}, try changing the date range to a larger
-range. By default, {kib} shows the last 15 minutes.
+include::./visualize-data.asciidoc[]
+
+:has_module_steps!:

--- a/filebeat/docs/include/running-modules.asciidoc
+++ b/filebeat/docs/include/running-modules.asciidoc
@@ -2,22 +2,40 @@
 [id="running-{modulename}-modules"]
 === Set up and run the module
 
-IMPORTANT: If you’ve secured Elasticsearch and Kibana, you need to configure the
-`username` and `password` options in the Elasticsearch output before setting up
-and running the module. See
-<<elasticsearch-output,Configure the Elasticsearch output>>.
+// REVIEWERS: Should we include docker commands here, too?
 
-Before doing these steps, verify that Elasticsearch and Kibana are running and
-that Elasticsearch is ready to receive data from {beatname_uc}.
+IMPORTANT: If you’ve secured {es} and {kib}, you need to configure the
+`username` and `password` options in the {es} output before setting up
+and running the module. See
+<<elasticsearch-output,Configure the {es} output>>.
+
+Before doing these steps, verify that {es} and {kib} are running and
+that {es} is ready to receive data from {beatname_uc}.
 
 To set up and run the module:
 
 . Enable the module:
 +
+*deb and rpm:*
++
 ["source","sh",subs="attributes"]
-----------------------------------------------------------------------
+----
+{beatname_lc} modules enable {modulename}
+----
++
+*mac:*
++
+["source","sh",subs="attributes"]
+----
 ./{beatname_lc} modules enable {modulename}
-----------------------------------------------------------------------
+----
++
+*win:*
++
+["source","sh",subs="attributes"]
+----
+PS > .{backslash}{beatname_lc}.exe modules enable {modulename}
+----
 +
 The <<modules-command,`modules enable`>> command enables the +{modulename}+
 config defined in the `modules.d` directory. See
@@ -25,31 +43,78 @@ config defined in the `modules.d` directory. See
 +
 To see a list of enabled and disabled modules, run:
 +
+*deb and rpm:*
++
 ["source","sh",subs="attributes"]
------
+----
+{beatname_lc} modules list
+----
++
+*mac:*
++
+["source","sh",subs="attributes"]
+----
 ./{beatname_lc} modules list
------
-
+----
++
+*win:*
++
+["source","sh",subs="attributes"]
+----
+PS > .{backslash}{beatname_lc}.exe modules list
+----
 
 . Set up the initial environment:
 +
+*deb and rpm:*
++
 ["source","sh",subs="attributes"]
-----------------------------------------------------------------------
+----
+{beatname_lc} setup -e
+----
++
+*mac:*
++
+["source","sh",subs="attributes"]
+----
 ./{beatname_lc} setup -e
-----------------------------------------------------------------------
+----
++
+*win:*
++
+["source","sh",subs="attributes"]
+----
+PS > .{backslash}{beatname_lc}.exe setup -e
+----
 +
 The <<setup-command,`setup`>> command loads the recommended index template for
-writing to Elasticsearch and deploys the sample dashboards for visualizing the
-data in Kibana. This is a one-time setup step. 
+writing to {es} and deploys the sample dashboards for visualizing the
+data in {kib}. This is a one-time setup step. 
 +
 The `-e` flag is optional and sends output to standard error instead of syslog.
 
 . Run {beatname_uc}:
 +
+*deb and rpm:*
++
 ["source","sh",subs="attributes"]
------
+----
+service {beatname_lc} start
+----
++
+*mac:*
++
+["source","sh",subs="attributes"]
+----
 ./{beatname_lc} -e
------
+----
++
+*win:*
++
+["source","sh",subs="attributes"]
+----
+PS > Start-Service {beatname_lc}
+----
 +
 If the module is configured correctly, you'll see
 `INFO Harvester started` messages for each file specified in the config.
@@ -64,14 +129,15 @@ See {libbeat}/config-file-permissions.html[Config File Ownership and Permissions
 in the _Beats Platform Reference_ if you encounter errors related to file
 ownership or permissions. 
 
-. Explore your data in Kibana:
-.. Open your browser and navigate to the *Dashboard* overview in Kibana:
+. Explore your data in {kib}:
+.. Open your browser and navigate to the *Dashboard* overview in {kib}:
 http://localhost:5601/app/kibana#/dashboards[http://localhost:5601/app/kibana#/dashboards].
-Replace `localhost` with the name of the Kibana host.
-.. If security is enabled, log in with the Kibana username and password that you
-used when you set up security.
+Replace `localhost` with the name of the {kib} host. If you're using an
+https://cloud.elastic.co/[Elastic Cloud] instance, log in to your cloud account,
+then navigate to the {kib} endpoint in your deployment.
+.. If necessary, log in with your {kib} username and password.
 .. Enter *{modulename}* in the search box, then open a dashboard and explore
 the visualizations for your parsed logs.
 +
-TIP: If you don’t see data in Kibana, try changing the date range to a larger
-range. By default, Kibana shows the last 15 minutes.
+TIP: If you don’t see data in {kib}, try changing the date range to a larger
+range. By default, {kib} shows the last 15 minutes.

--- a/filebeat/docs/include/set-paths.asciidoc
+++ b/filebeat/docs/include/set-paths.asciidoc
@@ -1,0 +1,45 @@
+Each module and fileset has variables that you can set to change the default
+behavior of the module, including the paths where the module looks for log
+files. You can set the path in configuration or from the command line. For
+example:
+
+[source,yaml]
+----
+- module: nginx
+  access:
+    var.paths: ["/var/log/nginx/access.log*"] <1> 
+----
+<1> Sets the path for `nginx` access log files.
+
+To set the path at the command line, use the `-M` flag. The variable name
+must include the module and fileset name. For example:
+
+*deb and rpm:*
+
+["source","sh",subs="attributes"]
+----
+{beatname_lc} -e -M "nginx.access.var.paths=[/var/log/nginx/access.log*]"
+----
+
+*mac:*
+
+["source","sh",subs="attributes"]
+----
+./{beatname_lc} -e -M "nginx.access.var.paths=[/usr/local/var/log/nginx/access.log*]"
+----
+
+*win:*
+
+["source","sh",subs="attributes"]
+----
+PS > .{backslash}{beatname_lc}.exe -e -M "nginx.access.var.paths=[c:/programdata/nginx/logs/*access.log*]"
+----
+
+You can specify multiple overrides. Each override must start with `-M`. 
+
+If you are running {beatname_uc} as a service, you cannot set paths from the
+command line. You must set the `var.paths` option in the module configuration
+file.
+
+For information about specific variables that you can set for each fileset,
+see the <<{beatname_lc}-modules,documentation for the modules>>.

--- a/filebeat/docs/include/setup-command.asciidoc
+++ b/filebeat/docs/include/setup-command.asciidoc
@@ -1,0 +1,28 @@
+--
+*deb and rpm:*
+
+["source","sh",subs="attributes"]
+----
+{beatname_lc} setup -e
+----
+
+*mac:*
+
+["source","sh",subs="attributes"]
+----
+./{beatname_lc} setup -e
+----
+
+*win:*
+
+["source","sh",subs="attributes"]
+----
+PS > .{backslash}{beatname_lc}.exe setup -e
+----
+
+The <<setup-command,`setup`>> command loads the recommended index template for
+writing to {es} and deploys the sample dashboards for visualizing the
+data in {kib}. This is a one-time setup step. 
+
+The `-e` flag is optional and sends output to standard error instead of syslog.
+--

--- a/filebeat/docs/include/visualize-data.asciidoc
+++ b/filebeat/docs/include/visualize-data.asciidoc
@@ -1,0 +1,13 @@
+. Explore your data in {kib}:
++
+.. Open your browser and navigate to the *Dashboard* overview in {kib}:
+http://localhost:5601/app/kibana#/dashboards[http://localhost:5601/app/kibana#/dashboards].
+Replace `localhost` with the name of the {kib} host. If you're using an
+https://cloud.elastic.co/[Elastic Cloud] instance, log in to your cloud account,
+then navigate to the {kib} endpoint in your deployment.
+.. If necessary, log in with your {kib} username and password.
+.. Enter the module name in the search box, then open a dashboard and explore
+the visualizations for your parsed logs.
++
+TIP: If you don’t see data in {kib}, try changing the date range to a larger
+range. By default, {kib} shows the last 15 minutes.

--- a/filebeat/docs/modules-getting-started.asciidoc
+++ b/filebeat/docs/modules-getting-started.asciidoc
@@ -1,35 +1,39 @@
-[[filebeat-modules-quickstart]]
-=== Quick start for common log formats
+:has_module_steps:
 
-Filebeat provides a set of pre-built modules that you can use to rapidly
+[[filebeat-modules-quickstart]]
+=== Quick start: modules for common log formats
+
+// REVIEWERS: Should we include docker commands here, too?
+
+{beatname_uc} provides a set of pre-built modules that you can use to rapidly
 implement and deploy a log monitoring solution, complete with sample dashboards
 and data visualizations, in about 5 minutes. These modules support common log
 formats, such as Nginx, Apache2, and MySQL, and can be run by issuing a simple
 command.
 
-This topic shows you how to run the basic modules out of the box without extra
+This topic shows you how to run the basic modules with minimal extra
 configuration. For detailed documentation and the full list of available
 modules, see <<filebeat-modules>>.
 
 If you are using a log file type that isn't supported by one of the available
-Filebeat modules, you'll need to set up and configure Filebeat manually by
+{beatname_uc} modules, you'll need to set up and configure {beatname_uc} manually by
 following the numbered steps under <<filebeat-getting-started>>.
 
 ==== Prerequisites
 
-Before running Filebeat modules, you need to:
+Before running {beatname_uc} modules, you need to:
 
 * Install and configure the Elastic stack. See
 {stack-ov}/get-started-elastic-stack.html[Getting started with the {stack}].
 
-* Complete the Filebeat installation instructions described in
-<<filebeat-installation>>. After installing Filebeat, return to this
+* Complete the {beatname_uc} installation instructions described in
+<<filebeat-installation>>. After installing {beatname_uc}, return to this
 quick start page.
 
 * Install the Ingest Node GeoIP and User Agent plugins. These plugins are
 required to capture the geographical location and browser information used by
 some of the visualizations available in the sample dashboards. You can install
-these plugins by running the following commands in the Elasticsearch home path:
+these plugins by running the following commands in the {es} home path:
 +
 [source,shell]
 ----------------------------------------------------------------------
@@ -37,88 +41,178 @@ sudo bin/elasticsearch-plugin install ingest-geoip
 sudo bin/elasticsearch-plugin install ingest-user-agent
 ----------------------------------------------------------------------
 +
-You need to restart Elasticsearch after running these commands.
+You need to restart {es} after running these commands.
 +
 If you are using an https://cloud.elastic.co/[Elastic Cloud] instance, you can
 enable the two plugins from the configuration page.
 
-* Verify that Elasticsearch and Kibana are running and that Elasticsearch is
-ready to receive data from Filebeat.
+* Verify that {es} and {kib} are running and that {es} is
+ready to receive data from {beatname_uc}.
 
 [[running-modules-quickstart]]
-==== Running Filebeat modules
+==== Running {beatname_uc} modules
 
-To set up and run Filebeat modules:
+To set up and run {beatname_uc} modules:
+
+. In the +{beatname_lc}.yml+ config file, set the location of the {es}
+installation. By default, {beatname_uc} assumes {es} is running locally on port
+9200.
++
+include::../../libbeat/docs/step-configure-output.asciidoc[]
 
 include::../../libbeat/docs/step-configure-credentials.asciidoc[]
 
-. Run the `setup` command to set up the initial environment. This command
-loads the recommended index template for writing to Elasticsearch and deploys
-the sample dashboards for visualizing the data in Kibana. For example:
+. Enable the modules you want to run. For example, the following command enables
+the system, nginx, and mysql modules:
 +
-[source,shell]
-----------------------------------------------------------------------
-./filebeat setup -e
-----------------------------------------------------------------------
+*deb and rpm:*
++
+["source","sh",subs="attributes"]
+----
+{beatname_lc} modules enable system nginx mysql
+----
++
+*mac:*
++
+["source","sh",subs="attributes"]
+----
+./{beatname_lc} modules enable system nginx mysql
+----
++
+*win:*
++
+["source","sh",subs="attributes"]
+----
+PS > .{backslash}{beatname_lc}.exe modules enable system nginx mysql
+----
++
+The <<modules-command,`modules enable`>> command enables the module configs
+defined in the `modules.d` directory. See
+<<configuration-{beatname_lc}-modules>> for other ways to enable modules.
++
+To see a list of enabled and disabled modules, run:
++
+*deb and rpm:*
++
+["source","sh",subs="attributes"]
+----
+{beatname_lc} modules list
+----
++
+*mac:*
++
+["source","sh",subs="attributes"]
+----
+./{beatname_lc} modules list
+----
++
+*win:*
++
+["source","sh",subs="attributes"]
+----
+PS > .{backslash}{beatname_lc}.exe modules list
+----
+
+. Set up the initial environment:
++
+*deb and rpm:*
++
+["source","sh",subs="attributes"]
+----
+{beatname_lc} setup -e
+----
++
+*mac:*
++
+["source","sh",subs="attributes"]
+----
+./{beatname_lc} setup -e
+----
++
+*win:*
++
+["source","sh",subs="attributes"]
+----
+PS > .{backslash}{beatname_lc}.exe setup -e
+----
++
+The <<setup-command,`setup`>> command loads the recommended index template for
+writing to {es} and deploys the sample dashboards for visualizing the
+data in {kib}. This is a one-time setup step. 
 +
 The `-e` flag is optional and sends output to standard error instead of syslog.
 
-. Start Filebeat and use the `--modules` flag to specify a comma-separated list
-of modules you want to run. The following example starts Filebeat with the
-`system` module enabled (it's assumed that you've already loaded the sample
-dashboards):
+. Run {beatname_uc}:
 +
-[source,shell]
-----------------------------------------------------------------------
-./filebeat -e --modules system
-----------------------------------------------------------------------
+*deb and rpm:*
 +
-This command takes care of configuring Filebeat and loading the ingest node
-pipelines and other configuration settings required to parse the log files.
+["source","sh",subs="attributes"]
+----
+service {beatname_lc} start
+----
 +
-To run more than one module, specify a comma-separated list of modules. For
-example:
+*mac:*
 +
-[source,shell]
-----------------------------------------------------------------------
-./filebeat -e --modules system,nginx,mysql
-----------------------------------------------------------------------
+["source","sh",subs="attributes"]
+----
+./{beatname_lc} -e
+----
 +
-When you start Filebeat, you should see messages indicating that Filebeat
-has started harvesters for all enabled modules. For example:
+*win:*
 +
-[source,shell]
-----------------------------------------------------------------------
-2017/08/16 23:39:15.414375 harvester.go:206: INFO Harvester started for file: /var/log/displaypolicyd.stdout.log
-----------------------------------------------------------------------
+["source","sh",subs="attributes"]
+----
+PS > Start-Service {beatname_lc}
+----
 +
-If you don't see this message for each log file that needs to be read,
-see <<setting-variables>> to find out how to set the path the files.
-
-NOTE: Depending on how you've installed Filebeat, you might see errors
-related to file ownership or permissions when you try to run Filebeat modules.
+If the module is configured correctly, you'll see
+`INFO Harvester started` messages for each file specified in the config.
++
+If your logs aren't in the default location, see <<setting-variables>> to find
+out how to set the path the files, then run {beatname_uc} after you've
+configured the module.
++
+NOTE: Depending on how you've installed {beatname_uc}, you might see errors
+related to file ownership or permissions when you try to run {beatname_uc} modules.
 See {libbeat}/config-file-permissions.html[Config File Ownership and Permissions]
 in the _Beats Platform Reference_ if you encounter errors related to file
-ownership or permissions.
-
-This getting started guide uses the `--modules` flag to enable modules
-at the command line when you run Filebeat. In a production environment, you'll
-probably want to use the configs in the `modules.d` directory instead. See
-<<configuration-filebeat-modules>> for more information.
+ownership or permissions. 
 
 [[setting-variables]]
 ==== Set the path variable
 
 The examples here assume that the logs you're harvesting are in the location
-expected for your OS and that the default behavior of Filebeat is appropriate
+expected for your OS and that the default behavior of {beatname_uc} is appropriate
 for your environment. Each module provides variables that you can set to fine
-tune the behavior of Filebeat, including the location where it looks for log
+tune the behavior of {beatname_uc}, including the location where it looks for log
 files. For example, the following command sets the path for the Nginx access
-logs:
+logs. For this command to work, the `nginx` module must be enabled.
 
-[source,shell]
+// REVIEWERS: I want to provide platform-specific examples, but I'm not sure
+// what theses commands look like for deb/rpm/windows. I assume we want to
+// tell users to start the service, but I don't think options like -M are
+// allowed when you start as a service. Are they? Hoping someone with
+// deb/rpm/windows experience can help me get the syntax right here.
+
+*deb and rpm:*
+
+["source","sh",subs="attributes"]
 ----
-./filebeat -e --modules nginx -M "nginx.access.var.paths=[/var/log/nginx/access.log*]"
+TBD
+----
+
+*mac:*
+
+["source","sh",subs="attributes"]
+----
+./{beatname_lc} -e -M "nginx.access.var.paths=[/var/log/nginx/access.log*]"
+----
+
+*win:*
+
+["source","sh",subs="attributes"]
+----
+PS > TBD
 ----
 
 See <<configuration-filebeat-modules>> for more information about setting
@@ -126,16 +220,19 @@ variables and advanced options.
 
 
 [[visualizing-data]]
-==== Visualize the data in Kibana
+==== Visualize the data in {kib}
 
-After you've confirmed that Filebeat is sending events to Elasticsearch, launch
-the Kibana web interface by pointing your browser to port 5601. For example,
-http://127.0.0.1:5601[http://127.0.0.1:5601].
+After confirming that {beatname_uc} is sending events to {es}, open your
+browser and navigate to the Dashboard overview in {kib}. For example:
+http://localhost:5601/app/kibana#/dashboards. Replace `localhost` with the name
+of the {kib} host. If you are using an https://cloud.elastic.co/[Elastic Cloud]
+instance, navigate to the {kib} endpoint and log in.
 
-Open the dashboard and explore the visualizations for your parsed logs.
+Open the dashboards for any modules that you've configured, and explore the
+visualizations for your parsed logs.
 
-TIP: If you don't see data in Kibana, try changing the date range to a larger
-range. By default, Kibana shows the last 15 minutes.
+TIP: If you don't see data in {kib}, try changing the date range to a larger
+range. By default, {kib} shows the last 15 minutes.
 
 Here's an example of the syslog dashboard:
 

--- a/filebeat/docs/modules-getting-started.asciidoc
+++ b/filebeat/docs/modules-getting-started.asciidoc
@@ -1,9 +1,8 @@
 :has_module_steps:
+:modulename: system nginx mysql
 
 [[filebeat-modules-quickstart]]
 === Quick start: modules for common log formats
-
-// REVIEWERS: Should we include docker commands here, too?
 
 {beatname_uc} provides a set of pre-built modules that you can use to rapidly
 implement and deploy a log monitoring solution, complete with sample dashboards
@@ -21,7 +20,7 @@ following the numbered steps under <<filebeat-getting-started>>.
 
 ==== Prerequisites
 
-Before running {beatname_uc} modules, you need to:
+Before running {beatname_uc} modules:
 
 * Install and configure the Elastic stack. See
 {stack-ov}/get-started-elastic-stack.html[Getting started with the {stack}].
@@ -65,175 +64,48 @@ include::../../libbeat/docs/step-configure-credentials.asciidoc[]
 . Enable the modules you want to run. For example, the following command enables
 the system, nginx, and mysql modules:
 +
-*deb and rpm:*
+include::./include/enable-modules-command.asciidoc[]
 +
-["source","sh",subs="attributes"]
-----
-{beatname_lc} modules enable system nginx mysql
-----
-+
-*mac:*
-+
-["source","sh",subs="attributes"]
-----
-./{beatname_lc} modules enable system nginx mysql
-----
-+
-*win:*
-+
-["source","sh",subs="attributes"]
-----
-PS > .{backslash}{beatname_lc}.exe modules enable system nginx mysql
-----
-+
-The <<modules-command,`modules enable`>> command enables the module configs
-defined in the `modules.d` directory. See
+This command enables the module configs defined in the `modules.d` directory. See
 <<configuration-{beatname_lc}-modules>> for other ways to enable modules.
 +
 To see a list of enabled and disabled modules, run:
 +
-*deb and rpm:*
-+
-["source","sh",subs="attributes"]
-----
-{beatname_lc} modules list
-----
-+
-*mac:*
-+
-["source","sh",subs="attributes"]
-----
-./{beatname_lc} modules list
-----
-+
-*win:*
-+
-["source","sh",subs="attributes"]
-----
-PS > .{backslash}{beatname_lc}.exe modules list
-----
+include::./include/list-modules-command.asciidoc[]
 
 . Set up the initial environment:
 +
-*deb and rpm:*
-+
-["source","sh",subs="attributes"]
-----
-{beatname_lc} setup -e
-----
-+
-*mac:*
-+
-["source","sh",subs="attributes"]
-----
-./{beatname_lc} setup -e
-----
-+
-*win:*
-+
-["source","sh",subs="attributes"]
-----
-PS > .{backslash}{beatname_lc}.exe setup -e
-----
-+
-The <<setup-command,`setup`>> command loads the recommended index template for
-writing to {es} and deploys the sample dashboards for visualizing the
-data in {kib}. This is a one-time setup step. 
-+
-The `-e` flag is optional and sends output to standard error instead of syslog.
+include::./include/setup-command.asciidoc[]
 
-. Run {beatname_uc}:
+. Run {beatname_uc}.
 +
-*deb and rpm:*
+If your logs aren't in the default location, 
+<<setting-variables,set the paths variable>> before running {beatname_uc}.
 +
-["source","sh",subs="attributes"]
-----
-service {beatname_lc} start
-----
-+
-*mac:*
-+
-["source","sh",subs="attributes"]
-----
-./{beatname_lc} -e
-----
-+
-*win:*
-+
-["source","sh",subs="attributes"]
-----
-PS > Start-Service {beatname_lc}
-----
-+
-If the module is configured correctly, you'll see
-`INFO Harvester started` messages for each file specified in the config.
-+
-If your logs aren't in the default location, see <<setting-variables>> to find
-out how to set the path the files, then run {beatname_uc} after you've
-configured the module.
-+
-NOTE: Depending on how you've installed {beatname_uc}, you might see errors
-related to file ownership or permissions when you try to run {beatname_uc} modules.
-See {libbeat}/config-file-permissions.html[Config File Ownership and Permissions]
-in the _Beats Platform Reference_ if you encounter errors related to file
-ownership or permissions. 
+include::./include/run-command.asciidoc[]
+
+include::./include/visualize-data.asciidoc[]
+
+[[example-dashboard]]
+==== Example dashboard
+
+Here's an example of the syslog dashboard:
+
+image:./images/kibana-system.png[Syslog dashboard]
+
 
 [[setting-variables]]
-==== Set the path variable
+==== Set the paths variable
 
 The examples here assume that the logs you're harvesting are in the location
 expected for your OS and that the default behavior of {beatname_uc} is appropriate
-for your environment. Each module provides variables that you can set to fine
-tune the behavior of {beatname_uc}, including the location where it looks for log
-files. For example, the following command sets the path for the Nginx access
-logs. For this command to work, the `nginx` module must be enabled.
+for your environment. 
 
-// REVIEWERS: I want to provide platform-specific examples, but I'm not sure
-// what theses commands look like for deb/rpm/windows. I assume we want to
-// tell users to start the service, but I don't think options like -M are
-// allowed when you start as a service. Are they? Hoping someone with
-// deb/rpm/windows experience can help me get the syntax right here.
-
-*deb and rpm:*
-
-["source","sh",subs="attributes"]
-----
-TBD
-----
-
-*mac:*
-
-["source","sh",subs="attributes"]
-----
-./{beatname_lc} -e -M "nginx.access.var.paths=[/var/log/nginx/access.log*]"
-----
-
-*win:*
-
-["source","sh",subs="attributes"]
-----
-PS > TBD
-----
+include::./include/set-paths.asciidoc[]
 
 See <<configuration-filebeat-modules>> for more information about setting
 variables and advanced options.
 
 
-[[visualizing-data]]
-==== Visualize the data in {kib}
-
-After confirming that {beatname_uc} is sending events to {es}, open your
-browser and navigate to the Dashboard overview in {kib}. For example:
-http://localhost:5601/app/kibana#/dashboards. Replace `localhost` with the name
-of the {kib} host. If you are using an https://cloud.elastic.co/[Elastic Cloud]
-instance, navigate to the {kib} endpoint and log in.
-
-Open the dashboards for any modules that you've configured, and explore the
-visualizations for your parsed logs.
-
-TIP: If you don't see data in {kib}, try changing the date range to a larger
-range. By default, {kib} shows the last 15 minutes.
-
-Here's an example of the syslog dashboard:
-
-image:./images/kibana-system.png[Syslog dashboard]
+:has_module_steps!:
+:modulename!:

--- a/filebeat/docs/modules/apache2.asciidoc
+++ b/filebeat/docs/modules/apache2.asciidoc
@@ -56,7 +56,7 @@ To specify the same settings at the command line, you use:
 
 ["source","sh",subs="attributes"]
 -----
-./{beatname_lc} --modules {modulename} -M "apache2.access.var.paths=[/path/to/apache2/access.log*]" -M "apache2.error.var.paths=[/path/to/log/apache2/error.log*]"
+-M "apache2.access.var.paths=[/path/to/apache2/access.log*]" -M "apache2.error.var.paths=[/path/to/log/apache2/error.log*]"
 -----
 
 

--- a/filebeat/docs/modules/auditd.asciidoc
+++ b/filebeat/docs/modules/auditd.asciidoc
@@ -50,7 +50,7 @@ To specify the same settings at the command line, you use:
 
 ["source","sh",subs="attributes"]
 -----
-./{beatname_lc} --modules {modulename} -M "auditd.log.var.paths=[/path/to/log/audit/audit.log*]"
+-M "auditd.log.var.paths=[/path/to/log/audit/audit.log*]"
 -----
 
 

--- a/filebeat/docs/modules/icinga.asciidoc
+++ b/filebeat/docs/modules/icinga.asciidoc
@@ -54,7 +54,7 @@ To specify the same settings at the command line, you use:
 
 ["source","sh",subs="attributes"]
 -----
-./{beatname_lc} --modules {modulename} -M "icinga.main.var.paths=[/path/to/log/icinga2/icinga2.log*]" -M "icinga.debug.var.paths=[/path/to/log/icinga2/debug.log*]" -M "icinga.startup.var.paths=[/path/to/log/icinga2/startup.log]"
+-M "icinga.main.var.paths=[/path/to/log/icinga2/icinga2.log*]" -M "icinga.debug.var.paths=[/path/to/log/icinga2/debug.log*]" -M "icinga.startup.var.paths=[/path/to/log/icinga2/startup.log]"
 -----
 
 

--- a/filebeat/docs/modules/iis.asciidoc
+++ b/filebeat/docs/modules/iis.asciidoc
@@ -51,7 +51,7 @@ To specify the same settings at the command line, you use:
 
 ["source","sh",subs="attributes"]
 -----
-./{beatname_lc} --modules {modulename} -M "iis.access.var.paths=[C:/inetpub/logs/LogFiles/*/*.log]" -M "iis.error.var.paths=[C:/Windows/System32/LogFiles/HTTPERR/*.log]"
+-M "iis.access.var.paths=[C:/inetpub/logs/LogFiles/*/*.log]" -M "iis.error.var.paths=[C:/Windows/System32/LogFiles/HTTPERR/*.log]"
 -----
 
 

--- a/filebeat/docs/modules/kafka.asciidoc
+++ b/filebeat/docs/modules/kafka.asciidoc
@@ -49,7 +49,7 @@ To specify the same settings at the command line, you use:
 
 ["source","sh",subs="attributes"]
 -----
-./{beatname_lc} --modules {modulename} -M "kafka.log.var.paths=[/path/to/logs/controller.log*, /path/to/logs/server.log*, /path/to/logs/state-change.log*, /path/to/logs/kafka-*.log*]"
+-M "kafka.log.var.paths=[/path/to/logs/controller.log*, /path/to/logs/server.log*, /path/to/logs/state-change.log*, /path/to/logs/kafka-*.log*]"
 -----
 
 

--- a/filebeat/docs/modules/logstash.asciidoc
+++ b/filebeat/docs/modules/logstash.asciidoc
@@ -62,7 +62,7 @@ To specify the same settings at the command line, you use:
 
 ["source","sh",subs="attributes"]
 -----
-./{beatname_lc} --modules {modulename} -M "logstash.log.var.paths=[/path/to/log/logstash/logstash-server.log*]" -M "logstash.slowlog.var.paths=[/path/to/log/logstash/logstash-slowlog.log*]"
+-M "logstash.log.var.paths=[/path/to/log/logstash/logstash-server.log*]" -M "logstash.slowlog.var.paths=[/path/to/log/logstash/logstash-slowlog.log*]"
 -----
 
 

--- a/filebeat/docs/modules/mongodb.asciidoc
+++ b/filebeat/docs/modules/mongodb.asciidoc
@@ -46,7 +46,7 @@ To specify the same settings at the command line, you use:
 
 ["source","sh",subs="attributes"]
 -----
-./{beatname_lc} --modules {modulename} -M "mongodb.log.var.paths=[/path/to/log/mongodb/*.log*]"
+-M "mongodb.log.var.paths=[/path/to/log/mongodb/*.log*]"
 -----
 
 

--- a/filebeat/docs/modules/mysql.asciidoc
+++ b/filebeat/docs/modules/mysql.asciidoc
@@ -51,7 +51,7 @@ To specify the same settings at the command line, you use:
 
 ["source","sh",subs="attributes"]
 -----
-./{beatname_lc} --modules {modulename} -M "mysql.error.var.paths=[/path/to/log/mysql/error.log*]" -M "mysql.slowlog.var.paths=[/path/to/log/mysql/mysql-slow.log*]"
+-M "mysql.error.var.paths=[/path/to/log/mysql/error.log*]" -M "mysql.slowlog.var.paths=[/path/to/log/mysql/mysql-slow.log*]"
 -----
 
  

--- a/filebeat/docs/modules/nginx.asciidoc
+++ b/filebeat/docs/modules/nginx.asciidoc
@@ -55,7 +55,7 @@ To specify the same settings at the command line, you use:
 
 ["source","sh",subs="attributes"]
 -----
-./{beatname_lc} --modules {modulename} -M "nginx.access.var.paths=[/path/to/log/nginx/access.log*]" -M "nginx.error.var.paths=[/path/to/log/nginx/error.log*]"
+-M "nginx.access.var.paths=[/path/to/log/nginx/access.log*]" -M "nginx.error.var.paths=[/path/to/log/nginx/error.log*]"
 -----
 
 

--- a/filebeat/docs/modules/osquery.asciidoc
+++ b/filebeat/docs/modules/osquery.asciidoc
@@ -53,7 +53,7 @@ To specify the same settings at the command line, you use:
 
 ["source","sh",subs="attributes"]
 -----
-./{beatname_lc} --modules {modulename} -M "osquery.result.var.paths=[/path/to/osqueryd.results.log*]"
+-M "osquery.result.var.paths=[/path/to/osqueryd.results.log*]"
 -----
 
 include::../include/config-option-intro.asciidoc[]

--- a/filebeat/docs/modules/postgresql.asciidoc
+++ b/filebeat/docs/modules/postgresql.asciidoc
@@ -54,7 +54,7 @@ To specify the same settings at the command line, you use:
 
 ["source","sh",subs="attributes"]
 -----
-./{beatname_lc} --modules {modulename} -M "postgresql.log.var.paths=[/path/to/log/postgres/*.log*]"
+-M "postgresql.log.var.paths=[/path/to/log/postgres/*.log*]"
 -----
 
 

--- a/filebeat/docs/modules/redis.asciidoc
+++ b/filebeat/docs/modules/redis.asciidoc
@@ -68,7 +68,7 @@ To specify the same settings at the command line, you use:
 
 ["source","sh",subs="attributes"]
 -----
-./{beatname_lc} --modules {modulename} -M "redis.log.var.paths=[/path/to/log/redis/redis-server.log*]" -M "redis.slowlog.var.hosts=[localhost:6378]" -M "redis.slowlog.var.password=[YOUR_PASSWORD]"
+-M "redis.log.var.paths=[/path/to/log/redis/redis-server.log*]" -M "redis.slowlog.var.hosts=[localhost:6378]" -M "redis.slowlog.var.password=[YOUR_PASSWORD]"
 -----
 
 

--- a/filebeat/docs/modules/system.asciidoc
+++ b/filebeat/docs/modules/system.asciidoc
@@ -55,7 +55,7 @@ To specify the same settings at the command line, you use:
 
 ["source","sh",subs="attributes"]
 -----
-./{beatname_lc} --modules {modulename} -M "system.syslog.var.paths=[/path/to/log/syslog*]" -M "system.auth.var.paths=[/path/to/log/auth.log*]"
+-M "system.syslog.var.paths=[/path/to/log/syslog*]" -M "system.auth.var.paths=[/path/to/log/auth.log*]"
 -----
 
 

--- a/filebeat/docs/modules/traefik.asciidoc
+++ b/filebeat/docs/modules/traefik.asciidoc
@@ -47,7 +47,7 @@ To specify the same settings at the command line, you use:
 
 ["source","sh",subs="attributes"]
 -----
-./{beatname_lc} --modules traefik -M "traefik.access.var.paths=[/path/to/traefik/access.log*]"
+-M "traefik.access.var.paths=[/path/to/traefik/access.log*]"
 -----
 
 

--- a/filebeat/module/apache2/_meta/docs.asciidoc
+++ b/filebeat/module/apache2/_meta/docs.asciidoc
@@ -51,7 +51,7 @@ To specify the same settings at the command line, you use:
 
 ["source","sh",subs="attributes"]
 -----
-./{beatname_lc} --modules {modulename} -M "apache2.access.var.paths=[/path/to/apache2/access.log*]" -M "apache2.error.var.paths=[/path/to/log/apache2/error.log*]"
+-M "apache2.access.var.paths=[/path/to/apache2/access.log*]" -M "apache2.error.var.paths=[/path/to/log/apache2/error.log*]"
 -----
 
 

--- a/filebeat/module/auditd/_meta/docs.asciidoc
+++ b/filebeat/module/auditd/_meta/docs.asciidoc
@@ -45,7 +45,7 @@ To specify the same settings at the command line, you use:
 
 ["source","sh",subs="attributes"]
 -----
-./{beatname_lc} --modules {modulename} -M "auditd.log.var.paths=[/path/to/log/audit/audit.log*]"
+-M "auditd.log.var.paths=[/path/to/log/audit/audit.log*]"
 -----
 
 

--- a/filebeat/module/icinga/_meta/docs.asciidoc
+++ b/filebeat/module/icinga/_meta/docs.asciidoc
@@ -49,7 +49,7 @@ To specify the same settings at the command line, you use:
 
 ["source","sh",subs="attributes"]
 -----
-./{beatname_lc} --modules {modulename} -M "icinga.main.var.paths=[/path/to/log/icinga2/icinga2.log*]" -M "icinga.debug.var.paths=[/path/to/log/icinga2/debug.log*]" -M "icinga.startup.var.paths=[/path/to/log/icinga2/startup.log]"
+-M "icinga.main.var.paths=[/path/to/log/icinga2/icinga2.log*]" -M "icinga.debug.var.paths=[/path/to/log/icinga2/debug.log*]" -M "icinga.startup.var.paths=[/path/to/log/icinga2/startup.log]"
 -----
 
 

--- a/filebeat/module/iis/_meta/docs.asciidoc
+++ b/filebeat/module/iis/_meta/docs.asciidoc
@@ -46,7 +46,7 @@ To specify the same settings at the command line, you use:
 
 ["source","sh",subs="attributes"]
 -----
-./{beatname_lc} --modules {modulename} -M "iis.access.var.paths=[C:/inetpub/logs/LogFiles/*/*.log]" -M "iis.error.var.paths=[C:/Windows/System32/LogFiles/HTTPERR/*.log]"
+-M "iis.access.var.paths=[C:/inetpub/logs/LogFiles/*/*.log]" -M "iis.error.var.paths=[C:/Windows/System32/LogFiles/HTTPERR/*.log]"
 -----
 
 

--- a/filebeat/module/kafka/_meta/docs.asciidoc
+++ b/filebeat/module/kafka/_meta/docs.asciidoc
@@ -44,7 +44,7 @@ To specify the same settings at the command line, you use:
 
 ["source","sh",subs="attributes"]
 -----
-./{beatname_lc} --modules {modulename} -M "kafka.log.var.paths=[/path/to/logs/controller.log*, /path/to/logs/server.log*, /path/to/logs/state-change.log*, /path/to/logs/kafka-*.log*]"
+-M "kafka.log.var.paths=[/path/to/logs/controller.log*, /path/to/logs/server.log*, /path/to/logs/state-change.log*, /path/to/logs/kafka-*.log*]"
 -----
 
 

--- a/filebeat/module/logstash/_meta/docs.asciidoc
+++ b/filebeat/module/logstash/_meta/docs.asciidoc
@@ -57,7 +57,7 @@ To specify the same settings at the command line, you use:
 
 ["source","sh",subs="attributes"]
 -----
-./{beatname_lc} --modules {modulename} -M "logstash.log.var.paths=[/path/to/log/logstash/logstash-server.log*]" -M "logstash.slowlog.var.paths=[/path/to/log/logstash/logstash-slowlog.log*]"
+-M "logstash.log.var.paths=[/path/to/log/logstash/logstash-server.log*]" -M "logstash.slowlog.var.paths=[/path/to/log/logstash/logstash-slowlog.log*]"
 -----
 
 

--- a/filebeat/module/mongodb/_meta/docs.asciidoc
+++ b/filebeat/module/mongodb/_meta/docs.asciidoc
@@ -41,7 +41,7 @@ To specify the same settings at the command line, you use:
 
 ["source","sh",subs="attributes"]
 -----
-./{beatname_lc} --modules {modulename} -M "mongodb.log.var.paths=[/path/to/log/mongodb/*.log*]"
+-M "mongodb.log.var.paths=[/path/to/log/mongodb/*.log*]"
 -----
 
 

--- a/filebeat/module/mysql/_meta/docs.asciidoc
+++ b/filebeat/module/mysql/_meta/docs.asciidoc
@@ -46,7 +46,7 @@ To specify the same settings at the command line, you use:
 
 ["source","sh",subs="attributes"]
 -----
-./{beatname_lc} --modules {modulename} -M "mysql.error.var.paths=[/path/to/log/mysql/error.log*]" -M "mysql.slowlog.var.paths=[/path/to/log/mysql/mysql-slow.log*]"
+-M "mysql.error.var.paths=[/path/to/log/mysql/error.log*]" -M "mysql.slowlog.var.paths=[/path/to/log/mysql/mysql-slow.log*]"
 -----
 
  

--- a/filebeat/module/nginx/_meta/docs.asciidoc
+++ b/filebeat/module/nginx/_meta/docs.asciidoc
@@ -50,7 +50,7 @@ To specify the same settings at the command line, you use:
 
 ["source","sh",subs="attributes"]
 -----
-./{beatname_lc} --modules {modulename} -M "nginx.access.var.paths=[/path/to/log/nginx/access.log*]" -M "nginx.error.var.paths=[/path/to/log/nginx/error.log*]"
+-M "nginx.access.var.paths=[/path/to/log/nginx/access.log*]" -M "nginx.error.var.paths=[/path/to/log/nginx/error.log*]"
 -----
 
 

--- a/filebeat/module/osquery/_meta/docs.asciidoc
+++ b/filebeat/module/osquery/_meta/docs.asciidoc
@@ -48,7 +48,7 @@ To specify the same settings at the command line, you use:
 
 ["source","sh",subs="attributes"]
 -----
-./{beatname_lc} --modules {modulename} -M "osquery.result.var.paths=[/path/to/osqueryd.results.log*]"
+-M "osquery.result.var.paths=[/path/to/osqueryd.results.log*]"
 -----
 
 include::../include/config-option-intro.asciidoc[]

--- a/filebeat/module/postgresql/_meta/docs.asciidoc
+++ b/filebeat/module/postgresql/_meta/docs.asciidoc
@@ -49,7 +49,7 @@ To specify the same settings at the command line, you use:
 
 ["source","sh",subs="attributes"]
 -----
-./{beatname_lc} --modules {modulename} -M "postgresql.log.var.paths=[/path/to/log/postgres/*.log*]"
+-M "postgresql.log.var.paths=[/path/to/log/postgres/*.log*]"
 -----
 
 

--- a/filebeat/module/redis/_meta/docs.asciidoc
+++ b/filebeat/module/redis/_meta/docs.asciidoc
@@ -63,7 +63,7 @@ To specify the same settings at the command line, you use:
 
 ["source","sh",subs="attributes"]
 -----
-./{beatname_lc} --modules {modulename} -M "redis.log.var.paths=[/path/to/log/redis/redis-server.log*]" -M "redis.slowlog.var.hosts=[localhost:6378]" -M "redis.slowlog.var.password=[YOUR_PASSWORD]"
+-M "redis.log.var.paths=[/path/to/log/redis/redis-server.log*]" -M "redis.slowlog.var.hosts=[localhost:6378]" -M "redis.slowlog.var.password=[YOUR_PASSWORD]"
 -----
 
 

--- a/filebeat/module/system/_meta/docs.asciidoc
+++ b/filebeat/module/system/_meta/docs.asciidoc
@@ -50,7 +50,7 @@ To specify the same settings at the command line, you use:
 
 ["source","sh",subs="attributes"]
 -----
-./{beatname_lc} --modules {modulename} -M "system.syslog.var.paths=[/path/to/log/syslog*]" -M "system.auth.var.paths=[/path/to/log/auth.log*]"
+-M "system.syslog.var.paths=[/path/to/log/syslog*]" -M "system.auth.var.paths=[/path/to/log/auth.log*]"
 -----
 
 

--- a/filebeat/module/traefik/_meta/docs.asciidoc
+++ b/filebeat/module/traefik/_meta/docs.asciidoc
@@ -42,7 +42,7 @@ To specify the same settings at the command line, you use:
 
 ["source","sh",subs="attributes"]
 -----
-./{beatname_lc} --modules traefik -M "traefik.access.var.paths=[/path/to/traefik/access.log*]"
+-M "traefik.access.var.paths=[/path/to/traefik/access.log*]"
 -----
 
 

--- a/heartbeat/docs/getting-started.asciidoc
+++ b/heartbeat/docs/getting-started.asciidoc
@@ -192,18 +192,7 @@ was started. Heartbeat adds the `@every` keyword to the syntax provided by the
 See <<configuring-howto-heartbeat>> for a full description of each
 configuration option.
 
-. If you are sending output directly to Elasticsearch (and not using Logstash),
-set the IP address and port where Heartbeat can find the Elasticsearch
-installation:
-+
-[source,yaml]
-----------------------------------------------------------------------
-output.elasticsearch:
-  hosts: ["192.168.1.42:9200"]
-----------------------------------------------------------------------
-+
-If you are sending output to Logstash, make sure you
-<<logstash-output,Configure the Logstash output>> instead.
+include::../../libbeat/docs/step-configure-output.asciidoc[]
 
 include::../../libbeat/docs/step-configure-kibana-endpoint.asciidoc[]
 
@@ -258,7 +247,7 @@ sudo chown root heartbeat.yml <1>
 sudo ./heartbeat -e -c heartbeat.yml -d "publish"
 ----------------------------------------------------------------------
 <1> You'll be running Heartbeat as root, so you need to change ownership of the
-configuration file, or run Heartbeat with `-strict.perms=false` specified. See
+configuration file, or run Heartbeat with `--strict.perms=false` specified. See
 {libbeat}/config-file-permissions.html[Config File Ownership and Permissions]
 in the _Beats Platform Reference_.
 

--- a/libbeat/docs/config-file-format.asciidoc
+++ b/libbeat/docs/config-file-format.asciidoc
@@ -324,7 +324,7 @@ to the same ownership and file permission checks.
 ==== Disabling strict permission checks
 
 You can disable strict permission checks from the command line by using
-`-strict.perms=false`, but we strongly encourage you to leave the checks enabled.
+`--strict.perms=false`, but we strongly encourage you to leave the checks enabled.
 
 [[config-file-format-cli]]
 === Command line arguments

--- a/libbeat/docs/gettingstarted.asciidoc
+++ b/libbeat/docs/gettingstarted.asciidoc
@@ -6,6 +6,15 @@ to install and configure the {stack}. To learn how to get up and running
 quickly, see {stack-ov}/get-started-elastic-stack.html[Getting started with the
 {stack}].
 
+[TIP]
+==============
+You can skip having to install {es} and {kib} by using our
+https://www.elastic.co/cloud/elasticsearch-service[hosted {es} Service] on
+Elastic Cloud. The {es} Service is available on both AWS and GCP.
+https://www.elastic.co/cloud/elasticsearch-service/signup[Try out the {es}
+Service for free].
+==============
+
 After installing the {stack}, see the {beats} getting started guides: 
 
 * {auditbeat-ref}/auditbeat-getting-started.html[Auditbeat]

--- a/libbeat/docs/opendashboards.asciidoc
+++ b/libbeat/docs/opendashboards.asciidoc
@@ -9,8 +9,11 @@
 //// include::../../libbeat/docs/opendashboards.asciidoc[]
 //////////////////////////////////////////////////////////////////////////
 
-To open the dashboards, launch the Kibana web interface by pointing your browser
-to port 5601. For example, http://127.0.0.1:5601[http://127.0.0.1:5601].
+To open the dashboards, launch the {kib} web interface by pointing your browser
+to port 5601. For example, http://localhost:5601[http://localhost:5601].
+Replace `localhost` with the name of the {kib} host.  If you're using an
+https://cloud.elastic.co/[Elastic Cloud] instance, log in to your cloud account,
+then navigate to the {kib} endpoint in your deployment.
 
 On the *Discover* page, make sure that the predefined +{beatname_lc}-*+ index
 pattern is selected to see {beatname_uc} data.
@@ -19,6 +22,9 @@ pattern is selected to see {beatname_uc} data.
 image:./images/kibana-created-indexes.png[Discover tab with index selected]
 
 Go to the *Dashboard* page and select the dashboard that you want to open.
+
+TIP: If you don’t see data in {kib}, try changing the date range to a larger
+range. By default, {kib} shows the last 15 minutes.
 
 [role="screenshot"]
 image:./images/kibana-navigation-vis.png[Navigation widget in Kibana]

--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -33,6 +33,7 @@ ifndef::no-redis-output[]
 endif::[]
 * <<file-output>>
 * <<console-output>>
+* <<configure-cloud-id>>
 
 If you've secured the {stack}, also read <<securing-{beatname_lc}>> for more about
 security-related configuration options.
@@ -1209,42 +1210,6 @@ Setting `bulk_max_size` to values less than or equal to 0 disables the
 splitting of batches. When splitting is disabled, the queue decides on the
 number of events to be contained in a batch.
 
-[[configuration-output-codec]]
-=== Configure the output codec
-
-++++
-<titleabbrev>Output codec</titleabbrev>
-++++
-
-For outputs that do not require a specific encoding, you can change the encoding
-by using the codec configuration. You can specify either the `json` or `format`
-codec. By default the `json` codec is used.
-
-*`json.pretty`*: If `pretty` is set to true, events will be nicely formatted. The default is false.
-
-*`json.escape_html`*: If `escape_html` is set to false, html symbols will not be escaped in strings. The default is true.
-
-Example configuration that uses the `json` codec with pretty printing enabled to write events to the console:
-
-[source,yaml]
-------------------------------------------------------------------------------
-output.console:
-  codec.json:
-    pretty: true
-    escape_html: false
-------------------------------------------------------------------------------
-
-*`format.string`*: Configurable format string used to create a custom formatted message.
-
-Example configurable that uses the `format` codec to print the events timestamp and message field to console:
-
-[source,yaml]
-------------------------------------------------------------------------------
-output.console:
-  codec.format:
-    string: '%{[@timestamp]} %{[message]}'
-------------------------------------------------------------------------------
-
 [[configure-cloud-id]]
 === Configure the output for the Elastic Cloud
 
@@ -1285,5 +1250,37 @@ When specified, the `cloud.auth` overwrites the `output.elasticsearch.username` 
 `output.elasticsearch.password` settings. Because the Kibana settings inherit
 the username and password from the Elasticsearch output, this can also be used
 to set the `setup.kibana.username` and `setup.kibana.password` options.
+
+[[configuration-output-codec]]
+=== Change the output codec
+
+For outputs that do not require a specific encoding, you can change the encoding
+by using the codec configuration. You can specify either the `json` or `format`
+codec. By default the `json` codec is used.
+
+*`json.pretty`*: If `pretty` is set to true, events will be nicely formatted. The default is false.
+
+*`json.escape_html`*: If `escape_html` is set to false, html symbols will not be escaped in strings. The default is true.
+
+Example configuration that uses the `json` codec with pretty printing enabled to write events to the console:
+
+[source,yaml]
+------------------------------------------------------------------------------
+output.console:
+  codec.json:
+    pretty: true
+    escape_html: false
+------------------------------------------------------------------------------
+
+*`format.string`*: Configurable format string used to create a custom formatted message.
+
+Example configurable that uses the `format` codec to print the events timestamp and message field to console:
+
+[source,yaml]
+------------------------------------------------------------------------------
+output.console:
+  codec.format:
+    string: '%{[@timestamp]} %{[message]}'
+------------------------------------------------------------------------------
 
 endif::[]

--- a/libbeat/docs/shared-getting-started-intro.asciidoc
+++ b/libbeat/docs/shared-getting-started-intro.asciidoc
@@ -2,12 +2,21 @@
 To get started with your own {beatname_uc} setup, install and configure these
 related products:
 
-* Elasticsearch for storing and indexing the data.
-* Kibana for the UI.
-* Logstash (optional) for parsing and enhancing the data.
+* {es} for storing and indexing the data.
+* {kib} for the UI.
+* {ls} (optional) for parsing and enhancing the data.
 
 See {stack-ov}/get-started-elastic-stack.html[Getting started with the {stack}]
 for more information.
+
+[TIP]
+==============
+You can skip having to install {es} and {kib} by using our
+https://www.elastic.co/cloud/elasticsearch-service[hosted {es} Service] on
+Elastic Cloud. The {es} Service is available on both AWS and GCP.
+https://www.elastic.co/cloud/elasticsearch-service/signup[Try out the {es}
+Service for free].
+==============
 
 After installing the {stack}, read the following topics to learn how to
 install, configure, and run {beatname_uc}:

--- a/libbeat/docs/step-configure-credentials.asciidoc
+++ b/libbeat/docs/step-configure-credentials.asciidoc
@@ -1,9 +1,20 @@
-. If you've secured Elasticsearch and Kibana, you need to specify credentials
-in the config file before you run the commands that set up and start
-{beatname_uc}. For example:
+. If {es} and {kib} are secured, you need to specify credentials in the config
+file before you run the commands that set up and start {beatname_uc}.
+
+* If you're running our
+https://www.elastic.co/cloud/elasticsearch-service[hosted {es} Service]
+on Elastic Cloud, specify your <<configure-cloud-id,cloud auth>> credentials.
+For example:
 +
---
-[source,yaml]
+["source","yaml",subs="attributes"]
+----------------------------------------------------------------------
+cloud.auth: "elastic:{pwd}"
+----------------------------------------------------------------------
+
+* If you're running {es} on your own hardware, specify your {es} and {kib}
+credentials:
++
+["source","yaml",subs="attributes"]
 ----
 output.elasticsearch:
   hosts: ["myEShost:9200"]
@@ -16,13 +27,11 @@ setup.kibana:
 ----
 <1> This examples shows a hard-coded password, but you should store sensitive
 values in the <<keystore,secrets keystore>>.
-<2> The `username` and `password` settings for Kibana are optional. If you don't
-specify credentials for Kibana, {beatname_uc} uses the `username` and `password`
-specified for the Elasticsearch output.
-<3> If you are planning to <<load-kibana-dashboards,set up the Kibana
-dashboards>>, the user must have the `kibana_user`
+<2> The `username` and `password` settings for {kib} are optional. If you don't
+specify credentials for {kib}, {beatname_uc} uses the `username` and `password`
+specified for the {es} output.
+<3> If you are planning to <<load-kibana-dashboards,set up the {kib} dashboards>>,
+the user must have the `kibana_user`
 {xpack-ref}/built-in-roles.html[built-in role] or equivalent privileges.
-
---
 +
 For more information, see <<securing-{beatname_lc}>>.

--- a/libbeat/docs/step-configure-credentials.asciidoc
+++ b/libbeat/docs/step-configure-credentials.asciidoc
@@ -1,4 +1,4 @@
-. If {es} and {kib} are secured, you need to specify credentials in the config
+. If {es} and {kib} are secured, set credentials in the +{beatname_lc}.yml+ config
 file before you run the commands that set up and start {beatname_uc}.
 
 * If you're running our

--- a/libbeat/docs/step-configure-kibana-endpoint.asciidoc
+++ b/libbeat/docs/step-configure-kibana-endpoint.asciidoc
@@ -1,17 +1,12 @@
-. If you plan to use the sample Kibana dashboards provided with {beatname_uc},
-configure the Kibana endpoint:
+. If you plan to use the sample {kib} dashboards provided with {beatname_uc},
+configure the {kib} endpoint. You can skip this step if {kib} is running on
+the same host as {es}.
 +
 [source,yaml]
 ----------------------------------------------------------------------
 setup.kibana:
-  host: "localhost:5601"
+  host: "mykibanahost:5601" <1>
 ----------------------------------------------------------------------
-+
---
-Where `host` is the hostname and port of the machine where Kibana is running,
-for example, `localhost:5601`.
-
-NOTE: If you specify a path after the port number, you need to include
-the scheme and port: `http://localhost:5601/path`.
-
---
+<1> The hostname and port of the machine where {kib} is running,
+for example, `mykibanahost:5601`. If you specify a path after the port number,
+include the scheme and port: `http://mykibanahost:5601/path`.

--- a/libbeat/docs/step-configure-output.asciidoc
+++ b/libbeat/docs/step-configure-output.asciidoc
@@ -1,0 +1,40 @@
+ifndef::has_module_steps[]
+. Configure the output. {beatname_uc} supports a variety of
+<<configuring-output,outputs>>, but typically you'll either send events directly
+to {es}, or to {ls} for additional processing.
++
+To send output directly to {es} (without using {ls}), set the location of the
+{es} installation:
++
+--
+endif::[]
+* If you're running our
+https://www.elastic.co/cloud/elasticsearch-service[hosted {es} Service]
+on Elastic Cloud, specify your <<configure-cloud-id,Cloud ID>>. For example:
++
+[source,yaml]
+----------------------------------------------------------------------
+cloud.id: "staging:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyRjZWM2ZjI2MWE3NGJmMjRjZTMzYmI4ODExYjg0Mjk0ZiRjNmMyY2E2ZDA0MjI0OWFmMGNjN2Q3YTllOTYyNTc0Mw=="
+----------------------------------------------------------------------
+
+* If you're running {es} on your own hardware, set the host and port where
+{beatname_uc} can find the {es} installation. For example:
++
+[source,yaml]
+----------------------------------------------------------------------
+output.elasticsearch:
+  hosts: ["myEShost:9200"]
+----------------------------------------------------------------------
+ifndef::has_module_steps[]
+--
++
+ifeval::["{beatname_lc}"!="filebeat" and "{beatname_lc}"!="winlogbeat"]
+To send output to {ls}, 
+<<logstash-output,Configure the {ls} output>> instead. For all other
+outputs, see <<configuring-output>>.
+endif::[]
+ifeval::[("{beatname_lc}"=="filebeat") or ("{beatname_lc}"=="winlogbeat")]
+To send output to {ls}, make sure you configure the Logstash output in
+<<config-{beatname_lc}-logstash>>. For all other outputs, see <<configuring-output>>.
+endif::[]
+endif::[]

--- a/libbeat/docs/step-look-at-config.asciidoc
+++ b/libbeat/docs/step-look-at-config.asciidoc
@@ -1,2 +1,2 @@
-Before starting {beatname_lc}, you should look at the configuration options in the
+Before starting {beatname_uc}, you should look at the configuration options in the
 configuration file. For more information about these options, see <<configuring-howto-{beatname_lc}>>.

--- a/metricbeat/docs/gettingstarted.asciidoc
+++ b/metricbeat/docs/gettingstarted.asciidoc
@@ -201,18 +201,7 @@ settings.
 See <<configuration-{beatname_lc}>> if you want to add the module configs to the
 +{beatname_lc}.yml+ file rather than using the `modules.d` directory.
 
-. If you are sending output directly to Elasticsearch (and not using Logstash),
-set the IP address and port where {beatname_uc} can find the Elasticsearch
-installation. For example:
-+
-[source,yaml]
-----------------------------------------------------------------------
-output.elasticsearch:
-  hosts: ["192.168.1.42:9200"]
-----------------------------------------------------------------------
-+
-If you are sending output to Logstash, make sure you
-<<logstash-output,Configure the Logstash output>> instead.
+include::../../libbeat/docs/step-configure-output.asciidoc[]
 
 include::../../libbeat/docs/step-configure-kibana-endpoint.asciidoc[]
 
@@ -273,7 +262,7 @@ sudo ./{beatname_lc} -e -c {beatname_lc}.yml -d "publish"
 ----------------------------------------------------------------------
 <1> You'll be running {beatname_uc} as root, so you need to change ownership of the
 configuration file and any configurations enabled in the `modules.d` directory,
-or run {beatname_uc} with `-strict.perms=false` specified. See
+or run {beatname_uc} with `--strict.perms=false` specified. See
 {libbeat}/config-file-permissions.html[Config File Ownership and Permissions]
 in the _Beats Platform Reference_.
 

--- a/packetbeat/docs/gettingstarted.asciidoc
+++ b/packetbeat/docs/gettingstarted.asciidoc
@@ -221,19 +221,7 @@ packetbeat.protocols:
 
 ----------------------------------------------------------------------
 +
-. If you are sending output directly to Elasticsearch (and not using Logstash),
-set the IP address and port where Packetbeat can find the Elasticsearch
-installation:
-+
-[source,yaml]
-----------------------------------------------------------------------
-#-------------------------- Elasticsearch output ------------------------------
-output.elasticsearch:
-  hosts: ["192.168.1.42:9200"]
-----------------------------------------------------------------------
-+
-If you are sending output to Logstash, make sure you
-<<logstash-output,Configure the Logstash output>> instead.
+include::../../libbeat/docs/step-configure-output.asciidoc[]
 
 include::../../libbeat/docs/step-configure-kibana-endpoint.asciidoc[]
 
@@ -298,7 +286,7 @@ sudo chown root packetbeat.yml <1>
 sudo ./packetbeat -e -c packetbeat.yml -d "publish"
 ----------------------------------------------------------------------
 <1> You'll be running Packetbeat as root, so you need to change ownership of the
-configuration file, or run Packetbeat with `-strict.perms=false` specified. See
+configuration file, or run Packetbeat with `--strict.perms=false` specified. See
 {libbeat}/config-file-permissions.html[Config File Ownership and Permissions]in
 the _Beats Platform Reference_.
 

--- a/winlogbeat/docs/getting-started.asciidoc
+++ b/winlogbeat/docs/getting-started.asciidoc
@@ -95,19 +95,7 @@ To obtain a list of available event logs, run `Get-EventLog *` in PowerShell.
 For more information about this command, see the configuration details for
 <<configuration-winlogbeat-options-event_logs-name,event_logs.name>>.
 
-. If you are sending output directly to Elasticsearch (and not using Logstash),
-set the IP address and port where Winlogbeat can find the Elasticsearch
-installation:
-+
-[source,yaml]
-----------------------------------------------------------------------
-output.elasticsearch:
-  hosts:
-    - localhost:9200
-----------------------------------------------------------------------
-+
-If you are sending output to Logstash, make sure you
-<<config-winlogbeat-logstash,Configure the Logstash output>> instead.
+include::../../libbeat/docs/step-configure-output.asciidoc[]
 
 include::../../libbeat/docs/step-configure-kibana-endpoint.asciidoc[]
 


### PR DESCRIPTION
Summary of changes:

- Added info to help cloud users get Beats set up correctly.
- Added more platform-specific commands for setting up and running Filebeat modules (to make the docs consistent).
- Did some minor cleanup to change product names > attribute references (still need to do a full cleanup, but trying to catch these as I open files).
- Moved the content about changing the output codec so that it appears at the end of the output config section (since the section applies to multiple outputs).
- Misc changes to make steps consistent, use similar language, etc across content.

I'm marking this as "in progress" because I need some input from reviewers before this is ready to merge. Please see comments flagged for REVIEWERS. 