### PR TITLE
Add temporary release manager work-around

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,6 +162,9 @@ release-manager-snapshot:
 # installed and used for the build.
 .PHONY: release-manager-release
 release-manager-release:
+	# XXX (andrewkroh on 2018-09-25): Clean the project prior to building to
+	# remove any state caused by prior builds of apm-server.
+	git clean -dfx
 	./dev-tools/run_with_go_ver $(MAKE) release
 
 # Installs the mage build tool from the vendor directory.


### PR DESCRIPTION
I believe that apm-server and beats are interacting due them both sharing the GOPATH in the release-manager.

apm-server is running before beats and is possibly creating some files in the beats repo that cause problems later when beats is built.

This cleans the beats repo prior to running the release process.