### PR TITLE
Cherry-pick #8219 to 6.3: Add missing changelog entry for #6641

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -196,6 +196,7 @@ https://github.com/elastic/beats/compare/v6.2.3...v6.3.0[View commits]
 - Fix map overwrite panics by cloning shared structs before doing the update. {pull}6947[6947]
 - Fix delays on autodiscovery events handling caused by blocking runner stops. {pull}7170[7170]
 - Do not emit Kubernetes autodiscover events for Pods without IP address. {pull}7235[7235]
+- Fix self metrics when containerized {pull}6641[6641]
 
 *Auditbeat*
 


### PR DESCRIPTION
Cherry-pick of PR #8219 to 6.3 branch. Original message: 

It should have been added since 6.3.0, but it wasn't then.