### PR TITLE
Correctly handle the case that the bucket doesnt' exist

### DIFF
--- a/x-pack/functionbeat/provider/aws/op_ensure_bucket.go
+++ b/x-pack/functionbeat/provider/aws/op_ensure_bucket.go
@@ -48,8 +48,11 @@ func (o *opEnsureBucket) Execute() error {
 				o.log.Debugf("Could not create bucket, resp: %v", resp)
 				return err
 			}
+			// bucket created successfully
+			return nil
 		}
 	}
 
+	// Catchall for unauthorized access.
 	return fmt.Errorf("bucket '%s' already exist and you don't have permission to access it", o.bucketName)
 }


### PR DESCRIPTION
This should have been catched by randomization in the integration suite. :(

Fix: #8910 