### PR TITLE
Improve Jolokia docs and remove proxy restriction

### DIFF
--- a/metricbeat/docs/modules/jolokia.asciidoc
+++ b/metricbeat/docs/modules/jolokia.asciidoc
@@ -5,13 +5,18 @@ This file is generated! See scripts/docs_collector.py
 [[metricbeat-module-jolokia]]
 == Jolokia module
 
-This is the Jolokia module.
+This module collects metrics from
+https://jolokia.org/reference/html/agents.html[Jolokia agents] running on a
+target JMX server or dedicated proxy server. The default metricset is `jmx`.
+
+To collect metrics, {beatname_uc} communicates with a Jolokia HTTP/REST
+endpoint that exposes the JMX metrics over HTTP/REST/JSON.
 
 [float]
 === Compatibility
 
-The Jolokia module is tested with Jolokia 1.5.0, it should work with any version
-since 1.2.2.
+The Jolokia module is tested with Jolokia 1.5.0. It should work with version
+1.2.2 and later.
 
 
 

--- a/metricbeat/module/jolokia/_meta/docs.asciidoc
+++ b/metricbeat/module/jolokia/_meta/docs.asciidoc
@@ -1,8 +1,13 @@
-This is the Jolokia module.
+This module collects metrics from
+https://jolokia.org/reference/html/agents.html[Jolokia agents] running on a
+target JMX server or dedicated proxy server. The default metricset is `jmx`.
+
+To collect metrics, {beatname_uc} communicates with a Jolokia HTTP/REST
+endpoint that exposes the JMX metrics over HTTP/REST/JSON.
 
 [float]
 === Compatibility
 
-The Jolokia module is tested with Jolokia 1.5.0, it should work with any version
-since 1.2.2.
+The Jolokia module is tested with Jolokia 1.5.0. It should work with version
+1.2.2 and later.
 

--- a/metricbeat/module/jolokia/jmx/_meta/docs.asciidoc
+++ b/metricbeat/module/jolokia/jmx/_meta/docs.asciidoc
@@ -3,7 +3,7 @@ https://jolokia.org/reference/html/agents.html[Jolokia agents].
 
 [float]
 === Features and configuration
-Tested with Jolokia 1.3.4.
+Tested with Jolokia 1.5.0.
 
 To collect metrics from a Jolokia instance, define a mapping section that
 specifies an MBean `ObjectName` followed by an array of attributes to fetch. For
@@ -11,15 +11,15 @@ each attribute in the array, specify the Elastic field name where the
 returned value will be saved. 
 
 For example, to get the `Uptime` attribute from the `java.lang:type=Runtime`
-MBean and map it to an event field called `jolokia.jmx.uptime`, configure the
-following mapping:
+MBean and map it to an event field called `jolokia.testnamespace.uptime`,
+configure the following mapping:
 
 [source,yaml]
 ----
 - module: jolokia
   metricsets: ["jmx"]
   hosts: ["localhost:8778"]
-  namespace: "metrics" <1>
+  namespace: "testnamespace" <1>
   jmx.mappings:
     - mbean: 'java.lang:type=Runtime'
       attributes:
@@ -31,9 +31,10 @@ following mapping:
           user: "jolokia"
           password: "s!cr!t"
 ----
-<1> The `namespace` setting is required.
-<2> This field will be called `jolokia.jmx.uptime` in the output event because
-the Beats framework adds a prefix to the name.  
+<1> The `namespace` setting is required. This setting is used along with the
+module name to qualify field names in the output event.
+<2> The field where the returned value will be saved. This field will be called
+`jolokia.testnamespace.uptime` in the output event.  
 <3> The `event` setting is optional. Use this setting to group all attributes
 with the same `event` value into the same event when sending data to Elastic. 
 

--- a/metricbeat/module/jolokia/jmx/_meta/docs.asciidoc
+++ b/metricbeat/module/jolokia/jmx/_meta/docs.asciidoc
@@ -48,8 +48,9 @@ It is required to set a namespace in the general module config section.
 
 [float]
 === Limitations
