### PR TITLE
Fix of PATH variable

### DIFF
--- a/docs/devguide/contributing.asciidoc
+++ b/docs/devguide/contributing.asciidoc
@@ -51,6 +51,8 @@ used for development is Go {go-version}.
 The location where you clone is important. Please clone under the source
 directory of your `GOPATH`. If you don't have `GOPATH` already set, you can
 simply set it to the `go` directory in your home (`export GOPATH=$HOME/go`).
+Don't forget setting up new PATH variable for correct mage execution:
+`export PATH="$GOPATH/bin:$PATH"`
 
 [source,shell]
 --------------------------------------------------------------------------------


### PR DESCRIPTION
If it is not set, you have a problem like this:

root@parallels-vm:/home/parallels/go/src/github.com/elastic/beats/filebeat# make update
Running virtualenv with interpreter /usr/bin/python2
New python executable in /home/parallels/go/src/github.com/elastic/beats/filebeat/build/python-env/bin/python2
Also creating executable in /home/parallels/go/src/github.com/elastic/beats/filebeat/build/python-env/bin/python
Installing setuptools, pkg_resources, pip, wheel...done.
go install github.com/elastic/beats/vendor/github.com/magefile/mage
../libbeat/scripts/Makefile:446: recipe for target 'mage' failed
make: [mage] Error 127 (ignored)
bash: mage: command not found
../libbeat/scripts/Makefile:310: recipe for target 'fields' failed
make: *** [fields] Error 127