### PR TITLE
Remove 5.x obsolete options checks

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -20,6 +20,7 @@ https://github.com/elastic/beats/compare/v6.4.0...master[Check the HEAD diff]
 - Use `initial_scan` action for new paths. {pull}7954[7954]
 - Rename beat.name to agent.type, beat.hostname to agent.hostname, beat.version to agent.version.
 - Rename `source.hostname` to `source.domain` in the auditd module. {pull}9027[9027]
+- Remove warning for deprecated option: "filters". {pull}9002[9002]
 
 *Filebeat*
 
@@ -29,12 +30,14 @@ https://github.com/elastic/beats/compare/v6.4.0...master[Check the HEAD diff]
 - Remove the deprecated `prospector(s)` option in the configuration use `input(s)` instead. {pull}8909[8909]
 - Rename `offset` to `log.offset`. {pull}8923[8923]
 - Rename `source_ecs` to `source` in the Filebeat Suricata module. {pull}8983[8983]
+- Remove warnings for deprecated options: "spool_size", "publish_async", "idle_timeout". {pull}9002[9002]
 
 *Heartbeat*
 
 *Journalbeat*
 
 *Metricbeat*
+- Remove warning for deprecated option: "filters". {pull}9002[9002]
 
 *Packetbeat*
 

--- a/filebeat/beater/filebeat.go
+++ b/filebeat/beater/filebeat.go
@@ -72,12 +72,11 @@ func New(b *beat.Beat, rawConfig *common.Config) (beat.Beater, error) {
 		return nil, fmt.Errorf("Error reading config file: %v", err)
 	}
 
