### PR TITLE
Cherry-pick #7831 to 6.x: Remove incorrect mention of HTTP_PROXY in docs

### DIFF
--- a/heartbeat/_meta/beat.reference.yml
+++ b/heartbeat/_meta/beat.reference.yml
@@ -163,7 +163,7 @@ heartbeat.monitors:
     # Interval between file file changed checks.
     #interval: 5s
 
-  # Optional HTTP proxy url. If not set HTTP_PROXY environment variable will be used.
+  # Optional HTTP proxy url.
   #proxy_url: ''
 
   # Total test connection and data exchange timeout

--- a/heartbeat/docs/heartbeat-options.asciidoc
+++ b/heartbeat/docs/heartbeat-options.asciidoc
@@ -390,8 +390,7 @@ Example configuration:
 [[monitor-http-proxy-url]]
 ==== `proxy_url`
 
-The HTTP proxy URL. This setting is optional. If not set, the HTTP_PROXY
-environment variable is used.
+The HTTP proxy URL. This setting is optional.
 
 [float]
 [[monitor-http-username]]

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -163,7 +163,7 @@ heartbeat.monitors:
     # Interval between file file changed checks.
     #interval: 5s
 
-  # Optional HTTP proxy url. If not set HTTP_PROXY environment variable will be used.
+  # Optional HTTP proxy url.
   #proxy_url: ''
 
   # Total test connection and data exchange timeout


### PR DESCRIPTION
Cherry-pick of PR #7831 to 6.x branch. Original message: 

The proxy_url setting in the hearbeat monitors does not fallback to
HTTP_PROXY on purpose. This is, so the configuration/network of outputs
and monitors are kept mostly separate.
This change removes all incorrect mentions of HTTP_PROXY in the
heartbeat monitors documentation and reference config file.