### PR TITLE
Cherry-pick #8929 to 6.5: Do not fail when reloading outputs

### DIFF
--- a/libbeat/publisher/pipeline/module.go
+++ b/libbeat/publisher/pipeline/module.go
@@ -134,7 +134,12 @@ func loadOutput(
 		outStats outputs.Observer
 	)
 	if monitors.Metrics != nil {
-		metrics = monitors.Metrics.NewRegistry("output")
+		metrics = monitors.Metrics.GetRegistry("output")
+		if metrics != nil {
+			metrics.Clear()
+		} else {
+			metrics = monitors.Metrics.NewRegistry("output")
+		}
 		outStats = outputs.NewStats(metrics)
 	}
 
@@ -147,7 +152,12 @@ func loadOutput(
 		monitoring.NewString(metrics, "type").Set(outcfg.Name())
 	}
 	if monitors.Telemetry != nil {
-		telemetry := monitors.Telemetry.NewRegistry("output")
+		telemetry := monitors.Telemetry.GetRegistry("output")
+		if telemetry != nil {
+			telemetry.Clear()
+		} else {
+			telemetry = monitors.Telemetry.NewRegistry("output")
+		}
 		monitoring.NewString(telemetry, "name").Set(outcfg.Name())
 	}
 


### PR DESCRIPTION
Cherry-pick of PR #8929 to 6.5 branch. Original message: 

This change fixes a bad backport from master, where this conditional
code was missing.

Without this change, reloading an output would result on the following error:
```
goroutine 75 [running]:
github.com/elastic/beats/libbeat/monitoring.panicErr(0x4dc5e00, 0xc420490a50)
	/go/src/github.com/elastic/beats/libbeat/monitoring/registry.go:257 +0x4a
github.com/elastic/beats/libbeat/monitoring.(*Registry).Add(0xc4200bc440, 0x4cf4b63, 0x6, 0x4dc61c0, 0xc42008ae00, 0x101)
	/go/src/github.com/elastic/beats/libbeat/monitoring/registry.go:155 +0xd5
github.com/elastic/beats/libbeat/monitoring.(*Registry).NewRegistry(0xc4200bc440, 0x4cf4b63, 0x6, 0x0, 0x0, 0x0, 0x4cf43b3)
	/go/src/github.com/elastic/beats/libbeat/monitoring/registry.go:94 +0x13f
github.com/elastic/beats/libbeat/publisher/pipeline.loadOutput(0x4cf713b, 0x8, 0x4cf713b, 0x8, 0x4cf2bc5, 0x5, 0xc4203e8a40, 0x1c, 0xc4203e8a40, 0x1c, ...)
	/go/src/github.com/elastic/beats/libbeat/publisher/pipeline/module.go:137 +0x3c0
github.com/elastic/beats/libbeat/publisher/pipeline.(*outputController).Reload(0xc420493860, 0xc420490840, 0x0, 0x0)
	/go/src/github.com/elastic/beats/libbeat/publisher/pipeline/controller.go:161 +0x140
github.com/elastic/beats/x-pack/libbeat/management.(*ConfigManager).reload(0xc420162c80, 0xc420326196, 0x6, 0xc4203fc030, 0x1, 0x1, 0x0, 0x0)
	/go/src/github.com/elastic/beats/x-pack/libbeat/management/manager.go:213 +0x660
github.com/elastic/beats/x-pack/libbeat/management.(*ConfigManager).apply(0xc420162c80)
	/go/src/github.com/elastic/beats/x-pack/libbeat/management/manager.go:185 +0x11f
github.com/elastic/beats/x-pack/libbeat/management.(*ConfigManager).worker(0xc420162c80)
	/go/src/github.com/elastic/beats/x-pack/libbeat/management/manager.go:144 +0x28a
created by github.com/elastic/beats/x-pack/libbeat/management.(*ConfigManager).Start
	/go/src/github.com/elastic/beats/x-pack/libbeat/management/manager.go:104 +0xe9
```

Tests for this use case are being added to master here: https://github.com/elastic/beats/pull/8762