### PR TITLE
Cherry-pick #8899 to 6.x: Fix improperly set config for CRI Flag in Docker Input

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -69,6 +69,7 @@ https://github.com/elastic/beats/compare/v6.4.0...6.x[Check the HEAD diff]
 - Fix RFC3339 timezone and nanoseconds parsing with the syslog input. {pull}8346[8346]
 - Mark the TCP and UDP input as GA. {pull}8125[8125]
 - Support multiline logs in logstash/log fileset of Filebeat. {pull}8562[8562]
+- Fix improperly set config for CRI Flag in Docker Input {pull}8899[8899]
 
 *Heartbeat*
 

--- a/filebeat/input/docker/input.go
+++ b/filebeat/input/docker/input.go
@@ -68,7 +68,7 @@ func NewInput(
 		return nil, errors.Wrap(err, "update input config")
 	}
 
-	if err := cfg.SetBool("docker-json.cri_flags", -1, config.Partial); err != nil {
+	if err := cfg.SetBool("docker-json.cri_flags", -1, config.CRIFlags); err != nil {
 		return nil, errors.Wrap(err, "update input config")
 	}
 


### PR DESCRIPTION
Cherry-pick of PR #8899 to 6.x branch. Original message: 

Minor bug fix to set the right config