### PR TITLE
Add missing namespace field in http server metricset

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -46,6 +46,7 @@ https://github.com/elastic/beats/compare/v6.4.0...master[Check the HEAD diff]
 
 - Fix golang.heap.gc.cpu_fraction type from long to float in Golang module. {pull}7789[7789]
 - Fixed a panic when the kvm module cannot establish a connection to libvirtd. {issue}7792[7792].
+- Add missing namespace field in http server metricset {pull}7890[7890]
 
 *Packetbeat*
 

--- a/metricbeat/module/http/server/server.go
+++ b/metricbeat/module/http/server/server.go
@@ -18,7 +18,8 @@
 package server
 
 import (
-	"github.com/elastic/beats/libbeat/common"
+	"fmt"
+
 	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	serverhelper "github.com/elastic/beats/metricbeat/helper/server"
 	"github.com/elastic/beats/metricbeat/helper/server/http"
@@ -83,10 +84,13 @@ func (m *MetricSet) Run(reporter mb.PushReporterV2) {
 				reporter.Error(err)
 			} else {
 				event := mb.Event{}
-				event.ModuleFields = common.MapStr{}
-				metricSetName := fields[mb.NamespaceKey].(string)
-				delete(fields, mb.NamespaceKey)
-				event.ModuleFields.Put(metricSetName, fields)
+				ns, ok := fields[mb.NamespaceKey].(string)
+				if ok {
+					ns = fmt.Sprintf("http.%s", ns)
+					delete(fields, mb.NamespaceKey)
+				}
+				event.MetricSetFields = fields
+				event.Namespace = ns
 				reporter.Event(event)
 			}
 


### PR DESCRIPTION
This PR adds back the missing `metricset.namespace` field in to payloads generated by http server.