### PR TITLE
Add linux command examples to the docs

### DIFF
--- a/auditbeat/docs/getting-started.asciidoc
+++ b/auditbeat/docs/getting-started.asciidoc
@@ -75,6 +75,25 @@ tar xzvf {beatname_lc}-{version}-darwin-x86_64.tar.gz
 
 endif::[]
 
+[[linux]]
+*linux:*
+
+ifeval::["{release-state}"=="unreleased"]
+
+Version {stack-version} of {beatname_uc} has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
+
+["source","sh",subs="attributes"]
+------------------------------------------------
+curl -L -O https://artifacts.elastic.co/downloads/beats/{beatname_lc}/{beatname_lc}-{version}-linux-x86_64.tar.gz
+tar xzvf {beatname_lc}-{version}-linux-x86_64.tar.gz
+------------------------------------------------
+
+endif::[]
+
 [[docker]]
 *docker:*
 
@@ -206,12 +225,12 @@ start {beatname_uc} in the foreground.
 sudo service {beatname_lc} start
 ----------------------------------------------------------------------
 
-*mac:*
+*mac and linux:*
 
 ["source","sh",subs="attributes"]
 ----------------------------------------------------------------------
 sudo chown root {beatname_lc}.yml <1>
-sudo ./{beatname_lc} -e -c {beatname_lc}.yml
+sudo ./{beatname_lc} -e
 ----------------------------------------------------------------------
 <1> To monitor system files, you'll be running {beatname_uc} as root, so you
 need to change ownership of the configuration file, or run {beatname_uc} with

--- a/auditbeat/docs/index.asciidoc
+++ b/auditbeat/docs/index.asciidoc
@@ -17,6 +17,7 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :mac_os:
 :docker_platform:
 :win_os:
+:linux_os:
 
 include::../../libbeat/docs/shared-beats-attributes.asciidoc[]
 

--- a/filebeat/docs/getting-started.asciidoc
+++ b/filebeat/docs/getting-started.asciidoc
@@ -75,6 +75,25 @@ tar xzvf filebeat-{version}-darwin-x86_64.tar.gz
 
 endif::[]
 
+[[linux]]
+*linux:*
+
+ifeval::["{release-state}"=="unreleased"]
+
+Version {version} of {beatname_uc} has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
+
+["source","sh",subs="attributes,callouts"]
+------------------------------------------------
+curl -L -O https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-{version}-linux-x86_64.tar.gz
+tar xzvf filebeat-{version}-linux-x86_64.tar.gz
+------------------------------------------------
+
+endif::[]
+
 [[docker]]
 *docker:*
 
@@ -223,12 +242,12 @@ sudo service {beatname_lc} start
 docker run {dockerimage}
 ----------------------------------------------------------------------
 
-*mac:*
+*mac and linux:*
 
 [source,shell]
 ----------------------------------------------------------------------
 sudo chown root filebeat.yml <1>
-sudo ./filebeat -e -c filebeat.yml
+sudo ./filebeat -e
 ----------------------------------------------------------------------
 <1> You'll be running Filebeat as root, so you need to change ownership
 of the configuration file, or run Filebeat with `--strict.perms=false`

--- a/filebeat/docs/include/enable-modules-command.asciidoc
+++ b/filebeat/docs/include/enable-modules-command.asciidoc
@@ -13,6 +13,13 @@
 ./{beatname_lc} modules enable {modulename}
 ----
 
+*linux:*
+
+["source","sh",subs="attributes"]
+----
+./{beatname_lc} modules enable {modulename}
+----
+
 *win:*
 
 ["source","sh",subs="attributes"]

--- a/filebeat/docs/include/list-modules-command.asciidoc
+++ b/filebeat/docs/include/list-modules-command.asciidoc
@@ -13,6 +13,13 @@
 ./{beatname_lc} modules list
 ----
 
+*linux:*
+
+["source","sh",subs="attributes"]
+----
+./{beatname_lc} modules list
+----
+
 *win:*
 
 ["source","sh",subs="attributes"]

--- a/filebeat/docs/include/run-command.asciidoc
+++ b/filebeat/docs/include/run-command.asciidoc
@@ -13,6 +13,13 @@ service {beatname_lc} start
 ./{beatname_lc} -e
 ----
 
