### PR TITLE
[WIP] Unify heartbeat jobs and tasks for simplicity

### DIFF
--- a/heartbeat/monitors/active/dialchain/builder.go
+++ b/heartbeat/monitors/active/dialchain/builder.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/elastic/beats/heartbeat/monitors"
+	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/outputs/transport"
 )
@@ -96,7 +97,7 @@ func (b *Builder) AddLayer(l Layer) {
 // Build create a new dialer, that will always use the constant address, no matter
 // which address is used to connect using the dialer.
 // The dialer chain will add per layer information to the given event.
-func (b *Builder) Build(addr string, event common.MapStr) (transport.Dialer, error) {
+func (b *Builder) Build(addr string, event *beat.Event) (transport.Dialer, error) {
 	// clone template, as multiple instance of a dialer can exist at the same time
 	dchain := b.template.Clone()
 
@@ -111,16 +112,18 @@ func (b *Builder) Build(addr string, event common.MapStr) (transport.Dialer, err
 // Run executes the given function with a new dialer instance.
 func (b *Builder) Run(
 	addr string,
-	fn func(transport.Dialer) (common.MapStr, error),
-) (common.MapStr, error) {
-	event := common.MapStr{}
+	fn func(transport.Dialer) (*beat.Event, error),
+) (*beat.Event, error) {
+	event := &beat.Event{}
 	dialer, err := b.Build(addr, event)
 	if err != nil {
 		return nil, err
 	}
 
 	results, err := fn(dialer)
-	event.DeepUpdate(results)
+	if results != nil {
+		monitors.MergeEventFields(event, results.Fields)
+	}
 	return event, err
 }
 
@@ -134,7 +137,7 @@ func MakeDialerJobs(
 	typ, scheme string,
 	endpoints []Endpoint,
 	mode monitors.IPSettings,
-	fn func(dialer transport.Dialer, addr string) (common.MapStr, error),
+	fn func(dialer transport.Dialer, addr string) (*beat.Event, error),
 ) ([]monitors.Job, error) {
 	var jobs []monitors.Job
 	for _, endpoint := range endpoints {
@@ -153,7 +156,7 @@ func makeEndpointJobs(
 	typ, scheme string,
 	endpoint Endpoint,
 	mode monitors.IPSettings,
-	fn func(transport.Dialer, string) (common.MapStr, error),
+	fn func(transport.Dialer, string) (*beat.Event, error),
 ) ([]monitors.Job, error) {
 
 	fields := common.MapStr{
@@ -172,8 +175,8 @@ func makeEndpointJobs(
 			jobName := jobName(typ, scheme, endpoint.Host, []uint16{port})
 			address := net.JoinHostPort(endpoint.Host, strconv.Itoa(int(port)))
 			settings := monitors.MakeJobSetting(jobName).WithFields(fields)
-			jobs[i] = monitors.MakeSimpleJob(settings, func() (common.MapStr, error) {
-				return b.Run(address, func(dialer transport.Dialer) (common.MapStr, error) {
+			jobs[i] = monitors.MakeSimpleJob(settings, func() (*beat.Event, error) {
+				return b.Run(address, func(dialer transport.Dialer) (*beat.Event, error) {
 					return fn(dialer, address)
 				})
 			})
@@ -187,12 +190,12 @@ func makeEndpointJobs(
 	settings := monitors.MakeHostJobSettings(jobName, endpoint.Host, mode).WithFields(fields)
 	job, err := monitors.MakeByHostJob(settings,
 		monitors.MakePingAllIPPortFactory(endpoint.Ports,
-			func(ip *net.IPAddr, port uint16) (common.MapStr, error) {
+			func(ip *net.IPAddr, port uint16) (*beat.Event, error) {
 				// use address from resolved IP
 				portStr := strconv.Itoa(int(port))
 				ipAddr := net.JoinHostPort(ip.String(), portStr)
 				hostAddr := net.JoinHostPort(endpoint.Host, portStr)
-				return b.Run(ipAddr, func(dialer transport.Dialer) (common.MapStr, error) {
+				return b.Run(ipAddr, func(dialer transport.Dialer) (*beat.Event, error) {
 					return fn(dialer, hostAddr)
 				})
 			}))

--- a/heartbeat/monitors/active/dialchain/net.go
+++ b/heartbeat/monitors/active/dialchain/net.go
@@ -23,7 +23,10 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/elastic/beats/heartbeat/monitors"
+
 	"github.com/elastic/beats/heartbeat/look"
+	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/outputs/transport"
@@ -64,7 +67,7 @@ func UDPDialer(to time.Duration) NetDialer {
 }
 
 func netDialer(timeout time.Duration) NetDialer {
-	return func(event common.MapStr) (transport.Dialer, error) {
+	return func(event *beat.Event) (transport.Dialer, error) {
 		return makeDialer(func(network, address string) (net.Conn, error) {
 			namespace := ""
 
@@ -86,7 +89,7 @@ func netDialer(timeout time.Duration) NetDialer {
 			if err != nil || portNum < 0 || portNum > (1<<16) {
 				return nil, fmt.Errorf("invalid port number '%v' used", port)
 			}
-			event.DeepUpdate(common.MapStr{
+			monitors.MergeEventFields(event, common.MapStr{
 				namespace: common.MapStr{
 					"port": uint16(portNum),
 				},
@@ -108,7 +111,7 @@ func netDialer(timeout time.Duration) NetDialer {
 			}
 
 			end := time.Now()
-			event.DeepUpdate(common.MapStr{
+			monitors.MergeEventFields(event, common.MapStr{
 				namespace: common.MapStr{
 					"rtt": common.MapStr{
 						"connect": look.RTT(end.Sub(start)),

--- a/heartbeat/monitors/active/dialchain/socks5.go
+++ b/heartbeat/monitors/active/dialchain/socks5.go
@@ -20,8 +20,9 @@ package dialchain
 import (
 	"net"
 
+	"github.com/elastic/beats/libbeat/beat"
+
 	"github.com/elastic/beats/heartbeat/look"
-	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/outputs/transport"
 )
 
@@ -35,7 +36,7 @@ import (
 //    }
 //  }
 func SOCKS5Layer(config *transport.ProxyConfig) Layer {
-	return func(event common.MapStr, next transport.Dialer) (transport.Dialer, error) {
+	return func(event *beat.Event, next transport.Dialer) (transport.Dialer, error) {
 		var timer timer
 
 		dialer, err := transport.ProxyDialer(config, startTimerAfterDial(&timer, next))
@@ -48,7 +49,7 @@ func SOCKS5Layer(config *transport.ProxyConfig) Layer {
 			// TODO: add proxy url to event?
 
 			timer.stop()
-			event.Put("socks5.rtt.connect", look.RTT(timer.duration()))
+			event.Fields.Put("socks5.rtt.connect", look.RTT(timer.duration()))
 			return conn, nil
 		}), nil
 	}

--- a/heartbeat/monitors/active/dialchain/tls.go
+++ b/heartbeat/monitors/active/dialchain/tls.go
@@ -24,7 +24,7 @@ import (
 	"time"
 
 	"github.com/elastic/beats/heartbeat/look"
-	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/outputs/transport"
 )
 
@@ -38,7 +38,7 @@ import (
 //    }
 //  }
 func TLSLayer(cfg *transport.TLSConfig, to time.Duration) Layer {
-	return func(event common.MapStr, next transport.Dialer) (transport.Dialer, error) {
+	return func(event *beat.Event, next transport.Dialer) (transport.Dialer, error) {
 		var timer timer
 
 		// Wrap next dialer so to start the timer when 'next' returns.
@@ -58,7 +58,7 @@ func TLSLayer(cfg *transport.TLSConfig, to time.Duration) Layer {
 
 			// TODO: extract TLS connection parameters from connection object.
 			timer.stop()
-			event.Put("tls.rtt.handshake", look.RTT(timer.duration()))
+			event.Fields.Put("tls.rtt.handshake", look.RTT(timer.duration()))
 
 			// Pointers because we need a nil value
 			var chainNotValidBefore *time.Time
@@ -80,8 +80,8 @@ func TLSLayer(cfg *transport.TLSConfig, to time.Duration) Layer {
 				}
 			}
 
-			event.Put("tls.certificate_not_valid_before", *chainNotValidBefore)
-			event.Put("tls.certificate_not_valid_after", *chainNotValidAfter)
+			event.Fields.Put("tls.certificate_not_valid_before", *chainNotValidBefore)
+			event.Fields.Put("tls.certificate_not_valid_after", *chainNotValidAfter)
 
 			return conn, nil
 		}), nil

--- a/heartbeat/monitors/active/dialchain/util.go
+++ b/heartbeat/monitors/active/dialchain/util.go
@@ -21,7 +21,7 @@ import (
 	"net"
 	"time"
 
-	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/outputs/transport"
 )
 
@@ -34,7 +34,7 @@ func IDLayer() Layer {
 	return _idLayer
 }
 
-var _idLayer = Layer(func(event common.MapStr, next transport.Dialer) (transport.Dialer, error) {
+var _idLayer = Layer(func(event *beat.Event, next transport.Dialer) (transport.Dialer, error) {
 	return next, nil
 })
 
@@ -43,7 +43,7 @@ var _idLayer = Layer(func(event common.MapStr, next transport.Dialer) (transport
 func ConstAddrLayer(address string) Layer {
 	build := constAddr(address)
 
-	return func(event common.MapStr, next transport.Dialer) (transport.Dialer, error) {
+	return func(event *beat.Event, next transport.Dialer) (transport.Dialer, error) {
 		return build(next), nil
 	}
 }
@@ -108,7 +108,7 @@ func constAddr(addr string) func(transport.Dialer) transport.Dialer {
 }
 
 func withNetDialer(layer NetDialer, fn func(transport.Dialer) transport.Dialer) NetDialer {
-	return func(event common.MapStr) (transport.Dialer, error) {
+	return func(event *beat.Event) (transport.Dialer, error) {
 		origDialer, err := layer.build(event)
 		if err != nil {
 			return nil, err
@@ -118,7 +118,7 @@ func withNetDialer(layer NetDialer, fn func(transport.Dialer) transport.Dialer) 
 }
 
 func withLayerDialer(layer Layer, fn func(transport.Dialer) transport.Dialer) Layer {
-	return func(event common.MapStr, next transport.Dialer) (transport.Dialer, error) {
+	return func(event *beat.Event, next transport.Dialer) (transport.Dialer, error) {
 		origDialer, err := layer.build(event, next)
 		if err != nil {
 			return nil, err

--- a/heartbeat/monitors/active/http/http_test.go
+++ b/heartbeat/monitors/active/http/http_test.go
@@ -40,13 +40,13 @@ import (
 	"github.com/elastic/beats/libbeat/testing/mapvaltest"
 )
 
-func testRequest(t *testing.T, testURL string) beat.Event {
+func testRequest(t *testing.T, testURL string) *beat.Event {
 	return testTLSRequest(t, testURL, nil)
 }
 
 // testTLSRequest tests the given request. certPath is optional, if given
 // an empty string no cert will be set.
-func testTLSRequest(t *testing.T, testURL string, extraConfig map[string]interface{}) beat.Event {
+func testTLSRequest(t *testing.T, testURL string, extraConfig map[string]interface{}) *beat.Event {
 	configSrc := map[string]interface{}{
 		"urls":    testURL,
 		"timeout": "1s",
@@ -74,7 +74,7 @@ func testTLSRequest(t *testing.T, testURL string, extraConfig map[string]interfa
 	return event
 }
 
-func checkServer(t *testing.T, handlerFunc http.HandlerFunc) (*httptest.Server, beat.Event) {
+func checkServer(t *testing.T, handlerFunc http.HandlerFunc) (*httptest.Server, *beat.Event) {
 	server := httptest.NewServer(handlerFunc)
 	defer server.Close()
 	event := testRequest(t, server.URL)

--- a/heartbeat/monitors/active/icmp/icmp.go
+++ b/heartbeat/monitors/active/icmp/icmp.go
@@ -21,11 +21,12 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/beat"
 
 	"github.com/elastic/beats/heartbeat/look"
 	"github.com/elastic/beats/heartbeat/monitors"
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
 )
 
 func init() {
@@ -96,16 +97,16 @@ func create(
 	return jobs, len(config.Hosts), nil
 }
 
-func createPingIPFactory(config *Config) func(*net.IPAddr) (common.MapStr, error) {
-	return func(ip *net.IPAddr) (common.MapStr, error) {
+func createPingIPFactory(config *Config) func(*net.IPAddr) (*beat.Event, error) {
+	return func(ip *net.IPAddr) (*beat.Event, error) {
 		rtt, n, err := loop.ping(ip, config.Timeout, config.Wait)
 
-		fields := common.MapStr{"requests": n}
+		icmpFields := common.MapStr{"requests": n}
 		if err == nil {
-			fields["rtt"] = look.RTT(rtt)
+			icmpFields["rtt"] = look.RTT(rtt)
 		}
 
-		event := common.MapStr{"icmp": fields}
+		event := &beat.Event{Fields: common.MapStr{"icmp": icmpFields}}
 		return event, err
 	}
 }

--- a/heartbeat/monitors/active/tcp/tcp.go
+++ b/heartbeat/monitors/active/tcp/tcp.go
@@ -23,13 +23,13 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/elastic/beats/heartbeat/monitors"
+	"github.com/elastic/beats/heartbeat/monitors/active/dialchain"
+	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/outputs"
 	"github.com/elastic/beats/libbeat/outputs/transport"
-
-	"github.com/elastic/beats/heartbeat/monitors"
-	"github.com/elastic/beats/heartbeat/monitors/active/dialchain"
 )
 
 func init() {
@@ -88,7 +88,7 @@ func create(
 		}
 
 		epJobs, err := dialchain.MakeDialerJobs(db, typ, scheme, eps, config.Mode,
-			func(dialer transport.Dialer, addr string) (common.MapStr, error) {
+			func(dialer transport.Dialer, addr string) (*beat.Event, error) {
 				return pingHost(dialer, addr, timeout, validator)
 			})
 		if err != nil {

--- a/heartbeat/monitors/active/tcp/tcp_test.go
+++ b/heartbeat/monitors/active/tcp/tcp_test.go
@@ -55,7 +55,7 @@ func testTCPCheck(t *testing.T, host string, port uint16) *beat.Event {
 
 	require.Equal(t, 1, endpoints)
 
-	return &event
+	return event
 }
 
 func testTLSTCPCheck(t *testing.T, host string, port uint16, certFileName string) *beat.Event {
@@ -77,7 +77,7 @@ func testTLSTCPCheck(t *testing.T, host string, port uint16, certFileName string
 
 	require.Equal(t, 1, endpoints)
 
-	return &event
+	return event
 }
 
 func setupServer(t *testing.T, serverCreator func(http.Handler) *httptest.Server) (*httptest.Server, uint16) {

--- a/heartbeat/monitors/job.go
+++ b/heartbeat/monitors/job.go
@@ -24,7 +24,7 @@ import (
 // Job represents the work done by a single check by a given Monitor.
 type Job interface {
 	Name() string
-	Run() (beat.Event, []jobRunner, error)
+	Run() (*beat.Event, []JobRunner, error)
 }
 
-type jobRunner func() (beat.Event, []jobRunner, error)
+type JobRunner func() (*beat.Event, []JobRunner, error)

--- a/heartbeat/monitors/task.go
+++ b/heartbeat/monitors/task.go
@@ -80,7 +80,7 @@ func newTask(job Job, config taskConfig, monitor *Monitor) (*task, error) {
 	return t, nil
 }
 
-func (t *task) prepareSchedulerJob(meta common.MapStr, run jobRunner) scheduler.TaskFunc {
+func (t *task) prepareSchedulerJob(meta common.MapStr, run JobRunner) scheduler.TaskFunc {
 	return func() []scheduler.TaskFunc {
 		event, next, err := run()
 		if err != nil {
@@ -88,8 +88,8 @@ func (t *task) prepareSchedulerJob(meta common.MapStr, run jobRunner) scheduler.
 		}
 
 		if event.Fields != nil {
-			event.Fields.DeepUpdate(meta)
-			t.client.Publish(event)
+			MergeEventFields(event, meta)
+			t.client.Publish(*event)
 		}
 
 		if len(next) == 0 {

--- a/libbeat/beat/event.go
+++ b/libbeat/beat/event.go
@@ -77,3 +77,13 @@ func (e *Event) PutValue(key string, v interface{}) (interface{}, error) {
 func (e *Event) Delete(key string) error {
 	return e.Fields.Delete(key)
 }
+
+// Copies the event. NOTE: Private data is not copied
+func (e *Event) Clone() *Event {
+	return &Event{
+		e.Timestamp,
+		e.Meta.Clone(),
+		e.Fields.Clone(),
+		nil,
+	}
+}


### PR DESCRIPTION
In heartbeat we have separate notions of jobs and tasks.

This can make following the code and sharing the code among monitors confusing. This patch unifies the two. There is a tiny amount of extra execution overhead.

Tasks only passed a single `common.MapStr`, where we now pass a `*beat.Event`, however, the benefit is that we have a more consistent and simple codebase.