### PR TITLE
Get host configuration for tests from compose

### DIFF
--- a/metricbeat/docker-compose.yml
+++ b/metricbeat/docker-compose.yml
@@ -1,4 +1,5 @@
-version: '2'
+version: "2.1"
+
 services:
   beat:
     build: ${PWD}/.
@@ -9,72 +10,57 @@ services:
       - ${PWD}/..:/go/src/github.com/elastic/beats/
       # This is required to on-demand launching the rest on containers for tests & also docker module tests:
       - /var/run/docker.sock:/var/run/docker.sock
+    network_mode: host
     command: make
-    env_file:
-      - ./module/aerospike/_meta/env
-      - ./module/apache/_meta/env
-      - ./module/ceph/_meta/env
-      - ./module/couchbase/_meta/env
-      - ./module/dropwizard/_meta/env
-      - ./module/elasticsearch/_meta/env
-      - ./module/envoyproxy/_meta/env
-      - ./module/etcd/_meta/env
-      - ./module/haproxy/_meta/env
-      - ./module/http/_meta/env
-      - ./module/jolokia/_meta/env
-      - ./module/kafka/_meta/env
-      - ./module/kibana/_meta/env
-      #- ./module/kubernetes/_meta/env
-      - ./module/logstash/_meta/env
-      - ./module/memcached/_meta/env
-      - ./module/mongodb/_meta/env
-      - ./module/munin/_meta/env
-      - ./module/mysql/_meta/env
-      - ./module/nginx/_meta/env
-      - ./module/php_fpm/_meta/env
-      - ./module/postgresql/_meta/env
-      - ./module/prometheus/_meta/env
-      - ./module/rabbitmq/_meta/env
-      - ./module/redis/_meta/env
-      - ./module/traefik/_meta/env
-      - ./module/uwsgi/_meta/env
-      - ./module/zookeeper/_meta/env
 
   # Modules
   aerospike:
-    build: ./module/aerospike/_meta
+    extends:
+      file: ./module/aerospike/docker-compose.yml
+      service: aerospike
 
   apache:
-    build: ./module/apache/_meta
+    extends:
+      file: ./module/apache/docker-compose.yml
+      service: apache
 
   apache_2_4_12:
+    extends:
+      file: ./module/apache/docker-compose.yml
+      service: apache
     build:
-      context: ./module/apache/_meta
-      dockerfile: Dockerfile.2.4.12
+      args:
+        APACHE_VERSION: 2.4.12
 
   ceph:
     build: ./module/ceph/_meta
+    ports:
+      - 5000
 
   couchbase:
     build: ./module/couchbase/_meta
+    ports:
+      - 8091
 
   dropwizard:
     build: ./module/dropwizard/_meta
+    ports:
+      - 8080
 
   elasticsearch:
-    build: ./module/elasticsearch/_meta
-    environment:
-      - "ES_JAVA_OPTS=-Xms90m -Xmx90m"
-      - "network.host="
-      - "transport.host=127.0.0.1"
-      - "http.host=0.0.0.0"
-      - "xpack.security.enabled=false"
+    extends:
+      file: ./module/elasticsearch/docker-compose.yml
+      service: elasticsearch
 
   envoyproxy:
     build: ./module/envoyproxy/_meta
+    ports:
+      - 9901
 
   etcd:
     build: ./module/etcd/_meta
+    ports:
+      - 2379
 
   etcd_3_2:
     build:
@@ -84,43 +70,77 @@ services:
 
   haproxy:
     build: ./module/haproxy/_meta
+    ports:
+      - 14567
+      - 14568
+      - 14569
 
   haproxy_1_6:
     build:
       context: ./module/haproxy/_meta
       dockerfile: Dockerfile.1.6
+    ports:
+      - 14567
+      - 14568
+      - 14569
 
   haproxy_1_7:
     build:
       context: ./module/haproxy/_meta
       dockerfile: Dockerfile.1.7
+    ports:
+      - 14567
+      - 14568
+      - 14569
 
   http:
     build: ./module/http/_meta
+    ports:
+      - 8080
 
   jolokia:
     build: ./module/jolokia/_meta
+    ports:
+      - 8778
 
   kafka:
