### PR TITLE
Cherry-pick #7961 to 6.x: Implement CheckConfig in RunnerFactory to make autodiscover check configs

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -73,6 +73,8 @@ https://github.com/elastic/beats/compare/v6.4.0...6.x[Check the HEAD diff]
 - Allow for cloud-id to specify a custom port. This makes cloud-id work in ECE contexts. {pull}7887[7887]
 - Add support to grow or shrink an existing spool file between restarts. {pull}7859[7859]
 - Make kubernetes autodiscover ignore events with empty container IDs {pull}7971[7971]
+- Add DNS processor with support for performing reverse lookups on IP addresses. {issue}7770[7770]
+- Implement CheckConfig in RunnerFactory to make autodiscover check configs {pull}7961[7961]
 
 *Auditbeat*
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -73,7 +73,6 @@ https://github.com/elastic/beats/compare/v6.4.0...6.x[Check the HEAD diff]
 - Allow for cloud-id to specify a custom port. This makes cloud-id work in ECE contexts. {pull}7887[7887]
 - Add support to grow or shrink an existing spool file between restarts. {pull}7859[7859]
 - Make kubernetes autodiscover ignore events with empty container IDs {pull}7971[7971]
-- Add DNS processor with support for performing reverse lookups on IP addresses. {issue}7770[7770]
 - Implement CheckConfig in RunnerFactory to make autodiscover check configs {pull}7961[7961]
 
 *Auditbeat*

--- a/filebeat/autodiscover/autodiscover.go
+++ b/filebeat/autodiscover/autodiscover.go
@@ -51,8 +51,10 @@ func (m *AutodiscoverAdapter) CreateConfig(e bus.Event) ([]*common.Config, error
 
 // CheckConfig tests given config to check if it will work or not, returns errors in case it won't work
 func (m *AutodiscoverAdapter) CheckConfig(c *common.Config) error {
-	// TODO implement config check for all modules
-	return nil
+	if c.HasField("module") {
+		return m.moduleFactory.CheckConfig(c)
+	}
+	return m.inputFactory.CheckConfig(c)
 }
 
 // Create a module or input from the given config

--- a/filebeat/fileset/factory.go
+++ b/filebeat/fileset/factory.go
@@ -117,6 +117,12 @@ func (f *Factory) Create(p beat.Pipeline, c *common.Config, meta *common.MapStrP
 	}, nil
 }
 
+// CheckConfig checks if a config is valid or not
+func (f *Factory) CheckConfig(config *common.Config) error {
+	// TODO: add code here once we know that spinning up a filebeat input to check for errors doesn't cause memory leaks.
+	return nil
+}
+
 func (p *inputsRunner) Start() {
 	// Load pipelines
 	if p.pipelineLoaderFactory != nil {

--- a/filebeat/input/runnerfactory.go
+++ b/filebeat/input/runnerfactory.go
@@ -56,3 +56,9 @@ func (r *RunnerFactory) Create(
 
 	return p, nil
 }
+
+// CheckConfig checks if a config is valid or not
+func (r *RunnerFactory) CheckConfig(config *common.Config) error {
+	// TODO: add code here once we know that spinning up a filebeat input to check for errors doesn't cause memory leaks.
+	return nil
+}

--- a/libbeat/autodiscover/autodiscover.go
+++ b/libbeat/autodiscover/autodiscover.go
@@ -45,9 +45,6 @@ type Adapter interface {
 	// CreateConfig generates a valid list of configs from the given event, the received event will have all keys defined by `StartFilter`
 	CreateConfig(bus.Event) ([]*common.Config, error)
 
-	// CheckConfig tests given config to check if it will work or not, returns errors in case it won't work
-	CheckConfig(*common.Config) error
-
 	// RunnerFactory provides runner creation by feeding valid configs
 	cfgfile.RunnerFactory
 

--- a/libbeat/cfgfile/list_test.go
+++ b/libbeat/cfgfile/list_test.go
@@ -58,6 +58,10 @@ func (r *runnerFactory) Create(x beat.Pipeline, c *common.Config, meta *common.M
 	return runner, err
 }
 
+func (r *runnerFactory) CheckConfig(config *common.Config) error {
+	return nil
+}
+
 func TestNewConfigs(t *testing.T) {
 	factory := &runnerFactory{}
 	list := NewRunnerList("", factory, nil)

--- a/libbeat/cfgfile/reload.go
+++ b/libbeat/cfgfile/reload.go
@@ -63,6 +63,7 @@ type Reload struct {
 
 type RunnerFactory interface {
 	Create(p beat.Pipeline, config *common.Config, meta *common.MapStrPointer) (Runner, error)
+	CheckConfig(config *common.Config) error
 }
 
 type Runner interface {

--- a/metricbeat/autodiscover/autodiscover.go
+++ b/metricbeat/autodiscover/autodiscover.go
@@ -49,8 +49,7 @@ func (m *AutodiscoverAdapter) CreateConfig(e bus.Event) ([]*common.Config, error
 
 // CheckConfig tests given config to check if it will work or not, returns errors in case it won't work
 func (m *AutodiscoverAdapter) CheckConfig(c *common.Config) error {
-	// TODO implement config check for all modules
-	return nil
+	return m.factory.CheckConfig(c)
 }
 
 // Create a module or prospector from the given config

--- a/metricbeat/mb/module/factory.go
+++ b/metricbeat/mb/module/factory.go
@@ -69,3 +69,13 @@ func (r *Factory) Create(p beat.Pipeline, c *common.Config, meta *common.MapStrP
 	mr := NewRunner(client, w)
 	return mr, nil
 }
+
+// CheckConfig checks if a config is valid or not
+func (r *Factory) CheckConfig(config *common.Config) error {
+	_, err := NewWrapper(config, mb.Registry, r.options...)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
Cherry-pick of PR #7961 to 6.x branch. Original message: 

After `autodiscover` was implemented to retry failed configs, it began to retry spinning up configs every 10s. This is great for configs that are actually valid as it might be a pipeline related issue. Configs that say dont have `hosts` on it will always fail. In such scenarios, we should check the validity of the config and if it is invalid, it should not be retried.

This PR, implements the missing `CheckConfig` API by moving it from `Adapter` interface into the `RunnerFactory` interface. It is implemented only for metricbeat right now. It needs to be enhanced to Filebeat once the Filebeat refactor is complete as there is a known memory leak on trying to simply trying to create an input and not start/stop it. 

In future, each module/input can expose an API which validates a config instead of trying to call the constructor which is not optimal. 