### PR TITLE
Cherry-pick #8464 to 6.4: Remove line carriages on asset generation

### DIFF
--- a/CHANGELOG-developer.asciidoc
+++ b/CHANGELOG-developer.asciidoc
@@ -34,6 +34,7 @@ The list below covers the major changes between 6.3.0 and master only.
 
 - Fix permissions of generated Filebeat filesets. {pull}7140[7140]
 - Collect fields from _meta/fields.yml too. {pull}8397[8397]
+- Fix issue on asset generation that could lead to different results in Windows. {pull}8464[8464]
 
 ==== Added
 

--- a/dev-tools/cmd/asset/asset.go
+++ b/dev-tools/cmd/asset/asset.go
@@ -27,6 +27,7 @@ import (
 	"go/format"
 	"io/ioutil"
 	"os"
+	"strings"
 
 	"github.com/elastic/beats/libbeat/asset"
 )
@@ -76,7 +77,9 @@ func main() {
 		}
 	}
 
-	encData, err := asset.EncodeData(string(data))
+	// Depending on OS or tools configuration, files can contain carriages (\r),
+	// what leads to different results, remove them before encoding.
+	encData, err := asset.EncodeData(strings.Replace(string(data), "\r", "", -1))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error encoding the data: %s\n", err)
 		os.Exit(1)


### PR DESCRIPTION
Cherry-pick of PR #8464 to 6.4 branch. Original message: 

On Windows, asset files can contain line carriages, what leads to
different encoded assets. Remove this carriages between encoding the
string.

This can be what is generating different asset files on #8394, thanks
to @narph for pointing to the possibility of carriages causing this 
problem.