### PR TITLE
Cleanup: xpack code for `elasticsearch/index_summary` metricset

### DIFF
--- a/metricbeat/module/elasticsearch/index_summary/data_xpack.go
+++ b/metricbeat/module/elasticsearch/index_summary/data_xpack.go
@@ -77,7 +77,6 @@ func eventMappingXPack(r mb.ReporterV2, m *MetricSet, info elasticsearch.Info, c
 
 	err := json.Unmarshal(content, &all)
 	if err != nil {
-		r.Error(err)
 		return []error{err}
 	}
 

--- a/metricbeat/module/elasticsearch/index_summary/data_xpack.go
+++ b/metricbeat/module/elasticsearch/index_summary/data_xpack.go
@@ -24,6 +24,7 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 	s "github.com/elastic/beats/libbeat/common/schema"
 	c "github.com/elastic/beats/libbeat/common/schema/mapstriface"
+	"github.com/elastic/beats/metricbeat/helper/elastic"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/module/elasticsearch"
 )
@@ -105,7 +106,7 @@ func eventMappingXPack(r mb.ReporterV2, m *MetricSet, info elasticsearch.Info, c
 	event.RootFields.Put("type", "indices_stats")
 	event.RootFields.Put("source_node", sourceNode)
 
-	event.Index = ".monitoring-es-6-mb"
+	event.Index = elastic.MakeXPackMonitoringIndexName(elastic.Elasticsearch)
 
 	r.Event(event)
 


### PR DESCRIPTION
This PR cleans up a couple of small things in the x-pack code of the `elasticsearch/index_summary` metricset:

- It un-hardcodes the name of the monitoring index that events will be reported into.
- It does not report errors as they will end up in `metricbeat-*` indices.