### PR TITLE
Fix permissions at systemd unit file

### DIFF
--- a/dev-tools/packaging/packages.yml
+++ b/dev-tools/packaging/packages.yml
@@ -58,7 +58,7 @@ shared:
         mode: 0755
       /lib/systemd/system/{{.BeatServiceName}}.service:
         template: '{{ elastic_beats_dir }}/dev-tools/packaging/templates/linux/systemd.unit.tmpl'
-        mode: 0755
+        mode: 0644
       /etc/init.d/{{.BeatServiceName}}:
         template: '{{ elastic_beats_dir }}/dev-tools/packaging/templates/{{.PackageType}}/init.sh.tmpl'
         mode: 0755


### PR DESCRIPTION
Systemd unit has wrong permissions. So systemd logs:
`Configuration file /lib/systemd/system/auditbeat.service is marked executable.
 Please remove executable permission bits. Proceeding anyway`