### PR TITLE
Cherry-pick #8890 to 6.5: Add remaining filesets to ES module docs

### DIFF
--- a/filebeat/docs/modules/elasticsearch.asciidoc
+++ b/filebeat/docs/modules/elasticsearch.asciidoc
@@ -34,6 +34,26 @@ include::../include/config-option-intro.asciidoc[]
 
 include::../include/var-paths.asciidoc[]
 
+[float]
+==== `gc` log fileset settings
+
+include::../include/var-paths.asciidoc[]
+
+[float]
+==== `audit` log fileset settings
+
+include::../include/var-paths.asciidoc[]
+
+[float]
+==== `slowlog` log fileset settings
+
+include::../include/var-paths.asciidoc[]
+
+[float]
+==== `deprecation` log fileset settings
+
+include::../include/var-paths.asciidoc[]
+
 :has-dashboards!:
 
 :fileset_ex!:

--- a/filebeat/module/elasticsearch/_meta/docs.asciidoc
+++ b/filebeat/module/elasticsearch/_meta/docs.asciidoc
@@ -29,6 +29,26 @@ include::../include/config-option-intro.asciidoc[]
 
 include::../include/var-paths.asciidoc[]
 
+[float]
+==== `gc` log fileset settings
+
+include::../include/var-paths.asciidoc[]
+
+[float]
+==== `audit` log fileset settings
+
+include::../include/var-paths.asciidoc[]
+
+[float]
+==== `slowlog` log fileset settings
+
+include::../include/var-paths.asciidoc[]
+
+[float]
+==== `deprecation` log fileset settings
+
+include::../include/var-paths.asciidoc[]
+
 :has-dashboards!:
 
 :fileset_ex!:


### PR DESCRIPTION
Cherry-pick of PR #8890 to 6.5 branch. Original message: 

The Elasticsearch module docs for Filebeat only contained configuration settings for the `server` fileset. This PR adds configuration settings docs for the remaining filesets in the module.