### PR TITLE
Cleanup CHANGELOG in the master branch

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -46,56 +46,22 @@ https://github.com/elastic/beats/compare/v6.4.0...master[Check the HEAD diff]
 
 *Affecting all Beats*
 
-- Fixed `add_host_metadata` not initializing correctly on Windows. {issue}7715[7715]
 - Fixed `-d` CLI flag by trimming spaces from selectors. {pull}7864[7864]
-- Fixed missing file unlock in spool file on Windows, so file can be reopened and locked. {pull}7859[7859]
-- Fix spool file opening/creation failing due to file locking on Windows. {pull}7859[7859]
-- Fix size of maximum mmaped read area in spool file on Windows. {pull}7859[7859]
-- Fix potential data loss on OS X in spool file by using fcntl with F_FULLFSYNC. {pull}7859[7859]
-- Improve fsync on linux, by assuming the kernel resets error flags of failed writes. {pull}7859[7859]
-- Remove unix-like permission checks on Windows, so files can be opened. {issue}7849[7849]
-- Deregister pipeline loader callback when inputsRunner is stopped. {pull}7893[7893]
-- Replace index patterns in TSVB visualizations. {pull}7929[7929]
 - Fixed Support `add_docker_metadata` in Windows by identifying systems' path separator. {issue}7797[7797]
-- Add backoff support to x-pack monitoring outputs. {issue}7966[7966]
-- Fix a race condition with the `add_host_metadata` and the event serialization. {pull}8223[8223] {pull}8653[8653]
-- Enforce that data used by k8s or docker doesn't use any reference. {pull}8240[8240]
-- Switch to different UUID lib due to to non-random generated UUIDs. {pull}8485[8485]
-- Fix race condition when publishing monitoring data. {pull}8646[8646]
-- Fix in-cluster kubernetes configuration on IPv6. {pull}8754[8754]
-- Fix bug in loading dashboards from zip file. {issue}8051[8051]
-- The export config subcommand should not display real value for field reference. {pull}xxx[xxx]
-- The export config subcommand should not display real value for field reference. {pull}8769[8769]
 - Do not panic when no tokenizer string is configured for a dissect processor. {issue}8895[8895]
 - Start autodiscover consumers before producers. {pull}7926[7926]
-- The setup command will not fail if no dashboard is available to import. {pull}8977[8977]
-- Fix central management configurations reload when a configuration is removed in Kibana. {issue}9010[9010]
 
 *Auditbeat*
-
-- Fixed a crash in the file_integrity module under Linux. {issue}7753[7753]
-- Fixed a data race in the file_integrity module. {issue}8009[8009]
-- Fixed a deadlock in the file_integrity module. {pull}8027[8027]
-- Fixed the RPM by designating the config file as configuration data in the RPM spec. {issue}8075[8075]
-- Fixed a concurrent map write panic in the auditd module. {pull}8158[8158]
 
 *Filebeat*
 
 - Fixed a memory leak when harvesters are closed. {pull}7820[7820]
-- Fix date format in Mongodb Ingest pipeline. {pull}7974[7974]
-- Mark the TCP and UDP input as GA. {pull}8125[8125]
-- Fixed a docker input error due to the offset update bug in partial log join.{pull}8177[8177]
-- Update CRI format to support partial/full tags. {pull}8265[8265]
-- Fix some errors happening when stopping syslog input. {pull}8347[8347]
-- Fix RFC3339 timezone and nanoseconds parsing with the syslog input. {pull}8346[8346]
-- Support multiline logs in logstash/log fileset of Filebeat. {pull}8562[8562]
 - Fix improperly set config for CRI Flag in Docker Input {pull}8899[8899]
 - Just enabling the `elasticsearch` fileset and starting Filebeat no longer causes an error. {pull}8891[8891]
 - Fix macOS default log path for elasticsearch module based on homebrew paths. {pul}8939[8939]
 
 *Heartbeat*
 
-- Fixed bug where HTTP responses with larger bodies would incorrectly report connection errors. {pull}8660[8660]
 - Heartbeat now always downloads the entire body of HTTP endpoints, even if no checks against the body content are declared. This fixes an issue where timing metrics would be incorrect in scenarios where the body wasn't used since the connection would be closed soon after the headers were sent, but before the entire body was. {pull}8894[8894]
 
 *Journalbeat*
@@ -103,25 +69,10 @@ https://github.com/elastic/beats/compare/v6.4.0...master[Check the HEAD diff]
 *Metricbeat*
 
 - Fix golang.heap.gc.cpu_fraction type from long to float in Golang module. {pull}7789[7789]
