### PR TITLE
Minor fixes to attributes in module docs

### DIFF
--- a/filebeat/docs/modules/kibana.asciidoc
+++ b/filebeat/docs/modules/kibana.asciidoc
@@ -23,15 +23,17 @@ include::../include/running-modules.asciidoc[]
 
 include::../include/configuring-intro.asciidoc[]
 
-//set the fileset name used in the included example
+//set the fileset name used in the included file
 :fileset_ex: log
 
 include::../include/config-option-intro.asciidoc[]
 
 [float]
-==== `{fileset}` log fileset settings
+==== `log` fileset settings
 
 include::../include/var-paths.asciidoc[]
+
+:fileset_ex!:
 
 
 [float]

--- a/filebeat/module/kibana/_meta/docs.asciidoc
+++ b/filebeat/module/kibana/_meta/docs.asciidoc
@@ -18,12 +18,14 @@ include::../include/running-modules.asciidoc[]
 
 include::../include/configuring-intro.asciidoc[]
 
-//set the fileset name used in the included example
+//set the fileset name used in the included file
 :fileset_ex: log
 
 include::../include/config-option-intro.asciidoc[]
 
 [float]
-==== `{fileset}` log fileset settings
+==== `log` fileset settings
 
 include::../include/var-paths.asciidoc[]
+
+:fileset_ex!:

--- a/filebeat/scripts/module/_meta/docs.asciidoc
+++ b/filebeat/scripts/module/_meta/docs.asciidoc
@@ -38,4 +38,6 @@ the relevant file. For example:
 
 include::../include/var-paths.asciidoc[]
 
+:fileset_ex!:
+
 :modulename!:


### PR DESCRIPTION
`{fileset}` should have been replaced by `log`, but wasn't, so it was showing up in the output.

Also clarified the usage of `fileset_ex` attribute.