### PR TITLE
Check license for CCR before attempting to fetch stats

### DIFF
--- a/metricbeat/module/elasticsearch/elasticsearch.go
+++ b/metricbeat/module/elasticsearch/elasticsearch.go
@@ -391,3 +391,24 @@ func getSettingGroup(allSettings common.MapStr, groupKey string) (common.MapStr,
 
 	return common.MapStr(v), nil
 }
+
+// IsCCRAvailable returns whether CCR is available or not, depending on the current license
+func IsCCRAvailable(http *helper.HTTP, resetURI string) (isAvailable bool, currentLicense string, err error) {
+	license, err := GetLicense(http, resetURI)
+	if err != nil {
+		return false, "", errors.Wrap(err, "error determining Elasticsearch license")
+	}
+
+	licenseType, err := license.GetValue("type")
+	if err != nil {
+		return false, "", errors.Wrap(err, "error determining Elasticsearch license type")
+	}
+
+	currentLicense, ok := licenseType.(string)
+	if !ok {
+		return false, "", fmt.Errorf("error determining Elasticsearch license type")
+	}
+
+	isAvailable = currentLicense == "trial" || currentLicense == "platinum"
+	return
+}


### PR DESCRIPTION
Resolves #8915.

This PR teaches the `Fetch()` method of the `elasticsearch/ccr` metricset to first check if the CCR feature is available per the current Elasticsearch license. If it isn't, the metricset logs+reports an **actionable** error message **every minute**.

Before this PR, there was no such check so the call to the CCR stats API would simply fail with a 403 error from Elasticsearch if Elasticsearch wasn't using a Trial or Platinum license. That unhelpful 403 error would get logged+reported every 10s (or whatever `period` the metricset was configured to).

## Before this PR

### In the `metricbeat` logs:

<img width="839" alt="screen shot 2018-11-08 at 4 42 28 pm" src="https://user-images.githubusercontent.com/51061/48236039-5fa30c80-e375-11e8-8d9d-64c4861fb35d.png">


### In the `metricbeat-*` index:

<img width="1491" alt="screen shot 2018-11-08 at 4 42 38 pm" src="https://user-images.githubusercontent.com/51061/48236036-5b76ef00-e375-11e8-9a21-7cde7620c80b.png">


## After this PR

### In the `metricbeat` logs:

<img width="1236" alt="screen shot 2018-11-08 at 4 35 19 pm" src="https://user-images.githubusercontent.com/51061/48235932-e4415b00-e374-11e8-8b39-a60e4fe87279.png">

### In the `metricbeat-*` index:

<img width="1495" alt="screen shot 2018-11-08 at 4 37 27 pm" src="https://user-images.githubusercontent.com/51061/48235909-d095f480-e374-11e8-9eea-718c0deacafa.png">
