### PR TITLE
[Elasticsearch Monitoring] Add cluster_metadata to cluster_stats docs

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -186,6 +186,7 @@ https://github.com/elastic/beats/compare/v6.4.0...master[Check the HEAD diff]
 - Add Kafka dashboard. {pull}8457[8457]
 - Add untyped metric support to the prometheus module. {pull}8681[8681]
 - Release Kafka module as GA. {pull}8854[8854]
+- Collect custom cluster `display_name` in `elasticsearch/cluster_stats` metricset. {pull}8445[8445]
 
 *Packetbeat*
 

--- a/metricbeat/module/elasticsearch/cluster_stats/data_xpack.go
+++ b/metricbeat/module/elasticsearch/cluster_stats/data_xpack.go
@@ -221,24 +221,26 @@ func eventMappingXPack(r mb.ReporterV2, m *MetricSet, info elasticsearch.Info, c
 		},
 	}
 
+	event := mb.Event{}
+	event.RootFields = common.MapStr{
+		"cluster_uuid":  info.ClusterID,
+		"cluster_name":  clusterName,
+		"timestamp":     common.Time(time.Now()),
+		"interval_ms":   m.Module().Config().Period / time.Millisecond,
+		"type":          "cluster_stats",
+		"license":       license,
+		"version":       info.Version.Number,
+		"cluster_stats": clusterStats,
+		"cluster_state": clusterState,
+		"stack_stats":   stackStats,
+	}
+
 	clusterSettings, err := getClusterMetadataSettings(m)
 	if err != nil {
 		return err
 	}
