### PR TITLE
Cherry-pick #8396 to 6.x: Set current year in generator templates

### DIFF
--- a/CHANGELOG-developer.asciidoc
+++ b/CHANGELOG-developer.asciidoc
@@ -46,3 +46,4 @@ The list below covers the major changes between 6.3.0 and master only.
 - New function `AddTagsWithKey` is added, so `common.MapStr` can be enriched with tags with an arbitrary key. {pull}7991[7991]
 - Libbeat provides a new function `cmd.GenRootCmdWithSettings` that should be preferred over deprecated functions
   `cmd.GenRootCmd`, `cmd.GenRootCmdWithRunFlags`, and `cmd.GenRootCmdWithIndexPrefixWithRunFlags`. {pull}7850[7850]
+- Set current year in generator templates. {pull}8396[8396]

--- a/generator/beat/{beat}/LICENSE.txt
+++ b/generator/beat/{beat}/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2017 {full_name}
+Copyright (c) {year} {full_name}
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/generator/beat/{beat}/NOTICE.txt
+++ b/generator/beat/{beat}/NOTICE.txt
@@ -1,5 +1,5 @@
 {beat}
-Copyright 2017 {full_name}
+Copyright {year} {full_name}
 
 This product includes software developed by The Apache Software
 Foundation (http://www.apache.org/).

--- a/generator/metricbeat/{beat}/LICENSE.txt
+++ b/generator/metricbeat/{beat}/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2017 {full_name}
+Copyright (c) {year} {full_name}
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/generator/metricbeat/{beat}/NOTICE.txt
+++ b/generator/metricbeat/{beat}/NOTICE.txt
@@ -1,5 +1,5 @@
 {beat}
-Copyright 2017 {full_name}
+Copyright {year} {full_name}
 
 This product includes software developed by The Apache Software
 Foundation (http://www.apache.org/).

--- a/script/generate.py
+++ b/script/generate.py
@@ -1,5 +1,6 @@
-import os
 import argparse
+import datetime
+import os
 
 # Creates a new beat or metricbeat based on the given parameters
 
@@ -97,7 +98,8 @@ def replace_variables(content):
         .replace("{beat}", beat) \
         .replace("{Beat}", beat.capitalize()) \
         .replace("{beat_path}", beat_path) \
-        .replace("{full_name}", full_name)
+        .replace("{full_name}", full_name) \
+        .replace("{year}", str(datetime.datetime.now().year))
 
 
 def get_parser():


### PR DESCRIPTION
Cherry-pick of PR #8396 to 6.x branch. Original message: 

Year in LICENSE and NOTICE generator templates is hardcoded to 2017, set it to current year.