### PR TITLE
Add conditions for each platform

### DIFF
--- a/auditbeat/docs/configuring-howto.asciidoc
+++ b/auditbeat/docs/configuring-howto.asciidoc
@@ -49,7 +49,6 @@ include::./auditbeat-general-options.asciidoc[]
 
 include::./reload-configuration.asciidoc[]
 
-:allplatforms:
 include::../../libbeat/docs/queueconfig.asciidoc[]
 
 include::../../libbeat/docs/outputconfig.asciidoc[]
@@ -70,10 +69,11 @@ include::../../libbeat/docs/loggingconfig.asciidoc[]
 
 :standalone:
 include::../../libbeat/docs/shared-env-vars.asciidoc[]
+:standalone!:
 
 :standalone:
-:allplatforms:
 include::../../libbeat/docs/yaml.asciidoc[]
+:standalone!:
 
 include::../../libbeat/docs/regexp.asciidoc[]
 

--- a/auditbeat/docs/getting-started.asciidoc
+++ b/auditbeat/docs/getting-started.asciidoc
@@ -199,14 +199,7 @@ NOTE: If you use an init.d script to start {beatname_uc} on deb or rpm, you can'
 specify command line flags (see <<command-line-options>>). To specify flags,
 start {beatname_uc} in the foreground.
 
-*deb:*
-
-["source","sh",subs="attributes"]
-----------------------------------------------------------------------
-sudo service {beatname_lc} start
-----------------------------------------------------------------------
-
-*rpm:*
+*deb and rpm:*
 
 ["source","sh",subs="attributes"]
 ----------------------------------------------------------------------

--- a/auditbeat/docs/getting-started.asciidoc
+++ b/auditbeat/docs/getting-started.asciidoc
@@ -181,13 +181,11 @@ include::../../libbeat/docs/step-look-at-config.asciidoc[]
 [id="{beatname_lc}-template"]
 === Step 3: Load the index template in {es}
 
-:allplatforms:
 include::../../libbeat/docs/shared-template-load.asciidoc[]
 
 [[load-kibana-dashboards]]
 === Step 4: Set up the {kib} dashboards
 
-:allplatforms:
 include::../../libbeat/docs/dashboards.asciidoc[]
 
 [id="{beatname_lc}-starting"]

--- a/auditbeat/docs/index.asciidoc
+++ b/auditbeat/docs/index.asciidoc
@@ -12,6 +12,11 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :discuss_forum: beats/{beatname_lc}
 :beat_default_index_prefix: {beatname_lc}
 :has_ml_jobs: yes
+:deb_os:
+:rpm_os:
+:mac_os:
+:docker_platform:
+:win_os:
 
 include::../../libbeat/docs/shared-beats-attributes.asciidoc[]
 

--- a/filebeat/docs/configuring-howto.asciidoc
+++ b/filebeat/docs/configuring-howto.asciidoc
@@ -54,7 +54,6 @@ include::./filebeat-general-options.asciidoc[]
 
 include::./reload-configuration.asciidoc[]
 
-:allplatforms:
 include::../../libbeat/docs/queueconfig.asciidoc[]
 
 include::../../libbeat/docs/outputconfig.asciidoc[]
@@ -77,14 +76,15 @@ include::../../libbeat/docs/loggingconfig.asciidoc[]
 
 :standalone:
 include::../../libbeat/docs/shared-env-vars.asciidoc[]
+:standalone!:
 
 :autodiscoverJolokia:
 :autodiscoverHints:
 include::../../libbeat/docs/shared-autodiscover.asciidoc[]
 
 :standalone:
-:allplatforms:
 include::../../libbeat/docs/yaml.asciidoc[]
+:standalone!:
 
 include::../../libbeat/docs/regexp.asciidoc[]
 

--- a/filebeat/docs/getting-started.asciidoc
+++ b/filebeat/docs/getting-started.asciidoc
@@ -186,19 +186,16 @@ include::../../libbeat/docs/step-look-at-config.asciidoc[]
 [[config-filebeat-logstash]]
 === Step 3: Configure Filebeat to use Logstash
 
-:allplatforms:
 include::../../libbeat/docs/shared-logstash-config.asciidoc[]
 
 [[filebeat-template]]
 === Step 4: Load the index template in Elasticsearch
 
-:allplatforms:
 include::../../libbeat/docs/shared-template-load.asciidoc[]
 
 [[load-kibana-dashboards]]
 === Step 5: Set up the Kibana dashboards
 
-:allplatforms:
 include::../../libbeat/docs/dashboards.asciidoc[]
 
 [[filebeat-starting]]

--- a/filebeat/docs/getting-started.asciidoc
+++ b/filebeat/docs/getting-started.asciidoc
@@ -209,14 +209,7 @@ NOTE: If you use an init.d script to start Filebeat on deb or rpm, you can't
 specify command line flags (see <<command-line-options>>). To specify flags,
 start Filebeat in the foreground.
 
-*deb:*
-
-["source","sh",subs="attributes"]
-----------------------------------------------------------------------
-sudo service {beatname_lc} start
-----------------------------------------------------------------------
-
-*rpm:*
+*deb and rpm:*
 
 ["source","sh",subs="attributes"]
 ----------------------------------------------------------------------

--- a/filebeat/docs/index.asciidoc
+++ b/filebeat/docs/index.asciidoc
@@ -12,6 +12,11 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :discuss_forum: beats/{beatname_lc}
 :beat_default_index_prefix: {beatname_lc}
 :has_ml_jobs: yes
