### PR TITLE
Cherry-pick #8092 to 6.x: Fix flaky clean_removed test

### DIFF
--- a/filebeat/tests/system/test_registrar.py
+++ b/filebeat/tests/system/test_registrar.py
@@ -895,6 +895,9 @@ class Test(BaseTest):
             lambda: self.output_has(lines=3),
             max_timeout=10)
 
+        # Make sure all states are cleaned up
+        self.wait_until(lambda: self.log_contains("Before: 1, After: 1, Pending: 0"))
+
         filebeat.check_kill_and_wait()
 
         # Check that the first to files were removed from the registry


### PR DESCRIPTION
Cherry-pick of PR #8092 to 6.x branch. Original message: 

This is a potential fix for the flaky clean_removed test. The problem in the test seems to be that sometimes not all states are cleaned up yet. This is changing it by waiting for all pending cleanups to happen.

Closes https://github.com/elastic/beats/issues/7690