### PR TITLE
Cherry-pick #9194 to 6.x: Add flag to disable docker cpu metrics collection per core

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -88,6 +88,8 @@ https://github.com/elastic/beats/compare/v6.5.0...6.x[Check the HEAD diff]
 
 - Collect custom cluster `display_name` in `elasticsearch/cluster_stats` metricset. {pull}8445[8445]
 - Test etcd module with etcd 3.3. {pull}9068[9068]
+- Add setting to disable docker cpu metrics per core. {pull}9194[9194]
+- The `elasticsearch/node` metricset now reports the Elasticsearch cluster UUID. {pull}8771[8771]
 
 *Packetbeat*
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -89,7 +89,6 @@ https://github.com/elastic/beats/compare/v6.5.0...6.x[Check the HEAD diff]
 - Collect custom cluster `display_name` in `elasticsearch/cluster_stats` metricset. {pull}8445[8445]
 - Test etcd module with etcd 3.3. {pull}9068[9068]
 - Add setting to disable docker cpu metrics per core. {pull}9194[9194]
-- The `elasticsearch/node` metricset now reports the Elasticsearch cluster UUID. {pull}8771[8771]
 
 *Packetbeat*
 

--- a/metricbeat/docs/modules/docker.asciidoc
+++ b/metricbeat/docs/modules/docker.asciidoc
@@ -50,6 +50,9 @@ metricbeat.modules:
   # If set to true, replace dots in labels with `_`.
   #labels.dedot: false
 
+  # If set to true, collects metrics per core.
+  #cpu.cores: true
+
   # To connect to Docker over TLS you must specify a client and CA certificate.
   #ssl:
     #certificate_authority: "/etc/pki/root/ca.pem"

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -178,6 +178,9 @@ metricbeat.modules:
   # If set to true, replace dots in labels with `_`.
   #labels.dedot: false
 
+  # If set to true, collects metrics per core.
+  #cpu.cores: true
+
   # To connect to Docker over TLS you must specify a client and CA certificate.
   #ssl:
     #certificate_authority: "/etc/pki/root/ca.pem"

--- a/metricbeat/module/docker/_meta/config.reference.yml
+++ b/metricbeat/module/docker/_meta/config.reference.yml
@@ -15,6 +15,9 @@
   # If set to true, replace dots in labels with `_`.
   #labels.dedot: false
 
+  # If set to true, collects metrics per core.
+  #cpu.cores: true
+
   # To connect to Docker over TLS you must specify a client and CA certificate.
   #ssl:
     #certificate_authority: "/etc/pki/root/ca.pem"

--- a/metricbeat/module/docker/cpu/cpu.go
+++ b/metricbeat/module/docker/cpu/cpu.go
@@ -51,10 +51,19 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 		return nil, err
 	}
 
+	cpuConfig := struct {
+		Cores bool `config:"cpu.cores"`
+	}{
+		Cores: true,
+	}
+	if err := base.Module().UnpackConfig(&cpuConfig); err != nil {
+		return nil, err
+	}
+
 	return &MetricSet{
 		BaseMetricSet: base,
 		dockerClient:  client,
-		cpuService:    &CPUService{},
+		cpuService:    &CPUService{Cores: cpuConfig.Cores},
 		dedot:         config.DeDot,
 	}, nil
 }

--- a/metricbeat/module/docker/cpu/helper.go
+++ b/metricbeat/module/docker/cpu/helper.go
@@ -38,7 +38,10 @@ type CPUStats struct {
 	SystemUsagePercentage       float64
 }
 
-type CPUService struct{}
+// CPUService is a helper to collect docker CPU metrics
+type CPUService struct {
+	Cores bool
+}
 
 func NewCpuService() *CPUService {
 	return &CPUService{}
@@ -57,10 +60,9 @@ func (c *CPUService) getCPUStatsList(rawStats []docker.Stat, dedot bool) []CPUSt
 func (c *CPUService) getCPUStats(myRawStat *docker.Stat, dedot bool) CPUStats {
 	usage := cpuUsage{Stat: myRawStat}
 
-	return CPUStats{
+	stats := CPUStats{
 		Time:                        common.Time(myRawStat.Stats.Read),
 		Container:                   docker.NewContainer(myRawStat.Container, dedot),
-		PerCpuUsage:                 usage.PerCPU(),
 		TotalUsage:                  usage.Total(),
 		UsageInKernelmode:           myRawStat.Stats.CPUStats.CPUUsage.UsageInKernelmode,
 		UsageInKernelmodePercentage: usage.InKernelMode(),
@@ -69,6 +71,12 @@ func (c *CPUService) getCPUStats(myRawStat *docker.Stat, dedot bool) CPUStats {
 		SystemUsage:                 myRawStat.Stats.CPUStats.SystemUsage,
 		SystemUsagePercentage:       usage.System(),
 	}
+
+	if c.Cores {
+		stats.PerCpuUsage = usage.PerCPU()
+	}
+
+	return stats
 }
 
 // TODO: These helper should be merged with the cpu helper in system/cpu


### PR DESCRIPTION
Cherry-pick of PR #9194 to 6.x branch. Original message: 

Docker CPU metrics collection per core can create loads of fields in hosts with lots of CPUs, and I am not sure if this is so useful. Add a flag to be able disable them by now on 6.6, and we can consider later to disable them by default on 7.0.