### PR TITLE
Cherry-pick #8533 to 6.x: Fix source_node logic in elasticsearch/shards xpack code

### DIFF
--- a/metricbeat/module/elasticsearch/shard/data.go
+++ b/metricbeat/module/elasticsearch/shard/data.go
@@ -37,9 +37,12 @@ var (
 )
 
 type stateStruct struct {
-	ClusterName  string `json:"cluster_name"`
-	StateID      string `json:"state_uuid"`
-	MasterNode   string `json:"master_node"`
+	ClusterName string `json:"cluster_name"`
+	StateID     string `json:"state_uuid"`
+	MasterNode  string `json:"master_node"`
+	Nodes       map[string]struct {
+		Name string `json:"name"`
+	} `json:"nodes"`
 	RoutingTable struct {
 		Indices map[string]struct {
 			Shards map[string][]map[string]interface{} `json:"shards"`

--- a/metricbeat/module/elasticsearch/shard/data_xpack.go
+++ b/metricbeat/module/elasticsearch/shard/data_xpack.go
@@ -34,26 +34,11 @@ func eventsMappingXPack(r mb.ReporterV2, m *MetricSet, content []byte) {
 		return
 	}
 
-	nodeInfo, err := elasticsearch.GetNodeInfo(m.HTTP, m.HostData().SanitizedURI+statePath, stateData.MasterNode)
-	if err != nil {
-		return
-	}
-
 	// TODO: This is currently needed because the cluser_uuid is `na` in stateData in case not the full state is requested.
 	// Will be fixed in: https://github.com/elastic/elasticsearch/pull/30656
 	clusterID, err := elasticsearch.GetClusterID(m.HTTP, m.HostData().SanitizedURI+statePath, stateData.MasterNode)
 	if err != nil {
 		return
-	}
-
-	sourceNode := common.MapStr{
-		"uuid":              stateData.MasterNode,
-		"host":              nodeInfo.Host,
-		"transport_address": nodeInfo.TransportAddress,
-		"ip":                nodeInfo.IP,
-		// This seems to be in the x-pack data a subset of the cluster_uuid not the name?
-		"name":      stateData.ClusterName,
-		"timestamp": common.Time(time.Now()),
 	}
 
 	for _, index := range stateData.RoutingTable.Indices {
@@ -77,17 +62,28 @@ func eventsMappingXPack(r mb.ReporterV2, m *MetricSet, content []byte) {
 					continue
 				}
 
-				event.RootFields = common.MapStr{}
-
 				event.RootFields = common.MapStr{
 					"timestamp":    time.Now(),
 					"cluster_uuid": clusterID,
 					"interval_ms":  m.Module().Config().Period.Nanoseconds() / 1000 / 1000,
 					"type":         "shards",
-					"source_node":  sourceNode,
 					"shard":        fields,
 					"state_uuid":   stateData.StateID,
 				}
+
+				// Build source_node object
+				nodeID, ok := shard["node"]
+				if !ok {
+					continue
+				}
+				if nodeID != nil { // shard has not been allocated yet
+					sourceNode, err := getSourceNode(nodeID.(string), stateData)
+					if err != nil {
+						continue
+					}
+					event.RootFields.Put("source_node", sourceNode)
+				}
+
 				event.Index = elastic.MakeXPackMonitoringIndexName(elastic.Elasticsearch)
 
 				r.Event(event)
@@ -95,4 +91,16 @@ func eventsMappingXPack(r mb.ReporterV2, m *MetricSet, content []byte) {
 			}
 		}
 	}
+}
+
+func getSourceNode(nodeID string, stateData *stateStruct) (common.MapStr, error) {
+	nodeInfo, ok := stateData.Nodes[nodeID]
+	if !ok {
+		return nil, elastic.MakeErrorForMissingField("nodes."+nodeID, elastic.Elasticsearch)
+	}
+
+	return common.MapStr{
+		"uuid": nodeID,
+		"name": nodeInfo.Name,
+	}, nil
 }

--- a/metricbeat/module/elasticsearch/shard/shard.go
+++ b/metricbeat/module/elasticsearch/shard/shard.go
@@ -35,7 +35,7 @@ func init() {
 }
 
 const (
-	statePath = "/_cluster/state/version,master_node,routing_table"
+	statePath = "/_cluster/state/version,nodes,master_node,routing_table"
 )
 
 // MetricSet type defines all fields of the MetricSet


### PR DESCRIPTION
Cherry-pick of PR #8533 to 6.x branch. Original message: 

This PR fixes the data in the `source_node` object present in `shards` type documents in `.monitoring-es-6-*`. It also saves an extra ES API call by requesting a bit of additional information (`nodes`) from the `GET _cluster/state` ES API call already being made by the metricset.

Note that the `source_node` object constructed by the `getSourceNode` function is partial. It only contains two fields, `uuid` and `name`, because these are the only two fields actually used by the Monitoring UI.