### PR TITLE
Skip sockets summary system tests on Windows

### DIFF
--- a/metricbeat/module/system/socket_summary/_meta/docs.asciidoc
+++ b/metricbeat/module/system/socket_summary/_meta/docs.asciidoc
@@ -12,7 +12,6 @@ This metricset is available on:
 - FreeBSD
 - Linux
 - macOS
-- Windows
 
 [float]
 === Configuration

--- a/metricbeat/module/system/socket_summary/socket_summary.go
+++ b/metricbeat/module/system/socket_summary/socket_summary.go
@@ -18,7 +18,10 @@
 package socket_summary
 
 import (
+	"runtime"
 	"syscall"
+
+	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/libbeat/common"
 
@@ -50,6 +53,9 @@ type MetricSet struct {
 // any MetricSet specific configuration options if there are any.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	cfgwarn.Experimental("The socket_summary metricset is experimental.")
+	if runtime.GOOS == "windows" {
+		return nil, errors.New("socket_summary metricset is not supported in Windows")
+	}
 
 	return &MetricSet{
 		BaseMetricSet: base,

--- a/metricbeat/tests/system/test_system.py
+++ b/metricbeat/tests/system/test_system.py
@@ -449,7 +449,7 @@ class Test(metricbeat.BaseTest):
         assert isinstance(output["system.process.cpu.start_time"], six.string_types)
         self.check_username(output["system.process.username"])
 
-    @unittest.skipUnless(re.match("(?i)win|linux|darwin|freebsd", sys.platform), "os")
+    @unittest.skipUnless(re.match("(?i)linux|darwin|freebsd", sys.platform), "os")
     def test_socket_summary(self):
         """
         Test system/socket_summary output.


### PR DESCRIPTION
Required method of gopsutil is not implemented for Windows.

Fixes #7868