### PR TITLE
Accept multiple ingest pipelines in Filebeat

### DIFF
--- a/CHANGELOG-developer.asciidoc
+++ b/CHANGELOG-developer.asciidoc
@@ -72,3 +72,4 @@ The list below covers the major changes between 6.3.0 and 7.0.0-alpha2 only.
 - Simplified exporting of dashboards. {pull}7730[7730]
 - Update Beats to use go 1.11.2 {pull}8746[8746]
 - Allow/Merge fields.yml overrides {pull}9188[9188]
+- Filesets can now define multiple ingest pipelines, with the first one considered as the root pipeline. {pull}8914[8914]

--- a/CHANGELOG-developer.asciidoc
+++ b/CHANGELOG-developer.asciidoc
@@ -72,4 +72,4 @@ The list below covers the major changes between 6.3.0 and 7.0.0-alpha2 only.
 - Simplified exporting of dashboards. {pull}7730[7730]
 - Update Beats to use go 1.11.2 {pull}8746[8746]
 - Allow/Merge fields.yml overrides {pull}9188[9188]
-- Filesets can now define multiple ingest pipelines, with the first one considered as the root pipeline. {pull}8914[8914]
+- Filesets can now define multiple ingest pipelines, with the first one considered as the entry point pipeline. {pull}8914[8914]

--- a/docs/devguide/modules-dev-guide.asciidoc
+++ b/docs/devguide/modules-dev-guide.asciidoc
@@ -244,8 +244,8 @@ considered to be the entry point pipeline.
 
 One reason for using multiple pipelines might be to send all logs harvested
 by this fileset to the entry point pipeline and have it delegate different parts of
