### PR TITLE
Upgrade test Docker images to latest versions

### DIFF
--- a/metricbeat/module/elasticsearch/_meta/Dockerfile
+++ b/metricbeat/module/elasticsearch/_meta/Dockerfile
@@ -1,2 +1,2 @@
 FROM docker.elastic.co/elasticsearch/elasticsearch:6.5.1
-HEALTHCHECK --interval=1s --retries=300 CMD curl -f http://localhost:9200/_xpack/license
+HEALTHCHECK --interval=1s --retries=300 CMD curl -f http://localhost:9200/_cluster/health

--- a/metricbeat/module/elasticsearch/_meta/Dockerfile
+++ b/metricbeat/module/elasticsearch/_meta/Dockerfile
@@ -1,2 +1,2 @@
 FROM docker.elastic.co/elasticsearch/elasticsearch:6.5.1
-HEALTHCHECK --interval=1s --retries=300 CMD curl -f http://localhost:9200
+HEALTHCHECK --interval=1s --retries=300 CMD curl -f http://localhost:9200/_xpack/license

--- a/metricbeat/module/elasticsearch/_meta/Dockerfile
+++ b/metricbeat/module/elasticsearch/_meta/Dockerfile
@@ -1,2 +1,2 @@
-FROM docker.elastic.co/elasticsearch/elasticsearch:6.4.3
+FROM docker.elastic.co/elasticsearch/elasticsearch:6.5.1
 HEALTHCHECK --interval=1s --retries=300 CMD curl -f http://localhost:9200

--- a/metricbeat/module/elasticsearch/ccr/_meta/test/test_follower_index.json
+++ b/metricbeat/module/elasticsearch/ccr/_meta/test/test_follower_index.json
@@ -1,0 +1,4 @@
+{
+    "remote_cluster": "same",
+    "leader_index": "pied_piper"
+}

--- a/metricbeat/module/elasticsearch/ccr/_meta/test/test_leader_index.json
+++ b/metricbeat/module/elasticsearch/ccr/_meta/test/test_leader_index.json
@@ -1,0 +1,5 @@
+{
+    "settings": {
+        "soft_deletes.enabled": true
+    }
+}

