### PR TITLE
Fix field name from summary to total

### DIFF
--- a/metricbeat/module/elasticsearch/node_stats/_meta/data-xpack.json
+++ b/metricbeat/module/elasticsearch/node_stats/_meta/data-xpack.json
@@ -27,7 +27,7 @@
     },
     "indices": {
         "fs": {
-            "summary": {
+            "total": {
                 "free_in_bytes": 20373749760,
                 "available_in_bytes": 20111605760,
                 "total_in_bytes": 249779191808

--- a/metricbeat/module/elasticsearch/node_stats/data_xpack.go
+++ b/metricbeat/module/elasticsearch/node_stats/data_xpack.go
@@ -155,7 +155,7 @@ var (
 			"watcher":    c.Dict("watcher", threadPoolStatsSchema),
 		}),
 		"fs": c.Dict("fs", s.Schema{
-			"summary": c.Dict("total", s.Schema{
+			"total": c.Dict("total", s.Schema{
 				"total_in_bytes":     c.Int("total_in_bytes"),
 				"free_in_bytes":      c.Int("free_in_bytes"),
 				"available_in_bytes": c.Int("available_in_bytes"),


### PR DESCRIPTION
During end-to-end testing of the Monitoring UI driven by Metricbeat monitoring ES, I found that the Node Listing page was displaying "N/A" for disk space metrics. Digging into the problem I found that the `elasticsearch/node_stats` metricset code (x-pack path) was indexing the wrong field name into `node_stats` documents in `.monitoring-es-6-mb-*`.

This PR fixes the field name.