### PR TITLE
Cherry-pick #8078 to 6.4: Fix config files in RPM spec

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -44,6 +44,7 @@ https://github.com/elastic/beats/compare/v6.4.0...6.4[Check the HEAD diff]
 *Auditbeat*
 
 - Fixed a crash in the file_integrity module under Linux. {issue}7753[7753]
+- Fixed the RPM by designating the config file as configuration data in the RPM spec. {issue}8075[8075]
 
 *Filebeat*
 
@@ -52,6 +53,8 @@ https://github.com/elastic/beats/compare/v6.4.0...6.4[Check the HEAD diff]
 *Heartbeat*
 
 *Metricbeat*
+
+- Fixed the RPM by designating the modules.d config files as configuration data in the RPM spec. {issue}8075[8075]
 
 *Packetbeat*
 

--- a/auditbeat/magefile.go
+++ b/auditbeat/magefile.go
@@ -149,6 +149,7 @@ func customizePackaging() {
 			Mode:   0600,
 			Source: "{{.PackageDir}}/auditbeat.yml",
 			Dep:    generateShortConfig,
+			Config: true,
 		}
 		referenceConfig = mage.PackageFile{
 			Mode:   0644,

--- a/metricbeat/magefile.go
+++ b/metricbeat/magefile.go
@@ -113,10 +113,12 @@ func customizePackaging() {
 		modulesDir = mage.PackageFile{
 			Mode:   0644,
 			Source: "modules.d",
+			Config: true,
 		}
 		windowsModulesDir = mage.PackageFile{
 			Mode:   0644,
 			Source: "{{.PackageDir}}/modules.d",
+			Config: true,
 			Dep: func(spec mage.PackageSpec) error {
 				if err := mage.Copy("modules.d", spec.MustExpand("{{.PackageDir}}/modules.d")); err != nil {
 					return errors.Wrap(err, "failed to copy modules.d dir")

--- a/packetbeat/magefile.go
+++ b/packetbeat/magefile.go
@@ -373,6 +373,7 @@ func customizePackaging() {
 		configYml = mage.PackageFile{
 			Mode:   0600,
 			Source: "{{.PackageDir}}/{{.BeatName}}.yml",
+			Config: true,
 			Dep: func(spec mage.PackageSpec) error {
 				if err := mage.Copy("packetbeat.yml",
 					spec.MustExpand("{{.PackageDir}}/packetbeat.yml")); err != nil {


### PR DESCRIPTION
Cherry-pick of PR #8078 to 6.4 branch. Original message: 

The Auditbeat config file, `/etc/auditbeat/auditbeat.yml`, was not correctly marked as `configfile` in the RPM spec.

The same issue affected Metricbeat's `/etc/metricbeat/modules.d/*`.

Packetbeat's config customizations were missing the `Config: true` but this didn't have any impact because
the config is only customized for Windows.

Fixes #8075