### PR TITLE
Cherry-pick #8961 to 6.5: Update conflicting python dependencies

### DIFF
--- a/libbeat/tests/system/requirements.txt
+++ b/libbeat/tests/system/requirements.txt
@@ -3,9 +3,9 @@ backports.ssl-match-hostname==3.5.0.1
 cached-property==1.4.2
 certifi==2018.1.18
 chardet==3.0.4
-docker==3.2.1
-docker-compose==1.21.0
-docker-pycreds==0.2.2
+docker==3.5.1
+docker-compose==1.23.1
+docker-pycreds==0.3.0
 dockerpty==0.4.1
 docopt==0.6.2
 elasticsearch==6.2.0


### PR DESCRIPTION
Cherry-pick of PR #8961 to 6.5 branch. Original message: 

Through updating requests to 2.20.0 some of the python dependencies have become incompatible.

This was introduced in https://github.com/elastic/beats/pull/8808. Not sure if it actually caused issues but warnings were shown when running make update.