### PR TITLE
Cherry-pick #8785 to 6.5: Add documentation for filebeat.registry_flush

### DIFF
--- a/filebeat/_meta/common.reference.p2.yml
+++ b/filebeat/_meta/common.reference.p2.yml
@@ -389,6 +389,12 @@ filebeat.inputs:
 # This option is not supported on Windows.
 #filebeat.registry_file_permissions: 0600
 
+# The timeout value that controls when registry entries are written to disk
+# (flushed). When an unwritten update exceeds this value, it triggers a write to
+# disk. When registry_flush is set to 0s, the registry is written to disk after
+# each batch of events has been published successfully. The default value is 0s.
+#filebeat.registry_flush: 0s
+
 # By default Ingest pipelines are not updated if a pipeline with the same ID
 # already exists. If this option is enabled Filebeat overwrites pipelines
 # everytime a new Elasticsearch connection is established.

--- a/filebeat/docs/filebeat-general-options.asciidoc
+++ b/filebeat/docs/filebeat-general-options.asciidoc
@@ -51,6 +51,25 @@ filebeat.registry_file_permissions: 0600
 -------------------------------------------------------------------------------------
 
 [float]
+==== `registry_flush`
+
+
+The timeout value that controls when registry entries are written to disk
+(flushed). When an unwritten update exceeds this value, it triggers a write to
+disk. When registry_flush is set to 0s, the registry is written to disk after
+each batch of events has been published successfully. The default value is 0s.
+
+NOTE: The registry is always updated when Filebeat shuts down normally. After an
+abnormal shutdown, the registry will not be up-to-date if the registry_flush
+value is >0s. Filebeat will send published events again (depending on values in
+the last updated registry file).
+
+NOTE: Filtering out a huge number of logs can cause many registry updates, slowing
+down processing. Setting registry_flush to a value >0s reduces write operations,
+helping Filebeat process more events.
+
+
+[float]
 ==== `config_dir`
 
 deprecated[6.0.0, Use <<load-input-config>> instead.]

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -757,6 +757,12 @@ filebeat.inputs:
 # This option is not supported on Windows.
 #filebeat.registry_file_permissions: 0600
 
+# The timeout value that controls when registry entries are written to disk
+# (flushed). When an unwritten update exceeds this value, it triggers a write to
+# disk. When registry_flush is set to 0s, the registry is written to disk after
+# each batch of events has been published successfully. The default value is 0s.
+#filebeat.registry_flush: 0s
+
 # By default Ingest pipelines are not updated if a pipeline with the same ID
 # already exists. If this option is enabled Filebeat overwrites pipelines
 # everytime a new Elasticsearch connection is established.


### PR DESCRIPTION
Cherry-pick of PR #8785 to 6.5 branch. Original message: 

