### PR TITLE
Cherry-pick #7851 to 6.x: Pipeline: Add check if exists. Change cmd output.

### DIFF
--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -392,7 +392,7 @@ func (b *Beat) TestConfig(bt beat.Creator) error {
 	}())
 }
 
-// Setup registers ES index template and kibana dashboards
+// Setup registers ES index template, kibana dashboards, ml jobs and pipelines.
 func (b *Beat) Setup(bt beat.Creator, template, dashboards, machineLearning, pipelines bool) error {
 	return handleError(func() error {
 		err := b.Init()
@@ -666,7 +666,6 @@ func (b *Beat) loadDashboards(ctx context.Context, force bool) error {
 // the elasticsearch output. It is important the the registration happens before
 // the publisher is created.
 func (b *Beat) registerTemplateLoading() error {
-
 	var cfg template.TemplateConfig
 
 	// Check if outputting to file is enabled, and output to file if it is

--- a/libbeat/cmd/setup.go
+++ b/libbeat/cmd/setup.go
@@ -55,6 +55,7 @@ func genSetupCmd(name, idxPrefix, version string, beatCreator beat.Creator) *cob
 				template = true
 				dashboards = true
 				machineLearning = true
+				pipelines = true
 			}
 
 			if err = beat.Setup(beatCreator, template, dashboards, machineLearning, pipelines); err != nil {
@@ -63,10 +64,10 @@ func genSetupCmd(name, idxPrefix, version string, beatCreator beat.Creator) *cob
 		},
 	}
 
-	setup.Flags().Bool("template", false, "Setup index template only")
-	setup.Flags().Bool("dashboards", false, "Setup dashboards only")
-	setup.Flags().Bool("machine-learning", false, "Setup machine learning job configurations only")
-	setup.Flags().Bool("pipelines", false, "Setup Ingest pipelines only")
+	setup.Flags().Bool("template", false, "Setup index template")
+	setup.Flags().Bool("dashboards", false, "Setup dashboards")
+	setup.Flags().Bool("machine-learning", false, "Setup machine learning job configurations")
+	setup.Flags().Bool("pipelines", false, "Setup Ingest pipelines")
 
 	return &setup
 }

--- a/libbeat/outputs/elasticsearch/api.go
+++ b/libbeat/outputs/elasticsearch/api.go
@@ -163,6 +163,16 @@ func (es *Connection) Delete(index string, docType string, id string, params map
 	return withQueryResult(es.apiCall("DELETE", index, docType, id, "", params, nil))
 }
 
+// PipelineExists checks if a pipeline with name id already exists.
+// Using: https://www.elastic.co/guide/en/elasticsearch/reference/current/get-pipeline-api.html
+func (es *Connection) PipelineExists(id string) (bool, error) {
+	status, _, err := es.apiCall("GET", "_ingest", "pipeline", id, "", nil, nil)
+	if status == 404 {
+		return false, nil
+	}
+	return status == 200, err
+}
+
 // CreatePipeline create a new ingest pipeline with name id.
 // Implements: https://www.elastic.co/guide/en/elasticsearch/reference/current/put-pipeline-api.html
 func (es *Connection) CreatePipeline(

--- a/libbeat/outputs/elasticsearch/api_integration_test.go
+++ b/libbeat/outputs/elasticsearch/api_integration_test.go
@@ -114,12 +114,28 @@ func TestIngest(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	exists, err := client.PipelineExists(pipeline)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exists == true {
+		t.Fatalf("Test expected PipelineExists to return false for %v", pipeline)
+	}
+
 	_, resp, err := client.CreatePipeline(pipeline, nil, pipelineBody)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !resp.Acknowledged {
 		t.Fatalf("Test pipeline %v not created", pipeline)
+	}
+
+	exists, err = client.PipelineExists(pipeline)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exists == false {
+		t.Fatalf("Test expected PipelineExists to return true for %v", pipeline)
 	}
 
 	params := map[string]string{"refresh": "true"}

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -355,7 +355,7 @@ docs:  ## @build Builds the documents for the beat
 docs-preview:  ## @build Preview the documents for the beat in the browser
 	PREVIEW=1 $(MAKE) docs
 
-### KIBANA FILES HANDLING ###
+### SETUP commands ###
 ES_URL?=http://localhost:9200
 KIBANA_URL?=http://localhost:5601
 


### PR DESCRIPTION
Cherry-pick of PR #7851 to 6.x branch. Original message: 

This PR is a precondition for https://github.com/elastic/apm-server/pull/1258

* Add API method to check if pipeline exists.
* Change output for `setup` command.
* Add make cmd for registering pipelines.