### PR TITLE
Fix heartbeat docs for config reloading

### DIFF
--- a/heartbeat/_meta/beat.reference.yml
+++ b/heartbeat/_meta/beat.reference.yml
@@ -63,6 +63,16 @@ heartbeat.monitors:
     # Interval between file file changed checks.
     #interval: 5s
 
+# Define a directory to load monitor definitions from. Definitions take the form
+# of individual yaml files.
+# heartbeat.config.monitors:
+  # Directory + glob pattern to search for configuration files
+  #path: /path/to/my/monitors.d/*.yml
+  # If enabled, heartbeat will periodically check the config.monitors path for changes
+  #reload.enabled: true
+  # How often to check for changes
+  #reload.period: 1s
+
 - type: tcp # monitor type `tcp`. Connect via TCP and optionally verify endpoint
             # by sending/receiving a custom payload
 

--- a/heartbeat/docs/heartbeat-options.asciidoc
+++ b/heartbeat/docs/heartbeat-options.asciidoc
@@ -52,6 +52,8 @@ happening to you. To do so you would instead have your +heartbeat.yml+ file cont
 heartbeat.config.monitors:
   # Directory + glob pattern to search for configuration files
   path: /path/to/my/monitors.d/*.yml
+  # If enabled, heartbeat will periodically check the config.monitors path for changes
+  reload.enabled: true
   # How often to check for changes
   reload.period: 1s
 ----------------------------------------------------------------------

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -63,6 +63,16 @@ heartbeat.monitors:
     # Interval between file file changed checks.
     #interval: 5s
 
+# Define a directory to load monitor definitions from. Definitions take the form
+# of individual yaml files.
+# heartbeat.config.monitors:
+  # Directory + glob pattern to search for configuration files
+  #path: /path/to/my/monitors.d/*.yml
+  # If enabled, heartbeat will periodically check the config.monitors path for changes
+  #reload.enabled: true
+  # How often to check for changes
+  #reload.period: 1s
+
 - type: tcp # monitor type `tcp`. Connect via TCP and optionally verify endpoint
             # by sending/receiving a custom payload
 


### PR DESCRIPTION
This commit fixes a nasty bug in the docs for config reloading where the `reload.enabled` option wasn't documented. Without this config reloading does not work.

This commit also adds these config options to the heartbeat.reference.yml file, which was an oversight in the original PR.

Fixes https://github.com/elastic/beats/pull/8839