### PR TITLE
Cherry-pick #8205 to 6.x: Add a reloadable objects registry

### DIFF
--- a/libbeat/autodiscover/autodiscover.go
+++ b/libbeat/autodiscover/autodiscover.go
@@ -27,6 +27,7 @@ import (
 	"github.com/elastic/beats/libbeat/cfgfile"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/bus"
+	"github.com/elastic/beats/libbeat/common/reload"
 	"github.com/elastic/beats/libbeat/logp"
 )
 
@@ -59,7 +60,7 @@ type Autodiscover struct {
 	defaultPipeline beat.Pipeline
 	adapter         Adapter
 	providers       []Provider
-	configs         map[uint64]*cfgfile.ConfigWithMeta
+	configs         map[uint64]*reload.ConfigWithMeta
 	runners         *cfgfile.RunnerList
 	meta            *meta.Map
 
@@ -86,7 +87,7 @@ func NewAutodiscover(name string, pipeline beat.Pipeline, adapter Adapter, confi
 		bus:             bus,
 		defaultPipeline: pipeline,
 		adapter:         adapter,
-		configs:         map[uint64]*cfgfile.ConfigWithMeta{},
+		configs:         map[uint64]*reload.ConfigWithMeta{},
 		runners:         cfgfile.NewRunnerList("autodiscover", adapter, pipeline),
 		providers:       providers,
 		meta:            meta.NewMap(),
@@ -135,7 +136,7 @@ func (a *Autodiscover) worker() {
 				logp.Debug(debugK, "Reloading existing autodiscover configs after error")
 			}
 
-			configs := make([]*cfgfile.ConfigWithMeta, 0, len(a.configs))
+			configs := make([]*reload.ConfigWithMeta, 0, len(a.configs))
 			for _, c := range a.configs {
 				configs = append(configs, c)
 			}
@@ -182,7 +183,7 @@ func (a *Autodiscover) handleStart(event bus.Event) bool {
 			continue
 		}
 
-		a.configs[hash] = &cfgfile.ConfigWithMeta{
+		a.configs[hash] = &reload.ConfigWithMeta{
 			Config: config,
 			Meta:   &dynFields,
 		}

--- a/libbeat/cfgfile/list.go
+++ b/libbeat/cfgfile/list.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/reload"
 	"github.com/elastic/beats/libbeat/logp"
 )
 
@@ -36,15 +37,6 @@ type RunnerList struct {
 	factory  RunnerFactory
 	pipeline beat.Pipeline
 	logger   *logp.Logger
-}
-
-// ConfigWithMeta holds a pair of common.Config and optional metadata for it
-type ConfigWithMeta struct {
-	// Config to store
-	Config *common.Config
-
-	// Meta data related to this config
-	Meta *common.MapStrPointer
 }
 
 // NewRunnerList builds and returns a RunnerList
@@ -58,13 +50,13 @@ func NewRunnerList(name string, factory RunnerFactory, pipeline beat.Pipeline) *
 }
 
 // Reload the list of runners to match the given state
-func (r *RunnerList) Reload(configs []*ConfigWithMeta) error {
+func (r *RunnerList) Reload(configs []*reload.ConfigWithMeta) error {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
 
 	var errs multierror.Errors
 
-	startList := map[uint64]*ConfigWithMeta{}
+	startList := map[uint64]*reload.ConfigWithMeta{}
 	stopList := r.copyRunnerList()
 
 	r.logger.Debugf("Starting reload procedure, current runners: %d", len(stopList))

--- a/libbeat/cfgfile/list_test.go
+++ b/libbeat/cfgfile/list_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/reload"
 )
 
 type runner struct {
@@ -66,7 +67,7 @@ func TestNewConfigs(t *testing.T) {
 	factory := &runnerFactory{}
 	list := NewRunnerList("", factory, nil)
 
-	list.Reload([]*ConfigWithMeta{
+	list.Reload([]*reload.ConfigWithMeta{
 		createConfig(1),
 		createConfig(2),
 		createConfig(3),
@@ -79,7 +80,7 @@ func TestReloadSameConfigs(t *testing.T) {
 	factory := &runnerFactory{}
 	list := NewRunnerList("", factory, nil)
 
-	list.Reload([]*ConfigWithMeta{
+	list.Reload([]*reload.ConfigWithMeta{
 		createConfig(1),
 		createConfig(2),
 		createConfig(3),
@@ -88,7 +89,7 @@ func TestReloadSameConfigs(t *testing.T) {
 	state := list.copyRunnerList()
 	assert.Equal(t, len(state), 3)
 
-	list.Reload([]*ConfigWithMeta{
+	list.Reload([]*reload.ConfigWithMeta{
 		createConfig(1),
 		createConfig(2),
 		createConfig(3),
@@ -102,7 +103,7 @@ func TestReloadStopConfigs(t *testing.T) {
 	factory := &runnerFactory{}
 	list := NewRunnerList("", factory, nil)
 
-	list.Reload([]*ConfigWithMeta{
+	list.Reload([]*reload.ConfigWithMeta{
 		createConfig(1),
 		createConfig(2),
 		createConfig(3),
@@ -110,7 +111,7 @@ func TestReloadStopConfigs(t *testing.T) {
 
 	assert.Equal(t, len(list.copyRunnerList()), 3)
 
-	list.Reload([]*ConfigWithMeta{
+	list.Reload([]*reload.ConfigWithMeta{
 		createConfig(1),
 		createConfig(3),
 	})
@@ -122,7 +123,7 @@ func TestReloadStartStopConfigs(t *testing.T) {
 	factory := &runnerFactory{}
 	list := NewRunnerList("", factory, nil)
 
-	list.Reload([]*ConfigWithMeta{
+	list.Reload([]*reload.ConfigWithMeta{
 		createConfig(1),
 		createConfig(2),
 		createConfig(3),
@@ -131,7 +132,7 @@ func TestReloadStartStopConfigs(t *testing.T) {
 	state := list.copyRunnerList()
 	assert.Equal(t, len(state), 3)
 
-	list.Reload([]*ConfigWithMeta{
+	list.Reload([]*reload.ConfigWithMeta{
 		createConfig(1),
 		createConfig(3),
 		createConfig(4),
@@ -145,7 +146,7 @@ func TestStopAll(t *testing.T) {
 	factory := &runnerFactory{}
 	list := NewRunnerList("", factory, nil)
 
-	list.Reload([]*ConfigWithMeta{
+	list.Reload([]*reload.ConfigWithMeta{
 		createConfig(1),
 		createConfig(2),
 		createConfig(3),
@@ -170,7 +171,7 @@ func TestHas(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	list.Reload([]*ConfigWithMeta{
+	list.Reload([]*reload.ConfigWithMeta{
 		config,
 	})
 
@@ -178,10 +179,10 @@ func TestHas(t *testing.T) {
 	assert.False(t, list.Has(0))
 }
 
-func createConfig(id int64) *ConfigWithMeta {
+func createConfig(id int64) *reload.ConfigWithMeta {
 	c := common.NewConfig()
 	c.SetInt("id", -1, id)
-	return &ConfigWithMeta{
+	return &reload.ConfigWithMeta{
 		Config: c,
 	}
 }

--- a/libbeat/cfgfile/reload.go
+++ b/libbeat/cfgfile/reload.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/reload"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/monitoring"
 	"github.com/elastic/beats/libbeat/paths"
@@ -203,9 +204,9 @@ func (rl *Reloader) Run(runnerFactory RunnerFactory) {
 	}
 }
 
-func (rl *Reloader) loadConfigs(files []string) ([]*ConfigWithMeta, error) {
+func (rl *Reloader) loadConfigs(files []string) ([]*reload.ConfigWithMeta, error) {
 	// Load all config objects
-	result := []*ConfigWithMeta{}
+	result := []*reload.ConfigWithMeta{}
 	var errs multierror.Errors
 	for _, file := range files {
 		configs, err := LoadList(file)
@@ -216,7 +217,7 @@ func (rl *Reloader) loadConfigs(files []string) ([]*ConfigWithMeta, error) {
 		}
 
 		for _, c := range configs {
-			result = append(result, &ConfigWithMeta{Config: c})
+			result = append(result, &reload.ConfigWithMeta{Config: c})
 		}
 	}
 

--- a/libbeat/common/reload/reload.go
+++ b/libbeat/common/reload/reload.go
@@ -1,0 +1,135 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package reload
+
+import (
+	"sync"
+
+	"github.com/pkg/errors"
+
+	"github.com/elastic/beats/libbeat/common"
+)
+
+// Register holds a registry of reloadable objects
+var Register = newRegistry()
+
+// ConfigWithMeta holds a pair of common.Config and optional metadata for it
+type ConfigWithMeta struct {
+	// Config to store
+	Config *common.Config
+
+	// Meta data related to this config
+	Meta *common.MapStrPointer
+}
+
+// ReloadableList provides a method to reload the configuration of a list of entities
+type ReloadableList interface {
+	Reload(configs []*ConfigWithMeta) error
+}
+
+// Reloadable provides a method to reload the configuration of an entity
+type Reloadable interface {
+	Reload(config *ConfigWithMeta) error
+}
+
+type registry struct {
+	sync.RWMutex
+	confsLists map[string]ReloadableList
+	confs      map[string]Reloadable
+}
+
+func newRegistry() *registry {
+	return &registry{
+		confsLists: make(map[string]ReloadableList),
+		confs:      make(map[string]Reloadable),
+	}
+}
+
+// Register declares a reloadable object
+func (r *registry) Register(name string, obj Reloadable) error {
+	r.Lock()
+	defer r.Unlock()
+
+	if obj == nil {
+		return errors.New("got a nil object")
+	}
+
+	if r.nameTaken(name) {
+		return errors.Errorf("%s configuration list is already registered", name)
+	}
+
+	r.confs[name] = obj
+	return nil
+}
+
+// RegisterList declares a reloadable list of configurations
+func (r *registry) RegisterList(name string, list ReloadableList) error {
+	r.Lock()
+	defer r.Unlock()
+
+	if list == nil {
+		return errors.New("got a nil object")
+	}
+
+	if r.nameTaken(name) {
+		return errors.Errorf("%s configuration is already registered", name)
+	}
+
+	r.confsLists[name] = list
+	return nil
+}
+
+// MustRegister declares a reloadable object
+func (r *registry) MustRegister(name string, obj Reloadable) {
+	if err := r.Register(name, obj); err != nil {
+		panic(err)
+	}
+}
+
+// MustRegisterList declares a reloadable object list
+func (r *registry) MustRegisterList(name string, list ReloadableList) {
+	if err := r.RegisterList(name, list); err != nil {
+		panic(err)
+	}
+}
+
+// Get returns the reloadable object with the given name, nil if not found
+func (r *registry) Get(name string) Reloadable {
+	r.RLock()
+	defer r.RUnlock()
+	return r.confs[name]
+}
+
+// GetList returns the reloadable list with the given name, nil if not found
+func (r *registry) GetList(name string) ReloadableList {
+	r.RLock()
+	defer r.RUnlock()
+	return r.confsLists[name]
+}
+
+func (r *registry) nameTaken(name string) bool {
+	if _, ok := r.confs[name]; ok {
+		return true
+	}
+
+	if _, ok := r.confsLists[name]; ok {
+		return true
+	}
+
+	return false
+}

--- a/libbeat/common/reload/reload_test.go
+++ b/libbeat/common/reload/reload_test.go
@@ -1,0 +1,83 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package reload
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type reloadable struct{}
+type reloadableList struct{}
+
+func (reloadable) Reload(config *ConfigWithMeta) error       { return nil }
+func (reloadableList) Reload(config []*ConfigWithMeta) error { return nil }
+
+func RegisterReloadable(t *testing.T) {
+	obj := reloadable{}
+	r := newRegistry()
+
+	r.Register("my.reloadable", obj)
+
+	assert.Equal(t, obj, r.Get("my.reloadable"))
+}
+
+func RegisterReloadableList(t *testing.T) {
+	objl := reloadableList{}
+	r := newRegistry()
+
+	r.RegisterList("my.reloadable", objl)
+
+	assert.Equal(t, objl, r.Get("my.reloadable"))
+}
+
+func TestRegisterNilFails(t *testing.T) {
+	r := newRegistry()
+
+	err := r.Register("name", nil)
+	assert.Error(t, err)
+
+	err = r.RegisterList("name", nil)
+	assert.Error(t, err)
+}
+
+func TestReRegisterFails(t *testing.T) {
+	r := newRegistry()
+
+	// two obj with the same name
+	err := r.Register("name", reloadable{})
+	assert.NoError(t, err)
+
+	err = r.Register("name", reloadable{})
+	assert.Error(t, err)
+
+	// two lists with the same name
+	err = r.RegisterList("foo", reloadableList{})
+	assert.NoError(t, err)
+
+	err = r.RegisterList("foo", reloadableList{})
+	assert.Error(t, err)
+
+	// one of each with the same name
+	err = r.Register("bar", reloadable{})
+	assert.NoError(t, err)
+
+	err = r.RegisterList("bar", reloadableList{})
+	assert.Error(t, err)
+}


### PR DESCRIPTION
Cherry-pick of PR #8205 to 6.x branch. Original message: 

This change allows us to register reloadable blocks of configurations while instantiating them. Central management will use this registry to retrieve reloadable blocks and handle their configs.