### PR TITLE
Add a reloadable objects registry

### DIFF
--- a/libbeat/autodiscover/autodiscover.go
+++ b/libbeat/autodiscover/autodiscover.go
@@ -27,6 +27,7 @@ import (
 	"github.com/elastic/beats/libbeat/cfgfile"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/bus"
+	"github.com/elastic/beats/libbeat/common/reload"
 	"github.com/elastic/beats/libbeat/logp"
 )
 
@@ -59,7 +60,7 @@ type Autodiscover struct {
 	defaultPipeline beat.Pipeline
 	adapter         Adapter
 	providers       []Provider
-	configs         map[uint64]*cfgfile.ConfigWithMeta
+	configs         map[uint64]*reload.ConfigWithMeta
 	runners         *cfgfile.RunnerList
 	meta            *meta.Map
 
@@ -86,7 +87,7 @@ func NewAutodiscover(name string, pipeline beat.Pipeline, adapter Adapter, confi
 		bus:             bus,
 		defaultPipeline: pipeline,
 		adapter:         adapter,
-		configs:         map[uint64]*cfgfile.ConfigWithMeta{},
+		configs:         map[uint64]*reload.ConfigWithMeta{},
 		runners:         cfgfile.NewRunnerList("autodiscover", adapter, pipeline),
 		providers:       providers,
 		meta:            meta.NewMap(),
@@ -135,7 +136,7 @@ func (a *Autodiscover) worker() {
 				logp.Debug(debugK, "Reloading existing autodiscover configs after error")
 			}
 
-			configs := make([]*cfgfile.ConfigWithMeta, 0, len(a.configs))
+			configs := make([]*reload.ConfigWithMeta, 0, len(a.configs))
 			for _, c := range a.configs {
 				configs = append(configs, c)
 			}
@@ -182,7 +183,7 @@ func (a *Autodiscover) handleStart(event bus.Event) bool {
 			continue
 		}
 
-		a.configs[hash] = &cfgfile.ConfigWithMeta{
+		a.configs[hash] = &reload.ConfigWithMeta{
 			Config: config,
 			Meta:   &dynFields,
 		}

--- a/libbeat/cfgfile/list.go
+++ b/libbeat/cfgfile/list.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/reload"
 	"github.com/elastic/beats/libbeat/logp"
 )
 
@@ -36,15 +37,6 @@ type RunnerList struct {
 	factory  RunnerFactory
 	pipeline beat.Pipeline
 	logger   *logp.Logger
-}
-
-// ConfigWithMeta holds a pair of common.Config and optional metadata for it
-type ConfigWithMeta struct {
-	// Config to store
-	Config *common.Config
-
-	// Meta data related to this config
-	Meta *common.MapStrPointer
 }
 
 // NewRunnerList builds and returns a RunnerList
@@ -58,13 +50,13 @@ func NewRunnerList(name string, factory RunnerFactory, pipeline beat.Pipeline) *
 }
 
 // Reload the list of runners to match the given state
-func (r *RunnerList) Reload(configs []*ConfigWithMeta) error {
+func (r *RunnerList) Reload(configs []*reload.ConfigWithMeta) error {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
 
 	var errs multierror.Errors
 
-	startList := map[uint64]*ConfigWithMeta{}
+	startList := map[uint64]*reload.ConfigWithMeta{}
 	stopList := r.copyRunnerList()
 
 	r.logger.Debugf("Starting reload procedure, current runners: %d", len(stopList))

--- a/libbeat/cfgfile/list_test.go
+++ b/libbeat/cfgfile/list_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/reload"
 )
 
 type runner struct {
@@ -66,7 +67,7 @@ func TestNewConfigs(t *testing.T) {
 	factory := &runnerFactory{}
 	list := NewRunnerList("", factory, nil)
 
-	list.Reload([]*ConfigWithMeta{
+	list.Reload([]*reload.ConfigWithMeta{
 		createConfig(1),
 		createConfig(2),
 		createConfig(3),
@@ -79,7 +80,7 @@ func TestReloadSameConfigs(t *testing.T) {
 	factory := &runnerFactory{}
 	list := NewRunnerList("", factory, nil)
 
-	list.Reload([]*ConfigWithMeta{
+	list.Reload([]*reload.ConfigWithMeta{
 		createConfig(1),
 		createConfig(2),
 		createConfig(3),
@@ -88,7 +89,7 @@ func TestReloadSameConfigs(t *testing.T) {
 	state := list.copyRunnerList()
 	assert.Equal(t, len(state), 3)
 
-	list.Reload([]*ConfigWithMeta{
+	list.Reload([]*reload.ConfigWithMeta{
 		createConfig(1),
 		createConfig(2),
 		createConfig(3),
@@ -102,7 +103,7 @@ func TestReloadStopConfigs(t *testing.T) {
 	factory := &runnerFactory{}
 	list := NewRunnerList("", factory, nil)
 
-	list.Reload([]*ConfigWithMeta{
+	list.Reload([]*reload.ConfigWithMeta{
 		createConfig(1),
 		createConfig(2),
 		createConfig(3),
@@ -110,7 +111,7 @@ func TestReloadStopConfigs(t *testing.T) {
 
 	assert.Equal(t, len(list.copyRunnerList()), 3)
 
-	list.Reload([]*ConfigWithMeta{
+	list.Reload([]*reload.ConfigWithMeta{
 		createConfig(1),
 		createConfig(3),
 	})
@@ -122,7 +123,7 @@ func TestReloadStartStopConfigs(t *testing.T) {
 	factory := &runnerFactory{}
 	list := NewRunnerList("", factory, nil)
 
-	list.Reload([]*ConfigWithMeta{
+	list.Reload([]*reload.ConfigWithMeta{
 		createConfig(1),
 		createConfig(2),
 		createConfig(3),
@@ -131,7 +132,7 @@ func TestReloadStartStopConfigs(t *testing.T) {
 	state := list.copyRunnerList()
 	assert.Equal(t, len(state), 3)
 
-	list.Reload([]*ConfigWithMeta{
+	list.Reload([]*reload.ConfigWithMeta{
 		createConfig(1),
 		createConfig(3),
 		createConfig(4),
@@ -145,7 +146,7 @@ func TestStopAll(t *testing.T) {
 	factory := &runnerFactory{}
 	list := NewRunnerList("", factory, nil)
 
-	list.Reload([]*ConfigWithMeta{
+	list.Reload([]*reload.ConfigWithMeta{
 		createConfig(1),
 		createConfig(2),
 		createConfig(3),
@@ -170,7 +171,7 @@ func TestHas(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	list.Reload([]*ConfigWithMeta{
+	list.Reload([]*reload.ConfigWithMeta{
 		config,
 	})
 
@@ -178,10 +179,10 @@ func TestHas(t *testing.T) {
 	assert.False(t, list.Has(0))
 }
 
-func createConfig(id int64) *ConfigWithMeta {
+func createConfig(id int64) *reload.ConfigWithMeta {
 	c := common.NewConfig()
 	c.SetInt("id", -1, id)
-	return &ConfigWithMeta{
+	return &reload.ConfigWithMeta{
 		Config: c,
 	}
 }

--- a/libbeat/cfgfile/reload.go
+++ b/libbeat/cfgfile/reload.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/reload"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/monitoring"
 	"github.com/elastic/beats/libbeat/paths"
@@ -203,9 +204,9 @@ func (rl *Reloader) Run(runnerFactory RunnerFactory) {
 	}
 }
 
-func (rl *Reloader) loadConfigs(files []string) ([]*ConfigWithMeta, error) {
+func (rl *Reloader) loadConfigs(files []string) ([]*reload.ConfigWithMeta, error) {
 	// Load all config objects
-	result := []*ConfigWithMeta{}
+	result := []*reload.ConfigWithMeta{}
 	var errs multierror.Errors
 	for _, file := range files {
 		configs, err := LoadList(file)
@@ -216,7 +217,7 @@ func (rl *Reloader) loadConfigs(files []string) ([]*ConfigWithMeta, error) {
 		}
 
 		for _, c := range configs {
-			result = append(result, &ConfigWithMeta{Config: c})
+			result = append(result, &reload.ConfigWithMeta{Config: c})
 		}
 	}
 

--- a/libbeat/common/reload/reload.go
+++ b/libbeat/common/reload/reload.go
@@ -65,7 +65,7 @@ func (r *registry) Register(name string, obj Reloadable) error {
 	defer r.Unlock()
 
 	if r == nil {
-		return errors.New("Got a nil object")
+		return errors.New("got a nil object")
 	}
 
 	if _, ok := r.confs[name]; ok {
@@ -82,7 +82,7 @@ func (r *registry) RegisterList(name string, list ReloadableList) error {
 	defer r.Unlock()
 
 	if r == nil {
-		return errors.New("Got a nil object")
+		return errors.New("got a nil object")
 	}
 
 	if _, ok := r.confsLists[name]; ok {

--- a/libbeat/common/reload/reload.go
+++ b/libbeat/common/reload/reload.go
@@ -69,8 +69,8 @@ func (r *registry) Register(name string, obj Reloadable) error {
 		return errors.New("got a nil object")
 	}
 
-	if _, ok := r.confs[name]; ok {
-		return errors.Errorf("%s configuration is already registered", name)
+	if r.nameTaken(name) {
+		return errors.Errorf("%s configuration list is already registered", name)
 	}
 
 	r.confs[name] = obj
@@ -86,8 +86,8 @@ func (r *registry) RegisterList(name string, list ReloadableList) error {
 		return errors.New("got a nil object")
 	}
 
-	if _, ok := r.confsLists[name]; ok {
-		return errors.Errorf("%s configuration list is already registered", name)
+	if r.nameTaken(name) {
+		return errors.Errorf("%s configuration is already registered", name)
 	}
 
 	r.confsLists[name] = list
@@ -120,4 +120,16 @@ func (r *registry) GetList(name string) ReloadableList {
 	r.RLock()
 	defer r.RUnlock()
 	return r.confsLists[name]
+}
+
+func (r *registry) nameTaken(name string) bool {
+	if _, ok := r.confs[name]; ok {
+		return true
+	}
+
+	if _, ok := r.confsLists[name]; ok {
+		return true
+	}
+
+	return false
 }

--- a/libbeat/common/reload/reload.go
+++ b/libbeat/common/reload/reload.go
@@ -1,0 +1,105 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package reload
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/elastic/beats/libbeat/common"
+)
+
+var register = newRegistry()
+
+// ConfigWithMeta holds a pair of common.Config and optional metadata for it
+type ConfigWithMeta struct {
+	// Config to store
+	Config *common.Config
+
+	// Meta data related to this config
+	Meta *common.MapStrPointer
+}
+
+// ReloadableList provides a method to reload the configuration of a list of entities
+type ReloadableList interface {
+	Reload(configs []*ConfigWithMeta) error
+}
+
+// Reloadable provides a method to reload the configuration of an entity
+type Reloadable interface {
+	Reload(config *ConfigWithMeta) error
+}
+
+type registry struct {
+	sync.RWMutex
+	confsLists map[string]ReloadableList
+	confs      map[string]Reloadable
+}
+
+func newRegistry() registry {
+	return registry{
+		confsLists: make(map[string]ReloadableList),
+		confs:      make(map[string]Reloadable),
+	}
+}
+
+// MustRegister declares a reloadable object
+func MustRegister(name string, r Reloadable) {
+	register.Lock()
+	defer register.Unlock()
+
+	if r == nil {
+		panic("Got a nil object")
+	}
+
+	if _, ok := register.confs[name]; ok {
+		panic(fmt.Sprintf("%s configuration is already registered", name))
+	}
+
+	register.confs[name] = r
+}
+
+// MustRegisterList declares a reloadable list of configurations
+func MustRegisterList(name string, list ReloadableList) {
+	register.Lock()
+	defer register.Unlock()
+
+	if list == nil {
+		panic("Got a nil object")
+	}
+
+	if _, ok := register.confsLists[name]; ok {
+		panic(fmt.Sprintf("%s configuration list is already registered", name))
+	}
+
+	register.confsLists[name] = list
+}
+
+// Get returns the reloadable object with the given name, nil if not found
+func Get(name string) Reloadable {
+	register.RLock()
+	defer register.RUnlock()
+	return register.confs[name]
+}
+
+// GetList returns the reloadable list with the given name, nil if not found
+func GetList(name string) ReloadableList {
+	register.RLock()
+	defer register.RUnlock()
+	return register.confsLists[name]
+}

--- a/libbeat/common/reload/reload_test.go
+++ b/libbeat/common/reload/reload_test.go
@@ -60,15 +60,24 @@ func TestRegisterNilFails(t *testing.T) {
 func TestReRegisterFails(t *testing.T) {
 	r := newRegistry()
 
+	// two obj with the same name
 	err := r.Register("name", reloadable{})
 	assert.NoError(t, err)
 
 	err = r.Register("name", reloadable{})
 	assert.Error(t, err)
 
-	err = r.RegisterList("name", reloadableList{})
+	// two lists with the same name
+	err = r.RegisterList("foo", reloadableList{})
 	assert.NoError(t, err)
 
-	err = r.RegisterList("name", reloadableList{})
+	err = r.RegisterList("foo", reloadableList{})
+	assert.Error(t, err)
+
+	// one of each with the same name
+	err = r.Register("bar", reloadable{})
+	assert.NoError(t, err)
+
+	err = r.RegisterList("bar", reloadableList{})
 	assert.Error(t, err)
 }

--- a/libbeat/common/reload/reload_test.go
+++ b/libbeat/common/reload/reload_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type nonreloadable struct{}
 type reloadable struct{}
 type reloadableList struct{}
 

--- a/libbeat/common/reload/reload_test.go
+++ b/libbeat/common/reload/reload_test.go
@@ -1,0 +1,69 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package reload
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type nonreloadable struct{}
+type reloadable struct{}
+type reloadableList struct{}
+
+func (reloadable) Reload(config *ConfigWithMeta) error       { return nil }
+func (reloadableList) Reload(config []*ConfigWithMeta) error { return nil }
+
+func RegisterReloadable(t *testing.T) {
+	r := reloadable{}
+
+	MustRegister("my.reloadable", reloadable{})
+
+	assert.Equal(t, r, Get("my.reloadable"))
+}
+
+func RegisterReloadableList(t *testing.T) {
+	r := reloadableList{}
+
+	MustRegisterList("my.reloadable", reloadableList{})
+
+	assert.Equal(t, r, Get("my.reloadable"))
+}
+
+func TestRegisterNilFails(t *testing.T) {
+	assert.Panics(t, func() {
+		MustRegister("name", nil)
+	})
+
+	assert.Panics(t, func() {
+		MustRegisterList("name", nil)
+	})
+}
+
+func TestReRegisterFails(t *testing.T) {
+	assert.Panics(t, func() {
+		MustRegister("name", reloadable{})
+		MustRegister("name", reloadable{})
+	})
+
+	assert.Panics(t, func() {
+		MustRegisterList("mylist", reloadableList{})
+		MustRegisterList("mylist", reloadableList{})
+	})
+}

--- a/libbeat/common/reload/reload_test.go
+++ b/libbeat/common/reload/reload_test.go
@@ -32,7 +32,7 @@ func (reloadableList) Reload(config []*ConfigWithMeta) error { return nil }
 
 func RegisterReloadable(t *testing.T) {
 	obj := reloadable{}
-	r := registry{}
+	r := newRegistry()
 
 	r.Register("my.reloadable", obj)
 
@@ -41,7 +41,7 @@ func RegisterReloadable(t *testing.T) {
 
 func RegisterReloadableList(t *testing.T) {
 	objl := reloadableList{}
-	r := registry{}
+	r := newRegistry()
 
 	r.RegisterList("my.reloadable", objl)
 
@@ -49,7 +49,7 @@ func RegisterReloadableList(t *testing.T) {
 }
 
 func TestRegisterNilFails(t *testing.T) {
-	r := registry{}
+	r := newRegistry()
 
 	err := r.Register("name", nil)
 	assert.Error(t, err)
@@ -59,7 +59,8 @@ func TestRegisterNilFails(t *testing.T) {
 }
 
 func TestReRegisterFails(t *testing.T) {
-	r := registry{}
+	r := newRegistry()
+
 	err := r.Register("name", reloadable{})
 	assert.NoError(t, err)
 

--- a/libbeat/common/reload/reload_test.go
+++ b/libbeat/common/reload/reload_test.go
@@ -31,39 +31,44 @@ func (reloadable) Reload(config *ConfigWithMeta) error       { return nil }
 func (reloadableList) Reload(config []*ConfigWithMeta) error { return nil }
 
 func RegisterReloadable(t *testing.T) {
-	r := reloadable{}
+	obj := reloadable{}
+	r := registry{}
 
-	MustRegister("my.reloadable", reloadable{})
+	r.Register("my.reloadable", obj)
 
-	assert.Equal(t, r, Get("my.reloadable"))
+	assert.Equal(t, obj, r.Get("my.reloadable"))
 }
 
 func RegisterReloadableList(t *testing.T) {
-	r := reloadableList{}
+	objl := reloadableList{}
+	r := registry{}
 
-	MustRegisterList("my.reloadable", reloadableList{})
+	r.RegisterList("my.reloadable", objl)
 
-	assert.Equal(t, r, Get("my.reloadable"))
+	assert.Equal(t, objl, r.Get("my.reloadable"))
 }
 
 func TestRegisterNilFails(t *testing.T) {
-	assert.Panics(t, func() {
-		MustRegister("name", nil)
-	})
+	r := registry{}
 
-	assert.Panics(t, func() {
-		MustRegisterList("name", nil)
-	})
+	err := r.Register("name", nil)
+	assert.Error(t, err)
+
+	err = r.RegisterList("name", nil)
+	assert.Error(t, err)
 }
 
 func TestReRegisterFails(t *testing.T) {
-	assert.Panics(t, func() {
-		MustRegister("name", reloadable{})
-		MustRegister("name", reloadable{})
-	})
+	r := registry{}
+	err := r.Register("name", reloadable{})
+	assert.NoError(t, err)
 
-	assert.Panics(t, func() {
-		MustRegisterList("mylist", reloadableList{})
-		MustRegisterList("mylist", reloadableList{})
-	})
+	err = r.Register("name", reloadable{})
+	assert.Error(t, err)
+
+	err = r.RegisterList("name", reloadableList{})
+	assert.NoError(t, err)
+
+	err = r.RegisterList("name", reloadableList{})
+	assert.Error(t, err)
 }


### PR DESCRIPTION
This change allows us to register reloadable blocks of configurations while instantiating them. Central management will use this registry to retrieve reloadable blocks and handle their configs.