### PR TITLE
Fix export_dashboards command

### DIFF
--- a/dev-tools/cmd/dashboards/export_dashboards.go
+++ b/dev-tools/cmd/dashboards/export_dashboards.go
@@ -117,7 +117,7 @@ func decodeValue(data common.MapStr, key string) {
 		return
 	}
 	s := v.(string)
-	var d common.MapStr
+	var d interface{}
 	json.Unmarshal([]byte(s), &d)
 
 	data.Put(key, d)


### PR DESCRIPTION
`panelJSON` is/can be an array, so marshaling to MapStr caused
problems. I think this was the root cause for #8952.