### PR TITLE
Filebeat: Elasticsearch server fileset: Add paths for Mac OSX and Windows

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -77,6 +77,7 @@ https://github.com/elastic/beats/compare/v6.4.0...master[Check the HEAD diff]
 - Fix RFC3339 timezone and nanoseconds parsing with the syslog input. {pull}8346[8346]
 - Support multiline logs in logstash/log fileset of Filebeat. {pull}8562[8562]
 - Fix improperly set config for CRI Flag in Docker Input {pull}8899[8899]
+- Just enabling the `elasticsearch` fileset and starting Filebeat no longer causes an error. {pull}8891[8891]
 
 *Heartbeat*
 

--- a/filebeat/module/elasticsearch/server/manifest.yml
+++ b/filebeat/module/elasticsearch/server/manifest.yml
@@ -4,8 +4,10 @@ var:
   - name: paths
     default:
       - /var/log/elasticsearch/*.log
-    os.darwin: []
-    os.windows: []
+    os.darwin:
+      - /usr/local/elasticsearch/*.log
+    os.windows:
+      - c:/ProgramData/Elastic/Elasticsearch/logs/*.log
 
 ingest_pipeline: ingest/pipeline.json
 prospector: config/log.yml


### PR DESCRIPTION
Resolves #8887.

This PR makes the `elasticsearch/server` fileset paths for Mac OSX and Windows consistent with other filesets' paths in the module. This also means that a user can now install Filebeat, enable the Elasticsearch module, and run Filebeat without any errors.