### PR TITLE
Cherry-pick #7971 to 6.x: Make kubernetes autodiscover ignore events with empty container IDs

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -68,6 +68,7 @@ https://github.com/elastic/beats/compare/v6.4.0...6.x[Check the HEAD diff]
 - Add backoff on error support to redis output. {pull}7781[7781]
 - Allow for cloud-id to specify a custom port. This makes cloud-id work in ECE contexts. {pull}7887[7887]
 - Add support to grow or shrink an existing spool file between restarts. {pull}7859[7859]
+- Make kubernetes autodiscover ignore events with empty container IDs {pull}7971[7971]
 
 *Auditbeat*
 

--- a/libbeat/autodiscover/providers/kubernetes/kubernetes.go
+++ b/libbeat/autodiscover/providers/kubernetes/kubernetes.go
@@ -156,8 +156,15 @@ func (p *Provider) emitEvents(pod *kubernetes.Pod, flag string, containers []*ku
 
 	// Emit container and port information
 	for _, c := range containers {
+		cid := containerIDs[c.GetName()]
+
+		// If there is a container ID that is empty then ignore it. It either means that the container is still starting
+		// up or the container is shutting down.
+		if cid == "" {
+			continue
+		}
 		cmeta := common.MapStr{
-			"id":      containerIDs[c.GetName()],
+			"id":      cid,
 			"name":    c.GetName(),
 			"image":   c.GetImage(),
 			"runtime": runtimes[c.GetName()],


### PR DESCRIPTION
Cherry-pick of PR #7971 to 6.x branch. Original message: 

There are scenarios where filebeat/metricbeat come up before the container is marked as `Running`. This would mean that the container's ID would not be persisted in the `Pod` object. With autodiscover has an infinite retry which keeps retrying the failed configuration even after another event was generated with the container ID.

This PR makes sure that an event without a container ID is ignored as neither filebeat nor metricbeat would have any use for it. Both would spin up a config after the container ID is available.