### PR TITLE
Log rotation by time interval

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -91,6 +91,7 @@ https://github.com/elastic/beats/compare/v6.4.0...master[Check the HEAD diff]
 
 *Affecting all Beats*
 
+- Added time-based log rotation. {pull}8349[8349]
 - Add backoff on error support to redis output. {pull}7781[7781]
 - Add field `host.os.kernel` to the add_host_metadata processor and to the
   internal monitoring data. {issue}7807[7807]

--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -1101,9 +1101,12 @@ logging.files:
   # Must be a valid Unix-style file permissions mask expressed in octal notation.
   #permissions: 0600
 
-  # Enable daily log file rotation in addition to size-based rotation. Defaults to
-  # disabled.
-  #daily: true
+  # Enable log file rotation on time intervals in addition to size-based rotation.
+  # Intervals must be at least 1s. Values of 1m, 1h, 24h, 7*24h, 30*24h, and 365*24h
+  # are boundary-aligned with minutes, hours, days, weeks, months, and years as
+  # reported by the local system clock. All other intervals are calculated from the
+  # unix epoch. Defaults to disabled.
+  #interval: 0
 
 # Set to true to log messages in json format.
 #logging.json: false

--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -542,11 +542,11 @@ output.elasticsearch:
   # and retry until all events are published.  Set max_retries to a value less
   # than 0 to retry until all events are published. The default is 3.
   #max_retries: 3
-  
+
   # The maximum number of events to bulk in a single Logstash request. The
   # default is 2048.
   #bulk_max_size: 2048
-  
+
   # The number of seconds to wait for responses from the Logstash server before
   # timing out. The default is 30s.
   #timeout: 30s
@@ -1100,6 +1100,10 @@ logging.files:
   # The permissions mask to apply when rotating log files. The default value is 0600.
   # Must be a valid Unix-style file permissions mask expressed in octal notation.
   #permissions: 0600
+
+  # Enable daily log file rotation in addition to size-based rotation. Defaults to
+  # disabled.
+  #daily: true
 
 # Set to true to log messages in json format.
 #logging.json: false

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -1210,11 +1210,11 @@ output.elasticsearch:
   # and retry until all events are published.  Set max_retries to a value less
   # than 0 to retry until all events are published. The default is 3.
   #max_retries: 3
-  
+
   # The maximum number of events to bulk in a single Logstash request. The
   # default is 2048.
   #bulk_max_size: 2048
-  
+
   # The number of seconds to wait for responses from the Logstash server before
   # timing out. The default is 30s.
   #timeout: 30s
@@ -1768,6 +1768,10 @@ logging.files:
   # The permissions mask to apply when rotating log files. The default value is 0600.
   # Must be a valid Unix-style file permissions mask expressed in octal notation.
   #permissions: 0600
+
+  # Enable daily log file rotation in addition to size-based rotation. Defaults to
+  # disabled.
+  #daily: true
 
 # Set to true to log messages in json format.
 #logging.json: false

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -1769,9 +1769,12 @@ logging.files:
   # Must be a valid Unix-style file permissions mask expressed in octal notation.
   #permissions: 0600
 
-  # Enable daily log file rotation in addition to size-based rotation. Defaults to
-  # disabled.
-  #daily: true
+  # Enable log file rotation on time intervals in addition to size-based rotation.
+  # Intervals must be at least 1s. Values of 1m, 1h, 24h, 7*24h, 30*24h, and 365*24h
+  # are boundary-aligned with minutes, hours, days, weeks, months, and years as
+  # reported by the local system clock. All other intervals are calculated from the
+  # unix epoch. Defaults to disabled.
+  #interval: 0
 
 # Set to true to log messages in json format.
 #logging.json: false

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -1216,9 +1216,12 @@ logging.files:
   # Must be a valid Unix-style file permissions mask expressed in octal notation.
   #permissions: 0600
 
-  # Enable daily log file rotation in addition to size-based rotation. Defaults to
-  # disabled.
-  #daily: true
+  # Enable log file rotation on time intervals in addition to size-based rotation.
+  # Intervals must be at least 1s. Values of 1m, 1h, 24h, 7*24h, 30*24h, and 365*24h
+  # are boundary-aligned with minutes, hours, days, weeks, months, and years as
+  # reported by the local system clock. All other intervals are calculated from the
+  # unix epoch. Defaults to disabled.
+  #interval: 0
 
 # Set to true to log messages in json format.
 #logging.json: false

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -657,11 +657,11 @@ output.elasticsearch:
   # and retry until all events are published.  Set max_retries to a value less
   # than 0 to retry until all events are published. The default is 3.
   #max_retries: 3
-  
+
   # The maximum number of events to bulk in a single Logstash request. The
   # default is 2048.
   #bulk_max_size: 2048
-  
+
   # The number of seconds to wait for responses from the Logstash server before
   # timing out. The default is 30s.
   #timeout: 30s
@@ -1215,6 +1215,10 @@ logging.files:
   # The permissions mask to apply when rotating log files. The default value is 0600.
   # Must be a valid Unix-style file permissions mask expressed in octal notation.
   #permissions: 0600
+
+  # Enable daily log file rotation in addition to size-based rotation. Defaults to
+  # disabled.
+  #daily: true
 
 # Set to true to log messages in json format.
 #logging.json: false

--- a/libbeat/_meta/config.reference.yml
+++ b/libbeat/_meta/config.reference.yml
@@ -430,11 +430,11 @@ output.elasticsearch:
   # and retry until all events are published.  Set max_retries to a value less
   # than 0 to retry until all events are published. The default is 3.
   #max_retries: 3
-  
+
   # The maximum number of events to bulk in a single Logstash request. The
   # default is 2048.
   #bulk_max_size: 2048
-  
+
   # The number of seconds to wait for responses from the Logstash server before
   # timing out. The default is 30s.
   #timeout: 30s
