### PR TITLE
Bump doc versions for 6.5 branch

### DIFF
--- a/deploy/kubernetes/auditbeat-kubernetes.yaml
+++ b/deploy/kubernetes/auditbeat-kubernetes.yaml
@@ -71,7 +71,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: auditbeat
-        image: docker.elastic.co/beats/auditbeat:6.4.0
+        image: docker.elastic.co/beats/auditbeat:6.5.0
         args: [
           "-c", "/etc/auditbeat.yml"
         ]

--- a/deploy/kubernetes/filebeat-kubernetes.yaml
+++ b/deploy/kubernetes/filebeat-kubernetes.yaml
@@ -69,7 +69,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: filebeat
-        image: docker.elastic.co/beats/filebeat:6.4.0
+        image: docker.elastic.co/beats/filebeat:6.5.0
         args: [
           "-c", "/etc/filebeat.yml",
           "-e",

--- a/deploy/kubernetes/metricbeat-kubernetes.yaml
+++ b/deploy/kubernetes/metricbeat-kubernetes.yaml
@@ -104,7 +104,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: metricbeat
-        image: docker.elastic.co/beats/metricbeat:6.4.0
+        image: docker.elastic.co/beats/metricbeat:6.5.0
         args: [
           "-c", "/etc/metricbeat.yml",
           "-e",
@@ -242,7 +242,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: metricbeat
-        image: docker.elastic.co/beats/metricbeat:6.4.0
+        image: docker.elastic.co/beats/metricbeat:6.5.0
         args: [
           "-c", "/etc/metricbeat.yml",
           "-e",

--- a/libbeat/docs/version.asciidoc
+++ b/libbeat/docs/version.asciidoc
@@ -1,8 +1,8 @@
-:stack-version: 6.4.0
-:doc-branch: 6.x
+:stack-version: 6.5.0
+:doc-branch: 6.5
 :go-version: 1.10.3
 :release-state: unreleased
 :python: 2.7.9
 :docker: 1.12
 :docker-compose: 1.11
-:branch: 6.x
+:branch: 6.5

--- a/metricbeat/modules.d/aerospike.yml.disabled
+++ b/metricbeat/modules.d/aerospike.yml.disabled
@@ -1,5 +1,5 @@
 # Module: aerospike
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.x/metricbeat-module-aerospike.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.5/metricbeat-module-aerospike.html
 
 - module: aerospike
   #metricsets:

--- a/metricbeat/modules.d/apache.yml.disabled
+++ b/metricbeat/modules.d/apache.yml.disabled
@@ -1,5 +1,5 @@
 # Module: apache
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.x/metricbeat-module-apache.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.5/metricbeat-module-apache.html
 
 - module: apache
   #metricsets:

--- a/metricbeat/modules.d/ceph.yml.disabled
+++ b/metricbeat/modules.d/ceph.yml.disabled
@@ -1,5 +1,5 @@
 # Module: ceph
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.x/metricbeat-module-ceph.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.5/metricbeat-module-ceph.html
 
 - module: ceph
   #metricsets:

--- a/metricbeat/modules.d/couchbase.yml.disabled
+++ b/metricbeat/modules.d/couchbase.yml.disabled
@@ -1,5 +1,5 @@
 # Module: couchbase
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.x/metricbeat-module-couchbase.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.5/metricbeat-module-couchbase.html
 
 - module: couchbase
   #metricsets:

--- a/metricbeat/modules.d/docker.yml.disabled
+++ b/metricbeat/modules.d/docker.yml.disabled
@@ -1,5 +1,5 @@
 # Module: docker
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.x/metricbeat-module-docker.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.5/metricbeat-module-docker.html
 
 - module: docker
   #metricsets:

--- a/metricbeat/modules.d/dropwizard.yml.disabled
+++ b/metricbeat/modules.d/dropwizard.yml.disabled
@@ -1,5 +1,5 @@
 # Module: dropwizard
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.x/metricbeat-module-dropwizard.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.5/metricbeat-module-dropwizard.html
 
 - module: dropwizard
   #metricsets:

--- a/metricbeat/modules.d/elasticsearch.yml.disabled
+++ b/metricbeat/modules.d/elasticsearch.yml.disabled
@@ -1,5 +1,5 @@
 # Module: elasticsearch
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.x/metricbeat-module-elasticsearch.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.5/metricbeat-module-elasticsearch.html
 
 - module: elasticsearch
   #metricsets:

--- a/metricbeat/modules.d/envoyproxy.yml.disabled
+++ b/metricbeat/modules.d/envoyproxy.yml.disabled
@@ -1,5 +1,5 @@
 # Module: envoyproxy
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.x/metricbeat-module-envoyproxy.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.5/metricbeat-module-envoyproxy.html
 
 - module: envoyproxy
   #metricsets:

--- a/metricbeat/modules.d/etcd.yml.disabled
+++ b/metricbeat/modules.d/etcd.yml.disabled
@@ -1,5 +1,5 @@
 # Module: etcd
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.x/metricbeat-module-etcd.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.5/metricbeat-module-etcd.html
 
 - module: etcd
   #metricsets:

--- a/metricbeat/modules.d/golang.yml.disabled
+++ b/metricbeat/modules.d/golang.yml.disabled
@@ -1,5 +1,5 @@
 # Module: golang
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.x/metricbeat-module-golang.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.5/metricbeat-module-golang.html
 
 - module: golang
   #metricsets:

--- a/metricbeat/modules.d/graphite.yml.disabled
+++ b/metricbeat/modules.d/graphite.yml.disabled
@@ -1,5 +1,5 @@
 # Module: graphite
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.x/metricbeat-module-graphite.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.5/metricbeat-module-graphite.html
 
 - module: graphite
   #metricsets:

--- a/metricbeat/modules.d/haproxy.yml.disabled
+++ b/metricbeat/modules.d/haproxy.yml.disabled
@@ -1,5 +1,5 @@
 # Module: haproxy
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.x/metricbeat-module-haproxy.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.5/metricbeat-module-haproxy.html
 
 - module: haproxy
   #metricsets:

--- a/metricbeat/modules.d/http.yml.disabled
+++ b/metricbeat/modules.d/http.yml.disabled
@@ -1,5 +1,5 @@
 # Module: http
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.x/metricbeat-module-http.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.5/metricbeat-module-http.html
 
 - module: http
   #metricsets:

--- a/metricbeat/modules.d/jolokia.yml.disabled
+++ b/metricbeat/modules.d/jolokia.yml.disabled
@@ -1,5 +1,5 @@
 # Module: jolokia
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.x/metricbeat-module-jolokia.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.5/metricbeat-module-jolokia.html
 
 - module: jolokia
   #metricsets: ["jmx"]

--- a/metricbeat/modules.d/kafka.yml.disabled
+++ b/metricbeat/modules.d/kafka.yml.disabled
@@ -1,5 +1,5 @@
 # Module: kafka
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.x/metricbeat-module-kafka.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.5/metricbeat-module-kafka.html
 
 - module: kafka
   #metricsets:

--- a/metricbeat/modules.d/kibana.yml.disabled
+++ b/metricbeat/modules.d/kibana.yml.disabled
@@ -1,5 +1,5 @@
 # Module: kibana
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.x/metricbeat-module-kibana.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.5/metricbeat-module-kibana.html
 
 - module: kibana
   #metricsets:

--- a/metricbeat/modules.d/kubernetes.yml.disabled
+++ b/metricbeat/modules.d/kubernetes.yml.disabled
@@ -1,5 +1,5 @@
 # Module: kubernetes
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.x/metricbeat-module-kubernetes.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.5/metricbeat-module-kubernetes.html
 
 # Node metrics, from kubelet:
 - module: kubernetes

--- a/metricbeat/modules.d/kvm.yml.disabled
+++ b/metricbeat/modules.d/kvm.yml.disabled
@@ -1,5 +1,5 @@
 # Module: kvm
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.x/metricbeat-module-kvm.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.5/metricbeat-module-kvm.html
 
 - module: kvm
   #metricsets:

--- a/metricbeat/modules.d/logstash.yml.disabled
+++ b/metricbeat/modules.d/logstash.yml.disabled
@@ -1,5 +1,5 @@
 # Module: logstash
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.x/metricbeat-module-logstash.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.5/metricbeat-module-logstash.html
 
 - module: logstash
   #metricsets:

--- a/metricbeat/modules.d/memcached.yml.disabled
+++ b/metricbeat/modules.d/memcached.yml.disabled
@@ -1,5 +1,5 @@
 # Module: memcached
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.x/metricbeat-module-memcached.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.5/metricbeat-module-memcached.html
 
 - module: memcached
 #  metricsets: ["stats"]

--- a/metricbeat/modules.d/mongodb.yml.disabled
+++ b/metricbeat/modules.d/mongodb.yml.disabled
@@ -1,5 +1,5 @@
 # Module: mongodb
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.x/metricbeat-module-mongodb.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.5/metricbeat-module-mongodb.html
 
 - module: mongodb
   #metricsets:

--- a/metricbeat/modules.d/munin.yml.disabled
+++ b/metricbeat/modules.d/munin.yml.disabled
@@ -1,5 +1,5 @@
 # Module: munin
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.x/metricbeat-module-munin.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.5/metricbeat-module-munin.html
 
 - module: munin
   #metricsets:

--- a/metricbeat/modules.d/mysql.yml.disabled
+++ b/metricbeat/modules.d/mysql.yml.disabled
@@ -1,5 +1,5 @@
 # Module: mysql
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.x/metricbeat-module-mysql.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.5/metricbeat-module-mysql.html
 
 - module: mysql
   #metricsets:

--- a/metricbeat/modules.d/nginx.yml.disabled
+++ b/metricbeat/modules.d/nginx.yml.disabled
@@ -1,5 +1,5 @@
 # Module: nginx
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.x/metricbeat-module-nginx.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.5/metricbeat-module-nginx.html
 
 - module: nginx
   #metricsets:

--- a/metricbeat/modules.d/php_fpm.yml.disabled
+++ b/metricbeat/modules.d/php_fpm.yml.disabled
@@ -1,5 +1,5 @@
 # Module: php_fpm
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.x/metricbeat-module-php_fpm.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.5/metricbeat-module-php_fpm.html
 
 - module: php_fpm
   #metricsets:

--- a/metricbeat/modules.d/postgresql.yml.disabled
+++ b/metricbeat/modules.d/postgresql.yml.disabled
@@ -1,5 +1,5 @@
 # Module: postgresql
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.x/metricbeat-module-postgresql.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.5/metricbeat-module-postgresql.html
 
 - module: postgresql
   #metricsets:

--- a/metricbeat/modules.d/prometheus.yml.disabled
+++ b/metricbeat/modules.d/prometheus.yml.disabled
@@ -1,5 +1,5 @@
 # Module: prometheus
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.x/metricbeat-module-prometheus.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.5/metricbeat-module-prometheus.html
 
 - module: prometheus
   #metricsets:

--- a/metricbeat/modules.d/rabbitmq.yml.disabled
+++ b/metricbeat/modules.d/rabbitmq.yml.disabled
@@ -1,5 +1,5 @@
 # Module: rabbitmq
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.x/metricbeat-module-rabbitmq.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.5/metricbeat-module-rabbitmq.html
 
 - module: rabbitmq
   #metricsets:

--- a/metricbeat/modules.d/redis.yml.disabled
+++ b/metricbeat/modules.d/redis.yml.disabled
@@ -1,5 +1,5 @@
 # Module: redis
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.x/metricbeat-module-redis.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.5/metricbeat-module-redis.html
 
 - module: redis
   #metricsets:

--- a/metricbeat/modules.d/system.yml
+++ b/metricbeat/modules.d/system.yml
@@ -1,5 +1,5 @@
 # Module: system
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.x/metricbeat-module-system.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.5/metricbeat-module-system.html
 
 - module: system
   period: 10s

--- a/metricbeat/modules.d/traefik.yml.disabled
+++ b/metricbeat/modules.d/traefik.yml.disabled
@@ -1,5 +1,5 @@
 # Module: traefik
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.x/metricbeat-module-traefik.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.5/metricbeat-module-traefik.html
 
 - module: traefik
   metricsets: ["health"]

--- a/metricbeat/modules.d/uwsgi.yml.disabled
+++ b/metricbeat/modules.d/uwsgi.yml.disabled
@@ -1,5 +1,5 @@
 # Module: uwsgi
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.x/metricbeat-module-uwsgi.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.5/metricbeat-module-uwsgi.html
 
 - module: uwsgi
   #metricsets:

--- a/metricbeat/modules.d/vsphere.yml.disabled
+++ b/metricbeat/modules.d/vsphere.yml.disabled
@@ -1,5 +1,5 @@
 # Module: vsphere
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.x/metricbeat-module-vsphere.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.5/metricbeat-module-vsphere.html
 
 - module: vsphere
   #metricsets:

--- a/metricbeat/modules.d/windows.yml.disabled
+++ b/metricbeat/modules.d/windows.yml.disabled
@@ -1,5 +1,5 @@
 # Module: windows
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.x/metricbeat-module-windows.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.5/metricbeat-module-windows.html
 
 - module: windows
   #metricsets:

--- a/metricbeat/modules.d/zookeeper.yml.disabled
+++ b/metricbeat/modules.d/zookeeper.yml.disabled
@@ -1,5 +1,5 @@
 # Module: zookeeper
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.x/metricbeat-module-zookeeper.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/6.5/metricbeat-module-zookeeper.html
 
 - module: zookeeper
   #metricsets:


### PR DESCRIPTION
We can bump these versions now because the docs won't show as "current" until we release 6.5.  

This will allow us to test the book links now.