### PR TITLE
Cherry-pick #7871 to 6.3: Recover metrics for old apache versions

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -40,6 +40,8 @@ https://github.com/elastic/beats/compare/v6.3.2...6.3[Check the HEAD diff]
 
 *Metricbeat*
 
+- Recover metrics for old apache versions removed by mistake on #6450. {pull}7871[7871]
+
 *Packetbeat*
 
 *Winlogbeat*

--- a/metricbeat/module/apache/status/data.go
+++ b/metricbeat/module/apache/status/data.go
@@ -54,16 +54,20 @@ var (
 
 	// Schema used till apache 2.4.12
 	schemaOld = s.Schema{
-		"total_accesses":   c.Int("Total Accesses"),
-		"total_kbytes":     c.Int("Total kBytes"),
-		"requests_per_sec": c.Float("ReqPerSec", s.Optional),
-		"bytes_per_sec":    c.Float("BytesPerSec", s.Optional),
+		"total_accesses":    c.Int("Total Accesses"),
+		"total_kbytes":      c.Int("Total kBytes"),
+		"requests_per_sec":  c.Float("ReqPerSec", s.Optional),
+		"bytes_per_sec":     c.Float("BytesPerSec", s.Optional),
+		"bytes_per_request": c.Float("BytesPerReq", s.Optional),
 		"workers": s.Object{
 			"busy": c.Int("BusyWorkers"),
 			"idle": c.Int("IdleWorkers"),
 		},
 		"uptime": s.Object{
 			"uptime": c.Int("Uptime"),
+		},
+		"cpu": s.Object{
+			"load": c.Float("CPULoad", s.Optional),
 		},
 		"connections": s.Object{
 			"total": c.Int("ConnsTotal", s.Optional),

--- a/metricbeat/tests/system/test_apache.py
+++ b/metricbeat/tests/system/test_apache.py
@@ -16,8 +16,8 @@ APACHE_STATUS_FIELDS = [
 
 APACHE_OLD_STATUS_FIELDS = [
     "hostname", "total_accesses", "total_kbytes",
-    "requests_per_sec", "bytes_per_sec",
-    "workers.busy", "workers.idle", "uptime",
+    "requests_per_sec", "bytes_per_sec", "bytes_per_request",
+    "workers.busy", "workers.idle", "uptime", "cpu",
     "connections", "scoreboard"
 ]
 


### PR DESCRIPTION
Cherry-pick of PR #7871 to 6.3 branch. Original message: 

Removed by mistake on #6450