### PR TITLE
Suppress dashboard info when dashboards aren't available

### DIFF
--- a/filebeat/docs/include/setup-command.asciidoc
+++ b/filebeat/docs/include/setup-command.asciidoc
@@ -21,8 +21,8 @@ PS > .{backslash}{beatname_lc}.exe setup -e
 ----
 
 The <<setup-command,`setup`>> command loads the recommended index template for
-writing to {es} and deploys the sample dashboards for visualizing the
-data in {kib}. This is a one-time setup step. 
+writing to {es} and deploys the sample dashboards (if available) for visualizing
+the data in {kib}. This is a one-time setup step. 
 
 The `-e` flag is optional and sends output to standard error instead of syslog.
 --

--- a/filebeat/docs/include/visualize-data.asciidoc
+++ b/filebeat/docs/include/visualize-data.asciidoc
@@ -1,3 +1,4 @@
+ifeval::["{has-dashboards}"=="true"]
 . Explore your data in {kib}:
 +
 .. Open your browser and navigate to the *Dashboard* overview in {kib}:
@@ -11,3 +12,4 @@ the visualizations for your parsed logs.
 +
 TIP: If you don’t see data in {kib}, try changing the date range to a larger
 range. By default, {kib} shows the last 15 minutes.
+endif::[]

--- a/filebeat/docs/include/what-happens.asciidoc
+++ b/filebeat/docs/include/what-happens.asciidoc
@@ -8,5 +8,6 @@ defaults)
 * Uses ingest node to parse and process the log lines, shaping the data into a structure suitable
 for visualizing in Kibana
 
+ifeval::["{has-dashboards}"=="true"]
 * Deploys dashboards for visualizing the log data
-  
+endif::[]

--- a/filebeat/docs/modules-getting-started.asciidoc
+++ b/filebeat/docs/modules-getting-started.asciidoc
@@ -6,9 +6,9 @@
 
 {beatname_uc} provides a set of pre-built modules that you can use to rapidly
 implement and deploy a log monitoring solution, complete with sample dashboards
-and data visualizations, in about 5 minutes. These modules support common log
-formats, such as Nginx, Apache2, and MySQL, and can be run by issuing a simple
-command.
+and data visualizations (when available), in about 5 minutes. These modules
+support common log formats, such as Nginx, Apache2, and MySQL, and can be run by
+issuing a simple command.
 
 This topic shows you how to run the basic modules with minimal extra
 configuration. For detailed documentation and the full list of available

--- a/filebeat/docs/modules-overview.asciidoc
+++ b/filebeat/docs/modules-overview.asciidoc
@@ -20,7 +20,8 @@ the following:
   correct types for each field. They also contain short descriptions for each
   of the fields.
 
-* Sample Kibana dashboards, which can be used to visualize the log files.
+* Sample Kibana dashboards, when available, that can be used to visualize the
+log files.
 
 {beatname_uc} automatically adjusts these configurations based on your environment
 and loads them to the respective Elastic stack components.

--- a/filebeat/docs/modules/apache2.asciidoc
+++ b/filebeat/docs/modules/apache2.asciidoc
@@ -4,6 +4,7 @@ This file is generated! See scripts/docs_collector.py
 
 [[filebeat-module-apache2]]
 :modulename: apache2
+:has-dashboards: true
 
 == Apache2 module
 
@@ -74,6 +75,12 @@ include::../include/var-paths.asciidoc[]
 ==== `error` log fileset settings
 
 include::../include/var-paths.asciidoc[]
+
+:has-dashboards!:
+
+:fileset_ex!:
+
+:modulename!:
 
 
 [float]

--- a/filebeat/docs/modules/auditd.asciidoc
+++ b/filebeat/docs/modules/auditd.asciidoc
@@ -4,6 +4,7 @@ This file is generated! See scripts/docs_collector.py
 
 [[filebeat-module-auditd]]
 :modulename: auditd
+:has-dashboards: true
 
 == Auditd module
 
@@ -65,6 +66,12 @@ include::../include/config-option-intro.asciidoc[]
 ==== `log` fileset settings
 
 include::../include/var-paths.asciidoc[]
