### PR TITLE
Mark docs as released in the 6.5 branch

### DIFF
--- a/libbeat/docs/version.asciidoc
+++ b/libbeat/docs/version.asciidoc
@@ -1,7 +1,7 @@
 :stack-version: 6.5.0
 :doc-branch: 6.5
 :go-version: 1.10.3
-:release-state: unreleased
+:release-state: released
 :python: 2.7.9
 :docker: 1.12
 :docker-compose: 1.11


### PR DESCRIPTION
Should be merged on the release day.