### PR TITLE
Cherry-pick #7795 to 6.x: Fix flaky generator tests, no git users

### DIFF
--- a/generator/common/Makefile
+++ b/generator/common/Makefile
@@ -17,6 +17,8 @@ test: prepare-test
 	${PREPARE_COMMAND} \
 	$(MAKE) git-init || exit 1 ; \
 	$(MAKE) update || exit 1 ; \
+	git config user.email "beats-jenkins@test.com" || exit 1 ; \
+	git config user.name "beats-jenkins" || exit 1 ; \
 	$(MAKE) git-add || exit 1 ; \
 	$(MAKE) check CHECK_HEADERS_DISABLED=y || exit 1 ; \
 	$(MAKE) || exit 1 ; \


### PR DESCRIPTION
Cherry-pick of PR #7795 to 6.x branch. Original message: 

Some jenkins slaves do not seem to have a global git users. This changes adds a local git user during building.

Error seen on Jenkins:

```
09:56:08 Makefile:33: recipe for target 'git-add' failed
09:56:08 *** Please tell me who you are.
```