-- Fixed a panic when the kvm module cannot establish a connection to libvirtd. {issue}7792[7792].
-- Recover metrics for old apache versions removed by mistake on #6450. {pull}7871[7871]
 - Add missing namespace field in http server metricset {pull}7890[7890]
-- Fixed the RPM by designating the modules.d config files as configuration data in the RPM spec. {issue}8075[8075]
-- Fixed the location of the modules.d dir in Deb and RPM packages. {issue}8104[8104]
-- Add docker diskio stats on Windows. {issue}6815[6815] {pull}8126[8126]
-- Fix incorrect type conversion of average response time in Haproxy dashboards {pull}8404[8404]
-- Fix dropwizard module parsing of metric names. {issue}8365[8365] {pull}6385[8385]
-- Added io disk read and write times to system module {issue}8473[8473] {pull}8508[8508]
-- Avoid mapping issues in kubernetes module. {pull}8487[8487]
-- Fix issue that would prevent kafka module to find a proper broker when port is not set {pull}8613[8613]
-- Fix range colors in multiple visualizations. {issue}8633[8633] {pull}8634[8634]
-- Fix incorrect header parsing on http metricbeat module {issue}8564[8564] {pull}8585[8585]
 
 *Packetbeat*
 
-- Fixed a seccomp related error where the `fcntl64` syscall was not permitted
-  on 32-bit Linux and the sniffer failed to start. {issue}7839[7839]
-- Added missing `cmdline` and `client_cmdline` fields to index template. {pull}8258[8258]
 - Fixed the mysql missing transactions if monitoring a connection from the start. {pull}8173[8173]
 
 *Winlogbeat*
@@ -132,25 +83,11 @@ https://github.com/elastic/beats/compare/v6.4.0...master[Check the HEAD diff]
 
 *Affecting all Beats*
 
-- Added time-based log rotation. {pull}8349[8349]
-- Add backoff on error support to redis output. {pull}7781[7781]
 - Add field `host.os.kernel` to the add_host_metadata processor and to the
   internal monitoring data. {issue}7807[7807]
-- Allow for cloud-id to specify a custom port. This makes cloud-id work in ECE contexts. {pull}7887[7887]
-- Add support to grow or shrink an existing spool file between restarts. {pull}7859[7859]
 - Add debug check to logp.Logger {pull}7965[7965]
-- Make kubernetes autodiscover ignore events with empty container IDs {pull}7971[7971]
-- Add DNS processor with support for performing reverse lookups on IP addresses. {issue}7770[7770]
-- Implement CheckConfig in RunnerFactory to make autodiscover check configs {pull}7961[7961]
 - Count HTTP 429 responses in the elasticsearch output {pull}8056[8056]
-- Report configured queue type. {pull}8091[8091]
-- Added the `add_process_metadata` processor to enrich events with process information. {pull}6789[6789]
-- Report number of open file handles on Windows. {pull}8329[8329]
-- Support for Kafka 2.0.0 in kafka output {pull}8399[8399]
-- Add setting `setup.kibana.space.id` to support Kibana Spaces {pull}7942[7942]
-- Add Beats Central Management {pull}8559[8559]
 - Allow Bus to buffer events in case listeners are not configured. {pull}8527[8527]
-- Enable `host` and `cloud` metadata processors by default. {pull}8596[8596]
 - Dissect will now flag event on parsing error. {pull}8751[8751]
 - add_cloud_metadata initialization is performed asynchronously to avoid delays on startup. {pull}8845[8845]
 
@@ -161,62 +98,30 @@ https://github.com/elastic/beats/compare/v6.4.0...master[Check the HEAD diff]
 - Make inputsource generic taking bufio.SplitFunc as input {pull}7746[7746]
 - Add custom unpack to log hints config to avoid env resolution {pull}7710[7710]
 - Make docker input check if container strings are empty {pull}7960[7960]
-- Add tag "truncated" to "log.flags" if incoming line is longer than configured limit. {pull}7991[7991]
-- Add tag "multiline" to "log.flags" if event consists of multiple lines. {pull}7997[7997]
-- Add haproxy module. {pull}8014[8014]
-- Release `docker` input as GA. {pull}8328[8328]
 - Keep unparsed user agent information in user_agent.original. {pull}8537[8537]
