### PR TITLE
Make docker input check if container strings are empty

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -85,6 +85,7 @@ https://github.com/elastic/beats/compare/v6.4.0...master[Check the HEAD diff]
 - Make inputsource generic taking bufio.SplitFunc as input {pull}7746[7746]
 - Add custom unpack to log hints config to avoid env resolution {pull}7710[7710]
 - Keep raw user agent information after parsing as user_agent_raw in Filebeat modules. {pull}7823[7832]
+- Make docker input check if container strings are empty {pull}7960[7960]
 
 *Heartbeat*
 


### PR DESCRIPTION
We have seen certain docker inputs being spun up with the config:
```
paths: [/var/lib/docker/containers/*.log]
```

This is because of empty container IDs. This PR makes sure that we do a check of empty strings to avoid this as there might be serious repercussions if that path had a valid file.