### PR TITLE
Cherry-pick #8783 to 6.x: Removed Envoy entry on docs

### DIFF
--- a/metricbeat/docs/modules/envoyproxy.asciidoc
+++ b/metricbeat/docs/modules/envoyproxy.asciidoc
@@ -7,8 +7,6 @@ This file is generated! See scripts/docs_collector.py
 
 experimental[]
 
-== envoyproxy module
-
 This is the envoyproxy module.
 
 The default metricset is `server`.

--- a/metricbeat/module/envoyproxy/_meta/docs.asciidoc
+++ b/metricbeat/module/envoyproxy/_meta/docs.asciidoc
@@ -1,5 +1,3 @@
-== envoyproxy module
-
 This is the envoyproxy module.
 
 The default metricset is `server`.


### PR DESCRIPTION
Cherry-pick of PR #8783 to 6.x branch. Original message: 

Related with this issue https://github.com/elastic/beats/issues/8759

I have run `make update` and it seems that the docs have been updated but I'm still not sure if this is going to solve the conflicting document