### PR TITLE
Auditbeat: Add include_paths to file integrity module

### DIFF
--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -84,6 +84,11 @@ auditbeat.modules:
   - '~$'
   - '/\.git($|/)'
 
+  # List of regular expressions used to explicitly include files. When configured,
+  # Auditbeat will ignore files unless they match a pattern.
+  include_files:
+  - '.ssh/'
+
   # Scan over the configured file paths at startup and send events for new or
   # modified files since the last time Auditbeat was running.
   scan_at_start: true

--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -86,8 +86,8 @@ auditbeat.modules:
 
   # List of regular expressions used to explicitly include files. When configured,
   # Auditbeat will ignore files unless they match a pattern.
-  include_files:
-  - '.ssh/'
+  #include_files:
+  #- '/\.ssh($|/)'
 
   # Scan over the configured file paths at startup and send events for new or
   # modified files since the last time Auditbeat was running.

--- a/auditbeat/docs/modules/file_integrity.asciidoc
+++ b/auditbeat/docs/modules/file_integrity.asciidoc
@@ -58,6 +58,8 @@ Linux.
   - '(?i)\.sw[nop]$'
   - '~$'
   - '/\.git($|/)'
+   include_files:
+  - '.ssh/'
   scan_at_start: true
   scan_rate_per_sec: 50 MiB
   max_file_size: 100 MiB
@@ -71,6 +73,14 @@ not supported. The specified paths should exist when the metricset is started.
 *`exclude_files`*:: A list of regular expressions used to filter out events
 for unwanted files. The expressions are matched against the full path of every
 file and directory. By default, no files are excluded. See <<regexp-support>>
+for a list of supported regexp patterns. It is recommended to wrap regular
+expressions in single quotation marks to avoid issues with YAML escaping
+rules.
+
+*`include_files`*:: A list of regular expressions used to explicitly include
+files. When configured, only files matching the pattern will be monitored.
+The expressions are matched against the full path of every file and directory.
+By default, all files are selected. See <<regexp-support>>
 for a list of supported regexp patterns. It is recommended to wrap regular
 expressions in single quotation marks to avoid issues with YAML escaping
 rules.

--- a/auditbeat/docs/modules/file_integrity.asciidoc
+++ b/auditbeat/docs/modules/file_integrity.asciidoc
@@ -58,8 +58,7 @@ Linux.
   - '(?i)\.sw[nop]$'
   - '~$'
   - '/\.git($|/)'
-  include_files:
-  - []
+  include_files: []
   scan_at_start: true
   scan_rate_per_sec: 50 MiB
   max_file_size: 100 MiB

--- a/auditbeat/docs/modules/file_integrity.asciidoc
+++ b/auditbeat/docs/modules/file_integrity.asciidoc
@@ -72,14 +72,18 @@ not supported. The specified paths should exist when the metricset is started.
 
 *`exclude_files`*:: A list of regular expressions used to filter out events
 for unwanted files. The expressions are matched against the full path of every
-file and directory. By default, no files are excluded. See <<regexp-support>>
+file and directory. When used in conjunction with `include_files`, file paths need
+to match both `include_files` and not match `exclude_files` to be selected.
+By default, no files are excluded. See <<regexp-support>>
 for a list of supported regexp patterns. It is recommended to wrap regular
 expressions in single quotation marks to avoid issues with YAML escaping
 rules.
 
-*`include_files`*:: A list of regular expressions used to explicitly include
-files. When configured, only files matching the pattern will be monitored.
+*`include_files`*:: A list of regular expressions used to specify which files to
+select. When configured, only files matching the pattern will be monitored.
 The expressions are matched against the full path of every file and directory.
+When used in conjunction with `exclude_files`, file paths need
+to match both `include_files` and not match `exclude_files` to be selected.
 By default, all files are selected. See <<regexp-support>>
 for a list of supported regexp patterns. It is recommended to wrap regular
 expressions in single quotation marks to avoid issues with YAML escaping

--- a/auditbeat/docs/modules/file_integrity.asciidoc
+++ b/auditbeat/docs/modules/file_integrity.asciidoc
@@ -58,8 +58,8 @@ Linux.
   - '(?i)\.sw[nop]$'
   - '~$'
   - '/\.git($|/)'
-   include_files:
-  - '.ssh/'
+  include_files:
+  - []
   scan_at_start: true
   scan_rate_per_sec: 50 MiB
   max_file_size: 100 MiB

--- a/auditbeat/module/file_integrity/_meta/config.yml.tmpl
+++ b/auditbeat/module/file_integrity/_meta/config.yml.tmpl
@@ -46,8 +46,13 @@
 
   # List of regular expressions used to explicitly include files. When configured,
   # Auditbeat will ignore files unless they match a pattern.
