### PR TITLE
Cherry-pick #8397 to 6.4: Collect custom fields in custom beats

### DIFF
--- a/CHANGELOG-developer.asciidoc
+++ b/CHANGELOG-developer.asciidoc
@@ -33,6 +33,7 @@ The list below covers the major changes between 6.3.0 and master only.
 ==== Bugfixes
 
 - Fix permissions of generated Filebeat filesets. {pull}7140[7140]
+- Collect fields from _meta/fields.yml too. {pull}8397[8397]
 
 ==== Added
 

--- a/libbeat/generator/fields/fields.go
+++ b/libbeat/generator/fields/fields.go
@@ -33,6 +33,8 @@ type YmlFile struct {
 
 func collectCommonFiles(esBeatsPath, beatPath string, fieldFiles []*YmlFile) ([]*YmlFile, error) {
 	commonFields := []string{
+		// Fields for custom beats
+		filepath.Join(beatPath, "_meta/fields.yml"),
 		filepath.Join(beatPath, "_meta/fields.common.yml"),
 	}
 


### PR DESCRIPTION
Cherry-pick of PR #8397 to 6.4 branch. Original message: 

Include `_meta/fields.yml` in the list of common fields, so fields defined in custom beats are used.

Current fields generator is checking for fields in `_meta/fields.common.yml`, but not on `_meta/fields.yml`, where custom beats have their fields by default.

Alternativelly we could move `generator/beat/{beat}/_meta/fields.yml` to `generator/beat/{beat}/_meta/fields.common.yml`, but in any case this change could be good for existing beats that have their fields in `_meta/fields.yml`.

There are users reporting problems with fields in custom beats that could be caused by this:
* ~~https://discuss.elastic.co/t/defining-dynamic-types-in-field-yml/149173~~
* https://discuss.elastic.co/t/beat-event-and-big-int-mapping/149197