### PR TITLE
Make ID lookups thread-safe (#42) ( cherry-pick ec7a7253 from go-libaudit)

### DIFF
--- a/vendor/github.com/elastic/go-libaudit/CHANGELOG.md
+++ b/vendor/github.com/elastic/go-libaudit/CHANGELOG.md
@@ -10,6 +10,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- aucoalesce - Made the user/group ID cache thread-safe. #42
+
 ### Deprecated
 
 ### Removed


### PR DESCRIPTION
Concurrent calls to aucoalesce.ResolveIDs() caused panics due to
concurrent map writes.