### PR TITLE
Use monitoring namespaces dynamically

### DIFF
--- a/libbeat/api/server.go
+++ b/libbeat/api/server.go
@@ -40,6 +40,7 @@ func Start(cfg *common.Config) {
 		mux := http.NewServeMux()
 
 		// register handlers
+		// TODO: make these dynamic based on namespaces
 		mux.HandleFunc("/", rootHandler())
 		mux.HandleFunc("/state", stateHandler)
 		mux.HandleFunc("/stats", statsHandler)


### PR DESCRIPTION
Currently namespaces are used for Monitoring in a couple of places:
* To setup Beats API endpoints like `/stats` and `/state` (where `stats` and `state` are namespace names).
* To internally report Beats monitoring data to X-Pack Monitoring indices.

These places explicitly refer to specific namespaces (i.e. hardcode the namespace names). Instead we would like to refer to these namespaces dynamically in this places. That way, registering a new namespace would automatically setup an API endpoint for that namespace as well as report it's data into X-Pack Monitoring indices.

This PR is an attempt to make this change.

### Still TODO
* Make namespace API endpoints creation dynamic
* Initialize new namespace fields in the right places