### PR TITLE
[Redis] Rename client input/output buffer metrics

### DIFF
--- a/metricbeat/module/redis/info/_meta/data.json
+++ b/metricbeat/module/redis/info/_meta/data.json
@@ -16,7 +16,9 @@
                 "biggest_input_buf": 0,
                 "blocked": 0,
                 "connected": 1,
-                "longest_output_list": 0
+                "longest_output_list": 0,
+                "max_output_buffer": 0,
+                "max_input_buffer": 0
             },
             "cluster": {
                 "enabled": false

--- a/metricbeat/module/redis/info/_meta/fields.yml
+++ b/metricbeat/module/redis/info/_meta/fields.yml
@@ -16,11 +16,19 @@
         - name: longest_output_list
           type: long
           description: >
-            Longest output list among current client connections.
+            Longest output list among current client connections. For Redis 4.x and below.
         - name: biggest_input_buf
           type: long
           description: >
-            Biggest input buffer among current client connections.
+            Biggest input buffer among current client connections. For Redis 4.x and below.
+        - name: max_output_buffer
+          type: long
+          description: >
+            Biggest output list among current client connections. For Redis 5.0 and above.
+        - name: max_input_buffer
+          type: long
+          description: >
+            Biggest input buffer among current client connections. For Redis 5.0 and above.
         - name: blocked
           type: long
           description: >

--- a/metricbeat/module/redis/info/data.go
+++ b/metricbeat/module/redis/info/data.go
@@ -26,10 +26,12 @@ import (
 var (
 	schema = s.Schema{
 		"clients": s.Object{
-			"connected":         c.Int("connected_clients"),
-			"max_output_buffer": c.Int("client_recent_max_output_buffer"),
-			"max_input_buffer":  c.Int("client_recent_max_input_buffer"),
-			"blocked":           c.Int("blocked_clients"),
+			"connected":           c.Int("connected_clients"),
+			"longest_output_list": c.Int("client_longest_output_list", s.Optional), // Redis 4.x and below
+			"biggest_input_buf":   c.Int("client_biggest_input_buf", s.Optional), // Redis 4.x and below
+			"max_output_buffer":   c.Int("client_recent_max_output_buffer", s.Optional), // Redis 5.0 and above
+			"max_input_buffer":    c.Int("client_recent_max_input_buffer", s.Optional), // Redis 5.0 and above
+			"blocked":             c.Int("blocked_clients"),
 		},
 		"cluster": s.Object{
 			"enabled": c.Bool("cluster_enabled"),

--- a/metricbeat/module/redis/info/data.go
+++ b/metricbeat/module/redis/info/data.go
@@ -26,10 +26,10 @@ import (
 var (
 	schema = s.Schema{
 		"clients": s.Object{
-			"connected":           c.Int("connected_clients"),
-			"longest_output_list": c.Int("client_longest_output_list"),
-			"biggest_input_buf":   c.Int("client_biggest_input_buf"),
-			"blocked":             c.Int("blocked_clients"),
+			"connected":         c.Int("connected_clients"),
+			"max_output_buffer": c.Int("client_recent_max_output_buffer"),
+			"max_input_buffer":  c.Int("client_recent_max_input_buffer"),
+			"blocked":           c.Int("blocked_clients"),
 		},
 		"cluster": s.Object{
 			"enabled": c.Bool("cluster_enabled"),

--- a/metricbeat/module/redis/info/data.go
+++ b/metricbeat/module/redis/info/data.go
@@ -27,10 +27,10 @@ var (
 	schema = s.Schema{
 		"clients": s.Object{
 			"connected":           c.Int("connected_clients"),
-			"longest_output_list": c.Int("client_longest_output_list", s.Optional), // Redis 4.x and below
-			"biggest_input_buf":   c.Int("client_biggest_input_buf", s.Optional), // Redis 4.x and below
+			"longest_output_list": c.Int("client_longest_output_list", s.Optional),      // Redis 4.x and below
+			"biggest_input_buf":   c.Int("client_biggest_input_buf", s.Optional),        // Redis 4.x and below
 			"max_output_buffer":   c.Int("client_recent_max_output_buffer", s.Optional), // Redis 5.0 and above
-			"max_input_buffer":    c.Int("client_recent_max_input_buffer", s.Optional), // Redis 5.0 and above
+			"max_input_buffer":    c.Int("client_recent_max_input_buffer", s.Optional),  // Redis 5.0 and above
 			"blocked":             c.Int("blocked_clients"),
 		},
 		"cluster": s.Object{


### PR DESCRIPTION
Hi,

In the upcoming Redis 5.0 release they changed client input/output buffer metrics: https://github.com/antirez/redis/commit/be88c0b16a53f5763d8fc1ae683f99ee39b0d68e. This PR is to reflect these changes.

Important:
- merge only after 5.0 is released
- contains breaking changes for metrics names (subject for discussion)