### PR TITLE
Cherry-pick #8461 to 6.x: Document need for distinct path.data values

### DIFF
--- a/libbeat/docs/shared-faq.asciidoc
+++ b/libbeat/docs/shared-faq.asciidoc
@@ -142,3 +142,9 @@ This is not a SSL problem. Make sure that Logstash is running and that there is 
 
 A firewall is refusing the connection. Check if a firewall is blocking the traffic on the client, the network, or the
 destination host.
+
+[float]
+[[monitoring-shows-fewer-than-expected-beats]]
+=== Monitoring UI shows fewer Beats than expected
+
+If you are running multiple Beat instances on the same host, make sure they each have a distinct `path.data` value.

--- a/libbeat/docs/shared-path-config.asciidoc
+++ b/libbeat/docs/shared-path-config.asciidoc
@@ -86,6 +86,9 @@ Example:
 path.data: /var/lib/beats
 ------------------------------------------------------------------------------
 
+TIP: When running multiple Beat instances on the same host, make sure they
+each have a distinct `path.data` value.
+
 [float]
 ==== `logs`
 


### PR DESCRIPTION
Cherry-pick of PR #8461 to 6.x branch. Original message: 

Closes https://github.com/elastic/kibana/issues/20199.

When running multiple beat instances on the same host, each instance must have a unique `path.data` value, otherwise there can be conflicts causing unexpected behavior. For example, the Monitoring UI will report fewer beats than expected.

This PR documents the need for distinct `path.data` values.