-- Better tracking of number of open file descriptors. {pull}7986[7986]
-- Added default and TCP parsing formats to HAproxy module {issue}8311[8311] {pull}8637[8637]
-- Add Suricata IDS/IDP/NSM module. {issue}8153[8153] {pull}8693[8693]
 - Allow to force CRI format parsing for better performance {pull}8424[8424]
-- Support for Kafka 2.0.0 {pull}8853[8853]
 
 *Heartbeat*
 
-- Added autodiscovery support {pull}8415[8415]
-- Added support for extra TLS/x509 metadata. {pull}7944[7944]
-- Added stats and state metrics for number of monitors and endpoints started. {pull}8621[8621]
+- Add automatic config file reloading. {pull}8023[8023]
 
 *Journalbeat*
 
-- Add journalbeat. {pull}8703[8703]
 - Add the ability to check against JSON HTTP bodies with conditions. {pull}8667[8667]
 
 *Metricbeat*
 
 - Add metrics about cache size to memcached module {pull}7740[7740]
-- Add `replstatus` metricset to MongoDB module {pull}7604[7604]
-- Move common kafka fields (broker, topic and partition.id) to the module level to facilitate events correlation {pull}7767[7767]
-- Add `metircs` metricset to MongoDB module. {pull}7611[7611]
-- Add fields for mermory fragmentation, memory allocator stats, copy on write, master-slave status, and active defragmentation to `info` metricset of Redis module. {pull}7695[7695]
 - Add experimental socket summary metricset to system module {pull}6782[6782]
-- Increase ignore_above for system.process.cmdline to 2048. {pull}8101[8100]
-- Add support to renamed fields planned for redis 5.0. {pull}8167[8167]
-- Allow TCP helper to support delimiters and graphite module to accept multiple metrics in a single payload. {pull}8278[8278]
-- Added 'died' PID state to process_system metricset on system module{pull}8275[8275]
-- Added `ccr` metricset to Elasticsearch module. {pull}8335[8335]
-- Added support for query params in configuration {issue}8286[8286] {pull}8292[8292]
-- Support for Kafka 2.0.0 {pull}8399[8399]
-- Add container image for docker metricsets. {issue}8214[8214] {pull}8438[8438]
-- Add support for `full` status page output for php-fpm module as a separate metricset called `process`. {pull}8394[8394]
-- Precalculate composed id fields for kafka dashboards. {pull}8504[8504]
-- Add Kafka dashboard. {pull}8457[8457]
-- Add untyped metric support to the prometheus module. {pull}8681[8681]
-- Release Kafka module as GA. {pull}8854[8854]
 - Collect custom cluster `display_name` in `elasticsearch/cluster_stats` metricset. {pull}8445[8445]
 
 *Packetbeat*
 
-- Added DHCP protocol support. {pull}7647[7647]
 - Add support to decode HTTP bodies compressed with `gzip` and `deflate`. {pull}7915[7915]
 - Added support to calculate certificates' fingerprints (MD5, SHA-1, SHA-256). {issue}8180[8180]
+- Support new TLS version negotiation introduced in TLS 1.3. {issue}8647[8647].
 
 *Winlogbeat*
-
-*Heartbeat*
-
-- Add automatic config file reloading. {pull}8023[8023]
 
 *Functionbeat*
 
@@ -229,19 +134,12 @@ https://github.com/elastic/beats/compare/v6.4.0...master[Check the HEAD diff]
 *Filebeat*
 
 *Heartbeat*
-- watch.poll_file is now deprecated and superceded by automatic config file reloading.
 
 *Journalbeat*
 
 *Metricbeat*
-- Redis `info` `replication.master_offset` has been deprecated in favor of `replication.master.offset`.{pull}7695[7695]
-- Redis `info` clients fields `longest_output_list` and `biggest_input_buf` have been renamed to `max_output_buffer` and `max_input_buffer` based on the names they will have in Redis 5.0, both fields will coexist during a time with the same value {pull}8167[8167].
-
-- Move common kafka fields (broker, topic and partition.id) to the module level {pull}7767[7767].
 
 *Packetbeat*
-
-- Support new TLS version negotiation introduced in TLS 1.3. {issue}8647[8647].
 
 *Winlogbeat*
 
@@ -251,6 +149,239 @@ https://github.com/elastic/beats/compare/v6.4.0...master[Check the HEAD diff]
 
 
 ////////////////////////////////////////////////////////////
