### PR TITLE
[Heartbeat] Read entire body before closing connection

### DIFF
--- a/heartbeat/hbtest/hbtestutil.go
+++ b/heartbeat/hbtest/hbtestutil.go
@@ -26,6 +26,7 @@ import (
 	"net/url"
 	"os"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -47,6 +48,20 @@ func HelloWorldHandler(status int) http.HandlerFunc {
 			}
 			w.WriteHeader(status)
 			io.WriteString(w, HelloWorldBody)
+		},
+	)
+}
+
+func LargeResponseHandler(bytes int) http.HandlerFunc {
+	var body strings.Builder
+	for i := 0; i < bytes; i++ {
+		body.WriteString("x")
+	}
+
+	return http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+			io.WriteString(w, body.String())
 		},
 	)
 }

--- a/heartbeat/hbtest/hbtestutil.go
+++ b/heartbeat/hbtest/hbtestutil.go
@@ -52,7 +52,10 @@ func HelloWorldHandler(status int) http.HandlerFunc {
 	)
 }
 
-func LargeResponseHandler(bytes int) http.HandlerFunc {
+// SizedResponseHandler responds with 200 to any request with a body
+// exactly the size of the `bytes` argument, where each byte is the
+// character 'x'
+func SizedResponseHandler(bytes int) http.HandlerFunc {
 	var body strings.Builder
 	for i := 0; i < bytes; i++ {
 		body.WriteString("x")

--- a/heartbeat/monitors/active/http/http_test.go
+++ b/heartbeat/monitors/active/http/http_test.go
@@ -211,7 +211,7 @@ func TestDownStatuses(t *testing.T) {
 }
 
 func TestLargeResponse(t *testing.T) {
-	server := httptest.NewServer(hbtest.LargeResponseHandler(1024 * 1024))
+	server := httptest.NewServer(hbtest.SizedResponseHandler(1024 * 1024))
 	defer server.Close()
 
 	configSrc := map[string]interface{}{

--- a/heartbeat/monitors/active/http/http_test.go
+++ b/heartbeat/monitors/active/http/http_test.go
@@ -210,6 +210,41 @@ func TestDownStatuses(t *testing.T) {
 	}
 }
 
+func TestLargeResponse(t *testing.T) {
+	server := httptest.NewServer(hbtest.LargeResponseHandler(1024 * 1024))
+	defer server.Close()
+
+	configSrc := map[string]interface{}{
+		"urls":                server.URL,
+		"timeout":             "1s",
+		"check.response.body": "x",
+	}
+
+	config, err := common.NewConfigFrom(configSrc)
+	require.NoError(t, err)
+
+	jobs, err := create("largeresp", config)
+	require.NoError(t, err)
+
+	job := jobs[0]
+
+	event, _, err := job.Run()
+	require.NoError(t, err)
+
+	port, err := hbtest.ServerPort(server)
+	require.NoError(t, err)
+
+	mapvaltest.Test(
+		t,
+		mapval.Strict(mapval.Compose(
+			hbtest.MonitorChecks("http@"+server.URL, server.URL, "127.0.0.1", "http", "up"),
+			hbtest.RespondingTCPChecks(port),
+			respondingHTTPChecks(server.URL, 200),
+		)),
+		event.Fields,
+	)
+}
+
 func TestHTTPSServer(t *testing.T) {
 	server := httptest.NewTLSServer(hbtest.HelloWorldHandler(http.StatusOK))
 	port, err := hbtest.ServerPort(server)


### PR DESCRIPTION
This fixes an issue where the connection would be closed after only a partial body read. The RoundTripper would close the conn before returning the response which included a partially buffered body. This would actually work for short responses, since the backing bufio would do a partial read, but would fail on all but the shortest responses.

Normally connection lifecycle is handled outside the realm of the `RoundTripper`, but for our purposes we don't want to re-use connections. Since it is a requirement that all response bodies be closed, we can piggy-back on top of that to ensure the connection is closed.

@urso I would like your feedback on this fix. If it looks good I'll add some unit tests around it.

Fixes #8588