### PR TITLE
Reset modulename attribute at the end of a file

### DIFF
--- a/filebeat/scripts/module/_meta/docs.asciidoc
+++ b/filebeat/scripts/module/_meta/docs.asciidoc
@@ -37,3 +37,5 @@ the relevant file. For example:
 ==== `{fileset}` log fileset settings
 
 include::../include/var-paths.asciidoc[]
+
+:modulename!:


### PR DESCRIPTION
As a best practice, we should reset attributes when the value is no longer needed. 

Because attribute values stay in scope (for each book) until they are reset, there's a danger that the value could show up later in the book if a topic uses the attribute without defining a value for it.
