### PR TITLE
Force pull of images on `make start-environment`

### DIFF
--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -377,6 +377,7 @@ build-image: write-environment
 # To use it for running the test, set ES_HOST and REDIS_HOST environment variable to the ip of your docker-machine.
 .PHONY: start-environment
 start-environment: stop-environment
+	${DOCKER_COMPOSE} pull --include-deps
 	${DOCKER_COMPOSE} up -d
 
 .PHONY: stop-environment


### PR DESCRIPTION
When using snapshots, image could be outdated, force pulling images before starting environment.

Ported from #8204 