### PR TITLE
Add x-pack badge to functionbeat topics

### DIFF
--- a/x-pack/functionbeat/docs/config-options.asciidoc
+++ b/x-pack/functionbeat/docs/config-options.asciidoc
@@ -1,4 +1,5 @@
 [id="configuration-{beatname_lc}-options"]
+[role="xpack"]
 == Configure functions
 
 ++++

--- a/x-pack/functionbeat/docs/configuring-howto.asciidoc
+++ b/x-pack/functionbeat/docs/configuring-howto.asciidoc
@@ -1,4 +1,5 @@
 [id="configuring-howto-{beatname_lc}"]
+[role="xpack"]
 = Configuring {beatname_uc}
 
 [partintro]
@@ -33,33 +34,44 @@ include::./config-options.asciidoc[]
 include::./general-options.asciidoc[]
 
 :allplatforms:
+[role="xpack"]
 include::{libbeat-dir}/docs/queueconfig.asciidoc[]
 :allplatforms!:
 
+[role="xpack"]
 include::{libbeat-dir}/docs/outputconfig.asciidoc[]
 
+[role="xpack"]
 include::{libbeat-dir}/docs/shared-ssl-config.asciidoc[]
 
 include::./filtering.asciidoc[]
 
+[role="xpack"]
 include::{libbeat-dir}/docs/shared-config-ingest.asciidoc[]
 
+[role="xpack"]
 include::{libbeat-dir}/docs/shared-kibana-config.asciidoc[]
 
+[role="xpack"]
 include::{libbeat-dir}/docs/setup-config.asciidoc[]
 
+[role="xpack"]
 include::{libbeat-dir}/docs/loggingconfig.asciidoc[]
 
 :standalone:
+[role="xpack"]
 include::{libbeat-dir}/docs/shared-env-vars.asciidoc[]
 :standalone!:
 
 :standalone:
 :allplatforms:
+[role="xpack"]
 include::{libbeat-dir}/docs/yaml.asciidoc[]
 :standalone!:
 :allplatforms!:
 
+[role="xpack"]
 include::{libbeat-dir}/docs/regexp.asciidoc[]
 
+[role="xpack"]
 include::{libbeat-dir}/docs/reference-yml.asciidoc[]

--- a/x-pack/functionbeat/docs/faq.asciidoc
+++ b/x-pack/functionbeat/docs/faq.asciidoc
@@ -1,4 +1,5 @@
 [[faq]]
+[role="xpack"]
 == Frequently asked questions
 
 This section contains frequently asked questions about {beatname_uc}. Also check

--- a/x-pack/functionbeat/docs/filtering.asciidoc
+++ b/x-pack/functionbeat/docs/filtering.asciidoc
@@ -1,4 +1,5 @@
 [[filtering-and-enhancing-data]]
+[role="xpack"]
 == Filter and enhance the exported data
 
 Your use case might require only a subset of the data exported by {beatname_uc},

--- a/x-pack/functionbeat/docs/general-options.asciidoc
+++ b/x-pack/functionbeat/docs/general-options.asciidoc
@@ -1,4 +1,5 @@
 [[configuration-general-options]]
+[role="xpack"]
 == Specify general settings
 
 You can specify settings in the +{beatname_lc}.yml+ config file to control the

--- a/x-pack/functionbeat/docs/getting-started.asciidoc
+++ b/x-pack/functionbeat/docs/getting-started.asciidoc
@@ -1,4 +1,5 @@
 [id="{beatname_lc}-getting-started"]
+[role="xpack"]
 == Getting Started With {beatname_uc}
 
 include::{libbeat-dir}/docs/shared-getting-started-intro.asciidoc[]
@@ -10,6 +11,7 @@ include::{libbeat-dir}/docs/shared-getting-started-intro.asciidoc[]
 * <<view-kibana-dashboards>>
 
 [id="{beatname_lc}-installation"]
+[role="xpack"]
 === Step 1: Download the {beatname_uc} package
 
 The {beatname_uc} package contains the command line tools, configuration file,
@@ -75,6 +77,7 @@ https://www.elastic.co/downloads/beats/{beatname_lc}[downloads page].
 endif::[]
 
 [id="{beatname_lc}-configuration"]
