### PR TITLE
Add support for HTTP encodings

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -95,6 +95,7 @@ https://github.com/elastic/beats/compare/v6.4.0...master[Check the HEAD diff]
 *Packetbeat*
 
 - Added DHCP protocol support. {pull}7647[7647]
+- Add support to decode HTTP bodies compressed with `gzip` and `deflate`. {pull}7915[7915]
 
 *Winlogbeat*
 

--- a/packetbeat/_meta/beat.reference.yml
+++ b/packetbeat/_meta/beat.reference.yml
@@ -195,6 +195,10 @@ packetbeat.protocols:
   # response payload.
   #include_response_body_for: []
 
+  # Whether the body of a request must be decoded when a content-encoding
+  # or transfer-encoding has been applied.
+  #decode_body: true
+
   # If the Cookie or Set-Cookie headers are sent, this option controls whether
   # they are split into individual values.
   #split_cookie: false

--- a/packetbeat/docs/packetbeat-options.asciidoc
+++ b/packetbeat/docs/packetbeat-options.asciidoc
@@ -681,7 +681,14 @@ packetbeat.protocols:
   include_body_for: ["text/html"]
 ------------------------------------------------------------------------------
 
+===== `decode_body`
 
+A boolean flag that controls decoding of HTTP payload. It interprets the
+`Content-Encoding` and `Transfer-Encoding` headers and uncompresses the entity
+body. Supported encodings are `gzip` and `deflate`. This option is only
+applicable in the cases where the HTTP payload is exported, that is, when
+one of the `include_*_body_for` options is specified or a POST request
+contains url-encoded parameters.
 
 ===== `split_cookie`
 

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -195,6 +195,10 @@ packetbeat.protocols:
   # response payload.
   #include_response_body_for: []
 
+  # Whether the body of a request must be decoded when a content-encoding
+  # or transfer-encoding has been applied.
+  #decode_body: true
+
   # If the Cookie or Set-Cookie headers are sent, this option controls whether
   # they are split into individual values.
   #split_cookie: false

--- a/packetbeat/protos/http/config.go
+++ b/packetbeat/protos/http/config.go
@@ -35,6 +35,7 @@ type httpConfig struct {
 	HideKeywords           []string `config:"hide_keywords"`
 	RedactAuthorization    bool     `config:"redact_authorization"`
 	MaxMessageSize         int      `config:"max_message_size"`
+	DecodeBody             bool     `config:"decode_body"`
 }
 
 var (
@@ -43,5 +44,6 @@ var (
 			TransactionTimeout: protos.DefaultTransactionExpiration,
 		},
 		MaxMessageSize: tcp.TCPMaxDataInStream,
+		DecodeBody:     true,
 	}
 )

--- a/packetbeat/protos/http/decode.go
+++ b/packetbeat/protos/http/decode.go
@@ -1,0 +1,110 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package http
+
+import (
+	"bytes"
+	"compress/flate"
+	"compress/gzip"
+	"io"
+
+	"github.com/pkg/errors"
+)
+
+var (
+	decoders = map[string]func(io.Reader) (io.ReadCloser, error){
+		"gzip":      decodeGZIP,
+		"x-gzip":    decodeGZIP,
+		"deflate":   decodeDeflate,
+		"x-deflate": decodeDeflate,
+
+		// Not really expected, withdrawn by RFC
+		"identity": decodeIdentity,
+
+		// Couldn't find an implementation of `compress` nor a server/library
+		// that supports it. Seems long dead.
+		// "compress":   nil,
+		// "x-compress": nil,
+	}
+
+	// ErrNoDecoder is returned when an unknown content-encoding is used.
+	ErrNoDecoder = errors.New("decoder not found")
+
+	// ErrSizeLimited is returned when
+	ErrSizeLimited = errors.New("body truncated due to size limitation")
+)
+
+func decodeHTTPBody(data []byte, format string, maxSize int) ([]byte, error) {
+	decoder, found := decoders[format]
+	if !found {
+		return nil, ErrNoDecoder
+	}
+	reader, err := decoder(bytes.NewReader(data))
+	if err != nil {
+		return nil, err
+	}
+	defer reader.Close()
+	return readMax(reader, maxSize)
+}
+
+func decodeGZIP(reader io.Reader) (io.ReadCloser, error) {
+	return gzip.NewReader(reader)
+}
+
+func decodeDeflate(reader io.Reader) (io.ReadCloser, error) {
+	return flate.NewReader(reader), nil
+}
+
+type closeDecorator struct {
+	io.Reader
+}
+
+func (closeDecorator) Close() error {
+	return nil
+}
+
+func decodeIdentity(reader io.Reader) (io.ReadCloser, error) {
+	return closeDecorator{reader}, nil
+}
+
+func readMax(reader io.Reader, maxSize int) (result []byte, err error) {
+	const minSize = 512
+	for used := 0; ; {
+		if len(result)-used < minSize {
+			grow := len(result) >> 1
+			if grow < minSize {
+				grow = minSize
+			}
+			result = append(result, make([]byte, grow)...)
+		}
+		n, err := reader.Read(result[used:])
+		if n > 0 {
+			used += n
+			if used > maxSize {
+				used = maxSize
+				err = ErrSizeLimited
+			}
+		}
+		if err != nil {
+			if err == io.EOF {
+				err = nil
+			}
+			return result[:used], err
+		}
+	}
+}


### PR DESCRIPTION
This patch adds support for decoding HTTP bodies based on the `Content-Encoding` and `Transfer-Encoding` headers. Supported decoders are `gzip` and `deflate`.

Multiple encoders are supported, for example:
```
Content-Encoding: gzip
Transfer-Encoding: chunked
```

Or the rarely used but allowed by the standard:

```
Transfer-Encoding: deflate, gzip
```

The difference between `Transfer-Encoding` and `Content-Encoding` is not relevant to packetbeat, so both are treated the same, with the exception that `chunked` can only appear as the last or only element of `Transfer-Encoding`.

To avoid decompression bombs, the value specified in `http.max_message_size` (default 10MB) is honored when decoding.

A new configuration option, `decode_body` (default true), has been added to the http protocol, allowing to disable this feature.
