### PR TITLE
Add tracking file for ECS migration

### DIFF
--- a/dev-tools/ecs-migration.yml
+++ b/dev-tools/ecs-migration.yml
@@ -1,0 +1,12 @@
+# The ECS migration file contains the information about all the Beats fields which are migrated to ECS in 7.0.
+# The goal of the file is to potentially have scripts on top of this information to convert visualisations and templates
+# based on this information in an automated way and to keep track of all changes which were applied.
+#
+# The format of the file is as following:
+#
+# - from: source-field-in-6.x
+#   to: target-filed-in-ECS
+#   # Alias field is useful for fields where there is a 1-1 mapping from old to new
+#   alias: true-if-alias-is-required-in-6x
+#   # Copy to is useful for fields where multiple fields map to the same ECS field
+#   copy_to: true-if-field-should-be-copied-to-target-in-6x


### PR DESCRIPTION
This file should help to track the migration of all files to ECS and then have potential automation on top to convert dashboards and other files which use the fields.

This file is extracted from https://github.com/elastic/beats/pull/8873 to make it available in multiple PRs.