### PR TITLE
[WIP] Filebeat. Added option to filebeat to read files without disk cache. #3501 

### DIFF
--- a/auditbeat/module/file_integrity/event.go
+++ b/auditbeat/module/file_integrity/event.go
@@ -402,7 +402,7 @@ func hashFile(name string, hashType ...HashType) (map[HashType]Digest, error) {
 		}
 	}
 
-	f, err := file.ReadOpen(name)
+	f, err := file.ReadOpen(name, false)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to open file for hashing")
 	}

--- a/auditbeat/module/file_integrity/fileinfo_windows.go
+++ b/auditbeat/module/file_integrity/fileinfo_windows.go
@@ -73,7 +73,7 @@ func NewMetadata(path string, info os.FileInfo) (*Metadata, error) {
 
 // fileOwner returns the SID and name (domain\user) of the file's owner.
 func fileOwner(path string) (sid, owner string, err error) {
-	f, err := file.ReadOpen(path)
+	f, err := file.ReadOpen(path, false)
 	if err != nil {
 		return "", "", errors.Wrap(err, "failed to open file to get owner")
 	}

--- a/filebeat/docs/inputs/input-common-harvester-options.asciidoc
+++ b/filebeat/docs/inputs/input-common-harvester-options.asciidoc
@@ -95,6 +95,12 @@ The size in bytes of the buffer that each harvester uses when fetching a file.
 The default is 16384.
 
 [float]
+===== `disk_cache_off`
+
+If true turns harvester will read log files without disk cache.
+Works on all systems except OpenBSD and Plan9.
+
+[float]
 ===== `max_bytes`
 
 The maximum number of bytes that a single log message can have. All bytes after

--- a/filebeat/input/log/config.go
+++ b/filebeat/input/log/config.go
@@ -91,10 +91,11 @@ type config struct {
 	RecursiveGlob  bool            `config:"recursive_glob.enabled"`
 
 	// Harvester
-	BufferSize int    `config:"harvester_buffer_size"`
-	Encoding   string `config:"encoding"`
-	ScanOrder  string `config:"scan.order"`
-	ScanSort   string `config:"scan.sort"`
+	BufferSize   int    `config:"harvester_buffer_size"`
+	Encoding     string `config:"encoding"`
+	ScanOrder    string `config:"scan.order"`
+	ScanSort     string `config:"scan.sort"`
+	DiskCacheOff bool   `config:"disk_cache_off"`
 
 	ExcludeLines []match.Matcher   `config:"exclude_lines"`
 	IncludeLines []match.Matcher   `config:"include_lines"`

--- a/filebeat/input/log/harvester.go
+++ b/filebeat/input/log/harvester.go
@@ -424,7 +424,7 @@ func (h *Harvester) shouldExportLine(line string) bool {
 // is returned and the harvester is closed. The file will be picked up again the next time
 // the file system is scanned
 func (h *Harvester) openFile() error {
-	f, err := file_helper.ReadOpen(h.state.Source)
+	f, err := file_helper.ReadOpen(h.state.Source, h.config.DiskCacheOff)
 	if err != nil {
 		return fmt.Errorf("Failed opening %s: %s", h.state.Source, err)
 	}
@@ -558,7 +558,7 @@ func (h *Harvester) newLogFileReader() (reader.Reader, error) {
 		return nil, err
 	}
 
-	r, err = readfile.NewEncodeReader(h.log, h.encoding, h.config.BufferSize)
+	r, err = readfile.NewEncodeReader(h.log, h.encoding, h.config.BufferSize, h.config.DiskCacheOff)
 	if err != nil {
 		return nil, err
 	}

--- a/filebeat/scripts/tester/main.go
+++ b/filebeat/scripts/tester/main.go
@@ -133,7 +133,7 @@ func getLogsFromFile(logfile string, conf *logReaderConfig) ([]string, error) {
 	}
 
 	var r reader.Reader
-	r, err = readfile.NewEncodeReader(f, enc, 4096)
+	r, err = readfile.NewEncodeReader(f, enc, 4096, false)
 	if err != nil {
 		return nil, err
 	}

--- a/heartbeat/monitors/active/http/http_test.go
+++ b/heartbeat/monitors/active/http/http_test.go
@@ -301,7 +301,7 @@ func TestHTTPSx509Auth(t *testing.T) {
 	clientKeyPath := path.Join(wd, "testdata", "client_key.pem")
 	clientCertPath := path.Join(wd, "testdata", "client_cert.pem")
 
-	certReader, err := file.ReadOpen(clientCertPath)
+	certReader, err := file.ReadOpen(clientCertPath, false)
 	require.NoError(t, err)
 
 	clientCertBytes, err := ioutil.ReadAll(certReader)

--- a/libbeat/common/file/file_open_other.go
+++ b/libbeat/common/file/file_open_other.go
@@ -1,0 +1,27 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// +build openbsd plan9
+
+package file
+
+// ReadOpen opens a file for reading only
+func ReadOpen(path string, diskCacheOff bool) (*os.File, error) {
+	flag := os.O_RDONLY
+	perm := os.FileMode(0)
+	return os.OpenFile(path, flag, perm)
+}

--- a/libbeat/common/file/file_open_unix.go
+++ b/libbeat/common/file/file_open_unix.go
@@ -1,0 +1,32 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// +build !darwin,!plan9,!openbsd
+
+package file
+
+import "os"
+
+// ReadOpen opens a file for reading only
+func ReadOpen(path string, diskCacheOff bool) (*os.File, error) {
+	flag := os.O_RDONLY
+	if diskCacheOff {
+		flag = flag | syscall.O_DIRECT
+	}
+	perm := os.FileMode(0)
+	return os.OpenFile(path, flag, perm)
+}

--- a/libbeat/common/file/file_open_windows.go
+++ b/libbeat/common/file/file_open_windows.go
@@ -1,0 +1,62 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package file
+
+const _FileFlagNoBuffering = 0x20000000
+
+// ReadOpen opens a file for reading only
+// As Windows blocks deleting a file when its open, some special params are passed here.
+func ReadOpen(path string, diskCacheOff bool) (*os.File, error) {
+	// Set all write flags
+	// This indirectly calls syscall_windows::Open method https://github.com/golang/go/blob/7ebcf5eac7047b1eef2443eda1786672b5c70f51/src/syscall/syscall_windows.go#L251
+	// As FILE_SHARE_DELETE cannot be passed to Open, os.CreateFile must be implemented directly
+
+	// This is mostly the code from syscall_windows::Open. Only difference is passing the Delete flag
+	// TODO: Open pull request to Golang so also Delete flag can be set
+	if len(path) == 0 {
+		return nil, fmt.Errorf("File '%s' not found. Error: %v", path, syscall.ERROR_FILE_NOT_FOUND)
+	}
+
+	pathp, err := syscall.UTF16PtrFromString(path)
+	if err != nil {
+		return nil, fmt.Errorf("Error converting to UTF16: %v", err)
+	}
+
+	var access uint32
+	access = syscall.GENERIC_READ
+
+	sharemode := uint32(syscall.FILE_SHARE_READ | syscall.FILE_SHARE_WRITE | syscall.FILE_SHARE_DELETE)
+
+	var sa *syscall.SecurityAttributes
+
+	var createmode uint32
+
+	createmode = syscall.OPEN_EXISTING
+	attrs := syscall.FILE_ATTRIBUTE_NORMAL
+	if diskCacheOff {
+		attrs = attrs | _FileFlagNoBuffering
+	}
+
+	handle, err := syscall.CreateFile(pathp, access, sharemode, sa, createmode, attrs, 0)
+
+	if err != nil {
+		return nil, fmt.Errorf("Error creating file '%s': %v", path, err)
+	}
+
+	return os.NewFile(uintptr(handle), path), nil
+}

--- a/libbeat/common/file/file_windows.go
+++ b/libbeat/common/file/file_windows.go
@@ -18,11 +18,9 @@
 package file
 
 import (
-	"fmt"
 	"os"
 	"reflect"
 	"strconv"
-	"syscall"
 )
 
 type StateOS struct {
@@ -68,42 +66,4 @@ func (fs StateOS) String() string {
 	current = append(current, '-')
 	current = strconv.AppendUint(current, fs.Vol, 10)
 	return string(current)
-}
-
-// ReadOpen opens a file for reading only
-// As Windows blocks deleting a file when its open, some special params are passed here.
-func ReadOpen(path string) (*os.File, error) {
-	// Set all write flags
-	// This indirectly calls syscall_windows::Open method https://github.com/golang/go/blob/7ebcf5eac7047b1eef2443eda1786672b5c70f51/src/syscall/syscall_windows.go#L251
-	// As FILE_SHARE_DELETE cannot be passed to Open, os.CreateFile must be implemented directly
-
-	// This is mostly the code from syscall_windows::Open. Only difference is passing the Delete flag
-	// TODO: Open pull request to Golang so also Delete flag can be set
-	if len(path) == 0 {
-		return nil, fmt.Errorf("File '%s' not found. Error: %v", path, syscall.ERROR_FILE_NOT_FOUND)
-	}
-
-	pathp, err := syscall.UTF16PtrFromString(path)
-	if err != nil {
-		return nil, fmt.Errorf("Error converting to UTF16: %v", err)
-	}
-
-	var access uint32
-	access = syscall.GENERIC_READ
-
-	sharemode := uint32(syscall.FILE_SHARE_READ | syscall.FILE_SHARE_WRITE | syscall.FILE_SHARE_DELETE)
-
-	var sa *syscall.SecurityAttributes
-
-	var createmode uint32
-
-	createmode = syscall.OPEN_EXISTING
-
-	handle, err := syscall.CreateFile(pathp, access, sharemode, sa, createmode, syscall.FILE_ATTRIBUTE_NORMAL, 0)
-
-	if err != nil {
-		return nil, fmt.Errorf("Error creating file '%s': %v", path, err)
-	}
-
-	return os.NewFile(uintptr(handle), path), nil
 }

--- a/libbeat/reader/multiline/multiline_test.go
+++ b/libbeat/reader/multiline/multiline_test.go
@@ -277,7 +277,7 @@ func createMultilineTestReader(t *testing.T, in *bytes.Buffer, cfg Config) reade
 	}
 
 	var r reader.Reader
-	r, err = readfile.NewEncodeReader(in, enc, 4096)
+	r, err = readfile.NewEncodeReader(in, enc, 4096, false)
 	if err != nil {
 		t.Fatalf("Failed to initialize line reader: %v", err)
 	}

--- a/libbeat/reader/readfile/align.go
+++ b/libbeat/reader/readfile/align.go
@@ -1,0 +1,28 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// +build !darwin,!plan9,!openbsd
+
+package readfile
+
+const (
+	// AlignSize is size to align the buffer to
+	AlignSize = 4096
+
+	// MinimumBlockSize is minimum block size to align
+	MinimumBlockSize = 4096
+)

--- a/libbeat/reader/readfile/align_darwin.go
+++ b/libbeat/reader/readfile/align_darwin.go
@@ -1,0 +1,26 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package readfile
+
+const (
+	// AlignSize is size to align the buffer to
+	AlignSize = 0
+
+	// MinimumBlockSize is minimum block size to align
+	MinimumBlockSize = 4096
+)

--- a/libbeat/reader/readfile/encode.go
+++ b/libbeat/reader/readfile/encode.go
@@ -37,8 +37,9 @@ func NewEncodeReader(
 	r io.Reader,
 	codec encoding.Encoding,
 	bufferSize int,
+	alignBuffer bool,
 ) (EncoderReader, error) {
-	eReader, err := NewLineReader(r, codec, bufferSize)
+	eReader, err := NewLineReader(r, codec, bufferSize, alignBuffer)
 	return EncoderReader{eReader}, err
 }
 

--- a/libbeat/reader/readfile/line_test.go
+++ b/libbeat/reader/readfile/line_test.go
@@ -68,7 +68,7 @@ func TestReaderEncodings(t *testing.T) {
 		}
 
 		// create line reader
-		reader, err := NewLineReader(buffer, codec, 1024)
+		reader, err := NewLineReader(buffer, codec, 1024, false)
 		if err != nil {
 			t.Errorf("failed to initialize reader: %v", err)
 			continue
@@ -159,7 +159,7 @@ func testReadLines(t *testing.T, inputLines [][]byte) {
 	// initialize reader
 	buffer := bytes.NewBuffer(inputStream)
 	codec, _ := encoding.Plain(buffer)
-	reader, err := NewLineReader(buffer, codec, buffer.Len())
+	reader, err := NewLineReader(buffer, codec, buffer.Len(), false)
 	if err != nil {
 		t.Fatalf("Error initializing reader: %v", err)
 	}

--- a/libbeat/reader/readfile/make_buffer.go
+++ b/libbeat/reader/readfile/make_buffer.go
@@ -1,0 +1,70 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// +build !plan9,!openbsd
+
+package readfile
+
+import (
+	"fmt"
+	"unsafe"
+)
+
+// alignment returns alignment of the block in memory
+// with reference to AlignSize
+//
+// Can't check alignment of a zero sized block as &block[0] is invalid
+func alignment(block []byte, AlignSize int) int {
+	return int(uintptr(unsafe.Pointer(&block[0])) & uintptr(AlignSize-1))
+}
+
+// AlignedBlock returns []byte of size BlockSize aligned to a multiple
+// of AlignSize in memory (must be power of two)
+func AlignedBlock(blockSize int) ([]byte, error) {
+	if blockSize < MinimumBlockSize {
+		blockSize = MinimumBlockSize
+	}
+
+	block := make([]byte, blockSize+AlignSize)
+	if AlignSize == 0 {
+		return block, nil
+	}
+	a := alignment(block, AlignSize)
+	offset := 0
+	if a != 0 {
+		offset = AlignSize - a
+	}
+	block = block[offset : offset+blockSize]
+	// Can't check alignment of a zero sized block
+	if blockSize != 0 {
+		a = alignment(block, AlignSize)
+		if a != 0 {
+			return nil, fmt.Errorf("Failed to align block")
+		}
+	}
+	return block, nil
+}
+
+// MakeBuffer returns []byte of bufferSize and aligns it if needed
+// Align works only on all systems except OpenBSD and Plan9
+func MakeBuffer(bufferSize int, align bool) ([]byte, error) {
+	if align {
+		return AlignedBlock(bufferSize)
+	}
+
+	return make([]byte, bufferSize), nil
+}

--- a/libbeat/reader/readfile/make_buffer_other.go
+++ b/libbeat/reader/readfile/make_buffer_other.go
@@ -1,0 +1,26 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// +build plan9,openbsd
+
+package readfile
+
+// MakeBuffer returns []byte of bufferSize and aligns it if needed
+// Align works only on all systems except OpenBSD and Plan9
+func MakeBuffer(size int, align bool) ([]byte, error) {
+	return make([]byte, size), nil
+}


### PR DESCRIPTION
Issue #3501.
I added option to read files without disk cache for darwin, windows and unix systems except OpenBSD and Plan9.
Almost all code I took https://github.com/ncw/directio here. 
I'll be glad if somebody reviewed this. 
Also I don't know how to write documentation to this project I edit only one file: `input-common-harvester-options.asciidoc`, may be it's not enough. 