### PR TITLE
Cherry-pick #8989 to 6.4: Add possible message to flaky test check

### DIFF
--- a/metricbeat/tests/system/test_cmd.py
+++ b/metricbeat/tests/system/test_cmd.py
@@ -136,7 +136,15 @@ class TestCommands(metricbeat.BaseTest):
             extra_args=["test", "modules"])
 
         assert exit_code == 0
-        assert self.log_contains("ERROR error making http request")
+        try:
+            assert any((
+                self.log_contains("ERROR error making http request"),
+                self.log_contains("ERROR timeout waiting for an event"),
+            ))
+        except:
+            # Print log to help debugging this if error message changes
+            print self.get_log()
+            raise
         assert self.log_contains("cpu...OK")
         assert self.log_contains("memory...OK")
 


### PR DESCRIPTION
Cherry-pick of PR #8989 to 6.4 branch. Original message: 

`TestCommands.test_modules_test_error` relays on the presence of an error
message, this error message seems to be different under some
circustances, as seen in CI builds.
    
Add the timeout message already [seen](https://github.com/elastic/beats/pull/8962#issuecomment-436932264), and print logs in case of failure
so it is more easy to fix if happens in the future.

Fixes #8412
