### PR TITLE
Allow user/passwd based enrollment

### DIFF
--- a/libbeat/common/cli/password.go
+++ b/libbeat/common/cli/password.go
@@ -35,7 +35,7 @@ var methods = map[string]method{
 }
 
 // ReadPassword allows to read a password passed as a command line parameter.
-// it offers several ways to read the password so it is not directly passed as a plain text argument:
+// It offers several ways to read the password so it is not directly passed as a plain text argument:
 //   stdin - Will prompt the user to input the password
 //   env:VAR_NAME - Will read the password from the given env variable
 //
@@ -46,7 +46,7 @@ func ReadPassword(def string) (string, error) {
 
 	var method, params string
 	parts := strings.SplitN(def, ":", 2)
-	method = parts[0]
+	method = strings.ToLower(parts[0])
 
 	if len(parts) == 2 {
 		params = parts[1]
@@ -54,7 +54,7 @@ func ReadPassword(def string) (string, error) {
 
 	m := methods[method]
 	if m == nil {
-		return "", fmt.Errorf("unknown password retrieval method %s", method)
+		return "", errors.New("unknown password source, use stdin or env:VAR_NAME")
 	}
 
 	return m(params)

--- a/libbeat/common/cli/password.go
+++ b/libbeat/common/cli/password.go
@@ -1,0 +1,78 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cli
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"syscall"
+
+	"github.com/pkg/errors"
+	"golang.org/x/crypto/ssh/terminal"
+)
+
+type method func(m string) (string, error)
+
+var methods = map[string]method{
+	"stdin": stdin,
+	"env":   env,
+}
+
+// ReadPassword allows to read a password passed as a command line parameter.
+// it offers several ways to read the password so it is not directly passed as a plain text argument:
+//   stdin - Will prompt the user to input the password
+//   env:VAR_NAME - Will read the password from the given env variable
+//
+func ReadPassword(def string) (string, error) {
+	if len(def) == 0 {
+		return "", errors.New("empty password definition")
+	}
+
+	var method, params string
+	parts := strings.SplitN(def, ":", 2)
+	method = parts[0]
+
+	if len(parts) == 2 {
+		params = parts[1]
+	}
+
+	m := methods[method]
+	if m == nil {
+		return "", fmt.Errorf("unknown password retrieval method %s", method)
+	}
+
+	return m(params)
+}
+
+func stdin(p string) (string, error) {
+	fmt.Print("Enter password: ")
+	bytePassword, err := terminal.ReadPassword(int(syscall.Stdin))
+	if err != nil {
+		return "", errors.Wrap(err, "reading password input")
+	}
+	return string(bytePassword), nil
+}
+
+func env(p string) (string, error) {
+	if len(p) == 0 {
+		return "", errors.New("env variable name is needed when using env: password method")
+	}
+
+	return os.Getenv(p), nil
+}

--- a/libbeat/common/cli/password_test.go
+++ b/libbeat/common/cli/password_test.go
@@ -1,0 +1,65 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cli
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReadPassword(t *testing.T) {
+	os.Setenv("FOO", "random")
+
+	tests := []struct {
+		name     string
+		input    string
+		password string
+		error    bool
+	}{
+		{
+			name:     "Test env variable",
+			input:    "env:FOO",
+			password: "random",
+		},
+		{
+			name:  "Test unknown method",
+			input: "foo:bar",
+			error: true,
+		},
+		{
+			name:  "Test empty input",
+			input: "",
+			error: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			password, err := ReadPassword(test.input)
+			assert.Equal(t, test.password, password)
+
+			if test.error {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/x-pack/libbeat/cmd/enroll.go
+++ b/x-pack/libbeat/cmd/enroll.go
@@ -13,6 +13,7 @@ import (
 	"github.com/elastic/beats/libbeat/cmd/instance"
 	"github.com/elastic/beats/libbeat/common/cli"
 	"github.com/elastic/beats/x-pack/libbeat/management"
+	"github.com/elastic/beats/x-pack/libbeat/management/api"
 )
 
 func getBeat(name, version string) (*instance.Beat, error) {
@@ -30,16 +31,52 @@ func getBeat(name, version string) (*instance.Beat, error) {
 }
 
 func genEnrollCmd(name, version string) *cobra.Command {
+	var username, password string
+
 	enrollCmd := cobra.Command{
-		Use:   "enroll <kibana_url> <enrollment_token>",
+		Use:   "enroll <kibana_url> [<enrollment_token>]",
 		Short: "Enroll in Kibana for Central Management",
-		Args:  cobra.ExactArgs(2),
+		Long: `This will enroll in  Kibana Beats Central Management. If you pass an enrollment token
+		it will be used. You can also enroll using a username and password combination.`,
+		Args: cobra.RangeArgs(1, 2),
 		Run: cli.RunWith(func(cmd *cobra.Command, args []string) error {
 			beat, err := getBeat(name, version)
 			kibanaURL := args[0]
-			enrollmentToken := args[1]
-			if err != nil {
-				return err
+
+			if username == "" && len(args) == 1 {
+				return errors.New("You should pass either an enrollment token or use --username flag")
+			}
+
+			var enrollmentToken string
+			if len(args) == 2 {
+				// use given enrollment token
+				enrollmentToken = args[1]
+				if err != nil {
+					return err
+				}
+			} else {
+				// retrieve an enrollment token using username/password
+				config, err := api.ConfigFromURL(kibanaURL)
+				if err != nil {
+					return err
+				}
+
+				// pass username/password
+				config.IgnoreVersion = true
+				config.Username = username
+				config.Password, err = cli.ReadPassword(password)
+				if err != nil {
+					return err
+				}
+
+				client, err := api.NewClient(config)
+				if err != nil {
+					return err
+				}
+				enrollmentToken, err = client.CreateEnrollmentToken()
+				if err != nil {
+					return errors.Wrap(err, "Creating a new enrollment token")
+				}
 			}
 
 			if err = management.Enroll(beat, kibanaURL, enrollmentToken); err != nil {
@@ -50,6 +87,9 @@ func genEnrollCmd(name, version string) *cobra.Command {
 			return nil
 		}),
 	}
+
+	enrollCmd.Flags().StringVar(&username, "username", "elastic", "Username to use when enrolling without token")
+	enrollCmd.Flags().StringVar(&password, "password", "stdin", "Method to read the password to use when enrolling without token (stdin or env:VAR_NAME)")
 
 	return &enrollCmd
 }

--- a/x-pack/libbeat/management/api/enrollment_token.go
+++ b/x-pack/libbeat/management/api/enrollment_token.go
@@ -1,0 +1,29 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package api
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// CreateEnrollmentToken talks to Kibana API and generates an enrollment token
+func (c *Client) CreateEnrollmentToken() (string, error) {
+	headers := http.Header{}
+
+	resp := struct {
+		Tokens []string `json:"tokens"`
+	}{}
+	_, err := c.request("POST", "/api/beats/enrollment_tokens", nil, headers, &resp)
+	if err != nil {
+		return "", err
+	}
+
+	if len(resp.Tokens) != 1 {
+		return "", fmt.Errorf("Unexpected number of tokens, got %d, only one expected", len(resp.Tokens))
+	}
+
+	return resp.Tokens[0], nil
+}

--- a/x-pack/libbeat/management/api/enrollment_token_test.go
+++ b/x-pack/libbeat/management/api/enrollment_token_test.go
@@ -1,0 +1,29 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEnrollmentToken(t *testing.T) {
+	server, client := newServerClientPair(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Check correct path is used
+		assert.Equal(t, "/api/beats/enrollment_tokens", r.URL.Path)
+		fmt.Fprintf(w, `{"tokens":["65074ff8639a4661ba7e1bd5ccc209ed"]}`)
+	}))
+	defer server.Close()
+
+	token, err := client.CreateEnrollmentToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, "65074ff8639a4661ba7e1bd5ccc209ed", token)
+}


### PR DESCRIPTION
This allows to enroll using the following workflow:

```
$ <beat> enroll http://kibana:5601
Enter password:

Enrolled and ready to retrieve settings from Kibana
```

It also allows to pass the password as an env variable:

```
$ PASS=...
$ <beat> enroll http://kibana:5601 --username elastic --password env:PASS

Enrolled and ready to retrieve settings from Kibana
```