### PR TITLE
Never default to a qualifier when none of them are set.

### DIFF
--- a/CHANGELOG-developer.asciidoc
+++ b/CHANGELOG-developer.asciidoc
@@ -37,6 +37,8 @@ The list below covers the major changes between 6.3.0 and master only.
 - Fix permissions of generated Filebeat filesets. {pull}7140[7140]
 - Collect fields from _meta/fields.yml too. {pull}8397[8397]
 - Fix issue on asset generation that could lead to different results in Windows. {pull}8464[8464]
+- Version subcommand doesn't have a default qualifier. {pull}9148[9148]
+
 
 ==== Added
 

--- a/CHANGELOG-developer.asciidoc
+++ b/CHANGELOG-developer.asciidoc
@@ -37,8 +37,7 @@ The list below covers the major changes between 6.3.0 and master only.
 - Fix permissions of generated Filebeat filesets. {pull}7140[7140]
 - Collect fields from _meta/fields.yml too. {pull}8397[8397]
 - Fix issue on asset generation that could lead to different results in Windows. {pull}8464[8464]
-- Version subcommand doesn't have a default qualifier. {pull}9148[9148]
-
+- Remove default version qualifier, you can use `VERSION_QUALIFIER` environment variable to set it. {pull}9148[9148]
 
 ==== Added
 

