### PR TITLE
check.response.body value must not be quoted

### DIFF
--- a/heartbeat/docs/heartbeat-options.asciidoc
+++ b/heartbeat/docs/heartbeat-options.asciidoc
@@ -479,7 +479,7 @@ contains JSON:
       'X-API-Key': '12345-mykey-67890'
   check.response:
     status: 200
-    body: '{"status": "ok"}'
+    body: {"status": "ok"}
 -------------------------------------------------------------------------------
 
 The following configuration shows how to check the response for multiple regex


### PR DESCRIPTION
When checking the response body of an http request, the expected string must not be quoted. Otherwise the quotes are expected to be part of the response body.