### PR TITLE
Add details to windows/service metricset test failures

### DIFF
--- a/metricbeat/module/windows/service/service_integration_windows_test.go
+++ b/metricbeat/module/windows/service/service_integration_windows_test.go
@@ -57,32 +57,35 @@ func TestReadService(t *testing.T) {
 
 	var wmiSrc []Win32Service
 
-	// Get services per WMI
+	// Get services from WMI.
 	err = wmi.Query("SELECT * FROM Win32_Service ", &wmiSrc)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// Get services per windows module
+	// Get services from Windows module.
 	services, err := reader.Read()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	//Compare them
+	// Compare our module's data against WMI.
 	for _, s := range services {
-		// Look if the service is in the wmi src
+		// Look if the service is in the WMI data.
 		var found bool
 		for _, w := range wmiSrc {
 			if w.Name == s["name"] {
 				if s["pid"] != nil {
-					assert.Equal(t, w.ProcessId, s["pid"])
+					assert.Equal(t, w.ProcessId, s["pid"],
+						"PID of service %v does not match", w.DisplayName)
 				}
-				assert.Equal(t, w.State, s["state"])
+				assert.Equal(t, w.State, s["state"],
+					"State of service %v does not match", w.DisplayName)
 
 				// For some services DisplayName and Name are the same. It seems to be a bug from the wmi query.
 				if w.DisplayName != w.Name {
-					assert.Equal(t, w.DisplayName, s["display_name"])
+					assert.Equal(t, w.DisplayName, s["display_name"],
+						"Display name of service %v does not match", w.Name)
 				}
 				found = true
 				break


### PR DESCRIPTION
This adds service names to the output of test failures to help us diagnose the cause
of the test failure in the future.

Relates to #7977