+[role="xpack"]
 === Step 2: Configure {beatname_uc}
 
 Before deploying {beatname_uc} to your serverless environment, you need to
@@ -153,12 +156,14 @@ include::{libbeat-dir}/docs/step-test-config.asciidoc[]
 include::{libbeat-dir}/docs/step-look-at-config.asciidoc[]
 
 [id="{beatname_lc}-template"]
+[role="xpack"]
 === Step 3: Load the index template in Elasticsearch
 
 :allplatforms:
 include::{libbeat-dir}/docs/shared-template-load.asciidoc[]
 
 [id="{beatname_lc}-deploying"]
+[role="xpack"]
 === Step 4: Deploy {beatname_uc} code to your serverless environment
 
 Before deploying functions to your serverless environment, make sure your user
@@ -208,6 +213,7 @@ TIP: If you change the configuration after deploying the function, use
 the <<update-command,`update` command>> to update your deployment.
 
 [[view-kibana-dashboards]]
+[role="xpack"]
 === Step 5: View your data in Kibana
 
 There are currently no example dashboards available for {beatname_uc}.

--- a/x-pack/functionbeat/docs/index.asciidoc
+++ b/x-pack/functionbeat/docs/index.asciidoc
@@ -36,10 +36,13 @@ include::./setting-up-running.asciidoc[]
 
 include::./configuring-howto.asciidoc[]
 
+[role="xpack"]
 include::./fields.asciidoc[]
 
+[role="xpack"]
 include::{libbeat-dir}/docs/monitoring/monitoring-beats.asciidoc[]
 
+[role="xpack"]
 include::{libbeat-dir}/docs/shared-securing-beat.asciidoc[]
 
 include::./troubleshooting.asciidoc[]

--- a/x-pack/functionbeat/docs/overview.asciidoc
+++ b/x-pack/functionbeat/docs/overview.asciidoc
@@ -1,4 +1,5 @@
 [id="{beatname_lc}-overview"]
+[role="xpack"]
 == {beatname_uc} overview
 
 ++++

--- a/x-pack/functionbeat/docs/setting-up-running.asciidoc
+++ b/x-pack/functionbeat/docs/setting-up-running.asciidoc
@@ -5,6 +5,7 @@
 /////
 
 [[setting-up-and-running]]
+[role="xpack"]
 == Setting up and running {beatname_uc}
 
 Before reading this section, see the
@@ -23,8 +24,11 @@ This section includes additional information on how to set up and run
 
 //MAINTAINERS: If you add a new file to this section, make sure you update the bulleted list ^^ too.
 
+[role="xpack"]
 include::{libbeat-dir}/docs/shared-directory-layout.asciidoc[]
 
+[role="xpack"]
 include::{libbeat-dir}/docs/keystore.asciidoc[]
 
+[role="xpack"]
 include::{libbeat-dir}/docs/command-reference.asciidoc[]

--- a/x-pack/functionbeat/docs/troubleshooting.asciidoc
+++ b/x-pack/functionbeat/docs/troubleshooting.asciidoc
@@ -1,4 +1,5 @@
 [[troubleshooting]]
+[role="xpack"]
 = Troubleshooting
 
 [partintro]
@@ -15,6 +16,7 @@ following tips:
 --
 
 [[getting-help]]
+[role="xpack"]
 == Get help
 
 include::{libbeat-dir}/docs/getting-help.asciidoc[]
@@ -22,6 +24,7 @@ include::{libbeat-dir}/docs/getting-help.asciidoc[]
 //sets block macro for debugging.asciidoc included in next section
 
 [id="enable-{beatname_lc}-debugging"]
+[role="xpack"]
 == Debug
 
 include::{libbeat-dir}/docs/debugging.asciidoc[]


### PR DESCRIPTION
The x-pack "badge" created by the xpack role is the only way we have right now of flagging content about features that require a license.

The best I can do for now is to add x-pack labels to most of the sections. I can use some conditional coding to add the x-pack role to topics that come from the shared files in libbeat, but I wonder if it's worth the effort.  We need a better way to flag the whole book.