### PR TITLE
Functionbeat use a concurrency of 5 by default for AWS lambda

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -39,6 +39,7 @@ https://github.com/elastic/beats/compare/v6.4.0...master[Check the HEAD diff]
 *Winlogbeat*
 
 *Functionbeat*
+- Function concurrency is now set to 5 instead of unreserved. {pull}8992[8992]
 
 ==== Bugfixes
 

--- a/x-pack/functionbeat/_meta/beat.reference.yml
+++ b/x-pack/functionbeat/_meta/beat.reference.yml
@@ -25,7 +25,7 @@ functionbeat.provider.aws.functions:
     description: "lambda function for cloudwatch logs"
 
     # Concurrency, is the reserved number of instances for that function.
-    # Default is unreserved.
+    # Default is 5.
     #
     # Note: There is a hard limit of 1000 functions of any kind per account.
     #concurrency: 5
@@ -62,7 +62,7 @@ functionbeat.provider.aws.functions:
     description: "lambda function for sqs events"
 
     # Concurrency, is the reserved number of instances for that function.
-    # Default is unreserved.
+    # Default is 5.
     #
     # Note: There is a hard limit of 1000 functions of any kind per account.
     #concurrency: 5

--- a/x-pack/functionbeat/_meta/beat.yml
+++ b/x-pack/functionbeat/_meta/beat.yml
@@ -26,7 +26,7 @@ functionbeat.provider.aws.functions:
     description: "lambda function for cloudwatch logs"
 
     # Concurrency, is the reserved number of instances for that function.
-    # Default is unreserved.
+    # Default is 5.
     #
     # Note: There is a hard limit of 1000 functions of any kind per account.
     #concurrency: 5
@@ -63,7 +63,7 @@ functionbeat.provider.aws.functions:
     description: "lambda function for SQS events"
 
     # Concurrency, is the reserved number of instances for that function.
-    # Default is unreserved.
+    # Default is 5.
     #
     # Note: There is a hard limit of 1000 functions of any kind per account.
     #concurrency: 5

--- a/x-pack/functionbeat/functionbeat.reference.yml
+++ b/x-pack/functionbeat/functionbeat.reference.yml
@@ -25,7 +25,7 @@ functionbeat.provider.aws.functions:
     description: "lambda function for cloudwatch logs"
 
     # Concurrency, is the reserved number of instances for that function.
-    # Default is unreserved.
+    # Default is 5.
     #
     # Note: There is a hard limit of 1000 functions of any kind per account.
     #concurrency: 5
@@ -62,7 +62,7 @@ functionbeat.provider.aws.functions:
     description: "lambda function for sqs events"
 
     # Concurrency, is the reserved number of instances for that function.
-    # Default is unreserved.
+    # Default is 5.
     #
     # Note: There is a hard limit of 1000 functions of any kind per account.
     #concurrency: 5

--- a/x-pack/functionbeat/functionbeat.yml
+++ b/x-pack/functionbeat/functionbeat.yml
@@ -26,7 +26,7 @@ functionbeat.provider.aws.functions:
     description: "lambda function for cloudwatch logs"
 
     # Concurrency, is the reserved number of instances for that function.
-    # Default is unreserved.
+    # Default is 5.
     #
     # Note: There is a hard limit of 1000 functions of any kind per account.
     #concurrency: 5
@@ -63,7 +63,7 @@ functionbeat.provider.aws.functions:
     description: "lambda function for SQS events"
 
     # Concurrency, is the reserved number of instances for that function.
-    # Default is unreserved.
+    # Default is 5.
     #
     # Note: There is a hard limit of 1000 functions of any kind per account.
     #concurrency: 5

--- a/x-pack/functionbeat/provider/aws/config.go
+++ b/x-pack/functionbeat/provider/aws/config.go
@@ -26,11 +26,11 @@ const maxMegabytes = 3008
 var DefaultLambdaConfig = &lambdaConfig{
 	MemorySize:  128 * 1024 * 1024,
 	Timeout:     time.Second * 3,
-	Concurrency: 0, // unreserve
+	Concurrency: 5,
 }
 
 type lambdaConfig struct {
-	Concurrency      int               `config:"concurrency" validate:"positive"`
+	Concurrency      int               `config:"concurrency" validate:"min=0,max=1000"`
 	DeadLetterConfig *deadLetterConfig `config:"dead_letter_config"`
 	Description      string            `config:"description"`
 	MemorySize       MemSizeFactor64   `config:"memory_size"`


### PR DESCRIPTION
This change the previous default of an unreserved concurrency, this
allow to have a more sane value to keep the cost down and still
allow people to turn the knob up to get better performance.