### PR TITLE
[POC][Idea] Create field mappings on the fly instead of using template

### DIFF
--- a/libbeat/template/load.go
+++ b/libbeat/template/load.go
@@ -75,6 +75,9 @@ func (l *Loader) Load() error {
 	if l.config.JSON.Enabled {
 		templateName = l.config.JSON.Name
 	}
+
+	tmpl.LoadBytes(l.fields)
+
 	// Check if template already exist or should be overwritten
 	exists := l.CheckTemplate(templateName)
 	if !exists || l.config.Overwrite {

--- a/libbeat/template/template.go
+++ b/libbeat/template/template.go
@@ -39,6 +39,8 @@ var (
 	dynamicTemplates []common.MapStr
 
 	defaultFields []string
+
+	Fields common.Fields
 )
 
 type Template struct {
@@ -119,6 +121,8 @@ func (t *Template) load(fields common.Fields) (common.MapStr, error) {
 	// Locking to make sure dynamicTemplates and defaultFields is not accessed in parallel
 	t.Lock()
 	defer t.Unlock()
+
+	Fields = fields
 
 	dynamicTemplates = nil
 	defaultFields = nil


### PR DESCRIPTION
Currently Beats loads in advance a template with all fields inside and each index will rely on the template. This PR turns this concept around by having a strict template without any fields inside. This means when a Beat tries to ingest data which does not exist yet the requested will be rejected. If it's a mapping rejection the Beat will check all the events which failed to send and get their fields and the ready the mappings for it. Out of these an index mapping is created and pushed to the index before the events are sent again.

This has the following advantages

* The mappings existing in an index are only for the fields that exist in an index
* If someone uses a different index pattern, the mapping is still applied even if the template would not match
* If we use an index per module, it just works and not all libbeat fields for the processors are added if they are not used (for example k8s)
* Every time a new index is created the mapping is recreated so if a module is used only once it will not be in all the following indices
* Support for adding new fields on the fly: With append_fields the user can add new fields to mapping without having to restart and it will work with reloading.

There are also disadvantages

* Every time a new index is created all mappings have to be sent again. So instead of having one request there are 3.
* Assuming 1000 Beats send data to one index, all the Beats will try to write the mappings again at the same time -> peak load?

Instead of trying to apply this change to the existing ingest path I could see this becoming interesting in combination with ILM as it would allow us there to use an index pattern which does not match the current template.

Questions

* How do we handle dynamic mapping fields? Should we add logic to Beats to also create them?
* What about fields which have no mapping assigned -> keyword or delete entry?
* Should we get rid of the template completely and always manually create an index?

Test implementation

In the current implementation most things are hard coded, global look ups and short cuts were taken as this is only meant as a POC. To test it first the template must be created:

```
PUT _template/metricbeat-7.0.0-alpha1
{
  "index_patterns": ["metricbeat-*"],
  "settings": {
    "number_of_shards": 1
  },
  "mappings": {
    "doc": {
      "dynamic": "strict"
    }
  }
}
```

As the code does not create indices automatically yet, the following index has to be added (adjust the date):

```
PUT metricbeat-7.0.0-alpha1-2018.08.15
```

The same index name must be hardcoded in the client.go file around 596.