-    build:
-      context: ./module/kafka/_meta
-      args:
-        KAFKA_VERSION: 2.0.0
+    extends:
+      file: ./module/kafka/docker-compose.yml
+      service: kafka
+    environment:
+      # Needed for python tests
+      KAFKA_ADVERTISED_HOST_AUTO: "yes"
 
   kafka_1_1_0:
+    extends:
+      file: ./module/kafka/docker-compose.yml
+      service: kafka
+    environment:
+      # Needed for python tests
+      KAFKA_ADVERTISED_HOST_AUTO: "yes"
+    image: metricbeat-kafka:1.1.0
     build:
-      context: ./module/kafka/_meta
       args:
         KAFKA_VERSION: 1.1.0
 
   kafka_0_10_2:
+    extends:
+      file: ./module/kafka/docker-compose.yml
+      service: kafka
+    environment:
+      # Needed for python tests
+      KAFKA_ADVERTISED_HOST_AUTO: "yes"
+    image: metricbeat-kafka:0.10.2.1
     build:
-      context: ./module/kafka/_meta
       args:
         KAFKA_VERSION: 0.10.2.1
 
   kibana:
     build: ./module/kibana/_meta
+    depends_on:
+      - elasticsearch
+    ports:
+      - 5601
 
   #kubernetes:
   #  build: ./module/kubernetes/_meta
@@ -142,60 +162,90 @@ services:
 
   logstash:
     build: ./module/logstash/_meta
+    ports:
+      - 9600
 
   memcached:
     build: ./module/memcached/_meta
+    ports:
+      - 11211
 
   mongodb:
     build: ./module/mongodb/_meta
     command: mongod --replSet beats
+    ports:
+      - 27017
 
   munin:
     build: ./module/munin/_meta
+    ports:
+      - 4949
 
   mysql:
     build: ./module/mysql/_meta
+    ports:
+      - 3306
 
   nginx:
     build: ./module/nginx/_meta
+    ports:
+      - 80
 
   phpfpm:
     build: ./module/php_fpm/_meta
+    ports:
+      - 81
 
   postgresql:
     build: ./module/postgresql/_meta
+    ports:
+      - 5432
 
   prometheus:
     build: ./module/prometheus/_meta
+    ports:
+      - 9090
 
   rabbitmq:
     build: ./module/rabbitmq/_meta
+    ports:
+      - 15672
 
   redis:
-    build: ./module/redis/_meta
+    extends:
+      file: ./module/redis/docker-compose.yml
+      service: redis
 
   redis_4:
-    build:
-      context: ./module/redis/_meta
-      args:
-        REDIS_VERSION: 4.0.11
+    extends:
+      file: ./module/redis/docker-compose.yml
+      service: redis
+    image: redis:4.0.11-alpine
 
   redis_5:
-    build:
-      context: ./module/redis/_meta
-      args:
-        REDIS_VERSION: 5.0-rc4
+    extends:
+      file: ./module/redis/docker-compose.yml
+      service: redis
+    image: redis:5.0-rc4-alpine
 
   traefik:
     build: ./module/traefik/_meta
+    ports:
+     - 8080
 
   uwsgi_tcp:
     build: ./module/uwsgi/_meta
     command: uwsgi --http :8080 --master --processes 1 --threads 2 --stats 0.0.0.0:9191 --memory-report --wsgi-file app.py
+    ports:
+      - 9191
 
   uwsgi_http:
     build: ./module/uwsgi/_meta
-    command: uwsgi --http :8080 --master --processes 1 --threads 2 --stats 0.0.0.0:9192 --memory-report --stats-http --wsgi-file app.py
+    command: uwsgi --http :8080 --master --processes 1 --threads 2 --stats 0.0.0.0:9191 --memory-report --stats-http --wsgi-file app.py
+    ports:
+      - 9191
 
   zookeeper:
     build: ./module/zookeeper/_meta
+    ports:
+      - 2181

--- a/metricbeat/docker-compose.yml
+++ b/metricbeat/docker-compose.yml
@@ -10,8 +10,36 @@ services:
       - ${PWD}/..:/go/src/github.com/elastic/beats/
       # This is required to on-demand launching the rest on containers for tests & also docker module tests:
       - /var/run/docker.sock:/var/run/docker.sock
