### PR TITLE
Cherry-pick #8819 to 6.5: Cherry-pick #8808 to 6.x: Update request to 2.20.0

### DIFF
--- a/journalbeat/_meta/beat.yml
+++ b/journalbeat/_meta/beat.yml
@@ -24,7 +24,7 @@ journalbeat.inputs:
   #max_backoff: 60s
 
   # Position to start reading from journal. Valid values: head, tail, cursor
-  seek: tail
+  seek: cursor
 
   # Exact matching for field values of events.
   # Matching for nginx entries: "systemd.unit=nginx"

--- a/journalbeat/config/config.go
+++ b/journalbeat/config/config.go
@@ -41,5 +41,5 @@ var DefaultConfig = Config{
 	RegistryFile: "registry",
 	Backoff:      1 * time.Second,
 	MaxBackoff:   60 * time.Second,
-	Seek:         "tail",
+	Seek:         "cursor",
 }

--- a/journalbeat/input/config.go
+++ b/journalbeat/input/config.go
@@ -53,7 +53,7 @@ var (
 		Backoff:       1 * time.Second,
 		BackoffFactor: 2,
 		MaxBackoff:    60 * time.Second,
-		Seek:          "tail",
+		Seek:          "cursor",
 	}
 )
 

--- a/journalbeat/journalbeat.reference.yml
+++ b/journalbeat/journalbeat.reference.yml
@@ -24,7 +24,7 @@ journalbeat.inputs:
   #max_backoff: 60s
 
   # Position to start reading from journal. Valid values: head, tail, cursor
-  seek: tail
+  seek: cursor
 
   # Exact matching for field values of events.
   # Matching for nginx entries: "systemd.unit=nginx"

--- a/journalbeat/journalbeat.yml
+++ b/journalbeat/journalbeat.yml
@@ -24,7 +24,7 @@ journalbeat.inputs:
   #max_backoff: 60s
 
   # Position to start reading from journal. Valid values: head, tail, cursor
-  seek: tail
+  seek: cursor
 
   # Exact matching for field values of events.
   # Matching for nginx entries: "systemd.unit=nginx"


### PR DESCRIPTION
Cherry-pick of PR #8819 to 6.5 branch. Original message: 

Cherry-pick of PR #8808 to 6.x branch. Original message: 

The Requests package through 2.19.1 before 2018-09-14 for Python sends an HTTP Authorization header to an http URI upon receiving a same-hostname https-to-http redirect, which makes it easier for remote attackers to discover credentials by sniffing the network.

https://nvd.nist.gov/vuln/detail/CVE-2018-18074