+*linux:*
+
+["source","sh",subs="attributes"]
+----
+./{beatname_lc} -e
+----
+
 *win:*
 
 ["source","sh",subs="attributes"]

--- a/filebeat/docs/include/set-paths.asciidoc
+++ b/filebeat/docs/include/set-paths.asciidoc
@@ -28,6 +28,13 @@ must include the module and fileset name. For example:
 ./{beatname_lc} -e -M "nginx.access.var.paths=[/usr/local/var/log/nginx/access.log*]"
 ----
 
+*linux:*
+
+["source","sh",subs="attributes"]
+----
+./{beatname_lc} -e -M "nginx.access.var.paths=[/usr/local/var/log/nginx/access.log*]"
+----
+
 *win:*
 
 ["source","sh",subs="attributes"]

--- a/filebeat/docs/include/setup-command.asciidoc
+++ b/filebeat/docs/include/setup-command.asciidoc
@@ -13,6 +13,13 @@
 ./{beatname_lc} setup -e
 ----
 
+*linux:*
+
+["source","sh",subs="attributes"]
+----
+./{beatname_lc} setup -e
+----
+
 *win:*
 
 ["source","sh",subs="attributes"]

--- a/filebeat/docs/index.asciidoc
+++ b/filebeat/docs/index.asciidoc
@@ -15,6 +15,7 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :deb_os:
 :rpm_os:
 :mac_os:
+:linux_os:
 :docker_platform:
 :win_os:
 

--- a/heartbeat/docs/getting-started.asciidoc
+++ b/heartbeat/docs/getting-started.asciidoc
@@ -81,6 +81,23 @@ tar xzvf heartbeat-{version}-darwin-x86_64.tar.gz
 
 endif::[]
 
+[[linux]]
+*linux:*
+
+ifeval::["{release-state}"=="unreleased"]
+
+Version {version} of {beatname_uc} has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
+
+["source","sh",subs="attributes"]
+------------------------------------------------
+curl -L -O {downloads}/heartbeat/heartbeat-{version}-linux-x86_64.tar.gz
+tar xzvf heartbeat-{version}-linux-x86_64.tar.gz
+------------------------------------------------
+endif::[]
 
 [[docker]]
 *docker:*
@@ -230,12 +247,12 @@ start Heartbeat in the foreground.
 sudo service {beatname_lc}-elastic start
 ----------------------------------------------------------------------
 
-*mac:*
+*mac and linux:*
 
 ["source","sh",subs="attributes"]
 ----------------------------------------------------------------------
 sudo chown root heartbeat.yml <1>
-sudo ./heartbeat -e -c heartbeat.yml
+sudo ./heartbeat -e
 ----------------------------------------------------------------------
 <1> You'll be running Heartbeat as root, so you need to change ownership of the
 configuration file, or run Heartbeat with `--strict.perms=false` specified. See

--- a/heartbeat/docs/index.asciidoc
+++ b/heartbeat/docs/index.asciidoc
@@ -15,6 +15,7 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :deb_os:
 :rpm_os:
 :mac_os:
+:linux_os:
 :docker_platform:
 :win_os:
 

--- a/journalbeat/docs/index.asciidoc
+++ b/journalbeat/docs/index.asciidoc
@@ -14,6 +14,7 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :libbeat-docs: Beats Platform Reference
 :deb_os:
 :rpm_os:
+:linux_os:
 :no_dashboards:
 
 include::../../libbeat/docs/shared-beats-attributes.asciidoc[]

--- a/libbeat/docs/dashboards.asciidoc
+++ b/libbeat/docs/dashboards.asciidoc
@@ -58,6 +58,15 @@ ifdef::mac_os[]
 ----------------------------------------------------------------------
 endif::mac_os[]
 
+ifdef::linux_os[]
+*linux:*
+
+["source","sh",subs="attributes"]
+----------------------------------------------------------------------
+./{beatname_lc} setup --dashboards
+----------------------------------------------------------------------
+endif::linux_os[]
+
 ifdef::docker_platform[]
 *docker:*
 
@@ -125,6 +134,19 @@ ifdef::mac_os[]
 ----
 endif::mac_os[]
 
