### PR TITLE
Cherry-pick #8889 to 6.x: Make functionbeat build process depends on linux/amd64

### DIFF
--- a/CHANGELOG-developer.asciidoc
+++ b/CHANGELOG-developer.asciidoc
@@ -60,3 +60,4 @@ The list below covers the major changes between 6.3.0 and master only.
 - Add `mage.GenerateFieldsGo` for generating fields.go files. {pull}8615[8615]
 - Add `mage.KibanaDashboards` for collecting Kibana dashboards and generating index patterns. {pull}8615[8615]
 - Allow to disable config resolver using the `Settings.DisableConfigResolver` field when initializing libbeat. {pull}8769[8769]
+- Add `mage.AddPlatforms` to allow to specify dependent platforms when building a beat. {pull}8889[8889]

--- a/dev-tools/mage/crossbuild.go
+++ b/dev-tools/mage/crossbuild.go
@@ -88,6 +88,17 @@ func ImageSelector(f ImageSelectorFunc) func(params *crossBuildParams) {
 	}
 }
 
+// AddPlatforms sets dependencies on others platforms.
+func AddPlatforms(expressions ...string) func(params *crossBuildParams) {
+	return func(params *crossBuildParams) {
+		var list BuildPlatformList
+		for _, expr := range expressions {
+			list = NewPlatformList(expr)
+			params.Platforms = params.Platforms.Merge(list)
+		}
+	}
+}
+
 type crossBuildParams struct {
 	Platforms     BuildPlatformList
 	Target        string

--- a/dev-tools/mage/platforms.go
+++ b/dev-tools/mage/platforms.go
@@ -445,6 +445,14 @@ func (list BuildPlatformList) Filter(expr string) BuildPlatformList {
 	return out.deduplicate()
 }
 
+// Merge creates a new list with the two list merged.
+func (list BuildPlatformList) Merge(with BuildPlatformList) BuildPlatformList {
+	out := make(BuildPlatformList, 0, len(list)+len(with))
+	out = append(list, with...)
+	out = append(out, with...)
+	return out.deduplicate()
+}
+
 // deduplicate removes duplicate platforms and sorts the list.
 func (list BuildPlatformList) deduplicate() BuildPlatformList {
 	set := map[string]BuildPlatform{}

--- a/x-pack/functionbeat/magefile.go
+++ b/x-pack/functionbeat/magefile.go
@@ -39,7 +39,7 @@ func BuildGoDaemon() error {
 
 // CrossBuild cross-builds the beat for all target platforms.
 func CrossBuild() error {
-	return mage.CrossBuild()
+	return mage.CrossBuild(mage.AddPlatforms("linux/amd64"))
 }
 
 // CrossBuildGoDaemon cross-builds the go-daemon binary using Docker.


### PR DESCRIPTION
Cherry-pick of PR #8889 to 6.x branch. Original message: 

Functionbeat packaging depends on a Linux binary that will be sent to
the serverless platform, previously the magefile for the project did not express
that dependency. This was causing problems when you were building the
packages only for a specific platform. This commit fixes that problem by
introducing `mage.WithPlatforms` this allows you to specific dependency
when you define the cross build logic.