### PR TITLE
Cherry-pick #8438 to 6.x: add container image for docker metricsets

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -116,6 +116,7 @@ https://github.com/elastic/beats/compare/v6.4.0...6.x[Check the HEAD diff]
 - Added `ccr` metricset to Elasticsearch module. {pull}8335[8335]
 - Support for Kafka 2.0.0 {pull}8399[8399]
 - Added support for query params in configuration {issue}8286[8286] {pull}8292[8292]
+- Add container image for docker metricsets. {issue}8214[8214] {pull}8438[8438]
 
 *Packetbeat*
 

--- a/metricbeat/module/docker/helper.go
+++ b/metricbeat/module/docker/helper.go
@@ -29,13 +29,15 @@ import (
 type Container struct {
 	ID     string
 	Name   string
+	Image  string
 	Labels common.MapStr
 }
 
 func (c *Container) ToMapStr() common.MapStr {
 	m := common.MapStr{
-		"id":   c.ID,
-		"name": c.Name,
+		"id":    c.ID,
+		"name":  c.Name,
+		"image": c.Image,
 	}
 
 	if len(c.Labels) > 0 {
@@ -52,6 +54,7 @@ func NewContainer(container *types.Container, dedot bool) *Container {
 		ID:     container.ID,
 		Name:   ExtractContainerName(container.Names),
 		Labels: DeDotLabels(container.Labels, dedot),
+		Image:  container.Image,
 	}
 }
 

--- a/metricbeat/module/docker/memory/memory_test.go
+++ b/metricbeat/module/docker/memory/memory_test.go
@@ -60,8 +60,9 @@ func TestMemoryService_GetMemoryStats(t *testing.T) {
 	expectedEvent := common.MapStr{
 		"_module": common.MapStr{
 			"container": common.MapStr{
-				"id":   containerID,
-				"name": "name1",
+				"id":    containerID,
+				"name":  "name1",
+				"image": "image",
 				"labels": common.MapStr{
 					"label1": "val1",
 					"label2": common.MapStr{


### PR DESCRIPTION
Cherry-pick of PR #8438 to 6.x branch. Original message: 

this fixes #8214 