-	err := cfgwarn.CheckRemoved5xSettings(rawConfig, "spool_size", "publish_async", "idle_timeout")
-	if err != nil {
-		return nil, err
-	}
-
-	if err := cfgwarn.CheckRemoved6xSettings(rawConfig, "prospectors", "config.prospectors"); err != nil {
+	if err := cfgwarn.CheckRemoved6xSettings(
+		rawConfig,
+		"prospectors",
+		"config.prospectors",
+	); err != nil {
 		return nil, err
 	}
 

--- a/filebeat/tests/system/test_base.py
+++ b/filebeat/tests/system/test_base.py
@@ -26,26 +26,6 @@ class Test(BaseTest):
         assert "@timestamp" in output
         assert "input.type" in output
 
-    def test_invalid_config_with_removed_settings(self):
-        """
-        Checks if filebeat fails to load if removed settings have been used:
-        """
-        self.render_config_template()
-
-        exit_code = self.run_beat(extra_args=[
-            "-E", "filebeat.spool_size=2048",
-            "-E", "filebeat.publish_async=true",
-            "-E", "filebeat.idle_timeout=1s",
-        ])
-
-        assert exit_code == 1
-        assert self.log_contains("setting 'filebeat.spool_size'"
-                                 " has been removed")
-        assert self.log_contains("setting 'filebeat.publish_async'"
-                                 " has been removed")
-        assert self.log_contains("setting 'filebeat.idle_timeout'"
-                                 " has been removed")
-
     @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_template(self):
         """

--- a/filebeat/tests/system/test_deprecated.py
+++ b/filebeat/tests/system/test_deprecated.py
@@ -36,3 +36,20 @@ class Test(BaseTest):
         filebeat.check_kill_and_wait()
 
         assert self.log_contains("DEPRECATED: input_type input config is deprecated")
+
+    def test_invalid_config_with_removed_settings(self):
+        """
+        Checks if filebeat fails to load if removed settings have been used:
+        """
+        self.render_config_template()
+
+        exit_code = self.run_beat(extra_args=[
+            "-E", "filebeat.prospectors=anything",
+            "-E", "filebeat.config.prospectors=anything",
+        ])
+
+        assert exit_code == 1
+        assert self.log_contains("setting 'filebeat.prospectors'"
+                                 " has been removed")
+        assert self.log_contains("setting 'filebeat.config.prospectors'"
+                                 " has been removed")

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -594,11 +594,6 @@ func (b *Beat) configure(settings Settings) error {
 
 	b.Beat.Config = &b.Config.BeatConfig
 
-	err = cfgwarn.CheckRemoved5xSettings(cfg, "queue_size", "bulk_queue_size")
-	if err != nil {
-		return err
-	}
-
 	if name := b.Config.Name; name != "" {
 		b.Info.Name = name
 	}

--- a/libbeat/common/cfgwarn/removed.go
+++ b/libbeat/common/cfgwarn/removed.go
@@ -45,8 +45,10 @@ func checkRemovedSetting(cfg *common.Config, setting string) error {
 	path := segments[:L-1]
 
 	current := cfg
+
+	// we are looking for any key that match the name.
 	for _, p := range path {
-		current, _ := current.Child(p, -1)
+		current, _ = current.Child(p, -1)
 		if current == nil {
 			break
 		}
@@ -62,16 +64,6 @@ func checkRemovedSetting(cfg *common.Config, setting string) error {
 	}
 
 	return fmt.Errorf("setting '%v' has been removed", current.PathOf(name))
-}
-
-// CheckRemoved5xSettings prints a warning if the obsolete setting is used.
-func CheckRemoved5xSettings(cfg *common.Config, settings ...string) error {
-	return checkRemovedSettings(cfg, settings...)
-}
-
-// CheckRemoved5xSetting prints a warning if the obsolete setting is used.
-func CheckRemoved5xSetting(cfg *common.Config, setting string) error {
-	return checkRemovedSetting(cfg, setting)
 }
 
 // CheckRemoved6xSettings prints a warning if the obsolete setting is used.

--- a/libbeat/common/cfgwarn/removed_test.go
+++ b/libbeat/common/cfgwarn/removed_test.go
@@ -50,14 +50,6 @@ func TestRemovedSetting(t *testing.T) {
 			}),
 			expected: errors.New("setting 'hello' has been removed"),
 		},
-		{
-			name:   "obsolete setting found",
-			lookup: "not.hello",
-			cfg: common.MustNewConfigFrom(map[string]interface{}{
-				"hello.world": "ok",
-			}),
-			expected: errors.New("setting 'hello' has been removed"),
-		},
 	}
 
 	functions := []struct {
@@ -104,16 +96,8 @@ func TestRemovedSettings(t *testing.T) {
 			expected: multierror.Errors{errors.New("setting 'hello' has been removed")}.Err(),
 		},
 		{
-			name:   "obsolete setting found",
-			lookup: []string{"not.hello"},
-			cfg: common.MustNewConfigFrom(map[string]interface{}{
-				"hello.world": "ok",
-			}),
-			expected: multierror.Errors{errors.New("setting 'hello' has been removed")}.Err(),
-		},
-		{
 			name:   "multiple obsolete settings",
-			lookup: []string{"not.hello", "bad"},
+			lookup: []string{"hello", "bad"},
 			cfg: common.MustNewConfigFrom(map[string]interface{}{
 				"hello.world": "ok",
 				"bad":         "true",
@@ -121,6 +105,18 @@ func TestRemovedSettings(t *testing.T) {
 			expected: multierror.Errors{
 				errors.New("setting 'hello' has been removed"),
 				errors.New("setting 'bad' has been removed"),
+			}.Err(),
+		},
+		{
+			name:   "multiple obsolete settings not on first level",
+			lookup: []string{"filebeat.config.prospectors", "filebeat.prospectors"},
+			cfg: common.MustNewConfigFrom(map[string]interface{}{
+				"filebeat.prospectors":        "ok",
+				"filebeat.config.prospectors": map[string]interface{}{"ok": "ok1"},
+			}),
+			expected: multierror.Errors{
+				errors.New("setting 'filebeat.config.prospectors' has been removed"),
+				errors.New("setting 'filebeat.prospectors' has been removed"),
 			}.Err(),
 		},
 	}

--- a/libbeat/outputs/output_reg.go
+++ b/libbeat/outputs/output_reg.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/common/cfgwarn"
 )
 
 var outputReg = map[string]Factory{}
@@ -59,10 +58,6 @@ func Load(info beat.Info, stats Observer, name string, config *common.Config) (G
 	factory := FindFactory(name)
 	if factory == nil {
 		return Group{}, fmt.Errorf("output type %v undefined", name)
-	}
-
-	if err := cfgwarn.CheckRemoved5xSetting(config, "flush_interval"); err != nil {
-		return Fail(err)
 	}
 
 	if stats == nil {

--- a/libbeat/tests/system/test_base.py
+++ b/libbeat/tests/system/test_base.py
@@ -82,20 +82,22 @@ class Test(BaseTest):
         assert exit_code == 0
         assert self.log_contains("Config OK") is True
 
-    def test_invalid_config_with_removed_settings(self):
-        """
-        Checks if libbeat fails to load if removed settings have been used:
-        """
-        self.render_config_template(console={"pretty": "false"})
+    # NOTE(ph): I've removed the code to crash with theses settings, but the test is still usefull if
+    # more settings are added.
+    # def test_invalid_config_with_removed_settings(self):
+    #     """
+    #     Checks if libbeat fails to load if removed settings have been used:
+    #     """
+    #     self.render_config_template(console={"pretty": "false"})
 
-        exit_code = self.run_beat(extra_args=[
-            "-E", "queue_size=2048",
-            "-E", "bulk_queue_size=1",
-        ])
+    #     exit_code = self.run_beat(extra_args=[
+    #         "-E", "queue_size=2048",
+    #         "-E", "bulk_queue_size=1",
+    #     ])
 
-        assert exit_code == 1
-        assert self.log_contains("setting 'queue_size' has been removed")
-        assert self.log_contains("setting 'bulk_queue_size' has been removed")
+    #     assert exit_code == 1
+    #     assert self.log_contains("setting 'queue_size' has been removed")
+    #     assert self.log_contains("setting 'bulk_queue_size' has been removed")
 
     def test_version_simple(self):
         """

--- a/metricbeat/beater/metricbeat.go
+++ b/metricbeat/beater/metricbeat.go
@@ -30,7 +30,6 @@ import (
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/cfgfile"
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/mb/module"
@@ -135,12 +134,6 @@ func newMetricbeat(b *beat.Beat, c *common.Config, options ...Option) (*Metricbe
 		}
 
 		failed := false
-
-		err := cfgwarn.CheckRemoved5xSettings(moduleCfg, "filters")
-		if err != nil {
-			errs = append(errs, err)
-			failed = true
-		}
 
 		connector, err := module.NewConnector(b.Publisher, moduleCfg, nil)
 		if err != nil {

--- a/metricbeat/mb/module/factory.go
+++ b/metricbeat/mb/module/factory.go
@@ -23,7 +23,6 @@ import (
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/cfgfile"
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/metricbeat/mb"
 )
 
@@ -44,10 +43,6 @@ func NewFactory(options ...Option) *Factory {
 func (r *Factory) Create(p beat.Pipeline, c *common.Config, meta *common.MapStrPointer) (cfgfile.Runner, error) {
 	var errs multierror.Errors
 
-	err := cfgwarn.CheckRemoved5xSettings(c, "filters")
-	if err != nil {
-		errs = append(errs, err)
-	}
 	connector, err := NewConnector(p, c, meta)
 	if err != nil {
 		errs = append(errs, err)

--- a/metricbeat/tests/system/test_config.py
+++ b/metricbeat/tests/system/test_config.py
@@ -7,24 +7,5 @@ import time
 
 
 class ConfigTest(metricbeat.BaseTest):
-
-    def test_invalid_config_with_removed_settings(self):
-        """
-        Checks if metricbeat fails to load a module if remove settings have been used:
-        """
-        self.render_config_template(modules=[{
-            "name": "system",
-            "metricsets": ["cpu"],
-            "period": "5s",
-        }])
-
-        exit_code = self.run_beat(extra_args=[
-            "-E",
-            "metricbeat.modules.0.filters.0.include_fields='field1,field2'"
-        ])
-        assert exit_code == 1
-        assert self.log_contains("setting 'metricbeat.modules.0.filters'"
-                                 " has been removed")
-
     def get_host(self):
         return 'http://' + os.getenv('ES_HOST', 'localhost') + ':' + os.getenv('ES_PORT', '9200')


### PR DESCRIPTION
Since we are moving to 7.0 its a good time to update the code and remove
deprecated code and warning for removed options.

Remove any 5.x options
Add tests for obsolete Filebeat 6.x options