### PR TITLE
[6.x] clean obsolote artifacts ingering around, fixes Jenkins builds (#7827)

### DIFF
--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -439,6 +439,7 @@ seccomp-package:
 mage:
 ifndef MAGE_PRESENT
 	go install ${MAGE_IMPORT_PATH}
+	@-mage -clean 2> /dev/null
 endif
 
 .PHONY: release


### PR DESCRIPTION
Backports the following commits to 6.x:
 - clean obsolote artifacts ingering around, fixes Jenkins builds  (#7827)