-    network_mode: host
     command: make
+    env_file:
+      - ./module/aerospike/_meta/env
+      - ./module/apache/_meta/env
+      - ./module/ceph/_meta/env
+      - ./module/couchbase/_meta/env
+      - ./module/dropwizard/_meta/env
+      - ./module/elasticsearch/_meta/env
+      - ./module/envoyproxy/_meta/env
+      - ./module/etcd/_meta/env
+      - ./module/haproxy/_meta/env
+      - ./module/http/_meta/env
+      - ./module/jolokia/_meta/env
+      - ./module/kafka/_meta/env
+      - ./module/kibana/_meta/env
+      #- ./module/kubernetes/_meta/env
+      - ./module/logstash/_meta/env
+      - ./module/memcached/_meta/env
+      - ./module/mongodb/_meta/env
+      - ./module/munin/_meta/env
+      - ./module/mysql/_meta/env
+      - ./module/nginx/_meta/env
+      - ./module/php_fpm/_meta/env
+      - ./module/postgresql/_meta/env
+      - ./module/prometheus/_meta/env
+      - ./module/rabbitmq/_meta/env
+      - ./module/redis/_meta/env
+      - ./module/traefik/_meta/env
+      - ./module/uwsgi/_meta/env
+      - ./module/zookeeper/_meta/env
 
   # Modules
   aerospike:

--- a/metricbeat/module/aerospike/_meta/Dockerfile
+++ b/metricbeat/module/aerospike/_meta/Dockerfile
@@ -1,4 +1,5 @@
-FROM aerospike:3.9.0
+ARG AEROSPIKE_VERSION=3.9.0
+
+FROM aerospike:$AEROSPIKE_VERSION
 
 RUN apt-get update && apt-get install -y netcat
-HEALTHCHECK --interval=1s --retries=90 CMD nc -z localhost 3000

--- a/metricbeat/module/aerospike/docker-compose.yml
+++ b/metricbeat/module/aerospike/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '2.1'
+
+services:
+  aerospike:
+    build:
+      context: ./_meta
+      args:
+        AEROSPIKE_VERSION: ${AEROSPIKE_VERSION:-3.9.0}
+    ports:
+      - "3000"
+    healthcheck:
+      test:
+      - "CMD-SHELL"
+      - "nc -z localhost 3000"
+      interval: 1s
+      retries: 90

--- a/metricbeat/module/apache/_meta/Dockerfile
+++ b/metricbeat/module/apache/_meta/Dockerfile
@@ -1,4 +1,5 @@
-FROM httpd:2.4.20
+ARG APACHE_VERSION
+FROM httpd:$APACHE_VERSION
 RUN apt-get update && apt-get install -y curl
 HEALTHCHECK --interval=1s --retries=90 CMD curl -f http://localhost
 COPY ./httpd.conf /usr/local/apache2/conf/httpd.conf

--- a/metricbeat/module/apache/_meta/Dockerfile.2.4.12
+++ b/metricbeat/module/apache/_meta/Dockerfile.2.4.12
@@ -1,4 +1,0 @@
-FROM httpd:2.4.12
-RUN apt-get update && apt-get install -y curl
-HEALTHCHECK --interval=1s --retries=90 CMD curl -f http://localhost
-COPY ./httpd.conf /usr/local/apache2/conf/httpd.conf

--- a/metricbeat/module/apache/docker-compose.yml
+++ b/metricbeat/module/apache/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '2.1'
+
+services:
+  apache:
+    build:
+      context: ./_meta
+      args:
+        APACHE_VERSION: ${APACHE_VERSION:-2.4.20}
+    ports:
+    - 80

--- a/metricbeat/module/elasticsearch/_meta/Dockerfile
+++ b/metricbeat/module/elasticsearch/_meta/Dockerfile
@@ -1,2 +1,0 @@
-FROM docker.elastic.co/elasticsearch/elasticsearch:6.4.3
-HEALTHCHECK --interval=1s --retries=300 CMD curl -f http://localhost:9200

