### PR TITLE
Add `managed` output

### DIFF
--- a/x-pack/libbeat/cmd/inject.go
+++ b/x-pack/libbeat/cmd/inject.go
@@ -7,7 +7,7 @@ package cmd
 import (
 	"github.com/elastic/beats/libbeat/cmd"
 
-	// register central management modules
+	// register central management packages
 	_ "github.com/elastic/beats/x-pack/libbeat/management"
 	_ "github.com/elastic/beats/x-pack/libbeat/outputs/managed"
 )

--- a/x-pack/libbeat/cmd/inject.go
+++ b/x-pack/libbeat/cmd/inject.go
@@ -7,8 +7,9 @@ package cmd
 import (
 	"github.com/elastic/beats/libbeat/cmd"
 
-	// register central management
+	// register central management modules
 	_ "github.com/elastic/beats/x-pack/libbeat/management"
+	_ "github.com/elastic/beats/x-pack/libbeat/outputs/managed"
 )
 
 // AddXPack extends the given root folder with XPack features

--- a/x-pack/libbeat/management/manager.go
+++ b/x-pack/libbeat/management/manager.go
@@ -105,6 +105,7 @@ func (cm *ConfigManager) Stop() {
 // central management can configure.
 func (cm *ConfigManager) CheckRawConfig(cfg *common.Config) error {
 	// TODO implement this method
+	// TODO check output is set to "managed"
 	return nil
 }
 

--- a/x-pack/libbeat/outputs/managed/managed.go
+++ b/x-pack/libbeat/outputs/managed/managed.go
@@ -1,19 +1,6 @@
-// Licensed to Elasticsearch B.V. under one or more contributor
-// license agreements. See the NOTICE file distributed with
-// this work for additional information regarding copyright
-// ownership. Elasticsearch B.V. licenses this file to you under
-// the Apache License, Version 2.0 (the "License"); you may
-// not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
 
 package pause
 

--- a/x-pack/libbeat/outputs/managed/managed.go
+++ b/x-pack/libbeat/outputs/managed/managed.go
@@ -2,7 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-package pause
+package managed
 
 import (
 	"time"
@@ -16,7 +16,7 @@ import (
 // managed output is used as a placeholder for central management
 // this output will cause the beat to pause the output until a real
 // output is configured
-// It's used both during startup (before we retrieved the current output settings)
+// It's used both during startup (before we retrieve the current output settings)
 // and can be also used to effectively pause the beat
 type managed struct{}
 

--- a/x-pack/libbeat/outputs/managed/managed.go
+++ b/x-pack/libbeat/outputs/managed/managed.go
@@ -1,0 +1,58 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package pause
+
+import (
+	"time"
+
+	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/outputs"
+	"github.com/elastic/beats/libbeat/publisher"
+)
+
+// managed output is used as a placeholder for central management
+// this output will cause the beat to pause the output until a real
+// output is configured
+// It's used both during startup (before we retrieved the current output settings)
+// and can be also used to effectively pause the beat
+type managed struct{}
+
+func init() {
+	outputs.RegisterType("managed", makeManaged)
+}
+
+func makeManaged(
+	beat beat.Info,
+	observer outputs.Observer,
+	cfg *common.Config,
+) (outputs.Group, error) {
+	c := &managed{}
+	return outputs.Success(0, 0, c)
+}
+
+func (c *managed) Close() error { return nil }
+func (c *managed) Publish(batch publisher.Batch) error {
+	time.Sleep(60 * time.Second)
+	batch.Retry()
+	return nil
+}
+
+func (c *managed) String() string {
+	return "managed"
+}


### PR DESCRIPTION
This output acts as a placeholder for Central Management. It's basically
a null output that request retry of all batches, which in fact creates
an output pause.

Central management will initially use this to set it as default
configuration. That will ensure a valid configuration after enrolling,
as configuring anything available in central management will be forbidden.

```
# Enrolled under Central Management, output is automatically configured:
output.managed: ~
```

In the future this can also be used as a way to pause the output if
the user request it in Central Management.


I plan to open a subsequent PR to overwrite `beat.yml` after enroll, it will disable local modules & configure this output