### PR TITLE
Cherry-pick #9023 to 6.5: Unset existing config blocks when they are missing

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -119,6 +119,7 @@ https://github.com/elastic/beats/compare/v6.4.0...v6.5.0[View commits]
 - Fix in-cluster kubernetes configuration on IPv6. {pull}8754[8754]
 - The export config subcommand should not display real value for field reference. {pull}8769[8769]
 - The setup command will not fail if no dashboard is available to import. {pull}8977[8977]
+- Fix central management configurations reload when a configuration is removed in Kibana. {issue}9010[9010]
 
 *Auditbeat*
 

--- a/libbeat/common/reload/reload.go
+++ b/libbeat/common/reload/reload.go
@@ -110,6 +110,23 @@ func (r *Registry) MustRegisterList(name string, list ReloadableList) {
 	}
 }
 
+// GetRegisteredNames returns the list of names registered
+func (r *Registry) GetRegisteredNames() []string {
+	r.RLock()
+	defer r.RUnlock()
+	var names []string
+
+	for name := range r.confs {
+		names = append(names, name)
+	}
+
+	for name := range r.confsLists {
+		names = append(names, name)
+	}
+
+	return names
+}
+
 // GetReloadable returns the reloadable object with the given name, nil if not found
 func (r *Registry) GetReloadable(name string) Reloadable {
 	r.RLock()

--- a/libbeat/publisher/pipeline/controller.go
+++ b/libbeat/publisher/pipeline/controller.go
@@ -154,8 +154,10 @@ func makeWorkQueue() workQueue {
 func (c *outputController) Reload(cfg *reload.ConfigWithMeta) error {
 	outputCfg := common.ConfigNamespace{}
 
-	if err := cfg.Config.Unpack(&outputCfg); err != nil {
-		return err
+	if cfg != nil {
+		if err := cfg.Config.Unpack(&outputCfg); err != nil {
+			return err
+		}
 	}
 
 	output, err := loadOutput(c.beat, c.monitors, outputCfg)


### PR DESCRIPTION
Cherry-pick of PR #9023 to 6.5 branch. Original message: 

When a configuration block type (ie output) is not set in Central
Management, Kibana doesn't return it in the payload.

Before this change, Beats was not taking that into account and missing
block types were not reloaded in case they changed. In particular that
means that if an output configuration exists and is removed, Beats won't
apply that change (disable the output).

This PR fixes that behavior by detecting missing types and applying nil
config to them.

Fixes #9010