### PR TITLE
fixing typo in title

### DIFF
--- a/metricbeat/module/postgresql/statement/_meta/docs.asciidoc
+++ b/metricbeat/module/postgresql/statement/_meta/docs.asciidoc
@@ -1,3 +1,3 @@
-=== postgresql statement MetricSet
+=== PostgreSQL statement metricset
 
 This is the statement metricset of the module postgresql.


### PR DESCRIPTION
currently there is a typo in the metricbeat documentation:

![grafik](https://user-images.githubusercontent.com/84055/45028105-056b8f80-b044-11e8-8332-d74e76b5c573.png)

This PR will correct this.