### PR TITLE
Refactor how configs are stored

### DIFF
--- a/x-pack/libbeat/management/api/configuration.go
+++ b/x-pack/libbeat/management/api/configuration.go
@@ -20,8 +20,14 @@ type ConfigBlock struct {
 	Raw map[string]interface{}
 }
 
-// ConfigBlocks holds a map of type -> list of configs
-type ConfigBlocks map[string][]*ConfigBlock
+// ConfigBlocksWithType is a list of config blocks with the same type
+type ConfigBlocksWithType struct {
+	Type   string
+	Blocks []*ConfigBlock
+}
+
+// ConfigBlocks holds a list of type + configs objects
+type ConfigBlocks []ConfigBlocksWithType
 
 // Config returns a common.Config object holding the config from this block
 func (c *ConfigBlock) Config() (*common.Config, error) {
@@ -55,9 +61,14 @@ func (c *Client) Configuration(accessToken string, beatUUID uuid.UUID) (ConfigBl
 		return nil, err
 	}
 
-	res := ConfigBlocks{}
+	blocks := map[string][]*ConfigBlock{}
 	for _, block := range resp.ConfigBlocks {
-		res[block.Type] = append(res[block.Type], &ConfigBlock{Raw: block.Raw})
+		blocks[block.Type] = append(blocks[block.Type], &ConfigBlock{Raw: block.Raw})
+	}
+
+	res := ConfigBlocks{}
+	for t, b := range blocks {
+		res = append(res, ConfigBlocksWithType{Type: t, Blocks: b})
 	}
 
 	return res, nil

--- a/x-pack/libbeat/management/api/configuration_test.go
+++ b/x-pack/libbeat/management/api/configuration_test.go
@@ -33,14 +33,24 @@ func TestConfiguration(t *testing.T) {
 	}
 
 	assert.Equal(t, 2, len(configs))
-	assert.Equal(t, &ConfigBlock{Raw: map[string]interface{}{
-		"module": "apache2",
-	}}, configs["filebeat.modules"][0])
+	checked := 0
+	for _, config := range configs {
+		if config.Type == "metricbeat.modules" {
+			assert.Equal(t, &ConfigBlock{Raw: map[string]interface{}{
+				"module": "system",
+				"period": "10s",
+			}}, config.Blocks[0])
+			checked++
 
-	assert.Equal(t, &ConfigBlock{Raw: map[string]interface{}{
-		"module": "system",
-		"period": "10s",
-	}}, configs["metricbeat.modules"][0])
+		} else if config.Type == "filebeat.modules" {
+			assert.Equal(t, &ConfigBlock{Raw: map[string]interface{}{
+				"module": "apache2",
+			}}, config.Blocks[0])
+			checked++
+		}
+	}
+
+	assert.Equal(t, 2, checked)
 }
 
 func TestConfigBlocksEqual(t *testing.T) {
@@ -58,19 +68,25 @@ func TestConfigBlocksEqual(t *testing.T) {
 		{
 			name: "single element",
 			a: ConfigBlocks{
-				"metricbeat.modules": []*ConfigBlock{
-					&ConfigBlock{
-						Raw: map[string]interface{}{
-							"foo": "bar",
+				ConfigBlocksWithType{
+					Type: "metricbeat.modules",
+					Blocks: []*ConfigBlock{
+						&ConfigBlock{
+							Raw: map[string]interface{}{
+								"foo": "bar",
+							},
 						},
 					},
 				},
 			},
 			b: ConfigBlocks{
-				"metricbeat.modules": []*ConfigBlock{
-					&ConfigBlock{
-						Raw: map[string]interface{}{
-							"foo": "bar",
+				ConfigBlocksWithType{
+					Type: "metricbeat.modules",
+					Blocks: []*ConfigBlock{
+						&ConfigBlock{
+							Raw: map[string]interface{}{
+								"foo": "bar",
+							},
 						},
 					},
 				},
@@ -80,24 +96,30 @@ func TestConfigBlocksEqual(t *testing.T) {
 		{
 			name: "different number of blocks",
 			a: ConfigBlocks{
-				"metricbeat.modules": []*ConfigBlock{
-					&ConfigBlock{
-						Raw: map[string]interface{}{
-							"foo": "bar",
+				ConfigBlocksWithType{
+					Type: "metricbeat.modules",
+					Blocks: []*ConfigBlock{
+						&ConfigBlock{
+							Raw: map[string]interface{}{
+								"foo": "bar",
+							},
 						},
-					},
-					&ConfigBlock{
-						Raw: map[string]interface{}{
-							"baz": "buzz",
+						&ConfigBlock{
+							Raw: map[string]interface{}{
+								"baz": "buzz",
+							},
 						},
 					},
 				},
 			},
 			b: ConfigBlocks{
-				"metricbeat.modules": []*ConfigBlock{
-					&ConfigBlock{
-						Raw: map[string]interface{}{
-							"foo": "bar",
+				ConfigBlocksWithType{
+					Type: "metricbeat.modules",
+					Blocks: []*ConfigBlock{
+						&ConfigBlock{
+							Raw: map[string]interface{}{
+								"foo": "bar",
+							},
 						},
 					},
 				},
@@ -107,19 +129,27 @@ func TestConfigBlocksEqual(t *testing.T) {
 		{
 			name: "different block",
 			a: ConfigBlocks{
-				"metricbeat.modules": []*ConfigBlock{
-					&ConfigBlock{
-						Raw: map[string]interface{}{
-							"baz": "buzz",
+				ConfigBlocksWithType{
+					Type: "metricbeat.modules",
+					Blocks: []*ConfigBlock{
+
+						&ConfigBlock{
+							Raw: map[string]interface{}{
+								"baz": "buzz",
+							},
 						},
 					},
 				},
 			},
 			b: ConfigBlocks{
-				"metricbeat.modules": []*ConfigBlock{
-					&ConfigBlock{
-						Raw: map[string]interface{}{
-							"foo": "bar",
+				ConfigBlocksWithType{
+					Type: "metricbeat.modules",
+					Blocks: []*ConfigBlock{
+
+						&ConfigBlock{
+							Raw: map[string]interface{}{
+								"foo": "bar",
+							},
 						},
 					},
 				},

--- a/x-pack/libbeat/management/manager.go
+++ b/x-pack/libbeat/management/manager.go
@@ -152,14 +152,15 @@ func (cm *ConfigManager) fetch() bool {
 		return false
 	}
 
+	cm.logger.Info("New configurations retrieved")
 	cm.config.Configs = configs
 
 	return true
 }
 
 func (cm *ConfigManager) apply() {
-	for blockType, blockList := range cm.config.Configs {
-		cm.reload(blockType, blockList)
+	for _, b := range cm.config.Configs {
+		cm.reload(b.Type, b.Blocks)
 	}
 }
 


### PR DESCRIPTION
Previous approach had some issues related to YAML, here:

```
configs:
  metricbeat.modules:
    - ...
  output:
    - ...
``` 

`metricbeat.modules` cannot be a key as it contains dots and creates hierarchy.

This change moves to a list based store like:

```
configs:
  - type: metricbeat.modules
    blocks:
      - ....
``` 

I also did some minor refactoring to how config changes are handled