### PR TITLE
Cherry-pick #7887 to 6.x: Allow custom port in cloud.id

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -49,7 +49,9 @@ https://github.com/elastic/beats/compare/v6.4.0...6.x[Check the HEAD diff]
 ==== Added
 
 *Affecting all Beats*
+
 - Add backoff on error support to redis output. {pull}7781[7781]
+- Allow for cloud-id to specify a custom port. This makes cloud-id work in ECE contexts. {pull}7887[7887]
 
 *Auditbeat*
 

--- a/libbeat/cloudid/cloudid.go
+++ b/libbeat/cloudid/cloudid.go
@@ -31,6 +31,8 @@ import (
 	"github.com/elastic/beats/libbeat/logp"
 )
 
+const defaultCloudPort = "443"
+
 // OverwriteSettings modifies the received config object by overwriting the
 // output.elasticsearch.hosts, output.elasticsearch.username, output.elasticsearch.password,
 // setup.kibana.host settings based on values derived from the cloud.id and cloud.auth
@@ -105,6 +107,16 @@ func OverwriteSettings(cfg *common.Config) error {
 	return nil
 }
 
+// extractPortFromName takes a string in the form `id:port` and returns the
+// ID and the port. If there's no `:`, the default port is returned
+func extractPortFromName(word string, defaultPort string) (id, port string) {
+	idx := strings.LastIndex(word, ":")
+	if idx >= 0 {
+		return word[:idx], word[idx+1:]
+	}
+	return word, defaultPort
+}
+
 // decodeCloudID decodes the cloud.id into elasticsearch-URL and kibana-URL
 func decodeCloudID(cloudID string) (string, string, error) {
 
@@ -126,9 +138,14 @@ func decodeCloudID(cloudID string) (string, string, error) {
 		return "", "", errors.Errorf("Expected at least 3 parts in %s", string(decoded))
 	}
 
-	// 4. form the URLs
-	esURL := url.URL{Scheme: "https", Host: fmt.Sprintf("%s.%s:443", words[1], words[0])}
-	kibanaURL := url.URL{Scheme: "https", Host: fmt.Sprintf("%s.%s:443", words[2], words[0])}
+	// 4. extract port from the ES and Kibana host, or use 443 as the default
+	host, port := extractPortFromName(words[0], defaultCloudPort)
+	esID, esPort := extractPortFromName(words[1], port)
+	kbID, kbPort := extractPortFromName(words[2], port)
+
+	// 5. form the URLs
+	esURL := url.URL{Scheme: "https", Host: fmt.Sprintf("%s.%s:%s", esID, host, esPort)}
+	kibanaURL := url.URL{Scheme: "https", Host: fmt.Sprintf("%s.%s:%s", kbID, host, kbPort)}
 
 	return esURL.String(), kibanaURL.String(), nil
 }

--- a/libbeat/cloudid/cloudid_test.go
+++ b/libbeat/cloudid/cloudid_test.go
@@ -51,6 +51,26 @@ func TestDecode(t *testing.T) {
 			expectedEsURL:     "https://8a0283af041f195f7729bc04c66a0fce.us-central1.gcp.cloud.es.io:443",
 			expectedKibanaURL: "https://0cd5cd568eebe53c89eb7cae5bac8b37.us-central1.gcp.cloud.es.io:443",
 		},
+		{
+			cloudID:           "custom-port:dXMtY2VudHJhbDEuZ2NwLmNsb3VkLmVzLmlvOjkyNDMkYWMzMWViYjkwMjQxNzczMTU3MDQzYzM0ZmQyNmZkNDYkYTRjMDYyMzBlNDhjOGZjZTdiZTg4YTA3NGEzYmIzZTA=",
+			expectedEsURL:     "https://ac31ebb90241773157043c34fd26fd46.us-central1.gcp.cloud.es.io:9243",
+			expectedKibanaURL: "https://a4c06230e48c8fce7be88a074a3bb3e0.us-central1.gcp.cloud.es.io:9243",
+		},
+		{
+			cloudID:           "different-es-kb-port:dXMtY2VudHJhbDEuZ2NwLmNsb3VkLmVzLmlvJGFjMzFlYmI5MDI0MTc3MzE1NzA0M2MzNGZkMjZmZDQ2OjkyNDMkYTRjMDYyMzBlNDhjOGZjZTdiZTg4YTA3NGEzYmIzZTA6OTI0NA==",
+			expectedEsURL:     "https://ac31ebb90241773157043c34fd26fd46.us-central1.gcp.cloud.es.io:9243",
+			expectedKibanaURL: "https://a4c06230e48c8fce7be88a074a3bb3e0.us-central1.gcp.cloud.es.io:9244",
+		},
+		{
+			cloudID:           "only-kb-set:dXMtY2VudHJhbDEuZ2NwLmNsb3VkLmVzLmlvJGFjMzFlYmI5MDI0MTc3MzE1NzA0M2MzNGZkMjZmZDQ2JGE0YzA2MjMwZTQ4YzhmY2U3YmU4OGEwNzRhM2JiM2UwOjkyNDQ=",
+			expectedEsURL:     "https://ac31ebb90241773157043c34fd26fd46.us-central1.gcp.cloud.es.io:443",
+			expectedKibanaURL: "https://a4c06230e48c8fce7be88a074a3bb3e0.us-central1.gcp.cloud.es.io:9244",
+		},
+		{
+			cloudID:           "host-and-kb-set:dXMtY2VudHJhbDEuZ2NwLmNsb3VkLmVzLmlvOjkyNDMkYWMzMWViYjkwMjQxNzczMTU3MDQzYzM0ZmQyNmZkNDYkYTRjMDYyMzBlNDhjOGZjZTdiZTg4YTA3NGEzYmIzZTA6OTI0NA==",
+			expectedEsURL:     "https://ac31ebb90241773157043c34fd26fd46.us-central1.gcp.cloud.es.io:9243",
+			expectedKibanaURL: "https://a4c06230e48c8fce7be88a074a3bb3e0.us-central1.gcp.cloud.es.io:9244",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Cherry-pick of PR #7887 to 6.x branch. Original message: 

Make it possible for the the cloud.id to contain a custom port. If the port is not specified, 443 is used, like before.

The custom port can be specified in multiple ways. The cloudid is formed like this: `<host>:<es-id>:<kb-id>`. The port can be specified either in es-id or kb-id, or in the host section. If specified in both, the more specific one wins (i.e. es-id over host).

Examples:

```
'us-central1.gcp.cloud.es.io:9243$ac31ebb90241773157043c34fd26fd46$a4c06230e48c8fce7be88a074a3bb3e0'
```

Results in:

```
ES: https://ac31ebb90241773157043c34fd26fd46.us-central1.gcp.cloud.es.io:9243
KB: https://a4c06230e48c8fce7be88a074a3bb3e0.us-central1.gcp.cloud.es.io:9243
```

Or:

```
'us-central1.gcp.cloud.es.io$ac31ebb90241773157043c34fd26fd46:9243$a4c06230e48c8fce7be88a074a3bb3e0:9244'
```

Results in:

```
ES: https://ac31ebb90241773157043c34fd26fd46.us-central1.gcp.cloud.es.io:9243
KB: https://a4c06230e48c8fce7be88a074a3bb3e0.us-central1.gcp.cloud.es.io:9244
```

This is proposed fix for #7794.