### PR TITLE
Force use of old osx image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,12 @@ services:
 
 language: go
 
+# Python seems broken since 2018/07/31
+# - https://blog.travis-ci.com/2018-07-19-xcode9-4-default-announce
+# - https://github.com/travis-ci/travis-ci/issues/9929
+# (TODO) Remove when fixed
+osx_image: xcode9.3
+
 # Make sure project can also be built on travis for clones of the repo
 go_import_path: github.com/elastic/beats
 


### PR DESCRIPTION
Python seems broken since 2018/07/31
* https://blog.travis-ci.com/2018-07-19-xcode9-4-default-announce
* https://github.com/travis-ci/travis-ci/issues/9929
