### PR TITLE
Use GenRootCmdWithSettings instead of deprecated functions

### DIFF
--- a/auditbeat/cmd/root.go
+++ b/auditbeat/cmd/root.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/elastic/beats/auditbeat/core"
 	"github.com/elastic/beats/libbeat/cmd"
+	"github.com/elastic/beats/libbeat/cmd/instance"
 	"github.com/elastic/beats/metricbeat/beater"
 	"github.com/elastic/beats/metricbeat/mb/module"
 )
@@ -46,6 +47,9 @@ func init() {
 		),
 	)
 	var runFlags = pflag.NewFlagSet(Name, pflag.ExitOnError)
-	RootCmd = cmd.GenRootCmdWithRunFlags(Name, "", create, runFlags)
+	RootCmd = cmd.GenRootCmdWithSettings(create, instance.Settings{
+		Name:     Name,
+		RunFlags: runFlags,
+	})
 	RootCmd.AddCommand(ShowCmd)
 }

--- a/filebeat/cmd/root.go
+++ b/filebeat/cmd/root.go
@@ -23,8 +23,8 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/elastic/beats/filebeat/beater"
-
-	cmd "github.com/elastic/beats/libbeat/cmd"
+	"github.com/elastic/beats/libbeat/cmd"
+	"github.com/elastic/beats/libbeat/cmd/instance"
 )
 
 // Name of this beat
@@ -38,7 +38,10 @@ func init() {
 	runFlags.AddGoFlag(flag.CommandLine.Lookup("once"))
 	runFlags.AddGoFlag(flag.CommandLine.Lookup("modules"))
 
-	RootCmd = cmd.GenRootCmdWithRunFlags(Name, "", beater.New, runFlags)
+	RootCmd = cmd.GenRootCmdWithSettings(beater.New, instance.Settings{
+		Name:     Name,
+		RunFlags: runFlags,
+	})
 	RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("M"))
 	RootCmd.TestCmd.Flags().AddGoFlag(flag.CommandLine.Lookup("modules"))
 	RootCmd.SetupCmd.Flags().AddGoFlag(flag.CommandLine.Lookup("modules"))

--- a/heartbeat/cmd/root.go
+++ b/heartbeat/cmd/root.go
@@ -22,11 +22,18 @@ import (
 	_ "github.com/elastic/beats/heartbeat/monitors/defaults"
 
 	"github.com/elastic/beats/heartbeat/beater"
-	cmd "github.com/elastic/beats/libbeat/cmd"
+	"github.com/elastic/beats/libbeat/cmd"
+	"github.com/elastic/beats/libbeat/cmd/instance"
 )
 
 // Name of this beat
 var Name = "heartbeat"
 
 // RootCmd to handle beats cli
-var RootCmd = cmd.GenRootCmd(Name, "", beater.New)
+var RootCmd *cmd.BeatsRootCmd
+
+func init() {
+	RootCmd = cmd.GenRootCmdWithSettings(beater.New, instance.Settings{
+		Name: Name,
+	})
+}

--- a/journalbeat/cmd/root.go
+++ b/journalbeat/cmd/root.go
@@ -19,12 +19,18 @@ package cmd
 
 import (
 	"github.com/elastic/beats/journalbeat/beater"
-
-	cmd "github.com/elastic/beats/libbeat/cmd"
+	"github.com/elastic/beats/libbeat/cmd"
+	"github.com/elastic/beats/libbeat/cmd/instance"
 )
 
 // Name of this beat
 var Name = "journalbeat"
 
 // RootCmd to handle beats cli
-var RootCmd = cmd.GenRootCmd(Name, "", beater.New)
+var RootCmd *cmd.BeatsRootCmd
+
+func init() {
+	RootCmd = cmd.GenRootCmdWithSettings(beater.New, instance.Settings{
+		Name: Name,
+	})
+}

--- a/libbeat/libbeat.go
+++ b/libbeat/libbeat.go
@@ -21,12 +21,18 @@ import (
 	"os"
 
 	"github.com/elastic/beats/libbeat/cmd"
+	"github.com/elastic/beats/libbeat/cmd/instance"
 	"github.com/elastic/beats/libbeat/mock"
 )
 
