### PR TITLE
Remove release state override

### DIFF
--- a/journalbeat/docs/index.asciidoc
+++ b/journalbeat/docs/index.asciidoc
@@ -18,8 +18,6 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 include::../../libbeat/docs/shared-beats-attributes.asciidoc[]
 
-:release-state: released
-
 include::./overview.asciidoc[]
 
 include::./getting-started.asciidoc[]

--- a/x-pack/functionbeat/docs/index.asciidoc
+++ b/x-pack/functionbeat/docs/index.asciidoc
@@ -26,8 +26,6 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 include::{libbeat-dir}/docs/shared-beats-attributes.asciidoc[]
 
-:release-state: released
-
 include::./overview.asciidoc[]
 
 include::./getting-started.asciidoc[]


### PR DESCRIPTION
Removes override that was added for testing purposes during development.

This PR needs to be back ported to 6.x and 6.5 because all branches should use the version specified in libbeat/docs/versions.asciidoc.