### PR TITLE
Adding x-pack code for `elasticsearch/index` metricset

### DIFF
--- a/metricbeat/module/elasticsearch/cluster_stats/cluster_stats.go
+++ b/metricbeat/module/elasticsearch/cluster_stats/cluster_stats.go
@@ -27,7 +27,7 @@ import (
 )
 
 func init() {
-	mb.Registry.MustAddMetricSet("elasticsearch", "cluster_stats", New,
+	mb.Registry.MustAddMetricSet(elasticsearch.ModuleName, "cluster_stats", New,
 		mb.WithHostParser(elasticsearch.HostParser),
 		mb.WithNamespace("elasticsearch.cluster.stats"),
 	)

--- a/metricbeat/module/elasticsearch/cluster_stats/data_xpack.go
+++ b/metricbeat/module/elasticsearch/cluster_stats/data_xpack.go
@@ -179,7 +179,8 @@ func eventMappingXPack(r mb.ReporterV2, m *MetricSet, content []byte) error {
 		return err
 	}
 
-	clusterState, err := elasticsearch.GetClusterState(m.HTTP, m.HTTP.GetURI())
+	clusterStateMetrics := []string{"version", "master_node", "nodes", "routing_table"}
+	clusterState, err := elasticsearch.GetClusterState(m.HTTP, m.HTTP.GetURI(), clusterStateMetrics)
 	if err != nil {
 		return err
 	}

--- a/metricbeat/module/elasticsearch/elasticsearch.go
+++ b/metricbeat/module/elasticsearch/elasticsearch.go
@@ -32,6 +32,9 @@ import (
 // Global clusterIdCache. Assumption is that the same node id never can belong to a different cluster id
 var clusterIDCache = map[string]string{}
 
+// ModuleName is the ame of this module
+const ModuleName = "elasticsearch"
+
 // Info construct contains the data from the Elasticsearch / endpoint
 type Info struct {
 	ClusterName string `json:"cluster_name"`

--- a/metricbeat/module/elasticsearch/elasticsearch.go
+++ b/metricbeat/module/elasticsearch/elasticsearch.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"strings"
 	"sync"
 	"time"
 
@@ -201,8 +202,13 @@ func GetLicense(http *helper.HTTP, resetURI string) (common.MapStr, error) {
 }
 
 // GetClusterState returns cluster state information
-func GetClusterState(http *helper.HTTP, resetURI string) (common.MapStr, error) {
-	content, err := fetchPath(http, resetURI, "_cluster/state/version,master_node,nodes,routing_table")
+func GetClusterState(http *helper.HTTP, resetURI string, metrics []string) (common.MapStr, error) {
+	clusterStateURI := "_cluster/state"
+	if metrics != nil && len(metrics) > 0 {
+		clusterStateURI += "/" + strings.Join(metrics, ",")
+	}
+
+	content, err := fetchPath(http, resetURI, clusterStateURI)
 	if err != nil {
 		return nil, err
 	}

--- a/metricbeat/module/elasticsearch/index/_meta/test/stats.700-alpha1.json
+++ b/metricbeat/module/elasticsearch/index/_meta/test/stats.700-alpha1.json
@@ -1,1601 +1,1601 @@
 {
     "_shards": {
-      "total": 9,
-      "successful": 8,
-      "failed": 0
+        "total": 9,
+        "successful": 8,
+        "failed": 0
     },
     "_all": {
-      "primaries": {
-        "docs": {
-          "count": 1257,
-          "deleted": 11
+        "primaries": {
+            "docs": {
+                "count": 1257,
+                "deleted": 11
+            },
+            "store": {
+                "size_in_bytes": 1686190
+            },
+            "indexing": {
+                "index_total": 1885,
+                "index_time_in_millis": 5788,
+                "index_current": 0,
+                "index_failed": 0,
+                "delete_total": 258,
+                "delete_time_in_millis": 182,
+                "delete_current": 0,
+                "noop_update_total": 0,
+                "is_throttled": false,
+                "throttle_time_in_millis": 0
+            },
+            "search": {
+                "open_contexts": 0,
+                "query_total": 81,
+                "query_time_in_millis": 39,
+                "query_current": 0,
+                "fetch_total": 56,
+                "fetch_time_in_millis": 41,
+                "fetch_current": 0,
+                "scroll_total": 2,
+                "scroll_time_in_millis": 314,
+                "scroll_current": 0,
+                "suggest_total": 0,
+                "suggest_time_in_millis": 0,
+                "suggest_current": 0
+            },
+            "merges": {
+                "current": 0,
+                "current_docs": 0,
+                "current_size_in_bytes": 0,
+                "total": 28,
+                "total_time_in_millis": 685,
+                "total_docs": 2500,
+                "total_size_in_bytes": 9078916,
+                "total_stopped_time_in_millis": 0,
+                "total_throttled_time_in_millis": 0,
+                "total_auto_throttle_in_bytes": 167772160
+            },
+            "refresh": {
+                "total": 207,
+                "total_time_in_millis": 8279,
+                "listeners": 0
+            },
+            "query_cache": {
+                "memory_size_in_bytes": 0,
+                "total_count": 0,
+                "hit_count": 0,
+                "miss_count": 0,
+                "cache_size": 0,
+                "cache_count": 0,
+                "evictions": 0
+            },
+            "fielddata": {
+                "memory_size_in_bytes": 0,
+                "evictions": 0
+            },
+            "segments": {
+                "count": 20,
+                "memory_in_bytes": 190357,
+                "terms_memory_in_bytes": 121595,
+                "stored_fields_memory_in_bytes": 6456,
+                "term_vectors_memory_in_bytes": 0,
+                "norms_memory_in_bytes": 10688,
+                "points_memory_in_bytes": 1282,
+                "doc_values_memory_in_bytes": 50336,
+                "index_writer_memory_in_bytes": 285894,
+                "version_map_memory_in_bytes": 60329,
+                "fixed_bit_set_memory_in_bytes": 344,
+                "max_unsafe_auto_id_timestamp": -1,
+                "file_sizes": {}
+            },
+            "request_cache": {
+                "memory_size_in_bytes": 0,
+                "evictions": 0,
+                "hit_count": 0,
+                "miss_count": 0
+            }
         },
-        "store": {
-          "size_in_bytes": 1686190
-        },
-        "indexing": {
-          "index_total": 1885,
-          "index_time_in_millis": 5788,
-          "index_current": 0,
-          "index_failed": 0,
-          "delete_total": 258,
-          "delete_time_in_millis": 182,
-          "delete_current": 0,
-          "noop_update_total": 0,
-          "is_throttled": false,
-          "throttle_time_in_millis": 0
-        },
-        "search": {
-          "open_contexts": 0,
-          "query_total": 81,
-          "query_time_in_millis": 39,
-          "query_current": 0,
-          "fetch_total": 56,
-          "fetch_time_in_millis": 41,
-          "fetch_current": 0,
-          "scroll_total": 2,
-          "scroll_time_in_millis": 314,
-          "scroll_current": 0,
-          "suggest_total": 0,
-          "suggest_time_in_millis": 0,
-          "suggest_current": 0
-        },
-        "merges": {
-          "current": 0,
-          "current_docs": 0,
-          "current_size_in_bytes": 0,
-          "total": 28,
-          "total_time_in_millis": 685,
-          "total_docs": 2500,
-          "total_size_in_bytes": 9078916,
-          "total_stopped_time_in_millis": 0,
-          "total_throttled_time_in_millis": 0,
-          "total_auto_throttle_in_bytes": 167772160
-        },
-        "refresh": {
-          "total": 207,
-          "total_time_in_millis": 8279,
-          "listeners": 0
-        },
-        "query_cache": {
-          "memory_size_in_bytes": 0,
-          "total_count": 0,
-          "hit_count": 0,
-          "miss_count": 0,
-          "cache_size": 0,
-          "cache_count": 0,
-          "evictions": 0
-        },
-        "fielddata": {
-          "memory_size_in_bytes": 0,
-          "evictions": 0
-        },
-        "segments": {
-          "count": 20,
-          "memory_in_bytes": 190357,
-          "terms_memory_in_bytes": 121595,
-          "stored_fields_memory_in_bytes": 6456,
-          "term_vectors_memory_in_bytes": 0,
-          "norms_memory_in_bytes": 10688,
-          "points_memory_in_bytes": 1282,
-          "doc_values_memory_in_bytes": 50336,
-          "index_writer_memory_in_bytes": 285894,
-          "version_map_memory_in_bytes": 60329,
-          "fixed_bit_set_memory_in_bytes": 344,
-          "max_unsafe_auto_id_timestamp": -1,
-          "file_sizes": {}
-        },
-        "request_cache": {
-          "memory_size_in_bytes": 0,
-          "evictions": 0,
-          "hit_count": 0,
-          "miss_count": 0
+        "total": {
+            "docs": {
+                "count": 1257,
+                "deleted": 11
+            },
+            "store": {
+                "size_in_bytes": 1686190
+            },
+            "indexing": {
+                "index_total": 1885,
+                "index_time_in_millis": 5788,
+                "index_current": 0,
+                "index_failed": 0,
+                "delete_total": 258,
+                "delete_time_in_millis": 182,
+                "delete_current": 0,
+                "noop_update_total": 0,
+                "is_throttled": false,
+                "throttle_time_in_millis": 0
+            },
+            "search": {
+                "open_contexts": 0,
+                "query_total": 81,
+                "query_time_in_millis": 39,
+                "query_current": 0,
+                "fetch_total": 56,
+                "fetch_time_in_millis": 41,
+                "fetch_current": 0,
+                "scroll_total": 2,
+                "scroll_time_in_millis": 314,
+                "scroll_current": 0,
+                "suggest_total": 0,
+                "suggest_time_in_millis": 0,
+                "suggest_current": 0
+            },
+            "merges": {
+                "current": 0,
+                "current_docs": 0,
+                "current_size_in_bytes": 0,
+                "total": 28,
+                "total_time_in_millis": 685,
+                "total_docs": 2500,
+                "total_size_in_bytes": 9078916,
+                "total_stopped_time_in_millis": 0,
+                "total_throttled_time_in_millis": 0,
+                "total_auto_throttle_in_bytes": 167772160
+            },
+            "refresh": {
+                "total": 207,
+                "total_time_in_millis": 8279,
+                "listeners": 0
+            },
+            "query_cache": {
+                "memory_size_in_bytes": 0,
+                "total_count": 0,
+                "hit_count": 0,
+                "miss_count": 0,
+                "cache_size": 0,
+                "cache_count": 0,
+                "evictions": 0
+            },
+            "fielddata": {
+                "memory_size_in_bytes": 0,
+                "evictions": 0
+            },
+            "segments": {
+                "count": 20,
+                "memory_in_bytes": 190357,
+                "terms_memory_in_bytes": 121595,
+                "stored_fields_memory_in_bytes": 6456,
+                "term_vectors_memory_in_bytes": 0,
+                "norms_memory_in_bytes": 10688,
+                "points_memory_in_bytes": 1282,
+                "doc_values_memory_in_bytes": 50336,
+                "index_writer_memory_in_bytes": 285894,
+                "version_map_memory_in_bytes": 60329,
+                "fixed_bit_set_memory_in_bytes": 344,
+                "max_unsafe_auto_id_timestamp": -1,
+                "file_sizes": {}
+            },
+            "request_cache": {
+                "memory_size_in_bytes": 0,
+                "evictions": 0,
+                "hit_count": 0,
+                "miss_count": 0
+            }
         }
-      },
-      "total": {
-        "docs": {
-          "count": 1257,
-          "deleted": 11
-        },
-        "store": {
-          "size_in_bytes": 1686190
-        },
-        "indexing": {
-          "index_total": 1885,
-          "index_time_in_millis": 5788,
-          "index_current": 0,
-          "index_failed": 0,
-          "delete_total": 258,
-          "delete_time_in_millis": 182,
-          "delete_current": 0,
-          "noop_update_total": 0,
-          "is_throttled": false,
-          "throttle_time_in_millis": 0
-        },
-        "search": {
-          "open_contexts": 0,
-          "query_total": 81,
-          "query_time_in_millis": 39,
-          "query_current": 0,
-          "fetch_total": 56,
-          "fetch_time_in_millis": 41,
-          "fetch_current": 0,
-          "scroll_total": 2,
-          "scroll_time_in_millis": 314,
-          "scroll_current": 0,
-          "suggest_total": 0,
-          "suggest_time_in_millis": 0,
-          "suggest_current": 0
-        },
-        "merges": {
-          "current": 0,
-          "current_docs": 0,
-          "current_size_in_bytes": 0,
-          "total": 28,
-          "total_time_in_millis": 685,
-          "total_docs": 2500,
-          "total_size_in_bytes": 9078916,
-          "total_stopped_time_in_millis": 0,
-          "total_throttled_time_in_millis": 0,
-          "total_auto_throttle_in_bytes": 167772160
-        },
-        "refresh": {
-          "total": 207,
-          "total_time_in_millis": 8279,
-          "listeners": 0
-        },
-        "query_cache": {
-          "memory_size_in_bytes": 0,
-          "total_count": 0,
-          "hit_count": 0,
-          "miss_count": 0,
-          "cache_size": 0,
-          "cache_count": 0,
-          "evictions": 0
-        },
-        "fielddata": {
-          "memory_size_in_bytes": 0,
-          "evictions": 0
-        },
-        "segments": {
-          "count": 20,
-          "memory_in_bytes": 190357,
-          "terms_memory_in_bytes": 121595,
-          "stored_fields_memory_in_bytes": 6456,
-          "term_vectors_memory_in_bytes": 0,
-          "norms_memory_in_bytes": 10688,
-          "points_memory_in_bytes": 1282,
-          "doc_values_memory_in_bytes": 50336,
-          "index_writer_memory_in_bytes": 285894,
-          "version_map_memory_in_bytes": 60329,
-          "fixed_bit_set_memory_in_bytes": 344,
-          "max_unsafe_auto_id_timestamp": -1,
-          "file_sizes": {}
-        },
-        "request_cache": {
-          "memory_size_in_bytes": 0,
-          "evictions": 0,
-          "hit_count": 0,
-          "miss_count": 0
-        }
-      }
     },
     "indices": {
-      ".watcher-history-9-2018.09.07": {
-        "uuid": "YXTxjaeMSh2Ma4RWXB4VPQ",
-        "primaries": {
-          "docs": {
-            "count": 504,
-            "deleted": 0
-          },
-          "store": {
-            "size_in_bytes": 951099
-          },
-          "indexing": {
-            "index_total": 258,
-            "index_time_in_millis": 3188,
-            "index_current": 0,
-            "index_failed": 0,
-            "delete_total": 0,
-            "delete_time_in_millis": 0,
-            "delete_current": 0,
-            "noop_update_total": 0,
-            "is_throttled": false,
-            "throttle_time_in_millis": 0
-          },
-          "search": {
-            "open_contexts": 0,
-            "query_total": 0,
-            "query_time_in_millis": 0,
-            "query_current": 0,
-            "fetch_total": 0,
-            "fetch_time_in_millis": 0,
-            "fetch_current": 0,
-            "scroll_total": 0,
-            "scroll_time_in_millis": 0,
-            "scroll_current": 0,
-            "suggest_total": 0,
-            "suggest_time_in_millis": 0,
-            "suggest_current": 0
-          },
-          "merges": {
-            "current": 0,
-            "current_docs": 0,
-            "current_size_in_bytes": 0,
-            "total": 21,
-            "total_time_in_millis": 532,
-            "total_docs": 1125,
-            "total_size_in_bytes": 6354962,
-            "total_stopped_time_in_millis": 0,
-            "total_throttled_time_in_millis": 0,
-            "total_auto_throttle_in_bytes": 20971520
-          },
-          "refresh": {
-            "total": 71,
-            "total_time_in_millis": 4247,
-            "listeners": 0
-          },
-          "query_cache": {
-            "memory_size_in_bytes": 0,
-            "total_count": 0,
-            "hit_count": 0,
-            "miss_count": 0,
-            "cache_size": 0,
-            "cache_count": 0,
-            "evictions": 0
-          },
-          "fielddata": {
-            "memory_size_in_bytes": 0,
-            "evictions": 0
-          },
-          "segments": {
-            "count": 6,
-            "memory_in_bytes": 108122,
-            "terms_memory_in_bytes": 88538,
-            "stored_fields_memory_in_bytes": 2088,
-            "term_vectors_memory_in_bytes": 0,
-            "norms_memory_in_bytes": 8448,
-            "points_memory_in_bytes": 96,
-            "doc_values_memory_in_bytes": 8952,
-            "index_writer_memory_in_bytes": 0,
-            "version_map_memory_in_bytes": 0,
-            "fixed_bit_set_memory_in_bytes": 344,
-            "max_unsafe_auto_id_timestamp": -1,
-            "file_sizes": {}
-          },
-          "request_cache": {
-            "memory_size_in_bytes": 0,
-            "evictions": 0,
-            "hit_count": 0,
-            "miss_count": 0
-          }
+        ".watcher-history-9-2018.09.07": {
+            "uuid": "YXTxjaeMSh2Ma4RWXB4VPQ",
+            "primaries": {
+                "docs": {
+                    "count": 504,
+                    "deleted": 0
+                },
+                "store": {
+                    "size_in_bytes": 951099
+                },
+                "indexing": {
+                    "index_total": 258,
+                    "index_time_in_millis": 3188,
+                    "index_current": 0,
+                    "index_failed": 0,
+                    "delete_total": 0,
+                    "delete_time_in_millis": 0,
+                    "delete_current": 0,
+                    "noop_update_total": 0,
+                    "is_throttled": false,
+                    "throttle_time_in_millis": 0
+                },
+                "search": {
+                    "open_contexts": 0,
+                    "query_total": 0,
+                    "query_time_in_millis": 0,
+                    "query_current": 0,
+                    "fetch_total": 0,
+                    "fetch_time_in_millis": 0,
+                    "fetch_current": 0,
+                    "scroll_total": 0,
+                    "scroll_time_in_millis": 0,
+                    "scroll_current": 0,
+                    "suggest_total": 0,
+                    "suggest_time_in_millis": 0,
+                    "suggest_current": 0
+                },
+                "merges": {
+                    "current": 0,
+                    "current_docs": 0,
+                    "current_size_in_bytes": 0,
+                    "total": 21,
+                    "total_time_in_millis": 532,
+                    "total_docs": 1125,
+                    "total_size_in_bytes": 6354962,
+                    "total_stopped_time_in_millis": 0,
+                    "total_throttled_time_in_millis": 0,
+                    "total_auto_throttle_in_bytes": 20971520
+                },
+                "refresh": {
+                    "total": 71,
+                    "total_time_in_millis": 4247,
+                    "listeners": 0
+                },
+                "query_cache": {
+                    "memory_size_in_bytes": 0,
+                    "total_count": 0,
+                    "hit_count": 0,
+                    "miss_count": 0,
+                    "cache_size": 0,
+                    "cache_count": 0,
+                    "evictions": 0
+                },
+                "fielddata": {
+                    "memory_size_in_bytes": 0,
+                    "evictions": 0
+                },
+                "segments": {
+                    "count": 6,
+                    "memory_in_bytes": 108122,
+                    "terms_memory_in_bytes": 88538,
+                    "stored_fields_memory_in_bytes": 2088,
+                    "term_vectors_memory_in_bytes": 0,
+                    "norms_memory_in_bytes": 8448,
+                    "points_memory_in_bytes": 96,
+                    "doc_values_memory_in_bytes": 8952,
+                    "index_writer_memory_in_bytes": 0,
+                    "version_map_memory_in_bytes": 0,
+                    "fixed_bit_set_memory_in_bytes": 344,
+                    "max_unsafe_auto_id_timestamp": -1,
+                    "file_sizes": {}
+                },
+                "request_cache": {
+                    "memory_size_in_bytes": 0,
+                    "evictions": 0,
+                    "hit_count": 0,
+                    "miss_count": 0
+                }
+            },
+            "total": {
+                "docs": {
+                    "count": 504,
+                    "deleted": 0
+                },
+                "store": {
+                    "size_in_bytes": 951099
+                },
+                "indexing": {
+                    "index_total": 258,
+                    "index_time_in_millis": 3188,
+                    "index_current": 0,
+                    "index_failed": 0,
+                    "delete_total": 0,
+                    "delete_time_in_millis": 0,
+                    "delete_current": 0,
+                    "noop_update_total": 0,
+                    "is_throttled": false,
+                    "throttle_time_in_millis": 0
+                },
+                "search": {
+                    "open_contexts": 0,
+                    "query_total": 0,
+                    "query_time_in_millis": 0,
+                    "query_current": 0,
+                    "fetch_total": 0,
+                    "fetch_time_in_millis": 0,
+                    "fetch_current": 0,
+                    "scroll_total": 0,
+                    "scroll_time_in_millis": 0,
+                    "scroll_current": 0,
+                    "suggest_total": 0,
+                    "suggest_time_in_millis": 0,
+                    "suggest_current": 0
+                },
+                "merges": {
+                    "current": 0,
+                    "current_docs": 0,
+                    "current_size_in_bytes": 0,
+                    "total": 21,
+                    "total_time_in_millis": 532,
+                    "total_docs": 1125,
+                    "total_size_in_bytes": 6354962,
+                    "total_stopped_time_in_millis": 0,
+                    "total_throttled_time_in_millis": 0,
+                    "total_auto_throttle_in_bytes": 20971520
+                },
+                "refresh": {
+                    "total": 71,
+                    "total_time_in_millis": 4247,
+                    "listeners": 0
+                },
+                "query_cache": {
+                    "memory_size_in_bytes": 0,
+                    "total_count": 0,
+                    "hit_count": 0,
+                    "miss_count": 0,
+                    "cache_size": 0,
+                    "cache_count": 0,
+                    "evictions": 0
+                },
+                "fielddata": {
+                    "memory_size_in_bytes": 0,
+                    "evictions": 0
+                },
+                "segments": {
+                    "count": 6,
+                    "memory_in_bytes": 108122,
+                    "terms_memory_in_bytes": 88538,
+                    "stored_fields_memory_in_bytes": 2088,
+                    "term_vectors_memory_in_bytes": 0,
+                    "norms_memory_in_bytes": 8448,
+                    "points_memory_in_bytes": 96,
+                    "doc_values_memory_in_bytes": 8952,
+                    "index_writer_memory_in_bytes": 0,
+                    "version_map_memory_in_bytes": 0,
+                    "fixed_bit_set_memory_in_bytes": 344,
+                    "max_unsafe_auto_id_timestamp": -1,
+                    "file_sizes": {}
+                },
+                "request_cache": {
+                    "memory_size_in_bytes": 0,
+                    "evictions": 0,
+                    "hit_count": 0,
+                    "miss_count": 0
+                }
+            }
         },
-        "total": {
-          "docs": {
-            "count": 504,
-            "deleted": 0
-          },
-          "store": {
-            "size_in_bytes": 951099
-          },
-          "indexing": {
-            "index_total": 258,
-            "index_time_in_millis": 3188,
-            "index_current": 0,
-            "index_failed": 0,
-            "delete_total": 0,
-            "delete_time_in_millis": 0,
-            "delete_current": 0,
-            "noop_update_total": 0,
-            "is_throttled": false,
-            "throttle_time_in_millis": 0
-          },
-          "search": {
-            "open_contexts": 0,
-            "query_total": 0,
-            "query_time_in_millis": 0,
-            "query_current": 0,
-            "fetch_total": 0,
-            "fetch_time_in_millis": 0,
-            "fetch_current": 0,
-            "scroll_total": 0,
-            "scroll_time_in_millis": 0,
-            "scroll_current": 0,
-            "suggest_total": 0,
-            "suggest_time_in_millis": 0,
-            "suggest_current": 0
-          },
-          "merges": {
-            "current": 0,
-            "current_docs": 0,
-            "current_size_in_bytes": 0,
-            "total": 21,
-            "total_time_in_millis": 532,
-            "total_docs": 1125,
-            "total_size_in_bytes": 6354962,
-            "total_stopped_time_in_millis": 0,
-            "total_throttled_time_in_millis": 0,
-            "total_auto_throttle_in_bytes": 20971520
-          },
-          "refresh": {
-            "total": 71,
-            "total_time_in_millis": 4247,
-            "listeners": 0
-          },
-          "query_cache": {
-            "memory_size_in_bytes": 0,
-            "total_count": 0,
-            "hit_count": 0,
-            "miss_count": 0,
-            "cache_size": 0,
-            "cache_count": 0,
-            "evictions": 0
-          },
-          "fielddata": {
-            "memory_size_in_bytes": 0,
-            "evictions": 0
-          },
-          "segments": {
-            "count": 6,
-            "memory_in_bytes": 108122,
-            "terms_memory_in_bytes": 88538,
-            "stored_fields_memory_in_bytes": 2088,
-            "term_vectors_memory_in_bytes": 0,
-            "norms_memory_in_bytes": 8448,
-            "points_memory_in_bytes": 96,
-            "doc_values_memory_in_bytes": 8952,
-            "index_writer_memory_in_bytes": 0,
-            "version_map_memory_in_bytes": 0,
-            "fixed_bit_set_memory_in_bytes": 344,
-            "max_unsafe_auto_id_timestamp": -1,
-            "file_sizes": {}
-          },
-          "request_cache": {
-            "memory_size_in_bytes": 0,
-            "evictions": 0,
-            "hit_count": 0,
-            "miss_count": 0
-          }
-        }
-      },
-      "testindex": {
-        "uuid": "Unl-J_-lRaijlYvhNdqdjw",
-        "primaries": {
-          "docs": {
-            "count": 0,
-            "deleted": 0
-          },
-          "store": {
-            "size_in_bytes": 261
-          },
-          "indexing": {
-            "index_total": 0,
-            "index_time_in_millis": 0,
-            "index_current": 0,
-            "index_failed": 0,
-            "delete_total": 0,
-            "delete_time_in_millis": 0,
-            "delete_current": 0,
-            "noop_update_total": 0,
-            "is_throttled": false,
-            "throttle_time_in_millis": 0
-          },
-          "search": {
-            "open_contexts": 0,
-            "query_total": 0,
-            "query_time_in_millis": 0,
-            "query_current": 0,
-            "fetch_total": 0,
-            "fetch_time_in_millis": 0,
-            "fetch_current": 0,
-            "scroll_total": 0,
-            "scroll_time_in_millis": 0,
-            "scroll_current": 0,
-            "suggest_total": 0,
-            "suggest_time_in_millis": 0,
-            "suggest_current": 0
-          },
-          "merges": {
-            "current": 0,
-            "current_docs": 0,
-            "current_size_in_bytes": 0,
-            "total": 0,
-            "total_time_in_millis": 0,
-            "total_docs": 0,
-            "total_size_in_bytes": 0,
-            "total_stopped_time_in_millis": 0,
-            "total_throttled_time_in_millis": 0,
-            "total_auto_throttle_in_bytes": 20971520
-          },
-          "refresh": {
-            "total": 2,
-            "total_time_in_millis": 0,
-            "listeners": 0
-          },
-          "query_cache": {
-            "memory_size_in_bytes": 0,
-            "total_count": 0,
-            "hit_count": 0,
-            "miss_count": 0,
-            "cache_size": 0,
-            "cache_count": 0,
-            "evictions": 0
-          },
-          "fielddata": {
-            "memory_size_in_bytes": 0,
-            "evictions": 0
-          },
-          "segments": {
-            "count": 0,
-            "memory_in_bytes": 0,
-            "terms_memory_in_bytes": 0,
-            "stored_fields_memory_in_bytes": 0,
-            "term_vectors_memory_in_bytes": 0,
-            "norms_memory_in_bytes": 0,
-            "points_memory_in_bytes": 0,
-            "doc_values_memory_in_bytes": 0,
-            "index_writer_memory_in_bytes": 0,
-            "version_map_memory_in_bytes": 0,
-            "fixed_bit_set_memory_in_bytes": 0,
-            "max_unsafe_auto_id_timestamp": -1,
-            "file_sizes": {}
-          },
-          "request_cache": {
-            "memory_size_in_bytes": 0,
-            "evictions": 0,
-            "hit_count": 0,
-            "miss_count": 0
-          }
+        "testindex": {
+            "uuid": "Unl-J_-lRaijlYvhNdqdjw",
+            "primaries": {
+                "docs": {
+                    "count": 0,
+                    "deleted": 0
+                },
+                "store": {
+                    "size_in_bytes": 261
+                },
+                "indexing": {
+                    "index_total": 0,
+                    "index_time_in_millis": 0,
+                    "index_current": 0,
+                    "index_failed": 0,
+                    "delete_total": 0,
+                    "delete_time_in_millis": 0,
+                    "delete_current": 0,
+                    "noop_update_total": 0,
+                    "is_throttled": false,
+                    "throttle_time_in_millis": 0
+                },
+                "search": {
+                    "open_contexts": 0,
+                    "query_total": 0,
+                    "query_time_in_millis": 0,
+                    "query_current": 0,
+                    "fetch_total": 0,
+                    "fetch_time_in_millis": 0,
+                    "fetch_current": 0,
+                    "scroll_total": 0,
+                    "scroll_time_in_millis": 0,
+                    "scroll_current": 0,
+                    "suggest_total": 0,
+                    "suggest_time_in_millis": 0,
+                    "suggest_current": 0
+                },
+                "merges": {
+                    "current": 0,
+                    "current_docs": 0,
+                    "current_size_in_bytes": 0,
+                    "total": 0,
+                    "total_time_in_millis": 0,
+                    "total_docs": 0,
+                    "total_size_in_bytes": 0,
+                    "total_stopped_time_in_millis": 0,
+                    "total_throttled_time_in_millis": 0,
+                    "total_auto_throttle_in_bytes": 20971520
+                },
+                "refresh": {
+                    "total": 2,
+                    "total_time_in_millis": 0,
+                    "listeners": 0
+                },
+                "query_cache": {
+                    "memory_size_in_bytes": 0,
+                    "total_count": 0,
+                    "hit_count": 0,
+                    "miss_count": 0,
+                    "cache_size": 0,
+                    "cache_count": 0,
+                    "evictions": 0
+                },
+                "fielddata": {
+                    "memory_size_in_bytes": 0,
+                    "evictions": 0
+                },
+                "segments": {
+                    "count": 0,
+                    "memory_in_bytes": 0,
+                    "terms_memory_in_bytes": 0,
+                    "stored_fields_memory_in_bytes": 0,
+                    "term_vectors_memory_in_bytes": 0,
+                    "norms_memory_in_bytes": 0,
+                    "points_memory_in_bytes": 0,
+                    "doc_values_memory_in_bytes": 0,
+                    "index_writer_memory_in_bytes": 0,
+                    "version_map_memory_in_bytes": 0,
+                    "fixed_bit_set_memory_in_bytes": 0,
+                    "max_unsafe_auto_id_timestamp": -1,
+                    "file_sizes": {}
+                },
+                "request_cache": {
+                    "memory_size_in_bytes": 0,
+                    "evictions": 0,
+                    "hit_count": 0,
+                    "miss_count": 0
+                }
+            },
+            "total": {
+                "docs": {
+                    "count": 0,
+                    "deleted": 0
+                },
+                "store": {
+                    "size_in_bytes": 261
+                },
+                "indexing": {
+                    "index_total": 0,
+                    "index_time_in_millis": 0,
+                    "index_current": 0,
+                    "index_failed": 0,
+                    "delete_total": 0,
+                    "delete_time_in_millis": 0,
+                    "delete_current": 0,
+                    "noop_update_total": 0,
+                    "is_throttled": false,
+                    "throttle_time_in_millis": 0
+                },
+                "search": {
+                    "open_contexts": 0,
+                    "query_total": 0,
+                    "query_time_in_millis": 0,
+                    "query_current": 0,
+                    "fetch_total": 0,
+                    "fetch_time_in_millis": 0,
+                    "fetch_current": 0,
+                    "scroll_total": 0,
+                    "scroll_time_in_millis": 0,
+                    "scroll_current": 0,
+                    "suggest_total": 0,
+                    "suggest_time_in_millis": 0,
+                    "suggest_current": 0
+                },
+                "merges": {
+                    "current": 0,
+                    "current_docs": 0,
+                    "current_size_in_bytes": 0,
+                    "total": 0,
+                    "total_time_in_millis": 0,
+                    "total_docs": 0,
+                    "total_size_in_bytes": 0,
+                    "total_stopped_time_in_millis": 0,
+                    "total_throttled_time_in_millis": 0,
+                    "total_auto_throttle_in_bytes": 20971520
+                },
+                "refresh": {
+                    "total": 2,
+                    "total_time_in_millis": 0,
+                    "listeners": 0
+                },
+                "query_cache": {
+                    "memory_size_in_bytes": 0,
+                    "total_count": 0,
+                    "hit_count": 0,
+                    "miss_count": 0,
+                    "cache_size": 0,
+                    "cache_count": 0,
+                    "evictions": 0
+                },
+                "fielddata": {
+                    "memory_size_in_bytes": 0,
+                    "evictions": 0
+                },
+                "segments": {
+                    "count": 0,
+                    "memory_in_bytes": 0,
+                    "terms_memory_in_bytes": 0,
+                    "stored_fields_memory_in_bytes": 0,
+                    "term_vectors_memory_in_bytes": 0,
+                    "norms_memory_in_bytes": 0,
+                    "points_memory_in_bytes": 0,
+                    "doc_values_memory_in_bytes": 0,
+                    "index_writer_memory_in_bytes": 0,
+                    "version_map_memory_in_bytes": 0,
+                    "fixed_bit_set_memory_in_bytes": 0,
+                    "max_unsafe_auto_id_timestamp": -1,
+                    "file_sizes": {}
+                },
+                "request_cache": {
+                    "memory_size_in_bytes": 0,
+                    "evictions": 0,
+                    "hit_count": 0,
+                    "miss_count": 0
+                }
+            }
         },
-        "total": {
-          "docs": {
-            "count": 0,
-            "deleted": 0
-          },
-          "store": {
-            "size_in_bytes": 261
-          },
-          "indexing": {
-            "index_total": 0,
-            "index_time_in_millis": 0,
-            "index_current": 0,
-            "index_failed": 0,
-            "delete_total": 0,
-            "delete_time_in_millis": 0,
-            "delete_current": 0,
-            "noop_update_total": 0,
-            "is_throttled": false,
-            "throttle_time_in_millis": 0
-          },
-          "search": {
-            "open_contexts": 0,
-            "query_total": 0,
-            "query_time_in_millis": 0,
-            "query_current": 0,
-            "fetch_total": 0,
-            "fetch_time_in_millis": 0,
-            "fetch_current": 0,
-            "scroll_total": 0,
-            "scroll_time_in_millis": 0,
-            "scroll_current": 0,
-            "suggest_total": 0,
-            "suggest_time_in_millis": 0,
-            "suggest_current": 0
-          },
-          "merges": {
-            "current": 0,
-            "current_docs": 0,
-            "current_size_in_bytes": 0,
-            "total": 0,
-            "total_time_in_millis": 0,
-            "total_docs": 0,
-            "total_size_in_bytes": 0,
-            "total_stopped_time_in_millis": 0,
-            "total_throttled_time_in_millis": 0,
-            "total_auto_throttle_in_bytes": 20971520
-          },
-          "refresh": {
-            "total": 2,
-            "total_time_in_millis": 0,
-            "listeners": 0
-          },
-          "query_cache": {
-            "memory_size_in_bytes": 0,
-            "total_count": 0,
-            "hit_count": 0,
-            "miss_count": 0,
-            "cache_size": 0,
-            "cache_count": 0,
-            "evictions": 0
-          },
-          "fielddata": {
-            "memory_size_in_bytes": 0,
-            "evictions": 0
-          },
-          "segments": {
-            "count": 0,
-            "memory_in_bytes": 0,
-            "terms_memory_in_bytes": 0,
-            "stored_fields_memory_in_bytes": 0,
-            "term_vectors_memory_in_bytes": 0,
-            "norms_memory_in_bytes": 0,
-            "points_memory_in_bytes": 0,
-            "doc_values_memory_in_bytes": 0,
-            "index_writer_memory_in_bytes": 0,
-            "version_map_memory_in_bytes": 0,
-            "fixed_bit_set_memory_in_bytes": 0,
-            "max_unsafe_auto_id_timestamp": -1,
-            "file_sizes": {}
-          },
-          "request_cache": {
-            "memory_size_in_bytes": 0,
-            "evictions": 0,
-            "hit_count": 0,
-            "miss_count": 0
-          }
-        }
-      },
-      ".monitoring-es-6-2018.09.07": {
-        "uuid": "h_L818ReSn2LPNmHUnQ5Gg",
-        "primaries": {
-          "docs": {
-            "count": 525,
-            "deleted": 11
-          },
-          "store": {
-            "size_in_bytes": 359632
-          },
-          "indexing": {
-            "index_total": 886,
-            "index_time_in_millis": 131,
-            "index_current": 0,
-            "index_failed": 0,
-            "delete_total": 0,
-            "delete_time_in_millis": 0,
-            "delete_current": 0,
-            "noop_update_total": 0,
-            "is_throttled": false,
-            "throttle_time_in_millis": 0
-          },
-          "search": {
-            "open_contexts": 0,
-            "query_total": 25,
-            "query_time_in_millis": 11,
-            "query_current": 0,
-            "fetch_total": 20,
-            "fetch_time_in_millis": 17,
-            "fetch_current": 0,
-            "scroll_total": 0,
-            "scroll_time_in_millis": 0,
-            "scroll_current": 0,
-            "suggest_total": 0,
-            "suggest_time_in_millis": 0,
-            "suggest_current": 0
-          },
-          "merges": {
-            "current": 0,
-            "current_docs": 0,
-            "current_size_in_bytes": 0,
-            "total": 4,
-            "total_time_in_millis": 77,
-            "total_docs": 1165,
-            "total_size_in_bytes": 2308238,
-            "total_stopped_time_in_millis": 0,
-            "total_throttled_time_in_millis": 0,
-            "total_auto_throttle_in_bytes": 20971520
-          },
-          "refresh": {
-            "total": 43,
-            "total_time_in_millis": 642,
-            "listeners": 0
-          },
-          "query_cache": {
-            "memory_size_in_bytes": 0,
-            "total_count": 0,
-            "hit_count": 0,
-            "miss_count": 0,
-            "cache_size": 0,
-            "cache_count": 0,
-            "evictions": 0
-          },
-          "fielddata": {
-            "memory_size_in_bytes": 0,
-            "evictions": 0
-          },
-          "segments": {
-            "count": 2,
-            "memory_in_bytes": 37649,
-            "terms_memory_in_bytes": 9128,
-            "stored_fields_memory_in_bytes": 640,
-            "term_vectors_memory_in_bytes": 0,
-            "norms_memory_in_bytes": 0,
-            "points_memory_in_bytes": 641,
-            "doc_values_memory_in_bytes": 27240,
-            "index_writer_memory_in_bytes": 0,
-            "version_map_memory_in_bytes": 0,
-            "fixed_bit_set_memory_in_bytes": 0,
-            "max_unsafe_auto_id_timestamp": -1,
-            "file_sizes": {}
-          },
-          "request_cache": {
-            "memory_size_in_bytes": 0,
-            "evictions": 0,
-            "hit_count": 0,
-            "miss_count": 0
-          }
+        ".monitoring-es-6-2018.09.07": {
+            "uuid": "h_L818ReSn2LPNmHUnQ5Gg",
+            "primaries": {
+                "docs": {
+                    "count": 525,
+                    "deleted": 11
+                },
+                "store": {
+                    "size_in_bytes": 359632
+                },
+                "indexing": {
+                    "index_total": 886,
+                    "index_time_in_millis": 131,
+                    "index_current": 0,
+                    "index_failed": 0,
+                    "delete_total": 0,
+                    "delete_time_in_millis": 0,
+                    "delete_current": 0,
+                    "noop_update_total": 0,
+                    "is_throttled": false,
+                    "throttle_time_in_millis": 0
+                },
+                "search": {
+                    "open_contexts": 0,
+                    "query_total": 25,
+                    "query_time_in_millis": 11,
+                    "query_current": 0,
+                    "fetch_total": 20,
+                    "fetch_time_in_millis": 17,
+                    "fetch_current": 0,
+                    "scroll_total": 0,
+                    "scroll_time_in_millis": 0,
+                    "scroll_current": 0,
+                    "suggest_total": 0,
+                    "suggest_time_in_millis": 0,
+                    "suggest_current": 0
+                },
+                "merges": {
+                    "current": 0,
+                    "current_docs": 0,
+                    "current_size_in_bytes": 0,
+                    "total": 4,
+                    "total_time_in_millis": 77,
+                    "total_docs": 1165,
+                    "total_size_in_bytes": 2308238,
+                    "total_stopped_time_in_millis": 0,
+                    "total_throttled_time_in_millis": 0,
+                    "total_auto_throttle_in_bytes": 20971520
+                },
+                "refresh": {
+                    "total": 43,
+                    "total_time_in_millis": 642,
+                    "listeners": 0
+                },
+                "query_cache": {
+                    "memory_size_in_bytes": 0,
+                    "total_count": 0,
+                    "hit_count": 0,
+                    "miss_count": 0,
+                    "cache_size": 0,
+                    "cache_count": 0,
+                    "evictions": 0
+                },
+                "fielddata": {
+                    "memory_size_in_bytes": 0,
+                    "evictions": 0
+                },
+                "segments": {
+                    "count": 2,
+                    "memory_in_bytes": 37649,
+                    "terms_memory_in_bytes": 9128,
+                    "stored_fields_memory_in_bytes": 640,
+                    "term_vectors_memory_in_bytes": 0,
+                    "norms_memory_in_bytes": 0,
+                    "points_memory_in_bytes": 641,
+                    "doc_values_memory_in_bytes": 27240,
+                    "index_writer_memory_in_bytes": 0,
+                    "version_map_memory_in_bytes": 0,
+                    "fixed_bit_set_memory_in_bytes": 0,
+                    "max_unsafe_auto_id_timestamp": -1,
+                    "file_sizes": {}
+                },
+                "request_cache": {
+                    "memory_size_in_bytes": 0,
+                    "evictions": 0,
+                    "hit_count": 0,
+                    "miss_count": 0
+                }
+            },
+            "total": {
+                "docs": {
+                    "count": 525,
+                    "deleted": 11
+                },
+                "store": {
+                    "size_in_bytes": 359632
+                },
+                "indexing": {
+                    "index_total": 886,
+                    "index_time_in_millis": 131,
+                    "index_current": 0,
+                    "index_failed": 0,
+                    "delete_total": 0,
+                    "delete_time_in_millis": 0,
+                    "delete_current": 0,
+                    "noop_update_total": 0,
+                    "is_throttled": false,
+                    "throttle_time_in_millis": 0
+                },
+                "search": {
+                    "open_contexts": 0,
+                    "query_total": 25,
+                    "query_time_in_millis": 11,
+                    "query_current": 0,
+                    "fetch_total": 20,
+                    "fetch_time_in_millis": 17,
+                    "fetch_current": 0,
+                    "scroll_total": 0,
+                    "scroll_time_in_millis": 0,
+                    "scroll_current": 0,
+                    "suggest_total": 0,
+                    "suggest_time_in_millis": 0,
+                    "suggest_current": 0
+                },
+                "merges": {
+                    "current": 0,
+                    "current_docs": 0,
+                    "current_size_in_bytes": 0,
+                    "total": 4,
+                    "total_time_in_millis": 77,
+                    "total_docs": 1165,
+                    "total_size_in_bytes": 2308238,
+                    "total_stopped_time_in_millis": 0,
+                    "total_throttled_time_in_millis": 0,
+                    "total_auto_throttle_in_bytes": 20971520
+                },
+                "refresh": {
+                    "total": 43,
+                    "total_time_in_millis": 642,
+                    "listeners": 0
+                },
+                "query_cache": {
+                    "memory_size_in_bytes": 0,
+                    "total_count": 0,
+                    "hit_count": 0,
+                    "miss_count": 0,
+                    "cache_size": 0,
+                    "cache_count": 0,
+                    "evictions": 0
+                },
+                "fielddata": {
+                    "memory_size_in_bytes": 0,
+                    "evictions": 0
+                },
+                "segments": {
+                    "count": 2,
+                    "memory_in_bytes": 37649,
+                    "terms_memory_in_bytes": 9128,
+                    "stored_fields_memory_in_bytes": 640,
+                    "term_vectors_memory_in_bytes": 0,
+                    "norms_memory_in_bytes": 0,
+                    "points_memory_in_bytes": 641,
+                    "doc_values_memory_in_bytes": 27240,
+                    "index_writer_memory_in_bytes": 0,
+                    "version_map_memory_in_bytes": 0,
+                    "fixed_bit_set_memory_in_bytes": 0,
+                    "max_unsafe_auto_id_timestamp": -1,
+                    "file_sizes": {}
+                },
+                "request_cache": {
+                    "memory_size_in_bytes": 0,
+                    "evictions": 0,
+                    "hit_count": 0,
+                    "miss_count": 0
+                }
+            }
         },
-        "total": {
-          "docs": {
-            "count": 525,
-            "deleted": 11
-          },
-          "store": {
-            "size_in_bytes": 359632
-          },
-          "indexing": {
-            "index_total": 886,
-            "index_time_in_millis": 131,
-            "index_current": 0,
-            "index_failed": 0,
-            "delete_total": 0,
-            "delete_time_in_millis": 0,
-            "delete_current": 0,
-            "noop_update_total": 0,
-            "is_throttled": false,
-            "throttle_time_in_millis": 0
-          },
-          "search": {
-            "open_contexts": 0,
-            "query_total": 25,
-            "query_time_in_millis": 11,
-            "query_current": 0,
-            "fetch_total": 20,
-            "fetch_time_in_millis": 17,
-            "fetch_current": 0,
-            "scroll_total": 0,
-            "scroll_time_in_millis": 0,
-            "scroll_current": 0,
-            "suggest_total": 0,
-            "suggest_time_in_millis": 0,
-            "suggest_current": 0
-          },
-          "merges": {
-            "current": 0,
-            "current_docs": 0,
-            "current_size_in_bytes": 0,
-            "total": 4,
-            "total_time_in_millis": 77,
-            "total_docs": 1165,
-            "total_size_in_bytes": 2308238,
-            "total_stopped_time_in_millis": 0,
-            "total_throttled_time_in_millis": 0,
-            "total_auto_throttle_in_bytes": 20971520
-          },
-          "refresh": {
-            "total": 43,
-            "total_time_in_millis": 642,
-            "listeners": 0
-          },
-          "query_cache": {
-            "memory_size_in_bytes": 0,
-            "total_count": 0,
-            "hit_count": 0,
-            "miss_count": 0,
-            "cache_size": 0,
-            "cache_count": 0,
-            "evictions": 0
-          },
-          "fielddata": {
-            "memory_size_in_bytes": 0,
-            "evictions": 0
-          },
-          "segments": {
-            "count": 2,
-            "memory_in_bytes": 37649,
-            "terms_memory_in_bytes": 9128,
-            "stored_fields_memory_in_bytes": 640,
-            "term_vectors_memory_in_bytes": 0,
-            "norms_memory_in_bytes": 0,
-            "points_memory_in_bytes": 641,
-            "doc_values_memory_in_bytes": 27240,
-            "index_writer_memory_in_bytes": 0,
-            "version_map_memory_in_bytes": 0,
-            "fixed_bit_set_memory_in_bytes": 0,
-            "max_unsafe_auto_id_timestamp": -1,
-            "file_sizes": {}
-          },
-          "request_cache": {
-            "memory_size_in_bytes": 0,
-            "evictions": 0,
-            "hit_count": 0,
-            "miss_count": 0
-          }
-        }
-      },
-      ".triggered_watches": {
-        "uuid": "FG9al3VzToqGrgG5o0zMSA",
-        "primaries": {
-          "docs": {
-            "count": 0,
-            "deleted": 0
-          },
-          "store": {
-            "size_in_bytes": 8372
-          },
-          "indexing": {
-            "index_total": 258,
-            "index_time_in_millis": 15,
-            "index_current": 0,
-            "index_failed": 0,
-            "delete_total": 258,
-            "delete_time_in_millis": 182,
-            "delete_current": 0,
-            "noop_update_total": 0,
-            "is_throttled": false,
-            "throttle_time_in_millis": 0
-          },
-          "search": {
-            "open_contexts": 0,
-            "query_total": 1,
-            "query_time_in_millis": 0,
-            "query_current": 0,
-            "fetch_total": 1,
-            "fetch_time_in_millis": 0,
-            "fetch_current": 0,
-            "scroll_total": 1,
-            "scroll_time_in_millis": 2,
-            "scroll_current": 0,
-            "suggest_total": 0,
-            "suggest_time_in_millis": 0,
-            "suggest_current": 0
-          },
-          "merges": {
-            "current": 0,
-            "current_docs": 0,
-            "current_size_in_bytes": 0,
-            "total": 0,
-            "total_time_in_millis": 0,
-            "total_docs": 0,
-            "total_size_in_bytes": 0,
-            "total_stopped_time_in_millis": 0,
-            "total_throttled_time_in_millis": 0,
-            "total_auto_throttle_in_bytes": 20971520
-          },
-          "refresh": {
-            "total": 3,
-            "total_time_in_millis": 0,
-            "listeners": 0
-          },
-          "query_cache": {
-            "memory_size_in_bytes": 0,
-            "total_count": 0,
-            "hit_count": 0,
-            "miss_count": 0,
-            "cache_size": 0,
-            "cache_count": 0,
-            "evictions": 0
-          },
-          "fielddata": {
-            "memory_size_in_bytes": 0,
-            "evictions": 0
-          },
-          "segments": {
-            "count": 0,
-            "memory_in_bytes": 0,
-            "terms_memory_in_bytes": 0,
-            "stored_fields_memory_in_bytes": 0,
-            "term_vectors_memory_in_bytes": 0,
-            "norms_memory_in_bytes": 0,
-            "points_memory_in_bytes": 0,
-            "doc_values_memory_in_bytes": 0,
-            "index_writer_memory_in_bytes": 285894,
-            "version_map_memory_in_bytes": 60329,
-            "fixed_bit_set_memory_in_bytes": 0,
-            "max_unsafe_auto_id_timestamp": -1,
-            "file_sizes": {}
-          },
-          "request_cache": {
-            "memory_size_in_bytes": 0,
-            "evictions": 0,
-            "hit_count": 0,
-            "miss_count": 0
-          }
+        ".triggered_watches": {
+            "uuid": "FG9al3VzToqGrgG5o0zMSA",
+            "primaries": {
+                "docs": {
+                    "count": 0,
+                    "deleted": 0
+                },
+                "store": {
+                    "size_in_bytes": 8372
+                },
+                "indexing": {
+                    "index_total": 258,
+                    "index_time_in_millis": 15,
+                    "index_current": 0,
+                    "index_failed": 0,
+                    "delete_total": 258,
+                    "delete_time_in_millis": 182,
+                    "delete_current": 0,
+                    "noop_update_total": 0,
+                    "is_throttled": false,
+                    "throttle_time_in_millis": 0
+                },
+                "search": {
+                    "open_contexts": 0,
+                    "query_total": 1,
+                    "query_time_in_millis": 0,
+                    "query_current": 0,
+                    "fetch_total": 1,
+                    "fetch_time_in_millis": 0,
+                    "fetch_current": 0,
+                    "scroll_total": 1,
+                    "scroll_time_in_millis": 2,
+                    "scroll_current": 0,
+                    "suggest_total": 0,
+                    "suggest_time_in_millis": 0,
+                    "suggest_current": 0
+                },
+                "merges": {
+                    "current": 0,
+                    "current_docs": 0,
+                    "current_size_in_bytes": 0,
+                    "total": 0,
+                    "total_time_in_millis": 0,
+                    "total_docs": 0,
+                    "total_size_in_bytes": 0,
+                    "total_stopped_time_in_millis": 0,
+                    "total_throttled_time_in_millis": 0,
+                    "total_auto_throttle_in_bytes": 20971520
+                },
+                "refresh": {
+                    "total": 3,
+                    "total_time_in_millis": 0,
+                    "listeners": 0
+                },
+                "query_cache": {
+                    "memory_size_in_bytes": 0,
+                    "total_count": 0,
+                    "hit_count": 0,
+                    "miss_count": 0,
+                    "cache_size": 0,
+                    "cache_count": 0,
+                    "evictions": 0
+                },
+                "fielddata": {
+                    "memory_size_in_bytes": 0,
+                    "evictions": 0
+                },
+                "segments": {
+                    "count": 0,
+                    "memory_in_bytes": 0,
+                    "terms_memory_in_bytes": 0,
+                    "stored_fields_memory_in_bytes": 0,
+                    "term_vectors_memory_in_bytes": 0,
+                    "norms_memory_in_bytes": 0,
+                    "points_memory_in_bytes": 0,
+                    "doc_values_memory_in_bytes": 0,
+                    "index_writer_memory_in_bytes": 285894,
+                    "version_map_memory_in_bytes": 60329,
+                    "fixed_bit_set_memory_in_bytes": 0,
+                    "max_unsafe_auto_id_timestamp": -1,
+                    "file_sizes": {}
+                },
+                "request_cache": {
+                    "memory_size_in_bytes": 0,
+                    "evictions": 0,
+                    "hit_count": 0,
+                    "miss_count": 0
+                }
+            },
+            "total": {
+                "docs": {
+                    "count": 0,
+                    "deleted": 0
+                },
+                "store": {
+                    "size_in_bytes": 8372
+                },
+                "indexing": {
+                    "index_total": 258,
+                    "index_time_in_millis": 15,
+                    "index_current": 0,
+                    "index_failed": 0,
+                    "delete_total": 258,
+                    "delete_time_in_millis": 182,
+                    "delete_current": 0,
+                    "noop_update_total": 0,
+                    "is_throttled": false,
+                    "throttle_time_in_millis": 0
+                },
+                "search": {
+                    "open_contexts": 0,
+                    "query_total": 1,
+                    "query_time_in_millis": 0,
+                    "query_current": 0,
+                    "fetch_total": 1,
+                    "fetch_time_in_millis": 0,
+                    "fetch_current": 0,
+                    "scroll_total": 1,
+                    "scroll_time_in_millis": 2,
+                    "scroll_current": 0,
+                    "suggest_total": 0,
+                    "suggest_time_in_millis": 0,
+                    "suggest_current": 0
+                },
+                "merges": {
+                    "current": 0,
+                    "current_docs": 0,
+                    "current_size_in_bytes": 0,
+                    "total": 0,
+                    "total_time_in_millis": 0,
+                    "total_docs": 0,
+                    "total_size_in_bytes": 0,
+                    "total_stopped_time_in_millis": 0,
+                    "total_throttled_time_in_millis": 0,
+                    "total_auto_throttle_in_bytes": 20971520
+                },
+                "refresh": {
+                    "total": 3,
+                    "total_time_in_millis": 0,
+                    "listeners": 0
+                },
+                "query_cache": {
+                    "memory_size_in_bytes": 0,
+                    "total_count": 0,
+                    "hit_count": 0,
+                    "miss_count": 0,
+                    "cache_size": 0,
+                    "cache_count": 0,
+                    "evictions": 0
+                },
+                "fielddata": {
+                    "memory_size_in_bytes": 0,
+                    "evictions": 0
+                },
+                "segments": {
+                    "count": 0,
+                    "memory_in_bytes": 0,
+                    "terms_memory_in_bytes": 0,
+                    "stored_fields_memory_in_bytes": 0,
+                    "term_vectors_memory_in_bytes": 0,
+                    "norms_memory_in_bytes": 0,
+                    "points_memory_in_bytes": 0,
+                    "doc_values_memory_in_bytes": 0,
+                    "index_writer_memory_in_bytes": 285894,
+                    "version_map_memory_in_bytes": 60329,
+                    "fixed_bit_set_memory_in_bytes": 0,
+                    "max_unsafe_auto_id_timestamp": -1,
+                    "file_sizes": {}
+                },
+                "request_cache": {
+                    "memory_size_in_bytes": 0,
+                    "evictions": 0,
+                    "hit_count": 0,
+                    "miss_count": 0
+                }
+            }
         },
-        "total": {
-          "docs": {
-            "count": 0,
-            "deleted": 0
-          },
-          "store": {
-            "size_in_bytes": 8372
-          },
-          "indexing": {
-            "index_total": 258,
-            "index_time_in_millis": 15,
-            "index_current": 0,
-            "index_failed": 0,
-            "delete_total": 258,
-            "delete_time_in_millis": 182,
-            "delete_current": 0,
-            "noop_update_total": 0,
-            "is_throttled": false,
-            "throttle_time_in_millis": 0
-          },
-          "search": {
-            "open_contexts": 0,
-            "query_total": 1,
-            "query_time_in_millis": 0,
-            "query_current": 0,
-            "fetch_total": 1,
-            "fetch_time_in_millis": 0,
-            "fetch_current": 0,
-            "scroll_total": 1,
-            "scroll_time_in_millis": 2,
-            "scroll_current": 0,
-            "suggest_total": 0,
-            "suggest_time_in_millis": 0,
-            "suggest_current": 0
-          },
-          "merges": {
-            "current": 0,
-            "current_docs": 0,
-            "current_size_in_bytes": 0,
-            "total": 0,
-            "total_time_in_millis": 0,
-            "total_docs": 0,
-            "total_size_in_bytes": 0,
-            "total_stopped_time_in_millis": 0,
-            "total_throttled_time_in_millis": 0,
-            "total_auto_throttle_in_bytes": 20971520
-          },
-          "refresh": {
-            "total": 3,
-            "total_time_in_millis": 0,
-            "listeners": 0
-          },
-          "query_cache": {
-            "memory_size_in_bytes": 0,
-            "total_count": 0,
-            "hit_count": 0,
-            "miss_count": 0,
-            "cache_size": 0,
-            "cache_count": 0,
-            "evictions": 0
-          },
-          "fielddata": {
-            "memory_size_in_bytes": 0,
-            "evictions": 0
-          },
-          "segments": {
-            "count": 0,
-            "memory_in_bytes": 0,
-            "terms_memory_in_bytes": 0,
-            "stored_fields_memory_in_bytes": 0,
-            "term_vectors_memory_in_bytes": 0,
-            "norms_memory_in_bytes": 0,
-            "points_memory_in_bytes": 0,
-            "doc_values_memory_in_bytes": 0,
-            "index_writer_memory_in_bytes": 285894,
-            "version_map_memory_in_bytes": 60329,
-            "fixed_bit_set_memory_in_bytes": 0,
-            "max_unsafe_auto_id_timestamp": -1,
-            "file_sizes": {}
-          },
-          "request_cache": {
-            "memory_size_in_bytes": 0,
-            "evictions": 0,
-            "hit_count": 0,
-            "miss_count": 0
-          }
-        }
-      },
-      ".kibana": {
-        "uuid": "NuBsP0VjTXK4qlsoearCBg",
-        "primaries": {
-          "docs": {
-            "count": 2,
-            "deleted": 0
-          },
-          "store": {
-            "size_in_bytes": 97891
-          },
-          "indexing": {
-            "index_total": 0,
-            "index_time_in_millis": 0,
-            "index_current": 0,
-            "index_failed": 0,
-            "delete_total": 0,
-            "delete_time_in_millis": 0,
-            "delete_current": 0,
-            "noop_update_total": 0,
-            "is_throttled": false,
-            "throttle_time_in_millis": 0
-          },
-          "search": {
-            "open_contexts": 0,
-            "query_total": 1,
-            "query_time_in_millis": 1,
-            "query_current": 0,
-            "fetch_total": 1,
-            "fetch_time_in_millis": 2,
-            "fetch_current": 0,
-            "scroll_total": 0,
-            "scroll_time_in_millis": 0,
-            "scroll_current": 0,
-            "suggest_total": 0,
-            "suggest_time_in_millis": 0,
-            "suggest_current": 0
-          },
-          "merges": {
-            "current": 0,
-            "current_docs": 0,
-            "current_size_in_bytes": 0,
-            "total": 0,
-            "total_time_in_millis": 0,
-            "total_docs": 0,
-            "total_size_in_bytes": 0,
-            "total_stopped_time_in_millis": 0,
-            "total_throttled_time_in_millis": 0,
-            "total_auto_throttle_in_bytes": 20971520
-          },
-          "refresh": {
-            "total": 2,
-            "total_time_in_millis": 0,
-            "listeners": 0
-          },
-          "query_cache": {
-            "memory_size_in_bytes": 0,
-            "total_count": 0,
-            "hit_count": 0,
-            "miss_count": 0,
-            "cache_size": 0,
-            "cache_count": 0,
-            "evictions": 0
-          },
-          "fielddata": {
-            "memory_size_in_bytes": 0,
-            "evictions": 0
-          },
-          "segments": {
-            "count": 2,
-            "memory_in_bytes": 4445,
-            "terms_memory_in_bytes": 3489,
-            "stored_fields_memory_in_bytes": 624,
-            "term_vectors_memory_in_bytes": 0,
-            "norms_memory_in_bytes": 192,
-            "points_memory_in_bytes": 4,
-            "doc_values_memory_in_bytes": 136,
-            "index_writer_memory_in_bytes": 0,
-            "version_map_memory_in_bytes": 0,
-            "fixed_bit_set_memory_in_bytes": 0,
-            "max_unsafe_auto_id_timestamp": -1,
-            "file_sizes": {}
-          },
-          "request_cache": {
-            "memory_size_in_bytes": 0,
-            "evictions": 0,
-            "hit_count": 0,
-            "miss_count": 0
-          }
+        ".kibana": {
+            "uuid": "NuBsP0VjTXK4qlsoearCBg",
+            "primaries": {
+                "docs": {
+                    "count": 2,
+                    "deleted": 0
+                },
+                "store": {
+                    "size_in_bytes": 97891
+                },
+                "indexing": {
+                    "index_total": 0,
+                    "index_time_in_millis": 0,
+                    "index_current": 0,
+                    "index_failed": 0,
+                    "delete_total": 0,
+                    "delete_time_in_millis": 0,
+                    "delete_current": 0,
+                    "noop_update_total": 0,
+                    "is_throttled": false,
+                    "throttle_time_in_millis": 0
+                },
+                "search": {
+                    "open_contexts": 0,
+                    "query_total": 1,
+                    "query_time_in_millis": 1,
+                    "query_current": 0,
+                    "fetch_total": 1,
+                    "fetch_time_in_millis": 2,
+                    "fetch_current": 0,
+                    "scroll_total": 0,
+                    "scroll_time_in_millis": 0,
+                    "scroll_current": 0,
+                    "suggest_total": 0,
+                    "suggest_time_in_millis": 0,
+                    "suggest_current": 0
+                },
+                "merges": {
+                    "current": 0,
+                    "current_docs": 0,
+                    "current_size_in_bytes": 0,
+                    "total": 0,
+                    "total_time_in_millis": 0,
+                    "total_docs": 0,
+                    "total_size_in_bytes": 0,
+                    "total_stopped_time_in_millis": 0,
+                    "total_throttled_time_in_millis": 0,
+                    "total_auto_throttle_in_bytes": 20971520
+                },
+                "refresh": {
+                    "total": 2,
+                    "total_time_in_millis": 0,
+                    "listeners": 0
+                },
+                "query_cache": {
+                    "memory_size_in_bytes": 0,
+                    "total_count": 0,
+                    "hit_count": 0,
+                    "miss_count": 0,
+                    "cache_size": 0,
+                    "cache_count": 0,
+                    "evictions": 0
+                },
+                "fielddata": {
+                    "memory_size_in_bytes": 0,
+                    "evictions": 0
+                },
+                "segments": {
+                    "count": 2,
+                    "memory_in_bytes": 4445,
+                    "terms_memory_in_bytes": 3489,
+                    "stored_fields_memory_in_bytes": 624,
+                    "term_vectors_memory_in_bytes": 0,
+                    "norms_memory_in_bytes": 192,
+                    "points_memory_in_bytes": 4,
+                    "doc_values_memory_in_bytes": 136,
+                    "index_writer_memory_in_bytes": 0,
+                    "version_map_memory_in_bytes": 0,
+                    "fixed_bit_set_memory_in_bytes": 0,
+                    "max_unsafe_auto_id_timestamp": -1,
+                    "file_sizes": {}
+                },
+                "request_cache": {
+                    "memory_size_in_bytes": 0,
+                    "evictions": 0,
+                    "hit_count": 0,
+                    "miss_count": 0
+                }
+            },
+            "total": {
+                "docs": {
+                    "count": 2,
+                    "deleted": 0
+                },
+                "store": {
+                    "size_in_bytes": 97891
+                },
+                "indexing": {
+                    "index_total": 0,
+                    "index_time_in_millis": 0,
+                    "index_current": 0,
+                    "index_failed": 0,
+                    "delete_total": 0,
+                    "delete_time_in_millis": 0,
+                    "delete_current": 0,
+                    "noop_update_total": 0,
+                    "is_throttled": false,
+                    "throttle_time_in_millis": 0
+                },
+                "search": {
+                    "open_contexts": 0,
+                    "query_total": 1,
+                    "query_time_in_millis": 1,
+                    "query_current": 0,
+                    "fetch_total": 1,
+                    "fetch_time_in_millis": 2,
+                    "fetch_current": 0,
+                    "scroll_total": 0,
+                    "scroll_time_in_millis": 0,
+                    "scroll_current": 0,
+                    "suggest_total": 0,
+                    "suggest_time_in_millis": 0,
+                    "suggest_current": 0
+                },
+                "merges": {
+                    "current": 0,
+                    "current_docs": 0,
+                    "current_size_in_bytes": 0,
+                    "total": 0,
+                    "total_time_in_millis": 0,
+                    "total_docs": 0,
+                    "total_size_in_bytes": 0,
+                    "total_stopped_time_in_millis": 0,
+                    "total_throttled_time_in_millis": 0,
+                    "total_auto_throttle_in_bytes": 20971520
+                },
+                "refresh": {
+                    "total": 2,
+                    "total_time_in_millis": 0,
+                    "listeners": 0
+                },
+                "query_cache": {
+                    "memory_size_in_bytes": 0,
+                    "total_count": 0,
+                    "hit_count": 0,
+                    "miss_count": 0,
+                    "cache_size": 0,
+                    "cache_count": 0,
+                    "evictions": 0
+                },
+                "fielddata": {
+                    "memory_size_in_bytes": 0,
+                    "evictions": 0
+                },
+                "segments": {
+                    "count": 2,
+                    "memory_in_bytes": 4445,
+                    "terms_memory_in_bytes": 3489,
+                    "stored_fields_memory_in_bytes": 624,
+                    "term_vectors_memory_in_bytes": 0,
+                    "norms_memory_in_bytes": 192,
+                    "points_memory_in_bytes": 4,
+                    "doc_values_memory_in_bytes": 136,
+                    "index_writer_memory_in_bytes": 0,
+                    "version_map_memory_in_bytes": 0,
+                    "fixed_bit_set_memory_in_bytes": 0,
+                    "max_unsafe_auto_id_timestamp": -1,
+                    "file_sizes": {}
+                },
+                "request_cache": {
+                    "memory_size_in_bytes": 0,
+                    "evictions": 0,
+                    "hit_count": 0,
+                    "miss_count": 0
+                }
+            }
         },
-        "total": {
-          "docs": {
-            "count": 2,
-            "deleted": 0
-          },
-          "store": {
-            "size_in_bytes": 97891
-          },
-          "indexing": {
-            "index_total": 0,
-            "index_time_in_millis": 0,
-            "index_current": 0,
-            "index_failed": 0,
-            "delete_total": 0,
-            "delete_time_in_millis": 0,
-            "delete_current": 0,
-            "noop_update_total": 0,
-            "is_throttled": false,
-            "throttle_time_in_millis": 0
-          },
-          "search": {
-            "open_contexts": 0,
-            "query_total": 1,
-            "query_time_in_millis": 1,
-            "query_current": 0,
-            "fetch_total": 1,
-            "fetch_time_in_millis": 2,
-            "fetch_current": 0,
-            "scroll_total": 0,
-            "scroll_time_in_millis": 0,
-            "scroll_current": 0,
-            "suggest_total": 0,
-            "suggest_time_in_millis": 0,
-            "suggest_current": 0
-          },
-          "merges": {
-            "current": 0,
-            "current_docs": 0,
-            "current_size_in_bytes": 0,
-            "total": 0,
-            "total_time_in_millis": 0,
-            "total_docs": 0,
-            "total_size_in_bytes": 0,
-            "total_stopped_time_in_millis": 0,
-            "total_throttled_time_in_millis": 0,
-            "total_auto_throttle_in_bytes": 20971520
-          },
-          "refresh": {
-            "total": 2,
-            "total_time_in_millis": 0,
-            "listeners": 0
-          },
-          "query_cache": {
-            "memory_size_in_bytes": 0,
-            "total_count": 0,
-            "hit_count": 0,
-            "miss_count": 0,
-            "cache_size": 0,
-            "cache_count": 0,
-            "evictions": 0
-          },
-          "fielddata": {
-            "memory_size_in_bytes": 0,
-            "evictions": 0
-          },
-          "segments": {
-            "count": 2,
-            "memory_in_bytes": 4445,
-            "terms_memory_in_bytes": 3489,
-            "stored_fields_memory_in_bytes": 624,
-            "term_vectors_memory_in_bytes": 0,
-            "norms_memory_in_bytes": 192,
-            "points_memory_in_bytes": 4,
-            "doc_values_memory_in_bytes": 136,
-            "index_writer_memory_in_bytes": 0,
-            "version_map_memory_in_bytes": 0,
-            "fixed_bit_set_memory_in_bytes": 0,
-            "max_unsafe_auto_id_timestamp": -1,
-            "file_sizes": {}
-          },
-          "request_cache": {
-            "memory_size_in_bytes": 0,
-            "evictions": 0,
-            "hit_count": 0,
-            "miss_count": 0
-          }
-        }
-      },
-      ".monitoring-alerts-6": {
-        "uuid": "sqYGwl2BRfW1E3KHFN9uRQ",
-        "primaries": {
-          "docs": {
-            "count": 1,
-            "deleted": 0
-          },
-          "store": {
-            "size_in_bytes": 6279
-          },
-          "indexing": {
-            "index_total": 6,
-            "index_time_in_millis": 16,
-            "index_current": 0,
-            "index_failed": 0,
-            "delete_total": 0,
-            "delete_time_in_millis": 0,
-            "delete_current": 0,
-            "noop_update_total": 0,
-            "is_throttled": false,
-            "throttle_time_in_millis": 0
-          },
-          "search": {
-            "open_contexts": 0,
-            "query_total": 30,
-            "query_time_in_millis": 6,
-            "query_current": 0,
-            "fetch_total": 30,
-            "fetch_time_in_millis": 2,
-            "fetch_current": 0,
-            "scroll_total": 0,
-            "scroll_time_in_millis": 0,
-            "scroll_current": 0,
-            "suggest_total": 0,
-            "suggest_time_in_millis": 0,
-            "suggest_current": 0
-          },
-          "merges": {
-            "current": 0,
-            "current_docs": 0,
-            "current_size_in_bytes": 0,
-            "total": 0,
-            "total_time_in_millis": 0,
-            "total_docs": 0,
-            "total_size_in_bytes": 0,
-            "total_stopped_time_in_millis": 0,
-            "total_throttled_time_in_millis": 0,
-            "total_auto_throttle_in_bytes": 20971520
-          },
-          "refresh": {
-            "total": 8,
-            "total_time_in_millis": 63,
-            "listeners": 0
-          },
-          "query_cache": {
-            "memory_size_in_bytes": 0,
-            "total_count": 0,
-            "hit_count": 0,
-            "miss_count": 0,
-            "cache_size": 0,
-            "cache_count": 0,
-            "evictions": 0
-          },
-          "fielddata": {
-            "memory_size_in_bytes": 0,
-            "evictions": 0
-          },
-          "segments": {
-            "count": 1,
-            "memory_in_bytes": 2153,
-            "terms_memory_in_bytes": 1639,
-            "stored_fields_memory_in_bytes": 312,
-            "term_vectors_memory_in_bytes": 0,
-            "norms_memory_in_bytes": 128,
-            "points_memory_in_bytes": 6,
-            "doc_values_memory_in_bytes": 68,
-            "index_writer_memory_in_bytes": 0,
-            "version_map_memory_in_bytes": 0,
-            "fixed_bit_set_memory_in_bytes": 0,
-            "max_unsafe_auto_id_timestamp": -1,
-            "file_sizes": {}
-          },
-          "request_cache": {
-            "memory_size_in_bytes": 0,
-            "evictions": 0,
-            "hit_count": 0,
-            "miss_count": 0
-          }
+        ".monitoring-alerts-6": {
+            "uuid": "sqYGwl2BRfW1E3KHFN9uRQ",
+            "primaries": {
+                "docs": {
+                    "count": 1,
+                    "deleted": 0
+                },
+                "store": {
+                    "size_in_bytes": 6279
+                },
+                "indexing": {
+                    "index_total": 6,
+                    "index_time_in_millis": 16,
+                    "index_current": 0,
+                    "index_failed": 0,
+                    "delete_total": 0,
+                    "delete_time_in_millis": 0,
+                    "delete_current": 0,
+                    "noop_update_total": 0,
+                    "is_throttled": false,
+                    "throttle_time_in_millis": 0
+                },
+                "search": {
+                    "open_contexts": 0,
+                    "query_total": 30,
+                    "query_time_in_millis": 6,
+                    "query_current": 0,
+                    "fetch_total": 30,
+                    "fetch_time_in_millis": 2,
+                    "fetch_current": 0,
+                    "scroll_total": 0,
+                    "scroll_time_in_millis": 0,
+                    "scroll_current": 0,
+                    "suggest_total": 0,
+                    "suggest_time_in_millis": 0,
+                    "suggest_current": 0
+                },
+                "merges": {
+                    "current": 0,
+                    "current_docs": 0,
+                    "current_size_in_bytes": 0,
+                    "total": 0,
+                    "total_time_in_millis": 0,
+                    "total_docs": 0,
+                    "total_size_in_bytes": 0,
+                    "total_stopped_time_in_millis": 0,
+                    "total_throttled_time_in_millis": 0,
+                    "total_auto_throttle_in_bytes": 20971520
+                },
+                "refresh": {
+                    "total": 8,
+                    "total_time_in_millis": 63,
+                    "listeners": 0
+                },
+                "query_cache": {
+                    "memory_size_in_bytes": 0,
+                    "total_count": 0,
+                    "hit_count": 0,
+                    "miss_count": 0,
+                    "cache_size": 0,
+                    "cache_count": 0,
+                    "evictions": 0
+                },
+                "fielddata": {
+                    "memory_size_in_bytes": 0,
+                    "evictions": 0
+                },
+                "segments": {
+                    "count": 1,
+                    "memory_in_bytes": 2153,
+                    "terms_memory_in_bytes": 1639,
+                    "stored_fields_memory_in_bytes": 312,
+                    "term_vectors_memory_in_bytes": 0,
+                    "norms_memory_in_bytes": 128,
+                    "points_memory_in_bytes": 6,
+                    "doc_values_memory_in_bytes": 68,
+                    "index_writer_memory_in_bytes": 0,
+                    "version_map_memory_in_bytes": 0,
+                    "fixed_bit_set_memory_in_bytes": 0,
+                    "max_unsafe_auto_id_timestamp": -1,
+                    "file_sizes": {}
+                },
+                "request_cache": {
+                    "memory_size_in_bytes": 0,
+                    "evictions": 0,
+                    "hit_count": 0,
+                    "miss_count": 0
+                }
+            },
+            "total": {
+                "docs": {
+                    "count": 1,
+                    "deleted": 0
+                },
+                "store": {
+                    "size_in_bytes": 6279
+                },
+                "indexing": {
+                    "index_total": 6,
+                    "index_time_in_millis": 16,
+                    "index_current": 0,
+                    "index_failed": 0,
+                    "delete_total": 0,
+                    "delete_time_in_millis": 0,
+                    "delete_current": 0,
+                    "noop_update_total": 0,
+                    "is_throttled": false,
+                    "throttle_time_in_millis": 0
+                },
+                "search": {
+                    "open_contexts": 0,
+                    "query_total": 30,
+                    "query_time_in_millis": 6,
+                    "query_current": 0,
+                    "fetch_total": 30,
+                    "fetch_time_in_millis": 2,
+                    "fetch_current": 0,
+                    "scroll_total": 0,
+                    "scroll_time_in_millis": 0,
+                    "scroll_current": 0,
+                    "suggest_total": 0,
+                    "suggest_time_in_millis": 0,
+                    "suggest_current": 0
+                },
+                "merges": {
+                    "current": 0,
+                    "current_docs": 0,
+                    "current_size_in_bytes": 0,
+                    "total": 0,
+                    "total_time_in_millis": 0,
+                    "total_docs": 0,
+                    "total_size_in_bytes": 0,
+                    "total_stopped_time_in_millis": 0,
+                    "total_throttled_time_in_millis": 0,
+                    "total_auto_throttle_in_bytes": 20971520
+                },
+                "refresh": {
+                    "total": 8,
+                    "total_time_in_millis": 63,
+                    "listeners": 0
+                },
+                "query_cache": {
+                    "memory_size_in_bytes": 0,
+                    "total_count": 0,
+                    "hit_count": 0,
+                    "miss_count": 0,
+                    "cache_size": 0,
+                    "cache_count": 0,
+                    "evictions": 0
+                },
+                "fielddata": {
+                    "memory_size_in_bytes": 0,
+                    "evictions": 0
+                },
+                "segments": {
+                    "count": 1,
+                    "memory_in_bytes": 2153,
+                    "terms_memory_in_bytes": 1639,
+                    "stored_fields_memory_in_bytes": 312,
+                    "term_vectors_memory_in_bytes": 0,
+                    "norms_memory_in_bytes": 128,
+                    "points_memory_in_bytes": 6,
+                    "doc_values_memory_in_bytes": 68,
+                    "index_writer_memory_in_bytes": 0,
+                    "version_map_memory_in_bytes": 0,
+                    "fixed_bit_set_memory_in_bytes": 0,
+                    "max_unsafe_auto_id_timestamp": -1,
+                    "file_sizes": {}
+                },
+                "request_cache": {
+                    "memory_size_in_bytes": 0,
+                    "evictions": 0,
+                    "hit_count": 0,
+                    "miss_count": 0
+                }
+            }
         },
-        "total": {
-          "docs": {
-            "count": 1,
-            "deleted": 0
-          },
-          "store": {
-            "size_in_bytes": 6279
-          },
-          "indexing": {
-            "index_total": 6,
-            "index_time_in_millis": 16,
-            "index_current": 0,
-            "index_failed": 0,
-            "delete_total": 0,
-            "delete_time_in_millis": 0,
-            "delete_current": 0,
-            "noop_update_total": 0,
-            "is_throttled": false,
-            "throttle_time_in_millis": 0
-          },
-          "search": {
-            "open_contexts": 0,
-            "query_total": 30,
-            "query_time_in_millis": 6,
-            "query_current": 0,
-            "fetch_total": 30,
-            "fetch_time_in_millis": 2,
-            "fetch_current": 0,
-            "scroll_total": 0,
-            "scroll_time_in_millis": 0,
-            "scroll_current": 0,
-            "suggest_total": 0,
-            "suggest_time_in_millis": 0,
-            "suggest_current": 0
-          },
-          "merges": {
-            "current": 0,
-            "current_docs": 0,
-            "current_size_in_bytes": 0,
-            "total": 0,
-            "total_time_in_millis": 0,
-            "total_docs": 0,
-            "total_size_in_bytes": 0,
-            "total_stopped_time_in_millis": 0,
-            "total_throttled_time_in_millis": 0,
-            "total_auto_throttle_in_bytes": 20971520
-          },
-          "refresh": {
-            "total": 8,
-            "total_time_in_millis": 63,
-            "listeners": 0
-          },
-          "query_cache": {
-            "memory_size_in_bytes": 0,
-            "total_count": 0,
-            "hit_count": 0,
-            "miss_count": 0,
-            "cache_size": 0,
-            "cache_count": 0,
-            "evictions": 0
-          },
-          "fielddata": {
-            "memory_size_in_bytes": 0,
-            "evictions": 0
-          },
-          "segments": {
-            "count": 1,
-            "memory_in_bytes": 2153,
-            "terms_memory_in_bytes": 1639,
-            "stored_fields_memory_in_bytes": 312,
-            "term_vectors_memory_in_bytes": 0,
-            "norms_memory_in_bytes": 128,
-            "points_memory_in_bytes": 6,
-            "doc_values_memory_in_bytes": 68,
-            "index_writer_memory_in_bytes": 0,
-            "version_map_memory_in_bytes": 0,
-            "fixed_bit_set_memory_in_bytes": 0,
-            "max_unsafe_auto_id_timestamp": -1,
-            "file_sizes": {}
-          },
-          "request_cache": {
-            "memory_size_in_bytes": 0,
-            "evictions": 0,
-            "hit_count": 0,
-            "miss_count": 0
-          }
-        }
-      },
-      ".monitoring-es-6-mb-2018.09.07": {
-        "uuid": "GAGg1lZrRzmvnAxh6k5ymA",
-        "primaries": {
-          "docs": {
-            "count": 219,
-            "deleted": 0
-          },
-          "store": {
-            "size_in_bytes": 169315
-          },
-          "indexing": {
-            "index_total": 219,
-            "index_time_in_millis": 48,
-            "index_current": 0,
-            "index_failed": 0,
-            "delete_total": 0,
-            "delete_time_in_millis": 0,
-            "delete_current": 0,
-            "noop_update_total": 0,
-            "is_throttled": false,
-            "throttle_time_in_millis": 0
-          },
-          "search": {
-            "open_contexts": 0,
-            "query_total": 22,
-            "query_time_in_millis": 4,
-            "query_current": 0,
-            "fetch_total": 2,
-            "fetch_time_in_millis": 0,
-            "fetch_current": 0,
-            "scroll_total": 0,
-            "scroll_time_in_millis": 0,
-            "scroll_current": 0,
-            "suggest_total": 0,
-            "suggest_time_in_millis": 0,
-            "suggest_current": 0
-          },
-          "merges": {
-            "current": 0,
-            "current_docs": 0,
-            "current_size_in_bytes": 0,
-            "total": 2,
-            "total_time_in_millis": 21,
-            "total_docs": 199,
-            "total_size_in_bytes": 348970,
-            "total_stopped_time_in_millis": 0,
-            "total_throttled_time_in_millis": 0,
-            "total_auto_throttle_in_bytes": 20971520
-          },
-          "refresh": {
-            "total": 26,
-            "total_time_in_millis": 271,
-            "listeners": 0
-          },
-          "query_cache": {
-            "memory_size_in_bytes": 0,
-            "total_count": 0,
-            "hit_count": 0,
-            "miss_count": 0,
-            "cache_size": 0,
-            "cache_count": 0,
-            "evictions": 0
-          },
-          "fielddata": {
-            "memory_size_in_bytes": 0,
-            "evictions": 0
-          },
-          "segments": {
-            "count": 4,
-            "memory_in_bytes": 19017,
-            "terms_memory_in_bytes": 3856,
-            "stored_fields_memory_in_bytes": 1232,
-            "term_vectors_memory_in_bytes": 0,
-            "norms_memory_in_bytes": 0,
-            "points_memory_in_bytes": 513,
-            "doc_values_memory_in_bytes": 13416,
-            "index_writer_memory_in_bytes": 0,
-            "version_map_memory_in_bytes": 0,
-            "fixed_bit_set_memory_in_bytes": 0,
-            "max_unsafe_auto_id_timestamp": -1,
-            "file_sizes": {}
-          },
-          "request_cache": {
-            "memory_size_in_bytes": 0,
-            "evictions": 0,
-            "hit_count": 0,
-            "miss_count": 0
-          }
+        ".monitoring-es-6-mb-2018.09.07": {
+            "uuid": "GAGg1lZrRzmvnAxh6k5ymA",
+            "primaries": {
+                "docs": {
+                    "count": 219,
+                    "deleted": 0
+                },
+                "store": {
+                    "size_in_bytes": 169315
+                },
+                "indexing": {
+                    "index_total": 219,
+                    "index_time_in_millis": 48,
+                    "index_current": 0,
+                    "index_failed": 0,
+                    "delete_total": 0,
+                    "delete_time_in_millis": 0,
+                    "delete_current": 0,
+                    "noop_update_total": 0,
+                    "is_throttled": false,
+                    "throttle_time_in_millis": 0
+                },
+                "search": {
+                    "open_contexts": 0,
+                    "query_total": 22,
+                    "query_time_in_millis": 4,
+                    "query_current": 0,
+                    "fetch_total": 2,
+                    "fetch_time_in_millis": 0,
+                    "fetch_current": 0,
+                    "scroll_total": 0,
+                    "scroll_time_in_millis": 0,
+                    "scroll_current": 0,
+                    "suggest_total": 0,
+                    "suggest_time_in_millis": 0,
+                    "suggest_current": 0
+                },
+                "merges": {
+                    "current": 0,
+                    "current_docs": 0,
+                    "current_size_in_bytes": 0,
+                    "total": 2,
+                    "total_time_in_millis": 21,
+                    "total_docs": 199,
+                    "total_size_in_bytes": 348970,
+                    "total_stopped_time_in_millis": 0,
+                    "total_throttled_time_in_millis": 0,
+                    "total_auto_throttle_in_bytes": 20971520
+                },
+                "refresh": {
+                    "total": 26,
+                    "total_time_in_millis": 271,
+                    "listeners": 0
+                },
+                "query_cache": {
+                    "memory_size_in_bytes": 0,
+                    "total_count": 0,
+                    "hit_count": 0,
+                    "miss_count": 0,
+                    "cache_size": 0,
+                    "cache_count": 0,
+                    "evictions": 0
+                },
+                "fielddata": {
+                    "memory_size_in_bytes": 0,
+                    "evictions": 0
+                },
+                "segments": {
+                    "count": 4,
+                    "memory_in_bytes": 19017,
+                    "terms_memory_in_bytes": 3856,
+                    "stored_fields_memory_in_bytes": 1232,
+                    "term_vectors_memory_in_bytes": 0,
+                    "norms_memory_in_bytes": 0,
+                    "points_memory_in_bytes": 513,
+                    "doc_values_memory_in_bytes": 13416,
+                    "index_writer_memory_in_bytes": 0,
+                    "version_map_memory_in_bytes": 0,
+                    "fixed_bit_set_memory_in_bytes": 0,
+                    "max_unsafe_auto_id_timestamp": -1,
+                    "file_sizes": {}
+                },
+                "request_cache": {
+                    "memory_size_in_bytes": 0,
+                    "evictions": 0,
+                    "hit_count": 0,
+                    "miss_count": 0
+                }
+            },
+            "total": {
+                "docs": {
+                    "count": 219,
+                    "deleted": 0
+                },
+                "store": {
+                    "size_in_bytes": 169315
+                },
+                "indexing": {
+                    "index_total": 219,
+                    "index_time_in_millis": 48,
+                    "index_current": 0,
+                    "index_failed": 0,
+                    "delete_total": 0,
+                    "delete_time_in_millis": 0,
+                    "delete_current": 0,
+                    "noop_update_total": 0,
+                    "is_throttled": false,
+                    "throttle_time_in_millis": 0
+                },
+                "search": {
+                    "open_contexts": 0,
+                    "query_total": 22,
+                    "query_time_in_millis": 4,
+                    "query_current": 0,
+                    "fetch_total": 2,
+                    "fetch_time_in_millis": 0,
+                    "fetch_current": 0,
+                    "scroll_total": 0,
+                    "scroll_time_in_millis": 0,
+                    "scroll_current": 0,
+                    "suggest_total": 0,
+                    "suggest_time_in_millis": 0,
+                    "suggest_current": 0
+                },
+                "merges": {
+                    "current": 0,
+                    "current_docs": 0,
+                    "current_size_in_bytes": 0,
+                    "total": 2,
+                    "total_time_in_millis": 21,
+                    "total_docs": 199,
+                    "total_size_in_bytes": 348970,
+                    "total_stopped_time_in_millis": 0,
+                    "total_throttled_time_in_millis": 0,
+                    "total_auto_throttle_in_bytes": 20971520
+                },
+                "refresh": {
+                    "total": 26,
+                    "total_time_in_millis": 271,
+                    "listeners": 0
+                },
+                "query_cache": {
+                    "memory_size_in_bytes": 0,
+                    "total_count": 0,
+                    "hit_count": 0,
+                    "miss_count": 0,
+                    "cache_size": 0,
+                    "cache_count": 0,
+                    "evictions": 0
+                },
+                "fielddata": {
+                    "memory_size_in_bytes": 0,
+                    "evictions": 0
+                },
+                "segments": {
+                    "count": 4,
+                    "memory_in_bytes": 19017,
+                    "terms_memory_in_bytes": 3856,
+                    "stored_fields_memory_in_bytes": 1232,
+                    "term_vectors_memory_in_bytes": 0,
+                    "norms_memory_in_bytes": 0,
+                    "points_memory_in_bytes": 513,
+                    "doc_values_memory_in_bytes": 13416,
+                    "index_writer_memory_in_bytes": 0,
+                    "version_map_memory_in_bytes": 0,
+                    "fixed_bit_set_memory_in_bytes": 0,
+                    "max_unsafe_auto_id_timestamp": -1,
+                    "file_sizes": {}
+                },
+                "request_cache": {
+                    "memory_size_in_bytes": 0,
+                    "evictions": 0,
+                    "hit_count": 0,
+                    "miss_count": 0
+                }
+            }
         },
-        "total": {
-          "docs": {
-            "count": 219,
-            "deleted": 0
-          },
-          "store": {
-            "size_in_bytes": 169315
-          },
-          "indexing": {
-            "index_total": 219,
-            "index_time_in_millis": 48,
-            "index_current": 0,
-            "index_failed": 0,
-            "delete_total": 0,
-            "delete_time_in_millis": 0,
-            "delete_current": 0,
-            "noop_update_total": 0,
-            "is_throttled": false,
-            "throttle_time_in_millis": 0
-          },
-          "search": {
-            "open_contexts": 0,
-            "query_total": 22,
-            "query_time_in_millis": 4,
-            "query_current": 0,
-            "fetch_total": 2,
-            "fetch_time_in_millis": 0,
-            "fetch_current": 0,
-            "scroll_total": 0,
-            "scroll_time_in_millis": 0,
-            "scroll_current": 0,
-            "suggest_total": 0,
-            "suggest_time_in_millis": 0,
-            "suggest_current": 0
-          },
-          "merges": {
-            "current": 0,
-            "current_docs": 0,
-            "current_size_in_bytes": 0,
-            "total": 2,
-            "total_time_in_millis": 21,
-            "total_docs": 199,
-            "total_size_in_bytes": 348970,
-            "total_stopped_time_in_millis": 0,
-            "total_throttled_time_in_millis": 0,
-            "total_auto_throttle_in_bytes": 20971520
-          },
-          "refresh": {
-            "total": 26,
-            "total_time_in_millis": 271,
-            "listeners": 0
-          },
-          "query_cache": {
-            "memory_size_in_bytes": 0,
-            "total_count": 0,
-            "hit_count": 0,
-            "miss_count": 0,
-            "cache_size": 0,
-            "cache_count": 0,
-            "evictions": 0
-          },
-          "fielddata": {
-            "memory_size_in_bytes": 0,
-            "evictions": 0
-          },
-          "segments": {
-            "count": 4,
-            "memory_in_bytes": 19017,
-            "terms_memory_in_bytes": 3856,
-            "stored_fields_memory_in_bytes": 1232,
-            "term_vectors_memory_in_bytes": 0,
-            "norms_memory_in_bytes": 0,
-            "points_memory_in_bytes": 513,
-            "doc_values_memory_in_bytes": 13416,
-            "index_writer_memory_in_bytes": 0,
-            "version_map_memory_in_bytes": 0,
-            "fixed_bit_set_memory_in_bytes": 0,
-            "max_unsafe_auto_id_timestamp": -1,
-            "file_sizes": {}
-          },
-          "request_cache": {
-            "memory_size_in_bytes": 0,
-            "evictions": 0,
-            "hit_count": 0,
-            "miss_count": 0
-          }
+        ".watches": {
+            "uuid": "Y0_ioAUSTs2r3cLAXOnfsA",
+            "primaries": {
+                "docs": {
+                    "count": 6,
+                    "deleted": 0
+                },
+                "store": {
+                    "size_in_bytes": 93341
+                },
+                "indexing": {
+                    "index_total": 258,
+                    "index_time_in_millis": 2390,
+                    "index_current": 0,
+                    "index_failed": 0,
+                    "delete_total": 0,
+                    "delete_time_in_millis": 0,
+                    "delete_current": 0,
+                    "noop_update_total": 0,
+                    "is_throttled": false,
+                    "throttle_time_in_millis": 0
+                },
+                "search": {
+                    "open_contexts": 0,
+                    "query_total": 2,
+                    "query_time_in_millis": 17,
+                    "query_current": 0,
+                    "fetch_total": 2,
+                    "fetch_time_in_millis": 20,
+                    "fetch_current": 0,
+                    "scroll_total": 1,
+                    "scroll_time_in_millis": 312,
+                    "scroll_current": 0,
+                    "suggest_total": 0,
+                    "suggest_time_in_millis": 0,
+                    "suggest_current": 0
+                },
+                "merges": {
+                    "current": 0,
+                    "current_docs": 0,
+                    "current_size_in_bytes": 0,
+                    "total": 1,
+                    "total_time_in_millis": 55,
+                    "total_docs": 11,
+                    "total_size_in_bytes": 66746,
+                    "total_stopped_time_in_millis": 0,
+                    "total_throttled_time_in_millis": 0,
+                    "total_auto_throttle_in_bytes": 20971520
+                },
+                "refresh": {
+                    "total": 52,
+                    "total_time_in_millis": 3056,
+                    "listeners": 0
+                },
+                "query_cache": {
+                    "memory_size_in_bytes": 0,
+                    "total_count": 0,
+                    "hit_count": 0,
+                    "miss_count": 0,
+                    "cache_size": 0,
+                    "cache_count": 0,
+                    "evictions": 0
+                },
+                "fielddata": {
+                    "memory_size_in_bytes": 0,
+                    "evictions": 0
+                },
+                "segments": {
+                    "count": 5,
+                    "memory_in_bytes": 18971,
+                    "terms_memory_in_bytes": 14945,
+                    "stored_fields_memory_in_bytes": 1560,
+                    "term_vectors_memory_in_bytes": 0,
+                    "norms_memory_in_bytes": 1920,
+                    "points_memory_in_bytes": 22,
+                    "doc_values_memory_in_bytes": 524,
+                    "index_writer_memory_in_bytes": 0,
+                    "version_map_memory_in_bytes": 0,
+                    "fixed_bit_set_memory_in_bytes": 0,
+                    "max_unsafe_auto_id_timestamp": -1,
+                    "file_sizes": {}
+                },
+                "request_cache": {
+                    "memory_size_in_bytes": 0,
+                    "evictions": 0,
+                    "hit_count": 0,
+                    "miss_count": 0
+                }
+            },
+            "total": {
+                "docs": {
+                    "count": 6,
+                    "deleted": 0
+                },
+                "store": {
+                    "size_in_bytes": 93341
+                },
+                "indexing": {
+                    "index_total": 258,
+                    "index_time_in_millis": 2390,
+                    "index_current": 0,
+                    "index_failed": 0,
+                    "delete_total": 0,
+                    "delete_time_in_millis": 0,
+                    "delete_current": 0,
+                    "noop_update_total": 0,
+                    "is_throttled": false,
+                    "throttle_time_in_millis": 0
+                },
+                "search": {
+                    "open_contexts": 0,
+                    "query_total": 2,
+                    "query_time_in_millis": 17,
+                    "query_current": 0,
+                    "fetch_total": 2,
+                    "fetch_time_in_millis": 20,
+                    "fetch_current": 0,
+                    "scroll_total": 1,
+                    "scroll_time_in_millis": 312,
+                    "scroll_current": 0,
+                    "suggest_total": 0,
+                    "suggest_time_in_millis": 0,
+                    "suggest_current": 0
+                },
+                "merges": {
+                    "current": 0,
+                    "current_docs": 0,
+                    "current_size_in_bytes": 0,
+                    "total": 1,
+                    "total_time_in_millis": 55,
+                    "total_docs": 11,
+                    "total_size_in_bytes": 66746,
+                    "total_stopped_time_in_millis": 0,
+                    "total_throttled_time_in_millis": 0,
+                    "total_auto_throttle_in_bytes": 20971520
+                },
+                "refresh": {
+                    "total": 52,
+                    "total_time_in_millis": 3056,
+                    "listeners": 0
+                },
+                "query_cache": {
+                    "memory_size_in_bytes": 0,
+                    "total_count": 0,
+                    "hit_count": 0,
+                    "miss_count": 0,
+                    "cache_size": 0,
+                    "cache_count": 0,
+                    "evictions": 0
+                },
+                "fielddata": {
+                    "memory_size_in_bytes": 0,
+                    "evictions": 0
+                },
+                "segments": {
+                    "count": 5,
+                    "memory_in_bytes": 18971,
+                    "terms_memory_in_bytes": 14945,
+                    "stored_fields_memory_in_bytes": 1560,
+                    "term_vectors_memory_in_bytes": 0,
+                    "norms_memory_in_bytes": 1920,
+                    "points_memory_in_bytes": 22,
+                    "doc_values_memory_in_bytes": 524,
+                    "index_writer_memory_in_bytes": 0,
+                    "version_map_memory_in_bytes": 0,
+                    "fixed_bit_set_memory_in_bytes": 0,
+                    "max_unsafe_auto_id_timestamp": -1,
+                    "file_sizes": {}
+                },
+                "request_cache": {
+                    "memory_size_in_bytes": 0,
+                    "evictions": 0,
+                    "hit_count": 0,
+                    "miss_count": 0
+                }
+            }
         }
-      },
-      ".watches": {
-        "uuid": "Y0_ioAUSTs2r3cLAXOnfsA",
-        "primaries": {
-          "docs": {
-            "count": 6,
-            "deleted": 0
-          },
-          "store": {
-            "size_in_bytes": 93341
-          },
-          "indexing": {
-            "index_total": 258,
-            "index_time_in_millis": 2390,
-            "index_current": 0,
-            "index_failed": 0,
-            "delete_total": 0,
-            "delete_time_in_millis": 0,
-            "delete_current": 0,
-            "noop_update_total": 0,
-            "is_throttled": false,
-            "throttle_time_in_millis": 0
-          },
-          "search": {
-            "open_contexts": 0,
-            "query_total": 2,
-            "query_time_in_millis": 17,
-            "query_current": 0,
-            "fetch_total": 2,
-            "fetch_time_in_millis": 20,
-            "fetch_current": 0,
-            "scroll_total": 1,
-            "scroll_time_in_millis": 312,
-            "scroll_current": 0,
-            "suggest_total": 0,
-            "suggest_time_in_millis": 0,
-            "suggest_current": 0
-          },
-          "merges": {
-            "current": 0,
-            "current_docs": 0,
-            "current_size_in_bytes": 0,
-            "total": 1,
-            "total_time_in_millis": 55,
-            "total_docs": 11,
-            "total_size_in_bytes": 66746,
-            "total_stopped_time_in_millis": 0,
-            "total_throttled_time_in_millis": 0,
-            "total_auto_throttle_in_bytes": 20971520
-          },
-          "refresh": {
-            "total": 52,
-            "total_time_in_millis": 3056,
-            "listeners": 0
-          },
-          "query_cache": {
-            "memory_size_in_bytes": 0,
-            "total_count": 0,
-            "hit_count": 0,
-            "miss_count": 0,
-            "cache_size": 0,
-            "cache_count": 0,
-            "evictions": 0
-          },
-          "fielddata": {
-            "memory_size_in_bytes": 0,
-            "evictions": 0
-          },
-          "segments": {
-            "count": 5,
-            "memory_in_bytes": 18971,
-            "terms_memory_in_bytes": 14945,
-            "stored_fields_memory_in_bytes": 1560,
-            "term_vectors_memory_in_bytes": 0,
-            "norms_memory_in_bytes": 1920,
-            "points_memory_in_bytes": 22,
-            "doc_values_memory_in_bytes": 524,
-            "index_writer_memory_in_bytes": 0,
-            "version_map_memory_in_bytes": 0,
-            "fixed_bit_set_memory_in_bytes": 0,
-            "max_unsafe_auto_id_timestamp": -1,
-            "file_sizes": {}
-          },
-          "request_cache": {
-            "memory_size_in_bytes": 0,
-            "evictions": 0,
-            "hit_count": 0,
-            "miss_count": 0
-          }
-        },
-        "total": {
-          "docs": {
-            "count": 6,
-            "deleted": 0
-          },
-          "store": {
-            "size_in_bytes": 93341
-          },
-          "indexing": {
-            "index_total": 258,
-            "index_time_in_millis": 2390,
-            "index_current": 0,
-            "index_failed": 0,
-            "delete_total": 0,
-            "delete_time_in_millis": 0,
-            "delete_current": 0,
-            "noop_update_total": 0,
-            "is_throttled": false,
-            "throttle_time_in_millis": 0
-          },
-          "search": {
-            "open_contexts": 0,
-            "query_total": 2,
-            "query_time_in_millis": 17,
-            "query_current": 0,
-            "fetch_total": 2,
-            "fetch_time_in_millis": 20,
-            "fetch_current": 0,
-            "scroll_total": 1,
-            "scroll_time_in_millis": 312,
-            "scroll_current": 0,
-            "suggest_total": 0,
-            "suggest_time_in_millis": 0,
-            "suggest_current": 0
-          },
-          "merges": {
-            "current": 0,
-            "current_docs": 0,
-            "current_size_in_bytes": 0,
-            "total": 1,
-            "total_time_in_millis": 55,
-            "total_docs": 11,
-            "total_size_in_bytes": 66746,
-            "total_stopped_time_in_millis": 0,
-            "total_throttled_time_in_millis": 0,
-            "total_auto_throttle_in_bytes": 20971520
-          },
-          "refresh": {
-            "total": 52,
-            "total_time_in_millis": 3056,
-            "listeners": 0
-          },
-          "query_cache": {
-            "memory_size_in_bytes": 0,
-            "total_count": 0,
-            "hit_count": 0,
-            "miss_count": 0,
-            "cache_size": 0,
-            "cache_count": 0,
-            "evictions": 0
-          },
-          "fielddata": {
-            "memory_size_in_bytes": 0,
-            "evictions": 0
-          },
-          "segments": {
-            "count": 5,
-            "memory_in_bytes": 18971,
-            "terms_memory_in_bytes": 14945,
-            "stored_fields_memory_in_bytes": 1560,
-            "term_vectors_memory_in_bytes": 0,
-            "norms_memory_in_bytes": 1920,
-            "points_memory_in_bytes": 22,
-            "doc_values_memory_in_bytes": 524,
-            "index_writer_memory_in_bytes": 0,
-            "version_map_memory_in_bytes": 0,
-            "fixed_bit_set_memory_in_bytes": 0,
-            "max_unsafe_auto_id_timestamp": -1,
-            "file_sizes": {}
-          },
-          "request_cache": {
-            "memory_size_in_bytes": 0,
-            "evictions": 0,
-            "hit_count": 0,
-            "miss_count": 0
-          }
-        }
-      }
     }
-  }
+}

--- a/metricbeat/module/elasticsearch/index/_meta/test/stats.700-alpha1.json
+++ b/metricbeat/module/elasticsearch/index/_meta/test/stats.700-alpha1.json
@@ -1,1473 +1,1601 @@
 {
-    "_shards" : {
-        "total" : 6,
-        "successful" : 5,
-        "failed" : 0
+    "_shards": {
+      "total": 9,
+      "successful": 8,
+      "failed": 0
     },
-    "_all" : {
-        "primaries" : {
-            "docs" : {
-                "count" : 41,
-                "deleted" : 0
-            },
-            "store" : {
-                "size_in_bytes" : 174153
-            },
-            "indexing" : {
-                "index_total" : 66,
-                "index_time_in_millis" : 2239,
-                "index_current" : 0,
-                "index_failed" : 0,
-                "delete_total" : 0,
-                "delete_time_in_millis" : 0,
-                "delete_current" : 0,
-                "noop_update_total" : 0,
-                "is_throttled" : false,
-                "throttle_time_in_millis" : 0
-            },
-            "get" : {
-                "total" : 6,
-                "time_in_millis" : 17,
-                "exists_total" : 0,
-                "exists_time_in_millis" : 0,
-                "missing_total" : 6,
-                "missing_time_in_millis" : 17,
-                "current" : 0
-            },
-            "search" : {
-                "open_contexts" : 0,
-                "query_total" : 3,
-                "query_time_in_millis" : 674,
-                "query_current" : 0,
-                "fetch_total" : 1,
-                "fetch_time_in_millis" : 23,
-                "fetch_current" : 0,
-                "scroll_total" : 1,
-                "scroll_time_in_millis" : 1068,
-                "scroll_current" : 0,
-                "suggest_total" : 0,
-                "suggest_time_in_millis" : 0,
-                "suggest_current" : 0
-            },
-            "merges" : {
-                "current" : 0,
-                "current_docs" : 0,
-                "current_size_in_bytes" : 0,
-                "total" : 0,
-                "total_time_in_millis" : 0,
-                "total_docs" : 0,
-                "total_size_in_bytes" : 0,
-                "total_stopped_time_in_millis" : 0,
-                "total_throttled_time_in_millis" : 0,
-                "total_auto_throttle_in_bytes" : 104857600
-            },
-            "refresh" : {
-                "total" : 26,
-                "total_time_in_millis" : 3076,
-                "listeners" : 0
-            },
-            "flush" : {
-                "total" : 0,
-                "periodic" : 0,
-                "total_time_in_millis" : 0
-            },
-            "warmer" : {
-                "current" : 0,
-                "total" : 17,
-                "total_time_in_millis" : 65
-            },
-            "query_cache" : {
-                "memory_size_in_bytes" : 0,
-                "total_count" : 0,
-                "hit_count" : 0,
-                "miss_count" : 0,
-                "cache_size" : 0,
-                "cache_count" : 0,
-                "evictions" : 0
-            },
-            "fielddata" : {
-                "memory_size_in_bytes" : 0,
-                "evictions" : 0
-            },
-            "completion" : {
-                "size_in_bytes" : 0
-            },
-            "segments" : {
-                "count" : 14,
-                "memory_in_bytes" : 60804,
-                "terms_memory_in_bytes" : 51071,
-                "stored_fields_memory_in_bytes" : 4368,
-                "term_vectors_memory_in_bytes" : 0,
-                "norms_memory_in_bytes" : 2304,
-                "points_memory_in_bytes" : 861,
-                "doc_values_memory_in_bytes" : 2200,
-                "index_writer_memory_in_bytes" : 4456672,
-                "version_map_memory_in_bytes" : 0,
-                "fixed_bit_set_memory_in_bytes" : 288,
-                "max_unsafe_auto_id_timestamp" : -1,
-                "file_sizes" : { }
-            },
-            "translog" : {
-                "operations" : 66,
-                "size_in_bytes" : 87028,
-                "uncommitted_operations" : 66,
-                "uncommitted_size_in_bytes" : 87028,
-                "earliest_last_modified_age" : 0
-            },
-            "request_cache" : {
-                "memory_size_in_bytes" : 0,
-                "evictions" : 0,
-                "hit_count" : 0,
-                "miss_count" : 2
-            },
-            "recovery" : {
-                "current_as_source" : 0,
-                "current_as_target" : 0,
-                "throttle_time_in_millis" : 0
-            }
+    "_all": {
+      "primaries": {
+        "docs": {
+          "count": 1257,
+          "deleted": 11
         },
-        "total" : {
-            "docs" : {
-                "count" : 41,
-                "deleted" : 0
-            },
-            "store" : {
-                "size_in_bytes" : 174153
-            },
-            "indexing" : {
-                "index_total" : 66,
-                "index_time_in_millis" : 2239,
-                "index_current" : 0,
-                "index_failed" : 0,
-                "delete_total" : 0,
-                "delete_time_in_millis" : 0,
-                "delete_current" : 0,
-                "noop_update_total" : 0,
-                "is_throttled" : false,
-                "throttle_time_in_millis" : 0
-            },
-            "get" : {
-                "total" : 6,
-                "time_in_millis" : 17,
-                "exists_total" : 0,
-                "exists_time_in_millis" : 0,
-                "missing_total" : 6,
-                "missing_time_in_millis" : 17,
-                "current" : 0
-            },
-            "search" : {
-                "open_contexts" : 0,
-                "query_total" : 3,
-                "query_time_in_millis" : 674,
-                "query_current" : 0,
-                "fetch_total" : 1,
-                "fetch_time_in_millis" : 23,
-                "fetch_current" : 0,
-                "scroll_total" : 1,
-                "scroll_time_in_millis" : 1068,
-                "scroll_current" : 0,
-                "suggest_total" : 0,
-                "suggest_time_in_millis" : 0,
-                "suggest_current" : 0
-            },
-            "merges" : {
-                "current" : 0,
-                "current_docs" : 0,
-                "current_size_in_bytes" : 0,
-                "total" : 0,
-                "total_time_in_millis" : 0,
-                "total_docs" : 0,
-                "total_size_in_bytes" : 0,
-                "total_stopped_time_in_millis" : 0,
-                "total_throttled_time_in_millis" : 0,
-                "total_auto_throttle_in_bytes" : 104857600
-            },
-            "refresh" : {
-                "total" : 26,
-                "total_time_in_millis" : 3076,
-                "listeners" : 0
-            },
-            "flush" : {
-                "total" : 0,
-                "periodic" : 0,
-                "total_time_in_millis" : 0
-            },
-            "warmer" : {
-                "current" : 0,
-                "total" : 17,
-                "total_time_in_millis" : 65
-            },
-            "query_cache" : {
-                "memory_size_in_bytes" : 0,
-                "total_count" : 0,
-                "hit_count" : 0,
-                "miss_count" : 0,
-                "cache_size" : 0,
-                "cache_count" : 0,
-                "evictions" : 0
-            },
-            "fielddata" : {
-                "memory_size_in_bytes" : 0,
-                "evictions" : 0
-            },
-            "completion" : {
-                "size_in_bytes" : 0
-            },
-            "segments" : {
-                "count" : 14,
-                "memory_in_bytes" : 60804,
-                "terms_memory_in_bytes" : 51071,
-                "stored_fields_memory_in_bytes" : 4368,
-                "term_vectors_memory_in_bytes" : 0,
-                "norms_memory_in_bytes" : 2304,
-                "points_memory_in_bytes" : 861,
-                "doc_values_memory_in_bytes" : 2200,
-                "index_writer_memory_in_bytes" : 4456672,
-                "version_map_memory_in_bytes" : 0,
-                "fixed_bit_set_memory_in_bytes" : 288,
-                "max_unsafe_auto_id_timestamp" : -1,
-                "file_sizes" : { }
-            },
-            "translog" : {
-                "operations" : 66,
-                "size_in_bytes" : 87028,
-                "uncommitted_operations" : 66,
-                "uncommitted_size_in_bytes" : 87028,
-                "earliest_last_modified_age" : 0
-            },
-            "request_cache" : {
-                "memory_size_in_bytes" : 0,
-                "evictions" : 0,
-                "hit_count" : 0,
-                "miss_count" : 2
-            },
-            "recovery" : {
-                "current_as_source" : 0,
-                "current_as_target" : 0,
-                "throttle_time_in_millis" : 0
-            }
+        "store": {
+          "size_in_bytes": 1686190
+        },
+        "indexing": {
+          "index_total": 1885,
+          "index_time_in_millis": 5788,
+          "index_current": 0,
+          "index_failed": 0,
+          "delete_total": 258,
+          "delete_time_in_millis": 182,
+          "delete_current": 0,
+          "noop_update_total": 0,
+          "is_throttled": false,
+          "throttle_time_in_millis": 0
+        },
+        "search": {
+          "open_contexts": 0,
+          "query_total": 81,
+          "query_time_in_millis": 39,
+          "query_current": 0,
+          "fetch_total": 56,
+          "fetch_time_in_millis": 41,
+          "fetch_current": 0,
+          "scroll_total": 2,
+          "scroll_time_in_millis": 314,
+          "scroll_current": 0,
+          "suggest_total": 0,
+          "suggest_time_in_millis": 0,
+          "suggest_current": 0
+        },
+        "merges": {
+          "current": 0,
+          "current_docs": 0,
+          "current_size_in_bytes": 0,
+          "total": 28,
+          "total_time_in_millis": 685,
+          "total_docs": 2500,
+          "total_size_in_bytes": 9078916,
+          "total_stopped_time_in_millis": 0,
+          "total_throttled_time_in_millis": 0,
+          "total_auto_throttle_in_bytes": 167772160
+        },
+        "refresh": {
+          "total": 207,
+          "total_time_in_millis": 8279,
+          "listeners": 0
+        },
+        "query_cache": {
+          "memory_size_in_bytes": 0,
+          "total_count": 0,
+          "hit_count": 0,
+          "miss_count": 0,
+          "cache_size": 0,
+          "cache_count": 0,
+          "evictions": 0
+        },
+        "fielddata": {
+          "memory_size_in_bytes": 0,
+          "evictions": 0
+        },
+        "segments": {
+          "count": 20,
+          "memory_in_bytes": 190357,
+          "terms_memory_in_bytes": 121595,
+          "stored_fields_memory_in_bytes": 6456,
+          "term_vectors_memory_in_bytes": 0,
+          "norms_memory_in_bytes": 10688,
+          "points_memory_in_bytes": 1282,
+          "doc_values_memory_in_bytes": 50336,
+          "index_writer_memory_in_bytes": 285894,
+          "version_map_memory_in_bytes": 60329,
+          "fixed_bit_set_memory_in_bytes": 344,
+          "max_unsafe_auto_id_timestamp": -1,
+          "file_sizes": {}
+        },
+        "request_cache": {
+          "memory_size_in_bytes": 0,
+          "evictions": 0,
+          "hit_count": 0,
+          "miss_count": 0
         }
+      },
+      "total": {
+        "docs": {
+          "count": 1257,
+          "deleted": 11
+        },
+        "store": {
+          "size_in_bytes": 1686190
+        },
+        "indexing": {
+          "index_total": 1885,
+          "index_time_in_millis": 5788,
+          "index_current": 0,
+          "index_failed": 0,
+          "delete_total": 258,
+          "delete_time_in_millis": 182,
+          "delete_current": 0,
+          "noop_update_total": 0,
+          "is_throttled": false,
+          "throttle_time_in_millis": 0
+        },
+        "search": {
+          "open_contexts": 0,
+          "query_total": 81,
+          "query_time_in_millis": 39,
+          "query_current": 0,
+          "fetch_total": 56,
+          "fetch_time_in_millis": 41,
+          "fetch_current": 0,
+          "scroll_total": 2,
+          "scroll_time_in_millis": 314,
+          "scroll_current": 0,
+          "suggest_total": 0,
+          "suggest_time_in_millis": 0,
+          "suggest_current": 0
+        },
+        "merges": {
+          "current": 0,
+          "current_docs": 0,
+          "current_size_in_bytes": 0,
+          "total": 28,
+          "total_time_in_millis": 685,
+          "total_docs": 2500,
+          "total_size_in_bytes": 9078916,
+          "total_stopped_time_in_millis": 0,
+          "total_throttled_time_in_millis": 0,
+          "total_auto_throttle_in_bytes": 167772160
+        },
+        "refresh": {
+          "total": 207,
+          "total_time_in_millis": 8279,
+          "listeners": 0
+        },
+        "query_cache": {
+          "memory_size_in_bytes": 0,
+          "total_count": 0,
+          "hit_count": 0,
+          "miss_count": 0,
+          "cache_size": 0,
+          "cache_count": 0,
+          "evictions": 0
+        },
+        "fielddata": {
+          "memory_size_in_bytes": 0,
+          "evictions": 0
+        },
+        "segments": {
+          "count": 20,
+          "memory_in_bytes": 190357,
+          "terms_memory_in_bytes": 121595,
+          "stored_fields_memory_in_bytes": 6456,
+          "term_vectors_memory_in_bytes": 0,
+          "norms_memory_in_bytes": 10688,
+          "points_memory_in_bytes": 1282,
+          "doc_values_memory_in_bytes": 50336,
+          "index_writer_memory_in_bytes": 285894,
+          "version_map_memory_in_bytes": 60329,
+          "fixed_bit_set_memory_in_bytes": 344,
+          "max_unsafe_auto_id_timestamp": -1,
+          "file_sizes": {}
+        },
+        "request_cache": {
+          "memory_size_in_bytes": 0,
+          "evictions": 0,
+          "hit_count": 0,
+          "miss_count": 0
+        }
+      }
     },
-    "indices" : {
-        ".monitoring-kibana-6-2018.05.18" : {
-            "primaries" : {
-                "docs" : {
-                    "count" : 3,
-                    "deleted" : 0
-                },
-                "store" : {
-                    "size_in_bytes" : 29114
-                },
-                "indexing" : {
-                    "index_total" : 3,
-                    "index_time_in_millis" : 449,
-                    "index_current" : 0,
-                    "index_failed" : 0,
-                    "delete_total" : 0,
-                    "delete_time_in_millis" : 0,
-                    "delete_current" : 0,
-                    "noop_update_total" : 0,
-                    "is_throttled" : false,
-                    "throttle_time_in_millis" : 0
-                },
-                "get" : {
-                    "total" : 0,
-                    "time_in_millis" : 0,
-                    "exists_total" : 0,
-                    "exists_time_in_millis" : 0,
-                    "missing_total" : 0,
-                    "missing_time_in_millis" : 0,
-                    "current" : 0
-                },
-                "search" : {
-                    "open_contexts" : 0,
-                    "query_total" : 1,
-                    "query_time_in_millis" : 135,
-                    "query_current" : 0,
-                    "fetch_total" : 0,
-                    "fetch_time_in_millis" : 0,
-                    "fetch_current" : 0,
-                    "scroll_total" : 0,
-                    "scroll_time_in_millis" : 0,
-                    "scroll_current" : 0,
-                    "suggest_total" : 0,
-                    "suggest_time_in_millis" : 0,
-                    "suggest_current" : 0
-                },
-                "merges" : {
-                    "current" : 0,
-                    "current_docs" : 0,
-                    "current_size_in_bytes" : 0,
-                    "total" : 0,
-                    "total_time_in_millis" : 0,
-                    "total_docs" : 0,
-                    "total_size_in_bytes" : 0,
-                    "total_stopped_time_in_millis" : 0,
-                    "total_throttled_time_in_millis" : 0,
-                    "total_auto_throttle_in_bytes" : 20971520
-                },
-                "refresh" : {
-                    "total" : 5,
-                    "total_time_in_millis" : 553,
-                    "listeners" : 0
-                },
-                "flush" : {
-                    "total" : 0,
-                    "periodic" : 0,
-                    "total_time_in_millis" : 0
-                },
-                "warmer" : {
-                    "current" : 0,
-                    "total" : 4,
-                    "total_time_in_millis" : 13
-                },
-                "query_cache" : {
-                    "memory_size_in_bytes" : 0,
-                    "total_count" : 0,
-                    "hit_count" : 0,
-                    "miss_count" : 0,
-                    "cache_size" : 0,
-                    "cache_count" : 0,
-                    "evictions" : 0
-                },
-                "fielddata" : {
-                    "memory_size_in_bytes" : 0,
-                    "evictions" : 0
-                },
-                "completion" : {
-                    "size_in_bytes" : 0
-                },
-                "segments" : {
-                    "count" : 3,
-                    "memory_in_bytes" : 11586,
-                    "terms_memory_in_bytes" : 10317,
-                    "stored_fields_memory_in_bytes" : 936,
-                    "term_vectors_memory_in_bytes" : 0,
-                    "norms_memory_in_bytes" : 0,
-                    "points_memory_in_bytes" : 129,
-                    "doc_values_memory_in_bytes" : 204,
-                    "index_writer_memory_in_bytes" : 0,
-                    "version_map_memory_in_bytes" : 0,
-                    "fixed_bit_set_memory_in_bytes" : 0,
-                    "max_unsafe_auto_id_timestamp" : -1,
-                    "file_sizes" : { }
-                },
-                "translog" : {
-                    "operations" : 3,
-                    "size_in_bytes" : 3814,
-                    "uncommitted_operations" : 3,
-                    "uncommitted_size_in_bytes" : 3814,
-                    "earliest_last_modified_age" : 0
-                },
-                "request_cache" : {
-                    "memory_size_in_bytes" : 0,
-                    "evictions" : 0,
-                    "hit_count" : 0,
-                    "miss_count" : 1
-                },
-                "recovery" : {
-                    "current_as_source" : 0,
-                    "current_as_target" : 0,
-                    "throttle_time_in_millis" : 0
-                }
-            },
-            "total" : {
-                "docs" : {
-                    "count" : 3,
-                    "deleted" : 0
-                },
-                "store" : {
-                    "size_in_bytes" : 29114
-                },
-                "indexing" : {
-                    "index_total" : 3,
-                    "index_time_in_millis" : 449,
-                    "index_current" : 0,
-                    "index_failed" : 0,
-                    "delete_total" : 0,
-                    "delete_time_in_millis" : 0,
-                    "delete_current" : 0,
-                    "noop_update_total" : 0,
-                    "is_throttled" : false,
-                    "throttle_time_in_millis" : 0
-                },
-                "get" : {
-                    "total" : 0,
-                    "time_in_millis" : 0,
-                    "exists_total" : 0,
-                    "exists_time_in_millis" : 0,
-                    "missing_total" : 0,
-                    "missing_time_in_millis" : 0,
-                    "current" : 0
-                },
-                "search" : {
-                    "open_contexts" : 0,
-                    "query_total" : 1,
-                    "query_time_in_millis" : 135,
-                    "query_current" : 0,
-                    "fetch_total" : 0,
-                    "fetch_time_in_millis" : 0,
-                    "fetch_current" : 0,
-                    "scroll_total" : 0,
-                    "scroll_time_in_millis" : 0,
-                    "scroll_current" : 0,
-                    "suggest_total" : 0,
-                    "suggest_time_in_millis" : 0,
-                    "suggest_current" : 0
-                },
-                "merges" : {
-                    "current" : 0,
-                    "current_docs" : 0,
-                    "current_size_in_bytes" : 0,
-                    "total" : 0,
-                    "total_time_in_millis" : 0,
-                    "total_docs" : 0,
-                    "total_size_in_bytes" : 0,
-                    "total_stopped_time_in_millis" : 0,
-                    "total_throttled_time_in_millis" : 0,
-                    "total_auto_throttle_in_bytes" : 20971520
-                },
-                "refresh" : {
-                    "total" : 5,
-                    "total_time_in_millis" : 553,
-                    "listeners" : 0
-                },
-                "flush" : {
-                    "total" : 0,
-                    "periodic" : 0,
-                    "total_time_in_millis" : 0
-                },
-                "warmer" : {
-                    "current" : 0,
-                    "total" : 4,
-                    "total_time_in_millis" : 13
-                },
-                "query_cache" : {
-                    "memory_size_in_bytes" : 0,
-                    "total_count" : 0,
-                    "hit_count" : 0,
-                    "miss_count" : 0,
-                    "cache_size" : 0,
-                    "cache_count" : 0,
-                    "evictions" : 0
-                },
-                "fielddata" : {
-                    "memory_size_in_bytes" : 0,
-                    "evictions" : 0
-                },
-                "completion" : {
-                    "size_in_bytes" : 0
-                },
-                "segments" : {
-                    "count" : 3,
-                    "memory_in_bytes" : 11586,
-                    "terms_memory_in_bytes" : 10317,
-                    "stored_fields_memory_in_bytes" : 936,
-                    "term_vectors_memory_in_bytes" : 0,
-                    "norms_memory_in_bytes" : 0,
-                    "points_memory_in_bytes" : 129,
-                    "doc_values_memory_in_bytes" : 204,
-                    "index_writer_memory_in_bytes" : 0,
-                    "version_map_memory_in_bytes" : 0,
-                    "fixed_bit_set_memory_in_bytes" : 0,
-                    "max_unsafe_auto_id_timestamp" : -1,
-                    "file_sizes" : { }
-                },
-                "translog" : {
-                    "operations" : 3,
-                    "size_in_bytes" : 3814,
-                    "uncommitted_operations" : 3,
-                    "uncommitted_size_in_bytes" : 3814,
-                    "earliest_last_modified_age" : 0
-                },
-                "request_cache" : {
-                    "memory_size_in_bytes" : 0,
-                    "evictions" : 0,
-                    "hit_count" : 0,
-                    "miss_count" : 1
-                },
-                "recovery" : {
-                    "current_as_source" : 0,
-                    "current_as_target" : 0,
-                    "throttle_time_in_millis" : 0
-                }
-            }
+    "indices": {
+      ".watcher-history-9-2018.09.07": {
+        "uuid": "YXTxjaeMSh2Ma4RWXB4VPQ",
+        "primaries": {
+          "docs": {
+            "count": 504,
+            "deleted": 0
+          },
+          "store": {
+            "size_in_bytes": 951099
+          },
+          "indexing": {
+            "index_total": 258,
+            "index_time_in_millis": 3188,
+            "index_current": 0,
+            "index_failed": 0,
+            "delete_total": 0,
+            "delete_time_in_millis": 0,
+            "delete_current": 0,
+            "noop_update_total": 0,
+            "is_throttled": false,
+            "throttle_time_in_millis": 0
+          },
+          "search": {
+            "open_contexts": 0,
+            "query_total": 0,
+            "query_time_in_millis": 0,
+            "query_current": 0,
+            "fetch_total": 0,
+            "fetch_time_in_millis": 0,
+            "fetch_current": 0,
+            "scroll_total": 0,
+            "scroll_time_in_millis": 0,
+            "scroll_current": 0,
+            "suggest_total": 0,
+            "suggest_time_in_millis": 0,
+            "suggest_current": 0
+          },
+          "merges": {
+            "current": 0,
+            "current_docs": 0,
+            "current_size_in_bytes": 0,
+            "total": 21,
+            "total_time_in_millis": 532,
+            "total_docs": 1125,
+            "total_size_in_bytes": 6354962,
+            "total_stopped_time_in_millis": 0,
+            "total_throttled_time_in_millis": 0,
+            "total_auto_throttle_in_bytes": 20971520
+          },
+          "refresh": {
+            "total": 71,
+            "total_time_in_millis": 4247,
+            "listeners": 0
+          },
+          "query_cache": {
+            "memory_size_in_bytes": 0,
+            "total_count": 0,
+            "hit_count": 0,
+            "miss_count": 0,
+            "cache_size": 0,
+            "cache_count": 0,
+            "evictions": 0
+          },
+          "fielddata": {
+            "memory_size_in_bytes": 0,
+            "evictions": 0
+          },
+          "segments": {
+            "count": 6,
+            "memory_in_bytes": 108122,
+            "terms_memory_in_bytes": 88538,
+            "stored_fields_memory_in_bytes": 2088,
+            "term_vectors_memory_in_bytes": 0,
+            "norms_memory_in_bytes": 8448,
+            "points_memory_in_bytes": 96,
+            "doc_values_memory_in_bytes": 8952,
+            "index_writer_memory_in_bytes": 0,
+            "version_map_memory_in_bytes": 0,
+            "fixed_bit_set_memory_in_bytes": 344,
+            "max_unsafe_auto_id_timestamp": -1,
+            "file_sizes": {}
+          },
+          "request_cache": {
+            "memory_size_in_bytes": 0,
+            "evictions": 0,
+            "hit_count": 0,
+            "miss_count": 0
+          }
         },
-        ".monitoring-logstash-6-2018.05.18" : {
-            "primaries" : {
-                "docs" : {
-                    "count" : 12,
-                    "deleted" : 0
-                },
-                "store" : {
-                    "size_in_bytes" : 28695
-                },
-                "indexing" : {
-                    "index_total" : 4,
-                    "index_time_in_millis" : 46,
-                    "index_current" : 0,
-                    "index_failed" : 0,
-                    "delete_total" : 0,
-                    "delete_time_in_millis" : 0,
-                    "delete_current" : 0,
-                    "noop_update_total" : 0,
-                    "is_throttled" : false,
-                    "throttle_time_in_millis" : 0
-                },
-                "get" : {
-                    "total" : 0,
-                    "time_in_millis" : 0,
-                    "exists_total" : 0,
-                    "exists_time_in_millis" : 0,
-                    "missing_total" : 0,
-                    "missing_time_in_millis" : 0,
-                    "current" : 0
-                },
-                "search" : {
-                    "open_contexts" : 0,
-                    "query_total" : 0,
-                    "query_time_in_millis" : 0,
-                    "query_current" : 0,
-                    "fetch_total" : 0,
-                    "fetch_time_in_millis" : 0,
-                    "fetch_current" : 0,
-                    "scroll_total" : 0,
-                    "scroll_time_in_millis" : 0,
-                    "scroll_current" : 0,
-                    "suggest_total" : 0,
-                    "suggest_time_in_millis" : 0,
-                    "suggest_current" : 0
-                },
-                "merges" : {
-                    "current" : 0,
-                    "current_docs" : 0,
-                    "current_size_in_bytes" : 0,
-                    "total" : 0,
-                    "total_time_in_millis" : 0,
-                    "total_docs" : 0,
-                    "total_size_in_bytes" : 0,
-                    "total_stopped_time_in_millis" : 0,
-                    "total_throttled_time_in_millis" : 0,
-                    "total_auto_throttle_in_bytes" : 20971520
-                },
-                "refresh" : {
-                    "total" : 4,
-                    "total_time_in_millis" : 233,
-                    "listeners" : 0
-                },
-                "flush" : {
-                    "total" : 0,
-                    "periodic" : 0,
-                    "total_time_in_millis" : 0
-                },
-                "warmer" : {
-                    "current" : 0,
-                    "total" : 3,
-                    "total_time_in_millis" : 36
-                },
-                "query_cache" : {
-                    "memory_size_in_bytes" : 0,
-                    "total_count" : 0,
-                    "hit_count" : 0,
-                    "miss_count" : 0,
-                    "cache_size" : 0,
-                    "cache_count" : 0,
-                    "evictions" : 0
-                },
-                "fielddata" : {
-                    "memory_size_in_bytes" : 0,
-                    "evictions" : 0
-                },
-                "completion" : {
-                    "size_in_bytes" : 0
-                },
-                "segments" : {
-                    "count" : 2,
-                    "memory_in_bytes" : 12760,
-                    "terms_memory_in_bytes" : 11828,
-                    "stored_fields_memory_in_bytes" : 624,
-                    "term_vectors_memory_in_bytes" : 0,
-                    "norms_memory_in_bytes" : 0,
-                    "points_memory_in_bytes" : 172,
-                    "doc_values_memory_in_bytes" : 136,
-                    "index_writer_memory_in_bytes" : 0,
-                    "version_map_memory_in_bytes" : 0,
-                    "fixed_bit_set_memory_in_bytes" : 288,
-                    "max_unsafe_auto_id_timestamp" : -1,
-                    "file_sizes" : { }
-                },
-                "translog" : {
-                    "operations" : 4,
-                    "size_in_bytes" : 12826,
-                    "uncommitted_operations" : 4,
-                    "uncommitted_size_in_bytes" : 12826,
-                    "earliest_last_modified_age" : 0
-                },
-                "request_cache" : {
-                    "memory_size_in_bytes" : 0,
-                    "evictions" : 0,
-                    "hit_count" : 0,
-                    "miss_count" : 0
-                },
-                "recovery" : {
-                    "current_as_source" : 0,
-                    "current_as_target" : 0,
-                    "throttle_time_in_millis" : 0
-                }
-            },
-            "total" : {
-                "docs" : {
-                    "count" : 12,
-                    "deleted" : 0
-                },
-                "store" : {
-                    "size_in_bytes" : 28695
-                },
-                "indexing" : {
-                    "index_total" : 4,
-                    "index_time_in_millis" : 46,
-                    "index_current" : 0,
-                    "index_failed" : 0,
-                    "delete_total" : 0,
-                    "delete_time_in_millis" : 0,
-                    "delete_current" : 0,
-                    "noop_update_total" : 0,
-                    "is_throttled" : false,
-                    "throttle_time_in_millis" : 0
-                },
-                "get" : {
-                    "total" : 0,
-                    "time_in_millis" : 0,
-                    "exists_total" : 0,
-                    "exists_time_in_millis" : 0,
-                    "missing_total" : 0,
-                    "missing_time_in_millis" : 0,
-                    "current" : 0
-                },
-                "search" : {
-                    "open_contexts" : 0,
-                    "query_total" : 0,
-                    "query_time_in_millis" : 0,
-                    "query_current" : 0,
-                    "fetch_total" : 0,
-                    "fetch_time_in_millis" : 0,
-                    "fetch_current" : 0,
-                    "scroll_total" : 0,
-                    "scroll_time_in_millis" : 0,
-                    "scroll_current" : 0,
-                    "suggest_total" : 0,
-                    "suggest_time_in_millis" : 0,
-                    "suggest_current" : 0
-                },
-                "merges" : {
-                    "current" : 0,
-                    "current_docs" : 0,
-                    "current_size_in_bytes" : 0,
-                    "total" : 0,
-                    "total_time_in_millis" : 0,
-                    "total_docs" : 0,
-                    "total_size_in_bytes" : 0,
-                    "total_stopped_time_in_millis" : 0,
-                    "total_throttled_time_in_millis" : 0,
-                    "total_auto_throttle_in_bytes" : 20971520
-                },
-                "refresh" : {
-                    "total" : 4,
-                    "total_time_in_millis" : 233,
-                    "listeners" : 0
-                },
-                "flush" : {
-                    "total" : 0,
-                    "periodic" : 0,
-                    "total_time_in_millis" : 0
-                },
-                "warmer" : {
-                    "current" : 0,
-                    "total" : 3,
-                    "total_time_in_millis" : 36
-                },
-                "query_cache" : {
-                    "memory_size_in_bytes" : 0,
-                    "total_count" : 0,
-                    "hit_count" : 0,
-                    "miss_count" : 0,
-                    "cache_size" : 0,
-                    "cache_count" : 0,
-                    "evictions" : 0
-                },
-                "fielddata" : {
-                    "memory_size_in_bytes" : 0,
-                    "evictions" : 0
-                },
-                "completion" : {
-                    "size_in_bytes" : 0
-                },
-                "segments" : {
-                    "count" : 2,
-                    "memory_in_bytes" : 12760,
-                    "terms_memory_in_bytes" : 11828,
-                    "stored_fields_memory_in_bytes" : 624,
-                    "term_vectors_memory_in_bytes" : 0,
-                    "norms_memory_in_bytes" : 0,
-                    "points_memory_in_bytes" : 172,
-                    "doc_values_memory_in_bytes" : 136,
-                    "index_writer_memory_in_bytes" : 0,
-                    "version_map_memory_in_bytes" : 0,
-                    "fixed_bit_set_memory_in_bytes" : 288,
-                    "max_unsafe_auto_id_timestamp" : -1,
-                    "file_sizes" : { }
-                },
-                "translog" : {
-                    "operations" : 4,
-                    "size_in_bytes" : 12826,
-                    "uncommitted_operations" : 4,
-                    "uncommitted_size_in_bytes" : 12826,
-                    "earliest_last_modified_age" : 0
-                },
-                "request_cache" : {
-                    "memory_size_in_bytes" : 0,
-                    "evictions" : 0,
-                    "hit_count" : 0,
-                    "miss_count" : 0
-                },
-                "recovery" : {
-                    "current_as_source" : 0,
-                    "current_as_target" : 0,
-                    "throttle_time_in_millis" : 0
-                }
-            }
-        },
-        ".monitoring-es-6-2018.05.18" : {
-            "primaries" : {
-                "docs" : {
-                    "count" : 20,
-                    "deleted" : 0
-                },
-                "store" : {
-                    "size_in_bytes" : 56958
-                },
-                "indexing" : {
-                    "index_total" : 20,
-                    "index_time_in_millis" : 375,
-                    "index_current" : 0,
-                    "index_failed" : 0,
-                    "delete_total" : 0,
-                    "delete_time_in_millis" : 0,
-                    "delete_current" : 0,
-                    "noop_update_total" : 0,
-                    "is_throttled" : false,
-                    "throttle_time_in_millis" : 0
-                },
-                "get" : {
-                    "total" : 0,
-                    "time_in_millis" : 0,
-                    "exists_total" : 0,
-                    "exists_time_in_millis" : 0,
-                    "missing_total" : 0,
-                    "missing_time_in_millis" : 0,
-                    "current" : 0
-                },
-                "search" : {
-                    "open_contexts" : 0,
-                    "query_total" : 0,
-                    "query_time_in_millis" : 0,
-                    "query_current" : 0,
-                    "fetch_total" : 0,
-                    "fetch_time_in_millis" : 0,
-                    "fetch_current" : 0,
-                    "scroll_total" : 0,
-                    "scroll_time_in_millis" : 0,
-                    "scroll_current" : 0,
-                    "suggest_total" : 0,
-                    "suggest_time_in_millis" : 0,
-                    "suggest_current" : 0
-                },
-                "merges" : {
-                    "current" : 0,
-                    "current_docs" : 0,
-                    "current_size_in_bytes" : 0,
-                    "total" : 0,
-                    "total_time_in_millis" : 0,
-                    "total_docs" : 0,
-                    "total_size_in_bytes" : 0,
-                    "total_stopped_time_in_millis" : 0,
-                    "total_throttled_time_in_millis" : 0,
-                    "total_auto_throttle_in_bytes" : 20971520
-                },
-                "refresh" : {
-                    "total" : 5,
-                    "total_time_in_millis" : 1053,
-                    "listeners" : 0
-                },
-                "flush" : {
-                    "total" : 0,
-                    "periodic" : 0,
-                    "total_time_in_millis" : 0
-                },
-                "warmer" : {
-                    "current" : 0,
-                    "total" : 3,
-                    "total_time_in_millis" : 0
-                },
-                "query_cache" : {
-                    "memory_size_in_bytes" : 0,
-                    "total_count" : 0,
-                    "hit_count" : 0,
-                    "miss_count" : 0,
-                    "cache_size" : 0,
-                    "cache_count" : 0,
-                    "evictions" : 0
-                },
-                "fielddata" : {
-                    "memory_size_in_bytes" : 0,
-                    "evictions" : 0
-                },
-                "completion" : {
-                    "size_in_bytes" : 0
-                },
-                "segments" : {
-                    "count" : 3,
-                    "memory_in_bytes" : 13730,
-                    "terms_memory_in_bytes" : 10992,
-                    "stored_fields_memory_in_bytes" : 936,
-                    "term_vectors_memory_in_bytes" : 0,
-                    "norms_memory_in_bytes" : 0,
-                    "points_memory_in_bytes" : 534,
-                    "doc_values_memory_in_bytes" : 1268,
-                    "index_writer_memory_in_bytes" : 0,
-                    "version_map_memory_in_bytes" : 0,
-                    "fixed_bit_set_memory_in_bytes" : 0,
-                    "max_unsafe_auto_id_timestamp" : -1,
-                    "file_sizes" : { }
-                },
-                "translog" : {
-                    "operations" : 20,
-                    "size_in_bytes" : 25320,
-                    "uncommitted_operations" : 20,
-                    "uncommitted_size_in_bytes" : 25320,
-                    "earliest_last_modified_age" : 0
-                },
-                "request_cache" : {
-                    "memory_size_in_bytes" : 0,
-                    "evictions" : 0,
-                    "hit_count" : 0,
-                    "miss_count" : 0
-                },
-                "recovery" : {
-                    "current_as_source" : 0,
-                    "current_as_target" : 0,
-                    "throttle_time_in_millis" : 0
-                }
-            },
-            "total" : {
-                "docs" : {
-                    "count" : 20,
-                    "deleted" : 0
-                },
-                "store" : {
-                    "size_in_bytes" : 56958
-                },
-                "indexing" : {
-                    "index_total" : 20,
-                    "index_time_in_millis" : 375,
-                    "index_current" : 0,
-                    "index_failed" : 0,
-                    "delete_total" : 0,
-                    "delete_time_in_millis" : 0,
-                    "delete_current" : 0,
-                    "noop_update_total" : 0,
-                    "is_throttled" : false,
-                    "throttle_time_in_millis" : 0
-                },
-                "get" : {
-                    "total" : 0,
-                    "time_in_millis" : 0,
-                    "exists_total" : 0,
-                    "exists_time_in_millis" : 0,
-                    "missing_total" : 0,
-                    "missing_time_in_millis" : 0,
-                    "current" : 0
-                },
-                "search" : {
-                    "open_contexts" : 0,
-                    "query_total" : 0,
-                    "query_time_in_millis" : 0,
-                    "query_current" : 0,
-                    "fetch_total" : 0,
-                    "fetch_time_in_millis" : 0,
-                    "fetch_current" : 0,
-                    "scroll_total" : 0,
-                    "scroll_time_in_millis" : 0,
-                    "scroll_current" : 0,
-                    "suggest_total" : 0,
-                    "suggest_time_in_millis" : 0,
-                    "suggest_current" : 0
-                },
-                "merges" : {
-                    "current" : 0,
-                    "current_docs" : 0,
-                    "current_size_in_bytes" : 0,
-                    "total" : 0,
-                    "total_time_in_millis" : 0,
-                    "total_docs" : 0,
-                    "total_size_in_bytes" : 0,
-                    "total_stopped_time_in_millis" : 0,
-                    "total_throttled_time_in_millis" : 0,
-                    "total_auto_throttle_in_bytes" : 20971520
-                },
-                "refresh" : {
-                    "total" : 5,
-                    "total_time_in_millis" : 1053,
-                    "listeners" : 0
-                },
-                "flush" : {
-                    "total" : 0,
-                    "periodic" : 0,
-                    "total_time_in_millis" : 0
-                },
-                "warmer" : {
-                    "current" : 0,
-                    "total" : 3,
-                    "total_time_in_millis" : 0
-                },
-                "query_cache" : {
-                    "memory_size_in_bytes" : 0,
-                    "total_count" : 0,
-                    "hit_count" : 0,
-                    "miss_count" : 0,
-                    "cache_size" : 0,
-                    "cache_count" : 0,
-                    "evictions" : 0
-                },
-                "fielddata" : {
-                    "memory_size_in_bytes" : 0,
-                    "evictions" : 0
-                },
-                "completion" : {
-                    "size_in_bytes" : 0
-                },
-                "segments" : {
-                    "count" : 3,
-                    "memory_in_bytes" : 13730,
-                    "terms_memory_in_bytes" : 10992,
-                    "stored_fields_memory_in_bytes" : 936,
-                    "term_vectors_memory_in_bytes" : 0,
-                    "norms_memory_in_bytes" : 0,
-                    "points_memory_in_bytes" : 534,
-                    "doc_values_memory_in_bytes" : 1268,
-                    "index_writer_memory_in_bytes" : 0,
-                    "version_map_memory_in_bytes" : 0,
-                    "fixed_bit_set_memory_in_bytes" : 0,
-                    "max_unsafe_auto_id_timestamp" : -1,
-                    "file_sizes" : { }
-                },
-                "translog" : {
-                    "operations" : 20,
-                    "size_in_bytes" : 25320,
-                    "uncommitted_operations" : 20,
-                    "uncommitted_size_in_bytes" : 25320,
-                    "earliest_last_modified_age" : 0
-                },
-                "request_cache" : {
-                    "memory_size_in_bytes" : 0,
-                    "evictions" : 0,
-                    "hit_count" : 0,
-                    "miss_count" : 0
-                },
-                "recovery" : {
-                    "current_as_source" : 0,
-                    "current_as_target" : 0,
-                    "throttle_time_in_millis" : 0
-                }
-            }
-        },
-        "metricbeat-7.0.0-alpha1-2018.05.18" : {
-            "primaries" : {
-                "docs" : {
-                    "count" : 0,
-                    "deleted" : 0
-                },
-                "store" : {
-                    "size_in_bytes" : 230
-                },
-                "indexing" : {
-                    "index_total" : 33,
-                    "index_time_in_millis" : 328,
-                    "index_current" : 0,
-                    "index_failed" : 0,
-                    "delete_total" : 0,
-                    "delete_time_in_millis" : 0,
-                    "delete_current" : 0,
-                    "noop_update_total" : 0,
-                    "is_throttled" : false,
-                    "throttle_time_in_millis" : 0
-                },
-                "get" : {
-                    "total" : 0,
-                    "time_in_millis" : 0,
-                    "exists_total" : 0,
-                    "exists_time_in_millis" : 0,
-                    "missing_total" : 0,
-                    "missing_time_in_millis" : 0,
-                    "current" : 0
-                },
-                "search" : {
-                    "open_contexts" : 0,
-                    "query_total" : 0,
-                    "query_time_in_millis" : 0,
-                    "query_current" : 0,
-                    "fetch_total" : 0,
-                    "fetch_time_in_millis" : 0,
-                    "fetch_current" : 0,
-                    "scroll_total" : 0,
-                    "scroll_time_in_millis" : 0,
-                    "scroll_current" : 0,
-                    "suggest_total" : 0,
-                    "suggest_time_in_millis" : 0,
-                    "suggest_current" : 0
-                },
-                "merges" : {
-                    "current" : 0,
-                    "current_docs" : 0,
-                    "current_size_in_bytes" : 0,
-                    "total" : 0,
-                    "total_time_in_millis" : 0,
-                    "total_docs" : 0,
-                    "total_size_in_bytes" : 0,
-                    "total_stopped_time_in_millis" : 0,
-                    "total_throttled_time_in_millis" : 0,
-                    "total_auto_throttle_in_bytes" : 20971520
-                },
-                "refresh" : {
-                    "total" : 2,
-                    "total_time_in_millis" : 0,
-                    "listeners" : 0
-                },
-                "flush" : {
-                    "total" : 0,
-                    "periodic" : 0,
-                    "total_time_in_millis" : 0
-                },
-                "warmer" : {
-                    "current" : 0,
-                    "total" : 1,
-                    "total_time_in_millis" : 2
-                },
-                "query_cache" : {
-                    "memory_size_in_bytes" : 0,
-                    "total_count" : 0,
-                    "hit_count" : 0,
-                    "miss_count" : 0,
-                    "cache_size" : 0,
-                    "cache_count" : 0,
-                    "evictions" : 0
-                },
-                "fielddata" : {
-                    "memory_size_in_bytes" : 0,
-                    "evictions" : 0
-                },
-                "completion" : {
-                    "size_in_bytes" : 0
-                },
-                "segments" : {
-                    "count" : 0,
-                    "memory_in_bytes" : 0,
-                    "terms_memory_in_bytes" : 0,
-                    "stored_fields_memory_in_bytes" : 0,
-                    "term_vectors_memory_in_bytes" : 0,
-                    "norms_memory_in_bytes" : 0,
-                    "points_memory_in_bytes" : 0,
-                    "doc_values_memory_in_bytes" : 0,
-                    "index_writer_memory_in_bytes" : 4456672,
-                    "version_map_memory_in_bytes" : 0,
-                    "fixed_bit_set_memory_in_bytes" : 0,
-                    "max_unsafe_auto_id_timestamp" : -1,
-                    "file_sizes" : { }
-                },
-                "translog" : {
-                    "operations" : 33,
-                    "size_in_bytes" : 18965,
-                    "uncommitted_operations" : 33,
-                    "uncommitted_size_in_bytes" : 18965,
-                    "earliest_last_modified_age" : 0
-                },
-                "request_cache" : {
-                    "memory_size_in_bytes" : 0,
-                    "evictions" : 0,
-                    "hit_count" : 0,
-                    "miss_count" : 0
-                },
-                "recovery" : {
-                    "current_as_source" : 0,
-                    "current_as_target" : 0,
-                    "throttle_time_in_millis" : 0
-                }
-            },
-            "total" : {
-                "docs" : {
-                    "count" : 0,
-                    "deleted" : 0
-                },
-                "store" : {
-                    "size_in_bytes" : 230
-                },
-                "indexing" : {
-                    "index_total" : 33,
-                    "index_time_in_millis" : 328,
-                    "index_current" : 0,
-                    "index_failed" : 0,
-                    "delete_total" : 0,
-                    "delete_time_in_millis" : 0,
-                    "delete_current" : 0,
-                    "noop_update_total" : 0,
-                    "is_throttled" : false,
-                    "throttle_time_in_millis" : 0
-                },
-                "get" : {
-                    "total" : 0,
-                    "time_in_millis" : 0,
-                    "exists_total" : 0,
-                    "exists_time_in_millis" : 0,
-                    "missing_total" : 0,
-                    "missing_time_in_millis" : 0,
-                    "current" : 0
-                },
-                "search" : {
-                    "open_contexts" : 0,
-                    "query_total" : 0,
-                    "query_time_in_millis" : 0,
-                    "query_current" : 0,
-                    "fetch_total" : 0,
-                    "fetch_time_in_millis" : 0,
-                    "fetch_current" : 0,
-                    "scroll_total" : 0,
-                    "scroll_time_in_millis" : 0,
-                    "scroll_current" : 0,
-                    "suggest_total" : 0,
-                    "suggest_time_in_millis" : 0,
-                    "suggest_current" : 0
-                },
-                "merges" : {
-                    "current" : 0,
-                    "current_docs" : 0,
-                    "current_size_in_bytes" : 0,
-                    "total" : 0,
-                    "total_time_in_millis" : 0,
-                    "total_docs" : 0,
-                    "total_size_in_bytes" : 0,
-                    "total_stopped_time_in_millis" : 0,
-                    "total_throttled_time_in_millis" : 0,
-                    "total_auto_throttle_in_bytes" : 20971520
-                },
-                "refresh" : {
-                    "total" : 2,
-                    "total_time_in_millis" : 0,
-                    "listeners" : 0
-                },
-                "flush" : {
-                    "total" : 0,
-                    "periodic" : 0,
-                    "total_time_in_millis" : 0
-                },
-                "warmer" : {
-                    "current" : 0,
-                    "total" : 1,
-                    "total_time_in_millis" : 2
-                },
-                "query_cache" : {
-                    "memory_size_in_bytes" : 0,
-                    "total_count" : 0,
-                    "hit_count" : 0,
-                    "miss_count" : 0,
-                    "cache_size" : 0,
-                    "cache_count" : 0,
-                    "evictions" : 0
-                },
-                "fielddata" : {
-                    "memory_size_in_bytes" : 0,
-                    "evictions" : 0
-                },
-                "completion" : {
-                    "size_in_bytes" : 0
-                },
-                "segments" : {
-                    "count" : 0,
-                    "memory_in_bytes" : 0,
-                    "terms_memory_in_bytes" : 0,
-                    "stored_fields_memory_in_bytes" : 0,
-                    "term_vectors_memory_in_bytes" : 0,
-                    "norms_memory_in_bytes" : 0,
-                    "points_memory_in_bytes" : 0,
-                    "doc_values_memory_in_bytes" : 0,
-                    "index_writer_memory_in_bytes" : 4456672,
-                    "version_map_memory_in_bytes" : 0,
-                    "fixed_bit_set_memory_in_bytes" : 0,
-                    "max_unsafe_auto_id_timestamp" : -1,
-                    "file_sizes" : { }
-                },
-                "translog" : {
-                    "operations" : 33,
-                    "size_in_bytes" : 18965,
-                    "uncommitted_operations" : 33,
-                    "uncommitted_size_in_bytes" : 18965,
-                    "earliest_last_modified_age" : 0
-                },
-                "request_cache" : {
-                    "memory_size_in_bytes" : 0,
-                    "evictions" : 0,
-                    "hit_count" : 0,
-                    "miss_count" : 0
-                },
-                "recovery" : {
-                    "current_as_source" : 0,
-                    "current_as_target" : 0,
-                    "throttle_time_in_millis" : 0
-                }
-            }
-        },
-        ".watches" : {
-            "primaries" : {
-                "docs" : {
-                    "count" : 6,
-                    "deleted" : 0
-                },
-                "store" : {
-                    "size_in_bytes" : 59156
-                },
-                "indexing" : {
-                    "index_total" : 6,
-                    "index_time_in_millis" : 1041,
-                    "index_current" : 0,
-                    "index_failed" : 0,
-                    "delete_total" : 0,
-                    "delete_time_in_millis" : 0,
-                    "delete_current" : 0,
-                    "noop_update_total" : 0,
-                    "is_throttled" : false,
-                    "throttle_time_in_millis" : 0
-                },
-                "get" : {
-                    "total" : 6,
-                    "time_in_millis" : 17,
-                    "exists_total" : 0,
-                    "exists_time_in_millis" : 0,
-                    "missing_total" : 6,
-                    "missing_time_in_millis" : 17,
-                    "current" : 0
-                },
-                "search" : {
-                    "open_contexts" : 0,
-                    "query_total" : 2,
-                    "query_time_in_millis" : 539,
-                    "query_current" : 0,
-                    "fetch_total" : 1,
-                    "fetch_time_in_millis" : 23,
-                    "fetch_current" : 0,
-                    "scroll_total" : 1,
-                    "scroll_time_in_millis" : 1068,
-                    "scroll_current" : 0,
-                    "suggest_total" : 0,
-                    "suggest_time_in_millis" : 0,
-                    "suggest_current" : 0
-                },
-                "merges" : {
-                    "current" : 0,
-                    "current_docs" : 0,
-                    "current_size_in_bytes" : 0,
-                    "total" : 0,
-                    "total_time_in_millis" : 0,
-                    "total_docs" : 0,
-                    "total_size_in_bytes" : 0,
-                    "total_stopped_time_in_millis" : 0,
-                    "total_throttled_time_in_millis" : 0,
-                    "total_auto_throttle_in_bytes" : 20971520
-                },
-                "refresh" : {
-                    "total" : 10,
-                    "total_time_in_millis" : 1237,
-                    "listeners" : 0
-                },
-                "flush" : {
-                    "total" : 0,
-                    "periodic" : 0,
-                    "total_time_in_millis" : 0
-                },
-                "warmer" : {
-                    "current" : 0,
-                    "total" : 6,
-                    "total_time_in_millis" : 14
-                },
-                "query_cache" : {
-                    "memory_size_in_bytes" : 0,
-                    "total_count" : 0,
-                    "hit_count" : 0,
-                    "miss_count" : 0,
-                    "cache_size" : 0,
-                    "cache_count" : 0,
-                    "evictions" : 0
-                },
-                "fielddata" : {
-                    "memory_size_in_bytes" : 0,
-                    "evictions" : 0
-                },
-                "completion" : {
-                    "size_in_bytes" : 0
-                },
-                "segments" : {
-                    "count" : 6,
-                    "memory_in_bytes" : 22728,
-                    "terms_memory_in_bytes" : 17934,
-                    "stored_fields_memory_in_bytes" : 1872,
-                    "term_vectors_memory_in_bytes" : 0,
-                    "norms_memory_in_bytes" : 2304,
-                    "points_memory_in_bytes" : 26,
-                    "doc_values_memory_in_bytes" : 592,
-                    "index_writer_memory_in_bytes" : 0,
-                    "version_map_memory_in_bytes" : 0,
-                    "fixed_bit_set_memory_in_bytes" : 0,
-                    "max_unsafe_auto_id_timestamp" : -1,
-                    "file_sizes" : { }
-                },
-                "translog" : {
-                    "operations" : 6,
-                    "size_in_bytes" : 26103,
-                    "uncommitted_operations" : 6,
-                    "uncommitted_size_in_bytes" : 26103,
-                    "earliest_last_modified_age" : 0
-                },
-                "request_cache" : {
-                    "memory_size_in_bytes" : 0,
-                    "evictions" : 0,
-                    "hit_count" : 0,
-                    "miss_count" : 1
-                },
-                "recovery" : {
-                    "current_as_source" : 0,
-                    "current_as_target" : 0,
-                    "throttle_time_in_millis" : 0
-                }
-            },
-            "total" : {
-                "docs" : {
-                    "count" : 6,
-                    "deleted" : 0
-                },
-                "store" : {
-                    "size_in_bytes" : 59156
-                },
-                "indexing" : {
-                    "index_total" : 6,
-                    "index_time_in_millis" : 1041,
-                    "index_current" : 0,
-                    "index_failed" : 0,
-                    "delete_total" : 0,
-                    "delete_time_in_millis" : 0,
-                    "delete_current" : 0,
-                    "noop_update_total" : 0,
-                    "is_throttled" : false,
-                    "throttle_time_in_millis" : 0
-                },
-                "get" : {
-                    "total" : 6,
-                    "time_in_millis" : 17,
-                    "exists_total" : 0,
-                    "exists_time_in_millis" : 0,
-                    "missing_total" : 6,
-                    "missing_time_in_millis" : 17,
-                    "current" : 0
-                },
-                "search" : {
-                    "open_contexts" : 0,
-                    "query_total" : 2,
-                    "query_time_in_millis" : 539,
-                    "query_current" : 0,
-                    "fetch_total" : 1,
-                    "fetch_time_in_millis" : 23,
-                    "fetch_current" : 0,
-                    "scroll_total" : 1,
-                    "scroll_time_in_millis" : 1068,
-                    "scroll_current" : 0,
-                    "suggest_total" : 0,
-                    "suggest_time_in_millis" : 0,
-                    "suggest_current" : 0
-                },
-                "merges" : {
-                    "current" : 0,
-                    "current_docs" : 0,
-                    "current_size_in_bytes" : 0,
-                    "total" : 0,
-                    "total_time_in_millis" : 0,
-                    "total_docs" : 0,
-                    "total_size_in_bytes" : 0,
-                    "total_stopped_time_in_millis" : 0,
-                    "total_throttled_time_in_millis" : 0,
-                    "total_auto_throttle_in_bytes" : 20971520
-                },
-                "refresh" : {
-                    "total" : 10,
-                    "total_time_in_millis" : 1237,
-                    "listeners" : 0
-                },
-                "flush" : {
-                    "total" : 0,
-                    "periodic" : 0,
-                    "total_time_in_millis" : 0
-                },
-                "warmer" : {
-                    "current" : 0,
-                    "total" : 6,
-                    "total_time_in_millis" : 14
-                },
-                "query_cache" : {
-                    "memory_size_in_bytes" : 0,
-                    "total_count" : 0,
-                    "hit_count" : 0,
-                    "miss_count" : 0,
-                    "cache_size" : 0,
-                    "cache_count" : 0,
-                    "evictions" : 0
-                },
-                "fielddata" : {
-                    "memory_size_in_bytes" : 0,
-                    "evictions" : 0
-                },
-                "completion" : {
-                    "size_in_bytes" : 0
-                },
-                "segments" : {
-                    "count" : 6,
-                    "memory_in_bytes" : 22728,
-                    "terms_memory_in_bytes" : 17934,
-                    "stored_fields_memory_in_bytes" : 1872,
-                    "term_vectors_memory_in_bytes" : 0,
-                    "norms_memory_in_bytes" : 2304,
-                    "points_memory_in_bytes" : 26,
-                    "doc_values_memory_in_bytes" : 592,
-                    "index_writer_memory_in_bytes" : 0,
-                    "version_map_memory_in_bytes" : 0,
-                    "fixed_bit_set_memory_in_bytes" : 0,
-                    "max_unsafe_auto_id_timestamp" : -1,
-                    "file_sizes" : { }
-                },
-                "translog" : {
-                    "operations" : 6,
-                    "size_in_bytes" : 26103,
-                    "uncommitted_operations" : 6,
-                    "uncommitted_size_in_bytes" : 26103,
-                    "earliest_last_modified_age" : 0
-                },
-                "request_cache" : {
-                    "memory_size_in_bytes" : 0,
-                    "evictions" : 0,
-                    "hit_count" : 0,
-                    "miss_count" : 1
-                },
-                "recovery" : {
-                    "current_as_source" : 0,
-                    "current_as_target" : 0,
-                    "throttle_time_in_millis" : 0
-                }
-            }
+        "total": {
+          "docs": {
+            "count": 504,
+            "deleted": 0
+          },
+          "store": {
+            "size_in_bytes": 951099
+          },
+          "indexing": {
+            "index_total": 258,
+            "index_time_in_millis": 3188,
+            "index_current": 0,
+            "index_failed": 0,
+            "delete_total": 0,
+            "delete_time_in_millis": 0,
+            "delete_current": 0,
+            "noop_update_total": 0,
+            "is_throttled": false,
+            "throttle_time_in_millis": 0
+          },
+          "search": {
+            "open_contexts": 0,
+            "query_total": 0,
+            "query_time_in_millis": 0,
+            "query_current": 0,
+            "fetch_total": 0,
+            "fetch_time_in_millis": 0,
+            "fetch_current": 0,
+            "scroll_total": 0,
+            "scroll_time_in_millis": 0,
+            "scroll_current": 0,
+            "suggest_total": 0,
+            "suggest_time_in_millis": 0,
+            "suggest_current": 0
+          },
+          "merges": {
+            "current": 0,
+            "current_docs": 0,
+            "current_size_in_bytes": 0,
+            "total": 21,
+            "total_time_in_millis": 532,
+            "total_docs": 1125,
+            "total_size_in_bytes": 6354962,
+            "total_stopped_time_in_millis": 0,
+            "total_throttled_time_in_millis": 0,
+            "total_auto_throttle_in_bytes": 20971520
+          },
+          "refresh": {
+            "total": 71,
+            "total_time_in_millis": 4247,
+            "listeners": 0
+          },
+          "query_cache": {
+            "memory_size_in_bytes": 0,
+            "total_count": 0,
+            "hit_count": 0,
+            "miss_count": 0,
+            "cache_size": 0,
+            "cache_count": 0,
+            "evictions": 0
+          },
+          "fielddata": {
+            "memory_size_in_bytes": 0,
+            "evictions": 0
+          },
+          "segments": {
+            "count": 6,
+            "memory_in_bytes": 108122,
+            "terms_memory_in_bytes": 88538,
+            "stored_fields_memory_in_bytes": 2088,
+            "term_vectors_memory_in_bytes": 0,
+            "norms_memory_in_bytes": 8448,
+            "points_memory_in_bytes": 96,
+            "doc_values_memory_in_bytes": 8952,
+            "index_writer_memory_in_bytes": 0,
+            "version_map_memory_in_bytes": 0,
+            "fixed_bit_set_memory_in_bytes": 344,
+            "max_unsafe_auto_id_timestamp": -1,
+            "file_sizes": {}
+          },
+          "request_cache": {
+            "memory_size_in_bytes": 0,
+            "evictions": 0,
+            "hit_count": 0,
+            "miss_count": 0
+          }
         }
+      },
+      "testindex": {
+        "uuid": "Unl-J_-lRaijlYvhNdqdjw",
+        "primaries": {
+          "docs": {
+            "count": 0,
+            "deleted": 0
+          },
+          "store": {
+            "size_in_bytes": 261
+          },
+          "indexing": {
+            "index_total": 0,
+            "index_time_in_millis": 0,
+            "index_current": 0,
+            "index_failed": 0,
+            "delete_total": 0,
+            "delete_time_in_millis": 0,
+            "delete_current": 0,
+            "noop_update_total": 0,
+            "is_throttled": false,
+            "throttle_time_in_millis": 0
+          },
+          "search": {
+            "open_contexts": 0,
+            "query_total": 0,
+            "query_time_in_millis": 0,
+            "query_current": 0,
+            "fetch_total": 0,
+            "fetch_time_in_millis": 0,
+            "fetch_current": 0,
+            "scroll_total": 0,
+            "scroll_time_in_millis": 0,
+            "scroll_current": 0,
+            "suggest_total": 0,
+            "suggest_time_in_millis": 0,
+            "suggest_current": 0
+          },
+          "merges": {
+            "current": 0,
+            "current_docs": 0,
+            "current_size_in_bytes": 0,
+            "total": 0,
+            "total_time_in_millis": 0,
+            "total_docs": 0,
+            "total_size_in_bytes": 0,
+            "total_stopped_time_in_millis": 0,
+            "total_throttled_time_in_millis": 0,
+            "total_auto_throttle_in_bytes": 20971520
+          },
+          "refresh": {
+            "total": 2,
+            "total_time_in_millis": 0,
+            "listeners": 0
+          },
+          "query_cache": {
+            "memory_size_in_bytes": 0,
+            "total_count": 0,
+            "hit_count": 0,
+            "miss_count": 0,
+            "cache_size": 0,
+            "cache_count": 0,
+            "evictions": 0
+          },
+          "fielddata": {
+            "memory_size_in_bytes": 0,
+            "evictions": 0
+          },
+          "segments": {
+            "count": 0,
+            "memory_in_bytes": 0,
+            "terms_memory_in_bytes": 0,
+            "stored_fields_memory_in_bytes": 0,
+            "term_vectors_memory_in_bytes": 0,
+            "norms_memory_in_bytes": 0,
+            "points_memory_in_bytes": 0,
+            "doc_values_memory_in_bytes": 0,
+            "index_writer_memory_in_bytes": 0,
+            "version_map_memory_in_bytes": 0,
+            "fixed_bit_set_memory_in_bytes": 0,
+            "max_unsafe_auto_id_timestamp": -1,
+            "file_sizes": {}
+          },
+          "request_cache": {
+            "memory_size_in_bytes": 0,
+            "evictions": 0,
+            "hit_count": 0,
+            "miss_count": 0
+          }
+        },
+        "total": {
+          "docs": {
+            "count": 0,
+            "deleted": 0
+          },
+          "store": {
+            "size_in_bytes": 261
+          },
+          "indexing": {
+            "index_total": 0,
+            "index_time_in_millis": 0,
+            "index_current": 0,
+            "index_failed": 0,
+            "delete_total": 0,
+            "delete_time_in_millis": 0,
+            "delete_current": 0,
+            "noop_update_total": 0,
+            "is_throttled": false,
+            "throttle_time_in_millis": 0
+          },
+          "search": {
+            "open_contexts": 0,
+            "query_total": 0,
+            "query_time_in_millis": 0,
+            "query_current": 0,
+            "fetch_total": 0,
+            "fetch_time_in_millis": 0,
+            "fetch_current": 0,
+            "scroll_total": 0,
+            "scroll_time_in_millis": 0,
+            "scroll_current": 0,
+            "suggest_total": 0,
+            "suggest_time_in_millis": 0,
+            "suggest_current": 0
+          },
+          "merges": {
+            "current": 0,
+            "current_docs": 0,
+            "current_size_in_bytes": 0,
+            "total": 0,
+            "total_time_in_millis": 0,
+            "total_docs": 0,
+            "total_size_in_bytes": 0,
+            "total_stopped_time_in_millis": 0,
+            "total_throttled_time_in_millis": 0,
+            "total_auto_throttle_in_bytes": 20971520
+          },
+          "refresh": {
+            "total": 2,
+            "total_time_in_millis": 0,
+            "listeners": 0
+          },
+          "query_cache": {
+            "memory_size_in_bytes": 0,
+            "total_count": 0,
+            "hit_count": 0,
+            "miss_count": 0,
+            "cache_size": 0,
+            "cache_count": 0,
+            "evictions": 0
+          },
+          "fielddata": {
+            "memory_size_in_bytes": 0,
+            "evictions": 0
+          },
+          "segments": {
+            "count": 0,
+            "memory_in_bytes": 0,
+            "terms_memory_in_bytes": 0,
+            "stored_fields_memory_in_bytes": 0,
+            "term_vectors_memory_in_bytes": 0,
+            "norms_memory_in_bytes": 0,
+            "points_memory_in_bytes": 0,
+            "doc_values_memory_in_bytes": 0,
+            "index_writer_memory_in_bytes": 0,
+            "version_map_memory_in_bytes": 0,
+            "fixed_bit_set_memory_in_bytes": 0,
+            "max_unsafe_auto_id_timestamp": -1,
+            "file_sizes": {}
+          },
+          "request_cache": {
+            "memory_size_in_bytes": 0,
+            "evictions": 0,
+            "hit_count": 0,
+            "miss_count": 0
+          }
+        }
+      },
+      ".monitoring-es-6-2018.09.07": {
+        "uuid": "h_L818ReSn2LPNmHUnQ5Gg",
+        "primaries": {
+          "docs": {
+            "count": 525,
+            "deleted": 11
+          },
+          "store": {
+            "size_in_bytes": 359632
+          },
+          "indexing": {
+            "index_total": 886,
+            "index_time_in_millis": 131,
+            "index_current": 0,
+            "index_failed": 0,
+            "delete_total": 0,
+            "delete_time_in_millis": 0,
+            "delete_current": 0,
+            "noop_update_total": 0,
+            "is_throttled": false,
+            "throttle_time_in_millis": 0
+          },
+          "search": {
+            "open_contexts": 0,
+            "query_total": 25,
+            "query_time_in_millis": 11,
+            "query_current": 0,
+            "fetch_total": 20,
+            "fetch_time_in_millis": 17,
+            "fetch_current": 0,
+            "scroll_total": 0,
+            "scroll_time_in_millis": 0,
+            "scroll_current": 0,
+            "suggest_total": 0,
+            "suggest_time_in_millis": 0,
+            "suggest_current": 0
+          },
+          "merges": {
+            "current": 0,
+            "current_docs": 0,
+            "current_size_in_bytes": 0,
+            "total": 4,
+            "total_time_in_millis": 77,
+            "total_docs": 1165,
+            "total_size_in_bytes": 2308238,
+            "total_stopped_time_in_millis": 0,
+            "total_throttled_time_in_millis": 0,
+            "total_auto_throttle_in_bytes": 20971520
+          },
+          "refresh": {
+            "total": 43,
+            "total_time_in_millis": 642,
+            "listeners": 0
+          },
+          "query_cache": {
+            "memory_size_in_bytes": 0,
+            "total_count": 0,
+            "hit_count": 0,
+            "miss_count": 0,
+            "cache_size": 0,
+            "cache_count": 0,
+            "evictions": 0
+          },
+          "fielddata": {
+            "memory_size_in_bytes": 0,
+            "evictions": 0
+          },
+          "segments": {
+            "count": 2,
+            "memory_in_bytes": 37649,
+            "terms_memory_in_bytes": 9128,
+            "stored_fields_memory_in_bytes": 640,
+            "term_vectors_memory_in_bytes": 0,
+            "norms_memory_in_bytes": 0,
+            "points_memory_in_bytes": 641,
+            "doc_values_memory_in_bytes": 27240,
+            "index_writer_memory_in_bytes": 0,
+            "version_map_memory_in_bytes": 0,
+            "fixed_bit_set_memory_in_bytes": 0,
+            "max_unsafe_auto_id_timestamp": -1,
+            "file_sizes": {}
+          },
+          "request_cache": {
+            "memory_size_in_bytes": 0,
+            "evictions": 0,
+            "hit_count": 0,
+            "miss_count": 0
+          }
+        },
+        "total": {
+          "docs": {
+            "count": 525,
+            "deleted": 11
+          },
+          "store": {
+            "size_in_bytes": 359632
+          },
+          "indexing": {
+            "index_total": 886,
+            "index_time_in_millis": 131,
+            "index_current": 0,
+            "index_failed": 0,
+            "delete_total": 0,
+            "delete_time_in_millis": 0,
+            "delete_current": 0,
+            "noop_update_total": 0,
+            "is_throttled": false,
+            "throttle_time_in_millis": 0
+          },
+          "search": {
+            "open_contexts": 0,
+            "query_total": 25,
+            "query_time_in_millis": 11,
+            "query_current": 0,
+            "fetch_total": 20,
+            "fetch_time_in_millis": 17,
+            "fetch_current": 0,
+            "scroll_total": 0,
+            "scroll_time_in_millis": 0,
+            "scroll_current": 0,
+            "suggest_total": 0,
+            "suggest_time_in_millis": 0,
+            "suggest_current": 0
+          },
+          "merges": {
+            "current": 0,
+            "current_docs": 0,
+            "current_size_in_bytes": 0,
+            "total": 4,
+            "total_time_in_millis": 77,
+            "total_docs": 1165,
+            "total_size_in_bytes": 2308238,
+            "total_stopped_time_in_millis": 0,
+            "total_throttled_time_in_millis": 0,
+            "total_auto_throttle_in_bytes": 20971520
+          },
+          "refresh": {
+            "total": 43,
+            "total_time_in_millis": 642,
+            "listeners": 0
+          },
+          "query_cache": {
+            "memory_size_in_bytes": 0,
+            "total_count": 0,
+            "hit_count": 0,
+            "miss_count": 0,
+            "cache_size": 0,
+            "cache_count": 0,
+            "evictions": 0
+          },
+          "fielddata": {
+            "memory_size_in_bytes": 0,
+            "evictions": 0
+          },
+          "segments": {
+            "count": 2,
+            "memory_in_bytes": 37649,
+            "terms_memory_in_bytes": 9128,
+            "stored_fields_memory_in_bytes": 640,
+            "term_vectors_memory_in_bytes": 0,
+            "norms_memory_in_bytes": 0,
+            "points_memory_in_bytes": 641,
+            "doc_values_memory_in_bytes": 27240,
+            "index_writer_memory_in_bytes": 0,
+            "version_map_memory_in_bytes": 0,
+            "fixed_bit_set_memory_in_bytes": 0,
+            "max_unsafe_auto_id_timestamp": -1,
+            "file_sizes": {}
+          },
+          "request_cache": {
+            "memory_size_in_bytes": 0,
+            "evictions": 0,
+            "hit_count": 0,
+            "miss_count": 0
+          }
+        }
+      },
+      ".triggered_watches": {
+        "uuid": "FG9al3VzToqGrgG5o0zMSA",
+        "primaries": {
+          "docs": {
+            "count": 0,
+            "deleted": 0
+          },
+          "store": {
+            "size_in_bytes": 8372
+          },
+          "indexing": {
+            "index_total": 258,
+            "index_time_in_millis": 15,
+            "index_current": 0,
+            "index_failed": 0,
+            "delete_total": 258,
+            "delete_time_in_millis": 182,
+            "delete_current": 0,
+            "noop_update_total": 0,
+            "is_throttled": false,
+            "throttle_time_in_millis": 0
+          },
+          "search": {
+            "open_contexts": 0,
+            "query_total": 1,
+            "query_time_in_millis": 0,
+            "query_current": 0,
+            "fetch_total": 1,
+            "fetch_time_in_millis": 0,
+            "fetch_current": 0,
+            "scroll_total": 1,
+            "scroll_time_in_millis": 2,
+            "scroll_current": 0,
+            "suggest_total": 0,
+            "suggest_time_in_millis": 0,
+            "suggest_current": 0
+          },
+          "merges": {
+            "current": 0,
+            "current_docs": 0,
+            "current_size_in_bytes": 0,
+            "total": 0,
+            "total_time_in_millis": 0,
+            "total_docs": 0,
+            "total_size_in_bytes": 0,
+            "total_stopped_time_in_millis": 0,
+            "total_throttled_time_in_millis": 0,
+            "total_auto_throttle_in_bytes": 20971520
+          },
+          "refresh": {
+            "total": 3,
+            "total_time_in_millis": 0,
+            "listeners": 0
+          },
+          "query_cache": {
+            "memory_size_in_bytes": 0,
+            "total_count": 0,
+            "hit_count": 0,
+            "miss_count": 0,
+            "cache_size": 0,
+            "cache_count": 0,
+            "evictions": 0
+          },
+          "fielddata": {
+            "memory_size_in_bytes": 0,
+            "evictions": 0
+          },
+          "segments": {
+            "count": 0,
+            "memory_in_bytes": 0,
+            "terms_memory_in_bytes": 0,
+            "stored_fields_memory_in_bytes": 0,
+            "term_vectors_memory_in_bytes": 0,
+            "norms_memory_in_bytes": 0,
+            "points_memory_in_bytes": 0,
+            "doc_values_memory_in_bytes": 0,
+            "index_writer_memory_in_bytes": 285894,
+            "version_map_memory_in_bytes": 60329,
+            "fixed_bit_set_memory_in_bytes": 0,
+            "max_unsafe_auto_id_timestamp": -1,
+            "file_sizes": {}
+          },
+          "request_cache": {
+            "memory_size_in_bytes": 0,
+            "evictions": 0,
+            "hit_count": 0,
+            "miss_count": 0
+          }
+        },
+        "total": {
+          "docs": {
+            "count": 0,
+            "deleted": 0
+          },
+          "store": {
+            "size_in_bytes": 8372
+          },
+          "indexing": {
+            "index_total": 258,
+            "index_time_in_millis": 15,
+            "index_current": 0,
+            "index_failed": 0,
+            "delete_total": 258,
+            "delete_time_in_millis": 182,
+            "delete_current": 0,
+            "noop_update_total": 0,
+            "is_throttled": false,
+            "throttle_time_in_millis": 0
+          },
+          "search": {
+            "open_contexts": 0,
+            "query_total": 1,
+            "query_time_in_millis": 0,
+            "query_current": 0,
+            "fetch_total": 1,
+            "fetch_time_in_millis": 0,
+            "fetch_current": 0,
+            "scroll_total": 1,
+            "scroll_time_in_millis": 2,
+            "scroll_current": 0,
+            "suggest_total": 0,
+            "suggest_time_in_millis": 0,
+            "suggest_current": 0
+          },
+          "merges": {
+            "current": 0,
+            "current_docs": 0,
+            "current_size_in_bytes": 0,
+            "total": 0,
+            "total_time_in_millis": 0,
+            "total_docs": 0,
+            "total_size_in_bytes": 0,
+            "total_stopped_time_in_millis": 0,
+            "total_throttled_time_in_millis": 0,
+            "total_auto_throttle_in_bytes": 20971520
+          },
+          "refresh": {
+            "total": 3,
+            "total_time_in_millis": 0,
+            "listeners": 0
+          },
+          "query_cache": {
+            "memory_size_in_bytes": 0,
+            "total_count": 0,
+            "hit_count": 0,
+            "miss_count": 0,
+            "cache_size": 0,
+            "cache_count": 0,
+            "evictions": 0
+          },
+          "fielddata": {
+            "memory_size_in_bytes": 0,
+            "evictions": 0
+          },
+          "segments": {
+            "count": 0,
+            "memory_in_bytes": 0,
+            "terms_memory_in_bytes": 0,
+            "stored_fields_memory_in_bytes": 0,
+            "term_vectors_memory_in_bytes": 0,
+            "norms_memory_in_bytes": 0,
+            "points_memory_in_bytes": 0,
+            "doc_values_memory_in_bytes": 0,
+            "index_writer_memory_in_bytes": 285894,
+            "version_map_memory_in_bytes": 60329,
+            "fixed_bit_set_memory_in_bytes": 0,
+            "max_unsafe_auto_id_timestamp": -1,
+            "file_sizes": {}
+          },
+          "request_cache": {
+            "memory_size_in_bytes": 0,
+            "evictions": 0,
+            "hit_count": 0,
+            "miss_count": 0
+          }
+        }
+      },
+      ".kibana": {
+        "uuid": "NuBsP0VjTXK4qlsoearCBg",
+        "primaries": {
+          "docs": {
+            "count": 2,
+            "deleted": 0
+          },
+          "store": {
+            "size_in_bytes": 97891
+          },
+          "indexing": {
+            "index_total": 0,
+            "index_time_in_millis": 0,
+            "index_current": 0,
+            "index_failed": 0,
+            "delete_total": 0,
+            "delete_time_in_millis": 0,
+            "delete_current": 0,
+            "noop_update_total": 0,
+            "is_throttled": false,
+            "throttle_time_in_millis": 0
+          },
+          "search": {
+            "open_contexts": 0,
+            "query_total": 1,
+            "query_time_in_millis": 1,
+            "query_current": 0,
+            "fetch_total": 1,
+            "fetch_time_in_millis": 2,
+            "fetch_current": 0,
+            "scroll_total": 0,
+            "scroll_time_in_millis": 0,
+            "scroll_current": 0,
+            "suggest_total": 0,
+            "suggest_time_in_millis": 0,
+            "suggest_current": 0
+          },
+          "merges": {
+            "current": 0,
+            "current_docs": 0,
+            "current_size_in_bytes": 0,
+            "total": 0,
+            "total_time_in_millis": 0,
+            "total_docs": 0,
+            "total_size_in_bytes": 0,
+            "total_stopped_time_in_millis": 0,
+            "total_throttled_time_in_millis": 0,
+            "total_auto_throttle_in_bytes": 20971520
+          },
+          "refresh": {
+            "total": 2,
+            "total_time_in_millis": 0,
+            "listeners": 0
+          },
+          "query_cache": {
+            "memory_size_in_bytes": 0,
+            "total_count": 0,
+            "hit_count": 0,
+            "miss_count": 0,
+            "cache_size": 0,
+            "cache_count": 0,
+            "evictions": 0
+          },
+          "fielddata": {
+            "memory_size_in_bytes": 0,
+            "evictions": 0
+          },
+          "segments": {
+            "count": 2,
+            "memory_in_bytes": 4445,
+            "terms_memory_in_bytes": 3489,
+            "stored_fields_memory_in_bytes": 624,
+            "term_vectors_memory_in_bytes": 0,
+            "norms_memory_in_bytes": 192,
+            "points_memory_in_bytes": 4,
+            "doc_values_memory_in_bytes": 136,
+            "index_writer_memory_in_bytes": 0,
+            "version_map_memory_in_bytes": 0,
+            "fixed_bit_set_memory_in_bytes": 0,
+            "max_unsafe_auto_id_timestamp": -1,
+            "file_sizes": {}
+          },
+          "request_cache": {
+            "memory_size_in_bytes": 0,
+            "evictions": 0,
+            "hit_count": 0,
+            "miss_count": 0
+          }
+        },
+        "total": {
+          "docs": {
+            "count": 2,
+            "deleted": 0
+          },
+          "store": {
+            "size_in_bytes": 97891
+          },
+          "indexing": {
+            "index_total": 0,
+            "index_time_in_millis": 0,
+            "index_current": 0,
+            "index_failed": 0,
+            "delete_total": 0,
+            "delete_time_in_millis": 0,
+            "delete_current": 0,
+            "noop_update_total": 0,
+            "is_throttled": false,
+            "throttle_time_in_millis": 0
+          },
+          "search": {
+            "open_contexts": 0,
+            "query_total": 1,
+            "query_time_in_millis": 1,
+            "query_current": 0,
+            "fetch_total": 1,
+            "fetch_time_in_millis": 2,
+            "fetch_current": 0,
+            "scroll_total": 0,
+            "scroll_time_in_millis": 0,
+            "scroll_current": 0,
+            "suggest_total": 0,
+            "suggest_time_in_millis": 0,
+            "suggest_current": 0
+          },
+          "merges": {
+            "current": 0,
+            "current_docs": 0,
+            "current_size_in_bytes": 0,
+            "total": 0,
+            "total_time_in_millis": 0,
+            "total_docs": 0,
+            "total_size_in_bytes": 0,
+            "total_stopped_time_in_millis": 0,
+            "total_throttled_time_in_millis": 0,
+            "total_auto_throttle_in_bytes": 20971520
+          },
+          "refresh": {
+            "total": 2,
+            "total_time_in_millis": 0,
+            "listeners": 0
+          },
+          "query_cache": {
+            "memory_size_in_bytes": 0,
+            "total_count": 0,
+            "hit_count": 0,
+            "miss_count": 0,
+            "cache_size": 0,
+            "cache_count": 0,
+            "evictions": 0
+          },
+          "fielddata": {
+            "memory_size_in_bytes": 0,
+            "evictions": 0
+          },
+          "segments": {
+            "count": 2,
+            "memory_in_bytes": 4445,
+            "terms_memory_in_bytes": 3489,
+            "stored_fields_memory_in_bytes": 624,
+            "term_vectors_memory_in_bytes": 0,
+            "norms_memory_in_bytes": 192,
+            "points_memory_in_bytes": 4,
+            "doc_values_memory_in_bytes": 136,
+            "index_writer_memory_in_bytes": 0,
+            "version_map_memory_in_bytes": 0,
+            "fixed_bit_set_memory_in_bytes": 0,
+            "max_unsafe_auto_id_timestamp": -1,
+            "file_sizes": {}
+          },
+          "request_cache": {
+            "memory_size_in_bytes": 0,
+            "evictions": 0,
+            "hit_count": 0,
+            "miss_count": 0
+          }
+        }
+      },
+      ".monitoring-alerts-6": {
+        "uuid": "sqYGwl2BRfW1E3KHFN9uRQ",
+        "primaries": {
+          "docs": {
+            "count": 1,
+            "deleted": 0
+          },
+          "store": {
+            "size_in_bytes": 6279
+          },
+          "indexing": {
+            "index_total": 6,
+            "index_time_in_millis": 16,
+            "index_current": 0,
+            "index_failed": 0,
+            "delete_total": 0,
+            "delete_time_in_millis": 0,
+            "delete_current": 0,
+            "noop_update_total": 0,
+            "is_throttled": false,
+            "throttle_time_in_millis": 0
+          },
+          "search": {
+            "open_contexts": 0,
+            "query_total": 30,
+            "query_time_in_millis": 6,
+            "query_current": 0,
+            "fetch_total": 30,
+            "fetch_time_in_millis": 2,
+            "fetch_current": 0,
+            "scroll_total": 0,
+            "scroll_time_in_millis": 0,
+            "scroll_current": 0,
+            "suggest_total": 0,
+            "suggest_time_in_millis": 0,
+            "suggest_current": 0
+          },
+          "merges": {
+            "current": 0,
+            "current_docs": 0,
+            "current_size_in_bytes": 0,
+            "total": 0,
+            "total_time_in_millis": 0,
+            "total_docs": 0,
+            "total_size_in_bytes": 0,
+            "total_stopped_time_in_millis": 0,
+            "total_throttled_time_in_millis": 0,
+            "total_auto_throttle_in_bytes": 20971520
+          },
+          "refresh": {
+            "total": 8,
+            "total_time_in_millis": 63,
+            "listeners": 0
+          },
+          "query_cache": {
+            "memory_size_in_bytes": 0,
+            "total_count": 0,
+            "hit_count": 0,
+            "miss_count": 0,
+            "cache_size": 0,
+            "cache_count": 0,
+            "evictions": 0
+          },
+          "fielddata": {
+            "memory_size_in_bytes": 0,
+            "evictions": 0
+          },
+          "segments": {
+            "count": 1,
+            "memory_in_bytes": 2153,
+            "terms_memory_in_bytes": 1639,
+            "stored_fields_memory_in_bytes": 312,
+            "term_vectors_memory_in_bytes": 0,
+            "norms_memory_in_bytes": 128,
+            "points_memory_in_bytes": 6,
+            "doc_values_memory_in_bytes": 68,
+            "index_writer_memory_in_bytes": 0,
+            "version_map_memory_in_bytes": 0,
+            "fixed_bit_set_memory_in_bytes": 0,
+            "max_unsafe_auto_id_timestamp": -1,
+            "file_sizes": {}
+          },
+          "request_cache": {
+            "memory_size_in_bytes": 0,
+            "evictions": 0,
+            "hit_count": 0,
+            "miss_count": 0
+          }
+        },
+        "total": {
+          "docs": {
+            "count": 1,
+            "deleted": 0
+          },
+          "store": {
+            "size_in_bytes": 6279
+          },
+          "indexing": {
+            "index_total": 6,
+            "index_time_in_millis": 16,
+            "index_current": 0,
+            "index_failed": 0,
+            "delete_total": 0,
+            "delete_time_in_millis": 0,
+            "delete_current": 0,
+            "noop_update_total": 0,
+            "is_throttled": false,
+            "throttle_time_in_millis": 0
+          },
+          "search": {
+            "open_contexts": 0,
+            "query_total": 30,
+            "query_time_in_millis": 6,
+            "query_current": 0,
+            "fetch_total": 30,
+            "fetch_time_in_millis": 2,
+            "fetch_current": 0,
+            "scroll_total": 0,
+            "scroll_time_in_millis": 0,
+            "scroll_current": 0,
+            "suggest_total": 0,
+            "suggest_time_in_millis": 0,
+            "suggest_current": 0
+          },
+          "merges": {
+            "current": 0,
+            "current_docs": 0,
+            "current_size_in_bytes": 0,
+            "total": 0,
+            "total_time_in_millis": 0,
+            "total_docs": 0,
+            "total_size_in_bytes": 0,
+            "total_stopped_time_in_millis": 0,
+            "total_throttled_time_in_millis": 0,
+            "total_auto_throttle_in_bytes": 20971520
+          },
+          "refresh": {
+            "total": 8,
+            "total_time_in_millis": 63,
+            "listeners": 0
+          },
+          "query_cache": {
+            "memory_size_in_bytes": 0,
+            "total_count": 0,
+            "hit_count": 0,
+            "miss_count": 0,
+            "cache_size": 0,
+            "cache_count": 0,
+            "evictions": 0
+          },
+          "fielddata": {
+            "memory_size_in_bytes": 0,
+            "evictions": 0
+          },
+          "segments": {
+            "count": 1,
+            "memory_in_bytes": 2153,
+            "terms_memory_in_bytes": 1639,
+            "stored_fields_memory_in_bytes": 312,
+            "term_vectors_memory_in_bytes": 0,
+            "norms_memory_in_bytes": 128,
+            "points_memory_in_bytes": 6,
+            "doc_values_memory_in_bytes": 68,
+            "index_writer_memory_in_bytes": 0,
+            "version_map_memory_in_bytes": 0,
+            "fixed_bit_set_memory_in_bytes": 0,
+            "max_unsafe_auto_id_timestamp": -1,
+            "file_sizes": {}
+          },
+          "request_cache": {
+            "memory_size_in_bytes": 0,
+            "evictions": 0,
+            "hit_count": 0,
+            "miss_count": 0
+          }
+        }
+      },
+      ".monitoring-es-6-mb-2018.09.07": {
+        "uuid": "GAGg1lZrRzmvnAxh6k5ymA",
+        "primaries": {
+          "docs": {
+            "count": 219,
+            "deleted": 0
+          },
+          "store": {
+            "size_in_bytes": 169315
+          },
+          "indexing": {
+            "index_total": 219,
+            "index_time_in_millis": 48,
+            "index_current": 0,
+            "index_failed": 0,
+            "delete_total": 0,
+            "delete_time_in_millis": 0,
+            "delete_current": 0,
+            "noop_update_total": 0,
+            "is_throttled": false,
+            "throttle_time_in_millis": 0
+          },
+          "search": {
+            "open_contexts": 0,
+            "query_total": 22,
+            "query_time_in_millis": 4,
+            "query_current": 0,
+            "fetch_total": 2,
+            "fetch_time_in_millis": 0,
+            "fetch_current": 0,
+            "scroll_total": 0,
+            "scroll_time_in_millis": 0,
+            "scroll_current": 0,
+            "suggest_total": 0,
+            "suggest_time_in_millis": 0,
+            "suggest_current": 0
+          },
+          "merges": {
+            "current": 0,
+            "current_docs": 0,
+            "current_size_in_bytes": 0,
+            "total": 2,
+            "total_time_in_millis": 21,
+            "total_docs": 199,
+            "total_size_in_bytes": 348970,
+            "total_stopped_time_in_millis": 0,
+            "total_throttled_time_in_millis": 0,
+            "total_auto_throttle_in_bytes": 20971520
+          },
+          "refresh": {
+            "total": 26,
+            "total_time_in_millis": 271,
+            "listeners": 0
+          },
+          "query_cache": {
+            "memory_size_in_bytes": 0,
+            "total_count": 0,
+            "hit_count": 0,
+            "miss_count": 0,
+            "cache_size": 0,
+            "cache_count": 0,
+            "evictions": 0
+          },
+          "fielddata": {
+            "memory_size_in_bytes": 0,
+            "evictions": 0
+          },
+          "segments": {
+            "count": 4,
+            "memory_in_bytes": 19017,
+            "terms_memory_in_bytes": 3856,
+            "stored_fields_memory_in_bytes": 1232,
+            "term_vectors_memory_in_bytes": 0,
+            "norms_memory_in_bytes": 0,
+            "points_memory_in_bytes": 513,
+            "doc_values_memory_in_bytes": 13416,
+            "index_writer_memory_in_bytes": 0,
+            "version_map_memory_in_bytes": 0,
+            "fixed_bit_set_memory_in_bytes": 0,
+            "max_unsafe_auto_id_timestamp": -1,
+            "file_sizes": {}
+          },
+          "request_cache": {
+            "memory_size_in_bytes": 0,
+            "evictions": 0,
+            "hit_count": 0,
+            "miss_count": 0
+          }
+        },
+        "total": {
+          "docs": {
+            "count": 219,
+            "deleted": 0
+          },
+          "store": {
+            "size_in_bytes": 169315
+          },
+          "indexing": {
+            "index_total": 219,
+            "index_time_in_millis": 48,
+            "index_current": 0,
+            "index_failed": 0,
+            "delete_total": 0,
+            "delete_time_in_millis": 0,
+            "delete_current": 0,
+            "noop_update_total": 0,
+            "is_throttled": false,
+            "throttle_time_in_millis": 0
+          },
+          "search": {
+            "open_contexts": 0,
+            "query_total": 22,
+            "query_time_in_millis": 4,
+            "query_current": 0,
+            "fetch_total": 2,
+            "fetch_time_in_millis": 0,
+            "fetch_current": 0,
+            "scroll_total": 0,
+            "scroll_time_in_millis": 0,
+            "scroll_current": 0,
+            "suggest_total": 0,
+            "suggest_time_in_millis": 0,
+            "suggest_current": 0
+          },
+          "merges": {
+            "current": 0,
+            "current_docs": 0,
+            "current_size_in_bytes": 0,
+            "total": 2,
+            "total_time_in_millis": 21,
+            "total_docs": 199,
+            "total_size_in_bytes": 348970,
+            "total_stopped_time_in_millis": 0,
+            "total_throttled_time_in_millis": 0,
+            "total_auto_throttle_in_bytes": 20971520
+          },
+          "refresh": {
+            "total": 26,
+            "total_time_in_millis": 271,
+            "listeners": 0
+          },
+          "query_cache": {
+            "memory_size_in_bytes": 0,
+            "total_count": 0,
+            "hit_count": 0,
+            "miss_count": 0,
+            "cache_size": 0,
+            "cache_count": 0,
+            "evictions": 0
+          },
+          "fielddata": {
+            "memory_size_in_bytes": 0,
+            "evictions": 0
+          },
+          "segments": {
+            "count": 4,
+            "memory_in_bytes": 19017,
+            "terms_memory_in_bytes": 3856,
+            "stored_fields_memory_in_bytes": 1232,
+            "term_vectors_memory_in_bytes": 0,
+            "norms_memory_in_bytes": 0,
+            "points_memory_in_bytes": 513,
+            "doc_values_memory_in_bytes": 13416,
+            "index_writer_memory_in_bytes": 0,
+            "version_map_memory_in_bytes": 0,
+            "fixed_bit_set_memory_in_bytes": 0,
+            "max_unsafe_auto_id_timestamp": -1,
+            "file_sizes": {}
+          },
+          "request_cache": {
+            "memory_size_in_bytes": 0,
+            "evictions": 0,
+            "hit_count": 0,
+            "miss_count": 0
+          }
+        }
+      },
+      ".watches": {
+        "uuid": "Y0_ioAUSTs2r3cLAXOnfsA",
+        "primaries": {
+          "docs": {
+            "count": 6,
+            "deleted": 0
+          },
+          "store": {
+            "size_in_bytes": 93341
+          },
+          "indexing": {
+            "index_total": 258,
+            "index_time_in_millis": 2390,
+            "index_current": 0,
+            "index_failed": 0,
+            "delete_total": 0,
+            "delete_time_in_millis": 0,
+            "delete_current": 0,
+            "noop_update_total": 0,
+            "is_throttled": false,
+            "throttle_time_in_millis": 0
+          },
+          "search": {
+            "open_contexts": 0,
+            "query_total": 2,
+            "query_time_in_millis": 17,
+            "query_current": 0,
+            "fetch_total": 2,
+            "fetch_time_in_millis": 20,
+            "fetch_current": 0,
+            "scroll_total": 1,
+            "scroll_time_in_millis": 312,
+            "scroll_current": 0,
+            "suggest_total": 0,
+            "suggest_time_in_millis": 0,
+            "suggest_current": 0
+          },
+          "merges": {
+            "current": 0,
+            "current_docs": 0,
+            "current_size_in_bytes": 0,
+            "total": 1,
+            "total_time_in_millis": 55,
+            "total_docs": 11,
+            "total_size_in_bytes": 66746,
+            "total_stopped_time_in_millis": 0,
+            "total_throttled_time_in_millis": 0,
+            "total_auto_throttle_in_bytes": 20971520
+          },
+          "refresh": {
+            "total": 52,
+            "total_time_in_millis": 3056,
+            "listeners": 0
+          },
+          "query_cache": {
+            "memory_size_in_bytes": 0,
+            "total_count": 0,
+            "hit_count": 0,
+            "miss_count": 0,
+            "cache_size": 0,
+            "cache_count": 0,
+            "evictions": 0
+          },
+          "fielddata": {
+            "memory_size_in_bytes": 0,
+            "evictions": 0
+          },
+          "segments": {
+            "count": 5,
+            "memory_in_bytes": 18971,
+            "terms_memory_in_bytes": 14945,
+            "stored_fields_memory_in_bytes": 1560,
+            "term_vectors_memory_in_bytes": 0,
+            "norms_memory_in_bytes": 1920,
+            "points_memory_in_bytes": 22,
+            "doc_values_memory_in_bytes": 524,
+            "index_writer_memory_in_bytes": 0,
+            "version_map_memory_in_bytes": 0,
+            "fixed_bit_set_memory_in_bytes": 0,
+            "max_unsafe_auto_id_timestamp": -1,
+            "file_sizes": {}
+          },
+          "request_cache": {
+            "memory_size_in_bytes": 0,
+            "evictions": 0,
+            "hit_count": 0,
+            "miss_count": 0
+          }
+        },
+        "total": {
+          "docs": {
+            "count": 6,
+            "deleted": 0
+          },
+          "store": {
+            "size_in_bytes": 93341
+          },
+          "indexing": {
+            "index_total": 258,
+            "index_time_in_millis": 2390,
+            "index_current": 0,
+            "index_failed": 0,
+            "delete_total": 0,
+            "delete_time_in_millis": 0,
+            "delete_current": 0,
+            "noop_update_total": 0,
+            "is_throttled": false,
+            "throttle_time_in_millis": 0
+          },
+          "search": {
+            "open_contexts": 0,
+            "query_total": 2,
+            "query_time_in_millis": 17,
+            "query_current": 0,
+            "fetch_total": 2,
+            "fetch_time_in_millis": 20,
+            "fetch_current": 0,
+            "scroll_total": 1,
+            "scroll_time_in_millis": 312,
+            "scroll_current": 0,
+            "suggest_total": 0,
+            "suggest_time_in_millis": 0,
+            "suggest_current": 0
+          },
+          "merges": {
+            "current": 0,
+            "current_docs": 0,
+            "current_size_in_bytes": 0,
+            "total": 1,
+            "total_time_in_millis": 55,
+            "total_docs": 11,
+            "total_size_in_bytes": 66746,
+            "total_stopped_time_in_millis": 0,
+            "total_throttled_time_in_millis": 0,
+            "total_auto_throttle_in_bytes": 20971520
+          },
+          "refresh": {
+            "total": 52,
+            "total_time_in_millis": 3056,
+            "listeners": 0
+          },
+          "query_cache": {
+            "memory_size_in_bytes": 0,
+            "total_count": 0,
+            "hit_count": 0,
+            "miss_count": 0,
+            "cache_size": 0,
+            "cache_count": 0,
+            "evictions": 0
+          },
+          "fielddata": {
+            "memory_size_in_bytes": 0,
+            "evictions": 0
+          },
+          "segments": {
+            "count": 5,
+            "memory_in_bytes": 18971,
+            "terms_memory_in_bytes": 14945,
+            "stored_fields_memory_in_bytes": 1560,
+            "term_vectors_memory_in_bytes": 0,
+            "norms_memory_in_bytes": 1920,
+            "points_memory_in_bytes": 22,
+            "doc_values_memory_in_bytes": 524,
+            "index_writer_memory_in_bytes": 0,
+            "version_map_memory_in_bytes": 0,
+            "fixed_bit_set_memory_in_bytes": 0,
+            "max_unsafe_auto_id_timestamp": -1,
+            "file_sizes": {}
+          },
+          "request_cache": {
+            "memory_size_in_bytes": 0,
+            "evictions": 0,
+            "hit_count": 0,
+            "miss_count": 0
+          }
+        }
+      }
     }
-}
+  }

--- a/metricbeat/module/elasticsearch/index/data.go
+++ b/metricbeat/module/elasticsearch/index/data.go
@@ -29,6 +29,10 @@ import (
 	"github.com/elastic/beats/metricbeat/module/elasticsearch"
 )
 
+type IndicesStruct struct {
+	Indices map[string]map[string]interface{} `json:"indices"`
+}
+
 var (
 	schema = s.Schema{
 		"total": c.Dict("total", s.Schema{
@@ -49,14 +53,10 @@ var (
 			}),
 		}),
 	}
-
-	indicesStruct struct {
-		Indices map[string]map[string]interface{} `json:"indices"`
-	}
 )
 
 func eventsMapping(r mb.ReporterV2, info elasticsearch.Info, content []byte) error {
-
+	var indicesStruct IndicesStruct
 	err := json.Unmarshal(content, &indicesStruct)
 	if err != nil {
 		r.Error(err)

--- a/metricbeat/module/elasticsearch/index/data.go
+++ b/metricbeat/module/elasticsearch/index/data.go
@@ -49,12 +49,13 @@ var (
 			}),
 		}),
 	}
+
+	indicesStruct struct {
+		Indices map[string]map[string]interface{} `json:"indices"`
+	}
 )
 
 func eventsMapping(r mb.ReporterV2, info elasticsearch.Info, content []byte) error {
-	var indicesStruct struct {
-		Indices map[string]map[string]interface{} `json:"indices"`
-	}
 
 	err := json.Unmarshal(content, &indicesStruct)
 	if err != nil {

--- a/metricbeat/module/elasticsearch/index/data_xpack.go
+++ b/metricbeat/module/elasticsearch/index/data_xpack.go
@@ -141,8 +141,6 @@ func addClusterStateFields(indexName string, indexStats, clusterState common.Map
 		return err
 	}
 
-	// TODO:
-
 	// "index_stats.created",
 	v, err := indexMetadata.GetValue("settings.index.creation_date")
 	if err != nil {

--- a/metricbeat/module/elasticsearch/index/data_xpack.go
+++ b/metricbeat/module/elasticsearch/index/data_xpack.go
@@ -93,6 +93,7 @@ var (
 )
 
 func eventsMappingXPack(r mb.ReporterV2, m *MetricSet, info elasticsearch.Info, content []byte) error {
+	var indicesStruct IndicesStruct
 	err := json.Unmarshal(content, &indicesStruct)
 	if err != nil {
 		m.Log.Errorw("Failure parsing Indices Stats Elasticsearch API response", "error", err)

--- a/metricbeat/module/elasticsearch/index/data_xpack.go
+++ b/metricbeat/module/elasticsearch/index/data_xpack.go
@@ -95,12 +95,14 @@ var (
 func eventsMappingXPack(r mb.ReporterV2, m *MetricSet, info elasticsearch.Info, content []byte) error {
 	err := json.Unmarshal(content, &indicesStruct)
 	if err != nil {
+		m.Log.Errorw("Failure parsing Indices Stats Elasticsearch API response", "error", err)
 		return err
 	}
 
 	clusterStateMetrics := []string{"metadata", "routing_table"}
 	clusterState, err := elasticsearch.GetClusterState(m.HTTP, m.HTTP.GetURI(), clusterStateMetrics)
 	if err != nil {
+		m.Log.Errorw("Failure retrieving cluster state from Elasticsearch", "error", err)
 		return err
 	}
 
@@ -108,12 +110,14 @@ func eventsMappingXPack(r mb.ReporterV2, m *MetricSet, info elasticsearch.Info, 
 		event := mb.Event{}
 		indexStats, err := xpackSchema.Apply(index)
 		if err != nil {
+			m.Log.Errorw("Failure applying index stats schema", "error", err)
 			continue
 		}
 		indexStats["index"] = name
 
 		err = addClusterStateFields(name, indexStats, clusterState)
 		if err != nil {
+			m.Log.Errorw("Failure adding cluster state fields", "error", err)
 			continue
 		}
 

--- a/metricbeat/module/elasticsearch/index/data_xpack.go
+++ b/metricbeat/module/elasticsearch/index/data_xpack.go
@@ -47,6 +47,7 @@ import (
 // "index_stats.shards.relocating",
 
 var (
+	// Based on https://github.com/elastic/elasticsearch/blob/master/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/collector/indices/IndexStatsMonitoringDoc.java#L127-L203
 	xpackSchema = s.Schema{
 		"uuid":      c.Str("uuid"),
 		"primaries": c.Dict("primaries", indexStatsSchema),

--- a/metricbeat/module/elasticsearch/index/data_xpack.go
+++ b/metricbeat/module/elasticsearch/index/data_xpack.go
@@ -1,0 +1,134 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package index
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/elastic/beats/libbeat/common"
+	s "github.com/elastic/beats/libbeat/common/schema"
+	c "github.com/elastic/beats/libbeat/common/schema/mapstriface"
+	"github.com/elastic/beats/metricbeat/helper/elastic"
+	"github.com/elastic/beats/metricbeat/mb"
+	"github.com/elastic/beats/metricbeat/module/elasticsearch"
+)
+
+// TODO:
+// "index_stats.created",
+// "index_stats.status",
+// "index_stats.version.created",
+// "index_stats.version.upgraded",
+// "index_stats.shards.total",
+// "index_stats.shards.primaries",
+// "index_stats.shards.replicas",
+// "index_stats.shards.active_total",
+// "index_stats.shards.active_primaries",
+// "index_stats.shards.active_replicas",
+// "index_stats.shards.unassigned_total",
+// "index_stats.shards.unassigned_primaries",
+// "index_stats.shards.unassigned_replicas",
+// "index_stats.shards.initializing",
+// "index_stats.shards.relocating",
+
+var (
+	xpackSchema = s.Schema{
+		"uuid":      c.Str("uuid"),
+		"primaries": c.Dict("primaries", indexStatsSchema),
+		"total":     c.Dict("total", indexStatsSchema),
+	}
+
+	indexStatsSchema = s.Schema{
+		"docs": c.Dict("docs", s.Schema{
+			"count": c.Int("count"),
+		}),
+		"fielddata": c.Dict("fielddata", s.Schema{
+			"memory_size_in_bytes": c.Int("memory_size_in_bytes"),
+			"evictions":            c.Int("evictions"),
+		}),
+		"indexing": c.Dict("indexing", s.Schema{
+			"index_total":             c.Int("index_total"),
+			"index_time_in_millis":    c.Int("index_time_in_millis"),
+			"throttle_time_in_millis": c.Int("throttle_time_in_millis"),
+		}),
+		"merges": c.Dict("merges", s.Schema{
+			"total_size_in_bytes": c.Int("total_size_in_bytes"),
+		}),
+		"query_cache":   c.Dict("query_cache", cacheStatsSchema),
+		"request_cache": c.Dict("request_cache", cacheStatsSchema),
+		"search": c.Dict("search", s.Schema{
+			"query_total":          c.Int("query_total"),
+			"query_time_in_millis": c.Int("query_time_in_millis"),
+		}),
+		"segments": c.Dict("segments", s.Schema{
+			"count":                         c.Int("count"),
+			"memory_in_bytes":               c.Int("memory_in_bytes"),
+			"terms_memory_in_bytes":         c.Int("terms_memory_in_bytes"),
+			"stored_fields_memory_in_bytes": c.Int("stored_fields_memory_in_bytes"),
+			"term_vectors_memory_in_bytes":  c.Int("term_vectors_memory_in_bytes"),
+			"norms_memory_in_bytes":         c.Int("norms_memory_in_bytes"),
+			"points_memory_in_bytes":        c.Int("points_memory_in_bytes"),
+			"doc_values_memory_in_bytes":    c.Int("doc_values_memory_in_bytes"),
+			"index_writer_memory_in_bytes":  c.Int("index_writer_memory_in_bytes"),
+			"version_map_memory_in_bytes":   c.Int("version_map_memory_in_bytes"),
+			"fixed_bit_set_memory_in_bytes": c.Int("fixed_bit_set_memory_in_bytes"),
+		}),
+		"store": c.Dict("store", s.Schema{
+			"size_in_bytes": c.Int("size_in_bytes"),
+		}),
+		"refresh": c.Dict("refresh", s.Schema{
+			"total_time_in_millis": c.Int("total_time_in_millis"),
+		}),
+	}
+
+	cacheStatsSchema = s.Schema{
+		"memory_size_in_bytes": c.Int("memory_size_in_bytes"),
+		"evictions":            c.Int("evictions"),
+		"hit_count":            c.Int("hit_count"),
+		"miss_count":           c.Int("miss_count"),
+	}
+)
+
+func eventsMappingXPack(r mb.ReporterV2, m *MetricSet, info elasticsearch.Info, content []byte) error {
+	err := json.Unmarshal(content, &indicesStruct)
+	if err != nil {
+		return err
+	}
+
+	for name, index := range indicesStruct.Indices {
+		event := mb.Event{}
+		indexStats, err := xpackSchema.Apply(index)
+		if err != nil {
+			continue
+		}
+		indexStats["index"] = name
+
+		event.RootFields = common.MapStr{
+			"cluster_uuid": info.ClusterID,
+			"timestamp":    common.Time(time.Now()),
+			"interval_ms":  m.Module().Config().Period / time.Millisecond,
+			"type":         "index_stats",
+			"index_stats":  indexStats,
+		}
+
+		event.Index = elastic.MakeXPackMonitoringIndexName(elastic.Elasticsearch)
+		r.Event(event)
+	}
+
+	return nil
+}

--- a/metricbeat/module/elasticsearch/index/index.go
+++ b/metricbeat/module/elasticsearch/index/index.go
@@ -33,7 +33,8 @@ func init() {
 }
 
 const (
-	statsPath = "/_stats/docs,fielddata,indexing,merge,search,segments,store,refresh,query_cache,request_cache"
+	statsMetrics = "docs,fielddata,indexing,merge,search,segments,store,refresh,query_cache,request_cache"
+	statsPath    = "/_stats/" + statsMetrics
 )
 
 // MetricSet type defines all fields of the MetricSet

--- a/metricbeat/module/elasticsearch/index/index.go
+++ b/metricbeat/module/elasticsearch/index/index.go
@@ -80,5 +80,13 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 		return
 	}
 
-	eventsMapping(r, *info, content)
+	if m.XPack {
+		eventsMappingXPack(r, m, *info, content)
+	} else {
+		err = eventsMapping(r, *info, content)
+		if err != nil {
+			r.Error(err)
+			return
+		}
+	}
 }

--- a/metricbeat/module/elasticsearch/index/index.go
+++ b/metricbeat/module/elasticsearch/index/index.go
@@ -33,7 +33,7 @@ func init() {
 }
 
 const (
-	statsPath = "/_stats"
+	statsPath = "/_stats/docs,fielddata,indexing,merge,search,segments,store,refresh,query_cache,request_cache"
 )
 
 // MetricSet type defines all fields of the MetricSet

--- a/metricbeat/module/elasticsearch/metricset.go
+++ b/metricbeat/module/elasticsearch/metricset.go
@@ -44,7 +44,7 @@ type MetricSet struct {
 	mb.BaseMetricSet
 	*helper.HTTP
 	XPack bool
-	log   *logp.Logger
+	Log   *logp.Logger
 }
 
 // NewMetricSet creates an metric set that can be used to build other metric

--- a/metricbeat/module/elasticsearch/metricset.go
+++ b/metricbeat/module/elasticsearch/metricset.go
@@ -19,6 +19,7 @@ package elasticsearch
 
 import (
 	"github.com/elastic/beats/libbeat/common/cfgwarn"
+	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/metricbeat/helper"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/mb/parse"
@@ -43,6 +44,7 @@ type MetricSet struct {
 	mb.BaseMetricSet
 	*helper.HTTP
 	XPack bool
+	log   *logp.Logger
 }
 
 // NewMetricSet creates an metric set that can be used to build other metric
@@ -67,9 +69,11 @@ func NewMetricSet(base mb.BaseMetricSet, subPath string) (*MetricSet, error) {
 		cfgwarn.Experimental("The experimental xpack.enabled flag in elasticsearch/node_stats metricset is enabled.")
 	}
 
+	log := logp.NewLogger(ModuleName)
 	return &MetricSet{
 		base,
 		http,
 		config.XPack,
+		log,
 	}, nil
 }


### PR DESCRIPTION
This PR teaches metricbeat to index `index_stats` documents into `.monitoring-es-6-mb-*` indices.