### PR TITLE
Cherry-pick #8770 to 6.x: Index cluster_uuid in elasticsearch/shard metricset

### DIFF
--- a/metricbeat/module/elasticsearch/shard/_meta/data.json
+++ b/metricbeat/module/elasticsearch/shard/_meta/data.json
@@ -6,6 +6,7 @@
     },
     "elasticsearch": {
         "cluster": {
+            "id": "91RpCx2xSQ21pVPTZfDK0Q",
             "name": "elasticsearch",
             "state": {
                 "id": "MBE4XrQOSf6ScXRTuCO1Pw"
@@ -20,6 +21,9 @@
         "shard": {
             "number": 0,
             "primary": true,
+            "relocating_node": {
+                "name": null
+            },
             "state": "STARTED"
         }
     },

--- a/metricbeat/module/elasticsearch/shard/data.go
+++ b/metricbeat/module/elasticsearch/shard/data.go
@@ -40,6 +40,7 @@ var (
 )
 
 type stateStruct struct {
+	ClusterID   string `json:"cluster_uuid"`
 	ClusterName string `json:"cluster_name"`
 	StateID     string `json:"state_uuid"`
 	MasterNode  string `json:"master_node"`
@@ -73,6 +74,7 @@ func eventsMapping(r mb.ReporterV2, content []byte) error {
 
 				event.ModuleFields = common.MapStr{}
 				event.ModuleFields.Put("cluster.state.id", stateData.StateID)
+				event.ModuleFields.Put("cluster.id", stateData.ClusterID)
 				event.ModuleFields.Put("cluster.name", stateData.ClusterName)
 
 				fields, err := schema.Apply(shard)


### PR DESCRIPTION
Cherry-pick of PR #8770 to 6.x branch. Original message: 

This PR teaches the `elasticsearch/shard` metricset to index the Elasticsearch `cluster_uuid` as the module-level `cluster.id` field.