-  include_files:
-  - '.ssh/'
+  {{ if eq .GOOS "windows" -}}
+  #include_files:
+  #- '\\\.ssh($|\)'
+  {{ else -}}
+  #include_files:
+  #- '/\.ssh($|/)'
+  {{- end }}
 
   # Scan over the configured file paths at startup and send events for new or
   # modified files since the last time Auditbeat was running.

--- a/auditbeat/module/file_integrity/_meta/config.yml.tmpl
+++ b/auditbeat/module/file_integrity/_meta/config.yml.tmpl
@@ -48,7 +48,7 @@
   # Auditbeat will ignore files unless they match a pattern.
   {{ if eq .GOOS "windows" -}}
   #include_files:
-  #- '\\\.ssh($|\)'
+  #- '\\\.ssh($|\\)'
   {{ else -}}
   #include_files:
   #- '/\.ssh($|/)'

--- a/auditbeat/module/file_integrity/_meta/config.yml.tmpl
+++ b/auditbeat/module/file_integrity/_meta/config.yml.tmpl
@@ -44,6 +44,11 @@
   - '/\.git($|/)'
   {{- end }}
 
+  # List of regular expressions used to explicitly include files. When configured,
+  # Auditbeat will ignore files unless they match a pattern.
+  include_files:
+  - '.ssh/'
+
   # Scan over the configured file paths at startup and send events for new or
   # modified files since the last time Auditbeat was running.
   scan_at_start: true

--- a/auditbeat/module/file_integrity/_meta/docs.asciidoc
+++ b/auditbeat/module/file_integrity/_meta/docs.asciidoc
@@ -67,14 +67,18 @@ not supported. The specified paths should exist when the metricset is started.
 
 *`exclude_files`*:: A list of regular expressions used to filter out events
 for unwanted files. The expressions are matched against the full path of every
-file and directory. By default, no files are excluded. See <<regexp-support>>
+file and directory. When used in conjunction with `include_files`, file paths need
+to match both `include_files` and not match `exclude_files` to be selected.
+By default, no files are excluded. See <<regexp-support>>
 for a list of supported regexp patterns. It is recommended to wrap regular
 expressions in single quotation marks to avoid issues with YAML escaping
 rules.
 
-*`include_files`*:: A list of regular expressions used to explicitly include
-files. When configured, only files matching the pattern will be monitored.
+*`include_files`*:: A list of regular expressions used to specify which files to
+select. When configured, only files matching the pattern will be monitored.
 The expressions are matched against the full path of every file and directory.
+When used in conjunction with `exclude_files`, file paths need
+to match both `include_files` and not match `exclude_files` to be selected.
 By default, all files are selected. See <<regexp-support>>
 for a list of supported regexp patterns. It is recommended to wrap regular
 expressions in single quotation marks to avoid issues with YAML escaping

--- a/auditbeat/module/file_integrity/_meta/docs.asciidoc
+++ b/auditbeat/module/file_integrity/_meta/docs.asciidoc
@@ -53,8 +53,8 @@ Linux.
   - '(?i)\.sw[nop]$'
   - '~$'
   - '/\.git($|/)'
-   include_files:
-  - '.ssh/'
+  include_files:
+  - []
   scan_at_start: true
   scan_rate_per_sec: 50 MiB
   max_file_size: 100 MiB

--- a/auditbeat/module/file_integrity/_meta/docs.asciidoc
+++ b/auditbeat/module/file_integrity/_meta/docs.asciidoc
@@ -53,8 +53,7 @@ Linux.
   - '(?i)\.sw[nop]$'
   - '~$'
   - '/\.git($|/)'
-  include_files:
-  - []
+  include_files: []
   scan_at_start: true
   scan_rate_per_sec: 50 MiB
   max_file_size: 100 MiB

--- a/auditbeat/module/file_integrity/_meta/docs.asciidoc
+++ b/auditbeat/module/file_integrity/_meta/docs.asciidoc
@@ -53,6 +53,8 @@ Linux.
   - '(?i)\.sw[nop]$'
   - '~$'
   - '/\.git($|/)'
+   include_files:
+  - '.ssh/'
   scan_at_start: true
   scan_rate_per_sec: 50 MiB
   max_file_size: 100 MiB
@@ -66,6 +68,14 @@ not supported. The specified paths should exist when the metricset is started.
 *`exclude_files`*:: A list of regular expressions used to filter out events
 for unwanted files. The expressions are matched against the full path of every
 file and directory. By default, no files are excluded. See <<regexp-support>>
