### PR TITLE
Add a version specifier parameter

### DIFF
--- a/dev-tools/mage/pkg.go
+++ b/dev-tools/mage/pkg.go
@@ -63,6 +63,7 @@ func Package() error {
 				spec.OS = target.GOOS()
 				spec.Arch = packageArch
 				spec.Snapshot = Snapshot
+				spec.VersionQualifier = VersionQualifier
 				spec.evalContext = map[string]interface{}{
 					"GOOS":        target.GOOS(),
 					"GOARCH":      target.GOARCH(),

--- a/dev-tools/mage/pkgtypes.go
+++ b/dev-tools/mage/pkgtypes.go
@@ -47,8 +47,8 @@ const (
 	// need to be written to disk for inclusion in a package.
 	packageStagingDir = "build/package"
 
-	// defaultBinaryName specifies the output file for zip and tar.gz.
-	defaultBinaryName = "{{.Name}}-{{.Version}}{{if .Snapshot}}-SNAPSHOT{{end}}{{if .OS}}-{{.OS}}{{end}}{{if .Arch}}-{{.Arch}}{{end}}"
+	// defaultBinaryName specifies the output file for zip, tar.gz, and dmg.
+	defaultBinaryName = "{{.Name}}-{{.Version}}{{.VersionQualifier}}{{if .Snapshot}}-SNAPSHOT{{end}}{{if .OS}}-{{.OS}}{{end}}{{if .Arch}}-{{.Arch}}{{end}}"
 )
 
 // PackageType defines the file format of the package (e.g. zip, rpm, etc).
@@ -79,6 +79,7 @@ type PackageSpec struct {
 	Arch              string                 `yaml:"arch,omitempty"`
 	Vendor            string                 `yaml:"vendor,omitempty"`
 	Snapshot          bool                   `yaml:"snapshot"`
+	VersionQualifier  string                 `yaml:"version_qualifier"`
 	Version           string                 `yaml:"version,omitempty"`
 	License           string                 `yaml:"license,omitempty"`
 	URL               string                 `yaml:"url,omitempty"`
@@ -606,7 +607,7 @@ func runFPM(spec PackageSpec, packageType PackageType) error {
 	}
 	defer os.Remove(inputTar)
 
-	outputFile, err := spec.Expand("{{.Name}}-{{.Version}}{{if .Snapshot}}-SNAPSHOT{{end}}-{{.Arch}}")
+	outputFile, err := spec.Expand("{{.Name}}-{{.Version}}{{.VersionQualifier}}{{if .Snapshot}}-SNAPSHOT{{end}}-{{.Arch}}")
 	if err != nil {
 		return err
 	}

--- a/dev-tools/mage/pkgtypes.go
+++ b/dev-tools/mage/pkgtypes.go
@@ -48,7 +48,7 @@ const (
 	packageStagingDir = "build/package"
 
 	// defaultBinaryName specifies the output file for zip, tar.gz, and dmg.
-	defaultBinaryName = "{{.Name}}-{{.Version}}{{.VersionQualifier}}{{if .Snapshot}}-SNAPSHOT{{end}}{{if .OS}}-{{.OS}}{{end}}{{if .Arch}}-{{.Arch}}{{end}}"
+	defaultBinaryName = "{{.Name}}-{{.Version}}{{if .VersionQualifier}}-{{.VersionQualifier}}{{end}}{{if .Snapshot}}-SNAPSHOT{{end}}{{if .OS}}-{{.OS}}{{end}}{{if .Arch}}-{{.Arch}}{{end}}"
 )
 
 // PackageType defines the file format of the package (e.g. zip, rpm, etc).
@@ -607,7 +607,7 @@ func runFPM(spec PackageSpec, packageType PackageType) error {
 	}
 	defer os.Remove(inputTar)
 
-	outputFile, err := spec.Expand("{{.Name}}-{{.Version}}{{.VersionQualifier}}{{if .Snapshot}}-SNAPSHOT{{end}}-{{.Arch}}")
+	outputFile, err := spec.Expand("{{.Name}}-{{.Version}}{{if .VersionQualifier}}-{{.VersionQualifier}}{{end}}{{if .Snapshot}}-SNAPSHOT{{end}}-{{.Arch}}")
 	if err != nil {
 		return err
 	}

--- a/dev-tools/mage/settings.go
+++ b/dev-tools/mage/settings.go
@@ -63,7 +63,8 @@ var (
 	BeatLicense     = EnvOr("BEAT_LICENSE", "ASL 2.0")
 	BeatURL         = EnvOr("BEAT_URL", "https://www.elastic.co/products/beats/"+BeatName)
 
-	Snapshot bool
+	Snapshot         bool
+	VersionQualifier = EnvOr("VERSION_QUALIFIER", "")
 
 	FuncMap = map[string]interface{}{
 		"beat_doc_branch":   BeatDocBranch,
@@ -117,19 +118,20 @@ func EnvMap(args ...map[string]interface{}) map[string]interface{} {
 
 func varMap(args ...map[string]interface{}) map[string]interface{} {
 	data := map[string]interface{}{
-		"GOOS":            GOOS,
-		"GOARCH":          GOARCH,
-		"GOARM":           GOARM,
-		"Platform":        Platform,
-		"BinaryExt":       BinaryExt,
-		"BeatName":        BeatName,
-		"BeatServiceName": BeatServiceName,
-		"BeatIndexPrefix": BeatIndexPrefix,
-		"BeatDescription": BeatDescription,
-		"BeatVendor":      BeatVendor,
-		"BeatLicense":     BeatLicense,
-		"BeatURL":         BeatURL,
-		"Snapshot":        Snapshot,
+		"GOOS":             GOOS,
+		"GOARCH":           GOARCH,
+		"GOARM":            GOARM,
+		"Platform":         Platform,
+		"BinaryExt":        BinaryExt,
+		"BeatName":         BeatName,
+		"BeatServiceName":  BeatServiceName,
+		"BeatIndexPrefix":  BeatIndexPrefix,
+		"BeatDescription":  BeatDescription,
+		"BeatVendor":       BeatVendor,
+		"BeatLicense":      BeatLicense,
+		"BeatURL":          BeatURL,
+		"Snapshot":         Snapshot,
+		"VersionQualifier": VersionQualifier,
 	}
 
 	// Add the extra args to the map.
@@ -145,18 +147,20 @@ func varMap(args ...map[string]interface{}) map[string]interface{} {
 func dumpVariables() (string, error) {
 	var dumpTemplate = `## Variables
 
-GOOS            = {{.GOOS}}
-GOARCH          = {{.GOARCH}}
-GOARM           = {{.GOARM}}
-Platform        = {{.Platform}}
-BinaryExt       = {{.BinaryExt}}
-BeatName        = {{.BeatName}}
-BeatServiceName = {{.BeatServiceName}}
-BeatIndexPrefix = {{.BeatIndexPrefix}}
-BeatDescription = {{.BeatDescription}}
-BeatVendor      = {{.BeatVendor}}
-BeatLicense     = {{.BeatLicense}}
-BeatURL         = {{.BeatURL}}
+GOOS             = {{.GOOS}}
+GOARCH           = {{.GOARCH}}
+GOARM            = {{.GOARM}}
+Platform         = {{.Platform}}
+BinaryExt        = {{.BinaryExt}}
+BeatName         = {{.BeatName}}
+BeatServiceName  = {{.BeatServiceName}}
+BeatIndexPrefix  = {{.BeatIndexPrefix}}
+BeatDescription  = {{.BeatDescription}}
+BeatVendor       = {{.BeatVendor}}
+BeatLicense      = {{.BeatLicense}}
+BeatURL          = {{.BeatURL}}
+VersionQualifier = {{.VersionQualifier}}
+Snapshot         = {{.Snapshot}}
 
 ## Functions
 

--- a/filebeat/magefile.go
+++ b/filebeat/magefile.go
@@ -82,8 +82,8 @@ func Package() {
 	mage.UseElasticBeatPackaging()
 	customizePackaging()
 
-	mg.Deps(Update, prepareModulePackaging)
-	mg.Deps(CrossBuild, CrossBuildXPack, CrossBuildGoDaemon)
+	//mg.Deps(Update, prepareModulePackaging)
+	//mg.Deps(CrossBuild, CrossBuildXPack, CrossBuildGoDaemon)
 	mg.SerialDeps(mage.Package, TestPackages)
 }
 

--- a/filebeat/magefile.go
+++ b/filebeat/magefile.go
@@ -82,8 +82,8 @@ func Package() {
 	mage.UseElasticBeatPackaging()
 	customizePackaging()
 
-	//mg.Deps(Update, prepareModulePackaging)
-	//mg.Deps(CrossBuild, CrossBuildXPack, CrossBuildGoDaemon)
+	mg.Deps(Update, prepareModulePackaging)
+	mg.Deps(CrossBuild, CrossBuildXPack, CrossBuildGoDaemon)
 	mg.SerialDeps(mage.Package, TestPackages)
 }
 

--- a/magefile.go
+++ b/magefile.go
@@ -55,7 +55,7 @@ func PackageBeatDashboards() error {
 				Content: "{{ commit }}\n",
 			},
 		},
-		OutputFile: "build/distributions/dashboards/{{.Name}}-{{.Version}}{{.VersionQualifier}}{{if .Snapshot}}-SNAPSHOT{{end}}",
+		OutputFile: "build/distributions/dashboards/{{.Name}}-{{.Version}}{{if .VersionQualifier}}-{{.VersionQualifier}}{{end}}{{if .Snapshot}}-SNAPSHOT{{end}}",
 	}
 
 	for _, beat := range Beats {

--- a/magefile.go
+++ b/magefile.go
@@ -46,15 +46,16 @@ func PackageBeatDashboards() error {
 	}
 
 	spec := mage.PackageSpec{
-		Name:     "beats-dashboards",
-		Version:  version,
-		Snapshot: mage.Snapshot,
+		Name:             "beats-dashboards",
+		Version:          version,
+		Snapshot:         mage.Snapshot,
+		VersionQualifier: mage.VersionQualifier,
 		Files: map[string]mage.PackageFile{
 			".build_hash.txt": mage.PackageFile{
 				Content: "{{ commit }}\n",
 			},
 		},
-		OutputFile: "build/distributions/dashboards/{{.Name}}-{{.Version}}{{if .Snapshot}}-SNAPSHOT{{end}}",
+		OutputFile: "build/distributions/dashboards/{{.Name}}-{{.Version}}{{.VersionQualifier}}{{if .Snapshot}}-SNAPSHOT{{end}}",
 	}
 
 	for _, beat := range Beats {
@@ -68,5 +69,5 @@ func PackageBeatDashboards() error {
 
 // DumpVariables writes the template variables and values to stdout.
 func DumpVariables() error {
-    return mage.DumpVariables()
+	return mage.DumpVariables()
 }

--- a/metricbeat/README.md
+++ b/metricbeat/README.md
@@ -26,6 +26,3 @@ If you are sure you found a bug or have a feature request, open an issue on
 We love contributions from our community! Please read the
 [CONTRIBUTING.md](../CONTRIBUTING.md) file.
 
-## Snapshots
-
-For testing purposes, we generate snapshot builds that you can find [here](https://beats-nightlies.s3.amazonaws.com/index.html?prefix=metricbeat). Please be aware that these are built on top of master and are not meant for production.

--- a/packetbeat/README.md
+++ b/packetbeat/README.md
@@ -40,6 +40,3 @@ If you are sure you found a bug or have a feature request, open an issue on
 We love contributions from our community! Please read the
 [CONTRIBUTING.md](../CONTRIBUTING.md) file.
 
-## Snapshots
-
-For testing purposes, we generate snapshot builds that you can find [here](https://beats-nightlies.s3.amazonaws.com/index.html?prefix=packetbeat). Please be aware that these are built on top of master and are not meant for production.


### PR DESCRIPTION
The VERSION_QUALIFIER env variable adds a custom text after the version.
Example run:

     VERSION_QUALIFIER=rc1 mage -v package

Closes #8186.