### PR TITLE
Cherry-pick #8801 to 6.4: mkdir for extracted dashboard files

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -31,6 +31,7 @@ https://github.com/elastic/beats/compare/v6.4.1...6.4[Check the HEAD diff]
 
 - Fix a race condition with the `add_host_metadata` and the event serialization. {pull}8223[8223] {pull}8653[8653]
 - Fix race condition when publishing monitoring data. {pull}8646[8646]
+- Fix bug in loading dashboards from zip file. {issue}8051[8051]
 
 *Auditbeat*
 

--- a/libbeat/dashboards/importer.go
+++ b/libbeat/dashboards/importer.go
@@ -131,6 +131,7 @@ func (imp Importer) unzip(archive, target string) error {
 	if err != nil {
 		return err
 	}
+	defer reader.Close()
 
 	// Closure to close the files on each iteration
 	unzipFile := func(file *zip.File) error {
@@ -149,6 +150,11 @@ func (imp Importer) unzip(archive, target string) error {
 		if file.FileInfo().IsDir() {
 			return os.MkdirAll(filePath, file.Mode())
 		}
+
+		if err = os.MkdirAll(filepath.Dir(filePath), 0755); err != nil {
+			return fmt.Errorf("failed making directory for file %v: %v", filePath, err)
+		}
+
 		fileReader, err := file.Open()
 		if err != nil {
 			return err


### PR DESCRIPTION
Cherry-pick of PR #8801 to 6.4 branch. Original message: 

Make the directory that contains the extracted file prior to creating the file. This makes it handle cases where there is not a directory entry inside the zip file.

I also made a fix to close the file handle for the .zip when done.

Fixes #8051