### PR TITLE
Cherry-pick #8551 to 6.x: Better error messaging for Elastic stacks' metricsets

### DIFF
--- a/metricbeat/mb/mb.go
+++ b/metricbeat/mb/mb.go
@@ -270,6 +270,12 @@ func (b *BaseMetricSet) Name() string {
 	return b.name
 }
 
+// FullyQualifiedName returns the complete name of the MetricSet, including the
+// name of the module.
+func (b *BaseMetricSet) FullyQualifiedName() string {
+	return b.Module().Name() + "/" + b.Name()
+}
+
 // Module returns the parent Module for the MetricSet.
 func (b *BaseMetricSet) Module() Module {
 	return b.module

--- a/metricbeat/module/elasticsearch/ccr/data.go
+++ b/metricbeat/module/elasticsearch/ccr/data.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 
 	"github.com/joeshaw/multierror"
+	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/libbeat/common"
 	s "github.com/elastic/beats/libbeat/common/schema"
@@ -54,6 +55,7 @@ func eventsMapping(r mb.ReporterV2, info elasticsearch.Info, content []byte) err
 	var data map[string]interface{}
 	err := json.Unmarshal(content, &data)
 	if err != nil {
+		err = errors.Wrap(err, "failure parsing Elasticsearch CCR Stats API response")
 		r.Error(err)
 		return err
 	}
@@ -83,7 +85,7 @@ func eventsMapping(r mb.ReporterV2, info elasticsearch.Info, content []byte) err
 			}
 
 			event.RootFields = common.MapStr{}
-			event.RootFields.Put("service.name", "elasticsearch")
+			event.RootFields.Put("service.name", elasticsearch.ModuleName)
 
 			event.ModuleFields = common.MapStr{}
 			event.ModuleFields.Put("cluster.name", info.ClusterName)

--- a/metricbeat/module/elasticsearch/ccr/data_xpack.go
+++ b/metricbeat/module/elasticsearch/ccr/data_xpack.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/joeshaw/multierror"
+	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/metricbeat/helper/elastic"
@@ -34,6 +35,7 @@ func eventsMappingXPack(r mb.ReporterV2, m *MetricSet, info elasticsearch.Info, 
 	var data map[string]interface{}
 	err := json.Unmarshal(content, &data)
 	if err != nil {
+		err = errors.Wrap(err, "failure parsing Elasticsearch CCR Stats API response")
 		r.Error(err)
 		return err
 	}

--- a/metricbeat/module/elasticsearch/cluster_stats/cluster_stats.go
+++ b/metricbeat/module/elasticsearch/cluster_stats/cluster_stats.go
@@ -18,7 +18,7 @@
 package cluster_stats
 
 import (
-	"fmt"
+	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/libbeat/logp"
@@ -44,7 +44,7 @@ type MetricSet struct {
 
 // New create a new instance of the MetricSet
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	cfgwarn.Beta("The elasticsearch cluster_stats metricset is beta")
+	cfgwarn.Beta("the " + base.FullyQualifiedName() + " metricset is beta")
 
 	ms, err := elasticsearch.NewMetricSet(base, clusterStatsPath)
 	if err != nil {
@@ -57,13 +57,13 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 func (m *MetricSet) Fetch(r mb.ReporterV2) {
 	isMaster, err := elasticsearch.IsMaster(m.HTTP, m.HostData().SanitizedURI+clusterStatsPath)
 	if err != nil {
-		r.Error(fmt.Errorf("Error fetching master info: %s", err))
+		r.Error(errors.Wrap(err, "error determining if connected Elasticsearch node is master"))
 		return
 	}
 
 	// Not master, no event sent
 	if !isMaster {
-		logp.Debug("elasticsearch", "Trying to fetch cluster stats from a non master node.")
+		logp.Debug(elasticsearch.ModuleName, "trying to fetch cluster stats from a non master node.")
 		return
 	}
 

--- a/metricbeat/module/elasticsearch/cluster_stats/data.go
+++ b/metricbeat/module/elasticsearch/cluster_stats/data.go
@@ -20,13 +20,14 @@ package cluster_stats
 import (
 	"encoding/json"
 
-	"github.com/elastic/beats/metricbeat/helper/elastic"
+	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/libbeat/common"
-
 	s "github.com/elastic/beats/libbeat/common/schema"
 	c "github.com/elastic/beats/libbeat/common/schema/mapstriface"
+	"github.com/elastic/beats/metricbeat/helper/elastic"
 	"github.com/elastic/beats/metricbeat/mb"
+	"github.com/elastic/beats/metricbeat/module/elasticsearch"
 )
 
 var (
@@ -56,12 +57,14 @@ func eventMapping(r mb.ReporterV2, content []byte) error {
 	var data map[string]interface{}
 	err := json.Unmarshal(content, &data)
 	if err != nil {
+		err = errors.Wrap(err, "failure parsing Elasticsearch Cluster Stats API response")
 		r.Error(err)
 		return err
 	}
 
 	metricSetFields, err := schema.Apply(data)
 	if err != nil {
+		err = errors.Wrap(err, "failure applying cluster stats schema")
 		r.Error(err)
 		return err
 	}
@@ -73,7 +76,7 @@ func eventMapping(r mb.ReporterV2, content []byte) error {
 
 	var event mb.Event
 	event.RootFields = common.MapStr{}
-	event.RootFields.Put("service.name", "elasticsearch")
+	event.RootFields.Put("service.name", elasticsearch.ModuleName)
 
 	event.ModuleFields = common.MapStr{}
 	event.ModuleFields.Put("cluster.name", clusterName)

--- a/metricbeat/module/elasticsearch/cluster_stats/data_xpack.go
+++ b/metricbeat/module/elasticsearch/cluster_stats/data_xpack.go
@@ -25,11 +25,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/elastic/beats/metricbeat/helper/elastic"
-	"github.com/elastic/beats/metricbeat/module/elasticsearch"
+	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/metricbeat/helper/elastic"
 	"github.com/elastic/beats/metricbeat/mb"
+	"github.com/elastic/beats/metricbeat/module/elasticsearch"
 )
 
 func clusterNeedsTLSEnabled(license, stackStats common.MapStr) (bool, error) {
@@ -145,7 +146,7 @@ func eventMappingXPack(r mb.ReporterV2, m *MetricSet, content []byte) error {
 	var data map[string]interface{}
 	err := json.Unmarshal(content, &data)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "failure parsing Elasticsearch Cluster Stats API response")
 	}
 
 	clusterStats := common.MapStr(data)
@@ -161,44 +162,44 @@ func eventMappingXPack(r mb.ReporterV2, m *MetricSet, content []byte) error {
 
 	info, err := elasticsearch.GetInfo(m.HTTP, m.HTTP.GetURI())
 	if err != nil {
-		return err
+		return errors.Wrap(err, "failed to get info from Elasticsearch")
 	}
 
 	license, err := elasticsearch.GetLicense(m.HTTP, m.HTTP.GetURI())
 	if err != nil {
-		return err
+		return errors.Wrap(err, "failed to get license from Elasticsearch")
 	}
 
 	clusterStateMetrics := []string{"version", "master_node", "nodes", "routing_table"}
 	clusterState, err := elasticsearch.GetClusterState(m.HTTP, m.HTTP.GetURI(), clusterStateMetrics)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "failed to get cluster state from Elasticsearch")
 	}
 
 	if err = elasticsearch.PassThruField("status", clusterStats, clusterState); err != nil {
-		return err
+		return errors.Wrap(err, "failed to pass through status field")
 	}
 
 	nodesHash, err := computeNodesHash(clusterState)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "failed to compute nodes hash")
 	}
 	clusterState.Put("nodes_hash", nodesHash)
 
 	usage, err := elasticsearch.GetStackUsage(m.HTTP, m.HTTP.GetURI())
 	if err != nil {
-		return err
+		return errors.Wrap(err, "failed to get stack usage from Elasticsearch")
 	}
 
 	clusterNeedsTLS, err := clusterNeedsTLSEnabled(license, usage)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "failed to determine if cluster needs TLS enabled")
 	}
 	license.Put("cluster_needs_tls", clusterNeedsTLS) // This powers a cluster alert for enabling TLS on the ES transport protocol
 
 	isAPMFound, err := apmIndicesExist(clusterState)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "failed to determine if APM indices exist")
 	}
 	delete(clusterState, "routing_table") // We don't want to index the routing table in monitoring indices
 

