### PR TITLE
Lengthen default test timeout to 15 seconds

### DIFF
--- a/libbeat/tests/system/beat/beat.py
+++ b/libbeat/tests/system/beat/beat.py
@@ -321,7 +321,7 @@ class TestCase(unittest.TestCase, ComposeMixin):
             # running tests in parallel
             pass
 
-    def wait_until(self, cond, max_timeout=10, poll_interval=0.1, name="cond"):
+    def wait_until(self, cond, max_timeout=15, poll_interval=0.1, name="cond"):
         """
         Waits until the cond function returns true,
         or until the max_timeout is reached. Calls the cond


### PR DESCRIPTION
On busy CI servers, I suspect some flakiness, as in the case of https://github.com/elastic/beats/pull/8667#pullrequestreview-169668965 is due to the server being temporarily too busy.

Let's try lengthening this time to see if that helps.