### PR TITLE
Cherry-pick #9062 to 6.5: Fix keystore's flaky tests

### DIFF
--- a/libbeat/tests/system/test_keystore.py
+++ b/libbeat/tests/system/test_keystore.py
@@ -22,21 +22,22 @@ class TestKeystore(KeystoreBase):
         Test that we correctly to string replacement with values from the keystore
         """
 
-        key = "elasticsearch_host"
-        secret = "myeleasticsearchsecrethost"
+        key = "mysecretpath"
+        secret = path.join(self.working_dir, "thisisultrasecretpath")
 
-        self.render_config_template(keystore_path=self.keystore_path, elasticsearch={
-            'hosts': "${%s}:9200" % key
-        })
+        self.render_config_template("mockbeat",
+                                    keystore_path=self.keystore_path,
+                                    output_file_path="${%s}" % key)
 
-        exit_code = self.run_beat(extra_args=["keystore", "create"])
+        exit_code = self.run_beat(extra_args=["keystore", "create"],
+                                  config="mockbeat.yml")
         assert exit_code == 0
 
         self.add_secret(key, secret)
-        proc = self.start_beat()
-        self.wait_until(lambda: self.log_contains("Elasticsearch url: http://myeleasticsearchsecrethost:9200"))
-        assert self.log_contains(secret)
+        proc = self.start_beat(config="mockbeat.yml")
+        self.wait_until(lambda: self.log_contains("ackloop:  done send ack"))
         proc.check_kill_and_wait()
+        assert path.exists(secret)
 
     def test_keystore_with_key_not_present(self):
         key = "elasticsearch_host"
@@ -56,20 +57,21 @@ class TestKeystore(KeystoreBase):
         """
 
         key = "output.elasticsearch.hosts.0"
-        secret = "myeleasticsearchsecrethost"
+        secret = path.join(self.working_dir, "myeleasticsearchsecrethost")
 
-        self.render_config_template(keystore_path=self.keystore_path, elasticsearch={
-            'hosts': "${%s}" % key
-        })
+        self.render_config_template("mockbeat",
+                                    keystore_path=self.keystore_path,
+                                    output_file_path="${%s}" % key)
 
-        exit_code = self.run_beat(extra_args=["keystore", "create"])
+        exit_code = self.run_beat(extra_args=["keystore", "create"],
+                                  config="mockbeat.yml")
         assert exit_code == 0
 
         self.add_secret(key, secret)
-        proc = self.start_beat()
-        self.wait_until(lambda: self.log_contains("Elasticsearch url: http://myeleasticsearchsecrethost:9200"))
-        assert self.log_contains(secret)
+        proc = self.start_beat(config="mockbeat.yml")
+        self.wait_until(lambda: self.log_contains("ackloop:  done send ack"))
         proc.check_kill_and_wait()
+        assert path.exists(secret)
 
     def test_export_config_with_keystore(self):
         """


### PR DESCRIPTION
Cherry-pick of PR #9062 to 6.5 branch. Original message: 

We are now using Mockbeat and the file output instead of using the ES
output and we now assert the Keystore log message, this should make the
test more stable and faster to run.

Fix the following:

```
test_keystore_with_present_key	failed 3 times:
 	elastic+beats+master+multijob-windows/beat=libbeat,label=windows	failed 2 times
 	elastic+beats+6.x+multijob-darwin/beat=libbeat,label=macosx	failed 1 times
test_keystore_with_nested_key	failed 2 times:
 	elastic+beats+6.5+multijob-windows/beat=libbeat,label=windows	failed 1 times
 	elastic+beats+master+multijob-windows/beat=libbeat,label=windows	failed 1 times
```