### PR TITLE
Remove link to Topbeat download page

### DIFF
--- a/topbeat/docs/gettingstarted.asciidoc
+++ b/topbeat/docs/gettingstarted.asciidoc
@@ -25,8 +25,6 @@ mac>> for OS X, and <<win, win>> for Windows).
 [NOTE]
 ==================================================
 If you use Apt or Yum, you can {libbeat}/setup-repositories.html[install Topbeat from our repositories] to update to the newest version more easily.
-
-See our https://www.elastic.co/downloads/beats/topbeat[download page] for other installation options, such as 32-bit images.
 ==================================================
 
 [[deb]]
@@ -59,8 +57,7 @@ tar xzvf topbeat-{version}-darwin.tgz
 [[win]]
 *win:*
 
-. Download the Topbeat Windows zip file from the
-https://www.elastic.co/downloads/beats/topbeat[downloads page].
+. Download the Topbeat https://download.elastic.co/beats/topbeat/topbeat-1.3.1-windows.zip[Windows zip file].
 
 . Extract the contents of the zip file into `C:\Program Files`.
 

--- a/topbeat/docs/page_header.html
+++ b/topbeat/docs/page_header.html
@@ -1,0 +1,4 @@
+Topbeat was replaced by <a href="https://www.elastic.co/products/beats/metricbeat">
+Metricbeat</a> in 5.0. To learn more about Metricbeat, see the
+<a href="https://www.elastic.co/guide/en/beats/metricbeat/current/index.html">
+Metricbeat documentation</a>. 


### PR DESCRIPTION
Removed link to download page in preparation for https://github.com/elastic/website-www.elastic.co/issues/2210.

Added a header that will appear on every page to point users to Metricbeat.