### PR TITLE
Remove line carriages on asset generation

### DIFF
--- a/CHANGELOG-developer.asciidoc
+++ b/CHANGELOG-developer.asciidoc
@@ -35,6 +35,7 @@ The list below covers the major changes between 6.3.0 and master only.
 
 - Fix permissions of generated Filebeat filesets. {pull}7140[7140]
 - Collect fields from _meta/fields.yml too. {pull}8397[8397]
+- Fix issue on asset generation that could lead to different results in Windows. {pull}8464[8464]
 
 ==== Added
 

--- a/dev-tools/cmd/asset/asset.go
+++ b/dev-tools/cmd/asset/asset.go
@@ -27,6 +27,7 @@ import (
 	"go/format"
 	"io/ioutil"
 	"os"
+	"strings"
 
 	"github.com/elastic/beats/libbeat/asset"
 	"github.com/elastic/beats/licenses"
@@ -79,7 +80,7 @@ func main() {
 		}
 	}
 
-	encData, err := asset.EncodeData(string(data))
+	encData, err := asset.EncodeData(strings.Replace(string(data), "\r", "", -1))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error encoding the data: %s\n", err)
 		os.Exit(1)

--- a/dev-tools/cmd/asset/asset.go
+++ b/dev-tools/cmd/asset/asset.go
@@ -80,6 +80,8 @@ func main() {
 		}
 	}
 
+	// Depending on OS or tools configuration, files can contain carriages (\r),
+	// what leads to different results, remove them before encoding.
 	encData, err := asset.EncodeData(strings.Replace(string(data), "\r", "", -1))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error encoding the data: %s\n", err)


### PR DESCRIPTION
On Windows, asset files can contain line carriages, what leads to
different encoded assets. Remove this carriages between encoding the
string.

This can be what is generating different asset files on #8394, thanks
to @narph for pointing to the possibility of carriages causing this 
problem.