### PR TITLE
Cherry-pick #8223 to 6.3: Fix a race condition with the add_host_metadata processor

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -29,6 +29,8 @@ https://github.com/elastic/beats/compare/v6.3.2...6.3[Check the HEAD diff]
 
 *Affecting all Beats*
 
+- Fix a race condition with the `add_host_metadata` and the event serialization. {pull}8223[8223]
+
 *Auditbeat*
 
 *Filebeat*

--- a/libbeat/processors/add_host_metadata/add_host_metadata.go
+++ b/libbeat/processors/add_host_metadata/add_host_metadata.go
@@ -38,7 +38,7 @@ func newHostMetadataProcessor(_ *common.Config) (processors.Processor, error) {
 // Run enriches the given event with the host meta data
 func (p *addHostMetadata) Run(event *beat.Event) (*beat.Event, error) {
 	p.loadData()
-	event.Fields.DeepUpdate(p.data)
+	event.Fields.DeepUpdate(p.data.Clone())
 	return event, nil
 }
 


### PR DESCRIPTION
Fix a race between updating the host data structure and the
serialization of events to json.

closes #8040

(cherry picked from commit 415715d5e7e63fa89c08976e1454686ea5963a6d)