--- a/auditbeat/magefile.go
+++ b/auditbeat/magefile.go
@@ -75,7 +75,7 @@ func Clean() error {
 // Package packages the Beat for distribution.
 // Use SNAPSHOT=true to build snapshots.
 // Use PLATFORMS to control the target platforms.
-// Use BEAT_VERSION_QUALIFIER to control the version qualifier.
+// Use VERSION_QUALIFIER to control the version qualifier.
 func Package() {
 	start := time.Now()
 	defer func() { fmt.Println("package ran for", time.Since(start)) }()

--- a/dev-tools/jenkins_release.sh
+++ b/dev-tools/jenkins_release.sh
@@ -18,7 +18,6 @@ trap cleanup EXIT
 
 # This controls the defaults used the Jenkins package job. They can be
 # overridden by setting them in the environement prior to running this script.
-export BEAT_VERSION_QUALIFIER="${VERSION_QUALIFIER}"
 export SNAPSHOT="${SNAPSHOT:-true}"
 export PLATFORMS="${PLATFORMS:-+linux/armv7 +linux/ppc64le +linux/s390x +linux/mips64}"
 

--- a/dev-tools/mage/crossbuild.go
+++ b/dev-tools/mage/crossbuild.go
@@ -247,7 +247,7 @@ func (b GolangCrossBuilder) Build() error {
 		)
 	}
 	if versionQualified {
-		args = append(args, "--env", "BEAT_VERSION_QUALIFIER="+versionQualifier)
+		args = append(args, "--env", "VERSION_QUALIFIER="+versionQualifier)
 	}
 	args = append(args,
 		"--rm",

--- a/dev-tools/mage/settings.go
+++ b/dev-tools/mage/settings.go
@@ -103,7 +103,7 @@ func init() {
 		panic(errors.Errorf("failed to parse SNAPSHOT env value", err))
 	}
 
-	versionQualifier, versionQualified = os.LookupEnv("BEAT_VERSION_QUALIFIER")
+	versionQualifier, versionQualified = os.LookupEnv("VERSION_QUALIFIER")
 }
 
 // EnvMap returns map containing the common settings variables and all variables
@@ -319,7 +319,7 @@ var (
 )
 
 // BeatQualifiedVersion returns the Beat's qualified version.  The value can be overwritten by
-// setting BEAT_VERSION_QUALIFIER in the environment.
+// setting VERSION_QUALIFIER in the environment.
 func BeatQualifiedVersion() (string, error) {
 	version, err := beatVersion()
 	if err != nil {

--- a/filebeat/magefile.go
+++ b/filebeat/magefile.go
@@ -75,7 +75,7 @@ func Clean() error {
 // Package packages the Beat for distribution.
 // Use SNAPSHOT=true to build snapshots.
 // Use PLATFORMS to control the target platforms.
-// Use BEAT_VERSION_QUALIFIER to control the version qualifier.
+// Use VERSION_QUALIFIER to control the version qualifier.
 func Package() {
 	start := time.Now()
 	defer func() { fmt.Println("package ran for", time.Since(start)) }()

--- a/heartbeat/magefile.go
+++ b/heartbeat/magefile.go
@@ -75,7 +75,7 @@ func Clean() error {
 // Package packages the Beat for distribution.
 // Use SNAPSHOT=true to build snapshots.
 // Use PLATFORMS to control the target platforms.
-// Use BEAT_VERSION_QUALIFIER to control the version qualifier.
+// Use VERSION_QUALIFIER to control the version qualifier.
 func Package() {
 	start := time.Now()
 	defer func() { fmt.Println("package ran for", time.Since(start)) }()

--- a/libbeat/version/helper.go
+++ b/libbeat/version/helper.go
@@ -31,7 +31,7 @@ func GetDefaultVersion() string {
 var (
 	buildTime = "unknown"
 	commit    = "unknown"
-	qualifier = "alpha1"
+	qualifier = ""
 )
 
 // BuildTime exposes the compile-time build time information.

--- a/metricbeat/magefile.go
+++ b/metricbeat/magefile.go
@@ -75,7 +75,7 @@ func Clean() error {
 // Package packages the Beat for distribution.
 // Use SNAPSHOT=true to build snapshots.
 // Use PLATFORMS to control the target platforms.
-// Use BEAT_VERSION_QUALIFIER to control the version qualifier.
+// Use VERSION_QUALIFIER to control the version qualifier.
 func Package() {
 	start := time.Now()
 	defer func() { fmt.Println("package ran for", time.Since(start)) }()

--- a/packetbeat/magefile.go
+++ b/packetbeat/magefile.go
@@ -113,7 +113,7 @@ func Clean() error {
 // Package packages the Beat for distribution.
 // Use SNAPSHOT=true to build snapshots.
 // Use PLATFORMS to control the target platforms.
-// Use BEAT_VERSION_QUALIFIER to control the version qualifier.
+// Use VERSION_QUALIFIER to control the version qualifier.
 func Package() {
 	start := time.Now()
 	defer func() { fmt.Println("package ran for", time.Since(start)) }()

--- a/winlogbeat/magefile.go
+++ b/winlogbeat/magefile.go
@@ -75,7 +75,7 @@ func Clean() error {
 // Package packages the Beat for distribution.
 // Use SNAPSHOT=true to build snapshots.
 // Use PLATFORMS to control the target platforms.
-// Use BEAT_VERSION_QUALIFIER to control the version qualifier.
+// Use VERSION_QUALIFIER to control the version qualifier.
 func Package() {
 	start := time.Now()
 	defer func() { fmt.Println("package ran for", time.Since(start)) }()


### PR DESCRIPTION
Remove default version qualifier and rename the environment variable to set it from `BEAT_VERSION_QUALIFIER` to `VERSION_QUALIFIER` this will align with other parts of the stack.

**Tested with filebeat.**
```
 ❯ ./filebeat version                                                                                                                                                                                                                                                                                                                                          [08:39:01]
filebeat version 7.0.0 (amd64), libbeat 7.0.0 [0a0c267dd8c33dfce4b009a367b84297fc1a9b92 built 2018-11-19 13:38:15 +0000 UTC]
```

**Without the patch**
```
 ❯ ./filebeat version                                                                                                                                                                                                                                                                                                                                          [08:40:07]
filebeat version 7.0.0-alpha1 (amd64), libbeat 7.0.0-alpha1 [b007837fde985832c257234b5a71bc863cbe2128 built 2018-11-19 13:39:59 +0000 UTC]
```

Fixes: #8384


**NOTES:** You may need to remove your `~/.magefile` cache to see the changes.