+:deb_os:
+:rpm_os:
+:mac_os:
+:docker_platform:
+:win_os:
 
 include::../../libbeat/docs/shared-beats-attributes.asciidoc[]
 

--- a/heartbeat/docs/configuring-howto.asciidoc
+++ b/heartbeat/docs/configuring-howto.asciidoc
@@ -46,7 +46,6 @@ include::./heartbeat-options.asciidoc[]
 
 include::./heartbeat-general-options.asciidoc[]
 
-:allplatforms:
 include::../../libbeat/docs/queueconfig.asciidoc[]
 
 include::../../libbeat/docs/outputconfig.asciidoc[]
@@ -67,12 +66,13 @@ include::../../libbeat/docs/loggingconfig.asciidoc[]
 
 :standalone:
 include::../../libbeat/docs/shared-env-vars.asciidoc[]
+:standalone!:
 
 include::../../libbeat/docs/shared-autodiscover.asciidoc[]
 
 :standalone:
-:allplatforms:
 include::../../libbeat/docs/yaml.asciidoc[]
+:standalone!:
 
 include::../../libbeat/docs/regexp.asciidoc[]
 

--- a/heartbeat/docs/getting-started.asciidoc
+++ b/heartbeat/docs/getting-started.asciidoc
@@ -223,14 +223,7 @@ NOTE: If you use an init.d script to start Heartbeat on deb or rpm, you can't
 specify command line flags (see <<command-line-options>>). To specify flags,
 start Heartbeat in the foreground.
 
-*deb:*
-
-["source","sh",subs="attributes"]
-----------------------------------------------------------------------
-sudo service {beatname_lc}-elastic start
-----------------------------------------------------------------------
-
-*rpm:*
+*deb and rpm:*
 
 ["source","sh",subs="attributes"]
 ----------------------------------------------------------------------

--- a/heartbeat/docs/getting-started.asciidoc
+++ b/heartbeat/docs/getting-started.asciidoc
@@ -205,13 +205,11 @@ include::../../libbeat/docs/step-look-at-config.asciidoc[]
 [[heartbeat-template]]
 === Step 3: Load the index template in Elasticsearch
 
-:allplatforms:
 include::../../libbeat/docs/shared-template-load.asciidoc[]
 
 [[load-kibana-dashboards]]
 === Step 4: Set up the Kibana dashboards
 
-:allplatforms:
 include::../../libbeat/docs/dashboards.asciidoc[]
 
 [[heartbeat-starting]]

--- a/heartbeat/docs/index.asciidoc
+++ b/heartbeat/docs/index.asciidoc
@@ -12,6 +12,11 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :discuss_forum: beats/{beatname_lc}
 :beat_default_index_prefix: {beatname_lc}
 :has_ml_jobs: yes
+:deb_os:
+:rpm_os:
+:mac_os:
+:docker_platform:
+:win_os:
 
 include::../../libbeat/docs/shared-beats-attributes.asciidoc[]
 

--- a/journalbeat/docs/configuring-howto.asciidoc
+++ b/journalbeat/docs/configuring-howto.asciidoc
@@ -47,9 +47,7 @@ include::./config-options.asciidoc[]
 
 include::./general-options.asciidoc[]
 
-:allplatforms:
 include::../../libbeat/docs/queueconfig.asciidoc[]
-:allplatforms!:
 
 include::../../libbeat/docs/outputconfig.asciidoc[]
 
@@ -75,10 +73,8 @@ include::../../libbeat/docs/shared-env-vars.asciidoc[]
 //include::../../libbeat/docs/shared-autodiscover.asciidoc[]
 
 :standalone:
-:allplatforms:
 include::../../libbeat/docs/yaml.asciidoc[]
 :standalone!:
-:allplatforms!:
 
 include::../../libbeat/docs/regexp.asciidoc[]
 

--- a/journalbeat/docs/getting-started.asciidoc
+++ b/journalbeat/docs/getting-started.asciidoc
@@ -204,14 +204,7 @@ NOTE: If you use an init.d script to start {beatname_uc} on deb or rpm, you can'
 specify command line flags (see <<command-line-options>>). To specify flags,
 start {beatname_uc} in the foreground.
 
-*deb:*
-
-["source","sh",subs="attributes"]
-----------------------------------------------------------------------
-sudo service {beatname_lc} start
-----------------------------------------------------------------------
-
-*rpm:*
+*deb and rpm:*
 
 ["source","sh",subs="attributes"]
 ----------------------------------------------------------------------

--- a/journalbeat/docs/getting-started.asciidoc
+++ b/journalbeat/docs/getting-started.asciidoc
@@ -182,7 +182,6 @@ include::../../libbeat/docs/step-look-at-config.asciidoc[]
 
 IMPORTANT: This documentation is placeholder content. It has not yet been reviewed.
 
-:allplatforms:
 include::../../libbeat/docs/shared-template-load.asciidoc[]
 
 [[load-kibana-dashboards]]
@@ -190,7 +189,6 @@ include::../../libbeat/docs/shared-template-load.asciidoc[]
 
 IMPORTANT: This documentation is placeholder content. It has not yet been reviewed.
 
-:allplatforms:
 include::../../libbeat/docs/dashboards.asciidoc[]
 
 [id="{beatname_lc}-starting"]

--- a/journalbeat/docs/index.asciidoc
+++ b/journalbeat/docs/index.asciidoc
@@ -13,6 +13,8 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :beat_default_index_prefix: {beatname_lc}
 :has_ml_jobs: no
 :libbeat-docs: Beats Platform Reference
