### PR TITLE
Cherry-pick #8316 to 6.x: Add required comments to heartbeat monitors

### DIFF
--- a/heartbeat/monitors/monitor.go
+++ b/heartbeat/monitors/monitor.go
@@ -215,6 +215,7 @@ func (m *Monitor) makeWatchTasks(monitorPlugin pluginBuilder) error {
 	return nil
 }
 
+// Start starts the monitor's execution using its configured scheduler.
 func (m *Monitor) Start() {
 	m.internalsMtx.Lock()
 	defer m.internalsMtx.Unlock()
@@ -228,6 +229,8 @@ func (m *Monitor) Start() {
 	}
 }
 
+// Stop stops the Monitor's execution in its configured scheduler.
+// This is safe to call even if the Monitor was never started.
 func (m *Monitor) Stop() {
 	m.internalsMtx.Lock()
 	defer m.internalsMtx.Unlock()

--- a/heartbeat/monitors/pluginconf.go
+++ b/heartbeat/monitors/pluginconf.go
@@ -18,19 +18,15 @@
 package monitors
 
 import (
-	"fmt"
-
 	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/libbeat/common"
 )
 
-type PluginDisabledError struct{}
+// ErrPluginDisabled is returned when the monitor plugin is marked as disabled.
+var ErrPluginDisabled = errors.New("Monitor not loaded, plugin is disabled")
 
-func (e PluginDisabledError) Error() string {
-	return fmt.Sprintf("Monitor not loaded, plugin is disabled")
-}
-
+// MonitorPluginInfo represents the generic configuration options around a monitor plugin.
 type MonitorPluginInfo struct {
 	Type    string `config:"type" validate:"required"`
 	Enabled bool   `config:"enabled"`
@@ -44,7 +40,7 @@ func pluginInfo(config *common.Config) (MonitorPluginInfo, error) {
 	}
 
 	if !mpi.Enabled {
-		return mpi, PluginDisabledError{}
+		return mpi, ErrPluginDisabled
 	}
 
 	return mpi, nil


### PR DESCRIPTION
Cherry-pick of PR #8316 to 6.x branch. Original message: 

Some of these functions needed comments to keep inline with go style guides. The change that introduced these was in #8023 .

I also simplified one error by using errors.New instead of a custom error struct.