### PR TITLE
Use beat name var when registering confs

### DIFF
--- a/metricbeat/beater/metricbeat.go
+++ b/metricbeat/beater/metricbeat.go
@@ -210,7 +210,7 @@ func (bt *Metricbeat) Run(b *beat.Beat) error {
 	// Centrally managed modules
 	factory := module.NewFactory(bt.moduleOptions...)
 	modules := cfgfile.NewRunnerList(management.DebugK, factory, b.Publisher)
-	reload.Register.MustRegisterList("metricbeat.modules", modules)
+	reload.Register.MustRegisterList(b.Info.Beat+".modules", modules)
 	wg.Add(1)
 	go func() {
 		defer wg.Done()


### PR DESCRIPTION
This should make Auditbeat or any other beat based on Metricbeat have
their own namespace for confs