### PR TITLE
Fix anchor ID in docs

### DIFF
--- a/auditbeat/docs/setting-up-running.asciidoc
+++ b/auditbeat/docs/setting-up-running.asciidoc
@@ -4,7 +4,7 @@
 // that is unique to each beat.
 /////
 
-[[seting-up-and-running]]
+[[setting-up-and-running]]
 == Setting up and running {beatname_uc}
 
 Before reading this section, see the

--- a/filebeat/docs/setting-up-running.asciidoc
+++ b/filebeat/docs/setting-up-running.asciidoc
@@ -4,7 +4,7 @@
 // that is unique to each beat.
 /////
 
-[[seting-up-and-running]]
+[[setting-up-and-running]]
 == Setting up and running {beatname_uc}
 
 Before reading this section, see the

--- a/heartbeat/docs/setting-up-running.asciidoc
+++ b/heartbeat/docs/setting-up-running.asciidoc
@@ -4,7 +4,7 @@
 // that is unique to each beat.
 /////
 
-[[seting-up-and-running]]
+[[setting-up-and-running]]
 == Setting up and running {beatname_uc}
 
 Before reading this section, see the

--- a/metricbeat/docs/setting-up-running.asciidoc
+++ b/metricbeat/docs/setting-up-running.asciidoc
@@ -4,7 +4,7 @@
 // that is unique to each beat.
 /////
 
-[[seting-up-and-running]]
+[[setting-up-and-running]]
 == Setting up and running {beatname_uc}
 
 Before reading this section, see the

--- a/packetbeat/docs/setting-up-running.asciidoc
+++ b/packetbeat/docs/setting-up-running.asciidoc
@@ -4,7 +4,7 @@
 // that is unique to each beat.
 /////
 
-[[seting-up-and-running]]
+[[setting-up-and-running]]
 == Setting up and running {beatname_uc}
 
 Before reading this section, see the

--- a/winlogbeat/docs/setting-up-running.asciidoc
+++ b/winlogbeat/docs/setting-up-running.asciidoc
@@ -4,7 +4,7 @@
 // that is unique to each beat.
 /////
 
-[[seting-up-and-running]]
+[[setting-up-and-running]]
 == Setting up and running {beatname_uc}
 
 Before reading this section, see the


### PR DESCRIPTION
This spelling fix was made in master, 6.x, and 6.4. Needs to be made in the other branches for the version switching to work correctly in the published docs.