+:deb_os:
+:rpm_os:
 
 include::../../libbeat/docs/shared-beats-attributes.asciidoc[]
 

--- a/libbeat/docs/config-file-format.asciidoc
+++ b/libbeat/docs/config-file-format.asciidoc
@@ -378,5 +378,4 @@ output.console:
 [[config-file-format-tips]]
 === YAML tips and gotchas
 
-:allplatforms:
 include::yaml.asciidoc[]

--- a/libbeat/docs/dashboards.asciidoc
+++ b/libbeat/docs/dashboards.asciidoc
@@ -32,9 +32,7 @@ the _Beats Developer Guide_.
 ifndef::only-elasticsearch[]
 If you've configured the Logstash output, see
 <<load-dashboards-logstash>>.
-endif::[]
-
-ifdef::allplatforms[]
+endif::only-elasticsearch[]
 
 ifeval::["{requires-sudo}"=="yes"]
 
@@ -42,32 +40,46 @@ include::../../libbeat/docs/shared-note-sudo.asciidoc[]
 
 endif::[]
 
-*deb and rpm:*
+ifdef::deb_os[]
+*deb:*
 
 ["source","sh",subs="attributes"]
 ----------------------------------------------------------------------
 {beatname_lc} setup --dashboards
 ----------------------------------------------------------------------
+endif::deb_os[]
 
+ifdef::rpm_os[]
+*rpm:*
 
+["source","sh",subs="attributes"]
+----------------------------------------------------------------------
+{beatname_lc} setup --dashboards
+----------------------------------------------------------------------
+endif::rpm_os[]
+
+ifdef::mac_os[]
 *mac:*
 
 ["source","sh",subs="attributes"]
 ----------------------------------------------------------------------
 ./{beatname_lc} setup --dashboards
 ----------------------------------------------------------------------
+endif::mac_os[]
 
-
+ifdef::docker_platform[]
 *docker:*
 
 ["source","sh",subs="attributes"]
 ----------------------------------------------------------------------
 docker run --net="host" {dockerimage} setup --dashboards
 ----------------------------------------------------------------------
+endif::docker_platform[]
 
+ifdef::win_os[]
+ifndef::win_only[]
 *win:*
-
-endif::allplatforms[]
+endif::win_only[]
 
 Open a PowerShell prompt as an Administrator (right-click the PowerShell icon
 and select *Run As Administrator*).
@@ -79,6 +91,7 @@ and run:
 ----------------------------------------------------------------------
 PS > .{backslash}{beatname_lc}.exe setup --dashboards
 ----------------------------------------------------------------------
+endif::win_os[]
 
 ifndef::only-elasticsearch[]
 [[load-dashboards-logstash]]
@@ -93,9 +106,8 @@ credentials.
 TIP: The example shows a hard-coded password, but you should store sensitive
 values in the <<keystore,secrets keystore>>.
 
-ifdef::allplatforms[]
-
-*deb and rpm:*
+ifdef::deb_os[]
+*deb:*
 
 ["source","sh",subs="attributes"]
 ----
@@ -106,8 +118,23 @@ ifdef::allplatforms[]
   -E output.elasticsearch.password={pwd} \
   -E setup.kibana.host=localhost:5601
 ----
+endif::deb_os[]
 
+ifdef::rpm_os[]
+*rpm:*
 
+["source","sh",subs="attributes"]
+----
+{beatname_lc} setup -e \
+  -E output.logstash.enabled=false \
+  -E output.elasticsearch.hosts=['localhost:9200'] \
+  -E output.elasticsearch.username={beat_default_index_prefix}_internal \
+  -E output.elasticsearch.password={pwd} \
+  -E setup.kibana.host=localhost:5601
+----
+endif::rpm_os[]
+
+ifdef::mac_os[]
 *mac:*
 
 ["source","sh",subs="attributes"]
@@ -119,8 +146,10 @@ ifdef::allplatforms[]
   -E output.elasticsearch.password={pwd} \
   -E setup.kibana.host=localhost:5601 
 ----
+endif::mac_os[]
 
 
+ifdef::docker_platform[]
 *docker:*
 
 ["source","sh",subs="attributes"]
@@ -132,11 +161,12 @@ docker run --net="host" {dockerimage} setup -e \
   -E output.elasticsearch.password={pwd} \
   -E setup.kibana.host=localhost:5601
 ----
+endif::docker_platform[]
 
-
+ifdef::win_os[]
+ifndef::win_only[]
 *win:*
-
-endif::allplatforms[]
+endif::win_only[]
 
 Open a PowerShell prompt as an Administrator (right-click the PowerShell icon
 and select *Run As Administrator*).
@@ -153,7 +183,7 @@ PS > .{backslash}{beatname_lc}.exe setup -e `
   -E output.elasticsearch.password={pwd} `
   -E setup.kibana.host=localhost:5601 
 ----
-
+endif::win_os[]
 
 endif::only-elasticsearch[]
 

--- a/libbeat/docs/dashboards.asciidoc
+++ b/libbeat/docs/dashboards.asciidoc
@@ -40,23 +40,14 @@ include::../../libbeat/docs/shared-note-sudo.asciidoc[]
 
 endif::[]
 
-ifdef::deb_os[]
-*deb:*
+ifdef::deb_os,rpm_os[]
+*deb and rpm:*
 
 ["source","sh",subs="attributes"]
 ----------------------------------------------------------------------
 {beatname_lc} setup --dashboards
 ----------------------------------------------------------------------
