### PR TITLE
Extend changelog entry

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -126,7 +126,7 @@ https://github.com/elastic/beats/compare/v6.4.0...master[Check the HEAD diff]
 - Add experimental socket summary metricset to system module {pull}6782[6782]
 - Increase ignore_above for system.process.cmdline to 2048. {pull}8101[8100]
 - Add support to renamed fields planned for redis 5.0. {pull}8167[8167]
-- Allow TCP helper to support delimiters. {pull}8278[8278]
+- Allow TCP helper to support delimiters and graphite module to accept multiple metrics in a single payload. {pull}8278[8278]
 
 *Packetbeat*
 

--- a/metricbeat/helper/server/tcp/tcp.go
+++ b/metricbeat/helper/server/tcp/tcp.go
@@ -99,19 +99,18 @@ func (g *TcpServer) watchMetrics() {
 			continue
 		}
 
-		if conn != nil {
-			go g.handle(conn)
-		}
+		go g.handle(conn)
 	}
 }
 
 func (g *TcpServer) handle(conn net.Conn) {
+	if conn == nil {
+		return
+	}
 	logp.Debug("tcp", "Handling new connection...")
 
 	// Close connection when this function ends
-	defer func() {
-		conn.Close()
-	}()
+	defer conn.Close()
 
 	// Get a new reader with buffer size as the same as receiveBufferSize
 	bufReader := bufio.NewReaderSize(conn, g.receiveBufferSize)


### PR DESCRIPTION
Follow up of #8278. Extend changelog entry so it also describes the change for graphite module, and remove unneeded function.

To be backported with the main change.

