### PR TITLE
Rephrase documentation of socket summary metricset

### DIFF
--- a/metricbeat/module/system/socket_summary/_meta/docs.asciidoc
+++ b/metricbeat/module/system/socket_summary/_meta/docs.asciidoc
@@ -1,11 +1,8 @@
-The System `socket_summary` metricset provides the summary of open network sockets in the host system.
+The System `socket_summary` metricset provides the summary of open network
+sockets in the host system.
 
-The following metrics are exported:
-* TCP
-    * all: All connections
-    * listening: All listening connections
-* UDP:
-    * all: All connections
+It collects a summary of metrics with the count of existing TCP and UDP
+connections and the count of listening ports.
 
 This metricset is available on:
 


### PR DESCRIPTION
Format in [documentation](https://www.elastic.co/guide/en/beats/metricbeat/6.5/metricbeat-metricset-system-socket_summary.html) is broken, change small list by phrase.