### PR TITLE
Cherry-pick #8641 to 6.x: Fix autopep8 checks by tying it to version 1.3.5 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ notice: python-env
 .PHONY: python-env
 python-env:
 	@test -d $(PYTHON_ENV) || virtualenv $(VIRTUALENV_PARAMS) $(PYTHON_ENV)
-	@$(PYTHON_ENV)/bin/pip install -q --upgrade pip autopep8 six
+	@$(PYTHON_ENV)/bin/pip install -q --upgrade pip autopep8==1.3.5 six
 	@# Work around pip bug. See: https://github.com/pypa/pip/issues/4464
 	@find $(PYTHON_ENV) -type d -name dist-packages -exec sh -c "echo dist-packages > {}.pth" ';'
 


### PR DESCRIPTION
Cherry-pick of PR #8641 to 6.x branch. Original message: 

The newest autopep8 release breaks our checks.