--- a/metricbeat/module/elasticsearch/docker-compose.yml
+++ b/metricbeat/module/elasticsearch/docker-compose.yml
@@ -1,0 +1,19 @@
+version: "2.1"
+
+services:
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTICSEARCH_VERSION:-6.4.3}
+    environment:
+      - "ES_JAVA_OPTS=-Xms90m -Xmx90m"
+      - "network.host="
+      - "transport.host=127.0.0.1"
+      - "http.host=0.0.0.0"
+      - "xpack.security.enabled=false"
+    ports:
+      - 9200
+    healthcheck:
+      test:
+      - "CMD-SHELL"
+      - "curl -f http://localhost:9200"
+      interval: 1s
+      retries: 300

--- a/metricbeat/module/elasticsearch/test_elasticsearch.py
+++ b/metricbeat/module/elasticsearch/test_elasticsearch.py
@@ -45,8 +45,7 @@ class Test(metricbeat.BaseTest):
                              ["service.name"], extras={"index_recovery.active_only": "false"})
 
     def get_hosts(self):
-        return [os.getenv('ES_HOST', 'localhost') + ':' +
-                os.getenv('ES_PORT', '9200')]
+        return [self.compose_host()]
 
     def create_ml_job(self):
         es = Elasticsearch(self.get_hosts())

--- a/metricbeat/module/kafka/_meta/Dockerfile
+++ b/metricbeat/module/kafka/_meta/Dockerfile
@@ -1,18 +1,18 @@
-FROM debian:stretch
+FROM openjdk:8-jre-alpine3.8
 
 ARG KAFKA_VERSION=2.0.0
 
 ENV KAFKA_HOME /kafka
-# The advertised host is kafka. This means it will not work if container is started locally and connected from localhost to it
 ENV KAFKA_LOGS_DIR="/kafka-logs"
 ENV _JAVA_OPTIONS "-Djava.net.preferIPv4Stack=true"
 ENV TERM=linux
 
-RUN apt-get update && apt-get install -y curl openjdk-8-jre-headless netcat dnsutils
+RUN apk add -u bash
 
-RUN mkdir -p ${KAFKA_LOGS_DIR} && mkdir -p ${KAFKA_HOME} && curl -s -o $INSTALL_DIR/kafka.tgz \
-    "http://ftp.wayne.edu/apache/kafka/${KAFKA_VERSION}/kafka_2.11-${KAFKA_VERSION}.tgz" && \
-    tar xzf ${INSTALL_DIR}/kafka.tgz -C ${KAFKA_HOME} --strip-components 1
+RUN mkdir -p ${KAFKA_LOGS_DIR} && mkdir -p ${KAFKA_HOME} && \
+    wget -q -O $INSTALL_DIR/kafka.tgz "http://ftp.wayne.edu/apache/kafka/${KAFKA_VERSION}/kafka_2.11-${KAFKA_VERSION}.tgz" && \
+    tar xzf ${INSTALL_DIR}/kafka.tgz -C ${KAFKA_HOME} --strip-components 1 && \
+    rm -f ${INSTALL_DIR}/kafka.tgz
 
 ADD run.sh /run.sh
 ADD healthcheck.sh /healthcheck.sh

--- a/metricbeat/module/kafka/docker-compose.yml
+++ b/metricbeat/module/kafka/docker-compose.yml
@@ -1,0 +1,11 @@
+version: "2.1"
+
+services:
+  kafka:
+    image: metricbeat-kafka:${KAFKA_VERSION:-2.0.0}
+    build:
+      context: ./_meta
+      args:
+        KAFKA_VERSION: ${KAFKA_VERSION:-2.0.0}
+    ports:
+    - 9092

--- a/metricbeat/module/redis/docker-compose.yml
+++ b/metricbeat/module/redis/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "2.1"
+
+services:
+  redis:
+    image: redis:${REDIS_VERSION:-4.0.11}-${IMAGE_OS:-alpine}
+    ports:
+      - 6379
+    healthcheck:
+      test:
+      - "CMD-SHELL"
+      - "redis-cli ping"
+      interval: 1s
+      retries: 90

