### PR TITLE
Replace unpublished ceph/demo image with ceph/daemon

### DIFF
--- a/metricbeat/module/ceph/_meta/Dockerfile
+++ b/metricbeat/module/ceph/_meta/Dockerfile
@@ -1,4 +1,4 @@
-FROM ceph/demo:tag-build-master-jewel-centos-7
+FROM ceph/daemon:latest-jewel
 
 ENV MON_IP 0.0.0.0
 ENV CEPH_PUBLIC_NETWORK 0.0.0.0/0


### PR DESCRIPTION
This image was deleted for unknown reasons. This image seems to do the right thing
(the tests all pass!).

Someone with more ceph experience should review.