### PR TITLE
Add support for untyped prometheus metrics

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -158,6 +158,7 @@ https://github.com/elastic/beats/compare/v6.4.0...master[Check the HEAD diff]
 - Add support for `full` status page output for php-fpm module as a separate metricset called `process`. {pull}8394[8394]
 - Precalculate composed id fields for kafka dashboards. {pull}8504[8504]
 - Add Kafka dashboard. {pull}8457[8457]
+- Add untyped metric support to the prometheus module. {pull}8681[8681]
 
 *Packetbeat*
 

--- a/metricbeat/module/prometheus/collector/collector_test.go
+++ b/metricbeat/module/prometheus/collector/collector_test.go
@@ -150,6 +150,34 @@ func TestGetPromEventsFromMetricFamily(t *testing.T) {
 				labelHash: "#",
 			},
 		},
+		{
+			Family: &dto.MetricFamily{
+				Name: proto.String("http_request_duration_microseconds"),
+				Help: proto.String("foo"),
+				Type: dto.MetricType_UNTYPED.Enum(),
+				Metric: []*dto.Metric{
+					{
+						Label: []*dto.LabelPair{
+							{
+								Name:  proto.String("handler"),
+								Value: proto.String("query"),
+							},
+						},
+						Untyped: &dto.Untyped{
+							Value: proto.Float64(10),
+						},
+					},
+				},
+			},
+			Event: PromEvent{
+				key: "http_request_duration_microseconds",
+				value: common.MapStr{
+					"value": float64(10),
+				},
+				labelHash: labels.String(),
+				labels:    labels,
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/metricbeat/module/prometheus/collector/data.go
+++ b/metricbeat/module/prometheus/collector/data.go
@@ -104,6 +104,11 @@ func GetPromEventsFromMetricFamily(mf *dto.MetricFamily) []PromEvent {
 			value["bucket"] = bucketMap
 		}
 
+		untyped := metric.GetUntyped()
+		if untyped != nil {
+			value["value"] = untyped.GetValue()
+		}
+
 		event.value = value
 
 		events = append(events, event)


### PR DESCRIPTION
Add support to the prometheus metricbeat module for reporting untyped
metrics from prometheus exporters.