### PR TITLE
Cherry-pick #8532 to 6.x: Allow elasticsearch/shard metricset xpack code to specify _id

### DIFF
--- a/metricbeat/mb/event.go
+++ b/metricbeat/mb/event.go
@@ -36,6 +36,7 @@ type Event struct {
 	MetricSetFields common.MapStr // Fields that will be namespaced under [module].[metricset].
 
 	Index     string        // Index name prefix. If set overwrites the default prefix.
+	ID        string        // ID of event. If set, overwrites the default ID.
 	Namespace string        // Fully qualified namespace to use for MetricSetFields.
 	Timestamp time.Time     // Timestamp when the event data was collected.
 	Error     error         // Error that occurred while collecting the event data.
@@ -81,6 +82,10 @@ func (e *Event) BeatEvent(module, metricSet string, modifiers ...EventModifier) 
 	// Set index prefix to overwrite default
 	if e.Index != "" {
 		b.Meta = common.MapStr{"index": e.Index}
+	}
+
+	if e.ID != "" {
+		b.SetID(e.ID)
 	}
 
 	if e.Error != nil {

--- a/metricbeat/mb/event_test.go
+++ b/metricbeat/mb/event_test.go
@@ -111,6 +111,40 @@ func TestEventConversionToBeatEvent(t *testing.T) {
 		}, e.Fields)
 	})
 
+	t.Run("with ID", func(t *testing.T) {
+		mbEvent := &Event{
+			ID:        "foobar",
+			Timestamp: timestamp,
+			RootFields: common.MapStr{
+				"type": "docker",
+			},
+			ModuleFields: common.MapStr{
+				"container": common.MapStr{
+					"name": "wordpress",
+				},
+			},
+			MetricSetFields: common.MapStr{
+				"ms": 1000,
+			},
+		}
+		e := mbEvent.BeatEvent(module, metricSet)
+		e = mbEvent.BeatEvent(module, metricSet)
+
+		assert.Equal(t, "foobar", e.Meta["id"])
+		assert.Equal(t, timestamp, e.Timestamp)
+		assert.Equal(t, common.MapStr{
+			"type": "docker",
+			"docker": common.MapStr{
+				"container": common.MapStr{
+					"name": "wordpress",
+				},
+				"uptime": common.MapStr{
+					"ms": 1000,
+				},
+			},
+		}, e.Fields)
+	})
+
 	t.Run("error message", func(t *testing.T) {
 		msg := "something failed"
 		e := (&Event{


### PR DESCRIPTION
Cherry-pick of PR #8532 to 6.x branch. Original message: 

Turns out documents in `.monitoring-es-6-*` with `type` = `"shards"` don't have auto-generated `_id`s like all other documents in `.monitoring-es-6-*`. Instead their `_id`s have a value composed from the cluster state ID, node ID (of the node the shard resides on, if allocated), index name, shard number, and shard type (`p`rimary or `r`eplica). 

For example, an `_id` of a `shards` type document for an allocated shard will look like `RTiWyB_4QY68kpUJ1_qe4Q:u7mFTBJUS6S-fcVLTZlEdA:.monitoring-es-6-2018.10.02:0:p`.

And an `_id` of a `shards` type document for an unallocated shard will look like `RTiWyB_4QY68kpUJ1_qe4Q:_na:metricbeat-7.0.0-alpha1-2018.10.01:0:r`.

This PR:
* teaches metricbeat events to accept an optional `ID` field and use it to override the `_id` in corresponding Elasticsearch documents, and
* creates the custom ID, as detailed above, for `shards` type documents to be indexed into `.monitoring-es-6-*`.

