### PR TITLE
Cherry-pick #8998 to 6.x: Correctly update the dictionary

### DIFF
--- a/libbeat/tests/system/beat/beat.py
+++ b/libbeat/tests/system/beat/beat.py
@@ -47,7 +47,7 @@ class Proc(object):
     def start(self):
         # ensure that the environment is inherited to the subprocess.
         variables = os.environ.copy()
-        variables = variables.update(self.env)
+        variables.update(self.env)
 
         if sys.platform.startswith("win"):
             self.proc = subprocess.Popen(


### PR DESCRIPTION
Cherry-pick of PR #8998 to 6.x branch. Original message: 

as pointed by @exekias, the update method of Dict doesn't return the
changes but does the change in place.

The gocode was still correct the behavior was not correctly tested.