+
+:has-dashboards!:
+
+:fileset_ex!:
+
+:modulename!:
 
 
 [float]

--- a/filebeat/docs/modules/elasticsearch.asciidoc
+++ b/filebeat/docs/modules/elasticsearch.asciidoc
@@ -4,6 +4,7 @@ This file is generated! See scripts/docs_collector.py
 
 [[filebeat-module-elasticsearch]]
 :modulename: elasticsearch
+:has-dashboards: false
 
 == Elasticsearch module
 
@@ -32,6 +33,12 @@ include::../include/config-option-intro.asciidoc[]
 ==== `server` log fileset settings
 
 include::../include/var-paths.asciidoc[]
+
+:has-dashboards!:
+
+:fileset_ex!:
+
+:modulename!:
 
 
 [float]

--- a/filebeat/docs/modules/haproxy.asciidoc
+++ b/filebeat/docs/modules/haproxy.asciidoc
@@ -4,6 +4,7 @@ This file is generated! See scripts/docs_collector.py
 
 [[filebeat-module-haproxy]]
 :modulename: haproxy
+:has-dashboards: true
 
 == haproxy module
 
@@ -52,6 +53,12 @@ include::../include/config-option-intro.asciidoc[]
 ==== `http` log fileset settings
 
 include::../include/var-paths.asciidoc[]
+
+:has-dashboards!:
+
+:fileset_ex!:
+
+:modulename!:
 
 
 [float]

--- a/filebeat/docs/modules/icinga.asciidoc
+++ b/filebeat/docs/modules/icinga.asciidoc
@@ -4,6 +4,7 @@ This file is generated! See scripts/docs_collector.py
 
 [[filebeat-module-icinga]]
 :modulename: icinga
+:has-dashboards: true
 
 == Icinga module
 
@@ -79,6 +80,12 @@ include::../include/var-paths.asciidoc[]
 ==== `startup` log fileset settings
 
 include::../include/var-paths.asciidoc[]
+
+:has-dashboards!:
+
+:fileset_ex!:
+
+:modulename!:
 
 
 [float]

--- a/filebeat/docs/modules/iis.asciidoc
+++ b/filebeat/docs/modules/iis.asciidoc
@@ -4,6 +4,7 @@ This file is generated! See scripts/docs_collector.py
 
 [[filebeat-module-iis]]
 :modulename: iis
+:has-dashboards: true
 
 == IIS module
 
@@ -69,6 +70,12 @@ include::../include/var-paths.asciidoc[]
 ==== `error` log fileset settings
 
 include::../include/var-paths.asciidoc[]
+
+:has-dashboards!:
+
+:fileset_ex!:
+
+:modulename!:
 
 
 [float]

--- a/filebeat/docs/modules/kafka.asciidoc
+++ b/filebeat/docs/modules/kafka.asciidoc
@@ -4,6 +4,7 @@ This file is generated! See scripts/docs_collector.py
 
 [[filebeat-module-kafka]]
 :modulename: kafka
+:has-dashboards: true
 
 == Kafka module
 
@@ -64,6 +65,12 @@ include::../include/config-option-intro.asciidoc[]
 include::../include/var-paths.asciidoc[]
 
 include::../include/var-convert-timezone.asciidoc[]
+
+:has-dashboards!:
+
+:fileset_ex!:
+
+:modulename!:
 
 
 [float]

--- a/filebeat/docs/modules/kibana.asciidoc
+++ b/filebeat/docs/modules/kibana.asciidoc
@@ -4,6 +4,7 @@ This file is generated! See scripts/docs_collector.py
 
 [[filebeat-module-kibana]]
 :modulename: kibana
+:has-dashboards: false
 
 == Kibana module
 
@@ -33,7 +34,11 @@ include::../include/config-option-intro.asciidoc[]
 
 include::../include/var-paths.asciidoc[]
 
+:has-dashboards!:
+
 :fileset_ex!:
+
+:modulename!:
 
 
 [float]