--- a/metricbeat/module/traefik/test_traefik.py
+++ b/metricbeat/module/traefik/test_traefik.py
@@ -25,5 +25,4 @@ class Test(metricbeat.BaseTest):
         self.check_metricset("traefik", metricset, self.get_hosts(), self.FIELDS + ["service.name"])
 
     def get_hosts(self):
-        return [os.getenv('TRAEFIK_HOST', 'localhost') + ':' +
-                os.getenv('TRAEFIK_API_PORT', '8080')]
+        return [self.compose_host()]

--- a/metricbeat/tests/system/test_aerospike.py
+++ b/metricbeat/tests/system/test_aerospike.py
@@ -16,5 +16,4 @@ class Test(metricbeat.BaseTest):
         self.check_metricset("aerospike", "namespace", self.get_hosts(), self.FIELDS)
 
     def get_hosts(self):
-        return [os.getenv('AEROSPIKE_HOST', 'localhost') + ':' +
-                os.getenv('AEROSPIKE_PORT', '3000')]
+        return [self.compose_host()]

--- a/metricbeat/tests/system/test_apache.py
+++ b/metricbeat/tests/system/test_apache.py
@@ -78,8 +78,7 @@ class ApacheStatusTest(metricbeat.BaseTest):
         # There are more fields that could be checked.
 
     def get_hosts(self):
-        return ['http://' + os.getenv('APACHE_HOST', 'localhost') + ':' +
-                os.getenv('APACHE_PORT', '80')]
+        return ['http://' + self.compose_host()]
 
 
 class ApacheOldStatusTest(ApacheStatusTest):
@@ -91,7 +90,3 @@ class ApacheOldStatusTest(ApacheStatusTest):
         apache_status = evt["apache"]["status"]
         self.assertItemsEqual(
             self.de_dot(APACHE_OLD_STATUS_FIELDS), apache_status.keys())
-
-    def get_hosts(self):
-        return ['http://' + os.getenv('APACHE_OLD_HOST', 'localhost') + ':' +
-                os.getenv('APACHE_PORT', '80')]

--- a/metricbeat/tests/system/test_base.py
+++ b/metricbeat/tests/system/test_base.py
@@ -75,3 +75,12 @@ class Test(BaseTest):
 
         assert exit_code == 0
         assert self.log_contains("Kibana dashboards successfully loaded.")
+
+    def get_elasticsearch_url(self):
+        return "http://" + self.compose_host("elasticsearch")
+
+    def get_kibana_url(self):
+        """
+        Returns kibana host URL
+        """
+        return "http://" + self.compose_host("kibana")

--- a/metricbeat/tests/system/test_ceph.py
+++ b/metricbeat/tests/system/test_ceph.py
@@ -24,5 +24,4 @@ class Test(metricbeat.BaseTest):
         self.check_metricset("ceph", metricset, self.get_hosts(), self.FIELDS)
 
     def get_hosts(self):
-        return [os.getenv('CEPH_HOST', 'localhost') + ':' +
-                os.getenv('CEPH_PORT', '5000')]
+        return [self.compose_host()]

--- a/metricbeat/tests/system/test_config.py
+++ b/metricbeat/tests/system/test_config.py
@@ -8,4 +8,4 @@ import time
 
 class ConfigTest(metricbeat.BaseTest):
     def get_host(self):
-        return 'http://' + os.getenv('ES_HOST', 'localhost') + ':' + os.getenv('ES_PORT', '9200')
+        return 'http://' + self.compose_host()

--- a/metricbeat/tests/system/test_couchbase.py
+++ b/metricbeat/tests/system/test_couchbase.py
@@ -22,5 +22,4 @@ class Test(metricbeat.BaseTest):
         self.check_metricset("couchbase", metricset, self.get_hosts(), self.FIELDS)
 
     def get_hosts(self):
-        return [os.getenv('COUCHBASE_HOST', 'localhost') + ':' +
-                os.getenv('COUCHBASE_PORT', '8091')]
+        return [self.compose_host()]

--- a/metricbeat/tests/system/test_docker.py
+++ b/metricbeat/tests/system/test_docker.py
@@ -6,6 +6,7 @@ from nose.plugins.attrib import attr
 
 
 class Test(metricbeat.BaseTest):
