### PR TITLE
Cherry-pick #8750 and #7768 to 6.x: Allow to use a star (*) to extract a value that can be referenced and add external test suite for dissect

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -13,6 +13,8 @@ https://github.com/elastic/beats/compare/v6.4.0...6.x[Check the HEAD diff]
 
 *Affecting all Beats*
 
+- Dissect syntax change, use * instead of ? when working with field reference. {issue}8054[8054]
+
 *Auditbeat*
 
 *Filebeat*

--- a/libbeat/processors/dissect/.gitignore
+++ b/libbeat/processors/dissect/.gitignore
@@ -1,1 +1,0 @@
-dissect_tests.json

--- a/libbeat/processors/dissect/const.go
+++ b/libbeat/processors/dissect/const.go
@@ -37,6 +37,7 @@ var (
 	appendIndirectPrefix = "+&"
 	indirectAppendPrefix = "&+"
 	greedySuffix         = "->"
+	pointerFieldPrefix   = "*"
 
 	defaultJoinString = " "
 

--- a/libbeat/processors/dissect/dissect.go
+++ b/libbeat/processors/dissect/dissect.go
@@ -133,7 +133,7 @@ func (d *Dissector) resolve(s string, p positions) Map {
 		f.Apply(s[pos.start:pos.end], m)
 	}
 
-	for _, f := range d.parser.skipFields {
+	for _, f := range d.parser.referenceFields {
 		delete(m, f.Key())
 	}
 	return m
@@ -145,5 +145,10 @@ func New(tokenizer string) (*Dissector, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	if err := validate(p); err != nil {
+		return nil, err
+	}
+
 	return &Dissector{parser: p, raw: tokenizer}, nil
 }

--- a/libbeat/processors/dissect/dissect_test.go
+++ b/libbeat/processors/dissect/dissect_test.go
@@ -19,15 +19,14 @@ package dissect
 
 import (
 	"encoding/json"
-	"flag"
+	"fmt"
 	"io/ioutil"
+	"os"
 	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
-
-var export = flag.Bool("test.export-dissect", false, "export dissect tests to JSON.")
 
 func TestNoToken(t *testing.T) {
 	_, err := New("hello")
@@ -51,196 +50,19 @@ type dissectTest struct {
 	Fail     bool   `json:"fail"`
 }
 
-var tests = []dissectTest{
-	{
-		Name: "When all the defined fields are captured by we have remaining data",
-		Tok:  "level=%{level} ts=%{timestamp} caller=%{caller} msg=\"%{message}\"",
-		Msg:  "level=info ts=2018-06-27T17:19:13.036579993Z caller=main.go:222 msg=\"Starting OK\" version=\"(version=2.3.1, branch=HEAD, revision=188ca45bd85ce843071e768d855722a9d9dabe03)\"}",
-		Expected: Map{
-			"level":     "info",
-			"timestamp": "2018-06-27T17:19:13.036579993Z",
-			"caller":    "main.go:222",
-			"message":   "Starting OK",
-		},
-	},
-	{
-		Name: "Complex stack trace",
-		Tok:  "%{day}-%{month}-%{year} %{hour} %{severity} [%{thread_id}] %{origin} %{message}",
-		Msg: `18-Apr-2018 06:53:20.411 INFO [http-nio-8080-exec-1] org.apache.coyote.http11.Http11Processor.service Error parsing HTTP request header
- Note: further occurrences of HTTP header parsing errors will be logged at DEBUG level.
- java.lang.IllegalArgumentException: Invalid character found in method name. HTTP method names must be tokens
-    at org.apache.coyote.http11.Http11InputBuffer.parseRequestLine(Http11InputBuffer.java:426)
-    at org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:687)
-    at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:66)
-    at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:790)
-    at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1459)
-    at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:49)
-    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
-    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
-    at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
-    at java.lang.Thread.run(Thread.java:748)`,
-		Expected: Map{
-			"day":       "18",
-			"month":     "Apr",
-			"year":      "2018",
-			"hour":      "06:53:20.411",
-			"severity":  "INFO",
-			"thread_id": "http-nio-8080-exec-1",
-			"origin":    "org.apache.coyote.http11.Http11Processor.service",
-			"message": `Error parsing HTTP request header
- Note: further occurrences of HTTP header parsing errors will be logged at DEBUG level.
- java.lang.IllegalArgumentException: Invalid character found in method name. HTTP method names must be tokens
-    at org.apache.coyote.http11.Http11InputBuffer.parseRequestLine(Http11InputBuffer.java:426)
-    at org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:687)
-    at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:66)
-    at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:790)
-    at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1459)
-    at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:49)
-    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
-    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
-    at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
-    at java.lang.Thread.run(Thread.java:748)`,
-		},
-	},
-	{
-		Name: "fails when delimiter is not found at the beginning of the string",
-		Tok:  "/var/log/%{key}.log",
-		Msg:  "foobar",
-		Fail: true,
-	},
-	{
-		Name: "fails when delimiter is not found after the key",
-		Tok:  "/var/log/%{key}.log",
-		Msg:  "/var/log/foobar",
-		Fail: true,
-	},
-	{
-		Name:     "simple dissect",
-		Tok:      "%{key}",
-		Msg:      "foobar",
-		Expected: Map{"key": "foobar"},
-	},
-	{
-		Name:     "dissect two replacement",
-		Tok:      "%{key1} %{key2}",
-		Msg:      "foo bar",
-		Expected: Map{"key1": "foo", "key2": "bar"},
-	},
-	{
-		Name:     "one level dissect not end of string",
-		Tok:      "/var/%{key}/log",
-		Msg:      "/var/foobar/log",
-		Expected: Map{"key": "foobar"},
-	},
-	{
-		Name:     "one level dissect",
-		Tok:      "/var/%{key}",
-		Msg:      "/var/foobar/log",
-		Expected: Map{"key": "foobar/log"},
-	},
-	{
-		Name:     "multiple keys dissect end of string",
-		Tok:      "/var/%{key}/log/%{key1}",
-		Msg:      "/var/foobar/log/apache",
-		Expected: Map{"key": "foobar", "key1": "apache"},
-	},
-	{
-		Name:     "multiple keys not end of string",
-		Tok:      "/var/%{key}/log/%{key1}.log",
-		Msg:      "/var/foobar/log/apache.log",
-		Expected: Map{"key": "foobar", "key1": "apache"},
-	},
-	{
-		Name:     "simple ordered",
-		Tok:      "%{+key/3} %{+key/1} %{+key/2}",
-		Msg:      "1 2 3",
-		Expected: Map{"key": "2 3 1"},
-	},
-	{
-		Name:     "simple append",
-		Tok:      "%{key}-%{+key}-%{+key}",
-		Msg:      "1-2-3",
-		Expected: Map{"key": "1-2-3"},
-	},
-	{
-		Name:     "indirect field",
-		Tok:      "%{key} %{&key}",
-		Msg:      "hello world",
-		Expected: Map{"key": "hello", "hello": "world"},
-	},
-	{
-		Name:     "skip field",
-		Tok:      "%{} %{key}",
-		Msg:      "hello world",
-		Expected: Map{"key": "world"},
-	},
-	{
-		Name:     "named skiped field with indirect",
-		Tok:      "%{?key} %{&key}",
-		Msg:      "hello world",
-		Expected: Map{"hello": "world"},
-	},
-	{
-		Name: "missing fields",
-		Tok:  "%{name},%{addr1},%{addr2},%{addr3},%{city},%{zip}",
-		Msg:  "Jane Doe,4321 Fifth Avenue,,,New York,87432",
-		Expected: Map{
-			"name":  "Jane Doe",
-			"addr1": "4321 Fifth Avenue",
-			"addr2": "",
-			"addr3": "",
-			"city":  "New York",
-			"zip":   "87432",
-		},
-	},
-	{
-		Name: "ignore right padding",
-		Tok:  "%{id} %{function->} %{server}",
-		Msg:  "00000043 ViewReceive     machine-321",
-		Expected: Map{
-			"id":       "00000043",
-			"function": "ViewReceive",
-			"server":   "machine-321",
-		},
-	},
-	{
-		Name: "padding on the last key need a delimiter",
-		Tok:  "%{id} %{function} %{server->} ",
-		Msg:  "00000043 ViewReceive machine-321    ",
-		Expected: Map{
-			"id":       "00000043",
-			"function": "ViewReceive",
-			"server":   "machine-321",
-		},
-	},
-	{
-		Name: "ignore left padding",
-		Tok:  "%{id->} %{function} %{server}",
-		Msg:  "00000043    ViewReceive machine-321",
-		Expected: Map{
-			"id":       "00000043",
-			"function": "ViewReceive",
-			"server":   "machine-321",
-		},
-	},
-	{
-		Name: "when the delimiters contains `{` and `}`",
-		Tok:  "{%{a}}{%{b}} %{rest}",
-		Msg:  "{c}{d} anything",
-		Expected: Map{
-			"a":    "c",
-			"b":    "d",
-			"rest": "anything",
-		},
-	},
+var tests []dissectTest
+
+func init() {
+	content, err := ioutil.ReadFile("testdata/dissect_tests.json")
+	if err != nil {
+		fmt.Printf("could not read the content of 'dissect_tests', error: %s", err)
+		os.Exit(1)
+	}
+
+	json.Unmarshal(content, &tests)
 }
 
 func TestDissect(t *testing.T) {
-	if export != nil && *export {
-		dumpJSON()
-		return
-	}
-
 	for _, test := range tests {
 		if test.Skip {
 			continue
@@ -349,16 +171,4 @@ func BenchmarkDissect(b *testing.B) {
 			o = re.FindAllStringSubmatch(by, -1)
 		}
 	})
-}
-
-func dumpJSON() {
-	b, err := json.MarshalIndent(&tests, "", "\t")
-	if err != nil {
-		panic("could not marshal json")
-	}
-
-	err = ioutil.WriteFile("dissect_tests.json", b, 0666)
-	if err != nil {
-		panic("could not write to file")
-	}
 }

--- a/libbeat/processors/dissect/field.go
+++ b/libbeat/processors/dissect/field.go
@@ -108,6 +108,8 @@ func (f skipField) IsSaveable() bool {
 // message: hello world
 // result:
 //	hello: world
+//
+// Deprecated: see pointerField
 type namedSkipField struct {
 	baseField
 }
@@ -117,6 +119,20 @@ func (f namedSkipField) Apply(b string, m Map) {
 }
 
 func (f namedSkipField) IsSaveable() bool {
+	return false
+}
+
+// pointerField will extract the content between the delimiters and we can reference it during when
+// extracing other values.
+type pointerField struct {
+	baseField
+}
+
+func (f pointerField) Apply(b string, m Map) {
+	m[f.Key()] = b
+}
+
+func (f pointerField) IsSaveable() bool {
 	return false
 }
 
@@ -192,6 +208,10 @@ func newField(id int, rawKey string, previous delimiter) (field, error) {
 		return newNamedSkipField(id, key[1:]), nil
 	}
 
+	if strings.HasPrefix(key, pointerFieldPrefix) {
+		return newPointerField(id, key[1:]), nil
+	}
+
 	if strings.HasPrefix(key, appendFieldPrefix) {
 		return newAppendField(id, key[1:], ordinal, greedy, previous), nil
 	}
@@ -209,6 +229,12 @@ func newSkipField(id int) skipField {
 
 func newNamedSkipField(id int, key string) namedSkipField {
 	return namedSkipField{
+		baseField{id: id, key: key},
+	}
+}
+
+func newPointerField(id int, key string) pointerField {
+	return pointerField{
 		baseField{id: id, key: key},
 	}
 }

--- a/libbeat/processors/dissect/testdata/dissect_tests.json
+++ b/libbeat/processors/dissect/testdata/dissect_tests.json
@@ -1,0 +1,235 @@
+[
+	{
+		"name": "When all the defined fields are captured by we have remaining data",
+		"tok": "level=%{level} ts=%{timestamp} caller=%{caller} msg=\"%{message}\"",
+		"msg": "level=info ts=2018-06-27T17:19:13.036579993Z caller=main.go:222 msg=\"Starting OK\" version=\"(version=2.3.1, branch=HEAD, revision=188ca45bd85ce843071e768d855722a9d9dabe03)\"}",
+		"expected": {
+			"caller": "main.go:222",
+			"level": "info",
+			"message": "Starting OK",
+			"timestamp": "2018-06-27T17:19:13.036579993Z"
+		},
+		"skip": false,
+		"fail": false
+	},
+	{
+		"name": "Complex stack trace",
+		"tok": "%{day}-%{month}-%{year} %{hour} %{severity} [%{thread_id}] %{origin} %{message}",
+		"msg": "18-Apr-2018 06:53:20.411 INFO [http-nio-8080-exec-1] org.apache.coyote.http11.Http11Processor.service Error parsing HTTP request header\n Note: further occurrences of HTTP header parsing errors will be logged at DEBUG level.\n java.lang.IllegalArgumentException: Invalid character found in method name. HTTP method names must be tokens\n    at org.apache.coyote.http11.Http11InputBuffer.parseRequestLine(Http11InputBuffer.java:426)\n    at org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:687)\n    at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:66)\n    at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:790)\n    at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1459)\n    at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:49)\n    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)\n    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)\n    at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)\n    at java.lang.Thread.run(Thread.java:748)",
+		"expected": {
+			"day": "18",
+			"hour": "06:53:20.411",
+			"message": "Error parsing HTTP request header\n Note: further occurrences of HTTP header parsing errors will be logged at DEBUG level.\n java.lang.IllegalArgumentException: Invalid character found in method name. HTTP method names must be tokens\n    at org.apache.coyote.http11.Http11InputBuffer.parseRequestLine(Http11InputBuffer.java:426)\n    at org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:687)\n    at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:66)\n    at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:790)\n    at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1459)\n    at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:49)\n    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)\n    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)\n    at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)\n    at java.lang.Thread.run(Thread.java:748)",
+			"month": "Apr",
+			"origin": "org.apache.coyote.http11.Http11Processor.service",
+			"severity": "INFO",
+			"thread_id": "http-nio-8080-exec-1",
+			"year": "2018"
+		},
+		"skip": false,
+		"fail": false
+	},
+	{
+		"name": "fails when delimiter is not found at the beginning of the string",
+		"tok": "/var/log/%{key}.log",
+		"msg": "foobar",
+		"expected": null,
+		"skip": false,
+		"fail": true
+	},
+	{
+		"name": "fails when delimiter is not found after the key",
+		"tok": "/var/log/%{key}.log",
+		"msg": "/var/log/foobar",
+		"expected": null,
+		"skip": false,
+		"fail": true
+	},
+	{
+		"name": "simple dissect",
+		"tok": "%{key}",
+		"msg": "foobar",
+		"expected": {
+			"key": "foobar"
+		},
+		"skip": false,
+		"fail": false
+	},
+	{
+		"name": "dissect two replacement",
+		"tok": "%{key1} %{key2}",
+		"msg": "foo bar",
+		"expected": {
+			"key1": "foo",
+			"key2": "bar"
+		},
+		"skip": false,
+		"fail": false
+	},
+	{
+		"name": "one level dissect not end of string",
+		"tok": "/var/%{key}/log",
+		"msg": "/var/foobar/log",
+		"expected": {
+			"key": "foobar"
+		},
+		"skip": false,
+		"fail": false
+	},
+	{
+		"name": "one level dissect",
+		"tok": "/var/%{key}",
+		"msg": "/var/foobar/log",
+		"expected": {
+			"key": "foobar/log"
+		},
+		"skip": false,
+		"fail": false
+	},
+	{
+		"name": "multiple keys dissect end of string",
+		"tok": "/var/%{key}/log/%{key1}",
+		"msg": "/var/foobar/log/apache",
+		"expected": {
+			"key": "foobar",
+			"key1": "apache"
+		},
+		"skip": false,
+		"fail": false
+	},
+	{
+		"name": "multiple keys not end of string",
+		"tok": "/var/%{key}/log/%{key1}.log",
+		"msg": "/var/foobar/log/apache.log",
+		"expected": {
+			"key": "foobar",
+			"key1": "apache"
+		},
+		"skip": false,
+		"fail": false
+	},
+	{
+		"name": "simple ordered",
+		"tok": "%{+key/3} %{+key/1} %{+key/2}",
+		"msg": "1 2 3",
+		"expected": {
+			"key": "2 3 1"
+		},
+		"skip": false,
+		"fail": false
+	},
+	{
+		"name": "simple append",
+		"tok": "%{key}-%{+key}-%{+key}",
+		"msg": "1-2-3",
+		"expected": {
+			"key": "1-2-3"
+		},
+		"skip": false,
+		"fail": false
+	},
+	{
+		"name": "indirect field",
+		"tok": "%{key} %{\u0026key}",
+		"msg": "hello world",
+		"expected": {
+			"hello": "world",
+			"key": "hello"
+		},
+		"skip": false,
+		"fail": false
+	},
+	{
+		"name": "skip field",
+		"tok": "%{} %{key}",
+		"msg": "hello world",
+		"expected": {
+			"key": "world"
+		},
+		"skip": false,
+		"fail": false
+	},
+	{
+		"name": "named skiped field with indirect",
+		"tok": "%{?key} %{\u0026key}",
+		"msg": "hello world",
+		"expected": {
+			"hello": "world"
+		},
+		"skip": false,
+		"fail": false
+	},
+	{
+		"name": "pointer field with indirect",
+		"tok": "%{*key} %{\u0026key}",
+		"msg": "hello world",
+		"expected": {
+			"hello": "world"
+		},
+		"skip": false,
+		"fail": false
+	},
+	{
+		"name": "missing fields",
+		"tok": "%{name},%{addr1},%{addr2},%{addr3},%{city},%{zip}",
+		"msg": "Jane Doe,4321 Fifth Avenue,,,New York,87432",
+		"expected": {
+			"addr1": "4321 Fifth Avenue",
+			"addr2": "",
+			"addr3": "",
+			"city": "New York",
+			"name": "Jane Doe",
+			"zip": "87432"
+		},
+		"skip": false,
+		"fail": false
+	},
+	{
+		"name": "ignore right padding",
+		"tok": "%{id} %{function-\u003e} %{server}",
+		"msg": "00000043 ViewReceive     machine-321",
+		"expected": {
+			"function": "ViewReceive",
+			"id": "00000043",
+			"server": "machine-321"
+		},
+		"skip": false,
+		"fail": false
+	},
+	{
+		"name": "padding on the last key need a delimiter",
+		"tok": "%{id} %{function} %{server-\u003e} ",
+		"msg": "00000043 ViewReceive machine-321    ",
+		"expected": {
+			"function": "ViewReceive",
+			"id": "00000043",
+			"server": "machine-321"
+		},
+		"skip": false,
+		"fail": false
+	},
+	{
+		"name": "ignore left padding",
+		"tok": "%{id-\u003e} %{function} %{server}",
+		"msg": "00000043    ViewReceive machine-321",
+		"expected": {
+			"function": "ViewReceive",
+			"id": "00000043",
+			"server": "machine-321"
+		},
+		"skip": false,
+		"fail": false
+	},
+	{
+		"name": "when the delimiters contains `{` and `}`",
+		"tok": "{%{a}}{%{b}} %{rest}",
+		"msg": "{c}{d} anything",
+		"expected": {
+			"a": "c",
+			"b": "d",
+			"rest": "anything"
+		},
+		"skip": false,
+		"fail": false
+	}
+]

--- a/libbeat/processors/dissect/testdata/dissect_tests.json
+++ b/libbeat/processors/dissect/testdata/dissect_tests.json
@@ -130,11 +130,10 @@
 	},
 	{
 		"name": "indirect field",
-		"tok": "%{key} %{\u0026key}",
+		"tok": "%{?key} %{\u0026key}",
 		"msg": "hello world",
 		"expected": {
 			"hello": "world",
-			"key": "hello"
 		},
 		"skip": false,
 		"fail": false

--- a/libbeat/processors/dissect/validate.go
+++ b/libbeat/processors/dissect/validate.go
@@ -1,0 +1,42 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dissect
+
+import (
+	"fmt"
+)
+
+func validate(p *parser) error {
+	indirectFields := filterFieldsWith(p.fields, isIndirectField)
+
+	for _, field := range indirectFields {
+		found := false
+		for _, reference := range p.referenceFields {
+			if reference.Key() == field.Key() {
+				found = true
+				break
+			}
+		}
+
+		if found == false {
+			return fmt.Errorf("missing reference for key '%s'", field.Key())
+		}
+	}
+
+	return nil
+}

--- a/libbeat/processors/dissect/validate_test.go
+++ b/libbeat/processors/dissect/validate_test.go
@@ -1,0 +1,54 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dissect
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		name        string
+		p           *parser
+		expectError bool
+	}{
+		{
+			name: "when we find reference field for all indirect field",
+			p: &parser{
+				fields:          []field{newIndirectField(1, "hello"), newNormalField(0, "hola", 1, false)},
+				referenceFields: []field{newPointerField(2, "hello")},
+			},
+			expectError: false,
+		},
+		{
+			name: "when we cannot find all the reference field for all indirect field",
+			p: &parser{
+				fields:          []field{newIndirectField(1, "hello"), newNormalField(0, "hola", 1, false)},
+				referenceFields: []field{newPointerField(2, "okhello")},
+			},
+			expectError: true,
+		},
+	}
+
+	for _, test := range tests {
+		err := validate(test.p)
+		assert.Equal(t, test.expectError, err != nil)
+	}
+}


### PR DESCRIPTION
Cherry-pick of PR #8750 to 6.x branch. Original message: 

This commit adds support for * instead of using a named skip field
(?field) this make it compatible with ingest pipeline syntax in 6.5.

We are also adding validation enforcing that each indirect field must use an existing
and valid reference.

Fix: #8054

Cherry-pick of PR #7768 to 6.x branch. Original message: 

We currently have three implementations of dissect (LS, Ingest
and beats), moving the common test case to an external file is the first
step to be able to converge to a common specification.