### PR TITLE
Add Central Management blacklisting

### DIFF
--- a/x-pack/libbeat/management/blacklist.go
+++ b/x-pack/libbeat/management/blacklist.go
@@ -1,0 +1,188 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package management
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/pkg/errors"
+
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/x-pack/libbeat/management/api"
+)
+
+// ConfigBlacklist takes a ConfigBlocks object and filter it based on the given
+// blacklist settings
+type ConfigBlacklist struct {
+	patterns map[string]*regexp.Regexp
+}
+
+// ConfigBlacklistSettings holds a list of fields and regular expressions to blacklist
+type ConfigBlacklistSettings map[string]string
+
+// Unpack unpacks nested fields set with dot notation like foo.bar into the proper nesting
+// in a nested map/slice structure.
+func (f ConfigBlacklistSettings) Unpack(to interface{}) error {
+	m, ok := to.(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("wrong type, expect map")
+	}
+
+	var expand func(key string, value interface{})
+
+	expand = func(key string, value interface{}) {
+		switch v := value.(type) {
+		case map[string]interface{}:
+			for k, val := range v {
+				expand(fmt.Sprintf("%v.%v", key, k), val)
+			}
+		case []interface{}:
+			for i := range v {
+				expand(fmt.Sprintf("%v.%v", key, i), v[i])
+			}
+		default:
+			m[key] = fmt.Sprintf("%s", value)
+		}
+	}
+
+	for k, val := range m {
+		expand(k, val)
+	}
+	return nil
+}
+
+// NewConfigBlacklist filters configs from CM according to a given blacklist
+func NewConfigBlacklist(patterns ConfigBlacklistSettings) (*ConfigBlacklist, error) {
+	list := ConfigBlacklist{
+		patterns: map[string]*regexp.Regexp{},
+	}
+
+	for field, pattern := range patterns {
+		exp, err := regexp.Compile(pattern)
+		if err != nil {
+			return nil, errors.Wrap(err, fmt.Sprintf("Given expression is not a valid regexp: %s", pattern))
+		}
+
+		list.patterns[field] = exp
+	}
+
+	return &list, nil
+}
+
+// Filter returns a copy of the given ConfigBlocks with the
+func (c *ConfigBlacklist) Filter(configBlocks api.ConfigBlocks) api.ConfigBlocks {
+	var result api.ConfigBlocks
+
+	for _, configs := range configBlocks {
+		newConfigs := api.ConfigBlocksWithType{Type: configs.Type}
+
+		for _, block := range configs.Blocks {
+			if c.blacklisted(configs.Type, block) {
+				logp.Err("Got a blacklisted configuration, ignoring it")
+				continue
+			}
+
+			newConfigs.Blocks = append(newConfigs.Blocks, block)
+		}
+
+		if len(newConfigs.Blocks) > 0 {
+			result = append(result, newConfigs)
+		}
+	}
+
+	return result
+}
+
+func (c *ConfigBlacklist) blacklisted(blockType string, block *api.ConfigBlock) bool {
+	cfg, err := block.ConfigWithMeta()
+	if err != nil {
+		return false
+	}
+
+	for field, pattern := range c.patterns {
+		prefix := blockType
+		if strings.Contains(field, ".") {
+			prefix += "."
+		}
+
+		if strings.HasPrefix(field, prefix) {
+			// This pattern affects a field on this block type
+			field = field[len(prefix):]
+			var segments []string
+			if len(field) > 0 {
+				segments = strings.Split(field, ".")
+			}
+			if c.blockMatches(pattern, segments, cfg.Config) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func (c *ConfigBlacklist) blockMatches(pattern *regexp.Regexp, segments []string, current *common.Config) bool {
+	if current.IsDict() {
+		switch len(segments) {
+		case 0:
+			for _, field := range current.GetFields() {
+				if pattern.MatchString(field) {
+					return true
+				}
+			}
+
+		case 1:
+			// Check field in the dict
+			val, err := current.String(segments[0], -1)
+			if err == nil {
+				return pattern.MatchString(val)
+			}
+			// not a string, traverse
+			child, _ := current.Child(segments[0], -1)
+			return child != nil && c.blockMatches(pattern, segments[1:], child)
+
+		default:
+			// traverse the tree
+			child, _ := current.Child(segments[0], -1)
+			return child != nil && c.blockMatches(pattern, segments[1:], child)
+
+		}
+	}
+
+	if current.IsArray() {
+		switch len(segments) {
+		case 0:
+			// List of elements, match strings
+			for count, _ := current.CountField(""); count > 0; count-- {
+				val, err := current.String("", count-1)
+				if err == nil && pattern.MatchString(val) {
+					return true
+				}
+
+				// not a string, traverse
+				child, _ := current.Child("", count-1)
+				if child != nil {
+					if c.blockMatches(pattern, segments, child) {
+						return true
+					}
+				}
+			}
+
+		default:
+			// List of elements, explode traversal to all of them
+			for count, _ := current.CountField(""); count > 0; count-- {
+				child, _ := current.Child("", count-1)
+				if child != nil && c.blockMatches(pattern, segments, child) {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
+}

--- a/x-pack/libbeat/management/blacklist_test.go
+++ b/x-pack/libbeat/management/blacklist_test.go
@@ -1,0 +1,311 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package management
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/x-pack/libbeat/management/api"
+)
+
+func TestConfigBlacklist(t *testing.T) {
+	tests := []struct {
+		name        string
+		patterns    map[string]string
+		blocks      api.ConfigBlocks
+		blacklisted bool
+
+		// only fill if blacklisted == true
+		expected api.ConfigBlocks
+	}{
+		{
+			name:        "No patterns",
+			blacklisted: false,
+			blocks: api.ConfigBlocks{
+				api.ConfigBlocksWithType{
+					Type: "output",
+					Blocks: []*api.ConfigBlock{
+						{
+							Raw: map[string]interface{}{
+								"output": "console",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:        "Blacklisted dict key",
+			blacklisted: true,
+			patterns: map[string]string{
+				"output": "^console$",
+			},
+			blocks: api.ConfigBlocks{
+				api.ConfigBlocksWithType{
+					Type: "output",
+					Blocks: []*api.ConfigBlock{
+						{
+							Raw: map[string]interface{}{
+								"console": map[string]interface{}{
+									"pretty": "true",
+								},
+							},
+						},
+						{
+							Raw: map[string]interface{}{
+								"elasticsearch": map[string]interface{}{
+									"host": "localhost",
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: api.ConfigBlocks{
+				api.ConfigBlocksWithType{
+					Type: "output",
+					Blocks: []*api.ConfigBlock{
+						{
+							Raw: map[string]interface{}{
+								"elasticsearch": map[string]interface{}{
+									"host": "localhost",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:        "Blacklisted value key",
+			blacklisted: true,
+			patterns: map[string]string{
+				"metricbeat.modules.module": "k.{8}s",
+			},
+			blocks: api.ConfigBlocks{
+				api.ConfigBlocksWithType{
+					Type: "metricbeat.modules",
+					Blocks: []*api.ConfigBlock{
+						{
+							Raw: map[string]interface{}{
+								"module": "kubernetes",
+								"hosts":  "localhost:10255",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:        "Blacklisted value in a list",
+			blacklisted: true,
+			patterns: map[string]string{
+				"metricbeat.modules.metricsets": "event",
+			},
+			blocks: api.ConfigBlocks{
+				api.ConfigBlocksWithType{
+					Type: "metricbeat.modules",
+					Blocks: []*api.ConfigBlock{
+						{
+							Raw: map[string]interface{}{
+								"module": "kubernetes",
+								"metricsets": []string{
+									"event",
+									"default",
+								},
+							},
+						},
+						{
+							Raw: map[string]interface{}{
+								"module": "kubernetes",
+								"metricsets": []string{
+									"default",
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: api.ConfigBlocks{
+				api.ConfigBlocksWithType{
+					Type: "metricbeat.modules",
+					Blocks: []*api.ConfigBlock{
+						{
+							Raw: map[string]interface{}{
+								"module": "kubernetes",
+								"metricsets": []string{
+									"default",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:        "Blacklisted value in a deep list",
+			blacklisted: true,
+			patterns: map[string]string{
+				"filebeat.inputs.containers.ids": "1ffeb0dbd13",
+			},
+			blocks: api.ConfigBlocks{
+				api.ConfigBlocksWithType{
+					Type: "metricbeat.modules",
+					Blocks: []*api.ConfigBlock{
+						{
+							Raw: map[string]interface{}{
+								"module": "kubernetes",
+								"metricsets": []string{
+									"event",
+									"default",
+								},
+							},
+						},
+					},
+				},
+				api.ConfigBlocksWithType{
+					Type: "filebeat.inputs",
+					Blocks: []*api.ConfigBlock{
+						{
+							Raw: map[string]interface{}{
+								"type": "docker",
+								"containers": map[string]interface{}{
+									"ids": []string{
+										"1ffeb0dbd13",
+									},
+								},
+							},
+						},
+						{
+							Raw: map[string]interface{}{
+								"type": "docker",
+								"containers": map[string]interface{}{
+									"ids": []string{
+										"256425931c2",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: api.ConfigBlocks{
+				api.ConfigBlocksWithType{
+					Type: "metricbeat.modules",
+					Blocks: []*api.ConfigBlock{
+						{
+							Raw: map[string]interface{}{
+								"module": "kubernetes",
+								"metricsets": []string{
+									"event",
+									"default",
+								},
+							},
+						},
+					},
+				},
+				api.ConfigBlocksWithType{
+					Type: "filebeat.inputs",
+					Blocks: []*api.ConfigBlock{
+						{
+							Raw: map[string]interface{}{
+								"type": "docker",
+								"containers": map[string]interface{}{
+									"ids": []string{
+										"256425931c2",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:        "Blacklisted dict key in a list",
+			blacklisted: true,
+			patterns: map[string]string{
+				"list.of.elements":            "forbidden",
+				"list.of.elements.disallowed": "yes",
+			},
+			blocks: api.ConfigBlocks{
+				api.ConfigBlocksWithType{
+					Type: "list",
+					Blocks: []*api.ConfigBlock{
+						{
+							Raw: map[string]interface{}{
+								"of": map[string]interface{}{
+									"elements": []interface{}{
+										map[string]interface{}{
+											"forbidden": "yes",
+										},
+									},
+								},
+							},
+						},
+						{
+							Raw: map[string]interface{}{
+								"of": map[string]interface{}{
+									"elements": []interface{}{
+										map[string]interface{}{
+											"allowed": "yes",
+										},
+									},
+								},
+							},
+						},
+						{
+							Raw: map[string]interface{}{
+								"of": map[string]interface{}{
+									"elements": []interface{}{
+										map[string]interface{}{
+											"disallowed": "yes",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: api.ConfigBlocks{
+				api.ConfigBlocksWithType{
+					Type: "list",
+					Blocks: []*api.ConfigBlock{
+						{
+							Raw: map[string]interface{}{
+								"of": map[string]interface{}{
+									"elements": []interface{}{
+										map[string]interface{}{
+											"allowed": "yes",
+										},
+									},
+								},
+							},
+						},
+					},
+				}},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			bl, err := NewConfigBlacklist(test.patterns)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			result := bl.Filter(test.blocks)
+			equal := api.ConfigBlocksEqual(result, test.blocks)
+			assert.Equal(t, test.blacklisted, !equal)
+
+			if test.blacklisted {
+				assert.Equal(t, test.expected, result)
+			}
+		})
+	}
+}

--- a/x-pack/libbeat/management/config.go
+++ b/x-pack/libbeat/management/config.go
@@ -77,11 +77,16 @@ type Config struct {
 	AccessToken string `config:"access_token" yaml:"access_token"`
 
 	Kibana *kibana.ClientConfig `config:"kibana" yaml:"kibana"`
+
+	Blacklist ConfigBlacklistSettings `config:"blacklist" yaml:"blacklist"`
 }
 
 func defaultConfig() *Config {
 	return &Config{
 		Period: 60 * time.Second,
+		Blacklist: ConfigBlacklistSettings{
+			"output": "console|file",
+		},
 	}
 }
 

--- a/x-pack/libbeat/management/manager.go
+++ b/x-pack/libbeat/management/manager.go
@@ -31,14 +31,15 @@ func init() {
 // ConfigManager handles internal config updates. By retrieving
 // new configs from Kibana and applying them to the Beat
 type ConfigManager struct {
-	config   *Config
-	cache    *Cache
-	logger   *logp.Logger
-	client   *api.Client
-	beatUUID uuid.UUID
-	done     chan struct{}
-	registry *reload.Registry
-	wg       sync.WaitGroup
+	config    *Config
+	cache     *Cache
+	logger    *logp.Logger
+	client    *api.Client
+	beatUUID  uuid.UUID
+	done      chan struct{}
+	registry  *reload.Registry
+	wg        sync.WaitGroup
+	blacklist *ConfigBlacklist
 }
 
 // NewConfigManager returns a X-Pack Beats Central Management manager
@@ -56,8 +57,16 @@ func NewConfigManager(config *common.Config, registry *reload.Registry, beatUUID
 func NewConfigManagerWithConfig(c *Config, registry *reload.Registry, beatUUID uuid.UUID) (management.ConfigManager, error) {
 	var client *api.Client
 	var cache *Cache
+	var blacklist *ConfigBlacklist
+
 	if c.Enabled {
 		var err error
+
+		// Initialize configs blacklist
+		blacklist, err = NewConfigBlacklist(c.Blacklist)
+		if err != nil {
+			return nil, errors.Wrap(err, "wrong settings for configurations blacklist")
+		}
 
 		// Initialize central management settings cache
 		cache = &Cache{
@@ -74,16 +83,18 @@ func NewConfigManagerWithConfig(c *Config, registry *reload.Registry, beatUUID u
 		if err != nil {
 			return nil, errors.Wrap(err, "initializing kibana client")
 		}
+
 	}
 
 	return &ConfigManager{
-		config:   c,
-		cache:    cache,
-		logger:   logp.NewLogger(management.DebugK),
-		client:   client,
-		done:     make(chan struct{}),
-		beatUUID: beatUUID,
-		registry: registry,
+		config:    c,
+		cache:     cache,
+		blacklist: blacklist,
+		logger:    logp.NewLogger(management.DebugK),
+		client:    client,
+		done:      make(chan struct{}),
+		beatUUID:  beatUUID,
+		registry:  registry,
 	}, nil
 }
 
@@ -187,8 +198,11 @@ func (cm *ConfigManager) apply() {
 		missing[name] = true
 	}
 
+	// Filter unwanted configs from the list
+	configs := cm.blacklist.Filter(cm.cache.Configs)
+
 	// Reload configs
-	for _, b := range cm.cache.Configs {
+	for _, b := range configs {
 		err := cm.reload(b.Type, b.Blocks)
 		configOK = configOK && err == nil
 		missing[b.Type] = false


### PR DESCRIPTION
This change allows to define local blacklist for configurations coming
from Central Management. If a configuration block matches the given
regular expession, it will be ignored:

For example:

```
management:
  blacklist:
    output: console
    metricbeat.modules.module: k.{18}s
```