### PR TITLE
Cherry-pick #7850 to 6.4: Allow a Beat to override monitoring-related fields

### DIFF
--- a/CHANGELOG-developer.asciidoc
+++ b/CHANGELOG-developer.asciidoc
@@ -41,3 +41,5 @@ The list below covers the major changes between 6.3.0 and master only.
 - Libbeat provides a global registry for beats developer that allow to register and retrieve plugin. {pull}7392[7392]
 - Added more options to control required and optional fields in schema.Apply(), error returned is a plain nil if no error happened {pull}7335[7335]
 - Packaging on MacOS now produces a .dmg file containing an installer (.pkg) and uninstaller for the Beat. {pull}7481[7481]
+- Libbeat provides a new function `cmd.GenRootCmdWithSettings` that should be preferred over deprecated functions
+  `cmd.GenRootCmd`, `cmd.GenRootCmdWithRunFlags`, and `cmd.GenRootCmdWithIndexPrefixWithRunFlags`. {pull}7850[7850]

--- a/generator/metricbeat/{beat}/main.go.tmpl
+++ b/generator/metricbeat/{beat}/main.go.tmpl
@@ -13,11 +13,12 @@ import (
 	_ "{beat_path}/include"
 )
 
-var Name = "{beat}"
-var IndexPrefix = "{beat}"
+var settings = instance.Settings{
+	Name: "{beat}",
+}
 
 func main() {
-	if err := instance.Run(Name, IndexPrefix, "", beater.DefaultCreator()); err != nil {
+	if err := instance.Run(settings, beater.DefaultCreator()); err != nil {
 		os.Exit(1)
 	}
 }

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -154,7 +154,11 @@ func initRand() {
 // implementation. bt is the `Creator` callback for creating a new beater
 // instance.
 // XXX Move this as a *Beat method?
-func Run(name, idxPrefix, version string, bt beat.Creator) error {
+func Run(settings Settings, bt beat.Creator) error {
+	name := settings.Name
+	idxPrefix := settings.IndexPrefix
+	version := settings.Version
+
 	return handleError(func() error {
 		defer func() {
 			if r := recover(); r != nil {
@@ -185,7 +189,7 @@ func Run(name, idxPrefix, version string, bt beat.Creator) error {
 		monitoring.NewString(beatRegistry, "name").Set(b.Info.Name)
 		monitoring.NewFunc(stateRegistry, "host", host.ReportInfo, monitoring.Report)
 
-		return b.launch(bt)
+		return b.launch(settings, bt)
 	}())
 }
 
@@ -306,7 +310,7 @@ func (b *Beat) createBeater(bt beat.Creator) (beat.Beater, error) {
 	return beater, nil
 }
 
-func (b *Beat) launch(bt beat.Creator) error {
+func (b *Beat) launch(settings Settings, bt beat.Creator) error {
 	defer logp.Sync()
 	defer logp.Info("%s stopped.", b.Info.Beat)
 
@@ -328,7 +332,10 @@ func (b *Beat) launch(bt beat.Creator) error {
 	}
 
 	if b.Config.Monitoring.Enabled() {
-		reporter, err := report.New(b.Info, b.Config.Monitoring, b.Config.Output)
+		settings := report.Settings{
+			DefaultUsername: settings.Monitoring.DefaultUsername,
+		}
+		reporter, err := report.New(b.Info, settings, b.Config.Monitoring, b.Config.Output)
 		if err != nil {
 			return err
 		}

--- a/libbeat/cmd/instance/settings.go
+++ b/libbeat/cmd/instance/settings.go
@@ -15,21 +15,19 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package beat
+package instance
 
-import "github.com/satori/go.uuid"
+import (
+	"github.com/spf13/pflag"
 
-// Info stores a beats instance meta data.
-type Info struct {
-	Beat        string    // The actual beat's name
-	IndexPrefix string    // The beat's index prefix in Elasticsearch.
-	Version     string    // The beat version. Defaults to the libbeat version when an implementation does not set a version
-	Name        string    // configured beat name
-	Hostname    string    // hostname
-	UUID        uuid.UUID // ID assigned to beat instance
+	"github.com/elastic/beats/libbeat/monitoring/report"
+)
 
-	// Monitoring-related fields
-	Monitoring struct {
-		DefaultUsername string // The default username to be used to connect to Elasticsearch Monitoring
-	}
+// Settings contains basic settings for any beat to pass into GenRootCmd
+type Settings struct {
+	Name        string
+	IndexPrefix string
+	Version     string
+	Monitoring  report.Settings
+	RunFlags    *pflag.FlagSet
 }

--- a/libbeat/cmd/root.go
+++ b/libbeat/cmd/root.go
@@ -23,6 +23,8 @@ import (
 	"os"
 	"strings"
 
+	"github.com/elastic/beats/libbeat/cmd/instance"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
@@ -52,22 +54,51 @@ type BeatsRootCmd struct {
 	KeystoreCmd   *cobra.Command
 }
 
-// GenRootCmd returns the root command to use for your beat. It takes
-// beat name as parameter, and also run command, which will be called if no args are
-// given (for backwards compatibility)
+// GenRootCmd returns the root command to use for your beat. It takes the beat name, version,
+// and run command, which will be called if no args are given (for backwards compatibility).
+//
+// Deprecated: Use GenRootCmdWithSettings instead.
 func GenRootCmd(name, version string, beatCreator beat.Creator) *BeatsRootCmd {
 	return GenRootCmdWithRunFlags(name, version, beatCreator, nil)
 }
 
 // GenRootCmdWithRunFlags returns the root command to use for your beat. It takes
-// beat name as parameter, and also run command, which will be called if no args are
-// given (for backwards compatibility). runFlags parameter must the flagset used by
-// run command
+// beat name, version, run command, and runFlags. runFlags parameter must the flagset used by
+// run command.
+//
+// Deprecated: Use GenRootCmdWithSettings instead.
 func GenRootCmdWithRunFlags(name, version string, beatCreator beat.Creator, runFlags *pflag.FlagSet) *BeatsRootCmd {
 	return GenRootCmdWithIndexPrefixWithRunFlags(name, name, version, beatCreator, runFlags)
 }
 
+// GenRootCmdWithIndexPrefixWithRunFlags returns the root command to use for your beat. It takes
+// beat name, index prefix, version, run command, and runFlags. runFlags parameter must the flagset used by
+// run command.
+//
+// Deprecated: Use GenRootCmdWithSettings instead.
 func GenRootCmdWithIndexPrefixWithRunFlags(name, indexPrefix, version string, beatCreator beat.Creator, runFlags *pflag.FlagSet) *BeatsRootCmd {
+	settings := instance.Settings{
+		Name:        name,
+		IndexPrefix: indexPrefix,
+		Version:     version,
+		RunFlags:    runFlags,
+	}
+	return GenRootCmdWithSettings(beatCreator, settings)
+}
+
+// GenRootCmdWithSettings returns the root command to use for your beat. It take the
+// run command, which will be called if no args are given (for backwards compatibility),
+// and beat settings
+func GenRootCmdWithSettings(beatCreator beat.Creator, settings instance.Settings) *BeatsRootCmd {
+	if settings.IndexPrefix == "" {
+		settings.IndexPrefix = settings.Name
+	}
+
+	name := settings.Name
+	version := settings.Version
+	indexPrefix := settings.IndexPrefix
+	runFlags := settings.RunFlags
+
 	rootCmd := &BeatsRootCmd{}
 	rootCmd.Use = name
 
@@ -79,7 +110,7 @@ func GenRootCmdWithIndexPrefixWithRunFlags(name, indexPrefix, version string, be
 
 	// must be updated prior to CLI flag handling.
 
-	rootCmd.RunCmd = genRunCmd(name, indexPrefix, version, beatCreator, runFlags)
+	rootCmd.RunCmd = genRunCmd(settings, beatCreator, runFlags)
 	rootCmd.SetupCmd = genSetupCmd(name, indexPrefix, version, beatCreator)
 	rootCmd.VersionCmd = genVersionCmd(name, version)
 	rootCmd.CompletionCmd = genCompletionCmd(name, version, rootCmd)

--- a/libbeat/cmd/run.go
+++ b/libbeat/cmd/run.go
@@ -28,12 +28,13 @@ import (
 	"github.com/elastic/beats/libbeat/cmd/instance"
 )
 
-func genRunCmd(name, idxPrefix, version string, beatCreator beat.Creator, runFlags *pflag.FlagSet) *cobra.Command {
+func genRunCmd(settings instance.Settings, beatCreator beat.Creator, runFlags *pflag.FlagSet) *cobra.Command {
+	name := settings.Name
 	runCmd := cobra.Command{
 		Use:   "run",
 		Short: "Run " + name,
 		Run: func(cmd *cobra.Command, args []string) {
-			err := instance.Run(name, idxPrefix, version, beatCreator)
+			err := instance.Run(settings, beatCreator)
 			if err != nil {
 				os.Exit(1)
 			}

--- a/libbeat/monitoring/report/elasticsearch/config.go
+++ b/libbeat/monitoring/report/elasticsearch/config.go
@@ -49,26 +49,3 @@ type backoff struct {
 	Init time.Duration
 	Max  time.Duration
 }
-
-var defaultConfig = config{
-	Hosts:            nil,
-	Protocol:         "http",
-	Params:           nil,
-	Headers:          nil,
-	Username:         "beats_system",
-	Password:         "",
-	ProxyURL:         "",
-	CompressionLevel: 0,
-	TLS:              nil,
-	MaxRetries:       3,
-	Timeout:          60 * time.Second,
-	MetricsPeriod:    10 * time.Second,
-	StatePeriod:      1 * time.Minute,
-	BulkMaxSize:      50,
-	BufferSize:       50,
-	Tags:             nil,
-	Backoff: backoff{
-		Init: 1 * time.Second,
-		Max:  60 * time.Second,
-	},
-}

--- a/libbeat/monitoring/report/elasticsearch/elasticsearch.go
+++ b/libbeat/monitoring/report/elasticsearch/elasticsearch.go
@@ -72,8 +72,39 @@ func init() {
 	report.RegisterReporterFactory("elasticsearch", makeReporter)
 }
 
-func makeReporter(beat beat.Info, cfg *common.Config) (report.Reporter, error) {
-	config := defaultConfig
+func defaultConfig(settings report.Settings) config {
+	c := config{
+		Hosts:            nil,
+		Protocol:         "http",
+		Params:           nil,
+		Headers:          nil,
+		Username:         "beats_system",
+		Password:         "",
+		ProxyURL:         "",
+		CompressionLevel: 0,
+		TLS:              nil,
+		MaxRetries:       3,
+		Timeout:          60 * time.Second,
+		MetricsPeriod:    10 * time.Second,
+		StatePeriod:      1 * time.Minute,
+		BulkMaxSize:      50,
+		BufferSize:       50,
+		Tags:             nil,
+		Backoff: backoff{
+			Init: 1 * time.Second,
+			Max:  60 * time.Second,
+		},
+	}
+
+	if settings.DefaultUsername != "" {
+		c.Username = settings.DefaultUsername
+	}
+
+	return c
+}
+
+func makeReporter(beat beat.Info, settings report.Settings, cfg *common.Config) (report.Reporter, error) {
+	config := defaultConfig(settings)
 	if err := cfg.Unpack(&config); err != nil {
 		return nil, err
 	}

--- a/libbeat/monitoring/report/report.go
+++ b/libbeat/monitoring/report/report.go
@@ -30,11 +30,15 @@ type config struct {
 	Reporter common.ConfigNamespace `config:",inline"`
 }
 
+type Settings struct {
+	DefaultUsername string
+}
+
 type Reporter interface {
 	Stop()
 }
 
-type ReporterFactory func(beat.Info, *common.Config) (Reporter, error)
+type ReporterFactory func(beat.Info, Settings, *common.Config) (Reporter, error)
 
 var (
 	defaultConfig = config{}
@@ -51,6 +55,7 @@ func RegisterReporterFactory(name string, f ReporterFactory) {
 
 func New(
 	beat beat.Info,
+	settings Settings,
 	cfg *common.Config,
 	outputs common.ConfigNamespace,
 ) (Reporter, error) {
@@ -64,7 +69,7 @@ func New(
 		return nil, fmt.Errorf("unknown reporter type '%v'", name)
 	}
 
-	return f(beat, cfg)
+	return f(beat, settings, cfg)
 }
 
 func getReporterConfig(


### PR DESCRIPTION
Cherry-pick of PR #7850 to 6.4 branch. Original message: 

By default all beats will use the `beats_system` user to talk to the Elasticsearch Monitoring bulk API. End-users can, of course, override this via the `xpack.monitoring.elasticsearch.username` configuration setting but sometimes a beat might want to specify a default other than `beats_system`. APM server is one such example wanting to use the `apm_system` user as it's default.

This PR makes it so a beat can override the Monitoring default username. This override should be done when the beat exports the `cmd.RootCmd` variable like so:

```golang
import (
    "github.com/elastic/beats/libbeat/cmd/instance"
    "github.com/elastic/beats/libbeat/monitoring/report"
)

var settings = instance.Settings{
	Name: "apm_server",
	Version: "",
	Monitoring: report.Settings{
          DefaultUsername: "apm_system",
        },
}
var RootCmd = cmd.GenRootCmdWithSettings(beater.New, settings)
```

---

### Deprecation notice
This PR introduces a new function, `cmd.GenRootCmdWithSettings`. See the code snippet above for sample usage. This new function should be preferred over now-deprecated functions, `cmd.GenRootCmd`, `cmd.GenRootCmdWithRunFlags`, and `cmd.GenRootCmdWithIndexPrefixWithRunFlags`. See examples below on how to upgrade from the using the deprecated functions to using the new function.

#### Upgrading from using `cmd.GenRootCmd`

```golang
// Before
var RootCmd = cmd.GenRootCmd("countbeat", "", beater.New)

// After
import "github.com/elastic/beats/libbeat/cmd/instance"
var settings = instance.Settings{
    Name: "countbeat",
}
var RootCmd = cmd.GenRootCmdWithSettings(beater.New, settings)
```

#### Upgrading from using `cmd.GenRootCmdWithRunFlags`

```golang
// Before
import "github.com/spf13/pflag"

var runFlags = pflag.NewFlagSet(Name, pflag.ExitOnError)
runFlags.AddGoFlag(flag.CommandLine.Lookup("I"))
runFlags.AddGoFlag(flag.CommandLine.Lookup("dump"))

var RootCmd = cmd.GenRootCmdWithRunFlags("countbeat", "", beater.New, runFlags)

// After
import (
    "github.com/spf13/pflag"
    "github.com/elastic/beats/libbeat/cmd/instance"
)

var runFlags = pflag.NewFlagSet(Name, pflag.ExitOnError)
runFlags.AddGoFlag(flag.CommandLine.Lookup("I"))
runFlags.AddGoFlag(flag.CommandLine.Lookup("dump"))

var settings = instance.Settings{
    Name: "countbeat",
    RunFlags: runFlags,
}
var RootCmd = cmd.GenRootCmdWithSettings(beater.New, settings)
```

#### Upgrading from using `cmd.GenRootCmdWithIndexPrefixWithRunFlags`

```golang
// Before
import "github.com/spf13/pflag"

var runFlags = pflag.NewFlagSet(Name, pflag.ExitOnError)
runFlags.AddGoFlag(flag.CommandLine.Lookup("I"))
runFlags.AddGoFlag(flag.CommandLine.Lookup("dump"))

var RootCmd = cmd.GenRootCmdWithIndexPrefixWithRunFlags("countbeat", "cb", "", beater.New, runFlags)

// After
import (
    "github.com/spf13/pflag"
    "github.com/elastic/beats/libbeat/cmd/instance"
)

var runFlags = pflag.NewFlagSet(Name, pflag.ExitOnError)
runFlags.AddGoFlag(flag.CommandLine.Lookup("I"))
runFlags.AddGoFlag(flag.CommandLine.Lookup("dump"))

var settings = instance.Settings{
    Name: "countbeat",
    IndexPrefix: "cb",
    RunFlags: runFlags,
}
var RootCmd = cmd.GenRootCmdWithSettings(beater.New, settings)
```