### PR TITLE
Cherry-pick #8223 to 6.x: Fix a race condition with the add_host_metadata processor

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -40,6 +40,7 @@ https://github.com/elastic/beats/compare/v6.4.0...6.x[Check the HEAD diff]
 - Deregister pipeline loader callback when inputsRunner is stopped. {pull}[7893][7893]
 - Add backoff support to x-pack monitoring outputs. {issue}7966[7966]
 - Removed execute permissions systemd unit file. {pull}7873[7873]
+- Fix a race condition with the `add_host_metadata` and the event serialization. {pull}8223[8223]
 
 *Auditbeat*
 

--- a/libbeat/processors/add_host_metadata/add_host_metadata.go
+++ b/libbeat/processors/add_host_metadata/add_host_metadata.go
@@ -70,7 +70,7 @@ func newHostMetadataProcessor(cfg *common.Config) (processors.Processor, error) 
 // Run enriches the given event with the host meta data
 func (p *addHostMetadata) Run(event *beat.Event) (*beat.Event, error) {
 	p.loadData()
-	event.Fields.DeepUpdate(p.data)
+	event.Fields.DeepUpdate(p.data.Clone())
 	return event, nil
 }
 


### PR DESCRIPTION
Cherry-pick of PR #8223 to 6.x branch. Original message: 

Fix a race between updating the host data structure and the
serialization of events to json.

closes #8040