### PR TITLE
Report kibana_settings to X-Pack Monitoring (#7664)

### DIFF
--- a/metricbeat/module/kibana/kibana.go
+++ b/metricbeat/module/kibana/kibana.go
@@ -29,6 +29,14 @@ import (
 	"github.com/elastic/beats/metricbeat/mb"
 )
 
+const (
+	// StatsAPIAvailableVersion is the version of Kibana since when the stats API is available
+	StatsAPIAvailableVersion = "6.4.0"
+
+	// SettingsAPIAvailableVersion is the version of Kibana since when the settings API is available
+	SettingsAPIAvailableVersion = "6.5.0"
+)
+
 // ReportErrorForMissingField reports and returns an error message for the given
 // field being missing in API response received from Kibana
 func ReportErrorForMissingField(field string, r mb.ReporterV2) error {
@@ -62,6 +70,30 @@ func GetVersion(http *helper.HTTP, currentPath string) (string, error) {
 	}
 
 	return versionStr, nil
+}
+
+func isKibanaAPIAvailable(currentKibanaVersion, apiAvailableInKibanaVersion string) (bool, error) {
+	currentVersion, err := common.NewVersion(currentKibanaVersion)
+	if err != nil {
+		return false, err
+	}
+
+	wantVersion, err := common.NewVersion(apiAvailableInKibanaVersion)
+	if err != nil {
+		return false, err
+	}
+
+	return !currentVersion.LessThan(wantVersion), nil
+}
+
+// IsStatsAPIAvailable returns whether the stats API is available in the given version of Kibana
+func IsStatsAPIAvailable(currentKibanaVersion string) (bool, error) {
+	return isKibanaAPIAvailable(currentKibanaVersion, StatsAPIAvailableVersion)
+}
+
+// IsSettingsAPIAvailable returns whether the settings API is available in the given version of Kibana
+func IsSettingsAPIAvailable(currentKibanaVersion string) (bool, error) {
+	return isKibanaAPIAvailable(currentKibanaVersion, SettingsAPIAvailableVersion)
 }
 
 func fetchPath(http *helper.HTTP, currentPath, newPath string) ([]byte, error) {

--- a/metricbeat/module/kibana/stats/_meta/test/settings.700.json
+++ b/metricbeat/module/kibana/stats/_meta/test/settings.700.json
@@ -1,0 +1,18 @@
+{
+    "cluster_uuid":"u5ii0pnQRka_P0gimfmthg",
+    "settings":{
+      "xpack":{
+        "default_admin_email":"jane@doe.com"
+      },
+      "kibana":{
+        "uuid":"5b2de169-2785-441b-ae8c-186a1936b17d",
+        "name":"Janes-MBP-2",
+        "index":".kibana",
+        "host":"localhost",
+        "transport_address":"localhost:5601",
+        "version":"7.0.0-alpha1",
+        "snapshot":false,
+        "status":"green"
+      }
+    }
+  }

--- a/metricbeat/module/kibana/stats/data_xpack_test.go
+++ b/metricbeat/module/kibana/stats/data_xpack_test.go
@@ -23,13 +23,14 @@ import (
 	"io/ioutil"
 	"path/filepath"
 	"testing"
+	"time"
 
 	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestEventMappingXPack(t *testing.T) {
+func TestEventMappingStatsXPack(t *testing.T) {
 
 	files, err := filepath.Glob("./_meta/test/stats-legacy.*.json")
 	assert.NoError(t, err)
@@ -39,7 +40,28 @@ func TestEventMappingXPack(t *testing.T) {
 		assert.NoError(t, err)
 
 		reporter := &mbtest.CapturingReporterV2{}
-		err = eventMappingXPack(reporter, 10000, input)
+		now := time.Now()
+
+		err = eventMappingStatsXPack(reporter, 10000, now, input)
+		assert.NoError(t, err, f)
+		assert.True(t, len(reporter.GetEvents()) >= 1, f)
+		assert.Equal(t, 0, len(reporter.GetErrors()), f)
+	}
+}
+
+func TestEventMappingSettingsXPack(t *testing.T) {
+
+	files, err := filepath.Glob("./_meta/test/settings.*.json")
+	assert.NoError(t, err)
+
+	for _, f := range files {
+		input, err := ioutil.ReadFile(f)
+		assert.NoError(t, err)
+
+		reporter := &mbtest.CapturingReporterV2{}
+		now := time.Now()
+
+		err = eventMappingSettingsXPack(reporter, 10000, now, input)
 		assert.NoError(t, err, f)
 		assert.True(t, len(reporter.GetEvents()) >= 1, f)
 		assert.Equal(t, 0, len(reporter.GetErrors()), f)


### PR DESCRIPTION
Resolves #7621.

Depends on https://github.com/elastic/kibana/pull/21100.

X-Pack Monitoring of Kibana requires two types of documents in the `.monitoring-kibana-*` indices: `kibana_stats` and `kibana_settings`. We made Metricbeat's `kibana/stats` metricset index `kibana_stats` documents into `.monitoring-kibana-*` in #7525. This PR makes the same metricset index `kibana_settings` documents into `.monitoring-kibana-*`.

### To test this PR
The idea is that metricbeat (specifically the kibana/stats metricset with `xpack.enabled: true`) will create exactly the same documents in `.monitoring-kibana-*` indices as Kibana's bulk uploader does today. 

1. Start up Elasticsearch (with the default Basic license is okay)
2. Start up Kibana (with the default Basic license is okay), checked out from `master`.
3. Enable Monitoring in Elasticsearch (via the cluster setting `xpack.monitoring.collection.enabled: true`). You can do this via [Elasticsearch's Cluster Update Settings API](https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-update-settings.html) or by clicking the "Turn on Monitoring" button in the Monitoring UI in Kibana.
4. Let Kibana run for ~20 seconds so a few documents are indexed into `.monitoring-kibana-*`.
5. Stop Kibana
6. From `.monitoring-kibana-*`, retrieve a document for `type = kibana_settings`
7. Delete the `.monitoring-kibana-*` indices.
8. In `kibana.yml`, set `xpack.monitoring.kibana.collection.enabled: false`. This will ensure that Kibana is no longer directly shipping its monitoring metrics to Elasticsearch.
9. Start up Kibana again, this time checked out from https://github.com/elastic/kibana/pull/21100.
10. Enable the `kibana` module in metricbeat: `./metricbeat modules enable kibana`.
11. In `modules.d/kibana.yml`, add the `stats` metricset and set `xpack.enabled: true`. Concretely, your `modules.d/kibana.yml` should look something like this:

      ```yaml
      - module: kibana
         metricsets:
         - stats
         period: 10s
         hosts: ["localhost:5601"]
         #basepath: ""
         #username: "user"
         #password: "secret"
         xpack.enabled: true
       ```

     Additionally, if your Kibana URLs have a basepath prefix, say `foo`, make sure to un-comment the `basepath` setting in the `kibana` module YAML file and set it's value to `"foo"`.

12. Start metricbeat.
13. Let metricbeat run for ~20 seconds so a few documents are indexed into `.monitoring-kibana-*`.
14. Stop metricbeat
15. From `.monitoring-kibana-*`, retrieve a document for `type = kibana_settings`.
16. Using a tool such as http://www.jsondiff.com, compare the documents indexed by Kibana's with those indexed by metricbeat. Verify that their structures are identical (same fields, not necessarily same values), except for these known and expected differences:
    1. Only Metricbeat-indexed documents are expected to contain the fields `@timestamp`, `beat`, `host`, and `metricset`. These are "standard" fields added by beats and metricbeat and don't have an adverse impact since they are additive.
    3. Only Kibana-indexed documents are expected to contain the field `source_node`. This field is used for debugging purposes only and not actually consumed by either the Monitoring UI or Telemetry feature in Kibana.

(cherry picked from commit 2af5ab9fc4825df68d399f57e6b16c9288a591c7)