### PR TITLE
[WIP] Add community dashboards page.

### DIFF
--- a/docs/devguide/contributing.asciidoc
+++ b/docs/devguide/contributing.asciidoc
@@ -45,7 +45,7 @@ Beats].
 [[adding-new-dashboard]]
 === Adding a New Dashboard
 
-If you want to create a new Dashboard, please read <<community-dashboards>>. You don't need to
+If you want to create a new dashboard, please read <<community-dashboards>>. You don't need to
 submit the code to this repository. Most new Beats start in their own repository
 and just make use of the libbeat packages. After you have a working Beat that
 you'd like to share with others, open a PR to add it to our list of

--- a/docs/devguide/contributing.asciidoc
+++ b/docs/devguide/contributing.asciidoc
@@ -40,6 +40,18 @@ you'd like to share with others, open a PR to add it to our list of
 https://github.com/elastic/beats/blob/master/libbeat/docs/communitybeats.asciidoc[community
 Beats].
 
+
+[float]
+[[adding-new-dashboard]]
+=== Adding a New Dashboard
+
+If you want to create a new Dashboard, please read <<community-dashboards>>. You don't need to
+submit the code to this repository. Most new Beats start in their own repository
+and just make use of the libbeat packages. After you have a working Beat that
+you'd like to share with others, open a PR to add it to our list of
+https://github.com/elastic/beats/blob/master/libbeat/docs/communitybeats.asciidoc[community
+Beats].
+
 [float]
 [[setting-up-dev-environment]]
 === Setting Up Your Dev Environment

--- a/libbeat/docs/communitydashboards.asciidoc
+++ b/libbeat/docs/communitydashboards.asciidoc
@@ -4,26 +4,27 @@
 //////////////////////////////////////////////////////////////////////////
 
 [[community-dashboards]]
-== Community Beats
+== Community Dashboards
 
 The open source community has been hard at work developing new Dashboards. You can check
 out some of them here. For information on exporting and importing dashboards see the documentation for
-https://www.elastic.co/guide/en/kibana/current/managing-saved-objects.html[Kibana Saved Objects].
+{kibana-ref}/managing-saved-objects.html[Kibana Saved Objects].
 
-Have a question about a community Dashboard? You can post questions and discuss issues in the
+Have a question about a community dashboard? You can post questions and discuss issues in the
 https://discuss.elastic.co/c/beats/community-dashboards[Community Dashboards] category of the Beats discussion forum.
 
-Have you created a Dashboard that's not listed? Add the name, description, and link to the homepage  of your Dashboard
+Have you created a dashboard that's not listed? Add the name, description, and link to the homepage of your dashboard
 to the source document for https://github.com/elastic/beats/blob/master/libbeat/docs/communitydashboards.asciidoc[Community Dashboards]
 and https://help.github.com/articles/using-pull-requests[open a pull request] in the https://github.com/elastic/beats[Beats GitHub repository]
 to get your change merged. When you're ready, go ahead and https://discuss.elastic.co/c/announcements[announce]
-your new Beat in the Elastic discussion forum.
+your new dashboard in the Elastic discussion forum.
 
 ifndef::dev-guide[]
 Want to contribute? See <<contributing-to-beats>>.
 endif::[]
 
-NOTE: Elastic provides no warranty or support for community-sourced Dashboards.
+NOTE: Elastic provides no warranty or support for community-sourced dashboards.
 
 [horizontal]
 
+https://github.com/elastic/somedashboard[somedashboard]:: Reads some data, and shows it on some dashboard.

--- a/libbeat/docs/communitydashboards.asciidoc
+++ b/libbeat/docs/communitydashboards.asciidoc
@@ -1,0 +1,29 @@
+//////////////////////////////////////////////////////////////////////////
+//// This content appears in both the Beats Platform Reference and the
+//// Beats Developer Guide.
+//////////////////////////////////////////////////////////////////////////
+
+[[community-dashboards]]
+== Community Beats
+
+The open source community has been hard at work developing new Dashboards. You can check
+out some of them here. For information on exporting and importing dashboards see the documentation for
+https://www.elastic.co/guide/en/kibana/current/managing-saved-objects.html[Kibana Saved Objects].
+
+Have a question about a community Dashboard? You can post questions and discuss issues in the
+https://discuss.elastic.co/c/beats/community-dashboards[Community Dashboards] category of the Beats discussion forum.
+
+Have you created a Dashboard that's not listed? Add the name, description, and link to the homepage  of your Dashboard
+to the source document for https://github.com/elastic/beats/blob/master/libbeat/docs/communitydashboards.asciidoc[Community Dashboards]
+and https://help.github.com/articles/using-pull-requests[open a pull request] in the https://github.com/elastic/beats[Beats GitHub repository]
+to get your change merged. When you're ready, go ahead and https://discuss.elastic.co/c/announcements[announce]
+your new Beat in the Elastic discussion forum.
+
+ifndef::dev-guide[]
+Want to contribute? See <<contributing-to-beats>>.
+endif::[]
+
+NOTE: Elastic provides no warranty or support for community-sourced Dashboards.
+
+[horizontal]
+

--- a/libbeat/docs/index.asciidoc
+++ b/libbeat/docs/index.asciidoc
@@ -19,6 +19,8 @@ include::./overview.asciidoc[]
 
 include::./communitybeats.asciidoc[]
 
+include::./communitydashboards.asciidoc[]
+
 include::./gettingstarted.asciidoc[]
 
 include::./breaking.asciidoc[]


### PR DESCRIPTION
This is an initial take on a community dashboard's page. The goal of this page is to make it easier for the community to share dashboards in a semi-official way with as little friction as possible.

I think we should seed this page with at least one community dashboard to give an idea of how this all works.

I'm also wondering if we should have more detailed discussions.

At any rate, I think this is a good starting point for this page. Looking forward to other's feedback.