### PR TITLE
Cherry-pick #7793 to 6.4: Fixes to metricbeat's KVM module

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -42,6 +42,7 @@ https://github.com/elastic/beats/compare/v6.4.1...6.4[Check the HEAD diff]
 
 - Recover metrics for old apache versions removed by mistake on #6450. {pull}7871[7871]
 - Avoid mapping issues in kubernetes module. {pull}8487[8487]
+- Fixed a panic when the kvm module cannot establish a connection to libvirtd. {issue}7792[7792].
 
 *Packetbeat*
 

--- a/metricbeat/docs/modules/kvm.asciidoc
+++ b/metricbeat/docs/modules/kvm.asciidoc
@@ -24,7 +24,10 @@ metricbeat.modules:
   metricsets: ["dommemstat"]
   enabled: true
   period: 10s
-  hosts: ["localhost"]
+  hosts: ["unix:///var/run/libvirt/libvirt-sock"]
+  # For remote hosts, setup network access in libvirtd.conf
+  # and use the tcp scheme:
+  # hosts: [ "tcp://<host>:16509" ]
 
   # Timeout to connect to Libvirt server
   #timeout: 1s

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -426,7 +426,10 @@ metricbeat.modules:
   metricsets: ["dommemstat"]
   enabled: true
   period: 10s
-  hosts: ["localhost"]
+  hosts: ["unix:///var/run/libvirt/libvirt-sock"]
+  # For remote hosts, setup network access in libvirtd.conf
+  # and use the tcp scheme:
+  # hosts: [ "tcp://<host>:16509" ]
 
   # Timeout to connect to Libvirt server
   #timeout: 1s

--- a/metricbeat/module/kvm/_meta/config.reference.yml
+++ b/metricbeat/module/kvm/_meta/config.reference.yml
@@ -2,7 +2,10 @@
   metricsets: ["dommemstat"]
   enabled: true
   period: 10s
-  hosts: ["localhost"]
+  hosts: ["unix:///var/run/libvirt/libvirt-sock"]
+  # For remote hosts, setup network access in libvirtd.conf
+  # and use the tcp scheme:
+  # hosts: [ "tcp://<host>:16509" ]
 
   # Timeout to connect to Libvirt server
   #timeout: 1s

--- a/metricbeat/module/kvm/_meta/config.yml
+++ b/metricbeat/module/kvm/_meta/config.yml
@@ -2,4 +2,4 @@
   #metricsets:
   #  - dommemstat
   period: 10s
-  hosts: ["localhost"]
+  hosts: ["unix:///var/run/libvirt/libvirt-sock"]

--- a/metricbeat/modules.d/kvm.yml.disabled
+++ b/metricbeat/modules.d/kvm.yml.disabled
@@ -5,4 +5,4 @@
   #metricsets:
   #  - dommemstat
   period: 10s
-  hosts: ["localhost"]
+  hosts: ["unix:///var/run/libvirt/libvirt-sock"]


### PR DESCRIPTION
Cherry-pick of PR #7793 to 6.4 branch. Original message: 

Some fixes to the kvm module:

- Improper error handling caused a panic when connection to libvirtd couldn't be established. Fixes #7792.
- Cleaned up error handling and reporting.
- The default configuration couldn't possibly work:
`host: [ "localhost" ]` results in the module trying to create a network connection without schema. It will always fail with `"dial: Unknown network  "`. 
For a default installation of `libvirtd`, the only possible method is to use:
`host: [ "unix:///var/run/libvirt/libvirt-sock" ]`.
Also some gidance is provided for setting up remote monitoring.