### PR TITLE
Reduce casting between []byte and string in CRI log processing

### DIFF
--- a/filebeat/input/log/config.go
+++ b/filebeat/input/log/config.go
@@ -106,6 +106,7 @@ type config struct {
 	DockerJSON *struct {
 		Stream   string `config:"stream"`
 		Partial  bool   `config:"partial"`
+		ForceCRI bool   `config:"force_cri_logs"`
 		CRIFlags bool   `config:"cri_flags"`
 	} `config:"docker-json"`
 }

--- a/filebeat/input/log/harvester.go
+++ b/filebeat/input/log/harvester.go
@@ -561,7 +561,7 @@ func (h *Harvester) newLogFileReader() (reader.Reader, error) {
 
 	if h.config.DockerJSON != nil {
 		// Docker json-file format, add custom parsing to the pipeline
-		r = readjson.New(r, h.config.DockerJSON.Stream, h.config.DockerJSON.Partial, h.config.DockerJSON.CRIFlags)
+		r = readjson.New(r, h.config.DockerJSON.Stream, h.config.DockerJSON.Partial, h.config.DockerJSON.ForceCRI, h.config.DockerJSON.CRIFlags)
 	}
 
 	if h.config.JSON != nil {

--- a/libbeat/reader/readjson/docker_json_unix.go
+++ b/libbeat/reader/readjson/docker_json_unix.go
@@ -1,0 +1,30 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+// +build linux darwin
+
+package readjson
+
+import (
+	"github.com/elastic/beats/libbeat/reader"
+)
+
+func stripNewLine(msg *reader.Message) {
+	l := len(msg.Content)
+	if l > 0 && msg.Content[l] == '\n' {
+		msg.Content = msg.Content[:l-1]
+	}
+}

--- a/libbeat/reader/readjson/docker_json_unix.go
+++ b/libbeat/reader/readjson/docker_json_unix.go
@@ -24,7 +24,7 @@ import (
 
 func stripNewLine(msg *reader.Message) {
 	l := len(msg.Content)
-	if l > 0 && msg.Content[l] == '\n' {
+	if l > 0 && msg.Content[l-1] == '\n' {
 		msg.Content = msg.Content[:l-1]
 	}
 }

--- a/libbeat/reader/readjson/docker_json_windows.go
+++ b/libbeat/reader/readjson/docker_json_windows.go
@@ -1,0 +1,30 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package readjson
+
+import (
+	"bytes"
+
+	"github.com/elastic/beats/libbeat/reader"
+)
+
+func stripNewLine(msg *reader.Message) {
+	msg.Content = bytes.TrimRightFunc(msg.Content, func(r rune) bool {
+		return r == '\n' || r == '\r'
+	})
+}


### PR DESCRIPTION
* Reduce casting from []byte to string and []byte again.
* If criflags are set to true, default to CRI log processing.
* Refactor CRI and json-file detection.
