### PR TITLE
fix the issue that "cmdline_grep" couldn't work on packetbeat

### DIFF
--- a/CHANGELOG-developer.asciidoc
+++ b/CHANGELOG-developer.asciidoc
@@ -37,6 +37,7 @@ The list below covers the major changes between 6.3.0 and master only.
 - Fix permissions of generated Filebeat filesets. {pull}7140[7140]
 - Collect fields from _meta/fields.yml too. {pull}8397[8397]
 - Fix issue on asset generation that could lead to different results in Windows. {pull}8464[8464]
+- Fix issue that `cmdline_grep` couldn't work on Packetbeat. {pull}8730[8730]
 
 ==== Added
 

--- a/libbeat/common/endpoint.go
+++ b/libbeat/common/endpoint.go
@@ -33,12 +33,14 @@ func MakeEndpointPair(tuple BaseTuple, cmdlineTuple *CmdlineTuple) (src Endpoint
 		IP:      tuple.SrcIP.String(),
 		Port:    tuple.SrcPort,
 		Proc:    string(cmdlineTuple.Src),
+		Name:    string(cmdlineTuple.Src),
 		Cmdline: string(cmdlineTuple.SrcCommand),
 	}
 	dst = Endpoint{
 		IP:      tuple.DstIP.String(),
 		Port:    tuple.DstPort,
 		Proc:    string(cmdlineTuple.Dst),
+		Name:    string(cmdlineTuple.Src),
 		Cmdline: string(cmdlineTuple.DstCommand),
 	}
 	return src, dst


### PR DESCRIPTION
At first I want to use Packetbeat to collect network data of process, and I add a `cmdline_grep` just like the document:
```
    packetbeat.procs:
        enabled: true
    monitored:
        - process: java
          cmdline_grep: java
```

But I didn't got any`proc` Fields in the data, So I check the source code, I think there might be some mistake at` packetbeat/flows/worker.go:323`, the `libbeat/common/endpoint.Endpont.Name` has not been set, but worker put this field into Event. And it work right after I modify the code.