--- a/filebeat/docs/modules/logstash.asciidoc
+++ b/filebeat/docs/modules/logstash.asciidoc
@@ -4,6 +4,8 @@ This file is generated! See scripts/docs_collector.py
 
 [[filebeat-module-logstash]]
 :modulename: logstash
+:has-dashboards: true
+
 == Logstash module
 
 The +{modulename}+ module parse logstash regular logs and the slow log, it will support the plain text format
@@ -91,6 +93,12 @@ include::../include/var-paths.asciidoc[]
 
 The configured Logstash log format. Possible values are: `json` or `plain`. The
 default is `plain`.
+
+:has-dashboards!:
+
+:fileset_ex!:
+
+:modulename!:
 
 
 [float]

--- a/filebeat/docs/modules/mongodb.asciidoc
+++ b/filebeat/docs/modules/mongodb.asciidoc
@@ -4,6 +4,7 @@ This file is generated! See scripts/docs_collector.py
 
 [[filebeat-module-mongodb]]
 :modulename: mongodb
+:has-dashboards: true
 
 == MongoDB module
 
@@ -59,6 +60,12 @@ include::../include/config-option-intro.asciidoc[]
 ==== `log` log fileset settings
 
 include::../include/var-paths.asciidoc[]
+
+:has-dashboards!:
+
+:fileset_ex!:
+
+:modulename!:
 
 
 [float]

--- a/filebeat/docs/modules/mysql.asciidoc
+++ b/filebeat/docs/modules/mysql.asciidoc
@@ -4,6 +4,7 @@ This file is generated! See scripts/docs_collector.py
 
 [[filebeat-module-mysql]]
 :modulename: mysql
+:has-dashboards: true
 
 == MySQL module
 
@@ -70,6 +71,12 @@ include::../include/var-paths.asciidoc[]
 ==== `slowlog` fileset settings
 
 include::../include/var-paths.asciidoc[]
+
+:has-dashboards!:
+
+:fileset_ex!:
+
+:modulename!:
 
 
 [float]

--- a/filebeat/docs/modules/nginx.asciidoc
+++ b/filebeat/docs/modules/nginx.asciidoc
@@ -4,6 +4,8 @@ This file is generated! See scripts/docs_collector.py
 
 [[filebeat-module-nginx]]
 :modulename: nginx
+:has-dashboards: true
+
 
 == Nginx module
 
@@ -75,6 +77,12 @@ include::../include/var-paths.asciidoc[]
 ==== `error` log fileset
 
 include::../include/var-paths.asciidoc[]
+
+:has-dashboards!:
+
+:fileset_ex!:
+
+:modulename!:
 
 
 [float]

--- a/filebeat/docs/modules/osquery.asciidoc
+++ b/filebeat/docs/modules/osquery.asciidoc
@@ -4,6 +4,7 @@ This file is generated! See scripts/docs_collector.py
 
 [[filebeat-module-osquery]]
 :modulename: osquery
+:has-dashboards: true
 
 == Osquery module
 
@@ -70,6 +71,12 @@ Set to false to copy the fields in the root of the document. If enabled, this
 setting also disables the renaming of some fields (e.g. `hostIdentifier` to
 `host_identifier`).  Note that if you set this to false, the sample dashboards
 coming with this module won't work correctly. The default is true.
+
+:has-dashboards!:
+
+:fileset_ex!:
+
+:modulename!:
 
 
 [float]

--- a/filebeat/docs/modules/postgresql.asciidoc
+++ b/filebeat/docs/modules/postgresql.asciidoc
@@ -4,6 +4,7 @@ This file is generated! See scripts/docs_collector.py
 
 [[filebeat-module-postgresql]]
 :modulename: postgresql
+:has-dashboards: true
 
 == PostgreSQL module
 
@@ -68,6 +69,12 @@ include::../include/config-option-intro.asciidoc[]
 
 include::../include/var-paths.asciidoc[]
 
+
+:has-dashboards!:
+
+:fileset_ex!:
+
+:modulename!:
 
 
 [float]

--- a/filebeat/docs/modules/redis.asciidoc
+++ b/filebeat/docs/modules/redis.asciidoc
@@ -4,6 +4,7 @@ This file is generated! See scripts/docs_collector.py
 
 [[filebeat-module-redis]]
 :modulename: redis