--- a/metricbeat/module/elasticsearch/index/data.go
+++ b/metricbeat/module/elasticsearch/index/data.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 
 	"github.com/joeshaw/multierror"
+	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/libbeat/common"
 	s "github.com/elastic/beats/libbeat/common/schema"
@@ -59,27 +60,28 @@ func eventsMapping(r mb.ReporterV2, info elasticsearch.Info, content []byte) err
 	var indicesStruct IndicesStruct
 	err := json.Unmarshal(content, &indicesStruct)
 	if err != nil {
+		err = errors.Wrap(err, "failure parsing Elasticsearch Stats API response")
 		r.Error(err)
 		return err
 	}
 
-	var errors multierror.Errors
+	var errs multierror.Errors
 	for name, index := range indicesStruct.Indices {
 		event := mb.Event{}
 		event.MetricSetFields, err = schema.Apply(index)
 		if err != nil {
 			r.Error(err)
-			errors = append(errors, err)
+			errs = append(errs, errors.Wrap(err, "failure applying index schema"))
 		}
 		// Write name here as full name only available as key
 		event.MetricSetFields["name"] = name
 		event.RootFields = common.MapStr{}
-		event.RootFields.Put("service.name", "elasticsearch")
+		event.RootFields.Put("service.name", elasticsearch.ModuleName)
 		event.ModuleFields = common.MapStr{}
 		event.ModuleFields.Put("cluster.name", info.ClusterName)
 		event.ModuleFields.Put("cluster.id", info.ClusterID)
 		r.Event(event)
 	}
 
-	return errors.Err()
+	return errs.Err()
 }

