### PR TITLE
Cherry-pick #8810 to 6.5: Build dummy journalbeat on non-windows

### DIFF
--- a/journalbeat/cmd/instance/metrics.go
+++ b/journalbeat/cmd/instance/metrics.go
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//+build linux,cgo
+
 package instance
 
 import (

--- a/journalbeat/cmd/instance/metrics_other.go
+++ b/journalbeat/cmd/instance/metrics_other.go
@@ -1,0 +1,26 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//+build !linux !cgo
+
+package instance
+
+// SetupJournalMetrics initializes and registers monitoring functions.
+func SetupJournalMetrics() {}
+
+// StopMonitoringJournal stops monitoring the journal under the path.
+func StopMonitoringJournal(path string) {}

--- a/journalbeat/reader/config.go
+++ b/journalbeat/reader/config.go
@@ -1,0 +1,41 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package reader
+
+import "time"
+
+// Config stores the options of a reder.
+type Config struct {
+	// Path is the path to the journal file.
+	Path string
+	// Seek specifies the seeking stategy.
+	// Possible values: head, tail, cursor.
+	Seek string
+	// MaxBackoff is the limit of the backoff time.
+	MaxBackoff time.Duration
+	// Backoff is the current interval to wait before
+	// attemting to read again from the journal.
+	Backoff time.Duration
+	// Matches store the key value pairs to match entries.
+	Matches []string
+}
+
+const (
+	// LocalSystemJournalID is the ID of the local system journal.
+	LocalSystemJournalID = "LOCAL_SYSTEM_JOURNAL"
+)

--- a/journalbeat/reader/fields.go
+++ b/journalbeat/reader/fields.go
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//+build linux,cgo
+
 package reader
 
 import "github.com/coreos/go-systemd/sdjournal"

--- a/journalbeat/reader/journal.go
+++ b/journalbeat/reader/journal.go
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//+build linux,cgo
+
 package reader
 
 import (
@@ -34,27 +36,6 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 )
-
-const (
-	// LocalSystemJournalID is the ID of the local system journal.
-	LocalSystemJournalID = "LOCAL_SYSTEM_JOURNAL"
-)
-
-// Config stores the options of a reder.
-type Config struct {
-	// Path is the path to the journal file.
-	Path string
-	// Seek specifies the seeking stategy.
-	// Possible values: head, tail, cursor.
-	Seek string
-	// MaxBackoff is the limit of the backoff time.
-	MaxBackoff time.Duration
-	// Backoff is the current interval to wait before
-	// attemting to read again from the journal.
-	Backoff time.Duration
-	// Matches store the key value pairs to match entries.
-	Matches []string
-}
 
 // Reader reads entries from journal(s).
 type Reader struct {

--- a/journalbeat/reader/journal_other.go
+++ b/journalbeat/reader/journal_other.go
@@ -1,0 +1,55 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//+build !linux !cgo
+
+package reader
+
+import (
+	"errors"
+
+	"github.com/elastic/beats/journalbeat/checkpoint"
+	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/logp"
+)
+
+// Reader stub for non linux builds.
+type Reader struct{}
+
+// New creates a new journal reader and moves the FP to the configured position.
+//
+// Note: New fails if journalbeat is not compiled for linux
+func New(c Config, done chan struct{}, state checkpoint.JournalState, logger *logp.Logger) (*Reader, error) {
+	return nil, errors.New("journald reader only supported on linux")
+}
+
+// NewLocal creates a reader to read form the local journal and moves the FP
+// to the configured position.
+//
+// Note: NewLocal fails if journalbeat is not compiled for linux
+func NewLocal(c Config, done chan struct{}, state checkpoint.JournalState, logger *logp.Logger) (*Reader, error) {
+	return nil, errors.New("journald reader only supported on linux")
+}
+
+// Next waits until a new event shows up and returns it.
+// It blocks until an event is returned or an error occurs.
+func (r *Reader) Next() (*beat.Event, error) {
+	return nil, nil
+}
+
+// Close closes the underlying journal reader.
+func (r *Reader) Close() {}

--- a/journalbeat/reader/journal_test.go
+++ b/journalbeat/reader/journal_test.go
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//+build linux,cgo
+
 package reader
 
 import (


### PR DESCRIPTION
Cherry-pick of PR #8810 to 6.5 branch. Original message: 

Journald and headers are only available on linux. With this change we
only build a stub-journalbeat and allow unit tests which do not require
linux dependencies (similar to winlogbeat)