### PR TITLE
Cherry-pick #8107 to 6.x: Test modules and modules.d folder contents in resulting packages

### DIFF
--- a/dev-tools/mage/pkg.go
+++ b/dev-tools/mage/pkg.go
@@ -96,9 +96,36 @@ func (b packageBuilder) Build() error {
 		b.Spec.Name, b.Type, b.Platform.Name)
 }
 
+type testPackagesParams struct {
+	HasModules  bool
+	HasModulesD bool
+}
+
+// TestPackagesOption defines a option to the TestPackages target.
+type TestPackagesOption func(params *testPackagesParams)
+
+// WithModules enables modules folder contents testing
+func WithModules() func(params *testPackagesParams) {
+	return func(params *testPackagesParams) {
+		params.HasModules = true
+	}
+}
+
+// WithModulesD enables modules.d folder contents testing
+func WithModulesD() func(params *testPackagesParams) {
+	return func(params *testPackagesParams) {
+		params.HasModulesD = true
+	}
+}
+
 // TestPackages executes the package tests on the produced binaries. These tests
 // inspect things like file ownership and mode.
-func TestPackages() error {
+func TestPackages(options ...TestPackagesOption) error {
+	params := testPackagesParams{}
+	for _, opt := range options {
+		opt(&params)
+	}
+
 	fmt.Println(">> Testing package contents")
 	goTest := sh.OutCmd("go", "test")
 
@@ -106,6 +133,15 @@ func TestPackages() error {
 	if mg.Verbose() {
 		args = append(args, "-v")
 	}
+
+	if params.HasModules {
+		args = append(args, "--modules")
+	}
+
+	if params.HasModulesD {
+		args = append(args, "--modules.d")
+	}
+
 	args = append(args,
 		MustExpand("{{ elastic_beats_dir }}/dev-tools/packaging/package_test.go"),
 		"-files",

--- a/dev-tools/packaging/package_test.go
+++ b/dev-tools/packaging/package_test.go
@@ -26,6 +26,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"flag"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -54,7 +55,9 @@ var (
 )
 
 var (
-	files = flag.String("files", "../build/distributions/*/*", "filepath glob containing package files")
+	files    = flag.String("files", "../build/distributions/*/*", "filepath glob containing package files")
+	modules  = flag.Bool("modules", false, "check modules folder contents")
+	modulesd = flag.Bool("modules.d", false, "check modules.d folder contents")
 )
 
 func TestRPM(t *testing.T) {
@@ -100,6 +103,7 @@ func checkRPM(t *testing.T, file string) {
 	checkManifestPermissions(t, p)
 	checkManifestOwner(t, p)
 	checkModulesPermissions(t, p)
+	checkModulesPresent(t, "/etc/", p)
 	checkModulesOwner(t, p)
 }
 
@@ -114,6 +118,7 @@ func checkDeb(t *testing.T, file string, buf *bytes.Buffer) {
 	checkConfigOwner(t, p)
 	checkManifestPermissions(t, p)
 	checkManifestOwner(t, p)
+	checkModulesPresent(t, "/etc/", p)
 	checkModulesPermissions(t, p)
 	checkModulesOwner(t, p)
 }
@@ -128,6 +133,7 @@ func checkTar(t *testing.T, file string) {
 	checkConfigPermissions(t, p)
 	checkConfigOwner(t, p)
 	checkManifestPermissions(t, p)
+	checkModulesPresent(t, "", p)
 	checkModulesPermissions(t, p)
 	checkModulesOwner(t, p)
 }
@@ -141,6 +147,7 @@ func checkZip(t *testing.T, file string) {
 
 	checkConfigPermissions(t, p)
 	checkManifestPermissions(t, p)
+	checkModulesPresent(t, "", p)
 	checkModulesPermissions(t, p)
 }
 
@@ -244,6 +251,35 @@ func checkModulesOwner(t *testing.T, p *packageFile) {
 			}
 		}
 	})
+}
+
+// Verify that modules.d folder is present and has module files in
+func checkModulesPresent(t *testing.T, prefix string, p *packageFile) {
+	minExpectedModules := 4
+
+	test := func(name string, r *regexp.Regexp) {
+		t.Run(fmt.Sprintf("%s %s contents", p.Name, name), func(t *testing.T) {
+			total := 0
+			for _, entry := range p.Contents {
+				if strings.HasPrefix(entry.File, prefix) && r.MatchString(entry.File) {
+					total++
+				}
+			}
+
+			if total < minExpectedModules {
+				t.Errorf("not enough modules found under %s: actual=%d, expected>=%d",
+					name, total, minExpectedModules)
+			}
+		})
+	}
+
+	if *modules {
+		test("modules", modulesFilePattern)
+	}
+
+	if *modulesd {
+		test("modules.d", modulesDirPattern)
+	}
 }
 
 // Helpers

--- a/filebeat/magefile.go
+++ b/filebeat/magefile.go
@@ -83,7 +83,7 @@ func Package() {
 
 // TestPackages tests the generated packages (i.e. file modes, owners, groups).
 func TestPackages() error {
-	return mage.TestPackages()
+	return mage.TestPackages(mage.WithModules(), mage.WithModulesD())
 }
 
 // Update updates the generated files (aka make update).

--- a/metricbeat/magefile.go
+++ b/metricbeat/magefile.go
@@ -83,7 +83,7 @@ func Package() {
 
 // TestPackages tests the generated packages (i.e. file modes, owners, groups).
 func TestPackages() error {
-	return mage.TestPackages()
+	return mage.TestPackages(mage.WithModulesD())
 }
 
 // Update updates the generated files (aka make update).


### PR DESCRIPTION
Cherry-pick of PR #8107 to 6.x branch. Original message: 

This change ensures that `modules` (Filebeat) and `modules.d` (Filebeat & Metricbeat) folders contain files in the right place.

Permissions and ownership were already tested

Part of #7488