### PR TITLE
Cherry-pick #8844 to 6.x: Make sure the functionbeat.yml and the functionbeat.reference.yml

### DIFF
--- a/x-pack/functionbeat/_meta/beat.yml
+++ b/x-pack/functionbeat/_meta/beat.yml
@@ -12,10 +12,13 @@
 # Configure functions to run on AWS Lambda, currently we assume that the credentials
 # are present in the environment to correctly create the function when using the CLI.
 #
+# Configure which S3 bucket we should upload the lambda artifact.
+functionbeat.provider.aws.deploy_bucket: "functionbeat-deploy"
+
 functionbeat.provider.aws.functions:
   # Define the list of function availables, each function required to have a unique name.
   # Create a function that accepts events coming from cloudwatchlogs.
-  - name: fn_cloudwatch_logs
+  - name: cloudwatch
     enabled: false
     type: cloudwatch_logs
 

--- a/x-pack/functionbeat/functionbeat.yml
+++ b/x-pack/functionbeat/functionbeat.yml
@@ -12,10 +12,13 @@
 # Configure functions to run on AWS Lambda, currently we assume that the credentials
 # are present in the environment to correctly create the function when using the CLI.
 #
+# Configure which S3 bucket we should upload the lambda artifact.
+functionbeat.provider.aws.deploy_bucket: "functionbeat-deploy"
+
 functionbeat.provider.aws.functions:
   # Define the list of function availables, each function required to have a unique name.
   # Create a function that accepts events coming from cloudwatchlogs.
-  - name: fn_cloudwatch_logs
+  - name: cloudwatch
     enabled: false
     type: cloudwatch_logs
 


### PR DESCRIPTION
Cherry-pick of PR #8844 to 6.x branch. Original message: 

Make sure the required options are the same on both files and also use the
same default name for the function.