### PR TITLE
add_cloud_metadata asynchronous initialization

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -133,6 +133,7 @@ https://github.com/elastic/beats/compare/v6.4.0...master[Check the HEAD diff]
 - Allow Bus to buffer events in case listeners are not configured. {pull}8527[8527]
 - Enable `host` and `cloud` metadata processors by default. {pull}8596[8596]
 - Dissect will now flag event on parsing error. {pull}8751[8751]
+- add_cloud_metadata initialization is performed asynchronously to avoid delays on startup. {pull}8845[8845]
 
 *Auditbeat*
 


### PR DESCRIPTION
Now that the add_cloud_metadata is enabled by default in all beats, we are losing 3 precious seconds every time a Beat is started outside a supported cloud environment.

This patch makes the cloud detection an asynchronous task so the Beat can start and only block if initialization is not completed at the time of the first enrichment.

Running in debug mode bypasses this parallelism as the processor needs to be initialized when its String() method is called.