### PR TITLE
Initial phase of separating decoder from line scanner

### DIFF
--- a/filebeat/reader/readfile/decoder.go
+++ b/filebeat/reader/readfile/decoder.go
@@ -1,0 +1,147 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package readfile
+
+import (
+	"io"
+
+	"golang.org/x/text/encoding"
+	"golang.org/x/text/transform"
+
+	"github.com/elastic/beats/libbeat/common/streambuf"
+)
+
+// decoderReader reads from an input file and converts its content into UTF-8.
+// It stores the size of the original bytes, so offset can be calculated later in
+// the line scanner.
+type decoderReader struct {
+	in         io.Reader
+	decoder    transform.Transformer
+	buf        *streambuf.Buffer
+	encodedBuf *streambuf.Buffer
+	offset     int // segment byte offset
+
+	bufferSize int
+}
+
+func newDecoderReader(in io.Reader, codec encoding.Encoding, bufferSize int) (*decoderReader, error) {
+	r := &decoderReader{
+		in:         in,
+		decoder:    codec.NewDecoder(),
+		buf:        streambuf.New(nil),
+		encodedBuf: streambuf.New(nil),
+		offset:     0, // TODO init correctly
+		bufferSize: bufferSize,
+	}
+
+	return r, nil
+}
+
+// seekToLastRead reads from the input file until the saved offset is reached.
+// It is the substitution of seeking in the file.
+// This function is no longer required after registry refactoring is done.
+func (r *decoderReader) seekToLastRead() error {
+	if r.offset == 0 {
+		return nil
+	}
+
+	remaining := r.offset
+	for remaining > 0 {
+		s := r.bufferSize
+		if remaining < s {
+			s = remaining
+		}
+
+		b := make([]byte, s)
+		n, err := r.in.Read(b)
+		remaining -= n
+		if err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+// read reads from an underlying file and converts it into UTF-8.
+func (r *decoderReader) read(buf []byte) (int, error) {
+	// collect leftover converted bytes
+	nb := 0
+	var err error
+	if r.buf.Len() != 0 {
+		nb, err = r.copyToOut(buf)
+		if err != nil {
+			return 0, err
+		}
+	}
+
+	b := make([]byte, r.bufferSize)
+	start := r.encodedBuf.Len()
+	// read from the underlying file
+	n, err := r.in.Read(b[start:])
+	if err != nil {
+		if err == io.EOF && start == 0 {
+			return 0, err
+		}
+	}
+
+	// collect leftover encoded bytes
+	if start > 0 {
+		enc, err := r.encodedBuf.Collect(start)
+		if err != nil {
+			return 0, err
+		}
+		r.encodedBuf.Reset()
+		b = append(enc, b[start:]...)
+	}
+
+	// convert encoded bytes into UTF-8
+	nDst, nSrc, err := r.decoder.Transform(buf[nb:], b[:start+n], false)
+	if err != nil {
+		if err == transform.ErrShortSrc {
+			r.encodedBuf.Append(b[nSrc:])
+			r.offset += nSrc
+			return nDst, nil
+		}
+		if err == transform.ErrShortDst {
+			r.encodedBuf.Append(b[nSrc : start+n])
+			r.offset += nSrc
+			return nDst, nil
+		}
+		return 0, err
+	}
+
+	r.offset += nSrc
+	return nDst, nil
+}
+
+func (r *decoderReader) copyToOut(out []byte) (int, error) {
+	until := len(out)
+	if r.buf.Len() < until {
+		until = r.buf.Len()
+	}
+	b, err := r.buf.Collect(until)
+	if err != nil {
+		return 0, err
+	}
+	r.buf.Reset()
+	return copy(out, b), nil
+}

--- a/filebeat/reader/readfile/encode.go
+++ b/filebeat/reader/readfile/encode.go
@@ -38,7 +38,12 @@ func NewEncodeReader(
 	codec encoding.Encoding,
 	bufferSize int,
 ) (EncoderReader, error) {
-	eReader, err := NewLineReader(r, codec, bufferSize)
+	config := Config{
+		Codec:      codec,
+		Separator:  []byte("\n"),
+		BufferSize: bufferSize,
+	}
+	eReader, err := NewLineReader(r, config)
 	return EncoderReader{eReader}, err
 }
 

--- a/filebeat/reader/readfile/line.go
+++ b/filebeat/reader/readfile/line.go
@@ -70,12 +70,8 @@ func (r *LineReader) SetState(s State) error {
 	r.lineScanner.segmentOffset = s.ConvertedSegmentOffset
 	r.lineScanner.streamOffset = s.ConvertedStreamOffset
 
-	// TODO rm when registry is refactored
-	err := r.lineScanner.in.seekToLastRead()
-	if err != nil {
-		return err
-	}
-	return r.lineScanner.seekToLastRead()
+	// TODO refactor when registry is refactored
+	return r.lineScanner.in.seekToLastRead(s.ConvertedSegmentOffset)
 }
 
 // Next reads the next line until the new line character

--- a/filebeat/reader/readfile/line.go
+++ b/filebeat/reader/readfile/line.go
@@ -18,15 +18,13 @@
 package readfile
 
 import (
+	"fmt"
 	"io"
 
 	"golang.org/x/text/encoding"
-	"golang.org/x/text/transform"
-
-	"github.com/elastic/beats/libbeat/common/streambuf"
-	"github.com/elastic/beats/libbeat/logp"
 )
 
+// Config stores the options of a LineReader
 type Config struct {
 	Codec      encoding.Encoding
 	Separator  []byte
@@ -39,6 +37,7 @@ type State struct {
 	ConvertedSegmentOffset int // offset in the UTF-8 segment returned by the decoderReader
 	ConvertedStreamOffset  int // number of total processed UTF-8 bytes
 }
+
 // lineReader reads lines from underlying reader, decoding the input stream
 // using the configured codec. The reader keeps track of bytes consumed
 // from raw input stream for every decoded line.
@@ -60,7 +59,7 @@ func NewLineReader(input io.Reader, c Config) (*LineReader, error) {
 	}, nil
 }
 
-// InitState initizalizas the state of the reader
+// SetState initizalizas the state of the reader
 // TODO update when registry is refactored
 func (r *LineReader) SetState(s State) error {
 	if s.ConvertedStreamOffset < s.ConvertedSegmentOffset {

--- a/filebeat/reader/readfile/line_test.go
+++ b/filebeat/reader/readfile/line_test.go
@@ -35,10 +35,40 @@ var tests = []struct {
 	encoding string
 	strings  []string
 }{
+	{"plain", []string{""}},
+	{"plain", []string{"", ""}},
+	{"plain", []string{"I can"}},
 	{"plain", []string{"I can", "eat glass"}},
+
+	{"latin1", []string{""}},
+	{"latin1", []string{"I can"}},
+	{"latin1", []string{"I kå Glas frässa"}},
 	{"latin1", []string{"I kå Glas frässa", "ond des macht mr nix!"}},
+
+	{"utf-8", []string{""}},
+	{"utf-8", []string{"I can"}},
+	{"utf-8", []string{"árvíztűrő tükörfúrógép"}},
+	{"utf-8", []string{"A nap tüze, látod,", "a fürge diákot", "a hegyre kicsalta: a csúcsra kiállt."}},
+
+	{"utf-16", []string{""}},
+	{"utf-16", []string{"I can"}},
+	{"utf-16", []string{"I can", "eat glass"}},
+	{"utf-16", []string{"Pot să mănânc sticlă"}},
+	{"utf-16", []string{"Pot să mănânc sticlă", "și ea nu mă rănește."}},
+	{"utf-16", []string{"\u0001234", "\u0000", "\u3453"}},
+
+	{"utf-16be", []string{""}},
+	{"utf-16be", []string{"I can"}},
+	{"utf-16be", []string{"I can", "eat glass"}},
+	{"utf-16be", []string{"Pot să mănânc sticlă"}},
 	{"utf-16be", []string{"Pot să mănânc sticlă", "și ea nu mă rănește."}},
+
+	{"utf-16le", []string{""}},
+	{"utf-16le", []string{"I can"}},
+	{"utf-16le", []string{"I can", "eat glass"}},
+	{"utf-16le", []string{"काचं शक्नोम्यत्तुम् ।"}},
 	{"utf-16le", []string{"काचं शक्नोम्यत्तुम् ।", "नोपहिनस्ति माम् ॥"}},
+
 	{"big5", []string{"我能吞下玻", "璃而不傷身體。"}},
 	{"gb18030", []string{"我能吞下玻璃", "而不傷身。體"}},
 	{"euc-kr", []string{" 나는 유리를 먹을 수 있어요.", " 그래도 아프지 않아요"}},

--- a/filebeat/reader/readfile/scanner.go
+++ b/filebeat/reader/readfile/scanner.go
@@ -18,8 +18,6 @@
 package readfile
 
 import (
-	"io"
-
 	"github.com/elastic/beats/libbeat/common/streambuf"
 )
 
@@ -43,41 +41,12 @@ func newLineScanner(in *decoderReader, separator []byte, bufferSize int) *lineSc
 	}
 }
 
-// seekToLastRead moves the fp to the last read position.
-// The number of bytes which needs to be read is the size of the
-// configured harvester_buffer_size when the state was written.
-func (s *lineScanner) seekToLastRead() error {
-	if s.streamOffset == 0 {
-		return nil
-	}
-
-	remaining := s.segmentOffset
-	for remaining > 0 {
-		size := s.bufferSize
-		if remaining < size {
-			size = remaining
-		}
-
-		b := make([]byte, size)
-		n, err := s.in.read(b)
-		remaining -= n
-		if err != nil {
-			if err == io.EOF {
-				return nil
-			}
-			return err
-		}
-	}
-
-	return nil
-}
-
 // Scan reads from the underlying decoder reader and returns decoded lines.
 func (s *lineScanner) scan() ([]byte, int, error) {
 	idx := s.buf.Index(s.separator)
 	for !separatorFound(idx) {
 		b := make([]byte, s.bufferSize)
-		n, err := s.in.read(b)
+		n, err := s.in.Read(b)
 		s.buf.Append(b[:n])
 		if err != nil {
 			return nil, 0, err

--- a/filebeat/reader/readfile/scanner.go
+++ b/filebeat/reader/readfile/scanner.go
@@ -1,0 +1,110 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package readfile
+
+import (
+	"io"
+
+	"github.com/elastic/beats/libbeat/common/streambuf"
+)
+
+// lineScanner scans for new lines separated by a configurable byte slice.
+type lineScanner struct {
+	in         *decoderReader
+	separator  []byte
+	bufferSize int
+
+	buf           *streambuf.Buffer
+	segmentOffset int
+	streamOffset  int
+}
+
+func newLineScanner(in *decoderReader, separator []byte, bufferSize int) *lineScanner {
+	return &lineScanner{
+		in:         in,
+		separator:  separator,
+		bufferSize: bufferSize,
+		buf:        streambuf.New(nil),
+	}
+}
+
+// seekToLastRead moves the fp to the last read position.
+// The number of bytes which needs to be read is the size of the
+// configured harvester_buffer_size when the state was written.
+func (s *lineScanner) seekToLastRead() error {
+	if s.streamOffset == 0 {
+		return nil
+	}
+
+	remaining := s.segmentOffset
+	for remaining > 0 {
+		size := s.bufferSize
+		if remaining < size {
+			size = remaining
+		}
+
+		b := make([]byte, size)
+		n, err := s.in.read(b)
+		remaining -= n
+		if err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Scan reads from the underlying decoder reader and returns decoded lines.
+func (s *lineScanner) scan() ([]byte, int, error) {
+	idx := s.buf.Index(s.separator)
+	for !separatorFound(idx) {
+		b := make([]byte, s.bufferSize)
+		n, err := s.in.read(b)
+		s.buf.Append(b[:n])
+		if err != nil {
+			return nil, 0, err
+		}
+
+		s.segmentOffset = 0
+		idx = s.buf.Index(s.separator)
+	}
+
+	return s.line(idx)
+}
+
+// separatorFound checks if a new separator was found.
+func separatorFound(i int) bool {
+	return i != -1
+}
+
+// line sets the offset of the scanner and returns a line.
+func (s *lineScanner) line(i int) ([]byte, int, error) {
+	line, err := s.buf.CollectUntil(s.separator)
+	if err != nil {
+		panic(err)
+	}
+
+	s.segmentOffset += i
+	s.streamOffset += i
+	s.buf.Reset()
+
+	return line, len(line), nil
+}


### PR DESCRIPTION
This PR is not integrated into the Filebeat properly, because it depends on the registry refactoring. So I am working on a feature branch. However, I still opened the PR to validate if the algorithm is viable. I also added unit tests which validates that readers are work as they supposed to.

### Algorithm
The algorithm uses two offsets: `EncodedOffset` and `ConvertedSegmentOffset`.
`EncodedOffset` is the position of the last read byte on the disk. You can move the file pointer here and start reading. (Temporarily it's not used during seeking, but when initializing the decoder, this number of bytes is read and ignored, so the reading can start from the appropriate byte.)
`ConvertedSegmentOffset` is the last read byte in a converted buffer coming from the decoder. This is set to zero every time a new converted bytes are read from the decoder. After a line is found `ConvertedSegmentOffset` is incremented.

### How to move on?
The next step is integrating this into the harvester.
- [ ] move fp in `log/harvester` to `EncodedOffset`
- [ ] remove unnecessary seeking by `Read`
- [ ] refactoring of state init in `LineReader`
- [ ] report state back to `log/harvester`

### More TODO
- [ ] limit event size in `lineScanner` set in `max_bytes`