### PR TITLE
Fix an issue where we were trying to  use a non existing directory when generating the fields.go

### DIFF
--- a/dev-tools/mage/fields.go
+++ b/dev-tools/mage/fields.go
@@ -18,6 +18,7 @@
 package mage
 
 import (
+	"os"
 	"path/filepath"
 
 	"github.com/magefile/mage/sh"
@@ -40,7 +41,11 @@ func OSSBeatDir(path ...string) string {
 
 	// Check if we need to correct ossDir because it's in x-pack.
 	if parentDir := filepath.Base(filepath.Dir(ossDir)); parentDir == "x-pack" {
-		ossDir = filepath.Join(ossDir, "../..", BeatName)
+		// If the OSS version of the beat exists.
+		tmp := filepath.Join(ossDir, "../..", BeatName)
+		if _, err := os.Stat(tmp); !os.IsNotExist(err) {
+			ossDir = tmp
+		}
 	}
 
 	return filepath.Join(append([]string{ossDir}, path...)...)

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -82,6 +82,7 @@ VIRTUALENV_PARAMS?=
 INTEGRATION_TESTS?=
 FIND=. ${PYTHON_ENV}/bin/activate; find . -type f -not -path "*/vendor/*" -not -path "*/build/*" -not -path "*/.git/*"
 PERM_EXEC?=$(shell [ `uname -s` = "Darwin" ] && echo "+111" || echo "/a+x")
+XPACK_ONLY?=false
 
 ifeq ($(DOCKER_CACHE),0)
 	DOCKER_NOCACHE=--no-cache
@@ -210,7 +211,7 @@ system-tests-environment: prepare-tests build-image
 	${DOCKER_COMPOSE} run -e INTEGRATION_TESTS=1 -e TESTING_ENVIRONMENT=${TESTING_ENVIRONMENT} -e DOCKER_COMPOSE_PROJECT_NAME=${DOCKER_COMPOSE_PROJECT_NAME} beat make system-tests
 	#This is a hack to run x-pack/filebeat module tests
 	@XPACKBEAT="${ES_BEATS}/x-pack/${BEAT_NAME}" ; \
-	if [ -e "$$XPACKBEAT/tests/system" ] ; then \
+	if [ -e "$$XPACKBEAT/tests/system" ] && [ $(XPACK_ONLY) = false ]; then \
 	    $(MAKE) -C ../x-pack/${BEAT_NAME} fields; \
 	    ${DOCKER_COMPOSE} run -e INTEGRATION_TESTS=1 -e MODULES_PATH="../../x-pack/${BEAT_NAME}/module" -e TESTING_ENVIRONMENT=${TESTING_ENVIRONMENT} -e DOCKER_COMPOSE_PROJECT_NAME=${DOCKER_COMPOSE_PROJECT_NAME} beat make -C "$$XPACKBEAT" ${BEAT_NAME}.test system-tests ; \
 	    $(MAKE) -C ../x-pack/${BEAT_NAME} fix-permissions; \

--- a/x-pack/functionbeat/Makefile
+++ b/x-pack/functionbeat/Makefile
@@ -7,6 +7,7 @@ TEST_ENVIRONMENT?=true
 GOX_FLAGS=-arch="amd64 386 arm ppc64 ppc64le"
 ES_BEATS?=../../
 FIELDS_FILE_PATH=module
+XPACK_ONLY?=true
 
 # Path to the libbeat Makefile
 include $(ES_BEATS)/libbeat/scripts/Makefile


### PR DESCRIPTION
Functionbeat doesn't have an OSS implementation.