### PR TITLE
Update links to point to new location for the stack getting started info

### DIFF
--- a/filebeat/docs/migration.asciidoc
+++ b/filebeat/docs/migration.asciidoc
@@ -31,7 +31,7 @@ https://github.com/elastic/logstash-forwarder[Logstash Forwarder] to {beatname_u
 
 {beatname_uc} requires the {logstash-ref}/plugins-inputs-beats.html[Beats input
 plugin for Logstash]. For information about getting started with this plugin,
-see {stack-ov}/get-started-elastic-stack.html#logstash-setup[Configure Logstash to
+see {stack-gs}/get-started-elastic-stack.html#logstash-setup[Configure Logstash to
 listen for Beats input] in the {stack} getting started tutorial.
 
 In both the 1.5.x and 2.x versions of Logstash, this plugin can be loaded in

--- a/filebeat/docs/modules-getting-started.asciidoc
+++ b/filebeat/docs/modules-getting-started.asciidoc
@@ -23,7 +23,7 @@ following the numbered steps under <<filebeat-getting-started>>.
 Before running {beatname_uc} modules:
 
 * Install and configure the Elastic stack. See
-{stack-ov}/get-started-elastic-stack.html[Getting started with the {stack}].
+{stack-gs}/get-started-elastic-stack.html[Getting started with the {stack}].
 
 * Complete the {beatname_uc} installation instructions described in
 <<filebeat-installation>>. After installing {beatname_uc}, return to this

--- a/libbeat/docs/gettingstarted.asciidoc
+++ b/libbeat/docs/gettingstarted.asciidoc
@@ -3,7 +3,7 @@
 
 Each Beat is a separately installable product. Before installing Beats, you need
 to install and configure the {stack}. To learn how to get up and running
-quickly, see {stack-ov}/get-started-elastic-stack.html[Getting started with the
+quickly, see {stack-gs}/get-started-elastic-stack.html[Getting started with the
 {stack}].
 
 [TIP]

--- a/libbeat/docs/shared-download-and-install.asciidoc
+++ b/libbeat/docs/shared-download-and-install.asciidoc
@@ -1,6 +1,6 @@
 
 *Before you begin*: If you haven't installed the {stack}, do that now. See
-{stack-ov}/get-started-elastic-stack.html[Getting started with the {stack}].
+{stack-gs}/get-started-elastic-stack.html[Getting started with the {stack}].
 
 To download and install {beatname_uc}, use the commands that work with your system
 (<<deb, deb>> for Debian/Ubuntu, <<rpm, rpm>> for Redhat/Centos/Fedora, <<mac,

--- a/libbeat/docs/shared-getting-started-intro.asciidoc
+++ b/libbeat/docs/shared-getting-started-intro.asciidoc
@@ -6,7 +6,7 @@ related products:
 * {kib} for the UI.
 * {ls} (optional) for parsing and enhancing the data.
 
-See {stack-ov}/get-started-elastic-stack.html[Getting started with the {stack}]
+See {stack-gs}/get-started-elastic-stack.html[Getting started with the {stack}]
 for more information.
 
 [TIP]

--- a/libbeat/docs/shared-logstash-config.asciidoc
+++ b/libbeat/docs/shared-logstash-config.asciidoc
@@ -14,7 +14,7 @@
 To send events to {ls}, you also need to create a {ls} configuration pipeline
 that listens for incoming Beats connections and indexes the received events into
 {es}. For more information, see the section about
-{stack-ov}/get-started-elastic-stack.html#logstash-setup[configuring {ls}] in
+{stack-gs}/get-started-elastic-stack.html#logstash-setup[configuring {ls}] in
 the {stack} getting started tutorial. Also see the documentation for the
 {logstash-ref}/plugins-inputs-beats.html[{beats} input] and
 {logstash-ref}/plugins-outputs-elasticsearch.html[{es} output] plugins.

--- a/winlogbeat/docs/getting-started.asciidoc
+++ b/winlogbeat/docs/getting-started.asciidoc
@@ -15,7 +15,7 @@ include::../../libbeat/docs/shared-getting-started-intro.asciidoc[]
 === Step 1: Install Winlogbeat
 
 *Before you begin*: If you haven't installed the {stack}, do that now. See
-{stack-ov}/get-started-elastic-stack.html[Getting started with the {stack}].
+{stack-gs}/get-started-elastic-stack.html[Getting started with the {stack}].
 
 . Download the Winlogbeat zip file from the
 https://www.elastic.co/downloads/beats/winlogbeat[downloads page].


### PR DESCRIPTION
Related to https://github.com/elastic/stack-docs/pull/110.

Fixes links to point to the new location for the stack getting started info.