### PR TITLE
Cherry-pick #8105 to 6.4: Move Metricbeat modules.d dir to /etc/metricbeat

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -56,6 +56,7 @@ https://github.com/elastic/beats/compare/v6.4.0...6.4[Check the HEAD diff]
 
 - Fix golang.heap.gc.cpu_fraction type from long to float in Golang module. {pull}7789[7789]
 - Fixed the RPM by designating the modules.d config files as configuration data in the RPM spec. {issue}8075[8075]
+- Fixed the location of the modules.d dir in Deb and RPM packages. {issue}8104[8104]
 
 *Packetbeat*
 

--- a/metricbeat/magefile.go
+++ b/metricbeat/magefile.go
@@ -106,9 +106,8 @@ func Fields() error {
 // not supported.
 func customizePackaging() {
 	var (
-		archiveModulesDir   = "modules.d"
-		linuxPkgModulesDir  = "/usr/share/{{.BeatName}}/modules.d"
-		darwinDMGModulesDir = "/Library/Application Support/{{.BeatVendor}}/{{.BeatName}}/modules.d"
+		archiveModulesDir = "modules.d"
+		unixModulesDir    = "/etc/{{.BeatName}}/modules.d"
 
 		modulesDir = mage.PackageFile{
 			Mode:   0644,
@@ -156,10 +155,8 @@ func customizePackaging() {
 			switch pkgType {
 			case mage.TarGz, mage.Zip:
 				args.Spec.Files[archiveModulesDir] = modulesDir
-			case mage.Deb, mage.RPM:
-				args.Spec.Files[linuxPkgModulesDir] = modulesDir
-			case mage.DMG:
-				args.Spec.Files[darwinDMGModulesDir] = modulesDir
+			case mage.Deb, mage.RPM, mage.DMG:
+				args.Spec.Files[unixModulesDir] = modulesDir
 			default:
 				panic(errors.Errorf("unhandled package type: %v", pkgType))
 			}


### PR DESCRIPTION
Cherry-pick of PR #8105 to 6.4 branch. Original message: 

This fixes the location of the Metricbeat modules.d directory as installed by .deb and .rpm packages.

Fixes #8104