+    COMPOSE_SERVICES = ["redis"]  # Just to have a container running
 
     @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
     def test_container_fields(self):

--- a/metricbeat/tests/system/test_dropwizard.py
+++ b/metricbeat/tests/system/test_dropwizard.py
@@ -30,5 +30,4 @@ class Test(metricbeat.BaseTest):
         self.assertTrue(len(output) >= 1)
 
     def get_hosts(self):
-        return [os.getenv('DROPWIZARD_HOST', 'localhost') + ':' +
-                os.getenv('DROPWIZARD_PORT', '8080')]
+        return [self.compose_host()]

--- a/metricbeat/tests/system/test_envoyproxy.py
+++ b/metricbeat/tests/system/test_envoyproxy.py
@@ -31,5 +31,4 @@ class Test(metricbeat.BaseTest):
         self.assert_fields_are_documented(evt)
 
     def get_hosts(self):
-        return [os.getenv('ENVOYPROXY_HOST', 'localhost') + ':' +
-                os.getenv('ENVOYPROXY_PORT', '9901')]
+        return [self.compose_host()]

--- a/metricbeat/tests/system/test_golang.py
+++ b/metricbeat/tests/system/test_golang.py
@@ -11,7 +11,7 @@ class Test(metricbeat.BaseTest):
     @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
     def test_stats(self):
         """
-        prometheus stats test
+        golang heap test
         """
         self.render_config_template(modules=[{
             "name": "golang",

--- a/metricbeat/tests/system/test_haproxy.py
+++ b/metricbeat/tests/system/test_haproxy.py
@@ -32,7 +32,7 @@ class HaproxyTest(metricbeat.BaseTest):
         self.render_config_template(modules=[{
             "name": "haproxy",
             "metricsets": ["info"],
-            "hosts": ["tcp://%s:%d" % (self.compose_hosts()[0], 14567)],
+            "hosts": ["tcp://%s" % (self.compose_host(port="14567/tcp"))],
             "period": "5s"
         }])
         self._test_info()
@@ -59,7 +59,7 @@ class HaproxyTest(metricbeat.BaseTest):
         self.render_config_template(modules=[{
             "name": "haproxy",
             "metricsets": ["stat"],
-            "hosts": ["tcp://%s:%d" % (self.compose_hosts()[0], 14567)],
+            "hosts": ["tcp://%s" % (self.compose_host(port="14567/tcp"))],
             "period": "5s"
         }])
         self._test_stat()
@@ -72,7 +72,7 @@ class HaproxyTest(metricbeat.BaseTest):
         self.render_config_template(modules=[{
             "name": "haproxy",
             "metricsets": ["stat"],
-            "hosts": ["http://%s:%d/stats" % (self.compose_hosts()[0], 14568)],
+            "hosts": ["http://%s/stats" % (self.compose_host(port="14568/tcp"))],
             "period": "5s"
         }])
         self._test_stat()
@@ -87,7 +87,7 @@ class HaproxyTest(metricbeat.BaseTest):
             "metricsets": ["stat"],
             "username": "admin",
             "password": "admin",
-            "hosts": ["http://%s:%d/stats" % (self.compose_hosts()[0], 14569)],
+            "hosts": ["http://%s/stats" % (self.compose_host(port="14569/tcp"))],
             "period": "5s"
         }])
         self._test_stat()

--- a/metricbeat/tests/system/test_http.py
+++ b/metricbeat/tests/system/test_http.py
@@ -76,4 +76,4 @@ class Test(metricbeat.BaseTest):
         self.assert_fields_are_documented(evt)
 
     def get_host(self):
-        return "http://" + os.getenv('HTTP_HOST', 'localhost') + ':' + os.getenv('HTTP_PORT', '8080')
+        return "http://" + self.compose_host()

--- a/metricbeat/tests/system/test_jolokia.py
+++ b/metricbeat/tests/system/test_jolokia.py
@@ -50,5 +50,4 @@ class Test(metricbeat.BaseTest):
         assert evt["jolokia"]["test"]["gc"]["collection_count"] >= 0
 
     def get_hosts(self):
