### PR TITLE
Allow to pass config overrides via the Settings Struct

### DIFF
--- a/CHANGELOG-developer.asciidoc
+++ b/CHANGELOG-developer.asciidoc
@@ -51,3 +51,4 @@ The list below covers the major changes between 6.3.0 and master only.
 - Libbeat provides a new function `cmd.GenRootCmdWithSettings` that should be preferred over deprecated functions
   `cmd.GenRootCmd`, `cmd.GenRootCmdWithRunFlags`, and `cmd.GenRootCmdWithIndexPrefixWithRunFlags`. {pull}7850[7850]
 - Set current year in generator templates. {pull}8396[8396]
+- You can now override default settings of libbeat by using instance.Settings. {pull}8449[8449]

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -229,8 +229,8 @@ func NewBeat(name, indexPrefix, v string) (*Beat, error) {
 	return &Beat{Beat: b}, nil
 }
 
-// init does initialization of things common to all actions (read confs, flags)
-func (b *Beat) Init() error {
+// InitWithSettings does initialization of things common to all actions (read confs, flags)
+func (b *Beat) InitWithSettings(settings Settings) error {
 	err := b.handleFlags()
 	if err != nil {
 		return err
@@ -240,11 +240,18 @@ func (b *Beat) Init() error {
 		return err
 	}
 
-	if err := b.configure(); err != nil {
+	if err := b.configure(settings); err != nil {
 		return err
 	}
 
 	return nil
+}
+
+// Init does initialization of things common to all actions (read confs, flags)
+//
+// Deprecated: use InitWithSettings
+func (b *Beat) Init() error {
+	return b.InitWithSettings(Settings{})
 }
 
 // BeatConfig returns config section for this beat
@@ -504,12 +511,24 @@ func (b *Beat) handleFlags() error {
 // config reads the configuration file from disk, parses the common options
 // defined in BeatConfig, initializes logging, and set GOMAXPROCS if defined
 // in the config. Lastly it invokes the Config method implemented by the beat.
-func (b *Beat) configure() error {
+func (b *Beat) configure(settings Settings) error {
 	var err error
 
 	cfg, err := cfgfile.Load("")
 	if err != nil {
 		return fmt.Errorf("error loading config file: %v", err)
+	}
+
+	// Overrides config defaults for a specific beat.
+	if settings.ConfigOverrides != nil {
+		c, _ := common.NewConfigFrom(map[string]interface{}{})
+		if err := c.Merge(settings.ConfigOverrides); err != nil {
+			return err
+		}
+		if err := c.Merge(cfg); err != nil {
+			return err
+		}
+		cfg = c
 	}
 
 	// We have to initialize the keystore before any unpack or merging the cloud

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -330,7 +330,7 @@ func (b *Beat) launch(settings Settings, bt beat.Creator) error {
 	defer logp.Sync()
 	defer logp.Info("%s stopped.", b.Info.Beat)
 
-	err := b.Init()
+	err := b.InitWithSettings(settings)
 	if err != nil {
 		return err
 	}
@@ -514,21 +514,9 @@ func (b *Beat) handleFlags() error {
 func (b *Beat) configure(settings Settings) error {
 	var err error
 
-	cfg, err := cfgfile.Load("")
+	cfg, err := cfgfile.Load("", settings.ConfigOverrides)
 	if err != nil {
 		return fmt.Errorf("error loading config file: %v", err)
-	}
-
-	// Overrides config defaults for a specific beat.
-	if settings.ConfigOverrides != nil {
-		c, _ := common.NewConfigFrom(map[string]interface{}{})
-		if err := c.Merge(settings.ConfigOverrides); err != nil {
-			return err
-		}
-		if err := c.Merge(cfg); err != nil {
-			return err
-		}
-		cfg = c
 	}
 
 	// We have to initialize the keystore before any unpack or merging the cloud

--- a/libbeat/cmd/instance/settings.go
+++ b/libbeat/cmd/instance/settings.go
@@ -20,14 +20,16 @@ package instance
 import (
 	"github.com/spf13/pflag"
 
+	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/monitoring/report"
 )
 
 // Settings contains basic settings for any beat to pass into GenRootCmd
 type Settings struct {
-	Name        string
-	IndexPrefix string
-	Version     string
-	Monitoring  report.Settings
-	RunFlags    *pflag.FlagSet
+	Name            string
+	IndexPrefix     string
+	Version         string
+	Monitoring      report.Settings
+	RunFlags        *pflag.FlagSet
+	ConfigOverrides *common.Config
 }


### PR DESCRIPTION
Sometime a custom beat that get executed want to override system
defaults instead of relying on code defined by libbeat.

This is the case with beatless, the queue has limits and flush values
that make sense when the beat is run on the edge but not on on AWS lambda.

Note that settings is passed via liberal common.Config no type checking is
done. I went that route because many parts of beats doesn't expose the
config struct outside of the package.

This is similar to explicitely defining them in the yaml.

**Notes:** this part of the code is pretty hard to unit test, we have to do some refactoring to make it happen :(