+ifdef::linux_os[]
+*linux:*
+
+["source","sh",subs="attributes"]
+----
+./{beatname_lc} setup -e \
+  -E output.logstash.enabled=false \
+  -E output.elasticsearch.hosts=['localhost:9200'] \
+  -E output.elasticsearch.username={beat_default_index_prefix}_internal \
+  -E output.elasticsearch.password={pwd} \
+  -E setup.kibana.host=localhost:5601 
+----
+endif::linux_os[]
 
 ifdef::docker_platform[]
 *docker:*

--- a/libbeat/docs/reference-yml.asciidoc
+++ b/libbeat/docs/reference-yml.asciidoc
@@ -5,9 +5,8 @@ The following reference file is available with your {beatname_uc} installation. 
 shows all non-deprecated {beatname_uc} options. You can copy from this file and paste
 configurations into the +{beatname_lc}.yml+ file to customize it.
 
-TIP: For rpm and deb, you'll find the reference configuration file at +/etc/{beatname_lc}/{beatname_lc}.reference.yml+. Under
-Docker, it's located at +/usr/share/{beatname_lc}/{beatname_lc}.reference.yml+. For mac and win,
-look in the archive that you just extracted.
+TIP: The reference file is located in the same directory as the
++{beatname_lc}.yml+ file. To locate the file, see <<directory-layout>>. 
 
 The contents of the file are included here for your convenience.
 

--- a/libbeat/docs/shared-template-load.asciidoc
+++ b/libbeat/docs/shared-template-load.asciidoc
@@ -155,14 +155,24 @@ ifdef::mac_os[]
 ----
 endif::mac_os[]
 
-ifdef::mac_os[]
+ifdef::linux_os[]
+*linux:*
+
+["source","sh",subs="attributes"]
+----
+./{beatname_lc} setup --template{disable_logstash} -E 'output.elasticsearch.hosts=["localhost:9200"]'
+----
+endif::linux_os[]
+
+
+ifdef::docker_platform[]
 *docker:*
 
 ["source","sh",subs="attributes"]
 ----------------------------------------------------------------------
 docker run {dockerimage} setup --template{disable_logstash} -E 'output.elasticsearch.hosts=["localhost:9200"]'
 ----------------------------------------------------------------------
-endif::mac_os[]
+endif::docker_platform[]
 
 ifdef::win_os[]
 ifndef::win_only[]
@@ -187,7 +197,9 @@ endif::win_os[]
 If you've already used {beatname_uc} to index data into Elasticsearch,
 the index may contain old documents. After you load the index template,
 you can delete the old documents from +{beatname_lc}-*+ to force Kibana to look
-at the newest documents. Use this command:
+at the newest documents.
+
+Use this command:
 
 ifdef::deb_os,rpm_os[]
 *deb and rpm:*
@@ -206,6 +218,15 @@ ifdef::mac_os[]
 curl -XDELETE 'http://localhost:9200/{beatname_lc}-*'
 ----------------------------------------------------------------------
 endif::mac_os[]
+
+ifdef::linux_os[]
+*linux:*
+
+["source","sh",subs="attributes"]
+----------------------------------------------------------------------
+curl -XDELETE 'http://localhost:9200/{beatname_lc}-*'
+----------------------------------------------------------------------
+endif::linux_os[]
 
 ifdef::win_os[]
 ifndef::win_only[]
@@ -249,6 +270,15 @@ ifdef::mac_os[]
 ----
 endif::mac_os[]
 
+ifdef::linux_os[]
+*linux:*
+
+["source","sh",subs="attributes"]
+----
+./{beatname_lc} export template > {beatname_lc}.template.json
+----
+endif::linux_os[]
+
 ifdef::win_os[]
 ifndef::win_only[]
 *win:*
@@ -279,6 +309,15 @@ ifdef::mac_os[]
 curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_template/{beatname_lc}-{stack-version} -d@{beatname_lc}.template.json
 ----
 endif::mac_os[]
+
+ifdef::linux_os[]
+*linux:*
+
+["source","sh",subs="attributes"]
+----
+curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_template/{beatname_lc}-{stack-version} -d@{beatname_lc}.template.json
+----
+endif::linux_os[]
 
 ifdef::win_os[]
 ifndef::win_only[]

