### PR TITLE
Add central management service

### DIFF
--- a/libbeat/beat/beat.go
+++ b/libbeat/beat/beat.go
@@ -19,6 +19,7 @@ package beat
 
 import (
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/management"
 )
 
 // Creator initializes and configures a new Beater instance used to execute
@@ -64,6 +65,8 @@ type Beat struct {
 	BeatConfig *common.Config // The beat's own configuration section
 
 	Fields []byte // Data from fields.yml
+
+	ConfigManager management.ConfigManager // config manager
 }
 
 // BeatConfig struct contains the basic configuration of every beat

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -573,7 +573,7 @@ func (b *Beat) configure() error {
 	logp.Info("Beat UUID: %v", b.Info.UUID)
 
 	// initialize config manager
-	b.ConfigManager, err = management.GetFactory()(reload.Register, b.Beat.Info.UUID)
+	b.ConfigManager, err = management.Factory()(reload.Register, b.Beat.Info.UUID)
 	if err != nil {
 		return err
 	}

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -46,6 +46,7 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/libbeat/common/file"
+	"github.com/elastic/beats/libbeat/common/reload"
 	"github.com/elastic/beats/libbeat/common/seccomp"
 	"github.com/elastic/beats/libbeat/dashboards"
 	"github.com/elastic/beats/libbeat/keystore"
@@ -572,7 +573,7 @@ func (b *Beat) configure() error {
 	logp.Info("Beat UUID: %v", b.Info.UUID)
 
 	// initialize config manager
-	b.ConfigManager, err = management.GetFactory()(b.Beat.Info.UUID)
+	b.ConfigManager, err = management.GetFactory()(reload.Register, b.Beat.Info.UUID)
 	if err != nil {
 		return err
 	}

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -35,6 +35,9 @@ import (
 	"github.com/satori/go.uuid"
 	"go.uber.org/zap"
 
+	"github.com/elastic/go-sysinfo"
+	"github.com/elastic/go-sysinfo/types"
+
 	"github.com/elastic/beats/libbeat/api"
 	"github.com/elastic/beats/libbeat/asset"
 	"github.com/elastic/beats/libbeat/beat"
@@ -48,6 +51,7 @@ import (
 	"github.com/elastic/beats/libbeat/keystore"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/logp/configure"
+	"github.com/elastic/beats/libbeat/management"
 	"github.com/elastic/beats/libbeat/metric/system/host"
 	"github.com/elastic/beats/libbeat/monitoring"
 	"github.com/elastic/beats/libbeat/monitoring/report"
@@ -59,8 +63,6 @@ import (
 	svc "github.com/elastic/beats/libbeat/service"
 	"github.com/elastic/beats/libbeat/template"
 	"github.com/elastic/beats/libbeat/version"
-	"github.com/elastic/go-sysinfo"
-	"github.com/elastic/go-sysinfo/types"
 
 	// Register publisher pipeline modules
 	_ "github.com/elastic/beats/libbeat/publisher/includes"
@@ -385,6 +387,10 @@ func (b *Beat) launch(settings Settings, bt beat.Creator) error {
 		api.Start(b.Config.HTTP)
 	}
 
+	// Launch config manager
+	b.ConfigManager.Start()
+	defer b.ConfigManager.Stop()
+
 	return beater.Run(&b.Beat)
 }
 
@@ -557,6 +563,16 @@ func (b *Beat) configure() error {
 
 	// log paths values to help with troubleshooting
 	logp.Info(paths.Paths.String())
+
+	// initialize config manager
+	b.ConfigManager, err = management.GetFactory()()
+	if err != nil {
+		return err
+	}
+
+	if err := b.ConfigManager.CheckRawConfig(b.RawConfig); err != nil {
+		return err
+	}
 
 	err = b.loadMeta()
 	if err != nil {

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -564,8 +564,15 @@ func (b *Beat) configure() error {
 	// log paths values to help with troubleshooting
 	logp.Info(paths.Paths.String())
 
+	err = b.loadMeta()
+	if err != nil {
+		return err
+	}
+
+	logp.Info("Beat UUID: %v", b.Info.UUID)
+
 	// initialize config manager
-	b.ConfigManager, err = management.GetFactory()()
+	b.ConfigManager, err = management.GetFactory()(b.Beat.Info.UUID)
 	if err != nil {
 		return err
 	}
@@ -573,13 +580,6 @@ func (b *Beat) configure() error {
 	if err := b.ConfigManager.CheckRawConfig(b.RawConfig); err != nil {
 		return err
 	}
-
-	err = b.loadMeta()
-	if err != nil {
-		return err
-	}
-
-	logp.Info("Beat UUID: %v", b.Info.UUID)
 
 	if maxProcs := b.Config.MaxProcs; maxProcs > 0 {
 		runtime.GOMAXPROCS(maxProcs)

--- a/libbeat/common/reload/reload.go
+++ b/libbeat/common/reload/reload.go
@@ -26,7 +26,7 @@ import (
 )
 
 // Register holds a registry of reloadable objects
-var Register = newRegistry()
+var Register = NewRegistry()
 
 // ConfigWithMeta holds a pair of common.Config and optional metadata for it
 type ConfigWithMeta struct {
@@ -54,7 +54,8 @@ type Registry struct {
 	confs      map[string]Reloadable
 }
 
-func newRegistry() *Registry {
+// NewRegistry initializes and returns a reload registry
+func NewRegistry() *Registry {
 	return &Registry{
 		confsLists: make(map[string]ReloadableList),
 		confs:      make(map[string]Reloadable),

--- a/libbeat/common/reload/reload.go
+++ b/libbeat/common/reload/reload.go
@@ -110,15 +110,15 @@ func (r *Registry) MustRegisterList(name string, list ReloadableList) {
 	}
 }
 
-// Get returns the reloadable object with the given name, nil if not found
-func (r *Registry) Get(name string) Reloadable {
+// GetReloadable returns the reloadable object with the given name, nil if not found
+func (r *Registry) GetReloadable(name string) Reloadable {
 	r.RLock()
 	defer r.RUnlock()
 	return r.confs[name]
 }
 
-// GetList returns the reloadable list with the given name, nil if not found
-func (r *Registry) GetList(name string) ReloadableList {
+// GetReloadableList returns the reloadable list with the given name, nil if not found
+func (r *Registry) GetReloadableList(name string) ReloadableList {
 	r.RLock()
 	defer r.RUnlock()
 	return r.confsLists[name]

--- a/libbeat/common/reload/reload.go
+++ b/libbeat/common/reload/reload.go
@@ -47,21 +47,22 @@ type Reloadable interface {
 	Reload(config *ConfigWithMeta) error
 }
 
-type registry struct {
+// Registry of reloadable objects and lists
+type Registry struct {
 	sync.RWMutex
 	confsLists map[string]ReloadableList
 	confs      map[string]Reloadable
 }
 
-func newRegistry() *registry {
-	return &registry{
+func newRegistry() *Registry {
+	return &Registry{
 		confsLists: make(map[string]ReloadableList),
 		confs:      make(map[string]Reloadable),
 	}
 }
 
 // Register declares a reloadable object
-func (r *registry) Register(name string, obj Reloadable) error {
+func (r *Registry) Register(name string, obj Reloadable) error {
 	r.Lock()
 	defer r.Unlock()
 
@@ -78,7 +79,7 @@ func (r *registry) Register(name string, obj Reloadable) error {
 }
 
 // RegisterList declares a reloadable list of configurations
-func (r *registry) RegisterList(name string, list ReloadableList) error {
+func (r *Registry) RegisterList(name string, list ReloadableList) error {
 	r.Lock()
 	defer r.Unlock()
 
@@ -95,34 +96,34 @@ func (r *registry) RegisterList(name string, list ReloadableList) error {
 }
 
 // MustRegister declares a reloadable object
-func (r *registry) MustRegister(name string, obj Reloadable) {
+func (r *Registry) MustRegister(name string, obj Reloadable) {
 	if err := r.Register(name, obj); err != nil {
 		panic(err)
 	}
 }
 
 // MustRegisterList declares a reloadable object list
-func (r *registry) MustRegisterList(name string, list ReloadableList) {
+func (r *Registry) MustRegisterList(name string, list ReloadableList) {
 	if err := r.RegisterList(name, list); err != nil {
 		panic(err)
 	}
 }
 
 // Get returns the reloadable object with the given name, nil if not found
-func (r *registry) Get(name string) Reloadable {
+func (r *Registry) Get(name string) Reloadable {
 	r.RLock()
 	defer r.RUnlock()
 	return r.confs[name]
 }
 
 // GetList returns the reloadable list with the given name, nil if not found
-func (r *registry) GetList(name string) ReloadableList {
+func (r *Registry) GetList(name string) ReloadableList {
 	r.RLock()
 	defer r.RUnlock()
 	return r.confsLists[name]
 }
 
-func (r *registry) nameTaken(name string) bool {
+func (r *Registry) nameTaken(name string) bool {
 	if _, ok := r.confs[name]; ok {
 		return true
 	}

--- a/libbeat/common/reload/reload_test.go
+++ b/libbeat/common/reload/reload_test.go
@@ -29,22 +29,22 @@ type reloadableList struct{}
 func (reloadable) Reload(config *ConfigWithMeta) error       { return nil }
 func (reloadableList) Reload(config []*ConfigWithMeta) error { return nil }
 
-func RegisterReloadable(t *testing.T) {
+func TestRegisterReloadable(t *testing.T) {
 	obj := reloadable{}
 	r := NewRegistry()
 
 	r.Register("my.reloadable", obj)
 
-	assert.Equal(t, obj, r.Get("my.reloadable"))
+	assert.Equal(t, obj, r.GetReloadable("my.reloadable"))
 }
 
-func RegisterReloadableList(t *testing.T) {
+func TestRegisterReloadableList(t *testing.T) {
 	objl := reloadableList{}
 	r := NewRegistry()
 
 	r.RegisterList("my.reloadable", objl)
 
-	assert.Equal(t, objl, r.Get("my.reloadable"))
+	assert.Equal(t, objl, r.GetReloadableList("my.reloadable"))
 }
 
 func TestRegisterNilFails(t *testing.T) {

--- a/libbeat/common/reload/reload_test.go
+++ b/libbeat/common/reload/reload_test.go
@@ -31,7 +31,7 @@ func (reloadableList) Reload(config []*ConfigWithMeta) error { return nil }
 
 func RegisterReloadable(t *testing.T) {
 	obj := reloadable{}
-	r := newRegistry()
+	r := NewRegistry()
 
 	r.Register("my.reloadable", obj)
 
@@ -40,7 +40,7 @@ func RegisterReloadable(t *testing.T) {
 
 func RegisterReloadableList(t *testing.T) {
 	objl := reloadableList{}
-	r := newRegistry()
+	r := NewRegistry()
 
 	r.RegisterList("my.reloadable", objl)
 
@@ -48,7 +48,7 @@ func RegisterReloadableList(t *testing.T) {
 }
 
 func TestRegisterNilFails(t *testing.T) {
-	r := newRegistry()
+	r := NewRegistry()
 
 	err := r.Register("name", nil)
 	assert.Error(t, err)
@@ -58,7 +58,7 @@ func TestRegisterNilFails(t *testing.T) {
 }
 
 func TestReRegisterFails(t *testing.T) {
-	r := newRegistry()
+	r := NewRegistry()
 
 	// two obj with the same name
 	err := r.Register("name", reloadable{})

--- a/libbeat/management/management.go
+++ b/libbeat/management/management.go
@@ -21,6 +21,7 @@ import (
 	"github.com/satori/go.uuid"
 
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/reload"
 	"github.com/elastic/beats/libbeat/feature"
 )
 
@@ -47,7 +48,7 @@ type ConfigManager interface {
 }
 
 // Factory for creating a config manager
-type Factory func(uuid.UUID) (ConfigManager, error)
+type Factory func(*reload.Registry, uuid.UUID) (ConfigManager, error)
 
 // Register a config manager
 func Register(name string, fn Factory, stability feature.Stability) {
@@ -75,7 +76,7 @@ func GetFactory() Factory {
 // nilManager, fallback when no manager is present
 type nilManager struct{}
 
-func nilFactory(uuid.UUID) (ConfigManager, error) { return nilManager{}, nil }
+func nilFactory(*reload.Registry, uuid.UUID) (ConfigManager, error) { return nilManager{}, nil }
 
 func (nilManager) Enabled() bool                           { return false }
 func (nilManager) Start()                                  {}

--- a/libbeat/management/management.go
+++ b/libbeat/management/management.go
@@ -47,25 +47,25 @@ type ConfigManager interface {
 	CheckRawConfig(cfg *common.Config) error
 }
 
-// Factory for creating a config manager
-type Factory func(*reload.Registry, uuid.UUID) (ConfigManager, error)
+// FactoryFunc for creating a config manager
+type FactoryFunc func(*reload.Registry, uuid.UUID) (ConfigManager, error)
 
 // Register a config manager
-func Register(name string, fn Factory, stability feature.Stability) {
+func Register(name string, fn FactoryFunc, stability feature.Stability) {
 	f := feature.New(Namespace, name, fn, feature.NewDetails(name, "", stability))
 	feature.MustRegister(f)
 }
 
-// GetFactory retrieves config manager constructor. If no one is registered
+// Factory retrieves config manager constructor. If no one is registered
 // it will create a nil manager
-func GetFactory() Factory {
+func Factory() FactoryFunc {
 	factories, err := feature.Registry.LookupAll(Namespace)
 	if err != nil {
 		return nilFactory
 	}
 
 	for _, f := range factories {
-		if factory, ok := f.Factory().(Factory); ok {
+		if factory, ok := f.Factory().(FactoryFunc); ok {
 			return factory
 		}
 	}

--- a/libbeat/management/management.go
+++ b/libbeat/management/management.go
@@ -18,6 +18,8 @@
 package management
 
 import (
+	"github.com/satori/go.uuid"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/feature"
 )
@@ -42,7 +44,7 @@ type ConfigManager interface {
 }
 
 // Factory for creating a config manager
-type Factory func() (ConfigManager, error)
+type Factory func(uuid.UUID) (ConfigManager, error)
 
 // Register a config manager
 func Register(name string, fn Factory, stability feature.Stability) {
@@ -70,7 +72,7 @@ func GetFactory() Factory {
 // nilManager, fallback when no manager is present
 type nilManager struct{}
 
-func nilFactory() (ConfigManager, error) { return nilManager{}, nil }
+func nilFactory(uuid.UUID) (ConfigManager, error) { return nilManager{}, nil }
 
 func (nilManager) Enabled() bool                           { return false }
 func (nilManager) Start()                                  {}

--- a/libbeat/management/management.go
+++ b/libbeat/management/management.go
@@ -1,0 +1,78 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package management
+
+import (
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/feature"
+)
+
+// Namespace is the feature namespace for queue definition.
+var Namespace = "libbeat.management"
+
+// ConfigManager interacts with the beat to update configurations
+// from an external source
+type ConfigManager interface {
+	// Enabled returns true if config manager is enabled
+	Enabled() bool
+
+	// Start the config manager
+	Start()
+
+	// Stop the config manager
+	Stop()
+
+	// CheckRawConfig check settings are correct before launching the beat
+	CheckRawConfig(cfg *common.Config) error
+}
+
+// Factory for creating a config manager
+type Factory func() (ConfigManager, error)
+
+// Register a config manager
+func Register(name string, fn Factory, stability feature.Stability) {
+	f := feature.New(Namespace, name, fn, feature.NewDetails(name, "", stability))
+	feature.MustRegister(f)
+}
+
+// GetFactory retrieves config manager constructor. If no one is registered
+// it will create a nil manager
+func GetFactory() Factory {
+	factories, err := feature.Registry.LookupAll(Namespace)
+	if err != nil {
+		return nilFactory
+	}
+
+	for _, f := range factories {
+		if factory, ok := f.Factory().(Factory); ok {
+			return factory
+		}
+	}
+
+	return nilFactory
+}
+
+// nilManager, fallback when no manager is present
+type nilManager struct{}
+
+func nilFactory() (ConfigManager, error) { return nilManager{}, nil }
+
+func (nilManager) Enabled() bool                           { return false }
+func (nilManager) Start()                                  {}
+func (nilManager) Stop()                                   {}
+func (nilManager) CheckRawConfig(cfg *common.Config) error { return nil }

--- a/libbeat/management/management.go
+++ b/libbeat/management/management.go
@@ -27,6 +27,9 @@ import (
 // Namespace is the feature namespace for queue definition.
 var Namespace = "libbeat.management"
 
+// DebugK used as key for all things central management
+var DebugK = "centralmgmt"
+
 // ConfigManager interacts with the beat to update configurations
 // from an external source
 type ConfigManager interface {

--- a/metricbeat/beater/metricbeat.go
+++ b/metricbeat/beater/metricbeat.go
@@ -210,7 +210,7 @@ func (bt *Metricbeat) Run(b *beat.Beat) error {
 	// Centrally managed modules
 	factory := module.NewFactory(bt.moduleOptions...)
 	modules := cfgfile.NewRunnerList(management.DebugK, factory, b.Publisher)
-	reload.MustRegisterList("metricbeat.modules", modules)
+	reload.Register.MustRegisterList("metricbeat.modules", modules)
 	wg.Add(1)
 	go func() {
 		defer wg.Done()

--- a/metricbeat/beater/metricbeat.go
+++ b/metricbeat/beater/metricbeat.go
@@ -20,6 +20,8 @@ package beater
 import (
 	"sync"
 
+	"github.com/elastic/beats/libbeat/common/reload"
+
 	"github.com/joeshaw/multierror"
 	"github.com/pkg/errors"
 
@@ -187,6 +189,7 @@ func newMetricbeat(b *beat.Beat, c *common.Config, options ...Option) (*Metricbe
 func (bt *Metricbeat) Run(b *beat.Beat) error {
 	var wg sync.WaitGroup
 
+	// Static modules (metricbeat.modules)
 	for _, m := range bt.modules {
 		client, err := m.connector.Connect()
 		if err != nil {
@@ -203,9 +206,20 @@ func (bt *Metricbeat) Run(b *beat.Beat) error {
 		}()
 	}
 
+	// Centrally managed modules
+	factory := module.NewFactory(bt.moduleOptions...)
+	modules := cfgfile.NewRunnerList("modules", factory, b.Publisher)
+	reload.MustRegisterList("metricbeat.modules", modules)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		<-bt.done
+		modules.Stop()
+	}()
+
+	// Dynamic file based modules (metricbeat.config.modules)
 	if bt.config.ConfigModules.Enabled() {
 		moduleReloader := cfgfile.NewReloader(b.Publisher, bt.config.ConfigModules)
-		factory := module.NewFactory(bt.moduleOptions...)
 
 		if err := moduleReloader.Check(factory); err != nil {
 			return err
@@ -220,6 +234,7 @@ func (bt *Metricbeat) Run(b *beat.Beat) error {
 		}()
 	}
 
+	// Autodiscover (metricbeat.autodiscover)
 	if bt.autodiscover != nil {
 		bt.autodiscover.Start()
 		wg.Add(1)

--- a/metricbeat/beater/metricbeat.go
+++ b/metricbeat/beater/metricbeat.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 
 	"github.com/elastic/beats/libbeat/common/reload"
+	"github.com/elastic/beats/libbeat/management"
 
 	"github.com/joeshaw/multierror"
 	"github.com/pkg/errors"
@@ -208,7 +209,7 @@ func (bt *Metricbeat) Run(b *beat.Beat) error {
 
 	// Centrally managed modules
 	factory := module.NewFactory(bt.moduleOptions...)
-	modules := cfgfile.NewRunnerList("modules", factory, b.Publisher)
+	modules := cfgfile.NewRunnerList(management.DebugK, factory, b.Publisher)
 	reload.MustRegisterList("metricbeat.modules", modules)
 	wg.Add(1)
 	go func() {

--- a/x-pack/libbeat/cmd/inject.go
+++ b/x-pack/libbeat/cmd/inject.go
@@ -4,7 +4,12 @@
 
 package cmd
 
-import "github.com/elastic/beats/libbeat/cmd"
+import (
+	"github.com/elastic/beats/libbeat/cmd"
+
+	// register central management
+	_ "github.com/elastic/beats/x-pack/libbeat/management"
+)
 
 // AddXPack extends the given root folder with XPack features
 func AddXPack(root *cmd.BeatsRootCmd, name string) {

--- a/x-pack/libbeat/management/api/client.go
+++ b/x-pack/libbeat/management/api/client.go
@@ -38,13 +38,12 @@ func ConfigFromURL(kibanaURL string) (*kibana.ClientConfig, error) {
 	}
 
 	return &kibana.ClientConfig{
-		Protocol:      data.Scheme,
-		Host:          data.Host,
-		Path:          data.Path,
-		Username:      username,
-		Password:      password,
-		Timeout:       defaultTimeout,
-		IgnoreVersion: true,
+		Protocol: data.Scheme,
+		Host:     data.Host,
+		Path:     data.Path,
+		Username: username,
+		Password: password,
+		Timeout:  defaultTimeout,
 	}, nil
 }
 

--- a/x-pack/libbeat/management/api/client_test.go
+++ b/x-pack/libbeat/management/api/client_test.go
@@ -24,6 +24,8 @@ func newServerClientPair(t *testing.T, handler http.HandlerFunc) (*httptest.Serv
 		t.Fatal(err)
 	}
 
+	config.IgnoreVersion = true
+
 	client, err := NewClient(config)
 	if err != nil {
 		t.Fatal(err)

--- a/x-pack/libbeat/management/api/configuration.go
+++ b/x-pack/libbeat/management/api/configuration.go
@@ -6,6 +6,7 @@ package api
 
 import (
 	"net/http"
+	"reflect"
 
 	"github.com/elastic/beats/libbeat/common/reload"
 
@@ -64,15 +65,13 @@ func (c *Client) Configuration(accessToken string, beatUUID uuid.UUID) (ConfigBl
 
 // ConfigBlocksEqual returns true if the given config blocks are equal, false if not
 func ConfigBlocksEqual(a, b ConfigBlocks) bool {
-	if (a == nil) != (b == nil) {
-		return false
-	}
-
 	if len(a) != len(b) {
 		return false
 	}
 
-	// TODO implement equals check
+	if len(a) == 0 {
+		return true
+	}
 
-	return false
+	return reflect.DeepEqual(a, b)
 }

--- a/x-pack/libbeat/management/api/configuration.go
+++ b/x-pack/libbeat/management/api/configuration.go
@@ -16,7 +16,7 @@ import (
 
 // ConfigBlock stores a piece of config from central management
 type ConfigBlock struct {
-	Raw string `json:"block_yml"`
+	Raw map[string]interface{} `json:"block_yml"`
 }
 
 type ConfigList struct {
@@ -29,7 +29,7 @@ type ConfigBlocks []ConfigList
 
 // Config returns a common.Config object holding the config from this block
 func (c *ConfigBlock) Config() (*common.Config, error) {
-	return common.NewConfigWithYAML([]byte(c.Raw), "")
+	return common.NewConfigFrom(c.Raw)
 }
 
 // ConfigWithMeta returns a reload.ConfigWithMeta object holding the config from this block, meta will be nil
@@ -50,8 +50,8 @@ func (c *Client) Configuration(accessToken string, beatUUID uuid.UUID) (ConfigBl
 
 	resp := struct {
 		ConfigBlocks []*struct {
-			Type string `json:"type"`
-			Raw  string `json:"block_yml"`
+			Type string                 `json:"type"`
+			Raw  map[string]interface{} `json:"config"`
 		} `json:"configuration_blocks"`
 	}{}
 	_, err := c.request("GET", "/api/beats/agent/"+beatUUID.String()+"/configuration", nil, headers, &resp)

--- a/x-pack/libbeat/management/api/configuration.go
+++ b/x-pack/libbeat/management/api/configuration.go
@@ -38,3 +38,22 @@ func (c *Client) Configuration(accessToken string, beatUUID uuid.UUID) ([]*Confi
 
 	return resp.ConfigBlocks, err
 }
+
+// ConfigBlocksEqual returns true if the given config blocks are equal, false if not
+func ConfigBlocksEqual(a, b []*ConfigBlock) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+
+	if len(a) != len(b) {
+		return false
+	}
+
+	for i := range a {
+		if a[i].Type != b[i].Type || a[i].Raw != b[i].Raw {
+			return false
+		}
+	}
+
+	return true
+}

--- a/x-pack/libbeat/management/api/configuration.go
+++ b/x-pack/libbeat/management/api/configuration.go
@@ -7,6 +7,8 @@ package api
 import (
 	"net/http"
 
+	"github.com/elastic/beats/libbeat/common/reload"
+
 	uuid "github.com/satori/go.uuid"
 
 	"github.com/elastic/beats/libbeat/common"
@@ -14,33 +16,67 @@ import (
 
 // ConfigBlock stores a piece of config from central management
 type ConfigBlock struct {
-	Type string `json:"type"`
-	Raw  string `json:"block_yml"`
+	Raw string `json:"block_yml"`
 }
+
+type ConfigList struct {
+	Type   string
+	Blocks []*ConfigBlock
+}
+
+// ConfigBlocks holds a list of (type, list of configs) pairs
+type ConfigBlocks []ConfigList
 
 // Config returns a common.Config object holding the config from this block
 func (c *ConfigBlock) Config() (*common.Config, error) {
 	return common.NewConfigWithYAML([]byte(c.Raw), "")
 }
 
+// ConfigWithMeta returns a reload.ConfigWithMeta object holding the config from this block, meta will be nil
+func (c *ConfigBlock) ConfigWithMeta() (*reload.ConfigWithMeta, error) {
+	config, err := c.Config()
+	if err != nil {
+		return nil, err
+	}
+	return &reload.ConfigWithMeta{
+		Config: config,
+	}, nil
+}
+
 // Configuration retrieves the list of configuration blocks from Kibana
-func (c *Client) Configuration(accessToken string, beatUUID uuid.UUID) ([]*ConfigBlock, error) {
+func (c *Client) Configuration(accessToken string, beatUUID uuid.UUID) (ConfigBlocks, error) {
 	headers := http.Header{}
 	headers.Set("kbn-beats-access-token", accessToken)
 
 	resp := struct {
-		ConfigBlocks []*ConfigBlock `json:"configuration_blocks"`
+		ConfigBlocks []*struct {
+			Type string `json:"type"`
+			Raw  string `json:"block_yml"`
+		} `json:"configuration_blocks"`
 	}{}
 	_, err := c.request("GET", "/api/beats/agent/"+beatUUID.String()+"/configuration", nil, headers, &resp)
 	if err != nil {
 		return nil, err
 	}
 
-	return resp.ConfigBlocks, err
+	configmap := map[string][]*ConfigBlock{}
+	for _, block := range resp.ConfigBlocks {
+		configmap[block.Type] = append(configmap[block.Type], &ConfigBlock{Raw: block.Raw})
+	}
+
+	res := ConfigBlocks{}
+	for t, blocks := range configmap {
+		res = append(res, ConfigList{
+			Type:   t,
+			Blocks: blocks,
+		})
+	}
+
+	return res, nil
 }
 
 // ConfigBlocksEqual returns true if the given config blocks are equal, false if not
-func ConfigBlocksEqual(a, b []*ConfigBlock) bool {
+func ConfigBlocksEqual(a, b ConfigBlocks) bool {
 	if (a == nil) != (b == nil) {
 		return false
 	}
@@ -49,11 +85,7 @@ func ConfigBlocksEqual(a, b []*ConfigBlock) bool {
 		return false
 	}
 
-	for i := range a {
-		if a[i].Type != b[i].Type || a[i].Raw != b[i].Raw {
-			return false
-		}
-	}
+	// TODO implement equals check
 
-	return true
+	return false
 }

--- a/x-pack/libbeat/management/api/configuration.go
+++ b/x-pack/libbeat/management/api/configuration.go
@@ -16,16 +16,11 @@ import (
 
 // ConfigBlock stores a piece of config from central management
 type ConfigBlock struct {
-	Raw map[string]interface{} `json:"block_yml"`
+	Raw map[string]interface{}
 }
 
-type ConfigList struct {
-	Type   string
-	Blocks []*ConfigBlock
-}
-
-// ConfigBlocks holds a list of (type, list of configs) pairs
-type ConfigBlocks []ConfigList
+// ConfigBlocks holds a map of type -> list of configs
+type ConfigBlocks map[string][]*ConfigBlock
 
 // Config returns a common.Config object holding the config from this block
 func (c *ConfigBlock) Config() (*common.Config, error) {
@@ -59,17 +54,9 @@ func (c *Client) Configuration(accessToken string, beatUUID uuid.UUID) (ConfigBl
 		return nil, err
 	}
 
-	configmap := map[string][]*ConfigBlock{}
-	for _, block := range resp.ConfigBlocks {
-		configmap[block.Type] = append(configmap[block.Type], &ConfigBlock{Raw: block.Raw})
-	}
-
 	res := ConfigBlocks{}
-	for t, blocks := range configmap {
-		res = append(res, ConfigList{
-			Type:   t,
-			Blocks: blocks,
-		})
+	for _, block := range resp.ConfigBlocks {
+		res[block.Type] = append(res[block.Type], &ConfigBlock{Raw: block.Raw})
 	}
 
 	return res, nil

--- a/x-pack/libbeat/management/api/configuration_test.go
+++ b/x-pack/libbeat/management/api/configuration_test.go
@@ -42,3 +42,95 @@ func TestConfiguration(t *testing.T) {
 		"period": "10s",
 	}}, configs["metricbeat.modules"][0])
 }
+
+func TestConfigBlocksEqual(t *testing.T) {
+	tests := []struct {
+		name  string
+		a, b  ConfigBlocks
+		equal bool
+	}{
+		{
+			name:  "empty lists or nil",
+			a:     nil,
+			b:     ConfigBlocks{},
+			equal: true,
+		},
+		{
+			name: "single element",
+			a: ConfigBlocks{
+				"metricbeat.modules": []*ConfigBlock{
+					&ConfigBlock{
+						Raw: map[string]interface{}{
+							"foo": "bar",
+						},
+					},
+				},
+			},
+			b: ConfigBlocks{
+				"metricbeat.modules": []*ConfigBlock{
+					&ConfigBlock{
+						Raw: map[string]interface{}{
+							"foo": "bar",
+						},
+					},
+				},
+			},
+			equal: true,
+		},
+		{
+			name: "different number of blocks",
+			a: ConfigBlocks{
+				"metricbeat.modules": []*ConfigBlock{
+					&ConfigBlock{
+						Raw: map[string]interface{}{
+							"foo": "bar",
+						},
+					},
+					&ConfigBlock{
+						Raw: map[string]interface{}{
+							"baz": "buzz",
+						},
+					},
+				},
+			},
+			b: ConfigBlocks{
+				"metricbeat.modules": []*ConfigBlock{
+					&ConfigBlock{
+						Raw: map[string]interface{}{
+							"foo": "bar",
+						},
+					},
+				},
+			},
+			equal: false,
+		},
+		{
+			name: "different block",
+			a: ConfigBlocks{
+				"metricbeat.modules": []*ConfigBlock{
+					&ConfigBlock{
+						Raw: map[string]interface{}{
+							"baz": "buzz",
+						},
+					},
+				},
+			},
+			b: ConfigBlocks{
+				"metricbeat.modules": []*ConfigBlock{
+					&ConfigBlock{
+						Raw: map[string]interface{}{
+							"foo": "bar",
+						},
+					},
+				},
+			},
+			equal: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.equal, ConfigBlocksEqual(test.a, test.b))
+		})
+	}
+}

--- a/x-pack/libbeat/management/api/configuration_test.go
+++ b/x-pack/libbeat/management/api/configuration_test.go
@@ -23,7 +23,7 @@ func TestConfiguration(t *testing.T) {
 		// Check enrollment token is correct
 		assert.Equal(t, "thisismyenrollmenttoken", r.Header.Get("kbn-beats-access-token"))
 
-		fmt.Fprintf(w, `{"configuration_blocks":[{"type":"filebeat.modules","block_yml":"module: apache2\n"},{"type":"metricbeat.modules","block_yml":"module: nginx\n"}]}`)
+		fmt.Fprintf(w, `{"configuration_blocks":[{"type":"filebeat.modules","config":{"module":"apache2"}},{"type":"metricbeat.modules","config":{"module":"system","period":"10s"}}]}`)
 	}))
 	defer server.Close()
 
@@ -33,4 +33,12 @@ func TestConfiguration(t *testing.T) {
 	}
 
 	assert.Equal(t, 2, len(configs))
+	assert.Equal(t, &ConfigBlock{Raw: map[string]interface{}{
+		"module": "apache2",
+	}}, configs["filebeat.modules"][0])
+
+	assert.Equal(t, &ConfigBlock{Raw: map[string]interface{}{
+		"module": "system",
+		"period": "10s",
+	}}, configs["metricbeat.modules"][0])
 }

--- a/x-pack/libbeat/management/config.go
+++ b/x-pack/libbeat/management/config.go
@@ -34,6 +34,10 @@ func (c *Config) Load() error {
 	path := paths.Resolve(paths.Data, "management.yml")
 	config, err := common.LoadFile(path)
 	if err != nil {
+		if os.IsNotExist(err) {
+			// File is not present, beat is not enrolled
+			return nil
+		}
 		return err
 	}
 

--- a/x-pack/libbeat/management/config.go
+++ b/x-pack/libbeat/management/config.go
@@ -51,7 +51,7 @@ func (c *Config) Load() error {
 		return err
 	}
 
-	if err = config.Unpack(c); err != nil {
+	if err = config.Unpack(&c); err != nil {
 		return err
 	}
 

--- a/x-pack/libbeat/management/config.go
+++ b/x-pack/libbeat/management/config.go
@@ -30,7 +30,7 @@ type Config struct {
 
 	Kibana *kibana.ClientConfig
 
-	Configs []*api.ConfigBlock
+	Configs api.ConfigBlocks
 }
 
 func defaultConfig() *Config {

--- a/x-pack/libbeat/management/config.go
+++ b/x-pack/libbeat/management/config.go
@@ -6,6 +6,7 @@ package management
 
 import (
 	"os"
+	"time"
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/file"
@@ -22,11 +23,20 @@ type Config struct {
 	// true when enrolled
 	Enabled bool
 
+	// Poll configs period
+	Period time.Duration
+
 	AccessToken string
 
 	Kibana *kibana.ClientConfig
 
 	Configs []*api.ConfigBlock
+}
+
+func defaultConfig() *Config {
+	return &Config{
+		Period: 60 * time.Second,
+	}
 }
 
 // Load settings from its source file

--- a/x-pack/libbeat/management/enroll.go
+++ b/x-pack/libbeat/management/enroll.go
@@ -17,6 +17,9 @@ func Enroll(beat *instance.Beat, kibanaURL, enrollmentToken string) error {
 		return err
 	}
 
+	// Ignore kibana version to avoid permission errors
+	config.IgnoreVersion = true
+
 	client, err := api.NewClient(config)
 	if err != nil {
 		return err

--- a/x-pack/libbeat/management/enroll.go
+++ b/x-pack/libbeat/management/enroll.go
@@ -29,11 +29,10 @@ func Enroll(beat *instance.Beat, kibanaURL, enrollmentToken string) error {
 
 	// Enrolled, persist state
 	// TODO use beat.Keystore() for access_token
-	settings := Config{
-		Enabled:     true,
-		AccessToken: accessToken,
-		Kibana:      config,
-	}
+	settings := defaultConfig()
+	settings.Enabled = true
+	settings.AccessToken = accessToken
+	settings.Kibana = config
 
 	return settings.Save()
 }

--- a/x-pack/libbeat/management/manager.go
+++ b/x-pack/libbeat/management/manager.go
@@ -100,8 +100,11 @@ func (cm *ConfigManager) Stop() {
 	cm.wg.Wait()
 }
 
-// CheckRawConfig check settings are correct to start the beat
+// CheckRawConfig check settings are correct to start the beat. This method
+// checks there are no collision between the existing configuration and what
+// central management can configure.
 func (cm *ConfigManager) CheckRawConfig(cfg *common.Config) error {
+	// TODO implement this method
 	return nil
 }
 

--- a/x-pack/libbeat/management/manager.go
+++ b/x-pack/libbeat/management/manager.go
@@ -166,7 +166,7 @@ func (cm *ConfigManager) apply() {
 func (cm *ConfigManager) reload(t string, blocks []*api.ConfigBlock) {
 	cm.logger.Infof("Applying settings for %s", t)
 
-	if obj := cm.registry.Get(t); obj != nil {
+	if obj := cm.registry.GetReloadable(t); obj != nil {
 		// Single object
 		if len(blocks) != 1 {
 			cm.logger.Errorf("got an invalid number of configs for %s: %d, expected: 1", t, len(blocks))
@@ -181,7 +181,7 @@ func (cm *ConfigManager) reload(t string, blocks []*api.ConfigBlock) {
 		if err := obj.Reload(config); err != nil {
 			cm.logger.Error(err)
 		}
-	} else if obj := cm.registry.GetList(t); obj != nil {
+	} else if obj := cm.registry.GetReloadableList(t); obj != nil {
 		// List
 		var configs []*reload.ConfigWithMeta
 		for _, block := range blocks {

--- a/x-pack/libbeat/management/manager.go
+++ b/x-pack/libbeat/management/manager.go
@@ -48,6 +48,10 @@ func NewConfigManager(beatUUID uuid.UUID) (management.ConfigManager, error) {
 	var client *api.Client
 	if c.Enabled {
 		var err error
+
+		// Ignore kibana version to avoid permission errors
+		c.Kibana.IgnoreVersion = true
+
 		client, err = api.NewClient(c.Kibana)
 		if err != nil {
 			return nil, errors.Wrap(err, "initializing kibana client")

--- a/x-pack/libbeat/management/manager.go
+++ b/x-pack/libbeat/management/manager.go
@@ -35,11 +35,12 @@ type ConfigManager struct {
 	client   *api.Client
 	beatUUID uuid.UUID
 	done     chan struct{}
+	registry *reload.Registry
 	wg       sync.WaitGroup
 }
 
 // NewConfigManager returns a X-Pack Beats Central Management manager
-func NewConfigManager(beatUUID uuid.UUID) (management.ConfigManager, error) {
+func NewConfigManager(registry *reload.Registry, beatUUID uuid.UUID) (management.ConfigManager, error) {
 	c := defaultConfig()
 	if err := c.Load(); err != nil {
 		return nil, errors.Wrap(err, "reading central management internal settings")
@@ -64,6 +65,7 @@ func NewConfigManager(beatUUID uuid.UUID) (management.ConfigManager, error) {
 		client:   client,
 		done:     make(chan struct{}),
 		beatUUID: beatUUID,
+		registry: registry,
 	}, nil
 }
 

--- a/x-pack/libbeat/management/manager.go
+++ b/x-pack/libbeat/management/manager.go
@@ -1,0 +1,67 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package management
+
+import (
+	"github.com/pkg/errors"
+
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
+	"github.com/elastic/beats/libbeat/feature"
+	"github.com/elastic/beats/libbeat/logp"
+
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/management"
+)
+
+func init() {
+	management.Register("x-pack", NewConfigManager, feature.Beta)
+}
+
+// ConfigManager handles internal config updates. By retrieving
+// new configs from Kibana and applying them to the Beat
+type ConfigManager struct {
+	Config *Config
+	logger *logp.Logger
+}
+
+// NewConfigManager returns a X-Pack Beats Central Management manager
+func NewConfigManager() (management.ConfigManager, error) {
+	c := &Config{}
+	if err := c.Load(); err != nil {
+		return nil, errors.Wrap(err, "reading central management internal settings")
+	}
+
+	return &ConfigManager{
+		Config: c,
+		logger: logp.NewLogger("centralmgmt"),
+	}, nil
+}
+
+// Enabled returns true if config management is enabled
+func (cm *ConfigManager) Enabled() bool {
+	return cm.Config.Enabled
+}
+
+// Start the config manager
+func (cm *ConfigManager) Start() {
+	if !cm.Enabled() {
+		return
+	}
+	cfgwarn.Beta("Central management is enabled")
+	cm.logger.Info("Starting central management service")
+}
+
+// Stop the config manager
+func (cm *ConfigManager) Stop() {
+	if !cm.Enabled() {
+		return
+	}
+	cm.logger.Info("Stopping central management service")
+}
+
+// CheckRawConfig check settings are correct to start the beat
+func (cm *ConfigManager) CheckRawConfig(cfg *common.Config) error {
+	return nil
+}

--- a/x-pack/libbeat/management/manager.go
+++ b/x-pack/libbeat/management/manager.go
@@ -145,15 +145,15 @@ func (cm *ConfigManager) fetch() bool {
 }
 
 func (cm *ConfigManager) apply() {
-	for _, blockList := range cm.config.Configs {
-		cm.reload(blockList.Type, blockList.Blocks)
+	for blockType, blockList := range cm.config.Configs {
+		cm.reload(blockType, blockList)
 	}
 }
 
 func (cm *ConfigManager) reload(t string, blocks []*api.ConfigBlock) {
 	cm.logger.Infof("Applying settings for %s", t)
 
-	if obj := reload.Get(t); obj != nil {
+	if obj := reload.Register.Get(t); obj != nil {
 		// Single object
 		if len(blocks) != 1 {
 			cm.logger.Errorf("got an invalid number of configs for %s: %d, expected: 1", t, len(blocks))
@@ -167,11 +167,8 @@ func (cm *ConfigManager) reload(t string, blocks []*api.ConfigBlock) {
 
 		if err := obj.Reload(config); err != nil {
 			cm.logger.Error(err)
-			return
 		}
-	}
-
-	if obj := reload.GetList(t); obj != nil {
+	} else if obj := reload.Register.GetList(t); obj != nil {
 		// List
 		var configs []*reload.ConfigWithMeta
 		for _, block := range blocks {

--- a/x-pack/libbeat/management/manager.go
+++ b/x-pack/libbeat/management/manager.go
@@ -5,11 +5,17 @@
 package management
 
 import (
+	"sync"
+	"time"
+
+	"github.com/satori/go.uuid"
+
 	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/libbeat/feature"
 	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/x-pack/libbeat/management/api"
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/management"
@@ -22,26 +28,38 @@ func init() {
 // ConfigManager handles internal config updates. By retrieving
 // new configs from Kibana and applying them to the Beat
 type ConfigManager struct {
-	Config *Config
-	logger *logp.Logger
+	config   *Config
+	logger   *logp.Logger
+	client   *api.Client
+	beatUUID uuid.UUID
+	done     chan struct{}
+	wg       sync.WaitGroup
 }
 
 // NewConfigManager returns a X-Pack Beats Central Management manager
-func NewConfigManager() (management.ConfigManager, error) {
-	c := &Config{}
+func NewConfigManager(beatUUID uuid.UUID) (management.ConfigManager, error) {
+	c := defaultConfig()
 	if err := c.Load(); err != nil {
 		return nil, errors.Wrap(err, "reading central management internal settings")
 	}
 
+	client, err := api.NewClient(c.Kibana)
+	if err != nil {
+		return nil, errors.Wrap(err, "initializing kibana client")
+	}
+
 	return &ConfigManager{
-		Config: c,
-		logger: logp.NewLogger("centralmgmt"),
+		config:   c,
+		logger:   logp.NewLogger("centralmgmt"),
+		client:   client,
+		done:     make(chan struct{}),
+		beatUUID: beatUUID,
 	}, nil
 }
 
 // Enabled returns true if config management is enabled
 func (cm *ConfigManager) Enabled() bool {
-	return cm.Config.Enabled
+	return cm.config.Enabled
 }
 
 // Start the config manager
@@ -51,6 +69,9 @@ func (cm *ConfigManager) Start() {
 	}
 	cfgwarn.Beta("Central management is enabled")
 	cm.logger.Info("Starting central management service")
+
+	cm.wg.Add(1)
+	go cm.worker()
 }
 
 // Stop the config manager
@@ -59,9 +80,49 @@ func (cm *ConfigManager) Stop() {
 		return
 	}
 	cm.logger.Info("Stopping central management service")
+	close(cm.done)
+	cm.wg.Wait()
 }
 
 // CheckRawConfig check settings are correct to start the beat
 func (cm *ConfigManager) CheckRawConfig(cfg *common.Config) error {
 	return nil
+}
+
+func (cm *ConfigManager) worker() {
+	defer cm.wg.Done()
+	sleep := 0 * time.Second
+	for {
+		select {
+		case <-cm.done:
+			return
+		case <-time.After(sleep):
+			sleep = cm.config.Period
+		}
+		cm.logger.Debug("Retrieving new configurations from Kibana")
+		configs, err := cm.client.Configuration(cm.config.AccessToken, cm.beatUUID)
+		if err != nil {
+			cm.logger.Errorf("error retriving new configurations: %s", err)
+			continue
+		}
+
+		if api.ConfigBlocksEqual(configs, cm.config.Configs) {
+			cm.logger.Debug("configuration didn't change, sleeping")
+			continue
+		}
+
+		cm.logger.Info("New configuration retrieved from central management, applying changes...")
+
+		// configs changed, apply changes
+		// TODO only reload the blocks that changed
+		for _, config := range configs {
+			cm.logger.Infof("%+v", config)
+		}
+
+		// store new configs (already applied)
+		cm.config.Configs = configs
+		if err := cm.config.Save(); err != nil {
+			cm.logger.Errorf("error storing central management state: %s", err)
+		}
+	}
 }

--- a/x-pack/libbeat/management/manager.go
+++ b/x-pack/libbeat/management/manager.go
@@ -45,9 +45,13 @@ func NewConfigManager(beatUUID uuid.UUID) (management.ConfigManager, error) {
 		return nil, errors.Wrap(err, "reading central management internal settings")
 	}
 
-	client, err := api.NewClient(c.Kibana)
-	if err != nil {
-		return nil, errors.Wrap(err, "initializing kibana client")
+	var client *api.Client
+	if c.Enabled {
+		var err error
+		client, err = api.NewClient(c.Kibana)
+		if err != nil {
+			return nil, errors.Wrap(err, "initializing kibana client")
+		}
 	}
 
 	return &ConfigManager{

--- a/x-pack/libbeat/management/manager_test.go
+++ b/x-pack/libbeat/management/manager_test.go
@@ -1,0 +1,93 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package management
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/satori/go.uuid"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/reload"
+	"github.com/elastic/beats/x-pack/libbeat/management/api"
+)
+
+type reloadable struct {
+	reloaded chan *reload.ConfigWithMeta
+}
+
+func (r *reloadable) Reload(c *reload.ConfigWithMeta) error {
+	r.reloaded <- c
+	return nil
+}
+
+func TestConfigManager(t *testing.T) {
+	registry := reload.NewRegistry()
+	id := uuid.NewV4()
+	accessToken := "footoken"
+	reloadable := reloadable{
+		reloaded: make(chan *reload.ConfigWithMeta, 1),
+	}
+	registry.MustRegister("test.block", &reloadable)
+
+	mux := http.NewServeMux()
+	i := 0
+	responses := []string{
+		// Initial load
+		`{"configuration_blocks":[{"type":"test.block","config":{"module":"apache2"}}]}`,
+
+		// No change, no reload
+		`{"configuration_blocks":[{"type":"test.block","config":{"module":"apache2"}}]}`,
+
+		// Changed, reload
+		`{"configuration_blocks":[{"type":"test.block","config":{"module":"system"}}]}`,
+	}
+	mux.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, fmt.Sprintf("/api/beats/agent/%s/configuration", id), r.RequestURI)
+		fmt.Fprintf(w, responses[i])
+		i++
+	}))
+
+	server := httptest.NewServer(mux)
+
+	c, err := api.ConfigFromURL(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	config := &Config{
+		Enabled:     true,
+		Period:      100 * time.Millisecond,
+		Kibana:      c,
+		AccessToken: accessToken,
+	}
+
+	manager, err := NewConfigManagerWithConfig(config, registry, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	manager.Start()
+
+	// On first reload we will get apache2 module
+	config1 := <-reloadable.reloaded
+	assert.Equal(t, &reload.ConfigWithMeta{
+		Config: common.MustNewConfigFrom(map[string]interface{}{
+			"module": "apache2",
+		}),
+	}, config1)
+
+	config2 := <-reloadable.reloaded
+	assert.Equal(t, &reload.ConfigWithMeta{
+		Config: common.MustNewConfigFrom(map[string]interface{}{
+			"module": "system",
+		}),
+	}, config2)
+}


### PR DESCRIPTION
Implement Central Management service. This service will be in charge of polling new configurations from Kibana and apply the changes across all Reloadable objects. See https://github.com/elastic/beats/pull/8205 for details on that.

Part of #7028