### PR TITLE
Use fork of `github.com/mitchellh/gox`

### DIFF
--- a/CHANGELOG-developer.asciidoc
+++ b/CHANGELOG-developer.asciidoc
@@ -54,3 +54,4 @@ The list below covers the major changes between 6.3.0 and master only.
 - Set current year in generator templates. {pull}8396[8396]
 - You can now override default settings of libbeat by using instance.Settings. {pull}8449[8449]
 - Add `-space-id` option to `export_dashboards.go` script to support Kibana Spaces {pull}7942[7942]
+- Use fork of github.com/mitchellh/gox. {pull}8654[8654]

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -106,6 +106,11 @@ ${BEAT_NAME}.test: $(GOFILES_ALL)
 .PHONY: crosscompile
 crosscompile: ## @build Cross-compile beat for the OS'es specified in GOX_OS variable. The binaries are placed in the build/bin directory.
 crosscompile: $(GOFILES)
+	# If CGO is enabled when cross-compiling, it is possible that each platform requires a different compiler.
+	# Right now github.com/mitchell/gox only supports setting one global C cross-compiler for every platform.
+	# My fork includes a flag which cat set different C compilers.
+	# After my PR gets merged or the functionality becomes available in the original tool, we are switching back.
+	# My PR: https://github.com/mitchellh/gox/pull/116
 	go get github.com/kvch/gox
 	mkdir -p ${BUILD_DIR}/bin
 	gox -output="${BUILD_DIR}/bin/{{.Dir}}-{{.OS}}-{{.Arch}}" -os="$(strip $(GOX_OS))" -osarch="$(strip $(GOX_OSARCH))" ${GOX_FLAGS}

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -106,7 +106,7 @@ ${BEAT_NAME}.test: $(GOFILES_ALL)
 .PHONY: crosscompile
 crosscompile: ## @build Cross-compile beat for the OS'es specified in GOX_OS variable. The binaries are placed in the build/bin directory.
 crosscompile: $(GOFILES)
-	go get github.com/mitchellh/gox
+	go get github.com/kvch/gox
 	mkdir -p ${BUILD_DIR}/bin
 	gox -output="${BUILD_DIR}/bin/{{.Dir}}-{{.OS}}-{{.Arch}}" -os="$(strip $(GOX_OS))" -osarch="$(strip $(GOX_OSARCH))" ${GOX_FLAGS}
 


### PR DESCRIPTION
In order to run `make crosscompile` for `journalbeat` different C cross-compilers are required. However, `github.com/mitchellh/gox` does not support using different compilers for each platform. I have opened a PR to support setting C compilers by platform: https://github.com/mitchellh/gox/pull/116
However, I haven't received any feedback since. Until `gox` does not support setting C compilers in some form we need to use my fork which has the required support.

My fork: https://github.com/kvch/gox

This feature will be also useful in if we decide to enable CGO for more Beats.