### PR TITLE
Cherry-pick #8308 to 6.x: Consistency in Elastic stack metricsets' code

### DIFF
--- a/metricbeat/helper/elastic/elastic.go
+++ b/metricbeat/helper/elastic/elastic.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/elastic/beats/libbeat/logp"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/metricbeat/mb"
 )
@@ -107,4 +109,10 @@ func IsFeatureAvailable(currentProductVersion, featureAvailableInProductVersion 
 	}
 
 	return !currentVersion.LessThan(wantVersion), nil
+}
+
+// ReportAndLogError reports and logs the given error
+func ReportAndLogError(err error, r mb.ReporterV2, l *logp.Logger) {
+	r.Error(err)
+	l.Error(err)
 }

--- a/metricbeat/module/elasticsearch/ccr/data.go
+++ b/metricbeat/module/elasticsearch/ccr/data.go
@@ -60,30 +60,19 @@ func eventsMapping(r mb.ReporterV2, info elasticsearch.Info, content []byte) err
 		return err
 	}
 
-	var errors multierror.Errors
+	var errs multierror.Errors
 	for _, followerShards := range data {
 
 		shards, ok := followerShards.([]interface{})
 		if !ok {
 			err := fmt.Errorf("shards is not an array")
-			errors = append(errors, err)
+			errs = append(errs, err)
+			r.Error(err)
 			continue
 		}
 
 		for _, s := range shards {
-			shard, ok := s.(map[string]interface{})
-			if !ok {
-				err := fmt.Errorf("shard is not an object")
-				errors = append(errors, err)
-				continue
-			}
 			event := mb.Event{}
-			event.MetricSetFields, err = schema.Apply(shard)
-			if err != nil {
-				errors = append(errors, err)
-				continue
-			}
-
 			event.RootFields = common.MapStr{}
 			event.RootFields.Put("service.name", elasticsearch.ModuleName)
 
@@ -91,9 +80,25 @@ func eventsMapping(r mb.ReporterV2, info elasticsearch.Info, content []byte) err
 			event.ModuleFields.Put("cluster.name", info.ClusterName)
 			event.ModuleFields.Put("cluster.id", info.ClusterID)
 
+			shard, ok := s.(map[string]interface{})
+			if !ok {
+				event.Error = fmt.Errorf("shard is not an object")
+				r.Event(event)
+				errs = append(errs, event.Error)
+				continue
+			}
+
+			event.MetricSetFields, err = schema.Apply(shard)
+			if err != nil {
+				event.Error = errors.Wrap(err, "failure applying shard schema")
+				r.Event(event)
+				errs = append(errs, event.Error)
+				continue
+			}
+
 			r.Event(event)
 		}
 	}
 
-	return errors.Err()
+	return errs.Err()
 }

--- a/metricbeat/module/elasticsearch/ccr/data_xpack.go
+++ b/metricbeat/module/elasticsearch/ccr/data_xpack.go
@@ -35,9 +35,7 @@ func eventsMappingXPack(r mb.ReporterV2, m *MetricSet, info elasticsearch.Info, 
 	var data map[string]interface{}
 	err := json.Unmarshal(content, &data)
 	if err != nil {
-		err = errors.Wrap(err, "failure parsing Elasticsearch CCR Stats API response")
-		r.Error(err)
-		return err
+		return errors.Wrap(err, "failure parsing Elasticsearch CCR Stats API response")
 	}
 
 	var errors multierror.Errors

--- a/metricbeat/module/elasticsearch/cluster_stats/data.go
+++ b/metricbeat/module/elasticsearch/cluster_stats/data.go
@@ -64,15 +64,16 @@ func eventMapping(r mb.ReporterV2, info elasticsearch.Info, content []byte) erro
 	var data map[string]interface{}
 	err := json.Unmarshal(content, &data)
 	if err != nil {
-		err = errors.Wrap(err, "failure parsing Elasticsearch Cluster Stats API response")
-		r.Error(err)
+		event.Error = errors.Wrap(err, "failure parsing Elasticsearch Cluster Stats API response")
+		r.Event(event)
+		return event.Error
 	}
 
 	metricSetFields, err := schema.Apply(data)
 	if err != nil {
-		err = errors.Wrap(err, "failure applying cluster stats schema")
-		r.Error(err)
-		return err
+		event.Error = errors.Wrap(err, "failure applying cluster stats schema")
+		r.Event(event)
+		return event.Error
 	}
 
 	event.MetricSetFields = metricSetFields

--- a/metricbeat/module/elasticsearch/elasticsearch.go
+++ b/metricbeat/module/elasticsearch/elasticsearch.go
@@ -30,13 +30,13 @@ import (
 	"github.com/elastic/beats/metricbeat/helper/elastic"
 )
 
-// CCRStatsAPIAvailableVersion is the version of Elasticsearch since when the CCR stats API is available
+// CCRStatsAPIAvailableVersion is the version of Elasticsearch since when the CCR stats API is available.
 const CCRStatsAPIAvailableVersion = "6.5.0"
 
-// Global clusterIdCache. Assumption is that the same node id never can belong to a different cluster id
+// Global clusterIdCache. Assumption is that the same node id never can belong to a different cluster id.
 var clusterIDCache = map[string]string{}
 
-// ModuleName is the ame of this module
+// ModuleName is the name of this module.
 const ModuleName = "elasticsearch"
 
 // Info construct contains the data from the Elasticsearch / endpoint
@@ -48,7 +48,7 @@ type Info struct {
 	} `json:"version"`
 }
 
