### PR TITLE
Cherry-pick #8754 to 6.5: Fix kubernetes in-cluster configuration on IPv6

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -48,6 +48,7 @@ https://github.com/elastic/beats/compare/v6.4.0...6.x[Check the HEAD diff]
 - Enforce that data used by k8s or docker doesn't use any reference. {pull}8240[8240]
 - Switch to different UUID lib due to to non-random generated UUIDs. {pull}8485[8485]
 - Fix race condition when publishing monitoring data. {pull}8646[8646]
+- Fix in-cluster kubernetes configuration on IPv6. {pull}8754[8754]
 
 *Auditbeat*
 

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -612,8 +612,8 @@ subcomponents is subject to the terms and conditions of the
 subcomponent's license, as noted in the LICENSE file.
 --------------------------------------------------------------------
 Dependency: github.com/ericchiang/k8s
-Version: v1.0.0
-Revision: 5912993f00cb7c971aaa54529a06bd3eecd6c3d4
+Version: =v1.0.0/in-cluster-ipv6
+Revision: 33b346590d1dd4eaac217471671f736bcdab492d
 License type (autodetected): Apache-2.0
 ./vendor/github.com/ericchiang/k8s/LICENSE:
 --------------------------------------------------------------------

--- a/libbeat/common/kubernetes/util.go
+++ b/libbeat/common/kubernetes/util.go
@@ -87,7 +87,7 @@ func DiscoverKubernetesNode(host string, inCluster bool, client *k8s.Client) (no
 		pod := v1.Pod{}
 		err = client.Get(context.TODO(), ns, podName, &pod)
 		if err != nil {
-			logp.Err("kubernetes: Querying for pod failed with error: ", err.Error())
+			logp.Err("kubernetes: Querying for pod failed with error: %v", err.Error())
 			return defaultNode
 		}
 		logp.Info("kubernetes: Using node %s discovered by in cluster pod node query", pod.Spec.GetNodeName())

--- a/vendor/github.com/ericchiang/k8s/client.go
+++ b/vendor/github.com/ericchiang/k8s/client.go
@@ -35,6 +35,7 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"strconv"
 	"time"
@@ -248,8 +249,12 @@ func NewInClusterClient() (*Client, error) {
 		return nil, err
 	}
 
+	server := url.URL{
+		Scheme: "https",
+		Host:   net.JoinHostPort(host, port),
+	}
 	cluster := Cluster{
-		Server:               "https://" + host + ":" + port,
+		Server:               server.String(),
 		CertificateAuthority: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
 	}
 	user := AuthInfo{TokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token"}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1097,12 +1097,13 @@
 			"versionExact": "v0.9.0"
 		},
 		{
-			"checksumSHA1": "hTxFrbA619JCHysWjXHa9U6bfto=",
+			"checksumSHA1": "Klc34HULvwvY4cGA/D8HmqtXLqw=",
+			"origin": "github.com/jsoriano/k8s",
 			"path": "github.com/ericchiang/k8s",
-			"revision": "5912993f00cb7c971aaa54529a06bd3eecd6c3d4",
-			"revisionTime": "2018-01-20T20:28:12Z",
-			"version": "v1.0.0",
-			"versionExact": "v1.0.0"
+			"revision": "33b346590d1dd4eaac217471671f736bcdab492d",
+			"revisionTime": "2018-10-25T16:06:03Z",
+			"version": "=v1.0.0/in-cluster-ipv6",
+			"versionExact": "v1.0.0/in-cluster-ipv6"
 		},
 		{
 			"checksumSHA1": "uQuMoUlS7hAWsB+Mwr/1B7+35BU=",


### PR DESCRIPTION
Cherry-pick of PR #8754 to 6.5 branch. Original message: 

Include patch for IPv6 in kubernetes client library (https://github.com/ericchiang/k8s/pull/103),
already merged in master but not released yet.

Fixes #8749