### PR TITLE
Cherry-pick #8935 to 6.x: Stop recommending publish debugging when running beats.

### DIFF
--- a/auditbeat/docs/getting-started.asciidoc
+++ b/auditbeat/docs/getting-started.asciidoc
@@ -220,7 +220,7 @@ sudo service {beatname_lc} start
 ["source","sh",subs="attributes"]
 ----------------------------------------------------------------------
 sudo chown root {beatname_lc}.yml <1>
-sudo ./{beatname_lc} -e -c {beatname_lc}.yml -d "publish"
+sudo ./{beatname_lc} -e -c {beatname_lc}.yml
 ----------------------------------------------------------------------
 <1> To monitor system files, you'll be running {beatname_uc} as root, so you
 need to change ownership of the configuration file, or run {beatname_uc} with

--- a/filebeat/docs/getting-started.asciidoc
+++ b/filebeat/docs/getting-started.asciidoc
@@ -238,7 +238,7 @@ docker run {dockerimage}
 [source,shell]
 ----------------------------------------------------------------------
 sudo chown root filebeat.yml <1>
-sudo ./filebeat -e -c filebeat.yml -d "publish"
+sudo ./filebeat -e -c filebeat.yml
 ----------------------------------------------------------------------
 <1> You'll be running Filebeat as root, so you need to change ownership
 of the configuration file, or run Filebeat with `--strict.perms=false`

--- a/heartbeat/docs/getting-started.asciidoc
+++ b/heartbeat/docs/getting-started.asciidoc
@@ -244,7 +244,7 @@ sudo service {beatname_lc}-elastic start
 ["source","sh",subs="attributes"]
 ----------------------------------------------------------------------
 sudo chown root heartbeat.yml <1>
-sudo ./heartbeat -e -c heartbeat.yml -d "publish"
+sudo ./heartbeat -e -c heartbeat.yml
 ----------------------------------------------------------------------
 <1> You'll be running Heartbeat as root, so you need to change ownership of the
 configuration file, or run Heartbeat with `--strict.perms=false` specified. See

--- a/metricbeat/docs/gettingstarted.asciidoc
+++ b/metricbeat/docs/gettingstarted.asciidoc
@@ -258,7 +258,7 @@ See <<running-on-docker>>.
 ----------------------------------------------------------------------
 sudo chown root {beatname_lc}.yml <1>
 sudo chown root modules.d/system.yml <1>
-sudo ./{beatname_lc} -e -c {beatname_lc}.yml -d "publish"
+sudo ./{beatname_lc} -e -c {beatname_lc}.yml
 ----------------------------------------------------------------------
 <1> You'll be running {beatname_uc} as root, so you need to change ownership of the
 configuration file and any configurations enabled in the `modules.d` directory,

--- a/packetbeat/docs/gettingstarted.asciidoc
+++ b/packetbeat/docs/gettingstarted.asciidoc
@@ -286,7 +286,7 @@ docker run {dockerimage}
 [source,shell]
 ----------------------------------------------------------------------
 sudo chown root packetbeat.yml <1>
-sudo ./packetbeat -e -c packetbeat.yml -d "publish"
+sudo ./packetbeat -e -c packetbeat.yml
 ----------------------------------------------------------------------
 <1> You'll be running Packetbeat as root, so you need to change ownership of the
 configuration file, or run Packetbeat with `--strict.perms=false` specified. See


### PR DESCRIPTION
Cherry-pick of PR #8935 to 6.x branch. Original message: 

Our instructions for running beats on every platform but OSX describe starting
them as a managed service. Mysteriously, for OSX we run the beat in the forgeground
and invoke it with `-d "publish"`. This leads to really verbose output that
is really unnecessary for someone trying a beat for the first time.

My suspicion is the `d` flag made it in there in a mistake and was perpetuated
through no intentional plan.