-var RootCmd = cmd.GenRootCmd(mock.Name, mock.Version, mock.New)
+// RootCmd to handle beats cli
+var RootCmd *cmd.BeatsRootCmd
 
 func main() {
+	RootCmd = cmd.GenRootCmdWithSettings(mock.New, instance.Settings{
+		Name:    mock.Name,
+		Version: mock.Version,
+	})
 	if err := RootCmd.Execute(); err != nil {
 		os.Exit(1)
 	}

--- a/metricbeat/cmd/root.go
+++ b/metricbeat/cmd/root.go
@@ -22,7 +22,8 @@ import (
 
 	"github.com/spf13/pflag"
 
-	cmd "github.com/elastic/beats/libbeat/cmd"
+	"github.com/elastic/beats/libbeat/cmd"
+	"github.com/elastic/beats/libbeat/cmd/instance"
 	"github.com/elastic/beats/metricbeat/beater"
 	"github.com/elastic/beats/metricbeat/cmd/test"
 
@@ -41,7 +42,10 @@ func init() {
 	var runFlags = pflag.NewFlagSet(Name, pflag.ExitOnError)
 	runFlags.AddGoFlag(flag.CommandLine.Lookup("system.hostfs"))
 
-	RootCmd = cmd.GenRootCmdWithRunFlags(Name, "", beater.DefaultCreator(), runFlags)
+	RootCmd = cmd.GenRootCmdWithSettings(beater.DefaultCreator(), instance.Settings{
+		Name:     Name,
+		RunFlags: runFlags,
+	})
 	RootCmd.AddCommand(cmd.GenModulesCmd(Name, "", buildModulesManager))
 	RootCmd.TestCmd.AddCommand(test.GenTestModulesCmd(Name, ""))
 }

--- a/packetbeat/cmd/root.go
+++ b/packetbeat/cmd/root.go
@@ -25,7 +25,8 @@ import (
 	// import protocol modules
 	_ "github.com/elastic/beats/packetbeat/include"
 
-	cmd "github.com/elastic/beats/libbeat/cmd"
+	"github.com/elastic/beats/libbeat/cmd"
+	"github.com/elastic/beats/libbeat/cmd/instance"
 	"github.com/elastic/beats/packetbeat/beater"
 )
 
@@ -43,6 +44,9 @@ func init() {
 	runFlags.AddGoFlag(flag.CommandLine.Lookup("l"))
 	runFlags.AddGoFlag(flag.CommandLine.Lookup("dump"))
 
-	RootCmd = cmd.GenRootCmdWithRunFlags(Name, "", beater.New, runFlags)
+	RootCmd = cmd.GenRootCmdWithSettings(beater.New, instance.Settings{
+		Name:     Name,
+		RunFlags: runFlags,
+	})
 	RootCmd.AddCommand(genDevicesCommand())
 }

--- a/winlogbeat/cmd/root.go
+++ b/winlogbeat/cmd/root.go
@@ -17,11 +17,20 @@
 
 package cmd
 
-import cmd "github.com/elastic/beats/libbeat/cmd"
-import "github.com/elastic/beats/winlogbeat/beater"
+import (
+	"github.com/elastic/beats/libbeat/cmd"
+	"github.com/elastic/beats/libbeat/cmd/instance"
+	"github.com/elastic/beats/winlogbeat/beater"
+)
 
 // Name of this beat
 var Name = "winlogbeat"
 
 // RootCmd to handle beats cli
-var RootCmd = cmd.GenRootCmd(Name, "", beater.New)
+var RootCmd *cmd.BeatsRootCmd
+
+func init() {
+	RootCmd = cmd.GenRootCmdWithSettings(beater.New, instance.Settings{
+		Name: Name,
+	})
+}

--- a/x-pack/libbeat/libbeat.go
+++ b/x-pack/libbeat/libbeat.go
@@ -8,14 +8,19 @@ import (
 	"os"
 
 	"github.com/elastic/beats/libbeat/cmd"
+	"github.com/elastic/beats/libbeat/cmd/instance"
 	"github.com/elastic/beats/libbeat/mock"
 	xpackcmd "github.com/elastic/beats/x-pack/libbeat/cmd"
 )
 
 // RootCmd to test libbeat
-var RootCmd = cmd.GenRootCmd(mock.Name, mock.Version, mock.New)
+var RootCmd *cmd.BeatsRootCmd
 
 func main() {
+	RootCmd = cmd.GenRootCmdWithSettings(mock.New, instance.Settings{
+		Name:    mock.Name,
+		Version: mock.Version,
+	})
 	xpackcmd.AddXPack(RootCmd, mock.Name)
 	if err := RootCmd.Execute(); err != nil {
 		os.Exit(1)


### PR DESCRIPTION
[GenRootCmd](https://github.com/elastic/beats/blob/master/libbeat/cmd/root.go#L59-L62) and [GenRootCmdWithRunFlags](https://github.com/elastic/beats/blob/master/libbeat/cmd/root.go#L68-L71) have been deprecated for a while, so I updated the commands to use [GenRootCmdWithSettings](https://github.com/elastic/beats/blob/master/libbeat/cmd/root.go#L91-L152) instead.