### PR TITLE
Set docs to released in branch 6.4

### DIFF
--- a/libbeat/docs/version.asciidoc
+++ b/libbeat/docs/version.asciidoc
@@ -1,7 +1,7 @@
 :stack-version: 6.4.0
 :doc-branch: 6.4
 :go-version: 1.10.3
-:release-state: unreleased
+:release-state: released
 :python: 2.7.9
 :docker: 1.12
 :docker-compose: 1.11


### PR DESCRIPTION
Should be merged on the day of the release only.