### PR TITLE
Cherry-pick #7718 to 6.x: Fetch github.com/docker/libcompose for libbeat go tests

### DIFF
--- a/dev-tools/jenkins_ci.ps1
+++ b/dev-tools/jenkins_ci.ps1
@@ -38,6 +38,10 @@ New-Item -ItemType directory -Path build\coverage | Out-Null
 New-Item -ItemType directory -Path build\system-tests | Out-Null
 New-Item -ItemType directory -Path build\system-tests\run | Out-Null
 
+# TODO (elastic/beats#5050): Use a vendored copy of this.
+echo "Fetching testing dependencies"
+exec { go get github.com/docker/libcompose }
+
 echo "Building fields.yml"
 exec { mage fields }
 
@@ -49,8 +53,6 @@ go test -v $(go list ./... | select-string -Pattern "vendor" -NotMatch) 2>&1 | O
 exec { Get-Content build/TEST-go-unit.out | go-junit-report.exe -set-exit-code | Out-File -encoding UTF8 build/TEST-go-unit.xml } "Unit test FAILURE"
 
 echo "System testing $env:beat"
-# TODO (elastic/beats#5050): Use a vendored copy of this.
-exec { go get github.com/docker/libcompose }
 # Get a CSV list of package names.
 $packages = $(go list ./... | select-string -Pattern "/vendor/" -NotMatch | select-string -Pattern "/scripts/cmd/" -NotMatch)
 $packages = ($packages|group|Select -ExpandProperty Name) -join ","

--- a/dev-tools/jenkins_ci.ps1
+++ b/dev-tools/jenkins_ci.ps1
@@ -22,7 +22,11 @@ $env:PATH = "$env:GOPATH\bin;C:\tools\mingw64\bin;$env:PATH"
 $env:MAGEFILE_CACHE = "$env:WORKSPACE\.magefile"
 
 exec { go install github.com/elastic/beats/vendor/github.com/magefile/mage }
-exec { go get -u github.com/jstemmer/go-junit-report }
+
+echo "Fetching testing dependencies"
+# TODO (elastic/beats#5050): Use a vendored copy of this.
+exec { go get github.com/docker/libcompose }
+exec { go get github.com/jstemmer/go-junit-report }
 
 if (Test-Path "$env:beat") {
     cd "$env:beat"
@@ -37,10 +41,6 @@ if (Test-Path "build") { Remove-Item -Recurse -Force build }
 New-Item -ItemType directory -Path build\coverage | Out-Null
 New-Item -ItemType directory -Path build\system-tests | Out-Null
 New-Item -ItemType directory -Path build\system-tests\run | Out-Null
-
-# TODO (elastic/beats#5050): Use a vendored copy of this.
-echo "Fetching testing dependencies"
-exec { go get github.com/docker/libcompose }
 
 echo "Building fields.yml"
 exec { mage fields }

--- a/libbeat/common/file/file_windows.go
+++ b/libbeat/common/file/file_windows.go
@@ -102,7 +102,7 @@ func ReadOpen(path string) (*os.File, error) {
 	handle, err := syscall.CreateFile(pathp, access, sharemode, sa, createmode, syscall.FILE_ATTRIBUTE_NORMAL, 0)
 
 	if err != nil {
-		return nil, fmt.Errorf("Error creating file '%s': %v", pathp, err)
+		return nil, fmt.Errorf("Error creating file '%s': %v", path, err)
 	}
 
 	return os.NewFile(uintptr(handle), path), nil


### PR DESCRIPTION
Cherry-pick of PR #7718 to 6.x branch. Original message: 

The libbeat tests were failing to compile and the error was uncaught. The cause was that github.com/docker/libcompose was not installed prior to running `go test` (relates to elastic/beats#5050). This moves `go get github.com/docker/libcompose` earlier in the script.

A separate change will be made in another commit to always report the `go test` exit code rather than the one from `go-junit-report`.

A few tests went undetected during this time and this includes fixes and skips.

- Fix arg type used in fmt.Errorf
    
    ```
    PS C:\Gopath\src\github.com\elastic\beats\libbeat\common\file> go test -json -v .
    # github.com/elastic/beats/libbeat/common/file
    .\file_windows.go:105: Errorf format %s has arg pathp of wrong type *uint16
    FAIL    github.com/elastic/beats/libbeat/common/file [build failed]
    ```

- Skip failing tests in libbeat

  - elastic/beats#7720
  - elastic/beats#7721

Failing test output:
https://beats-ci.elastic.co/job/elastic+beats+master+multijob-windows/1271/beat=libbeat,label=windows/artifact/src/github.com/elastic/beats/libbeat/build/TEST-go-unit.out/*view*/