### PR TITLE
Try to fix failures in mac builds in travis for 5.6 branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,7 @@ matrix:
       env: TARGETS="-C metricbeat testsuite"
       go: $GO_VERSION
     - os: osx
+      osx_image: xcode9.3
       env: TARGETS="TEST_ENVIRONMENT=0 -C metricbeat testsuite"
       go: $GO_VERSION
     - os: linux


### PR DESCRIPTION
Mac builds in travis for branch 5.6 are failing because of test processes got killed, trying to fix it. According to Travis FAQ, it could be related to some resource exhaustion.

https://docs.travis-ci.com/user/common-build-problems/#my-build-script-is-killed-without-any-error