### PR TITLE
Cherry-pick #8028 to 6.x: Fix flakey apache module timeout test

### DIFF
--- a/metricbeat/module/apache/status/status_test.go
+++ b/metricbeat/module/apache/status/status_test.go
@@ -147,13 +147,20 @@ func TestFetchEventContents(t *testing.T) {
 // TestFetchTimeout verifies that the HTTP request times out and an error is
 // returned.
 func TestFetchTimeout(t *testing.T) {
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
 		w.Header().Set("Content-Type", "text/plain; charset=ISO-8859-1")
 		w.Write([]byte(response))
-		time.Sleep(100 * time.Millisecond)
+
+		wg.Wait()
 	}))
-	defer server.Close()
+	defer func() {
+		wg.Done()
+		server.Close()
+	}()
 
 	config := map[string]interface{}{
 		"module":     "apache",


### PR DESCRIPTION
Cherry-pick of PR #8028 to 6.x branch. Original message: 

This attempts to fix a flakey apache module test by making it less sensitive to timing issues.

Before this patch there was only 50ms for slack for the timeout to happen. My thesis here is that under contention > 50ms of delay was introduced, likely by the Kernel thread scheduler.

By switching to a wait group we have a more deterministic test. Additionally, we now cleanup the server go routine more precisely. It now ends exactly when the test is done, instead of us having it hang around for a fixed interval.

Fixes #7726