### PR TITLE
init configuration with settings in export commands too

### DIFF
--- a/libbeat/cmd/export.go
+++ b/libbeat/cmd/export.go
@@ -21,16 +21,17 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/elastic/beats/libbeat/cmd/export"
+	"github.com/elastic/beats/libbeat/cmd/instance"
 )
 
-func genExportCmd(name, idxPrefix, beatVersion string) *cobra.Command {
+func genExportCmd(settings instance.Settings, name, idxPrefix, beatVersion string) *cobra.Command {
 	exportCmd := &cobra.Command{
 		Use:   "export",
 		Short: "Export current config or index template",
 	}
 
-	exportCmd.AddCommand(export.GenExportConfigCmd(name, idxPrefix, beatVersion))
-	exportCmd.AddCommand(export.GenTemplateConfigCmd(name, idxPrefix, beatVersion))
+	exportCmd.AddCommand(export.GenExportConfigCmd(settings, name, idxPrefix, beatVersion))
+	exportCmd.AddCommand(export.GenTemplateConfigCmd(settings, name, idxPrefix, beatVersion))
 	exportCmd.AddCommand(export.GenDashboardCmd(name, idxPrefix, beatVersion))
 
 	return exportCmd

--- a/libbeat/cmd/export/config.go
+++ b/libbeat/cmd/export/config.go
@@ -29,23 +29,23 @@ import (
 )
 
 // GenExportConfigCmd write to stdout the current configuration in the YAML format.
-func GenExportConfigCmd(name, idxPrefix, beatVersion string) *cobra.Command {
+func GenExportConfigCmd(settings instance.Settings, name, idxPrefix, beatVersion string) *cobra.Command {
 	return &cobra.Command{
 		Use:   "config",
 		Short: "Export current config to stdout",
 		Run: cli.RunWith(func(cmd *cobra.Command, args []string) error {
-			return exportConfig(name, idxPrefix, beatVersion)
+			return exportConfig(settings, name, idxPrefix, beatVersion)
 		}),
 	}
 }
 
-func exportConfig(name, idxPrefix, beatVersion string) error {
+func exportConfig(settings instance.Settings, name, idxPrefix, beatVersion string) error {
 	b, err := instance.NewBeat(name, idxPrefix, beatVersion)
 	if err != nil {
 		return fmt.Errorf("error initializing beat: %s", err)
 	}
 
-	err = b.Init()
+	err = b.InitWithSettings(settings)
 	if err != nil {
 		return fmt.Errorf("error initializing beat: %s", err)
 	}

--- a/libbeat/cmd/export/template.go
+++ b/libbeat/cmd/export/template.go
@@ -29,7 +29,7 @@ import (
 	"github.com/elastic/beats/libbeat/template"
 )
 
-func GenTemplateConfigCmd(name, idxPrefix, beatVersion string) *cobra.Command {
+func GenTemplateConfigCmd(settings instance.Settings, name, idxPrefix, beatVersion string) *cobra.Command {
 	genTemplateConfigCmd := &cobra.Command{
 		Use:   "template",
 		Short: "Export index template to stdout",
@@ -42,7 +42,7 @@ func GenTemplateConfigCmd(name, idxPrefix, beatVersion string) *cobra.Command {
 				fmt.Fprintf(os.Stderr, "Error initializing beat: %s\n", err)
 				os.Exit(1)
 			}
-			err = b.Init()
+			err = b.InitWithSettings(settings)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Error initializing beat: %s\n", err)
 				os.Exit(1)

--- a/libbeat/cmd/root.go
+++ b/libbeat/cmd/root.go
@@ -114,7 +114,7 @@ func GenRootCmdWithSettings(beatCreator beat.Creator, settings instance.Settings
 	rootCmd.SetupCmd = genSetupCmd(name, indexPrefix, version, beatCreator)
 	rootCmd.VersionCmd = genVersionCmd(name, version)
 	rootCmd.CompletionCmd = genCompletionCmd(name, version, rootCmd)
-	rootCmd.ExportCmd = genExportCmd(name, indexPrefix, version)
+	rootCmd.ExportCmd = genExportCmd(settings, name, indexPrefix, version)
 	rootCmd.TestCmd = genTestCmd(name, version, beatCreator)
 	rootCmd.KeystoreCmd = genKeystoreCmd(name, indexPrefix, version, runFlags)
 


### PR DESCRIPTION
The run command currently respects settings passed in while other commands do not.  This puts us in a tough spot where settings are overridden for `run`, but not for other commands, like `export`.  This surfaced most recently when overriding the template `total_fields` limit in elastic/apm-server#1461.  While starting apm-server would generate a template with the correct `total_fields` in place, `export template` reports a different value.

This change syncs the export commands with run.  I believe `apm-server` is the only Elastic product built on the beats framework that is affected by this issue, as other beats do not utilize this functionality.