### PR TITLE
Index cluster.id and cluster.name in elasticsearch/index_recovery metricset

### DIFF
--- a/metricbeat/module/elasticsearch/index_recovery/_meta/data.json
+++ b/metricbeat/module/elasticsearch/index_recovery/_meta/data.json
@@ -1,12 +1,16 @@
 {
     "@timestamp": "2017-10-12T08:05:34.853Z",
-    "beat": {
+    "agent": {
         "hostname": "host.example.com",
         "name": "host.example.com"
     },
     "elasticsearch": {
+        "cluster": {
+            "id": "3LbUkLkURz--FR-YO0wLNA",
+            "name": "es1"
+        },
         "index": {
-            "name": "test-index",
+            "name": ".monitoring-es-6-2018.11.20",
             "recovery": {
                 "id": 0,
                 "primary": true,
@@ -14,8 +18,8 @@
                 "stage": "DONE",
                 "target": {
                     "host": "127.0.0.1",
-                    "id": "ODWb5m6zT9q0lf8YTPyWWg",
-                    "name": "ODWb5m6"
+                    "id": "FMRmkE3HTU6xxxoFK-06Ww",
+                    "name": "es1_1"
                 },
                 "type": "EMPTY_STORE"
             }

--- a/metricbeat/module/elasticsearch/index_recovery/data.go
+++ b/metricbeat/module/elasticsearch/index_recovery/data.go
@@ -55,7 +55,7 @@ var (
 	}
 )
 
-func eventsMapping(r mb.ReporterV2, content []byte) error {
+func eventsMapping(r mb.ReporterV2, info elasticsearch.Info, content []byte) error {
 
 	var data map[string]map[string][]map[string]interface{}
 
@@ -82,6 +82,8 @@ func eventsMapping(r mb.ReporterV2, content []byte) error {
 			event.RootFields.Put("service.name", elasticsearch.ModuleName)
 
 			event.ModuleFields = common.MapStr{}
+			event.ModuleFields.Put("cluster.name", info.ClusterName)
+			event.ModuleFields.Put("cluster.id", info.ClusterID)
 			event.ModuleFields.Put("index.name", indexName)
 
 			event.MetricSetFields, err = schema.Apply(data)

--- a/metricbeat/module/elasticsearch/index_recovery/data_test.go
+++ b/metricbeat/module/elasticsearch/index_recovery/data_test.go
@@ -26,5 +26,5 @@ import (
 )
 
 func TestMapper(t *testing.T) {
-	elasticsearch.TestMapper(t, "./_meta/test/recovery.*.json", eventsMapping)
+	elasticsearch.TestMapperWithInfo(t, "./_meta/test/recovery.*.json", eventsMapping)
 }

--- a/metricbeat/module/elasticsearch/index_recovery/data_xpack.go
+++ b/metricbeat/module/elasticsearch/index_recovery/data_xpack.go
@@ -30,7 +30,7 @@ import (
 	"github.com/elastic/beats/metricbeat/module/elasticsearch"
 )
 
-func eventsMappingXPack(r mb.ReporterV2, m *MetricSet, content []byte) error {
+func eventsMappingXPack(r mb.ReporterV2, m *MetricSet, info elasticsearch.Info, content []byte) error {
 	var data map[string]interface{}
 	err := json.Unmarshal(content, &data)
 	if err != nil {
@@ -67,11 +67,6 @@ func eventsMappingXPack(r mb.ReporterV2, m *MetricSet, content []byte) error {
 
 	indexRecovery := common.MapStr{}
 	indexRecovery["shards"] = results
-
-	info, err := elasticsearch.GetInfo(m.HTTP, m.HTTP.GetURI())
-	if err != nil {
-		return errors.Wrap(err, "failed to retrieve info from Elasticsearch")
-	}
 
 	event := mb.Event{}
 	event.RootFields = common.MapStr{

--- a/metricbeat/module/elasticsearch/index_recovery/index_recovery.go
+++ b/metricbeat/module/elasticsearch/index_recovery/index_recovery.go
@@ -72,7 +72,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 
 // Fetch gathers stats for each index from the _stats API
 func (m *MetricSet) Fetch(r mb.ReporterV2) {
-	isMaster, err := elasticsearch.IsMaster(m.HTTP, m.HostData().SanitizedURI+m.recoveryPath)
+	isMaster, err := elasticsearch.IsMaster(m.HTTP, m.getServiceURI())
 	if err != nil {
 		err = errors.Wrap(err, "error determining if connected Elasticsearch node is master")
 		elastic.ReportAndLogError(err, r, m.Log)
@@ -85,6 +85,12 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 		return
 	}
 
+	info, err := elasticsearch.GetInfo(m.HTTP, m.getServiceURI())
+	if err != nil {
+		elastic.ReportAndLogError(err, r, m.Log)
+		return
+	}
+
 	content, err := m.HTTP.FetchContent()
 	if err != nil {
 		elastic.ReportAndLogError(err, r, m.Log)
@@ -92,13 +98,18 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 	}
 
 	if m.MetricSet.XPack {
-		err = eventsMappingXPack(r, m, content)
+		err = eventsMappingXPack(r, m, *info, content)
 	} else {
-		err = eventsMapping(r, content)
+		err = eventsMapping(r, *info, content)
 	}
 
 	if err != nil {
 		m.Log.Error(err)
 		return
 	}
+}
+
+func (m *MetricSet) getServiceURI() string {
+	return m.HostData().SanitizedURI + m.recoveryPath
+
 }


### PR DESCRIPTION
This PR teaches the `elasticsearch/index_recovery` metricset to index the Elasticsearch `cluster_uuid` and `cluster_name` as the module-level `cluster.id` and `cluster.name` fields, respectively.