### PR TITLE
Fix processor autodiscovery docs for Filebeat

### DIFF
--- a/filebeat/docs/autodiscover-hints.asciidoc
+++ b/filebeat/docs/autodiscover-hints.asciidoc
@@ -73,10 +73,10 @@ of supported processors.
 In order to provide ordering of the processor definition, numbers can be provided. If not, the hints builder will do
 arbitrary ordering:
 
-["source","yaml",subs="attributes"]
+["source","yaml"]
 -------------------------------------------------------------------------------------
-co.elastic.logs/processors.1.dissect.tokenizer: "%\{key1} %\{key2}"
-co.elastic.logs/processors.dissect.tokenizer: "%\{key2} %\{key1}"
+co.elastic.logs/processors.1.dissect.tokenizer: "%{key1} %{key2}"
+co.elastic.logs/processors.dissect.tokenizer: "%{key2} %{key1}"
 -------------------------------------------------------------------------------------
 
 In the above sample the processor definition tagged with `1` would be executed first.

--- a/filebeat/docs/autodiscover-hints.asciidoc
+++ b/filebeat/docs/autodiscover-hints.asciidoc
@@ -75,8 +75,8 @@ arbitrary ordering:
 
 ["source","yaml",subs="attributes"]
 -------------------------------------------------------------------------------------
-co.elastic.logs/processors.1.dissect.tokenizer: "%{key1} %{key2}"
-co.elastic.logs/processors.dissect.tokenizer: "%{key2} %{key1}"
+co.elastic.logs/processors.1.dissect.tokenizer: "%\{key1} %\{key2}"
+co.elastic.logs/processors.dissect.tokenizer: "%\{key2} %\{key1}"
 -------------------------------------------------------------------------------------
 
 In the above sample the processor definition tagged with `1` would be executed first.


### PR DESCRIPTION
{ needs escaping as otherwise asciidoc will show an empty code block.