### PR TITLE
Cherry-pick #8951 to 6.x: Add documentation for json.is_array setting

### DIFF
--- a/metricbeat/module/http/json/_meta/docs.asciidoc
+++ b/metricbeat/module/http/json/_meta/docs.asciidoc
@@ -46,6 +46,11 @@ Here the response from `date.jsontest.com` is returned in the configured `http_j
 It is required to set a namespace in the general module config section.
 
 [float]
+==== json.is_array
+With this configuration enabled the `json` metriset expects the JSON structure returned by the HTTP endpoint to be an array. Further,
+it creates separate events for each element in the array.
+
+[float]
 ==== request.enabled
 With this configuration enabled additional information about the request are included. This includes the following information:
 

--- a/metricbeat/module/http/json/_meta/docs.asciidoc
+++ b/metricbeat/module/http/json/_meta/docs.asciidoc
@@ -47,7 +47,7 @@ It is required to set a namespace in the general module config section.
 
 [float]
 ==== json.is_array
-With this configuration enabled the `json` metriset expects the JSON structure returned by the HTTP endpoint to be an array. Further,
+With this configuration enabled the `json` metricset expects the JSON structure returned by the HTTP endpoint to be an array. Further,
 it creates separate events for each element in the array.
 
 [float]


### PR DESCRIPTION
Cherry-pick of PR #8951 to 6.x branch. Original message: 

Motivated by https://discuss.elastic.co/t/how-to-query-json-url-with-http-module/155572 and follow up doc PR to https://github.com/elastic/beats/pull/6480.

This PR documents the `json.is_array` setting supported by the `http/json` metricset. The setting was introduced in #6480 but not documented at the time.