### PR TITLE
Cherry-pick #8125 to 6.x: Mark the TCP input and the UDP input as GA

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -58,6 +58,7 @@ https://github.com/elastic/beats/compare/v6.4.0...6.x[Check the HEAD diff]
 - Update CRI format to support partial/full tags. {pull}8265[8265]
 - Fix some errors happening when stopping syslog input. {pull}8347[8347]
 - Fix RFC3339 timezone and nanoseconds parsing with the syslog input. {pull}8346[8346]
+- Mark the TCP and UDP input as GA. {pull}8125[8125]
 
 *Heartbeat*
 

--- a/filebeat/docs/inputs/input-tcp.asciidoc
+++ b/filebeat/docs/inputs/input-tcp.asciidoc
@@ -7,8 +7,6 @@
 <titleabbrev>TCP</titleabbrev>
 ++++
 
-experimental[]
-
 Use the `TCP` input to read events over TCP.
 
 Example configuration:

--- a/filebeat/docs/inputs/input-udp.asciidoc
+++ b/filebeat/docs/inputs/input-udp.asciidoc
@@ -7,8 +7,6 @@
 <titleabbrev>UDP</titleabbrev>
 ++++
 
-experimental[]
-
 Use the `udp` input to read events over UDP.
 
 Example configuration:

--- a/filebeat/input/tcp/input.go
+++ b/filebeat/input/tcp/input.go
@@ -29,7 +29,6 @@ import (
 	"github.com/elastic/beats/filebeat/util"
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/libbeat/logp"
 )
 
@@ -56,7 +55,6 @@ func NewInput(
 	outlet channel.Connector,
 	context input.Context,
 ) (input.Input, error) {
-	cfgwarn.Experimental("TCP input type is used")
 
 	out, err := outlet(cfg, context.DynamicFields)
 	if err != nil {

--- a/filebeat/input/udp/input.go
+++ b/filebeat/input/udp/input.go
@@ -29,7 +29,6 @@ import (
 	"github.com/elastic/beats/filebeat/util"
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/libbeat/logp"
 )
 
@@ -54,7 +53,6 @@ func NewInput(
 	outlet channel.Connector,
 	context input.Context,
 ) (input.Input, error) {
-	cfgwarn.Experimental("UDP input type is used")
 
 	out, err := outlet(cfg, context.DynamicFields)
 	if err != nil {


### PR DESCRIPTION
Cherry-pick of PR #8125 to 6.x branch. Original message: 

The API and features seems to be stable enough that we mark both of
theses input as GA.

After discussing with @ruflin I think its fine to set theses two input as GA for 6.5.