### PR TITLE
Dashboard exporting saves to file in case of modules

### DIFF
--- a/filebeat/scripts/generator/dashboards.go
+++ b/filebeat/scripts/generator/dashboards.go
@@ -1,0 +1,89 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package generator
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/paths"
+)
+
+const (
+	dashboardEntry = `- id: %s
+  file: %s
+`
+)
+
+func AddModuleDashboard(beatName, module, kibanaVersion, dashboardID string, dashboard common.MapStr, suffix string) error {
+	version, err := common.NewVersion(kibanaVersion)
+	if err != nil {
+		return err
+	}
+	if version.Major < 6 {
+		return fmt.Errorf("saving exported dashboards is not available for Kibana version '%s'", version.String())
+	}
+
+	modulePath := filepath.Join(paths.Resolve(paths.Home, "module"), module)
+	stat, err := os.Stat(modulePath)
+	if err != nil || !stat.IsDir() {
+		return fmt.Errorf("no such module: %s\n", modulePath)
+	}
+
+	dashboardFile := strings.Title(beatName) + "-" + module + "-" + suffix + ".json"
+
+	err = saveDashboardToFile(version, dashboard, dashboardFile, modulePath)
+	if err != nil {
+		return fmt.Errorf("cannot save dashboard to file: %+v", err)
+	}
+
+	return addDashboardToModuleYML(dashboardID, dashboardFile, modulePath)
+}
+
+func saveDashboardToFile(version *common.Version, dashboard common.MapStr, dashboardFile, modulePath string) error {
+	dashboardsPath := "_meta/kibana/" + strconv.Itoa(version.Major) + "/dashboard"
+	err := CreateDirectories(modulePath, dashboardsPath)
+	if err != nil {
+		return err
+	}
+
+	dashboardPath := filepath.Join(modulePath, dashboardsPath, dashboardFile)
+	bytes, err := json.Marshal(dashboard)
+	if err != nil {
+		return err
+	}
+
+	return ioutil.WriteFile(dashboardPath, bytes, 0644)
+}
+
+func addDashboardToModuleYML(dashboardID, dashboardFile, modulePath string) error {
+	content := fmt.Sprintf(dashboardEntry, dashboardID, dashboardFile)
+
+	f, err := os.OpenFile(filepath.Join(modulePath, "module.yml"), os.O_WRONLY|os.O_APPEND, 0644)
+	if err == nil {
+		_, err = f.Write([]byte(content))
+	}
+
+	return err
+}

--- a/filebeat/scripts/generator/fileset/main.go
+++ b/filebeat/scripts/generator/fileset/main.go
@@ -32,7 +32,7 @@ func generateFileset(module, fileset, modulesPath, beatsPath string) error {
 		return fmt.Errorf("fileset already exists: %s", fileset)
 	}
 
-	err := generator.CreateDirectories(filesetPath, []string{"", "_meta", "test", "config", "ingest"})
+	err := generator.CreateDirectories(filesetPath, "", "_meta", "test", "config", "ingest")
 	if err != nil {
 		return err
 	}

--- a/filebeat/scripts/generator/generator.go
+++ b/filebeat/scripts/generator/generator.go
@@ -35,7 +35,7 @@ func DirExists(dir string) bool {
 }
 
 // CreateDirectories create directories in baseDir
-func CreateDirectories(baseDir string, directories []string) error {
+func CreateDirectories(baseDir string, directories ...string) error {
 	for _, d := range directories {
 		p := path.Join(baseDir, d)
 		err := os.MkdirAll(p, 0750)

--- a/filebeat/scripts/generator/module/main.go
+++ b/filebeat/scripts/generator/module/main.go
@@ -32,11 +32,6 @@ func generateModule(module, modulesPath, beatsPath string) error {
 		return fmt.Errorf("module already exists: %s", module)
 	}
 
-	err := generator.CreateDirectories(modulePath, []string{path.Join("_meta", "kibana", "6")})
-	if err != nil {
-		return err
-	}
-
 	replace := map[string]string{"module": module}
 	templatesPath := path.Join(beatsPath, "scripts", "module")
 	filesToCopy := []string{
@@ -45,7 +40,7 @@ func generateModule(module, modulesPath, beatsPath string) error {
 		path.Join("_meta", "config.yml"),
 		"module.yml",
 	}
-	generator.CopyTemplates(templatesPath, modulePath, filesToCopy, replace)
+	err := generator.CopyTemplates(templatesPath, modulePath, filesToCopy, replace)
 	if err != nil {
 		return err
 	}

--- a/filebeat/scripts/generator/module/main.go
+++ b/filebeat/scripts/generator/module/main.go
@@ -39,7 +39,12 @@ func generateModule(module, modulesPath, beatsPath string) error {
 
 	replace := map[string]string{"module": module}
 	templatesPath := path.Join(beatsPath, "scripts", "module")
-	filesToCopy := []string{path.Join("_meta", "fields.yml"), path.Join("_meta", "docs.asciidoc"), path.Join("_meta", "config.yml"), path.Join("module.yml")}
+	filesToCopy := []string{
+		path.Join("_meta", "fields.yml"),
+		path.Join("_meta", "docs.asciidoc"),
+		path.Join("_meta", "config.yml"),
+		"module.yml",
+	}
 	generator.CopyTemplates(templatesPath, modulePath, filesToCopy, replace)
 	if err != nil {
 		return err


### PR DESCRIPTION
Based on https://github.com/elastic/beats/pull/7506#discussion_r200923815

This PR adds two new flags to `export dashboard` command: `-module`, `-suffix`.
The flag `module` requires an existing module name. If it is set the command creates a `{modulename}/_meta/kibana/{kibanaversion}/dashboard` directories if missing. `{kibanaversion}` is the version of the Kibana instance the dashboard is downloaded from. After the directories are created, the dashboard is saved as `{Beatname}-{modulename}-{suffix}.json`. `-suffix` is not required, by default it is set to `"overview"`. Once the file is downloaded and saved, it is added to the `module.yml` of the module.

So from now on the module generator does not create kibana directories. It was unnecessary at that point, because not all modules come with dashboards.
The following recipe is the current hybrid (for a time being) process to create new modules:
```
$ make create-module MODULE=mymodule
$ make create-fileset MODULE=mymodule FILESET=myfileset
```
To export the dashboard the following command is called:
```
$ ./filebeat export dashboard -id {imagine-a-uuid-here} -module mymodule
```
This creates the the required directories, downloads the dashboard, saves it in the required file and adds it to `modules.yml`. Previously, all steps needed to be done manually except for the first two.

This only supported from Kibana 6.x. If someone wants to export dashboard from an earlier version, he/she has to follow this docs: https://www.elastic.co/guide/en/beats/devguide/current/export-dashboards.html#_exporting_kibana_5_x_dashboards

The behaviour of `export dashboard -id {imagine-a-uuid-here}` remains unchanged. Thus, no breaking changes are introduced.

I added the flags to `libbeat` to support all Beats which has similar module handling as Filebeat does. This will be also useful when modules/filesets of Filebeat are moved to libbeat.

### Limitations
- A new dashboard is added to `module.yml` whenever it is exported this way. There is no check if the UUID is unique in that file. A possible workaround is to delete all entries with the same UUID except for the last one. As it is the latest dashboard with that UUID. 

### TODO
- [ ] add either a unit test or an E2E test