### PR TITLE
Fix failing heartbeat tests due to port allocations and timeouts

### DIFF
--- a/heartbeat/tests/system/config/heartbeat.yml.j2
+++ b/heartbeat/tests/system/config/heartbeat.yml.j2
@@ -4,6 +4,9 @@ heartbeat.monitors:
 {% for monitor in monitors -%}
 - type: {{ monitor.type }}
   schedule: '{{ monitor.schedule|default("@every 1s") }}'
+  {%- if monitor.timeout is defined %}
+  timeout: {{monitor.timeout}}
+  {% endif -%}
 
   {%- if monitor.tags is defined %}
   tags:

--- a/heartbeat/tests/system/heartbeat.py
+++ b/heartbeat/tests/system/heartbeat.py
@@ -27,7 +27,7 @@ class BaseTest(TestCase):
                 self.end_headers()
                 self.wfile.write(content)
 
-        server = BaseHTTPServer.HTTPServer(('localhost', 8185), HTTPHandler)
+        server = BaseHTTPServer.HTTPServer(('localhost', 0), HTTPHandler)
 
         thread = threading.Thread(target=server.serve_forever)
         thread.start()
@@ -39,6 +39,7 @@ class BaseTest(TestCase):
         return """
 - type: http
   schedule: "@every 1s"
+  timeout: 3s
   urls: ["{url}"]
         """[1:-1].format(url=url)
 
@@ -48,6 +49,7 @@ class BaseTest(TestCase):
         return """
 - type: tcp
   schedule: "@every 1s"
+  timeout: 3s
   hosts: [{host_str}]
         """[1:-1].format(host_str=host_str)
 

--- a/heartbeat/tests/system/test_monitor.py
+++ b/heartbeat/tests/system/test_monitor.py
@@ -2,6 +2,7 @@ from heartbeat import BaseTest
 from parameterized import parameterized
 import os
 from nose.plugins.skip import SkipTest
+import nose.tools
 
 
 class Test(BaseTest):
@@ -19,7 +20,7 @@ class Test(BaseTest):
         self.render_config_template(
             monitors=[{
                 "type": "http",
-                "urls": ["http://localhost:8185"],
+                "urls": ["http://localhost:{}".format(server.server_port)],
             }],
         )
 
@@ -41,34 +42,39 @@ class Test(BaseTest):
         self.assert_fields_are_documented(output[0])
 
     @parameterized.expand([
-        ("8185", "up"),
-        ("8186", "down"),
+        (lambda server: "localhost:{}".format(server.server_port), "up"),
+        # This IP is reserved in IPv4
+        (lambda server: "207.254.52.220:1233", "down"),
     ])
-    def test_tcp(self, port, status):
+    def test_tcp(self, url, status):
         """
         Test tcp server
         """
         server = self.start_server("hello world", 200)
-        self.render_config_template(
-            monitors=[{
-                "type": "tcp",
-                "hosts": ["localhost:" + port],
-            }],
-        )
+        try:
+            self.render_config_template(
+                monitors=[{
+                    "type": "tcp",
+                    "hosts": [url(server)],
+                    "timeout": "3s"
+                }],
+            )
 
-        proc = self.start_beat()
-        self.wait_until(lambda: self.log_contains("heartbeat is running"))
+            proc = self.start_beat()
+            try:
+                self.wait_until(lambda: self.log_contains(
+                    "heartbeat is running"))
 
-        self.wait_until(
-            lambda: self.output_has(lines=1))
+                self.wait_until(
+                    lambda: self.output_has(lines=1))
+            finally:
+                proc.check_kill_and_wait()
 
-        proc.check_kill_and_wait()
-
-        server.shutdown()
-
-        output = self.read_output()
-        assert status == output[0]["monitor.status"]
-        if os.name == "nt":
-            # Currently skipped on Windows as fields.yml not generated
-            raise SkipTest
-        self.assert_fields_are_documented(output[0])
+            output = self.read_output()
+            nose.tools.assert_equal(status, output[0]["monitor.status"])
+            if os.name == "nt":
+                # Currently skipped on Windows as fields.yml not generated
+                raise SkipTest
+            self.assert_fields_are_documented(output[0])
+        finally:
+            server.shutdown()