--- a/metricbeat/docs/gettingstarted.asciidoc
+++ b/metricbeat/docs/gettingstarted.asciidoc
@@ -84,6 +84,25 @@ tar xzvf {beatname_lc}-{version}-darwin-x86_64.tar.gz
 
 endif::[]
 
+[[linux]]
+*linux:*
+
+ifeval::["{release-state}"=="unreleased"]
+
+Version {stack-version} of {beatname_uc} has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
+
+["source","sh",subs="attributes"]
+------------------------------------------------
+curl -L -O https://artifacts.elastic.co/downloads/beats/{beatname_lc}/{beatname_lc}-{version}-linux-x86_64.tar.gz
+tar xzvf {beatname_lc}-{version}-linux-x86_64.tar.gz
+------------------------------------------------
+
+endif::[]
+
 [[docker]]
 *docker:*
 
@@ -178,7 +197,7 @@ The following examples enable the `apache` and `mysql` configs in the
 {beatname_lc} modules enable apache mysql
 ----
 +
-*mac:*
+*mac and linux:*
 +
 ["source","sh",subs="attributes"]
 ----
@@ -243,13 +262,13 @@ sudo service {beatname_lc} start
 
 See <<running-on-docker>>.
 
-*mac:*
+*mac and linux:*
 
 ["source","sh",subs="attributes,callouts"]
 ----------------------------------------------------------------------
 sudo chown root {beatname_lc}.yml <1>
 sudo chown root modules.d/system.yml <1>
-sudo ./{beatname_lc} -e -c {beatname_lc}.yml
+sudo ./{beatname_lc} -e
 ----------------------------------------------------------------------
 <1> You'll be running {beatname_uc} as root, so you need to change ownership of the
 configuration file and any configurations enabled in the `modules.d` directory,

--- a/metricbeat/docs/index.asciidoc
+++ b/metricbeat/docs/index.asciidoc
@@ -15,6 +15,7 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :deb_os:
 :rpm_os:
 :mac_os:
+:linux_os:
 :docker_platform:
 :win_os:
 

--- a/packetbeat/docs/gettingstarted.asciidoc
+++ b/packetbeat/docs/gettingstarted.asciidoc
@@ -96,6 +96,25 @@ tar xzvf packetbeat-{version}-darwin-x86_64.tar.gz
 
 endif::[]
 
+[[linux]]
+*linux:*
+
+ifeval::["{release-state}"=="unreleased"]
+
+Version {stack-version} of {beatname_uc} has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
+
+["source","sh",subs="attributes,callouts"]
+----------------------------------------------------------------------
+curl -L -O https://artifacts.elastic.co/downloads/beats/packetbeat/packetbeat-{version}-linux-x86_64.tar.gz
+tar xzvf packetbeat-{version}-linux-x86_64.tar.gz
+----------------------------------------------------------------------
+
+endif::[]
+
 [[win]]
 *win:*
 
@@ -272,12 +291,12 @@ sudo service {beatname_lc} start
 docker run {dockerimage}
 ----------------------------------------------------------------------
 
-*mac:*
+*mac and linux:*
 
 [source,shell]
 ----------------------------------------------------------------------
 sudo chown root packetbeat.yml <1>
-sudo ./packetbeat -e -c packetbeat.yml
+sudo ./packetbeat -e
 ----------------------------------------------------------------------
 <1> You'll be running Packetbeat as root, so you need to change ownership of the
 configuration file, or run Packetbeat with `--strict.perms=false` specified. See

--- a/packetbeat/docs/index.asciidoc
+++ b/packetbeat/docs/index.asciidoc
@@ -15,6 +15,7 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :deb_os:
 :rpm_os:
 :mac_os:
+:linux_os:
 :docker_platform:
 :win_os:
 


### PR DESCRIPTION
This PR adds Linux commands to the docs for all the Beats.

I realize that this introduces some repetition. Although I'd like to collapse "linux" and "win" into single examples, it's not feasible (without even more conditional coding, which gets ugly) because some beats don't support both linux *and* windows.

What I really want is a widget for displaying command examples that lets users choose their platform, but this isn't possible yet, so we'll have to accept the repetition. :-/