+:has-dashboards: true
 
 == Redis module
 
@@ -97,6 +98,11 @@ left empty, `localhost:6379` is assumed.
 The password to use to connect to Redis, in case Redis authentication is enabled
 (the `requirepass` option in the Redis configuration).
 
+:has-dashboards!:
+
+:fileset_ex!:
+
+:modulename!:
 
 
 [float]

--- a/filebeat/docs/modules/system.asciidoc
+++ b/filebeat/docs/modules/system.asciidoc
@@ -4,6 +4,7 @@ This file is generated! See scripts/docs_collector.py
 
 [[filebeat-module-system]]
 :modulename: system
+:has-dashboards: true
 
 == System module
 
@@ -81,7 +82,11 @@ include::../include/var-paths.asciidoc[]
 
 include::../include/var-convert-timezone.asciidoc[]
 
+:has-dashboards!:
 
+:fileset_ex!:
+
+:modulename!:
 
 
 [float]

--- a/filebeat/docs/modules/traefik.asciidoc
+++ b/filebeat/docs/modules/traefik.asciidoc
@@ -4,6 +4,7 @@ This file is generated! See scripts/docs_collector.py
 
 [[filebeat-module-traefik]]
 :modulename: traefik
+:has-dashboards: true
 
 == Traefik module
 
@@ -61,6 +62,11 @@ include::../include/config-option-intro.asciidoc[]
 
 include::../include/var-paths.asciidoc[]
 
+:has-dashboards!:
+
+:fileset_ex!:
+
+:modulename!:
 
 
 [float]

--- a/filebeat/module/apache2/_meta/docs.asciidoc
+++ b/filebeat/module/apache2/_meta/docs.asciidoc
@@ -1,4 +1,5 @@
 :modulename: apache2
+:has-dashboards: true
 
 == Apache2 module
 
@@ -69,3 +70,9 @@ include::../include/var-paths.asciidoc[]
 ==== `error` log fileset settings
 
 include::../include/var-paths.asciidoc[]
+
+:has-dashboards!:
+
+:fileset_ex!:
+
+:modulename!:

--- a/filebeat/module/auditd/_meta/docs.asciidoc
+++ b/filebeat/module/auditd/_meta/docs.asciidoc
@@ -1,4 +1,5 @@
 :modulename: auditd
+:has-dashboards: true
 
 == Auditd module
 
@@ -60,3 +61,9 @@ include::../include/config-option-intro.asciidoc[]
 ==== `log` fileset settings
 
 include::../include/var-paths.asciidoc[]
+
+:has-dashboards!:
+
+:fileset_ex!:
+
+:modulename!:

--- a/filebeat/module/elasticsearch/_meta/docs.asciidoc
+++ b/filebeat/module/elasticsearch/_meta/docs.asciidoc
@@ -1,4 +1,5 @@
 :modulename: elasticsearch
+:has-dashboards: false
 
 == Elasticsearch module
 
@@ -27,3 +28,9 @@ include::../include/config-option-intro.asciidoc[]
 ==== `server` log fileset settings
 
 include::../include/var-paths.asciidoc[]
+
+:has-dashboards!:
+
+:fileset_ex!:
+
+:modulename!:

--- a/filebeat/module/haproxy/_meta/docs.asciidoc
+++ b/filebeat/module/haproxy/_meta/docs.asciidoc
@@ -1,4 +1,5 @@
 :modulename: haproxy
+:has-dashboards: true
 
 == haproxy module
 
@@ -47,3 +48,9 @@ include::../include/config-option-intro.asciidoc[]
 ==== `http` log fileset settings
 
 include::../include/var-paths.asciidoc[]
+
+:has-dashboards!:
+
+:fileset_ex!:
+
+:modulename!:

--- a/filebeat/module/icinga/_meta/docs.asciidoc
+++ b/filebeat/module/icinga/_meta/docs.asciidoc
@@ -1,4 +1,5 @@
 :modulename: icinga
+:has-dashboards: true
 
 == Icinga module
 
