### PR TITLE
Cherry-pick #8980 to 6.5:  apply new goimports rules to libbeat

### DIFF
--- a/filebeat/reader/docker_json/docker_json.go
+++ b/filebeat/reader/docker_json/docker_json.go
@@ -23,10 +23,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/elastic/beats/filebeat/reader"
 	"github.com/elastic/beats/libbeat/common"
-
-	"github.com/pkg/errors"
 )
 
 // Reader processor renames a given field

--- a/filebeat/reader/docker_json/docker_json_test.go
+++ b/filebeat/reader/docker_json/docker_json_test.go
@@ -21,10 +21,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/beats/filebeat/reader"
 	"github.com/elastic/beats/libbeat/common"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestDockerJSON(t *testing.T) {

--- a/filebeat/reader/readfile/encoding/utf16_test.go
+++ b/filebeat/reader/readfile/encoding/utf16_test.go
@@ -25,7 +25,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
 	"golang.org/x/text/encoding/unicode"
 	"golang.org/x/text/transform"
 )

--- a/libbeat/autodiscover/autodiscover_test.go
+++ b/libbeat/autodiscover/autodiscover_test.go
@@ -23,12 +23,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/cfgfile"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/bus"
-
-	"github.com/stretchr/testify/assert"
 )
 
 type mockRunner struct {

--- a/libbeat/autodiscover/meta/meta_test.go
+++ b/libbeat/autodiscover/meta/meta_test.go
@@ -20,9 +20,9 @@ package meta
 import (
 	"testing"
 
-	"github.com/elastic/beats/libbeat/common"
-
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/libbeat/common"
 )
 
 func TestStoreNil(t *testing.T) {

--- a/libbeat/autodiscover/providers/docker/docker_integration_test.go
+++ b/libbeat/autodiscover/providers/docker/docker_integration_test.go
@@ -23,11 +23,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/bus"
 	dk "github.com/elastic/beats/libbeat/tests/docker"
-
-	"github.com/stretchr/testify/assert"
 )
 
 // Test docker start emits an autodiscover event

--- a/libbeat/autodiscover/template/config_test.go
+++ b/libbeat/autodiscover/template/config_test.go
@@ -20,10 +20,10 @@ package template
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/bus"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestConfigsMapping(t *testing.T) {

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -34,13 +34,8 @@ import (
 	"time"
 
 	"github.com/gofrs/uuid"
-	"go.uber.org/zap"
-
 	errw "github.com/pkg/errors"
-
-	"github.com/elastic/go-sysinfo"
-	"github.com/elastic/go-sysinfo/types"
-	ucfg "github.com/elastic/go-ucfg"
+	"go.uber.org/zap"
 
 	"github.com/elastic/beats/libbeat/api"
 	"github.com/elastic/beats/libbeat/asset"
@@ -68,28 +63,9 @@ import (
 	svc "github.com/elastic/beats/libbeat/service"
 	"github.com/elastic/beats/libbeat/template"
 	"github.com/elastic/beats/libbeat/version"
-
-	// Register publisher pipeline modules
-	_ "github.com/elastic/beats/libbeat/publisher/includes"
-
-	// Register default processors.
-	_ "github.com/elastic/beats/libbeat/processors/actions"
-	_ "github.com/elastic/beats/libbeat/processors/add_cloud_metadata"
-	_ "github.com/elastic/beats/libbeat/processors/add_docker_metadata"
-	_ "github.com/elastic/beats/libbeat/processors/add_host_metadata"
-	_ "github.com/elastic/beats/libbeat/processors/add_kubernetes_metadata"
-	_ "github.com/elastic/beats/libbeat/processors/add_locale"
-	_ "github.com/elastic/beats/libbeat/processors/add_process_metadata"
-	_ "github.com/elastic/beats/libbeat/processors/dissect"
-	_ "github.com/elastic/beats/libbeat/processors/dns"
-
-	// Register autodiscover providers
-	_ "github.com/elastic/beats/libbeat/autodiscover/providers/docker"
-	_ "github.com/elastic/beats/libbeat/autodiscover/providers/jolokia"
-	_ "github.com/elastic/beats/libbeat/autodiscover/providers/kubernetes"
-
-	// Register default monitoring reporting
-	_ "github.com/elastic/beats/libbeat/monitoring/report/elasticsearch"
+	"github.com/elastic/go-sysinfo"
+	"github.com/elastic/go-sysinfo/types"
+	ucfg "github.com/elastic/go-ucfg"
 )
 
 // Beat provides the runnable and configurable instance of a beat.

--- a/libbeat/cmd/instance/imports.go
+++ b/libbeat/cmd/instance/imports.go
@@ -1,0 +1,35 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package instance
+
+import (
+	_ "github.com/elastic/beats/libbeat/autodiscover/providers/docker" // Register autodiscover providers
+	_ "github.com/elastic/beats/libbeat/autodiscover/providers/jolokia"
+	_ "github.com/elastic/beats/libbeat/autodiscover/providers/kubernetes"
+	_ "github.com/elastic/beats/libbeat/monitoring/report/elasticsearch" // Register default monitoring reporting
+	_ "github.com/elastic/beats/libbeat/processors/actions"              // Register default processors.
+	_ "github.com/elastic/beats/libbeat/processors/add_cloud_metadata"
+	_ "github.com/elastic/beats/libbeat/processors/add_docker_metadata"
+	_ "github.com/elastic/beats/libbeat/processors/add_host_metadata"
+	_ "github.com/elastic/beats/libbeat/processors/add_kubernetes_metadata"
+	_ "github.com/elastic/beats/libbeat/processors/add_locale"
+	_ "github.com/elastic/beats/libbeat/processors/add_process_metadata"
+	_ "github.com/elastic/beats/libbeat/processors/dissect"
+	_ "github.com/elastic/beats/libbeat/processors/dns"
+	_ "github.com/elastic/beats/libbeat/publisher/includes" // Register publisher pipeline modules
+)

--- a/libbeat/cmd/root.go
+++ b/libbeat/cmd/root.go
@@ -23,13 +23,12 @@ import (
 	"os"
 	"strings"
 
-	"github.com/elastic/beats/libbeat/cmd/instance"
-
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/cfgfile"
+	"github.com/elastic/beats/libbeat/cmd/instance"
 )
 
 func init() {

--- a/libbeat/common/config.go
+++ b/libbeat/common/config.go
@@ -27,12 +27,11 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/elastic/beats/libbeat/common/file"
+	"github.com/elastic/beats/libbeat/logp"
 	ucfg "github.com/elastic/go-ucfg"
 	"github.com/elastic/go-ucfg/cfgutil"
 	"github.com/elastic/go-ucfg/yaml"
-
-	"github.com/elastic/beats/libbeat/common/file"
-	"github.com/elastic/beats/libbeat/logp"
 )
 
 var flagStrictPerms = flag.Bool("strict.perms", true, "Strict permission checking on config files")

--- a/libbeat/common/docker/client.go
+++ b/libbeat/common/docker/client.go
@@ -21,12 +21,12 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/elastic/beats/libbeat/logp"
-
 	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/client"
 	"golang.org/x/net/context"
+
+	"github.com/elastic/beats/libbeat/logp"
 )
 
 // NewClient builds and returns a new Docker client

--- a/libbeat/common/event.go
+++ b/libbeat/common/event.go
@@ -26,9 +26,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/elastic/beats/libbeat/logp"
-
 	"github.com/pkg/errors"
+
+	"github.com/elastic/beats/libbeat/logp"
 )
 
 const eventDebugSelector = "event"

