### PR TITLE
add routing support in event Meta 

### DIFF
--- a/libbeat/outputs/elasticsearch/client.go
+++ b/libbeat/outputs/elasticsearch/client.go
@@ -416,7 +416,7 @@ func createEventBulkMeta(
 		ID:       id,
 	}
 
-	if id != "" {
+	if id == "" {
 		return bulkCreateAction{meta}, nil
 	}
 	return bulkIndexAction{meta}, nil

--- a/libbeat/outputs/elasticsearch/client.go
+++ b/libbeat/outputs/elasticsearch/client.go
@@ -105,6 +105,7 @@ type bulkEventMeta struct {
 	DocType  string `json:"_type" struct:"_type"`
 	Pipeline string `json:"pipeline,omitempty" struct:"pipeline,omitempty"`
 	ID       string `json:"_id,omitempty" struct:"_id,omitempty"`
+	Routing  string `json:"_routing,omitempty" struct:"_routing,omitempty"`
 }
 
 type bulkResultStats struct {
@@ -398,13 +399,22 @@ func createEventBulkMeta(
 		return nil, err
 	}
 
-	var id string
+	var id, routing string
 	if m := event.Meta; m != nil {
 		if tmp := m["id"]; tmp != nil {
 			if s, ok := tmp.(string); ok {
 				id = s
 			} else {
 				logp.Err("Event ID '%v' is no string value", id)
+			}
+
+		}
+
+		if tmp := m["routing"]; tmp != nil {
+			if s, ok := tmp.(string); ok {
+				routing = s
+			} else {
+				logp.Err("Event Routing '%v' is no string value", routing)
 			}
 		}
 	}
@@ -414,9 +424,10 @@ func createEventBulkMeta(
 		DocType:  eventType,
 		Pipeline: pipeline,
 		ID:       id,
+		Routing:  routing,
 	}
 
-	if id == "" {
+	if id != "" {
 		return bulkCreateAction{meta}, nil
 	}
 	return bulkIndexAction{meta}, nil


### PR DESCRIPTION
When use join field type.child routing must be same as parent routing .so add routing support in event meta for this situation.
