### PR TITLE
Cherry-pick #9068 to 6.x: Add tests for etcd 3.3 on metricbeat module

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -78,6 +78,7 @@ https://github.com/elastic/beats/compare/v6.5.0...6.x[Check the HEAD diff]
 *Metricbeat*
 
 - Collect custom cluster `display_name` in `elasticsearch/cluster_stats` metricset. {pull}8445[8445]
+- Test etcd module with etcd 3.3. {pull}9068[9068]
 
 *Packetbeat*
 

--- a/metricbeat/docker-compose.yml
+++ b/metricbeat/docker-compose.yml
@@ -76,6 +76,12 @@ services:
   etcd:
     build: ./module/etcd/_meta
 
+  etcd_3_2:
+    build:
+      context: ./module/etcd/_meta
+      args:
+        ETCD_VERSION: v3.2.25
+
   haproxy:
     build: ./module/haproxy/_meta
 

--- a/metricbeat/docs/modules/etcd.asciidoc
+++ b/metricbeat/docs/modules/etcd.asciidoc
@@ -14,7 +14,7 @@ The default metricsets are `leader`, `self` and `store`.
 [float]
 === Compatibility
 
-The etcd module is tested with etcd 3.2.
+The etcd module is tested with etcd 3.2 and 3.3.
 
 
 [float]

--- a/metricbeat/module/etcd/_meta/Dockerfile
+++ b/metricbeat/module/etcd/_meta/Dockerfile
@@ -1,3 +1,4 @@
-FROM quay.io/coreos/etcd:v3.2
+ARG ETCD_VERSION=v3.3.10
+FROM quay.io/coreos/etcd:$ETCD_VERSION
 HEALTHCHECK --interval=1s --retries=90 CMD wget -O - http://localhost:2379/health | grep true
 CMD ["/usr/local/bin/etcd", "--advertise-client-urls", "http://0.0.0.0:2379,http://0.0.0.0:4001", "--listen-client-urls", "http://0.0.0.0:2379,http://0.0.0.0:4001"]

--- a/metricbeat/module/etcd/_meta/docs.asciidoc
+++ b/metricbeat/module/etcd/_meta/docs.asciidoc
@@ -5,4 +5,4 @@ The default metricsets are `leader`, `self` and `store`.
 [float]
 === Compatibility
 
-The etcd module is tested with etcd 3.2.
+The etcd module is tested with etcd 3.2 and 3.3.

--- a/metricbeat/module/etcd/test_etcd.py
+++ b/metricbeat/module/etcd/test_etcd.py
@@ -1,0 +1,33 @@
+import os
+import sys
+import unittest
+import time
+from parameterized import parameterized
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '../../tests/system'))
+
+import metricbeat
+
+
+class Test(metricbeat.BaseTest):
+    COMPOSE_SERVICES = ['etcd']
+
+    @parameterized.expand([
+        "leader",
+        "self",
+        "store",
+    ])
+    @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
+    def test_metricset(self, metricset):
+        """
+        etcd metricset tests
+        """
+        self.check_metricset("etcd", metricset, self.get_hosts(), ['etcd.' + metricset])
+
+    def get_hosts(self):
+        return [self.compose_hosts()[0] + ':' +
+                os.getenv('ETCD_PORT', '2379')]
+
+
+class Test_3_2(Test):
+    COMPOSE_SERVICES = ['etcd_3_2']


### PR DESCRIPTION
Cherry-pick of PR #9068 to 6.x branch. Original message: 

