### PR TITLE
Cherry-pick #8679 to 6.x: Report last config apply result when polling for metrics

### DIFF
--- a/x-pack/libbeat/management/api/configuration.go
+++ b/x-pack/libbeat/management/api/configuration.go
@@ -5,6 +5,7 @@
 package api
 
 import (
+	"fmt"
 	"net/http"
 	"reflect"
 
@@ -46,7 +47,7 @@ func (c *ConfigBlock) ConfigWithMeta() (*reload.ConfigWithMeta, error) {
 }
 
 // Configuration retrieves the list of configuration blocks from Kibana
-func (c *Client) Configuration(accessToken string, beatUUID uuid.UUID) (ConfigBlocks, error) {
+func (c *Client) Configuration(accessToken string, beatUUID uuid.UUID, configOK bool) (ConfigBlocks, error) {
 	headers := http.Header{}
 	headers.Set("kbn-beats-access-token", accessToken)
 
@@ -56,7 +57,8 @@ func (c *Client) Configuration(accessToken string, beatUUID uuid.UUID) (ConfigBl
 			Raw  map[string]interface{} `json:"config"`
 		} `json:"configuration_blocks"`
 	}{}
-	_, err := c.request("GET", "/api/beats/agent/"+beatUUID.String()+"/configuration", nil, headers, &resp)
+	url := fmt.Sprintf("/api/beats/agent/%s/configuration?validSetting=%t", beatUUID, configOK)
+	_, err := c.request("GET", url, nil, headers, &resp)
 	if err != nil {
 		return nil, err
 	}

--- a/x-pack/libbeat/management/api/configuration_test.go
+++ b/x-pack/libbeat/management/api/configuration_test.go
@@ -26,11 +26,13 @@ func TestConfiguration(t *testing.T) {
 		// Check enrollment token is correct
 		assert.Equal(t, "thisismyenrollmenttoken", r.Header.Get("kbn-beats-access-token"))
 
+		assert.Equal(t, "false", r.URL.Query().Get("validSetting"))
+
 		fmt.Fprintf(w, `{"configuration_blocks":[{"type":"filebeat.modules","config":{"module":"apache2"}},{"type":"metricbeat.modules","config":{"module":"system","period":"10s"}}]}`)
 	}))
 	defer server.Close()
 
-	configs, err := client.Configuration("thisismyenrollmenttoken", beatUUID)
+	configs, err := client.Configuration("thisismyenrollmenttoken", beatUUID, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/x-pack/libbeat/management/cache.go
+++ b/x-pack/libbeat/management/cache.go
@@ -19,7 +19,9 @@ import (
 
 // Cache keeps a copy of configs provided by Kibana, it's used when Kibana is down
 type Cache struct {
-	Configs api.ConfigBlocks
+	// ConfigOK is true if last config update was successful
+	ConfigOK bool
+	Configs  api.ConfigBlocks
 }
 
 // Load settings from its source file

--- a/x-pack/libbeat/management/manager_test.go
+++ b/x-pack/libbeat/management/manager_test.go
@@ -53,7 +53,7 @@ func TestConfigManager(t *testing.T) {
 		`{"configuration_blocks":[{"type":"test.block","config":{"module":"system"}}]}`,
 	}
 	mux.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, fmt.Sprintf("/api/beats/agent/%s/configuration", id), r.RequestURI)
+		assert.Equal(t, fmt.Sprintf("/api/beats/agent/%s/configuration?validSetting=true", id), r.RequestURI)
 		fmt.Fprintf(w, responses[i])
 		i++
 	}))


### PR DESCRIPTION
Cherry-pick of PR #8679 to 6.x branch. Original message: 

This change adapts the central management client to https://github.com/elastic/kibana/pull/24246. It will report configuration status so users can know if something is failing on the beat side.