### PR TITLE
filebeat returns error if meta.json exists but is empty (no UUID)

### DIFF
--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -644,12 +644,12 @@ func (b *Beat) loadMeta() error {
 
 	if err == nil {
 		m := meta{}
-		
+
 		fi, err := f.Stat()
 		if err != nil {
 			return fmt.Errorf("Beat meta file stat error: %v", err)
 		}
-		
+
 		if fi.Size() != 0 {
 			if err := json.NewDecoder(f).Decode(&m); err != nil {
 				f.Close()

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -644,16 +644,24 @@ func (b *Beat) loadMeta() error {
 
 	if err == nil {
 		m := meta{}
-		if err := json.NewDecoder(f).Decode(&m); err != nil {
-			f.Close()
-			return fmt.Errorf("Beat meta file reading error: %v", err)
+		
+		fi, err := f.Stat()
+		if err != nil {
+			return fmt.Errorf("Beat meta file stat error: %v", err)
 		}
+		
+		if fi.Size() != 0 {
+			if err := json.NewDecoder(f).Decode(&m); err != nil {
+				f.Close()
+				return fmt.Errorf("Beat meta file reading error: %v", err)
+			}
 
-		f.Close()
-		valid := m.UUID != uuid.Nil
-		if valid {
-			b.Info.UUID = m.UUID
-			return nil
+			f.Close()
+			valid := m.UUID != uuid.Nil
+			if valid {
+				b.Info.UUID = m.UUID
+				return nil
+			}
 		}
 	}
 


### PR DESCRIPTION
In [beat.go](https://github.com/elastic/beats/blob/master/libbeat/cmd/instance/beat.go) line 639 is where the function that handles meta.json and the UUID starts. Everything works perfectly if meta.json doesn't exist on startup because it will just get created. If it already exists then everything gets handled correctly as well. The problem comes if meta.json exists but is empty (no UUID). Instead of creating a UUID and putting it in the empty meta.json file, an error is returned (line 656). This pull request changes one simple thing: it checks if the size of meta.json is 0. If the size is not 0 then it continues like it normally does (checking the UUID). If the size is 0 then it skips checking the UUID and creates a new UUID and adds it to the empty meta.json

This problem was brought to my attention when using filebeat on a raspberry pi. Once the image with filebeat is installed on the pi, it would occasionally create an empty meta.json file on the first startup.