### PR TITLE
Use naming conventions for the Suricata dashboards

### DIFF
--- a/x-pack/filebeat/module/suricata/_meta/kibana/6/dashboard/Filebeat-Suricata-Alert-Overview.json
+++ b/x-pack/filebeat/module/suricata/_meta/kibana/6/dashboard/Filebeat-Suricata-Alert-Overview.json
@@ -1,774 +1,675 @@
 {
-    "objects": [
-        {
-            "attributes": {
-                "description": "", 
-                "kibanaSavedObjectMeta": {
-                    "searchSourceJSON": {
-                        "filter": [], 
-                        "query": {
-                            "language": "kuery", 
-                            "query": ""
-                        }
-                    }
-                }, 
-                "savedSearchId": "1c2bcec0-86d1-11e8-b59d-21efb914e65c", 
-                "title": "Suricata - Top Alerting Hosts - Histogram", 
-                "uiStateJSON": {}, 
-                "version": 1, 
-                "visState": {
-                    "aggs": [
-                        {
-                            "enabled": true, 
-                            "id": "1", 
-                            "params": {}, 
-                            "schema": "metric", 
-                            "type": "count"
-                        }, 
-                        {
-                            "enabled": true, 
-                            "id": "2", 
-                            "params": {
-                                "customInterval": "2h", 
-                                "extended_bounds": {}, 
-                                "field": "@timestamp", 
-                                "interval": "auto", 
-                                "min_doc_count": 1
-                            }, 
-                            "schema": "segment", 
-                            "type": "date_histogram"
-                        }, 
-                        {
-                            "enabled": true, 
-                            "id": "3", 
-                            "params": {
-                                "field": "host.name", 
-                                "missingBucket": false, 
-                                "missingBucketLabel": "Missing", 
-                                "order": "desc", 
-                                "orderBy": "1", 
-                                "otherBucket": false, 
-                                "otherBucketLabel": "Other", 
-                                "size": 10
-                            }, 
-                            "schema": "group", 
-                            "type": "terms"
-                        }
-                    ], 
-                    "params": {
-                        "addLegend": true, 
-                        "addTimeMarker": false, 
-                        "addTooltip": true, 
-                        "categoryAxes": [
-                            {
-                                "id": "CategoryAxis-1", 
-                                "labels": {
-                                    "show": true, 
-                                    "truncate": 100
-                                }, 
-                                "position": "bottom", 
-                                "scale": {
-                                    "type": "linear"
-                                }, 
-                                "show": true, 
-                                "style": {}, 
-                                "title": {}, 
-                                "type": "category"
-                            }
-                        ], 
-                        "grid": {
-                            "categoryLines": false, 
-                            "style": {
-                                "color": "#eee"
-                            }
-                        }, 
-                        "legendPosition": "right", 
-                        "seriesParams": [
-                            {
-                                "data": {
-                                    "id": "1", 
-                                    "label": "Count"
-                                }, 
-                                "drawLinesBetweenPoints": true, 
-                                "mode": "stacked", 
-                                "show": "true", 
-                                "showCircles": true, 
-                                "type": "histogram", 
-                                "valueAxis": "ValueAxis-1"
-                            }
-                        ], 
-                        "times": [], 
-                        "type": "histogram", 
-                        "valueAxes": [
-                            {
-                                "id": "ValueAxis-1", 
-                                "labels": {
-                                    "filter": false, 
-                                    "rotate": 0, 
-                                    "show": true, 
-                                    "truncate": 100
-                                }, 
-                                "name": "LeftAxis-1", 
-                                "position": "left", 
-                                "scale": {
-                                    "mode": "normal", 
-                                    "type": "linear"
-                                }, 
-                                "show": true, 
-                                "style": {}, 
-                                "title": {
-                                    "text": "Count"
-                                }, 
-                                "type": "value"
-                            }
-                        ]
-                    }, 
-                    "title": "Suricata - Top Alerting Hosts - Histogram", 
-                    "type": "histogram"
-                }
-            }, 
-            "id": "494fa290-86d2-11e8-b59d-21efb914e65c", 
-            "type": "visualization", 
-            "updated_at": "2018-07-13T19:23:56.600Z", 
-            "version": 1
-        }, 
-        {
-            "attributes": {
-                "description": "", 
-                "kibanaSavedObjectMeta": {
-                    "searchSourceJSON": {
-                        "filter": [], 
-                        "query": {
-                            "language": "kuery", 
-                            "query": ""
-                        }
-                    }
-                }, 
-                "savedSearchId": "1c2bcec0-86d1-11e8-b59d-21efb914e65c", 
-                "title": "Suricata - Top Alert Signatures - Table", 
-                "uiStateJSON": {
-                    "vis": {
-                        "params": {
-                            "sort": {
-                                "columnIndex": null, 
-                                "direction": null
-                            }
-                        }
-                    }
-                }, 
-                "version": 1, 
-                "visState": {
-                    "aggs": [
-                        {
-                            "enabled": true, 
-                            "id": "1", 
-                            "params": {}, 
-                            "schema": "metric", 
-                            "type": "count"
-                        }, 
-                        {
-                            "enabled": true, 
-                            "id": "2", 
-                            "params": {
-                                "customLabel": "Alert Signature", 
-                                "field": "suricata.eve.alert.signature", 
-                                "missingBucket": false, 
-                                "missingBucketLabel": "Missing", 
-                                "order": "desc", 
-                                "orderBy": "1", 
-                                "otherBucket": false, 
-                                "otherBucketLabel": "Other", 
-                                "size": 10
-                            }, 
-                            "schema": "bucket", 
-                            "type": "terms"
-                        }, 
-                        {
-                            "enabled": true, 
-                            "id": "3", 
-                            "params": {
-                                "customLabel": "Alert Category", 
-                                "field": "suricata.eve.alert.category", 
-                                "missingBucket": false, 
-                                "missingBucketLabel": "Missing", 
-                                "order": "desc", 
-                                "orderBy": "1", 
-                                "otherBucket": false, 
-                                "otherBucketLabel": "Other", 
-                                "size": 5
-                            }, 
-                            "schema": "bucket", 
-                            "type": "terms"
-                        }
-                    ], 
-                    "params": {
-                        "perPage": 10, 
-                        "showMeticsAtAllLevels": false, 
-                        "showPartialRows": false, 
-                        "showTotal": false, 
-                        "sort": {
-                            "columnIndex": null, 
-                            "direction": null
-                        }, 
-                        "totalFunc": "sum"
-                    }, 
-                    "title": "Suricata - Top Alert Signatures - Table", 
-                    "type": "table"
-                }
-            }, 
-            "id": "16033310-86d3-11e8-b59d-21efb914e65c", 
-            "type": "visualization", 
-            "updated_at": "2018-07-13T19:30:34.777Z", 
-            "version": 3
-        }, 
-        {
-            "attributes": {
-                "columns": [
-                    "host.name", 
-                    "suricata.eve.flow_id", 
-                    "source_ecs.ip",
-                    "source_ecs.port",
-                    "destination.ip",
-                    "destination.port",
-                    "source_ecs.geo.country_iso_code",
-                    "destination.geo.country_iso_code"
-                ], 
-                "description": "", 
-                "hits": 0, 
-                "kibanaSavedObjectMeta": {
-                    "searchSourceJSON": {
-                        "filter": [
-                            {
-                                "$state": {
-                                    "store": "appState"
-                                }, 
-                                "meta": {
-                                    "alias": null, 
-                                    "disabled": false, 
-                                    "index": "filebeat-*", 
-                                    "key": "event.type",
-                                    "negate": false, 
-                                    "params": {
-                                        "query": "alert", 
-                                        "type": "phrase"
-                                    }, 
-                                    "type": "phrase", 
-                                    "value": "alert"
-                                }, 
-                                "query": {
-                                    "match": {
-                                        "event.type": {
-                                            "query": "alert", 
-                                            "type": "phrase"
-                                        }
-                                    }
-                                }
-                            }, 
-                            {
-                                "$state": {
-                                    "store": "appState"
-                                }, 
-                                "meta": {
-                                    "alias": null, 
-                                    "disabled": false, 
-                                    "index": "filebeat-*", 
-                                    "key": "fileset.module", 
-                                    "negate": false, 
-                                    "params": {
-                                        "query": "suricata", 
-                                        "type": "phrase"
-                                    }, 
-                                    "type": "phrase", 
-                                    "value": "suricata"
-                                }, 
-                                "query": {
-                                    "match": {
-                                        "fileset.module": {
-                                            "query": "suricata", 
-                                            "type": "phrase"
-                                        }
-                                    }
-                                }
-                            }
-                        ], 
-                        "highlightAll": true, 
-                        "index": "filebeat-*", 
-                        "query": {
-                            "language": "kuery", 
-                            "query": ""
-                        }, 
-                        "version": true
-                    }
-                }, 
-                "sort": [
-                    "@timestamp", 
-                    "desc"
-                ], 
-                "title": "Suricata Alerts", 
-                "version": 1
-            }, 
-            "id": "1c2bcec0-86d1-11e8-b59d-21efb914e65c", 
-            "type": "search", 
-            "updated_at": "2018-07-13T19:57:03.700Z", 
-            "version": 3
-        }, 
-        {
-            "attributes": {
-                "description": "", 
-                "kibanaSavedObjectMeta": {
-                    "searchSourceJSON": {
-                        "filter": [], 
-                        "query": {
-                            "language": "kuery", 
-                            "query": ""
-                        }
-                    }
-                }, 
-                "savedSearchId": "1c2bcec0-86d1-11e8-b59d-21efb914e65c", 
-                "title": "Suricata - Alert - Source Location - Map", 
-                "uiStateJSON": {}, 
-                "version": 1, 
-                "visState": {
-                    "aggs": [
-                        {
-                            "enabled": true, 
-                            "id": "1", 
-                            "params": {}, 
-                            "schema": "metric", 
-                            "type": "count"
-                        }, 
-                        {
-                            "enabled": true, 
-                            "id": "2", 
-                            "params": {
-                                "autoPrecision": true, 
-                                "field": "source_ecs.geo.location",
-                                "isFilteredByCollar": true, 
-                                "precision": 2, 
-                                "useGeocentroid": true
-                            }, 
-                            "schema": "segment", 
-                            "type": "geohash_grid"
-                        }
-                    ], 
-                    "params": {
-                        "addTooltip": true, 
-                        "heatClusterSize": 1.5, 
-                        "isDesaturated": true, 
-                        "legendPosition": "bottomright", 
-                        "mapCenter": [
-                            0, 
-                            0
-                        ], 
-                        "mapType": "Scaled Circle Markers", 
-                        "mapZoom": 2, 
-                        "wms": {
-                            "baseLayersAreLoaded": {}, 
-                            "enabled": false, 
-                            "options": {
-                                "format": "image/png", 
-                                "transparent": true
-                            }, 
-                            "selectedTmsLayer": {
-                                "attribution": "<p>&#169; <a href=\"http://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors | <a href=\"https://www.elastic.co/elastic-maps-service\">Elastic Maps Service</a></p>&#10;", 
-                                "id": "road_map", 
-                                "maxZoom": 18, 
-                                "minZoom": 0, 
-                                "subdomains": [], 
-                                "url": "https://tiles.maps.elastic.co/v2/default/{z}/{x}/{y}.png?elastic_tile_service_tos=agree&my_app_name=kibana&my_app_version=6.3.0&license=fc9de2c1-5f06-4080-8dd0-8a334171d89a"
-                            }, 
-                            "tmsLayers": [
-                                {
-                                    "attribution": "<p>&#169; <a href=\"http://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors | <a href=\"https://www.elastic.co/elastic-maps-service\">Elastic Maps Service</a></p>&#10;", 
-                                    "id": "road_map", 
-                                    "maxZoom": 18, 
-                                    "minZoom": 0, 
-                                    "subdomains": [], 
-                                    "url": "https://tiles.maps.elastic.co/v2/default/{z}/{x}/{y}.png?elastic_tile_service_tos=agree&my_app_name=kibana&my_app_version=6.3.0&license=fc9de2c1-5f06-4080-8dd0-8a334171d89a"
-                                }
-                            ]
-                        }
-                    }, 
-                    "title": "Suricata - Alert - Source Location - Map", 
-                    "type": "tile_map"
-                }
-            }, 
-            "id": "85fed080-86d7-11e8-b59d-21efb914e65c", 
-            "type": "visualization", 
-            "updated_at": "2018-07-13T20:15:21.156Z", 
-            "version": 2
-        }, 
-        {
-            "attributes": {
-                "description": "", 
-                "kibanaSavedObjectMeta": {
-                    "searchSourceJSON": {
-                        "filter": [], 
-                        "query": {
-                            "language": "kuery", 
-                            "query": ""
-                        }
-                    }
-                }, 
-                "savedSearchId": "1c2bcec0-86d1-11e8-b59d-21efb914e65c", 
-                "title": "Suricata - Alert - Destination Location - Map", 
-                "uiStateJSON": {}, 
-                "version": 1, 
-                "visState": {
-                    "aggs": [
-                        {
-                            "enabled": true, 
-                            "id": "1", 
-                            "params": {}, 
-                            "schema": "metric", 
-                            "type": "count"
-                        }, 
-                        {
-                            "enabled": true, 
-                            "id": "2", 
-                            "params": {
-                                "autoPrecision": true, 
-                                "field": "destination.geo.location",
-                                "isFilteredByCollar": true, 
-                                "precision": 2, 
-                                "useGeocentroid": true
-                            }, 
-                            "schema": "segment", 
-                            "type": "geohash_grid"
-                        }
-                    ], 
-                    "params": {
-                        "addTooltip": true, 
-                        "heatClusterSize": 1.5, 
-                        "isDesaturated": true, 
-                        "legendPosition": "bottomright", 
-                        "mapCenter": [
-                            0, 
-                            0
-                        ], 
-                        "mapType": "Scaled Circle Markers", 
-                        "mapZoom": 2, 
-                        "wms": {
-                            "baseLayersAreLoaded": {}, 
-                            "enabled": false, 
-                            "options": {
-                                "format": "image/png", 
-                                "transparent": true
-                            }, 
-                            "selectedTmsLayer": {
-                                "attribution": "<p>&#169; <a href=\"http://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors | <a href=\"https://www.elastic.co/elastic-maps-service\">Elastic Maps Service</a></p>&#10;", 
-                                "id": "road_map", 
-                                "maxZoom": 18, 
-                                "minZoom": 0, 
-                                "subdomains": [], 
-                                "url": "https://tiles.maps.elastic.co/v2/default/{z}/{x}/{y}.png?elastic_tile_service_tos=agree&my_app_name=kibana&my_app_version=6.3.0&license=fc9de2c1-5f06-4080-8dd0-8a334171d89a"
-                            }, 
-                            "tmsLayers": [
-                                {
-                                    "attribution": "<p>&#169; <a href=\"http://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors | <a href=\"https://www.elastic.co/elastic-maps-service\">Elastic Maps Service</a></p>&#10;", 
-                                    "id": "road_map", 
-                                    "maxZoom": 18, 
-                                    "minZoom": 0, 
-                                    "subdomains": [], 
-                                    "url": "https://tiles.maps.elastic.co/v2/default/{z}/{x}/{y}.png?elastic_tile_service_tos=agree&my_app_name=kibana&my_app_version=6.3.0&license=fc9de2c1-5f06-4080-8dd0-8a334171d89a"
-                                }
-                            ]
-                        }
-                    }, 
-                    "title": "Suricata - Alert - Destination Location - Map", 
-                    "type": "tile_map"
-                }
-            }, 
-            "id": "a09ca070-86d7-11e8-b59d-21efb914e65c", 
-            "type": "visualization", 
-            "updated_at": "2018-07-13T20:13:08.322Z", 
-            "version": 3
-        }, 
-        {
-            "attributes": {
-                "description": "", 
-                "kibanaSavedObjectMeta": {
-                    "searchSourceJSON": {
-                        "filter": [], 
-                        "query": {
-                            "language": "kuery", 
-                            "query": ""
-                        }
-                    }
-                }, 
-                "savedSearchId": "1c2bcec0-86d1-11e8-b59d-21efb914e65c", 
-                "title": "Suricata - Alerts - Top Destination Countries - Table", 
-                "uiStateJSON": {
-                    "vis": {
-                        "params": {
-                            "sort": {
-                                "columnIndex": null, 
-                                "direction": null
-                            }
-                        }
-                    }
-                }, 
-                "version": 1, 
-                "visState": {
-                    "aggs": [
-                        {
-                            "enabled": true, 
-                            "id": "1", 
-                            "params": {}, 
-                            "schema": "metric", 
-                            "type": "count"
-                        }, 
-                        {
-                            "enabled": true, 
-                            "id": "2", 
-                            "params": {
-                                "customLabel": "Source Country", 
-                                "field": "destination.geo.country_iso_code",
-                                "missingBucket": false, 
-                                "missingBucketLabel": "Missing", 
-                                "order": "desc", 
-                                "orderBy": "1", 
-                                "otherBucket": false, 
-                                "otherBucketLabel": "Other", 
-                                "size": 10
-                            }, 
-                            "schema": "bucket", 
-                            "type": "terms"
-                        }
-                    ], 
-                    "params": {
-                        "perPage": 5, 
-                        "showMeticsAtAllLevels": false, 
-                        "showPartialRows": false, 
-                        "showTotal": false, 
-                        "sort": {
-                            "columnIndex": null, 
-                            "direction": null
-                        }, 
-                        "totalFunc": "sum"
-                    }, 
-                    "title": "Suricata - Alerts - Top Destination Countries - Table", 
-                    "type": "table"
-                }
-            }, 
-            "id": "2ccdc1a0-86d8-11e8-b59d-21efb914e65c", 
-            "type": "visualization", 
-            "updated_at": "2018-07-13T20:08:27.835Z", 
-            "version": 4
-        }, 
-        {
-            "attributes": {
-                "description": "", 
-                "kibanaSavedObjectMeta": {
-                    "searchSourceJSON": {
-                        "filter": [], 
-                        "query": {
-                            "language": "kuery", 
-                            "query": ""
-                        }
-                    }
-                }, 
-                "savedSearchId": "1c2bcec0-86d1-11e8-b59d-21efb914e65c", 
-                "title": "Suricata - Alerts - Top Source Countries - Table", 
-                "uiStateJSON": {
-                    "vis": {
-                        "params": {
-                            "sort": {
-                                "columnIndex": null, 
-                                "direction": null
-                            }
-                        }
-                    }
-                }, 
-                "version": 1, 
-                "visState": {
-                    "aggs": [
-                        {
-                            "enabled": true, 
-                            "id": "1", 
-                            "params": {}, 
-                            "schema": "metric", 
-                            "type": "count"
-                        }, 
-                        {
-                            "enabled": true, 
-                            "id": "2", 
-                            "params": {
-                                "customLabel": "Source Country", 
-                                "field": "source_ecs.geo.country_iso_code",
-                                "missingBucket": false, 
-                                "missingBucketLabel": "Missing", 
-                                "order": "desc", 
-                                "orderBy": "1", 
-                                "otherBucket": false, 
-                                "otherBucketLabel": "Other", 
-                                "size": 10
-                            }, 
-                            "schema": "bucket", 
-                            "type": "terms"
-                        }
-                    ], 
-                    "params": {
-                        "perPage": 5, 
-                        "showMeticsAtAllLevels": false, 
-                        "showPartialRows": false, 
-                        "showTotal": false, 
-                        "sort": {
-                            "columnIndex": null, 
-                            "direction": null
-                        }, 
-                        "totalFunc": "sum"
-                    }, 
-                    "title": "Suricata - Alerts - Top Source Countries - Table", 
-                    "type": "table"
-                }
-            }, 
-            "id": "c7b8b8f0-86d8-11e8-b59d-21efb914e65c", 
-            "type": "visualization", 
-            "updated_at": "2018-07-13T20:10:25.663Z", 
-            "version": 1
-        }, 
-        {
-            "attributes": {
-                "description": "", 
-                "hits": 0, 
-                "kibanaSavedObjectMeta": {
-                    "searchSourceJSON": {
-                        "filter": [], 
-                        "highlightAll": true, 
-                        "query": {
-                            "language": "kuery", 
-                            "query": ""
-                        }, 
-                        "version": true
-                    }
-                }, 
-                "optionsJSON": {
-                    "darkTheme": false, 
-                    "hidePanelTitles": false, 
-                    "useMargins": true
-                }, 
-                "panelsJSON": [
-                    {
-                        "embeddableConfig": {}, 
-                        "gridData": {
-                            "h": 10, 
-                            "i": "1", 
-                            "w": 23, 
-                            "x": 0, 
-                            "y": 0
-                        }, 
-                        "id": "494fa290-86d2-11e8-b59d-21efb914e65c", 
-                        "panelIndex": "1", 
-                        "type": "visualization", 
-                        "version": "6.3.0"
-                    }, 
-                    {
-                        "embeddableConfig": {}, 
-                        "gridData": {
-                            "h": 22, 
-                            "i": "2", 
-                            "w": 25, 
-                            "x": 23, 
-                            "y": 0
-                        }, 
-                        "id": "16033310-86d3-11e8-b59d-21efb914e65c", 
-                        "panelIndex": "2", 
-                        "type": "visualization", 
-                        "version": "6.3.0"
-                    }, 
-                    {
-                        "embeddableConfig": {}, 
-                        "gridData": {
-                            "h": 16, 
-                            "i": "3", 
-                            "w": 48, 
-                            "x": 0, 
-                            "y": 37
-                        }, 
-                        "id": "1c2bcec0-86d1-11e8-b59d-21efb914e65c", 
-                        "panelIndex": "3", 
-                        "type": "search", 
-                        "version": "6.3.0"
-                    }, 
-                    {
-                        "embeddableConfig": {
-                            "mapCenter": [
-                                38.548165423046584, 
-                                -6.328125000000001
-                            ], 
-                            "mapZoom": 2
-                        }, 
-                        "gridData": {
-                            "h": 15, 
-                            "i": "4", 
-                            "w": 23, 
-                            "x": 0, 
-                            "y": 22
-                        }, 
-                        "id": "85fed080-86d7-11e8-b59d-21efb914e65c", 
-                        "panelIndex": "4", 
-                        "type": "visualization", 
-                        "version": "6.3.0"
-                    }, 
-                    {
-                        "embeddableConfig": {
-                            "mapCenter": [
-                                41.77131167976407, 
-                                1.9335937500000002
-                            ], 
-                            "mapZoom": 2
-                        }, 
-                        "gridData": {
-                            "h": 15, 
-                            "i": "5", 
-                            "w": 25, 
-                            "x": 23, 
-                            "y": 22
-                        }, 
-                        "id": "a09ca070-86d7-11e8-b59d-21efb914e65c", 
-                        "panelIndex": "5", 
-                        "type": "visualization", 
-                        "version": "6.3.0"
-                    }, 
-                    {
-                        "embeddableConfig": {}, 
-                        "gridData": {
-                            "h": 12, 
-                            "i": "7", 
-                            "w": 12, 
-                            "x": 11, 
-                            "y": 10
-                        }, 
-                        "id": "2ccdc1a0-86d8-11e8-b59d-21efb914e65c", 
-                        "panelIndex": "7", 
-                        "type": "visualization", 
-                        "version": "6.3.0"
-                    }, 
-                    {
-                        "embeddableConfig": {}, 
-                        "gridData": {
-                            "h": 12, 
-                            "i": "8", 
-                            "w": 11, 
-                            "x": 0, 
-                            "y": 10
-                        }, 
-                        "id": "c7b8b8f0-86d8-11e8-b59d-21efb914e65c", 
-                        "panelIndex": "8", 
-                        "type": "visualization", 
-                        "version": "6.3.0"
-                    }
-                ], 
-                "timeRestore": false, 
-                "title": "Suricata Alert Overview", 
-                "version": 1
-            }, 
-            "id": "05268ee0-86d1-11e8-b59d-21efb914e65c", 
-            "type": "dashboard", 
-            "updated_at": "2018-07-13T20:16:05.559Z", 
-            "version": 7
+  "objects": [
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "savedSearchId": "1c2bcec0-86d1-11e8-b59d-21efb914e65c",
+        "title": "Top Alerting Hosts [Suricata]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customInterval": "2h",
+                "extended_bounds": {},
+                "field": "@timestamp",
+                "interval": "auto",
+                "min_doc_count": 1
+              },
+              "schema": "segment",
+              "type": "date_histogram"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "field": "host.name",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 10
+              },
+              "schema": "group",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTimeMarker": false,
+            "addTooltip": true,
+            "categoryAxes": [
+              {
+                "id": "CategoryAxis-1",
+                "labels": {
+                  "show": true,
+                  "truncate": 100
+                },
+                "position": "bottom",
+                "scale": {
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {},
+                "type": "category"
+              }
+            ],
+            "grid": {
+              "categoryLines": false,
+              "style": {
+                "color": "#eee"
+              }
+            },
+            "legendPosition": "right",
+            "seriesParams": [
+              {
+                "data": {
+                  "id": "1",
+                  "label": "Count"
+                },
+                "drawLinesBetweenPoints": true,
+                "mode": "stacked",
+                "show": "true",
+                "showCircles": true,
+                "type": "histogram",
+                "valueAxis": "ValueAxis-1"
+              }
+            ],
+            "times": [],
+            "type": "histogram",
+            "valueAxes": [
+              {
+                "id": "ValueAxis-1",
+                "labels": {
+                  "filter": false,
+                  "rotate": 0,
+                  "show": true,
+                  "truncate": 100
+                },
+                "name": "LeftAxis-1",
+                "position": "left",
+                "scale": {
+                  "mode": "normal",
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {
+                  "text": "Count"
+                },
+                "type": "value"
+              }
+            ]
+          },
+          "title": "Top Alerting Hosts [Suricata]",
+          "type": "histogram"
         }
-    ], 
-    "version": "6.3.0"
+      },
+      "id": "494fa290-86d2-11e8-b59d-21efb914e65c",
+      "type": "visualization",
+      "updated_at": "2018-10-22T11:16:48.797Z",
+      "version": 3
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "savedSearchId": "1c2bcec0-86d1-11e8-b59d-21efb914e65c",
+        "title": "Top Alert Signatures [Suricata]",
+        "uiStateJSON": {
+          "vis": {
+            "params": {
+              "sort": {
+                "columnIndex": null,
+                "direction": null
+              }
+            }
+          }
+        },
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "Alert Signature",
+                "field": "suricata.eve.alert.signature",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 10
+              },
+              "schema": "bucket",
+              "type": "terms"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "customLabel": "Alert Category",
+                "field": "suricata.eve.alert.category",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "bucket",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "perPage": 10,
+            "showMetricsAtAllLevels": false,
+            "showPartialRows": false,
+            "showTotal": false,
+            "sort": {
+              "columnIndex": null,
+              "direction": null
+            },
+            "totalFunc": "sum"
+          },
+          "title": "Top Alert Signatures [Suricata]",
+          "type": "table"
+        }
+      },
+      "id": "16033310-86d3-11e8-b59d-21efb914e65c",
+      "type": "visualization",
+      "updated_at": "2018-10-22T11:17:14.911Z",
+      "version": 4
+    },
+    {
+      "attributes": {
+        "columns": [
+          "host.name",
+          "suricata.eve.flow_id",
+          "suricata.eve.src_ip",
+          "suricata.eve.src_port",
+          "suricata.eve.dest_ip",
+          "suricata.eve.dest_port",
+          "source_ecs.geo.country_iso_code",
+          "destination.geo.country_iso_code"
+        ],
+        "description": "",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [
+              {
+                "$state": {
+                  "store": "appState"
+                },
+                "meta": {
+                  "alias": null,
+                  "disabled": false,
+                  "index": "filebeat-*",
+                  "key": "event.type",
+                  "negate": false,
+                  "params": {
+                    "query": "alert",
+                    "type": "phrase"
+                  },
+                  "type": "phrase",
+                  "value": "alert"
+                },
+                "query": {
+                  "match": {
+                    "event.type": {
+                      "query": "alert",
+                      "type": "phrase"
+                    }
+                  }
+                }
+              },
+              {
+                "$state": {
+                  "store": "appState"
+                },
+                "meta": {
+                  "alias": null,
+                  "disabled": false,
+                  "index": "filebeat-*",
+                  "key": "fileset.module",
+                  "negate": false,
+                  "params": {
+                    "query": "suricata",
+                    "type": "phrase"
+                  },
+                  "type": "phrase",
+                  "value": "suricata"
+                },
+                "query": {
+                  "match": {
+                    "fileset.module": {
+                      "query": "suricata",
+                      "type": "phrase"
+                    }
+                  }
+                }
+              }
+            ],
+            "highlightAll": true,
+            "index": "filebeat-*",
+            "query": {
+              "language": "kuery",
+              "query": ""
+            },
+            "version": true
+          }
+        },
+        "sort": [
+          "@timestamp",
+          "desc"
+        ],
+        "title": "Alerts [Suricata]",
+        "version": 1
+      },
+      "id": "1c2bcec0-86d1-11e8-b59d-21efb914e65c",
+      "type": "search",
+      "updated_at": "2018-10-22T11:23:24.475Z",
+      "version": 3
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "savedSearchId": "1c2bcec0-86d1-11e8-b59d-21efb914e65c",
+        "title": "Alert - Source Location [Suricata]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "autoPrecision": true,
+                "field": "source_ecs.geo.location",
+                "isFilteredByCollar": true,
+                "mapCenter": [
+                  0,
+                  0
+                ],
+                "mapZoom": 2,
+                "precision": 2,
+                "useGeocentroid": true
+              },
+              "schema": "segment",
+              "type": "geohash_grid"
+            }
+          ],
+          "params": {
+            "addTooltip": true,
+            "colorSchema": "Yellow to Red",
+            "heatClusterSize": 1.5,
+            "isDesaturated": true,
+            "legendPosition": "bottomright",
+            "mapCenter": [
+              0,
+              0
+            ],
+            "mapType": "Scaled Circle Markers",
+            "mapZoom": 2,
+            "wms": {
+              "baseLayersAreLoaded": {},
+              "enabled": false,
+              "options": {
+                "format": "image/png",
+                "transparent": true
+              },
+              "selectedTmsLayer": {
+                "attribution": "\u003cp\u003e\u0026#169; \u003ca href=\"http://www.openstreetmap.org/copyright\"\u003eOpenStreetMap\u003c/a\u003e contributors | \u003ca href=\"https://www.elastic.co/elastic-maps-service\"\u003eElastic Maps Service\u003c/a\u003e\u003c/p\u003e\u0026#10;",
+                "id": "road_map",
+                "maxZoom": 18,
+                "minZoom": 0,
+                "subdomains": [],
+                "url": "https://tiles.maps.elastic.co/v2/default/{z}/{x}/{y}.png?elastic_tile_service_tos=agree\u0026my_app_name=kibana\u0026my_app_version=6.3.0\u0026license=fc9de2c1-5f06-4080-8dd0-8a334171d89a"
+              },
+              "tmsLayers": [
+                {
+                  "attribution": "\u003cp\u003e\u0026#169; \u003ca href=\"http://www.openstreetmap.org/copyright\"\u003eOpenStreetMap\u003c/a\u003e contributors | \u003ca href=\"https://www.elastic.co/elastic-maps-service\"\u003eElastic Maps Service\u003c/a\u003e\u003c/p\u003e\u0026#10;",
+                  "id": "road_map",
+                  "maxZoom": 18,
+                  "minZoom": 0,
+                  "subdomains": [],
+                  "url": "https://tiles.maps.elastic.co/v2/default/{z}/{x}/{y}.png?elastic_tile_service_tos=agree\u0026my_app_name=kibana\u0026my_app_version=6.3.0\u0026license=fc9de2c1-5f06-4080-8dd0-8a334171d89a"
+                }
+              ]
+            }
+          },
+          "title": "Alert - Source Location [Suricata]",
+          "type": "tile_map"
+        }
+      },
+      "id": "85fed080-86d7-11e8-b59d-21efb914e65c",
+      "type": "visualization",
+      "updated_at": "2018-10-22T11:22:25.267Z",
+      "version": 3
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "savedSearchId": "1c2bcec0-86d1-11e8-b59d-21efb914e65c",
+        "title": "Alert - Destination Location [Suricata]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "autoPrecision": true,
+                "field": "destination.geo.location",
+                "isFilteredByCollar": true,
+                "mapCenter": [
+                  0,
+                  0
+                ],
+                "mapZoom": 2,
+                "precision": 2,
+                "useGeocentroid": true
+              },
+              "schema": "segment",
+              "type": "geohash_grid"
+            }
+          ],
+          "params": {
+            "addTooltip": true,
+            "colorSchema": "Yellow to Red",
+            "heatClusterSize": 1.5,
+            "isDesaturated": true,
+            "legendPosition": "bottomright",
+            "mapCenter": [
+              0,
+              0
+            ],
+            "mapType": "Scaled Circle Markers",
+            "mapZoom": 2,
+            "wms": {
+              "baseLayersAreLoaded": {},
+              "enabled": false,
+              "options": {
+                "format": "image/png",
+                "transparent": true
+              },
+              "selectedTmsLayer": {
+                "attribution": "\u003cp\u003e\u0026#169; \u003ca href=\"http://www.openstreetmap.org/copyright\"\u003eOpenStreetMap\u003c/a\u003e contributors | \u003ca href=\"https://www.elastic.co/elastic-maps-service\"\u003eElastic Maps Service\u003c/a\u003e\u003c/p\u003e\u0026#10;",
+                "id": "road_map",
+                "maxZoom": 18,
+                "minZoom": 0,
+                "subdomains": [],
+                "url": "https://tiles.maps.elastic.co/v2/default/{z}/{x}/{y}.png?elastic_tile_service_tos=agree\u0026my_app_name=kibana\u0026my_app_version=6.3.0\u0026license=fc9de2c1-5f06-4080-8dd0-8a334171d89a"
+              },
+              "tmsLayers": [
+                {
+                  "attribution": "\u003cp\u003e\u0026#169; \u003ca href=\"http://www.openstreetmap.org/copyright\"\u003eOpenStreetMap\u003c/a\u003e contributors | \u003ca href=\"https://www.elastic.co/elastic-maps-service\"\u003eElastic Maps Service\u003c/a\u003e\u003c/p\u003e\u0026#10;",
+                  "id": "road_map",
+                  "maxZoom": 18,
+                  "minZoom": 0,
+                  "subdomains": [],
+                  "url": "https://tiles.maps.elastic.co/v2/default/{z}/{x}/{y}.png?elastic_tile_service_tos=agree\u0026my_app_name=kibana\u0026my_app_version=6.3.0\u0026license=fc9de2c1-5f06-4080-8dd0-8a334171d89a"
+                }
+              ]
+            }
+          },
+          "title": "Alert - Destination Location [Suricata]",
+          "type": "tile_map"
+        }
+      },
+      "id": "a09ca070-86d7-11e8-b59d-21efb914e65c",
+      "type": "visualization",
+      "updated_at": "2018-10-22T11:22:53.717Z",
+      "version": 3
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "savedSearchId": "1c2bcec0-86d1-11e8-b59d-21efb914e65c",
+        "title": "Alerts - Top Destination Countries [Suricata]",
+        "uiStateJSON": {
+          "vis": {
+            "params": {
+              "sort": {
+                "columnIndex": null,
+                "direction": null
+              }
+            }
+          }
+        },
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "Source Country",
+                "field": "destination.geo.country_iso_code",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 10
+              },
+              "schema": "bucket",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "perPage": 5,
+            "showMetricsAtAllLevels": false,
+            "showPartialRows": false,
+            "showTotal": false,
+            "sort": {
+              "columnIndex": null,
+              "direction": null
+            },
+            "totalFunc": "sum"
+          },
+          "title": "Alerts - Top Destination Countries [Suricata]",
+          "type": "table"
+        }
+      },
+      "id": "2ccdc1a0-86d8-11e8-b59d-21efb914e65c",
+      "type": "visualization",
+      "updated_at": "2018-10-22T11:18:16.637Z",
+      "version": 4
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "savedSearchId": "1c2bcec0-86d1-11e8-b59d-21efb914e65c",
+        "title": "Alerts - Top Source Countries [Suricata]",
+        "uiStateJSON": {
+          "vis": {
+            "params": {
+              "sort": {
+                "columnIndex": null,
+                "direction": null
+              }
+            }
+          }
+        },
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "Source Country",
+                "field": "source_ecs.geo.country_iso_code",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 10
+              },
+              "schema": "bucket",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "perPage": 5,
+            "showMetricsAtAllLevels": false,
+            "showPartialRows": false,
+            "showTotal": false,
+            "sort": {
+              "columnIndex": null,
+              "direction": null
+            },
+            "totalFunc": "sum"
+          },
+          "title": "Alerts - Top Source Countries [Suricata]",
+          "type": "table"
+        }
+      },
+      "id": "c7b8b8f0-86d8-11e8-b59d-21efb914e65c",
+      "type": "visualization",
+      "updated_at": "2018-10-22T11:17:48.498Z",
+      "version": 4
+    },
+    {
+      "attributes": {
+        "description": "Overview of the Suricata Alerts dashboard.",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "highlightAll": true,
+            "query": {
+              "language": "kuery",
+              "query": ""
+            },
+            "version": true
+          }
+        },
+        "optionsJSON": {
+          "darkTheme": false,
+          "hidePanelTitles": false,
+          "useMargins": true
+        },
+        "panelsJSON": null,
+        "timeRestore": false,
+        "title": "[Suricata] Alert Overview",
+        "version": 1
+      },
+      "id": "05268ee0-86d1-11e8-b59d-21efb914e65c",
+      "type": "dashboard",
+      "updated_at": "2018-10-22T11:24:06.482Z",
+      "version": 5
+    }
+  ],
+  "version": "6.4.2"
 }

