### PR TITLE
Update elastic snapshot version

### DIFF
--- a/testing/environments/args.yml
+++ b/testing/environments/args.yml
@@ -6,5 +6,5 @@ services:
     build:
       args:
         DOWNLOAD_URL: https://snapshots.elastic.co/downloads
-        ELASTIC_VERSION: 6.4.0-SNAPSHOT
+        ELASTIC_VERSION: 6.4.2-SNAPSHOT
         CACHE_BUST: 20180724


### PR DESCRIPTION
This should fix errors starting environments in 6.4 branch.