### PR TITLE
Cherry-pick #8827 to 6.x: cherrypick_pr: Support non-ascii characters in PR title and description

### DIFF
--- a/dev-tools/cherrypick_pr
+++ b/dev-tools/cherrypick_pr
@@ -131,11 +131,11 @@ def main():
 
         # create PR
         request = session.post(base + "/pulls", json=dict(
-            title="Cherry-pick #{} to {}: {}".format(args.pr_number, args.to_branch, original_pr["title"]),
+            title="Cherry-pick #{} to {}: {}".format(args.pr_number, args.to_branch, original_pr["title"].encode('utf-8')),
             head=remote_user + ":" + tmp_branch,
             base=args.to_branch,
             body="Cherry-pick of PR #{} to {} branch. Original message: \n\n{}"
-            .format(args.pr_number, args.to_branch, original_pr["body"])
+            .format(args.pr_number, args.to_branch, original_pr["body"].encode('utf-8'))
         ))
         if request.status_code > 299:
             print("Creating PR failed: {}".format(request.json()))


### PR DESCRIPTION
Cherry-pick of PR #8827 to 6.x branch. Original message: 

The script in `dev-tools/cherrypick_pr` fails to create a PR in Github if the original PR title or description contains non-ascii characters  ツ 