@@ -74,3 +75,9 @@ include::../include/var-paths.asciidoc[]
 ==== `startup` log fileset settings
 
 include::../include/var-paths.asciidoc[]
+
+:has-dashboards!:
+
+:fileset_ex!:
+
+:modulename!:

--- a/filebeat/module/iis/_meta/docs.asciidoc
+++ b/filebeat/module/iis/_meta/docs.asciidoc
@@ -1,4 +1,5 @@
 :modulename: iis
+:has-dashboards: true
 
 == IIS module
 
@@ -64,3 +65,9 @@ include::../include/var-paths.asciidoc[]
 ==== `error` log fileset settings
 
 include::../include/var-paths.asciidoc[]
+
+:has-dashboards!:
+
+:fileset_ex!:
+
+:modulename!:

--- a/filebeat/module/kafka/_meta/docs.asciidoc
+++ b/filebeat/module/kafka/_meta/docs.asciidoc
@@ -1,4 +1,5 @@
 :modulename: kafka
+:has-dashboards: true
 
 == Kafka module
 
@@ -59,3 +60,9 @@ include::../include/config-option-intro.asciidoc[]
 include::../include/var-paths.asciidoc[]
 
 include::../include/var-convert-timezone.asciidoc[]
+
+:has-dashboards!:
+
+:fileset_ex!:
+
+:modulename!:

--- a/filebeat/module/kibana/_meta/docs.asciidoc
+++ b/filebeat/module/kibana/_meta/docs.asciidoc
@@ -1,4 +1,5 @@
 :modulename: kibana
+:has-dashboards: false
 
 == Kibana module
 
@@ -28,4 +29,8 @@ include::../include/config-option-intro.asciidoc[]
 
 include::../include/var-paths.asciidoc[]
 
+:has-dashboards!:
+
 :fileset_ex!:
+
+:modulename!:

--- a/filebeat/module/logstash/_meta/docs.asciidoc
+++ b/filebeat/module/logstash/_meta/docs.asciidoc
@@ -1,4 +1,6 @@
 :modulename: logstash
+:has-dashboards: true
+
 == Logstash module
 
 The +{modulename}+ module parse logstash regular logs and the slow log, it will support the plain text format
@@ -86,3 +88,9 @@ include::../include/var-paths.asciidoc[]
 
 The configured Logstash log format. Possible values are: `json` or `plain`. The
 default is `plain`.
+
+:has-dashboards!:
+
+:fileset_ex!:
+
+:modulename!:

--- a/filebeat/module/mongodb/_meta/docs.asciidoc
+++ b/filebeat/module/mongodb/_meta/docs.asciidoc
@@ -1,4 +1,5 @@
 :modulename: mongodb
+:has-dashboards: true
 
 == MongoDB module
 
@@ -54,3 +55,9 @@ include::../include/config-option-intro.asciidoc[]
 ==== `log` log fileset settings
 
 include::../include/var-paths.asciidoc[]
+
+:has-dashboards!:
+
+:fileset_ex!:
+
+:modulename!:

--- a/filebeat/module/mysql/_meta/docs.asciidoc
+++ b/filebeat/module/mysql/_meta/docs.asciidoc
@@ -1,4 +1,5 @@
 :modulename: mysql
+:has-dashboards: true
 
 == MySQL module
 
@@ -65,3 +66,9 @@ include::../include/var-paths.asciidoc[]
 ==== `slowlog` fileset settings
 
 include::../include/var-paths.asciidoc[]
+
+:has-dashboards!:
+
+:fileset_ex!:
+
+:modulename!:

--- a/filebeat/module/nginx/_meta/docs.asciidoc
+++ b/filebeat/module/nginx/_meta/docs.asciidoc
@@ -1,4 +1,6 @@
 :modulename: nginx
+:has-dashboards: true
+
 
 == Nginx module
 
@@ -70,3 +72,9 @@ include::../include/var-paths.asciidoc[]
 ==== `error` log fileset
 
 include::../include/var-paths.asciidoc[]
+
+:has-dashboards!:
+
+:fileset_ex!:
+
+:modulename!:

