### PR TITLE
Add handling of Github HTTP URLs to cherrypick_pr

### DIFF
--- a/dev-tools/cherrypick_pr
+++ b/dev-tools/cherrypick_pr
@@ -127,7 +127,7 @@ def main():
         # get the github username from the remote where we pushed
         remote_url = check_output("git remote get-url {}".format(remote),
                                   shell=True)
-        remote_user = re.search("github.com:(.+)/beats", remote_url).group(1)
+        remote_user = re.search("github.com[:/](.+)/beats", remote_url).group(1)
 
         # create PR
         request = session.post(base + "/pulls", json=dict(


### PR DESCRIPTION
I personally use HTTP URLs as my Github remotes locally. They have a slightly different format (`github.com/cwurm/beats.git` instead of `github.com:cwurm/beats.git`).

This expands the regex in `cherrypick_pr` determining the Github user to handle HTTP URLs as well.