### PR TITLE
Fix update when no AWS service are modified

### DIFF
--- a/x-pack/functionbeat/provider/aws/cli_manager.go
+++ b/x-pack/functionbeat/provider/aws/cli_manager.go
@@ -168,12 +168,6 @@ func (c *CLIManager) stackName(name string) string {
 	return "fnb-" + name + "-stack"
 }
 
-func (c *CLIManager) codeKey(name string, content []byte) string {
-	sha := sha256.Sum256(content)
-	checksum := base64.RawURLEncoding.EncodeToString(sha[:])
-	return "functionbeat-deployment/" + name + "-" + checksum + "/functionbeat.zip"
-}
-
 func (c *CLIManager) deployTemplate(update bool, name string) error {
 	c.log.Debug("Compressing all assets into an artifact")
 	content, err := core.MakeZip()
@@ -189,7 +183,7 @@ func (c *CLIManager) deployTemplate(update bool, name string) error {
 
 	fnTemplate := function.Template()
 
-	templateLoc := c.codeKey(name, content)
+	templateLoc := codeKey(name, content)
 
 	to := c.template(function, name, templateLoc)
 	if err := mergeTemplate(to, fnTemplate); err != nil {
@@ -339,4 +333,10 @@ func mergeTemplate(to, from *cloudformation.Template) error {
 	}
 
 	return nil
+}
+
+func codeKey(name string, content []byte) string {
+	sha := sha256.Sum256(content)
+	checksum := base64.RawURLEncoding.EncodeToString(sha[:])
+	return "functionbeat-deployment/" + name + "-" + checksum + "/functionbeat.zip"
 }

--- a/x-pack/functionbeat/provider/aws/cli_manager.go
+++ b/x-pack/functionbeat/provider/aws/cli_manager.go
@@ -183,9 +183,9 @@ func (c *CLIManager) deployTemplate(update bool, name string) error {
 
 	fnTemplate := function.Template()
 
-	templateLoc := codeKey(name, content)
+	codeLoc := codeKey(name, content)
 
-	to := c.template(function, name, templateLoc)
+	to := c.template(function, name, codeLoc)
 	if err := mergeTemplate(to, fnTemplate); err != nil {
 		return err
 	}
@@ -199,7 +199,7 @@ func (c *CLIManager) deployTemplate(update bool, name string) error {
 
 	executer := newExecutor(c.log)
 	executer.Add(newOpEnsureBucket(c.log, c.awsCfg, bucket))
-	executer.Add(newOpUploadToBucket(c.log, c.awsCfg, bucket, templateLoc, content))
+	executer.Add(newOpUploadToBucket(c.log, c.awsCfg, bucket, codeLoc, content))
 	executer.Add(newOpUploadToBucket(
 		c.log,
 		c.awsCfg,
@@ -224,6 +224,7 @@ func (c *CLIManager) deployTemplate(update bool, name string) error {
 	}
 
 	executer.Add(newOpWaitCloudFormation(c.log, c.awsCfg, c.stackName(name)))
+	executer.Add(newOpDeleteFileBucket(c.log, c.awsCfg, bucket, codeLoc))
 
 	if err := executer.Execute(); err != nil {
 		if rollbackErr := executer.Rollback(); rollbackErr != nil {

--- a/x-pack/functionbeat/provider/aws/cli_manager_test.go
+++ b/x-pack/functionbeat/provider/aws/cli_manager_test.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 package aws
 
 import (

--- a/x-pack/functionbeat/provider/aws/cli_manager_test.go
+++ b/x-pack/functionbeat/provider/aws/cli_manager_test.go
@@ -1,0 +1,36 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/libbeat/common"
+)
+
+func TestCodeKey(t *testing.T) {
+	t.Run("same bytes content return the same key", func(t *testing.T) {
+		name := "hello"
+		content, err := common.RandomBytes(100)
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		assert.Equal(t, codeKey(name, content), codeKey(name, content))
+	})
+
+	t.Run("different bytes return a different key", func(t *testing.T) {
+		name := "hello"
+		content, err := common.RandomBytes(100)
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		other, err := common.RandomBytes(100)
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		assert.NotEqual(t, codeKey(name, content), codeKey(name, other))
+	})
+}

--- a/x-pack/functionbeat/provider/aws/op_delete_file_bucket.go
+++ b/x-pack/functionbeat/provider/aws/op_delete_file_bucket.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 package aws
 
 import (

--- a/x-pack/functionbeat/provider/aws/op_delete_file_bucket.go
+++ b/x-pack/functionbeat/provider/aws/op_delete_file_bucket.go
@@ -1,0 +1,46 @@
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+
+	"github.com/elastic/beats/libbeat/logp"
+)
+
+type opDeleteFileBucket struct {
+	log        *logp.Logger
+	svc        *s3.S3
+	bucketName string
+	path       string
+}
+
+func newOpDeleteFileBucket(
+	log *logp.Logger,
+	config aws.Config,
+	bucketName, path string,
+) *opDeleteFileBucket {
+	return &opDeleteFileBucket{
+		log:        log,
+		svc:        s3.New(config),
+		bucketName: bucketName,
+		path:       path,
+	}
+}
+
+func (o *opDeleteFileBucket) Execute() error {
+	o.log.Debugf("Removing file '%s' on bucket '%s'", o.path, o.bucketName)
+	input := &s3.DeleteObjectInput{
+		Bucket: aws.String(o.bucketName),
+		Key:    aws.String(o.path),
+	}
+
+	req := o.svc.DeleteObjectRequest(input)
+	resp, err := req.Send()
+
+	if err != nil {
+		o.log.Debugf("Could not remove object to S3, resp: %v", resp)
+		return err
+	}
+	o.log.Debug("Remove successful")
+	return nil
+}

--- a/x-pack/functionbeat/provider/aws/op_upload_to_bucket.go
+++ b/x-pack/functionbeat/provider/aws/op_upload_to_bucket.go
@@ -57,8 +57,11 @@ func (o *opUploadToBucket) Execute() error {
 }
 
 func (o *opUploadToBucket) Rollback() error {
-	// The error will be logged but do not enforce a failure because the file could have been removed
-	// before.
-	newOpDeleteFileBucket(o.log, o.config, o.bucketName, o.path).Execute()
+	// The error will be logged but we do not enforce a hard failure because the file could have
+	// been removed before.
+	err := newOpDeleteFileBucket(o.log, o.config, o.bucketName, o.path).Execute()
+	if err != nil {
+		o.log.Debugf("Fail to delete file on bucket, error: %+v", err)
+	}
 	return nil
 }

--- a/x-pack/functionbeat/provider/aws/op_upload_to_bucket.go
+++ b/x-pack/functionbeat/provider/aws/op_upload_to_bucket.go
@@ -57,5 +57,8 @@ func (o *opUploadToBucket) Execute() error {
 }
 
 func (o *opUploadToBucket) Rollback() error {
-	return newOpDeleteFileBucket(o.log, o.config, o.bucketName, o.path).Execute()
+	// The error will be logged but do not enforce a failure because the file could have been removed
+	// before.
+	newOpDeleteFileBucket(o.log, o.config, o.bucketName, o.path).Execute()
+	return nil
 }

--- a/x-pack/functionbeat/provider/aws/op_upload_to_bucket.go
+++ b/x-pack/functionbeat/provider/aws/op_upload_to_bucket.go
@@ -19,6 +19,7 @@ type opUploadToBucket struct {
 	bucketName string
 	path       string
 	raw        []byte
+	config     aws.Config
 }
 
 func newOpUploadToBucket(
@@ -33,6 +34,7 @@ func newOpUploadToBucket(
 		bucketName: bucketName,
 		path:       path,
 		raw:        raw,
+		config:     config,
 	}
 }
 
@@ -52,4 +54,8 @@ func (o *opUploadToBucket) Execute() error {
 	}
 	o.log.Debug("Upload successful")
 	return nil
+}
+
+func (o *opUploadToBucket) Rollback() error {
+	return newOpDeleteFileBucket(o.log, o.config, o.bucketName, o.path).Execute()
 }


### PR DESCRIPTION
When you are pushing a cloudformation template and no resources has
changed but the artifact with the configuration is different,
cloudformation will not publish the new method.

To go around that, each time that the package is pushed to S3 when
change the URL of the template, since the stack point to a new URL it
will trigger an update to the lambda function.