### PR TITLE
Add a wait baseline when looking up registry values

### DIFF
--- a/filebeat/tests/system/test_registrar.py
+++ b/filebeat/tests/system/test_registrar.py
@@ -809,9 +809,8 @@ class Test(BaseTest):
             lambda: self.log_contains_count("Registry file updated") > 1,
             max_timeout=15)
 
-        if os.name == "nt":
-            # On windows registry recreation can take a bit longer
-            time.sleep(1)
+        # Syncing file on disk is always susceptible to timing issues.
+        time.sleep(1)
 
         data = self.get_registry()
         assert len(data) == 2


### PR DESCRIPTION
With the nature of VMs and disk, writing or reading a file can be out of sync.
Instead of only sleeping only the windows case we sleep on every tested
platform before asserting the content of the registry.

closes #8102 

**Notes:** I am not a fan of adding sleeps call to existing code, but we are in the processing of writing a new registry. The new system offer better way to look for changes in the form of an oplog. So we could refactor the test to check for opload changes instead of the active registry.