### PR TITLE
Registry backend compliance tests

### DIFF
--- a/libbeat/registry/backend/cptest/cptest.go
+++ b/libbeat/registry/backend/cptest/cptest.go
@@ -1,0 +1,563 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cptest
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/libbeat/registry/backend"
+)
+
+// BackendFactory is used to instantiate and configure a registry using a
+// temporary test path.
+type BackendFactory func(testPath string) (backend.Registry, error)
+
+var defaultTempDir string
+var keepTmpDir bool
+
+func init() {
+	flag.StringVar(&defaultTempDir, "dir", "", "Temporary directory for use by the tests")
+	flag.BoolVar(&keepTmpDir, "keep", false, "Keep temporary test directories")
+}
+
+// TestBackendCompliance defines a many tests any registry compliant backend must pass.
+func TestBackendCompliance(t *testing.T, factory BackendFactory) {
+	t.Run("init registry", WithPath(factory, func(t *testing.T, reg *Registry) {
+		// none
+	}))
+
+	t.Run("access store", WithPath(factory, func(t *testing.T, reg *Registry) {
+		store := reg.Access("test1")
+		defer store.Close()
+
+		store2 := reg.Access("test2")
+		defer store2.Close()
+	}))
+
+	t.Run("readonly tx can not write", WithPath(factory, func(t *testing.T, reg *Registry) {
+		testReadonlyTx(t, reg)
+	}))
+
+	t.Run("remove", withBackend(factory, testRemove))
+	t.Run("set-get", withBackend(factory, testSetGet))
+	t.Run("update", withBackend(factory, testUpdate))
+	t.Run("iteration", withBackend(factory, testIter))
+}
+
+func testSetGet(t *testing.T, factory BackendFactory) {
+	runWithBools(t, "reopen", func(t *testing.T, reopen bool) {
+		t.Run("one entry", WithStore(factory, func(t *testing.T, store *Store) {
+			type entry struct{ A int }
+			key := makeKey("key")
+			value := entry{A: 1}
+
+			store.Set(key, value)
+			store.ReopenIf(reopen)
+
+			var actual entry
+			store.GetValue(key, &actual)
+			assert.Equal(t, value, actual)
+		}))
+
+		t.Run("multiple entries", withBools("singletx", func(t *testing.T, singleTx bool) {
+			RunWithStore(t, factory, func(store *Store) {
+				type entry struct{ A int }
+				keys := makeKeys(10)
+
+				if singleTx {
+					store.MustUpdate(func(tx *Tx) {
+						for i, k := range keys {
+							tx.MustSet(k, entry{i})
+						}
+					})
+					store.ReopenIf(reopen)
+				} else {
+					for i, k := range keys {
+						store.Set(k, entry{i})
+						store.ReopenIf(reopen)
+					}
+				}
+
+				// validate
+				for i, k := range keys {
+					var act entry
+					store.GetValue(k, &act)
+					assert.Equal(t, entry{i}, act)
+				}
+			})
+		}))
+
+		t.Run("stores are isolated", WithPath(factory, func(t *testing.T, reg *Registry) {
+			type entry struct{ A int }
+			key := makeKey("key")
+
+			s1 := reg.Access("test1")
+			defer s1.Close()
+
+			s2 := reg.Access("test2")
+			defer s2.Close()
+
+			// insert into s1 is not visible in s2
+			s1.Set(key, entry{1})
+			require.False(t, s2.Has(key))
+			s1.ReopenIf(reopen)
+			s2.ReopenIf(reopen)
+
+			// insert key into s2
+			s2.Set(key, entry{2})
+			s1.ReopenIf(reopen)
+			s2.ReopenIf(reopen)
+
+			// check values are different in s1/s2
+			check := func(s *Store, expected int) {
+				var actual entry
+				s.GetValue(key, &actual)
+				require.Equal(t, entry{expected}, actual)
+			}
+			check(s1, 1)
+			check(s2, 2)
+		}))
+
+		t.Run("overwrite entry", WithStore(factory, func(t *testing.T, store *Store) {
+			type entry1 struct{ A int }
+			type entry2 struct{ B int }
+			type entry struct {
+				A int
+				B int
+			}
+
+			key := makeKey("key")
+
+			store.Set(key, entry1{1})
+			store.ReopenIf(reopen)
+
+			store.MustUpdate(func(tx *Tx) {
+				dec := tx.MustGet(key)
+
+				// read original value
+				var actual entry
+				must(t, dec.Decode(&actual), "faile to decode value")
+				assert.Equal(t, entry{A: 1, B: 0}, actual, "invalid value in store")
+
+				tx.MustSet(key, entry2{B: 1})
+
+				// try to get update via decoder
+				actual = entry{}
+				must(t, dec.Decode(&actual), "faile to decode value")
+				assert.Equal(t, entry{A: 0, B: 1}, actual, "decoder state must reflect changes")
+
+				// try to get update via tx
+				actual = entry{}
+				tx.MustGetValue(key, &actual)
+				assert.Equal(t, entry{A: 0, B: 1}, actual, "transaction state must reflect changes")
+			})
+
+			store.ReopenIf(reopen)
+
+			// check updated entry is in store
+			var actual entry
+			store.GetValue(key, &actual)
+			assert.Equal(t, entry{A: 0, B: 1}, actual)
+		}))
+
+		t.Run("get invalid after tx", withBools("readonly", func(t *testing.T, readonly bool) {
+			RunWithStore(t, factory, func(store *Store) {
+				type entry struct{ A int }
+				key := makeKey("key")
+				store.Set(key, entry{1})
+				store.ReopenIf(reopen)
+
+				var dec backend.ValueDecoder
+				func() {
+					tx := store.Begin(readonly)
+					defer tx.Close()
+
+					dec = tx.MustGet(key)
+				}()
+
+				var tmp entry
+				require.NotNil(t, dec)
+				assert.Error(t, dec.Decode(&tmp), "expected decoder to fail outside tx")
+			})
+		}))
+
+		t.Run("decode fails after remove", WithStore(factory, func(t *testing.T, store *Store) {
+			type entry struct{ A int }
+			key := makeKey("key")
+			store.Set(key, entry{1})
+			store.ReopenIf(reopen)
+
+			store.MustUpdate(func(tx *Tx) {
+				dec := tx.MustGet(key)
+				require.NotNil(t, dec)
+
+				tx.Remove(key)
+
+				// validate
+				var tmp entry
+				assert.Error(t, dec.Decode(&tmp), "expect decode to fail after remove")
+			})
+		}))
+	})
+
+	t.Run("get unknown", withBools("readonly", func(t *testing.T, readonly bool) {
+		RunWithStore(t, factory, func(store *Store) {
+			tx := store.Begin(readonly)
+			defer tx.Close()
+
+			dec, err := tx.Get(makeKey("unknown"))
+			assert.NoError(t, err, "get must not error on unknown key")
+			assert.Nil(t, dec, "value must be nil")
+		})
+	}))
+
+	t.Run("failing tx", WithStore(factory, func(t *testing.T, store *Store) {
+		type entry struct{ A int }
+		key := makeKey("key")
+
+		store.Update(func(tx *Tx) bool {
+			tx.MustSet(key, entry{1})
+			require.True(t, tx.Has(key))
+			return false // fail transaction
+		})
+
+		require.False(t, store.Has(key))
+	}))
+}
+
+func testReadonlyTx(t *testing.T, reg *Registry) {
+	store := reg.Access("test")
+	defer store.Close()
+
+	tx := store.Begin(true)
+	defer tx.Close()
+
+	err := tx.Set(makeKey("key"), map[string]interface{}{})
+	if err == nil {
+		t.Error("expected write on readonly transaction to fail")
+	}
+}
+
+func testRemove(t *testing.T, factory BackendFactory) {
+	type entry struct{ A int }
+	key := makeKey("key")
+
+	t.Run("unknown pair", WithStore(factory, func(t *testing.T, store *Store) {
+		tx := store.Begin(false)
+		must(t, tx.Remove(key), "be silent about remove of unknown value")
+	}))
+
+	runWithBools(t, "reopen", func(t *testing.T, reopen bool) {
+		t.Run("stored value", WithStore(factory, func(t *testing.T, store *Store) {
+			store.Set(key, entry{1})
+			store.ReopenIf(reopen)
+			assert.True(t, store.Has(key), "value not in store")
+
+			store.MustUpdate(func(tx *Tx) {
+				must(t, tx.Remove(key), "failed to remove entry")
+				assert.False(t, tx.Has(key))
+			})
+
+			store.ReopenIf(reopen)
+			assert.False(t, store.Has(key), "value not removed")
+		}))
+
+		t.Run("remove new in tx", WithStore(factory, func(t *testing.T, store *Store) {
+			store.MustUpdate(func(tx *Tx) {
+				tx.MustSet(key, entry{1})
+				require.True(t, tx.Has(key))
+				must(t, tx.Remove(key), "failed to remove new entry")
+				require.False(t, tx.Has(key))
+			})
+
+			store.ReopenIf(reopen)
+			require.False(t, store.Has(key))
+		}))
+
+		t.Run("remove in failing tx", WithStore(factory, func(t *testing.T, store *Store) {
+			store.Set(key, entry{1})
+
+			store.Update(func(tx *Tx) bool {
+				assert.True(t, tx.Has(key))
+				tx.Remove(key)
+				assert.False(t, tx.Has(key))
+				return false
+			})
+
+			assert.True(t, store.Has(key))
+		}))
+	})
+}
+
+func testUpdate(t *testing.T, factory BackendFactory) {
+	type entryA struct{ A int }
+	type entryB struct{ B int }
+	type entry struct {
+		A int
+		B int
+	}
+
+	runWithBools(t, "reopen", func(t *testing.T, reopen bool) {
+		t.Run("unknown entry inserts", WithStore(factory, func(t *testing.T, store *Store) {
+			key := makeKey("key")
+			store.UpdValue(key, entryA{1})
+			store.ReopenIf(reopen)
+
+			assert.True(t, store.Has(key))
+
+			act := entry{A: 2, B: 2}
+			store.GetValue(key, &act)
+			assert.Equal(t, entry{A: 1, B: 2}, act)
+		}))
+
+		t.Run("subset of fields", WithStore(factory, func(t *testing.T, store *Store) {
+			key := makeKey("key")
+			store.Set(key, entry{A: 2, B: 2})
+			store.ReopenIf(reopen)
+			store.UpdValue(key, entryA{A: 1})
+			store.ReopenIf(reopen)
+
+			act := entry{A: 0, B: 0}
+			store.GetValue(key, &act)
+			assert.Equal(t, entry{A: 1, B: 2}, act)
+		}))
+
+		t.Run("failing tx with unknown", WithStore(factory, func(t *testing.T, store *Store) {
+			key := makeKey("key")
+			store.Update(func(tx *Tx) bool {
+				must(t, tx.Update(key, entryA{3}), "failed to update entry")
+				return false
+			})
+			assert.False(t, store.Has(key))
+		}))
+
+		t.Run("failing tx", WithStore(factory, func(t *testing.T, store *Store) {
+			key := makeKey("key")
+			store.Set(key, entry{A: 1, B: 2})
+			store.ReopenIf(reopen)
+
+			store.Update(func(tx *Tx) bool {
+				must(t, tx.Update(key, entryA{3}), "failed to update entry")
+				return false
+			})
+
+			act := entry{A: 0, B: 0}
+			store.GetValue(key, &act)
+			assert.Equal(t, entry{A: 1, B: 2}, act)
+		}))
+
+		t.Run("update removed will insert", WithStore(factory, func(t *testing.T, store *Store) {
+			key := makeKey("key")
+			store.Set(key, entry{A: 1, B: 2})
+			store.ReopenIf(reopen)
+
+			store.MustUpdate(func(tx *Tx) {
+				must(t, tx.Remove(key), "failed to remove known key")
+				must(t, tx.Update(key, entry{B: 1}), "failed to update removed entry")
+			})
+			store.ReopenIf(reopen)
+
+			act := entry{A: 0, B: 0}
+			store.GetValue(key, &act)
+			assert.Equal(t, entry{A: 0, B: 1}, act)
+		}))
+
+		t.Run("multiple updates in tx", WithStore(factory, func(t *testing.T, store *Store) {
+			key := makeKey("key")
+			store.MustUpdate(func(tx *Tx) {
+				must(t, tx.Set(key, entryA{A: 1}), "insert failed")
+				must(t, tx.Update(key, entryB{B: 2}), "failed to add new field")
+				must(t, tx.Update(key, entryA{A: 2}), "failed to update first field")
+				must(t, tx.Update(key, entryB{B: 3}), "failed to update second field")
+			})
+			store.ReopenIf(reopen)
+
+			act := entry{A: 0, B: 0}
+			store.GetValue(key, &act)
+			assert.Equal(t, entry{A: 2, B: 3}, act)
+		}))
+	})
+}
+
+func testIter(t *testing.T, factory BackendFactory) {
+	type entry struct{ A int }
+
+	insert := func(store *Store, keys [][]byte) {
+		store.MustUpdate(func(tx *Tx) {
+			for i, k := range keys {
+				tx.MustSet(k, entry{i})
+			}
+		})
+	}
+
+	runWithBools(t, "readonly", func(t *testing.T, readonly bool) {
+		withTx := func(store *Store, readonly bool, fn func(tx *Tx)) {
+			tx := store.Begin(readonly)
+			defer tx.Close()
+			fn(tx)
+		}
+
+		t.Run("keys in empty store", WithStore(factory, func(t *testing.T, store *Store) {
+			withTx(store, readonly, func(tx *Tx) {
+				err := tx.EachKey(false, func(k backend.Key) (bool, error) {
+					return true, nil
+				})
+				assert.NoError(t, err)
+			})
+		}))
+
+		t.Run("pairs in empty store", WithStore(factory, func(t *testing.T, store *Store) {
+			withTx(store, readonly, func(tx *Tx) {
+				err := tx.Each(false, func(k backend.Key, val backend.ValueDecoder) (bool, error) {
+					return true, nil
+				})
+				assert.NoError(t, err)
+			})
+		}))
+
+		t.Run("keys", WithStore(factory, func(t *testing.T, store *Store) {
+			keys := makeKeys(10)
+			insert(store, keys)
+
+			collected := map[string]int{}
+			withTx(store, readonly, func(tx *Tx) {
+				err := tx.EachKey(false, func(k backend.Key) (bool, error) {
+					var tmp entry
+					tx.MustGetValue(k, &tmp)
+					collected[string(k)] = tmp.A
+					return true, nil
+				})
+				assert.NoError(t, err)
+			})
+
+			for i, k := range keys {
+				act, exists := collected[string(k)]
+				require.True(t, exists)
+				assert.Equal(t, i, act)
+			}
+		}))
+
+		t.Run("pairs", WithStore(factory, func(t *testing.T, store *Store) {
+			keys := makeKeys(10)
+			insert(store, keys)
+
+			collected := map[string]int{}
+			withTx(store, readonly, func(tx *Tx) {
+				err := tx.Each(false, func(k backend.Key, dec backend.ValueDecoder) (bool, error) {
+					var tmp entry
+					must(t, dec.Decode(&tmp), "failed to decode entry")
+					collected[string(k)] = tmp.A
+					return true, nil
+				})
+				assert.NoError(t, err)
+			})
+
+			for i, k := range keys {
+				act, exists := collected[string(k)]
+				require.True(t, exists)
+				assert.Equal(t, i, act)
+			}
+		}))
+	})
+
+	t.Run("pairs in active tx", WithStore(factory, func(t *testing.T, store *Store) {
+		keys := makeKeys(10)
+
+		collected := map[string]int{}
+		store.MustUpdate(func(tx *Tx) {
+			for i, k := range keys {
+				tx.MustSet(k, entry{i})
+			}
+
+			err := tx.Each(false, func(k backend.Key, dec backend.ValueDecoder) (bool, error) {
+				var tmp entry
+				must(t, dec.Decode(&tmp), "failed to decode entry")
+				collected[string(k)] = tmp.A
+				return true, nil
+			})
+			assert.NoError(t, err)
+		})
+
+		for i, k := range keys {
+			act, exists := collected[string(k)]
+			require.True(t, exists, "entry %s is missing", k)
+			assert.Equal(t, i, act)
+		}
+	}))
+
+	t.Run("filled store with inserts in tx", WithStore(factory, func(t *testing.T, store *Store) {
+		keys := makeKeys(20)
+		sep := len(keys) / 2
+
+		insert(store, keys[:sep])
+		collected := map[string]int{}
+		store.MustUpdate(func(tx *Tx) {
+			for i, k := range keys[sep:] {
+				tx.MustSet(k, entry{i + sep})
+			}
+
+			err := tx.Each(false, func(k backend.Key, dec backend.ValueDecoder) (bool, error) {
+				var tmp entry
+				must(t, dec.Decode(&tmp), "failed to decode entry")
+				collected[string(k)] = tmp.A
+				return true, nil
+			})
+			assert.NoError(t, err)
+		})
+
+		for i, k := range keys {
+			act, exists := collected[string(k)]
+			require.True(t, exists, "entry %s is missing", k)
+			assert.Equal(t, i, act)
+		}
+	}))
+
+	t.Run("filled store with updates in tx", WithStore(factory, func(t *testing.T, store *Store) {
+		keys := makeKeys(20)
+		sep := len(keys) / 2
+
+		insert(store, keys)
+		collected := map[string]int{}
+		store.MustUpdate(func(tx *Tx) {
+			for i, k := range keys[sep:] {
+				must(t, tx.Update(k, entry{i}), "update failed")
+			}
+
+			err := tx.Each(false, func(k backend.Key, dec backend.ValueDecoder) (bool, error) {
+				var tmp entry
+				must(t, dec.Decode(&tmp), "failed to decode entry")
+				collected[string(k)] = tmp.A
+				return true, nil
+			})
+			assert.NoError(t, err)
+		})
+
+		for i, k := range keys {
+			act, exists := collected[string(k)]
+			require.True(t, exists, "entry %s is missing", k)
+			if i >= sep {
+				i -= sep
+			}
+			assert.Equal(t, i, act)
+		}
+	}))
+}