--- a/x-pack/filebeat/module/suricata/_meta/kibana/6/dashboard/Filebeat-Suricata-Overview.json
+++ b/x-pack/filebeat/module/suricata/_meta/kibana/6/dashboard/Filebeat-Suricata-Overview.json
@@ -1,919 +1,792 @@
 {
-    "objects": [
-        {
-            "attributes": {
-                "description": "", 
-                "kibanaSavedObjectMeta": {
-                    "searchSourceJSON": {
-                        "filter": [], 
-                        "query": {
-                            "language": "kuery", 
-                            "query": ""
-                        }
-                    }
-                }, 
-                "savedSearchId": "13dd22f0-86cc-11e8-b59d-21efb914e65c", 
-                "title": "Suricata - Activity Types over Time - Histogram", 
-                "uiStateJSON": {}, 
-                "version": 1, 
-                "visState": {
-                    "aggs": [
-                        {
-                            "enabled": true, 
-                            "id": "1", 
-                            "params": {}, 
-                            "schema": "metric", 
-                            "type": "count"
-                        }, 
-                        {
-                            "enabled": true, 
-                            "id": "2", 
-                            "params": {
-                                "customInterval": "2h", 
-                                "extended_bounds": {}, 
-                                "field": "@timestamp", 
-                                "interval": "auto", 
-                                "min_doc_count": 1
-                            }, 
-                            "schema": "segment", 
-                            "type": "date_histogram"
-                        }, 
-                        {
-                            "enabled": true, 
-                            "id": "3", 
-                            "params": {
-                                "field": "event.type",
-                                "missingBucket": false, 
-                                "missingBucketLabel": "Missing", 
-                                "order": "desc", 
-                                "orderBy": "1", 
-                                "otherBucket": false, 
-                                "otherBucketLabel": "Other", 
-                                "size": 20
-                            }, 
-                            "schema": "group", 
-                            "type": "terms"
-                        }
-                    ], 
-                    "params": {
-                        "addLegend": true, 
-                        "addTimeMarker": false, 
-                        "addTooltip": true, 
-                        "categoryAxes": [
-                            {
-                                "id": "CategoryAxis-1", 
-                                "labels": {
-                                    "show": true, 
-                                    "truncate": 100
-                                }, 
-                                "position": "bottom", 
-                                "scale": {
-                                    "type": "linear"
-                                }, 
-                                "show": true, 
-                                "style": {}, 
-                                "title": {}, 
-                                "type": "category"
-                            }
-                        ], 
-                        "grid": {
-                            "categoryLines": false, 
-                            "style": {
-                                "color": "#eee"
-                            }
-                        }, 
-                        "legendPosition": "right", 
-                        "seriesParams": [
-                            {
-                                "data": {
-                                    "id": "1", 
-                                    "label": "Count"
-                                }, 
-                                "drawLinesBetweenPoints": true, 
-                                "mode": "stacked", 
-                                "show": "true", 
-                                "showCircles": true, 
-                                "type": "histogram", 
-                                "valueAxis": "ValueAxis-1"
-                            }
-                        ], 
-                        "times": [], 
-                        "type": "histogram", 
-                        "valueAxes": [
-                            {
-                                "id": "ValueAxis-1", 
-                                "labels": {
-                                    "filter": false, 
-                                    "rotate": 0, 
-                                    "show": true, 
-                                    "truncate": 100
-                                }, 
-                                "name": "LeftAxis-1", 
-                                "position": "left", 
-                                "scale": {
-                                    "mode": "normal", 
-                                    "type": "linear"
-                                }, 
-                                "show": true, 
-                                "style": {}, 
-                                "title": {
-                                    "text": "Count"
-                                }, 
-                                "type": "value"
-                            }
-                        ]
-                    }, 
-                    "title": "Suricata - Activity Types over Time - Histogram", 
-                    "type": "histogram"
-                }
-            }, 
-            "id": "c7d46c60-86da-11e8-b59d-21efb914e65c", 
-            "type": "visualization", 
-            "updated_at": "2018-07-13T20:33:15.446Z", 
-            "version": 2
-        }, 
-        {
-            "attributes": {
-                "description": "", 
-                "kibanaSavedObjectMeta": {
-                    "searchSourceJSON": {
-                        "filter": [], 
-                        "query": {
-                            "language": "kuery", 
-                            "query": ""
-                        }
-                    }
-                }, 
-                "savedSearchId": "13dd22f0-86cc-11e8-b59d-21efb914e65c", 
-                "title": "Suricata - Event Types - Pie", 
-                "uiStateJSON": {}, 
-                "version": 1, 
-                "visState": {
-                    "aggs": [
-                        {
-                            "enabled": true, 
-                            "id": "1", 
-                            "params": {}, 
-                            "schema": "metric", 
-                            "type": "count"
-                        }, 
-                        {
-                            "enabled": true, 
-                            "id": "2", 
-                            "params": {
-                                "field": "event.type",
-                                "missingBucket": false, 
-                                "missingBucketLabel": "Missing", 
-                                "order": "desc", 
-                                "orderBy": "1", 
-                                "otherBucket": false, 
-                                "otherBucketLabel": "Other", 
-                                "size": 20
-                            }, 
-                            "schema": "segment", 
-                            "type": "terms"
-                        }
-                    ], 
-                    "params": {
-                        "addLegend": true, 
-                        "addTooltip": true, 
-                        "isDonut": true, 
-                        "labels": {
-                            "last_level": true, 
-                            "show": false, 
-                            "truncate": 100, 
-                            "values": true
-                        }, 
-                        "legendPosition": "bottom", 
-                        "type": "pie"
-                    }, 
-                    "title": "Suricata - Event Types - Pie", 
-                    "type": "pie"
-                }
-            }, 
-            "id": "0a0aa630-86db-11e8-b59d-21efb914e65c", 
-            "type": "visualization", 
-            "updated_at": "2018-07-13T20:26:35.923Z", 
-            "version": 1
-        }, 
-        {
-            "attributes": {
-                "description": "", 
-                "kibanaSavedObjectMeta": {
-                    "searchSourceJSON": {
-                        "filter": [], 
-                        "query": {
-                            "language": "kuery", 
-                            "query": ""
-                        }
-                    }
-                }, 
-                "savedSearchId": "13dd22f0-86cc-11e8-b59d-21efb914e65c", 
-                "title": "Suricata - Top Application Protocols", 
-                "uiStateJSON": {}, 
-                "version": 1, 
-                "visState": {
-                    "aggs": [
-                        {
-                            "enabled": true, 
-                            "id": "1", 
-                            "params": {}, 
-                            "schema": "metric", 
-                            "type": "count"
-                        }, 
-                        {
-                            "enabled": true, 
-                            "id": "2", 
-                            "params": {
-                                "field": "suricata.eve.app_proto", 
-                                "missingBucket": false, 
-                                "missingBucketLabel": "Missing", 
-                                "order": "desc", 
-                                "orderBy": "1", 
-                                "otherBucket": false, 
-                                "otherBucketLabel": "Other", 
-                                "size": 10
-                            }, 
-                            "schema": "segment", 
-                            "type": "terms"
-                        }
-                    ], 
-                    "params": {
-                        "addLegend": true, 
-                        "addTooltip": true, 
-                        "isDonut": true, 
-                        "labels": {
-                            "last_level": true, 
-                            "show": false, 
-                            "truncate": 100, 
-                            "values": true
-                        }, 
-                        "legendPosition": "bottom", 
-                        "type": "pie"
-                    }, 
-                    "title": "Suricata - Top Application Protocols", 
-                    "type": "pie"
-                }
-            }, 
-            "id": "728f64c0-86db-11e8-b59d-21efb914e65c", 
-            "type": "visualization", 
-            "updated_at": "2018-07-13T20:41:52.359Z", 
-            "version": 3
-        }, 
-        {
-            "attributes": {
-                "description": "", 
-                "kibanaSavedObjectMeta": {
-                    "searchSourceJSON": {
-                        "filter": [], 
-                        "query": {
-                            "language": "kuery", 
-                            "query": ""
-                        }
-                    }
-                }, 
-                "savedSearchId": "13dd22f0-86cc-11e8-b59d-21efb914e65c", 
-                "title": "Suricata - Top Hosts Generating Events - Histogram", 
-                "uiStateJSON": {}, 
-                "version": 1, 
-                "visState": {
-                    "aggs": [
-                        {
-                            "enabled": true, 
-                            "id": "1", 
-                            "params": {}, 
-                            "schema": "metric", 
-                            "type": "count"
-                        }, 
-                        {
-                            "enabled": true, 
-                            "id": "2", 
-                            "params": {
-                                "customInterval": "2h", 
-                                "extended_bounds": {}, 
-                                "field": "@timestamp", 
-                                "interval": "auto", 
-                                "min_doc_count": 1
-                            }, 
-                            "schema": "segment", 
-                            "type": "date_histogram"
-                        }, 
-                        {
-                            "enabled": true, 
-                            "id": "3", 
-                            "params": {
-                                "field": "host.name", 
-                                "missingBucket": false, 
-                                "missingBucketLabel": "Missing", 
-                                "order": "desc", 
-                                "orderBy": "1", 
-                                "otherBucket": false, 
-                                "otherBucketLabel": "Other", 
-                                "size": 10
-                            }, 
-                            "schema": "group", 
-                            "type": "terms"
-                        }
-                    ], 
-                    "params": {
-                        "addLegend": true, 
-                        "addTimeMarker": false, 
-                        "addTooltip": true, 
-                        "categoryAxes": [
-                            {
-                                "id": "CategoryAxis-1", 
-                                "labels": {
-                                    "show": true, 
-                                    "truncate": 100
-                                }, 
-                                "position": "bottom", 
-                                "scale": {
-                                    "type": "linear"
-                                }, 
-                                "show": true, 
-                                "style": {}, 
-                                "title": {}, 
-                                "type": "category"
-                            }
-                        ], 
-                        "grid": {
-                            "categoryLines": false, 
-                            "style": {
-                                "color": "#eee"
-                            }
-                        }, 
-                        "legendPosition": "right", 
-                        "seriesParams": [
-                            {
-                                "data": {
-                                    "id": "1", 
-                                    "label": "Count"
-                                }, 
-                                "drawLinesBetweenPoints": true, 
-                                "mode": "stacked", 
-                                "show": "true", 
-                                "showCircles": true, 
-                                "type": "histogram", 
-                                "valueAxis": "ValueAxis-1"
-                            }
-                        ], 
-                        "times": [], 
-                        "type": "histogram", 
-                        "valueAxes": [
-                            {
-                                "id": "ValueAxis-1", 
-                                "labels": {
-                                    "filter": false, 
-                                    "rotate": 0, 
-                                    "show": true, 
-                                    "truncate": 100
-                                }, 
-                                "name": "LeftAxis-1", 
-                                "position": "left", 
-                                "scale": {
-                                    "mode": "normal", 
-                                    "type": "linear"
-                                }, 
-                                "show": true, 
-                                "style": {}, 
-                                "title": {
-                                    "text": "Count"
-                                }, 
-                                "type": "value"
-                            }
-                        ]
-                    }, 
-                    "title": "Suricata - Top Hosts Generating Events - Histogram", 
-                    "type": "histogram"
-                }
-            }, 
-            "id": "9d5b5b50-86db-11e8-b59d-21efb914e65c", 
-            "type": "visualization", 
-            "updated_at": "2018-07-13T20:33:36.892Z", 
-            "version": 4
-        }, 
-        {
-            "attributes": {
-                "columns": [
-                    "host.name", 
-                    "event.type", 
-                    "suricata.eve.flow_id", 
-                    "suricata.eve.proto", 
-                    "source_ecs.ip", 
-                    "source_ecs.port",
-                    "destination.ip",
-                    "destination.port",
-                    "destination.geo.region_name", 
-                    "destination.geo.country_iso_code"
-                ], 
-                "description": "", 
-                "hits": 0, 
-                "kibanaSavedObjectMeta": {
-                    "searchSourceJSON": {
-                        "filter": [
-                            {
-                                "$state": {
-                                    "store": "appState"
-                                }, 
-                                "meta": {
-                                    "alias": null, 
-                                    "disabled": false, 
-                                    "index": "filebeat-*", 
-                                    "key": "event.type", 
-                                    "negate": true, 
-                                    "params": {
-                                        "query": "stats", 
-                                        "type": "phrase"
-                                    }, 
-                                    "type": "phrase", 
-                                    "value": "stats"
-                                }, 
-                                "query": {
-                                    "match": {
-                                        "event.type": {
-                                            "query": "stats", 
-                                            "type": "phrase"
-                                        }
-                                    }
-                                }
-                            }, 
-                            {
-                                "$state": {
-                                    "store": "appState"
-                                }, 
-                                "meta": {
-                                    "alias": null, 
-                                    "disabled": false, 
-                                    "index": "filebeat-*", 
-                                    "key": "fileset.module", 
-                                    "negate": false, 
-                                    "params": {
-                                        "query": "suricata", 
-                                        "type": "phrase"
-                                    }, 
-                                    "type": "phrase", 
-                                    "value": "suricata"
-                                }, 
-                                "query": {
-                                    "match": {
-                                        "fileset.module": {
-                                            "query": "suricata", 
-                                            "type": "phrase"
-                                        }
-                                    }
-                                }
-                            }
-                        ], 
-                        "highlightAll": true, 
-                        "index": "filebeat-*", 
-                        "query": {
-                            "language": "kuery", 
-                            "query": ""
-                        }, 
-                        "version": true
-                    }
-                }, 
-                "sort": [
-                    "@timestamp", 
-                    "desc"
-                ], 
-                "title": "Suricata Events", 
-                "version": 1
-            }, 
-            "id": "13dd22f0-86cc-11e8-b59d-21efb914e65c", 
-            "type": "search", 
-            "updated_at": "2018-07-13T19:46:58.156Z", 
-            "version": 5
-        }, 
-        {
-            "attributes": {
-                "description": "", 
-                "kibanaSavedObjectMeta": {
-                    "searchSourceJSON": {
-                        "filter": [], 
-                        "query": {
-                            "language": "kuery", 
-                            "query": ""
-                        }
-                    }
-                }, 
-                "savedSearchId": "13dd22f0-86cc-11e8-b59d-21efb914e65c", 
-                "title": "Suricata - Top Connection Source Countries - Tags", 
-                "uiStateJSON": {}, 
-                "version": 1, 
-                "visState": {
-                    "aggs": [
-                        {
-                            "enabled": true, 
-                            "id": "1", 
-                            "params": {}, 
-                            "schema": "metric", 
-                            "type": "count"
-                        }, 
-                        {
-                            "enabled": true, 
-                            "id": "2", 
-                            "params": {
-                                "customLabel": "Top Connection Source Countries", 
-                                "field": "source_ecs.geo.country_iso_code",
-                                "missingBucket": false, 
-                                "missingBucketLabel": "Missing", 
-                                "order": "desc", 
-                                "orderBy": "1", 
-                                "otherBucket": false, 
-                                "otherBucketLabel": "Other", 
-                                "size": 10
-                            }, 
-                            "schema": "segment", 
-                            "type": "terms"
-                        }
-                    ], 
-                    "params": {
-                        "maxFontSize": 72, 
-                        "minFontSize": 18, 
-                        "orientation": "single", 
-                        "scale": "linear", 
-                        "showLabel": true
-                    }, 
-                    "title": "Suricata - Top Connection Source Countries - Tags", 
-                    "type": "tagcloud"
-                }
-            }, 
-            "id": "5f99eb50-86dc-11e8-b59d-21efb914e65c", 
-            "type": "visualization", 
-            "updated_at": "2018-07-13T20:36:53.506Z", 
-            "version": 2
-        }, 
-        {
-            "attributes": {
-                "description": "", 
-                "kibanaSavedObjectMeta": {
-                    "searchSourceJSON": {
-                        "filter": [], 
-                        "query": {
-                            "language": "kuery", 
-                            "query": ""
-                        }
-                    }
-                }, 
-                "savedSearchId": "13dd22f0-86cc-11e8-b59d-21efb914e65c", 
-                "title": "Suricata - Top Connection Destination Countries - Tags", 
-                "uiStateJSON": {}, 
-                "version": 1, 
-                "visState": {
-                    "aggs": [
-                        {
-                            "enabled": true, 
-                            "id": "1", 
-                            "params": {}, 
-                            "schema": "metric", 
-                            "type": "count"
-                        }, 
-                        {
-                            "enabled": true, 
-                            "id": "2", 
-                            "params": {
-                                "customLabel": "Top Connection Destination Countries", 
-                                "field": "destination.geo.country_iso_code",
-                                "missingBucket": false, 
-                                "missingBucketLabel": "Missing", 
-                                "order": "desc", 
-                                "orderBy": "1", 
-                                "otherBucket": false, 
-                                "otherBucketLabel": "Other", 
-                                "size": 10
-                            }, 
-                            "schema": "segment", 
-                            "type": "terms"
-                        }
-                    ], 
-                    "params": {
-                        "maxFontSize": 72, 
-                        "minFontSize": 18, 
-                        "orientation": "single", 
-                        "scale": "linear", 
-                        "showLabel": true
-                    }, 
-                    "title": "Suricata - Top Connection Destination Countries - Tags", 
-                    "type": "tagcloud"
-                }
-            }, 
-            "id": "8e7f88d0-86dc-11e8-b59d-21efb914e65c", 
-            "type": "visualization", 
-            "updated_at": "2018-07-13T20:38:43.193Z", 
-            "version": 2
-        }, 
-        {
-            "attributes": {
-                "description": "", 
-                "kibanaSavedObjectMeta": {
-                    "searchSourceJSON": {
-                        "filter": [], 
-                        "query": {
-                            "language": "kuery", 
-                            "query": ""
-                        }
-                    }
-                }, 
-                "savedSearchId": "13dd22f0-86cc-11e8-b59d-21efb914e65c", 
-                "title": "Suricata - Top Network Protocols", 
-                "uiStateJSON": {}, 
-                "version": 1, 
-                "visState": {
-                    "aggs": [
-                        {
-                            "enabled": true, 
-                            "id": "1", 
-                            "params": {}, 
-                            "schema": "metric", 
-                            "type": "count"
-                        }, 
-                        {
-                            "enabled": true, 
-                            "id": "2", 
-                            "params": {
-                                "field": "suricata.eve.proto", 
-                                "missingBucket": false, 
-                                "missingBucketLabel": "Missing", 
-                                "order": "desc", 
-                                "orderBy": "1", 
-                                "otherBucket": false, 
-                                "otherBucketLabel": "Other", 
-                                "size": 10
-                            }, 
-                            "schema": "segment", 
-                            "type": "terms"
-                        }
-                    ], 
-                    "params": {
-                        "addLegend": true, 
-                        "addTooltip": true, 
-                        "isDonut": true, 
-                        "labels": {
-                            "last_level": true, 
-                            "show": false, 
-                            "truncate": 100, 
-                            "values": true
-                        }, 
-                        "legendPosition": "bottom", 
-                        "type": "pie"
-                    }, 
-                    "title": "Suricata - Top Network Protocols", 
-                    "type": "pie"
-                }
-            }, 
-            "id": "0a363820-86dd-11e8-b59d-21efb914e65c", 
-            "type": "visualization", 
-            "updated_at": "2018-07-13T20:40:55.202Z", 
-            "version": 1
-        }, 
-        {
-            "attributes": {
-                "columns": [
-                    "host.name", 
-                    "suricata.eve.stats.detect.alert", 
-                    "suricata.eve.stats.app_layer.flow.dns_udp", 
-                    "suricata.eve.stats.app_layer.flow.tls", 
-                    "suricata.eve.stats.app_layer.flow.http", 
-                    "suricata.eve.stats.app_layer.flow.ssh", 
-                    "suricata.eve.stats.tcp.sessions"
-                ], 
-                "description": "", 
-                "hits": 0, 
-                "kibanaSavedObjectMeta": {
-                    "searchSourceJSON": {
-                        "filter": [
-                            {
-                                "$state": {
-                                    "store": "globalState"
-                                }, 
-                                "meta": {
-                                    "alias": null, 
-                                    "disabled": false, 
-                                    "index": "filebeat-*", 
-                                    "key": "fileset.module", 
-                                    "negate": false, 
-                                    "params": {
-                                        "query": "suricata", 
-                                        "type": "phrase"
-                                    }, 
-                                    "type": "phrase", 
-                                    "value": "suricata"
-                                }, 
-                                "query": {
-                                    "match": {
-                                        "fileset.module": {
-                                            "query": "suricata", 
-                                            "type": "phrase"
-                                        }
-                                    }
-                                }
-                            }, 
-                            {
-                                "$state": {
-                                    "store": "globalState"
-                                }, 
-                                "meta": {
-                                    "alias": null, 
-                                    "disabled": false, 
-                                    "index": "filebeat-*", 
-                                    "key": "event.type", 
-                                    "negate": false, 
-                                    "params": {
-                                        "query": "stats", 
-                                        "type": "phrase"
-                                    }, 
-                                    "type": "phrase", 
-                                    "value": "stats"
-                                }, 
-                                "query": {
-                                    "match": {
-                                        "event.type": {
-                                            "query": "stats", 
-                                            "type": "phrase"
-                                        }
-                                    }
-                                }
-                            }
-                        ], 
-                        "highlightAll": true, 
-                        "index": "filebeat-*", 
-                        "query": {
-                            "language": "kuery", 
-                            "query": ""
-                        }, 
-                        "version": true
-                    }
-                }, 
-                "sort": [
-                    "@timestamp", 
-                    "desc"
-                ], 
-                "title": "Suricata Host Stats", 
-                "version": 1
-            }, 
-            "id": "d57a2db0-86ca-11e8-b59d-21efb914e65c", 
-            "type": "search", 
-            "updated_at": "2018-07-13T18:33:19.353Z", 
-            "version": 3
-        }, 
-        {
-            "attributes": {
-                "description": "", 
-                "hits": 0, 
-                "kibanaSavedObjectMeta": {
-                    "searchSourceJSON": {
-                        "filter": [], 
-                        "highlightAll": true, 
-                        "query": {
-                            "language": "kuery", 
-                            "query": ""
-                        }, 
-                        "version": true
-                    }
-                }, 
-                "optionsJSON": {
-                    "darkTheme": false, 
-                    "hidePanelTitles": false, 
-                    "useMargins": true
-                }, 
-                "panelsJSON": [
-                    {
-                        "embeddableConfig": {}, 
-                        "gridData": {
-                            "h": 10, 
-                            "i": "1", 
-                            "w": 48, 
-                            "x": 0, 
-                            "y": 0
-                        }, 
-                        "id": "c7d46c60-86da-11e8-b59d-21efb914e65c", 
-                        "panelIndex": "1", 
-                        "type": "visualization", 
-                        "version": "6.3.0"
-                    }, 
-                    {
-                        "embeddableConfig": {}, 
-                        "gridData": {
-                            "h": 14, 
-                            "i": "2", 
-                            "w": 9, 
-                            "x": 0, 
-                            "y": 20
-                        }, 
-                        "id": "0a0aa630-86db-11e8-b59d-21efb914e65c", 
-                        "panelIndex": "2", 
-                        "type": "visualization", 
-                        "version": "6.3.0"
-                    }, 
-                    {
-                        "embeddableConfig": {}, 
-                        "gridData": {
-                            "h": 14, 
-                            "i": "3", 
-                            "w": 11, 
-                            "x": 19, 
-                            "y": 20
-                        }, 
-                        "id": "728f64c0-86db-11e8-b59d-21efb914e65c", 
-                        "panelIndex": "3", 
-                        "type": "visualization", 
-                        "version": "6.3.0"
-                    }, 
-                    {
-                        "embeddableConfig": {}, 
-                        "gridData": {
-                            "h": 10, 
-                            "i": "4", 
-                            "w": 48, 
-                            "x": 0, 
-                            "y": 10
-                        }, 
-                        "id": "9d5b5b50-86db-11e8-b59d-21efb914e65c", 
-                        "panelIndex": "4", 
-                        "type": "visualization", 
-                        "version": "6.3.0"
-                    }, 
-                    {
-                        "embeddableConfig": {}, 
-                        "gridData": {
-                            "h": 19, 
-                            "i": "5", 
-                            "w": 48, 
-                            "x": 0, 
-                            "y": 34
-                        }, 
-                        "id": "13dd22f0-86cc-11e8-b59d-21efb914e65c", 
-                        "panelIndex": "5", 
-                        "type": "search", 
-                        "version": "6.3.0"
-                    }, 
-                    {
-                        "embeddableConfig": {}, 
-                        "gridData": {
-                            "h": 14, 
-                            "i": "6", 
-                            "w": 9, 
-                            "x": 30, 
-                            "y": 20
-                        }, 
-                        "id": "5f99eb50-86dc-11e8-b59d-21efb914e65c", 
-                        "panelIndex": "6", 
-                        "type": "visualization", 
-                        "version": "6.3.0"
-                    }, 
-                    {
-                        "embeddableConfig": {}, 
-                        "gridData": {
-                            "h": 14, 
-                            "i": "7", 
-                            "w": 9, 
-                            "x": 39, 
-                            "y": 20
-                        }, 
-                        "id": "8e7f88d0-86dc-11e8-b59d-21efb914e65c", 
-                        "panelIndex": "7", 
-                        "type": "visualization", 
-                        "version": "6.3.0"
-                    }, 
-                    {
-                        "embeddableConfig": {}, 
-                        "gridData": {
-                            "h": 14, 
-                            "i": "8", 
-                            "w": 10, 
-                            "x": 9, 
-                            "y": 20
-                        }, 
-                        "id": "0a363820-86dd-11e8-b59d-21efb914e65c", 
-                        "panelIndex": "8", 
-                        "type": "visualization", 
-                        "version": "6.3.0"
-                    }, 
-                    {
-                        "embeddableConfig": {}, 
-                        "gridData": {
-                            "h": 16, 
-                            "i": "9", 
-                            "w": 48, 
-                            "x": 0, 
-                            "y": 53
-                        }, 
-                        "id": "d57a2db0-86ca-11e8-b59d-21efb914e65c", 
-                        "panelIndex": "9", 
-                        "type": "search", 
-                        "version": "6.3.0"
-                    }
-                ], 
-                "timeRestore": false, 
-                "title": "Suricata Events Overview", 
-                "version": 1
-            }, 
-            "id": "78289c40-86da-11e8-b59d-21efb914e65c", 
-            "type": "dashboard", 
-            "updated_at": "2018-07-13T20:44:29.794Z", 
-            "version": 6
+  "objects": [
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "savedSearchId": "13dd22f0-86cc-11e8-b59d-21efb914e65c",
+        "title": "Activity Types over Time [Suricata]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customInterval": "2h",
+                "extended_bounds": {},
+                "field": "@timestamp",
+                "interval": "auto",
+                "min_doc_count": 1
+              },
+              "schema": "segment",
+              "type": "date_histogram"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "field": "event.type",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 20
+              },
+              "schema": "group",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTimeMarker": false,
+            "addTooltip": true,
+            "categoryAxes": [
+              {
+                "id": "CategoryAxis-1",
+                "labels": {
+                  "show": true,
+                  "truncate": 100
+                },
+                "position": "bottom",
+                "scale": {
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {},
+                "type": "category"
+              }
+            ],
+            "grid": {
+              "categoryLines": false,
+              "style": {
+                "color": "#eee"
+              }
+            },
+            "legendPosition": "right",
+            "seriesParams": [
+              {
+                "data": {
+                  "id": "1",
+                  "label": "Count"
+                },
+                "drawLinesBetweenPoints": true,
+                "mode": "stacked",
+                "show": "true",
+                "showCircles": true,
+                "type": "histogram",
+                "valueAxis": "ValueAxis-1"
+              }
+            ],
+            "times": [],
+            "type": "histogram",
+            "valueAxes": [
+              {
+                "id": "ValueAxis-1",
+                "labels": {
+                  "filter": false,
+                  "rotate": 0,
+                  "show": true,
+                  "truncate": 100
+                },
+                "name": "LeftAxis-1",
+                "position": "left",
+                "scale": {
+                  "mode": "normal",
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {
+                  "text": "Count"
+                },
+                "type": "value"
+              }
+            ]
+          },
+          "title": "Activity Types over Time [Suricata]",
+          "type": "histogram"
         }
-    ], 
-    "version": "6.3.0"
+      },
+      "id": "c7d46c60-86da-11e8-b59d-21efb914e65c",
+      "type": "visualization",
+      "updated_at": "2018-10-22T11:25:34.250Z",
+      "version": 4
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "savedSearchId": "13dd22f0-86cc-11e8-b59d-21efb914e65c",
+        "title": "Event Types [Suricata]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "field": "event.type",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 20
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "isDonut": true,
+            "labels": {
+              "last_level": true,
+              "show": false,
+              "truncate": 100,
+              "values": true
+            },
+            "legendPosition": "bottom",
+            "type": "pie"
+          },
+          "title": "Event Types [Suricata]",
+          "type": "pie"
+        }
+      },
+      "id": "0a0aa630-86db-11e8-b59d-21efb914e65c",
+      "type": "visualization",
+      "updated_at": "2018-10-22T11:26:45.879Z",
+      "version": 4
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "savedSearchId": "13dd22f0-86cc-11e8-b59d-21efb914e65c",
+        "title": "Top Application Protocols [Suricata]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "field": "suricata.eve.app_proto",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 10
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "isDonut": true,
+            "labels": {
+              "last_level": true,
+              "show": false,
+              "truncate": 100,
+              "values": true
+            },
+            "legendPosition": "bottom",
+            "type": "pie"
+          },
+          "title": "Top Application Protocols [Suricata]",
+          "type": "pie"
+        }
+      },
+      "id": "728f64c0-86db-11e8-b59d-21efb914e65c",
+      "type": "visualization",
+      "updated_at": "2018-10-22T11:28:56.796Z",
+      "version": 4
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "savedSearchId": "13dd22f0-86cc-11e8-b59d-21efb914e65c",
+        "title": "Top Hosts Generating Events [Suricata]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customInterval": "2h",
+                "extended_bounds": {},
+                "field": "@timestamp",
+                "interval": "auto",
+                "min_doc_count": 1
+              },
+              "schema": "segment",
+              "type": "date_histogram"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "field": "host.name",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 10
+              },
+              "schema": "group",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTimeMarker": false,
+            "addTooltip": true,
+            "categoryAxes": [
+              {
+                "id": "CategoryAxis-1",
+                "labels": {
+                  "show": true,
+                  "truncate": 100
+                },
+                "position": "bottom",
+                "scale": {
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {},
+                "type": "category"
+              }
+            ],
+            "grid": {
+              "categoryLines": false,
+              "style": {
+                "color": "#eee"
+              }
+            },
+            "legendPosition": "right",
+            "seriesParams": [
+              {
+                "data": {
+                  "id": "1",
+                  "label": "Count"
+                },
+                "drawLinesBetweenPoints": true,
+                "mode": "stacked",
+                "show": "true",
+                "showCircles": true,
+                "type": "histogram",
+                "valueAxis": "ValueAxis-1"
+              }
+            ],
+            "times": [],
+            "type": "histogram",
+            "valueAxes": [
+              {
+                "id": "ValueAxis-1",
+                "labels": {
+                  "filter": false,
+                  "rotate": 0,
+                  "show": true,
+                  "truncate": 100
+                },
+                "name": "LeftAxis-1",
+                "position": "left",
+                "scale": {
+                  "mode": "normal",
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {
+                  "text": "Count"
+                },
+                "type": "value"
+              }
+            ]
+          },
+          "title": "Top Hosts Generating Events [Suricata]",
+          "type": "histogram"
+        }
+      },
+      "id": "9d5b5b50-86db-11e8-b59d-21efb914e65c",
+      "type": "visualization",
+      "updated_at": "2018-10-22T11:26:06.499Z",
+      "version": 4
+    },
+    {
+      "attributes": {
+        "columns": [
+          "host.name",
+          "event.type",
+          "suricata.eve.flow_id",
+          "suricata.eve.proto",
+          "source_ecs.ip",
+          "suricata.eve.src_port",
+          "suricata.eve.dest_ip",
+          "suricata.eve.dest_port",
+          "destination.geo.region_name",
+          "destination.geo.country_iso_code"
+        ],
+        "description": "",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [
+              {
+                "$state": {
+                  "store": "appState"
+                },
+                "meta": {
+                  "alias": null,
+                  "disabled": false,
+                  "index": "filebeat-*",
+                  "key": "event.type",
+                  "negate": true,
+                  "params": {
+                    "query": "stats",
+                    "type": "phrase"
+                  },
+                  "type": "phrase",
+                  "value": "stats"
+                },
+                "query": {
+                  "match": {
+                    "event.type": {
+                      "query": "stats",
+                      "type": "phrase"
+                    }
+                  }
+                }
+              },
+              {
+                "$state": {
+                  "store": "appState"
+                },
+                "meta": {
+                  "alias": null,
+                  "disabled": false,
+                  "index": "filebeat-*",
+                  "key": "fileset.module",
+                  "negate": false,
+                  "params": {
+                    "query": "suricata",
+                    "type": "phrase"
+                  },
+                  "type": "phrase",
+                  "value": "suricata"
+                },
+                "query": {
+                  "match": {
+                    "fileset.module": {
+                      "query": "suricata",
+                      "type": "phrase"
+                    }
+                  }
+                }
+              }
+            ],
+            "highlightAll": true,
+            "index": "filebeat-*",
+            "query": {
+              "language": "kuery",
+              "query": ""
+            },
+            "version": true
+          }
+        },
+        "sort": [
+          "@timestamp",
+          "desc"
+        ],
+        "title": "Events [Suricata]",
+        "version": 1
+      },
+      "id": "13dd22f0-86cc-11e8-b59d-21efb914e65c",
+      "type": "search",
+      "updated_at": "2018-10-22T11:32:43.869Z",
+      "version": 3
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "savedSearchId": "13dd22f0-86cc-11e8-b59d-21efb914e65c",
+        "title": "Top Connection Source Countries [Suricata]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "Top Connection Source Countries",
+                "field": "source_ecs.geo.country_iso_code",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 10
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "maxFontSize": 72,
+            "minFontSize": 18,
+            "orientation": "single",
+            "scale": "linear",
+            "showLabel": true
+          },
+          "title": "Top Connection Source Countries [Suricata]",
+          "type": "tagcloud"
+        }
+      },
+      "id": "5f99eb50-86dc-11e8-b59d-21efb914e65c",
+      "type": "visualization",
+      "updated_at": "2018-10-22T11:31:03.468Z",
+      "version": 4
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "savedSearchId": "13dd22f0-86cc-11e8-b59d-21efb914e65c",
+        "title": "Top Connection Destination Countries [Suricata]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customLabel": "Top Connection Destination Countries",
+                "field": "destination.geo.country_iso_code",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 10
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "maxFontSize": 72,
+            "minFontSize": 18,
+            "orientation": "single",
+            "scale": "linear",
+            "showLabel": true
+          },
+          "title": "Top Connection Destination Countries [Suricata]",
+          "type": "tagcloud"
+        }
+      },
+      "id": "8e7f88d0-86dc-11e8-b59d-21efb914e65c",
+      "type": "visualization",
+      "updated_at": "2018-10-22T11:31:56.335Z",
+      "version": 4
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "savedSearchId": "13dd22f0-86cc-11e8-b59d-21efb914e65c",
+        "title": "Top Network Protocols [Suricata]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "field": "suricata.eve.proto",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 10
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "isDonut": true,
+            "labels": {
+              "last_level": true,
+              "show": false,
+              "truncate": 100,
+              "values": true
+            },
+            "legendPosition": "bottom",
+            "type": "pie"
+          },
+          "title": "Top Network Protocols [Suricata]",
+          "type": "pie"
+        }
+      },
+      "id": "0a363820-86dd-11e8-b59d-21efb914e65c",
+      "type": "visualization",
+      "updated_at": "2018-10-22T11:27:45.760Z",
+      "version": 4
+    },
+    {
+      "attributes": {
+        "columns": [
+          "host.name",
+          "suricata.eve.stats.detect.alert",
+          "suricata.eve.stats.app_layer.flow.dns_udp",
+          "suricata.eve.stats.app_layer.flow.tls",
+          "suricata.eve.stats.app_layer.flow.http",
+          "suricata.eve.stats.app_layer.flow.ssh",
+          "suricata.eve.stats.tcp.sessions"
+        ],
+        "description": "",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [
+              {
+                "$state": {
+                  "store": "appState"
+                },
+                "meta": {
+                  "alias": null,
+                  "disabled": false,
+                  "index": "filebeat-*",
+                  "key": "fileset.module",
+                  "negate": false,
+                  "params": {
+                    "query": "suricata",
+                    "type": "phrase"
+                  },
+                  "type": "phrase",
+                  "value": "suricata"
+                },
+                "query": {
+                  "match": {
+                    "fileset.module": {
+                      "query": "suricata",
+                      "type": "phrase"
+                    }
+                  }
+                }
+              },
+              {
+                "$state": {
+                  "store": "appState"
+                },
+                "meta": {
+                  "alias": null,
+                  "disabled": false,
+                  "index": "filebeat-*",
+                  "key": "event.type",
+                  "negate": false,
+                  "params": {
+                    "query": "stats",
+                    "type": "phrase"
+                  },
+                  "type": "phrase",
+                  "value": "stats"
+                },
+                "query": {
+                  "match": {
+                    "event.type": {
+                      "query": "stats",
+                      "type": "phrase"
+                    }
+                  }
+                }
+              }
+            ],
+            "highlightAll": true,
+            "index": "filebeat-*",
+            "query": {
+              "language": "kuery",
+              "query": ""
+            },
+            "version": true
+          }
+        },
+        "sort": [
+          "@timestamp",
+          "desc"
+        ],
+        "title": "Host Stats [Suricata]",
+        "version": 1
+      },
+      "id": "d57a2db0-86ca-11e8-b59d-21efb914e65c",
+      "type": "search",
+      "updated_at": "2018-10-22T11:33:41.467Z",
+      "version": 4
+    },
+    {
+      "attributes": {
+        "description": "Overview of the Surcata events dashboard.",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "highlightAll": true,
+            "query": {
+              "language": "kuery",
+              "query": ""
+            },
+            "version": true
+          }
+        },
+        "optionsJSON": {
+          "darkTheme": false,
+          "hidePanelTitles": false,
+          "useMargins": true
+        },
+        "panelsJSON": null,
+        "timeRestore": false,
+        "title": "[Suricata] Events Overview",
+        "version": 1
+      },
+      "id": "78289c40-86da-11e8-b59d-21efb914e65c",
+      "type": "dashboard",
+      "updated_at": "2018-10-22T11:34:16.665Z",
+      "version": 4
+    }
+  ],
+  "version": "6.4.2"
 }


### PR DESCRIPTION
Mostly making all vis and searches end in [Suricata].

Part of #8153.