### PR TITLE
Windows tests should fail build on error

### DIFF
--- a/dev-tools/jenkins_ci.ps1
+++ b/dev-tools/jenkins_ci.ps1
@@ -1,14 +1,20 @@
-function Exec
-{
+function Exec {
+    [CmdletBinding()]
     param(
-        [Parameter(Position=0,Mandatory=1)][scriptblock]$cmd,
-        [Parameter(Position=1,Mandatory=0)][string]$errorMessage = ($msgs.error_bad_command -f $cmd)
+        [Parameter(Mandatory = $true)]
+        [scriptblock]$cmd,
+        [string]$errorMessage = ($msgs.error_bad_command -f $cmd)
     )
 
-    & $cmd
-    if ($LastExitCode -ne 0) {
-        Write-Error $errorMessage
-        exit $LastExitCode
+    try {
+        $global:lastexitcode = 0
+        & $cmd
+        if ($lastexitcode -ne 0) {
+            throw $errorMessage
+        }
+    }
+    catch [Exception] {
+        throw $_
     }
 }
 

--- a/dev-tools/jenkins_ci.ps1
+++ b/dev-tools/jenkins_ci.ps1
@@ -12,6 +12,8 @@ function Exec
     }
 }
 
+exec { please fail the build }
+
 # Setup Go.
 $env:GOPATH = $env:WORKSPACE
 $env:PATH = "$env:GOPATH\bin;C:\tools\mingw64\bin;$env:PATH"

--- a/dev-tools/jenkins_ci.ps1
+++ b/dev-tools/jenkins_ci.ps1
@@ -18,8 +18,6 @@ function Exec {
     }
 }
 
-exec { please fail the build } "Should have failed"
-
 # Setup Go.
 $env:GOPATH = $env:WORKSPACE
 $env:PATH = "$env:GOPATH\bin;C:\tools\mingw64\bin;$env:PATH"
@@ -54,7 +52,7 @@ echo "Building fields.yml"
 exec { mage fields } "mage fields FAILURE"
 
 echo "Building $env:beat"
-exec { mage build } "Build FAILURE" "mage build FAILURE"
+exec { mage build } "Build FAILURE"
 
 echo "Unit testing $env:beat"
 exec { mage goTestUnit } "mage goTestUnit FAILURE"

--- a/dev-tools/jenkins_ci.ps1
+++ b/dev-tools/jenkins_ci.ps1
@@ -18,7 +18,7 @@ function Exec {
     }
 }
 
-exec { please fail the build }
+exec { please fail the build } "Should have failed"
 
 # Setup Go.
 $env:GOPATH = $env:WORKSPACE
@@ -34,7 +34,7 @@ $env:TEST_COVERAGE = "true"
 $env:RACE_DETECTOR = "true"
 
 # Install mage from vendor.
-exec { go install github.com/elastic/beats/vendor/github.com/magefile/mage }
+exec { go install github.com/elastic/beats/vendor/github.com/magefile/mage } "mage install FAILURE"
 
 if (Test-Path "$env:beat") {
     cd "$env:beat"
@@ -51,18 +51,18 @@ New-Item -ItemType directory -Path build\system-tests | Out-Null
 New-Item -ItemType directory -Path build\system-tests\run | Out-Null
 
 echo "Building fields.yml"
-exec { mage fields }
+exec { mage fields } "mage fields FAILURE"
 
 echo "Building $env:beat"
-exec { mage build } "Build FAILURE"
+exec { mage build } "Build FAILURE" "mage build FAILURE"
 
 echo "Unit testing $env:beat"
-exec { mage goTestUnit }
+exec { mage goTestUnit } "mage goTestUnit FAILURE"
 
 echo "System testing $env:beat"
 # Get a CSV list of package names.
 $packages = $(go list ./... | select-string -Pattern "/vendor/" -NotMatch | select-string -Pattern "/scripts/cmd/" -NotMatch)
 $packages = ($packages|group|Select -ExpandProperty Name) -join ","
-exec { go test -race -c -cover -covermode=atomic -coverpkg $packages }
-exec { cd tests/system }
+exec { go test -race -c -cover -covermode=atomic -coverpkg $packages } "go test -race -cover FAILURE"
+Set-Location -Path tests/system
 exec { nosetests --with-timer --with-xunit --xunit-file=../../build/TEST-system.xml } "System test FAILURE"


### PR DESCRIPTION
While working on elastic/apm-server#1301, we determined a failure within the `exec` function didn't fail the build.  Here we'll:

1. reproduce the result by introducing an intentional failure
2. assuming that does not fail the build, port https://github.com/elastic/apm-server/pull/1301/commits/72610530255fef69e2846c764b1303ba2bcd8ad1 over and confirm fix
3. remove intentional failure

While tested locally with a window vagrant worker,  I'd like to reproduce on the real ci workers before proceeding.