### PR TITLE
Update Elasticsearch module examples to show http in the URL

### DIFF
--- a/libbeat/docs/shared-kibana-config.asciidoc
+++ b/libbeat/docs/shared-kibana-config.asciidoc
@@ -35,7 +35,7 @@ Here is an example configuration:
 
 [source,yaml]
 ----
-setup.kibana.host: "localhost:5601"
+setup.kibana.host: "http://localhost:5601"
 ----
 
 [float]
@@ -71,7 +71,7 @@ Example config:
 [source,yaml]
 ----
 setup.kibana.host: "192.0.2.255:5601"
-setup.kibana.protocol: "https"
+setup.kibana.protocol: "http"
 setup.kibana.path: /kibana
 ----
 
@@ -109,8 +109,7 @@ Example configuration:
 
 [source,yaml]
 ----
-setup.kibana.host: "192.0.2.255:5601"
-setup.kibana.protocol: "https"
+setup.kibana.host: "https://192.0.2.255:5601"
 setup.kibana.ssl.enabled: true
 setup.kibana.ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 setup.kibana.ssl.certificate: "/etc/pki/client/cert.pem"

--- a/libbeat/docs/shared-ssl-config.asciidoc
+++ b/libbeat/docs/shared-ssl-config.asciidoc
@@ -13,7 +13,7 @@ Example output config with SSL enabled:
 
 [source,yaml]
 ----
-output.elasticsearch.hosts: ["192.168.1.42:9200"]
+output.elasticsearch.hosts: ["https://192.168.1.42:9200"]
 output.elasticsearch.ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 output.elasticsearch.ssl.certificate: "/etc/pki/client/cert.pem"
 output.elasticsearch.ssl.key: "/etc/pki/client/cert.key"
@@ -27,8 +27,7 @@ Example Kibana endpoint config with SSL enabled:
 
 [source,yaml]
 ----
-setup.kibana.host: "192.0.2.255:5601"
-setup.kibana.protocol: "https"
+setup.kibana.host: "https://192.0.2.255:5601"
 setup.kibana.ssl.enabled: true
 setup.kibana.ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 setup.kibana.ssl.certificate: "/etc/pki/client/cert.pem"

--- a/metricbeat/docs/modules/elasticsearch.asciidoc
+++ b/metricbeat/docs/modules/elasticsearch.asciidoc
@@ -37,7 +37,7 @@ metricbeat.modules:
     #- shard
     #- ml_job
   period: 10s
-  hosts: ["localhost:9200"]
+  hosts: ["http://localhost:9200"]
 
   # Set to false to fetch all entries
   #index_recovery.active_only: true

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -204,7 +204,7 @@ metricbeat.modules:
     #- shard
     #- ml_job
   period: 10s
-  hosts: ["localhost:9200"]
+  hosts: ["http://localhost:9200"]
 
   # Set to false to fetch all entries
   #index_recovery.active_only: true

--- a/metricbeat/module/elasticsearch/_meta/config.reference.yml
+++ b/metricbeat/module/elasticsearch/_meta/config.reference.yml
@@ -8,7 +8,7 @@
     #- shard
     #- ml_job
   period: 10s
-  hosts: ["localhost:9200"]
+  hosts: ["http://localhost:9200"]
 
   # Set to false to fetch all entries
   #index_recovery.active_only: true

--- a/metricbeat/module/elasticsearch/_meta/config.yml
+++ b/metricbeat/module/elasticsearch/_meta/config.yml
@@ -3,6 +3,6 @@
   #  - node
   #  - node_stats
   period: 10s
-  hosts: ["localhost:9200"]
+  hosts: ["http://localhost:9200"]
   #username: "user"
   #password: "secret"

--- a/metricbeat/modules.d/elasticsearch.yml.disabled
+++ b/metricbeat/modules.d/elasticsearch.yml.disabled
@@ -6,6 +6,6 @@
   #  - node
   #  - node_stats
   period: 10s
-  hosts: ["localhost:9200"]
+  hosts: ["http://localhost:9200"]
   #username: "user"
   #password: "secret"


### PR DESCRIPTION
Closes https://github.com/elastic/beats/issues/6115

I've updated the examples by removing `protocol` from the examples *except* where we specifically describe the `protocol` option. 