### PR TITLE
Cherry-pick #8656 to 6.x: Do not rely on an specific memcached version for autodiscover test

### DIFF
--- a/metricbeat/tests/system/test_autodiscover.py
+++ b/metricbeat/tests/system/test_autodiscover.py
@@ -25,7 +25,7 @@ class TestAutodiscover(metricbeat.BaseTest):
                 'docker': {
                     'templates': '''
                       - condition:
-                          equals.docker.container.image: memcached:1.5.3
+                          equals.docker.container.image: memcached:latest
                         config:
                           - module: memcached
                             metricsets: ["stats"]
@@ -37,8 +37,8 @@ class TestAutodiscover(metricbeat.BaseTest):
         )
 
         proc = self.start_beat()
-        docker_client.images.pull('memcached:1.5.3')
-        container = docker_client.containers.run('memcached:1.5.3', detach=True)
+        docker_client.images.pull('memcached:latest')
+        container = docker_client.containers.run('memcached:latest', detach=True)
 
         self.wait_until(lambda: self.log_contains('Starting runner: memcached'))
 
@@ -51,7 +51,7 @@ class TestAutodiscover(metricbeat.BaseTest):
         proc.check_kill_and_wait()
 
         # Check metadata is added
-        assert output[0]['docker']['container']['image'] == 'memcached:1.5.3'
+        assert output[0]['docker']['container']['image'] == 'memcached:latest'
         assert output[0]['docker']['container']['labels'] == {}
         assert 'name' in output[0]['docker']['container']
 
@@ -74,13 +74,13 @@ class TestAutodiscover(metricbeat.BaseTest):
         )
 
         proc = self.start_beat()
-        docker_client.images.pull('memcached:1.5.3')
+        docker_client.images.pull('memcached:latest')
         labels = {
             'co.elastic.metrics/module': 'memcached',
             'co.elastic.metrics/period': '1s',
             'co.elastic.metrics/hosts': "'${data.host}:11211'",
         }
-        container = docker_client.containers.run('memcached:1.5.3', labels=labels, detach=True)
+        container = docker_client.containers.run('memcached:latest', labels=labels, detach=True)
 
         self.wait_until(lambda: self.log_contains('Starting runner: memcached'))
 
@@ -93,5 +93,5 @@ class TestAutodiscover(metricbeat.BaseTest):
         proc.check_kill_and_wait()
 
         # Check metadata is added
-        assert output[0]['docker']['container']['image'] == 'memcached:1.5.3'
+        assert output[0]['docker']['container']['image'] == 'memcached:latest'
         assert 'name' in output[0]['docker']['container']


### PR DESCRIPTION
Cherry-pick of PR #8656 to 6.x branch. Original message: 

Issue seen in travis:
```
======================================================================
ERROR: Test docker autodiscover starts modules from templates
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/go/src/github.com/elastic/beats/metricbeat/tests/system/test_autodiscover.py", line 40, in test_docker
    docker_client.images.pull('memcached:1.5.3')
  File "/usr/local/lib/python2.7/dist-packages/docker/models/images.py", line 415, in pull
    repository, tag, '@' if tag.startswith('sha256:') else ':'
  File "/usr/local/lib/python2.7/dist-packages/docker/models/images.py", line 295, in get
    return self.prepare_model(self.client.api.inspect_image(name))
  File "/usr/local/lib/python2.7/dist-packages/docker/utils/decorators.py", line 19, in wrapped
    return f(self, resource_id, *args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/docker/api/image.py", line 245, in inspect_image
    self._get(self._url("/images/{0}/json", image)), True
  File "/usr/local/lib/python2.7/dist-packages/docker/api/client.py", line 231, in _result
    self._raise_for_status(response)
  File "/usr/local/lib/python2.7/dist-packages/docker/api/client.py", line 227, in _raise_for_status
    raise create_api_error_from_http_exception(e)
  File "/usr/local/lib/python2.7/dist-packages/docker/errors.py", line 31, in create_api_error_from_http_exception
    raise cls(e, response=response, explanation=explanation)
ImageNotFound: 404 Client Error: Not Found ("no such image: memcached:1.5.3: No such image: memcached:1.5.3")
```

Old versions are sometimes removed, as this test is not about the module
itself we can use the latest tag here.
