### PR TITLE
Add docker-compose+reqs for heartbeat

### DIFF
--- a/heartbeat/Dockerfile
+++ b/heartbeat/Dockerfile
@@ -1,0 +1,21 @@
+FROM golang:1.10.3
+MAINTAINER Nicolas Ruflin <ruflin@elastic.co>
+
+RUN set -x && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+         netcat python-pip virtualenv && \
+    apt-get clean
+
+RUN pip install --upgrade pip
+RUN pip install --upgrade setuptools
+RUN pip install --upgrade docker-compose==1.21.0
+
+# Setup work environment
+ENV HEARTBEAT_PATH /go/src/github.com/elastic/beats/heartbeat
+
+RUN mkdir -p $HEARTBEAT_PATH/build/coverage
+WORKDIR $HEARTBEAT_PATH
+
+# Add healthcheck for docker/healthcheck metricset to check during testing
+HEALTHCHECK CMD exit 0

--- a/heartbeat/Makefile
+++ b/heartbeat/Makefile
@@ -1,7 +1,7 @@
 BEAT_NAME=heartbeat
 BEAT_TITLE=Heartbeat
 SYSTEM_TESTS=true
-TEST_ENVIRONMENT=false
+TEST_ENVIRONMENT=true
 
 # Path to the libbeat Makefile
 -include ../libbeat/scripts/Makefile

--- a/heartbeat/Makefile
+++ b/heartbeat/Makefile
@@ -1,7 +1,7 @@
 BEAT_NAME=heartbeat
 BEAT_TITLE=Heartbeat
 SYSTEM_TESTS=true
-TEST_ENVIRONMENT=true
+TEST_ENVIRONMENT?=true
 
 # Path to the libbeat Makefile
 -include ../libbeat/scripts/Makefile

--- a/heartbeat/docker-compose.yml
+++ b/heartbeat/docker-compose.yml
@@ -1,0 +1,41 @@
+version: '2.1'
+services:
+  beat:
+    build: ${PWD}/.
+    depends_on:
+    - proxy_dep
+    env_file:
+    - ${PWD}/build/test.env
+    environment:
+    - REDIS_HOST=redis
+    - REDIS_PORT=6379
+    - KIBANA_HOST=kibana
+    - KIBANA_PORT=5601
+    working_dir: /go/src/github.com/elastic/beats/heartbeat
+    volumes:
+    - ${PWD}/..:/go/src/github.com/elastic/beats/
+    # We launch docker containers to test docker autodiscover:
+    - /var/run/docker.sock:/var/run/docker.sock
+    command: make
+
+  # This is a proxy used to block beats until all services are healthy.
+  # See: https://github.com/docker/compose/issues/4369
+  proxy_dep:
+    image: busybox
+    depends_on:
+      elasticsearch: { condition: service_healthy }
+      kibana:        { condition: service_healthy }
+      redis:         { condition: service_healthy }
+
+  elasticsearch:
+    extends:
+      file: ${ES_BEATS}/testing/environments/${TESTING_ENVIRONMENT}.yml
+      service: elasticsearch
+
+  kibana:
+    extends:
+      file: ${ES_BEATS}/testing/environments/${TESTING_ENVIRONMENT}.yml
+      service: kibana
+
+  redis:
+    build: ${PWD}/tests/docker_support/redis

--- a/heartbeat/docker-compose.yml
+++ b/heartbeat/docker-compose.yml
@@ -21,13 +21,7 @@ services:
   proxy_dep:
     image: busybox
     depends_on:
-      elasticsearch: { condition: service_healthy }
       redis:         { condition: service_healthy }
-
-  elasticsearch:
-    extends:
-      file: ${ES_BEATS}/testing/environments/${TESTING_ENVIRONMENT}.yml
-      service: elasticsearch
 
   redis:
     build: ${PWD}/tests/docker_support/redis

--- a/heartbeat/docker-compose.yml
+++ b/heartbeat/docker-compose.yml
@@ -21,7 +21,13 @@ services:
   proxy_dep:
     image: busybox
     depends_on:
+      elasticsearch: { condition: service_healthy }
       redis:         { condition: service_healthy }
+
+  elasticsearch:
+    extends:
+      file: ${ES_BEATS}/testing/environments/${TESTING_ENVIRONMENT}.yml
+      service: elasticsearch
 
   redis:
     build: ${PWD}/tests/docker_support/redis

--- a/heartbeat/docker-compose.yml
+++ b/heartbeat/docker-compose.yml
@@ -9,8 +9,6 @@ services:
     environment:
     - REDIS_HOST=redis
     - REDIS_PORT=6379
-    - KIBANA_HOST=kibana
-    - KIBANA_PORT=5601
     working_dir: /go/src/github.com/elastic/beats/heartbeat
     volumes:
     - ${PWD}/..:/go/src/github.com/elastic/beats/
@@ -24,18 +22,12 @@ services:
     image: busybox
     depends_on:
       elasticsearch: { condition: service_healthy }
-      kibana:        { condition: service_healthy }
       redis:         { condition: service_healthy }
 
   elasticsearch:
     extends:
       file: ${ES_BEATS}/testing/environments/${TESTING_ENVIRONMENT}.yml
       service: elasticsearch
-
-  kibana:
-    extends:
-      file: ${ES_BEATS}/testing/environments/${TESTING_ENVIRONMENT}.yml
-      service: kibana
 
   redis:
     build: ${PWD}/tests/docker_support/redis

--- a/heartbeat/tests/docker_support/redis/Dockerfile
+++ b/heartbeat/tests/docker_support/redis/Dockerfile
@@ -1,0 +1,2 @@
+FROM redis:3.2.4-alpine
+HEALTHCHECK CMD nc -z localhost 6379


### PR DESCRIPTION
These were never added and are causing the *-environment build tasks to fail.

I think this is causing the errors in #8475 