### PR TITLE
Cherry-pick #8660 to 6.x: [Heartbeat] Read entire body before closing connection

### DIFF
--- a/heartbeat/hbtest/hbtestutil.go
+++ b/heartbeat/hbtest/hbtestutil.go
@@ -26,6 +26,7 @@ import (
 	"net/url"
 	"os"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -47,6 +48,23 @@ func HelloWorldHandler(status int) http.HandlerFunc {
 			}
 			w.WriteHeader(status)
 			io.WriteString(w, HelloWorldBody)
+		},
+	)
+}
+
+// SizedResponseHandler responds with 200 to any request with a body
+// exactly the size of the `bytes` argument, where each byte is the
+// character 'x'
+func SizedResponseHandler(bytes int) http.HandlerFunc {
+	var body strings.Builder
+	for i := 0; i < bytes; i++ {
+		body.WriteString("x")
+	}
+
+	return http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+			io.WriteString(w, body.String())
 		},
 	)
 }

--- a/heartbeat/monitors/active/http/simple_transp.go
+++ b/heartbeat/monitors/active/http/simple_transp.go
@@ -85,7 +85,6 @@ func (t *SimpleTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer conn.Close()
 
 	requestedGzip := false
 	if t.DisableCompression &&
@@ -128,6 +127,21 @@ func (t *SimpleTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	case ret = <-readerDone:
 		break
 	case <-done:
+		// We need to free resources from the main reader
+		// We start by closing the conn, which will most likely cause an error
+		// in the read goroutine (unless we are right on the boundary between timeout and success)
+		// and will free up both the connection and cause that go routine to terminate.
+		conn.Close()
+		// Now we block waiting for that goroutine to finish. We do this synchronously
+		// because with a closed connection it should return immediately.
+		// We can ignore the ret.err value because the error is most likely due to us
+		// prematurely closing the conn
+		ret := <-readerDone
+		// If the body has been allocated we need to close it
+		if ret.resp != nil {
+			ret.resp.Body.Close()
+		}
+		// finally, return the real error. No need to return a response here
 		return nil, errors.New("http: request timed out while waiting for response")
 	}
 	close(readerDone)
@@ -147,6 +161,22 @@ func (t *SimpleTransport) writeRequest(conn net.Conn, req *http.Request) error {
 	return err
 }
 
+// comboConnReadCloser wraps a ReadCloser that is backed by
+// on a net.Conn. It will close the net.Conn when the ReadCloser is closed.
+type comboConnReadCloser struct {
+	conn net.Conn
+	rc   io.ReadCloser
+}
+
+func (c comboConnReadCloser) Read(p []byte) (n int, err error) {
+	return c.rc.Read(p)
+}
+
+func (c comboConnReadCloser) Close() error {
+	defer c.conn.Close()
+	return c.rc.Close()
+}
+
 func (t *SimpleTransport) readResponse(
 	conn net.Conn,
 	req *http.Request,
@@ -157,6 +187,7 @@ func (t *SimpleTransport) readResponse(
 	if err != nil {
 		return nil, err
 	}
+	resp.Body = comboConnReadCloser{conn, resp.Body}
 
 	t.sigStartRead()
 


### PR DESCRIPTION
Cherry-pick of PR #8660 to 6.x branch. Original message: 

This fixes an issue where the connection would be closed after only a partial body read. The RoundTripper would close the conn before returning the response which included a partially buffered body. This would actually work for short responses, since the backing bufio would do a partial read, but would fail on all but the shortest responses.

Normally connection lifecycle is handled outside the realm of the `RoundTripper`, but for our purposes we don't want to re-use connections. Since it is a requirement that all response bodies be closed, we can piggy-back on top of that to ensure the connection is closed.

@urso I would like your feedback on this fix. If it looks good I'll add some unit tests around it.

Fixes #8588