### PR TITLE
Cherry-pick #8587 to 6.x: Update vendored github.com/elastic/go-ucfg to v0.6.4

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -476,8 +476,8 @@ Apache License 2.0
 
 --------------------------------------------------------------------
 Dependency: github.com/elastic/go-ucfg
-Version: v0.6.1
-Revision: 581f7b1fe9d84f4c18ef0694d6e0eb944a925dae
+Version: v0.6.4
+Revision: e81c02ad8f1ab46b9e8b07f0832245c0c2e1d13c
 License type (autodetected): Apache-2.0
 ./vendor/github.com/elastic/go-ucfg/LICENSE:
 --------------------------------------------------------------------

--- a/vendor/github.com/elastic/go-ucfg/CHANGELOG.md
+++ b/vendor/github.com/elastic/go-ucfg/CHANGELOG.md
@@ -14,6 +14,24 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+## [0.6.4]
+
+### Fixed
+- Do not treat $ as escape char in plain strings/regexes #120
+
+## [0.6.3]
+
+### Changed
+- Remove UUID lib and use pseudo-random IDs instead. #118
+
+## [0.6.2]
+
+### Changed
+- New UUID lib: github.com/gofrs/uuid. #116
+
+### Fixed
+- Fix escape character not removed from escaped string #115
+
 ## [0.6.1]
 
 ### Fixed
@@ -202,7 +220,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Introduced CHANGELOG.md for documenting changes to ucfg.
 
 
-[Unreleased]: https://github.com/elastic/go-ucfg/compare/v0.6.1...HEAD
+[Unreleased]: https://github.com/elastic/go-ucfg/compare/v0.6.4...HEAD
+[0.6.4]: https://github.com/elastic/go-ucfg/compare/v0.6.3...v0.6.4
+[0.6.3]: https://github.com/elastic/go-ucfg/compare/v0.6.2...v0.6.3
+[0.6.2]: https://github.com/elastic/go-ucfg/compare/v0.6.1...v0.6.2
 [0.6.1]: https://github.com/elastic/go-ucfg/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/elastic/go-ucfg/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/elastic/go-ucfg/compare/v0.5.0...v0.5.1

--- a/vendor/github.com/elastic/go-ucfg/merge.go
+++ b/vendor/github.com/elastic/go-ucfg/merge.go
@@ -508,7 +508,7 @@ func normalizeString(ctx context, opts *options, str string) (value, Error) {
 
 	switch p := varexp.(type) {
 	case constExp:
-		return newString(ctx, opts.meta, str), nil
+		return newString(ctx, opts.meta, string(p)), nil
 	case *reference:
 		return newRef(ctx, opts.meta, p), nil
 	}

--- a/vendor/github.com/elastic/go-ucfg/types.go
+++ b/vendor/github.com/elastic/go-ucfg/types.go
@@ -24,8 +24,7 @@ import (
 	"strconv"
 	"strings"
 	"sync/atomic"
-
-	uuid "github.com/satori/go.uuid"
+	"time"
 
 	"github.com/elastic/go-ucfg/internal/parse"
 )
@@ -186,8 +185,10 @@ func newSplice(ctx context, m *Meta, s varEvaler) *cfgDynamic {
 }
 
 func newDyn(ctx context, m *Meta, val dynValue) *cfgDynamic {
-	id := string(atomic.AddInt32(&spliceSeq, 1)) + uuid.NewV4().String()
-	return &cfgDynamic{cfgPrimitive{ctx, m}, cacheID(id), val}
+	seq := atomic.AddInt32(&spliceSeq, 1)
+	dyn := &cfgDynamic{cfgPrimitive: cfgPrimitive{ctx, m}, dyn: val}
+	dyn.id = cacheID(fmt.Sprintf("%8X-%4X-%p", time.Now().Unix(), seq, dyn))
+	return dyn
 }
 
 func (p *cfgPrimitive) Context() context                { return p.ctx }

--- a/vendor/github.com/elastic/go-ucfg/variables.go
+++ b/vendor/github.com/elastic/go-ucfg/variables.go
@@ -429,8 +429,10 @@ func lexer(in string) (<-chan token, <-chan error) {
 					lex <- openToken
 					off++
 					varcount++
-				default: // escape any symbol
+				case '$', '}': // escape $} and $$
 					content = content[:idx] + content[off:]
+					continue
+				default:
 					continue
 				}
 			}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -678,12 +678,12 @@
 			"versionExact": "v0.0.3"
 		},
 		{
-			"checksumSHA1": "MK8/w0Idj7kRBUiBabARPdm9hOo=",
+			"checksumSHA1": "+FZjRtpNIIvf+ZteS0y6IGw/JA8=",
 			"path": "github.com/elastic/go-ucfg",
-			"revision": "581f7b1fe9d84f4c18ef0694d6e0eb944a925dae",
-			"revisionTime": "2018-07-13T14:04:29Z",
-			"version": "v0.6.1",
-			"versionExact": "v0.6.1"
+			"revision": "e81c02ad8f1ab46b9e8b07f0832245c0c2e1d13c",
+			"revisionTime": "2018-10-05T15:55:04Z",
+			"version": "v0.6.4",
+			"versionExact": "v0.6.4"
 		},
 		{
 			"checksumSHA1": "X+R/CD8SokJrmlxFTx2nSevRDhQ=",


### PR DESCRIPTION
Cherry-pick of PR #8587 to 6.x branch. Original message: 

Blocks #8458 