-        return [os.getenv('JOLOKIA_HOST', 'localhost') + ':' +
-                os.getenv('JOLOKIA_PORT', '8778')]
+        return [self.compose_host()]

--- a/metricbeat/tests/system/test_kafka.py
+++ b/metricbeat/tests/system/test_kafka.py
@@ -43,8 +43,7 @@ class KafkaTest(metricbeat.BaseTest):
         producer.send('foobar', b'some_message_bytes')
 
     def get_hosts(self):
-        return [self.compose_hosts()[0] + ':' +
-                os.getenv('KAFKA_PORT', '9092')]
+        return [self.compose_host()]
 
 
 class Kafka_1_1_0_Test(KafkaTest):

--- a/metricbeat/tests/system/test_kibana.py
+++ b/metricbeat/tests/system/test_kibana.py
@@ -48,8 +48,7 @@ class Test(metricbeat.BaseTest):
         self.assert_fields_are_documented(evt)
 
     def get_hosts(self):
-        return [os.getenv('KIBANA_HOST', 'localhost') + ':' +
-                os.getenv('KIBANA_PORT', '5601')]
+        return [self.compose_host("kibana")]
 
     def get_version(self):
         host = self.get_hosts()[0]

--- a/metricbeat/tests/system/test_kubernetes.py
+++ b/metricbeat/tests/system/test_kubernetes.py
@@ -77,16 +77,8 @@ class Test(metricbeat.BaseTest):
 
     @classmethod
     def get_kubelet_hosts(cls):
-        return [
-            "http://" +
-            os.getenv('KUBELET_HOST', 'localhost') + ':' +
-            os.getenv('KUBELET_PORT', '10255')
-        ]
+        return [self.compose_host("kubernetes")]
 
     @classmethod
     def get_kube_state_hosts(cls):
-        return [
-            "http://" +
-            os.getenv('KUBE_STATE_METRICS_HOST', 'localhost') + ':' +
-            os.getenv('KUBE_STATE_METRICS_PORT', '18080')
-        ]
+        return [self.compose_host("kubestate")]

--- a/metricbeat/tests/system/test_logstash.py
+++ b/metricbeat/tests/system/test_logstash.py
@@ -55,5 +55,4 @@ class Test(metricbeat.BaseTest):
         self.assert_fields_are_documented(evt)
 
     def get_hosts(self):
-        return [os.getenv('LOGSTASH_HOST', 'localhost') + ':' +
-                os.getenv('LOGSTASH_PORT', '9600')]
+        return [self.compose_host()]

--- a/metricbeat/tests/system/test_memcached.py
+++ b/metricbeat/tests/system/test_memcached.py
@@ -31,5 +31,4 @@ class Test(metricbeat.BaseTest):
         self.assert_fields_are_documented(evt)
 
     def get_hosts(self):
-        return [os.getenv('MEMCACHED_HOST', 'localhost') + ':' +
-                os.getenv('MEMCACHED_PORT', '11211')]
+        return [self.compose_host()]

--- a/metricbeat/tests/system/test_mongodb.py
+++ b/metricbeat/tests/system/test_mongodb.py
@@ -36,5 +36,4 @@ class Test(metricbeat.BaseTest):
         self.assert_fields_are_documented(evt)
 
     def get_hosts(self):
-        return [os.getenv('MONGODB_HOST', 'localhost') + ':' +
-                os.getenv('MONGODB_PORT', '27017')]
+        return [self.compose_host()]

--- a/metricbeat/tests/system/test_munin.py
+++ b/metricbeat/tests/system/test_munin.py
@@ -34,5 +34,4 @@ class Test(metricbeat.BaseTest):
         assert evt["munin"][namespace]["cpu"]["user"] > 0
 
     def get_hosts(self):
-        return [os.getenv('MUNIN_HOST', 'localhost') + ':' +
-                os.getenv('MUNIN_PORT', '4949')]
+        return [self.compose_host()]

--- a/metricbeat/tests/system/test_mysql.py
+++ b/metricbeat/tests/system/test_mysql.py
@@ -40,4 +40,4 @@ class Test(metricbeat.BaseTest):
         self.assert_fields_are_documented(evt)
 
     def get_hosts(self):
