### PR TITLE
Add logging trace at debug level for the pipeline client.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -39,6 +39,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha1...master[Check the HEAD d
 - Log events at the debug level when dropped by encoding problems. {pull}9251[9251]
 - Refresh host metadata in add_host_metadata. {pull}9359[9359]
 - When collecting swap metrics for beats telemetry or system metricbeat module handle cases of free swap being bigger than total swap by assuming no swap is being used. {issue}6271[6271] {pull}9383[9383]
+- Adding logging traces at debug level when the pipeline client receives the following events: onFilteredOut, onDroppedOnPublish. {pull}9016[9016]
 
 *Auditbeat*
 
@@ -336,8 +337,6 @@ https://github.com/elastic/beats/compare/v6.4.0...v6.5.0[View commits]
 - Report configured queue type. {pull}8091[8091]
 - Enable `host` and `cloud` metadata processors by default. {pull}8596[8596]
 - Autodiscovery no longer requires that the `condition` field be set. If left unset all configs will be matched. {pull}9029[9029]
-- Dissect will now flag event on parsing error. {pull}8751[8751]
-- Adding logging traces at debug level when the pipeline client receives the following events: onFilteredOut, onDroppedOnPublish. {pull}9016[9016]
 
 *Auditbeat*
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -337,7 +337,7 @@ https://github.com/elastic/beats/compare/v6.4.0...v6.5.0[View commits]
 - Enable `host` and `cloud` metadata processors by default. {pull}8596[8596]
 - Autodiscovery no longer requires that the `condition` field be set. If left unset all configs will be matched. {pull}9029[9029]
 - Dissect will now flag event on parsing error. {pull}8751[8751]
-- Adding logging traces at debug level when the pipeline client receives the following events: onFilteredOut, onDroppedOnPublish. {pull}xxx[xxx]
+- Adding logging traces at debug level when the pipeline client receives the following events: onFilteredOut, onDroppedOnPublish. {pull}9016[9016]
 
 *Auditbeat*
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -336,6 +336,10 @@ https://github.com/elastic/beats/compare/v6.4.0...v6.5.0[View commits]
 - Report configured queue type. {pull}8091[8091]
 - Enable `host` and `cloud` metadata processors by default. {pull}8596[8596]
 - Autodiscovery no longer requires that the `condition` field be set. If left unset all configs will be matched. {pull}9029[9029]
+- Dissect will now flag event on parsing error. {pull}8751[8751]
+- Adding logging traces at debug level when the pipeline client receives the following events: onFilteredOut, onDroppedOnPublish. {pull}xxx[xxx]
+
+*Auditbeat*
 
 *Filebeat*
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -338,8 +338,6 @@ https://github.com/elastic/beats/compare/v6.4.0...v6.5.0[View commits]
 - Enable `host` and `cloud` metadata processors by default. {pull}8596[8596]
 - Autodiscovery no longer requires that the `condition` field be set. If left unset all configs will be matched. {pull}9029[9029]
 
-*Auditbeat*
-
 *Filebeat*
 
 - Add tag "truncated" to "log.flags" if incoming line is longer than configured limit. {pull}7991[7991]

--- a/libbeat/publisher/pipeline/client.go
+++ b/libbeat/publisher/pipeline/client.go
@@ -190,6 +190,7 @@ func (c *client) onPublished() {
 }
 
 func (c *client) onFilteredOut(e beat.Event) {
+	c.pipeline.logger.Debug("client: receives onFilteredOut for event: %+v", e)
 	c.pipeline.observer.filteredEvent()
 	if c.eventer != nil {
 		c.eventer.FilteredOut(e)
@@ -197,6 +198,7 @@ func (c *client) onFilteredOut(e beat.Event) {
 }
 
 func (c *client) onDroppedOnPublish(e beat.Event) {
+	c.pipeline.logger.Debug("client: receives onDroppedOnPublish for event: %+v", e)
 	c.pipeline.observer.failedPublishEvent()
 	if c.eventer != nil {
 		c.eventer.DroppedOnPublish(e)

--- a/libbeat/publisher/pipeline/client.go
+++ b/libbeat/publisher/pipeline/client.go
@@ -190,7 +190,7 @@ func (c *client) onPublished() {
 }
 
 func (c *client) onFilteredOut(e beat.Event) {
-	c.pipeline.logger.Debug("Pipeline client receives 'onFilteredOut' callback for event: %+v", e)
+	c.pipeline.logger.Debug("Pipeline client receives callback 'onFilteredOut' for event: %+v", e)
 	c.pipeline.observer.filteredEvent()
 	if c.eventer != nil {
 		c.eventer.FilteredOut(e)
@@ -198,7 +198,7 @@ func (c *client) onFilteredOut(e beat.Event) {
 }
 
 func (c *client) onDroppedOnPublish(e beat.Event) {
-	c.pipeline.logger.Debug("Pipeline client receives 'onDroppedOnPublish' callback for event: %+v", e)
+	c.pipeline.logger.Debug("Pipeline client receives callback 'onDroppedOnPublish' for event: %+v", e)
 	c.pipeline.observer.failedPublishEvent()
 	if c.eventer != nil {
 		c.eventer.DroppedOnPublish(e)

--- a/libbeat/publisher/pipeline/client.go
+++ b/libbeat/publisher/pipeline/client.go
@@ -190,7 +190,7 @@ func (c *client) onPublished() {
 }
 
 func (c *client) onFilteredOut(e beat.Event) {
-	c.pipeline.logger.Debug("client: receives onFilteredOut for event: %+v", e)
+	c.pipeline.logger.Debug("Pipeline client receives 'onFilteredOut' callback for event: %+v", e)
 	c.pipeline.observer.filteredEvent()
 	if c.eventer != nil {
 		c.eventer.FilteredOut(e)
@@ -198,7 +198,7 @@ func (c *client) onFilteredOut(e beat.Event) {
 }
 
 func (c *client) onDroppedOnPublish(e beat.Event) {
-	c.pipeline.logger.Debug("client: receives onDroppedOnPublish for event: %+v", e)
+	c.pipeline.logger.Debug("Pipeline client receives 'onDroppedOnPublish' callback for event: %+v", e)
 	c.pipeline.observer.failedPublishEvent()
 	if c.eventer != nil {
 		c.eventer.DroppedOnPublish(e)


### PR DESCRIPTION
To allow easier debugging when events are not sent by the output we
have added a few log statements at debug level for the onFilteredOut and
the onDroppedOnPublish events.