### PR TITLE
Remove shared content that is not relevant

### DIFF
--- a/libbeat/docs/shared-directory-layout.asciidoc
+++ b/libbeat/docs/shared-directory-layout.asciidoc
@@ -24,8 +24,10 @@ The directory layout of an installation is as follows:
 | logs   | The location for the logs created by {beatname_uc}. | {path.home}/logs | path.logs
 |=======================================================================
 
+ifndef::serverless[]
 You can change these settings by using CLI flags or setting
 <<configuration-path,path options>> in the configuration file.
+endif::serverless[]
 
 ==== Default paths
 

--- a/libbeat/docs/shared-download-and-install.asciidoc
+++ b/libbeat/docs/shared-download-and-install.asciidoc
@@ -7,6 +7,7 @@ system.
 
 ifeval::["{release-state}"!="unreleased"]
 
+ifndef::no_repos[]
 [NOTE]
 ==================================================
 If you use Apt or Yum, you can <<setup-repositories,install {beatname_uc} from our
@@ -15,5 +16,6 @@ repositories>> to update to the newest version more easily.
 See our https://www.elastic.co/downloads/beats/{beatname_lc}[download page] for
 other installation options, such as 32-bit images.
 ==================================================
+endif::no_repos[]
 
 endif::[]

--- a/libbeat/docs/shared-faq.asciidoc
+++ b/libbeat/docs/shared-faq.asciidoc
@@ -34,6 +34,7 @@ paths in single quotation marks (see <<wrap-paths-in-quotes>>).
 
 Also see the general advice under <<yaml-tips>>.
 
+ifndef::only-elasticsearch[]
 [float]
 [[connection-problem]]
 === Logstash connection doesn't work?
@@ -54,7 +55,9 @@ telnet <hostname or IP> 5044
 input plugin for Logstash] is installed and configured. Note that Beats will not
 connect to the Lumberjack input plugin. To learn how to install and update
 plugins, see {logstash-ref}/working-with-plugins.html[Working with plugins].
+endif::only-elasticsearch[]
 
+ifndef::only-elasticsearch[]
 [float]
 [[metadata-missing]]
 === @metadata is missing in Logstash?
@@ -64,7 +67,9 @@ queue (for example, Redis or Kafka), the `@metadata` field will not be available
 
 TIP: To preserve `@metadata` fields, use the Logstash mutate filter with the rename setting to rename the fields to
 non-internal fields.
+endif::only-elasticsearch[]
 
+ifndef::only-elasticsearch[]
 [float]
 [[diff-logstash-beats]]
 === Difference between Logstash and Beats?
@@ -77,7 +82,9 @@ and transforming data from a variety of sources.
 
 For more information, see the https://www.elastic.co/guide/en/logstash/current/introduction.html[Logstash Introduction] and
 the https://www.elastic.co/guide/en/beats/libbeat/current/beats-reference.html[Beats Overview].
+endif::only-elasticsearch[]
 
+ifndef::only-elasticsearch[]
 [float]
 [[ssl-client-fails]]
 === SSL client fails to connect to Logstash?
@@ -142,6 +149,7 @@ This is not a SSL problem. Make sure that Logstash is running and that there is 
 
 A firewall is refusing the connection. Check if a firewall is blocking the traffic on the client, the network, or the
 destination host.
+endif::only-elasticsearch[]
 
 [float]
 [[monitoring-shows-fewer-than-expected-beats]]

--- a/libbeat/docs/shared-securing-beat.asciidoc
+++ b/libbeat/docs/shared-securing-beat.asciidoc
@@ -9,9 +9,13 @@ process and securing communication between {beatname_uc} and other products in
 the Elastic stack:
 
 * <<securing-communication-elasticsearch>>
+ifndef::only-elasticsearch[]
 * <<configuring-ssl-logstash>>
+endif::only-elasticsearch[]
 * <<securing-beats>>
+ifndef::only-elasticsearch[]
 * <<linux-seccomp>>
+endif::only-elasticsearch[]
 
 ifdef::beat-specific-security[]
 include::{beat-specific-security}[]
@@ -28,11 +32,15 @@ include::./https.asciidoc[]
 
 //sets block macro for shared-ssl-logstash-config.asciidoc included in next section
 
+ifndef::only-elasticsearch[]
 [[configuring-ssl-logstash]]
 == Secure communication with Logstash by using SSL
 
 include::./shared-ssl-logstash-config.asciidoc[]