--- a/filebeat/module/osquery/_meta/docs.asciidoc
+++ b/filebeat/module/osquery/_meta/docs.asciidoc
@@ -1,4 +1,5 @@
 :modulename: osquery
+:has-dashboards: true
 
 == Osquery module
 
@@ -65,3 +66,9 @@ Set to false to copy the fields in the root of the document. If enabled, this
 setting also disables the renaming of some fields (e.g. `hostIdentifier` to
 `host_identifier`).  Note that if you set this to false, the sample dashboards
 coming with this module won't work correctly. The default is true.
+
+:has-dashboards!:
+
+:fileset_ex!:
+
+:modulename!:

--- a/filebeat/module/postgresql/_meta/docs.asciidoc
+++ b/filebeat/module/postgresql/_meta/docs.asciidoc
@@ -1,4 +1,5 @@
 :modulename: postgresql
+:has-dashboards: true
 
 == PostgreSQL module
 
@@ -63,3 +64,9 @@ include::../include/config-option-intro.asciidoc[]
 
 include::../include/var-paths.asciidoc[]
 
+
+:has-dashboards!:
+
+:fileset_ex!:
+
+:modulename!:

--- a/filebeat/module/redis/_meta/docs.asciidoc
+++ b/filebeat/module/redis/_meta/docs.asciidoc
@@ -1,4 +1,5 @@
 :modulename: redis
+:has-dashboards: true
 
 == Redis module
 
@@ -92,3 +93,8 @@ left empty, `localhost:6379` is assumed.
 The password to use to connect to Redis, in case Redis authentication is enabled
 (the `requirepass` option in the Redis configuration).
 
+:has-dashboards!:
+
+:fileset_ex!:
+
+:modulename!:

--- a/filebeat/module/system/_meta/docs.asciidoc
+++ b/filebeat/module/system/_meta/docs.asciidoc
@@ -1,4 +1,5 @@
 :modulename: system
+:has-dashboards: true
 
 == System module
 
@@ -76,4 +77,8 @@ include::../include/var-paths.asciidoc[]
 
 include::../include/var-convert-timezone.asciidoc[]
 
+:has-dashboards!:
 
+:fileset_ex!:
+
+:modulename!:

--- a/filebeat/module/traefik/_meta/docs.asciidoc
+++ b/filebeat/module/traefik/_meta/docs.asciidoc
@@ -1,4 +1,5 @@
 :modulename: traefik
+:has-dashboards: true
 
 == Traefik module
 
@@ -56,3 +57,8 @@ include::../include/config-option-intro.asciidoc[]
 
 include::../include/var-paths.asciidoc[]
 
+:has-dashboards!:
+
+:fileset_ex!:
+
+:modulename!:

--- a/filebeat/scripts/module/_meta/docs.asciidoc
+++ b/filebeat/scripts/module/_meta/docs.asciidoc
@@ -1,4 +1,5 @@
 :modulename: {module}
+:has-dashboards: true
 
 == {module} module
 
@@ -19,7 +20,8 @@ include::../include/running-modules.asciidoc[]
 
 This module comes with a sample dashboard. For example:
 
-TODO: include an image of a sample dashboard
+TODO: include an image of a sample dashboard. If you do not include a dashboard,
+remove this section and set `:has-dashboards: false` at the top of this file.
 
 include::../include/configuring-intro.asciidoc[]
 
@@ -37,6 +39,8 @@ the relevant file. For example:
 ==== `{fileset}` log fileset settings
 
 include::../include/var-paths.asciidoc[]
+
+:has-dashboards!:
 
 :fileset_ex!:
 


### PR DESCRIPTION
Closes #8381 

With these changes in place, dashboard-related content will be suppressed for Filebeat modules that do not include dashboards. I also did some cleanup work because attributes should be reset when their values are no longer needed. 

Implementation note:
It would have been simpler to implement this as an `ifndef` but I was concerned that new module contributors would overlook the need to add the attribute. Having an attribute defined at the top of the file makes it more obvious that there's something to define, even if the module developer inadvertently removes the dashboard section without reading it first. 