### PR TITLE
Add GetLicense to Elasticsearch client

### DIFF
--- a/libbeat/outputs/elasticsearch/client_integration_test.go
+++ b/libbeat/outputs/elasticsearch/client_integration_test.go
@@ -242,6 +242,15 @@ func TestClientBulkPublishEventsWithPipeline(t *testing.T) {
 	assert.Equal(t, 1, getCount("testfield:0")) // no pipeline
 }
 
+func TestGetLicense(t *testing.T) {
+	_, client := connectTestEs(t, nil)
+	license, err := client.GetLicense()
+	assert.NoError(t, err)
+
+	// We expect a platinum license because we tests against a trial license
+	assert.Equal(t, LicensePlatinum, license)
+}
+
 func connectTestEs(t *testing.T, cfg interface{}) (outputs.Client, *Client) {
 	config, err := common.NewConfigFrom(map[string]interface{}{
 		"hosts":            internal.GetEsHost(),


### PR DESCRIPTION
This allows feature like ILM to check the License of the Elasticsearch cluster to see if the feature will work or not.

Open questions:

* Should we check for expiration?
* I only tested with trial and basic, is the license type for gold and platinum correct?
* Is trial always platinum license?
* What does the API endpoint look like if the trial is expired?