@@ -988,6 +988,10 @@ logging.files:
   # The permissions mask to apply when rotating log files. The default value is 0600.
   # Must be a valid Unix-style file permissions mask expressed in octal notation.
   #permissions: 0600
+
+  # Enable daily log file rotation in addition to size-based rotation. Defaults to
+  # disabled.
+  #daily: true
 
 # Set to true to log messages in json format.
 #logging.json: false

--- a/libbeat/_meta/config.reference.yml
+++ b/libbeat/_meta/config.reference.yml
@@ -989,9 +989,12 @@ logging.files:
   # Must be a valid Unix-style file permissions mask expressed in octal notation.
   #permissions: 0600
 
-  # Enable daily log file rotation in addition to size-based rotation. Defaults to
-  # disabled.
-  #daily: true
+  # Enable log file rotation on time intervals in addition to size-based rotation.
+  # Intervals must be at least 1s. Values of 1m, 1h, 24h, 7*24h, 30*24h, and 365*24h
+  # are boundary-aligned with minutes, hours, days, weeks, months, and years as
+  # reported by the local system clock. All other intervals are calculated from the
+  # unix epoch. Defaults to disabled.
+  #interval: 0
 
 # Set to true to log messages in json format.
 #logging.json: false

--- a/libbeat/common/file/interval_rotator.go
+++ b/libbeat/common/file/interval_rotator.go
@@ -163,47 +163,32 @@ func IntervalLogIndex(filename string) (uint64, int, error) {
 }
 
 func newSecond(lastTime time.Time, currentTime time.Time) bool {
-	return currentTime.Second() != lastTime.Second() ||
-		currentTime.Minute() != lastTime.Minute() ||
-		currentTime.Hour() != lastTime.Hour() ||
-		currentTime.Day() != lastTime.Day() ||
-		currentTime.Month() != lastTime.Month() ||
-		currentTime.Year() != lastTime.Year()
+	return lastTime.Second() != currentTime.Second() || newMinute(lastTime, currentTime)
 }
 
 func newMinute(lastTime time.Time, currentTime time.Time) bool {
-	return currentTime.Minute() != lastTime.Minute() ||
-		currentTime.Hour() != lastTime.Hour() ||
-		currentTime.Day() != lastTime.Day() ||
-		currentTime.Month() != lastTime.Month() ||
-		currentTime.Year() != lastTime.Year()
+	return lastTime.Minute() != currentTime.Minute() || newHour(lastTime, currentTime)
 }
 
 func newHour(lastTime time.Time, currentTime time.Time) bool {
-	return currentTime.Hour() != lastTime.Hour() ||
-		currentTime.Day() != lastTime.Day() ||
-		currentTime.Month() != lastTime.Month() ||
-		currentTime.Year() != lastTime.Year()
+	return lastTime.Hour() != currentTime.Hour() || newDay(lastTime, currentTime)
 }
 
 func newDay(lastTime time.Time, currentTime time.Time) bool {
-	return currentTime.Day() != lastTime.Day() ||
-		currentTime.Month() != lastTime.Month() ||
-		currentTime.Year() != lastTime.Year()
+	return lastTime.Day() != currentTime.Day() || newMonth(lastTime, currentTime)
 }
 
 func newWeek(lastTime time.Time, currentTime time.Time) bool {
 	lastYear, lastWeek := lastTime.ISOWeek()
 	currentYear, currentWeek := currentTime.ISOWeek()
-	return currentWeek != lastWeek ||
-		currentYear != lastYear
+	return lastWeek != currentWeek ||
+		lastYear != currentYear
 }
 
 func newMonth(lastTime time.Time, currentTime time.Time) bool {
-	return currentTime.Month() != lastTime.Month() ||
-		currentTime.Year() != lastTime.Year()
+	return lastTime.Month() != currentTime.Month() || newYear(lastTime, currentTime)
 }
 
 func newYear(lastTime time.Time, currentTime time.Time) bool {
-	return currentTime.Year() != lastTime.Year()
+	return lastTime.Year() != currentTime.Year()
 }

--- a/libbeat/common/file/interval_rotator.go
+++ b/libbeat/common/file/interval_rotator.go
@@ -39,7 +39,7 @@ type clock interface {
 	Now() time.Time
 }
 
