### PR TITLE
Add debug check to logp.Logger

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -74,6 +74,7 @@ https://github.com/elastic/beats/compare/v6.4.0...master[Check the HEAD diff]
   internal monitoring data. {issue}7807[7807]
 - Allow for cloud-id to specify a custom port. This makes cloud-id work in ECE contexts. {pull}7887[7887]
 - Add support to grow or shrink an existing spool file between restarts. {pull}7859[7859]
+- Add debug check to logp.Logger {pull}7965[7965]
 
 *Auditbeat*
 

--- a/libbeat/logp/logger.go
+++ b/libbeat/logp/logger.go
@@ -27,7 +27,8 @@ type LogOption = zap.Option
 
 // Logger logs messages to the configured output.
 type Logger struct {
-	sugar *zap.SugaredLogger
+	logger *zap.Logger
+	sugar  *zap.SugaredLogger
 }
 
 func newLogger(rootLogger *zap.Logger, selector string, options ...LogOption) *Logger {
@@ -35,7 +36,7 @@ func newLogger(rootLogger *zap.Logger, selector string, options ...LogOption) *L
 		WithOptions(zap.AddCallerSkip(1)).
 		WithOptions(options...).
 		Named(selector)
-	return &Logger{log.Sugar()}
+	return &Logger{log, log.Sugar()}
 }
 
 // NewLogger returns a new Logger labeled with the name of the selector. This
@@ -50,13 +51,15 @@ func NewLogger(selector string, options ...LogOption) *Logger {
 // With creates a child logger and adds structured context to it. Fields added
 // to the child don't affect the parent, and vice versa.
 func (l *Logger) With(args ...interface{}) *Logger {
-	return &Logger{l.sugar.With(args...)}
+	sugar := l.sugar.With(args...)
+	return &Logger{sugar.Desugar(), sugar}
 }
 
 // Named adds a new path segment to the logger's name. Segments are joined by
 // periods.
 func (l *Logger) Named(name string) *Logger {
-	return &Logger{l.sugar.Named(name)}
+	logger := l.logger.Named(name)
+	return &Logger{logger, logger.Sugar()}
 }
 
 // Sprint
@@ -99,7 +102,7 @@ func (l *Logger) DPanic(args ...interface{}) {
 
 // IsDebug checks to see if the given logger is Debug enabled.
 func (l *Logger) IsDebug() bool {
-	return l.sugar.Desugar().Check(zapcore.DebugLevel, "") != nil
+	return l.logger.Check(zapcore.DebugLevel, "") != nil
 }
 
 // Sprintf

--- a/libbeat/logp/logger.go
+++ b/libbeat/logp/logger.go
@@ -19,6 +19,7 @@ package logp
 
 import (
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 // LogOption configures a Logger.
@@ -94,6 +95,11 @@ func (l *Logger) Panic(args ...interface{}) {
 // logger then panics.
 func (l *Logger) DPanic(args ...interface{}) {
 	l.sugar.DPanic(args...)
+}
+
+// IsDebug checks to see if the given logger is Debug enabled.
+func (l *Logger) IsDebug() bool {
+	return l.sugar.Desugar().Check(zapcore.DebugLevel, "") != nil
 }
 
 // Sprintf


### PR DESCRIPTION
This PR adds a debug check

I made sure to check if `Desugar()` is expensive or not.  The API is documented as follows:

```
// Desugar unwraps a SugaredLogger, exposing the original Logger. Desugaring
// is quite inexpensive, so it's reasonable for a single application to use
// both Loggers and SugaredLoggers, converting between them on the boundaries
// of performance-sensitive code.
```