### PR TITLE
Cherry-pick #9191 to 6.5: Fix download link for Kafka

### DIFF
--- a/metricbeat/module/kafka/_meta/Dockerfile
+++ b/metricbeat/module/kafka/_meta/Dockerfile
@@ -11,7 +11,7 @@ ENV TERM=linux
 RUN apt-get update && apt-get install -y curl openjdk-8-jre-headless netcat dnsutils
 
 RUN mkdir -p ${KAFKA_LOGS_DIR} && mkdir -p ${KAFKA_HOME} && curl -s -o $INSTALL_DIR/kafka.tgz \
-    "http://ftp.wayne.edu/apache/kafka/${KAFKA_VERSION}/kafka_2.11-${KAFKA_VERSION}.tgz" && \
+    "https://archive.apache.org/dist/kafka/${KAFKA_VERSION}/kafka_2.11-${KAFKA_VERSION}.tgz" && \
     tar xzf ${INSTALL_DIR}/kafka.tgz -C ${KAFKA_HOME} --strip-components 1
 
 ADD run.sh /run.sh


### PR DESCRIPTION
Cherry-pick of PR #9191 to 6.5 branch. Original message: 

The download link in the Kafka Docker image was not valid anymore.