### PR TITLE
Close changelog for 6.5.0 release

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -197,6 +197,7 @@ https://github.com/elastic/beats/compare/v6.4.0...v6.5.0[View commits]
 
 *Heartbeat*
 
+- Heartbeat is marked as GA.
 - Add automatic config file reloading. {pull}8023[8023]
 - Added autodiscovery support {pull}8415[8415]
 - Added support for extra TLS/x509 metadata. {pull}7944[7944]

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -7,7 +7,7 @@
 // Template, add newest changes here
 
 === Beats version HEAD
-https://github.com/elastic/beats/compare/v6.4.0...6.x[Check the HEAD diff]
+https://github.com/elastic/beats/compare/v6.5.0...6.5[Check the HEAD diff]
 
 ==== Breaking changes
 
@@ -28,6 +28,73 @@ https://github.com/elastic/beats/compare/v6.4.0...6.x[Check the HEAD diff]
 *Winlogbeat*
 
 *Functionbeat*
+
+==== Bugfixes
+
+*Affecting all Beats*
+
+*Auditbeat*
+
+*Filebeat*
+
+*Heartbeat*
+
+*Journalbeat*
+
+*Metricbeat*
+
+*Packetbeat*
+
+*Winlogbeat*
+
+*Functionbeat*
+
+==== Added
+
+*Affecting all Beats*
+
+*Auditbeat*
+
+*Filebeat*
+
+*Heartbeat*
+
+*Journalbeat*
+
+*Metricbeat*
+
+*Packetbeat*
+
+*Winlogbeat*
+
+*Heartbeat*
+
+*Functionbeat*
+
+==== Deprecated
+
+*Affecting all Beats*
+
+*Filebeat*
+
+*Heartbeat*
+
+*Journalbeat*
+
+*Packetbeat*
+
+*Winlogbeat*
+
+*Functionbeat*
+
+==== Known Issue
+
+
+////////////////////////////////////////////////////////////
+
+[[release-notes-6.5.0]]
+=== Beats version 6.5.0
+https://github.com/elastic/beats/compare/v6.4.0...v6.5.0[View commits]
 
 ==== Bugfixes
 
@@ -75,8 +142,6 @@ https://github.com/elastic/beats/compare/v6.4.0...6.x[Check the HEAD diff]
 
 - Fixed bug where HTTP responses with larger bodies would incorrectly report connection errors. {pull}8660[8660]
 
-*Journalbeat*
-
 *Metricbeat*
 
 - Fix golang.heap.gc.cpu_fraction type from long to float in Golang module. {pull}7789[7789]
@@ -99,10 +164,6 @@ https://github.com/elastic/beats/compare/v6.4.0...6.x[Check the HEAD diff]
   on 32-bit Linux and the sniffer failed to start. {issue}7839[7839]
 - Added missing `cmdline` and `client_cmdline` fields to index template. {pull}8258[8258]
 
-*Winlogbeat*
-
-*Functionbeat*
-
 ==== Added
 
 *Affecting all Beats*
@@ -123,8 +184,6 @@ https://github.com/elastic/beats/compare/v6.4.0...6.x[Check the HEAD diff]
 - Report configured queue type. {pull}8091[8091]
 - Enable `host` and `cloud` metadata processors by default. {pull}8596[8596]
 
-*Auditbeat*
-
 *Filebeat*
 
 - Add tag "truncated" to "log.flags" if incoming line is longer than configured limit. {pull}7991[7991]
@@ -138,6 +197,7 @@ https://github.com/elastic/beats/compare/v6.4.0...6.x[Check the HEAD diff]
 
 *Heartbeat*
 
+- Add automatic config file reloading. {pull}8023[8023]
 - Added autodiscovery support {pull}8415[8415]
 - Added support for extra TLS/x509 metadata. {pull}7944[7944]
 - Added stats and state metrics for number of monitors and endpoints started. {pull}8621[8621]
@@ -170,43 +230,98 @@ https://github.com/elastic/beats/compare/v6.4.0...6.x[Check the HEAD diff]
 
 - Added DHCP protocol support. {pull}7647[7647]
 
-*Winlogbeat*
-
-*Heartbeat*
-
-- Add automatic config file reloading. {pull}8023[8023]
-
 *Functionbeat*
 
 - Initial version of Functionbeat. {pull}8678[8678]
 
 ==== Deprecated
 
+*Heartbeat*
+
+- watch.poll_file is now deprecated and superceded by automatic config file reloading.
+
+*Metricbeat*
+
+- Redis `info` `replication.master_offset` has been deprecated in favor of `replication.master.offset`.{pull}7695[7695]
+- Redis `info` clients fields `longest_output_list` and `biggest_input_buf` have been renamed to `max_output_buffer` and `max_input_buffer` based on the names they will have in Redis 5.0, both fields will coexist during a time with the same value {pull}8167[8167].
+- Move common kafka fields (broker, topic and partition.id) to the module level {pull}7767[7767].
+
+
+
+[[release-notes-6.4.3]]
+=== Beats version 6.4.3
+https://github.com/elastic/beats/compare/v6.4.2...v6.4.3[View commits]
+
+==== Bugfixes
+
 *Affecting all Beats*
