### PR TITLE
Allow Bus to buffer events in case listeners are not configured

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -113,6 +113,7 @@ https://github.com/elastic/beats/compare/v6.4.0...master[Check the HEAD diff]
 - Support for Kafka 2.0.0 in kafka output {pull}8399[8399]
 - Add setting `setup.kibana.space.id` to support Kibana Spaces {pull}7942[7942]
 - Add Beats Central Management {pull}8559[8559]
+- Allow Bus to buffer events in case listeners are not configured. {pull}8527[8527]
 
 *Auditbeat*
 

--- a/libbeat/common/bus/bus_test.go
+++ b/libbeat/common/bus/bus_test.go
@@ -101,3 +101,19 @@ func TestListenerClose(t *testing.T) {
 	event = <-listener.Events()
 	assert.Equal(t, event, Event(nil))
 }
+
+func TestUnsubscribedBus(t *testing.T) {
+	bus := NewBusWithStore("name", 2)
+	bus.Publish(Event{"first": "event"})
+
+	listener := bus.Subscribe()
+	bus.Publish(Event{"second": "event"})
+	event := <-listener.Events()
+	event1 := <-listener.Events()
+	assert.Equal(t, event, Event{"first": "event"})
+	assert.Equal(t, event1, Event{"second": "event"})
+
+	bus.Publish(Event{"a": 1, "b": 2})
+	event2 := <-listener.Events()
+	assert.Equal(t, event2, Event{"a": 1, "b": 2})
+}


### PR DESCRIPTION
This PR allows Beats to store events in a temporary channel in case there is not subscribed listener. 

cc: @exekias please see if this is a valid usecase.