### PR TITLE
Cherry-pick #8044 to 5.6: Metricbeat: Replace ceph image from demo to daemon

### DIFF
--- a/metricbeat/module/ceph/_meta/Dockerfile
+++ b/metricbeat/module/ceph/_meta/Dockerfile
@@ -1,6 +1,8 @@
-FROM ceph/demo
-
-ENV MON_IP 0.0.0.0
-ENV CEPH_PUBLIC_NETWORK 0.0.0.0/0
+FROM ceph/daemon:master-6373c6a-jewel-centos-7-x86_64
 
 EXPOSE 5000
+
+ENV NETWORK_AUTO_DETECT 4
+ENV DEMO_DAEMONS osd,rest_api
+
+CMD ["demo"]


### PR DESCRIPTION
Cherry-pick of PR #8044 to 5.6 branch. Original message: 

