### PR TITLE
Add missing config options to Logstash section of reference.yml

### DIFF
--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -439,10 +439,6 @@ output.elasticsearch:
   # The Logstash hosts
   #hosts: ["localhost:5044"]
 
-  # The Logstash port to use if hosts does not contain a port number. The default
-  # is 5044.
-  #port: 5044
-  
   # Number of workers per Logstash host.
   #worker: 1
 

--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -439,6 +439,10 @@ output.elasticsearch:
   # The Logstash hosts
   #hosts: ["localhost:5044"]
 
+  # The Logstash port to use if hosts does not contain a port number. The default
+  # is 5044.
+  #port: 5044
+  
   # Number of workers per Logstash host.
   #worker: 1
 
@@ -523,6 +527,21 @@ output.elasticsearch:
   # Configure what types of renegotiation are supported. Valid options are
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
+
+  # The number of times to retry publishing an event after a publishing failure.
+  # After the specified number of retries, the events are typically dropped.
+  # Some Beats, such as Filebeat and Winlogbeat, ignore the max_retries setting
+  # and retry until all events are published.  Set max_retries to a value less
+  # than 0 to retry until all events are published. The default is 3.
+  #max_retries: 3
+  
+  # The maximum number of events to bulk in a single Logstash request. The
+  # default is 2048.
+  #bulk_max_size: 2048
+  
+  # The number of seconds to wait for responses from the Logstash server before
+  # timing out. The default is 30s.
+  #timeout: 30s
 
 #------------------------------- Kafka output ----------------------------------
 #output.kafka:

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -1099,6 +1099,10 @@ output.elasticsearch:
   # The Logstash hosts
   #hosts: ["localhost:5044"]
 
+  # The Logstash port to use if hosts does not contain a port number. The default
+  # is 5044.
+  #port: 5044
+  
   # Number of workers per Logstash host.
   #worker: 1
 
@@ -1183,6 +1187,21 @@ output.elasticsearch:
   # Configure what types of renegotiation are supported. Valid options are
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
+
+  # The number of times to retry publishing an event after a publishing failure.
+  # After the specified number of retries, the events are typically dropped.
+  # Some Beats, such as Filebeat and Winlogbeat, ignore the max_retries setting
+  # and retry until all events are published.  Set max_retries to a value less
+  # than 0 to retry until all events are published. The default is 3.
+  #max_retries: 3
+  
+  # The maximum number of events to bulk in a single Logstash request. The
+  # default is 2048.
+  #bulk_max_size: 2048
+  
+  # The number of seconds to wait for responses from the Logstash server before
+  # timing out. The default is 30s.
+  #timeout: 30s
 
 #------------------------------- Kafka output ----------------------------------
 #output.kafka:

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -1099,10 +1099,6 @@ output.elasticsearch:
   # The Logstash hosts
   #hosts: ["localhost:5044"]
 
-  # The Logstash port to use if hosts does not contain a port number. The default
-  # is 5044.
-  #port: 5044
-  
   # Number of workers per Logstash host.
   #worker: 1
 

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -546,6 +546,10 @@ output.elasticsearch:
   # The Logstash hosts
   #hosts: ["localhost:5044"]
 
+  # The Logstash port to use if hosts does not contain a port number. The default
+  # is 5044.
+  #port: 5044
+  
   # Number of workers per Logstash host.
   #worker: 1
 
@@ -630,6 +634,21 @@ output.elasticsearch:
   # Configure what types of renegotiation are supported. Valid options are
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
+
+  # The number of times to retry publishing an event after a publishing failure.
+  # After the specified number of retries, the events are typically dropped.
+  # Some Beats, such as Filebeat and Winlogbeat, ignore the max_retries setting
+  # and retry until all events are published.  Set max_retries to a value less
+  # than 0 to retry until all events are published. The default is 3.
+  #max_retries: 3
+  
+  # The maximum number of events to bulk in a single Logstash request. The
+  # default is 2048.
+  #bulk_max_size: 2048
+  
+  # The number of seconds to wait for responses from the Logstash server before
+  # timing out. The default is 30s.
+  #timeout: 30s
 
 #------------------------------- Kafka output ----------------------------------
 #output.kafka:

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -546,10 +546,6 @@ output.elasticsearch:
   # The Logstash hosts
   #hosts: ["localhost:5044"]
 
-  # The Logstash port to use if hosts does not contain a port number. The default
-  # is 5044.
-  #port: 5044
-  
   # Number of workers per Logstash host.
   #worker: 1
 

--- a/libbeat/_meta/config.reference.yml
+++ b/libbeat/_meta/config.reference.yml
@@ -332,10 +332,6 @@ output.elasticsearch:
   # The Logstash hosts
   #hosts: ["localhost:5044"]
 
-  # The Logstash port to use if hosts does not contain a port number. The default
-  # is 5044.
-  #port: 5044
-  
   # Number of workers per Logstash host.
   #worker: 1
 

--- a/libbeat/_meta/config.reference.yml
+++ b/libbeat/_meta/config.reference.yml
@@ -332,6 +332,10 @@ output.elasticsearch:
   # The Logstash hosts
   #hosts: ["localhost:5044"]
 
+  # The Logstash port to use if hosts does not contain a port number. The default
+  # is 5044.
+  #port: 5044
+  
   # Number of workers per Logstash host.
   #worker: 1
 
