### PR TITLE
Adding AckMultiplexer and Sync clients

### DIFF
--- a/x-pack/beatless/core/ack_multiplexer.go
+++ b/x-pack/beatless/core/ack_multiplexer.go
@@ -1,0 +1,117 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package core
+
+import (
+	"errors"
+	"sync"
+
+	"github.com/elastic/beats/libbeat/logp"
+)
+
+// AckMultiplexer registers itself as a pipeline AckEvents Handler and allow to dynamic add or
+// remove specific ack handlers. This is useful if you have client that pushes events to the pipeline
+// and need to ack to another upstream systems. The AckMultiplexer uses the beat.Event.Private field
+// to have a pointer to a struct implementing the SourceAcker interface.
+//
+// Caveats: Users of the the AckMultiplexer are responsable to add cleanup ackers, if the ackers
+// is not found for an events we will just ignore it.
+
+// Errors returned when adding or removing ackers.
+var (
+	ErrAlreadyExist = errors.New("acker already exist")
+	ErrUnknown      = errors.New("unknown acker")
+)
+
+// sourceAcker is the callbacks interface when new events get ACK.
+type sourceAcker interface {
+	AckEvents([]interface{})
+}
+
+// SourceMetadata contains metadata about the clients who emitted the events, this struct will be
+// saved in the Private field in the beat.Event.
+type SourceMetadata struct {
+	Acker sourceAcker
+}
+
+// AckMultiplexer needs to be registered as the ACKEvents on the publisher.
+type AckMultiplexer struct {
+	sync.RWMutex
+	ackers map[sourceAcker]sourceAcker
+	log    *logp.Logger
+}
+
+// NewAckMultiplexer creates a new ack multiplexer.
+func NewAckMultiplexer() *AckMultiplexer {
+	return &AckMultiplexer{
+		ackers: make(map[sourceAcker]sourceAcker),
+		log:    logp.NewLogger("ack-multiplexer"),
+	}
+}
+
+// AddAcker adds a new acker.
+func (am *AckMultiplexer) AddAcker(acker sourceAcker) error {
+	am.Lock()
+	defer am.Unlock()
+	defer am.log.Debug("acker added")
+
+	_, found := am.ackers[acker]
+	if found {
+		return ErrAlreadyExist
+	}
+
+	am.ackers[acker] = acker
+	return nil
+}
+
+// RemoveAcker removes the specified acker.
+func (am *AckMultiplexer) RemoveAcker(acker sourceAcker) error {
+	am.Lock()
+	defer am.Unlock()
+	defer am.log.Debug("acker removed")
+
+	_, found := am.ackers[acker]
+	if !found {
+		return ErrUnknown
+	}
+
+	delete(am.ackers, acker)
+	return nil
+}
+
+// AckEvents receives the global ACK and send the events down to the right client handler.
+func (am *AckMultiplexer) AckEvents(data []interface{}) {
+	am.log.Debugw("ack events", "count", len(data))
+	ordered := make(map[sourceAcker][]interface{}, len(am.ackers))
+
+	for _, d := range data {
+		if data == nil {
+			am.log.Debug("received nil data from the ACK handler")
+			continue
+		}
+
+		sm, ok := d.(SourceMetadata)
+		if !ok {
+			am.log.Debugf("incompatible type, expecting 'SourceMetadata' and received '%T'", d)
+			continue
+		}
+
+		v, _ := ordered[sm.Acker]
+		v = append(v, d)
+		ordered[sm.Acker] = v
+	}
+
+	am.RLock()
+	defer am.RUnlock()
+	for a, d := range ordered {
+		acker, ok := am.ackers[a]
+		if !ok {
+			am.log.Debug("acker not found, ignoring")
+			continue
+		}
+		am.log.Debugw("sending batch of ACKs to a specific acker", "count", len(d))
+		acker.AckEvents(d)
+	}
+}

