### PR TITLE
Cherry-pick #8027 to 6.x: Fix data race and deadlock in file_integrity module

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -47,6 +47,7 @@ https://github.com/elastic/beats/compare/v6.4.0...6.x[Check the HEAD diff]
 - Fixed the RPM by designating the config file as configuration data in the RPM spec. {issue}8075[8075]
 - Fixed a concurrent map write panic in the auditd module. {pull}8158[8158]
 - Fixed a data race in the file_integrity module. {issue}8009[8009]
+- Fixed a deadlock in the file_integrity module. {pull}8027[8027]
 
 *Filebeat*
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -46,6 +46,7 @@ https://github.com/elastic/beats/compare/v6.4.0...6.x[Check the HEAD diff]
 - Fixed a crash in the file_integrity module under Linux. {issue}7753[7753]
 - Fixed the RPM by designating the config file as configuration data in the RPM spec. {issue}8075[8075]
 - Fixed a concurrent map write panic in the auditd module. {pull}8158[8158]
+- Fixed a data race in the file_integrity module. {issue}8009[8009]
 
 *Filebeat*
 

--- a/auditbeat/module/file_integrity/eventreader_fsnotify.go
+++ b/auditbeat/module/file_integrity/eventreader_fsnotify.go
@@ -47,7 +47,6 @@ func NewEventReader(c Config) (EventProducer, error) {
 	return &reader{
 		watcher: watcher,
 		config:  c,
-		eventC:  make(chan Event, 1),
 		log:     logp.NewLogger(moduleName),
 	}, nil
 }
@@ -56,7 +55,16 @@ func (r *reader) Start(done <-chan struct{}) (<-chan Event, error) {
 	if err := r.watcher.Start(); err != nil {
 		return nil, errors.Wrap(err, "unable to start watcher")
 	}
-	go r.consumeEvents(done)
+
+	queueDone := make(chan struct{})
+	queueC := make(chan []*Event)
+
+	// Launch a separate goroutine to fetch all events that happen while
+	// watches are being installed.
+	go func() {
+		defer close(queueC)
+		queueC <- r.enqueueEvents(queueDone)
+	}()
 
 	// Windows implementation of fsnotify needs to have the watched paths
 	// installed after the event consumer is started, to avoid a potential
@@ -73,10 +81,31 @@ func (r *reader) Start(done <-chan struct{}) (<-chan Event, error) {
 		}
 	}
 
+	close(queueDone)
+	events := <-queueC
+
+	// Populate callee's event channel with the previously received events
+	r.eventC = make(chan Event, 1+len(events))
+	for _, ev := range events {
+		r.eventC <- *ev
+	}
+
+	go r.consumeEvents(done)
+
 	r.log.Infow("Started fsnotify watcher",
 		"file_path", r.config.Paths,
 		"recursive", r.config.Recursive)
 	return r.eventC, nil
+}
+
+func (r *reader) enqueueEvents(done <-chan struct{}) (events []*Event) {
+	for {
+		ev := r.nextEvent(done)
+		if ev == nil {
+			return
+		}
+		events = append(events, ev)
+	}
 }
 
 func (r *reader) consumeEvents(done <-chan struct{}) {
@@ -84,10 +113,21 @@ func (r *reader) consumeEvents(done <-chan struct{}) {
 	defer r.watcher.Close()
 
 	for {
-		select {
-		case <-done:
+		ev := r.nextEvent(done)
+		if ev == nil {
 			r.log.Debug("fsnotify reader terminated")
 			return
+		}
+		r.eventC <- *ev
+	}
+}
+
+func (r *reader) nextEvent(done <-chan struct{}) *Event {
+	for {
+		select {
+		case <-done:
+			return nil
+
 		case event := <-r.watcher.EventChannel():
 			if event.Name == "" || r.config.IsExcludedPath(event.Name) {
 				continue
@@ -101,7 +141,8 @@ func (r *reader) consumeEvents(done <-chan struct{}) {
 				r.config.MaxFileSizeBytes, r.config.HashTypes)
 			e.rtt = time.Since(start)
 
-			r.eventC <- e
+			return &e
+
 		case err := <-r.watcher.ErrorChannel():
 			// a bug in fsnotify can cause spurious nil errors to be sent
 			// on the error channel.

--- a/auditbeat/module/file_integrity/monitor/monitor_test.go
+++ b/auditbeat/module/file_integrity/monitor/monitor_test.go
@@ -211,8 +211,9 @@ func TestRecursiveSubdirPermissions(t *testing.T) {
 	watcher, err := New(true)
 	assertNoError(t, err)
 
-	assertNoError(t, watcher.Add(dir))
 	assertNoError(t, watcher.Start())
+	assertNoError(t, watcher.Add(dir))
+
 	defer func() {
 		assertNoError(t, watcher.Close())
 	}()


### PR DESCRIPTION
Cherry-pick of PR #8027 to 6.x branch. Original message: 

This PR fixes two issues with auditbeat's file_integrity module:
- Concurrent map write in #8009 
Auditbeat's file_integrity module had a data race in its recursive watcher implementation for Linux. Was caused by file watches being installed from different goroutines.
This patch fixes the problem by moving watch installation to the same goroutine that processes inotify's events, guaranteeing that watches are installed in order, which is necessary for consistence.

- deadlock when file integrity monitor is started
    A deadlock is possible in auditbeat's file_integrity module under Windows: When enough events arrive while watches are being installed, the event channel can fill causing the installation of a watch to block. This patch makes sure that events are received while watches are being installed, and at the same time ensures that no event is lost.