### PR TITLE
 Version Information for kafka-output unclear

### DIFF
--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -789,6 +789,7 @@ output.kafka:
 
 NOTE: Events bigger than <<kafka-max_message_bytes,`max_message_bytes`>> will be dropped. To avoid this problem, make sure {beatname_uc} does not generate events bigger than <<kafka-max_message_bytes,`max_message_bytes`>>.
 
+[[kafka-compatibility]]
 ==== Compatibility
 
 This output works with all Kafka versions in between 0.11 and 2.0.0. Older versions
@@ -812,11 +813,13 @@ The cluster metadata contain the actual Kafka brokers events are published to.
 
 ===== `version`
 
-Kafka version ${beatname_lc} is assumed to run against. Defaults to 1.0.0.
+Kafka version {beatname_lc} is assumed to run against. Defaults to 1.0.0.
 
 Event timestamps will be added, if version 0.10.0.0+ is enabled.
 
-Valid values are all kafka releases in between `0.8.2.0` and `1.1.1`.
+Valid values are all kafka releases in between `0.11` and `2.0.0`.
+
+See <<kafka-compatibility,`Compatibility`>> for information on supported versions.
 
 ===== `username`
 

--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -817,7 +817,7 @@ Kafka version {beatname_lc} is assumed to run against. Defaults to 1.0.0.
 
 Event timestamps will be added, if version 0.10.0.0+ is enabled.
 
-Valid values are all kafka releases in between `0.11` and `2.0.0`.
+Valid values are all kafka releases in between `0.8.2.0` and `2.0.0`.
 
 See <<kafka-compatibility,`Compatibility`>> for information on supported versions.
 

--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -819,7 +819,7 @@ Event timestamps will be added, if version 0.10.0.0+ is enabled.
 
 Valid values are all kafka releases in between `0.8.2.0` and `2.0.0`.
 
-See <<kafka-compatibility,`Compatibility`>> for information on supported versions.
+See <<kafka-compatibility>> for information on supported versions.
 
 ===== `username`
 


### PR DESCRIPTION
In the paragraph "compatibility" it is mentioned that versions 0.11 to 2.0.0 are supported.
In the description of the parameter "version" it is mentioned that all versions from 0.8.2.0 to 1.1.1 are valid.
It would be useful to mention the supported versions. This would avoid misinterpretations.
I assume that the information in the paragraph "compatibility" is correct.