### PR TITLE
Fix config files in RPM spec

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -47,6 +47,7 @@ https://github.com/elastic/beats/compare/v6.4.0...master[Check the HEAD diff]
 - Fixed a crash in the file_integrity module under Linux. {issue}7753[7753]
 - Fixed a data race in the file_integrity module. {issue}8009[8009]
 - Fixed a deadlock in the file_integrity module. {pull}8027[8027]
+- Fixed the RPM by designating the config file as configuration data in the RPM spec. {issue}8075[8075]
 
 *Filebeat*
 
@@ -63,6 +64,7 @@ https://github.com/elastic/beats/compare/v6.4.0...master[Check the HEAD diff]
 - Fixed a panic when the kvm module cannot establish a connection to libvirtd. {issue}7792[7792].
 - Recover metrics for old apache versions removed by mistake on #6450. {pull}7871[7871]
 - Add missing namespace field in http server metricset {pull}7890[7890]
+- Fixed the RPM by designating the modules.d config files as configuration data in the RPM spec. {issue}8075[8075]
 
 *Packetbeat*
 

--- a/auditbeat/magefile.go
+++ b/auditbeat/magefile.go
@@ -169,6 +169,7 @@ func customizePackaging() {
 			Mode:   0600,
 			Source: "{{.PackageDir}}/auditbeat.yml",
 			Dep:    generateShortConfig,
+			Config: true,
 		}
 		referenceConfig = mage.PackageFile{
 			Mode:   0644,

--- a/metricbeat/magefile.go
+++ b/metricbeat/magefile.go
@@ -133,10 +133,12 @@ func customizePackaging() {
 		modulesDir = mage.PackageFile{
 			Mode:   0644,
 			Source: "modules.d",
+			Config: true,
 		}
 		windowsModulesDir = mage.PackageFile{
 			Mode:   0644,
 			Source: "{{.PackageDir}}/modules.d",
+			Config: true,
 			Dep: func(spec mage.PackageSpec) error {
 				if err := mage.Copy("modules.d", spec.MustExpand("{{.PackageDir}}/modules.d")); err != nil {
 					return errors.Wrap(err, "failed to copy modules.d dir")

--- a/packetbeat/magefile.go
+++ b/packetbeat/magefile.go
@@ -407,6 +407,7 @@ func customizePackaging() {
 		configYml = mage.PackageFile{
 			Mode:   0600,
 			Source: "{{.PackageDir}}/{{.BeatName}}.yml",
+			Config: true,
 			Dep: func(spec mage.PackageSpec) error {
 				if err := mage.Copy("packetbeat.yml",
 					spec.MustExpand("{{.PackageDir}}/packetbeat.yml")); err != nil {


### PR DESCRIPTION
The Auditbeat config file, `/etc/auditbeat/auditbeat.yml`, was not correctly marked as `configfile` in the RPM spec.

The same issue affected Metricbeat's `/etc/metricbeat/modules.d/*`.

Packetbeat's config customizations were missing the `Config: true` but this didn't have any impact because
the config is only customized for Windows.

Fixes #8075