### PR TITLE
Trim space from debug selectors in -d

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -30,6 +30,7 @@ https://github.com/elastic/beats/compare/v6.4.0...master[Check the HEAD diff]
 *Affecting all Beats*
 
 - Fixed `add_host_metadata` not initializing correctly on Windows. {issue}7715[7715]
+- Fixed `-d` CLI flag by trimming spaces from selectors. {pull}7864[7864]
 
 *Auditbeat*
 

--- a/libbeat/logp/core.go
+++ b/libbeat/logp/core.go
@@ -23,6 +23,7 @@ import (
 	golog "log"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"unsafe"
 
@@ -89,7 +90,7 @@ func Configure(cfg Config) error {
 	selectors := make(map[string]struct{}, len(cfg.Selectors))
 	if cfg.Level.Enabled(DebugLevel) && len(cfg.Selectors) > 0 {
 		for _, sel := range cfg.Selectors {
-			selectors[sel] = struct{}{}
+			selectors[strings.TrimSpace(sel)] = struct{}{}
 		}
 
 		// Default to all enabled if no selectors are specified.

--- a/libbeat/logp/core_test.go
+++ b/libbeat/logp/core_test.go
@@ -54,9 +54,11 @@ func TestLogger(t *testing.T) {
 }
 
 func TestLoggerSelectors(t *testing.T) {
-	if err := DevelopmentSetup(WithSelectors("good"), ToObserverOutput()); err != nil {
+	if err := DevelopmentSetup(WithSelectors("good", " padded "), ToObserverOutput()); err != nil {
 		t.Fatal(err)
 	}
+
+	assert.True(t, HasSelector("padded"))
 
 	good := NewLogger("good")
 	bad := NewLogger("bad")


### PR DESCRIPTION
Using `-d "publish, processors"` wasn't working expected because `processors` included a leading space. Each selector is now trimmed.

Workarounds include using `-d publish -d processors` or `-d publish,processors`.