### PR TITLE
Fix Heartbeat CHANGELOG

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -21,8 +21,6 @@ https://github.com/elastic/beats/compare/v6.4.0...master[Check the HEAD diff]
 
 *Heartbeat*
 
-- Added autodiscovery support {pull}8415[8415]
-
 *Metricbeat*
 
 *Packetbeat*
@@ -71,7 +69,7 @@ https://github.com/elastic/beats/compare/v6.4.0...master[Check the HEAD diff]
 
 *Heartbeat*
 
-- Added support for extra TLS/x509 metadata. {pull}7944[7944]
+- Fixed bug where HTTP responses with larger bodies would incorrectly report connection errors. {pull}8660[8660]
 
 *Metricbeat*
 
@@ -141,6 +139,10 @@ https://github.com/elastic/beats/compare/v6.4.0...master[Check the HEAD diff]
 - Allow to force CRI format parsing for better performance {pull}8424[8424]
 
 *Heartbeat*
+
+- Added autodiscovery support {pull}8415[8415]
+- Added support for extra TLS/x509 metadata. {pull}7944[7944]
+- Added stats and state metrics for number of monitors and endpoints started. {pull}8621[8621]
 
 *Metricbeat*
 


### PR DESCRIPTION
The heartbeat changelog was incorrect in a number of ways. Two entries were missing, and one was in the wrong section. This straightens everything out.