### PR TITLE
Skip building journalbeat files on non Linuxes

### DIFF
--- a/journalbeat/beater/journalbeat.go
+++ b/journalbeat/beater/journalbeat.go
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// +build linux,cgo
+
 package beater
 
 import (

--- a/journalbeat/beater/journalbeat_other.go
+++ b/journalbeat/beater/journalbeat_other.go
@@ -15,7 +15,4 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// +build !integration
-// +build linux,cgo
-
-package config
+package beater

--- a/journalbeat/cmd/instance/metrics.go
+++ b/journalbeat/cmd/instance/metrics.go
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// +build linux,cgo
+
 package instance
 
 import (

--- a/journalbeat/cmd/instance/metrics_other.go
+++ b/journalbeat/cmd/instance/metrics_other.go
@@ -15,7 +15,4 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// +build !integration
-// +build linux,cgo
-
-package config
+package instance

--- a/journalbeat/cmd/root.go
+++ b/journalbeat/cmd/root.go
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// +build linux,cgo
+
 package cmd
 
 import (

--- a/journalbeat/cmd/root_other.go
+++ b/journalbeat/cmd/root_other.go
@@ -15,7 +15,24 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// +build !integration
-// +build linux,cgo
+// +build !linux !cgo
 
-package config
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/elastic/beats/libbeat/beat"
+	cmd "github.com/elastic/beats/libbeat/cmd"
+	"github.com/elastic/beats/libbeat/common"
+)
+
+// Name of this beat
+var Name = "journalbeat"
+
+// RootCmd to handle beats cli
+var RootCmd = cmd.GenRootCmd(Name, "", newBeat)
+
+func newBeat(b *beat.Beat, cfg *common.Config) (beat.Beater, error) {
+	return nil, fmt.Errorf("journalbeat is not supported on your platform")
+}

--- a/journalbeat/input/config.go
+++ b/journalbeat/input/config.go
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// +build linux,cgo
+
 package input
 
 import (

--- a/journalbeat/input/input.go
+++ b/journalbeat/input/input.go
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// +build linux,cgo
+
 package input
 
 import (

--- a/journalbeat/input/input_other.go
+++ b/journalbeat/input/input_other.go
@@ -15,7 +15,4 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// +build !integration
-// +build linux,cgo
-
-package config
+package input

--- a/journalbeat/main_test.go
+++ b/journalbeat/main_test.go
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// +build linux,cgo
+
 package main
 
 // This file is mandatory as otherwise the journalbeat.test binary is not generated correctly.

--- a/journalbeat/reader/fields.go
+++ b/journalbeat/reader/fields.go
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// +build linux,cgo
+
 package reader
 
 import "github.com/coreos/go-systemd/sdjournal"

--- a/journalbeat/reader/journal.go
+++ b/journalbeat/reader/journal.go
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// +build linux,cgo
+
 package reader
 
 import (

--- a/journalbeat/reader/journal_other.go
+++ b/journalbeat/reader/journal_other.go
@@ -15,7 +15,4 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// +build !integration
-// +build linux,cgo
-
-package config
+package reader

--- a/journalbeat/reader/journal_test.go
+++ b/journalbeat/reader/journal_test.go
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// +build linux,cgo
+
 package reader
 
 import (


### PR DESCRIPTION
Previously, `make check` failed on Darwin, because not all files of `journalbeat` are available for every platforms. Error message:
```
../vendor/github.com/coreos/go-systemd/sdjournal/functions.go:19:2: build constraints exclude all Go files in /home/n/go/src/github.com/elastic/beats/vendor/github.com/coreos/pkg/dlopen
```

Build constraints and placeholder files are added to skip building journalbeat on platforms it is not supposed run on.