### PR TITLE
Removed Envoy entry on docs

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -646,6 +646,7 @@ https://github.com/elastic/beats/compare/v6.3.0...v6.3.1[View commits]
 - Fix field mapping for the system process CPU ticks fields. {pull}7230[7230]
 - Ensure canonical naming for JMX beans is disabled in Jolokia module. {pull}7047[7047]
 - Fix Jolokia attribute mapping when using wildcards and MBean names with multiple properties. {pull}7321[7321]
+- Remove duplicated envoy entry from docs {issue}8759[8759]
 
 *Packetbeat*
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -646,7 +646,6 @@ https://github.com/elastic/beats/compare/v6.3.0...v6.3.1[View commits]
 - Fix field mapping for the system process CPU ticks fields. {pull}7230[7230]
 - Ensure canonical naming for JMX beans is disabled in Jolokia module. {pull}7047[7047]
 - Fix Jolokia attribute mapping when using wildcards and MBean names with multiple properties. {pull}7321[7321]
-- Remove duplicated envoy entry from docs {issue}8759[8759]
 
 *Packetbeat*
 

--- a/metricbeat/docs/modules/envoyproxy.asciidoc
+++ b/metricbeat/docs/modules/envoyproxy.asciidoc
@@ -7,8 +7,6 @@ This file is generated! See scripts/docs_collector.py
 
 experimental[]
 
-== envoyproxy module
-
 This is the envoyproxy module.
 
 The default metricset is `server`.

--- a/metricbeat/module/envoyproxy/_meta/docs.asciidoc
+++ b/metricbeat/module/envoyproxy/_meta/docs.asciidoc
@@ -1,5 +1,3 @@
-== envoyproxy module
-
 This is the envoyproxy module.
 
 The default metricset is `server`.


### PR DESCRIPTION
Related with this issue https://github.com/elastic/beats/issues/8759

I have run `make update` and it seems that the docs have been updated but I'm still not sure if this is going to solve the conflicting document