-endif::deb_os[]
-
-ifdef::rpm_os[]
-*rpm:*
-
-["source","sh",subs="attributes"]
-----------------------------------------------------------------------
-{beatname_lc} setup --dashboards
-----------------------------------------------------------------------
-endif::rpm_os[]
+endif::deb_os,rpm_os[]
 
 ifdef::mac_os[]
 *mac:*
@@ -106,8 +97,8 @@ credentials.
 TIP: The example shows a hard-coded password, but you should store sensitive
 values in the <<keystore,secrets keystore>>.
 
-ifdef::deb_os[]
-*deb:*
+ifdef::deb_os,rpm_os[]
+*deb and rpm:*
 
 ["source","sh",subs="attributes"]
 ----
@@ -118,21 +109,7 @@ ifdef::deb_os[]
   -E output.elasticsearch.password={pwd} \
   -E setup.kibana.host=localhost:5601
 ----
-endif::deb_os[]
-
-ifdef::rpm_os[]
-*rpm:*
-
-["source","sh",subs="attributes"]
-----
-{beatname_lc} setup -e \
-  -E output.logstash.enabled=false \
-  -E output.elasticsearch.hosts=['localhost:9200'] \
-  -E output.elasticsearch.username={beat_default_index_prefix}_internal \
-  -E output.elasticsearch.password={pwd} \
-  -E setup.kibana.host=localhost:5601
-----
-endif::rpm_os[]
+endif::deb_os,rpm_os[]
 
 ifdef::mac_os[]
 *mac:*

--- a/libbeat/docs/shared-directory-layout.asciidoc
+++ b/libbeat/docs/shared-directory-layout.asciidoc
@@ -24,14 +24,14 @@ The directory layout of an installation is as follows:
 | logs   | The location for the logs created by {beatname_uc}. | {path.home}/logs | path.logs
 |=======================================================================
 
-You can change these settings by using CLI flags or setting <<configuration-path,path options>> in the configuration
-file.
+You can change these settings by using CLI flags or setting
+<<configuration-path,path options>> in the configuration file.
 
 ==== Default paths
 
 {beatname_uc} uses the following default paths unless you explicitly change them.
 
-ifeval::["{beatname_lc}"!="winlogbeat"]
+ifndef::win_only[]
 
 [float]
 ===== deb and rpm
@@ -50,6 +50,9 @@ the systemd unit file.  Make sure that you start the {beatname_uc} service by us
 the preferred operating system method (init scripts or `systemctl`).
 Otherwise the paths might be set incorrectly.
 
+endif::win_only[]
+
+ifdef::docker_platform[]
 [float]
 ===== docker
 [cols="<h,<,<m",options="header",]
@@ -62,10 +65,10 @@ Otherwise the paths might be set incorrectly.
 | logs   | The location for the logs created by {beatname_uc}. | /usr/share/{beatname_lc}/logs
 |=======================================================================
 
-endif::[]
+endif::docker_platform[]
 
 [float]
-===== zip, tar.gz, and tgz
+===== zip, tar.gz, or tgz
 [cols="<h,<,<m",options="header",]
 |=======================================================================
 | Type   | Description | Location
@@ -76,24 +79,24 @@ endif::[]
 | logs   | The location for the logs created by {beatname_uc}. | {extract.path}/logs
 |=======================================================================
 
-For the zip, tar.gz and tgz distributions, these paths are based on the location of the
-extracted binary file. This means that if you start {beatname_uc} with the following simple command,
-all paths are set correctly:
+For the zip, tar.gz, or tgz distributions, these paths are based on the location
+of the extracted binary file. This means that if you start {beatname_uc} with
+the following simple command, all paths are set correctly:
 
-ifeval::["{beatname_lc}"!="winlogbeat"]
+ifndef::win_only[]
 
-["source","sh",subs="attributes,callouts"]
+["source","sh",subs="attributes"]
 ----------------------------------------------------------------------
 ./{beatname_lc}
-------------------------------------------------------------------------------
+----------------------------------------------------------------------
 
-endif::[]
+endif::win_only[]
 
-ifeval::["{beatname_lc}"=="winlogbeat"]
+ifdef::win_only[]
 
-["source","sh",subs="attributes,callouts"]
+["source","sh",subs="attributes"]
 ----------------------------------------------------------------------
 Start-Service {beatname_lc}
 ----------------------------------------------------------------------
 
-endif::[]
+endif::win_only[]

--- a/libbeat/docs/shared-logstash-config.asciidoc
+++ b/libbeat/docs/shared-logstash-config.asciidoc
@@ -39,16 +39,16 @@ Beats connections.
 For this configuration, you must <<load-template-manually,load the index template into Elasticsearch manually>>
 because the options for auto loading the template are only available for the Elasticsearch output.
 
-ifdef::allplatforms[]
+ifndef::win-only[]
 
 include::../../libbeat/docs/step-test-config.asciidoc[]
 
-endif::allplatforms[]
+endif::win-only[]
 
-ifdef::win[]
+ifdef::win-only[]
 
 TIP: To test your configuration file, change to the directory where the {beatname_uc}
 binary is installed, and run {beatname_uc} in the foreground with the following
 options specified: +.\winlogbeat.exe test config -c .\winlogbeat.yml -e+.
 
-endif::win[]
+endif::win-only[]