-type realClock struct {}
+type realClock struct{}
 
 func (realClock) Now() time.Time {
 	return time.Now()
@@ -87,7 +87,7 @@ func (r *intervalRotator) initialize() error {
 	default:
 		r.arbitrary = true
 		r.fileFormat = "2006-01-02-15-04-05"
-		r.newInterval = func (lastTime time.Time, currentTime time.Time ) bool {
+		r.newInterval = func(lastTime time.Time, currentTime time.Time) bool {
 			lastInterval := lastTime.Unix() / (int64(r.interval) / int64(time.Second))
 			currentInterval := currentTime.Unix() / (int64(r.interval) / int64(time.Second))
 			return lastInterval != currentInterval

--- a/libbeat/common/file/interval_rotator.go
+++ b/libbeat/common/file/interval_rotator.go
@@ -45,7 +45,7 @@ func (realClock) Now() time.Time {
 	return time.Now()
 }
 
-func NewIntervalRotator(interval time.Duration) (*intervalRotator, error) {
+func newIntervalRotator(interval time.Duration) (*intervalRotator, error) {
 	if interval == 0 {
 		return nil, nil
 	}
@@ -135,8 +135,9 @@ func (r *intervalRotator) SortIntervalLogs(strings []string) {
 	)
 }
 
-// Given a log filename in the form [prefix]-[formattedDate]-n, returns the filename after
-// zero-padding the trailing n so that foo-[date]-2 sorts before foo-[date]-10.
+// OrderIntervalLogs, when given a log filename in the form [prefix]-[formattedDate]-n
+// returns the filename after zero-padding the trailing n so that foo-[date]-2 sorts
+// before foo-[date]-10.
 func OrderIntervalLogs(filename string) string {
 	index, i, err := IntervalLogIndex(filename)
 	if err == nil {
@@ -146,7 +147,7 @@ func OrderIntervalLogs(filename string) string {
 	return ""
 }
 
-// Given a log filename in the form [prefix]-[formattedDate]-n, returns n as int
+// IntervalLogIndex returns n as int given a log filename in the form [prefix]-[formattedDate]-n
 func IntervalLogIndex(filename string) (uint64, int, error) {
 	i := len(filename) - 1
 	for ; i >= 0; i-- {

--- a/libbeat/common/file/interval_rotator.go
+++ b/libbeat/common/file/interval_rotator.go
@@ -1,0 +1,208 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package file
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strconv"
+	"time"
+)
+
+type intervalRotator struct {
+	interval    time.Duration
+	lastRotate  time.Time
+	fileFormat  string
+	clock       clock
+	weekly      bool
+	arbitrary   bool
+	newInterval func(lastTime time.Time, currentTime time.Time) bool
+}
+
+type clock interface {
+	Now() time.Time
+}
+
+type realClock struct {}
+
+func (realClock) Now() time.Time {
+	return time.Now()
+}
+
+func NewIntervalRotator(interval time.Duration) (*intervalRotator, error) {
+	if interval == 0 {
+		return nil, nil
+	}
+	if interval < time.Second && interval != 0 {
+		return nil, errors.New("the minimum time interval for log rotation is 1 second")
+	}
+
+	ir := &intervalRotator{interval: (interval / time.Second) * time.Second} // drop fractional seconds
+	ir.initialize()
+	return ir, nil
+}
+
+func (r *intervalRotator) initialize() error {
+	r.clock = realClock{}
+
+	switch r.interval {
+	case time.Second:
+		r.fileFormat = "2006-01-02-15-04-05"
+		r.newInterval = newSecond
+	case time.Minute:
+		r.fileFormat = "2006-01-02-15-04"
+		r.newInterval = newMinute
+	case time.Hour:
+		r.fileFormat = "2006-01-02-15"
+		r.newInterval = newHour
+	case 24 * time.Hour: // calendar day
+		r.fileFormat = "2006-01-02"
+		r.newInterval = newDay
+	case 7 * 24 * time.Hour: // calendar week
+		r.fileFormat = ""
+		r.newInterval = newWeek
+		r.weekly = true
+	case 30 * 24 * time.Hour: // calendar month
+		r.fileFormat = "2006-01"
+		r.newInterval = newMonth
+	case 365 * 24 * time.Hour: // calendar year
+		r.fileFormat = "2006"
+		r.newInterval = newYear
+	default:
+		r.arbitrary = true
+		r.fileFormat = "2006-01-02-15-04-05"
+		r.newInterval = func (lastTime time.Time, currentTime time.Time ) bool {
+			lastInterval := lastTime.Unix() / (int64(r.interval) / int64(time.Second))
+			currentInterval := currentTime.Unix() / (int64(r.interval) / int64(time.Second))
+			return lastInterval != currentInterval
+		}
+	}
+	return nil
+}
+
+func (r *intervalRotator) LogPrefix(filename string, modTime time.Time) string {
+	var t time.Time
+	if r.lastRotate.IsZero() {
+		t = modTime
+	} else {
+		t = r.lastRotate
+	}
+
+	if r.weekly {
+		y, w := t.ISOWeek()
+		return fmt.Sprintf("%s-%04d-%02d-", filename, y, w)
+	}
+	if r.arbitrary {
+		intervalNumber := t.Unix() / (int64(r.interval) / int64(time.Second))
+		intervalStart := time.Unix(0, intervalNumber*int64(r.interval))
+		return fmt.Sprintf("%s-%s-", filename, intervalStart.Format(r.fileFormat))
+	}
+	return fmt.Sprintf("%s-%s-", filename, t.Format(r.fileFormat))
+}
+
+func (r *intervalRotator) NewInterval() bool {
+	now := r.clock.Now()
+	newInterval := r.newInterval(r.lastRotate, now)
+	return newInterval
+}
+
+func (r *intervalRotator) Rotate() {
+	r.lastRotate = r.clock.Now()
+}
+
+func (r *intervalRotator) SortIntervalLogs(strings []string) {
+	sort.Slice(
+		strings,
+		func(i, j int) bool {
+			return OrderIntervalLogs(strings[i]) < OrderIntervalLogs(strings[j])
+		},
+	)
+}
+
+// Given a log filename in the form [prefix]-[formattedDate]-n, returns the filename after
+// zero-padding the trailing n so that foo-[date]-2 sorts before foo-[date]-10.
+func OrderIntervalLogs(filename string) string {
+	index, i, err := IntervalLogIndex(filename)
+	if err == nil {
+		return filename[:i] + fmt.Sprintf("%020d", index)
+	}
+
+	return ""
+}
+
+// Given a log filename in the form [prefix]-[formattedDate]-n, returns n as int
+func IntervalLogIndex(filename string) (uint64, int, error) {
+	i := len(filename) - 1
+	for ; i >= 0; i-- {
+		if '0' > filename[i] || filename[i] > '9' {
+			break
+		}
+	}
+	i++
+
+	s64 := filename[i:]
+	u64, err := strconv.ParseUint(s64, 10, 64)
+	return u64, i, err
+}
+
+func newSecond(lastTime time.Time, currentTime time.Time) bool {
+	return currentTime.Second() != lastTime.Second() ||
+		currentTime.Minute() != lastTime.Minute() ||
+		currentTime.Hour() != lastTime.Hour() ||
+		currentTime.Day() != lastTime.Day() ||
+		currentTime.Month() != lastTime.Month() ||
+		currentTime.Year() != lastTime.Year()
+}
+
+func newMinute(lastTime time.Time, currentTime time.Time) bool {
+	return currentTime.Minute() != lastTime.Minute() ||
+		currentTime.Hour() != lastTime.Hour() ||
+		currentTime.Day() != lastTime.Day() ||
+		currentTime.Month() != lastTime.Month() ||
+		currentTime.Year() != lastTime.Year()
+}
+
+func newHour(lastTime time.Time, currentTime time.Time) bool {
+	return currentTime.Hour() != lastTime.Hour() ||
+		currentTime.Day() != lastTime.Day() ||
+		currentTime.Month() != lastTime.Month() ||
+		currentTime.Year() != lastTime.Year()
+}
+
+func newDay(lastTime time.Time, currentTime time.Time) bool {
+	return currentTime.Day() != lastTime.Day() ||
+		currentTime.Month() != lastTime.Month() ||
+		currentTime.Year() != lastTime.Year()
+}
+
+func newWeek(lastTime time.Time, currentTime time.Time) bool {
+	lastYear, lastWeek := lastTime.ISOWeek()
+	currentYear, currentWeek := currentTime.ISOWeek()
+	return currentWeek != lastWeek ||
+		currentYear != lastYear
+}
+
+func newMonth(lastTime time.Time, currentTime time.Time) bool {
+	return currentTime.Month() != lastTime.Month() ||
+		currentTime.Year() != lastTime.Year()
+}
+
+func newYear(lastTime time.Time, currentTime time.Time) bool {
+	return currentTime.Year() != lastTime.Year()
+}

--- a/libbeat/common/file/interval_rotator_test.go
+++ b/libbeat/common/file/interval_rotator_test.go
@@ -1,0 +1,277 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package file
+
+import (
+	"testing"
+	"time"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSecondRotator(t *testing.T) {
+	a, err := NewIntervalRotator(time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	clock := &testClock{time.Date(2018, 12, 31, 0, 0, 1, 100, time.Local)}
+	a.clock = clock
+	a.Rotate()
+	assert.Equal(t, "foo-2018-12-31-00-00-01-", a.LogPrefix("foo", time.Now()))
+
+	n := a.NewInterval()
+	assert.False(t, n)
+
+	clock.time = clock.time.Add(900 * time.Millisecond)
+	n = a.NewInterval()
+	assert.False(t, n)
+	assert.Equal(t, "foo-2018-12-31-00-00-01-", a.LogPrefix("foo", time.Now()))
+
+	clock.time = clock.time.Add(100 * time.Millisecond)
+	n = a.NewInterval()
+	assert.True(t, n)
+	a.Rotate()
+	assert.Equal(t, "foo-2018-12-31-00-00-02-", a.LogPrefix("foo", time.Now()))
+}
+
+func TestMinuteRotator(t *testing.T) {
+	a, err := NewIntervalRotator(time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	clock := &testClock{time.Date(2018, 12, 31, 0, 1, 1, 0, time.Local)}
+	a.clock = clock
+	a.Rotate()
+	assert.Equal(t, "foo-2018-12-31-00-01-", a.LogPrefix("foo", time.Now()))
+
+	n := a.NewInterval()
+	assert.False(t, n)
+
+	clock.time = clock.time.Add(58 * time.Second)
+	n = a.NewInterval()
+	assert.False(t, n)
+	assert.Equal(t, "foo-2018-12-31-00-01-", a.LogPrefix("foo", time.Now()))
+
+	clock.time = clock.time.Add(time.Second)
+	n = a.NewInterval()
+	assert.True(t, n)
+	a.Rotate()
+	assert.Equal(t, "foo-2018-12-31-00-02-", a.LogPrefix("foo", time.Now()))
+}
+
+func TestHourlyRotator(t *testing.T) {
+	a, err := NewIntervalRotator(time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	clock := &testClock{time.Date(2018, 12, 31, 1, 0, 1, 0, time.Local)}
+	a.clock = clock
+	a.Rotate()
+	assert.Equal(t, "foo-2018-12-31-01-", a.LogPrefix("foo", time.Now()))
+
+	n := a.NewInterval()
+	assert.False(t, n)
+
+	clock.time = clock.time.Add(58 * time.Minute)
+	n = a.NewInterval()
+	assert.False(t, n)
+	assert.Equal(t, "foo-2018-12-31-01-", a.LogPrefix("foo", time.Now()))
+
+	clock.time = clock.time.Add(time.Minute + 59 * time.Second)
+	n = a.NewInterval()
+	assert.True(t, n)
+	a.Rotate()
+	assert.Equal(t, "foo-2018-12-31-02-", a.LogPrefix("foo", time.Now()))
+}
+
+func TestDailyRotator(t *testing.T) {
+	a, err := NewIntervalRotator(24 * time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	clock := &testClock{time.Date(2018, 12, 31, 0, 0, 0, 0, time.Local)}
+	a.clock = clock
+	a.Rotate()
+	assert.Equal(t, "foo-2018-12-31-", a.LogPrefix("foo", time.Now()))
+
+	n := a.NewInterval()
+	assert.False(t, n)
+
+	clock.time = clock.time.Add(23 * time.Hour)
+	n = a.NewInterval()
+	assert.False(t, n)
+	assert.Equal(t, "foo-2018-12-31-", a.LogPrefix("foo", time.Now()))
+
+	clock.time = clock.time.Add(time.Hour)
+	n = a.NewInterval()
+	assert.True(t, n)
+	a.Rotate()
+	assert.Equal(t, "foo-2019-01-01-", a.LogPrefix("foo", time.Now()))
+}
+
+func TestWeeklyRotator(t *testing.T) {
+	a, err := NewIntervalRotator(7 * 24 * time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Monday, 2018-Dec-31
+	clock := &testClock{time.Date(2018, 12, 31, 0, 0, 0, 0, time.Local)}
+	a.clock = clock
+	a.Rotate()
+	assert.Equal(t, "foo-2019-01-", a.LogPrefix("foo", time.Now()))
+
+	n := a.NewInterval()
+	assert.False(t, n)
+
+	// Sunday, 2019-Jan-6
+	clock.time = clock.time.Add(6 * 24 * time.Hour)
+	n = a.NewInterval()
+	assert.False(t, n)
+	assert.Equal(t, "foo-2019-01-", a.LogPrefix("foo", time.Now()))
+
+	// Monday, 2019-Jan-7
+	clock.time = clock.time.Add(24 * time.Hour)
+	n = a.NewInterval()
+	assert.True(t, n)
+	a.Rotate()
+	assert.Equal(t, "foo-2019-02-", a.LogPrefix("foo", time.Now()))
+}
+
+func TestMonthlyRotator(t *testing.T) {
+	a, err := NewIntervalRotator(30 * 24 * time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	clock := &testClock{time.Date(2018, 12, 1, 0, 0, 0, 0, time.Local)}
+	a.clock = clock
+	a.Rotate()
+	assert.Equal(t, "foo-2018-12-", a.LogPrefix("foo", time.Now()))
+
+	n := a.NewInterval()
+	assert.False(t, n)
+
+	clock.time = clock.time.Add(30 * 24 * time.Hour)
+	n = a.NewInterval()
+	assert.False(t, n)
+	assert.Equal(t, "foo-2018-12-", a.LogPrefix("foo", time.Now()))
+
+	clock.time = clock.time.Add(24 * time.Hour)
+	n = a.NewInterval()
+	assert.True(t, n)
+	a.Rotate()
+	assert.Equal(t, "foo-2019-01-", a.LogPrefix("foo", time.Now()))
+}
+
+func TestYearlyRotator(t *testing.T) {
+	a, err := NewIntervalRotator(365 * 24 * time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	clock := &testClock{time.Date(2018, 12, 31, 0, 0, 0, 0, time.Local)}
+	a.clock = clock
+	a.Rotate()
+	assert.Equal(t, "foo-2018-", a.LogPrefix("foo", time.Now()))
+
+	n := a.NewInterval()
+	assert.False(t, n)
+
+	clock.time = clock.time.Add(23 * time.Hour)
+	n = a.NewInterval()
+	assert.False(t, n)
+	assert.Equal(t, "foo-2018-", a.LogPrefix("foo", time.Now()))
+
+	clock.time = clock.time.Add(time.Hour)
+	n = a.NewInterval()
+	assert.True(t, n)
+	a.Rotate()
+	assert.Equal(t, "foo-2019-", a.LogPrefix("foo", time.Now()))
+}
+
+
+func TestArbitraryIntervalRotator(t *testing.T) {
+	a, err := NewIntervalRotator(3 * time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Monday, 2018-Dec-31
+	clock := &testClock{time.Date(2018, 12, 31, 0, 0, 1, 0, time.Local)}
+	a.clock = clock
+	assert.Equal(t, "foo-2018-12-30-00-00-00-", a.LogPrefix("foo", time.Date(2018, 12, 30, 0, 0, 0, 0, time.Local)))
+	a.Rotate()
+	n := a.NewInterval()
+	assert.False(t, n)
+	assert.Equal(t, "foo-2018-12-31-00-00-00-", a.LogPrefix("foo", time.Now()))
+
+	clock.time = clock.time.Add(time.Second)
+	n = a.NewInterval()
+	assert.False(t, n)
+	assert.Equal(t, "foo-2018-12-31-00-00-00-", a.LogPrefix("foo", time.Now()))
+
+	clock.time = clock.time.Add(time.Second)
+	n = a.NewInterval()
+	assert.True(t, n)
+	a.Rotate()
+	assert.Equal(t, "foo-2018-12-31-00-00-03-", a.LogPrefix("foo", time.Now()))
+
+	clock.time = clock.time.Add(time.Second)
+	n = a.NewInterval()
+	assert.False(t, n)
+	assert.Equal(t, "foo-2018-12-31-00-00-03-", a.LogPrefix("foo", time.Now()))
+
+	clock.time = clock.time.Add(time.Second)
+	n = a.NewInterval()
+	assert.False(t, n)
+	assert.Equal(t, "foo-2018-12-31-00-00-03-", a.LogPrefix("foo", time.Now()))
+
+	clock.time = clock.time.Add(time.Second)
+	n = a.NewInterval()
+	assert.True(t, n)
+	a.Rotate()
+	assert.Equal(t, "foo-2018-12-31-00-00-06-", a.LogPrefix("foo", time.Now()))
+}
+
+func TestIntervalIsTruncatedToSeconds(t *testing.T) {
+	a, err := NewIntervalRotator(2345 * time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, 2*time.Second, a.interval)
+}
+
+func TestZeroIntervalIsNil(t *testing.T) {
+	a, err := NewIntervalRotator(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.True(t, a == nil)
+}
+
+type testClock struct {
+	time time.Time
+}
+
+func (t testClock) Now() time.Time {
+	return t.time
+}

--- a/libbeat/common/file/interval_rotator_test.go
+++ b/libbeat/common/file/interval_rotator_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestSecondRotator(t *testing.T) {
-	a, err := NewIntervalRotator(time.Second)
+	a, err := newIntervalRotator(time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -50,7 +50,7 @@ func TestSecondRotator(t *testing.T) {
 }
 
 func TestMinuteRotator(t *testing.T) {
-	a, err := NewIntervalRotator(time.Minute)
+	a, err := newIntervalRotator(time.Minute)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -76,7 +76,7 @@ func TestMinuteRotator(t *testing.T) {
 }
 
 func TestHourlyRotator(t *testing.T) {
-	a, err := NewIntervalRotator(time.Hour)
+	a, err := newIntervalRotator(time.Hour)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -102,7 +102,7 @@ func TestHourlyRotator(t *testing.T) {
 }
 
 func TestDailyRotator(t *testing.T) {
-	a, err := NewIntervalRotator(24 * time.Hour)
+	a, err := newIntervalRotator(24 * time.Hour)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -128,7 +128,7 @@ func TestDailyRotator(t *testing.T) {
 }
 
 func TestWeeklyRotator(t *testing.T) {
-	a, err := NewIntervalRotator(7 * 24 * time.Hour)
+	a, err := newIntervalRotator(7 * 24 * time.Hour)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -157,7 +157,7 @@ func TestWeeklyRotator(t *testing.T) {
 }
 
 func TestMonthlyRotator(t *testing.T) {
-	a, err := NewIntervalRotator(30 * 24 * time.Hour)
+	a, err := newIntervalRotator(30 * 24 * time.Hour)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -183,7 +183,7 @@ func TestMonthlyRotator(t *testing.T) {
 }
 
 func TestYearlyRotator(t *testing.T) {
-	a, err := NewIntervalRotator(365 * 24 * time.Hour)
+	a, err := newIntervalRotator(365 * 24 * time.Hour)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -210,7 +210,7 @@ func TestYearlyRotator(t *testing.T) {
 
 
 func TestArbitraryIntervalRotator(t *testing.T) {
-	a, err := NewIntervalRotator(3 * time.Second)
+	a, err := newIntervalRotator(3 * time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -253,7 +253,7 @@ func TestArbitraryIntervalRotator(t *testing.T) {
 }
 
 func TestIntervalIsTruncatedToSeconds(t *testing.T) {
-	a, err := NewIntervalRotator(2345 * time.Millisecond)
+	a, err := newIntervalRotator(2345 * time.Millisecond)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -261,7 +261,7 @@ func TestIntervalIsTruncatedToSeconds(t *testing.T) {
 }
 
 func TestZeroIntervalIsNil(t *testing.T) {
-	a, err := NewIntervalRotator(0)
+	a, err := newIntervalRotator(0)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libbeat/common/file/interval_rotator_test.go
+++ b/libbeat/common/file/interval_rotator_test.go
@@ -20,6 +20,7 @@ package file
 import (
 	"testing"
 	"time"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -94,7 +95,7 @@ func TestHourlyRotator(t *testing.T) {
 	assert.False(t, n)
 	assert.Equal(t, "foo-2018-12-31-01-", a.LogPrefix("foo", time.Now()))
 
-	clock.time = clock.time.Add(time.Minute + 59 * time.Second)
+	clock.time = clock.time.Add(time.Minute + 59*time.Second)
 	n = a.NewInterval()
 	assert.True(t, n)
 	a.Rotate()
@@ -207,7 +208,6 @@ func TestYearlyRotator(t *testing.T) {
 	a.Rotate()
 	assert.Equal(t, "foo-2019-", a.LogPrefix("foo", time.Now()))
 }
-
 
 func TestArbitraryIntervalRotator(t *testing.T) {
 	a, err := newIntervalRotator(3 * time.Second)

--- a/libbeat/common/file/rotator.go
+++ b/libbeat/common/file/rotator.go
@@ -115,8 +115,8 @@ func WithLogger(l Logger) RotatorOption {
 	}
 }
 
-// Daily enables or disables log rotation by time interval in addition to log
-// rotation by size. The default is disabled.
+// Interval sets the time interval for log rotation in addition to log
+// rotation by size. The default is 0 for disabled.
 func Interval(d time.Duration) RotatorOption {
 	return func(r *Rotator) {
 		r.interval = d
@@ -147,7 +147,7 @@ func NewFileRotator(filename string, options ...RotatorOption) (*Rotator, error)
 		return nil, errors.Errorf("file rotator permissions mask of %o is invalid", r.permissions)
 	}
 	var err error
-	r.intervalRotator, err = NewIntervalRotator(r.interval)
+	r.intervalRotator, err = newIntervalRotator(r.interval)
 	if err != nil {
 		return nil, err
 	}

--- a/libbeat/common/file/rotator.go
+++ b/libbeat/common/file/rotator.go
@@ -328,7 +328,6 @@ func (r *Rotator) purgeOldIntervalBackups() error {
 	return nil
 }
 
-
 func (r *Rotator) purgeOldSizedBackups() error {
 	for i := r.maxBackups; i < MaxBackupsLimit; i++ {
 		name := r.backupName(i + 1)
@@ -368,7 +367,7 @@ func (r *Rotator) rotate(reason rotateReason) error {
 }
 
 func (r *Rotator) rotateByInterval(reason rotateReason) error {
-	fi, err :=  os.Stat(r.filename)
+	fi, err := os.Stat(r.filename)
 	if os.IsNotExist(err) {
 		return nil
 	} else if err != nil {

--- a/libbeat/common/file/rotator_test.go
+++ b/libbeat/common/file/rotator_test.go
@@ -139,7 +139,7 @@ func TestDailyRotation(t *testing.T) {
 
 	maxSizeBytes := uint(500)
 	filename := filepath.Join(dir, logname)
-	r, err := file.NewFileRotator(filename, file.MaxBackups(2), file.Daily(true), file.MaxSizeBytes(maxSizeBytes))
+	r, err := file.NewFileRotator(filename, file.MaxBackups(2), file.Interval(24*time.Hour), file.MaxSizeBytes(maxSizeBytes))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libbeat/common/file/rotator_test.go
+++ b/libbeat/common/file/rotator_test.go
@@ -24,6 +24,7 @@ import (
 	"sort"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -97,6 +98,86 @@ func TestFileRotatorConcurrently(t *testing.T) {
 		}()
 	}
 	wg.Wait()
+}
+
+func TestDailyRotation(t *testing.T) {
+	dir, err := ioutil.TempDir("", "daily_file_rotator")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	logname := "daily"
+	dateFormat := "2006-01-02"
+	today := time.Now().Format(dateFormat)
+	yesterday := time.Now().AddDate(0, 0, -1).Format(dateFormat)
+	twoDaysAgo := time.Now().AddDate(0, 0, -2).Format(dateFormat)
+
+	// seed directory with existing log files
+	files := []string{
+		logname + "-" + yesterday + "-1",
+		logname + "-" + yesterday + "-2",
+		logname + "-" + yesterday + "-3",
+		logname + "-" + yesterday + "-4",
+		logname + "-" + yesterday + "-5",
+		logname + "-" + yesterday + "-6",
+		logname + "-" + yesterday + "-7",
+		logname + "-" + yesterday + "-8",
+		logname + "-" + yesterday + "-9",
+		logname + "-" + yesterday + "-10",
+		logname + "-" + yesterday + "-11",
+		logname + "-" + yesterday + "-12",
+		logname + "-" + yesterday + "-13",
+		logname + "-" + twoDaysAgo + "-1",
+		logname + "-" + twoDaysAgo + "-2",
+		logname + "-" + twoDaysAgo + "-3",
+	}
+
+	for _, f := range files {
+		CreateFile(t, filepath.Join(dir, f))
+	}
+
+	maxSizeBytes := uint(500)
+	filename := filepath.Join(dir, logname)
+	r, err := file.NewFileRotator(filename, file.MaxBackups(2), file.Daily(true), file.MaxSizeBytes(maxSizeBytes))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+
+	Rotate(t, r)
+
+	AssertDirContents(t, dir, logname+"-"+yesterday+"-12", logname+"-"+yesterday+"-13")
+
+	WriteMsg(t, r)
+
+	AssertDirContents(t, dir, logname+"-"+yesterday+"-12", logname+"-"+yesterday+"-13", logname)
+
+	Rotate(t, r)
+
+	AssertDirContents(t, dir, logname+"-"+yesterday+"-13", logname+"-"+today+"-1")
+
+	WriteMsg(t, r)
+
+	AssertDirContents(t, dir, logname+"-"+yesterday+"-13", logname+"-"+today+"-1", logname)
+
+	for i := 0; i < (int(maxSizeBytes)/len(logMessage))+1; i++ {
+		WriteMsg(t, r)
+	}
+
+	AssertDirContents(t, dir, logname+"-"+today+"-1", logname+"-"+today+"-2", logname)
+}
+
+func CreateFile(t *testing.T, filename string) {
+	t.Helper()
+	f, err := os.Create(filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = f.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
 }
 
 func AssertDirContents(t *testing.T, dir string, files ...string) {

--- a/libbeat/docs/loggingconfig.asciidoc
+++ b/libbeat/docs/loggingconfig.asciidoc
@@ -156,6 +156,12 @@ Examples:
 associated with the file, as well as read access to all other users.
 
 [float]
+==== `logging.files.daily`
+
+Enables daily log file rotation in addition to size-based rotation. Defaults to disabled.
+
+
+[float]
 ==== `logging.json`
 
 When true, logs messages in JSON format. The default is false.

--- a/libbeat/docs/loggingconfig.asciidoc
+++ b/libbeat/docs/loggingconfig.asciidoc
@@ -156,10 +156,13 @@ Examples:
 associated with the file, as well as read access to all other users.
 
 [float]
-==== `logging.files.daily`
+==== `logging.files.interval`
 
-Enables daily log file rotation in addition to size-based rotation. Defaults to disabled.
-
+Enable log file rotation on time intervals in addition to size-based rotation.
+Intervals must be at least 1s. Values of 1m, 1h, 24h, 7*24h, 30*24h, and 365*24h
+are boundary-aligned with minutes, hours, days, weeks, months, and years as
+reported by the local system clock. All other intervals are calculated from the
+unix epoch. Defaults to disabled.
 
 [float]
 ==== `logging.json`

--- a/libbeat/logp/config.go
+++ b/libbeat/logp/config.go
@@ -17,6 +17,8 @@
 
 package logp
 
+import "time"
+
 // Config contains the configuration options for the logger. To create a Config
 // from a common.Config use logp/config.Build.
 type Config struct {
@@ -40,12 +42,12 @@ type Config struct {
 
 // FileConfig contains the configuration options for the file output.
 type FileConfig struct {
-	Path        string `config:"path"`
-	Name        string `config:"name"`
-	MaxSize     uint   `config:"rotateeverybytes" validate:"min=1"`
-	MaxBackups  uint   `config:"keepfiles" validate:"max=1024"`
-	Permissions uint32 `config:"permissions"`
-	Daily       bool   `config:"daily"`
+	Path        string        `config:"path"`
+	Name        string        `config:"name"`
+	MaxSize     uint          `config:"rotateeverybytes" validate:"min=1"`
+	MaxBackups  uint          `config:"keepfiles" validate:"max=1024"`
+	Permissions uint32        `config:"permissions"`
+	Interval    time.Duration `config:"interval"`
 }
 
 var defaultConfig = Config{
@@ -55,7 +57,7 @@ var defaultConfig = Config{
 		MaxSize:     10 * 1024 * 1024,
 		MaxBackups:  7,
 		Permissions: 0600,
-		Daily:       false,
+		Interval:    0,
 	},
 	addCaller: true,
 }

--- a/libbeat/logp/config.go
+++ b/libbeat/logp/config.go
@@ -45,6 +45,7 @@ type FileConfig struct {
 	MaxSize     uint   `config:"rotateeverybytes" validate:"min=1"`
 	MaxBackups  uint   `config:"keepfiles" validate:"max=1024"`
 	Permissions uint32 `config:"permissions"`
+	Daily       bool   `config:"daily"`
 }
 
 var defaultConfig = Config{
@@ -54,6 +55,7 @@ var defaultConfig = Config{
 		MaxSize:     10 * 1024 * 1024,
 		MaxBackups:  7,
 		Permissions: 0600,
+		Daily:       false,
 	},
 	addCaller: true,
 }

--- a/libbeat/logp/core.go
+++ b/libbeat/logp/core.go
@@ -196,7 +196,7 @@ func makeFileOutput(cfg Config) (zapcore.Core, error) {
 		file.MaxSizeBytes(cfg.Files.MaxSize),
 		file.MaxBackups(cfg.Files.MaxBackups),
 		file.Permissions(os.FileMode(cfg.Files.Permissions)),
-		file.Daily(cfg.Files.Daily),
+		file.Interval(cfg.Files.Interval),
 	)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create file rotator")

--- a/libbeat/logp/core.go
+++ b/libbeat/logp/core.go
@@ -196,6 +196,7 @@ func makeFileOutput(cfg Config) (zapcore.Core, error) {
 		file.MaxSizeBytes(cfg.Files.MaxSize),
 		file.MaxBackups(cfg.Files.MaxBackups),
 		file.Permissions(os.FileMode(cfg.Files.Permissions)),
+		file.Daily(cfg.Files.Daily),
 	)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create file rotator")

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -1107,11 +1107,11 @@ output.elasticsearch:
   # and retry until all events are published.  Set max_retries to a value less
   # than 0 to retry until all events are published. The default is 3.
   #max_retries: 3
-  
+
   # The maximum number of events to bulk in a single Logstash request. The
   # default is 2048.
   #bulk_max_size: 2048
-  
+
   # The number of seconds to wait for responses from the Logstash server before
   # timing out. The default is 30s.
   #timeout: 30s
@@ -1665,6 +1665,10 @@ logging.files:
   # The permissions mask to apply when rotating log files. The default value is 0600.
   # Must be a valid Unix-style file permissions mask expressed in octal notation.
   #permissions: 0600
+
+  # Enable daily log file rotation in addition to size-based rotation. Defaults to
+  # disabled.
+  #daily: true
 
 # Set to true to log messages in json format.
 #logging.json: false

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -1666,9 +1666,12 @@ logging.files:
   # Must be a valid Unix-style file permissions mask expressed in octal notation.
   #permissions: 0600
 
-  # Enable daily log file rotation in addition to size-based rotation. Defaults to
-  # disabled.
-  #daily: true
+  # Enable log file rotation on time intervals in addition to size-based rotation.
+  # Intervals must be at least 1s. Values of 1m, 1h, 24h, 7*24h, 30*24h, and 365*24h
+  # are boundary-aligned with minutes, hours, days, weeks, months, and years as
+  # reported by the local system clock. All other intervals are calculated from the
+  # unix epoch. Defaults to disabled.
+  #interval: 0
 
 # Set to true to log messages in json format.
 #logging.json: false

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -1478,9 +1478,12 @@ logging.files:
   # Must be a valid Unix-style file permissions mask expressed in octal notation.
   #permissions: 0600
 
-  # Enable daily log file rotation in addition to size-based rotation. Defaults to
-  # disabled.
-  #daily: true
+  # Enable log file rotation on time intervals in addition to size-based rotation.
+  # Intervals must be at least 1s. Values of 1m, 1h, 24h, 7*24h, 30*24h, and 365*24h
+  # are boundary-aligned with minutes, hours, days, weeks, months, and years as
+  # reported by the local system clock. All other intervals are calculated from the
+  # unix epoch. Defaults to disabled.
+  #interval: 0
 
 # Set to true to log messages in json format.
 #logging.json: false

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -919,11 +919,11 @@ output.elasticsearch:
   # and retry until all events are published.  Set max_retries to a value less
   # than 0 to retry until all events are published. The default is 3.
   #max_retries: 3
-  
+
   # The maximum number of events to bulk in a single Logstash request. The
   # default is 2048.
   #bulk_max_size: 2048
-  
+
   # The number of seconds to wait for responses from the Logstash server before
   # timing out. The default is 30s.
   #timeout: 30s
@@ -1477,6 +1477,10 @@ logging.files:
   # The permissions mask to apply when rotating log files. The default value is 0600.
   # Must be a valid Unix-style file permissions mask expressed in octal notation.
   #permissions: 0600
+
+  # Enable daily log file rotation in addition to size-based rotation. Defaults to
+  # disabled.
+  #daily: true
 
 # Set to true to log messages in json format.
 #logging.json: false

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -1018,9 +1018,12 @@ logging.files:
   # Must be a valid Unix-style file permissions mask expressed in octal notation.
   #permissions: 0600
 
-  # Enable daily log file rotation in addition to size-based rotation. Defaults to
-  # disabled.
-  #daily: true
+  # Enable log file rotation on time intervals in addition to size-based rotation.
+  # Intervals must be at least 1s. Values of 1m, 1h, 24h, 7*24h, 30*24h, and 365*24h
+  # are boundary-aligned with minutes, hours, days, weeks, months, and years as
+  # reported by the local system clock. All other intervals are calculated from the
+  # unix epoch. Defaults to disabled.
+  #interval: 0
 
 # Set to true to log messages in json format.
 #logging.json: false

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -459,11 +459,11 @@ output.elasticsearch:
   # and retry until all events are published.  Set max_retries to a value less
   # than 0 to retry until all events are published. The default is 3.
   #max_retries: 3
-  
+
   # The maximum number of events to bulk in a single Logstash request. The
   # default is 2048.
   #bulk_max_size: 2048
-  
+
   # The number of seconds to wait for responses from the Logstash server before
   # timing out. The default is 30s.
   #timeout: 30s
@@ -1017,6 +1017,10 @@ logging.files:
   # The permissions mask to apply when rotating log files. The default value is 0600.
   # Must be a valid Unix-style file permissions mask expressed in octal notation.
   #permissions: 0600
+
+  # Enable daily log file rotation in addition to size-based rotation. Defaults to
+  # disabled.
+  #daily: true
 
 # Set to true to log messages in json format.
 #logging.json: false


### PR DESCRIPTION
Adds optional log rotation by time interval in addition to size-based log rotation. It's modeled after ES's log rotation which defaults to daily log rotation in which the current log file is rotated to _filename_-yyyy-MM-dd-n where _n_ is incremented if either the max file size is reached or a beat is started more than once per day. The rotation interval is configurable down to `1s`. Values of `1m`, `1h`, `24h`, `7*24h`, `30*24h`, and `365*24h` are treated specially by being boundary-aligned with minutes, hours, days, weeks, months, and years as reported by the local system clock.

The `keepfiles` setting is also honored as the oldest backup files are removed during rotation.

Fixes #7990.
