### PR TITLE
Cherry-pick #8404 to 6.4: Fix incorrect type conversion of average response time in Haproxy dashboards

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -37,6 +37,8 @@ https://github.com/elastic/beats/compare/v6.4.1...6.4[Check the HEAD diff]
 
 *Metricbeat*
 
+- Fix incorrect type conversion of average response time in Haproxy dashboards {pull}8404[8404]
+
 *Packetbeat*
 
 *Winlogbeat*

--- a/metricbeat/module/haproxy/_meta/kibana/6/dashboard/Metricbeat-haproxy-visualizations.json
+++ b/metricbeat/module/haproxy/_meta/kibana/6/dashboard/Metricbeat-haproxy-visualizations.json
@@ -729,7 +729,7 @@
                                 "chart_type": "line", 
                                 "color": "#68BC00", 
                                 "fill": 0.5, 
-                                "formatter": "s,ms,0", 
+                                "formatter": "ms,ms,0", 
                                 "id": "61ca57f1-469d-11e7-af02-69e470af7417", 
                                 "label": "Average response time", 
                                 "line_width": 1, 


### PR DESCRIPTION
Cherry-pick of PR #8404 to 6.4 branch. Original message: 

Average response time in haproxy dashboard was being converted from seconds to milliseconds, but it is already in milliseconds, so it was showing values 1000 times greater than the expected ones.

Reported in https://discuss.elastic.co/t/average-response-time-on-haproxy-dashboard/149391