### PR TITLE
Cherry-pick #7825 to 6.x: Fix panic in case of failing test

### DIFF
--- a/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
+++ b/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
@@ -73,9 +73,12 @@ func TestFetch(t *testing.T) {
 			f := mbtest.NewReportingMetricSetV2(t, getConfig(metricSet))
 			events, errs := mbtest.ReportingFetchV2(f)
 
-			assert.NotNil(t, events)
-			assert.Nil(t, errs)
-			t.Logf("%s/%s event: %+v", f.Module().Name(), f.Name(), events[0].BeatEvent("elasticsearch", metricSet).Fields.StringToPrint())
+			assert.Empty(t, errs)
+			if !assert.NotEmpty(t, events) {
+				t.FailNow()
+			}
+			t.Logf("%s/%s event: %+v", f.Module().Name(), f.Name(),
+				events[0].BeatEvent("elasticsearch", metricSet).Fields.StringToPrint())
 		})
 	}
 }


### PR DESCRIPTION
Cherry-pick of PR #7825 to 6.x branch. Original message: 

Events list can be empty if test fails, provoking a panic by out of
range index if we try to log the first event.