### PR TITLE
Cherry-pick #7750 to 6.x: [Kibana metricset] Make system test conditional on Kibana version

### DIFF
--- a/metricbeat/tests/system/test_kibana.py
+++ b/metricbeat/tests/system/test_kibana.py
@@ -4,6 +4,7 @@ import unittest
 from nose.plugins.skip import SkipTest
 import urllib2
 import json
+import semver
 
 
 class Test(metricbeat.BaseTest):
@@ -16,9 +17,6 @@ class Test(metricbeat.BaseTest):
         """
         kibana status metricset test
         """
-        # FIXME: Need to skip conditionally for Kibana versions < 6.4.0 (see commented out
-        # code below)
-        raise SkipTest
 
         env = os.environ.get('TESTING_ENVIRONMENT')
 
@@ -26,10 +24,10 @@ class Test(metricbeat.BaseTest):
             # Skip for 5.x and 2.x tests as Kibana endpoint not available
             raise SkipTest
 
-        # version = self.get_version()
-        # if semver.compare(version, "6.4.0") == -1:
-        #     # Skip for Kibana versions < 6.4.0 as Kibana endpoint not available
-        #     raise SkipTest
+        version = self.get_version()
+        if semver.compare(version, "6.4.0") == -1:
+            # Skip for Kibana versions < 6.4.0 as Kibana endpoint not available
+            raise SkipTest
 
         self.render_config_template(modules=[{
             "name": "kibana",
@@ -55,7 +53,7 @@ class Test(metricbeat.BaseTest):
 
     def get_version(self):
         host = self.get_hosts()[0]
-        res = urllib2.urlopen(host + "/api/status").read()
+        res = urllib2.urlopen("http://" + host + "/api/status").read()
 
         body = json.loads(res)
         version = body["version"]["number"]


### PR DESCRIPTION
Cherry-pick of PR #7750 to 6.x branch. Original message: 

Resolves #7733. 

The kibana/stats metricset requires the kibana stats API to exist, which only exists in 6.4.0 and above. So we skip the system test if we're testing with a kibana instance running a version before 6.4.0.x