### PR TITLE
Cherry-pick #8836 to 6.5: Make sure that packages.yml use the same files definition

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -36,6 +36,7 @@ https://github.com/elastic/beats/compare/v6.5.0...6.5[Check the HEAD diff]
 *Auditbeat*
 
 *Filebeat*
+- Make sure the Filebeat Elastic licensed packages uses the Elastic binary instead of the OSS. #8836
 
 *Heartbeat*
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -36,7 +36,7 @@ https://github.com/elastic/beats/compare/v6.5.0...6.5[Check the HEAD diff]
 *Auditbeat*
 
 *Filebeat*
-- Make sure the Filebeat Elastic licensed packages uses the Elastic binary instead of the OSS. #8836
+- Make sure the Filebeat Elastic licensed packages uses the Elastic binary instead of the OSS. {pull}8836[8836]
 
 *Heartbeat*
 

--- a/dev-tools/packaging/packages.yml
+++ b/dev-tools/packaging/packages.yml
@@ -349,8 +349,9 @@ specs:
       spec:
         <<: *windows_binary_spec
         <<: *elastic_license_for_binaries
-        '{{.BeatName}}{{.BinaryExt}}':
-          source: ../x-pack/{{.BeatName}}/build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
+        files:
+          '{{.BeatName}}{{.BinaryExt}}':
+            source: ../x-pack/{{.BeatName}}/build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
 
     - os: darwin
       types: [tgz]

--- a/x-pack/functionbeat/dev-tools/packaging/packages.yml
+++ b/x-pack/functionbeat/dev-tools/packaging/packages.yml
@@ -80,8 +80,9 @@ specs:
         <<: *binary_spec
         <<: *functionbeat_binaries
         <<: *elastic_license_for_binaries
-        '{{.BeatName}}{{.BinaryExt}}':
-          source: build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
+        files:
+          '{{.BeatName}}{{.BinaryExt}}':
+            source: build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
 
     - os: darwin
       types: [tgz]


### PR DESCRIPTION
Cherry-pick of PR #8836 to 6.5 branch. Original message: 

This PR make sure the definition style used by the packages.yml and the custom
function packages.yml match.