--- a/x-pack/beatless/core/ack_multiplexer_test.go
+++ b/x-pack/beatless/core/ack_multiplexer_test.go
@@ -1,0 +1,67 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package core
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type simpleSourceAcker struct {
+	c int
+}
+
+func (s *simpleSourceAcker) AckEvents(data []interface{}) {
+	s.c = len(data)
+}
+
+func TestAckMultiplexer(t *testing.T) {
+	t.Run("when acker exists", func(t *testing.T) {
+		a := NewAckMultiplexer()
+		s := &simpleSourceAcker{}
+		a.AddAcker(s)
+		a.AckEvents([]interface{}{SourceMetadata{Acker: s}})
+		assert.Equal(t, 1, s.c)
+	})
+
+	t.Run("when acker don't exist", func(t *testing.T) {
+		a := NewAckMultiplexer()
+		s := &simpleSourceAcker{}
+		a.AddAcker(s)
+		a.AckEvents([]interface{}{SourceMetadata{Acker: &simpleSourceAcker{}}})
+		assert.Equal(t, 0, s.c)
+	})
+
+	t.Run("when multiple simultanous ackers exists", func(t *testing.T) {
+		a := NewAckMultiplexer()
+		s1 := &simpleSourceAcker{}
+		a.AddAcker(s1)
+
+		s2 := &simpleSourceAcker{}
+		a.AddAcker(s2)
+
+		a.AckEvents([]interface{}{
+			SourceMetadata{Acker: s1},
+			SourceMetadata{Acker: s2},
+			SourceMetadata{Acker: s1},
+			SourceMetadata{Acker: s2},
+			SourceMetadata{Acker: s2},
+		})
+		assert.Equal(t, 2, s1.c)
+		assert.Equal(t, 3, s2.c)
+	})
+
+	t.Run("when acker exists will stop receiving events when removed", func(t *testing.T) {
+		a := NewAckMultiplexer()
+		s := &simpleSourceAcker{}
+		a.AddAcker(s)
+		a.AckEvents([]interface{}{SourceMetadata{Acker: s}})
+		assert.Equal(t, 1, s.c)
+		a.RemoveAcker(s)
+		a.AckEvents([]interface{}{SourceMetadata{Acker: s}})
+		assert.Equal(t, 1, s.c)
+	})
+}

--- a/x-pack/beatless/core/sync_client.go
+++ b/x-pack/beatless/core/sync_client.go
@@ -1,0 +1,92 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package core
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/elastic/beats/libbeat/beat"
+)
+
+// Client implements the interface used by all the beatless function, we only implement a synchronous
+// client. This interface superseed the core beat.Client interface inside beatless because our publish
+// and publishAll methods can return an error.
+type Client interface {
+	// Publish accepts a unique events and will publish it to the pipeline.
+	Publish(context.Context, beat.Event) error
+
+	// PublishAll accepts a list of multiple events and will publish them to the pipeline.
+	PublishAll(context.Context, []beat.Event) error
+
+	// Close closes the current client, no events will be accepted.
+	Close() error
+}
+
+// SyncClient wraps an existing beat.Client and provide a sync interface, when a new client is created.
+// it need to be added to the AckMultiplexer.
+type SyncClient struct {
+	client      beat.Client
+	eventsAcked chan int
+}
+
+// NewSyncClient returns a new sync client.
+func NewSyncClient(client beat.Client) *SyncClient {
+	return &SyncClient{client: client, eventsAcked: make(chan int)}
+}
+
+// Publish publishes one event to the pipeline and will wait the ACK before returning.
+// The call is also unblocked via context cancellation or timeout.
+func (s *SyncClient) Publish(ctx context.Context, event beat.Event) error {
+	event.Private = SourceMetadata{Acker: s}
+	s.client.Publish(event)
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-s.eventsAcked:
+		return nil
+	}
+}
+
+// PublishAll publish a slice of events to the pipeline and will wait the ACK before returning.
+func (s *SyncClient) PublishAll(ctx context.Context, events []beat.Event) error {
+	for _, e := range events {
+		e.Private = SourceMetadata{Acker: s}
+	}
+	s.client.PublishAll(events)
+	ackedCount := 0
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case count := <-s.eventsAcked:
+			ackedCount += count
+		}
+
+		if ackedCount == len(events) {
+			return nil
+		}
+
+		if ackedCount > len(events) {
+			// Something is definitively wrong and should not happen.
+			panic(fmt.Sprintf("Too many ACKS received, expected: %d, received: %d", len(events), ackedCount))
+		}
+	}
+}
+
+// Close closes the wrapped beat.Client.
+func (s *SyncClient) Close() error {
+	defer close(s.eventsAcked)
+	return s.client.Close()
+}
+
+// AckEvents receives an array with all the event acked for this client.
+func (s *SyncClient) AckEvents(events []interface{}) {
+	select {
+	case s.eventsAcked <- len(events):
+		return
+	}
+}