--- a/metricbeat/module/elasticsearch/index_recovery/data.go
+++ b/metricbeat/module/elasticsearch/index_recovery/data.go
@@ -20,10 +20,13 @@ package index_recovery
 import (
 	"encoding/json"
 
+	"github.com/pkg/errors"
+
 	"github.com/elastic/beats/libbeat/common"
 	s "github.com/elastic/beats/libbeat/common/schema"
 	c "github.com/elastic/beats/libbeat/common/schema/mapstriface"
 	"github.com/elastic/beats/metricbeat/mb"
+	"github.com/elastic/beats/metricbeat/module/elasticsearch"
 )
 
 var (
@@ -56,6 +59,8 @@ func eventsMapping(r mb.ReporterV2, content []byte) error {
 
 	err := json.Unmarshal(content, &data)
 	if err != nil {
+		err = errors.Wrap(err, "failure parsing Elasticsearch Recovery API response")
+		r.Error(err)
 		return err
 	}
 
@@ -70,7 +75,7 @@ func eventsMapping(r mb.ReporterV2, content []byte) error {
 			event.MetricSetFields, _ = schema.Apply(data)
 			event.ModuleFields.Put("index.name", indexName)
 			event.RootFields = common.MapStr{}
-			event.RootFields.Put("service.name", "elasticsearch")
+			event.RootFields.Put("service.name", elasticsearch.ModuleName)
 			r.Event(event)
 		}
 	}

--- a/metricbeat/module/elasticsearch/index_recovery/data_xpack.go
+++ b/metricbeat/module/elasticsearch/index_recovery/data_xpack.go
@@ -21,6 +21,8 @@ import (
 	"encoding/json"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/metricbeat/helper/elastic"
 	"github.com/elastic/beats/metricbeat/mb"
@@ -31,7 +33,7 @@ func eventsMappingXPack(r mb.ReporterV2, m *MetricSet, content []byte) error {
 	var data map[string]interface{}
 	err := json.Unmarshal(content, &data)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "failure parsing Elasticsearch Recovery API response")
 	}
 
 	var results []map[string]interface{}
@@ -67,7 +69,7 @@ func eventsMappingXPack(r mb.ReporterV2, m *MetricSet, content []byte) error {
 
 	info, err := elasticsearch.GetInfo(m.HTTP, m.HTTP.GetURI())
 	if err != nil {
-		return err
+		return errors.Wrap(err, "failed to retrieve info from Elasticsearch")
 	}
 
 	event := mb.Event{}

--- a/metricbeat/module/elasticsearch/ml_job/data.go
+++ b/metricbeat/module/elasticsearch/ml_job/data.go
@@ -21,11 +21,13 @@ import (
 	"encoding/json"
 
 	"github.com/joeshaw/multierror"
+	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/libbeat/common"
 	s "github.com/elastic/beats/libbeat/common/schema"
 	c "github.com/elastic/beats/libbeat/common/schema/mapstriface"
 	"github.com/elastic/beats/metricbeat/mb"
+	"github.com/elastic/beats/metricbeat/module/elasticsearch"
 )
 
 var (
@@ -48,6 +50,8 @@ func eventsMapping(r mb.ReporterV2, content []byte) error {
 	jobsData := &jobsStruct{}
 	err := json.Unmarshal(content, jobsData)
 	if err != nil {
+		err = errors.Wrap(err, "failure parsing Elasticsearch ML Job Stats API response")
+		r.Error(err)
 		return err
 	}
 
@@ -58,11 +62,11 @@ func eventsMapping(r mb.ReporterV2, content []byte) error {
 
 		event.MetricSetFields, err = schema.Apply(job)
 		if err != nil {
-			errs = append(errs, err)
+			errs = append(errs, errors.Wrap(err, "failure applying ml job schema"))
 		}
 
 		event.RootFields = common.MapStr{}
-		event.RootFields.Put("service.name", "elasticsearch")
+		event.RootFields.Put("service.name", elasticsearch.ModuleName)
 		r.Event(event)
 	}
 	return errs.Err()

--- a/metricbeat/module/elasticsearch/ml_job/data_xpack.go
+++ b/metricbeat/module/elasticsearch/ml_job/data_xpack.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/metricbeat/helper/elastic"
 	"github.com/elastic/beats/metricbeat/mb"
@@ -31,13 +33,13 @@ import (
 func eventsMappingXPack(r mb.ReporterV2, m *MetricSet, content []byte) error {
 	info, err := elasticsearch.GetInfo(m.HTTP, m.HTTP.GetURI())
 	if err != nil {
-		return err
+		return errors.Wrap(err, "failed to get info from Elasticsearch")
 	}
 
 	var data map[string]interface{}
 	err = json.Unmarshal(content, &data)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "failure parsing Elasticsearch ML Job Stats API response")
 	}
 
 	jobs, ok := data["jobs"]
@@ -47,7 +49,7 @@ func eventsMappingXPack(r mb.ReporterV2, m *MetricSet, content []byte) error {
 
 	jobsArr, ok := jobs.([]interface{})
 	if !ok {
-		return fmt.Errorf("jobs is not an array of objects")
+		return fmt.Errorf("jobs is not an array of maps")
 	}
 
 	for _, job := range jobsArr {

--- a/metricbeat/module/elasticsearch/ml_job/ml_job.go
+++ b/metricbeat/module/elasticsearch/ml_job/ml_job.go
@@ -18,6 +18,8 @@
 package ml_job
 
 import (
+	"github.com/pkg/errors"
+
 	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/metricbeat/mb"
@@ -25,7 +27,7 @@ import (
 )
 
 func init() {
-	mb.Registry.MustAddMetricSet("elasticsearch", "ml_job", New,
+	mb.Registry.MustAddMetricSet(elasticsearch.ModuleName, "ml_job", New,
 		mb.WithHostParser(elasticsearch.HostParser),
 		mb.WithNamespace("elasticsearch.ml.job"),
 	)
@@ -43,7 +45,7 @@ type MetricSet struct {
 // New creates a new instance of the MetricSet. New is responsible for unpacking
 // any MetricSet specific configuration options if there are any.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	cfgwarn.Beta("The elasticsearch ml_job metricset is beta.")
+	cfgwarn.Beta("The " + base.FullyQualifiedName() + " metricset is beta.")
 
 	// Get the stats from the local node
 	ms, err := elasticsearch.NewMetricSet(base, jobPath)
@@ -58,13 +60,13 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 
 	isMaster, err := elasticsearch.IsMaster(m.HTTP, m.HostData().SanitizedURI+jobPath)
 	if err != nil {
-		r.Error(err)
+		r.Error(errors.Wrap(err, "error determining if connected Elasticsearch node is master"))
 		return
 	}
 
 	// Not master, no event sent
 	if !isMaster {
-		logp.Debug("elasticsearch", "Trying to fetch machine learning job stats from a non-master node.")
+		logp.Debug(elasticsearch.ModuleName, "Trying to fetch machine learning job stats from a non-master node.")
 		return
 	}
 

--- a/metricbeat/module/elasticsearch/node/node.go
+++ b/metricbeat/module/elasticsearch/node/node.go
@@ -22,12 +22,13 @@ import (
 	"github.com/elastic/beats/metricbeat/helper"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/mb/parse"
+	"github.com/elastic/beats/metricbeat/module/elasticsearch"
 )
 
 // init registers the MetricSet with the central registry.
 // The New method will be called after the setup of the module and before starting to fetch data
 func init() {
-	mb.Registry.MustAddMetricSet("elasticsearch", "node", New,
+	mb.Registry.MustAddMetricSet(elasticsearch.ModuleName, "node", New,
 		mb.WithHostParser(hostParser),
 		mb.DefaultMetricSet(),
 	)
@@ -50,7 +51,7 @@ type MetricSet struct {
 
 // New create a new instance of the MetricSet
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	cfgwarn.Beta("The elasticsearch node metricset is beta")
+	cfgwarn.Beta("The " + base.FullyQualifiedName() + " metricset is beta")
 
 	http, err := helper.NewHTTP(base)
 	if err != nil {

--- a/metricbeat/module/elasticsearch/node_stats/node_stats.go
+++ b/metricbeat/module/elasticsearch/node_stats/node_stats.go
@@ -26,7 +26,7 @@ import (
 // init registers the MetricSet with the central registry.
 // The New method will be called after the setup of the module and before starting to fetch data
 func init() {
-	mb.Registry.MustAddMetricSet("elasticsearch", "node_stats", New,
+	mb.Registry.MustAddMetricSet(elasticsearch.ModuleName, "node_stats", New,
 		mb.WithHostParser(elasticsearch.HostParser),
 		mb.DefaultMetricSet(),
 		mb.WithNamespace("elasticsearch.node.stats"),
@@ -44,7 +44,7 @@ type MetricSet struct {
 
 // New create a new instance of the MetricSet
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	cfgwarn.Beta("The elasticsearch node_stats metricset is beta")
+	cfgwarn.Beta("The " + base.FullyQualifiedName() + " metricset is beta")
 
 	// Get the stats from the local node
 	ms, err := elasticsearch.NewMetricSet(base, nodeStatsPath)

--- a/metricbeat/module/elasticsearch/pending_tasks/data_test.go
+++ b/metricbeat/module/elasticsearch/pending_tasks/data_test.go
@@ -23,11 +23,13 @@ import (
 	"io/ioutil"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/beats/libbeat/common"
-	s "github.com/elastic/beats/libbeat/common/schema"
+	"github.com/elastic/beats/metricbeat/mb"
+	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
 )
 
 //Events Mapping
@@ -37,7 +39,8 @@ func TestEmptyQueueShouldGiveNoError(t *testing.T) {
 	content, err := ioutil.ReadFile(file)
 	assert.NoError(t, err)
 
-	_, err = eventsMapping(content)
+	reporter := &mbtest.CapturingReporterV2{}
+	err = eventsMapping(reporter, content)
 	assert.NoError(t, err)
 }
 
@@ -46,8 +49,11 @@ func TestNotEmptyQueueShouldGiveNoError(t *testing.T) {
 	content, err := ioutil.ReadFile(file)
 	assert.NoError(t, err)
 
-	_, err = eventsMapping(content)
+	reporter := &mbtest.CapturingReporterV2{}
+	err = eventsMapping(reporter, content)
 	assert.NoError(t, err)
+	assert.True(t, len(reporter.GetEvents()) >= 1)
+	assert.Zero(t, len(reporter.GetErrors()))
 }
 
 func TestEmptyQueueShouldGiveZeroEvent(t *testing.T) {
@@ -55,18 +61,10 @@ func TestEmptyQueueShouldGiveZeroEvent(t *testing.T) {
 	content, err := ioutil.ReadFile(file)
 	assert.NoError(t, err)
 
-	events, _ := eventsMapping(content)
-	assert.Zero(t, len(events))
-}
-
-func TestEmptyQueueShouldGiveNilEvent(t *testing.T) {
-	file := "./_meta/test/empty.json"
-	content, err := ioutil.ReadFile(file)
-	assert.NoError(t, err)
-
-	events, _ := eventsMapping(content)
-
-	assert.Nil(t, events)
+	reporter := &mbtest.CapturingReporterV2{}
+	err = eventsMapping(reporter, content)
+	assert.Zero(t, len(reporter.GetEvents()))
+	assert.Zero(t, len(reporter.GetErrors()))
 }
 
 func TestNotEmptyQueueShouldGiveSeveralEvents(t *testing.T) {
@@ -74,9 +72,10 @@ func TestNotEmptyQueueShouldGiveSeveralEvents(t *testing.T) {
 	content, err := ioutil.ReadFile(file)
 	assert.NoError(t, err)
 
-	events, _ := eventsMapping(content)
-
-	assert.Equal(t, 3, len(events))
+	reporter := &mbtest.CapturingReporterV2{}
+	err = eventsMapping(reporter, content)
+	assert.Equal(t, 3, len(reporter.GetEvents()))
+	assert.Zero(t, len(reporter.GetErrors()))
 }
 
 func TestInvalidJsonForRequiredFieldShouldThrowError(t *testing.T) {
@@ -84,12 +83,8 @@ func TestInvalidJsonForRequiredFieldShouldThrowError(t *testing.T) {
 	content, err := ioutil.ReadFile(file)
 	assert.NoError(t, err)
 
-	var notFoundKeys []string
-	expectedNotFoundKeys := []string{"source"}
-	_, err = eventsMapping(content, s.NotFoundKeys(func(keys []string) {
-		notFoundKeys = keys
-	}))
-	assert.ElementsMatch(t, expectedNotFoundKeys, notFoundKeys)
+	reporter := &mbtest.CapturingReporterV2{}
+	err = eventsMapping(reporter, content)
 	assert.Error(t, err)
 }
 
@@ -98,46 +93,88 @@ func TestInvalidJsonForBadFormatShouldThrowError(t *testing.T) {
 	content, err := ioutil.ReadFile(file)
 	assert.NoError(t, err)
 
-	_, err = eventsMapping(content)
+	reporter := &mbtest.CapturingReporterV2{}
+	err = eventsMapping(reporter, content)
 	assert.Error(t, err)
 }
 
 func TestEventsMappedMatchToContentReceived(t *testing.T) {
 	testCases := []struct {
 		given    string
-		expected []common.MapStr
+		expected []mb.Event
 	}{
-		{"./_meta/test/empty.json", []common.MapStr(nil)},
-		{"./_meta/test/task.622.json", []common.MapStr{common.MapStr{
-			"priority":         "URGENT",
-			"source":           "create-index [foo_9], cause [api]",
-			"time_in_queue.ms": int64(86),
-			"insert_order":     int64(101),
-		}}},
-		{"./_meta/test/tasks.622.json", []common.MapStr{common.MapStr{
-			"priority":         "URGENT",
-			"source":           "create-index [foo_9], cause [api]",
-			"time_in_queue.ms": int64(86),
-			"insert_order":     int64(101)},
-			common.MapStr{
-				"priority":         "HIGH",
-				"source":           "shard-started ([foo_2][1], node[tMTocMvQQgGCkj7QDHl3OA], [P], s[INITIALIZING]), reason [after recovery from shard_store]",
-				"time_in_queue.ms": int64(842),
-				"insert_order":     int64(46),
-			}, common.MapStr{
-				"priority":         "HIGH",
-				"source":           "shard-started ([foo_2][0], node[tMTocMvQQgGCkj7QDHl3OA], [P], s[INITIALIZING]), reason [after recovery from shard_store]",
-				"time_in_queue.ms": int64(858),
-				"insert_order":     int64(45),
-			}}},
+		{"./_meta/test/empty.json", []mb.Event(nil)},
+		{"./_meta/test/task.622.json", []mb.Event{
+			mb.Event{
+				RootFields: common.MapStr{
+					"service": common.MapStr{
+						"name": "elasticsearch",
+					},
+				},
+				MetricSetFields: common.MapStr{
+					"priority":         "URGENT",
+					"source":           "create-index [foo_9], cause [api]",
+					"time_in_queue.ms": int64(86),
+					"insert_order":     int64(101),
+				},
+				Timestamp: time.Time{},
+				Took:      0,
+			},
+		}},
+		{"./_meta/test/tasks.622.json", []mb.Event{
+			mb.Event{
+				RootFields: common.MapStr{
+					"service": common.MapStr{
+						"name": "elasticsearch",
+					},
+				},
+				MetricSetFields: common.MapStr{
+					"priority":         "URGENT",
+					"source":           "create-index [foo_9], cause [api]",
+					"time_in_queue.ms": int64(86),
+					"insert_order":     int64(101),
+				},
+				Timestamp: time.Time{},
+				Took:      0,
+			},
+			mb.Event{
+				RootFields: common.MapStr{
+					"service": common.MapStr{
+						"name": "elasticsearch",
+					},
+				},
+				MetricSetFields: common.MapStr{"priority": "HIGH",
+					"source":           "shard-started ([foo_2][1], node[tMTocMvQQgGCkj7QDHl3OA], [P], s[INITIALIZING]), reason [after recovery from shard_store]",
+					"time_in_queue.ms": int64(842),
+					"insert_order":     int64(46),
+				},
+				Timestamp: time.Time{},
+				Took:      0,
+			}, mb.Event{
+				RootFields: common.MapStr{
+					"service": common.MapStr{
+						"name": "elasticsearch",
+					},
+				},
+				MetricSetFields: common.MapStr{
+					"priority":         "HIGH",
+					"source":           "shard-started ([foo_2][0], node[tMTocMvQQgGCkj7QDHl3OA], [P], s[INITIALIZING]), reason [after recovery from shard_store]",
+					"time_in_queue.ms": int64(858),
+					"insert_order":     int64(45),
+				}, Timestamp: time.Time{},
+				Took: 0,
+			},
+		}},
 	}
 
 	for _, testCase := range testCases {
 		content, err := ioutil.ReadFile(testCase.given)
 		assert.NoError(t, err)
 
-		events, _ := eventsMapping(content)
+		reporter := &mbtest.CapturingReporterV2{}
+		err = eventsMapping(reporter, content)
 
+		events := reporter.GetEvents()
 		if !reflect.DeepEqual(testCase.expected, events) {
 			t.Errorf("Expected %v, actual: %v", testCase.expected, events)
 		}

--- a/metricbeat/module/elasticsearch/shard/data_xpack.go
+++ b/metricbeat/module/elasticsearch/shard/data_xpack.go
@@ -21,24 +21,26 @@ import (
 	"encoding/json"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/metricbeat/helper/elastic"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/module/elasticsearch"
 )
 
-func eventsMappingXPack(r mb.ReporterV2, m *MetricSet, content []byte) {
+func eventsMappingXPack(r mb.ReporterV2, m *MetricSet, content []byte) error {
 	stateData := &stateStruct{}
 	err := json.Unmarshal(content, stateData)
 	if err != nil {
-		return
+		return errors.Wrap(err, "failure parsing Elasticsearch Cluster State API response")
 	}
 
 	// TODO: This is currently needed because the cluser_uuid is `na` in stateData in case not the full state is requested.
 	// Will be fixed in: https://github.com/elastic/elasticsearch/pull/30656
 	clusterID, err := elasticsearch.GetClusterID(m.HTTP, m.HostData().SanitizedURI+statePath, stateData.MasterNode)
 	if err != nil {
-		return
+		return errors.Wrap(err, "failed to get cluster ID from Elasticsearch")
 	}
 
 	for _, index := range stateData.RoutingTable.Indices {
@@ -91,6 +93,7 @@ func eventsMappingXPack(r mb.ReporterV2, m *MetricSet, content []byte) {
 			}
 		}
 	}
+	return nil
 }
 
 func getSourceNode(nodeID string, stateData *stateStruct) (common.MapStr, error) {

--- a/metricbeat/module/kibana/kibana.go
+++ b/metricbeat/module/kibana/kibana.go
@@ -31,6 +31,9 @@ import (
 )
 
 const (
+	// ModuleName is the name of this module
+	ModuleName = "kibana"
+
 	// StatsAPIAvailableVersion is the version of Kibana since when the stats API is available
 	StatsAPIAvailableVersion = "6.4.0"
 

--- a/metricbeat/module/kibana/stats/data.go
+++ b/metricbeat/module/kibana/stats/data.go
@@ -20,11 +20,14 @@ package stats
 import (
 	"encoding/json"
 
+	"github.com/pkg/errors"
+
 	"github.com/elastic/beats/libbeat/common"
 	s "github.com/elastic/beats/libbeat/common/schema"
 	c "github.com/elastic/beats/libbeat/common/schema/mapstriface"
 	"github.com/elastic/beats/metricbeat/helper/elastic"
 	"github.com/elastic/beats/metricbeat/mb"
+	"github.com/elastic/beats/metricbeat/module/kibana"
 )
 
 var (
@@ -83,18 +86,19 @@ func eventMapping(r mb.ReporterV2, content []byte) error {
 	var data map[string]interface{}
 	err := json.Unmarshal(content, &data)
 	if err != nil {
+		err = errors.Wrap(err, "failure parsing Kibana Stats API response")
 		r.Error(err)
 		return err
 	}
 
 	dataFields, err := schema.Apply(data)
 	if err != nil {
-		r.Error(err)
+		r.Error(errors.Wrap(err, "failure to apply stats schema"))
 	}
 
 	var event mb.Event
 	event.RootFields = common.MapStr{}
-	event.RootFields.Put("service.name", "kibana")
+	event.RootFields.Put("service.name", kibana.ModuleName)
 
 	// Set elasticsearch cluster id
 	elasticsearchClusterID, ok := data["cluster_uuid"]
@@ -117,6 +121,5 @@ func eventMapping(r mb.ReporterV2, content []byte) error {
 	event.MetricSetFields = dataFields
 
 	r.Event(event)
-
-	return err
+	return nil
 }

--- a/metricbeat/module/kibana/stats/data_xpack.go
+++ b/metricbeat/module/kibana/stats/data_xpack.go
@@ -21,6 +21,8 @@ import (
 	"encoding/json"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/elastic/beats/libbeat/common"
 	s "github.com/elastic/beats/libbeat/common/schema"
 	c "github.com/elastic/beats/libbeat/common/schema/mapstriface"
@@ -162,12 +164,12 @@ func eventMappingXPack(r mb.ReporterV2, intervalMs int64, now time.Time, content
 	var data map[string]interface{}
 	err := json.Unmarshal(content, &data)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "failure parsing Kibana API response")
 	}
 
 	t, clusterUUID, fields, err := dataParserFunc(r, data, now)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "failure to parse data")
 	}
 
 	var event mb.Event

--- a/metricbeat/module/kibana/stats/stats.go
+++ b/metricbeat/module/kibana/stats/stats.go
@@ -32,7 +32,7 @@ import (
 // init registers the MetricSet with the central registry.
 // The New method will be called after the setup of the module and before starting to fetch data
 func init() {
-	mb.Registry.MustAddMetricSet("kibana", "stats", New,
+	mb.Registry.MustAddMetricSet(kibana.ModuleName, "stats", New,
 		mb.WithHostParser(hostParser),
 	)
 }
@@ -60,7 +60,7 @@ type MetricSet struct {
 
 // New create a new instance of the MetricSet
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	cfgwarn.Experimental("The kibana stats metricset is experimental")
+	cfgwarn.Experimental("The " + base.FullyQualifiedName() + " metricset is experimental")
 
 	config := kibana.DefaultConfig()
 	if err := base.Module().UnpackConfig(&config); err != nil {
@@ -83,12 +83,12 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	}
 
 	if !isStatsAPIAvailable {
-		const errorMsg = "The kibana stats metricset is only supported with Kibana >= %v. You are currently running Kibana %v"
-		return nil, fmt.Errorf(errorMsg, kibana.StatsAPIAvailableVersion, kibanaVersion)
+		const errorMsg = "The %v metricset is only supported with Kibana >= %v. You are currently running Kibana %v"
+		return nil, fmt.Errorf(errorMsg, base.FullyQualifiedName(), kibana.StatsAPIAvailableVersion, kibanaVersion)
 	}
 
 	if config.XPackEnabled {
-		cfgwarn.Experimental("The experimental xpack.enabled flag in kibana/stats metricset is enabled.")
+		cfgwarn.Experimental("The experimental xpack.enabled flag in the " + base.FullyQualifiedName() + " metricset is enabled.")
 
 		// Use legacy API response so we can passthru usage as-is
 		statsHTTP.SetURI(statsHTTP.GetURI() + "&legacy=true")
@@ -96,7 +96,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 
 	var settingsHTTP *helper.HTTP
 	if config.XPackEnabled {
-		cfgwarn.Experimental("The experimental xpack.enabled flag in kibana/stats metricset is enabled.")
+		cfgwarn.Experimental("The experimental xpack.enabled flag in the " + base.FullyQualifiedName() + " metricset is enabled.")
 
 		isSettingsAPIAvailable, err := kibana.IsSettingsAPIAvailable(kibanaVersion)
 		if err != nil {
@@ -104,8 +104,8 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 		}
 
 		if !isSettingsAPIAvailable {
-			const errorMsg = "The kibana stats metricset with X-Pack enabled is only supported with Kibana >= %v. You are currently running Kibana %v"
-			return nil, fmt.Errorf(errorMsg, kibana.SettingsAPIAvailableVersion, kibanaVersion)
+			const errorMsg = "The %v metricset with X-Pack enabled is only supported with Kibana >= %v. You are currently running Kibana %v"
+			return nil, fmt.Errorf(errorMsg, base.FullyQualifiedName(), kibana.SettingsAPIAvailableVersion, kibanaVersion)
 		}
 
 		settingsHTTP, err = helper.NewHTTP(base)

--- a/metricbeat/module/logstash/logstash.go
+++ b/metricbeat/module/logstash/logstash.go
@@ -15,27 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// +build !integration
+package logstash
 
-package status
-
-import (
-	"io/ioutil"
-	"testing"
-
-	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
-
-	"github.com/stretchr/testify/assert"
-)
-
-func TestEventMapping(t *testing.T) {
-	f := "./_meta/test/input.json"
-	content, err := ioutil.ReadFile(f)
-	assert.NoError(t, err)
-
-	reporter := &mbtest.CapturingReporterV2{}
-	err = eventMapping(reporter, content)
-	assert.NoError(t, err, f)
-	assert.True(t, len(reporter.GetEvents()) >= 1, f)
-	assert.Equal(t, 0, len(reporter.GetErrors()), f)
-}
+// ModuleName is the name of this module.
+const ModuleName = "logstash"

--- a/metricbeat/module/logstash/node/data_test.go
+++ b/metricbeat/module/logstash/node/data_test.go
@@ -24,6 +24,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -36,9 +38,11 @@ func TestEventMapping(t *testing.T) {
 		content, err := ioutil.ReadFile(f)
 		assert.NoError(t, err)
 
-		event, err := eventMapping(content)
+		reporter := &mbtest.CapturingReporterV2{}
+		err = eventMapping(reporter, content)
 
 		assert.NoError(t, err, f)
-		assert.True(t, len(event) >= 1, f)
+		assert.True(t, len(reporter.GetEvents()) >= 1, f)
+		assert.Equal(t, 0, len(reporter.GetErrors()), f)
 	}
 }

--- a/metricbeat/module/logstash/node/node.go
+++ b/metricbeat/module/logstash/node/node.go
@@ -18,17 +18,17 @@
 package node
 
 import (
-	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/metricbeat/helper"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/mb/parse"
+	"github.com/elastic/beats/metricbeat/module/logstash"
 )
 
 // init registers the MetricSet with the central registry.
 // The New method will be called after the setup of the module and before starting to fetch data
 func init() {
-	mb.Registry.MustAddMetricSet("logstash", "node", New,
+	mb.Registry.MustAddMetricSet(logstash.ModuleName, "node", New,
 		mb.WithHostParser(hostParser),
 		mb.DefaultMetricSet(),
 	)
@@ -64,12 +64,12 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // Fetch methods implements the data gathering and data conversion to the right format
 // It returns the event which is then forward to the output. In case of an error, a
 // descriptive error must be returned.
-func (m *MetricSet) Fetch() (common.MapStr, error) {
+func (m *MetricSet) Fetch(r mb.ReporterV2) {
 	content, err := m.http.FetchContent()
 	if err != nil {
-		return nil, err
+		r.Error(err)
+		return
 	}
 
-	event, _ := eventMapping(content)
-	return event, nil
+	eventMapping(r, content)
 }

--- a/metricbeat/module/logstash/node_stats/data.go
+++ b/metricbeat/module/logstash/node_stats/data.go
@@ -20,9 +20,13 @@ package node_stats
 import (
 	"encoding/json"
 
+	"github.com/pkg/errors"
+
 	"github.com/elastic/beats/libbeat/common"
 	s "github.com/elastic/beats/libbeat/common/schema"
 	c "github.com/elastic/beats/libbeat/common/schema/mapstriface"
+	"github.com/elastic/beats/metricbeat/mb"
+	"github.com/elastic/beats/metricbeat/module/logstash"
 )
 
 var (
@@ -35,11 +39,26 @@ var (
 	}
 )
 
-func eventMapping(content []byte) (common.MapStr, error) {
+func eventMapping(r mb.ReporterV2, content []byte) error {
 	var data map[string]interface{}
 	err := json.Unmarshal(content, &data)
 	if err != nil {
-		return nil, err
+		err = errors.Wrap(err, "failure parsing Logstash Node Stats API response")
+		r.Error(err)
+		return err
 	}
-	return schema.Apply(data)
+
+	fields, err := schema.Apply(data)
+	if err != nil {
+		r.Error(errors.Wrap(err, "failure applying node stats schema"))
+	}
+
+	event := mb.Event{}
+	event.RootFields = common.MapStr{}
+	event.RootFields.Put("service.name", logstash.ModuleName)
+
+	event.MetricSetFields = fields
+
+	r.Event(event)
+	return nil
 }

--- a/metricbeat/module/logstash/node_stats/data_test.go
+++ b/metricbeat/module/logstash/node_stats/data_test.go
@@ -24,6 +24,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -36,9 +38,11 @@ func TestEventMapping(t *testing.T) {
 		content, err := ioutil.ReadFile(f)
 		assert.NoError(t, err)
 
-		event, err := eventMapping(content)
+		reporter := &mbtest.CapturingReporterV2{}
+		err = eventMapping(reporter, content)
 
 		assert.NoError(t, err, f)
-		assert.True(t, len(event) >= 1, f)
+		assert.True(t, len(reporter.GetEvents()) >= 1, f)
+		assert.Equal(t, 0, len(reporter.GetErrors()), f)
 	}
 }

--- a/metricbeat/module/logstash/node_stats/node_stats.go
+++ b/metricbeat/module/logstash/node_stats/node_stats.go
@@ -18,15 +18,14 @@
 package node_stats
 
 import (
-	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/metricbeat/helper"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/mb/parse"
+	"github.com/elastic/beats/metricbeat/module/logstash"
 )
 
 const (
-	moduleName    = "logstash"
 	metricsetName = "node_stats"
 	namespace     = "logstash.node.stats"
 )
@@ -34,7 +33,7 @@ const (
 // init registers the MetricSet with the central registry.
 // The New method will be called after the setup of the module and before starting to fetch data
 func init() {
-	mb.Registry.MustAddMetricSet(moduleName, metricsetName, New,
+	mb.Registry.MustAddMetricSet(logstash.ModuleName, metricsetName, New,
 		mb.WithHostParser(hostParser),
 		mb.WithNamespace(namespace),
 		mb.DefaultMetricSet(),
@@ -72,12 +71,12 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // Fetch methods implements the data gathering and data conversion to the right format
 // It returns the event which is then forward to the output. In case of an error, a
 // descriptive error must be returned.
-func (m *MetricSet) Fetch() (common.MapStr, error) {
+func (m *MetricSet) Fetch(r mb.ReporterV2) {
 	content, err := m.http.FetchContent()
 	if err != nil {
-		return nil, err
+		r.Error(err)
+		return
 	}
 
-	event, _ := eventMapping(content)
-	return event, nil
+	eventMapping(r, content)
 }

--- a/metricbeat/module/logstash/node_stats/node_stats_integration_test.go
+++ b/metricbeat/module/logstash/node_stats/node_stats_integration_test.go
@@ -32,21 +32,24 @@ import (
 func TestFetch(t *testing.T) {
 	compose.EnsureUp(t, "logstash")
 
-	f := mbtest.NewEventFetcher(t, logstash.GetConfig("node_stats"))
-	event, err := f.Fetch()
-	if !assert.NoError(t, err) {
+	f := mbtest.NewReportingMetricSetV2(t, logstash.GetConfig("node_stats"))
+	events, errs := mbtest.ReportingFetchV2(f)
+
+	assert.Empty(t, errs)
+	if !assert.NotEmpty(t, events) {
 		t.FailNow()
 	}
 
-	assert.NotNil(t, event)
-	t.Logf("%s/%s event: %+v", f.Module().Name(), f.Name(), event)
+	t.Logf("%s/%s event: %+v", f.Module().Name(), f.Name(),
+		events[0].BeatEvent("logstash", "node_stats").Fields.StringToPrint())
 }
 
 func TestData(t *testing.T) {
 	compose.EnsureUp(t, "logstash")
 
-	f := mbtest.NewEventFetcher(t, logstash.GetConfig("node_stats"))
-	err := mbtest.WriteEvent(f, t)
+	config := logstash.GetConfig("node_stats")
+	f := mbtest.NewReportingMetricSetV2(t, config)
+	err := mbtest.WriteEventsReporterV2(f, t, "")
 	if err != nil {
 		t.Fatal("write", err)
 	}


### PR DESCRIPTION
Cherry-pick of PR #8551 to 6.x branch. Original message: 

This PR makes error messages better and more consistent across all metricsets for Elastic stack products, including the xpack monitoring code paths:

* [x] `elasticsearch/ccr`
* [x] `elasticsearch/cluster_stats`
* [x] `elasticsearch/index`
* [x] `elasticsearch/index_recovery`
* [x] `elasticsearch/index_summary`
* [x] `elasticsearch/ml_job`
* [x] `elasticsearch/node`
* [x] `elasticsearch/node_stats`
* [x] `elasticsearch/pending_tasks`
* [x] `elasticsearch/shard`
* [x] `kibana/status`
* [x] `kibana/stats`
* [x] `logstash/node`
* [x] `logstash/node_stats`