### PR TITLE
Cherry-pick #9171 to 6.x: Fix panic on docker healthcheck collection

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -55,6 +55,7 @@ https://github.com/elastic/beats/compare/v6.5.0...6.x[Check the HEAD diff]
 *Metricbeat*
 
 - Fix race condition when enriching events with kubernetes metadata. {issue}9055[9055] {issue}9067[9067]
+- Fix panic on docker healthcheck collection on dockers without healthchecks. {pull}9171[9171]
 
 *Packetbeat*
 

--- a/metricbeat/module/docker/healthcheck/data.go
+++ b/metricbeat/module/docker/healthcheck/data.go
@@ -50,6 +50,12 @@ func eventMapping(cont *types.Container, m *MetricSet) common.MapStr {
 		logp.Err("Error inspecting container %v: %v", cont.ID, err)
 		return nil
 	}
+
+	// Check if the container has any health check
+	if container.State.Health == nil {
+		return nil
+	}
+
 	lastEvent := len(container.State.Health.Log) - 1
 
 	// Checks if a healthcheck already happened


### PR DESCRIPTION
Cherry-pick of PR #9171 to 6.x branch. Original message: 

Fix panic on docker healthcheck collection on dockers without healthchecks.