-        return [os.getenv('MYSQL_DSN', 'root:test@tcp(localhost:3306)/')]
+        return ['root:test@tcp({})/'.format(self.compose_host())]

--- a/metricbeat/tests/system/test_phpfpm.py
+++ b/metricbeat/tests/system/test_phpfpm.py
@@ -34,5 +34,4 @@ class Test(metricbeat.BaseTest):
         self.assert_fields_are_documented(evt)
 
     def get_hosts(self):
-        return [os.getenv('PHPFPM_HOST', 'localhost') + ':' +
-                os.getenv('PHPFPM_PORT', '81')]
+        return [self.compose_host()]

--- a/metricbeat/tests/system/test_postgresql.py
+++ b/metricbeat/tests/system/test_postgresql.py
@@ -19,8 +19,14 @@ class Test(metricbeat.BaseTest):
             self.assert_fields_are_documented(evt)
 
     def get_hosts(self):
-        return [os.getenv("POSTGRESQL_DSN")], os.getenv("POSTGRESQL_USERNAME"), \
-            os.getenv("POSTGRESQL_PASSWORD")
+        username = "postgres"
+        host = self.compose_host()
+        dsn = "postgres://{}?sslmode=disable".format(host)
+        return (
+            [dsn],
+            username,
+            os.getenv("POSTGRESQL_PASSWORD"),
+        )
 
     @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
     @attr('integration')

--- a/metricbeat/tests/system/test_prometheus.py
+++ b/metricbeat/tests/system/test_prometheus.py
@@ -34,5 +34,4 @@ class Test(metricbeat.BaseTest):
         self.assert_fields_are_documented(evt)
 
     def get_hosts(self):
-        return ["http://" + os.getenv('PROMETHEUS_HOST', 'localhost') + ':' +
-                os.getenv('PROMETHEUS_PORT', '9090')]
+        return [self.compose_host()]

--- a/metricbeat/tests/system/test_redis.py
+++ b/metricbeat/tests/system/test_redis.py
@@ -59,9 +59,10 @@ class Test(metricbeat.BaseTest):
         """
 
         # At least one event must be inserted so db stats exist
+        host, port = self.compose_host().split(":")
         r = redis.StrictRedis(
-            host=self.compose_hosts()[0],
-            port=os.getenv('REDIS_PORT', '6379'),
+            host=host,
+            port=port,
             db=0)
         r.set('foo', 'bar')
 
@@ -120,8 +121,7 @@ class Test(metricbeat.BaseTest):
         self.assertItemsEqual(self.de_dot(CPU_FIELDS), redis_info["cpu"].keys())
 
     def get_hosts(self):
-        return [self.compose_hosts()[0] + ':' +
-                os.getenv('REDIS_PORT', '6379')]
+        return [self.compose_host()]
 
 
 class TestRedis4(Test):

--- a/metricbeat/tests/system/test_zookeeper.py
+++ b/metricbeat/tests/system/test_zookeeper.py
@@ -51,5 +51,4 @@ class ZooKeeperMntrTest(metricbeat.BaseTest):
         self.assert_fields_are_documented(evt)
 
     def get_hosts(self):
-        return [os.getenv('ZOOKEEPER_HOST', 'localhost') + ':' +
-                os.getenv('ZOOKEEPER_PORT', '2181')]
+        return [self.compose_host()]


### PR DESCRIPTION
Current hosts configuration in integration and system tests rely on environment variables and/or specific hostnames. This complicates testing multiple versions of the same service as they have to be deployed as different services. It also requires to add environment variables to set up the execution of the tests of a single module.

But the host information can be also extracted from docker, docker knows the hostname, and exposed ports can also be declared in docker compose. This PR aims to replace the environment variables with the information obtained from docker on system tests (python). A follow up PR would do the same for integration tests.

`NO_COMPOSE` variable can still be used along with `<SERVICE>_HOST` to test against a specific instance of a service. `<SERVICE>_HOST` must be in the form `host:port` now. `NO_COMPOSE` is also honored on stop.

Some other changes are also included for some dockers to parameterize versions in some services.

Cherry-picks parts of #7957 