+endif::only-elasticsearch[]
 
 include::./security/securing-beats.asciidoc[]
 
+ifndef::only-elasticsearch[]
 include::./security/linux-seccomp.asciidoc[]
+endif::only-elasticsearch[]

--- a/x-pack/functionbeat/docs/configuring-howto.asciidoc
+++ b/x-pack/functionbeat/docs/configuring-howto.asciidoc
@@ -18,14 +18,12 @@ The following topics describe how to configure {beatname_uc}:
 * <<configuration-ssl>>
 * <<filtering-and-enhancing-data>>
 * <<configuring-ingest-node>>
-* <<configuration-path>>
 * <<setup-kibana-endpoint>>
 * <<configuration-template>>
 * <<configuration-logging>>
 * <<using-environ-vars>>
 * <<yaml-tips>>
 * <<regexp-support>>
-* <<http-endpoint>>
 * <<{beatname_lc}-reference-yml>>
 
 --
@@ -46,8 +44,6 @@ include::./filtering.asciidoc[]
 
 include::{libbeat-dir}/docs/shared-config-ingest.asciidoc[]
 
-include::{libbeat-dir}/docs/shared-path-config.asciidoc[]
-
 include::{libbeat-dir}/docs/shared-kibana-config.asciidoc[]
 
 include::{libbeat-dir}/docs/setup-config.asciidoc[]
@@ -65,7 +61,5 @@ include::{libbeat-dir}/docs/yaml.asciidoc[]
 :allplatforms!:
 
 include::{libbeat-dir}/docs/regexp.asciidoc[]
-
-include::{libbeat-dir}/docs/http-endpoint.asciidoc[]
 
 include::{libbeat-dir}/docs/reference-yml.asciidoc[]

--- a/x-pack/functionbeat/docs/faq.asciidoc
+++ b/x-pack/functionbeat/docs/faq.asciidoc
@@ -5,7 +5,4 @@ This section contains frequently asked questions about {beatname_uc}. Also check
 out the https://discuss.elastic.co/c/beats/{beatname_lc}[{beatname_uc}
 discussion forum].
 
-
-include::{libbeat-dir}/docs/faq-limit-bandwidth.asciidoc[]
-
 include::{libbeat-dir}/docs/shared-faq.asciidoc[]

--- a/x-pack/functionbeat/docs/getting-started.asciidoc
+++ b/x-pack/functionbeat/docs/getting-started.asciidoc
@@ -8,7 +8,6 @@ include::{libbeat-dir}/docs/shared-getting-started-intro.asciidoc[]
 * <<{beatname_lc}-template>>
 * <<{beatname_lc}-deploying>>
 * <<view-kibana-dashboards>>
-* <<setup-repositories>>
 
 [id="{beatname_lc}-installation"]
 === Step 1: Download the {beatname_uc} package

--- a/x-pack/functionbeat/docs/index.asciidoc
+++ b/x-pack/functionbeat/docs/index.asciidoc
@@ -22,6 +22,7 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :win_os:
 :linux_os:
 :no_dashboards:
+:no_repos:
 
 include::{libbeat-dir}/docs/shared-beats-attributes.asciidoc[]
 
@@ -30,8 +31,6 @@ include::{libbeat-dir}/docs/shared-beats-attributes.asciidoc[]
 include::./overview.asciidoc[]
 
 include::./getting-started.asciidoc[]
-
-include::{libbeat-dir}/docs/repositories.asciidoc[]
 
 include::./setting-up-running.asciidoc[]
 


### PR DESCRIPTION
Follow up issue for https://github.com/elastic/beats/pull/8744. Removes shared content that is not relevant to functionbeat.

- [x] Remove the following topics because they are not relevant to functionbeat:
  - [x] Set up project paths: Nothing can be really change in provider container.
  - [x] HTTP Endpoint: This will not be accessible
  - [x] FAQ topics that aren't relevant:
    - [x] Logstash connection doesn’t work?
    - [x] Need to limit bandwidth used by Functionbeat?
    - [x] @metadata is missing in Logstash?  SSL client fails to connect to Logstash?
  - [x]  The following sections under security because they are not relevant to functionbeat:
    - [x] Secure communication with Logstash by using SSL
    - [x] Use Linux Secure Computing Mode (seccomp)