### PR TITLE
Cherry-pick #9022 to 6.x: Add ip and status to heartbeat dashboard table

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -233,6 +233,7 @@ https://github.com/elastic/beats/compare/v6.4.0...v6.5.0[View commits]
 - Added autodiscovery support {pull}8415[8415]
 - Added support for extra TLS/x509 metadata. {pull}7944[7944]
 - Added stats and state metrics for number of monitors and endpoints started. {pull}8621[8621]
+- Add last monitor status to dashboard table. Further break out monitors in dashboard table by monitor.ip. {pull}9022[9022]
 
 *Journalbeat*
 

--- a/heartbeat/monitors/active/http/_meta/kibana/6/dashboard/Heartbeat-http-monitor.json
+++ b/heartbeat/monitors/active/http/_meta/kibana/6/dashboard/Heartbeat-http-monitor.json
@@ -1,702 +1,745 @@
 {
-    "objects": [
-        {
-            "attributes": {
-                "description": "",
-                "kibanaSavedObjectMeta": {
-                    "searchSourceJSON": {
-                        "filter": []
-                    }
-                },
-                "savedSearchId": "02014c80-29d2-11e7-a68f-bfaa2341cc52",
-                "title": "HTTP ping times",
-                "uiStateJSON": {},
-                "version": 1,
-                "visState": {
-                    "aggs": [
-                        {
-                            "enabled": true,
-                            "id": "1",
-                            "params": {
-                                "customLabel": "",
-                                "field": "resolve.rtt.us"
-                            },
-                            "schema": "metric",
-                            "type": "max"
-                        },
-                        {
-                            "enabled": true,
-                            "id": "3",
-                            "params": {
-                                "field": "tcp.rtt.connect.us"
-                            },
-                            "schema": "metric",
-                            "type": "max"
-                        },
-                        {
-                            "enabled": true,
-                            "id": "5",
-                            "params": {
-                                "field": "tls.rtt.handshake.us"
-                            },
-                            "schema": "metric",
-                            "type": "max"
-                        },
-                        {
-                            "enabled": true,
-                            "id": "4",
-                            "params": {
-                                "field": "http.rtt.response_header.us"
-                            },
-                            "schema": "metric",
-                            "type": "max"
-                        },
-                        {
-                            "enabled": true,
-                            "id": "2",
-                            "params": {
-                                "customInterval": "2h",
-                                "extended_bounds": {},
-                                "field": "@timestamp",
-                                "interval": "auto",
-                                "min_doc_count": 1
-                            },
-                            "schema": "segment",
-                            "type": "date_histogram"
-                        }
-                    ],
-                    "listeners": {},
-                    "params": {
-                        "addLegend": true,
-                        "addTimeMarker": false,
-                        "addTooltip": true,
-                        "defaultYExtents": false,
-                        "interpolate": "linear",
-                        "legendPosition": "right",
-                        "mode": "stacked",
-                        "scale": "linear",
-                        "setYExtents": false,
-                        "times": []
-                    },
-                    "title": "HTTP ping times",
-                    "type": "area"
-                }
-            },
-            "id": "c65ef340-eb19-11e6-be20-559646f8b9ba",
-            "type": "visualization",
-            "version": 1
+  "objects": [
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": []
+          }
         },
-        {
-            "attributes": {
-                "description": "",
-                "kibanaSavedObjectMeta": {
-                    "searchSourceJSON": {
-                        "filter": []
-                    }
-                },
-                "savedSearchId": "02014c80-29d2-11e7-a68f-bfaa2341cc52",
-                "title": "HTTP monitors status",
-                "uiStateJSON": {
-                    "vis": {
-                        "colors": {
-                            "200": "#B7DBAB",
-                            "monitor.status: down": "#E24D42",
-                            "monitor.status: up": "#629E51"
-                        },
-                        "legendOpen": true
-                    }
-                },
-                "version": 1,
-                "visState": {
-                    "aggs": [
-                        {
-                            "enabled": true,
-                            "id": "1",
-                            "params": {
-                                "field": "monitor.id"
-                            },
-                            "schema": "metric",
-                            "type": "cardinality"
-                        },
-                        {
-                            "enabled": true,
-                            "id": "3",
-                            "params": {
-                                "filters": [
-                                    {
-                                        "input": {
-                                            "query": {
-                                                "query_string": {
-                                                    "analyze_wildcard": true,
-                                                    "query": "monitor.status: up"
-                                                }
-                                            }
-                                        },
-                                        "label": ""
-                                    },
-                                    {
-                                        "input": {
-                                            "query": {
-                                                "query_string": {
-                                                    "analyze_wildcard": true,
-                                                    "query": "monitor.status: down"
-                                                }
-                                            }
-                                        }
-                                    }
-                                ]
-                            },
-                            "schema": "segment",
-                            "type": "filters"
-                        },
-                        {
-                            "enabled": true,
-                            "id": "2",
-                            "params": {
-                                "field": "http.response.status_code",
-                                "order": "desc",
-                                "orderBy": "1",
-                                "size": 5
-                            },
-                            "schema": "segment",
-                            "type": "terms"
-                        }
-                    ],
-                    "listeners": {},
-                    "params": {
-                        "addLegend": true,
-                        "addTooltip": true,
-                        "isDonut": false,
-                        "legendPosition": "bottom"
-                    },
-                    "title": "HTTP monitors status",
-                    "type": "pie"
-                }
+        "savedSearchId": "02014c80-29d2-11e7-a68f-bfaa2341cc52",
+        "title": "HTTP ping times",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "customLabel": "",
+                "field": "resolve.rtt.us"
+              },
+              "schema": "metric",
+              "type": "max"
             },
-            "id": "920e8140-eb1a-11e6-be20-559646f8b9ba",
-            "type": "visualization",
-            "version": 1
-        },
-        {
-            "attributes": {
-                "description": "",
-                "kibanaSavedObjectMeta": {
-                    "searchSourceJSON": {
-                        "filter": []
-                    }
-                },
-                "savedSearchId": "02014c80-29d2-11e7-a68f-bfaa2341cc52",
-                "title": "HTTP monitors",
-                "uiStateJSON": {
-                    "vis": {
-                        "params": {
-                            "sort": {
-                                "columnIndex": null,
-                                "direction": null
-                            }
-                        }
-                    }
-                },
-                "version": 1,
-                "visState": {
-                    "aggs": [
-                        {
-                            "enabled": true,
-                            "id": "1",
-                            "params": {
-                                "field": "monitor.duration.us"
-                            },
-                            "schema": "metric",
-                            "type": "max"
-                        },
-                        {
-                            "enabled": true,
-                            "id": "2",
-                            "params": {
-                                "field": "monitor.id",
-                                "order": "desc",
-                                "orderBy": "1",
-                                "size": 5
-                            },
-                            "schema": "bucket",
-                            "type": "terms"
-                        },
-                        {
-                            "enabled": true,
-                            "id": "5",
-                            "params": {
-                                "field": "resolve.rtt.us"
-                            },
-                            "schema": "metric",
-                            "type": "max"
-                        },
-                        {
-                            "enabled": true,
-                            "id": "6",
-                            "params": {
-                                "field": "tcp.rtt.connect.us"
-                            },
-                            "schema": "metric",
-                            "type": "max"
-                        },
-                        {
-                            "enabled": true,
-                            "id": "7",
-                            "params": {
-                                "field": "tls.rtt.handshake.us"
-                            },
-                            "schema": "metric",
-                            "type": "max"
-                        },
-                        {
-                            "enabled": true,
-                            "id": "8",
-                            "params": {
-                                "field": "http.rtt.response_header.us"
-                            },
-                            "schema": "metric",
-                            "type": "max"
-                        }
-                    ],
-                    "listeners": {},
-                    "params": {
-                        "perPage": 10,
-                        "showMeticsAtAllLevels": false,
-                        "showPartialRows": false,
-                        "showTotal": false,
-                        "sort": {
-                            "columnIndex": null,
-                            "direction": null
-                        },
-                        "totalFunc": "sum"
-                    },
-                    "title": "HTTP monitors",
-                    "type": "table"
-                }
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "field": "tcp.rtt.connect.us"
+              },
+              "schema": "metric",
+              "type": "max"
             },
-            "id": "1738dbc0-eb1d-11e6-be20-559646f8b9ba",
-            "type": "visualization",
-            "version": 1
-        },
-        {
-            "attributes": {
-                "description": "",
-                "kibanaSavedObjectMeta": {
-                    "searchSourceJSON": {
-                        "filter": [],
-                        "query": {
-                            "language": "lucene",
-                            "query": ""
-                        }
-                    }
-                },
-                "savedSearchId": "02014c80-29d2-11e7-a68f-bfaa2341cc52",
-                "title": "HTTP up status",
-                "uiStateJSON": {
-                    "vis": {
-                        "colors": {
-                            "monitor.status: down": "#E24D42",
-                            "monitor.status: up": "#629E51"
-                        }
-                    }
-                },
-                "version": 1,
-                "visState": {
-                    "aggs": [
-                        {
-                            "enabled": true,
-                            "id": "1",
-                            "params": {},
-                            "schema": "metric",
-                            "type": "count"
-                        },
-                        {
-                            "enabled": true,
-                            "id": "2",
-                            "params": {
-                                "customInterval": "2h",
-                                "extended_bounds": {},
-                                "field": "@timestamp",
-                                "interval": "auto",
-                                "min_doc_count": 1
-                            },
-                            "schema": "segment",
-                            "type": "date_histogram"
-                        },
-                        {
-                            "enabled": true,
-                            "id": "3",
-                            "params": {
-                                "filters": [
-                                    {
-                                        "input": {
-                                            "query": "monitor.status: down"
-                                        },
-                                        "label": ""
-                                    },
-                                    {
-                                        "input": {
-                                            "query": "monitor.status: up"
-                                        }
-                                    }
-                                ]
-                            },
-                            "schema": "group",
-                            "type": "filters"
-                        }
-                    ],
-                    "params": {
-                        "addLegend": true,
-                        "addTimeMarker": false,
-                        "addTooltip": true,
-                        "categoryAxes": [
-                            {
-                                "id": "CategoryAxis-1",
-                                "labels": {
-                                    "show": true,
-                                    "truncate": 100
-                                },
-                                "position": "bottom",
-                                "scale": {
-                                    "type": "linear"
-                                },
-                                "show": true,
-                                "style": {},
-                                "title": {},
-                                "type": "category"
-                            }
-                        ],
-                        "defaultYExtents": false,
-                        "grid": {
-                            "categoryLines": false,
-                            "style": {
-                                "color": "#eee"
-                            }
-                        },
-                        "interpolate": "linear",
-                        "legendPosition": "right",
-                        "mode": "percentage",
-                        "scale": "linear",
-                        "seriesParams": [
-                            {
-                                "data": {
-                                    "id": "1",
-                                    "label": "Percentage of Count"
-                                },
-                                "interpolate": "linear",
-                                "mode": "stacked",
-                                "show": "true",
-                                "type": "area",
-                                "valueAxis": "ValueAxis-1"
-                            }
-                        ],
-                        "setYExtents": true,
-                        "times": [],
-                        "type": "area",
-                        "valueAxes": [
-                            {
-                                "id": "ValueAxis-1",
-                                "labels": {
-                                    "filter": false,
-                                    "rotate": 0,
-                                    "show": true,
-                                    "truncate": 100
-                                },
-                                "name": "LeftAxis-1",
-                                "position": "left",
-                                "scale": {
-                                    "defaultYExtents": false,
-                                    "max": 100,
-                                    "min": 0,
-                                    "mode": "percentage",
-                                    "setYExtents": true,
-                                    "type": "linear"
-                                },
-                                "show": true,
-                                "style": {},
-                                "title": {
-                                    "text": "Percentage of Count"
-                                },
-                                "type": "value"
-                            }
-                        ],
-                        "yAxis": {
-                            "max": 100,
-                            "min": 0
-                        }
-                    },
-                    "title": "HTTP up status",
-                    "type": "area"
-                }
+            {
+              "enabled": true,
+              "id": "5",
+              "params": {
+                "field": "tls.rtt.handshake.us"
+              },
+              "schema": "metric",
+              "type": "max"
             },
-            "id": "091c3a90-eb1e-11e6-be20-559646f8b9ba",
-            "type": "visualization",
-            "version": 2
-        },
-        {
-            "attributes": {
-                "description": "",
-                "kibanaSavedObjectMeta": {
-                    "searchSourceJSON": {
-                        "filter": []
-                    }
-                },
-                "savedSearchId": "02014c80-29d2-11e7-a68f-bfaa2341cc52",
-                "title": "HTTP duration heatmap",
-                "uiStateJSON": {
-                    "vis": {
-                        "defaultColors": {
-                            "0 - 2": "rgb(247,251,255)",
-                            "10 - 11": "rgb(23,100,171)",
-                            "11 - 12": "rgb(8,74,145)",
-                            "2 - 3": "rgb(227,238,249)",
-                            "3 - 4": "rgb(208,225,242)",
-                            "4 - 5": "rgb(182,212,233)",
-                            "5 - 6": "rgb(148,196,223)",
-                            "6 - 8": "rgb(107,174,214)",
-                            "8 - 9": "rgb(74,152,201)",
-                            "9 - 10": "rgb(46,126,188)"
-                        }
-                    }
-                },
-                "version": 1,
-                "visState": {
-                    "aggs": [
-                        {
-                            "enabled": true,
-                            "id": "1",
-                            "params": {},
-                            "schema": "metric",
-                            "type": "count"
-                        },
-                        {
-                            "enabled": true,
-                            "id": "2",
-                            "params": {
-                                "customInterval": "2h",
-                                "extended_bounds": {},
-                                "field": "@timestamp",
-                                "interval": "auto",
-                                "min_doc_count": 1
-                            },
-                            "schema": "segment",
-                            "type": "date_histogram"
-                        },
-                        {
-                            "enabled": true,
-                            "id": "3",
-                            "params": {
-                                "extended_bounds": {},
-                                "field": "monitor.duration.us",
-                                "interval": 50000
-                            },
-                            "schema": "group",
-                            "type": "histogram"
-                        }
-                    ],
-                    "listeners": {},
-                    "params": {
-                        "addLegend": true,
-                        "addTooltip": true,
-                        "colorSchema": "Blues",
-                        "colorsNumber": 10,
-                        "colorsRange": [],
-                        "enableHover": false,
-                        "invertColors": false,
-                        "legendPosition": "right",
-                        "percentageMode": false,
-                        "setColorRange": false,
-                        "times": [],
-                        "valueAxes": [
-                            {
-                                "id": "ValueAxis-1",
-                                "labels": {
-                                    "color": "#555",
-                                    "rotate": 0,
-                                    "show": false
-                                },
-                                "scale": {
-                                    "defaultYExtents": false,
-                                    "type": "linear"
-                                },
-                                "show": false,
-                                "type": "value"
-                            }
-                        ]
-                    },
-                    "title": "HTTP duration heatmap",
-                    "type": "heatmap"
-                }
+            {
+              "enabled": true,
+              "id": "4",
+              "params": {
+                "field": "http.rtt.response_header.us"
+              },
+              "schema": "metric",
+              "type": "max"
             },
-            "id": "0f4c0560-eb20-11e6-9f11-159ff202874a",
-            "type": "visualization",
-            "version": 1
-        },
-        {
-            "attributes": {
-                "columns": [
-                    "monitor.id",
-                    "http.url",
-                    "monitor.status",
-                    "http.response.status_code",
-                    "monitor.duration.us",
-                    "tcp.rtt.connect.us",
-                    "tls.rtt.handshake.us",
-                    "resolve.rtt.us",
-                    "http.rtt.content.us"
-                ],
-                "description": "",
-                "hits": 0,
-                "kibanaSavedObjectMeta": {
-                    "searchSourceJSON": {
-                        "filter": [
-                            {
-                                "$state": {
-                                    "store": "appState"
-                                },
-                                "meta": {
-                                    "alias": null,
-                                    "disabled": false,
-                                    "index": "heartbeat-*",
-                                    "key": "monitor.type",
-                                    "negate": false,
-                                    "value": "http"
-                                },
-                                "query": {
-                                    "match": {
-                                        "monitor.type": {
-                                            "query": "http",
-                                            "type": "phrase"
-                                        }
-                                    }
-                                }
-                            }
-                        ],
-                        "highlightAll": true,
-                        "index": "heartbeat-*",
-                        "query": {
-                            "query_string": {
-                                "analyze_wildcard": true,
-                                "query": "*"
-                            }
-                        }
-                    }
-                },
-                "sort": [
-                    "@timestamp",
-                    "desc"
-                ],
-                "title": "Heartbeat HTTP pings",
-                "version": 1
-            },
-            "id": "02014c80-29d2-11e7-a68f-bfaa2341cc52",
-            "type": "search",
-            "version": 1
-        },
-        {
-            "attributes": {
-                "description": "",
-                "hits": 0,
-                "kibanaSavedObjectMeta": {
-                    "searchSourceJSON": {
-                        "filter": [
-                            {
-                                "query": {
-                                    "query_string": {
-                                        "analyze_wildcard": true,
-                                        "query": "*"
-                                    }
-                                }
-                            }
-                        ]
-                    }
-                },
-                "optionsJSON": {
-                    "darkTheme": false
-                },
-                "panelsJSON": [
-                    {
-                        "col": 1,
-                        "id": "c65ef340-eb19-11e6-be20-559646f8b9ba",
-                        "panelIndex": 1,
-                        "row": 7,
-                        "size_x": 12,
-                        "size_y": 4,
-                        "type": "visualization"
-                    },
-                    {
-                        "col": 9,
-                        "id": "920e8140-eb1a-11e6-be20-559646f8b9ba",
-                        "panelIndex": 2,
-                        "row": 1,
-                        "size_x": 4,
-                        "size_y": 4,
-                        "type": "visualization"
-                    },
-                    {
-                        "col": 1,
-                        "id": "1738dbc0-eb1d-11e6-be20-559646f8b9ba",
-                        "panelIndex": 3,
-                        "row": 1,
-                        "size_x": 8,
-                        "size_y": 4,
-                        "type": "visualization"
-                    },
-                    {
-                        "col": 1,
-                        "id": "091c3a90-eb1e-11e6-be20-559646f8b9ba",
-                        "panelIndex": 4,
-                        "row": 5,
-                        "size_x": 12,
-                        "size_y": 2,
-                        "type": "visualization"
-                    },
-                    {
-                        "col": 1,
-                        "id": "0f4c0560-eb20-11e6-9f11-159ff202874a",
-                        "panelIndex": 5,
-                        "row": 11,
-                        "size_x": 12,
-                        "size_y": 5,
-                        "type": "visualization"
-                    }
-                ],
-                "timeRestore": false,
-                "title": "Heartbeat HTTP monitoring",
-                "uiStateJSON": {
-                    "P-3": {
-                        "vis": {
-                            "params": {
-                                "sort": {
-                                    "columnIndex": null,
-                                    "direction": null
-                                }
-                            }
-                        }
-                    },
-                    "P-5": {
-                        "vis": {
-                            "defaultColors": {
-                                "0 - 2": "rgb(247,251,255)",
-                                "10 - 11": "rgb(23,100,171)",
-                                "11 - 12": "rgb(8,74,145)",
-                                "2 - 3": "rgb(227,238,249)",
-                                "3 - 4": "rgb(208,225,242)",
-                                "4 - 5": "rgb(182,212,233)",
-                                "5 - 6": "rgb(148,196,223)",
-                                "6 - 8": "rgb(107,174,214)",
-                                "8 - 9": "rgb(74,152,201)",
-                                "9 - 10": "rgb(46,126,188)"
-                            }
-                        }
-                    }
-                },
-                "version": 1
-            },
-            "id": "f3e771c0-eb19-11e6-be20-559646f8b9ba",
-            "type": "dashboard",
-            "version": 1
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customInterval": "2h",
+                "extended_bounds": {},
+                "field": "@timestamp",
+                "interval": "auto",
+                "min_doc_count": 1
+              },
+              "schema": "segment",
+              "type": "date_histogram"
+            }
+          ],
+          "listeners": {},
+          "params": {
+            "addLegend": true,
+            "addTimeMarker": false,
+            "addTooltip": true,
+            "defaultYExtents": false,
+            "interpolate": "linear",
+            "legendPosition": "right",
+            "mode": "stacked",
+            "scale": "linear",
+            "setYExtents": false,
+            "times": []
+          },
+          "title": "HTTP ping times",
+          "type": "area"
         }
