### PR TITLE
Move central management settings to beat config file

### DIFF
--- a/filebeat/beater/filebeat.go
+++ b/filebeat/beater/filebeat.go
@@ -119,7 +119,7 @@ func New(b *beat.Beat, rawConfig *common.Config) (beat.Beater, error) {
 		haveEnabledInputs = true
 	}
 
-	if !config.ConfigInput.Enabled() && !config.ConfigModules.Enabled() && !haveEnabledInputs && config.Autodiscover == nil {
+	if !config.ConfigInput.Enabled() && !config.ConfigModules.Enabled() && !haveEnabledInputs && config.Autodiscover == nil && !b.ConfigManager.Enabled() {
 		if !b.InSetupCmd {
 			return nil, errors.New("no modules or inputs enabled and configuration reloading disabled. What files do you want me to watch?")
 		}

--- a/libbeat/cfgfile/cfgfile.go
+++ b/libbeat/cfgfile/cfgfile.go
@@ -73,6 +73,10 @@ func ChangeDefaultCfgfileFlag(beatName string) error {
 // GetDefaultCfgfile gets the full path of the default config file. Understood
 // as the first value for the `-c` flag. By default this will be `<beatname>.yml`
 func GetDefaultCfgfile() string {
+	if len(configfiles.List()) == 0 {
+		return ""
+	}
+
 	cfg := configfiles.List()[0]
 	cfgpath := GetPathConfig()
 

--- a/libbeat/cfgfile/cfgfile.go
+++ b/libbeat/cfgfile/cfgfile.go
@@ -70,6 +70,18 @@ func ChangeDefaultCfgfileFlag(beatName string) error {
 	return nil
 }
 
+// GetDefaultCfgfile gets the full path of the default config file. Understood
+// as the first value for the `-c` flag. By default this will be `<beatname>.yml`
+func GetDefaultCfgfile() string {
+	cfg := configfiles.List()[0]
+	cfgpath := GetPathConfig()
+
+	if !filepath.IsAbs(cfg) {
+		return filepath.Join(cfgpath, cfg)
+	}
+	return cfg
+}
+
 // HandleFlags adapts default config settings based on command line flags.
 func HandleFlags() error {
 	// default for the home path is the binary location

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -119,7 +119,7 @@ type beatConfig struct {
 	Monitoring *common.Config  `config:"xpack.monitoring"`
 
 	// central managmenet settings
-	Management *common.Config `config:"xpack.management"`
+	Management *common.Config `config:"management"`
 
 	// elastic stack 'setup' configurations
 	Dashboards *common.Config `config:"setup.dashboards"`

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -118,6 +118,9 @@ type beatConfig struct {
 	Pipeline   pipeline.Config `config:",inline"`
 	Monitoring *common.Config  `config:"xpack.monitoring"`
 
+	// central managmenet settings
+	Management *common.Config `config:"xpack.management"`
+
 	// elastic stack 'setup' configurations
 	Dashboards *common.Config `config:"setup.dashboards"`
 	Template   *common.Config `config:"setup.template"`
@@ -588,7 +591,7 @@ func (b *Beat) configure(settings Settings) error {
 	logp.Info("Beat UUID: %v", b.Info.UUID)
 
 	// initialize config manager
-	b.ConfigManager, err = management.Factory()(reload.Register, b.Beat.Info.UUID)
+	b.ConfigManager, err = management.Factory()(b.Config.Management, reload.Register, b.Beat.Info.UUID)
 	if err != nil {
 		return err
 	}

--- a/libbeat/common/cli/confirm.go
+++ b/libbeat/common/cli/confirm.go
@@ -1,0 +1,64 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cli
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// Confirm shows the confirmation text and ask the user to answer (y/n)
+// default will be shown in uppercase and be selected if the user hits enter
+// returns true for yes, false for no
+func Confirm(prompt string, def bool) (bool, error) {
+	reader := bufio.NewReader(os.Stdin)
+	return confirm(reader, prompt, def)
+}
+
+func confirm(r io.Reader, prompt string, def bool) (bool, error) {
+	options := " [Y/n]"
+	if !def {
+		options = " [y/N]"
+	}
+
+	reader := bufio.NewScanner(r)
+	for {
+		fmt.Print(prompt + options + ":")
+
+		if !reader.Scan() {
+			break
+		}
+		switch strings.ToLower(reader.Text()) {
+		case "":
+			return def, nil
+		case "y", "yes", "yeah":
+			return true, nil
+		case "n", "no":
+			return false, nil
+		default:
+			fmt.Println("Please write 'y' or 'n'")
+		}
+	}
+
+	return false, errors.New("error reading user input")
+}

--- a/libbeat/common/cli/confirm_test.go
+++ b/libbeat/common/cli/confirm_test.go
@@ -1,0 +1,80 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfirm(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		def    bool
+		result bool
+		error  bool
+	}{
+		{
+			name:   "Test default yes",
+			input:  "\n",
+			def:    true,
+			result: true,
+		},
+		{
+			name:   "Test default no",
+			input:  "\n",
+			def:    false,
+			result: false,
+		},
+		{
+			name:   "Test YeS",
+			input:  "YeS\n",
+			def:    false,
+			result: true,
+		},
+		{
+			name:   "Test Y",
+			input:  "Y\n",
+			def:    false,
+			result: true,
+		},
+		{
+			name:   "Test No",
+			input:  "No\n",
+			def:    true,
+			result: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			r := strings.NewReader(test.input)
+			result, err := confirm(r, "prompt", test.def)
+			assert.Equal(t, test.result, result)
+
+			if test.error {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/libbeat/common/cli/password.go
+++ b/libbeat/common/cli/password.go
@@ -66,6 +66,7 @@ func stdin(p string) (string, error) {
 	if err != nil {
 		return "", errors.Wrap(err, "reading password input")
 	}
+	fmt.Println()
 	return string(bytePassword), nil
 }
 

--- a/libbeat/common/transport/tlscommon/config.go
+++ b/libbeat/common/transport/tlscommon/config.go
@@ -25,14 +25,14 @@ import (
 
 // Config defines the user configurable options in the yaml file.
 type Config struct {
-	Enabled          *bool                   `config:"enabled"`
-	VerificationMode TLSVerificationMode     `config:"verification_mode"` // one of 'none', 'full'
-	Versions         []TLSVersion            `config:"supported_protocols"`
-	CipherSuites     []tlsCipherSuite        `config:"cipher_suites"`
-	CAs              []string                `config:"certificate_authorities"`
-	Certificate      CertificateConfig       `config:",inline"`
-	CurveTypes       []tlsCurveType          `config:"curve_types"`
-	Renegotiation    tlsRenegotiationSupport `config:"renegotiation"`
+	Enabled          *bool                   `config:"enabled" yml:"enabled"`
+	VerificationMode TLSVerificationMode     `config:"verification_mode" yaml:"verification_mode"` // one of 'none', 'full'
+	Versions         []TLSVersion            `config:"supported_protocols" yaml:"supported_protocols"`
+	CipherSuites     []tlsCipherSuite        `config:"cipher_suites" yaml:"cipher_suites"`
+	CAs              []string                `config:"certificate_authorities" yaml:"certificate_authorities"`
+	Certificate      CertificateConfig       `config:",inline" yaml:",inline"`
+	CurveTypes       []tlsCurveType          `config:"curve_types" yaml:"curve_types"`
+	Renegotiation    tlsRenegotiationSupport `config:"renegotiation" yaml:"renegotation"`
 }
 
 // LoadTLSConfig will load a certificate from config with all TLS based keys

--- a/libbeat/common/transport/tlscommon/config.go
+++ b/libbeat/common/transport/tlscommon/config.go
@@ -25,7 +25,7 @@ import (
 
 // Config defines the user configurable options in the yaml file.
 type Config struct {
-	Enabled          *bool                   `config:"enabled" yml:"enabled"`
+	Enabled          *bool                   `config:"enabled" yaml:"enabled"`
 	VerificationMode TLSVerificationMode     `config:"verification_mode" yaml:"verification_mode"` // one of 'none', 'full'
 	Versions         []TLSVersion            `config:"supported_protocols" yaml:"supported_protocols"`
 	CipherSuites     []tlsCipherSuite        `config:"cipher_suites" yaml:"cipher_suites"`

--- a/libbeat/common/transport/tlscommon/types.go
+++ b/libbeat/common/transport/tlscommon/types.go
@@ -264,9 +264,9 @@ func (r *tlsRenegotiationSupport) Unpack(s string) error {
 
 // CertificateConfig define a common set of fields for a certificate.
 type CertificateConfig struct {
-	Certificate string `config:"certificate"`
-	Key         string `config:"key"`
-	Passphrase  string `config:"key_passphrase"`
+	Certificate string `config:"certificate" yaml:"certificate"`
+	Key         string `config:"key" yaml:"key"`
+	Passphrase  string `config:"key_passphrase" yaml:"key_passphrase"`
 }
 
 // Validate validates the CertificateConfig

--- a/libbeat/kibana/client_config.go
+++ b/libbeat/kibana/client_config.go
@@ -25,14 +25,14 @@ import (
 
 // ClientConfig to connect to Kibana
 type ClientConfig struct {
-	Protocol      string            `config:"protocol"`
-	Host          string            `config:"host"`
-	Path          string            `config:"path"`
-	SpaceID       string            `config:"space.id"`
-	Username      string            `config:"username"`
-	Password      string            `config:"password"`
-	TLS           *tlscommon.Config `config:"ssl"`
-	Timeout       time.Duration     `config:"timeout"`
+	Protocol      string            `config:"protocol" yaml:"protocol"`
+	Host          string            `config:"host" yaml:"host"`
+	Path          string            `config:"path" yaml:"path"`
+	SpaceID       string            `config:"space.id" yaml:"space.id"`
+	Username      string            `config:"username" yaml:"username"`
+	Password      string            `config:"password" yaml:"password"`
+	TLS           *tlscommon.Config `config:"ssl" yaml:"ssl"`
+	Timeout       time.Duration     `config:"timeout" yaml:"timeout"`
 	IgnoreVersion bool
 }
 

--- a/libbeat/management/management.go
+++ b/libbeat/management/management.go
@@ -48,7 +48,7 @@ type ConfigManager interface {
 }
 
 // FactoryFunc for creating a config manager
-type FactoryFunc func(*reload.Registry, uuid.UUID) (ConfigManager, error)
+type FactoryFunc func(*common.Config, *reload.Registry, uuid.UUID) (ConfigManager, error)
 
 // Register a config manager
 func Register(name string, fn FactoryFunc, stability feature.Stability) {
@@ -76,7 +76,9 @@ func Factory() FactoryFunc {
 // nilManager, fallback when no manager is present
 type nilManager struct{}
 
-func nilFactory(*reload.Registry, uuid.UUID) (ConfigManager, error) { return nilManager{}, nil }
+func nilFactory(*common.Config, *reload.Registry, uuid.UUID) (ConfigManager, error) {
+	return nilManager{}, nil
+}
 
 func (nilManager) Enabled() bool                           { return false }
 func (nilManager) Start()                                  {}

--- a/metricbeat/beater/metricbeat.go
+++ b/metricbeat/beater/metricbeat.go
@@ -107,7 +107,7 @@ func newMetricbeat(b *beat.Beat, c *common.Config, options ...Option) (*Metricbe
 		return nil, errors.Wrap(err, "error reading configuration file")
 	}
 
-	dynamicCfgEnabled := config.ConfigModules.Enabled() || config.Autodiscover != nil
+	dynamicCfgEnabled := config.ConfigModules.Enabled() || config.Autodiscover != nil || b.ConfigManager.Enabled()
 	if !dynamicCfgEnabled && len(config.Modules) == 0 {
 		return nil, mb.ErrEmptyConfig
 	}

--- a/x-pack/libbeat/cmd/enroll.go
+++ b/x-pack/libbeat/cmd/enroll.go
@@ -41,6 +41,10 @@ func genEnrollCmd(name, version string) *cobra.Command {
 		Args: cobra.RangeArgs(1, 2),
 		Run: cli.RunWith(func(cmd *cobra.Command, args []string) error {
 			beat, err := getBeat(name, version)
+			if err != nil {
+				return err
+			}
+
 			kibanaURL := args[0]
 
 			if username == "" && len(args) == 1 {
@@ -75,7 +79,7 @@ func genEnrollCmd(name, version string) *cobra.Command {
 				}
 				enrollmentToken, err = client.CreateEnrollmentToken()
 				if err != nil {
-					return errors.Wrap(err, "Creating a new enrollment token")
+					return errors.Wrap(err, "Error creating a new enrollment token")
 				}
 			}
 

--- a/x-pack/libbeat/cmd/enroll.go
+++ b/x-pack/libbeat/cmd/enroll.go
@@ -32,6 +32,7 @@ func getBeat(name, version string) (*instance.Beat, error) {
 
 func genEnrollCmd(name, version string) *cobra.Command {
 	var username, password string
+	var force bool
 
 	enrollCmd := cobra.Command{
 		Use:   "enroll <kibana_url> [<enrollment_token>]",
@@ -83,17 +84,23 @@ func genEnrollCmd(name, version string) *cobra.Command {
 				}
 			}
 
-			if err = management.Enroll(beat, kibanaURL, enrollmentToken); err != nil {
+			enrolled, err := management.Enroll(beat, kibanaURL, enrollmentToken, force)
+			if err != nil {
 				return errors.Wrap(err, "Error while enrolling")
 			}
 
-			fmt.Println("Enrolled and ready to retrieve settings from Kibana")
+			if enrolled {
+				fmt.Println("Enrolled and ready to retrieve settings from Kibana")
+			} else {
+				fmt.Println("Operation canceled by the user")
+			}
 			return nil
 		}),
 	}
 
 	enrollCmd.Flags().StringVar(&username, "username", "elastic", "Username to use when enrolling without token")
 	enrollCmd.Flags().StringVar(&password, "password", "stdin", "Method to read the password to use when enrolling without token (stdin or env:VAR_NAME)")
+	enrollCmd.Flags().BoolVar(&force, "force", false, "Force overwrite of current configuraiton, do not prompt for confirmation")
 
 	return &enrollCmd
 }

--- a/x-pack/libbeat/cmd/enroll.go
+++ b/x-pack/libbeat/cmd/enroll.go
@@ -92,7 +92,7 @@ func genEnrollCmd(name, version string) *cobra.Command {
 			if enrolled {
 				fmt.Println("Enrolled and ready to retrieve settings from Kibana")
 			} else {
-				fmt.Println("Operation canceled by the user")
+				fmt.Println("Enrollment was canceled by the user")
 			}
 			return nil
 		}),

--- a/x-pack/libbeat/management/api/enroll_test.go
+++ b/x-pack/libbeat/management/api/enroll_test.go
@@ -62,7 +62,10 @@ func TestEnrollValid(t *testing.T) {
 }
 
 func TestEnrollError(t *testing.T) {
-	beatUUID := uuid.NewV4()
+	beatUUID, err := uuid.NewV4()
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	server, client := newServerClientPair(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"message": "Invalid enrollment token"}`, 400)

--- a/x-pack/libbeat/management/cache.go
+++ b/x-pack/libbeat/management/cache.go
@@ -5,6 +5,7 @@
 package management
 
 import (
+	"io/ioutil"
 	"os"
 
 	"github.com/elastic/beats/libbeat/common"
@@ -51,18 +52,10 @@ func (c *Cache) Save() error {
 
 	// write temporary file first
 	tempFile := path + ".new"
-	f, err := os.OpenFile(tempFile, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
-	if err != nil {
+	if err := ioutil.WriteFile(tempFile, data, 0600); err != nil {
 		return errors.Wrap(err, "failed to store central management settings")
 	}
 
-	_, err = f.Write(data)
-	f.Close()
-	if err != nil {
-		return err
-	}
-
 	// move temporary file into final location
-	err = file.SafeFileRotate(path, tempFile)
-	return err
+	return file.SafeFileRotate(path, tempFile)
 }

--- a/x-pack/libbeat/management/cache.go
+++ b/x-pack/libbeat/management/cache.go
@@ -1,0 +1,68 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package management
+
+import (
+	"os"
+
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/file"
+	"github.com/elastic/beats/libbeat/paths"
+	"github.com/elastic/beats/x-pack/libbeat/management/api"
+
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v2"
+)
+
+// Cache keeps a copy of configs provided by Kibana, it's used when Kibana is down
+type Cache struct {
+	Configs api.ConfigBlocks
+}
+
+// Load settings from its source file
+func (c *Cache) Load() error {
+	path := paths.Resolve(paths.Data, "management.yml")
+	config, err := common.LoadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// File is not present, beat is not enrolled
+			return nil
+		}
+		return err
+	}
+
+	if err = config.Unpack(&c); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Save settings to management.yml file
+func (c *Cache) Save() error {
+	path := paths.Resolve(paths.Data, "management.yml")
+
+	data, err := yaml.Marshal(c)
+	if err != nil {
+		return err
+	}
+
+	// write temporary file first
+	tempFile := path + ".new"
+	f, err := os.OpenFile(tempFile, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		return errors.Wrap(err, "failed to store central management settings")
+	}
+
+	_, err = f.Write(data)
+	f.Close()
+	if err != nil {
+		return err
+	}
+
+	// move temporary file into final location
+	err = file.SafeFileRotate(path, tempFile)
+	return err
+}

--- a/x-pack/libbeat/management/config.go
+++ b/x-pack/libbeat/management/config.go
@@ -5,32 +5,79 @@
 package management
 
 import (
-	"os"
+	"io"
+	"text/template"
 	"time"
 
-	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/common/file"
-	"github.com/elastic/beats/libbeat/kibana"
-	"github.com/elastic/beats/libbeat/paths"
-	"github.com/elastic/beats/x-pack/libbeat/management/api"
-
-	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
+
+	"github.com/elastic/beats/libbeat/kibana"
 )
+
+// ManagedConfigTemplate is used to overwrite settings file during enrollment
+const ManagedConfigTemplate = `
+
+#========================= Central Management =================================
+
+# Beats is configured under central management, you can define most settings
+# from the Kibana UI. You can update this file to configure the settings that
+# are not supported by Kibana Beats management.
+
+{{.CentralManagementSettings}}
+
+#================================ General =====================================
+
+# The name of the shipper that publishes the network data. It can be used to group
+# all the transactions sent by a single shipper in the web interface.
+#name:
+
+# The tags of the shipper are included in their own field with each
+# transaction published.
+#tags: ["service-X", "web-tier"]
+
+# Optional fields that you can specify to add additional information to the
+# output.
+#fields:
+#  env: staging
+
+#================================ Logging =====================================
+
+# Sets log level. The default log level is info.
+# Available log levels are: error, warning, info, debug
+#logging.level: debug
+
+# At debug level, you can selectively enable logging only for some components.
+# To enable all selectors use ["*"]. Examples of other selectors are "beat",
+# "publish", "service".
+#logging.selectors: ["*"]
+
+#============================== Xpack Monitoring ===============================
+# beatname can export internal metrics to a central Elasticsearch monitoring
+# cluster.  This requires xpack monitoring to be enabled in Elasticsearch.  The
+# reporting is disabled by default.
+
+# Set to true to enable the monitoring reporter.
+#xpack.monitoring.enabled: false
+
+# Uncomment to send the metrics to Elasticsearch. Most settings from the
+# Elasticsearch output are accepted here as well. Any setting that is not set is
+# automatically inherited from the Elasticsearch output configuration, so if you
+# have the Elasticsearch output configured, you can simply uncomment the
+# following line.
+#xpack.monitoring.elasticsearch:
+`
 
 // Config for central management
 type Config struct {
 	// true when enrolled
-	Enabled bool
+	Enabled bool `config:"enabled"`
 
 	// Poll configs period
-	Period time.Duration
+	Period time.Duration `config:"period"`
 
-	AccessToken string
+	AccessToken string `config:"access_token"`
 
-	Kibana *kibana.ClientConfig
-
-	Configs api.ConfigBlocks
+	Kibana *kibana.ClientConfig `config:"kibana"`
 }
 
 func defaultConfig() *Config {
@@ -39,48 +86,22 @@ func defaultConfig() *Config {
 	}
 }
 
-// Load settings from its source file
-func (c *Config) Load() error {
-	path := paths.Resolve(paths.Data, "management.yml")
-	config, err := common.LoadFile(path)
-	if err != nil {
-		if os.IsNotExist(err) {
-			// File is not present, beat is not enrolled
-			return nil
-		}
-		return err
-	}
-
-	if err = config.Unpack(&c); err != nil {
-		return err
-	}
-
-	return nil
+type templateParams struct {
+	CentralManagementSettings string
 }
 
-// Save settings to management.yml file
-func (c *Config) Save() error {
-	path := paths.Resolve(paths.Data, "management.yml")
+// OverwriteConfigFile will overwrite beat settings file with the enrolled template
+func (c *Config) OverwriteConfigFile(wr io.Writer) error {
+	t := template.Must(template.New("beat.management.yml").Parse(ManagedConfigTemplate))
 
 	data, err := yaml.Marshal(c)
 	if err != nil {
 		return err
 	}
 
-	// write temporary file first
-	tempFile := path + ".new"
-	f, err := os.OpenFile(tempFile, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
-	if err != nil {
-		return errors.Wrap(err, "failed to store central management settings")
+	params := templateParams{
+		CentralManagementSettings: string(data),
 	}
 
-	_, err = f.Write(data)
-	f.Close()
-	if err != nil {
-		return err
-	}
-
-	// move temporary file into final location
-	err = file.SafeFileRotate(path, tempFile)
-	return err
+	return t.Execute(wr, params)
 }

--- a/x-pack/libbeat/management/config.go
+++ b/x-pack/libbeat/management/config.go
@@ -70,14 +70,14 @@ const ManagedConfigTemplate = `
 // Config for central management
 type Config struct {
 	// true when enrolled
-	Enabled bool `config:"enabled"`
+	Enabled bool `config:"enabled" yaml:"enabled"`
 
 	// Poll configs period
-	Period time.Duration `config:"period"`
+	Period time.Duration `config:"period" yaml:"period"`
 
-	AccessToken string `config:"access_token"`
+	AccessToken string `config:"access_token" yaml:"access_token"`
 
-	Kibana *kibana.ClientConfig `config:"kibana"`
+	Kibana *kibana.ClientConfig `config:"kibana" yaml:"kibana"`
 }
 
 func defaultConfig() *Config {

--- a/x-pack/libbeat/management/config.go
+++ b/x-pack/libbeat/management/config.go
@@ -51,7 +51,7 @@ const ManagedConfigTemplate = `
 #logging.selectors: ["*"]
 
 #============================== Xpack Monitoring ===============================
-# beatname can export internal metrics to a central Elasticsearch monitoring
+# {{.BeatName}} can export internal metrics to a central Elasticsearch monitoring
 # cluster.  This requires xpack monitoring to be enabled in Elasticsearch.  The
 # reporting is disabled by default.
 
@@ -87,10 +87,11 @@ func defaultConfig() *Config {
 
 type templateParams struct {
 	CentralManagementSettings string
+	BeatName                  string
 }
 
 // OverwriteConfigFile will overwrite beat settings file with the enrolled template
-func (c *Config) OverwriteConfigFile(wr io.Writer) error {
+func (c *Config) OverwriteConfigFile(wr io.Writer, beatName string) error {
 	t := template.Must(template.New("beat.management.yml").Parse(ManagedConfigTemplate))
 
 	tmp := struct {
@@ -106,6 +107,7 @@ func (c *Config) OverwriteConfigFile(wr io.Writer) error {
 
 	params := templateParams{
 		CentralManagementSettings: string(data),
+		BeatName:                  beatName,
 	}
 
 	return t.Execute(wr, params)

--- a/x-pack/libbeat/management/config.go
+++ b/x-pack/libbeat/management/config.go
@@ -95,7 +95,7 @@ func (c *Config) OverwriteConfigFile(wr io.Writer, beatName string) error {
 	t := template.Must(template.New("beat.management.yml").Parse(ManagedConfigTemplate))
 
 	tmp := struct {
-		Management *Config `yaml:"xpack.management"`
+		Management *Config `yaml:"management"`
 	}{
 		Management: c,
 	}

--- a/x-pack/libbeat/management/config.go
+++ b/x-pack/libbeat/management/config.go
@@ -24,7 +24,6 @@ const ManagedConfigTemplate = `
 # are not supported by Kibana Beats management.
 
 {{.CentralManagementSettings}}
-
 #================================ General =====================================
 
 # The name of the shipper that publishes the network data. It can be used to group
@@ -94,7 +93,13 @@ type templateParams struct {
 func (c *Config) OverwriteConfigFile(wr io.Writer) error {
 	t := template.Must(template.New("beat.management.yml").Parse(ManagedConfigTemplate))
 
-	data, err := yaml.Marshal(c)
+	tmp := struct {
+		Management *Config `yaml:"xpack.management"`
+	}{
+		Management: c,
+	}
+
+	data, err := yaml.Marshal(tmp)
 	if err != nil {
 		return err
 	}

--- a/x-pack/libbeat/management/enroll.go
+++ b/x-pack/libbeat/management/enroll.go
@@ -50,7 +50,7 @@ func Enroll(beat *instance.Beat, kibanaURL, enrollmentToken string) error {
 	}
 	defer f.Close()
 
-	if err := config.OverwriteConfigFile(f); err != nil {
+	if err := config.OverwriteConfigFile(f, beat.Beat.Info.Beat); err != nil {
 		return errors.Wrap(err, "overriding settings file")
 	}
 

--- a/x-pack/libbeat/management/enroll.go
+++ b/x-pack/libbeat/management/enroll.go
@@ -17,7 +17,7 @@ import (
 	"github.com/elastic/beats/x-pack/libbeat/management/api"
 )
 
-const accessTokenK = "management.accesstoken"
+const accessTokenKey = "management.accesstoken"
 
 // Enroll this beat to the given kibana
 // This will use Central Management API to enroll and retrieve an access key for config retrieval
@@ -48,7 +48,7 @@ func Enroll(beat *instance.Beat, kibanaURL, enrollmentToken string, force bool) 
 	// Enrolled, persist state
 	config := defaultConfig()
 	config.Enabled = true
-	config.AccessToken = "${" + accessTokenK + "}"
+	config.AccessToken = "${" + accessTokenKey + "}"
 	config.Kibana = kibanaConfig
 
 	confirm, err := confirmConfigOverwrite(force)
@@ -90,7 +90,7 @@ func storeAccessToken(beat *instance.Beat, accessToken string) error {
 		}
 	}
 
-	if err := keystore.Store(accessTokenK, []byte(accessToken)); err != nil {
+	if err := keystore.Store(accessTokenKey, []byte(accessToken)); err != nil {
 		return errors.Wrap(err, "error storing the access token")
 	}
 

--- a/x-pack/libbeat/management/manager.go
+++ b/x-pack/libbeat/management/manager.go
@@ -31,6 +31,7 @@ func init() {
 // new configs from Kibana and applying them to the Beat
 type ConfigManager struct {
 	config   *Config
+	cache    *Cache
 	logger   *logp.Logger
 	client   *api.Client
 	beatUUID uuid.UUID
@@ -40,10 +41,10 @@ type ConfigManager struct {
 }
 
 // NewConfigManager returns a X-Pack Beats Central Management manager
-func NewConfigManager(registry *reload.Registry, beatUUID uuid.UUID) (management.ConfigManager, error) {
+func NewConfigManager(config *common.Config, registry *reload.Registry, beatUUID uuid.UUID) (management.ConfigManager, error) {
 	c := defaultConfig()
-	if err := c.Load(); err != nil {
-		return nil, errors.Wrap(err, "reading central management internal settings")
+	if err := config.Unpack(&c); err != nil {
+		return nil, errors.Wrap(err, "parsing central management settings")
 	}
 	return NewConfigManagerWithConfig(c, registry, beatUUID)
 }
@@ -51,8 +52,15 @@ func NewConfigManager(registry *reload.Registry, beatUUID uuid.UUID) (management
 // NewConfigManagerWithConfig returns a X-Pack Beats Central Management manager
 func NewConfigManagerWithConfig(c *Config, registry *reload.Registry, beatUUID uuid.UUID) (management.ConfigManager, error) {
 	var client *api.Client
+	var cache *Cache
 	if c.Enabled {
 		var err error
+
+		// Initialize central management settings cache
+		cache = &Cache{}
+		if err := cache.Load(); err != nil {
+			return nil, errors.Wrap(err, "reading central management internal cache")
+		}
 
 		// Ignore kibana version to avoid permission errors
 		c.Kibana.IgnoreVersion = true
@@ -65,6 +73,7 @@ func NewConfigManagerWithConfig(c *Config, registry *reload.Registry, beatUUID u
 
 	return &ConfigManager{
 		config:   c,
+		cache:    cache,
 		logger:   logp.NewLogger(management.DebugK),
 		client:   client,
 		done:     make(chan struct{}),
@@ -133,7 +142,7 @@ func (cm *ConfigManager) worker() {
 		if changed {
 			// store new configs (already applied)
 			cm.logger.Info("Storing new state")
-			if err := cm.config.Save(); err != nil {
+			if err := cm.cache.Save(); err != nil {
 				cm.logger.Errorf("error storing central management state: %s", err)
 			}
 		}
@@ -154,19 +163,19 @@ func (cm *ConfigManager) fetch() bool {
 		return false
 	}
 
-	if api.ConfigBlocksEqual(configs, cm.config.Configs) {
+	if api.ConfigBlocksEqual(configs, cm.cache.Configs) {
 		cm.logger.Debug("configuration didn't change, sleeping")
 		return false
 	}
 
 	cm.logger.Info("New configurations retrieved")
-	cm.config.Configs = configs
+	cm.cache.Configs = configs
 
 	return true
 }
 
 func (cm *ConfigManager) apply() {
-	for _, b := range cm.config.Configs {
+	for _, b := range cm.cache.Configs {
 		cm.reload(b.Type, b.Blocks)
 	}
 }

--- a/x-pack/libbeat/management/manager.go
+++ b/x-pack/libbeat/management/manager.go
@@ -43,8 +43,10 @@ type ConfigManager struct {
 // NewConfigManager returns a X-Pack Beats Central Management manager
 func NewConfigManager(config *common.Config, registry *reload.Registry, beatUUID uuid.UUID) (management.ConfigManager, error) {
 	c := defaultConfig()
-	if err := config.Unpack(&c); err != nil {
-		return nil, errors.Wrap(err, "parsing central management settings")
+	if config != nil {
+		if err := config.Unpack(&c); err != nil {
+			return nil, errors.Wrap(err, "parsing central management settings")
+		}
 	}
 	return NewConfigManagerWithConfig(c, registry, beatUUID)
 }


### PR DESCRIPTION
This change moves central management settings to the beat config, instead of having its own internal file.

In order to make this work well, `enroll` command will override existing settings to:

1. Put its own settings in the file.
2. Remove existing settings for centrally managed configurations, as they won't be allowed any longer

Before overriding the existing config, the `enroll` command will ask for confirmation and do a backup of it in all cases.