### PR TITLE
Backport to 1.0.1: Remove link to Topbeat download page (#8366)

### DIFF
--- a/topbeat/docs/gettingstarted.asciidoc
+++ b/topbeat/docs/gettingstarted.asciidoc
@@ -22,9 +22,7 @@ mac>> for OS X, and <<win, win>> for Windows).
 
 [NOTE]
 ==================================================
-If you use Apt or Yum, you can {libbeat}/setup-repositories.html[install Topbeat from our repositories] to update to the newest version more easily. 
-
-See our https://www.elastic.co/downloads/beats/topbeat[download page] for other installation options, such as 32-bit images. 
+If you use Apt or Yum, you can {libbeat}/setup-repositories.html[install Topbeat from our repositories] to update to the newest version more easily.
 ==================================================
 
 [[deb]]
@@ -57,8 +55,7 @@ tar xzvf topbeat-{version}-darwin.tgz
 [[win]]
 *win:*
 
-. Download the Topbeat Windows zip file from the
-https://www.elastic.co/downloads/beats/topbeat[downloads page].
+. Download the Topbeat https://download.elastic.co/beats/topbeat/topbeat-{version}-windows.zip[Windows zip file].
 
 . Extract the contents of the zip file into `C:\Program Files`.
 

--- a/topbeat/docs/page_header.html
+++ b/topbeat/docs/page_header.html
@@ -1,0 +1,4 @@
+Topbeat was replaced by <a href="https://www.elastic.co/products/beats/metricbeat">
+Metricbeat</a> in 5.0. To learn more about Metricbeat, see the
+<a href="https://www.elastic.co/guide/en/beats/metricbeat/current/index.html">
+Metricbeat documentation</a>. 


### PR DESCRIPTION
Cherrypicks #8366 into the 1.0.1 branch. This fix is required in old branches so that we can remove the topbeat download page.