### PR TITLE
Cherry-pick #8954 to 6.x: Fix export_dashboards command

### DIFF
--- a/dev-tools/cmd/dashboards/export_dashboards.go
+++ b/dev-tools/cmd/dashboards/export_dashboards.go
@@ -117,7 +117,7 @@ func decodeValue(data common.MapStr, key string) {
 		return
 	}
 	s := v.(string)
-	var d common.MapStr
+	var d interface{}
 	json.Unmarshal([]byte(s), &d)
 
 	data.Put(key, d)


### PR DESCRIPTION
Cherry-pick of PR #8954 to 6.x branch. Original message: 

`panelJSON` is/can be an array, so marshaling to MapStr caused
problems. I think this was the root cause for #8952.