### PR TITLE
Backport to 6.x: Remove release state override (#9080)

### DIFF
--- a/journalbeat/docs/index.asciidoc
+++ b/journalbeat/docs/index.asciidoc
@@ -18,8 +18,6 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 include::../../libbeat/docs/shared-beats-attributes.asciidoc[]
 
-:release-state: released
-
 include::./overview.asciidoc[]
 
 include::./getting-started.asciidoc[]

--- a/x-pack/functionbeat/docs/index.asciidoc
+++ b/x-pack/functionbeat/docs/index.asciidoc
@@ -25,8 +25,6 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 include::{libbeat-dir}/docs/shared-beats-attributes.asciidoc[]
 
-:release-state: released
-
 include::./overview.asciidoc[]
 
 include::./getting-started.asciidoc[]


### PR DESCRIPTION
Cherry-picks #9080 into 6.x branch.