### PR TITLE
Move Metricbeat modules.d dir to /etc/metricbeat

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -66,6 +66,7 @@ https://github.com/elastic/beats/compare/v6.4.0...master[Check the HEAD diff]
 - Recover metrics for old apache versions removed by mistake on #6450. {pull}7871[7871]
 - Add missing namespace field in http server metricset {pull}7890[7890]
 - Fixed the RPM by designating the modules.d config files as configuration data in the RPM spec. {issue}8075[8075]
+- Fixed the location of the modules.d dir in Deb and RPM packages. {issue}8104[8104]
 
 *Packetbeat*
 

--- a/metricbeat/magefile.go
+++ b/metricbeat/magefile.go
@@ -126,9 +126,8 @@ func GoTestIntegration(ctx context.Context) error {
 // not supported.
 func customizePackaging() {
 	var (
-		archiveModulesDir   = "modules.d"
-		linuxPkgModulesDir  = "/usr/share/{{.BeatName}}/modules.d"
-		darwinDMGModulesDir = "/Library/Application Support/{{.BeatVendor}}/{{.BeatName}}/modules.d"
+		archiveModulesDir = "modules.d"
+		unixModulesDir    = "/etc/{{.BeatName}}/modules.d"
 
 		modulesDir = mage.PackageFile{
 			Mode:   0644,
@@ -176,10 +175,8 @@ func customizePackaging() {
 			switch pkgType {
 			case mage.TarGz, mage.Zip:
 				args.Spec.Files[archiveModulesDir] = modulesDir
-			case mage.Deb, mage.RPM:
-				args.Spec.Files[linuxPkgModulesDir] = modulesDir
-			case mage.DMG:
-				args.Spec.Files[darwinDMGModulesDir] = modulesDir
+			case mage.Deb, mage.RPM, mage.DMG:
+				args.Spec.Files[unixModulesDir] = modulesDir
 			default:
 				panic(errors.Errorf("unhandled package type: %v", pkgType))
 			}


### PR DESCRIPTION
This fixes the location of the Metricbeat modules.d directory as installed by .deb and .rpm packages.

Fixes #8104