### PR TITLE
Cherry-pick #8297 to 6.x: parameterize beat monitoring docs

### DIFF
--- a/libbeat/docs/monitoring/monitoring-beats.asciidoc
+++ b/libbeat/docs/monitoring/monitoring-beats.asciidoc
@@ -17,7 +17,7 @@
 [partintro]
 --
 
-NOTE: {monitoring} for {beatname_uc} requires {es} 6.2 or later.
+NOTE: {monitoring} for {beatname_uc} requires {es} {beat_monitoring_version} or later.
 
 {monitoring} enables you to easily monitor {beatname_uc} from {kib}. For more
 information, see
@@ -27,8 +27,8 @@ information, see
 To configure {beatname_uc} to collect and send monitoring metrics:
 
 . Create a user that has appropriate authority to send system-level monitoring
-data to {es}. For example, you can use the built-in `beats_system` user or
-assign the built-in `beats_system` role to another user. For more
+data to {es}. For example, you can use the built-in +{beat_monitoring_user}+ user or
+assign the built-in +{beat_monitoring_user}+ role to another user. For more
 information, see
 {xpack-ref}/setting-up-authentication.html[Setting Up User Authentication] and
 {xpack-ref}/built-in-roles.html[Built-in Roles].
@@ -45,14 +45,14 @@ xpack.monitoring.enabled: true
 If you configured a different output, such as {ls}, you must specify additional
 configuration options. For example:
 
-[source, yml]
+["source","yml",subs="attributes"]
 --------------------
 xpack.monitoring:
   enabled: true
   elasticsearch:
     hosts: ["https://example.com:9200", "https://example2.com:9200"]
-    username: beats_system
-    password: beatspassword
+    username: {beat_monitoring_user}
+    password: somepassword
 --------------------
 
 NOTE: Currently you must send monitoring data to the same cluster as all other events.

--- a/libbeat/docs/security/beats-system.asciidoc
+++ b/libbeat/docs/security/beats-system.asciidoc
@@ -1,18 +1,19 @@
 [role="xpack"]
 [[beats-system-user]]
-=== Set the password for the `beats_system` built-in user
+=== Set the password for the built-in monitoring user
 
 {security} provides built-in user credentials in {es} that have a fixed set of
-privileges. In 6.3.0 and later releases, there is a `beats_system` built-in user,
-which {beatname_uc} uses to store monitoring information in {es}.
+privileges. In {beat_monitoring_user_version} and later releases, there is a
++{beat_monitoring_user}+ built-in user, which {beatname_uc} uses to store
+monitoring information in {es}.
 
 The initial passwords for all of the built-in users are set by using the
 `setup-passwords` tool in {es}. Thereafter, you can change the passwords by
 using the *Management > Users* page in Kibana or the
 {ref}/security-api-change-password.html[Change Password API].
 
-IMPORTANT: If you upgraded from {es} version 6.2 or earlier, you will not
-have set a password for the `beats_system` user. A user with the
+IMPORTANT: If you upgraded from {es} version {beat_monitoring_version} or earlier, you will not
+have set a password for the +{beat_monitoring_user}+ user. A user with the
 `manage_security` privilege must change the password for this built-in user.
 
 For more

--- a/libbeat/docs/security/securing-beats.asciidoc
+++ b/libbeat/docs/security/securing-beats.asciidoc
@@ -35,13 +35,11 @@ access to the indices {beatname_uc} creates.
 If encryption is enabled on the cluster, you need to enable HTTPS in the
 {beatname_uc} configuration.
 
-ifeval::["{beatname_lc}"!="apm-server"]
 . <<beats-system-user>>.
 +
-{beatname_uc} uses the `beats_system` user to send monitoring data to {es}. If
+{beatname_uc} uses the +{beat_monitoring_user}+ user to send monitoring data to {es}. If
 you plan to monitor {beatname_uc} in {kib} and have not yet set up the
 password, set it up now.
-endif::[]
 
 For more information about {security}, see
 {xpack-ref}/xpack-security.html[Securing the {stack}].
@@ -83,6 +81,4 @@ include::user-access.asciidoc[]
 
 include::tls.asciidoc[]
 
-ifeval::["{beatname_lc}"!="apm-server"]
 include::beats-system.asciidoc[]
-endif::[]

--- a/libbeat/docs/shared-beats-attributes.asciidoc
+++ b/libbeat/docs/shared-beats-attributes.asciidoc
@@ -19,3 +19,6 @@
 :ES-version: {stack-version}
 :LS-version: {stack-version}
 :Kibana-version: {stack-version}
+:beat_monitoring_user: beats_system
+:beat_monitoring_user_version: 6.3.0
+:beat_monitoring_version: 6.2


### PR DESCRIPTION
Cherry-pick of PR #8297 to 6.x branch. Original message: 

to support apm-server xpack monitoring documentation needed for elastic/apm-server#1378.