### PR TITLE
 Dissect tag on parsing error 

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -128,6 +128,7 @@ https://github.com/elastic/beats/compare/v6.4.0...master[Check the HEAD diff]
 - Add Beats Central Management {pull}8559[8559]
 - Allow Bus to buffer events in case listeners are not configured. {pull}8527[8527]
 - Enable `host` and `cloud` metadata processors by default. {pull}8596[8596]
+- Dissect will now tag event on parsing error. {pull}8751[8751]
 
 *Auditbeat*
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -128,7 +128,7 @@ https://github.com/elastic/beats/compare/v6.4.0...master[Check the HEAD diff]
 - Add Beats Central Management {pull}8559[8559]
 - Allow Bus to buffer events in case listeners are not configured. {pull}8527[8527]
 - Enable `host` and `cloud` metadata processors by default. {pull}8596[8596]
-- Dissect will now tag event on parsing error. {pull}8751[8751]
+- Dissect will now flag event on parsing error. {pull}8751[8751]
 
 *Auditbeat*
 

--- a/libbeat/beat/event.go
+++ b/libbeat/beat/event.go
@@ -24,6 +24,9 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 )
 
+// FlagField fields used to keep information or errors when events are parsed.
+const FlagField = "log.flags"
+
 // Event is the common event format shared by all beats.
 // Every event must have a timestamp and provide encodable Fields in `Fields`.
 // The `Meta`-fields can be used to pass additional meta-data to the outputs.

--- a/libbeat/processors/dissect/processor.go
+++ b/libbeat/processors/dissect/processor.go
@@ -27,6 +27,8 @@ import (
 	"github.com/elastic/beats/libbeat/processors"
 )
 
+const tagParsingError = "dissect_parsing_error"
+
 type processor struct {
 	config config
 }
@@ -60,6 +62,14 @@ func (p *processor) Run(event *beat.Event) (*beat.Event, error) {
 
 	m, err := p.config.Tokenizer.Dissect(s)
 	if err != nil {
+		if err := common.AddTagsWithKey(
+			event.Fields,
+			beat.FlagField,
+			[]string{tagParsingError},
+		); err != nil {
+			return event, errors.Wrap(err, "cannot add new tag the event")
+		}
+
 		return event, err
 	}
 

--- a/libbeat/processors/dissect/processor.go
+++ b/libbeat/processors/dissect/processor.go
@@ -27,7 +27,7 @@ import (
 	"github.com/elastic/beats/libbeat/processors"
 )
 
-const tagParsingError = "dissect_parsing_error"
+const flagParsingError = "dissect_parsing_error"
 
 type processor struct {
 	config config
@@ -65,9 +65,9 @@ func (p *processor) Run(event *beat.Event) (*beat.Event, error) {
 		if err := common.AddTagsWithKey(
 			event.Fields,
 			beat.FlagField,
-			[]string{tagParsingError},
+			[]string{flagParsingError},
 		); err != nil {
-			return event, errors.Wrap(err, "cannot add new tag the event")
+			return event, errors.Wrap(err, "cannot add new flag the event")
 		}
 
 		return event, err

--- a/libbeat/processors/dissect/processor_test.go
+++ b/libbeat/processors/dissect/processor_test.go
@@ -176,3 +176,59 @@ func TestFieldAlreadyExist(t *testing.T) {
 		})
 	}
 }
+
+func TestErrorTagging(t *testing.T) {
+	t.Run("when the parsing fails add a tag", func(t *testing.T) {
+		c, err := common.NewConfigFrom(map[string]interface{}{
+			"tokenizer": "%{ok} - %{notvalid}",
+		})
+
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		processor, err := newProcessor(c)
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		e := beat.Event{Fields: common.MapStr{"message": "hello world"}}
+		event, err := processor.Run(&e)
+
+		if !assert.Error(t, err) {
+			return
+		}
+
+		tags, err := event.GetValue(beat.FlagField)
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		assert.Contains(t, tags, tagParsingError)
+	})
+
+	t.Run("when the parsing is succesful do not add a tag", func(t *testing.T) {
+		c, err := common.NewConfigFrom(map[string]interface{}{
+			"tokenizer": "%{ok} %{valid}",
+		})
+
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		processor, err := newProcessor(c)
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		e := beat.Event{Fields: common.MapStr{"message": "hello world"}}
+		event, err := processor.Run(&e)
+
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		_, err = event.GetValue(beat.FlagField)
+		assert.Error(t, err)
+	})
+}

--- a/libbeat/processors/dissect/processor_test.go
+++ b/libbeat/processors/dissect/processor_test.go
@@ -177,8 +177,8 @@ func TestFieldAlreadyExist(t *testing.T) {
 	}
 }
 
-func TestErrorTagging(t *testing.T) {
-	t.Run("when the parsing fails add a tag", func(t *testing.T) {
+func TestErrorFlagging(t *testing.T) {
+	t.Run("when the parsing fails add a flag", func(t *testing.T) {
 		c, err := common.NewConfigFrom(map[string]interface{}{
 			"tokenizer": "%{ok} - %{notvalid}",
 		})
@@ -199,15 +199,15 @@ func TestErrorTagging(t *testing.T) {
 			return
 		}
 
-		tags, err := event.GetValue(beat.FlagField)
+		flags, err := event.GetValue(beat.FlagField)
 		if !assert.NoError(t, err) {
 			return
 		}
 
-		assert.Contains(t, tags, tagParsingError)
+		assert.Contains(t, flags, flagParsingError)
 	})
 
-	t.Run("when the parsing is succesful do not add a tag", func(t *testing.T) {
+	t.Run("when the parsing is succesful do not add a flag", func(t *testing.T) {
 		c, err := common.NewConfigFrom(map[string]interface{}{
 			"tokenizer": "%{ok} %{valid}",
 		})


### PR DESCRIPTION
Before when a parsing error occurred the events was returned untouched
and an error was logged, if you don't look at your logs you have no
the idea that the tokenizer was not able to match your string.

Instead, when a parsing error occurs in the Dissect processor, we will now
add a tag named 'dissect_parsing_error' to the 'log.flags' field.
With that information, you are now able to reprocess your data or do
filtering on the UI.

Fixes: #8123