--- a/x-pack/beatless/core/sync_client_test.go
+++ b/x-pack/beatless/core/sync_client_test.go
@@ -1,0 +1,134 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/common/atomic"
+)
+
+type simpleClient struct {
+	EventCount atomic.Int
+	Received   chan struct{}
+}
+
+func (sc *simpleClient) Publish(event beat.Event) {
+	defer close(sc.Received)
+	sc.EventCount.Inc()
+}
+
+func (sc *simpleClient) PublishAll(events []beat.Event) {
+	defer close(sc.Received)
+	sc.EventCount.Add(len(events))
+}
+
+func newSimpleClient() *simpleClient {
+	return &simpleClient{Received: make(chan struct{})}
+}
+
+func (sc simpleClient) Close() error { return nil }
+
+func TestSyncClient(t *testing.T) {
+	t.Run("Publish", func(t *testing.T) {
+		e := beat.Event{}
+		events := []interface{}{e}
+
+		c := newSimpleClient()
+		sc := NewSyncClient(c)
+
+		// The go routine will be blocked until all the events
+		// are acked.
+		unblocked := make(chan struct{})
+		go func(t *testing.T, e beat.Event) {
+			defer close(unblocked)
+			err := sc.Publish(context.Background(), e)
+			assert.NoError(t, err)
+		}(t, e)
+
+		// Wait to receive the events before Acking all of them.
+		select {
+		case <-c.Received:
+			sc.AckEvents(events)
+		}
+
+		assert.Equal(t, 1, c.EventCount.Load())
+
+		// Make sure we the goroutine is not blocked.
+		select {
+		case <-unblocked:
+			return
+		}
+	})
+
+	t.Run("PublishAll single ACK", func(t *testing.T) {
+		events := []beat.Event{beat.Event{}, beat.Event{}}
+
+		c := newSimpleClient()
+		sc := NewSyncClient(c)
+
+		// The go routine will be blocked until all the events
+		// are acked.
+		unblocked := make(chan struct{})
+		go func(t *testing.T, events []beat.Event) {
+			defer close(unblocked)
+			err := sc.PublishAll(context.Background(), events)
+			assert.NoError(t, err)
+		}(t, events)
+
+		// Wait to receive the events before Acking all of them.
+		select {
+		case <-c.Received:
+			// Event instance doesn't need to match since the multiplexer already takes care
+			// of routing the correct events.
+			sc.AckEvents([]interface{}{beat.Event{}, beat.Event{}})
+		}
+
+		assert.Equal(t, 2, c.EventCount.Load())
+
+		// Make sure we the goroutine is not blocked.
+		select {
+		case <-unblocked:
+			return
+		}
+	})
+
+	t.Run("PublishAll multiple ACKs", func(t *testing.T) {
+		events := []beat.Event{beat.Event{}, beat.Event{}}
+
+		c := newSimpleClient()
+		sc := NewSyncClient(c)
+
+		// The go routine will be blocked until all the events
+		// are acked.
+		unblocked := make(chan struct{})
+		go func(t *testing.T, events []beat.Event) {
+			defer close(unblocked)
+			err := sc.PublishAll(context.Background(), events)
+			assert.NoError(t, err)
+		}(t, events)
+
+		// Wait to receive the events before Acking all of them.
+		select {
+		case <-c.Received:
+			// Event instance doesn't need to match since the multiplexer already takes care
+			// of routing the correct events.
+			sc.AckEvents([]interface{}{beat.Event{}})
+			sc.AckEvents([]interface{}{beat.Event{}})
+		}
+
+		assert.Equal(t, 2, c.EventCount.Load())
+
+		// Make sure we the goroutine is not blocked.
+		select {
+		case <-unblocked:
+			return
+		}
+	})
+}


### PR DESCRIPTION
This PR add a SyncClient and a AckMultiplexer that allow to register
multiple clients as acker and will take the events coming from the
global handler and redirect them to the appropriate sync client.

The sync clients will be blocked until the ack is received, this is
important in the context of beatless, because as soon as the method
return the serverless provider can suspend the process. With the normal
async pipeline this mean that the events are not send to the output.

Usage:
```golang
// Routes the Acked events to the original client by the function
// emitting the event.
ackMultiplexer := core.NewAckMultiplexer()
b.Publisher.SetACKHandler(beat.PipelineACKHandler{
  ACKEvents: ackMultiplexer.AckEvents,
})

client, err := connector.Connect(b.Publisher.Connect())
if err != nil {
  return nil, err
}

sc := core.NewSyncClient(client)
err = ackMultiplexer.AddAcker(sc)
  if err != nil {
    return nil, err
  }

err := sc.Publish(context.Background(), beat.Event{}) // this will block
until is received of context is cancelled.
}