### PR TITLE
Cherry-pick #8071 to 6.x: Fix set_version script

### DIFF
--- a/dev-tools/set_version
+++ b/dev-tools/set_version
@@ -34,10 +34,19 @@ def get_rootfolder():
     # Libbeat detected
     return os.path.dirname(script_directory)
 
-def create_from_template(filename, template, version):
-    with open(filename, "w") as f:
-        f.write(template.format(version=version))
-        print ("Set version {} in file {}".format(version, filename))
+def replace_in_file(filename, varname, version):
+    new_lines = []
+    with open(filename, 'r') as f:
+        for line in f:
+            if line.startswith("const " + varname):
+                new_lines.append('const {} = "{}"\n'.format(varname, version))
+            else:
+                new_lines.append(line)
+
+    with open(filename, 'w') as f:
+        for line in new_lines:
+            f.write(line)
+    print ("Set version {} in file {}".format(version, filename))
 
 def main():
     parser = argparse.ArgumentParser(


### PR DESCRIPTION
Cherry-pick of PR #8071 to 6.x branch. Original message: 

There was an error in #8058, where no new line was added at the
end of the generated file, causing `go vet` to fail.