### PR TITLE
Cherry-pick #7866 to 6.4: Install virtualenv in OSX travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -152,6 +152,8 @@ before_install:
   - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
   - chmod +x docker-compose
   - sudo mv docker-compose /usr/local/bin
+  - if [ $TRAVIS_OS_NAME = osx ]; then pip install virtualenv; fi
+
 
 # Skips installations step
 install: true


### PR DESCRIPTION
Cherry-pick of PR #7866 to 6.4 branch. Original message: 

Try to install virtualenv in OSX in travis builds after https://github.com/travis-ci/travis-ci/issues/9929

Continues with #7826