### PR TITLE
Add support for log tags in newest CRI spec

### DIFF
--- a/libbeat/reader/readjson/docker_json.go
+++ b/libbeat/reader/readjson/docker_json.go
@@ -39,16 +39,12 @@ type DockerJSONReader struct {
 	partial bool
 }
 
-type dockerLog struct {
-	Timestamp string `json:"time"`
-	Log       string `json:"log"`
-	Stream    string `json:"stream"`
-}
-
-type crioLog struct {
-	Timestamp time.Time
-	Stream    string
-	Log       []byte
+type logLine struct {
+	Partial   bool      `json:"-"`
+	Timestamp time.Time `json:"-"`
+	Time      string    `json:"time"`
+	Stream    string    `json:"stream"`
+	Log       string    `json:"log"`
 }
 
 // New creates a new reader renaming a field
@@ -63,41 +59,51 @@ func New(r reader.Reader, stream string, partial bool) *DockerJSONReader {
 // parseCRILog parses logs in CRI log format.
 // CRI log format example :
 // 2017-09-12T22:32:21.212861448Z stdout 2017-09-12 22:32:21.212 [INFO][88] table.go 710: Invalidating dataplane cache
-func parseCRILog(message reader.Message, msg *crioLog) (reader.Message, error) {
-	log := strings.SplitN(string(message.Content), " ", 3)
+func parseCRILog(message *reader.Message, msg *logLine) error {
+	log := strings.SplitN(string(message.Content), " ", 4)
 	if len(log) < 3 {
-		return message, errors.New("invalid CRI log")
+		return errors.New("invalid CRI log")
 	}
 	ts, err := time.Parse(time.RFC3339, log[0])
 	if err != nil {
-		return message, errors.Wrap(err, "parsing CRI timestamp")
+		return errors.Wrap(err, "parsing CRI timestamp")
 	}
 
-	msg.Timestamp = ts
+	// Extract tags, currently only P(artial) or F(ull) are available
+	tags := strings.Split(log[2], ":")
+	partial := false
+	for _, tag := range tags {
+		if tag == "P" {
+			partial = true
+		}
+	}
+
+	msg.Partial = partial
 	msg.Stream = log[1]
-	msg.Log = []byte(log[2])
+	msg.Log = log[3]
 	message.AddFields(common.MapStr{
 		"stream": msg.Stream,
 	})
-	message.Content = msg.Log
+	message.Content = []byte(msg.Log)
 	message.Ts = ts
 
-	return message, nil
+	return nil
 }
 
 // parseReaderLog parses logs in Docker JSON log format.
 // Docker JSON log format example:
 // {"log":"1:M 09 Nov 13:27:36.276 # User requested shutdown...\n","stream":"stdout"}
-func parseDockerJSONLog(message reader.Message, msg *dockerLog) (reader.Message, error) {
+func parseDockerJSONLog(message *reader.Message, msg *logLine) error {
 	dec := json.NewDecoder(bytes.NewReader(message.Content))
+
 	if err := dec.Decode(&msg); err != nil {
-		return message, errors.Wrap(err, "decoding docker JSON")
+		return errors.Wrap(err, "decoding docker JSON")
 	}
 
 	// Parse timestamp
-	ts, err := time.Parse(time.RFC3339, msg.Timestamp)
+	ts, err := time.Parse(time.RFC3339, msg.Time)
 	if err != nil {
-		return message, errors.Wrap(err, "parsing docker timestamp")
+		return errors.Wrap(err, "parsing docker timestamp")
 	}
 
 	message.AddFields(common.MapStr{
@@ -105,8 +111,17 @@ func parseDockerJSONLog(message reader.Message, msg *dockerLog) (reader.Message,
 	})
 	message.Content = []byte(msg.Log)
 	message.Ts = ts
+	msg.Partial = message.Content[len(message.Content)-1] != byte('\n')
 
-	return message, nil
+	return nil
+}
+
+func parseLine(message *reader.Message, msg *logLine) error {
+	if strings.HasPrefix(string(message.Content), "{") {
+		return parseDockerJSONLog(message, msg)
+	}
+
+	return parseCRILog(message, msg)
 }
 
 // Next returns the next line.
@@ -117,32 +132,27 @@ func (p *DockerJSONReader) Next() (reader.Message, error) {
 			return message, err
 		}
 
-		var dockerLine dockerLog
-		var crioLine crioLog
+		var logLine logLine
+		err = parseLine(&message, &logLine)
+		if err != nil {
+			return message, err
+		}
 
-		if strings.HasPrefix(string(message.Content), "{") {
-			message, err = parseDockerJSONLog(message, &dockerLine)
+		// Handle multiline messages, join partial lines
+		for p.partial && logLine.Partial {
+			next, err := p.reader.Next()
 			if err != nil {
 				return message, err
 			}
-			// Handle multiline messages, join lines that don't end with \n
-			for p.partial && message.Content[len(message.Content)-1] != byte('\n') {
-				next, err := p.reader.Next()
-				if err != nil {
-					return message, err
-				}
-				next, err = parseDockerJSONLog(next, &dockerLine)
-				if err != nil {
-					return message, err
-				}
-				message.Content = append(message.Content, next.Content...)
-				message.Bytes += next.Bytes
+			err = parseLine(&next, &logLine)
+			if err != nil {
+				return message, err
 			}
-		} else {
-			message, err = parseCRILog(message, &crioLine)
+			message.Content = append(message.Content, next.Content...)
+			message.Bytes += next.Bytes
 		}
 
-		if p.stream != "all" && p.stream != dockerLine.Stream && p.stream != crioLine.Stream {
+		if p.stream != "all" && p.stream != logLine.Stream {
 			continue
 		}
 

--- a/libbeat/reader/readjson/docker_json_test.go
+++ b/libbeat/reader/readjson/docker_json_test.go
@@ -29,14 +29,15 @@ import (
 
 func TestDockerJSON(t *testing.T) {
 	tests := []struct {
+		name            string
 		input           [][]byte
 		stream          string
 		partial         bool
 		expectedError   bool
 		expectedMessage reader.Message
 	}{
-		// Common log message
 		{
+			name:   "Common log message",
 			input:  [][]byte{[]byte(`{"log":"1:M 09 Nov 13:27:36.276 # User requested shutdown...\n","stream":"stdout","time":"2017-11-09T13:27:36.277747246Z"}`)},
 			stream: "all",
 			expectedMessage: reader.Message{
@@ -46,43 +47,43 @@ func TestDockerJSON(t *testing.T) {
 				Bytes:   122,
 			},
 		},
-		// Wrong JSON
 		{
+			name:          "Wrong JSON",
 			input:         [][]byte{[]byte(`this is not JSON`)},
 			stream:        "all",
 			expectedError: true,
 		},
-		// Wrong CRI
 		{
+			name:          "Wrong CRI",
 			input:         [][]byte{[]byte(`2017-09-12T22:32:21.212861448Z stdout`)},
 			stream:        "all",
 			expectedError: true,
 		},
-		// Wrong CRI
 		{
+			name:          "Wrong CRI",
 			input:         [][]byte{[]byte(`{this is not JSON nor CRI`)},
 			stream:        "all",
 			expectedError: true,
 		},
-		// Missing time
 		{
+			name:          "Missing time",
 			input:         [][]byte{[]byte(`{"log":"1:M 09 Nov 13:27:36.276 # User requested shutdown...\n","stream":"stdout"}`)},
 			stream:        "all",
 			expectedError: true,
 		},
-		// CRI log
 		{
-			input:  [][]byte{[]byte(`2017-09-12T22:32:21.212861448Z stdout 2017-09-12 22:32:21.212 [INFO][88] table.go 710: Invalidating dataplane cache`)},
+			name:   "CRI log",
+			input:  [][]byte{[]byte(`2017-09-12T22:32:21.212861448Z stdout F 2017-09-12 22:32:21.212 [INFO][88] table.go 710: Invalidating dataplane cache`)},
 			stream: "all",
 			expectedMessage: reader.Message{
 				Content: []byte("2017-09-12 22:32:21.212 [INFO][88] table.go 710: Invalidating dataplane cache"),
 				Fields:  common.MapStr{"stream": "stdout"},
 				Ts:      time.Date(2017, 9, 12, 22, 32, 21, 212861448, time.UTC),
-				Bytes:   115,
+				Bytes:   117,
 			},
 		},
-		// Filtering stream
 		{
+			name: "Filtering stream",
 			input: [][]byte{
 				[]byte(`{"log":"filtered\n","stream":"stdout","time":"2017-11-09T13:27:36.277747246Z"}`),
 				[]byte(`{"log":"unfiltered\n","stream":"stderr","time":"2017-11-09T13:27:36.277747246Z"}`),
@@ -96,23 +97,23 @@ func TestDockerJSON(t *testing.T) {
 				Bytes:   80,
 			},
 		},
-		// Filtering stream
 		{
+			name: "Filtering stream",
 			input: [][]byte{
-				[]byte(`2017-10-12T13:32:21.232861448Z stdout 2017-10-12 13:32:21.212 [INFO][88] table.go 710: Invalidating dataplane cache`),
-				[]byte(`2017-11-12T23:32:21.212771448Z stderr 2017-11-12 23:32:21.212 [ERROR][77] table.go 111: error`),
-				[]byte(`2017-12-12T10:32:21.212864448Z stdout 2017-12-12 10:32:21.212 [WARN][88] table.go 222: Warn`),
+				[]byte(`2017-10-12T13:32:21.232861448Z stdout F 2017-10-12 13:32:21.212 [INFO][88] table.go 710: Invalidating dataplane cache`),
+				[]byte(`2017-11-12T23:32:21.212771448Z stderr F 2017-11-12 23:32:21.212 [ERROR][77] table.go 111: error`),
+				[]byte(`2017-12-12T10:32:21.212864448Z stdout F 2017-12-12 10:32:21.212 [WARN][88] table.go 222: Warn`),
 			},
 			stream: "stderr",
 			expectedMessage: reader.Message{
 				Content: []byte("2017-11-12 23:32:21.212 [ERROR][77] table.go 111: error"),
 				Fields:  common.MapStr{"stream": "stderr"},
 				Ts:      time.Date(2017, 11, 12, 23, 32, 21, 212771448, time.UTC),
-				Bytes:   93,
+				Bytes:   95,
 			},
 		},
-		// Split lines
 		{
+			name: "Split lines",
 			input: [][]byte{
 				[]byte(`{"log":"1:M 09 Nov 13:27:36.276 # User requested ","stream":"stdout","time":"2017-11-09T13:27:36.277747246Z"}`),
 				[]byte(`{"log":"shutdown...\n","stream":"stdout","time":"2017-11-09T13:27:36.277747246Z"}`),
@@ -126,8 +127,23 @@ func TestDockerJSON(t *testing.T) {
 				Bytes:   190,
 			},
 		},
-		// Split lines with partial disabled
 		{
+			name: "Split lines",
+			input: [][]byte{
+				[]byte(`2017-10-12T13:32:21.232861448Z stdout P 2017-10-12 13:32:21.212 [INFO][88] table.go 710: Invalidating dataplane cache`),
+				[]byte(`2017-11-12T23:32:21.212771448Z stdout F  error`),
+			},
+			stream:  "stdout",
+			partial: true,
+			expectedMessage: reader.Message{
+				Content: []byte("2017-10-12 13:32:21.212 [INFO][88] table.go 710: Invalidating dataplane cache error"),
+				Fields:  common.MapStr{"stream": "stdout"},
+				Ts:      time.Date(2017, 10, 12, 13, 32, 21, 232861448, time.UTC),
+				Bytes:   163,
+			},
+		},
+		{
+			name: "Split lines with partial disabled",
 			input: [][]byte{
 				[]byte(`{"log":"1:M 09 Nov 13:27:36.276 # User requested ","stream":"stdout","time":"2017-11-09T13:27:36.277747246Z"}`),
 				[]byte(`{"log":"shutdown...\n","stream":"stdout","time":"2017-11-09T13:27:36.277747246Z"}`),
@@ -144,15 +160,21 @@ func TestDockerJSON(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		r := &mockReader{messages: test.input}
-		json := New(r, test.stream, test.partial)
-		message, err := json.Next()
+		t.Run(test.name, func(t *testing.T) {
+			r := &mockReader{messages: test.input}
+			json := New(r, test.stream, test.partial)
+			message, err := json.Next()
 
-		assert.Equal(t, test.expectedError, err != nil)
+			if test.expectedError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
 
-		if err == nil {
-			assert.EqualValues(t, test.expectedMessage, message)
-		}
+			if err == nil {
+				assert.EqualValues(t, test.expectedMessage, message)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
CRI spec has changed to include tags (to tell if the line is full or
partial):

```
2016-10-06T00:17:09.669794202Z stdout F The content of the log entry 1
2016-10-06T00:17:09.669794202Z stdout P First line of log entry 2
2016-10-06T00:17:09.669794202Z stdout P Second line of the log entry 2
2016-10-06T00:17:10.113242941Z stderr F Last line of the log entry 2
```

I still have to determine how this affects the older format, obviously
this change is breaking it, but to be seen if CRI is still supporting
it.

For more details you can check:
https://github.com/kubernetes/community/blob/master/contributors/design-proposals/node/kubelet-cri-logging.md

Fixes #8257