--- a/libbeat/common/safemapstr/safemapstr_test.go
+++ b/libbeat/common/safemapstr/safemapstr_test.go
@@ -20,9 +20,9 @@ package safemapstr
 import (
 	"testing"
 
-	"github.com/elastic/beats/libbeat/common"
-
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/libbeat/common"
 )
 
 func TestPut(t *testing.T) {

--- a/libbeat/common/streambuf/streambuf.go
+++ b/libbeat/common/streambuf/streambuf.go
@@ -33,10 +33,10 @@
 package streambuf
 
 import (
-	"github.com/elastic/beats/libbeat/logp"
-
 	"bytes"
 	"errors"
+
+	"github.com/elastic/beats/libbeat/logp"
 )
 
 // Error returned if Append or Write operation is not allowed due to the buffer

--- a/libbeat/common/x509util/x509util_test.go
+++ b/libbeat/common/x509util/x509util_test.go
@@ -19,9 +19,8 @@ package x509util
 
 import (
 	"crypto/x509"
-	"testing"
-
 	"encoding/pem"
+	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/libbeat/logp/level.go
+++ b/libbeat/logp/level.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-
 	"go.uber.org/zap/zapcore"
 )
 

--- a/libbeat/monitoring/report/elasticsearch/elasticsearch.go
+++ b/libbeat/monitoring/report/elasticsearch/elasticsearch.go
@@ -22,10 +22,9 @@ import (
 	"io"
 	"math/rand"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
-
-	"strconv"
 
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"

--- a/libbeat/outputs/codec/common.go
+++ b/libbeat/outputs/codec/common.go
@@ -20,10 +20,9 @@ package codec
 import (
 	"time"
 
-	"github.com/elastic/go-structform"
-
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/dtfmt"
+	"github.com/elastic/go-structform"
 )
 
 func MakeTimestampEncoder() func(*time.Time, structform.ExtVisitor) error {

--- a/libbeat/outputs/codec/json/json.go
+++ b/libbeat/outputs/codec/json/json.go
@@ -21,12 +21,11 @@ import (
 	"bytes"
 	stdjson "encoding/json"
 
-	"github.com/elastic/go-structform/gotype"
-	"github.com/elastic/go-structform/json"
-
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/outputs/codec"
+	"github.com/elastic/go-structform/gotype"
+	"github.com/elastic/go-structform/json"
 )
 
 // Encoder for serializing a beat.Event to json.

--- a/libbeat/outputs/elasticsearch/api_mock_test.go
+++ b/libbeat/outputs/elasticsearch/api_mock_test.go
@@ -20,12 +20,11 @@
 package elasticsearch
 
 import (
-	"fmt"
-	"os"
-
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 

--- a/libbeat/outputs/elasticsearch/enc.go
+++ b/libbeat/outputs/elasticsearch/enc.go
@@ -24,12 +24,11 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/elastic/go-structform/gotype"
-	"github.com/elastic/go-structform/json"
-
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/outputs/codec"
+	"github.com/elastic/go-structform/gotype"
+	"github.com/elastic/go-structform/json"
 )
 
 type bodyEncoder interface {

--- a/libbeat/outputs/kafka/kafka_integration_test.go
+++ b/libbeat/outputs/kafka/kafka_integration_test.go
@@ -30,7 +30,6 @@ import (
 	"time"
 
 	"github.com/Shopify/sarama"
-
 	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/beats/libbeat/beat"
@@ -38,10 +37,9 @@ import (
 	"github.com/elastic/beats/libbeat/common/fmtstr"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/outputs"
-	"github.com/elastic/beats/libbeat/outputs/outest"
-
 	_ "github.com/elastic/beats/libbeat/outputs/codec/format"
 	_ "github.com/elastic/beats/libbeat/outputs/codec/json"
+	"github.com/elastic/beats/libbeat/outputs/outest"
 )
 
 const (

--- a/libbeat/outputs/logstash/client_test.go
+++ b/libbeat/outputs/logstash/client_test.go
@@ -24,15 +24,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/elastic/go-lumber/server/v2"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/outputs/outest"
 	"github.com/elastic/beats/libbeat/outputs/transport"
 	"github.com/elastic/beats/libbeat/outputs/transport/transptest"
-
-	"github.com/stretchr/testify/assert"
+	"github.com/elastic/go-lumber/server/v2"
 )
 
 const (

--- a/libbeat/outputs/logstash/logstash_test.go
+++ b/libbeat/outputs/logstash/logstash_test.go
@@ -25,13 +25,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/elastic/go-lumber/server/v2"
-
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/outputs"
 	"github.com/elastic/beats/libbeat/outputs/outest"
 	"github.com/elastic/beats/libbeat/outputs/transport/transptest"
+	"github.com/elastic/go-lumber/server/v2"
 )
 
 const (

--- a/libbeat/outputs/redis/redis_integration_test.go
+++ b/libbeat/outputs/redis/redis_integration_test.go
@@ -27,17 +27,15 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/garyburd/redigo/redis"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/outputs"
-	"github.com/elastic/beats/libbeat/outputs/outest"
-
 	_ "github.com/elastic/beats/libbeat/outputs/codec/format"
 	_ "github.com/elastic/beats/libbeat/outputs/codec/json"
+	"github.com/elastic/beats/libbeat/outputs/outest"
 )
 
 const (

--- a/libbeat/processors/actions/rename_test.go
+++ b/libbeat/processors/actions/rename_test.go
@@ -18,11 +18,10 @@
 package actions
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"reflect"
 
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"

--- a/libbeat/processors/add_docker_metadata/add_docker_metadata_test.go
+++ b/libbeat/processors/add_docker_metadata/add_docker_metadata_test.go
@@ -20,7 +20,6 @@ package add_docker_metadata
 import (
 	"fmt"
 	"os"
-	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"

--- a/libbeat/processors/add_docker_metadata/add_docker_metadata_test.go
+++ b/libbeat/processors/add_docker_metadata/add_docker_metadata_test.go
@@ -20,6 +20,7 @@ package add_docker_metadata
 import (
 	"fmt"
 	"os"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"

--- a/libbeat/processors/add_host_metadata/add_host_metadata_test.go
+++ b/libbeat/processors/add_host_metadata/add_host_metadata_test.go
@@ -18,12 +18,11 @@
 package add_host_metadata
 
 import (
+	"runtime"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
-
-	"runtime"
 
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"

--- a/libbeat/processors/processor_test.go
+++ b/libbeat/processors/processor_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/processors"
-
 	_ "github.com/elastic/beats/libbeat/processors/actions"
 	_ "github.com/elastic/beats/libbeat/processors/add_cloud_metadata"
 )

--- a/libbeat/publisher/includes/includes.go
+++ b/libbeat/publisher/includes/includes.go
@@ -19,18 +19,14 @@ package includes
 
 import (
 	// import queue types
-	_ "github.com/elastic/beats/libbeat/publisher/queue/memqueue"
-	_ "github.com/elastic/beats/libbeat/publisher/queue/spool"
-
-	// load supported output plugins
+	_ "github.com/elastic/beats/libbeat/outputs/codec/format"
+	_ "github.com/elastic/beats/libbeat/outputs/codec/json"
 	_ "github.com/elastic/beats/libbeat/outputs/console"
 	_ "github.com/elastic/beats/libbeat/outputs/elasticsearch"
 	_ "github.com/elastic/beats/libbeat/outputs/fileout"
 	_ "github.com/elastic/beats/libbeat/outputs/kafka"
 	_ "github.com/elastic/beats/libbeat/outputs/logstash"
 	_ "github.com/elastic/beats/libbeat/outputs/redis"
-
-	// load support output codec
-	_ "github.com/elastic/beats/libbeat/outputs/codec/format"
-	_ "github.com/elastic/beats/libbeat/outputs/codec/json"
+	_ "github.com/elastic/beats/libbeat/publisher/queue/memqueue"
+	_ "github.com/elastic/beats/libbeat/publisher/queue/spool"
 )

--- a/libbeat/publisher/pipeline/pipeline.go
+++ b/libbeat/publisher/pipeline/pipeline.go
@@ -25,13 +25,12 @@ import (
 	"sync"
 	"time"
 
-	"github.com/elastic/beats/libbeat/common/reload"
-	"github.com/elastic/beats/libbeat/monitoring"
-
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/atomic"
+	"github.com/elastic/beats/libbeat/common/reload"
 	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/monitoring"
 	"github.com/elastic/beats/libbeat/outputs"
 	"github.com/elastic/beats/libbeat/processors"
 	"github.com/elastic/beats/libbeat/publisher"

--- a/libbeat/publisher/pipeline/stress/stress_test.go
+++ b/libbeat/publisher/pipeline/stress/stress_test.go
@@ -31,8 +31,6 @@ import (
 
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
-
-	// import queue types
 	"github.com/elastic/beats/libbeat/publisher/pipeline/stress"
 	_ "github.com/elastic/beats/libbeat/publisher/queue/memqueue"
 	_ "github.com/elastic/beats/libbeat/publisher/queue/spool"

--- a/libbeat/publisher/queue/spool/codec.go
+++ b/libbeat/publisher/queue/spool/codec.go
@@ -22,15 +22,14 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/publisher"
 	"github.com/elastic/go-structform"
 	"github.com/elastic/go-structform/cborl"
 	"github.com/elastic/go-structform/gotype"
 	"github.com/elastic/go-structform/json"
 	"github.com/elastic/go-structform/ubjson"
-
-	"github.com/elastic/beats/libbeat/beat"
-	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/publisher"
 )
 
 type encoder struct {

--- a/libbeat/scripts/cmd/stress_pipeline/main.go
+++ b/libbeat/scripts/cmd/stress_pipeline/main.go
@@ -28,19 +28,15 @@ import (
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
 	logpcfg "github.com/elastic/beats/libbeat/logp/configure"
-	"github.com/elastic/beats/libbeat/paths"
-	"github.com/elastic/beats/libbeat/publisher/pipeline/stress"
-	"github.com/elastic/beats/libbeat/service"
-
-	// import queue types
-	_ "github.com/elastic/beats/libbeat/publisher/queue/memqueue"
-	_ "github.com/elastic/beats/libbeat/publisher/queue/spool"
-
-	// import outputs
 	_ "github.com/elastic/beats/libbeat/outputs/console"
 	_ "github.com/elastic/beats/libbeat/outputs/elasticsearch"
 	_ "github.com/elastic/beats/libbeat/outputs/fileout"
 	_ "github.com/elastic/beats/libbeat/outputs/logstash"
+	"github.com/elastic/beats/libbeat/paths"
+	"github.com/elastic/beats/libbeat/publisher/pipeline/stress"
+	_ "github.com/elastic/beats/libbeat/publisher/queue/memqueue"
+	_ "github.com/elastic/beats/libbeat/publisher/queue/spool"
+	"github.com/elastic/beats/libbeat/service"
 )
 
 var (

--- a/libbeat/service/service.go
+++ b/libbeat/service/service.go
@@ -23,6 +23,8 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"net/http"
+	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"runtime"
@@ -32,9 +34,6 @@ import (
 
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/monitoring"
-
-	"net/http"
-	_ "net/http/pprof"
 )
 
 // HandleSignals manages OS signals that ask the service/daemon to stop.

--- a/libbeat/template/load_integration_test.go
+++ b/libbeat/template/load_integration_test.go
@@ -24,12 +24,12 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/outputs/elasticsearch/estest"
 	"github.com/elastic/beats/libbeat/version"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestCheckTemplate(t *testing.T) {

--- a/libbeat/template/processor_test.go
+++ b/libbeat/template/processor_test.go
@@ -20,9 +20,9 @@ package template
 import (
 	"testing"
 
-	"github.com/elastic/beats/libbeat/common"
-
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/libbeat/common"
 )
 
 func TestProcessor(t *testing.T) {

--- a/libbeat/testing/mapvaltest/mapvaltest.go
+++ b/libbeat/testing/mapvaltest/mapvaltest.go
@@ -24,9 +24,8 @@ package mapvaltest
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/davecgh/go-spew/spew"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/mapval"

--- a/libbeat/tests/compose/wrapper.go
+++ b/libbeat/tests/compose/wrapper.go
@@ -24,11 +24,10 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/pkg/errors"
-
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/client"
+	"github.com/pkg/errors"
 )
 
 const (


### PR DESCRIPTION
Cherry-pick of PR #8980 to 6.5 branch. Original message: 

To smooth the path to updating goimports.