### PR TITLE
Wait for context finalization to provoke http timeouts on tests

### DIFF
--- a/metricbeat/module/apache/status/status_test.go
+++ b/metricbeat/module/apache/status/status_test.go
@@ -147,20 +147,13 @@ func TestFetchEventContents(t *testing.T) {
 // TestFetchTimeout verifies that the HTTP request times out and an error is
 // returned.
 func TestFetchTimeout(t *testing.T) {
-	wg := sync.WaitGroup{}
-	wg.Add(1)
-
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
 		w.Header().Set("Content-Type", "text/plain; charset=ISO-8859-1")
 		w.Write([]byte(response))
-
-		wg.Wait()
+		<-r.Context().Done()
 	}))
-	defer func() {
-		wg.Done()
-		server.Close()
-	}()
+	defer server.Close()
 
 	config := map[string]interface{}{
 		"module":     "apache",

--- a/metricbeat/module/envoyproxy/server/server_test.go
+++ b/metricbeat/module/envoyproxy/server/server_test.go
@@ -118,7 +118,7 @@ func TestFetchTimeout(t *testing.T) {
 		w.WriteHeader(200)
 		w.Header().Set("Content-Type", "text/plain; charset=UTF-8")
 		w.Write([]byte(response))
-		time.Sleep(100 * time.Millisecond)
+		<-r.Context().Done()
 	}))
 	defer server.Close()
 


### PR DESCRIPTION
Wait for request context to be done.

Related to #8028, it does basically the same, but also for envoyproxy, and using the request context (that is canceled when the server is stopped) instead of adding a wait group.