### PR TITLE
Change accept to accept4 for 32-bit

### DIFF
--- a/auditbeat/module/auditd/_meta/audit.rules.d/sample-rules-linux-32bit.conf
+++ b/auditbeat/module/auditd/_meta/audit.rules.d/sample-rules-linux-32bit.conf
@@ -2,7 +2,7 @@
 -a always,exit -F arch=b32 -S execve,execveat -k exec
 
 ## External access (warning: these can be expensive to audit).
--a always,exit -F arch=b32 -S accept,bind,connect -F key=external-access
+-a always,exit -F arch=b32 -S accept4,bind,connect -F key=external-access
 
 ## Identity changes.
 -w /etc/group -p wa -k identity


### PR DESCRIPTION
For i386 the accept syscall is named `accept4`.