--- a/heartbeat/tests/system/test_monitor.py
+++ b/heartbeat/tests/system/test_monitor.py
@@ -44,7 +44,7 @@ class Test(BaseTest):
     @parameterized.expand([
         (lambda server: "localhost:{}".format(server.server_port), "up"),
         # This IP is reserved in IPv4
-        (lambda server: "207.254.52.220:1233", "down"),
+        (lambda server: "203.0.113.1:1233", "down"),
     ])
     def test_tcp(self, url, status):
         """
@@ -71,7 +71,7 @@ class Test(BaseTest):
                 proc.check_kill_and_wait()
 
             output = self.read_output()
-            nose.tools.assert_equal(status, output[0]["monitor.status"])
+            self.assert_last_status(status)
             if os.name == "nt":
                 # Currently skipped on Windows as fields.yml not generated
                 raise SkipTest

--- a/heartbeat/tests/system/test_reload.py
+++ b/heartbeat/tests/system/test_reload.py
@@ -18,17 +18,17 @@ class Test(BaseTest):
             cfg_file = "test.yml"
 
             self.write_dyn_config(
-                cfg_file, self.http_cfg("http://localhost:8185"))
+                cfg_file, self.http_cfg("http://localhost:{}".format(server.server_port)))
 
             self.wait_until(lambda: self.output_has(lines=1))
 
             self.assert_last_status("up")
 
             self.write_dyn_config(
-                cfg_file, self.http_cfg("http://localhost:8186"))
+                cfg_file, self.http_cfg("http://203.0.113.1:8186"))
 
             self.wait_until(lambda: self.last_output_line()[
-                            "http.url"] == "http://localhost:8186")
+                            "http.url"] == "http://203.0.113.1:8186")
 
             self.assert_last_status("down")
 
@@ -47,7 +47,7 @@ class Test(BaseTest):
             cfg_file = "test.yml"
 
             self.write_dyn_config(
-                cfg_file, self.http_cfg("http://localhost:8185"))
+                cfg_file, self.http_cfg("http://localhost:{}".format(server.server_port)))
 
             self.wait_until(lambda: self.output_has(lines=2))
 
@@ -57,9 +57,9 @@ class Test(BaseTest):
 
             # Ensure the job was removed from the scheduler
             self.wait_until(lambda: self.log_contains(
-                "Remove scheduler job 'http@http://localhost:8185"))
+                "Remove scheduler job 'http@http://localhost:{}".format(server.server_port)))
             self.wait_until(lambda: self.log_contains(
-                "Job 'http@http://localhost:8185' returned"))
+                "Job 'http@http://localhost:{}' returned".format(server.server_port)))
 
             self.proc.check_kill_and_wait()
         finally:
@@ -77,7 +77,7 @@ class Test(BaseTest):
         server = self.start_server("hello world", 200)
         try:
             self.write_dyn_config(
-                "test.yml", self.http_cfg("http://localhost:8185"))
+                "test.yml", self.http_cfg("http://localhost:{}".format(server.server_port)))
 
             self.wait_until(lambda: self.log_contains(
                 "Starting reload procedure, current runners: 1"))

--- a/heartbeat/tests/system/test_telemetry.py
+++ b/heartbeat/tests/system/test_telemetry.py
@@ -27,7 +27,8 @@ class Test(BaseTest):
             cfg_file = "test.yml"
 
             self.write_dyn_config(
-                cfg_file, self.http_cfg("http://localhost:8185")
+                cfg_file, self.http_cfg(
+                    "http://localhost:{}".format(server.server_port))
             )
 
             self.wait_until(lambda: self.output_has(lines=1))
@@ -47,7 +48,7 @@ class Test(BaseTest):
                 }
             })
 
-            tcp_hosts = ["localhost:8185", "localhost:12345"]
+            tcp_hosts = ["localhost:123", "localhost:456"]
 
             self.write_dyn_config(
                 cfg_file, self.tcp_cfg(*tcp_hosts)


### PR DESCRIPTION
This fixes two sources of errors

Integ tests used a hardcoded port rather than letting the OS pick.
This change sets the port to '0' and lets the OS choose

The other change is to set shorter timeouts for tests against purposely down endpoints.
This makes heartbeat timeout faster than the tests timeouts to let these tests succeed