-    ],
-    "version": "6.0.0-SNAPSHOT"
+      },
+      "id": "c65ef340-eb19-11e6-be20-559646f8b9ba",
+      "type": "visualization",
+      "updated_at": "2018-11-07T19:12:21.881Z",
+      "version": 2
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": []
+          }
+        },
+        "savedSearchId": "02014c80-29d2-11e7-a68f-bfaa2341cc52",
+        "title": "HTTP monitors status",
+        "uiStateJSON": {
+          "vis": {
+            "colors": {
+              "200": "#B7DBAB",
+              "monitor.status: down": "#E24D42",
+              "monitor.status: up": "#629E51"
+            },
+            "legendOpen": true
+          }
+        },
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "field": "monitor.id"
+              },
+              "schema": "metric",
+              "type": "cardinality"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "filters": [
+                  {
+                    "input": {
+                      "query": {
+                        "query_string": {
+                          "analyze_wildcard": true,
+                          "query": "monitor.status: up"
+                        }
+                      }
+                    },
+                    "label": ""
+                  },
+                  {
+                    "input": {
+                      "query": {
+                        "query_string": {
+                          "analyze_wildcard": true,
+                          "query": "monitor.status: down"
+                        }
+                      }
+                    }
+                  }
+                ]
+              },
+              "schema": "segment",
+              "type": "filters"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "field": "http.response.status_code",
+                "order": "desc",
+                "orderBy": "1",
+                "size": 5
+              },
+              "schema": "segment",
+              "type": "terms"
+            }
+          ],
+          "listeners": {},
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "isDonut": false,
+            "legendPosition": "bottom"
+          },
+          "title": "HTTP monitors status",
+          "type": "pie"
+        }
+      },
+      "id": "920e8140-eb1a-11e6-be20-559646f8b9ba",
+      "type": "visualization",
+      "updated_at": "2018-11-07T19:12:21.881Z",
+      "version": 2
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "savedSearchId": "02014c80-29d2-11e7-a68f-bfaa2341cc52",
+        "title": "HTTP monitors",
+        "uiStateJSON": {
+          "vis": {
+            "params": {
+              "sort": {
+                "columnIndex": null,
+                "direction": null
+              }
+            }
+          }
+        },
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "field": "monitor.id",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "bucket",
+              "type": "terms"
+            },
+            {
+              "enabled": true,
+              "id": "9",
+              "params": {
+                "aggregate": "concat",
+                "field": "monitor.status",
+                "size": 1,
+                "sortField": "@timestamp",
+                "sortOrder": "desc"
+              },
+              "schema": "metric",
+              "type": "top_hits"
+            },
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {
+                "field": "monitor.duration.us"
+              },
+              "schema": "metric",
+              "type": "max"
+            },
+            {
+              "enabled": true,
+              "id": "5",
+              "params": {
+                "field": "resolve.rtt.us"
+              },
+              "schema": "metric",
+              "type": "max"
+            },
+            {
+              "enabled": true,
+              "id": "6",
+              "params": {
+                "field": "tcp.rtt.connect.us"
+              },
+              "schema": "metric",
+              "type": "max"
+            },
+            {
+              "enabled": true,
+              "id": "7",
+              "params": {
+                "field": "tls.rtt.handshake.us"
+              },
+              "schema": "metric",
+              "type": "max"
+            },
+            {
+              "enabled": true,
+              "id": "8",
+              "params": {
+                "field": "http.rtt.response_header.us"
+              },
+              "schema": "metric",
+              "type": "max"
+            },
+            {
+              "enabled": true,
+              "id": "10",
+              "params": {
+                "field": "monitor.ip",
+                "missingBucket": false,
+                "missingBucketLabel": "Missing",
+                "order": "desc",
+                "orderBy": "1",
+                "otherBucket": false,
+                "otherBucketLabel": "Other",
+                "size": 5
+              },
+              "schema": "bucket",
+              "type": "terms"
+            }
+          ],
+          "params": {
+            "perPage": 10,
+            "showMetricsAtAllLevels": false,
+            "showPartialRows": false,
+            "showTotal": false,
+            "sort": {
+              "columnIndex": null,
+              "direction": null
+            },
+            "totalFunc": "sum"
+          },
+          "title": "HTTP monitors",
+          "type": "table"
+        }
+      },
+      "id": "1738dbc0-eb1d-11e6-be20-559646f8b9ba",
+      "type": "visualization",
+      "updated_at": "2018-11-07T19:16:14.694Z",
+      "version": 3
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "lucene",
+              "query": ""
+            }
+          }
+        },
+        "savedSearchId": "02014c80-29d2-11e7-a68f-bfaa2341cc52",
+        "title": "HTTP up status",
+        "uiStateJSON": {
+          "vis": {
+            "colors": {
+              "monitor.status: down": "#E24D42",
+              "monitor.status: up": "#629E51"
+            }
+          }
+        },
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customInterval": "2h",
+                "extended_bounds": {},
+                "field": "@timestamp",
+                "interval": "auto",
+                "min_doc_count": 1
+              },
+              "schema": "segment",
+              "type": "date_histogram"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "filters": [
+                  {
+                    "input": {
+                      "query": "monitor.status: down"
+                    },
+                    "label": ""
+                  },
+                  {
+                    "input": {
+                      "query": "monitor.status: up"
+                    }
+                  }
+                ]
+              },
+              "schema": "group",
+              "type": "filters"
+            }
+          ],
+          "params": {
+            "addLegend": true,
+            "addTimeMarker": false,
+            "addTooltip": true,
+            "categoryAxes": [
+              {
+                "id": "CategoryAxis-1",
+                "labels": {
+                  "show": true,
+                  "truncate": 100
+                },
+                "position": "bottom",
+                "scale": {
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {},
+                "type": "category"
+              }
+            ],
+            "defaultYExtents": false,
+            "grid": {
+              "categoryLines": false,
+              "style": {
+                "color": "#eee"
+              }
+            },
+            "interpolate": "linear",
+            "legendPosition": "right",
+            "mode": "percentage",
+            "scale": "linear",
+            "seriesParams": [
+              {
+                "data": {
+                  "id": "1",
+                  "label": "Percentage of Count"
+                },
+                "interpolate": "linear",
+                "mode": "stacked",
+                "show": "true",
+                "type": "area",
+                "valueAxis": "ValueAxis-1"
+              }
+            ],
+            "setYExtents": true,
+            "times": [],
+            "type": "area",
+            "valueAxes": [
+              {
+                "id": "ValueAxis-1",
+                "labels": {
+                  "filter": false,
+                  "rotate": 0,
+                  "show": true,
+                  "truncate": 100
+                },
+                "name": "LeftAxis-1",
+                "position": "left",
+                "scale": {
+                  "defaultYExtents": false,
+                  "max": 100,
+                  "min": 0,
+                  "mode": "percentage",
+                  "setYExtents": true,
+                  "type": "linear"
+                },
+                "show": true,
+                "style": {},
+                "title": {
+                  "text": "Percentage of Count"
+                },
+                "type": "value"
+              }
+            ],
+            "yAxis": {
+              "max": 100,
+              "min": 0
+            }
+          },
+          "title": "HTTP up status",
+          "type": "area"
+        }
+      },
+      "id": "091c3a90-eb1e-11e6-be20-559646f8b9ba",
+      "type": "visualization",
+      "updated_at": "2018-11-07T19:12:21.881Z",
+      "version": 2
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": []
+          }
+        },
+        "savedSearchId": "02014c80-29d2-11e7-a68f-bfaa2341cc52",
+        "title": "HTTP duration heatmap",
+        "uiStateJSON": {
+          "vis": {
+            "defaultColors": {
+              "0 - 2": "rgb(247,251,255)",
+              "10 - 11": "rgb(23,100,171)",
+              "11 - 12": "rgb(8,74,145)",
+              "2 - 3": "rgb(227,238,249)",
+              "3 - 4": "rgb(208,225,242)",
+              "4 - 5": "rgb(182,212,233)",
+              "5 - 6": "rgb(148,196,223)",
+              "6 - 8": "rgb(107,174,214)",
+              "8 - 9": "rgb(74,152,201)",
+              "9 - 10": "rgb(46,126,188)"
+            }
+          }
+        },
+        "version": 1,
+        "visState": {
+          "aggs": [
+            {
+              "enabled": true,
+              "id": "1",
+              "params": {},
+              "schema": "metric",
+              "type": "count"
+            },
+            {
+              "enabled": true,
+              "id": "2",
+              "params": {
+                "customInterval": "2h",
+                "extended_bounds": {},
+                "field": "@timestamp",
+                "interval": "auto",
+                "min_doc_count": 1
+              },
+              "schema": "segment",
+              "type": "date_histogram"
+            },
+            {
+              "enabled": true,
+              "id": "3",
+              "params": {
+                "extended_bounds": {},
+                "field": "monitor.duration.us",
+                "interval": 50000
+              },
+              "schema": "group",
+              "type": "histogram"
+            }
+          ],
+          "listeners": {},
+          "params": {
+            "addLegend": true,
+            "addTooltip": true,
+            "colorSchema": "Blues",
+            "colorsNumber": 10,
+            "colorsRange": [],
+            "enableHover": false,
+            "invertColors": false,
+            "legendPosition": "right",
+            "percentageMode": false,
+            "setColorRange": false,
+            "times": [],
+            "valueAxes": [
+              {
+                "id": "ValueAxis-1",
+                "labels": {
+                  "color": "#555",
+                  "rotate": 0,
+                  "show": false
+                },
+                "scale": {
+                  "defaultYExtents": false,
+                  "type": "linear"
+                },
+                "show": false,
+                "type": "value"
+              }
+            ]
+          },
+          "title": "HTTP duration heatmap",
+          "type": "heatmap"
+        }
+      },
+      "id": "0f4c0560-eb20-11e6-9f11-159ff202874a",
+      "type": "visualization",
+      "updated_at": "2018-11-07T19:12:21.881Z",
+      "version": 2
+    },
+    {
+      "attributes": {
+        "columns": [
+          "monitor.id",
+          "http.url",
+          "monitor.status",
+          "http.response.status_code",
+          "monitor.duration.us",
+          "tcp.rtt.connect.us",
+          "tls.rtt.handshake.us",
+          "resolve.rtt.us",
+          "http.rtt.content.us"
+        ],
+        "description": "",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [
+              {
+                "$state": {
+                  "store": "appState"
+                },
+                "meta": {
+                  "alias": null,
+                  "disabled": false,
+                  "index": "heartbeat-*",
+                  "key": "monitor.type",
+                  "negate": false,
+                  "value": "http"
+                },
+                "query": {
+                  "match": {
+                    "monitor.type": {
+                      "query": "http",
+                      "type": "phrase"
+                    }
+                  }
+                }
+              }
+            ],
+            "highlightAll": true,
+            "index": "heartbeat-*",
+            "query": {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "*"
+              }
+            }
+          }
+        },
+        "sort": [
+          "@timestamp",
+          "desc"
+        ],
+        "title": "Heartbeat HTTP pings",
+        "version": 1
+      },
+      "id": "02014c80-29d2-11e7-a68f-bfaa2341cc52",
+      "type": "search",
+      "updated_at": "2018-11-07T19:12:21.881Z",
+      "version": 2
+    },
+    {
+      "attributes": {
+        "description": "",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [
+              {
+                "query": {
+                  "query_string": {
+                    "analyze_wildcard": true,
+                    "query": "*"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        "optionsJSON": {
+          "darkTheme": false
+        },
+        "panelsJSON": [
+          {
+            "col": 1,
+            "id": "c65ef340-eb19-11e6-be20-559646f8b9ba",
+            "panelIndex": 1,
+            "row": 7,
+            "size_x": 12,
+            "size_y": 4,
+            "type": "visualization"
+          },
+          {
+            "col": 9,
+            "id": "920e8140-eb1a-11e6-be20-559646f8b9ba",
+            "panelIndex": 2,
+            "row": 1,
+            "size_x": 4,
+            "size_y": 4,
+            "type": "visualization"
+          },
+          {
+            "col": 1,
+            "id": "1738dbc0-eb1d-11e6-be20-559646f8b9ba",
+            "panelIndex": 3,
+            "row": 1,
+            "size_x": 8,
+            "size_y": 4,
+            "type": "visualization"
+          },
+          {
+            "col": 1,
+            "id": "091c3a90-eb1e-11e6-be20-559646f8b9ba",
+            "panelIndex": 4,
+            "row": 5,
+            "size_x": 12,
+            "size_y": 2,
+            "type": "visualization"
+          },
+          {
+            "col": 1,
+            "id": "0f4c0560-eb20-11e6-9f11-159ff202874a",
+            "panelIndex": 5,
+            "row": 11,
+            "size_x": 12,
+            "size_y": 5,
+            "type": "visualization"
+          }
+        ],
+        "timeRestore": false,
+        "title": "Heartbeat HTTP monitoring",
+        "uiStateJSON": {
+          "P-3": {
+            "vis": {
+              "params": {
+                "sort": {
+                  "columnIndex": null,
+                  "direction": null
+                }
+              }
+            }
+          },
+          "P-5": {
+            "vis": {
+              "defaultColors": {
+                "0 - 2": "rgb(247,251,255)",
+                "10 - 11": "rgb(23,100,171)",
+                "11 - 12": "rgb(8,74,145)",
+                "2 - 3": "rgb(227,238,249)",
+                "3 - 4": "rgb(208,225,242)",
+                "4 - 5": "rgb(182,212,233)",
+                "5 - 6": "rgb(148,196,223)",
+                "6 - 8": "rgb(107,174,214)",
+                "8 - 9": "rgb(74,152,201)",
+                "9 - 10": "rgb(46,126,188)"
+              }
+            }
+          }
+        },
+        "version": 1
+      },
+      "id": "f3e771c0-eb19-11e6-be20-559646f8b9ba",
+      "type": "dashboard",
+      "updated_at": "2018-11-07T19:12:21.881Z",
+      "version": 2
+    }
+  ],
+  "version": "6.5.0"
 }


### PR DESCRIPTION
Cherry-pick of PR #9022 to 6.x branch. Original message: 

The heartbeat dashboard table currently doesn't include these fields by default.
These fields are useful for two reasons:

1. A given monitor.id often runs against separate IPs which may have different downtime results
2. Viewing the latest status for a given id/status tuple is a common use case. It answers the question: "what's down?".

Fixes https://github.com/elastic/beats/issues/8972