### PR TITLE
Cherry-pick #9067 to 6.4: Fix race condition when enriching events with Kubernetes metadata

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -37,6 +37,8 @@ https://github.com/elastic/beats/compare/v6.4.3...6.4[Check the HEAD diff]
 
 *Metricbeat*
 
+- Fix race condition when enriching events with kubernetes metadata. {issue}9055[9055] {issue}9067[9067]
+
 *Packetbeat*
 
 *Winlogbeat*

--- a/metricbeat/module/kubernetes/util/kubernetes.go
+++ b/metricbeat/module/kubernetes/util/kubernetes.go
@@ -294,6 +294,8 @@ func (m *enricher) Stop() {
 }
 
 func (m *enricher) Enrich(events []common.MapStr) {
+	m.RLock()
+	defer m.RUnlock()
 	for _, event := range events {
 		if meta := m.metadata[m.index(event)]; meta != nil {
 			event.DeepUpdate(common.MapStr{


### PR DESCRIPTION
Cherry-pick of PR #9067 to 6.4 branch. Original message: 

Fixes #9055 