@@ -416,6 +420,21 @@ output.elasticsearch:
   # Configure what types of renegotiation are supported. Valid options are
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
+
+  # The number of times to retry publishing an event after a publishing failure.
+  # After the specified number of retries, the events are typically dropped.
+  # Some Beats, such as Filebeat and Winlogbeat, ignore the max_retries setting
+  # and retry until all events are published.  Set max_retries to a value less
+  # than 0 to retry until all events are published. The default is 3.
+  #max_retries: 3
+  
+  # The maximum number of events to bulk in a single Logstash request. The
+  # default is 2048.
+  #bulk_max_size: 2048
+  
+  # The number of seconds to wait for responses from the Logstash server before
+  # timing out. The default is 30s.
+  #timeout: 30s
 
 #------------------------------- Kafka output ----------------------------------
 #output.kafka:

--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -538,7 +538,7 @@ configured. The default value is 2.
 deprecated[5.0.0]
 
 The default port to use if the port number is not given in <<hosts,`hosts`>>. The default port number
-is 10200.
+is 5044.
 
 ===== `proxy_url`
 

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -1009,6 +1009,10 @@ output.elasticsearch:
   # The Logstash hosts
   #hosts: ["localhost:5044"]
 
+  # The Logstash port to use if hosts does not contain a port number. The default
+  # is 5044.
+  #port: 5044
+  
   # Number of workers per Logstash host.
   #worker: 1
 
@@ -1093,6 +1097,21 @@ output.elasticsearch:
   # Configure what types of renegotiation are supported. Valid options are
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
+
+  # The number of times to retry publishing an event after a publishing failure.
+  # After the specified number of retries, the events are typically dropped.
+  # Some Beats, such as Filebeat and Winlogbeat, ignore the max_retries setting
+  # and retry until all events are published.  Set max_retries to a value less
+  # than 0 to retry until all events are published. The default is 3.
+  #max_retries: 3
+  
+  # The maximum number of events to bulk in a single Logstash request. The
+  # default is 2048.
+  #bulk_max_size: 2048
+  
+  # The number of seconds to wait for responses from the Logstash server before
+  # timing out. The default is 30s.
+  #timeout: 30s
 
 #------------------------------- Kafka output ----------------------------------
 #output.kafka:

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -1009,10 +1009,6 @@ output.elasticsearch:
   # The Logstash hosts
   #hosts: ["localhost:5044"]
 
-  # The Logstash port to use if hosts does not contain a port number. The default
-  # is 5044.
-  #port: 5044
-  
   # Number of workers per Logstash host.
   #worker: 1
 

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -809,10 +809,6 @@ output.elasticsearch:
   # The Logstash hosts
   #hosts: ["localhost:5044"]
 
-  # The Logstash port to use if hosts does not contain a port number. The default
-  # is 5044.
-  #port: 5044
-  
   # Number of workers per Logstash host.
   #worker: 1
 

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -809,6 +809,10 @@ output.elasticsearch:
   # The Logstash hosts
   #hosts: ["localhost:5044"]
 
+  # The Logstash port to use if hosts does not contain a port number. The default
+  # is 5044.
+  #port: 5044
+  
   # Number of workers per Logstash host.
   #worker: 1
 
@@ -893,6 +897,21 @@ output.elasticsearch:
   # Configure what types of renegotiation are supported. Valid options are
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
+
+  # The number of times to retry publishing an event after a publishing failure.
+  # After the specified number of retries, the events are typically dropped.
+  # Some Beats, such as Filebeat and Winlogbeat, ignore the max_retries setting
+  # and retry until all events are published.  Set max_retries to a value less
+  # than 0 to retry until all events are published. The default is 3.
+  #max_retries: 3
+  
+  # The maximum number of events to bulk in a single Logstash request. The
+  # default is 2048.
+  #bulk_max_size: 2048
+  
+  # The number of seconds to wait for responses from the Logstash server before
+  # timing out. The default is 30s.
+  #timeout: 30s
 
 #------------------------------- Kafka output ----------------------------------
 #output.kafka:

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -361,10 +361,6 @@ output.elasticsearch:
   # The Logstash hosts
   #hosts: ["localhost:5044"]
 
-  # The Logstash port to use if hosts does not contain a port number. The default
-  # is 5044.
-  #port: 5044
-  
   # Number of workers per Logstash host.
   #worker: 1
 

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -361,6 +361,10 @@ output.elasticsearch:
   # The Logstash hosts
   #hosts: ["localhost:5044"]
 
+  # The Logstash port to use if hosts does not contain a port number. The default
+  # is 5044.
+  #port: 5044
+  
   # Number of workers per Logstash host.
   #worker: 1
 
@@ -445,6 +449,21 @@ output.elasticsearch:
   # Configure what types of renegotiation are supported. Valid options are
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
+
+  # The number of times to retry publishing an event after a publishing failure.
+  # After the specified number of retries, the events are typically dropped.
+  # Some Beats, such as Filebeat and Winlogbeat, ignore the max_retries setting
+  # and retry until all events are published.  Set max_retries to a value less
+  # than 0 to retry until all events are published. The default is 3.
+  #max_retries: 3
+  
+  # The maximum number of events to bulk in a single Logstash request. The
+  # default is 2048.
+  #bulk_max_size: 2048
+  
+  # The number of seconds to wait for responses from the Logstash server before
+  # timing out. The default is 30s.
+  #timeout: 30s
 
 #------------------------------- Kafka output ----------------------------------
 #output.kafka:


### PR DESCRIPTION
Closes #3062 

A couple of open issues:

- [x] So do we want to remove the deprecation statement under `port` in the [reference docs](https://www.elastic.co/guide/en/beats/filebeat/current/logstash-output.html#port)? (NO)
- [x] The [reference docs](https://www.elastic.co/guide/en/beats/filebeat/current/logstash-output.html#port) say that the default setting for `port` is 10200, but the [code here](https://github.com/elastic/beats/blob/master/libbeat/outputs/logstash/config.go#L50) says 5044.  I'll change it in the reference docs (assuming I'm reading the code correctly...let me know). (Fixed docs.)