### PR TITLE
Fix a race condition on add_host_metadata

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -45,7 +45,7 @@ https://github.com/elastic/beats/compare/v6.4.0...master[Check the HEAD diff]
 - Replace index patterns in TSVB visualizations. {pull}7929[7929]
 - Fixed Support `add_docker_metadata` in Windows by identifying systems' path separator. {issue}7797[7797]
 - Add backoff support to x-pack monitoring outputs. {issue}7966[7966]
-- Fix a race condition with the `add_host_metadata` and the event serialization. {pull}8223[8223]
+- Fix a race condition with the `add_host_metadata` and the event serialization. {pull}8653[8653]
 - Enforce that data used by k8s or docker doesn't use any reference. {pull}8240[8240]
 - Switch to different UUID lib due to to non-random generated UUIDs. {pull}8485[8485]
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -45,7 +45,7 @@ https://github.com/elastic/beats/compare/v6.4.0...master[Check the HEAD diff]
 - Replace index patterns in TSVB visualizations. {pull}7929[7929]
 - Fixed Support `add_docker_metadata` in Windows by identifying systems' path separator. {issue}7797[7797]
 - Add backoff support to x-pack monitoring outputs. {issue}7966[7966]
-- Fix a race condition with the `add_host_metadata` and the event serialization. {pull}8653[8653]
+- Fix a race condition with the `add_host_metadata` and the event serialization. {pull}8223[8223] {pull}8653[8653]
 - Enforce that data used by k8s or docker doesn't use any reference. {pull}8240[8240]
 - Switch to different UUID lib due to to non-random generated UUIDs. {pull}8485[8485]
 

--- a/libbeat/processors/add_host_metadata/add_host_metadata.go
+++ b/libbeat/processors/add_host_metadata/add_host_metadata.go
@@ -114,7 +114,7 @@ func (p *addHostMetadata) loadData() {
 	p.data.Set(data)
 }
 
-func (p addHostMetadata) getNetInfo() ([]string, []string, error) {
+func (p *addHostMetadata) getNetInfo() ([]string, []string, error) {
 	var ipList []string
 	var hwList []string
 
@@ -159,7 +159,7 @@ func (p addHostMetadata) getNetInfo() ([]string, []string, error) {
 	return ipList, hwList, errs.Err()
 }
 
-func (p addHostMetadata) String() string {
+func (p *addHostMetadata) String() string {
 	return fmt.Sprintf("%v=[netinfo.enabled=[%v]]",
 		processorName, p.config.NetInfoEnabled)
 }

--- a/libbeat/processors/add_host_metadata/add_host_metadata.go
+++ b/libbeat/processors/add_host_metadata/add_host_metadata.go
@@ -71,7 +71,7 @@ func newHostMetadataProcessor(cfg *common.Config) (processors.Processor, error) 
 // Run enriches the given event with the host meta data
 func (p *addHostMetadata) Run(event *beat.Event) (*beat.Event, error) {
 	p.loadData()
-	event.Fields.DeepUpdate(p.data.Get())
+	event.Fields.DeepUpdate(p.data.Get().Clone())
 	return event, nil
 }
 

--- a/libbeat/processors/add_host_metadata/add_host_metadata.go
+++ b/libbeat/processors/add_host_metadata/add_host_metadata.go
@@ -69,6 +69,7 @@ func newHostMetadataProcessor(cfg *common.Config) (processors.Processor, error) 
 		config: config,
 		data:   common.NewMapStrPointer(nil),
 	}
+	p.loadData()
 	return p, nil
 }
 

--- a/libbeat/processors/add_host_metadata/add_host_metadata.go
+++ b/libbeat/processors/add_host_metadata/add_host_metadata.go
@@ -106,7 +106,7 @@ func (p *addHostMetadata) loadData() {
 	p.lastUpdate = time.Now()
 }
 
-func (p addHostMetadata) getNetInfo() ([]string, []string, error) {
+func (p *addHostMetadata) getNetInfo() ([]string, []string, error) {
 	var ipList []string
 	var hwList []string
 
@@ -151,7 +151,7 @@ func (p addHostMetadata) getNetInfo() ([]string, []string, error) {
 	return ipList, hwList, errs.Err()
 }
 
-func (p addHostMetadata) String() string {
+func (p *addHostMetadata) String() string {
 	return fmt.Sprintf("%v=[netinfo.enabled=[%v]]",
 		processorName, p.config.NetInfoEnabled)
 }


### PR DESCRIPTION
Not sure if adding a mutex at this level will be too blocking for events processing, I have also though on other options to reduce contention on reads:
* Using a RWLock, but we'd still need to write-lock first to check expiration and update
* Using a RWLock and a go-routine to do periodic updates, but afaik we wouldn't have a way to stop it if the processor is removed.

Continues with #8223 