### PR TITLE
Cherry-pick #8367 to 6.4: [auditbeat] Improve file monitor flaky test

### DIFF
--- a/auditbeat/module/file_integrity/monitor/monitor_test.go
+++ b/auditbeat/module/file_integrity/monitor/monitor_test.go
@@ -293,17 +293,30 @@ func testDirOps(t *testing.T, dir string, watcher Watcher) {
 	assert.Equal(t, fpath, ev.Name)
 	assert.Equal(t, fsnotify.Write, ev.Op)
 
+	// Consume all leftover writes to fpath
+	for err == nil && ev.Name == fpath && ev.Op == fsnotify.Write {
+		ev, err = readTimeout(t, watcher)
+	}
+
+	// Helper to read events ignoring a write to the parent dir, which seems
+	// to trigger sometimes under Windows when moving files around in a dir.
+	readIgnoreParent := func(t *testing.T, w Watcher) (fsnotify.Event, error) {
+		for {
+			ev, err := readTimeout(t, w)
+			if err != nil || ev.Name != dir || ev.Op != fsnotify.Write {
+				return ev, err
+			}
+		}
+	}
+
 	// Move
 	err = os.Rename(fpath, fpath2)
 	assertNoError(t, err)
 
-	evRename, err := readTimeout(t, watcher)
+	evRename, err := readIgnoreParent(t, watcher)
 	assertNoError(t, err)
-	// Sometimes a duplicate Write can be received under Linux, skip
-	if evRename.Op == fsnotify.Write {
-		evRename, err = readTimeout(t, watcher)
-	}
-	evCreate, err := readTimeout(t, watcher)
+
+	evCreate, err := readIgnoreParent(t, watcher)
 	assertNoError(t, err)
 
 	if evRename.Op != fsnotify.Rename {
@@ -320,14 +333,9 @@ func testDirOps(t *testing.T, dir string, watcher Watcher) {
 	err = os.Remove(fpath2)
 	assertNoError(t, err)
 
-	ev, err = readTimeout(t, watcher)
+	ev, err = readIgnoreParent(t, watcher)
 	assertNoError(t, err)
 
-	// Windows: A write to the parent directory sneaks in
-	if ev.Op == fsnotify.Write && ev.Name == dir {
-		ev, err = readTimeout(t, watcher)
-		assertNoError(t, err)
-	}
 	assert.Equal(t, fpath2, ev.Name)
 	assert.Equal(t, fsnotify.Remove, ev.Op)
 }


### PR DESCRIPTION
Cherry-pick of PR #8367 to 6.4 branch. Original message: 

This is to prevent flaky test failures that have been occurring under Windows recently.

Closes #8208