### PR TITLE
Update newbeat.asciidoc

### DIFF
--- a/docs/devguide/newbeat.asciidoc
+++ b/docs/devguide/newbeat.asciidoc
@@ -39,9 +39,10 @@ original Packetbeat authors.
 
 For general information about contributing to Beats, see <<beats-contributing>>.
 
-After you have https://golang.org/doc/install[installed Go] and set up the
+After you have https://golang.org/doc/install[installed Go] make sure you have set up the
 https://golang.org/doc/code.html#GOPATH[GOPATH] environment variable to point to
-your preferred workspace location, clone the Beats repository in the correct location
+your preferred workspace location and that your Go bin directory is on your PATH.
+Once Go is configured clone the Beats repository in the correct location
 under `GOPATH`:
 
 [source,shell]


### PR DESCRIPTION
If your go bin is not on your path then make setup fails as the steps after building mage assume it can be run using the filename alone. Alternative fix would be to change the setup code to use $GOPATH/bin/mage instead of just calling mage and assuming it is on the path.