### PR TITLE
Cherry-pick #8419 to 6.x: improve keystore test resiliency

### DIFF
--- a/libbeat/tests/system/test_keystore.py
+++ b/libbeat/tests/system/test_keystore.py
@@ -34,7 +34,7 @@ class TestKeystore(KeystoreBase):
 
         self.add_secret(key, secret)
         proc = self.start_beat()
-        self.wait_until(lambda: self.log_contains("no such host"))
+        self.wait_until(lambda: self.log_contains("Elasticsearch url: http://myeleasticsearchsecrethost:9200"))
         assert self.log_contains(secret)
         proc.check_kill_and_wait()
 
@@ -67,6 +67,6 @@ class TestKeystore(KeystoreBase):
 
         self.add_secret(key, secret)
         proc = self.start_beat()
-        self.wait_until(lambda: self.log_contains("no such host"))
+        self.wait_until(lambda: self.log_contains("Elasticsearch url: http://myeleasticsearchsecrethost:9200"))
         assert self.log_contains(secret)
         proc.check_kill_and_wait()


### PR DESCRIPTION
Cherry-pick of PR #8419 to 6.x branch. Original message: 

Switch to check logs for the expected elasticsearch url instead of the error that usually occurs under CI.

failure condition for test to pass:
```
INFO    elasticsearch/client.go:164    Elasticsearch url: http://myeleasticsearchsecrethost:9200
DEBUG    [elasticsearch]    elasticsearch/client.go:694    ES Ping(url=http://myeleasticsearchsecrethost:9200)
DEBUG    [elasticsearch]    elasticsearch/client.go:698    Ping request failed with: Get http://myeleasticsearchsecrethost:9200: lookup myeleasticsearchsecrethost on 8.8.8.8:53: no such host
```

GCP reports:
```
INFO    elasticsearch/client.go:164    Elasticsearch url: http://myeleasticsearchsecrethost:9200
DEBUG    [elasticsearch]    elasticsearch/client.go:694    ES Ping(url=http://myeleasticsearchsecrethost:9200)
DEBUG    [elasticsearch]    elasticsearch/client.go:698    Ping request failed with: Get http://myeleasticsearchsecrethost:9200: lookup myeleasticsearchsecrethost on 127.0.0.53:53: server misbehaving
```

In the coffee shop, everything resolves to their portal, so no failure is logged along with the info before the test times out.