### PR TITLE
Add API client to retrieve configurations from CM

### DIFF
--- a/libbeat/common/config.go
+++ b/libbeat/common/config.go
@@ -28,11 +28,11 @@ import (
 	"strings"
 
 	ucfg "github.com/elastic/go-ucfg"
+	"github.com/elastic/go-ucfg/cfgutil"
 	"github.com/elastic/go-ucfg/yaml"
 
 	"github.com/elastic/beats/libbeat/common/file"
 	"github.com/elastic/beats/libbeat/logp"
-	"github.com/elastic/go-ucfg/cfgutil"
 )
 
 var flagStrictPerms = flag.Bool("strict.perms", true, "Strict permission checking on config files")

--- a/x-pack/libbeat/management/api/configuration.go
+++ b/x-pack/libbeat/management/api/configuration.go
@@ -1,0 +1,40 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package api
+
+import (
+	"net/http"
+
+	uuid "github.com/satori/go.uuid"
+
+	"github.com/elastic/beats/libbeat/common"
+)
+
+// ConfigBlock stores a piece of config from central management
+type ConfigBlock struct {
+	Type string `json:"type"`
+	Raw  string `json:"block_yml"`
+}
+
+// Config returns a common.Config object holding the config from this block
+func (c *ConfigBlock) Config() (*common.Config, error) {
+	return common.NewConfigWithYAML([]byte(c.Raw), "")
+}
+
+// Configuration retrieves the list of configuration blocks from Kibana
+func (c *Client) Configuration(accessToken string, beatUUID uuid.UUID) ([]*ConfigBlock, error) {
+	headers := http.Header{}
+	headers.Set("kbn-beats-access-token", accessToken)
+
+	resp := struct {
+		ConfigBlocks []*ConfigBlock `json:"configuration_blocks"`
+	}{}
+	_, err := c.request("GET", "/api/beats/agent/"+beatUUID.String()+"/configuration", nil, headers, &resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.ConfigBlocks, err
+}

--- a/x-pack/libbeat/management/api/configuration_test.go
+++ b/x-pack/libbeat/management/api/configuration_test.go
@@ -1,0 +1,36 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/satori/go.uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfiguration(t *testing.T) {
+	beatUUID := uuid.NewV4()
+
+	server, client := newServerClientPair(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Check correct path is used
+		assert.Equal(t, "/api/beats/agent/"+beatUUID.String()+"/configuration", r.URL.Path)
+
+		// Check enrollment token is correct
+		assert.Equal(t, "thisismyenrollmenttoken", r.Header.Get("kbn-beats-access-token"))
+
+		fmt.Fprintf(w, `{"configuration_blocks":[{"type":"filebeat.modules","block_yml":"module: apache2\n"},{"type":"metricbeat.modules","block_yml":"module: nginx\n"}]}`)
+	}))
+	defer server.Close()
+
+	configs, err := client.Configuration("thisismyenrollmenttoken", beatUUID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, 2, len(configs))
+}

--- a/x-pack/libbeat/management/config.go
+++ b/x-pack/libbeat/management/config.go
@@ -11,6 +11,7 @@ import (
 	"github.com/elastic/beats/libbeat/common/file"
 	"github.com/elastic/beats/libbeat/kibana"
 	"github.com/elastic/beats/libbeat/paths"
+	"github.com/elastic/beats/x-pack/libbeat/management/api"
 
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
@@ -25,10 +26,7 @@ type Config struct {
 
 	Kibana *kibana.ClientConfig
 
-	Configs []struct {
-		Name   string
-		Config *common.Config
-	}
+	Configs []*api.ConfigBlock
 }
 
 // Load settings from its source file


### PR DESCRIPTION
This client will be used to poll configs from Kibana Central Management API. It uses the access token stored by the enroll command to authenticate the requests.