+
+[[release-notes-6.5.0]]
+=== Beats version 6.5.0
+https://github.com/elastic/beats/compare/v6.4.0...v6.5.0[View commits]
+
+==== Bugfixes
+
+*Affecting all Beats*
+
+- Fixed `add_host_metadata` not initializing correctly on Windows. {issue}7715[7715]
+- Fixed missing file unlock in spool file on Windows, so file can be reopened and locked. {pull}7859[7859]
+- Fix spool file opening/creation failing due to file locking on Windows. {pull}7859[7859]
+- Fix size of maximum mmaped read area in spool file on Windows. {pull}7859[7859]
+- Fix potential data loss on OS X in spool file by using fcntl with F_FULLFSYNC. {pull}7859[7859]
+- Improve fsync on linux, by assuming the kernel resets error flags of failed writes. {pull}7859[7859]
+- Remove unix-like permission checks on Windows, so files can be opened. {issue}7849[7849]
+- Replace index patterns in TSVB visualizations. {pull}7929[7929]
+- Deregister pipeline loader callback when inputsRunner is stopped. {pull}[7893][7893]
+- Add backoff support to x-pack monitoring outputs. {issue}7966[7966]
+- Removed execute permissions systemd unit file. {pull}7873[7873]
+- Fix a race condition with the `add_host_metadata` and the event serialization. {pull}8223[8223] {pull}8653[8653]
+- Enforce that data used by k8s or docker doesn't use any reference. {pull}8240[8240]
+- Switch to different UUID lib due to to non-random generated UUIDs. {pull}8485[8485]
+- Fix race condition when publishing monitoring data. {pull}8646[8646]
+- Fix bug in loading dashboards from zip file. {issue}8051[8051]
+- Fix in-cluster kubernetes configuration on IPv6. {pull}8754[8754]
+- The export config subcommand should not display real value for field reference. {pull}8769[8769]
+- The setup command will not fail if no dashboard is available to import. {pull}8977[8977]
+- Fix central management configurations reload when a configuration is removed in Kibana. {issue}9010[9010]
+
+*Auditbeat*
+
+- Fixed a crash in the file_integrity module under Linux. {issue}7753[7753]
+- Fixed the RPM by designating the config file as configuration data in the RPM spec. {issue}8075[8075]
+- Fixed a concurrent map write panic in the auditd module. {pull}8158[8158]
+- Fixed a data race in the file_integrity module. {issue}8009[8009]
+- Fixed a deadlock in the file_integrity module. {pull}8027[8027]
+
+*Filebeat*
+
+- Fix date format in Mongodb Ingest pipeline. {pull}7974[7974]
+- Fixed a docker input error due to the offset update bug in partial log join.{pull}8177[8177]
+- Update CRI format to support partial/full tags. {pull}8265[8265]
+- Fix some errors happening when stopping syslog input. {pull}8347[8347]
+- Fix RFC3339 timezone and nanoseconds parsing with the syslog input. {pull}8346[8346]
+- Mark the TCP and UDP input as GA. {pull}8125[8125]
+- Support multiline logs in logstash/log fileset of Filebeat. {pull}8562[8562]
+
+*Heartbeat*
+
+- Fixed bug where HTTP responses with larger bodies would incorrectly report connection errors. {pull}8660[8660]
+
+*Metricbeat*
+
+- Fix golang.heap.gc.cpu_fraction type from long to float in Golang module. {pull}7789[7789]
+- Fixed the RPM by designating the modules.d config files as configuration data in the RPM spec. {issue}8075[8075]
+- Fixed the location of the modules.d dir in Deb and RPM packages. {issue}8104[8104]
+- Add docker diskio stats on Windows. {issue}6815[6815] {pull}8126[8126]
+- Fix incorrect type conversion of average response time in Haproxy dashboards {pull}8404[8404]
+- Added io disk read and write times to system module {issue}8473[8473] {pull}8508[8508]
+- Avoid mapping issues in kubernetes module. {pull}8487[8487]
+- Recover metrics for old apache versions removed by mistake on #6450. {pull}7871[7871]
+- Fix dropwizard module parsing of metric names. {issue}8365[8365] {pull}6385[8385]
+- Fix issue that would prevent kafka module to find a proper broker when port is not set {pull}8613[8613]
+- Fix range colors in multiple visualizations. {issue}8633[8633] {pull}8634[8634]
+- Fix incorrect header parsing on http metricbeat module {issue}8564[8564] {pull}8585[8585]
+- Fixed a panic when the kvm module cannot establish a connection to libvirtd. {issue}7792[7792].
+
+*Packetbeat*
+
+- Fixed a seccomp related error where the `fcntl64` syscall was not permitted
+  on 32-bit Linux and the sniffer failed to start. {issue}7839[7839]
+- Added missing `cmdline` and `client_cmdline` fields to index template. {pull}8258[8258]
+
+==== Added
+
+*Affecting all Beats*
+
+- Added time-based log rotation. {pull}8349[8349]
+- Add backoff on error support to redis output. {pull}7781[7781]
+- Allow for cloud-id to specify a custom port. This makes cloud-id work in ECE contexts. {pull}7887[7887]
+- Add support to grow or shrink an existing spool file between restarts. {pull}7859[7859]
+- Make kubernetes autodiscover ignore events with empty container IDs {pull}7971[7971]
+- Implement CheckConfig in RunnerFactory to make autodiscover check configs {pull}7961[7961]
+- Add DNS processor with support for performing reverse lookups on IP addresses. {issue}7770[7770]
+- Support for Kafka 2.0.0 in kafka output {pull}8399[8399]
+- Add setting `setup.kibana.space.id` to support Kibana Spaces {pull}7942[7942]
+- Better tracking of number of open file descriptors. {pull}7986[7986]
+- Report number of open file handles on Windows. {pull}8329[8329]
+- Added the `add_process_metadata` processor to enrich events with process information. {pull}6789[6789]
+- Add Beats Central Management {pull}8559[8559]
+- Report configured queue type. {pull}8091[8091]
+- Enable `host` and `cloud` metadata processors by default. {pull}8596[8596]
+
+*Filebeat*
+
+- Add tag "truncated" to "log.flags" if incoming line is longer than configured limit. {pull}7991[7991]
+- Add haproxy module. {pull}8014[8014]
+- Add tag "multiline" to "log.flags" if event consists of multiple lines. {pull}7997[7997]
+- Release `docker` input as GA. {pull}8328[8328]
+- Keep unparsed user agent information in user_agent.original. {pull}7823[7832]
+- Added default and TCP parsing formats to HAproxy module {issue}8311[8311] {pull}8637[8637]
+- Add Suricata IDS/IDP/NSM module. {issue}8153[8153] {pull}8693[8693]
+- Support for Kafka 2.0.0 {pull}8853[8853]
+
+*Heartbeat*
+
+- Heartbeat is marked as GA.
+- Add automatic config file reloading. {pull}8023[8023]
+- Added autodiscovery support {pull}8415[8415]
+- Added support for extra TLS/x509 metadata. {pull}7944[7944]
+- Added stats and state metrics for number of monitors and endpoints started. {pull}8621[8621]
+
+*Journalbeat*
+
+- Add journalbeat. {pull}8703[8703]
+
+*Metricbeat*
+
+- Add `replstatus` metricset to MongoDB module {pull}7604[7604]
+- Add experimental socket summary metricset to system module {pull}6782[6782]
+- Move common kafka fields (broker, topic and partition.id) to the module level to facilitate events correlation {pull}7767[7767]
+- Add fields for memory fragmentation, memory allocator stats, copy on write, master-slave status, and active defragmentation to `info` metricset of Redis module. {pull}7695[7695]
+- Increase ignore_above for system.process.cmdline to 2048. {pull}8101[8100]
+- Add support to renamed fields planned for redis 5.0. {pull}8167[8167]
+- Allow TCP helper to support delimiters and graphite module to accept multiple metrics in a single payload. {pull}8278[8278]
+- Added 'died' PID state to process_system metricset on system module {pull}8275[8275]
+- Add `metrics` metricset to MongoDB module. {pull}7611[7611]
+- Added `ccr` metricset to Elasticsearch module. {pull}8335[8335]
+- Support for Kafka 2.0.0 {pull}8399[8399]
+- Added support for query params in configuration {issue}8286[8286] {pull}8292[8292]
+- Add container image for docker metricsets. {issue}8214[8214] {pull}8438[8438]
+- Precalculate composed id fields for kafka dashboards. {pull}8504[8504]
+- Add support for `full` status page output for php-fpm module as a separate metricset called `process`. {pull}8394[8394]
+- Add Kafka dashboard. {pull}8457[8457]
+- Release Kafka module as GA. {pull}8854[8854]
+
+*Packetbeat*
+
+- Added DHCP protocol support. {pull}7647[7647]
+
+*Functionbeat*
+
+- Initial version of Functionbeat. {pull}8678[8678]
+
+==== Deprecated
+
+*Heartbeat*
+
+- watch.poll_file is now deprecated and superceded by automatic config file reloading.
+
+*Metricbeat*
+
+- Redis `info` `replication.master_offset` has been deprecated in favor of `replication.master.offset`.{pull}7695[7695]
+- Redis `info` clients fields `longest_output_list` and `biggest_input_buf` have been renamed to `max_output_buffer` and `max_input_buffer` based on the names they will have in Redis 5.0, both fields will coexist during a time with the same value {pull}8167[8167].
+- Move common kafka fields (broker, topic and partition.id) to the module level {pull}7767[7767].
+
+
+
+[[release-notes-6.4.3]]
+=== Beats version 6.4.3
+https://github.com/elastic/beats/compare/v6.4.2...v6.4.3[View commits]
+
+==== Bugfixes
+
+*Affecting all Beats*
+
+- Fix a race condition with the `add_host_metadata` and the event serialization. {pull}8223[8223] {pull}8653[8653]
+- Fix race condition when publishing monitoring data. {pull}8646[8646]
+- Fix bug in loading dashboards from zip file. {issue}8051[8051]
+- The export config subcommand should not display real value for field reference. {pull}8769[8769]
+
+*Filebeat*
+
+- Fix typo in Filebeat IIS Kibana visualization. {pull}8604[8604]
+
+*Metricbeat*
+
+- Recover metrics for old Apache versions removed by mistake on #6450. {pull}7871[7871]
+- Avoid mapping issues in Kubernetes module. {pull}8487[8487]
+- Fixed a panic when the KVM module cannot establish a connection to libvirtd. {issue}7792[7792]
+
+
+[[release-notes-6.4.2]]
+=== Beats version 6.4.2
+https://github.com/elastic/beats/compare/v6.4.1...v6.4.2[View commits]
+
+==== Bugfixes
+
+*Filebeat*
+
+- Fix some errors happening when stopping syslog input. {pull}8347[8347]
+- Fix RFC3339 timezone and nanoseconds parsing with the syslog input. {pull}8346[8346]
+
+*Metricbeat*
+
+- Fix incorrect type conversion of average response time in Haproxy dashboards {pull}8404[8404]
+- Fix dropwizard module parsing of metric names. {issue}8365[8365] {pull}6385[8385]
+
+[[release-notes-6.4.1]]
+=== Beats version 6.4.1
+https://github.com/elastic/beats/compare/v6.4.0...v6.4.1[View commits]
+
+==== Bugfixes
+
+*Affecting all Beats*
+
+- Add backoff support to x-pack monitoring outputs. {issue}7966[7966]
+- Removed execute permissions systemd unit file. {pull}7873[7873]
+- Fix a race condition with the `add_host_metadata` and the event serialization. {pull}8223[8223]
+- Enforce that data used by k8s or docker doesn't use any reference. {pull}8240[8240]
+- Implement CheckConfig in RunnerFactory to make autodiscover check configs {pull}7961[7961]
+- Make kubernetes autodiscover ignore events with empty container IDs {pull}7971[7971]
+
+*Auditbeat*
+
+- Fixed a concurrent map write panic in the auditd module. {pull}8158[8158]
+- Fixed the RPM by designating the config file as configuration data in the RPM spec. {issue}8075[8075]
+
+*Filebeat*
+
+- Fixed a docker input error due to the offset update bug in partial log join.{pull}8177[8177]
+- Update CRI format to support partial/full tags. {pull}8265[8265]
+
+*Metricbeat*
+
+- Fixed the location of the modules.d dir in Deb and RPM packages. {issue}8104[8104]
+- Fixed the RPM by designating the modules.d config files as configuration data in the RPM spec. {issue}8075[8075]
+- Fix golang.heap.gc.cpu_fraction type from long to float in Golang module. {pull}7789[7789]
+
+*Packetbeat*
+
+- Added missing `cmdline` and `client_cmdline` fields to index template. {pull}8258[8258]
 
 [[release-notes-6.4.0]]
 === Beats version 6.4.0

--- a/libbeat/docs/release.asciidoc
+++ b/libbeat/docs/release.asciidoc
@@ -8,6 +8,10 @@ This section summarizes the changes in each release. Also read
 <<breaking-changes>> for more detail about changes that affect
 upgrade.
 
+* <<release-notes-6.5.0>>
+* <<release-notes-6.4.3>>
+* <<release-notes-6.4.2>>
+* <<release-notes-6.4.1>>
 * <<release-notes-6.4.0>>
 * <<release-notes-6.3.1>>
 * <<release-notes-6.3.0>>


### PR DESCRIPTION
Copied all releases from the 6.5 branch, and removed duplicate entries.