### PR TITLE
Forward port to master: doc changes (#7593 and #7816)

### DIFF
--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -1162,8 +1162,8 @@ rotated. The default value is 10240 KB.
 ===== `number_of_files`
 
 The maximum number of files to save under <<path,`path`>>. When this number of files is reached, the
-oldest file is deleted, and the rest of the files are shifted from last to first. The default
-is 7 files.
+oldest file is deleted, and the rest of the files are shifted from last to first.
+The number of files must be between 2 and 1024. The default is 7.
 
 ===== `permissions`
 

--- a/libbeat/docs/shared-docker.asciidoc
+++ b/libbeat/docs/shared-docker.asciidoc
@@ -74,7 +74,7 @@ ifeval::["{beatname_lc}"!="auditbeat"]
 FROM {dockerimage}
 COPY {beatname_lc}.yml /usr/share/{beatname_lc}/{beatname_lc}.yml
 USER root
-RUN chown {beatname_lc} /usr/share/{beatname_lc}/{beatname_lc}.yml
+RUN chown root:{beatname_lc} /usr/share/{beatname_lc}/{beatname_lc}.yml
 USER {beatname_lc}
 --------------------------------------------
 


### PR DESCRIPTION
Forward ports the following changes to master:

https://github.com/elastic/beats/pull/7593
https://github.com/elastic/beats/pull/7816