### PR TITLE
Force input to file in filebeat module tests

### DIFF
--- a/filebeat/tests/system/test_modules.py
+++ b/filebeat/tests/system/test_modules.py
@@ -106,6 +106,8 @@ class Test(BaseTest):
             "-M", "{module}.*.enabled=false".format(module=module),
             "-M", "{module}.{fileset}.enabled=true".format(
                 module=module, fileset=fileset),
+            "-M", "{module}.{fileset}.var.input=file".format(
+                module=module, fileset=fileset),
             "-M", "{module}.{fileset}.var.paths=[{test_file}]".format(
                 module=module, fileset=fileset, test_file=test_file),
             "-M", "*.*.input.close_eof=true",


### PR DESCRIPTION
There can be modules that support multiple inputs, currently we only
support module tests with file input so modules whose default input is a
different one fails. This change assumes that a `var.input` setting is
used to select the input, and sets it to file on tests.