### PR TITLE
Cherry-pick #8347 to 6.4: Reduce errors on filebeat syslog stop

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -33,6 +33,8 @@ https://github.com/elastic/beats/compare/v6.4.1...6.4[Check the HEAD diff]
 
 *Filebeat*
 
+- Fix some errors happening when stopping syslog input. {pull}8347[8347]
+
 *Heartbeat*
 
 *Metricbeat*

--- a/filebeat/input/syslog/input.go
+++ b/filebeat/input/syslog/input.go
@@ -174,6 +174,7 @@ func (p *Input) Run() {
 		err := p.server.Start()
 		if err != nil {
 			p.log.Error("Error starting the server", "error", err)
+			return
 		}
 		p.started = true
 	}
@@ -184,6 +185,10 @@ func (p *Input) Stop() {
 	defer p.outlet.Close()
 	p.Lock()
 	defer p.Unlock()
+
+	if !p.started {
+		return
+	}
 
 	p.log.Info("Stopping Syslog input")
 	p.server.Stop()


### PR DESCRIPTION
Cherry-pick of PR #8347 to 6.4 branch. Original message: 

Fix a couple of errors seen when syslog input is stopped.

In case the input couldn't be started (e.g. port was already in use), there was a nil pointer reference when trying to stop it:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x12facac]

goroutine 81 [running]:
github.com/elastic/beats/filebeat/inputsource/udp.(*Server).Stop(0xc42008a100)
	/go/src/github.com/elastic/beats/filebeat/inputsource/udp/server.go:118 +0x7c
github.com/elastic/beats/filebeat/input/syslog.(*Input).Stop(0xc42008a140)
	/go/src/github.com/elastic/beats/filebeat/input/syslog/input.go:189 +0xeb
github.com/elastic/beats/filebeat/input.(*Runner).stop(0xc42025e2a0)
	/go/src/github.com/elastic/beats/filebeat/input/input.go:173 +0xcd
github.com/elastic/beats/filebeat/input.(*Runner).Start.func1.1(0xc420277410, 0xc42025e2a0)
	/go/src/github.com/elastic/beats/filebeat/input/input.go:128 +0x39
github.com/elastic/beats/filebeat/input.(*Runner).Start.func1(0xc420277410, 0xc42025e2a0)
	/go/src/github.com/elastic/beats/filebeat/input/input.go:133 +0x5c
created by github.com/elastic/beats/filebeat/input.(*Runner).Start
	/go/src/github.com/elastic/beats/filebeat/input/input.go:125 +0x16e
```

In any case, on stop, this error was logged lots of times:
```
2018-09-18T17:37:42.818Z	ERROR	[udp]	udp/server.go:99	Error reading from the socket *net.OpError read udp 127.0.0.1:9000: use of closed network connection	{"address": "localhost:9000"}
```