### PR TITLE
Mask uint64 with 63bit mask by default

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -12,6 +12,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha1...master[Check the HEAD d
 ==== Breaking changes
 
 *Affecting all Beats*
+- Automaticall cap signed integers to 63bits. {pull}8991[8991]
 
 *Auditbeat*
 

--- a/libbeat/common/event.go
+++ b/libbeat/common/event.go
@@ -184,7 +184,7 @@ func normalizeValue(value interface{}, keys ...string) (interface{}, []error) {
 			}
 		}
 		if !mask {
-			return arr, nil
+			return value, nil
 		}
 
 		tmp := make([]uint64, len(arr))

--- a/libbeat/common/event.go
+++ b/libbeat/common/event.go
@@ -170,8 +170,29 @@ func normalizeValue(value interface{}, keys ...string) (interface{}, []error) {
 	case bool, []bool:
 	case int, int8, int16, int32, int64:
 	case []int, []int8, []int16, []int32, []int64:
-	case uint, uint8, uint16, uint32, uint64:
-	case []uint, []uint8, []uint16, []uint32, []uint64:
+	case uint, uint8, uint16, uint32:
+	case uint64:
+		return value.(uint64) &^ (1 << 63), nil
+	case []uint, []uint8, []uint16, []uint32:
+	case []uint64:
+		arr := value.([]uint64)
+		mask := false
+		for _, v := range arr {
+			if v >= (1 << 63) {
+				mask = true
+				break
+			}
+		}
+		if !mask {
+			return arr, nil
+		}
+
+		tmp := make([]uint64, len(arr))
+		for i, v := range arr {
+			tmp[i] = v &^ (1 << 63)
+		}
+		return tmp, nil
+
 	case float64:
 		return Float(value.(float64)), nil
 	case float32:
@@ -200,7 +221,7 @@ func normalizeValue(value interface{}, keys ...string) (interface{}, []error) {
 		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 			return v.Int(), nil
 		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-			return v.Uint(), nil
+			return v.Uint() &^ (1 << 63), nil
 		case reflect.Float32, reflect.Float64:
 			return Float(v.Float()), nil
 		case reflect.Complex64, reflect.Complex128:

--- a/libbeat/common/event_test.go
+++ b/libbeat/common/event_test.go
@@ -236,7 +236,7 @@ func TestNormalizeValue(t *testing.T) {
 	type myuint64 uint64
 
 	runTests(checkEq, map[string]testCase{
-		"nil": {nil, nil},
+		"nil":                               {nil, nil},
 		"pointers are dereferenced":         {&someString, someString},
 		"drop nil string pointer":           {nilStringPtr, nil},
 		"drop nil time pointer":             {nilTimePtr, nil},

--- a/libbeat/common/event_test.go
+++ b/libbeat/common/event_test.go
@@ -198,6 +198,30 @@ func TestConvertNestedStruct(t *testing.T) {
 func TestNormalizeValue(t *testing.T) {
 	logp.TestingSetup()
 
+	type testCase struct{ in, out interface{} }
+
+	runTests := func(check func(t *testing.T, a, b interface{}), tests map[string]testCase) {
+		for name, test := range tests {
+			test := test
+			t.Run(name, func(t *testing.T) {
+				out, err := normalizeValue(test.in)
+				if err != nil {
+					t.Error(err)
+					return
+				}
+				check(t, test.out, out)
+			})
+		}
+	}
+
+	checkEq := func(t *testing.T, a, b interface{}) {
+		assert.Equal(t, a, b)
+	}
+
+	checkDelta := func(t *testing.T, a, b interface{}) {
+		assert.InDelta(t, a, float64(b.(Float)), 0.000001)
+	}
+
 	var nilStringPtr *string
 	var nilTimePtr *time.Time
 	someString := "foo"
@@ -209,73 +233,55 @@ func TestNormalizeValue(t *testing.T) {
 	type mybool bool
 	type myint int32
 	type myuint uint8
+	type myuint64 uint64
 
-	var tests = []struct {
-		in  interface{}
-		out interface{}
-	}{
-		{nil, nil},
-		{&someString, someString},       // Pointers are dereferenced.
-		{nilStringPtr, nil},             // Nil pointers are dropped.
-		{nilTimePtr, nil},               // Nil pointers are dropped.
-		{uuidValue, uuidValue.String()}, // Struct that honors the TextMarshaler contract.
-		{NetString("test"), "test"},     // It honors the TextMarshaler contract.
-		{true, true},
-		{int8(8), int8(8)},
-		{uint8(8), uint8(8)},
-		{"hello", "hello"},
-		{map[string]interface{}{"foo": "bar"}, MapStr{"foo": "bar"}},
+	runTests(checkEq, map[string]testCase{
+		"nil": {nil, nil},
+		"pointers are dereferenced":         {&someString, someString},
+		"drop nil string pointer":           {nilStringPtr, nil},
+		"drop nil time pointer":             {nilTimePtr, nil},
+		"UUID supports TextMarshaller":      {uuidValue, uuidValue.String()},
+		"NetString supports TextMarshaller": {NetString("test"), "test"},
+		"bool value":                        {true, true},
+		"int8 value":                        {int8(8), int8(8)},
+		"uint8 value":                       {uint8(8), uint8(8)},
+		"uint64 masked":                     {uint64(1<<63 + 10), uint64(10)},
+		"string value":                      {"hello", "hello"},
+		"map to MapStr":                     {map[string]interface{}{"foo": "bar"}, MapStr{"foo": "bar"}},
 
 		// Other map types are converted using marshalUnmarshal which will lose
 		// type information for arrays which become []interface{} and numbers
 		// which all become float64.
-		{map[string]string{"foo": "bar"}, MapStr{"foo": "bar"}},
-		{map[string][]string{"list": {"foo", "bar"}}, MapStr{"list": []interface{}{"foo", "bar"}}},
+		"map[string]string to MapStr":   {map[string]string{"foo": "bar"}, MapStr{"foo": "bar"}},
+		"map[string][]string to MapStr": {map[string][]string{"list": {"foo", "bar"}}, MapStr{"list": []interface{}{"foo", "bar"}}},
 
-		{[]string{"foo", "bar"}, []string{"foo", "bar"}},
-		{[]bool{true, false}, []bool{true, false}},
-		{[]string{"foo", "bar"}, []string{"foo", "bar"}},
-		{[]int{10, 11}, []int{10, 11}},
-		{[]MapStr{{"foo": "bar"}}, []MapStr{{"foo": "bar"}}},
-		{[]map[string]interface{}{{"foo": "bar"}}, []MapStr{{"foo": "bar"}}},
+		"array of strings":       {[]string{"foo", "bar"}, []string{"foo", "bar"}},
+		"array of bools":         {[]bool{true, false}, []bool{true, false}},
+		"array of ints":          {[]int{10, 11}, []int{10, 11}},
+		"array of uint64 ok":     {[]uint64{1, 2, 3}, []uint64{1, 2, 3}},
+		"array of uint64 masked": {[]uint64{1<<63 + 1, 1<<63 + 2, 1<<63 + 3}, []uint64{1, 2, 3}},
+		"array of MapStr":        {[]MapStr{{"foo": "bar"}}, []MapStr{{"foo": "bar"}}},
+		"array of map to MapStr": {[]map[string]interface{}{{"foo": "bar"}}, []MapStr{{"foo": "bar"}}},
 
 		// Wrapper types are converted to primitives using reflection.
-		{mybool(true), true},
-		{myint(32), int64(32)},
-		{myuint(8), uint64(8)},
+		"custom bool type":          {mybool(true), true},
+		"custom int type":           {myint(32), int64(32)},
+		"custom uint type":          {myuint(8), uint64(8)},
+		"custom uint64 type ok":     {myuint64(23), uint64(23)},
+		"custom uint64 type masked": {myuint64(1<<63 + 42), uint64(42)},
 
 		// Slices of wrapper types are converted to an []interface{} of primitives.
-		{[]mybool{true, false}, []interface{}{true, false}},
-		{[]myint{32}, []interface{}{int64(32)}},
-		{[]myuint{8}, []interface{}{uint64(8)}},
-	}
+		"array of custom bool type":     {[]mybool{true, false}, []interface{}{true, false}},
+		"array of custom int type":      {[]myint{32}, []interface{}{int64(32)}},
+		"array of custom uint type":     {[]myuint{8}, []interface{}{uint64(8)}},
+		"array of custom uint64 ok":     {[]myuint64{64}, []interface{}{uint64(64)}},
+		"array of custom uint64 masked": {[]myuint64{1<<63 + 64}, []interface{}{uint64(64)}},
+	})
 
-	for i, test := range tests {
-		out, err := normalizeValue(test.in)
-		if err != nil {
-			t.Error(err)
-			continue
-		}
-
-		assert.Equal(t, test.out, out, "Test case %v", i)
-	}
-
-	var floatTests = []struct {
-		in  interface{}
-		out interface{}
-	}{
-		{float32(1), float64(1)},
-		{float64(1), float64(1)},
-	}
-
-	for i, test := range floatTests {
-		out, err := normalizeValue(test.in)
-		if err != nil {
-			t.Error(err)
-			continue
-		}
-		assert.InDelta(t, test.out, float64(out.(Float)), 0.000001, "(approximate) Test case %v", i)
-	}
+	runTests(checkDelta, map[string]testCase{
+		"float32 value": {float32(1), float64(1)},
+		"float64 value": {float64(1), float64(1)},
+	})
 }
 
 func TestNormalizeMapError(t *testing.T) {


### PR DESCRIPTION
64bit unsigned values can not be stored in ES. This PR applies a 63bit mask to all values of type uint64.

We normally see uint64 in either counters, but sometimes with gauges. For pure counter values we normally use derivatives in order to show rates. As aggregations convert values to float before computing the derivate, it makes no differences if counters are converted to int64 or if we keep only 63bits. For gauges a values > 2^64 is often times some kind of special flag (e.g. infinite). If the 63bit representation is not good enough we push the responsibility back to the module to either: convert the value into a another type or create an object with additional information/flags.