-// NodeInfo struct cotains data about the node
+// NodeInfo struct cotains data about the node.
 type NodeInfo struct {
 	Host             string `json:"host"`
 	TransportAddress string `json:"transport_address"`
@@ -57,7 +57,7 @@ type NodeInfo struct {
 	ID               string
 }
 
-// GetClusterID fetches cluster id for given nodeID
+// GetClusterID fetches cluster id for given nodeID.
 func GetClusterID(http *helper.HTTP, uri string, nodeID string) (string, error) {
 	// Check if cluster id already cached. If yes, return it.
 	if clusterID, ok := clusterIDCache[nodeID]; ok {
@@ -73,7 +73,7 @@ func GetClusterID(http *helper.HTTP, uri string, nodeID string) (string, error) 
 	return info.ClusterID, nil
 }
 
-// IsMaster checks if the given node host is a master node
+// IsMaster checks if the given node host is a master node.
 //
 // The detection of the master is done in two steps:
 // * Fetch node name from /_nodes/_local/name
@@ -130,7 +130,7 @@ func getMasterName(http *helper.HTTP, uri string) (string, error) {
 	return clusterStruct.MasterNode, nil
 }
 
-// GetInfo returns the data for the Elasticsearch / endpoint
+// GetInfo returns the data for the Elasticsearch / endpoint.
 func GetInfo(http *helper.HTTP, uri string) (*Info, error) {
 
 	content, err := fetchPath(http, uri, "/")
@@ -157,7 +157,7 @@ func fetchPath(http *helper.HTTP, uri, path string) ([]byte, error) {
 	return http.FetchContent()
 }
 
-// GetNodeInfo returns the node information
+// GetNodeInfo returns the node information.
 func GetNodeInfo(http *helper.HTTP, uri string, nodeID string) (*NodeInfo, error) {
 
 	content, err := fetchPath(http, uri, "/_nodes/_local/nodes")
@@ -184,7 +184,7 @@ func GetNodeInfo(http *helper.HTTP, uri string, nodeID string) (*NodeInfo, error
 
 // GetLicense returns license information. Since we don't expect license information
 // to change frequently, the information is cached for 1 minute to avoid
-// hitting Elasticsearch frequently
+// hitting Elasticsearch frequently.
 func GetLicense(http *helper.HTTP, resetURI string) (common.MapStr, error) {
 	// First, check the cache
 	license := licenseCache.get()
@@ -218,7 +218,7 @@ func GetLicense(http *helper.HTTP, resetURI string) (common.MapStr, error) {
 	return licenseCache.get(), nil
 }
 
-// GetClusterState returns cluster state information
+// GetClusterState returns cluster state information.
 func GetClusterState(http *helper.HTTP, resetURI string, metrics []string) (common.MapStr, error) {
 	clusterStateURI := "_cluster/state"
 	if metrics != nil && len(metrics) > 0 {
@@ -235,7 +235,7 @@ func GetClusterState(http *helper.HTTP, resetURI string, metrics []string) (comm
 	return clusterState, err
 }
 
-// GetStackUsage returns stack usage information
+// GetStackUsage returns stack usage information.
 func GetStackUsage(http *helper.HTTP, resetURI string) (common.MapStr, error) {
 	content, err := fetchPath(http, resetURI, "_xpack/usage")
 	if err != nil {
@@ -248,7 +248,7 @@ func GetStackUsage(http *helper.HTTP, resetURI string) (common.MapStr, error) {
 }
 
 // PassThruField copies the field at the given path from the given source data object into
-// the same path in the given target data object
+// the same path in the given target data object.
 func PassThruField(fieldPath string, sourceData, targetData common.MapStr) error {
 	fieldValue, err := sourceData.GetValue(fieldPath)
 	if err != nil {
@@ -260,12 +260,12 @@ func PassThruField(fieldPath string, sourceData, targetData common.MapStr) error
 }
 
 // IsCCRStatsAPIAvailable returns whether the CCR stats API is available in the given version
-// of Elasticsearch
+// of Elasticsearch.
 func IsCCRStatsAPIAvailable(currentElasticsearchVersion string) (bool, error) {
 	return elastic.IsFeatureAvailable(currentElasticsearchVersion, CCRStatsAPIAvailableVersion)
 }
 
-// Global cache for license information. Assumption is that license information changes infrequently
+// Global cache for license information. Assumption is that license information changes infrequently.
 var licenseCache = &_licenseCache{}
 
 type _licenseCache struct {

--- a/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
+++ b/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
@@ -126,7 +126,7 @@ func getEnvPort() string {
 // GetConfig returns config for elasticsearch module
 func getConfig(metricset string) map[string]interface{} {
 	return map[string]interface{}{
-		"module":     "elasticsearch",
+		"module":     elasticsearch.ModuleName,
 		"metricsets": []string{metricset},
 		"hosts":      []string{getEnvHost() + ":" + getEnvPort()},
 		"index_recovery.active_only": false,

--- a/metricbeat/module/elasticsearch/index/data.go
+++ b/metricbeat/module/elasticsearch/index/data.go
@@ -68,18 +68,23 @@ func eventsMapping(r mb.ReporterV2, info elasticsearch.Info, content []byte) err
 	var errs multierror.Errors
 	for name, index := range indicesStruct.Indices {
 		event := mb.Event{}
-		event.MetricSetFields, err = schema.Apply(index)
-		if err != nil {
-			r.Error(err)
-			errs = append(errs, errors.Wrap(err, "failure applying index schema"))
-		}
-		// Write name here as full name only available as key
-		event.MetricSetFields["name"] = name
+
 		event.RootFields = common.MapStr{}
 		event.RootFields.Put("service.name", elasticsearch.ModuleName)
+
 		event.ModuleFields = common.MapStr{}
 		event.ModuleFields.Put("cluster.name", info.ClusterName)
 		event.ModuleFields.Put("cluster.id", info.ClusterID)
+
+		event.MetricSetFields, err = schema.Apply(index)
+		if err != nil {
+			event.Error = errors.Wrap(err, "failure applying index schema")
+			r.Event(event)
+			errs = append(errs, event.Error)
+			continue
+		}
+		// Write name here as full name only available as key
+		event.MetricSetFields["name"] = name
 		r.Event(event)
 	}
 

--- a/metricbeat/module/elasticsearch/index/index.go
+++ b/metricbeat/module/elasticsearch/index/index.go
@@ -21,7 +21,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/libbeat/common/cfgwarn"
-	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/metricbeat/helper/elastic"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/module/elasticsearch"
 )
@@ -46,7 +46,7 @@ type MetricSet struct {
 
 // New create a new instance of the MetricSet
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	cfgwarn.Beta("The " + base.FullyQualifiedName() + " metricset is beta")
+	cfgwarn.Beta("the " + base.FullyQualifiedName() + " metricset is beta")
 
 	// TODO: This currently gets index data for all indices. Make it configurable.
 	ms, err := elasticsearch.NewMetricSet(base, statsPath)
@@ -61,35 +61,38 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 
 	isMaster, err := elasticsearch.IsMaster(m.HTTP, m.HostData().SanitizedURI+statsPath)
 	if err != nil {
-		r.Error(errors.Wrap(err, "error determining if connected Elasticsearch node is master"))
+		err = errors.Wrap(err, "error determining if connected Elasticsearch node is master")
+		elastic.ReportAndLogError(err, r, m.Log)
 		return
 	}
 
 	// Not master, no event sent
 	if !isMaster {
-		logp.Debug(elasticsearch.ModuleName, "Trying to fetch index stats from a non-master node.")
+		m.Log.Debug("trying to fetch index stats from a non-master node")
 		return
 	}
 
 	content, err := m.HTTP.FetchContent()
 	if err != nil {
-		r.Error(err)
+		elastic.ReportAndLogError(err, r, m.Log)
 		return
 	}
 
 	info, err := elasticsearch.GetInfo(m.HTTP, m.HostData().SanitizedURI)
 	if err != nil {
-		r.Error(errors.Wrap(err, "failed to get info from Elasticsearch"))
+		err = errors.Wrap(err, "failed to get info from Elasticsearch")
+		elastic.ReportAndLogError(err, r, m.Log)
 		return
 	}
 
 	if m.XPack {
-		eventsMappingXPack(r, m, *info, content)
+		err = eventsMappingXPack(r, m, *info, content)
 	} else {
 		err = eventsMapping(r, *info, content)
-		if err != nil {
-			r.Error(err)
-			return
-		}
+	}
+
+	if err != nil {
+		m.Log.Error(err)
+		return
 	}
 }

--- a/metricbeat/module/elasticsearch/index_recovery/data_xpack.go
+++ b/metricbeat/module/elasticsearch/index_recovery/data_xpack.go
@@ -19,6 +19,7 @@ package index_recovery
 
 import (
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/pkg/errors"
@@ -40,23 +41,23 @@ func eventsMappingXPack(r mb.ReporterV2, m *MetricSet, content []byte) error {
 	for indexName, indexData := range data {
 		indexData, ok := indexData.(map[string]interface{})
 		if !ok {
-			continue
+			return fmt.Errorf("%v is not a map", indexName)
 		}
 
 		shards, ok := indexData["shards"]
 		if !ok {
-			continue
+			return elastic.MakeErrorForMissingField(indexName+".shards", elastic.Elasticsearch)
 		}
 
 		shardsArr, ok := shards.([]interface{})
 		if !ok {
-			continue
+			return fmt.Errorf("%v.shards is not an array", indexName)
 		}
 
-		for _, shard := range shardsArr {
+		for shardIdx, shard := range shardsArr {
 			shard, ok := shard.(map[string]interface{})
 			if !ok {
-				continue
+				return fmt.Errorf("%v.shards[%v] is not a map", indexName, shardIdx)
 			}
 
 			shard["index_name"] = indexName

--- a/metricbeat/module/elasticsearch/index_recovery/index_recovery.go
+++ b/metricbeat/module/elasticsearch/index_recovery/index_recovery.go
@@ -21,7 +21,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/libbeat/common/cfgwarn"
-	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/metricbeat/helper/elastic"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/module/elasticsearch"
 )
@@ -72,31 +72,33 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 
 // Fetch gathers stats for each index from the _stats API
 func (m *MetricSet) Fetch(r mb.ReporterV2) {
-
 	isMaster, err := elasticsearch.IsMaster(m.HTTP, m.HostData().SanitizedURI+m.recoveryPath)
 	if err != nil {
-		r.Error(errors.Wrap(err, "error determining if connected Elasticsearch node is master"))
+		err = errors.Wrap(err, "error determining if connected Elasticsearch node is master")
+		elastic.ReportAndLogError(err, r, m.Log)
 		return
 	}
 
 	// Not master, no event sent
 	if !isMaster {
-		logp.Debug(elasticsearch.ModuleName, "Trying to fetch index recovery stats from a non-master node.")
+		m.Log.Debug("trying to fetch index recovery stats from a non-master node")
 		return
 	}
 
 	content, err := m.HTTP.FetchContent()
 	if err != nil {
-		r.Error(err)
+		elastic.ReportAndLogError(err, r, m.Log)
 		return
 	}
 
 	if m.MetricSet.XPack {
-		eventsMappingXPack(r, m, content)
+		err = eventsMappingXPack(r, m, content)
 	} else {
 		err = eventsMapping(r, content)
-		if err != nil {
-			r.Error(err)
-		}
+	}
+
+	if err != nil {
+		m.Log.Error(err)
+		return
 	}
 }

--- a/metricbeat/module/elasticsearch/index_summary/data_xpack.go
+++ b/metricbeat/module/elasticsearch/index_summary/data_xpack.go
@@ -72,32 +72,21 @@ var (
 	}
 )
 
-func eventMappingXPack(r mb.ReporterV2, m *MetricSet, info elasticsearch.Info, content []byte) []error {
+func eventMappingXPack(r mb.ReporterV2, m *MetricSet, info elasticsearch.Info, content []byte) error {
 	var all struct {
 		Data map[string]interface{} `json:"_all"`
 	}
 
 	err := json.Unmarshal(content, &all)
 	if err != nil {
-		return []error{errors.Wrap(err, "failure parsing Elasticsearch Stats API response")}
+		return errors.Wrap(err, "failure parsing Elasticsearch Stats API response")
 	}
-
-	var errs []error
 
 	fields, err := schemaXPack.Apply(all.Data)
 	if err != nil {
-		errs = append(errs, errors.Wrap(err, "failure applying stats schema"))
+		return errors.Wrap(err, "failure applying stats schema")
 	}
 
-	nodeInfo, err := elasticsearch.GetNodeInfo(m.HTTP, m.HostData().SanitizedURI+statsPath, "")
-	sourceNode := common.MapStr{
-		"uuid":              nodeInfo.ID,
-		"host":              nodeInfo.Host,
-		"transport_address": nodeInfo.TransportAddress,
-		"ip":                nodeInfo.IP,
-		"name":              nodeInfo.Name,
-		"timestamp":         common.Time(time.Now()),
-	}
 	event := mb.Event{}
 	event.RootFields = common.MapStr{}
 	event.RootFields.Put("indices_stats._all", fields)
@@ -105,10 +94,9 @@ func eventMappingXPack(r mb.ReporterV2, m *MetricSet, info elasticsearch.Info, c
 	event.RootFields.Put("timestamp", common.Time(time.Now()))
 	event.RootFields.Put("interval_ms", m.Module().Config().Period/time.Millisecond)
 	event.RootFields.Put("type", "indices_stats")
-	event.RootFields.Put("source_node", sourceNode)
 
 	event.Index = elastic.MakeXPackMonitoringIndexName(elastic.Elasticsearch)
 
 	r.Event(event)
-	return errs
+	return nil
 }

--- a/metricbeat/module/elasticsearch/index_summary/index_summary.go
+++ b/metricbeat/module/elasticsearch/index_summary/index_summary.go
@@ -21,7 +21,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/libbeat/common/cfgwarn"
-	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/metricbeat/helper/elastic"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/mb/parse"
 	"github.com/elastic/beats/metricbeat/module/elasticsearch"
@@ -54,7 +54,7 @@ type MetricSet struct {
 
 // New create a new instance of the MetricSet
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	cfgwarn.Beta("The  " + base.FullyQualifiedName() + " metricset is beta")
+	cfgwarn.Beta("the " + base.FullyQualifiedName() + " metricset is beta")
 
 	// Get the stats from the local node
 	ms, err := elasticsearch.NewMetricSet(base, statsPath)
@@ -68,32 +68,38 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 func (m *MetricSet) Fetch(r mb.ReporterV2) {
 	isMaster, err := elasticsearch.IsMaster(m.HTTP, m.HostData().SanitizedURI+statsPath)
 	if err != nil {
-		r.Error(errors.Wrap(err, "error determining if connected Elasticsearch node is master"))
+		err = errors.Wrap(err, "error determining if connected Elasticsearch node is master")
+		elastic.ReportAndLogError(err, r, m.Log)
 		return
 	}
 
 	// Not master, no event sent
 	if !isMaster {
-		logp.Debug(elasticsearch.ModuleName, "Trying to fetch index summary stats from a non-master node.")
+		m.Log.Debug("trying to fetch index summary stats from a non-master node")
 		return
 	}
 
 	content, err := m.HTTP.FetchContent()
 	if err != nil {
-		r.Error(err)
+		elastic.ReportAndLogError(err, r, m.Log)
 		return
 	}
 
 	info, err := elasticsearch.GetInfo(m.HTTP, m.HostData().SanitizedURI+statsPath)
 	if err != nil {
-		r.Error(errors.Wrap(err, "failed to get info from Elasticsearch"))
+		err = errors.Wrap(err, "failed to get info from Elasticsearch")
+		elastic.ReportAndLogError(err, r, m.Log)
 		return
 	}
 
 	if m.XPack {
-		eventMappingXPack(r, m, *info, content)
+		err = eventMappingXPack(r, m, *info, content)
 	} else {
-		eventMapping(r, *info, content)
+		err = eventMapping(r, *info, content)
 	}
 
+	if err != nil {
+		m.Log.Error(err)
+		return
+	}
 }

--- a/metricbeat/module/elasticsearch/ml_job/data.go
+++ b/metricbeat/module/elasticsearch/ml_job/data.go
@@ -60,13 +60,15 @@ func eventsMapping(r mb.ReporterV2, content []byte) error {
 
 		event := mb.Event{}
 
-		event.MetricSetFields, err = schema.Apply(job)
-		if err != nil {
-			errs = append(errs, errors.Wrap(err, "failure applying ml job schema"))
-		}
-
 		event.RootFields = common.MapStr{}
 		event.RootFields.Put("service.name", elasticsearch.ModuleName)
+
+		event.MetricSetFields, err = schema.Apply(job)
+		if err != nil {
+			event.Error = errors.Wrap(err, "failure applying ml job schema")
+			errs = append(errs, event.Error)
+		}
+
 		r.Event(event)
 	}
 	return errs.Err()

--- a/metricbeat/module/elasticsearch/ml_job/data_xpack.go
+++ b/metricbeat/module/elasticsearch/ml_job/data_xpack.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/joeshaw/multierror"
 	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/libbeat/common"
@@ -52,9 +53,11 @@ func eventsMappingXPack(r mb.ReporterV2, m *MetricSet, content []byte) error {
 		return fmt.Errorf("jobs is not an array of maps")
 	}
 
+	var errs multierror.Errors
 	for _, job := range jobsArr {
 		job, ok = job.(map[string]interface{})
 		if !ok {
+			errs = append(errs, fmt.Errorf("job is not a map"))
 			continue
 		}
 
@@ -71,5 +74,5 @@ func eventsMappingXPack(r mb.ReporterV2, m *MetricSet, content []byte) error {
 		r.Event(event)
 	}
 
-	return nil
+	return errs.Err()
 }

--- a/metricbeat/module/elasticsearch/ml_job/ml_job.go
+++ b/metricbeat/module/elasticsearch/ml_job/ml_job.go
@@ -21,7 +21,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/libbeat/common/cfgwarn"
-	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/metricbeat/helper/elastic"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/module/elasticsearch"
 )
@@ -60,29 +60,31 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 
 	isMaster, err := elasticsearch.IsMaster(m.HTTP, m.HostData().SanitizedURI+jobPath)
 	if err != nil {
-		r.Error(errors.Wrap(err, "error determining if connected Elasticsearch node is master"))
+		err = errors.Wrap(err, "error determining if connected Elasticsearch node is master")
+		elastic.ReportAndLogError(err, r, m.Log)
 		return
 	}
 
 	// Not master, no event sent
 	if !isMaster {
-		logp.Debug(elasticsearch.ModuleName, "Trying to fetch machine learning job stats from a non-master node.")
+		m.Log.Debug("trying to fetch machine learning job stats from a non-master node")
 		return
 	}
 
 	content, err := m.HTTP.FetchContent()
 	if err != nil {
-		r.Error(err)
+		elastic.ReportAndLogError(err, r, m.Log)
 		return
 	}
 
 	if m.XPack {
-		eventsMappingXPack(r, m, content)
+		err = eventsMappingXPack(r, m, content)
 	} else {
 		err = eventsMapping(r, content)
-		if err != nil {
-			r.Error(err)
-			return
-		}
+	}
+
+	if err != nil {
+		m.Log.Error(err)
+		return
 	}
 }

--- a/metricbeat/module/elasticsearch/node/node_test.go
+++ b/metricbeat/module/elasticsearch/node/node_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
+	"github.com/elastic/beats/metricbeat/module/elasticsearch"
 )
 
 func TestFetch(t *testing.T) {
@@ -52,7 +53,7 @@ func TestFetch(t *testing.T) {
 			defer server.Close()
 
 			config := map[string]interface{}{
-				"module":     "elasticsearch",
+				"module":     elasticsearch.ModuleName,
 				"metricsets": []string{"node"},
 				"hosts":      []string{server.URL},
 			}

--- a/metricbeat/module/elasticsearch/node_stats/data_xpack.go
+++ b/metricbeat/module/elasticsearch/node_stats/data_xpack.go
@@ -22,25 +22,18 @@ import (
 
 	"time"
 
+	"github.com/joeshaw/multierror"
 	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/libbeat/common"
 	s "github.com/elastic/beats/libbeat/common/schema"
 	c "github.com/elastic/beats/libbeat/common/schema/mapstriface"
-	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/metricbeat/helper/elastic"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/module/elasticsearch"
 )
 
 var (
-	sourceNodeXpack = s.Schema{
-		"host":              c.Str("host"),
-		"transport_address": c.Str("transport_address"),
-		"ip":                c.Str("ip"),
-		"name":              c.Str("name"),
-	}
-
 	schemaXpack = s.Schema{
 		"indices": c.Dict("indices", s.Schema{
 			"docs": c.Dict("docs", s.Schema{
@@ -186,29 +179,27 @@ func eventsMappingXPack(r mb.ReporterV2, m *MetricSet, content []byte) error {
 	// it will provid the data for multiple nodes. This will mean the detection of the
 	// master node will not be accurate anymore as often in these cases a proxy is in front
 	// of ES and it's not know if the request will be routed to the same node as before.
+	var errs multierror.Errors
 	for nodeID, node := range nodesStruct.Nodes {
 		clusterID, err := elasticsearch.GetClusterID(m.HTTP, m.HTTP.GetURI(), nodeID)
 		if err != nil {
-			logp.Err("could not fetch cluster id: %s", err)
+			errs = append(errs, errors.Wrap(err, "could not fetch cluster id"))
 			continue
 		}
 
 		isMaster, err := elasticsearch.IsMaster(m.HTTP, m.HTTP.GetURI())
 		if err != nil {
-			logp.Err("error determining if connected Elasticsearch node is master: %s", err)
+			errs = append(errs, errors.Wrap(err, "error determining if connected Elasticsearch node is master"))
 			continue
 		}
+
 		event := mb.Event{}
-		// Build source_node object
-		sourceNode, _ := sourceNodeXpack.Apply(node)
-		sourceNode["uuid"] = nodeID
 
 		nodeData, err := schemaXpack.Apply(node)
 		if err != nil {
-			logp.Err("failure to apply node schema: %s", err)
+			errs = append(errs, errors.Wrap(err, "failure to apply node schema"))
 			continue
 		}
-
 		nodeData["node_master"] = isMaster
 		nodeData["node_id"] = nodeID
 
@@ -217,12 +208,11 @@ func eventsMappingXPack(r mb.ReporterV2, m *MetricSet, content []byte) error {
 			"cluster_uuid": clusterID,
 			"interval_ms":  m.Module().Config().Period.Nanoseconds() / 1000 / 1000,
 			"type":         "node_stats",
-			"source_node":  sourceNode,
 			"node_stats":   nodeData,
 		}
 
 		event.Index = elastic.MakeXPackMonitoringIndexName(elastic.Elasticsearch)
 		r.Event(event)
 	}
-	return nil
+	return errs.Err()
 }

--- a/metricbeat/module/elasticsearch/node_stats/node_stats.go
+++ b/metricbeat/module/elasticsearch/node_stats/node_stats.go
@@ -19,6 +19,7 @@ package node_stats
 
 import (
 	"github.com/elastic/beats/libbeat/common/cfgwarn"
+	"github.com/elastic/beats/metricbeat/helper/elastic"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/module/elasticsearch"
 )
@@ -58,13 +59,21 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 func (m *MetricSet) Fetch(r mb.ReporterV2) {
 	content, err := m.HTTP.FetchContent()
 	if err != nil {
-		r.Error(err)
+		elastic.ReportAndLogError(err, r, m.Log)
 		return
 	}
 
-	if m.MetricSet.XPack {
-		eventsMappingXPack(r, m, content)
+	if m.XPack {
+		err = eventsMappingXPack(r, m, content)
+		if err != nil {
+			m.Log.Error(err)
+			return
+		}
 	} else {
-		eventsMapping(r, content)
+		err = eventsMapping(r, content)
+		if err != nil {
+			elastic.ReportAndLogError(err, r, m.Log)
+			return
+		}
 	}
 }

--- a/metricbeat/module/elasticsearch/pending_tasks/data.go
+++ b/metricbeat/module/elasticsearch/pending_tasks/data.go
@@ -59,13 +59,16 @@ func eventsMapping(r mb.ReporterV2, content []byte) error {
 	var errs multierror.Errors
 	for _, task := range tasksStruct.Tasks {
 		event := mb.Event{}
-		event.MetricSetFields, err = schema.Apply(task)
-		if err != nil {
-			errs = append(errs, errors.Wrap(err, "failure applying task schema"))
-		}
 
 		event.RootFields = common.MapStr{}
 		event.RootFields.Put("service.name", elasticsearch.ModuleName)
+
+		event.MetricSetFields, err = schema.Apply(task)
+		if err != nil {
+			event.Error = errors.Wrap(err, "failure applying task schema")
+			errs = append(errs, event.Error)
+		}
+
 		r.Event(event)
 	}
 

--- a/metricbeat/module/elasticsearch/pending_tasks/pending_tasks.go
+++ b/metricbeat/module/elasticsearch/pending_tasks/pending_tasks.go
@@ -21,25 +21,23 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/libbeat/common/cfgwarn"
-	"github.com/elastic/beats/libbeat/logp"
-	"github.com/elastic/beats/metricbeat/helper"
+	"github.com/elastic/beats/metricbeat/helper/elastic"
 	"github.com/elastic/beats/metricbeat/mb"
-	"github.com/elastic/beats/metricbeat/mb/parse"
 	"github.com/elastic/beats/metricbeat/module/elasticsearch"
 )
 
 // init registers the MetricSet with the central registry.
 // The New method will be called after the setup of the module and before starting to fetch data
 func init() {
-	mb.Registry.AddMetricSet(elasticsearch.ModuleName, "pending_tasks", New, hostParser)
+	mb.Registry.MustAddMetricSet(elasticsearch.ModuleName, "pending_tasks", New,
+		mb.WithHostParser(elasticsearch.HostParser),
+		mb.DefaultMetricSet(),
+		mb.WithNamespace("elasticsearch.pending_tasks"),
+	)
 }
 
-var (
-	hostParser = parse.URLHostParserBuilder{
-		DefaultScheme: "http",
-		PathConfigKey: "path",
-		DefaultPath:   "_cluster/pending_tasks",
-	}.Build()
+const (
+	pendingTasksPath = "/_cluster/pending_tasks"
 )
 
 // MetricSet holds any configuration or state information. It must implement
@@ -47,45 +45,46 @@ var (
 // mb.BaseMetricSet because it implements all of the required mb.MetricSet
 // interface methods except for Fetch.
 type MetricSet struct {
-	mb.BaseMetricSet
-	http *helper.HTTP
+	*elasticsearch.MetricSet
 }
 
 // New creates a new instance of the MetricSet. New is responsible for unpacking
 // any MetricSet specific configuration options if there are any.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	cfgwarn.Beta("The " + base.FullyQualifiedName() + " metricset is beta.")
+	cfgwarn.Beta("the " + base.FullyQualifiedName() + " metricset is beta")
 
-	http, err := helper.NewHTTP(base)
+	ms, err := elasticsearch.NewMetricSet(base, pendingTasksPath)
 	if err != nil {
 		return nil, err
 	}
 
-	return &MetricSet{
-		base,
-		http,
-	}, nil
+	return &MetricSet{MetricSet: ms}, nil
 }
 
 // Fetch methods implements the data gathering and data conversion to the right format
 func (m *MetricSet) Fetch(r mb.ReporterV2) {
-	isMaster, err := elasticsearch.IsMaster(m.http, m.HostData().SanitizedURI)
+	isMaster, err := elasticsearch.IsMaster(m.HTTP, m.HostData().SanitizedURI+pendingTasksPath)
 	if err != nil {
-		r.Error(errors.Wrap(err, "error determining if connected Elasticsearch node is master"))
+		err := errors.Wrap(err, "error determining if connected Elasticsearch node is master")
+		elastic.ReportAndLogError(err, r, m.Log)
 		return
 	}
 
 	// Not master, no event sent
 	if !isMaster {
-		logp.Debug(elasticsearch.ModuleName, "Trying to fetch pending tasks from a non-master node.")
+		m.Log.Debug("trying to fetch pending tasks from a non-master node")
 		return
 	}
 
-	content, err := m.http.FetchContent()
+	content, err := m.HTTP.FetchContent()
 	if err != nil {
-		r.Error(err)
+		elastic.ReportAndLogError(err, r, m.Log)
 		return
 	}
 
-	eventsMapping(r, content)
+	err = eventsMapping(r, content)
+	if err != nil {
+		m.Log.Error(err)
+		return
+	}
 }

--- a/metricbeat/module/elasticsearch/shard/data.go
+++ b/metricbeat/module/elasticsearch/shard/data.go
@@ -20,6 +20,7 @@ package shard
 import (
 	"encoding/json"
 
+	"github.com/joeshaw/multierror"
 	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/libbeat/common"
@@ -61,32 +62,45 @@ func eventsMapping(r mb.ReporterV2, content []byte) error {
 		return err
 	}
 
+	var errs multierror.Errors
 	for _, index := range stateData.RoutingTable.Indices {
 		for _, shards := range index.Shards {
 			for _, shard := range shards {
 				event := mb.Event{}
 
+				event.RootFields = common.MapStr{}
+				event.RootFields.Put("service.name", elasticsearch.ModuleName)
+
+				event.ModuleFields = common.MapStr{}
+				event.ModuleFields.Put("cluster.state.id", stateData.StateID)
+				event.ModuleFields.Put("cluster.name", stateData.ClusterName)
+
 				fields, err := schema.Apply(shard)
 				if err != nil {
-					r.Error(errors.Wrap(err, "failure applying shard schema"))
+					event.Error = errors.Wrap(err, "failure applying shard schema")
+					r.Event(event)
+					errs = append(errs, event.Error)
 					continue
 				}
 
 				// Handle node field: could be string or null
 				err = elasticsearch.PassThruField("node", shard, fields)
 				if err != nil {
-					r.Error(errors.Wrap(err, "failure passing through node field"))
+					event.Error = errors.Wrap(err, "failure passing through node field")
+					r.Event(event)
+					errs = append(errs, event.Error)
 					continue
 				}
 
 				// Handle relocating_node field: could be string or null
 				err = elasticsearch.PassThruField("relocating_node", shard, fields)
 				if err != nil {
-					r.Error(errors.Wrap(err, "failure passing through relocating_node field"))
+					event.Error = errors.Wrap(err, "failure passing through relocating_node field")
+					r.Event(event)
+					errs = append(errs, event.Error)
 					continue
 				}
 
-				event.ModuleFields = common.MapStr{}
 				event.ModuleFields.Put("node.name", fields["node"])
 				delete(fields, "node")
 
@@ -100,15 +114,9 @@ func eventsMapping(r mb.ReporterV2, content []byte) error {
 				delete(event.MetricSetFields, "relocating_node")
 				event.MetricSetFields.Put("relocating_node.name", fields["relocating_node"])
 
-				event.ModuleFields.Put("cluster.state.id", stateData.StateID)
-				event.ModuleFields.Put("cluster.name", stateData.ClusterName)
-
-				event.RootFields = common.MapStr{}
-				event.RootFields.Put("service.name", elasticsearch.ModuleName)
-
 				r.Event(event)
 			}
 		}
 	}
-	return nil
+	return errs.Err()
 }

--- a/metricbeat/module/kibana/metricset.go
+++ b/metricbeat/module/kibana/metricset.go
@@ -15,64 +15,41 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package elasticsearch
+package kibana
 
 import (
 	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/libbeat/logp"
-	"github.com/elastic/beats/metricbeat/helper"
 	"github.com/elastic/beats/metricbeat/mb"
-	"github.com/elastic/beats/metricbeat/mb/parse"
 )
 
-const (
-	defaultScheme = "http"
-	pathConfigKey = "path"
-)
-
-var (
-	// HostParser parses host urls for RabbitMQ management plugin
-	HostParser = parse.URLHostParserBuilder{
-		DefaultScheme: defaultScheme,
-		PathConfigKey: pathConfigKey,
-	}.Build()
-)
-
-// MetricSet can be used to build other metric sets that query RabbitMQ
-// management plugin
+// MetricSet can be used to build other metricsets within the Kibana module.
 type MetricSet struct {
 	mb.BaseMetricSet
-	*helper.HTTP
-	XPack bool
-	Log   *logp.Logger
+	XPackEnabled bool
+	Log          *logp.Logger
 }
 
-// NewMetricSet creates an metric set that can be used to build other metric
-// sets that query RabbitMQ management plugin
-func NewMetricSet(base mb.BaseMetricSet, subPath string) (*MetricSet, error) {
-	http, err := helper.NewHTTP(base)
-	if err != nil {
-		return nil, err
-	}
-	http.SetURI(http.GetURI() + subPath)
-
+// NewMetricSet creates a metricset that can be used to build other metricsets
+// within the Kibana module.
+func NewMetricSet(base mb.BaseMetricSet) (*MetricSet, error) {
 	config := struct {
-		XPack bool `config:"xpack.enabled"`
+		xPackEnabled bool `config:"xpack.enabled"`
 	}{
-		XPack: false,
+		xPackEnabled: false,
 	}
+
 	if err := base.Module().UnpackConfig(&config); err != nil {
 		return nil, err
 	}
 
-	if config.XPack {
-		cfgwarn.Experimental("The experimental xpack.enabled flag in " + base.FullyQualifiedName() + " metricset is enabled.")
+	if config.xPackEnabled {
+		cfgwarn.Experimental("The experimental xpack.enabled flag in the " + base.FullyQualifiedName() + " metricset is enabled.")
 	}
 
 	return &MetricSet{
 		base,
-		http,
-		config.XPack,
+		config.xPackEnabled,
 		logp.NewLogger(ModuleName),
 	}, nil
 }

--- a/metricbeat/module/kibana/stats/data.go
+++ b/metricbeat/module/kibana/stats/data.go
@@ -93,7 +93,9 @@ func eventMapping(r mb.ReporterV2, content []byte) error {
 
 	dataFields, err := schema.Apply(data)
 	if err != nil {
-		r.Error(errors.Wrap(err, "failure to apply stats schema"))
+		err = errors.Wrap(err, "failure to apply stats schema")
+		r.Error(err)
+		return err
 	}
 
 	var event mb.Event
@@ -103,18 +105,24 @@ func eventMapping(r mb.ReporterV2, content []byte) error {
 	// Set elasticsearch cluster id
 	elasticsearchClusterID, ok := data["cluster_uuid"]
 	if !ok {
-		return elastic.ReportErrorForMissingField("cluster_uuid", elastic.Kibana, r)
+		event.Error = elastic.MakeErrorForMissingField("cluster_uuid", elastic.Kibana)
+		r.Event(event)
+		return event.Error
 	}
 	event.RootFields.Put("elasticsearch.cluster.id", elasticsearchClusterID)
 
 	// Set process PID
 	process, ok := data["process"].(map[string]interface{})
 	if !ok {
-		return elastic.ReportErrorForMissingField("process", elastic.Kibana, r)
+		event.Error = elastic.MakeErrorForMissingField("process", elastic.Kibana)
+		r.Event(event)
+		return event.Error
 	}
 	pid, ok := process["pid"].(float64)
 	if !ok {
-		return elastic.ReportErrorForMissingField("process.pid", elastic.Kibana, r)
+		event.Error = elastic.MakeErrorForMissingField("process.pid", elastic.Kibana)
+		r.Event(event)
+		return event.Error
 	}
 	event.RootFields.Put("process.pid", int(pid))
 

--- a/metricbeat/module/kibana/status/status.go
+++ b/metricbeat/module/kibana/status/status.go
@@ -20,6 +20,7 @@ package status
 import (
 	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/metricbeat/helper"
+	"github.com/elastic/beats/metricbeat/helper/elastic"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/mb/parse"
 	"github.com/elastic/beats/metricbeat/module/kibana"
@@ -44,7 +45,7 @@ var (
 
 // MetricSet type defines all fields of the MetricSet
 type MetricSet struct {
-	mb.BaseMetricSet
+	*kibana.MetricSet
 	http *helper.HTTP
 }
 
@@ -52,12 +53,18 @@ type MetricSet struct {
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	cfgwarn.Beta("The " + base.FullyQualifiedName() + " metricset is beta")
 
+	ms, err := kibana.NewMetricSet(base)
+	if err != nil {
+		return nil, err
+	}
+
 	http, err := helper.NewHTTP(base)
 	if err != nil {
 		return nil, err
 	}
+
 	return &MetricSet{
-		base,
+		ms,
 		http,
 	}, nil
 }
@@ -68,10 +75,14 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 func (m *MetricSet) Fetch(r mb.ReporterV2) {
 	content, err := m.http.FetchContent()
 	if err != nil {
-		r.Error(err)
+		elastic.ReportAndLogError(err, r, m.Log)
 		return
 	}
 
-	eventMapping(r, content)
-	return
+	err = eventMapping(r, content)
+
+	if err != nil {
+		m.Log.Error(err)
+		return
+	}
 }

--- a/metricbeat/module/logstash/logstash.go
+++ b/metricbeat/module/logstash/logstash.go
@@ -17,5 +17,25 @@
 
 package logstash
 
+import (
+	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/metricbeat/mb"
+)
+
 // ModuleName is the name of this module.
 const ModuleName = "logstash"
+
+// MetricSet can be used to build other metricsets within the Logstash module.
+type MetricSet struct {
+	mb.BaseMetricSet
+	Log *logp.Logger
+}
+
+// NewMetricSet creates a metricset that can be used to build other metricsets
+// within the Logstash module.
+func NewMetricSet(base mb.BaseMetricSet) (*MetricSet, error) {
+	return &MetricSet{
+		base,
+		logp.NewLogger(ModuleName),
+	}, nil
+}

--- a/metricbeat/module/logstash/node/data_test.go
+++ b/metricbeat/module/logstash/node/data_test.go
@@ -35,11 +35,11 @@ func TestEventMapping(t *testing.T) {
 	assert.NoError(t, err)
 
 	for _, f := range files {
-		content, err := ioutil.ReadFile(f)
+		input, err := ioutil.ReadFile(f)
 		assert.NoError(t, err)
 
 		reporter := &mbtest.CapturingReporterV2{}
-		err = eventMapping(reporter, content)
+		err = eventMapping(reporter, input)
 
 		assert.NoError(t, err, f)
 		assert.True(t, len(reporter.GetEvents()) >= 1, f)

--- a/metricbeat/module/logstash/node/node_integration_test.go
+++ b/metricbeat/module/logstash/node/node_integration_test.go
@@ -22,11 +22,11 @@ package node
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/beats/libbeat/tests/compose"
 	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
 	"github.com/elastic/beats/metricbeat/module/logstash"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestFetch(t *testing.T) {

--- a/metricbeat/module/logstash/node_stats/data.go
+++ b/metricbeat/module/logstash/node_stats/data.go
@@ -40,22 +40,24 @@ var (
 )
 
 func eventMapping(r mb.ReporterV2, content []byte) error {
+	event := mb.Event{}
+	event.RootFields = common.MapStr{}
+	event.RootFields.Put("service.name", logstash.ModuleName)
+
 	var data map[string]interface{}
 	err := json.Unmarshal(content, &data)
 	if err != nil {
-		err = errors.Wrap(err, "failure parsing Logstash Node Stats API response")
-		r.Error(err)
-		return err
+		event.Error = errors.Wrap(err, "failure parsing Logstash Node Stats API response")
+		r.Event(event)
+		return event.Error
 	}
 
 	fields, err := schema.Apply(data)
 	if err != nil {
-		r.Error(errors.Wrap(err, "failure applying node stats schema"))
+		event.Error = errors.Wrap(err, "failure applying node stats schema")
+		r.Event(event)
+		return event.Error
 	}
-
-	event := mb.Event{}
-	event.RootFields = common.MapStr{}
-	event.RootFields.Put("service.name", logstash.ModuleName)
 
 	event.MetricSetFields = fields
 

--- a/metricbeat/module/logstash/node_stats/data_test.go
+++ b/metricbeat/module/logstash/node_stats/data_test.go
@@ -35,11 +35,11 @@ func TestEventMapping(t *testing.T) {
 	assert.NoError(t, err)
 
 	for _, f := range files {
-		content, err := ioutil.ReadFile(f)
+		input, err := ioutil.ReadFile(f)
 		assert.NoError(t, err)
 
 		reporter := &mbtest.CapturingReporterV2{}
-		err = eventMapping(reporter, content)
+		err = eventMapping(reporter, input)
 
 		assert.NoError(t, err, f)
 		assert.True(t, len(reporter.GetEvents()) >= 1, f)

--- a/metricbeat/module/logstash/node_stats/node_stats.go
+++ b/metricbeat/module/logstash/node_stats/node_stats.go
@@ -20,22 +20,19 @@ package node_stats
 import (
 	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/metricbeat/helper"
+	"github.com/elastic/beats/metricbeat/helper/elastic"
+
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/mb/parse"
 	"github.com/elastic/beats/metricbeat/module/logstash"
 )
 
-const (
-	metricsetName = "node_stats"
-	namespace     = "logstash.node.stats"
-)
-
 // init registers the MetricSet with the central registry.
 // The New method will be called after the setup of the module and before starting to fetch data
 func init() {
-	mb.Registry.MustAddMetricSet(logstash.ModuleName, metricsetName, New,
+	mb.Registry.MustAddMetricSet(logstash.ModuleName, "node_stats", New,
 		mb.WithHostParser(hostParser),
-		mb.WithNamespace(namespace),
+		mb.WithNamespace("logstash.node.stats"),
 		mb.DefaultMetricSet(),
 	)
 }
@@ -50,20 +47,25 @@ var (
 
 // MetricSet type defines all fields of the MetricSet
 type MetricSet struct {
-	mb.BaseMetricSet
+	*logstash.MetricSet
 	http *helper.HTTP
 }
 
 // New create a new instance of the MetricSet
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	cfgwarn.Beta("The logstash node_stats metricset is beta")
+	cfgwarn.Beta("the " + base.FullyQualifiedName() + " metricset is beta")
+
+	ms, err := logstash.NewMetricSet(base)
+	if err != nil {
+		return nil, err
+	}
 
 	http, err := helper.NewHTTP(base)
 	if err != nil {
 		return nil, err
 	}
 	return &MetricSet{
-		base,
+		ms,
 		http,
 	}, nil
 }
@@ -74,9 +76,13 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 func (m *MetricSet) Fetch(r mb.ReporterV2) {
 	content, err := m.http.FetchContent()
 	if err != nil {
-		r.Error(err)
+		elastic.ReportAndLogError(err, r, m.Log)
 		return
 	}
 
-	eventMapping(r, content)
+	err = eventMapping(r, content)
+	if err != nil {
+		m.Log.Error(err)
+		return
+	}
 }

--- a/metricbeat/module/logstash/node_stats/node_stats_integration_test.go
+++ b/metricbeat/module/logstash/node_stats/node_stats_integration_test.go
@@ -22,11 +22,11 @@ package node_stats
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/beats/libbeat/tests/compose"
 	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
 	"github.com/elastic/beats/metricbeat/module/logstash"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestFetch(t *testing.T) {

--- a/metricbeat/module/logstash/testing.go
+++ b/metricbeat/module/logstash/testing.go
@@ -42,7 +42,7 @@ func GetEnvPort() string {
 // GetConfig for Logstash
 func GetConfig(metricset string) map[string]interface{} {
 	return map[string]interface{}{
-		"module":     "logstash",
+		"module":     ModuleName,
 		"metricsets": []string{metricset},
 		"hosts":      []string{GetEnvHost() + ":" + GetEnvPort()},
 	}


### PR DESCRIPTION
Cherry-pick of PR #8308 to 6.x branch. Original message: 

This PR makes error messages, reporting, and logging consistent across all metricsets for Elastic stack products, including the xpack monitoring code paths:

* [x] `elasticsearch/ccr`
* [x] `elasticsearch/cluster_stats`
* [x] `elasticsearch/index`
* [x] `elasticsearch/index_recovery`
* [x] `elasticsearch/index_summary`
* [x] `elasticsearch/ml_job`
* [x] `elasticsearch/node`
* [x] `elasticsearch/node_stats`
* [x] `elasticsearch/pending_tasks`
* [x] `elasticsearch/shard`
* [x] `kibana/status`
* [x] `kibana/stats`
* [x] `logstash/node`
* [x] `logstash/node_stats`