### PR TITLE
Remove incorrect docs for system.cpu.total.value

### DIFF
--- a/metricbeat/docs/fields.asciidoc
+++ b/metricbeat/docs/fields.asciidoc
@@ -12676,16 +12676,6 @@ The percentage of CPU time spent in non-idle state.
 
 --
 
-*`system.cpu.total.value`*::
-+
---
-type: long
-
-The value of CPU usage since starting the process.
-
-
---
-
 *`system.cpu.user.ticks`*::
 +
 --

--- a/metricbeat/module/system/cpu/_meta/fields.yml
+++ b/metricbeat/module/system/cpu/_meta/fields.yml
@@ -128,14 +128,6 @@
       description: >
         The percentage of CPU time spent in non-idle state.
 
-
-    # Total
-    - name: total.value
-      type: long
-      description: >
-        The value of CPU usage since starting the process.
-
-
     # Ticks
     - name: user.ticks
       type: long


### PR DESCRIPTION
Closes https://github.com/elastic/beats/issues/8010.

This changes has already been made in master, 6.x, and 6.4.