### PR TITLE
Cherry-pick #8808 to 6.5: Update request to 2.20.0

### DIFF
--- a/libbeat/tests/system/requirements.txt
+++ b/libbeat/tests/system/requirements.txt
@@ -21,7 +21,7 @@ nose-timer==0.7.1
 pycodestyle==2.4.0
 PyYAML==3.12
 redis==2.10.6
-requests==2.18.4
+requests==2.20.0
 six==1.11.0
 termcolor==1.1.0
 texttable==0.9.1


### PR DESCRIPTION
Cherry-pick of PR #8808 to 6.5 branch. Original message: 

The Requests package through 2.19.1 before 2018-09-14 for Python sends an HTTP Authorization header to an http URI upon receiving a same-hostname https-to-http redirect, which makes it easier for remote attackers to discover credentials by sniffing the network.

https://nvd.nist.gov/vuln/detail/CVE-2018-18074