### PR TITLE
Cherry-pick #8646 to 6.x: Fix race in monitoring output

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -43,6 +43,7 @@ https://github.com/elastic/beats/compare/v6.4.0...6.x[Check the HEAD diff]
 - Fix a race condition with the `add_host_metadata` and the event serialization. {pull}8223[8223]
 - Enforce that data used by k8s or docker doesn't use any reference. {pull}8240[8240]
 - Switch to different UUID lib due to to non-random generated UUIDs. {pull}8485[8485]
+- Fix race condition when publishing monitoring data. {pull}8646[8646]
 
 *Auditbeat*
 

--- a/libbeat/monitoring/report/elasticsearch/client.go
+++ b/libbeat/monitoring/report/elasticsearch/client.go
@@ -34,16 +34,6 @@ type publishClient struct {
 	params map[string]string
 }
 
-var (
-	// monitoring beats action
-	actMonitoringBeats = common.MapStr{
-		"index": common.MapStr{
-			"_index":   "",
-			"_routing": nil,
-		},
-	}
-)
-
 func newPublishClient(
 	es *esout.Client,
 	params map[string]string,
@@ -122,15 +112,19 @@ func (c *publishClient) Publish(batch publisher.Batch) error {
 				}
 			}
 		}
-		actMonitoringBeats.Put("index._type", t)
 
-		bulk := [2]interface{}{
-			actMonitoringBeats,
-			report.Event{
-				Timestamp: event.Content.Timestamp,
-				Fields:    event.Content.Fields,
+		action := common.MapStr{
+			"index": common.MapStr{
+				"_type":    t,
+				"_index":   "",
+				"_routing": nil,
 			},
 		}
+		document := report.Event{
+			Timestamp: event.Content.Timestamp,
+			Fields:    event.Content.Fields,
+		}
+		bulk := [2]interface{}{action, document}
 
 		// Currently one request per event is sent. Reason is that each event can contain different
 		// interval params and X-Pack requires to send the interval param.


### PR DESCRIPTION
Cherry-pick of PR #8646 to 6.x branch. Original message: 

The action part of the bulk request used to be a constant (used to use
'var' for init purposes only), but with 6.4 we have had to introduce the
`index._type` field per monitoring type.
With the introduction of telemetry we ended up with 2 publisher
pipelines and 2 outputs, each with slightly different parameters, yet
the action part has become a 'global' shared variable, that was modified
by each reporter. If metrics and telemetry publish events at the same
time, there is a race in modifying the global and serializing the bulk
request.

This change removes the global and creates an action item per event,
such that there will be no sharing at all.