### PR TITLE
Cherry-pick #8623 to 6.x: Fix make fmt after vendoring goimports

### DIFF
--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -134,7 +134,7 @@ endif
 
 .PHONY: fmt
 fmt: add-headers python-env ## @build Runs `goimports -l -w` and `autopep8`on the project's source code, modifying any files that do not match its style.
-	@go get $(GOIMPORTS_REPO)
+	@go get $(ES_BEATS)/vendor/$(GOIMPORTS_REPO)
 	@goimports -local ${GOIMPORTS_LOCAL_PREFIX} -l -w ${GOFILES_NOVENDOR}
 	@${FIND} -name '*.py' -exec ${PYTHON_ENV}/bin/autopep8 --in-place --max-line-length 120  {} \;
 


### PR DESCRIPTION
Cherry-pick of PR #8623 to 6.x branch. Original message: 

Fix make fmt after #8619 