### PR TITLE
No condition required for autodiscover. Bool condition added

### DIFF
--- a/heartbeat/heartbeat.yml
+++ b/heartbeat/heartbeat.yml
@@ -9,18 +9,15 @@
 
 ############################# Heartbeat ######################################
 
-# Configure monitors
-heartbeat.monitors:
-- type: http
-
-  # List or urls to query
-  urls: ["http://localhost:9200"]
-
-  # Configure task schedule
-  schedule: '@every 10s'
-
-  # Total test connection and data exchange timeout
-  #timeout: 16s
+heartbeat.autodiscover:
+  providers:
+  - type: docker
+    templates:
+    - config:
+      - type: tcp
+        hosts: ["${data.host}:${data.port}"]
+        schedule: "@every 1s"
+        timeout: 1s
 
 #==================== Elasticsearch template setting ==========================
 

--- a/libbeat/autodiscover/template/config.go
+++ b/libbeat/autodiscover/template/config.go
@@ -45,14 +45,19 @@ type MapperSettings []*struct {
 func NewConfigMapper(configs MapperSettings) (*Mapper, error) {
 	var mapper Mapper
 	for _, c := range configs {
-		condition, err := conditions.NewCondition(c.ConditionConfig)
-		if err != nil {
-			return nil, err
+		condMap := &ConditionMap{Configs: c.Configs}
+
+		if c.ConditionConfig == nil {
+			condMap.Condition = conditions.Bool(true)
+		} else {
+			var err error
+			condMap.Condition, err = conditions.NewCondition(c.ConditionConfig)
+			if err != nil {
+				return nil, err
+			}
 		}
-		mapper = append(mapper, &ConditionMap{
-			Condition: condition,
-			Configs:   c.Configs,
-		})
+
+		mapper = append(mapper, condMap)
 	}
 
 	return &mapper, nil

--- a/libbeat/autodiscover/template/config_test.go
+++ b/libbeat/autodiscover/template/config_test.go
@@ -60,6 +60,16 @@ func TestConfigsMapping(t *testing.T) {
 			},
 			expected: []*common.Config{config},
 		},
+		// No condition
+		{
+			mapping: `
+- config:
+    - correct: config`,
+			event: bus.Event{
+				"foo": 3,
+			},
+			expected: []*common.Config{config},
+		},
 	}
 
 	for _, test := range tests {

--- a/libbeat/conditions/bool.go
+++ b/libbeat/conditions/bool.go
@@ -1,0 +1,33 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package conditions
+
+import "fmt"
+
+// Bool always returns true.
+type Bool bool
+
+// Check will always return true for a Bool condition.
+func (c Bool) Check(event ValuesMap) bool {
+	return bool(c)
+}
+
+// String
+func (c Bool) String() string {
+	return fmt.Sprintf("bool(%t)", c)
+}

--- a/libbeat/conditions/bool_test.go
+++ b/libbeat/conditions/bool_test.go
@@ -1,0 +1,44 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package conditions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBoolTrue(t *testing.T) {
+	tval := true
+	config := Config{Bool: &tval}
+
+	c, err := NewCondition(&config)
+	require.NoError(t, err)
+
+	require.True(t, c.Check(nil))
+}
+
+func TestBoolFalse(t *testing.T) {
+	fval := false
+	config := Config{Bool: &fval}
+
+	c, err := NewCondition(&config)
+	require.NoError(t, err)
+
+	require.False(t, c.Check(nil))
+}

--- a/libbeat/conditions/conditions.go
+++ b/libbeat/conditions/conditions.go
@@ -36,6 +36,7 @@ type Config struct {
 	OR        []Config `config:"or"`
 	AND       []Config `config:"and"`
 	NOT       *Config  `config:"not"`
+	Bool      *bool    `config:"bool"`
 }
 
 // Condition is the interface for all defined conditions
@@ -85,6 +86,8 @@ func NewCondition(config *Config) (Condition, error) {
 		if err == nil {
 			condition, err = NewNotCondition(inner)
 		}
+	case config.Bool != nil:
+		condition = Bool(*config.Bool)
 	default:
 		err = errors.New("missing condition")
 	}

--- a/libbeat/docs/processors-using.asciidoc
+++ b/libbeat/docs/processors-using.asciidoc
@@ -205,6 +205,7 @@ The supported conditions are:
 * <<condition-or, `or`>>
 * <<condition-and, `and`>>
 * <<condition-not, `not`>>
+* <<condition-bool, `bool`>>
 
 
 [float]
@@ -398,6 +399,26 @@ For example, to configure the condition `NOT status = OK`:
 not:
   equals:
     status: OK
+------
+
+
+[float]
+[[condition-bool]]
+===== `bool`
+
+The `bool` operator returns a constant boolean value. Use it for debugging purposes where
+it is more convenient to always have a given value than simply remove the config.
+
+[source,yaml]
+-------
+bool: <true|false>
+-------
+
+For example, to configure the condition to always be true:
+
+[source,yaml]
+------
+bool: true
 ------
 
 [[add-cloud-metadata]]


### PR DESCRIPTION
This patch allows you to use the autodiscover without any filtering via conditions. Today, if you want to disable the conditions syntax on autodiscover you have to makeup a weird condition that does nothing (like checking for the hostname, if it's always there).

I initially considered doing this by making the condition nullable via a pointer, but
then decided that boolean conditions can be convenient (and are as fast for this purpose)
and might be generally nice for the conditions language.

So, instead, this accomplishes the same by inserting an always true condition if the
conditions config option is omitted.