### PR TITLE
Add ingest-user-agent to the required plugins list

### DIFF
--- a/x-pack/filebeat/module/suricata/eve/manifest.yml
+++ b/x-pack/filebeat/module/suricata/eve/manifest.yml
@@ -19,5 +19,5 @@ input: config/eve.yml
 requires.processors:
 - name: geoip
   plugin: ingest-geoip
-# - name: user_agent
-#   plugin: ingest-user-agent
+- name: user_agent
+  plugin: ingest-user-agent


### PR DESCRIPTION
The ingest pipeline for suricata's eve fileset uses the user-agent plugin.
This updates the manifest to include this requirement.

