### PR TITLE
Cherry-pick #8193 to 6.x: Start docker-machine for packaging on Jenkins

### DIFF
--- a/dev-tools/common.bash
+++ b/dev-tools/common.bash
@@ -96,3 +96,14 @@ jenkins_setup() {
   # each run starts from a clean slate.
   export MAGEFILE_CACHE="${WORKSPACE}/.magefile"
 }
+
+docker_setup() {
+  OS="$(uname)"
+  case $OS in
+    'Darwin')
+      # Start the docker machine VM (ignore error if it's already running).
+      docker-machine start default || true
+      eval $(docker-machine env default)
+      ;;
+  esac
+}

--- a/dev-tools/jenkins_release.sh
+++ b/dev-tools/jenkins_release.sh
@@ -7,6 +7,7 @@ set -euox pipefail
 source $(dirname "$0")/common.bash
 
 jenkins_setup
+docker_setup
 
 cleanup() {
   echo "Running cleanup..."


### PR DESCRIPTION
Cherry-pick of PR #8193 to 6.x branch. Original message: 

The Docker setup steps that are necessary on macOS hosts are moved here so we don't have to tweak things in JJB when changes need to be made.