--- a/libbeat/docs/shared-template-load.asciidoc
+++ b/libbeat/docs/shared-template-load.asciidoc
@@ -7,11 +7,6 @@
 //// resolve Beat names: beatname_uc and beatname_lc
 //// Use the following include to pull this content into a doc file:
 //// include::../../libbeat/docs/shared-template-load.asciidoc[]
-//// If you want to include conditional content, you also need to
-//// add the following doc attribute definition  before the
-//// include statement so that you have:
-//// :allplatforms:
-//// include::../../libbeat/docs/shared-template-load.asciidoc[]
 //// This content must be embedded underneath a level 3 heading.
 //////////////////////////////////////////////////////////////////////////
 
@@ -35,19 +30,19 @@ ifndef::only-elasticsearch[]
 NOTE: A connection to Elasticsearch is required to load the index template. If
 the output is not Elasticsearch, you must
 <<load-template-manually,load the template manually>>. 
-endif::[]
+endif::only-elasticsearch[]
 
 For more information, see:
 
 ifdef::only-elasticsearch[]
 * <<load-template-auto>>
 * <<load-template-manually>>
-endif::[]
+endif::only-elasticsearch[]
 
 ifndef::only-elasticsearch[]
 * <<load-template-auto>>
 * <<load-template-manually>> - required for non-Elasticsearch output
-endif::[]
+endif::only-elasticsearch[]
 
 [[load-template-auto]]
 ==== Configure template loading
@@ -138,7 +133,7 @@ If another output is enabled, you need
 to temporarily disable that output and enable Elasticsearch by using the
 `-E` option. The examples here assume that Logstash output is enabled. You can
 omit the `-E` flags if Elasticsearch output is already enabled.
-endif::[]
+endif::only-elasticsearch[]
 
 If you are connecting to a secured Elasticsearch cluster, make sure you've
 configured credentials as described in <<{beatname_lc}-configuration>>.
@@ -146,17 +141,21 @@ configured credentials as described in <<{beatname_lc}-configuration>>.
 If the host running {beatname_uc} does not have direct connectivity to
 Elasticsearch, see <<load-template-manually-alternate>>.
 
+ifndef::win_only[]
 To load the template, use the appropriate command for your system.
+endif::win_only[]
+
+ifdef::win_only[]
+To load the template:
+endif::win_only[]
 
 ifndef::only-elasticsearch[]
 :disable_logstash: {sp}-E output.logstash.enabled=false
-endif::[]
+endif::only-elasticsearch[]
 
 ifdef::only-elasticsearch[]
 :disable_logstash:
-endif::[]
-
-ifdef::allplatforms[]
+endif::only-elasticsearch[]
 
 ifeval::["{requires-sudo}"=="yes"]
 
@@ -164,31 +163,44 @@ include::./shared-note-sudo.asciidoc[]
 
 endif::[]
 
-*deb and rpm:*
+ifdef::deb_os[]
+*deb:*
 ["source","sh",subs="attributes"]
 ----
 {beatname_lc} setup --template{disable_logstash} -E 'output.elasticsearch.hosts=["localhost:9200"]'
 ----
+endif::deb_os[]
 
+ifdef::rpm_os[]
+*rpm:*
+["source","sh",subs="attributes"]
+----
+{beatname_lc} setup --template{disable_logstash} -E 'output.elasticsearch.hosts=["localhost:9200"]'
+----
+endif::rpm_os[]
+
+ifdef::mac_os[]
 *mac:*
 
 ["source","sh",subs="attributes"]
 ----
 ./{beatname_lc} setup --template{disable_logstash} -E 'output.elasticsearch.hosts=["localhost:9200"]'
 ----
+endif::mac_os[]
 
-
+ifdef::mac_os[]
 *docker:*
 
 ["source","sh",subs="attributes"]
 ----------------------------------------------------------------------
 docker run {dockerimage} setup --template{disable_logstash} -E 'output.elasticsearch.hosts=["localhost:9200"]'
 ----------------------------------------------------------------------
+endif::mac_os[]
 
-
+ifdef::win_os[]
+ifndef::win_only[]
 *win:*
-
-endif::allplatforms[]
+endif::win_only[]
 
 Open a PowerShell prompt as an Administrator (right-click the PowerShell icon
 and select *Run As Administrator*).
@@ -200,7 +212,7 @@ and run:
 ----------------------------------------------------------------------
 PS > .{backslash}{beatname_lc}.exe setup --template{disable_logstash} -E 'output.elasticsearch.hosts=["localhost:9200"]'
 ----------------------------------------------------------------------
-
+endif::win_os[]
 
 [[force-kibana-new]]
 ===== Force Kibana to look at newest documents
@@ -210,20 +222,43 @@ the index may contain old documents. After you load the index template,
 you can delete the old documents from +{beatname_lc}-*+ to force Kibana to look
 at the newest documents. Use this command:
 
-*deb, rpm, and mac:*
+ifdef::deb_os[]
+*deb:*
 
 ["source","sh",subs="attributes"]
 ----------------------------------------------------------------------
 curl -XDELETE 'http://localhost:9200/{beatname_lc}-*'
 ----------------------------------------------------------------------
+endif::deb_os[]
 
+ifdef::rpm_os[]
+*rpm:*
+
+["source","sh",subs="attributes"]
+----------------------------------------------------------------------
+curl -XDELETE 'http://localhost:9200/{beatname_lc}-*'
+----------------------------------------------------------------------
+endif::rpm_os[]
+
+ifdef::mac_os[]
+*mac:*
+
+["source","sh",subs="attributes"]
+----------------------------------------------------------------------
+curl -XDELETE 'http://localhost:9200/{beatname_lc}-*'
+----------------------------------------------------------------------
+endif::mac_os[]
+
+ifdef::win_os[]
+ifndef::win_only[]
 *win:*