-No authentication against Jolokia is supported yet.
-All Jolokia requests have canonicalNaming set to false (details see here: https://jolokia.org/reference/html/protocol.html).
+All Jolokia requests have `canonicalNaming` set to `false`. See the
+https://jolokia.org/reference/html/protocol.html[Jolokia Protocol] documentation
+for more detail about this parameter.
 
 
 [float]

--- a/metricbeat/module/jolokia/jmx/_meta/docs.asciidoc
+++ b/metricbeat/module/jolokia/jmx/_meta/docs.asciidoc
@@ -1,50 +1,57 @@
-This is the `jmx` metricset of the Jolokia module.
+The `jmx` metricset collects metrics from
+https://jolokia.org/reference/html/agents.html[Jolokia agents].
 
 [float]
 === Features and configuration
 Tested with Jolokia 1.3.4.
 
-Metrics to be collected from each Jolokia instance are defined in the mapping section with an MBean ObjectName and
-an array of Attributes to be requested with Elastic field names under which the return values should be saved.
+To collect metrics from a Jolokia instance, define a mapping section that
+specifies an MBean `ObjectName` followed by an array of attributes to fetch. For
+each attribute in the array, specify the Elastic field name where the
+returned value will be saved. 
 
-For example: to get the "Uptime" attribute from the "java.lang:type=Runtime" MBean and map it to something like
-"uptime" (actually "jolokia.jmx.uptime", the prexif is added by beats framework) you have to configure following
-mapping:
+For example, to get the `Uptime` attribute from the `java.lang:type=Runtime`
+MBean and map it to an event field called `jolokia.jmx.uptime`, configure the
+following mapping:
 
 [source,yaml]
----
+----
 - module: jolokia
   metricsets: ["jmx"]
   hosts: ["localhost:8778"]
-  namespace: "metrics"
+  namespace: "metrics" <1>
   jmx.mappings:
     - mbean: 'java.lang:type=Runtime'
       attributes:
         - attr: Uptime
-          field: uptime
-          event: uptime
+          field: uptime <2>
+          event: uptime <3>
       target:
           url: "service:jmx:rmi:///jndi/rmi://targethost:9999/jmxrmi"
           user: "jolokia"
           password: "s!cr!t"
----
+----
+<1> The `namespace` setting is required.
+<2> This field will be called `jolokia.jmx.uptime` in the output event because
+the Beats framework adds a prefix to the name.  
+<3> The `event` setting is optional. Use this setting to group all attributes
+with the same `event` value into the same event when sending data to Elastic. 
 
-In case the underlying attribute is an object (e.g. see HeapMemoryUsage attribute in java.lang:type=Memory) its
-structure will be published to Elastic "as is".
+If the underlying attribute is an object (such as the `HeapMemoryUsage`
+attribute in `java.lang:type=Memory`), its structure will be published to
+Elastic "as is".
 
-It is possible to configure nested metric aliases by using dots in the mapping name (e.g. gc.cms_collection_time). For examples please refer to the
+You can configure nested metric aliases by using dots in the mapping name (for
+example, `gc.cms_collection_time`). For more examples, see
 https://github.com/elastic/beats/blob/{doc-branch}/metricbeat/module/jolokia/jmx/_meta/test/config.yml[/jolokia/jmx/test/config.yml].
 
-All metrics from a single mapping will be POSTed to the defined host/port and sent to Elastic as a single event.
-To make it possible to differentiate between metrics from multiple similar applications running on the same host,
-please configure multiple modules.
+All metrics from a single mapping will be POSTed to the defined host/port and
+sent to Elastic as a single event. To make it possible to differentiate between
+metrics from multiple similar applications running on the same host, you should
+configure multiple modules.
 
-When wildcards are used, an event will be sent to Elastic for each matching mbean, in that case a `mbean` field is added.
-
-Optionally, an `event` name can be added to each attribute, this makes all metrics with the same `event`
-to be grouped in the same event when being sent to Elastic.
-
-It is required to set a namespace in the general module config section.
+When wildcards are used, an event is sent to Elastic for each matching
+MBean, and an `mbean` field is added to the event.
 
 [float]
 === Limitations
@@ -55,5 +62,6 @@ for more detail about this parameter.
 
 [float]
 === Exposed fields, dashboards, indexes, etc.
-Since this is a very general module that can be tailored for any application that exposes its metrics over Jolokia, it
-comes with no exposed fields description, dashboards or index patterns.
+Because this module is very general and can be tailored for any application that
+exposes its metrics over Jolokia, it comes with no exposed field descriptions,
+dashboards, or index patterns.


### PR DESCRIPTION
Summary of changes:
- Adds more detail to the docs based on #4344.
- Adds edits for the existing content.
- Removes the following restriction because the wording was confusing (made it sound like basic auth wasn't supported). As of the following PR, the restriction is (I think!) no longer valid: https://github.com/elastic/beats/commit/3a61bcf4c28f6a8998bd0c47f7ccf8cd25dc01ee#diff-9e05d174fee20e0fb0c968cb62628002

Closes https://github.com/elastic/beats/issues/6897 and #4344.

NOTE: I plan to backport this change to 6.4 only (unless there is a strong objection and reviewers think this must be in 6.3)


