### PR TITLE
Fix macOS default log path for elasticsearch module based on brew pat…

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -71,6 +71,7 @@ https://github.com/elastic/beats/compare/v6.4.0...6.x[Check the HEAD diff]
 - Support multiline logs in logstash/log fileset of Filebeat. {pull}8562[8562]
 - Fix improperly set config for CRI Flag in Docker Input {pull}8899[8899]
 - Just enabling the `elasticsearch` fileset and starting Filebeat no longer causes an error. {pull}8891[8891]
+- Fix macOS default log path for elasticsearch module based on homebrew paths. {pul}8939[8939]
 
 *Heartbeat*
 

--- a/filebeat/module/elasticsearch/audit/manifest.yml
+++ b/filebeat/module/elasticsearch/audit/manifest.yml
@@ -5,7 +5,7 @@ var:
     default:
       - /var/log/elasticsearch/*_access.log
     os.darwin:
-      - /usr/local/elasticsearch/*_access.log
+      - /usr/local/var/lib/elasticsearch/*_access.log
     os.windows:
       - c:/ProgramData/Elastic/Elasticsearch/logs/*_access.log
 

--- a/filebeat/module/elasticsearch/deprecation/manifest.yml
+++ b/filebeat/module/elasticsearch/deprecation/manifest.yml
@@ -5,7 +5,7 @@ var:
     default:
       - /var/log/elasticsearch/*_deprecation.log
     os.darwin:
-      - /usr/local/elasticsearch/*_deprecation.log
+      - /usr/local/var/lib/elasticsearch/*_deprecation.log
     os.windows:
       - c:/ProgramData/Elastic/Elasticsearch/logs/*_deprecation.log
 

--- a/filebeat/module/elasticsearch/gc/manifest.yml
+++ b/filebeat/module/elasticsearch/gc/manifest.yml
@@ -6,8 +6,8 @@ var:
       - /var/log/elasticsearch/gc.log.[0-9]*
       - /var/log/elasticsearch/gc.log
     os.darwin:
-      - /usr/local/elasticsearch/gc.log.[0-9]*
-      - /usr/local/elasticsearch/gc.log
+      - /usr/local/var/lib/elasticsearch/gc.log.[0-9]*
+      - /usr/local/var/lib/elasticsearch/gc.log
     os.windows:
       - c:/ProgramData/Elastic/Elasticsearch/logs/gc.log.*
       - c:/ProgramData/Elastic/Elasticsearch/logs/gc.log

--- a/filebeat/module/elasticsearch/server/manifest.yml
+++ b/filebeat/module/elasticsearch/server/manifest.yml
@@ -5,7 +5,7 @@ var:
     default:
       - /var/log/elasticsearch/*.log
     os.darwin:
-      - /usr/local/elasticsearch/*.log
+      - /usr/local/var/lib/elasticsearch/*.log
     os.windows:
       - c:/ProgramData/Elastic/Elasticsearch/logs/*.log
 

--- a/filebeat/module/elasticsearch/slowlog/manifest.yml
+++ b/filebeat/module/elasticsearch/slowlog/manifest.yml
@@ -6,8 +6,8 @@ var:
       - /var/log/elasticsearch/*_index_search_slowlog.log
       - /var/log/elasticsearch/*_index_indexing_slowlog.log
     os.darwin:
-      - /usr/local/elasticsearch/*_index_search_slowlog.log
-      - /usr/local/elasticsearch/*_index_indexing_slowlog.log
+      - /usr/local/var/lib/elasticsearch/*_index_search_slowlog.log
+      - /usr/local/var/lib/elasticsearch/*_index_indexing_slowlog.log
     os.windows:
       - c:/ProgramData/Elastic/Elasticsearch/logs/*_index_search_slowlog.log
       - c:/ProgramData/Elastic/Elasticsearch/logs/*_index_indexing_slowlog.log


### PR DESCRIPTION
…hs (#8939)

* Fix macOS default log path for elasticsearch module based on homebrew paths.

* Add changelog record for macOS default path fix.

(cherry picked from commit 3f07231ce2b9943c5ca853dda351068c120f5670)