### PR TITLE
Change default seeking of journalbeat to `cursor`

### DIFF
--- a/journalbeat/_meta/beat.yml
+++ b/journalbeat/_meta/beat.yml
@@ -24,7 +24,7 @@ journalbeat.inputs:
   #max_backoff: 60s
 
   # Position to start reading from journal. Valid values: head, tail, cursor
-  seek: tail
+  seek: cursor
 
   # Exact matching for field values of events.
   # Matching for nginx entries: "systemd.unit=nginx"

--- a/journalbeat/config/config.go
+++ b/journalbeat/config/config.go
@@ -41,5 +41,5 @@ var DefaultConfig = Config{
 	RegistryFile: "registry",
 	Backoff:      1 * time.Second,
 	MaxBackoff:   60 * time.Second,
-	Seek:         "tail",
+	Seek:         "cursor",
 }

--- a/journalbeat/input/config.go
+++ b/journalbeat/input/config.go
@@ -53,7 +53,7 @@ var (
 		Backoff:       1 * time.Second,
 		BackoffFactor: 2,
 		MaxBackoff:    60 * time.Second,
-		Seek:          "tail",
+		Seek:          "cursor",
 	}
 )
 

--- a/journalbeat/journalbeat.reference.yml
+++ b/journalbeat/journalbeat.reference.yml
@@ -24,7 +24,7 @@ journalbeat.inputs:
   #max_backoff: 60s
 
   # Position to start reading from journal. Valid values: head, tail, cursor
-  seek: tail
+  seek: cursor
 
   # Exact matching for field values of events.
   # Matching for nginx entries: "systemd.unit=nginx"

--- a/journalbeat/journalbeat.yml
+++ b/journalbeat/journalbeat.yml
@@ -24,7 +24,7 @@ journalbeat.inputs:
   #max_backoff: 60s
 
   # Position to start reading from journal. Valid values: head, tail, cursor
-  seek: tail
+  seek: cursor
 
   # Exact matching for field values of events.
   # Matching for nginx entries: "systemd.unit=nginx"


### PR DESCRIPTION
Previously `tail` was the default value. However, users would want to start reading journals where journalbeat left off. So `cursor` is a better choice.