### PR TITLE
Cherry-pick #8158 to 6.4: Fix a concurrent map write panic in auditd module

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -45,6 +45,7 @@ https://github.com/elastic/beats/compare/v6.4.0...6.4[Check the HEAD diff]
 
 - Fixed a crash in the file_integrity module under Linux. {issue}7753[7753]
 - Fixed the RPM by designating the config file as configuration data in the RPM spec. {issue}8075[8075]
+- Fixed a concurrent map write panic in the auditd module. {pull}8158[8158]
 
 *Filebeat*
 

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -372,7 +372,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 --------------------------------------------------------------------
 Dependency: github.com/elastic/go-libaudit
-Revision: ec7a7253716958d85ea854cbef4aaffcd6cbd50b
+Version: v0.4.0
+Revision: 39073a2988f718067d85d27a4d18b1b57de5d947
 License type (autodetected): Apache-2.0
 ./vendor/github.com/elastic/go-libaudit/LICENSE.txt:
 --------------------------------------------------------------------

--- a/vendor/github.com/elastic/go-libaudit/CHANGELOG.md
+++ b/vendor/github.com/elastic/go-libaudit/CHANGELOG.md
@@ -6,11 +6,19 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+### Changed
+
+### Removed
+
+## [0.4.0]
+
+### Added
+
 - Added method to convert kernel rules to text format in order to display them.
 
 ### Changed
 
-- aucoalesce - Made the user/group ID cache thread-safe. #42
+- aucoalesce - Made the user/group ID cache thread-safe. #42 #45
 
 ### Deprecated
 

--- a/vendor/github.com/elastic/go-libaudit/aucoalesce/id_lookup.go
+++ b/vendor/github.com/elastic/go-libaudit/aucoalesce/id_lookup.go
@@ -48,9 +48,9 @@ type UserCache struct {
 	mutex      sync.Mutex
 }
 
-// NewUserCache returns a new UserCache. UserCache is not thread-safe.
-func NewUserCache(expiration time.Duration) UserCache {
-	return UserCache{
+// NewUserCache returns a new UserCache. UserCache is thread-safe.
+func NewUserCache(expiration time.Duration) *UserCache {
+	return &UserCache{
 		expiration: expiration,
 		data: map[string]stringItem{
 			"0": {timeout: time.Unix(math.MaxInt64, 0), value: "root"},
@@ -91,9 +91,9 @@ type GroupCache struct {
 	mutex      sync.Mutex
 }
 
-// NewGroupCache returns a new GroupCache. GroupCache is not thread-safe.
-func NewGroupCache(expiration time.Duration) GroupCache {
-	return GroupCache{
+// NewGroupCache returns a new GroupCache. GroupCache is thread-safe.
+func NewGroupCache(expiration time.Duration) *GroupCache {
+	return &GroupCache{
 		expiration: expiration,
 		data: map[string]stringItem{
 			"0": {timeout: time.Unix(math.MaxInt64, 0), value: "root"},
@@ -136,7 +136,7 @@ func ResolveIDs(event *Event) {
 
 // ResolveIDsFromCaches translates all uid and gid values to their associated
 // names using the provided caches. Prior to Go 1.9 this requires cgo on Linux.
-func ResolveIDsFromCaches(event *Event, users UserCache, groups GroupCache) {
+func ResolveIDsFromCaches(event *Event, users *UserCache, groups *GroupCache) {
 	// Actor
 	if v := users.LookupUID(event.Summary.Actor.Primary); v != "" {
 		event.Summary.Actor.Primary = v

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -373,34 +373,44 @@
 			"revisionTime": "2016-08-05T00:47:13Z"
 		},
 		{
-			"checksumSHA1": "D/7cJ8oboLL/gQxr57kfvDBtMZE=",
+			"checksumSHA1": "vNnw1bUS8Ct+8H64QuA2DWRJ9SQ=",
 			"path": "github.com/elastic/go-libaudit",
-			"revision": "ec7a7253716958d85ea854cbef4aaffcd6cbd50b",
-			"revisionTime": "2018-08-07T15:01:12Z"
+			"revision": "39073a2988f718067d85d27a4d18b1b57de5d947",
+			"revisionTime": "2018-08-29T20:25:13Z",
+			"version": "v0.4.0",
+			"versionExact": "v0.4.0"
 		},
 		{
-			"checksumSHA1": "QTR02jPgqq2P6mZKMWUdAUQPVbQ=",
+			"checksumSHA1": "NRGAFJY7u1wYeXtNzLlI5/MnBMQ=",
 			"path": "github.com/elastic/go-libaudit/aucoalesce",
-			"revision": "ec7a7253716958d85ea854cbef4aaffcd6cbd50b",
-			"revisionTime": "2018-08-07T15:01:12Z"
+			"revision": "39073a2988f718067d85d27a4d18b1b57de5d947",
+			"revisionTime": "2018-08-29T20:25:13Z",
+			"version": "v0.4.0",
+			"versionExact": "v0.4.0"
 		},
 		{
 			"checksumSHA1": "6OK3lLgocjmIUyLo8xNhYGpwE1E=",
 			"path": "github.com/elastic/go-libaudit/auparse",
-			"revision": "ec7a7253716958d85ea854cbef4aaffcd6cbd50b",
-			"revisionTime": "2018-08-07T15:01:12Z"
+			"revision": "39073a2988f718067d85d27a4d18b1b57de5d947",
+			"revisionTime": "2018-08-29T20:25:13Z",
+			"version": "v0.4.0",
+			"versionExact": "v0.4.0"
 		},
 		{
 			"checksumSHA1": "zGv2vPwSLoFCRt1kcD81pBzTo+0=",
 			"path": "github.com/elastic/go-libaudit/rule",
-			"revision": "ec7a7253716958d85ea854cbef4aaffcd6cbd50b",
-			"revisionTime": "2018-08-07T15:01:12Z"
+			"revision": "39073a2988f718067d85d27a4d18b1b57de5d947",
+			"revisionTime": "2018-08-29T20:25:13Z",
+			"version": "v0.4.0",
+			"versionExact": "v0.4.0"
 		},
 		{
 			"checksumSHA1": "5C083BvwcAVSKquRXbxXa950/wE=",
 			"path": "github.com/elastic/go-libaudit/rule/flags",
-			"revision": "ec7a7253716958d85ea854cbef4aaffcd6cbd50b",
-			"revisionTime": "2018-08-07T15:01:12Z"
+			"revision": "39073a2988f718067d85d27a4d18b1b57de5d947",
+			"revisionTime": "2018-08-29T20:25:13Z",
+			"version": "v0.4.0",
+			"versionExact": "v0.4.0"
 		},
 		{
 			"checksumSHA1": "3jizmlZPCyo6FAZY8Trk9jA8NH4=",


### PR DESCRIPTION
Cherry-pick of PR #8158 to 6.4 branch. Original message: 

Update github.com/elastic/go-libaudit to v0.4.0, which includes the fix for this issue.