### PR TITLE
Propagate Sync error when running SafeFileRotate

### DIFF
--- a/libbeat/common/file/helper_other.go
+++ b/libbeat/common/file/helper_other.go
@@ -40,7 +40,6 @@ func SafeFileRotate(path, tempfile string) error {
 		return nil // ignore error
 	}
 	defer f.Close()
-	f.Sync()
 
-	return nil
+	return f.Sync()
 }


### PR DESCRIPTION
Previously, it was possible `SafeFileRotate` encountered an error without propagating it, because the return value of `os.Sync` was not utilized.
From now on the errors from `Sync` are propagated.