### PR TITLE
Remove redundante metrics/logger if pipeline.Monitors is used

### DIFF
--- a/libbeat/monitoring/report/elasticsearch/elasticsearch.go
+++ b/libbeat/monitoring/report/elasticsearch/elasticsearch.go
@@ -171,8 +171,10 @@ func makeReporter(beat beat.Info, settings report.Settings, cfg *common.Config) 
 
 	pipeline, err := pipeline.New(
 		beat,
-		pipeline.Monitors{},
-		monitoring,
+		pipeline.Monitors{
+			Metrics: monitoring,
+			Logger:  logp.NewLogger(selector),
+		},
 		queueFactory,
 		outputs.Group{
 			Clients:   []outputs.Client{outClient},

--- a/libbeat/publisher/pipeline/client.go
+++ b/libbeat/publisher/pipeline/client.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common/atomic"
+	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/publisher"
 	"github.com/elastic/beats/libbeat/publisher/queue"
 )
@@ -67,7 +68,7 @@ func (c *client) publish(e beat.Event) {
 	var (
 		event   = &e
 		publish = true
-		log     = c.pipeline.logger
+		log     = c.pipeline.monitors.Logger
 	)
 
 	c.onNewEvent()
@@ -137,7 +138,7 @@ func (c *client) Close() error {
 	// first stop ack handling. ACK handler might block (with timeout), waiting
 	// for pending events to be ACKed.
 
-	log := c.pipeline.logger
+	log := c.logger()
 
 	if !c.isOpen.Swap(false) {
 		return nil // closed or already closing
@@ -162,6 +163,10 @@ func (c *client) Close() error {
 
 	c.onClosed()
 	return nil
+}
+
+func (c *client) logger() *logp.Logger {
+	return c.pipeline.monitors.Logger
 }
 
 func (c *client) onClosing() {

--- a/libbeat/publisher/pipeline/client.go
+++ b/libbeat/publisher/pipeline/client.go
@@ -195,7 +195,9 @@ func (c *client) onPublished() {
 }
 
 func (c *client) onFilteredOut(e beat.Event) {
-	c.pipeline.logger.Debug("Pipeline client receives callback 'onFilteredOut' for event: %+v", e)
+	log := c.logger()
+
+	log.Debug("Pipeline client receives callback 'onFilteredOut' for event: %+v", e)
 	c.pipeline.observer.filteredEvent()
 	if c.eventer != nil {
 		c.eventer.FilteredOut(e)
@@ -203,7 +205,9 @@ func (c *client) onFilteredOut(e beat.Event) {
 }
 
 func (c *client) onDroppedOnPublish(e beat.Event) {
-	c.pipeline.logger.Debug("Pipeline client receives callback 'onDroppedOnPublish' for event: %+v", e)
+	log := c.logger()
+
+	log.Debug("Pipeline client receives callback 'onDroppedOnPublish' for event: %+v", e)
 	c.pipeline.observer.failedPublishEvent()
 	if c.eventer != nil {
 		c.eventer.DroppedOnPublish(e)

--- a/libbeat/publisher/pipeline/controller.go
+++ b/libbeat/publisher/pipeline/controller.go
@@ -21,7 +21,6 @@ import (
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/reload"
-	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/outputs"
 	"github.com/elastic/beats/libbeat/publisher/queue"
 )
@@ -33,7 +32,6 @@ import (
 type outputController struct {
 	beat     beat.Info
 	monitors Monitors
-	logger   *logp.Logger
 	observer outputObserver
 
 	queue queue.Queue
@@ -63,21 +61,19 @@ type outputWorker interface {
 func newOutputController(
 	beat beat.Info,
 	monitors Monitors,
-	log *logp.Logger,
 	observer outputObserver,
 	b queue.Queue,
 ) *outputController {
 	c := &outputController{
 		beat:     beat,
 		monitors: monitors,
-		logger:   log,
 		observer: observer,
 		queue:    b,
 	}
 
 	ctx := &batchContext{}
-	c.consumer = newEventConsumer(log, b, ctx)
-	c.retryer = newRetryer(log, observer, nil, c.consumer)
+	c.consumer = newEventConsumer(monitors.Logger, b, ctx)
+	c.retryer = newRetryer(monitors.Logger, observer, nil, c.consumer)
 	ctx.observer = observer
 	ctx.retryer = c.retryer
 

--- a/libbeat/publisher/pipeline/module.go
+++ b/libbeat/publisher/pipeline/module.go
@@ -100,7 +100,7 @@ func Load(
 		return nil, err
 	}
 
-	p, err := New(beatInfo, monitors, monitors.Metrics, queueBuilder, out, settings)
+	p, err := New(beatInfo, monitors, queueBuilder, out, settings)
 	if err != nil {
 		return nil, err
 	}

--- a/libbeat/publisher/pipeline/pipeline.go
+++ b/libbeat/publisher/pipeline/pipeline.go
@@ -165,6 +165,7 @@ func New(
 
 	annotations := settings.Annotations
 	processors := settings.Processors
+	log := monitors.Logger
 	disabledOutput := settings.Disabled
 	p := &Pipeline{
 		beatInfo:         beat,
@@ -172,7 +173,7 @@ func New(
 		observer:         nilObserver,
 		waitCloseMode:    settings.WaitCloseMode,
 		waitCloseTimeout: settings.WaitClose,
-		processors:       makePipelineProcessors(annotations, processors, disabledOutput),
+		processors:       makePipelineProcessors(log, annotations, processors, disabledOutput),
 	}
 	p.ackBuilder = &pipelineEmptyACK{p}
 	p.ackActive = atomic.MakeBool(true)
@@ -405,6 +406,7 @@ func (e *waitCloser) wait() {
 }
 
 func makePipelineProcessors(
+	log *logp.Logger,
 	annotations Annotations,
 	processors *processors.Processors,
 	disabled bool,
@@ -415,7 +417,7 @@ func makePipelineProcessors(
 
 	hasProcessors := processors != nil && len(processors.List) > 0
 	if hasProcessors {
-		tmp := &program{title: "global"}
+		tmp := newProgram("global", log)
 		for _, p := range processors.List {
 			tmp.add(p)
 		}

--- a/libbeat/publisher/pipeline/processor.go
+++ b/libbeat/publisher/pipeline/processor.go
@@ -183,7 +183,7 @@ func (p *program) Run(event *beat.Event) (*beat.Event, error) {
 			//      We want processors having this kind of implicit behavior
 			//      on errors?
 
-			p.log.Debug("filter", "fail to apply processor %s: %s", p, err)
+			p.log.Debugf("Fail to apply processor %s: %s", p, err)
 		}
 
 		if event == nil {
@@ -295,7 +295,7 @@ func debugPrintProcessor(info beat.Info, monitors Monitors) *processorFn {
 			return event, nil
 		}
 
-		log.Debug("publish", "Publish event: %s", b)
+		log.Debugf("Publish event: %s", b)
 		return event, nil
 	})
 }

--- a/libbeat/publisher/pipeline/processor.go
+++ b/libbeat/publisher/pipeline/processor.go
@@ -149,6 +149,13 @@ func newProcessorPipeline(
 	return processors
 }
 
+func newProgram(title string, log *logp.Logger) *program {
+	return &program{
+		title: title,
+		log:   log,
+	}
+}
+
 func (p *program) add(processor processors.Processor) {
 	if processor != nil {
 		p.list = append(p.list, processor)
@@ -309,11 +316,9 @@ func makeClientProcessors(
 		return nil
 	}
 
-	return &program{
-		title: "client",
-		log:   monitors.Logger,
-		list:  procs.All(),
-	}
+	p := newProgram("client", monitors.Logger)
+	p.list = procs.All()
+	return p
 }
 
 func hasKey(m common.MapStr, key string) bool {

--- a/libbeat/publisher/pipeline/processor.go
+++ b/libbeat/publisher/pipeline/processor.go
@@ -31,6 +31,7 @@ import (
 )
 
 type program struct {
+	log   *logp.Logger
 	title string
 	list  []beat.Processor
 }
@@ -59,16 +60,20 @@ type processorFn struct {
 // 10. (P) (if output disabled) dropEvent
 func newProcessorPipeline(
 	info beat.Info,
+	monitors Monitors,
 	global pipelineProcessors,
 	config beat.ClientConfig,
 ) beat.Processor {
 	var (
 		// pipeline processors
-		processors = &program{title: "processPipeline"}
+		processors = &program{
+			title: "processPipeline",
+			log:   monitors.Logger,
+		}
 
 		// client fields and metadata
 		clientMeta      = config.Meta
-		localProcessors = makeClientProcessors(config)
+		localProcessors = makeClientProcessors(monitors, config)
 	)
 
 	needsCopy := global.alwaysCopy || localProcessors != nil || global.processors != nil
@@ -133,7 +138,7 @@ func newProcessorPipeline(
 
 	// setup 9: debug print final event (P)
 	if logp.IsDebug("publish") {
-		processors.add(debugPrintProcessor(info))
+		processors.add(debugPrintProcessor(info, monitors))
 	}
 
 	// setup 10: drop all events if outputs are disabled (P)
@@ -178,7 +183,7 @@ func (p *program) Run(event *beat.Event) (*beat.Event, error) {
 			//      We want processors having this kind of implicit behavior
 			//      on errors?
 
-			logp.Debug("filter", "fail to apply processor %s: %s", p, err)
+			p.log.Debug("filter", "fail to apply processor %s: %s", p, err)
 		}
 
 		if event == nil {
@@ -271,7 +276,7 @@ func createAgentFields(info beat.Info) common.MapStr {
 	return common.MapStr{"agent": metadata}
 }
 
-func debugPrintProcessor(info beat.Info) *processorFn {
+func debugPrintProcessor(info beat.Info, monitors Monitors) *processorFn {
 	// ensure only one go-routine is using the encoder (in case
 	// beat.Client is shared between multiple go-routines by accident)
 	var mux sync.Mutex
@@ -280,6 +285,7 @@ func debugPrintProcessor(info beat.Info) *processorFn {
 		Pretty:     true,
 		EscapeHTML: false,
 	})
+	log := monitors.Logger
 	return newProcessor("debugPrint", func(event *beat.Event) (*beat.Event, error) {
 		mux.Lock()
 		defer mux.Unlock()
@@ -289,12 +295,15 @@ func debugPrintProcessor(info beat.Info) *processorFn {
 			return event, nil
 		}
 
-		logp.Debug("publish", "Publish event: %s", b)
+		log.Debug("publish", "Publish event: %s", b)
 		return event, nil
 	})
 }
 
-func makeClientProcessors(config beat.ClientConfig) processors.Processor {
+func makeClientProcessors(
+	monitors Monitors,
+	config beat.ClientConfig,
+) processors.Processor {
 	procs := config.Processor
 	if procs == nil || len(procs.All()) == 0 {
 		return nil
@@ -302,6 +311,7 @@ func makeClientProcessors(config beat.ClientConfig) processors.Processor {
 
 	return &program{
 		title: "client",
+		log:   monitors.Logger,
 		list:  procs.All(),
 	}
 }

--- a/libbeat/publisher/pipeline/processor_test.go
+++ b/libbeat/publisher/pipeline/processor_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
 )
 
 func TestProcessors(t *testing.T) {
@@ -380,6 +381,10 @@ func TestProcessors(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
+			monitors := Monitors{
+				Logger: logp.NewLogger("test processors"),
+			}
+
 			// create processor pipelines
 			programs := make([]beat.Processor, len(test.local))
 			info := defaultInfo
@@ -388,7 +393,7 @@ func TestProcessors(t *testing.T) {
 			}
 			for i, local := range test.local {
 				local.config.SkipAgentMetadata = !local.includeAgentMetadata
-				programs[i] = newProcessorPipeline(info, test.global, local.config)
+				programs[i] = newProcessorPipeline(info, monitors, test.global, local.config)
 			}
 
 			// run processor pipelines in parallel


### PR DESCRIPTION
This PR cleans up redundant use of Monitors, Loggers and metrics registry.

Also fixes accidental removal of internal x-pack monitoring metrics on the monitoring output.