+
+- Fix a race condition with the `add_host_metadata` and the event serialization. {pull}8223[8223] {pull}8653[8653]
+- Fix race condition when publishing monitoring data. {pull}8646[8646]
+- Fix bug in loading dashboards from zip file. {issue}8051[8051]
+- The export config subcommand should not display real value for field reference. {pull}8769[8769]
 
 *Filebeat*
 
-*Heartbeat*
-- watch.poll_file is now deprecated and superceded by automatic config file reloading.
-
-*Journalbeat*
+- Fix typo in Filebeat IIS Kibana visualization. {pull}8604[8604]
 
 *Metricbeat*
-- Redis `info` `replication.master_offset` has been deprecated in favor of `replication.master.offset`.{pull}7695[7695]
-- Redis `info` clients fields `longest_output_list` and `biggest_input_buf` have been renamed to `max_output_buffer` and `max_input_buffer` based on the names they will have in Redis 5.0, both fields will coexist during a time with the same value {pull}8167[8167].
 
-- Move common kafka fields (broker, topic and partition.id) to the module level {pull}7767[7767].
+- Recover metrics for old Apache versions removed by mistake on #6450. {pull}7871[7871]
+- Avoid mapping issues in Kubernetes module. {pull}8487[8487]
+- Fixed a panic when the KVM module cannot establish a connection to libvirtd. {issue}7792[7792]
+
+
+[[release-notes-6.4.2]]
+=== Beats version 6.4.2
+https://github.com/elastic/beats/compare/v6.4.1...v6.4.2[View commits]
+
+==== Bugfixes
+
+*Filebeat*
+
+- Fix some errors happening when stopping syslog input. {pull}8347[8347]
+- Fix RFC3339 timezone and nanoseconds parsing with the syslog input. {pull}8346[8346]
+
+*Metricbeat*
+
+- Fix incorrect type conversion of average response time in Haproxy dashboards {pull}8404[8404]
+- Fix dropwizard module parsing of metric names. {issue}8365[8365] {pull}6385[8385]
+
+[[release-notes-6.4.1]]
+=== Beats version 6.4.1
+https://github.com/elastic/beats/compare/v6.4.0...v6.4.1[View commits]
+
+==== Bugfixes
+
+*Affecting all Beats*
+
+- Add backoff support to x-pack monitoring outputs. {issue}7966[7966]
+- Removed execute permissions systemd unit file. {pull}7873[7873]
+- Fix a race condition with the `add_host_metadata` and the event serialization. {pull}8223[8223]
+- Enforce that data used by k8s or docker doesn't use any reference. {pull}8240[8240]
+- Implement CheckConfig in RunnerFactory to make autodiscover check configs {pull}7961[7961]
+- Make kubernetes autodiscover ignore events with empty container IDs {pull}7971[7971]
+
+*Auditbeat*
+
+- Fixed a concurrent map write panic in the auditd module. {pull}8158[8158]
+- Fixed the RPM by designating the config file as configuration data in the RPM spec. {issue}8075[8075]
+
+*Filebeat*
+
+- Fixed a docker input error due to the offset update bug in partial log join.{pull}8177[8177]
+- Update CRI format to support partial/full tags. {pull}8265[8265]
+
+*Metricbeat*
+
+- Fixed the location of the modules.d dir in Deb and RPM packages. {issue}8104[8104]
+- Fixed the RPM by designating the modules.d config files as configuration data in the RPM spec. {issue}8075[8075]
+- Fix golang.heap.gc.cpu_fraction type from long to float in Golang module. {pull}7789[7789]
 
 *Packetbeat*
 
-*Winlogbeat*
-
-*Functionbeat*
-
-==== Known Issue
-
-
-////////////////////////////////////////////////////////////
+- Added missing `cmdline` and `client_cmdline` fields to index template. {pull}8258[8258]
 
 [[release-notes-6.4.0]]
 === Beats version 6.4.0

--- a/libbeat/docs/release.asciidoc
+++ b/libbeat/docs/release.asciidoc
@@ -8,6 +8,10 @@ This section summarizes the changes in each release. Also read
 <<breaking-changes>> for more detail about changes that affect
 upgrade.
 
+* <<release-notes-6.5.0>>
+* <<release-notes-6.4.3>>
+* <<release-notes-6.4.2>>
+* <<release-notes-6.4.1>>
 * <<release-notes-6.4.0>>
 * <<release-notes-6.3.1>>
 * <<release-notes-6.3.0>>


### PR DESCRIPTION
As per a recent conversation with Clint, I'm keeping all entries between 6.4.0 and 6.5.0. Perviously I was doing since the last patch release, but this is easier.