### PR TITLE
Remove beta label from add_kubernetes_metadata docs

### DIFF
--- a/libbeat/docs/processors-using.asciidoc
+++ b/libbeat/docs/processors-using.asciidoc
@@ -719,8 +719,6 @@ section.
 [[add-kubernetes-metadata]]
 === Add Kubernetes metadata
 
-beta[]
-
 The `add_kubernetes_metadata` processor annotates each event with relevant
 metadata based on which Kubernetes pod the event originated from. Each event is
 annotated with:


### PR DESCRIPTION
In https://github.com/elastic/beats/pull/6105 add_kubernetes_metadata processor was promoted to GA but the beta label was left in the docs. This cleans it up.

This PR needs backport to 6.x, 6.4, 6.3 and 6.2 as the processor went GA in 6.2.