### PR TITLE
Cherry-pick #9069 to 6.5: Propagate Sync error when running SafeFileRotate

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -33,6 +33,12 @@ https://github.com/elastic/beats/compare/v6.5.0...6.5[Check the HEAD diff]
 
 *Affecting all Beats*
 
+- Fixed `-d` CLI flag by trimming spaces from selectors. {pull}7864[7864]
+- Fixed Support `add_docker_metadata` in Windows by identifying systems' path separator. {issue}7797[7797]
+- Do not panic when no tokenizer string is configured for a dissect processor. {issue}8895[8895]
+- Start autodiscover consumers before producers. {pull}7926[7926]
+- Propagate Sync error when running SafeFileRotate. {pull}9069[9069]
+
 *Auditbeat*
 
 *Filebeat*

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -33,10 +33,6 @@ https://github.com/elastic/beats/compare/v6.5.0...6.5[Check the HEAD diff]
 
 *Affecting all Beats*
 
-- Fixed `-d` CLI flag by trimming spaces from selectors. {pull}7864[7864]
-- Fixed Support `add_docker_metadata` in Windows by identifying systems' path separator. {issue}7797[7797]
-- Do not panic when no tokenizer string is configured for a dissect processor. {issue}8895[8895]
-- Start autodiscover consumers before producers. {pull}7926[7926]
 - Propagate Sync error when running SafeFileRotate. {pull}9069[9069]
 
 *Auditbeat*

--- a/libbeat/common/file/helper_other.go
+++ b/libbeat/common/file/helper_other.go
@@ -40,7 +40,6 @@ func SafeFileRotate(path, tempfile string) error {
 		return nil // ignore error
 	}
 	defer f.Close()
-	f.Sync()
 
-	return nil
+	return f.Sync()
 }


### PR DESCRIPTION
Cherry-pick of PR #9069 to 6.5 branch. Original message: 

Previously, it was possible `SafeFileRotate` encountered an error without propagating it, because the return value of `os.Sync` was not utilized.
From now on the errors from `Sync` are propagated.