### PR TITLE
Deregister pipeline loader callback when inputsRunner is stopped

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -37,6 +37,7 @@ https://github.com/elastic/beats/compare/v6.4.0...master[Check the HEAD diff]
 - Fix potential data loss on OS X in spool file by using fcntl with F_FULLFSYNC. {pull}7859[7859]
 - Improve fsync on linux, by assuming the kernel resets error flags of failed writes. {pull}7859[7859]
 - Remove unix-like permission checks on Windows, so files can be opened. {issue}7849[7849]
+- Deregister pipeline loader callback when inputsRunner is stopped. {pull}[7893][7893]
 
 *Auditbeat*
 

--- a/filebeat/fileset/factory.go
+++ b/filebeat/fileset/factory.go
@@ -18,6 +18,8 @@
 package fileset
 
 import (
+	uuid "github.com/satori/go.uuid"
+
 	"github.com/elastic/beats/filebeat/channel"
 	input "github.com/elastic/beats/filebeat/prospector"
 	"github.com/elastic/beats/filebeat/registrar"
@@ -46,7 +48,7 @@ type Factory struct {
 	beatVersion           string
 	pipelineLoaderFactory PipelineLoaderFactory
 	overwritePipelines    bool
-	pipelineCallbackID    int
+	pipelineCallbackID    uuid.UUID
 	beatDone              chan struct{}
 }
 
@@ -56,7 +58,7 @@ type inputsRunner struct {
 	moduleRegistry        *ModuleRegistry
 	inputs                []*input.Runner
 	pipelineLoaderFactory PipelineLoaderFactory
-	pipelineCallbackID    int
+	pipelineCallbackID    uuid.UUID
 	overwritePipelines    bool
 }
 
@@ -69,7 +71,7 @@ func NewFactory(outlet channel.Factory, registrar *registrar.Registrar, beatVers
 		beatVersion:           beatVersion,
 		beatDone:              beatDone,
 		pipelineLoaderFactory: pipelineLoaderFactory,
-		pipelineCallbackID:    -1,
+		pipelineCallbackID:    uuid.Nil,
 		overwritePipelines:    overwritePipelines,
 	}
 }
@@ -147,7 +149,7 @@ func (p *inputsRunner) Start() {
 	}
 }
 func (p *inputsRunner) Stop() {
-	if p.pipelineCallbackID != -1 {
+	if p.pipelineCallbackID != uuid.Nil {
 		elasticsearch.DeregisterConnectCallback(p.pipelineCallbackID)
 	}
 

--- a/filebeat/fileset/factory.go
+++ b/filebeat/fileset/factory.go
@@ -46,7 +46,7 @@ type Factory struct {
 	beatVersion           string
 	pipelineLoaderFactory PipelineLoaderFactory
 	overwritePipelines    bool
-	pipelineCallbackId    int
+	pipelineCallbackID    int
 	beatDone              chan struct{}
 }
 
@@ -56,7 +56,7 @@ type inputsRunner struct {
 	moduleRegistry        *ModuleRegistry
 	inputs                []*input.Runner
 	pipelineLoaderFactory PipelineLoaderFactory
-	pipelineCallbackId    int
+	pipelineCallbackID    int
 	overwritePipelines    bool
 }
 
@@ -69,7 +69,7 @@ func NewFactory(outlet channel.Factory, registrar *registrar.Registrar, beatVers
 		beatVersion:           beatVersion,
 		beatDone:              beatDone,
 		pipelineLoaderFactory: pipelineLoaderFactory,
-		pipelineCallbackId:    -1,
+		pipelineCallbackID:    -1,
 		overwritePipelines:    overwritePipelines,
 	}
 }
@@ -110,7 +110,7 @@ func (f *Factory) Create(p beat.Pipeline, c *common.Config, meta *common.MapStrP
 		moduleRegistry:        m,
 		inputs:                inputs,
 		pipelineLoaderFactory: f.pipelineLoaderFactory,
-		pipelineCallbackId:    f.pipelineCallbackId,
+		pipelineCallbackID:    f.pipelineCallbackID,
 		overwritePipelines:    f.overwritePipelines,
 	}, nil
 }
@@ -134,7 +134,7 @@ func (p *inputsRunner) Start() {
 		callback := func(esClient *elasticsearch.Client) error {
 			return p.moduleRegistry.LoadPipelines(esClient, p.overwritePipelines)
 		}
-		p.pipelineCallbackId = elasticsearch.RegisterConnectCallback(callback)
+		p.pipelineCallbackID = elasticsearch.RegisterConnectCallback(callback)
 	}
 
 	for _, input := range p.inputs {
@@ -147,8 +147,8 @@ func (p *inputsRunner) Start() {
 	}
 }
 func (p *inputsRunner) Stop() {
-	if p.pipelineCallbackId != -1 {
-		elasticsearch.DeregisterConnectCallback(p.pipelineCallbackId)
+	if p.pipelineCallbackID != -1 {
+		elasticsearch.DeregisterConnectCallback(p.pipelineCallbackID)
 	}
 
 	for _, input := range p.inputs {

--- a/libbeat/outputs/elasticsearch/elasticsearch_test.go
+++ b/libbeat/outputs/elasticsearch/elasticsearch_test.go
@@ -1,0 +1,45 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package elasticsearch
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConnectCallbacksManagement(t *testing.T) {
+	f0 := func(client *Client) error { fmt.Println("i am function #0"); return nil }
+	f1 := func(client *Client) error { fmt.Println("i am function #1"); return nil }
+	f2 := func(client *Client) error { fmt.Println("i am function #2"); return nil }
+
+	id0 := RegisterConnectCallback(f0)
+	id1 := RegisterConnectCallback(f1)
+	id2 := RegisterConnectCallback(f2)
+
+	assert.Equal(t, 0, id0)
+	assert.Equal(t, 1, id1)
+	assert.Equal(t, 2, id2)
+
+	t.Logf("removing second callback")
+	DeregisterConnectCallback(id1)
+	if _, ok := connectCallbackRegistry.callbacks[id2]; !ok {
+		t.Fatalf("third callback cannot be retrieved")
+	}
+}

--- a/libbeat/outputs/elasticsearch/elasticsearch_test.go
+++ b/libbeat/outputs/elasticsearch/elasticsearch_test.go
@@ -20,8 +20,6 @@ package elasticsearch
 import (
 	"fmt"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestConnectCallbacksManagement(t *testing.T) {
@@ -29,13 +27,9 @@ func TestConnectCallbacksManagement(t *testing.T) {
 	f1 := func(client *Client) error { fmt.Println("i am function #1"); return nil }
 	f2 := func(client *Client) error { fmt.Println("i am function #2"); return nil }
 
-	id0 := RegisterConnectCallback(f0)
+	_ = RegisterConnectCallback(f0)
 	id1 := RegisterConnectCallback(f1)
 	id2 := RegisterConnectCallback(f2)
-
-	assert.Equal(t, 0, id0)
-	assert.Equal(t, 1, id1)
-	assert.Equal(t, 2, id2)
 
 	t.Logf("removing second callback")
 	DeregisterConnectCallback(id1)


### PR DESCRIPTION
From now on `connectCallback`s of Elasticsearch can be deregistered.
Pipeline loader callbacks are deregistered when `inputsRunner` is stopped, so unnecessary callback calls are eliminated after reload and during autodiscovery. This also lets the GC to collect leftover states e.g. `moduleRegistry`.

Closes #7891 