### PR TITLE
Cherry-pick #8074 to 6.4: Wait for context finalization to provoke http timeouts on tests

### DIFF
--- a/metricbeat/module/apache/status/status_test.go
+++ b/metricbeat/module/apache/status/status_test.go
@@ -151,7 +151,7 @@ func TestFetchTimeout(t *testing.T) {
 		w.WriteHeader(200)
 		w.Header().Set("Content-Type", "text/plain; charset=ISO-8859-1")
 		w.Write([]byte(response))
-		time.Sleep(100 * time.Millisecond)
+		<-r.Context().Done()
 	}))
 	defer server.Close()
 

--- a/metricbeat/module/envoyproxy/server/server_test.go
+++ b/metricbeat/module/envoyproxy/server/server_test.go
@@ -118,7 +118,7 @@ func TestFetchTimeout(t *testing.T) {
 		w.WriteHeader(200)
 		w.Header().Set("Content-Type", "text/plain; charset=UTF-8")
 		w.Write([]byte(response))
-		time.Sleep(100 * time.Millisecond)
+		<-r.Context().Done()
 	}))
 	defer server.Close()
 


### PR DESCRIPTION
Cherry-pick of PR #8074 to 6.4 branch. Original message: 

Wait for request context to be done.

Related to #8028, it does basically the same, but also for envoyproxy, and using the request context (that is canceled when the server is stopped) instead of adding a wait group.