--- a/libbeat/registry/backend/cptest/cptest.go
+++ b/libbeat/registry/backend/cptest/cptest.go
@@ -162,7 +162,7 @@ func testSetGet(t *testing.T, factory BackendFactory) {
 
 				// try to get update via decoder
 				actual = entry{}
-				must(t, dec.Decode(&actual), "faile to decode value")
+				must(t, dec.Decode(&actual), "failed to decode value")
 				assert.Equal(t, entry{A: 0, B: 1}, actual, "decoder state must reflect changes")
 
 				// try to get update via tx

--- a/libbeat/registry/backend/cptest/reg.go
+++ b/libbeat/registry/backend/cptest/reg.go
@@ -79,7 +79,7 @@ func (s *Store) Reopen() {
 
 	store, err := s.Registry.Registry.Access(s.name)
 	if err != nil {
-		t.Fatalf("Repoen failed: %v", err)
+		t.Fatalf("Reopen failed: %v", err)
 	}
 
 	s.Store = store
@@ -116,7 +116,7 @@ func (s *Store) MustUpdate(fn func(tx *Tx)) {
 	})
 }
 
-// Update create a new write transaction. The transaction is only comitted if
+// Update create a new write transaction. The transaction is only committed if
 // fn return true.
 // The test fails if the transaction is supposed to succeed, but the final commit fails.
 func (s *Store) Update(fn func(tx *Tx) bool) {

--- a/libbeat/registry/backend/cptest/reg.go
+++ b/libbeat/registry/backend/cptest/reg.go
@@ -1,0 +1,218 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cptest
+
+import (
+	"testing"
+
+	"github.com/elastic/beats/libbeat/registry/backend"
+)
+
+// Registry wraps a backend.Registry and adds testing.T. The methods on
+// Registry check and report errors to the testing instance, while the actual
+// error return type - normally returned by the registry frontend - is removed
+// from the Registry methods.
+type Registry struct {
+	T *testing.T
+	backend.Registry
+}
+
+// Store is returned when accessing a store from the testing Registry.
+// The store methods check and report unexpected backend errors to the
+// underlying testing instance.
+type Store struct {
+	backend.Store
+
+	Registry *Registry
+	name     string
+}
+
+// Tx is returned by the testing store. Tx wraps a backend transaction, adding
+// a many convenience methods.
+type Tx struct {
+	Store *Store
+	backend.Tx
+}
+
+// Access creates a new test Store, by accessing and wrapping the backend
+// store.
+func (r *Registry) Access(name string) *Store {
+	t := r.T
+	s, err := r.Registry.Access(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &Store{Registry: r, name: name, Store: s}
+}
+
+// ReopenIf reopens the store if b is true.
+func (s *Store) ReopenIf(b bool) {
+	if b {
+		s.Reopen()
+	}
+}
+
+// Reopen reopens the store by closing the backend store and using the registry
+// backend to access the same store again.
+func (s *Store) Reopen() {
+	t := s.Registry.T
+
+	s.Close()
+	if t.Failed() {
+		t.Fatal("Test already failed")
+	}
+
+	store, err := s.Registry.Registry.Access(s.name)
+	if err != nil {
+		t.Fatalf("Repoen failed: %v", err)
+	}
+
+	s.Store = store
+}
+
+// Close closes the testing store.
+func (s *Store) Close() {
+	t := s.Registry.T
+
+	if err := s.Store.Close(); err != nil {
+		t.Errorf("error closing store %q: %v", s.name, err)
+	}
+}
+
+// Begin creates a new transaction. The test will fail immediately (Fatal), if
+// the backend returns an unexpected error.
+func (s *Store) Begin(readonly bool) *Tx {
+	t := s.Registry.T
+
+	tx, err := s.Store.Begin(readonly)
+	if err != nil {
+		t.Fatalf("Failed to create transaction: %v", err)
+	}
+
+	return &Tx{Store: s, Tx: tx}
+}
+
+// MustUpdate create a Write transaction that must succeed. MustUpdate fails if
+// the final commit fails.
+func (s *Store) MustUpdate(fn func(tx *Tx)) {
+	s.Update(func(tx *Tx) bool {
+		fn(tx)
+		return true
+	})
+}
+
+// Update create a new write transaction. The transaction is only comitted if
+// fn return true.
+// The test fails if the transaction is supposed to succeed, but the final commit fails.
+func (s *Store) Update(fn func(tx *Tx) bool) {
+	tx := s.Begin(false)
+	defer tx.Close()
+
+	commit := fn(tx)
+
+	t := s.Registry.T
+	if commit && !t.Failed() {
+		must(t, tx.Commit(), "commit failed")
+	}
+}
+
+// View runs fn with a temporary readonly transaction.
+func (s *Store) View(fn func(tx *Tx)) {
+	tx := s.Begin(true)
+	defer tx.Close()
+	fn(tx)
+}
+
+// Set sets a key-value using a temporary transaction.
+func (s *Store) Set(key []byte, val interface{}) {
+	s.MustUpdate(func(tx *Tx) { tx.MustSet(key, val) })
+}
+
+// UpdValue updates a key-value pair using a temporary write transaction.
+func (s *Store) UpdValue(key []byte, val interface{}) {
+	s.MustUpdate(func(tx *Tx) {
+		t := s.Registry.T
+		must(t, tx.Update(key, val), "update failed")
+	})
+}
+
+// Remove removes a key-value pair using a temporary write transaction.
+func (s *Store) Remove(key []byte) {
+	s.MustUpdate(func(tx *Tx) {
+		t := s.Registry.T
+		must(t, tx.Remove(key), "unexpected error on remove")
+	})
+}
+
+// Has checks if a key exists in the store, using a temporary readonly transaction.
+func (s *Store) Has(key []byte) (found bool) {
+	s.View(func(tx *Tx) { found = tx.Has(key) })
+	return found
+}
+
+// GetValue decodes a key-value pair into to, using a temporary readonly transaction.
+func (s *Store) GetValue(k []byte, to interface{}) {
+	s.View(func(tx *Tx) {
+		tx.MustGetValue(k, to)
+	})
+}
+
+// Has checks if a key exists in the store or within the current transaction.
+// The test fails if the backend reports an error.
+func (tx *Tx) Has(k []byte) bool {
+	t := tx.Store.Registry.T
+	found, err := tx.Tx.Has(k)
+	must(t, err, "error testing for key presence")
+	return found
+}
+
+// MustGet returns the value decoder for a key-value pair, or nil if the key is unknown.
+// The test fails if the backend reports an error.
+func (tx *Tx) MustGet(k []byte) backend.ValueDecoder {
+	dec, err := tx.Get(k)
+	must(tx.Store.Registry.T, err, "unknown key")
+	return dec
+}
+
+// GetValue decodes a key-value pair into to, only if the key exists.
+// Error returned by the backend will be returned.
+func (tx *Tx) GetValue(k []byte, to interface{}) error {
+	dec, err := tx.Get(k)
+	if err == nil && dec != nil {
+		err = dec.Decode(to)
+	}
+	return err
+}
+
+// MustGetValue decodes a key-value pair into to, only if the key exists.
+// The test fails if the backend reports an error.
+func (tx *Tx) MustGetValue(k []byte, to interface{}) {
+	t := tx.Store.Registry.T
+
+	err := tx.GetValue(k, to)
+	if err != nil {
+		t.Fatalf("Failed to read key: %q", k)
+	}
+}
+
+// MustSet sets a key value pair in the current transaction.
+// The test fails if the backend reports an error.
+func (tx *Tx) MustSet(k []byte, v interface{}) {
+	t := tx.Store.Registry.T
+	must(t, tx.Tx.Set(k, v), "must set value")
+}

--- a/libbeat/registry/backend/cptest/util.go
+++ b/libbeat/registry/backend/cptest/util.go
@@ -25,7 +25,7 @@ import (
 )
 
 // RunWithPath uses the factory to create and configure a registry with a
-// temporary test path. The test function fn is called with the new reigstry.
+// temporary test path. The test function fn is called with the new registry.
 // The registry is closed once the test finishes and the temporary is deleted
 // afterwards (unless the `-keep` CLI flag is used).
 func RunWithPath(t *testing.T, factory BackendFactory, fn func(*Registry)) {
@@ -36,7 +36,7 @@ func RunWithPath(t *testing.T, factory BackendFactory, fn func(*Registry)) {
 
 // WithPath wraps a registry aware test function into a normalized test
 // function that can be used with `t.Run`.
-// The factory is used to create and configure the reigstry with a temporary
+// The factory is used to create and configure the registry with a temporary
 // test path.  The registry is closed and the temporary test directoy is delete
 // if the test function returns or panics.
 func WithPath(factory BackendFactory, fn func(*testing.T, *Registry)) func(t *testing.T) {

--- a/libbeat/registry/backend/cptest/util.go
+++ b/libbeat/registry/backend/cptest/util.go
@@ -1,0 +1,122 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cptest
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+// RunWithPath uses the factory to create and configure a registry with a
+// temporary test path. The test function fn is called with the new reigstry.
+// The registry is closed once the test finishes and the temporary is deleted
+// afterwards (unless the `-keep` CLI flag is used).
+func RunWithPath(t *testing.T, factory BackendFactory, fn func(*Registry)) {
+	WithPath(factory, func(_ *testing.T, reg *Registry) {
+		fn(reg)
+	})(t)
+}
+
+// WithPath wraps a registry aware test function into a normalized test
+// function that can be used with `t.Run`.
+// The factory is used to create and configure the reigstry with a temporary
+// test path.  The registry is closed and the temporary test directoy is delete
+// if the test function returns or panics.
+func WithPath(factory BackendFactory, fn func(*testing.T, *Registry)) func(t *testing.T) {
+	return func(t *testing.T) {
+		path, err := ioutil.TempDir(defaultTempDir, "")
+		if err != nil {
+			t.Fatalf("Failed to create temporary test directory: %v", err)
+		}
+
+		t.Logf("Test tmp dir: %v", path)
+		if !keepTmpDir {
+			defer os.RemoveAll(path)
+		}
+
+		reg, err := factory(path)
+		if err != nil {
+			t.Fatalf("Failed to create registry: %v", err)
+		}
+		defer reg.Close()
+
+		fn(t, &Registry{T: t, Registry: reg})
+	}
+}
+
+// RunWithStore uses the factory to create a registry and temporary store, that
+// is used with fn.  The temporary directory used for the store is deleted once
+// fn returns.
+func RunWithStore(t *testing.T, factory BackendFactory, fn func(*Store)) {
+	WithStore(factory, func(_ *testing.T, store *Store) {
+		fn(store)
+	})(t)
+}
+
+// WithStore wraps a store aware test function into a normalized test function
+// that can be used with `t.Run`.  WithStore is based on WithPath, but will
+// create and pass a test store (named "test") to the test function. The test
+// store is closed once the test function returns or panics.
+func WithStore(factory BackendFactory, fn func(*testing.T, *Store)) func(*testing.T) {
+	return WithPath(factory, func(t *testing.T, reg *Registry) {
+		store := reg.Access("test")
+		defer store.Close()
+		fn(t, store)
+	})
+}
+
+func makeKey(s string) []byte {
+	return []byte(s)
+}
+
+func makeKeys(n int) [][]byte {
+	keys := make([][]byte, n)
+	for i := range keys {
+		keys[i] = makeKey(fmt.Sprintf("key%v", i))
+	}
+	return keys
+}
+
+func withBackend(factory BackendFactory, fn func(*testing.T, BackendFactory)) func(*testing.T) {
+	return func(t *testing.T) {
+		fn(t, factory)
+	}
+}
+
+func runWithBools(t *testing.T, name string, fn func(*testing.T, bool)) {
+	withBools(name, fn)(t)
+}
+
+func withBools(name string, fn func(*testing.T, bool)) func(t *testing.T) {
+	return func(t *testing.T) {
+		for _, b := range []bool{false, true} {
+			b := b
+			t.Run(fmt.Sprintf("%v=%v", name, b), func(t *testing.T) {
+				fn(t, b)
+			})
+		}
+	}
+}
+
+func must(t *testing.T, err error, msg string) {
+	if err != nil {
+		t.Fatal(msg, ":", err)
+	}
+}


### PR DESCRIPTION
Requires: #8068 

The registry supports alternative implementations by using a generic
backend type. A backend must support transactions and should be
ACID compliant. The `libbeat/registry/backend/cptest` package defines a
many tests any backend implementation must succeed, so it can be used by
the registry frontend.