### PR TITLE
Cherry-pick #8328 to 6.x: Promote `docker` input to GA

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -95,6 +95,7 @@ https://github.com/elastic/beats/compare/v6.4.0...6.x[Check the HEAD diff]
 - Add tag "truncated" to "log.flags" if incoming line is longer than configured limit. {pull}7991[7991]
 - Add haproxy module. {pull}8014[8014]
 - Add tag "multiline" to "log.flags" if event consists of multiple lines. {pull}7997[7997]
+- Release `docker` input as GA. {pull}8328[8328]
 
 *Heartbeat*
 

--- a/filebeat/docs/inputs/input-docker.asciidoc
+++ b/filebeat/docs/inputs/input-docker.asciidoc
@@ -7,8 +7,6 @@
 <titleabbrev>Docker</titleabbrev>
 ++++
 
-experimental[]
-
 Use the `docker` input to read logs from Docker containers.
 
 This input searches for container logs under its path, and parse them into

--- a/filebeat/input/docker/input.go
+++ b/filebeat/input/docker/input.go
@@ -25,7 +25,7 @@ import (
 	"github.com/elastic/beats/filebeat/input"
 	"github.com/elastic/beats/filebeat/input/log"
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/common/cfgwarn"
+	"github.com/elastic/beats/libbeat/logp"
 
 	"github.com/pkg/errors"
 )
@@ -43,7 +43,7 @@ func NewInput(
 	outletFactory channel.Connector,
 	context input.Context,
 ) (input.Input, error) {
-	cfgwarn.Experimental("Docker input is enabled.")
+	logger := logp.NewLogger("docker")
 
 	config := defaultConfig
 	if err := cfg.Unpack(&config); err != nil {


### PR DESCRIPTION
Cherry-pick of PR #8328 to 6.x branch. Original message: 

