### PR TITLE
Make docs target depend on update

### DIFF
--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -363,7 +363,7 @@ endif
 	  -version ${BEAT_VERSION} -out _meta/kibana.generated
 
 .PHONY: docs
-docs:  ## @build Builds the documents for the beat
+docs: update ## @build Builds the documents for the beat
 	sh ${ES_BEATS}/script/build_docs.sh ${BEAT_NAME} ${BEAT_PATH}/docs ${BUILD_DIR}
 
 .PHONY: docs-preview


### PR DESCRIPTION
One has to run `make update` before they run `make docs`, at least in Filebeat, so this makes the `docs` target depend on `update`. That way, one can simply run `make docs` without having to also run `make update` first.