### PR TITLE
Allow a Beat to override monitoring-related fields

### DIFF
--- a/CHANGELOG-developer.asciidoc
+++ b/CHANGELOG-developer.asciidoc
@@ -47,3 +47,5 @@ The list below covers the major changes between 6.3.0 and master only.
 - Beats packaging now build non-oss binaries from code located in the x-pack folder. {issue}7783[7783]
 - New function `AddTagsWithKey` is added, so `common.MapStr` can be enriched with tags with an arbitrary key. {pull}7991[7991]
 - Move filebeat/reader to libbeat/reader {pull}8206[8206]
+- Libbeat provides a new function `cmd.GenRootCmdWithSettings` that should be preferred over deprecated functions
+  `cmd.GenRootCmd`, `cmd.GenRootCmdWithRunFlags`, and `cmd.GenRootCmdWithIndexPrefixWithRunFlags`. {pull}7850[7850]

--- a/generator/metricbeat/{beat}/main.go.tmpl
+++ b/generator/metricbeat/{beat}/main.go.tmpl
@@ -14,7 +14,7 @@ import (
 )
 
 var settings = instance.Settings{
-    Name: "{beat}",
+	Name: "{beat}",
 }
 
 func main() {

--- a/generator/metricbeat/{beat}/main.go.tmpl
+++ b/generator/metricbeat/{beat}/main.go.tmpl
@@ -13,11 +13,12 @@ import (
 	_ "{beat_path}/include"
 )
 
-var Name = "{beat}"
-var IndexPrefix = "{beat}"
+var settings = instance.Settings{
+    Name: "{beat}",
+}
 
 func main() {
-	if err := instance.Run(Name, IndexPrefix, "", beater.DefaultCreator()); err != nil {
+	if err := instance.Run(settings, beater.DefaultCreator()); err != nil {
 		os.Exit(1)
 	}
 }

--- a/libbeat/beat/info.go
+++ b/libbeat/beat/info.go
@@ -27,4 +27,11 @@ type Info struct {
 	Name        string    // configured beat name
 	Hostname    string    // hostname
 	UUID        uuid.UUID // ID assigned to beat instance
+
+	// Monitoring-related fields
+	Monitoring struct {
+		DefaultUsername  string // The default username to be used to connect to Elasticsearch Monitoring
+		SystemID         string // The system_id to pass to Elasticsearch Monitoring
+		SystemAPIVersion string // The system_api_version to pass to Elasticsearch Monitoring
+	}
 }

--- a/libbeat/beat/info.go
+++ b/libbeat/beat/info.go
@@ -30,8 +30,7 @@ type Info struct {
 
 	// Monitoring-related fields
 	Monitoring struct {
-		DefaultUsername  string // The default username to be used to connect to Elasticsearch Monitoring
-		SystemID         string // The system_id to pass to Elasticsearch Monitoring
-		SystemAPIVersion string // The system_api_version to pass to Elasticsearch Monitoring
+		DefaultUsername string // The default username to be used to connect to Elasticsearch Monitoring
+		SystemID        string // The system_id to pass to Elasticsearch Monitoring
 	}
 }

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -155,7 +155,11 @@ func initRand() {
 // implementation. bt is the `Creator` callback for creating a new beater
 // instance.
 // XXX Move this as a *Beat method?
-func Run(name, idxPrefix, version string, bt beat.Creator) error {
+func Run(settings Settings, bt beat.Creator) error {
+	name := settings.Name
+	idxPrefix := settings.IndexPrefix
+	version := settings.Version
+
 	return handleError(func() error {
 		defer func() {
 			if r := recover(); r != nil {
@@ -186,7 +190,7 @@ func Run(name, idxPrefix, version string, bt beat.Creator) error {
 		monitoring.NewString(beatRegistry, "name").Set(b.Info.Name)
 		monitoring.NewFunc(stateRegistry, "host", host.ReportInfo, monitoring.Report)
 
-		return b.launch(bt)
+		return b.launch(settings, bt)
 	}())
 }
 
@@ -314,7 +318,7 @@ func (b *Beat) createBeater(bt beat.Creator) (beat.Beater, error) {
 	return beater, nil
 }
 
-func (b *Beat) launch(bt beat.Creator) error {
+func (b *Beat) launch(settings Settings, bt beat.Creator) error {
 	defer logp.Sync()
 	defer logp.Info("%s stopped.", b.Info.Beat)
 
@@ -336,7 +340,11 @@ func (b *Beat) launch(bt beat.Creator) error {
 	}
 
 	if b.Config.Monitoring.Enabled() {
-		reporter, err := report.New(b.Info, b.Config.Monitoring, b.Config.Output)
+		settings := report.Settings{
+			Beat:            b.Info,
+			DefaultUsername: settings.MonitoringDefaultUsername,
+		}
+		reporter, err := report.New(settings, b.Config.Monitoring, b.Config.Output)
 		if err != nil {
 			return err
 		}

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -341,10 +341,9 @@ func (b *Beat) launch(settings Settings, bt beat.Creator) error {
 
 	if b.Config.Monitoring.Enabled() {
 		settings := report.Settings{
-			Beat:            b.Info,
 			DefaultUsername: settings.Monitoring.DefaultUsername,
 		}
-		reporter, err := report.New(settings, b.Config.Monitoring, b.Config.Output)
+		reporter, err := report.New(b.Info, settings, b.Config.Monitoring, b.Config.Output)
 		if err != nil {
 			return err
 		}

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -342,7 +342,7 @@ func (b *Beat) launch(settings Settings, bt beat.Creator) error {
 	if b.Config.Monitoring.Enabled() {
 		settings := report.Settings{
 			Beat:            b.Info,
-			DefaultUsername: settings.MonitoringDefaultUsername,
+			DefaultUsername: settings.Monitoring.DefaultUsername,
 		}
 		reporter, err := report.New(settings, b.Config.Monitoring, b.Config.Output)
 		if err != nil {

--- a/libbeat/cmd/instance/settings.go
+++ b/libbeat/cmd/instance/settings.go
@@ -15,21 +15,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package beat
+package instance
 
-import "github.com/satori/go.uuid"
-
-// Info stores a beats instance meta data.
-type Info struct {
-	Beat        string    // The actual beat's name
-	IndexPrefix string    // The beat's index prefix in Elasticsearch.
-	Version     string    // The beat version. Defaults to the libbeat version when an implementation does not set a version
-	Name        string    // configured beat name
-	Hostname    string    // hostname
-	UUID        uuid.UUID // ID assigned to beat instance
-
-	// Monitoring-related fields
-	Monitoring struct {
-		DefaultUsername string // The default username to be used to connect to Elasticsearch Monitoring
-	}
+// Settings contains basic settings for any beat to pass into GenRootCmd
+type Settings struct {
+	Name                      string
+	IndexPrefix               string
+	Version                   string
+	MonitoringDefaultUsername string
 }

--- a/libbeat/cmd/instance/settings.go
+++ b/libbeat/cmd/instance/settings.go
@@ -17,12 +17,15 @@
 
 package instance
 
+import "github.com/spf13/pflag"
+
 // Settings contains basic settings for any beat to pass into GenRootCmd
 type Settings struct {
 	Name        string
 	IndexPrefix string
 	Version     string
 	Monitoring  MonitoringConfig
+	RunFlags    *pflag.FlagSet
 }
 
 // MonitoringConfig contains monitoring-specific settings

--- a/libbeat/cmd/instance/settings.go
+++ b/libbeat/cmd/instance/settings.go
@@ -19,8 +19,13 @@ package instance
 
 // Settings contains basic settings for any beat to pass into GenRootCmd
 type Settings struct {
-	Name                      string
-	IndexPrefix               string
-	Version                   string
-	MonitoringDefaultUsername string
+	Name        string
+	IndexPrefix string
+	Version     string
+	Monitoring  MonitoringConfig
+}
+
+// MonitoringConfig contains monitoring-specific settings
+type MonitoringConfig struct {
+	DefaultUsername string
 }

--- a/libbeat/cmd/instance/settings.go
+++ b/libbeat/cmd/instance/settings.go
@@ -17,18 +17,17 @@
 
 package instance
 
-import "github.com/spf13/pflag"
+import (
+	"github.com/spf13/pflag"
+
+	"github.com/elastic/beats/libbeat/monitoring/report"
+)
 
 // Settings contains basic settings for any beat to pass into GenRootCmd
 type Settings struct {
 	Name        string
 	IndexPrefix string
 	Version     string
-	Monitoring  MonitoringConfig
+	Monitoring  report.Settings
 	RunFlags    *pflag.FlagSet
-}
-
-// MonitoringConfig contains monitoring-specific settings
-type MonitoringConfig struct {
-	DefaultUsername string
 }

--- a/libbeat/cmd/root.go
+++ b/libbeat/cmd/root.go
@@ -72,24 +72,19 @@ func GenRootCmdWithIndexPrefixWithRunFlags(name, indexPrefix, version string, be
 		Name:        name,
 		IndexPrefix: indexPrefix,
 		Version:     version,
+		RunFlags:    runFlags,
 	}
-	return GenRootCmdWithSettingsWithRunFlags(beatCreator, settings, runFlags)
+	return GenRootCmdWithSettings(beatCreator, settings)
 }
 
 // GenRootCmdWithSettings returns the root command to use for your beat. It take the
 // run command, which will be called if no args are given (for backwards compatibility),
 // and beat settings
 func GenRootCmdWithSettings(beatCreator beat.Creator, settings instance.Settings) *BeatsRootCmd {
-	return GenRootCmdWithSettingsWithRunFlags(beatCreator, settings, nil)
-}
-
-// GenRootCmdWithSettingsWithRunFlags returns the root command to use for your beat. It takes the
-// run command, which will be called if no args are given (for backwards compatibility),
-// beat settings, and runFlags. runFlags parameter must the flagset used by run command
-func GenRootCmdWithSettingsWithRunFlags(beatCreator beat.Creator, settings instance.Settings, runFlags *pflag.FlagSet) *BeatsRootCmd {
 	name := settings.Name
 	version := settings.Version
 	indexPrefix := settings.IndexPrefix
+	runFlags := settings.RunFlags
 
 	rootCmd := &BeatsRootCmd{}
 	rootCmd.Use = name

--- a/libbeat/cmd/root.go
+++ b/libbeat/cmd/root.go
@@ -87,6 +87,10 @@ func GenRootCmdWithIndexPrefixWithRunFlags(name, indexPrefix, version string, be
 // run command, which will be called if no args are given (for backwards compatibility),
 // and beat settings
 func GenRootCmdWithSettings(beatCreator beat.Creator, settings instance.Settings) *BeatsRootCmd {
+	if settings.IndexPrefix == "" {
+		settings.IndexPrefix = settings.Name
+	}
+
 	name := settings.Name
 	version := settings.Version
 	indexPrefix := settings.IndexPrefix

--- a/libbeat/cmd/root.go
+++ b/libbeat/cmd/root.go
@@ -55,24 +55,27 @@ type BeatsRootCmd struct {
 }
 
 // GenRootCmd returns the root command to use for your beat. It takes the beat name, version,
-// and run command, which will be called if no args are given (for backwards compatibility)
-// DEPRECATED! Use GenRootCmdWithSettings instead.
+// and run command, which will be called if no args are given (for backwards compatibility).
+//
+// Deprecated: Use GenRootCmdWithSettings instead.
 func GenRootCmd(name, version string, beatCreator beat.Creator) *BeatsRootCmd {
 	return GenRootCmdWithRunFlags(name, version, beatCreator, nil)
 }
 
 // GenRootCmdWithRunFlags returns the root command to use for your beat. It takes
 // beat name, version, run command, and runFlags. runFlags parameter must the flagset used by
-// run command
-// DEPRECATED! Use GenRootCmdWithSettings instead.
+// run command.
+//
+// Deprecated: Use GenRootCmdWithSettings instead.
 func GenRootCmdWithRunFlags(name, version string, beatCreator beat.Creator, runFlags *pflag.FlagSet) *BeatsRootCmd {
 	return GenRootCmdWithIndexPrefixWithRunFlags(name, name, version, beatCreator, runFlags)
 }
 
 // GenRootCmdWithIndexPrefixWithRunFlags returns the root command to use for your beat. It takes
 // beat name, index prefix, version, run command, and runFlags. runFlags parameter must the flagset used by
-// run command
-// DEPRECATED! Use GenRootCmdWithSettings instead.
+// run command.
+//
+// Deprecated: Use GenRootCmdWithSettings instead.
 func GenRootCmdWithIndexPrefixWithRunFlags(name, indexPrefix, version string, beatCreator beat.Creator, runFlags *pflag.FlagSet) *BeatsRootCmd {
 	settings := instance.Settings{
 		Name:        name,

--- a/libbeat/cmd/root.go
+++ b/libbeat/cmd/root.go
@@ -56,6 +56,7 @@ type BeatsRootCmd struct {
 
 // GenRootCmd returns the root command to use for your beat. It takes the beat name, version,
 // and run command, which will be called if no args are given (for backwards compatibility)
+// DEPRECATED! Use GenRootCmdWithSettings instead.
 func GenRootCmd(name, version string, beatCreator beat.Creator) *BeatsRootCmd {
 	return GenRootCmdWithRunFlags(name, version, beatCreator, nil)
 }
@@ -63,10 +64,15 @@ func GenRootCmd(name, version string, beatCreator beat.Creator) *BeatsRootCmd {
 // GenRootCmdWithRunFlags returns the root command to use for your beat. It takes
 // beat name, version, run command, and runFlags. runFlags parameter must the flagset used by
 // run command
+// DEPRECATED! Use GenRootCmdWithSettings instead.
 func GenRootCmdWithRunFlags(name, version string, beatCreator beat.Creator, runFlags *pflag.FlagSet) *BeatsRootCmd {
 	return GenRootCmdWithIndexPrefixWithRunFlags(name, name, version, beatCreator, runFlags)
 }
 
+// GenRootCmdWithIndexPrefixWithRunFlags returns the root command to use for your beat. It takes
+// beat name, index prefix, version, run command, and runFlags. runFlags parameter must the flagset used by
+// run command
+// DEPRECATED! Use GenRootCmdWithSettings instead.
 func GenRootCmdWithIndexPrefixWithRunFlags(name, indexPrefix, version string, beatCreator beat.Creator, runFlags *pflag.FlagSet) *BeatsRootCmd {
 	settings := instance.Settings{
 		Name:        name,

--- a/libbeat/cmd/run.go
+++ b/libbeat/cmd/run.go
@@ -28,12 +28,13 @@ import (
 	"github.com/elastic/beats/libbeat/cmd/instance"
 )
 
-func genRunCmd(name, idxPrefix, version string, beatCreator beat.Creator, runFlags *pflag.FlagSet) *cobra.Command {
+func genRunCmd(settings instance.Settings, beatCreator beat.Creator, runFlags *pflag.FlagSet) *cobra.Command {
+	name := settings.Name
 	runCmd := cobra.Command{
 		Use:   "run",
 		Short: "Run " + name,
 		Run: func(cmd *cobra.Command, args []string) {
-			err := instance.Run(name, idxPrefix, version, beatCreator)
+			err := instance.Run(settings, beatCreator)
 			if err != nil {
 				os.Exit(1)
 			}

--- a/libbeat/monitoring/report/elasticsearch/config.go
+++ b/libbeat/monitoring/report/elasticsearch/config.go
@@ -49,26 +49,3 @@ type backoff struct {
 	Init time.Duration
 	Max  time.Duration
 }
-
-var defaultConfig = config{
-	Hosts:            nil,
-	Protocol:         "http",
-	Params:           nil,
-	Headers:          nil,
-	Username:         "beats_system",
-	Password:         "",
-	ProxyURL:         "",
-	CompressionLevel: 0,
-	TLS:              nil,
-	MaxRetries:       3,
-	Timeout:          60 * time.Second,
-	MetricsPeriod:    10 * time.Second,
-	StatePeriod:      1 * time.Minute,
-	BulkMaxSize:      50,
-	BufferSize:       50,
-	Tags:             nil,
-	Backoff: backoff{
-		Init: 1 * time.Second,
-		Max:  60 * time.Second,
-	},
-}

--- a/libbeat/monitoring/report/elasticsearch/config.go
+++ b/libbeat/monitoring/report/elasticsearch/config.go
@@ -55,7 +55,7 @@ var defaultConfig = config{
 	Protocol:         "http",
 	Params:           nil,
 	Headers:          nil,
-	Username:         "beats_system",
+	Username:         "beats_system", // TODO: allow any beat to override this default
 	Password:         "",
 	ProxyURL:         "",
 	CompressionLevel: 0,

--- a/libbeat/monitoring/report/elasticsearch/config.go
+++ b/libbeat/monitoring/report/elasticsearch/config.go
@@ -55,7 +55,7 @@ var defaultConfig = config{
 	Protocol:         "http",
 	Params:           nil,
 	Headers:          nil,
-	Username:         "beats_system", // TODO: allow any beat to override this default
+	Username:         "beats_system",
 	Password:         "",
 	ProxyURL:         "",
 	CompressionLevel: 0,

--- a/libbeat/monitoring/report/elasticsearch/elasticsearch.go
+++ b/libbeat/monitoring/report/elasticsearch/elasticsearch.go
@@ -85,10 +85,6 @@ func overrideParamsFromBeat(params map[string]interface{}, beat beat.Info) {
 	if beat.Monitoring.SystemID != "" {
 		params["system_id"] = beat.Monitoring.SystemID
 	}
-
-	if beat.Monitoring.SystemAPIVersion != "" {
-		params["system_api_version"] = beat.Monitoring.SystemAPIVersion
-	}
 }
 
 func makeReporter(beat beat.Info, cfg *common.Config) (report.Reporter, error) {

--- a/libbeat/monitoring/report/elasticsearch/elasticsearch.go
+++ b/libbeat/monitoring/report/elasticsearch/elasticsearch.go
@@ -81,7 +81,7 @@ func overrideConfigFromBeat(config *config, beat beat.Info) {
 	}
 }
 
-func overrideParamsFromBeat(params map[string]interface{}, beat beat.Info) {
+func overrideParamsFromBeat(params map[string]string, beat beat.Info) {
 	if beat.Monitoring.SystemID != "" {
 		params["system_id"] = beat.Monitoring.SystemID
 	}

--- a/libbeat/monitoring/report/elasticsearch/elasticsearch.go
+++ b/libbeat/monitoring/report/elasticsearch/elasticsearch.go
@@ -66,6 +66,7 @@ var debugf = logp.MakeDebug(selector)
 var errNoMonitoring = errors.New("xpack monitoring not available")
 
 // default monitoring api parameters
+// TODO: allow any beat to override
 var defaultParams = map[string]string{
 	"system_id":          "beats",
 	"system_api_version": "6",

--- a/libbeat/monitoring/report/elasticsearch/elasticsearch.go
+++ b/libbeat/monitoring/report/elasticsearch/elasticsearch.go
@@ -75,16 +75,40 @@ func init() {
 	report.RegisterReporterFactory("elasticsearch", makeReporter)
 }
 
-func overrideConfigFromBeat(config *config, settings report.Settings) {
-	if settings.DefaultUsername != "" {
-		config.Username = settings.DefaultUsername
+func defaultConfig(settings report.Settings) config {
+	c := config{
+		Hosts:            nil,
+		Protocol:         "http",
+		Params:           nil,
+		Headers:          nil,
+		Username:         "beats_system",
+		Password:         "",
+		ProxyURL:         "",
+		CompressionLevel: 0,
+		TLS:              nil,
+		MaxRetries:       3,
+		Timeout:          60 * time.Second,
+		MetricsPeriod:    10 * time.Second,
+		StatePeriod:      1 * time.Minute,
+		BulkMaxSize:      50,
+		BufferSize:       50,
+		Tags:             nil,
+		Backoff: backoff{
+			Init: 1 * time.Second,
+			Max:  60 * time.Second,
+		},
 	}
+
+	if settings.DefaultUsername != "" {
+		c.Username = settings.DefaultUsername
+	}
+
+	return c
 }
 
 func makeReporter(settings report.Settings, cfg *common.Config) (report.Reporter, error) {
 	log := logp.L().Named(selector)
-	config := defaultConfig
-	overrideConfigFromBeat(&config, settings)
+	config := defaultConfig(settings)
 	if err := cfg.Unpack(&config); err != nil {
 		return nil, err
 	}

--- a/libbeat/monitoring/report/elasticsearch/elasticsearch.go
+++ b/libbeat/monitoring/report/elasticsearch/elasticsearch.go
@@ -106,7 +106,7 @@ func defaultConfig(settings report.Settings) config {
 	return c
 }
 
-func makeReporter(settings report.Settings, cfg *common.Config) (report.Reporter, error) {
+func makeReporter(beat beat.Info, settings report.Settings, cfg *common.Config) (report.Reporter, error) {
 	log := logp.L().Named(selector)
 	config := defaultConfig(settings)
 	if err := cfg.Unpack(&config); err != nil {
@@ -170,7 +170,6 @@ func makeReporter(settings report.Settings, cfg *common.Config) (report.Reporter
 	outClient := outputs.NewFailoverClient(clients)
 	outClient = outputs.WithBackoff(outClient, config.Backoff.Init, config.Backoff.Max)
 
-	beat := settings.Beat
 	pipeline, err := pipeline.New(
 		beat,
 		monitoring,

--- a/libbeat/monitoring/report/report.go
+++ b/libbeat/monitoring/report/report.go
@@ -30,11 +30,16 @@ type config struct {
 	Reporter common.ConfigNamespace `config:",inline"`
 }
 
+type Settings struct {
+	Beat            beat.Info
+	DefaultUsername string
+}
+
 type Reporter interface {
 	Stop()
 }
 
-type ReporterFactory func(beat.Info, *common.Config) (Reporter, error)
+type ReporterFactory func(Settings, *common.Config) (Reporter, error)
 
 var (
 	defaultConfig = config{}
@@ -50,7 +55,7 @@ func RegisterReporterFactory(name string, f ReporterFactory) {
 }
 
 func New(
-	beat beat.Info,
+	settings Settings,
 	cfg *common.Config,
 	outputs common.ConfigNamespace,
 ) (Reporter, error) {
@@ -64,7 +69,7 @@ func New(
 		return nil, fmt.Errorf("unknown reporter type '%v'", name)
 	}
 
-	return f(beat, cfg)
+	return f(settings, cfg)
 }
 
 func getReporterConfig(

--- a/libbeat/monitoring/report/report.go
+++ b/libbeat/monitoring/report/report.go
@@ -31,7 +31,6 @@ type config struct {
 }
 
 type Settings struct {
-	Beat            beat.Info
 	DefaultUsername string
 }
 
@@ -39,7 +38,7 @@ type Reporter interface {
 	Stop()
 }
 
-type ReporterFactory func(Settings, *common.Config) (Reporter, error)
+type ReporterFactory func(beat.Info, Settings, *common.Config) (Reporter, error)
 
 var (
 	defaultConfig = config{}
@@ -55,6 +54,7 @@ func RegisterReporterFactory(name string, f ReporterFactory) {
 }
 
 func New(
+	beat beat.Info,
 	settings Settings,
 	cfg *common.Config,
 	outputs common.ConfigNamespace,
@@ -69,7 +69,7 @@ func New(
 		return nil, fmt.Errorf("unknown reporter type '%v'", name)
 	}
 
-	return f(settings, cfg)
+	return f(beat, settings, cfg)
 }
 
 func getReporterConfig(


### PR DESCRIPTION
By default all beats will use the `beats_system` user to talk to the Elasticsearch Monitoring bulk API. End-users can, of course, override this via the `xpack.monitoring.elasticsearch.username` configuration setting but sometimes a beat might want to specify a default other than `beats_system`. APM server is one such example wanting to use the `apm_system` user as it's default.

This PR makes it so a beat can override the Monitoring default username. This override should be done when the beat exports the `cmd.RootCmd` variable like so:

```golang
import (
    "github.com/elastic/beats/libbeat/cmd/instance"
    "github.com/elastic/beats/libbeat/monitoring/report"
)

var settings = instance.Settings{
	Name: "apm_server",
	Version: "",
	Monitoring: report.Settings{
          DefaultUsername: "apm_system",
        },
}
var RootCmd = cmd.GenRootCmdWithSettings(beater.New, settings)
```

---

### Deprecation notice
This PR introduces a new function, `cmd.GenRootCmdWithSettings`. See the code snippet above for sample usage. This new function should be preferred over now-deprecated functions, `cmd.GenRootCmd`, `cmd.GenRootCmdWithRunFlags`, and `cmd.GenRootCmdWithIndexPrefixWithRunFlags`. See examples below on how to upgrade from the using the deprecated functions to using the new function.

#### Upgrading from using `cmd.GenRootCmd`

```golang
// Before
var RootCmd = cmd.GenRootCmd("countbeat", "", beater.New)

// After
import "github.com/elastic/beats/libbeat/cmd/instance"
var settings = instance.Settings{
    Name: "countbeat",
}
var RootCmd = cmd.GenRootCmdWithSettings(beater.New, settings)
```

#### Upgrading from using `cmd.GenRootCmdWithRunFlags`

```golang
// Before
import "github.com/spf13/pflag"

var runFlags = pflag.NewFlagSet(Name, pflag.ExitOnError)
runFlags.AddGoFlag(flag.CommandLine.Lookup("I"))
runFlags.AddGoFlag(flag.CommandLine.Lookup("dump"))

var RootCmd = cmd.GenRootCmdWithRunFlags("countbeat", "", beater.New, runFlags)

// After
import (
    "github.com/spf13/pflag"
    "github.com/elastic/beats/libbeat/cmd/instance"
)

var runFlags = pflag.NewFlagSet(Name, pflag.ExitOnError)
runFlags.AddGoFlag(flag.CommandLine.Lookup("I"))
runFlags.AddGoFlag(flag.CommandLine.Lookup("dump"))

var settings = instance.Settings{
    Name: "countbeat",
    RunFlags: runFlags,
}
var RootCmd = cmd.GenRootCmdWithSettings(beater.New, settings)
```

#### Upgrading from using `cmd.GenRootCmdWithIndexPrefixWithRunFlags`

```golang
// Before
import "github.com/spf13/pflag"

var runFlags = pflag.NewFlagSet(Name, pflag.ExitOnError)
runFlags.AddGoFlag(flag.CommandLine.Lookup("I"))
runFlags.AddGoFlag(flag.CommandLine.Lookup("dump"))

var RootCmd = cmd.GenRootCmdWithIndexPrefixWithRunFlags("countbeat", "cb", "", beater.New, runFlags)

// After
import (
    "github.com/spf13/pflag"
    "github.com/elastic/beats/libbeat/cmd/instance"
)

var runFlags = pflag.NewFlagSet(Name, pflag.ExitOnError)
runFlags.AddGoFlag(flag.CommandLine.Lookup("I"))
runFlags.AddGoFlag(flag.CommandLine.Lookup("dump"))

var settings = instance.Settings{
    Name: "countbeat",
    IndexPrefix: "cb",
    RunFlags: runFlags,
}
var RootCmd = cmd.GenRootCmdWithSettings(beater.New, settings)
```