### PR TITLE
mkdir for extracted dashboard files

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -52,6 +52,7 @@ https://github.com/elastic/beats/compare/v6.4.0...master[Check the HEAD diff]
 - Switch to different UUID lib due to to non-random generated UUIDs. {pull}8485[8485]
 - Fix race condition when publishing monitoring data. {pull}8646[8646]
 - Fix in-cluster kubernetes configuration on IPv6. {pull}8754[8754]
+- Fix bug in loading dashboards from zip file. {issue}8051[8051]
 
 *Auditbeat*
 

--- a/libbeat/dashboards/importer.go
+++ b/libbeat/dashboards/importer.go
@@ -131,6 +131,7 @@ func (imp Importer) unzip(archive, target string) error {
 	if err != nil {
 		return err
 	}
+	defer reader.Close()
 
 	// Closure to close the files on each iteration
 	unzipFile := func(file *zip.File) error {
@@ -149,6 +150,11 @@ func (imp Importer) unzip(archive, target string) error {
 		if file.FileInfo().IsDir() {
 			return os.MkdirAll(filePath, file.Mode())
 		}
+
+		if err = os.MkdirAll(filepath.Dir(filePath), 0755); err != nil {
+			return fmt.Errorf("failed making directory for file %v: %v", filePath, err)
+		}
+
 		fileReader, err := file.Open()
 		if err != nil {
 			return err


### PR DESCRIPTION
Make the directory that contains the extracted file prior to creating the file. This makes it handle cases where there is not a directory entry inside the zip file.

I also made a fix to close the file handle for the .zip when done.

Fixes #8051