### PR TITLE
Cherry-pick #8209 to 6.4: Disable kubernetes integration tests

### DIFF
--- a/metricbeat/docker-compose.yml
+++ b/metricbeat/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - ./module/jolokia/_meta/env
       - ./module/kafka/_meta/env
       - ./module/kibana/_meta/env
-      - ./module/kubernetes/_meta/env
+      #- ./module/kubernetes/_meta/env
       - ./module/logstash/_meta/env
       - ./module/memcached/_meta/env
       - ./module/mongodb/_meta/env
@@ -108,23 +108,23 @@ services:
   kibana:
     build: ./module/kibana/_meta
 
-  kubernetes:
-    build: ./module/kubernetes/_meta
-    network_mode: host
-    pid: host
-    privileged: true
-    volumes:
-      - /:/rootfs:ro
-      - /sys:/sys
-      - /var/lib/docker:/var/lib/docker
-      - /var/run:/var/run
+  #kubernetes:
+  #  build: ./module/kubernetes/_meta
+  #  network_mode: host
+  #  pid: host
+  #  privileged: true
+  #  volumes:
+  #    - /:/rootfs:ro
+  #    - /sys:/sys
+  #    - /var/lib/docker:/var/lib/docker
+  #    - /var/run:/var/run
 
-  kubestate:
-    build:
-      context: ./module/kubernetes/_meta/
-      dockerfile: Dockerfile.kube-state
-    depends_on:
-      - kubernetes
+  #kubestate:
+  #  build:
+  #    context: ./module/kubernetes/_meta/
+  #    dockerfile: Dockerfile.kube-state
+  #  depends_on:
+  #    - kubernetes
 
   logstash:
     build: ./module/logstash/_meta

--- a/metricbeat/tests/system/test_kubernetes.py
+++ b/metricbeat/tests/system/test_kubernetes.py
@@ -7,24 +7,25 @@ KUBERNETES_FIELDS = metricbeat.COMMON_FIELDS + ["kubernetes"]
 
 class Test(metricbeat.BaseTest):
 
-    COMPOSE_SERVICES = ['kubernetes']  # 'kubestate']
+    # Tests are disabled as current docker-compose settings fail to start in many cases:
+    # COMPOSE_SERVICES = ['kubernetes']  # 'kubestate']
 
-    @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
+    @unittest.skipUnless(False and metricbeat.INTEGRATION_TESTS, "integration test")
     def test_kubelet_node(self):
         """ Kubernetes kubelet node metricset tests """
         self._test_metricset('node', 1, self.get_kubelet_hosts())
 
-    @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
+    @unittest.skipUnless(False and metricbeat.INTEGRATION_TESTS, "integration test")
     def test_kubelet_system(self):
         """ Kubernetes kubelet system metricset tests """
         self._test_metricset('system', 2, self.get_kubelet_hosts())
 
-    @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
+    @unittest.skipUnless(False and metricbeat.INTEGRATION_TESTS, "integration test")
     def test_kubelet_pod(self):
         """ Kubernetes kubelet pod metricset tests """
         self._test_metricset('pod', 1, self.get_kubelet_hosts())
 
-    @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
+    @unittest.skipUnless(False and metricbeat.INTEGRATION_TESTS, "integration test")
     def test_kubelet_container(self):
         """ Kubernetes kubelet container metricset tests """
         self._test_metricset('container', 1, self.get_kubelet_hosts())
@@ -35,13 +36,13 @@ class Test(metricbeat.BaseTest):
         """ Kubernetes state node metricset tests """
         self._test_metricset('state_node', 1, self.get_kube_state_hosts())
 
-    @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
+    @unittest.skipUnless(False and metricbeat.INTEGRATION_TESTS, "integration test")
     @unittest.skip("flacky kube-state-metrics container healthcheck")
     def test_state_pod(self):
         """ Kubernetes state pod metricset tests """
         self._test_metricset('state_pod', 1, self.get_kube_state_hosts())
 
-    @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
+    @unittest.skipUnless(False and metricbeat.INTEGRATION_TESTS, "integration test")
     @unittest.skip("flacky kube-state-metrics container healthcheck")
     def test_state_container(self):
         """ Kubernetes state container metricset tests """


### PR DESCRIPTION
Cherry-pick of PR #8209 to 6.4 branch. Original message: 

They are not deterministic as of today, the kubernetes docker-compose
is failing sometimes.

Closes #7973