### PR TITLE
Add configuration option to keep raw JSON messages

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -19,7 +19,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha1...master[Check the HEAD d
 
 *Filebeat*
 
-- Keep raw JSON messages. {pull}9172[9172]
+- Add configuration option to keep raw JSON messages. {pull}9172[9172]
 
 *Heartbeat*
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -19,6 +19,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha1...master[Check the HEAD d
 
 *Filebeat*
 
+- Keep raw JSON messages. {pull}9172[9172]
+
 *Heartbeat*
 
 *Journalbeat*

--- a/filebeat/_meta/common.reference.p2.yml
+++ b/filebeat/_meta/common.reference.p2.yml
@@ -107,6 +107,9 @@ filebeat.inputs:
   # be used.
   #json.add_error_key: false
 
+  # Keep the original unparsed line under log.original field.
+  #json.keep_original_message: false
+
   ### Multiline options
 
   # Multiline can be used for log messages spanning multiple lines. This is common
@@ -354,6 +357,9 @@ filebeat.inputs:
 
   # Combine partial lines flagged by `json-file` format
   #combine_partials: true
+
+  # Keep the original unparsed line under log.original field.
+  #keep_original_message: false
 
   # Use this to read from all containers, replace * with a container id to read from one:
   #containers:

--- a/filebeat/_meta/common.reference.p2.yml
+++ b/filebeat/_meta/common.reference.p2.yml
@@ -108,7 +108,7 @@ filebeat.inputs:
   #json.add_error_key: false
 
   # Keep the original unparsed line under log.original field.
-  #json.keep_original_message: false
+  #json.keep_original: false
 
   ### Multiline options
 
@@ -359,7 +359,7 @@ filebeat.inputs:
   #combine_partials: true
 
   # Keep the original unparsed line under log.original field.
-  #keep_original_message: false
+  #keep_original: false
 
   # Use this to read from all containers, replace * with a container id to read from one:
   #containers:

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -476,7 +476,7 @@ filebeat.inputs:
   #json.add_error_key: false
 
   # Keep the original unparsed line under log.original field.
-  #json.keep_original_message: false
+  #json.keep_original: false
 
   ### Multiline options
 
@@ -727,7 +727,7 @@ filebeat.inputs:
   #combine_partials: true
 
   # Keep the original unparsed line under log.original field.
-  #keep_original_message: false
+  #keep_original: false
 
   # Use this to read from all containers, replace * with a container id to read from one:
   #containers:

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -475,6 +475,9 @@ filebeat.inputs:
   # be used.
   #json.add_error_key: false
 
+  # Keep the original unparsed line under log.original field.
+  #json.keep_original_message: false
+
   ### Multiline options
 
   # Multiline can be used for log messages spanning multiple lines. This is common
@@ -722,6 +725,9 @@ filebeat.inputs:
 
   # Combine partial lines flagged by `json-file` format
   #combine_partials: true
+
+  # Keep the original unparsed line under log.original field.
+  #keep_original_message: false
 
   # Use this to read from all containers, replace * with a container id to read from one:
   #containers:

--- a/filebeat/input/docker/config.go
+++ b/filebeat/input/docker/config.go
@@ -18,7 +18,8 @@
 package docker
 
 var defaultConfig = config{
-	Partial: true,
+	Partial:      true,
+	KeepOriginal: false,
 	Containers: containers{
 		IDs:    []string{},
 		Path:   "/var/lib/docker/containers",
@@ -37,6 +38,9 @@ type config struct {
 
 	// Fore CRI format (don't perform autodetection)
 	CRIForce bool `config:"cri.force"`
+
+	// Keep original raw message
+	KeepOriginal bool `config:"keep_original_message"`
 }
 
 type containers struct {

--- a/filebeat/input/docker/config.go
+++ b/filebeat/input/docker/config.go
@@ -40,7 +40,7 @@ type config struct {
 	CRIForce bool `config:"cri.force"`
 
 	// Keep original raw message
-	KeepOriginal bool `config:"keep_original_message"`
+	KeepOriginal bool `config:"keep_original"`
 }
 
 type containers struct {

--- a/filebeat/input/log/config.go
+++ b/filebeat/input/log/config.go
@@ -108,7 +108,7 @@ type config struct {
 		Partial      bool   `config:"partial"`
 		ForceCRI     bool   `config:"force_cri_logs"`
 		CRIFlags     bool   `config:"cri_flags"`
-		KeepOriginal bool   `config:"keep_original_message"`
+		KeepOriginal bool   `config:"keep_original"`
 	} `config:"docker-json"`
 }
 

--- a/filebeat/input/log/config.go
+++ b/filebeat/input/log/config.go
@@ -104,10 +104,11 @@ type config struct {
 
 	// Hidden on purpose, used by the docker input:
 	DockerJSON *struct {
-		Stream   string `config:"stream"`
-		Partial  bool   `config:"partial"`
-		ForceCRI bool   `config:"force_cri_logs"`
-		CRIFlags bool   `config:"cri_flags"`
+		Stream       string `config:"stream"`
+		Partial      bool   `config:"partial"`
+		ForceCRI     bool   `config:"force_cri_logs"`
+		CRIFlags     bool   `config:"cri_flags"`
+		KeepOriginal bool   `config:"keep_original_message"`
 	} `config:"docker-json"`
 }
 

--- a/filebeat/scripts/tester/main.go
+++ b/filebeat/scripts/tester/main.go
@@ -151,7 +151,7 @@ func getLogsFromFile(logfile string, conf *logReaderConfig) ([]string, error) {
 			Match:   conf.matchMode,
 			Pattern: &p,
 		}
-		r, err = multiline.New(r, "\n", 1<<20, &c)
+		r, err = multiline.New(r, "\n", 1<<20, false, &c)
 		if err != nil {
 			return nil, err
 		}

--- a/filebeat/tests/files/logs/json_multiline.log
+++ b/filebeat/tests/files/logs/json_multiline.log
@@ -1,0 +1,4 @@
+{"log_line": "[2018-05-05 18:00] line 1"}
+{"log_line": "    line 2"}
+{"log_line": "    line 3"}
+

--- a/filebeat/tests/system/config/filebeat.yml.j2
+++ b/filebeat/tests/system/config/filebeat.yml.j2
@@ -75,7 +75,7 @@ filebeat.{{input_config | default("inputs")}}:
     {% if json.overwrite_keys %}overwrite_keys: true{% endif %}
     {% if json.add_error_key %}add_error_key: true{% endif %}
     {% if json.ignore_decoding_error %}ignore_decoding_error: true{% endif %}
-    {% if json.keep_original_message %}keep_original_message: true{% endif %}
+    {% if json.keep_original %}keep_original: true{% endif %}
   {% endif %}
 
   {% if multiline %}

--- a/filebeat/tests/system/config/filebeat.yml.j2
+++ b/filebeat/tests/system/config/filebeat.yml.j2
@@ -75,6 +75,7 @@ filebeat.{{input_config | default("inputs")}}:
     {% if json.overwrite_keys %}overwrite_keys: true{% endif %}
     {% if json.add_error_key %}add_error_key: true{% endif %}
     {% if json.ignore_decoding_error %}ignore_decoding_error: true{% endif %}
+    {% if json.keep_original_message %}keep_original_message: true{% endif %}
   {% endif %}
 
   {% if multiline %}

--- a/filebeat/tests/system/test_json.py
+++ b/filebeat/tests/system/test_json.py
@@ -413,14 +413,14 @@ class Test(BaseTest):
 
     def test_keep_original(self):
         """
-        JSON events contain raw version if json.keep_original_message is set
+        JSON events contain raw version if json.keep_original is set
         """
 
         self.render_config_template(
             path=os.path.abspath(self.working_dir) + "/log/*",
             json=dict(
                 keys_under_root=True,
-                keep_original_message=True,
+                keep_original=True,
             )
         )
 
@@ -440,14 +440,14 @@ class Test(BaseTest):
 
     def test_keep_original_multiline(self):
         """
-        Multiline JSON events contain raw version if json.keep_original_message is set
+        Multiline JSON events contain raw version if json.keep_original is set
         """
 
         self.render_config_template(
             path=os.path.abspath(self.working_dir) + "/log/*",
             json=dict(
                 keys_under_root=True,
-                keep_original_message=True,
+                keep_original=True,
                 message_key="log_line",
             ),
             multiline=True,

--- a/libbeat/reader/message.go
+++ b/libbeat/reader/message.go
@@ -26,10 +26,11 @@ import (
 // Message represents a reader event with timestamp, content and actual number
 // of bytes read from input before decoding.
 type Message struct {
-	Ts      time.Time     // timestamp the content was read
-	Content []byte        // actual content read
-	Bytes   int           // total number of bytes read to generate the message
-	Fields  common.MapStr // optional fields that can be added by reader
+	Ts       time.Time     // timestamp the content was read
+	Content  []byte        // actual content read
+	Original []byte        // unparsed content
+	Bytes    int           // total number of bytes read to generate the message
+	Fields   common.MapStr // optional fields that can be added by reader
 }
 
 // IsEmpty returns true in case the message is empty

--- a/libbeat/reader/multiline/multiline_test.go
+++ b/libbeat/reader/multiline/multiline_test.go
@@ -282,7 +282,7 @@ func createMultilineTestReader(t *testing.T, in *bytes.Buffer, cfg Config) reade
 		t.Fatalf("Failed to initialize line reader: %v", err)
 	}
 
-	r, err = New(readfile.NewStripNewline(r), "\n", 1<<20, &cfg)
+	r, err = New(readfile.NewStripNewline(r), "\n", 1<<20, false, &cfg)
 	if err != nil {
 		t.Fatalf("failed to initialize reader: %v", err)
 	}

--- a/libbeat/reader/readfile/limit.go
+++ b/libbeat/reader/readfile/limit.go
@@ -40,5 +40,10 @@ func (r *LimitReader) Next() (reader.Message, error) {
 		message.Content = message.Content[:r.maxBytes]
 		message.AddFlagsWithKey("log.flags", "truncated")
 	}
+
+	if len(message.Original) > r.maxBytes {
+		message.Original = message.Original[:r.maxBytes]
+	}
+
 	return message, err
 }

--- a/libbeat/reader/readfile/strip_newline.go
+++ b/libbeat/reader/readfile/strip_newline.go
@@ -42,6 +42,11 @@ func (p *StripNewline) Next() (reader.Message, error) {
 	L := message.Content
 	message.Content = L[:len(L)-lineEndingChars(L)]
 
+	if len(message.Original) > 0 {
+		O := message.Original
+		message.Original = O[:len(O)-lineEndingChars(O)]
+	}
+
 	return message, err
 }
 

--- a/libbeat/reader/readjson/docker_json.go
+++ b/libbeat/reader/readjson/docker_json.go
@@ -195,7 +195,8 @@ func (p *DockerJSONReader) Next() (reader.Message, error) {
 				return message, err
 			}
 
-			original = append(original, message.Content...)
+			original = append(original, []byte("\n")...)
+			original = append(original, next.Content...)
 
 			err = p.parseLine(&next, &logLine)
 			if err != nil {

--- a/libbeat/reader/readjson/json.go
+++ b/libbeat/reader/readjson/json.go
@@ -100,6 +100,10 @@ func (r *JSONReader) Next() (reader.Message, error) {
 		return message, err
 	}
 
+	if r.cfg.KeepOriginal {
+		message.Original = message.Content
+	}
+
 	var fields common.MapStr
 	message.Content, fields = r.decode(message.Content)
 	message.AddFields(common.MapStr{"json": fields})

--- a/libbeat/reader/readjson/json_config.go
+++ b/libbeat/reader/readjson/json_config.go
@@ -24,7 +24,7 @@ type Config struct {
 	OverwriteKeys       bool   `config:"overwrite_keys"`
 	AddErrorKey         bool   `config:"add_error_key"`
 	IgnoreDecodingError bool   `config:"ignore_decoding_error"`
-	KeepOriginal        bool   `config:"keep_original_message"`
+	KeepOriginal        bool   `config:"keep_original"`
 }
 
 // Validate validates the Config option for JSON reader.

--- a/libbeat/reader/readjson/json_config.go
+++ b/libbeat/reader/readjson/json_config.go
@@ -24,6 +24,7 @@ type Config struct {
 	OverwriteKeys       bool   `config:"overwrite_keys"`
 	AddErrorKey         bool   `config:"add_error_key"`
 	IgnoreDecodingError bool   `config:"ignore_decoding_error"`
+	KeepOriginal        bool   `config:"keep_original_message"`
 }
 
 // Validate validates the Config option for JSON reader.

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -485,6 +485,9 @@ filebeat.inputs:
   # be used.
   #json.add_error_key: false
 
+  # Keep the original unparsed line under log.original field.
+  #json.keep_original: false
+
   ### Multiline options
 
   # Multiline can be used for log messages spanning multiple lines. This is common
@@ -732,6 +735,9 @@ filebeat.inputs:
 
   # Combine partial lines flagged by `json-file` format
   #combine_partials: true
+
+  # Keep the original unparsed line under log.original field.
+  #keep_original: false
 
   # Use this to read from all containers, replace * with a container id to read from one:
   #containers:


### PR DESCRIPTION
New configuration option is added for `docker` input and `json` settings of `log` input named `keep_original`. By default it is set to false.

If the option is set, the raw content is published under `log.original` field. The length of the original message is limited by `max_bytes` option of the input.

If `log.original` is part of the incoming event, the field added by Filebeat is overwritten. It behaves the same as `log.offset` or `log.source`. (If `log.original` is part of the event, it is possible to keep both fields by setting `json.fields_under_root` to `false`.)

Partial implementation of #8083 