### PR TITLE
Fixed Support add_docker_metadata in Windows [#7797]

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -39,6 +39,7 @@ https://github.com/elastic/beats/compare/v6.4.0...master[Check the HEAD diff]
 - Remove unix-like permission checks on Windows, so files can be opened. {issue}7849[7849]
 - Deregister pipeline loader callback when inputsRunner is stopped. {pull}7893[7893]
 - Replace index patterns in TSVB visualizations. {pull}7929[7929]
+- Fixed Support `add_docker_metadata` in Windows by identifying systems' path separator. {issue}7797[7797]
 
 *Auditbeat*
 

--- a/libbeat/processors/add_docker_metadata/add_docker_metadata.go
+++ b/libbeat/processors/add_docker_metadata/add_docker_metadata.go
@@ -85,7 +85,7 @@ func buildDockerMetadataProcessor(cfg *common.Config, watcherConstructor docker.
 	if config.MatchSource {
 		var procConf, _ = common.NewConfigFrom(map[string]interface{}{
 			"field":     "source",
-			"separator": "/",
+			"separator": string(os.PathSeparator),
 			"index":     config.SourceIndex,
 			"target":    "docker.container.id",
 		})

--- a/libbeat/processors/add_docker_metadata/add_docker_metadata_test.go
+++ b/libbeat/processors/add_docker_metadata/add_docker_metadata_test.go
@@ -24,6 +24,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"runtime"
+
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/bus"
@@ -167,9 +169,17 @@ func TestMatchSource(t *testing.T) {
 		}))
 	assert.NoError(t, err, "initializing add_docker_metadata processor")
 
-	input := common.MapStr{
-		"source": "/var/lib/docker/containers/FABADA/foo.log",
+	var inputSource string
+	switch runtime.GOOS {
+	case "windows":
+		inputSource = "C:\\ProgramData\\docker\\containers\\FABADA\\foo.log"
+	default:
+		inputSource = "/var/lib/docker/containers/FABADA/foo.log"
 	}
+	input := common.MapStr{
+		"source": inputSource,
+	}
+
 	result, err := p.Run(&beat.Event{Fields: input})
 	assert.NoError(t, err, "processing an event")
 
@@ -185,7 +195,7 @@ func TestMatchSource(t *testing.T) {
 				"name": "name",
 			},
 		},
-		"source": "/var/lib/docker/containers/FABADA/foo.log",
+		"source": inputSource,
 	}, result.Fields)
 }
 


### PR DESCRIPTION
Right now the separator used to parse container's logpaths is "/",
which fails to parse paths on Windows systems. This is resolved
by using os.PathSeparator to identify the seperator of the runtime
system.

Closes #7797