### PR TITLE
Cherry-pick #8894 to 6.x: Read whole body on each request

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -77,6 +77,7 @@ https://github.com/elastic/beats/compare/v6.4.0...6.x[Check the HEAD diff]
 *Heartbeat*
 
 - Fixed bug where HTTP responses with larger bodies would incorrectly report connection errors. {pull}8660[8660]
+- Heartbeat now always downloads the entire body of HTTP endpoints, even if no checks against the body content are declared. This fixes an issue where timing metrics would be incorrect in scenarios where the body wasn't used since the connection would be closed soon after the headers were sent, but before the entire body was. {pull}8894[8894]
 
 *Journalbeat*
 

--- a/heartbeat/tests/system/heartbeat.py
+++ b/heartbeat/tests/system/heartbeat.py
@@ -8,6 +8,7 @@ sys.path.append(os.path.join(os.path.dirname(
     __file__), '../../../libbeat/tests/system'))
 
 from beat.beat import TestCase
+from time import sleep
 
 
 class BaseTest(TestCase):
@@ -19,12 +20,15 @@ class BaseTest(TestCase):
             os.path.join(os.path.dirname(__file__), "../../"))
         super(BaseTest, self).setUpClass()
 
-    def start_server(self, content, status_code):
+    def start_server(self, content, status_code, **kwargs):
         class HTTPHandler(BaseHTTPServer.BaseHTTPRequestHandler):
             def do_GET(self):
                 self.send_response(status_code)
                 self.send_header('Content-Type', 'application/json')
                 self.end_headers()
+                if "write_delay" in kwargs:
+                    sleep(float(kwargs["write_delay"]))
+
                 self.wfile.write(content)
 
         server = BaseHTTPServer.HTTPServer(('localhost', 0), HTTPHandler)


### PR DESCRIPTION
Cherry-pick of PR #8894 to 6.x branch. Original message: 

We currently do not read the entire HTTP body unless the user has a regex match declared. We should always do this as part of our HTTP checks.