### PR TITLE
Various minor fixes to elasticsearch/node_stats metricset x-pack code

### DIFF
--- a/metricbeat/module/elasticsearch/cluster_stats/data_xpack.go
+++ b/metricbeat/module/elasticsearch/cluster_stats/data_xpack.go
@@ -34,9 +34,9 @@ import (
 
 func clusterNeedsTLSEnabled(license, stackStats common.MapStr) (bool, error) {
 	// TLS does not need to be enabled if license type is something other than trial
-	value, err := license.GetValue("license.type")
+	value, err := license.GetValue("type")
 	if err != nil {
-		return false, elastic.MakeErrorForMissingField("license.type", elastic.Elasticsearch)
+		return false, elastic.MakeErrorForMissingField("type", elastic.Elasticsearch)
 	}
 
 	licenseType, ok := value.(string)

--- a/metricbeat/module/elasticsearch/elasticsearch.go
+++ b/metricbeat/module/elasticsearch/elasticsearch.go
@@ -196,9 +196,19 @@ func GetLicense(http *helper.HTTP, resetURI string) (common.MapStr, error) {
 			return nil, err
 		}
 
-		err = json.Unmarshal(content, &license)
+		var data common.MapStr
+		err = json.Unmarshal(content, &data)
 		if err != nil {
 			return nil, err
+		}
+
+		l, err := data.GetValue("license")
+		if err != nil {
+			return nil, err
+		}
+		license, ok := l.(map[string]interface{})
+		if !ok {
+			return nil, elastic.MakeErrorForMissingField("license", elastic.Elasticsearch)
 		}
 
 		// Cache license for a minute

--- a/metricbeat/module/elasticsearch/node_stats/data_xpack.go
+++ b/metricbeat/module/elasticsearch/node_stats/data_xpack.go
@@ -89,9 +89,9 @@ var (
 		"os": c.Dict("os", s.Schema{
 			"cpu": c.Dict("cpu", s.Schema{
 				"load_average": c.Dict("load_average", s.Schema{
-					"1m":  c.Float("1m"),
-					"5m":  c.Float("5m"),
-					"15m": c.Float("15m"),
+					"1m":  c.Float("1m", s.Optional),
+					"5m":  c.Float("5m", s.Optional),
+					"15m": c.Float("15m", s.Optional),
 				}),
 			}),
 			"cgroup": c.Dict("cgroup", s.Schema{

--- a/metricbeat/module/elasticsearch/node_stats/data_xpack.go
+++ b/metricbeat/module/elasticsearch/node_stats/data_xpack.go
@@ -182,13 +182,13 @@ func eventsMappingXPack(r mb.ReporterV2, m *MetricSet, content []byte) {
 	// master node will not be accurate anymore as often in these cases a proxy is in front
 	// of ES and it's not know if the request will be routed to the same node as before.
 	for nodeID, node := range nodesStruct.Nodes {
-		clusterID, err := elasticsearch.GetClusterID(m.HTTP, m.HostData().SanitizedURI, nodeID)
+		clusterID, err := elasticsearch.GetClusterID(m.HTTP, m.HTTP.GetURI(), nodeID)
 		if err != nil {
 			logp.Err("could not fetch cluster id: %s", err)
 			continue
 		}
 
-		isMaster, _ := elasticsearch.IsMaster(m.HTTP, m.HostData().SanitizedURI)
+		isMaster, _ := elasticsearch.IsMaster(m.HTTP, m.HTTP.GetURI())
 
 		event := mb.Event{}
 		// Build source_node object

--- a/metricbeat/module/elasticsearch/node_stats/data_xpack.go
+++ b/metricbeat/module/elasticsearch/node_stats/data_xpack.go
@@ -115,7 +115,7 @@ var (
 					"limit_in_bytes": c.Str("limit_in_bytes"),
 					"usage_in_bytes": c.Str("usage_in_bytes"),
 				}),
-			}),
+			}, c.DictOptional),
 		}),
 		"process": c.Dict("process", s.Schema{
 			"open_file_descriptors": c.Int("open_file_descriptors"),

--- a/metricbeat/module/elasticsearch/node_stats/data_xpack.go
+++ b/metricbeat/module/elasticsearch/node_stats/data_xpack.go
@@ -144,41 +144,13 @@ var (
 			}),
 		}),
 		"thread_pool": c.Dict("thread_pool", s.Schema{
-			"bulk": c.Dict("bulk", s.Schema{
-				"threads":  c.Int("threads"),
-				"queue":    c.Int("queue"),
-				"rejected": c.Int("rejected"),
-			}),
-			"generic": c.Dict("generic", s.Schema{
-				"threads":  c.Int("threads"),
-				"queue":    c.Int("queue"),
-				"rejected": c.Int("rejected"),
-			}),
-			"get": c.Dict("get", s.Schema{
-				"threads":  c.Int("threads"),
-				"queue":    c.Int("queue"),
-				"rejected": c.Int("rejected"),
-			}),
-			"index": c.Dict("index", s.Schema{
-				"threads":  c.Int("threads"),
-				"queue":    c.Int("queue"),
-				"rejected": c.Int("rejected"),
-			}),
-			"management": c.Dict("management", s.Schema{
-				"threads":  c.Int("threads"),
-				"queue":    c.Int("queue"),
-				"rejected": c.Int("rejected"),
-			}),
-			"search": c.Dict("search", s.Schema{
-				"threads":  c.Int("threads"),
-				"queue":    c.Int("queue"),
-				"rejected": c.Int("rejected"),
-			}),
-			"watcher": c.Dict("watcher", s.Schema{
-				"threads":  c.Int("threads"),
-				"queue":    c.Int("queue"),
-				"rejected": c.Int("rejected"),
-			}),
+			"analyze":    c.Dict("analyze", threadPoolStatsSchema),
+			"write":      c.Dict("write", threadPoolStatsSchema),
+			"generic":    c.Dict("generic", threadPoolStatsSchema),
+			"get":        c.Dict("get", threadPoolStatsSchema),
+			"management": c.Dict("management", threadPoolStatsSchema),
+			"search":     c.Dict("search", threadPoolStatsSchema),
+			"watcher":    c.Dict("watcher", threadPoolStatsSchema),
 		}),
 		"fs": c.Dict("fs", s.Schema{
 			"summary": c.Dict("total", s.Schema{
@@ -187,6 +159,12 @@ var (
 				"available_in_bytes": c.Int("available_in_bytes"),
 			}),
 		}),
+	}
+
+	threadPoolStatsSchema = s.Schema{
+		"threads":  c.Int("threads"),
+		"queue":    c.Int("queue"),
+		"rejected": c.Int("rejected"),
 	}
 )
 


### PR DESCRIPTION
Based on recent testing I found a few issues in the `elasticsearch/nodes_stats` metricset's x-pack code path:

* The ES Node Stats API doesn't report load stats for 1m, 5m, and 15m until it has collected them. So we should make these fields optional in our schema.

* The ES Node Stats API doesn't report cgroup stats unless ES is running in a container. So we should make this field optional in our schema.

* The code was incorrectly double nesting the `license` field, that is `"license": { "license": { ... } }`.

* The code was calling other ES APIs but not passing the correct reset URI to the functions making these API calls. As a result only one `node_stats` document would get indexed into `.monitoring-es-6-mb-*` the first time the metricset's `Fetch()` function. After that no new `node_stats` documents would get indexed because the `content` received by the `eventMappingXPack` function did not contain Node Stats API response data!

This PR fixes these issues.