+endif::win_only[]
 
 ["source","sh",subs="attributes"]
 ----------------------------------------------------------------------
 PS > Invoke-RestMethod -Method Delete "http://localhost:9200/{beatname_lc}-*"
 ----------------------------------------------------------------------
-
+endif::win_os[]
 
 This command deletes all indices that match the pattern +{beat_default_index_prefix}-*+.
 Before running this command, make sure you want to delete all indices that match
@@ -236,43 +271,82 @@ If the host running {beatname_uc} does not have direct connectivity to
 Elasticsearch, you can export the index template to a file, move it to a
 machine that does have connectivity, and then install the template manually.
 
-. Export the index template:
-+
-ifdef::allplatforms[]
-*deb and rpm:*
-+
+To export the index template, run:
+ifdef::deb_os[]
+
+*deb:*
+
 ["source","sh",subs="attributes"]
 ----
 {beatname_lc} export template > {beatname_lc}.template.json
 ----
-+
+endif::deb_os[]
+ifdef::rpm_os[]
+
+*rpm:*
+
+["source","sh",subs="attributes"]
+----
+{beatname_lc} export template > {beatname_lc}.template.json
+----
+endif::rpm_os[]
+ifdef::mac_os[]
+
 *mac:*
-+
+
 ["source","sh",subs="attributes"]
 ----
 ./{beatname_lc} export template > {beatname_lc}.template.json
 ----
-+
+endif::mac_os[]
+
+ifdef::win_os[]
+ifndef::win_only[]
 *win:*
-+
-endif::allplatforms[]
+endif::win_only[]
+
 ["source","sh",subs="attributes"]
 ----
 PS > .{backslash}{beatname_lc}.exe export template --es.version {stack-version} | Out-File -Encoding UTF8 {beatname_lc}.template.json
 ----
+endif::win_os[]
 
-. Install the template:
-+
-*deb, rpm, and mac:*
-+
+To install the template, run:
+ifdef::deb_os[]
+
+*deb:*
+
 ["source","sh",subs="attributes"]
 ----
 curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_template/{beatname_lc}-{stack-version} -d@{beatname_lc}.template.json
 ----
-+
+endif::deb_os[]
+ifdef::rpm_os[]
+
+*rpm:*
+
+["source","sh",subs="attributes"]
+----
+curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_template/{beatname_lc}-{stack-version} -d@{beatname_lc}.template.json
+----
+endif::rpm_os[]
+ifdef::mac_os[]
+
+*mac:*
+
+["source","sh",subs="attributes"]
+----
+curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_template/{beatname_lc}-{stack-version} -d@{beatname_lc}.template.json
+----
+endif::mac_os[]
+
+ifdef::win_os[]
+ifndef::win_only[]
 *win:*
-+
+endif::win_only[]
+
 ["source","sh",subs="attributes"]
 ----
 PS > Invoke-RestMethod -Method Put -ContentType "application/json" -InFile {beatname_lc}.template.json -Uri http://localhost:9200/_template/{beatname_lc}-{stack-version}
 ----
+endif::win_os[]

--- a/libbeat/docs/shared-template-load.asciidoc
+++ b/libbeat/docs/shared-template-load.asciidoc
@@ -163,21 +163,13 @@ include::./shared-note-sudo.asciidoc[]
 
 endif::[]
 
-ifdef::deb_os[]
-*deb:*
+ifdef::deb_os,rpm_os[]
+*deb and rpm:*
 ["source","sh",subs="attributes"]
 ----
 {beatname_lc} setup --template{disable_logstash} -E 'output.elasticsearch.hosts=["localhost:9200"]'
 ----
-endif::deb_os[]
-
-ifdef::rpm_os[]
-*rpm:*
-["source","sh",subs="attributes"]
-----
-{beatname_lc} setup --template{disable_logstash} -E 'output.elasticsearch.hosts=["localhost:9200"]'
-----
-endif::rpm_os[]
+endif::deb_os,rpm_os[]
 
 ifdef::mac_os[]
 *mac:*
@@ -222,23 +214,14 @@ the index may contain old documents. After you load the index template,
 you can delete the old documents from +{beatname_lc}-*+ to force Kibana to look
 at the newest documents. Use this command:
 
-ifdef::deb_os[]
-*deb:*
+ifdef::deb_os,rpm_os[]
+*deb and rpm:*
 
 ["source","sh",subs="attributes"]
 ----------------------------------------------------------------------
 curl -XDELETE 'http://localhost:9200/{beatname_lc}-*'
 ----------------------------------------------------------------------
-endif::deb_os[]
-
-ifdef::rpm_os[]
-*rpm:*
-
-["source","sh",subs="attributes"]
-----------------------------------------------------------------------
-curl -XDELETE 'http://localhost:9200/{beatname_lc}-*'
-----------------------------------------------------------------------
-endif::rpm_os[]
+endif::deb_os,rpm_os[]
 
 ifdef::mac_os[]
 *mac:*
@@ -272,26 +255,17 @@ Elasticsearch, you can export the index template to a file, move it to a
 machine that does have connectivity, and then install the template manually.
 
 To export the index template, run:
-ifdef::deb_os[]
 
