### PR TITLE
Cherry-pick #8006 to 6.x: Use unique event log for Winlogbeat system tests

### DIFF
--- a/winlogbeat/tests/system/winlogbeat.py
+++ b/winlogbeat/tests/system/winlogbeat.py
@@ -1,3 +1,4 @@
+import hashlib
 import os
 import platform
 import sys
@@ -14,6 +15,10 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '../../../libbeat/tests/
 
 from beat.beat import TestCase
 
+PROVIDER = "WinlogbeatTestPython"
+APP_NAME = "SystemTest"
+OTHER_APP_NAME = "OtherSystemTestApp"
+
 
 class BaseTest(TestCase):
 
@@ -25,15 +30,24 @@ class BaseTest(TestCase):
 
 
 class WriteReadTest(BaseTest):
-    providerName = "WinlogbeatTestPython"
-    applicationName = "SystemTest"
-    otherAppName = "OtherSystemTestApp"
+    providerName = PROVIDER
+    applicationName = APP_NAME
+    otherAppName = OTHER_APP_NAME
+    testSuffix = None
     sid = None
     sidString = None
     api = None
 
     def setUp(self):
         super(WriteReadTest, self).setUp()
+
+        # Every test will use its own event log and application names to ensure
+        # isolation.
+        self.testSuffix = "_" + hashlib.sha256(self.api + self._testMethodName).hexdigest()[:5]
+        self.providerName = PROVIDER + self.testSuffix
+        self.applicationName = APP_NAME + self.testSuffix
+        self.otherAppName = OTHER_APP_NAME + self.testSuffix
+
         win32evtlogutil.AddSourceToRegistry(self.applicationName,
                                             "%systemroot%\\system32\\EventCreate.exe",
                                             self.providerName)


### PR DESCRIPTION
Cherry-pick of PR #8006 to 6.x branch. Original message: 

This changes the Winlogbeat system tests to use a unique event log for each test case.
The event log name and the registered source applications will each be suffixed with
a short hash created from the Windows API name (eventlogging or wineventlog) and the
python test name.

This should help isolate the test cases from one another.

Fixes #7902