### PR TITLE
fix bulk index  request bug

### DIFF
--- a/libbeat/outputs/elasticsearch/client.go
+++ b/libbeat/outputs/elasticsearch/client.go
@@ -416,7 +416,7 @@ func createEventBulkMeta(
 		ID:       id,
 	}
 
-	if id != "" {
+	if id == "" {
 		return bulkCreateAction{meta}, nil
 	}
 	return bulkIndexAction{meta}, nil


### PR DESCRIPTION
When create a bulk request ,bulk item id is null should use create action  other than use index action.this logic seem to be conversed
