### PR TITLE
Introduce `service.type` for all Metricbeat modules

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -69,6 +69,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha1...master[Check the HEAD d
 
 - Add setting to disable docker cpu metrics per core. {pull}9194[9194]
 - The `elasticsearch/node` metricset now reports the Elasticsearch cluster UUID. {pull}8771[8771]
+- Add service.type field to Metricbeat. {pull}8965[8965]
 
 *Packetbeat*
 

--- a/metricbeat/mb/event.go
+++ b/metricbeat/mb/event.go
@@ -41,6 +41,7 @@ type Event struct {
 	Timestamp time.Time     // Timestamp when the event data was collected.
 	Error     error         // Error that occurred while collecting the event data.
 	Host      string        // Host from which the data was collected.
+	Service   string        // Service type
 	Took      time.Duration // Amount of time it took to collect the event data.
 }
 
@@ -64,6 +65,12 @@ func (e *Event) BeatEvent(module, metricSet string, modifiers ...EventModifier) 
 		b.Fields.Put(module, e.ModuleFields)
 		e.ModuleFields = nil
 	}
+
+	// If service is not set, falls back to the module name
+	if e.Service == "" {
+		e.Service = module
+	}
+	e.RootFields.Put("service.type", e.Service)
 
 	if len(e.MetricSetFields) > 0 {
 		switch e.Namespace {

--- a/metricbeat/mb/event_test.go
+++ b/metricbeat/mb/event_test.go
@@ -63,6 +63,9 @@ func TestEventConversionToBeatEvent(t *testing.T) {
 					"ms": 1000,
 				},
 			},
+			"service": common.MapStr{
+				"type": "docker",
+			},
 		}, e.Fields)
 	})
 
@@ -95,6 +98,9 @@ func TestEventConversionToBeatEvent(t *testing.T) {
 					"ms": 1000,
 				},
 			},
+			"service": common.MapStr{
+				"type": "docker",
+			},
 		}, e.Fields)
 	})
 
@@ -108,6 +114,9 @@ func TestEventConversionToBeatEvent(t *testing.T) {
 		assert.Equal(t, common.MapStr{
 			"module":    module,
 			"metricset": metricSet,
+			"service": common.MapStr{
+				"type": "docker",
+			},
 		}, e.Fields)
 	})
 
@@ -141,6 +150,9 @@ func TestEventConversionToBeatEvent(t *testing.T) {
 				"uptime": common.MapStr{
 					"ms": 1000,
 				},
+			},
+			"service": common.MapStr{
+				"type": "docker",
 			},
 		}, e.Fields)
 	})

--- a/metricbeat/mb/module/example_test.go
+++ b/metricbeat/mb/module/example_test.go
@@ -99,6 +99,9 @@ func ExampleWrapper() {
 	//     "module": "fake",
 	//     "name": "eventfetcher",
 	//     "rtt": 111
+	//   },
+	//   "service": {
+	//     "type": "fake"
 	//   }
 	// }
 }

--- a/metricbeat/tests/system/metricbeat.py
+++ b/metricbeat/tests/system/metricbeat.py
@@ -7,7 +7,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '../../../libbeat/tests/
 from beat.beat import TestCase
 
 COMMON_FIELDS = ["@timestamp", "agent", "metricset.name", "metricset.host",
-                 "metricset.module", "metricset.rtt", "host.name", "service"]
+                 "metricset.module", "metricset.rtt", "host.name", "service.name"]
 
 INTEGRATION_TESTS = os.environ.get('INTEGRATION_TESTS', False)
 

--- a/metricbeat/tests/system/metricbeat.py
+++ b/metricbeat/tests/system/metricbeat.py
@@ -7,7 +7,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '../../../libbeat/tests/
 from beat.beat import TestCase
 
 COMMON_FIELDS = ["@timestamp", "agent", "metricset.name", "metricset.host",
-                 "metricset.module", "metricset.rtt", "host.name"]
+                 "metricset.module", "metricset.rtt", "host.name", "service"]
 
 INTEGRATION_TESTS = os.environ.get('INTEGRATION_TESTS', False)
 

--- a/metricbeat/tests/system/test_processors.py
+++ b/metricbeat/tests/system/test_processors.py
@@ -35,7 +35,7 @@ class Test(metricbeat.BaseTest):
         print(evt.keys())
         self.assertItemsEqual(self.de_dot([
             'agent', '@timestamp', 'system', 'metricset.module',
-            'metricset.rtt', 'metricset.name', 'host'
+            'metricset.rtt', 'metricset.name', 'host', 'service'
         ]), evt.keys())
         cpu = evt["system"]["cpu"]
         print(cpu.keys())

--- a/metricbeat/tests/system/test_redis.py
+++ b/metricbeat/tests/system/test_redis.py
@@ -92,7 +92,7 @@ class Test(metricbeat.BaseTest):
         Test local processors for Redis info event.
         """
         fields = ["clients", "cpu"]
-        eventFields = ['beat', 'metricset']
+        eventFields = ['beat', 'metricset', 'service']
         eventFields += ['redis.info.' + f for f in fields]
         self.render_config_template(modules=[{
             "name": "redis",


### PR DESCRIPTION
The service.type describes which service a dataset is connecting to. This is not necessarily the same for all datasets in one module. An example here is the K8s module which reaches out to 3 different services.

For now the default is just set to the module name if none is set. Unfortunately changing K8s module was not as easy as I though as it still has the old Fetch methods so the variables can not be set.

Questions:
* As in most cases for use service.name and service.type are the same, should we also set service.name by default?