### PR TITLE
Cherry-pick #9125 to 6.x: Fix division by zero on diskio metricset

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -25,6 +25,8 @@ https://github.com/elastic/beats/compare/v6.5.0...6.x[Check the HEAD diff]
 
 *Metricbeat*
 
+- Fix issue preventing diskio metrics collection for idle disks. {issue}9124[9124] {pull}9125[9125]
+
 *Packetbeat*
 
 *Winlogbeat*

--- a/metricbeat/module/system/diskio/diskstat_linux.go
+++ b/metricbeat/module/system/diskio/diskstat_linux.go
@@ -98,8 +98,12 @@ func (stat *DiskIOStat) CalIOStatistics(counter disk.IOCountersStat) (DiskIOMetr
 	result.AvgRequestSize = size
 	result.AvgQueueSize = queue
 	result.AvgAwaitTime = wait
-	result.AvgReadAwaitTime = float64(rd_ticks) / float64(rd_ios)
-	result.AvgWriteAwaitTime = float64(wr_ticks) / float64(wr_ios)
+	if rd_ios > 0 {
+		result.AvgReadAwaitTime = float64(rd_ticks) / float64(rd_ios)
+	}
+	if wr_ios > 0 {
+		result.AvgWriteAwaitTime = float64(wr_ticks) / float64(wr_ios)
+	}
 	result.AvgServiceTime = svct
 	result.BusyPct = 100.0 * float64(ticks) / deltams
 	if result.BusyPct > 100.0 {


### PR DESCRIPTION
Cherry-pick of PR #9125 to 6.x branch. Original message: 

Fixes #9124 