### PR TITLE
Fix typo in field name

### DIFF
--- a/metricbeat/module/elasticsearch/index_summary/data_xpack.go
+++ b/metricbeat/module/elasticsearch/index_summary/data_xpack.go
@@ -99,7 +99,7 @@ func eventMappingXPack(r mb.ReporterV2, m *MetricSet, info elasticsearch.Info, c
 	event := mb.Event{}
 	event.RootFields = common.MapStr{}
 	event.RootFields.Put("indices_stats._all", fields)
-	event.RootFields.Put("cluser_uuid", info.ClusterID)
+	event.RootFields.Put("cluster_uuid", info.ClusterID)
 	event.RootFields.Put("timestamp", common.Time(time.Now()))
 	event.RootFields.Put("interval_ms", m.Module().Config().Period/time.Millisecond)
 	event.RootFields.Put("type", "indices_stats")


### PR DESCRIPTION
Should be `cluster_uuid`, not `cluser_uuid` (missing `t`).