### PR TITLE
(Backport to 6.x) Make heartbeat GA! 🎉 (#8392)

### DIFF
--- a/heartbeat/beater/heartbeat.go
+++ b/heartbeat/beater/heartbeat.go
@@ -29,7 +29,6 @@ import (
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/cfgfile"
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/libbeat/logp"
 )
 
@@ -44,8 +43,6 @@ type Heartbeat struct {
 
 // New creates a new heartbeat.
 func New(b *beat.Beat, rawConfig *common.Config) (beat.Beater, error) {
-	cfgwarn.Beta("Heartbeat is beta software")
-
 	parsedConfig := config.DefaultConfig
 	if err := rawConfig.Unpack(&parsedConfig); err != nil {
 		return nil, fmt.Errorf("Error reading config file: %v", err)

--- a/heartbeat/docs/page_header.html
+++ b/heartbeat/docs/page_header.html
@@ -1,4 +1,0 @@
-This functionality is in beta and is subject to change. The design and
-code is considered to be less mature than official GA features. Elastic will
-take a best effort approach to fix any issues, but beta features are not
-subject to the support SLA of official GA features.


### PR DESCRIPTION
Now that config reloading is baked in we can finally mark heartbeat as GA software.

(cherry picked from commit 5bd2c3fe7036a81ef6cdc0a9cc35376051c71a97)