### PR TITLE
Cherry-pick #8474 to 6.x: Various minor fixes to elasticsearch/node_stats metricset x-pack code

### DIFF
--- a/metricbeat/module/elasticsearch/cluster_stats/data_xpack.go
+++ b/metricbeat/module/elasticsearch/cluster_stats/data_xpack.go
@@ -34,9 +34,9 @@ import (
 
 func clusterNeedsTLSEnabled(license, stackStats common.MapStr) (bool, error) {
 	// TLS does not need to be enabled if license type is something other than trial
-	value, err := license.GetValue("license.type")
+	value, err := license.GetValue("type")
 	if err != nil {
-		return false, elastic.MakeErrorForMissingField("license.type", elastic.Elasticsearch)
+		return false, elastic.MakeErrorForMissingField("type", elastic.Elasticsearch)
 	}
 
 	licenseType, ok := value.(string)

--- a/metricbeat/module/elasticsearch/elasticsearch.go
+++ b/metricbeat/module/elasticsearch/elasticsearch.go
@@ -196,9 +196,19 @@ func GetLicense(http *helper.HTTP, resetURI string) (common.MapStr, error) {
 			return nil, err
 		}
 
-		err = json.Unmarshal(content, &license)
+		var data common.MapStr
+		err = json.Unmarshal(content, &data)
 		if err != nil {
 			return nil, err
+		}
+
+		l, err := data.GetValue("license")
+		if err != nil {
+			return nil, err
+		}
+		license, ok := l.(map[string]interface{})
+		if !ok {
+			return nil, elastic.MakeErrorForMissingField("license", elastic.Elasticsearch)
 		}
 
 		// Cache license for a minute


### PR DESCRIPTION
Cherry-pick of PR #8474 to 6.x branch. Original message: 

Based on recent testing I found a few issues in the `elasticsearch/nodes_stats` metricset's x-pack code path:

* The ES Node Stats API doesn't report load stats for 1m, 5m, and 15m until it has collected them. So we should make these fields optional in our schema.

* The ES Node Stats API doesn't report cgroup stats unless ES is running in a container. So we should make this field optional in our schema.

* The code was incorrectly double nesting the `license` field, that is `"license": { "license": { ... } }`.

* The code was calling other ES APIs but not passing the correct reset URI to the functions making these API calls. As a result only one `node_stats` document would get indexed into `.monitoring-es-6-mb-*` the first time the metricset's `Fetch()` function. After that no new `node_stats` documents would get indexed because the `content` received by the `eventMappingXPack` function did not contain Node Stats API response data!

This PR fixes these issues.