### PR TITLE
Cherry-pick #5894 to 5.6: Avoid xargs -r because of macOS

### DIFF
--- a/dev-tools/jenkins_ci.sh
+++ b/dev-tools/jenkins_ci.sh
@@ -19,11 +19,19 @@ jenkins_setup
 cleanup() {
   echo "Running cleanup..."
   rm -rf $TEMP_PYTHON_ENV
-  make stop-environment fix-permissions
-  echo "Killing all running containers..."
-  docker ps -q | xargs -r docker kill || true
-  echo "Cleaning stopped docker containers and dangling images/networks/volumes..."
-  docker system prune -f || true
+
+  if docker info > /dev/null ; then
+    make stop-environment || true
+    make fix-permissions || true
+    echo "Killing all running containers..."
+    ids=$(docker ps -q)
+    if [ -n "$ids" ]; then
+      docker kill $ids
+    fi  
+    echo "Cleaning stopped docker containers and dangling images/networks/volumes..."
+    docker system prune -f || true
+  fi
+
   echo "Cleanup complete."
 }
 trap cleanup EXIT


### PR DESCRIPTION
macOS does not support the -r argument to xargs so work around that.

(cherry-pick of 6d0d9ace2b14d753821e319af7593943668812b7)