### PR TITLE
Backport to 6.2: Remove beta label from add_kubernetes_metadata docs (#7907)

### DIFF
--- a/libbeat/docs/processors-using.asciidoc
+++ b/libbeat/docs/processors-using.asciidoc
@@ -515,8 +515,6 @@ the required fields, `@timestamp` and `type`, are exported.
 [[add-kubernetes-metadata]]
 === Add Kubernetes metadata
 
-beta[]
-
 The `add_kubernetes_metadata` processor annotates each event with relevant
 metadata based on which Kubernetes pod the event originated from. Each event is
 annotated with:


### PR DESCRIPTION
Cherry-picks #7907 into 6.2 branch.