-
-	event := mb.Event{}
-	event.RootFields = common.MapStr{
-		"cluster_uuid":     info.ClusterID,
-		"cluster_name":     clusterName,
-		"timestamp":        common.Time(time.Now()),
-		"interval_ms":      m.Module().Config().Period / time.Millisecond,
-		"type":             "cluster_stats",
-		"license":          license,
-		"version":          info.Version.Number,
-		"cluster_stats":    clusterStats,
-		"cluster_state":    clusterState,
-		"stack_stats":      stackStats,
-		"cluster_settings": clusterSettings,
+	if clusterSettings != nil {
+		event.RootFields.Put("cluster_settings", clusterSettings)
 	}
 
 	event.Index = elastic.MakeXPackMonitoringIndexName(elastic.Elasticsearch)

--- a/metricbeat/module/elasticsearch/cluster_stats/data_xpack.go
+++ b/metricbeat/module/elasticsearch/cluster_stats/data_xpack.go
@@ -143,7 +143,8 @@ func apmIndicesExist(clusterState common.MapStr) (bool, error) {
 }
 
 func getClusterMetadataSettings(m *MetricSet) (common.MapStr, error) {
-	filterPaths := []string{"*.cluster.metadata"}
+	// For security reasons we only get the display_name setting
+	filterPaths := []string{"*.cluster.metadata.display_name"}
 	clusterSettings, err := elasticsearch.GetClusterSettingsWithDefaults(m.HTTP, m.HTTP.GetURI(), filterPaths)
 	if err != nil {
 		return nil, errors.Wrap(err, "failure to get cluster settings")

--- a/metricbeat/module/elasticsearch/cluster_stats/data_xpack.go
+++ b/metricbeat/module/elasticsearch/cluster_stats/data_xpack.go
@@ -154,9 +154,7 @@ func getClusterMetadataSettings(m *MetricSet) (common.MapStr, error) {
 		return nil, errors.Wrap(err, "failure to merge cluster settings")
 	}
 
-	clusterMetadataSettings := common.MapStr{}
-	clusterMetadataSettings.Put("cluster.metadata", clusterSettings)
-	return clusterMetadataSettings, nil
+	return clusterSettings, nil
 }
 
 func eventMappingXPack(r mb.ReporterV2, m *MetricSet, info elasticsearch.Info, content []byte) error {

--- a/metricbeat/module/elasticsearch/elasticsearch.go
+++ b/metricbeat/module/elasticsearch/elasticsearch.go
@@ -309,8 +309,25 @@ func MergeClusterSettings(clusterSettings common.MapStr) (common.MapStr, error) 
 	}
 
 	// Transient settings override persistent settings which override default settings
-	settings.DeepUpdate(persistentSettings)
-	settings.DeepUpdate(transientSettings)
+	if settings == nil {
+		settings = persistentSettings
+	}
+
+	if settings == nil {
+		settings = transientSettings
+	}
+
+	if settings == nil {
+		return nil, nil
+	}
+
+	if persistentSettings != nil {
+		settings.DeepUpdate(persistentSettings)
+	}
+
+	if transientSettings != nil {
+		settings.DeepUpdate(transientSettings)
+	}
 
 	return settings, nil
 }
@@ -359,7 +376,7 @@ func getSettingGroup(allSettings common.MapStr, groupKey string) (common.MapStr,
 	}
 
 	if !hasSettingGroup {
-		return common.MapStr{}, nil
+		return nil, nil
 	}
 
 	settings, err := allSettings.GetValue(groupKey)

--- a/metricbeat/module/elasticsearch/elasticsearch.go
+++ b/metricbeat/module/elasticsearch/elasticsearch.go
@@ -25,6 +25,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/metricbeat/helper"
 	"github.com/elastic/beats/metricbeat/helper/elastic"
@@ -96,7 +98,7 @@ func IsMaster(http *helper.HTTP, uri string) (bool, error) {
 }
 
 func getNodeName(http *helper.HTTP, uri string) (string, error) {
-	content, err := fetchPath(http, uri, "/_nodes/_local/nodes")
+	content, err := fetchPath(http, uri, "/_nodes/_local/nodes", "")
 	if err != nil {
 		return "", err
 	}
@@ -116,7 +118,7 @@ func getNodeName(http *helper.HTTP, uri string) (string, error) {
 
 func getMasterName(http *helper.HTTP, uri string) (string, error) {
 	// TODO: evaluate on why when run with ?local=true request does not contain master_node field
-	content, err := fetchPath(http, uri, "_cluster/state/master_node")
+	content, err := fetchPath(http, uri, "_cluster/state/master_node", "")
 	if err != nil {
 		return "", err
 	}
@@ -133,7 +135,7 @@ func getMasterName(http *helper.HTTP, uri string) (string, error) {
 // GetInfo returns the data for the Elasticsearch / endpoint.
 func GetInfo(http *helper.HTTP, uri string) (*Info, error) {
 
-	content, err := fetchPath(http, uri, "/")
+	content, err := fetchPath(http, uri, "/", "")
 	if err != nil {
 		return nil, err
 	}
@@ -144,13 +146,13 @@ func GetInfo(http *helper.HTTP, uri string) (*Info, error) {
 	return info, nil
 }
 
-func fetchPath(http *helper.HTTP, uri, path string) ([]byte, error) {
+func fetchPath(http *helper.HTTP, uri, path string, query string) ([]byte, error) {
 	defer http.SetURI(uri)
 
 	// Parses the uri to replace the path
 	u, _ := url.Parse(uri)
 	u.Path = path
-	u.RawQuery = ""
+	u.RawQuery = query
 
 	// Http helper includes the HostData with username and password
 	http.SetURI(u.String())
@@ -160,7 +162,7 @@ func fetchPath(http *helper.HTTP, uri, path string) ([]byte, error) {
 // GetNodeInfo returns the node information.
 func GetNodeInfo(http *helper.HTTP, uri string, nodeID string) (*NodeInfo, error) {
 
-	content, err := fetchPath(http, uri, "/_nodes/_local/nodes")
+	content, err := fetchPath(http, uri, "/_nodes/_local/nodes", "")
 	if err != nil {
 		return nil, err
 	}
@@ -191,7 +193,7 @@ func GetLicense(http *helper.HTTP, resetURI string) (common.MapStr, error) {
 
 	// Not cached, fetch license from Elasticsearch
 	if license == nil {
-		content, err := fetchPath(http, resetURI, "_xpack/license")
+		content, err := fetchPath(http, resetURI, "_xpack/license", "")
 		if err != nil {
 			return nil, err
 		}
@@ -225,7 +227,7 @@ func GetClusterState(http *helper.HTTP, resetURI string, metrics []string) (comm
 		clusterStateURI += "/" + strings.Join(metrics, ",")
 	}
 
-	content, err := fetchPath(http, resetURI, clusterStateURI)
+	content, err := fetchPath(http, resetURI, clusterStateURI, "")
 	if err != nil {
 		return nil, err
 	}
@@ -235,9 +237,39 @@ func GetClusterState(http *helper.HTTP, resetURI string, metrics []string) (comm
 	return clusterState, err
 }
 
+// GetClusterSettingsWithDefaults returns cluster settings.
+func GetClusterSettingsWithDefaults(http *helper.HTTP, resetURI string, filterPaths []string) (common.MapStr, error) {
+	return GetClusterSettings(http, resetURI, true, filterPaths)
+}
+
+// GetClusterSettings returns cluster settings
+func GetClusterSettings(http *helper.HTTP, resetURI string, includeDefaults bool, filterPaths []string) (common.MapStr, error) {
+	clusterSettingsURI := "_cluster/settings"
+	var queryParams []string
+	if includeDefaults {
+		queryParams = append(queryParams, "include_defaults=true")
+	}
+
+	if filterPaths != nil && len(filterPaths) > 0 {
+		filterPathQueryParam := "filter_path=" + strings.Join(filterPaths, ",")
+		queryParams = append(queryParams, filterPathQueryParam)
+	}
+
+	queryString := strings.Join(queryParams, "&")
+
+	content, err := fetchPath(http, resetURI, clusterSettingsURI, queryString)
+	if err != nil {
+		return nil, err
+	}
+
+	var clusterSettings map[string]interface{}
+	err = json.Unmarshal(content, &clusterSettings)
+	return clusterSettings, err
+}
+
 // GetStackUsage returns stack usage information.
 func GetStackUsage(http *helper.HTTP, resetURI string) (common.MapStr, error) {
-	content, err := fetchPath(http, resetURI, "_xpack/usage")
+	content, err := fetchPath(http, resetURI, "_xpack/usage", "")
 	if err != nil {
 		return nil, err
 	}
@@ -257,6 +289,30 @@ func PassThruField(fieldPath string, sourceData, targetData common.MapStr) error
 
 	targetData.Put(fieldPath, fieldValue)
 	return nil
+}
+
+// MergeClusterSettings merges cluster settings in the correct precedence order
+func MergeClusterSettings(clusterSettings common.MapStr) (common.MapStr, error) {
+	transientSettings, err := getSettingGroup(clusterSettings, "transient")
+	if err != nil {
+		return nil, err
+	}
+
+	persistentSettings, err := getSettingGroup(clusterSettings, "persistent")
+	if err != nil {
+		return nil, err
+	}
+
+	settings, err := getSettingGroup(clusterSettings, "default")
+	if err != nil {
+		return nil, err
+	}
+
+	// Transient settings override persistent settings which override default settings
+	settings.DeepUpdate(persistentSettings)
+	settings.DeepUpdate(transientSettings)
+
+	return settings, nil
 }
 
 // IsCCRStatsAPIAvailable returns whether the CCR stats API is available in the given version
@@ -294,4 +350,27 @@ func (c *_licenseCache) set(license common.MapStr, ttl time.Duration) {
 	c.license = license
 	c.ttl = ttl
 	c.cachedOn = time.Now()
+}
+
+func getSettingGroup(allSettings common.MapStr, groupKey string) (common.MapStr, error) {
+	hasSettingGroup, err := allSettings.HasKey(groupKey)
+	if err != nil {
+		return nil, errors.Wrap(err, "failure to determine if "+groupKey+" settings exist")
+	}
+
+	if !hasSettingGroup {
+		return common.MapStr{}, nil
+	}
+
+	settings, err := allSettings.GetValue(groupKey)
+	if err != nil {
+		return nil, errors.Wrap(err, "failure to extract "+groupKey+" settings")
+	}
+
+	v, ok := settings.(map[string]interface{})
+	if !ok {
+		return nil, errors.Wrap(err, groupKey+" settings are not a map")
+	}
+
+	return common.MapStr(v), nil
 }


### PR DESCRIPTION
Porting over https://github.com/elastic/elasticsearch/pull/33860 to the Metricbeat Elasticsearch module (X-Pack Monitoring code path).

This PR teaches Elasticsearch X-Pack Monitoring to collect cluster metadata, if any is set, and index it into `cluster_stats` docs in `.monitoring-es-6-mb-*`.

After this PR, `cluster_stats` docs in `.monitoring-es-6-mb-*` will contain an additional top-level `cluster_settings` field like so:

```
{
   ...
   "cluster_settings": {
     "cluster": {
       "metadata": {
         ...
       }
     }
   }
}
```