### PR TITLE
Cherry-pick #8044 to 6.x: Metricbeat: Replace ceph image from demo to daemon

### DIFF
--- a/metricbeat/module/ceph/_meta/Dockerfile
+++ b/metricbeat/module/ceph/_meta/Dockerfile
@@ -1,7 +1,4 @@
-FROM ceph/demo:tag-build-master-jewel-centos-7
-
-ENV MON_IP 0.0.0.0
-ENV CEPH_PUBLIC_NETWORK 0.0.0.0/0
+FROM ceph/daemon:master-6373c6a-jewel-centos-7-x86_64
 
 RUN yum -q install -y jq && yum clean all && rm -fr /var/cache/yum
 
@@ -11,3 +8,8 @@ HEALTHCHECK --interval=1s --retries=300 \
         | jq .output.health.health_services[0].mons[0] \
         | grep health
 EXPOSE 5000
+
+ENV NETWORK_AUTO_DETECT 4
+ENV DEMO_DAEMONS osd,rest_api
+
+CMD ["demo"]


### PR DESCRIPTION
Cherry-pick of PR #8044 to 6.x branch. Original message: 

