### PR TITLE
Cherry-pick #8653 to 6.4: Fix a race condition on add_host_metadata

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -29,6 +29,7 @@ https://github.com/elastic/beats/compare/v6.4.1...6.4[Check the HEAD diff]
 
 *Affecting all Beats*
 
+- Fix a race condition with the `add_host_metadata` and the event serialization. {pull}8223[8223] {pull}8653[8653]
 - Fix race condition when publishing monitoring data. {pull}8646[8646]
 
 *Auditbeat*

--- a/libbeat/processors/add_host_metadata/add_host_metadata.go
+++ b/libbeat/processors/add_host_metadata/add_host_metadata.go
@@ -20,6 +20,7 @@ package add_host_metadata
 import (
 	"fmt"
 	"net"
+	"sync"
 	"time"
 
 	"github.com/joeshaw/multierror"
@@ -40,9 +41,12 @@ func init() {
 
 type addHostMetadata struct {
 	info       types.HostInfo
-	lastUpdate time.Time
-	data       common.MapStr
-	config     Config
+	lastUpdate struct {
+		time.Time
+		sync.Mutex
+	}
+	data   common.MapStrPointer
+	config Config
 }
 
 const (
@@ -63,42 +67,55 @@ func newHostMetadataProcessor(cfg *common.Config) (processors.Processor, error) 
 	p := &addHostMetadata{
 		info:   h.Info(),
 		config: config,
+		data:   common.NewMapStrPointer(nil),
 	}
+	p.loadData()
 	return p, nil
 }
 
 // Run enriches the given event with the host meta data
 func (p *addHostMetadata) Run(event *beat.Event) (*beat.Event, error) {
 	p.loadData()
-	event.Fields.DeepUpdate(p.data.Clone())
+	event.Fields.DeepUpdate(p.data.Get().Clone())
 	return event, nil
 }
 
-func (p *addHostMetadata) loadData() {
+func (p *addHostMetadata) expired() bool {
+	p.lastUpdate.Lock()
+	defer p.lastUpdate.Unlock()
 
-	// Check if cache is expired
-	if p.lastUpdate.Add(cacheExpiration).Before(time.Now()) {
-		p.data = host.MapHostInfo(p.info)
-
-		if p.config.NetInfoEnabled {
-			// IP-address and MAC-address
-			var ipList, hwList, err = p.getNetInfo()
-			if err != nil {
-				logp.Info("Error when getting network information %v", err)
-			}
-
-			if len(ipList) > 0 {
-				p.data.Put("host.ip", ipList)
-			}
-			if len(hwList) > 0 {
-				p.data.Put("host.mac", hwList)
-			}
-		}
-		p.lastUpdate = time.Now()
+	if p.lastUpdate.Add(cacheExpiration).After(time.Now()) {
+		return false
 	}
+	p.lastUpdate.Time = time.Now()
+	return true
 }
 
-func (p addHostMetadata) getNetInfo() ([]string, []string, error) {
+func (p *addHostMetadata) loadData() {
+	if !p.expired() {
+		return
+	}
+
+	data := host.MapHostInfo(p.info)
+	if p.config.NetInfoEnabled {
+		// IP-address and MAC-address
+		var ipList, hwList, err = p.getNetInfo()
+		if err != nil {
+			logp.Info("Error when getting network information %v", err)
+		}
+
+		if len(ipList) > 0 {
+			data.Put("host.ip", ipList)
+		}
+		if len(hwList) > 0 {
+			data.Put("host.mac", hwList)
+		}
+	}
+
+	p.data.Set(data)
+}
+
+func (p *addHostMetadata) getNetInfo() ([]string, []string, error) {
 	var ipList []string
 	var hwList []string
 
@@ -143,7 +160,7 @@ func (p addHostMetadata) getNetInfo() ([]string, []string, error) {
 	return ipList, hwList, errs.Err()
 }
 
-func (p addHostMetadata) String() string {
+func (p *addHostMetadata) String() string {
 	return fmt.Sprintf("%v=[netinfo.enabled=[%v]]",
 		processorName, p.config.NetInfoEnabled)
 }


### PR DESCRIPTION
Cherry-pick of PR #8653 to 6.4 branch. Original message: 

Not sure if adding a mutex at this level will be too blocking for events processing, I have also though on other options to reduce contention on reads:
* Using a RWLock, but we'd still need to write-lock first to check expiration and update
* Using a RWLock and a go-routine to do periodic updates, but afaik we wouldn't have a way to stop it if the processor is removed.

Continues with #8223 