### PR TITLE
Update vendored elastic/go-libaudit

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -401,7 +401,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 --------------------------------------------------------------------
 Dependency: github.com/elastic/go-libaudit
-Revision: 0c842c62c7c04344b204e2059eadd98c757defe0
+Revision: ec7a7253716958d85ea854cbef4aaffcd6cbd50b
 License type (autodetected): Apache-2.0
 ./vendor/github.com/elastic/go-libaudit/LICENSE.txt:
 --------------------------------------------------------------------

--- a/vendor/github.com/elastic/go-libaudit/CHANGELOG.md
+++ b/vendor/github.com/elastic/go-libaudit/CHANGELOG.md
@@ -10,6 +10,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- aucoalesce - Made the user/group ID cache thread-safe. #42
+
 ### Deprecated
 
 ### Removed

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -379,34 +379,34 @@
 			"revisionTime": "2016-08-05T00:47:13Z"
 		},
 		{
-			"checksumSHA1": "1NvZjGE2MFmIxQQJ87s/wUKQFnY=",
+			"checksumSHA1": "D/7cJ8oboLL/gQxr57kfvDBtMZE=",
 			"path": "github.com/elastic/go-libaudit",
-			"revision": "0c842c62c7c04344b204e2059eadd98c757defe0",
-			"revisionTime": "2018-06-20T15:43:49Z"
+			"revision": "ec7a7253716958d85ea854cbef4aaffcd6cbd50b",
+			"revisionTime": "2018-08-07T15:01:12Z"
 		},
 		{
-			"checksumSHA1": "3V0tnqlCgmCXnbocuTqUKluynm8=",
+			"checksumSHA1": "QTR02jPgqq2P6mZKMWUdAUQPVbQ=",
 			"path": "github.com/elastic/go-libaudit/aucoalesce",
-			"revision": "0c842c62c7c04344b204e2059eadd98c757defe0",
-			"revisionTime": "2018-06-20T15:43:49Z"
+			"revision": "ec7a7253716958d85ea854cbef4aaffcd6cbd50b",
+			"revisionTime": "2018-08-07T15:01:12Z"
 		},
 		{
 			"checksumSHA1": "6OK3lLgocjmIUyLo8xNhYGpwE1E=",
 			"path": "github.com/elastic/go-libaudit/auparse",
-			"revision": "0c842c62c7c04344b204e2059eadd98c757defe0",
-			"revisionTime": "2018-06-20T15:43:49Z"
+			"revision": "ec7a7253716958d85ea854cbef4aaffcd6cbd50b",
+			"revisionTime": "2018-08-07T15:01:12Z"
 		},
 		{
 			"checksumSHA1": "zGv2vPwSLoFCRt1kcD81pBzTo+0=",
 			"path": "github.com/elastic/go-libaudit/rule",
-			"revision": "0c842c62c7c04344b204e2059eadd98c757defe0",
-			"revisionTime": "2018-06-20T15:43:49Z"
+			"revision": "ec7a7253716958d85ea854cbef4aaffcd6cbd50b",
+			"revisionTime": "2018-08-07T15:01:12Z"
 		},
 		{
 			"checksumSHA1": "5C083BvwcAVSKquRXbxXa950/wE=",
 			"path": "github.com/elastic/go-libaudit/rule/flags",
-			"revision": "0c842c62c7c04344b204e2059eadd98c757defe0",
-			"revisionTime": "2018-06-20T15:43:49Z"
+			"revision": "ec7a7253716958d85ea854cbef4aaffcd6cbd50b",
+			"revisionTime": "2018-08-07T15:01:12Z"
 		},
 		{
 			"checksumSHA1": "3jizmlZPCyo6FAZY8Trk9jA8NH4=",


### PR DESCRIPTION
Addresses a panic in auditbeat's auditd module.

Fixes #7896