-*deb:*
-
-["source","sh",subs="attributes"]
-----
-{beatname_lc} export template > {beatname_lc}.template.json
-----
-endif::deb_os[]
-ifdef::rpm_os[]
-
-*rpm:*
+ifdef::deb_os,rpm_os[]
+*deb and rpm:*
 
 ["source","sh",subs="attributes"]
 ----
 {beatname_lc} export template > {beatname_lc}.template.json
 ----
-endif::rpm_os[]
+endif::deb_os,rpm_os[]
+
 ifdef::mac_os[]
-
 *mac:*
 
 ["source","sh",subs="attributes"]
@@ -312,26 +286,17 @@ PS > .{backslash}{beatname_lc}.exe export template --es.version {stack-version} 
 endif::win_os[]
 
 To install the template, run:
-ifdef::deb_os[]
 
-*deb:*
-
-["source","sh",subs="attributes"]
-----
-curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_template/{beatname_lc}-{stack-version} -d@{beatname_lc}.template.json
-----
-endif::deb_os[]
-ifdef::rpm_os[]
-
-*rpm:*
+ifdef::deb_os,rpm_os[]
+*deb and rpm:*
 
 ["source","sh",subs="attributes"]
 ----
 curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_template/{beatname_lc}-{stack-version} -d@{beatname_lc}.template.json
 ----
-endif::rpm_os[]
+endif::deb_os,rpm_os[]
+
 ifdef::mac_os[]
-
 *mac:*
 
 ["source","sh",subs="attributes"]

--- a/libbeat/docs/yaml.asciidoc
+++ b/libbeat/docs/yaml.asciidoc
@@ -46,23 +46,23 @@ Simply change to the directory where the binary is installed, and run
 the Beat in the foreground with the `test config` command specified. For
 example:
 
-ifdef::allplatforms[]
+ifndef::win-only[]
 
 ["source","shell",subs="attributes"]
 ----------------------------------------------------------------------
 {beatname_lc} test config -c {beatname_lc}.yml
 ----------------------------------------------------------------------
 
-endif::allplatforms[]
+endif::win-only[]
 
-ifdef::win[]
+ifdef::win-only[]
 
 ["source","shell",subs="attributes"]
 ----------------------------------------------------------------------
 .\winlogbeat.exe test config -c .\winlogbeat.yml -e
 ----------------------------------------------------------------------
 
-endif::win[]
+endif::win-only[]
 
 You'll see a message if the Beat finds an error in the file.
 

--- a/metricbeat/docs/configuring-howto.asciidoc
+++ b/metricbeat/docs/configuring-howto.asciidoc
@@ -47,7 +47,6 @@ include::./metricbeat-general-options.asciidoc[]
 
 include::./reload-configuration.asciidoc[]
 
-:allplatforms:
 include::../../libbeat/docs/queueconfig.asciidoc[]
 
 include::../../libbeat/docs/outputconfig.asciidoc[]
@@ -68,14 +67,15 @@ include::../../libbeat/docs/loggingconfig.asciidoc[]
 
 :standalone:
 include::../../libbeat/docs/shared-env-vars.asciidoc[]
+:standalone!:
 
 :autodiscoverJolokia:
 :autodiscoverHints:
 include::../../libbeat/docs/shared-autodiscover.asciidoc[]
 
 :standalone:
-:allplatforms:
 include::../../libbeat/docs/yaml.asciidoc[]
+:standalone!:
 
 include::../../libbeat/docs/regexp.asciidoc[]
 

--- a/metricbeat/docs/gettingstarted.asciidoc
+++ b/metricbeat/docs/gettingstarted.asciidoc
@@ -232,14 +232,7 @@ NOTE: If you use an init.d script to start {beatname_uc} on deb or rpm, you can'
 specify command line flags (see <<command-line-options>>). To specify flags,
 start {beatname_uc} in the foreground.
 
-*deb:*
-
-["source","sh",subs="attributes"]
-----------------------------------------------------------------------
-sudo service {beatname_lc} start
-----------------------------------------------------------------------
-
-*rpm:*
+*deb and rpm:*
 
 ["source","sh",subs="attributes"]
 ----------------------------------------------------------------------

--- a/metricbeat/docs/gettingstarted.asciidoc
+++ b/metricbeat/docs/gettingstarted.asciidoc
@@ -214,13 +214,11 @@ include::../../libbeat/docs/step-look-at-config.asciidoc[]
 [id="{beatname_lc}-template"]
 === Step 3: Load the index template in Elasticsearch
 
-:allplatforms:
 include::../../libbeat/docs/shared-template-load.asciidoc[]
 
 [[load-kibana-dashboards]]
 === Step 4: Set up the Kibana dashboards
 
-:allplatforms:
 include::../../libbeat/docs/dashboards.asciidoc[]
 
 [id="{beatname_lc}-starting"]

--- a/metricbeat/docs/index.asciidoc
+++ b/metricbeat/docs/index.asciidoc
@@ -12,6 +12,11 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :discuss_forum: beats/{beatname_lc}
 :beat_default_index_prefix: {beatname_lc}
 :has_ml_jobs: yes
+:deb_os:
+:rpm_os:
+:mac_os:
+:docker_platform:
+:win_os:
 
 include::../../libbeat/docs/shared-beats-attributes.asciidoc[]
 

--- a/packetbeat/docs/configuring-howto.asciidoc
+++ b/packetbeat/docs/configuring-howto.asciidoc
@@ -46,7 +46,6 @@ include::./packetbeat-options.asciidoc[]
 
 include::./packetbeat-general-options.asciidoc[]
 
