### PR TITLE
Do not set a default value for the version qualifier

### DIFF
--- a/dev-tools/jenkins_release.sh
+++ b/dev-tools/jenkins_release.sh
@@ -18,7 +18,7 @@ trap cleanup EXIT
 
 # This controls the defaults used the Jenkins package job. They can be
 # overridden by setting them in the environement prior to running this script.
-export BEAT_VERSION_QUALIFIER="${VERSION_QUALIFIER:-alpha1}"
+export BEAT_VERSION_QUALIFIER="${VERSION_QUALIFIER}"
 export SNAPSHOT="${SNAPSHOT:-true}"
 export PLATFORMS="${PLATFORMS:-+linux/armv7 +linux/ppc64le +linux/s390x +linux/mips64}"
 


### PR DESCRIPTION
Version qualifier should be handled by the release manager and not beats