### PR TITLE
Adding the SSL certificate authorities as an example

### DIFF
--- a/metricbeat/docs/modules/elasticsearch.asciidoc
+++ b/metricbeat/docs/modules/elasticsearch.asciidoc
@@ -38,6 +38,9 @@ metricbeat.modules:
     #- ml_job
   period: 10s
   hosts: ["localhost:9200"]
+  #username: "elastic"
+  #password: "changeme"
+  #ssl.certificate_authorities: [ "/etc/pki/root/ca.pem" ]
 
   # Set to false to fetch all entries
   #index_recovery.active_only: true


### PR DESCRIPTION
Just to make it a bit easier for users to connect to secure elastic installations 