-:allplatforms:
 include::../../libbeat/docs/queueconfig.asciidoc[]
 
 include::../../libbeat/docs/outputconfig.asciidoc[]
@@ -69,10 +68,11 @@ include::../../libbeat/docs/loggingconfig.asciidoc[]
 
 :standalone:
 include::../../libbeat/docs/shared-env-vars.asciidoc[]
+:standalone!:
 
 :standalone:
-:allplatforms:
 include::../../libbeat/docs/yaml.asciidoc[]
+:standalone!:
 
 include::../../libbeat/docs/http-endpoint.asciidoc[]
 

--- a/packetbeat/docs/gettingstarted.asciidoc
+++ b/packetbeat/docs/gettingstarted.asciidoc
@@ -239,14 +239,12 @@ include::../../libbeat/docs/step-look-at-config.asciidoc[]
 === Step 3: Load the index template in Elasticsearch
 
 :requires-sudo: yes
-:allplatforms:
 include::../../libbeat/docs/shared-template-load.asciidoc[]
 
 [[load-kibana-dashboards]]
 === Step 4: Set up the Kibana dashboards
 
 :requires-sudo: yes
-:allplatforms:
 include::../../libbeat/docs/dashboards.asciidoc[]
 
 [[packetbeat-starting]]

--- a/packetbeat/docs/gettingstarted.asciidoc
+++ b/packetbeat/docs/gettingstarted.asciidoc
@@ -258,14 +258,7 @@ NOTE: If you use an init.d script to start Packetbeat on deb or rpm, you can't
 specify command line flags (see <<command-line-options>>). To specify flags,
 start Packetbeat in the foreground.
 
-*deb:*
-
-["source","sh",subs="attributes"]
-----------------------------------------------------------------------
-sudo service {beatname_lc} start
-----------------------------------------------------------------------
-
-*rpm:*
+*deb and rpm:*
 
 ["source","sh",subs="attributes"]
 ----------------------------------------------------------------------

--- a/packetbeat/docs/index.asciidoc
+++ b/packetbeat/docs/index.asciidoc
@@ -12,6 +12,11 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :discuss_forum: beats/{beatname_lc}
 :beat_default_index_prefix: {beatname_lc}
 :has_ml_jobs: yes
+:deb_os:
+:rpm_os:
+:mac_os:
+:docker_platform:
+:win_os:
 
 include::../../libbeat/docs/shared-beats-attributes.asciidoc[]
 

--- a/winlogbeat/docs/configuring-howto.asciidoc
+++ b/winlogbeat/docs/configuring-howto.asciidoc
@@ -40,7 +40,6 @@ include::./winlogbeat-options.asciidoc[]
 
 include::./winlogbeat-general-options.asciidoc[]
 
-:win:
 include::../../libbeat/docs/queueconfig.asciidoc[]
 
 include::../../libbeat/docs/outputconfig.asciidoc[]
@@ -61,10 +60,11 @@ include::../../libbeat/docs/loggingconfig.asciidoc[]
 
 :standalone:
 include::../../libbeat/docs/shared-env-vars.asciidoc[]
+:standalone!:
 
 :standalone:
-:win:
 include::../../libbeat/docs/yaml.asciidoc[]
+:standalone!:
 
 include::../../libbeat/docs/http-endpoint.asciidoc[]
 

--- a/winlogbeat/docs/getting-started.asciidoc
+++ b/winlogbeat/docs/getting-started.asciidoc
@@ -111,7 +111,6 @@ PS C:\Program Files\Winlogbeat> .\winlogbeat.exe test config -c .\winlogbeat.yml
 [[config-winlogbeat-logstash]]
 === Step 3: Configure Winlogbeat to use Logstash
 
-:win:
 include::../../libbeat/docs/shared-logstash-config.asciidoc[]
 
 [[winlogbeat-template]]
@@ -122,7 +121,6 @@ include::../../libbeat/docs/shared-template-load.asciidoc[]
 [[load-kibana-dashboards]]
 === Step 5: Set up the Kibana dashboards
 
-:win:
 include::../../libbeat/docs/dashboards.asciidoc[]
 
 [[winlogbeat-starting]]

--- a/winlogbeat/docs/index.asciidoc
+++ b/winlogbeat/docs/index.asciidoc
@@ -12,6 +12,8 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :discuss_forum: beats/{beatname_lc}
 :beat_default_index_prefix: {beatname_lc}
 :has_ml_jobs: yes
+:win_os:
+:win_only:
 
 include::../../libbeat/docs/shared-beats-attributes.asciidoc[]
 


### PR DESCRIPTION
Summary of changes:

- Added attributes to use for conditionally rendering commands based on the platforms supported by a Beat (this is required by Journalbeat).
- Created a separate example for each OS. We could probably continue combining deb and rpm in a single command example, but separating them gives us maximum flexibility for conditionally rendering examples in the future.
- Removed `allplatforms` and changed the files to use `win-only` to render content that's only relevant when windows is the only supported platform (currently true for Winlogbeat).
- Added attribute resets where the `standalone` attribute is used (resetting attributes when you no longer want them to be in scope is a best practice).
- Added attribute names to `endif` statements to make it easier to read the asciidoc source when there are nested conditions.

Open issues (to be addressed in future PRs): 
- I still need to add linux commands. I'll do that in another PR. 
- The docker commands are a bit of a mess (inconsistent coverage). It's been suggested that we remove the docker commands from the GS and point users to the topic about running on docker. I might do this, but wanted the focus of this PR to be conditional settings.