--- a/metricbeat/module/elasticsearch/ccr/_meta/test/test_remote_settings.json
+++ b/metricbeat/module/elasticsearch/ccr/_meta/test/test_remote_settings.json
@@ -1,0 +1,13 @@
+{
+    "transient": {
+        "cluster": {
+            "remote": {
+                "same": {
+                    "seeds": [
+                        "127.0.0.1:9300"
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
+++ b/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
@@ -72,6 +72,9 @@ func TestFetch(t *testing.T) {
 	err = createMLJob(host)
 	assert.NoError(t, err)
 
+	err = createCCRStats(host)
+	assert.NoError(t, err)
+
 	for _, metricSet := range metricSets {
 		checkSkip(t, metricSet, host)
 		t.Run(metricSet, func(t *testing.T) {
@@ -187,36 +190,71 @@ func createMLJob(host string) error {
 		return err
 	}
 
-	client := &http.Client{}
-
 	jobURL := "/_xpack/ml/anomaly_detectors/total-requests"
 
 	if checkExists("http://" + host + jobURL) {
 		return nil
 	}
 
-	req, err := http.NewRequest("PUT", "http://"+host+jobURL, bytes.NewReader(mlJob))
-	if err != nil {
-		return err
-	}
-	req.Header.Add("Content-Type", "application/json")
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return err
-	}
+	body, resp, err := httpPutJson(host, jobURL, mlJob)
 
 	if resp.StatusCode != 200 {
 		return fmt.Errorf("HTTP error loading ml job %d: %s, %s", resp.StatusCode, resp.Status, body)
 	}
 
 	return nil
+}
+
+func createCCRStats(host string) error {
+	err := setupCCRRemote(host)
+	if err != nil {
+		return err
+	}
+
+	err = createCCRLeaderIndex(host)
+	if err != nil {
+		return err
+	}
+
+	err = createCCRFollowerIndex(host)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func setupCCRRemote(host string) error {
+	remoteSettings, err := ioutil.ReadFile("ccr/_meta/test/test_remote_settings.json")
+	if err != nil {
+		return err
+	}
+
+	settingsURL := "/_cluster/settings"
+	_, _, err = httpPutJson(host, settingsURL, remoteSettings)
+	return err
+}
+
+func createCCRLeaderIndex(host string) error {
+	leaderIndex, err := ioutil.ReadFile("ccr/_meta/test/test_leader_index.json")
+	if err != nil {
+		return err
+	}
+
+	indexURL := "/pied_piper"
+	_, _, err = httpPutJson(host, indexURL, leaderIndex)
+	return err
+}
+
+func createCCRFollowerIndex(host string) error {
+	followerIndex, err := ioutil.ReadFile("ccr/_meta/test/test_follower_index.json")
+	if err != nil {
+		return err
+	}
+
+	followURL := "/rats/_ccr/follow"
+	_, _, err = httpPutJson(host, followURL, followerIndex)
+	return err
 }
 
 func checkExists(url string) bool {
@@ -276,4 +314,26 @@ func getElasticsearchVersion(elasticsearchHostPort string) (string, error) {
 		return "", err
 	}
 	return version.(string), nil
+}
+
+func httpPutJson(host, path string, body []byte) ([]byte, *http.Response, error) {
+	req, err := http.NewRequest("PUT", "http://"+host+path, bytes.NewReader(body))
+	if err != nil {
+		return nil, nil, err
+	}
+	req.Header.Add("Content-Type", "application/json")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err = ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return body, resp, nil
 }

--- a/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
+++ b/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
@@ -196,7 +196,7 @@ func createMLJob(host string) error {
 		return nil
 	}
 
-	body, resp, err := httpPutJson(host, jobURL, mlJob)
+	body, resp, err := httpPutJSON(host, jobURL, mlJob)
 
 	if resp.StatusCode != 200 {
 		return fmt.Errorf("HTTP error loading ml job %d: %s, %s", resp.StatusCode, resp.Status, body)
@@ -231,7 +231,7 @@ func setupCCRRemote(host string) error {
 	}
 
 	settingsURL := "/_cluster/settings"
-	_, _, err = httpPutJson(host, settingsURL, remoteSettings)
+	_, _, err = httpPutJSON(host, settingsURL, remoteSettings)
 	return err
 }
 
@@ -242,7 +242,7 @@ func createCCRLeaderIndex(host string) error {
 	}
 
 	indexURL := "/pied_piper"
-	_, _, err = httpPutJson(host, indexURL, leaderIndex)
+	_, _, err = httpPutJSON(host, indexURL, leaderIndex)
 	return err
 }
 
@@ -253,7 +253,7 @@ func createCCRFollowerIndex(host string) error {
 	}
 
 	followURL := "/rats/_ccr/follow"
-	_, _, err = httpPutJson(host, followURL, followerIndex)
+	_, _, err = httpPutJSON(host, followURL, followerIndex)
 	return err
 }
 
@@ -316,7 +316,7 @@ func getElasticsearchVersion(elasticsearchHostPort string) (string, error) {
 	return version.(string), nil
 }
 
-func httpPutJson(host, path string, body []byte) ([]byte, *http.Response, error) {
+func httpPutJSON(host, path string, body []byte) ([]byte, *http.Response, error) {
 	req, err := http.NewRequest("PUT", "http://"+host+path, bytes.NewReader(body))
 	if err != nil {
 		return nil, nil, err

--- a/metricbeat/module/elasticsearch/test_elasticsearch.py
+++ b/metricbeat/module/elasticsearch/test_elasticsearch.py
@@ -76,7 +76,8 @@ class Test(metricbeat.BaseTest):
     def setup_ccr_remote(self):
         es = Elasticsearch(self.get_hosts())
 
-        file = os.path.join(self.beat_path, "module", "elasticsearch", "ccr", "_meta", "test", "test_remote_settings.json")
+        file = os.path.join(self.beat_path, "module", "elasticsearch", "ccr",
+                            "_meta", "test", "test_remote_settings.json")
 
         body = {}
         with open(file, 'r') as f:
@@ -100,7 +101,8 @@ class Test(metricbeat.BaseTest):
     def create_ccr_follower_index(self):
         es = Elasticsearch(self.get_hosts())
 
-        file = os.path.join(self.beat_path, "module", "elasticsearch", "ccr", "_meta", "test", "test_follower_index.json")
+        file = os.path.join(self.beat_path, "module", "elasticsearch", "ccr",
+                            "_meta", "test", "test_follower_index.json")
 
         body = {}
         with open(file, 'r') as f:

--- a/metricbeat/module/elasticsearch/test_elasticsearch.py
+++ b/metricbeat/module/elasticsearch/test_elasticsearch.py
@@ -36,6 +36,7 @@ class Test(metricbeat.BaseTest):
         """
         self.check_skip(metricset)
 
+        self.start_trial()
         if metricset == "ml_job":
             self.create_ml_job()
 
@@ -51,13 +52,6 @@ class Test(metricbeat.BaseTest):
     def create_ml_job(self):
         es = Elasticsearch(self.get_hosts())
 
-        # Enable xpack trial
-        try:
-            es.transport.perform_request('POST', "/_xpack/license/start_trial?acknowledge=true")
-        except:
-            e = sys.exc_info()[0]
-            print "Trial already enabled. Error: {}".format(e)
-
         # Check if an ml job already exists
         response = es.transport.perform_request('GET', "/_xpack/ml/anomaly_detectors/_all/")
         if response["count"] > 0:
@@ -71,6 +65,16 @@ class Test(metricbeat.BaseTest):
 
         path = "/_xpack/ml/anomaly_detectors/test"
         es.transport.perform_request('PUT', path, body=body)
+
+    def start_trial(self):
+        es = Elasticsearch(self.get_hosts())
+
+        # Enable xpack trial
+        try:
+            es.transport.perform_request('POST', "/_xpack/license/start_trial?acknowledge=true")
+        except:
+            e = sys.exc_info()[0]
+            print "Trial already enabled. Error: {}".format(e)
 
     def check_skip(self, metricset):
         if metricset != "ccr":

--- a/metricbeat/module/elasticsearch/test_elasticsearch.py
+++ b/metricbeat/module/elasticsearch/test_elasticsearch.py
@@ -34,15 +34,15 @@ class Test(metricbeat.BaseTest):
         """
         elasticsearch metricset tests
         """
-        self.check_skip(metricset)
-
-        self.start_trial()
-        if metricset == "ml_job":
-            self.create_ml_job()
-        if metricset == "ccr":
-            self.create_ccr_stats()
-
         es = Elasticsearch(self.get_hosts())
+        self.check_skip(metricset, es)
+
+        self.start_trial(es)
+        if metricset == "ml_job":
+            self.create_ml_job(es)
+        if metricset == "ccr":
+            self.create_ccr_stats(es)
+
         es.indices.create(index='test-index', ignore=400)
         self.check_metricset("elasticsearch", metricset, self.get_hosts(), self.FIELDS +
                              ["service.name"], extras={"index_recovery.active_only": "false"})
@@ -51,9 +51,7 @@ class Test(metricbeat.BaseTest):
         return [os.getenv('ES_HOST', 'localhost') + ':' +
                 os.getenv('ES_PORT', '9200')]
 
-    def create_ml_job(self):
-        es = Elasticsearch(self.get_hosts())
-
+    def create_ml_job(self, es):
         # Check if an ml job already exists
         response = es.transport.perform_request('GET', "/_xpack/ml/anomaly_detectors/_all/")
         if response["count"] > 0:
@@ -68,14 +66,12 @@ class Test(metricbeat.BaseTest):
         path = "/_xpack/ml/anomaly_detectors/test"
         es.transport.perform_request('PUT', path, body=body)
 
-    def create_ccr_stats(self):
-        self.setup_ccr_remote()
-        self.create_ccr_leader_index()
-        self.create_ccr_follower_index()
+    def create_ccr_stats(self, es):
+        self.setup_ccr_remote(es)
+        self.create_ccr_leader_index(es)
+        self.create_ccr_follower_index(es)
 
-    def setup_ccr_remote(self):
-        es = Elasticsearch(self.get_hosts())
-
+    def setup_ccr_remote(self, es):
         file = os.path.join(self.beat_path, "module", "elasticsearch", "ccr",
                             "_meta", "test", "test_remote_settings.json")
 
@@ -86,9 +82,7 @@ class Test(metricbeat.BaseTest):
         path = "/_cluster/settings"
         es.transport.perform_request('PUT', path, body=body)
 
-    def create_ccr_leader_index(self):
-        es = Elasticsearch(self.get_hosts())
-
+    def create_ccr_leader_index(self, es):
         file = os.path.join(self.beat_path, "module", "elasticsearch", "ccr", "_meta", "test", "test_leader_index.json")
 
         body = {}
@@ -98,9 +92,7 @@ class Test(metricbeat.BaseTest):
         path = "/pied_piper"
         es.transport.perform_request('PUT', path, body=body)
 
-    def create_ccr_follower_index(self):
-        es = Elasticsearch(self.get_hosts())
-
+    def create_ccr_follower_index(self, es):
         file = os.path.join(self.beat_path, "module", "elasticsearch", "ccr",
                             "_meta", "test", "test_follower_index.json")
 
@@ -111,9 +103,7 @@ class Test(metricbeat.BaseTest):
         path = "/rats/_ccr/follow"
         es.transport.perform_request('PUT', path, body=body)
 
-    def start_trial(self):
-        es = Elasticsearch(self.get_hosts())
-
+    def start_trial(self, es):
         # Check if trial is already enabled
         response = es.transport.perform_request('GET', "/_xpack/license")
         if response["license"]["type"] == "trial":
@@ -126,21 +116,16 @@ class Test(metricbeat.BaseTest):
             e = sys.exc_info()[0]
             print "Trial already enabled. Error: {}".format(e)
 
-    def check_skip(self, metricset):
+    def check_skip(self, metricset, es):
         if metricset != "ccr":
             return
 
-        version = self.get_version()
+        version = self.get_version(es)
         if semver.compare(version, "6.5.0") == -1:
             # Skip CCR metricset system test for Elasticsearch versions < 6.5.0 as CCR Stats
             # API endpoint is not available
             raise SkipTest("elasticsearch/ccr metricset system test only valid with Elasticsearch versions >= 6.5.0")
 
-    def get_version(self):
-        host = self.get_hosts()[0]
-        res = urllib2.urlopen("http://" + host + "/").read()
-
-        body = json.loads(res)
-        version = body["version"]["number"]
-
-        return version
+    def get_version(self, es):
+        response = es.transport.perform_request('GET', "/")
+        return response["version"]["number"]

--- a/metricbeat/module/elasticsearch/test_elasticsearch.py
+++ b/metricbeat/module/elasticsearch/test_elasticsearch.py
@@ -5,7 +5,6 @@ import unittest
 from elasticsearch import Elasticsearch, TransportError
 from parameterized import parameterized
 from nose.plugins.skip import SkipTest
-from time import sleep
 import urllib2
 import json
 import semver
@@ -13,10 +12,6 @@ import semver
 sys.path.append(os.path.join(os.path.dirname(__file__), '../../tests/system'))
 
 import metricbeat
-
-
-def setup_module():
-    sleep(25)
 
 
 class Test(metricbeat.BaseTest):

--- a/metricbeat/module/elasticsearch/test_elasticsearch.py
+++ b/metricbeat/module/elasticsearch/test_elasticsearch.py
@@ -5,6 +5,7 @@ import unittest
 from elasticsearch import Elasticsearch, TransportError
 from parameterized import parameterized
 from nose.plugins.skip import SkipTest
+from time import sleep
 import urllib2
 import json
 import semver
@@ -13,6 +14,8 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '../../tests/system'))
 
 import metricbeat
 
+def setup_module():
+    sleep(25)
 
 class Test(metricbeat.BaseTest):
 

--- a/metricbeat/module/elasticsearch/test_elasticsearch.py
+++ b/metricbeat/module/elasticsearch/test_elasticsearch.py
@@ -14,8 +14,10 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '../../tests/system'))
 
 import metricbeat
 
+
 def setup_module():
     sleep(25)
+
 
 class Test(metricbeat.BaseTest):
 

--- a/metricbeat/module/kibana/_meta/Dockerfile
+++ b/metricbeat/module/kibana/_meta/Dockerfile
@@ -1,2 +1,2 @@
-FROM docker.elastic.co/kibana/kibana:6.4.3
+FROM docker.elastic.co/kibana/kibana:6.5.1
 HEALTHCHECK --interval=1s --retries=300 CMD curl -f http://localhost:5601/api/status | grep '"disconnects"'


### PR DESCRIPTION
This PR upgrades the Elasticsearch and Kibana Docker images to their latest versions in their respective Metricbeat module tests.

In addition to the actual version upgrade changes, this PR also contains several changes necessary to get the integration and system tests for the `elasticsearch/ccr` metricset passing. These tests existed before this PR but were skipped because:
- the CCR feature only exists in Elasticsearch 6.5.0 onwards,
- the tests had a check to skip if the version of Elasticsearch being used in the tests was < 6.5.0, and
- we were using Elasticsearch 6.4.3 until this PR came along and upgraded it.

