### PR TITLE
Cherry-pick #8240 to 6.x: Clone any cached data from docker and k8s

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -41,6 +41,7 @@ https://github.com/elastic/beats/compare/v6.4.0...6.x[Check the HEAD diff]
 - Add backoff support to x-pack monitoring outputs. {issue}7966[7966]
 - Removed execute permissions systemd unit file. {pull}7873[7873]
 - Fix a race condition with the `add_host_metadata` and the event serialization. {pull}8223[8223]
+- Enforce that data used by k8s or docker doesn't use any reference. {pull}8240[8240]
 
 *Auditbeat*
 

--- a/libbeat/processors/add_docker_metadata/add_docker_metadata.go
+++ b/libbeat/processors/add_docker_metadata/add_docker_metadata.go
@@ -181,7 +181,7 @@ func (d *addDockerMetadata) Run(event *beat.Event) (*beat.Event, error) {
 		meta.Put("container.id", container.ID)
 		meta.Put("container.image", container.Image)
 		meta.Put("container.name", container.Name)
-		event.Fields["docker"] = meta
+		event.Fields["docker"] = meta.Clone()
 	} else {
 		d.log.Debugf("Container not found: cid=%s", cid)
 	}

--- a/libbeat/processors/add_kubernetes_metadata/kubernetes.go
+++ b/libbeat/processors/add_kubernetes_metadata/kubernetes.go
@@ -155,7 +155,7 @@ func (k *kubernetesAnnotator) Run(event *beat.Event) (*beat.Event, error) {
 	}
 
 	event.Fields.DeepUpdate(common.MapStr{
-		"kubernetes": metadata,
+		"kubernetes": metadata.Clone(),
 	})
 
 	return event, nil


### PR DESCRIPTION
Cherry-pick of PR #8240 to 6.x branch. Original message: 

Using cached data can lead to race condition if we have some reference
in place, this commit force a clone on the retrieved data so each event
has his own copy.