### PR TITLE
Log autodiscover config errors as Error instead of debug.

### DIFF
--- a/libbeat/autodiscover/autodiscover.go
+++ b/libbeat/autodiscover/autodiscover.go
@@ -18,6 +18,7 @@
 package autodiscover
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/pkg/errors"
@@ -171,7 +172,7 @@ func (a *Autodiscover) handleStart(event bus.Event) bool {
 
 		err = a.adapter.CheckConfig(config)
 		if err != nil {
-			logp.Debug(debugK, "Check failed for config %v: %v, won't start runner", config, err)
+			logp.Error(errors.Wrap(err, fmt.Sprintf("Auto discover config check failed for config %v, won't start runner", config)))
 			continue
 		}
 


### PR DESCRIPTION
If an invalid config is being generated by autodiscover, the user probably wants to know about it.

I personally found this to be quite confusing myself. Debug logging is usually for finding either bugs in the code or extreme detail. I would say ensuring a config is valid is part of the standard set of operations.