-the processing to different sub-pipelines. You can read details about setting
-this up in the `ingest/*.json` section below.
+the processing to other pipelines. You can read details about setting
+this up in <<ingest-json-entry-point-pipeline, the `ingest/*.json` section>>.
 
 [float]
 ==== config/*.yml
@@ -354,14 +354,15 @@ Note that you should follow the convention of naming of fields prefixed with the
 module and fileset name: `{module}.{fileset}.field`, e.g.
 `nginx.access.remote_ip`. Also, please review our <<event-conventions>>.
 
-In 6.6 and later, ingest pipelines can use the `pipeline` processor to delegate
-part of the processing to another sub-pipeline.
+[[ingest-json-entry-point-pipeline]]
+{ref}/conditionals-with-multiple-pipelines.html[In 6.6 and later], ingest pipelines can use the
+`pipeline` processor to delegate parts of the processings to other pipelines.
 
 [source,json]
 ----
 {
   "pipeline": {
-    "name": "name-of-sub-pipeline"
+    "name": "name-of-another-pipeline"
   }
 }
 ----
@@ -369,8 +370,8 @@ part of the processing to another sub-pipeline.
 This can be useful if you want a fileset to ingest the same _logical_ information
 presented in different formats, e.g. csv vs. json versions of the same log files.
 Imagine an entry point ingest pipeline that detects the format of a log entry and then conditionally
-delegates further processing of that log entry, depending on the format, to a specific
-sub-pipeline.
+delegates further processing of that log entry, depending on the format, to another
+pipeline.
 
 [source,json]
 ----
@@ -432,9 +433,8 @@ template function.
 }
 ----
 
-Using this template function will allow Filebeat to convert the specified
-pipeline name into the actual, fully-qualified pipeline ID that is actually
-stored in Elasticsearch.
+Using the template function allows Filebeat to convert the specified pipeline name
+into the fully-qualified pipeline ID that is stored in Elasticsearch.
 
 While developing the pipeline definition, we recommend making use of the
 {elasticsearch}/simulate-pipeline-api.html[Simulate Pipeline API] for testing

--- a/docs/devguide/modules-dev-guide.asciidoc
+++ b/docs/devguide/modules-dev-guide.asciidoc
@@ -355,17 +355,9 @@ module and fileset name: `{module}.{fileset}.field`, e.g.
 `nginx.access.remote_ip`. Also, please review our <<event-conventions>>.
 
 [[ingest-json-entry-point-pipeline]]
-{ref}/conditionals-with-multiple-pipelines.html[In 6.6 and later], ingest pipelines can use the
-`pipeline` processor to delegate parts of the processings to other pipelines.
-
-[source,json]
-----
-{
-  "pipeline": {
-    "name": "name-of-another-pipeline"
-  }
-}
-----
+In 6.6 and later, ingest pipelines can use the
+{ref}/conditionals-with-multiple-pipelines.html[`pipeline` processor] to delegate
+parts of the processings to other pipelines.
 
 This can be useful if you want a fileset to ingest the same _logical_ information
 presented in different formats, e.g. csv vs. json versions of the same log files.
@@ -373,7 +365,7 @@ Imagine an entry point ingest pipeline that detects the format of a log entry an
 delegates further processing of that log entry, depending on the format, to another
 pipeline.
 
-[source,json]
+["source","json",subs="callouts"]
 ----
 {
   "processors": [
@@ -391,18 +383,20 @@ pipeline.
     {
       "pipeline": {
         "if": "ctx.first_char == '{'"
-        "name": "json-log-processing-pipeline"
+        "name": "{< IngestPipeline "json-log-processing-pipeline" >}" <1>
       }
     },
     {
       "pipeline": {
         "if": "ctx.first_char != '{'"
-        "name": "plain-log-processing-pipeline"
+        "name": "{< IngestPipeline "plain-log-processing-pipeline" >}"
       }
     }
   ]
 }
 ----
+<1>  Use the `IngestPipeline` template function to resolve the name. This function converts the
+specified name into the fully qualified pipeline ID that is stored in Elasticsearch.
 
 In order for the above pipeline to work, Filebeat must load the entry point pipeline
 as well as any sub-pipelines into Elasticsearch. You can tell Filebeat to do
@@ -416,25 +410,6 @@ ingest_pipeline:
   - ingest/plain_logs.json
   - ingest/json_logs.json
 ----
-
-Additionally, any `pipeline` processors referencing one of the pipelines in the
-metricset in the processor's `name` field must do so using the `IngestPipeline`
-template function.
-
-[source,json]
-----
-    {
-      "pipeline": {
-        "if": "ctx.first_char != '{'"
-        "name": "{< IngestPipeline "plain_logs" >}"
-      }
-    }
-  ]
-}
-----
-
-Using the template function allows Filebeat to convert the specified pipeline name
-into the fully-qualified pipeline ID that is stored in Elasticsearch.
 
 While developing the pipeline definition, we recommend making use of the
 {elasticsearch}/simulate-pipeline-api.html[Simulate Pipeline API] for testing

--- a/docs/devguide/modules-dev-guide.asciidoc
+++ b/docs/devguide/modules-dev-guide.asciidoc
@@ -240,10 +240,10 @@ ingest_pipeline:
 ----
 
 When multiple ingest pipelines are specified the first one in the list is
-considered to be the root pipeline.
+considered to be the entry point pipeline.
 
 One reason for using multiple pipelines might be to send all logs harvested
-by this fileset to the root pipeline and have it delegate different parts of
+by this fileset to the entry point pipeline and have it delegate different parts of
 the processing to different sub-pipelines. You can read details about setting
 this up in the `ingest/*.json` section below.
 
@@ -368,7 +368,7 @@ part of the processing to another sub-pipeline.
 
 This can be useful if you want a fileset to ingest the same _logical_ information
 presented in different formats, e.g. csv vs. json versions of the same log files.
-Imagine a root ingest pipeline that detects the format of a log entry and then conditionally
+Imagine an entry point ingest pipeline that detects the format of a log entry and then conditionally
 delegates further processing of that log entry, depending on the format, to a specific
 sub-pipeline.
 
@@ -403,10 +403,10 @@ sub-pipeline.
 }
 ----
 
-In order for the above pipeline to work, Filebeat must load the root pipeline
+In order for the above pipeline to work, Filebeat must load the entry point pipeline
 as well as any sub-pipelines into Elasticsearch. You can tell Filebeat to do
 so by specifying all the necessary pipelines for the fileset in its `manifest.yml`
-file. The first pipeline in the list is considered to be the root pipeline.
+file. The first pipeline in the list is considered to be the entry point pipeline.
 
 [source,yaml]
 ----

--- a/docs/devguide/modules-dev-guide.asciidoc
+++ b/docs/devguide/modules-dev-guide.asciidoc
@@ -229,6 +229,24 @@ This example selects the ingest pipeline file based on the value of the
 resolve to `ingest/with_plugins.json` (assuming the variable value isn't
 overridden at runtime.)
 
+In 6.6 and later, you can specify multiple ingest pipelines.
+
+[source,yaml]
+----
+ingest_pipeline:
+  - ingest/main.json
+  - ingest/plain_logs.json
+  - ingest/json_logs.json
+----
+
+When multiple ingest pipelines are specified the first one in the list is
+considered to be the root pipeline.
+
+One reason for using multiple pipelines might be to send all logs harvested
+by this fileset to the root pipeline and have it delegate different parts of
+the processing to different sub-pipelines. You can read details about setting
+this up in the `ingest/*.json` section below.
+
 [float]
 ==== config/*.yml
 
@@ -335,6 +353,88 @@ Here is an example for parsing the Nginx access logs.
 Note that you should follow the convention of naming of fields prefixed with the
 module and fileset name: `{module}.{fileset}.field`, e.g.
 `nginx.access.remote_ip`. Also, please review our <<event-conventions>>.
+
+In 6.6 and later, ingest pipelines can use the `pipeline` processor to delegate
+part of the processing to another sub-pipeline.
+
+[source,json]
+----
+{
+  "pipeline": {
+    "name": "name-of-sub-pipeline"
+  }
+}
+----
+
+This can be useful if you want a fileset to ingest the same _logical_ information
+presented in different formats, e.g. csv vs. json versions of the same log files.
+Imagine a root ingest pipeline that detects the format of a log entry and then conditionally
+delegates further processing of that log entry, depending on the format, to a specific
+sub-pipeline.
+
+[source,json]
+----
+{
+  "processors": [
+    {
+      "grok": {
+        "field": "message",
+        "patterns": [
+          "^%{CHAR:first_char}"
+        ],
+        "pattern_definitions": {
+          "CHAR": "."
+        }
+      }
+    },
+    {
+      "pipeline": {
+        "if": "ctx.first_char == '{'"
+        "name": "json-log-processing-pipeline"
+      }
+    },
+    {
+      "pipeline": {
+        "if": "ctx.first_char != '{'"
+        "name": "plain-log-processing-pipeline"
+      }
+    }
+  ]
+}
+----
+
+In order for the above pipeline to work, Filebeat must load the root pipeline
+as well as any sub-pipelines into Elasticsearch. You can tell Filebeat to do
+so by specifying all the necessary pipelines for the fileset in its `manifest.yml`
+file. The first pipeline in the list is considered to be the root pipeline.
+
+[source,yaml]
+----
+ingest_pipeline:
+  - ingest/main.json
+  - ingest/plain_logs.json
+  - ingest/json_logs.json
+----
+
+Additionally, any `pipeline` processors referencing one of the pipelines in the
+metricset in the processor's `name` field must do so using the `IngestPipeline`
+template function.
+
+[source,json]
+----
+    {
+      "pipeline": {
+        "if": "ctx.first_char != '{'"
+        "name": "{< IngestPipeline "plain_logs" >}"
+      }
+    }
+  ]
+}
+----
+
+Using this template function will allow Filebeat to convert the specified
+pipeline name into the actual, fully-qualified pipeline ID that is actually
+stored in Elasticsearch.
 
 While developing the pipeline definition, we recommend making use of the
 {elasticsearch}/simulate-pipeline-api.html[Simulate Pipeline API] for testing

--- a/docs/devguide/modules-dev-guide.asciidoc
+++ b/docs/devguide/modules-dev-guide.asciidoc
@@ -382,13 +382,13 @@ pipeline.
     },
     {
       "pipeline": {
-        "if": "ctx.first_char == '{'"
+        "if": "ctx.first_char == '{'",
         "name": "{< IngestPipeline "json-log-processing-pipeline" >}" <1>
       }
     },
     {
       "pipeline": {
-        "if": "ctx.first_char != '{'"
+        "if": "ctx.first_char != '{'",
         "name": "{< IngestPipeline "plain-log-processing-pipeline" >}"
       }
     }

--- a/filebeat/_meta/test/module/foo/_meta/config.yml
+++ b/filebeat/_meta/test/module/foo/_meta/config.yml
@@ -1,0 +1,8 @@
+- module: foo
+  # Fileset with multiple pipelines
+  multi:
+    enabled: true
+
+  # Fileset with multiple pipelines with the last one being bad
+  multibad:
+    enabled: true

--- a/filebeat/_meta/test/module/foo/multi/config/multi.yml
+++ b/filebeat/_meta/test/module/foo/multi/config/multi.yml
@@ -1,0 +1,8 @@
+type: log
+paths:
+  - /tmp
+exclude_files: [".gz$"]
+
+fields:
+  service.name: "foo"
+fields_under_root: true

--- a/filebeat/_meta/test/module/foo/multi/ingest/json_logs.json
+++ b/filebeat/_meta/test/module/foo/multi/ingest/json_logs.json
@@ -1,0 +1,10 @@
+{
+    "processors": [
+        {
+            "rename": {
+                "field": "json",
+                "target_field": "log.meta"
+            }
+        }
+    ]
+}

--- a/filebeat/_meta/test/module/foo/multi/ingest/pipeline.json
+++ b/filebeat/_meta/test/module/foo/multi/ingest/pipeline.json
@@ -1,0 +1,27 @@
+{
+    "processors": [
+        {
+            "grok": {
+                "field": "message",
+                "patterns": [
+                    "^%{CHAR:first_char}"
+                ],
+                "pattern_definitions": {
+                    "CHAR": "."
+                }
+            }
+        },
+        {
+            "pipeline": {
+                "if": "ctx.first_char == '{'",
+                "name": "{< IngestPipeline "json_logs" >}"
+            }
+        },
+        {
+            "pipeline": {
+                "if": "ctx.first_char != '{'",
+                "name": "{< IngestPipeline "plain_logs" >}"
+            }
+        }
+    ]
+}

--- a/filebeat/_meta/test/module/foo/multi/ingest/plain_logs.json
+++ b/filebeat/_meta/test/module/foo/multi/ingest/plain_logs.json
@@ -1,0 +1,12 @@
+{
+    "processors": [
+        {
+            "grok": {
+                "field": "message",
+                "patterns": [
+                    "^%{DATA:some_data}"
+                ]
+            }
+        }
+    ]
+}

--- a/filebeat/_meta/test/module/foo/multi/manifest.yml
+++ b/filebeat/_meta/test/module/foo/multi/manifest.yml
@@ -1,0 +1,8 @@
+module_version: 1.0
+
+ingest_pipeline:
+  - ingest/pipeline.json
+  - ingest/json_logs.json
+  - ingest/plain_logs.json
+
+input: config/multi.yml

--- a/filebeat/_meta/test/module/foo/multibad/config/multi.yml
+++ b/filebeat/_meta/test/module/foo/multibad/config/multi.yml
@@ -1,0 +1,8 @@
+type: log
+paths:
+  - /tmp
+exclude_files: [".gz$"]
+
+fields:
+  service.name: "foo"
+fields_under_root: true

--- a/filebeat/_meta/test/module/foo/multibad/ingest/json_logs.json
+++ b/filebeat/_meta/test/module/foo/multibad/ingest/json_logs.json
@@ -1,0 +1,10 @@
+{
+    "processors": [
+        {
+            "rename": {
+                "field": "json",
+                "target_field": "log.meta"
+            }
+        }
+    ]
+}

--- a/filebeat/_meta/test/module/foo/multibad/ingest/pipeline.json
+++ b/filebeat/_meta/test/module/foo/multibad/ingest/pipeline.json
@@ -1,0 +1,27 @@
+{
+    "processors": [
+        {
+            "grok": {
+                "field": "message",
+                "patterns": [
+                    "^%{CHAR:first_char}"
+                ],
+                "pattern_definitions": {
+                    "CHAR": "."
+                }
+            }
+        },
+        {
+            "pipeline": {
+                "if": "ctx.first_char == '{'",
+                "name": "{< IngestPipeline "json_logs" >}"
+            }
+        },
+        {
+            "pipeline": {
+                "if": "ctx.first_char != '{'",
+                "name": "{< IngestPipeline "plain_logs" >}"
+            }
+        }
+    ]
+}

--- a/filebeat/_meta/test/module/foo/multibad/ingest/plain_logs_bad.json
+++ b/filebeat/_meta/test/module/foo/multibad/ingest/plain_logs_bad.json
@@ -1,0 +1,12 @@
+{
+    "processors": [
+        {
+            "invalid_processor": {
+                "field": "message",
+                "patterns": [
+                    "^%{DATA:some_data}"
+                ]
+            }
+        }
+    ]
+}

--- a/filebeat/_meta/test/module/foo/multibad/manifest.yml
+++ b/filebeat/_meta/test/module/foo/multibad/manifest.yml
@@ -1,0 +1,8 @@
+module_version: 1.0
+
+ingest_pipeline:
+  - ingest/pipeline.json
+  - ingest/json_logs.json
+  - ingest/plain_logs_bad.json
+
+input: config/multi.yml

--- a/filebeat/fileset/fileset.go
+++ b/filebeat/fileset/fileset.go
@@ -297,11 +297,11 @@ func getTemplateFunctions(vars map[string]interface{}) (template.FuncMap, error)
 	}
 
 	return template.FuncMap{
-		"IngestPipeline": func(shortName string) string {
+		"IngestPipeline": func(shortID string) string {
 			return formatPipelineID(
 				builtinVars["module"].(string),
 				builtinVars["fileset"].(string),
-				shortName,
+				shortID,
 				builtinVars["beatVersion"].(string),
 			)
 		},

--- a/filebeat/fileset/fileset.go
+++ b/filebeat/fileset/fileset.go
@@ -34,7 +34,7 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/pkg/errors"
+	errw "github.com/pkg/errors"
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/cfgwarn"
@@ -274,7 +274,7 @@ func applyTemplate(vars map[string]interface{}, templateString string, specialDe
 
 	tplFunctions, err := getTemplateFunctions(vars)
 	if err != nil {
-		return "", errors.Wrap(err, "error fetching template functions")
+		return "", errw.Wrap(err, "error fetching template functions")
 	}
 	tpl = tpl.Funcs(tplFunctions)
 

--- a/filebeat/fileset/fileset_test.go
+++ b/filebeat/fileset/fileset_test.go
@@ -49,7 +49,7 @@ func TestLoadManifestNginx(t *testing.T) {
 	manifest, err := fs.readManifest()
 	assert.NoError(t, err)
 	assert.Equal(t, manifest.ModuleVersion, "1.0")
-	assert.Equal(t, manifest.IngestPipeline, "ingest/default.json")
+	assert.Equal(t, manifest.IngestPipeline, []string{"ingest/default.json"})
 	assert.Equal(t, manifest.Input, "config/nginx-access.yml")
 
 	vars := manifest.Vars
@@ -67,7 +67,7 @@ func TestGetBuiltinVars(t *testing.T) {
 	assert.IsType(t, vars["hostname"], "a-mac-with-esc-key")
 	assert.IsType(t, vars["domain"], "local")
 	assert.Equal(t, "nginx", vars["module"])
-	assert.Equal(t, "access", vars["metricset"])
+	assert.Equal(t, "access", vars["fileset"])
 	assert.Equal(t, "6.6.0", vars["beatVersion"])
 }
 
@@ -148,14 +148,16 @@ func TestResolveVariable(t *testing.T) {
 		{
 			Value: "test-{{.value}}",
 			Vars: map[string]interface{}{
-				"value": 2,
+				"value":   2,
+				"builtin": map[string]interface{}{},
 			},
 			Expected: "test-2",
 		},
 		{
 			Value: []interface{}{"test-{{.value}}", "test1-{{.value}}"},
 			Vars: map[string]interface{}{
-				"value": 2,
+				"value":   2,
+				"builtin": map[string]interface{}{},
 			},
 			Expected: []interface{}{"test-2", "test1-2"},
 		},

--- a/filebeat/fileset/fileset_test.go
+++ b/filebeat/fileset/fileset_test.go
@@ -65,6 +65,9 @@ func TestGetBuiltinVars(t *testing.T) {
 
 	assert.IsType(t, vars["hostname"], "a-mac-with-esc-key")
 	assert.IsType(t, vars["domain"], "local")
+	assert.Equal(t, "nginx", vars["module"])
+	assert.Equal(t, "access", vars["metricset"])
+	assert.Equal(t, "6.6.0", vars["beatVersion"])
 }
 
 func TestEvaluateVarsNginx(t *testing.T) {

--- a/filebeat/fileset/fileset_test.go
+++ b/filebeat/fileset/fileset_test.go
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+	"text/template"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -272,4 +273,15 @@ func TestGetPipelineConvertTS(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetTemplateFunctions(t *testing.T) {
+	vars := map[string]interface{}{
+		"builtin": map[string]interface{}{},
+	}
+	templateFunctions, err := getTemplateFunctions(vars)
+	assert.NoError(t, err)
+	assert.IsType(t, template.FuncMap{}, templateFunctions)
+	assert.Len(t, templateFunctions, 1)
+	assert.Contains(t, templateFunctions, "IngestPipeline")
 }

--- a/filebeat/fileset/modules_integration_test.go
+++ b/filebeat/fileset/modules_integration_test.go
@@ -143,3 +143,97 @@ func hasIngest(client *elasticsearch.Client) bool {
 	v := client.GetVersion()
 	return v.Major >= 5
 }
+
+func hasIngestPipelineProcessor(client *elasticsearch.Client) bool {
+	v := client.GetVersion()
+	return v.Major > 6 || (v.Major == 6 && v.Minor >= 5)
+}
+
+func TestLoadMultiplePipelines(t *testing.T) {
+	client := estest.GetTestingElasticsearch(t)
+	if !hasIngest(client) {
+		t.Skip("Skip tests because ingest is missing in this elasticsearch version: ", client.GetVersion())
+	}
+
+	if !hasIngestPipelineProcessor(client) {
+		t.Skip("Skip tests because ingest is missing the pipeline processor: ", client.GetVersion())
+	}
+
+	client.Request("DELETE", "/_ingest/pipeline/filebeat-6.6.0-foo-multi-pipeline", "", nil, nil)
+	client.Request("DELETE", "/_ingest/pipeline/filebeat-6.6.0-foo-multi-json_logs", "", nil, nil)
+	client.Request("DELETE", "/_ingest/pipeline/filebeat-6.6.0-foo-multi-plain_logs", "", nil, nil)
+
+	modulesPath, err := filepath.Abs("../_meta/test/module")
+	assert.NoError(t, err)
+
+	enabled := true
+	disabled := false
+	filesetConfigs := map[string]*FilesetConfig{
+		"multi":    &FilesetConfig{Enabled: &enabled},
+		"multibad": &FilesetConfig{Enabled: &disabled},
+	}
+	configs := []*ModuleConfig{
+		&ModuleConfig{"foo", &enabled, filesetConfigs},
+	}
+
+	reg, err := newModuleRegistry(modulesPath, configs, nil, "6.6.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = reg.LoadPipelines(client, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	status, _, _ := client.Request("GET", "/_ingest/pipeline/filebeat-6.6.0-foo-multi-pipeline", "", nil, nil)
+	assert.Equal(t, 200, status)
+	status, _, _ = client.Request("GET", "/_ingest/pipeline/filebeat-6.6.0-foo-multi-json_logs", "", nil, nil)
+	assert.Equal(t, 200, status)
+	status, _, _ = client.Request("GET", "/_ingest/pipeline/filebeat-6.6.0-foo-multi-plain_logs", "", nil, nil)
+	assert.Equal(t, 200, status)
+}
+
+func TestLoadMultiplePipelinesWithRollback(t *testing.T) {
+	client := estest.GetTestingElasticsearch(t)
+	if !hasIngest(client) {
+		t.Skip("Skip tests because ingest is missing in this elasticsearch version: ", client.GetVersion())
+	}
+
+	if !hasIngestPipelineProcessor(client) {
+		t.Skip("Skip tests because ingest is missing the pipeline processor: ", client.GetVersion())
+	}
+
+	client.Request("DELETE", "/_ingest/pipeline/filebeat-6.6.0-foo-multibad-pipeline", "", nil, nil)
+	client.Request("DELETE", "/_ingest/pipeline/filebeat-6.6.0-foo-multibad-json_logs", "", nil, nil)
+	client.Request("DELETE", "/_ingest/pipeline/filebeat-6.6.0-foo-multibad-plain_logs_bad", "", nil, nil)
+
+	modulesPath, err := filepath.Abs("../_meta/test/module")
+	assert.NoError(t, err)
+
+	enabled := true
+	disabled := false
+	filesetConfigs := map[string]*FilesetConfig{
+		"multi":    &FilesetConfig{Enabled: &disabled},
+		"multibad": &FilesetConfig{Enabled: &enabled},
+	}
+	configs := []*ModuleConfig{
+		&ModuleConfig{"foo", &enabled, filesetConfigs},
+	}
+
+	reg, err := newModuleRegistry(modulesPath, configs, nil, "6.6.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = reg.LoadPipelines(client, false)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "invalid_processor")
+
+	status, _, _ := client.Request("GET", "/_ingest/pipeline/filebeat-6.6.0-foo-multibad-pipeline", "", nil, nil)
+	assert.Equal(t, 404, status)
+	status, _, _ = client.Request("GET", "/_ingest/pipeline/filebeat-6.6.0-foo-multibad-json_logs", "", nil, nil)
+	assert.Equal(t, 404, status)
+	status, _, _ = client.Request("GET", "/_ingest/pipeline/filebeat-6.6.0-foo-multibad-plain_logs_bad", "", nil, nil)
+	assert.Equal(t, 404, status)
+}

--- a/filebeat/fileset/pipelines.go
+++ b/filebeat/fileset/pipelines.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/joeshaw/multierror"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 )
@@ -55,11 +57,29 @@ func (reg *ModuleRegistry) LoadPipelines(esClient PipelineLoader, overwrite bool
 			if err != nil {
 				return fmt.Errorf("Error getting pipeline for fileset %s/%s: %v", module, name, err)
 			}
+
+			var pipelineIDsLoaded []string
 			for _, pipeline := range pipelines {
 				err = loadPipeline(esClient, pipeline.id, pipeline.contents, overwrite)
 				if err != nil {
-					return fmt.Errorf("Error loading pipeline for fileset %s/%s: %v", module, name, err)
+					err = fmt.Errorf("Error loading pipeline for fileset %s/%s: %v", module, name, err)
+					break
 				}
+				pipelineIDsLoaded = append(pipelineIDsLoaded, pipeline.id)
+			}
+
+			if err != nil {
+				// Rollback pipelines and return errors
+				// TODO: Instead of attempting to load all pipelines and then rolling back loaded ones when there's an
+				// error, validate all pipelines before loading any of them. This requires https://github.com/elastic/elasticsearch/issues/35495.
+				errs := multierror.Errors{err}
+				for _, pipelineID := range pipelineIDsLoaded {
+					err = deletePipeline(esClient, pipelineID)
+					if err != nil {
+						errs = append(errs, err)
+					}
+				}
+				return errs.Err()
 			}
 		}
 	}
@@ -67,7 +87,7 @@ func (reg *ModuleRegistry) LoadPipelines(esClient PipelineLoader, overwrite bool
 }
 
 func loadPipeline(esClient PipelineLoader, pipelineID string, content map[string]interface{}, overwrite bool) error {
-	path := "/_ingest/pipeline/" + pipelineID
+	path := makeIngestPipelinePath(pipelineID)
 	if !overwrite {
 		status, _, _ := esClient.Request("GET", path, "", nil, nil)
 		if status == 200 {
@@ -81,6 +101,16 @@ func loadPipeline(esClient PipelineLoader, pipelineID string, content map[string
 	}
 	logp.Info("Elasticsearch pipeline with ID '%s' loaded", pipelineID)
 	return nil
+}
+
+func deletePipeline(esClient PipelineLoader, pipelineID string) error {
+	path := makeIngestPipelinePath(pipelineID)
+	_, _, err := esClient.Request("DELETE", path, "", nil, nil)
+	return err
+}
+
+func makeIngestPipelinePath(pipelineID string) string {
+	return "/_ingest/pipeline/" + pipelineID
 }
 
 func interpretError(initialErr error, body []byte) error {

--- a/filebeat/fileset/pipelines.go
+++ b/filebeat/fileset/pipelines.go
@@ -51,7 +51,7 @@ func (reg *ModuleRegistry) LoadPipelines(esClient PipelineLoader, overwrite bool
 				}
 			}
 
-			pipelines, err := fileset.GetPipelines(esClient.GetVersion())
+			pipelines, err := fileset.getPipelines(esClient.GetVersion())
 			if err != nil {
 				return fmt.Errorf("Error getting pipeline for fileset %s/%s: %v", module, name, err)
 			}

--- a/filebeat/fileset/pipelines.go
+++ b/filebeat/fileset/pipelines.go
@@ -51,13 +51,15 @@ func (reg *ModuleRegistry) LoadPipelines(esClient PipelineLoader, overwrite bool
 				}
 			}
 
-			pipelineID, content, err := fileset.GetPipeline(esClient.GetVersion())
+			pipelines, err := fileset.GetPipelines(esClient.GetVersion())
 			if err != nil {
 				return fmt.Errorf("Error getting pipeline for fileset %s/%s: %v", module, name, err)
 			}
-			err = loadPipeline(esClient, pipelineID, content, overwrite)
-			if err != nil {
-				return fmt.Errorf("Error loading pipeline for fileset %s/%s: %v", module, name, err)
+			for _, pipeline := range pipelines {
+				err = loadPipeline(esClient, pipeline.id, pipeline.contents, overwrite)
+				if err != nil {
+					return fmt.Errorf("Error loading pipeline for fileset %s/%s: %v", module, name, err)
+				}
 			}
 		}
 	}

--- a/filebeat/fileset/pipelines.go
+++ b/filebeat/fileset/pipelines.go
@@ -51,7 +51,7 @@ func (reg *ModuleRegistry) LoadPipelines(esClient PipelineLoader, overwrite bool
 				}
 			}
 
-			pipelines, err := fileset.getPipelines(esClient.GetVersion())
+			pipelines, err := fileset.GetPipelines(esClient.GetVersion())
 			if err != nil {
 				return fmt.Errorf("Error getting pipeline for fileset %s/%s: %v", module, name, err)
 			}


### PR DESCRIPTION
Motivated by https://github.com/elastic/beats/pull/8852#issuecomment-434973388.

Starting with 6.5.0, Elasticsearch Ingest Pipelines have gained the ability to:
- run sub-pipelines via the [`pipeline` processor](https://www.elastic.co/guide/en/elasticsearch/reference/6.5/pipeline-processor.html), and
- conditionally run processors via an [`if` field](https://www.elastic.co/guide/en/elasticsearch/reference/6.5/ingest-processors.html).

These abilities combined present the opportunity for a fileset to ingest the same _logical_ information presented in different formats, e.g. plaintext vs. json versions of the same log files. Imagine an entry point ingest pipeline that detects the format of a log entry and then conditionally delegates further processing of that log entry, depending on the format, to another pipeline.

This PR allows filesets to specify one or more ingest pipelines via the `ingest_pipeline` property in their `manifest.yml`. If more than one ingest pipeline is specified, the first one is taken to be the entry point ingest pipeline.

#### Example with multiple pipelines
```yaml
ingest_pipeline:
  - pipeline-ze-boss.json 
  - pipeline-plain.json
  - pipeline-json.json
```
#### Example with a single pipeline
_This is just to show that the existing functionality will continue to work as-is._
```yaml
ingest_pipeline: pipeline.json
```

Now, if the root pipeline wants to delegate processing to another pipeline, it must use a `pipeline` processor to do so. This processor's `name` field will need to reference the other pipeline by its name. To ensure correct referencing, the `name` field must be specified as follows:

```json
{
  "pipeline" : {
    "name": "{< IngestPipeline "pipeline-plain" >}"
  }
}
```

This will ensure that the specified name gets correctly converted to the corresponding name in Elasticsearch, since Filebeat prefixes it's "raw" Ingest pipeline names with `filebeat-<version>-<module>-<fileset>-` when loading them into Elasticsearch. 
