### PR TITLE
Fix source_node logic in elasticsearch/shards xpack code

### DIFF
--- a/metricbeat/module/elasticsearch/shard/data.go
+++ b/metricbeat/module/elasticsearch/shard/data.go
@@ -37,9 +37,12 @@ var (
 )
 
 type stateStruct struct {
-	ClusterName  string `json:"cluster_name"`
-	StateID      string `json:"state_uuid"`
-	MasterNode   string `json:"master_node"`
+	ClusterName string `json:"cluster_name"`
+	StateID     string `json:"state_uuid"`
+	MasterNode  string `json:"master_node"`
+	Nodes       map[string]struct {
+		Name string `json:"name"`
+	} `json:"nodes"`
 	RoutingTable struct {
 		Indices map[string]struct {
 			Shards map[string][]map[string]interface{} `json:"shards"`

--- a/metricbeat/module/elasticsearch/shard/shard.go
+++ b/metricbeat/module/elasticsearch/shard/shard.go
@@ -35,7 +35,7 @@ func init() {
 }
 
 const (
-	statePath = "/_cluster/state/version,master_node,routing_table"
+	statePath = "/_cluster/state/version,nodes,master_node,routing_table"
 )
 
 // MetricSet type defines all fields of the MetricSet


### PR DESCRIPTION
This PR fixes the data in the `source_node` object present in `shards` type documents in `.monitoring-es-6-*`. It also saves an extra ES API call by requesting a bit of additional information (`nodes`) from the `GET _cluster/state` ES API call already being made.

Note that the `source_node` object constructed by the `getSourceNode` function is partial. It only contains two fields, `uuid` and `name`, because these are the only two fields actually used by the Monitoring UI.