### PR TITLE
package dashboards with qualified version

### DIFF
--- a/dev-tools/mage/settings.go
+++ b/dev-tools/mage/settings.go
@@ -320,7 +320,7 @@ var (
 // BeatQualifiedVersion returns the Beat's qualified version.  The value can be overwritten by
 // setting BEAT_VERSION_QUALIFIER in the environment.
 func BeatQualifiedVersion() (string, error) {
-	version, err := BeatVersion()
+	version, err := beatVersion()
 	if err != nil {
 		return "", err
 	}
@@ -333,7 +333,7 @@ func BeatQualifiedVersion() (string, error) {
 
 // BeatVersion returns the Beat's version. The value can be overridden by
 // setting BEAT_VERSION in the environment.
-func BeatVersion() (string, error) {
+func beatVersion() (string, error) {
 	beatVersionOnce.Do(func() {
 		beatVersionValue = os.Getenv("BEAT_VERSION")
 		if beatVersionValue != "" {

--- a/magefile.go
+++ b/magefile.go
@@ -40,7 +40,7 @@ var (
 // PackageBeatDashboards packages the dashboards from all Beats into a zip
 // file. The dashboards must be generated first.
 func PackageBeatDashboards() error {
-	version, err := mage.BeatVersion()
+	version, err := mage.BeatQualifiedVersion()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
before:
```
$ BEAT_VERSION_QUALIFIER=alpha2 mage PackageBeatDashboards
$ find build/distributions/dashboards
build/distributions/dashboards/beats-dashboards-7.0.0.zip.sha512
build/distributions/dashboards/beats-dashboards-7.0.0.zip
```

after:
```
$ BEAT_VERSION_QUALIFIER=alpha2 mage PackageBeatDashboards
$ find build/distributions/dashboards
build/distributions/dashboards/beats-dashboards-7.0.0-alpha2.zip
build/distributions/dashboards/beats-dashboards-7.0.0-alpha2.zip.sha512
```