### PR TITLE
Cherry-pick #7820 to 6.4: Fix goroutine leak in SubOutlet

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -38,6 +38,8 @@ https://github.com/elastic/beats/compare/v6.4.0...6.4[Check the HEAD diff]
 
 *Filebeat*
 
+- Fixed a memory leak when harvesters are closed. {pull}7820[7820]
+
 *Heartbeat*
 
 *Metricbeat*


### PR DESCRIPTION
Cherry-pick of PR #7820 to 6.4 branch. Original message: 

This fixes a goroutine leaking every time that a harvester is closed.