### PR TITLE
Fix description of host setting in kubernetes configurations

### DIFF
--- a/libbeat/docs/processors-using.asciidoc
+++ b/libbeat/docs/processors-using.asciidoc
@@ -791,8 +791,9 @@ The `add_kubernetes_metadata` processor has the following configuration settings
 
 `in_cluster`:: (Optional) Use in cluster settings for Kubernetes client, `true`
 by default.
-`host`:: (Optional) In case `in_cluster` is false, use this host to connect to
-Kubernetes API.
+`host`:: (Optional) Identify the node where {beatname_lc} is running in case it
+cannot be accurately detected, as when running {beatname_lc} in host network
+mode.
 `kube_config`:: (Optional) Use given config file as configuration for Kubernetes
 client.
 `default_indexers.enabled`:: (Optional) Enable/Disable default pod indexers, in

--- a/libbeat/docs/shared-autodiscover.asciidoc
+++ b/libbeat/docs/shared-autodiscover.asciidoc
@@ -164,8 +164,9 @@ The `kubernetes` autodiscover provider has the following configuration settings:
 
 `in_cluster`:: (Optional) Use in cluster settings for Kubernetes client, `true`
   by default.
-`host`:: (Optional) In case `in_cluster` is false, use this host to connect to
-  Kubernetes API.
+`host`:: (Optional) Identify the node where {beatname_lc} is running in case it
+  cannot be accurately detected, as when running {beatname_lc} in host network
+  mode.
 `kube_config`:: (Optional) Use given config file as configuration for Kubernetes
   client.
 


### PR DESCRIPTION
According to documentation of the `host` setting for kuberntes configurations, it seems to expect a host to connect to the API server when `in_cluster` is set to false. But this field is really used to identify the host where the beat is running, and doesn't seem related to `in_cluster`.
This can be seen in the examples added in #8029.