+for a list of supported regexp patterns. It is recommended to wrap regular
+expressions in single quotation marks to avoid issues with YAML escaping
+rules.
+
+*`include_files`*:: A list of regular expressions used to explicitly include
+files. When configured, only files matching the pattern will be monitored.
+The expressions are matched against the full path of every file and directory.
+By default, all files are selected. See <<regexp-support>>
 for a list of supported regexp patterns. It is recommended to wrap regular
 expressions in single quotation marks to avoid issues with YAML escaping
 rules.

--- a/auditbeat/module/file_integrity/config.go
+++ b/auditbeat/module/file_integrity/config.go
@@ -79,6 +79,7 @@ type Config struct {
 	ScanRateBytesPerSec uint64          `config:",ignore"`
 	Recursive           bool            `config:"recursive"` // Recursive enables recursive monitoring of directories.
 	ExcludeFiles        []match.Matcher `config:"exclude_files"`
+	IncludeFiles        []match.Matcher `config:"include_files"`
 }
 
 // Validate validates the config data and return an error explaining all the
@@ -140,6 +141,20 @@ func deduplicate(in []string) []string {
 // IsExcludedPath checks if a path matches the exclude_files regular expressions.
 func (c *Config) IsExcludedPath(path string) bool {
 	for _, matcher := range c.ExcludeFiles {
+		if matcher.MatchString(path) {
+			return true
+		}
+	}
+	return false
+}
+
+// IsIncludedPath checks if a path matches the include_files regular expressions.
+func (c *Config) IsIncludedPath(path string) bool {
+	if c.IncludeFiles == nil {
+		return true
+	}
+
+	for _, matcher := range c.IncludeFiles {
 		if matcher.MatchString(path) {
 			return true
 		}

--- a/auditbeat/module/file_integrity/config.go
+++ b/auditbeat/module/file_integrity/config.go
@@ -150,7 +150,7 @@ func (c *Config) IsExcludedPath(path string) bool {
 
 // IsIncludedPath checks if a path matches the include_files regular expressions.
 func (c *Config) IsIncludedPath(path string) bool {
-	if c.IncludeFiles == nil {
+	if len(c.IncludeFiles) == 0 {
 		return true
 	}
 

--- a/auditbeat/module/file_integrity/config_test.go
+++ b/auditbeat/module/file_integrity/config_test.go
@@ -37,6 +37,7 @@ func TestConfig(t *testing.T) {
 		"max_file_size":     "1 GiB",
 		"scan_rate_per_sec": "10MiB",
 		"exclude_files":     []string{`\.DS_Store$`, `\.swp$`},
+		"include_files":     []string{`\.ssh/$`},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -53,6 +54,8 @@ func TestConfig(t *testing.T) {
 	assert.Len(t, c.ExcludeFiles, 2)
 	assert.EqualValues(t, `\.DS_Store(?-m:$)`, c.ExcludeFiles[0].String())
 	assert.EqualValues(t, `\.swp(?-m:$)`, c.ExcludeFiles[1].String())
+	assert.Len(t, c.IncludeFiles, 1)
+	assert.EqualValues(t, `\.ssh/(?-m:$)`, c.IncludeFiles[0].String())
 }
 
 func TestConfigInvalid(t *testing.T) {

--- a/auditbeat/module/file_integrity/eventreader_fsevents.go
+++ b/auditbeat/module/file_integrity/eventreader_fsevents.go
@@ -153,7 +153,8 @@ func (r *fsreader) consumeEvents(done <-chan struct{}) {
 			return
 		case events := <-r.stream.Events:
 			for _, event := range events {
-				if !r.isWatched(event.Path) || r.config.IsExcludedPath(event.Path) {
+				if !r.isWatched(event.Path) || r.config.IsExcludedPath(event.Path) ||
+					!r.config.IsIncludedPath(event.Path) {
 					continue
 				}
 				r.log.Debugw("Received FSEvents event",

--- a/auditbeat/module/file_integrity/eventreader_fsnotify.go
+++ b/auditbeat/module/file_integrity/eventreader_fsnotify.go
@@ -89,7 +89,8 @@ func (r *reader) consumeEvents(done <-chan struct{}) {
 			r.log.Debug("fsnotify reader terminated")
 			return
 		case event := <-r.watcher.EventChannel():
-			if event.Name == "" || r.config.IsExcludedPath(event.Name) {
+			if event.Name == "" || r.config.IsExcludedPath(event.Name) ||
+				!r.config.IsIncludedPath(event.Name) {
 				continue
 			}
 			r.log.Debugw("Received fsnotify event",


### PR DESCRIPTION
Addresses https://github.com/elastic/beats/issues/7707 by introducing a new `include_files` parameter to the `file_integrity` module, similar to the existing `exclude_files`.