### PR TITLE
Cherry-pick #9003 to 6.x: Check license for CCR before attempting to fetch stats

### DIFF
--- a/metricbeat/module/elasticsearch/elasticsearch.go
+++ b/metricbeat/module/elasticsearch/elasticsearch.go
@@ -59,6 +59,23 @@ type NodeInfo struct {
 	ID               string
 }
 
+// License contains data about the Elasticsearch license
+type License struct {
+	Status            string    `json:"status"`
+	ID                string    `json:"uid"`
+	Type              string    `json:"type"`
+	IssueDate         time.Time `json:"issue_date"`
+	IssueDateInMillis int       `json:"issue_date_in_millis"`
+	MaxNodes          int       `json:"max_nodes"`
+	IssuedTo          string    `json:"issued_to"`
+	Issuer            string    `json:"issuer"`
+	StartDateInMillis int       `json:"start_date_in_millis"`
+}
+
+type licenseWrapper struct {
+	License License `json:"license"`
+}
+
 // GetClusterID fetches cluster id for given nodeID.
 func GetClusterID(http *helper.HTTP, uri string, nodeID string) (string, error) {
 	// Check if cluster id already cached. If yes, return it.
@@ -187,7 +204,7 @@ func GetNodeInfo(http *helper.HTTP, uri string, nodeID string) (*NodeInfo, error
 // GetLicense returns license information. Since we don't expect license information
 // to change frequently, the information is cached for 1 minute to avoid
 // hitting Elasticsearch frequently.
-func GetLicense(http *helper.HTTP, resetURI string) (common.MapStr, error) {
+func GetLicense(http *helper.HTTP, resetURI string) (*License, error) {
 	// First, check the cache
 	license := licenseCache.get()
 
@@ -198,23 +215,14 @@ func GetLicense(http *helper.HTTP, resetURI string) (common.MapStr, error) {
 			return nil, err
 		}
 
-		var data common.MapStr
+		var data licenseWrapper
 		err = json.Unmarshal(content, &data)
 		if err != nil {
 			return nil, err
 		}
 
-		l, err := data.GetValue("license")
-		if err != nil {
-			return nil, err
-		}
-		license, ok := l.(map[string]interface{})
-		if !ok {
-			return nil, elastic.MakeErrorForMissingField("license", elastic.Elasticsearch)
-		}
-
 		// Cache license for a minute
-		licenseCache.set(license, time.Minute)
+		licenseCache.set(&data.License, time.Minute)
 	}
 
 	return licenseCache.get(), nil
@@ -332,23 +340,17 @@ func MergeClusterSettings(clusterSettings common.MapStr) (common.MapStr, error) 
 	return settings, nil
 }
 
-// IsCCRStatsAPIAvailable returns whether the CCR stats API is available in the given version
-// of Elasticsearch.
-func IsCCRStatsAPIAvailable(currentElasticsearchVersion string) (bool, error) {
-	return elastic.IsFeatureAvailable(currentElasticsearchVersion, CCRStatsAPIAvailableVersion)
-}
-
 // Global cache for license information. Assumption is that license information changes infrequently.
 var licenseCache = &_licenseCache{}
 
 type _licenseCache struct {
 	sync.RWMutex
-	license  common.MapStr
+	license  *License
 	cachedOn time.Time
 	ttl      time.Duration
 }
 
-func (c *_licenseCache) get() common.MapStr {
+func (c *_licenseCache) get() *License {
 	c.Lock()
 	defer c.Unlock()
 
@@ -360,13 +362,26 @@ func (c *_licenseCache) get() common.MapStr {
 	return c.license
 }
 
-func (c *_licenseCache) set(license common.MapStr, ttl time.Duration) {
+func (c *_licenseCache) set(license *License, ttl time.Duration) {
 	c.Lock()
 	defer c.Unlock()
 
 	c.license = license
 	c.ttl = ttl
 	c.cachedOn = time.Now()
+}
+
+// IsOneOf returns whether the license is one of the specified candidate licenses
+func (l *License) IsOneOf(candidateLicenses ...string) bool {
+	t := l.Type
+
+	for _, candidateLicense := range candidateLicenses {
+		if candidateLicense == t {
+			return true
+		}
+	}
+
+	return false
 }
 
 func getSettingGroup(allSettings common.MapStr, groupKey string) (common.MapStr, error) {

--- a/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
+++ b/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/tests/compose"
+	"github.com/elastic/beats/metricbeat/helper/elastic"
 	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
 	"github.com/elastic/beats/metricbeat/module/elasticsearch"
 	_ "github.com/elastic/beats/metricbeat/module/elasticsearch/ccr"
@@ -242,7 +243,7 @@ func checkSkip(t *testing.T, metricset string, host string) {
 		t.Fatal("getting elasticsearch version", err)
 	}
 
-	isCCRStatsAPIAvailable, err := elasticsearch.IsCCRStatsAPIAvailable(version)
+	isCCRStatsAPIAvailable, err := elastic.IsFeatureAvailable(version, elasticsearch.CCRStatsAPIAvailableVersion)
 	if err != nil {
 		t.Fatal("checking if elasticsearch CCR stats API is available", err)
 	}


### PR DESCRIPTION
Cherry-pick of PR #9003 to 6.x branch. Original message: 

Resolves #8915.

This PR teaches the `Fetch()` method of the `elasticsearch/ccr` metricset to first check if the CCR feature is available per the current Elasticsearch license. If it isn't, the metricset logs+reports an **actionable** error message **every minute**.

Before this PR, there was no such check so the call to the CCR stats API would simply fail with a 403 error from Elasticsearch if Elasticsearch wasn't using a Trial or Platinum license. That unhelpful 403 error would get logged+reported every 10s (or whatever `period` the metricset was configured to).

## Before this PR

### In the `metricbeat` logs:

<img width="839" alt="screen shot 2018-11-08 at 4 42 28 pm" src="https://user-images.githubusercontent.com/51061/48236039-5fa30c80-e375-11e8-8d9d-64c4861fb35d.png">


### In the `metricbeat-*` index:

<img width="1491" alt="screen shot 2018-11-08 at 4 42 38 pm" src="https://user-images.githubusercontent.com/51061/48236036-5b76ef00-e375-11e8-9a21-7cde7620c80b.png">


## After this PR

### In the `metricbeat` logs:

<img width="1236" alt="screen shot 2018-11-08 at 4 35 19 pm" src="https://user-images.githubusercontent.com/51061/48235932-e4415b00-e374-11e8-8b39-a60e4fe87279.png">

### In the `metricbeat-*` index:

<img width="1495" alt="screen shot 2018-11-08 at 4 37 27 pm" src="https://user-images.githubusercontent.com/51061/48235909-d095f480-e374-11e8-9eea-718c0deacafa.png">
