### PR TITLE
Cherry-pick #7840 to 6.x: Add fcntl64 to the default seccomp policy for 32-bit binaries

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -49,6 +49,9 @@ https://github.com/elastic/beats/compare/v6.4.0...6.x[Check the HEAD diff]
 
 *Packetbeat*
 
+- Fixed a seccomp related error where the `fcntl64` syscall was not permitted
+  on 32-bit Linux and the sniffer failed to start. {issue}7839[7839]
+
 *Winlogbeat*
 
 

--- a/libbeat/common/seccomp/policy_linux_386.go
+++ b/libbeat/common/seccomp/policy_linux_386.go
@@ -46,6 +46,7 @@ func init() {
 					"fchmod",
 					"fchown32",
 					"fcntl",
+					"fcntl64",
 					"fdatasync",
 					"flock",
 					"fstat64",

--- a/libbeat/common/seccomp/seccomp-profiler-allow.txt
+++ b/libbeat/common/seccomp/seccomp-profiler-allow.txt
@@ -11,6 +11,7 @@ stat
 
 # cgo tsg/gopacket
 poll
+fcntl64
 
 # system testing binaries w/ race detector
 clock_gettime

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -430,8 +430,8 @@ seccomp:
 # Generates seccomp profiles based on the binaries produced by the package target.
 .PHONY: seccomp-package
 seccomp-package:
-	SECCOMP_BINARY=build/package/${BEAT_NAME}-linux-386 $(MAKE) seccomp
-	SECCOMP_BINARY=build/package/${BEAT_NAME}-linux-amd64 $(MAKE) seccomp
+	SECCOMP_BINARY=build/golang-crossbuild/${BEAT_NAME}-linux-386 $(MAKE) seccomp
+	SECCOMP_BINARY=build/golang-crossbuild/${BEAT_NAME}-linux-amd64 $(MAKE) seccomp
 
 ### Packaging targets ####
 


### PR DESCRIPTION
Cherry-pick of PR #7840 to 6.x branch. Original message: 

Fixes #7839

I received an error while running the 32-bit Packetbeat binary on a 64-bit Debian 9 OS.

```
2018-06-07T14:33:10.103Z    ERROR    instance/beat.go:714    Exiting: Sniffer main loop failed: Error starting sniffer: can't get FD flags when changing filter: Operation not permitted
```

When the error occurred this is what Auditbeat reported. 0x40000003 is i386 and 221 is fcntl64.

```
{
  "event": {
    "category": "dac-decision",
    "type": "seccomp",
    "action": "violated-seccomp-policy",
    "module": "auditd"
  },
  "process": {
    "pid": "30690",
    "name": "packetbeat",
    "exe": "/beats/packetbeat/build/distributions/packetbeat-7.0.0-alpha1-SNAPSHOT-linux-x86/packetbeat"
  },
  "auditd": {
    "data": {
      "code": "0x50000",
      "sig": "0",
      "syscall": "221",
      "compat": "1",
      "ip": "0xf775ab49",
      "arch": "40000003"
    }
  }
}
```