### PR TITLE
Cherry-pick #7873 to 6.4: Fix permissions at systemd unit file

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -41,6 +41,7 @@ https://github.com/elastic/beats/compare/v6.4.0...6.4[Check the HEAD diff]
 - Deregister pipeline loader callback when inputsRunner is stopped. {pull}7893[7893]
 - Replace index patterns in TSVB visualizations. {pull}7929[7929]
 - Add backoff support to x-pack monitoring outputs. {issue}7966[7966]
+- Removed execute permissions systemd unit file. {pull}7873[7873]
 
 *Auditbeat*
 

--- a/dev-tools/packaging/packages.yml
+++ b/dev-tools/packaging/packages.yml
@@ -58,7 +58,7 @@ shared:
         mode: 0755
       /lib/systemd/system/{{.BeatServiceName}}.service:
         template: '{{ elastic_beats_dir }}/dev-tools/packaging/templates/linux/systemd.unit.tmpl'
-        mode: 0755
+        mode: 0644
       /etc/init.d/{{.BeatServiceName}}:
         template: '{{ elastic_beats_dir }}/dev-tools/packaging/templates/{{.PackageType}}/init.sh.tmpl'
         mode: 0755


### PR DESCRIPTION
Cherry-pick of PR #7873 to 6.4 branch. Original message: 

Systemd unit has wrong permissions. So systemd logs:
`Configuration file /lib/systemd/system/auditbeat.service is marked executable.
 Please remove executable permission bits. Proceeding anyway`