### PR TITLE
Cherry-pick #8449 to 6.4: Allow to pass config overrides via the Settings Struct

### DIFF
--- a/CHANGELOG-developer.asciidoc
+++ b/CHANGELOG-developer.asciidoc
@@ -43,3 +43,4 @@ The list below covers the major changes between 6.3.0 and master only.
 - Packaging on MacOS now produces a .dmg file containing an installer (.pkg) and uninstaller for the Beat. {pull}7481[7481]
 - Libbeat provides a new function `cmd.GenRootCmdWithSettings` that should be preferred over deprecated functions
   `cmd.GenRootCmd`, `cmd.GenRootCmdWithRunFlags`, and `cmd.GenRootCmdWithIndexPrefixWithRunFlags`. {pull}7850[7850]
+- You can now override default settings of libbeat by using instance.Settings. {pull}8449[8449]

--- a/libbeat/cmd/instance/settings.go
+++ b/libbeat/cmd/instance/settings.go
@@ -20,14 +20,16 @@ package instance
 import (
 	"github.com/spf13/pflag"
 
+	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/monitoring/report"
 )
 
 // Settings contains basic settings for any beat to pass into GenRootCmd
 type Settings struct {
-	Name        string
-	IndexPrefix string
-	Version     string
-	Monitoring  report.Settings
-	RunFlags    *pflag.FlagSet
+	Name            string
+	IndexPrefix     string
+	Version         string
+	Monitoring      report.Settings
+	RunFlags        *pflag.FlagSet
+	ConfigOverrides *common.Config
 }


### PR DESCRIPTION
Cherry-pick of PR #8449 to 6.4 branch. Original message: 

Sometime a custom beat that get executed want to override system
defaults instead of relying on code defined by libbeat.

This is the case with beatless, the queue has limits and flush values
that make sense when the beat is run on the edge but not on on AWS lambda.

Note that settings is passed via liberal common.Config no type checking is
done. I went that route because many parts of beats doesn't expose the
config struct outside of the package.

This is similar to explicitely defining them in the yaml.

**Notes:** this part of the code is pretty hard to unit test, we have to do some refactoring to make it happen :(