### PR TITLE
Support shipping directly to monitoring cluster

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -89,6 +89,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - New processor: `copy_fields`. {pull}11303[11303]
 - Add `error.message` to events when `fail_on_error` is set in `rename` and `copy_fields` processors. {pull}11303[11303]
 - New processor: `truncate_fields`. {pull}11297[11297]
+- Allow a beat to ship monitoring data directly to an Elasticsearch monitoring clsuter. {pull}9260[9260]
 
 *Auditbeat*
 

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -815,11 +815,11 @@ func (b *Beat) registerClusterUUIDFetching() error {
 
 // Build and return a callback to fetch the Elasticsearch cluster_uuid for monitoring
 func (b *Beat) clusterUUIDFetchingCallback() (elasticsearch.ConnectCallback, error) {
-	var response struct {
-		ClusterUUID string `json:"cluster_uuid"`
-	}
-
 	callback := func(esClient *elasticsearch.Client) error {
+		var response struct {
+			ClusterUUID string `json:"cluster_uuid"`
+		}
+
 		status, body, err := esClient.Request("GET", "/", "", nil, nil)
 		if err != nil {
 			return errw.Wrap(err, "error querying /")

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -1008,11 +1008,11 @@ func selectMonitoringConfig(beatCfg beatConfig) (*common.Config, error) {
 		const warnMonitoringDeprecatedConfig = "xpack.monitoring.* settings are deprecated. Use monitoring.* instead, but set monitoring.elasticsearch.hosts to monitoring cluster hosts"
 		cfgwarn.Deprecate("7.0", warnMonitoringDeprecatedConfig)
 		monitoringCfg := beatCfg.XPackMonitoring
-		monitoringCfg.SetString("_format", -1, report.ReportingFormatProduction)
+		monitoringCfg.SetInt("_format", -1, int64(report.ReportingFormatXPackMonitoringBulk))
 		return monitoringCfg, nil
 	case beatCfg.Monitoring.Enabled():
 		monitoringCfg := beatCfg.Monitoring
-		monitoringCfg.SetString("_format", -1, report.ReportingFormatMonitoring)
+		monitoringCfg.SetInt("_format", -1, int64(report.ReportingFormatBulk))
 		return monitoringCfg, nil
 	default:
 		return nil, nil

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -999,10 +999,10 @@ func initPaths(cfg *common.Config) error {
 func selectMonitoringConfig(beatCfg beatConfig) (*common.Config, error) {
 	switch {
 	case beatCfg.Monitoring.Enabled() && beatCfg.XPackMonitoring.Enabled():
-		const errMonitoringBothConfigEnabled = "both xpack.monitoring.* and monitoring.* cannot be set. Prefer to set monitoring.* and set monitoring.hosts to monitoring cluster hosts"
+		const errMonitoringBothConfigEnabled = "both xpack.monitoring.* and monitoring.* cannot be set. Prefer to set monitoring.* and set monitoring.elasticsearch.hosts to monitoring cluster hosts"
 		return nil, errors.New(errMonitoringBothConfigEnabled)
 	case beatCfg.XPackMonitoring.Enabled():
-		const warnMonitoringDeprecatedConfig = "xpack.monitoring.* settings are deprecated. Use monitoring.* instead, but set monitoring.hosts to monitoring cluster hosts"
+		const warnMonitoringDeprecatedConfig = "xpack.monitoring.* settings are deprecated. Use monitoring.* instead, but set monitoring.elasticsearch.hosts to monitoring cluster hosts"
 		cfgwarn.Deprecate("7.0", warnMonitoringDeprecatedConfig)
 		monitoringCfg := beatCfg.XPackMonitoring
 		monitoringCfg.SetString("_format", -1, report.ReportingFormatProduction)

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -369,9 +369,12 @@ func (b *Beat) launch(settings Settings, bt beat.Creator) error {
 		return err
 	}
 
-	if monitoringCfg, err := selectMonitoringConfig(b.Config); err != nil {
+	monitoringCfg, err := selectMonitoringConfig(b.Config)
+	if err != nil {
 		return err
-	} else if monitoringCfg.Enabled() {
+	}
+
+	if monitoringCfg.Enabled() {
 		settings := report.Settings{
 			DefaultUsername: settings.Monitoring.DefaultUsername,
 		}

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -106,7 +106,7 @@ type beatConfig struct {
 	Pipeline pipeline.Config `config:",inline"`
 
 	// monitoring settings
-	monitoring.MonitoringBeatConfig `config:",inline"`
+	MonitoringBeatConfig monitoring.BeatConfig `config:",inline"`
 
 	// central management settings
 	Management *common.Config `config:"management"`

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -364,12 +364,9 @@ func (b *Beat) launch(settings Settings, bt beat.Creator) error {
 		return err
 	}
 
-	if b.Config.MonitoringNew.Enabled() || b.Config.Monitoring.Enabled() {
-		monitoringCfg, err := chooseMonitoringConfig(b.Config)
-		if err != nil {
-			return err
-		}
-
+	if monitoringCfg, err := selectMonitoringConfig(b.Config); err != nil {
+		return err
+	} else if monitoringCfg.Enabled() {
 		settings := report.Settings{
 			DefaultUsername: settings.Monitoring.DefaultUsername,
 		}

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -369,7 +369,7 @@ func (b *Beat) launch(settings Settings, bt beat.Creator) error {
 		return err
 	}
 
-	monitoringCfg, err := monitoring.SelectConfig(b.Config.MonitoringBeatConfig)
+	monitoringCfg, reporterSettings, err := monitoring.SelectConfig(b.Config.MonitoringBeatConfig)
 	if err != nil {
 		return err
 	}
@@ -377,6 +377,7 @@ func (b *Beat) launch(settings Settings, bt beat.Creator) error {
 	if monitoringCfg.Enabled() {
 		settings := report.Settings{
 			DefaultUsername: settings.Monitoring.DefaultUsername,
+			Format:          reporterSettings.Format,
 		}
 		reporter, err := report.New(b.Info, settings, monitoringCfg, b.Config.Output)
 		if err != nil {

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -39,6 +39,10 @@ import (
 	errw "github.com/pkg/errors"
 	"go.uber.org/zap"
 
+	sysinfo "github.com/elastic/go-sysinfo"
+	"github.com/elastic/go-sysinfo/types"
+	ucfg "github.com/elastic/go-ucfg"
+
 	"github.com/elastic/beats/libbeat/api"
 	"github.com/elastic/beats/libbeat/asset"
 	"github.com/elastic/beats/libbeat/beat"
@@ -66,9 +70,6 @@ import (
 	"github.com/elastic/beats/libbeat/publisher/processing"
 	svc "github.com/elastic/beats/libbeat/service"
 	"github.com/elastic/beats/libbeat/version"
-	sysinfo "github.com/elastic/go-sysinfo"
-	"github.com/elastic/go-sysinfo/types"
-	ucfg "github.com/elastic/go-ucfg"
 )
 
 // Beat provides the runnable and configurable instance of a beat.

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -816,7 +816,11 @@ func (b *Beat) clusterUUIDFetchingCalling() (elasticsearch.ConnectCallback, erro
 			return fmt.Errorf("Error unmarshaling json when querying /. Body: %s", body)
 		}
 
-		// TODO: "Save" cluster_uuid somewhere? State namespace? New namespace?
+		stateRegistry := monitoring.GetNamespace("state").GetRegistry()
+		outputsRegistry := stateRegistry.NewRegistry("outputs")
+		elasticsearchRegistry := outputsRegistry.NewRegistry("elasticsearch")
+		monitoring.NewString(elasticsearchRegistry, "cluster_uuid").Set(response.ClusterUUID)
+
 		return nil
 	}
 

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -104,9 +104,9 @@ type beatConfig struct {
 	Keystore      *common.Config `config:"keystore"`
 
 	// output/publishing related configurations
-	Pipeline      pipeline.Config `config:",inline"`
-	Monitoring    *common.Config  `config:"xpack.monitoring"`
-	MonitoringNew *common.Config  `config:"monitoring"`
+	Pipeline        pipeline.Config `config:",inline"`
+	XPackMonitoring *common.Config  `config:"xpack.monitoring"`
+	Monitoring      *common.Config  `config:"monitoring"`
 
 	// central management settings
 	Management *common.Config `config:"management"`
@@ -982,17 +982,17 @@ func initPaths(cfg *common.Config) error {
 
 func selectMonitoringConfig(beatCfg beatConfig) (*common.Config, error) {
 	switch {
-	case beatCfg.MonitoringNew.Enabled() && beatCfg.Monitoring.Enabled():
+	case beatCfg.Monitoring.Enabled() && beatCfg.XPackMonitoring.Enabled():
 		const errMonitoringBothConfigEnabled = "both xpack.monitoring.* and monitoring.* cannot be set. Prefer to set monitoring.* and set monitoring.hosts to monitoring cluster hosts"
 		return nil, errors.New(errMonitoringBothConfigEnabled)
-	case beatCfg.Monitoring.Enabled():
+	case beatCfg.XPackMonitoring.Enabled():
 		const warnMonitoringDeprecatedConfig = "xpack.monitoring.* settings are deprecated. Use monitoring.* instead, but set monitoring.hosts to monitoring cluster hosts"
 		cfgwarn.Deprecate("7.0", warnMonitoringDeprecatedConfig)
-		monitoringCfg := beatCfg.Monitoring
+		monitoringCfg := beatCfg.XPackMonitoring
 		monitoringCfg.SetString("_format", -1, "production")
 		return monitoringCfg, nil
-	case beatCfg.MonitoringNew.Enabled():
-		monitoringCfg := beatCfg.MonitoringNew
+	case beatCfg.Monitoring.Enabled():
+		monitoringCfg := beatCfg.Monitoring
 		monitoringCfg.SetString("_format", -1, "monitoring")
 		return monitoringCfg, nil
 	default:

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -989,11 +989,11 @@ func selectMonitoringConfig(beatCfg beatConfig) (*common.Config, error) {
 		const warnMonitoringDeprecatedConfig = "xpack.monitoring.* settings are deprecated. Use monitoring.* instead, but set monitoring.hosts to monitoring cluster hosts"
 		cfgwarn.Deprecate("7.0", warnMonitoringDeprecatedConfig)
 		monitoringCfg := beatCfg.Monitoring
-		monitoringCfg.SetString("format", -1, "production")
+		monitoringCfg.SetString("_format", -1, "production")
 		return monitoringCfg, nil
 	case beatCfg.MonitoringNew.Enabled():
 		monitoringCfg := beatCfg.MonitoringNew
-		monitoringCfg.SetString("format", -1, "monitoring")
+		monitoringCfg.SetString("_format", -1, "monitoring")
 		return monitoringCfg, nil
 	default:
 		return nil, nil

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -989,11 +989,11 @@ func selectMonitoringConfig(beatCfg beatConfig) (*common.Config, error) {
 		const warnMonitoringDeprecatedConfig = "xpack.monitoring.* settings are deprecated. Use monitoring.* instead, but set monitoring.hosts to monitoring cluster hosts"
 		cfgwarn.Deprecate("7.0", warnMonitoringDeprecatedConfig)
 		monitoringCfg := beatCfg.XPackMonitoring
-		monitoringCfg.SetString("_format", -1, "production")
+		monitoringCfg.SetString("_format", -1, report.ReportingFormatProduction)
 		return monitoringCfg, nil
 	case beatCfg.Monitoring.Enabled():
 		monitoringCfg := beatCfg.Monitoring
-		monitoringCfg.SetString("_format", -1, "monitoring")
+		monitoringCfg.SetString("_format", -1, report.ReportingFormatMonitoring)
 		return monitoringCfg, nil
 	default:
 		return nil, nil

--- a/libbeat/monitoring/monitoring.go
+++ b/libbeat/monitoring/monitoring.go
@@ -25,8 +25,8 @@ import (
 	"github.com/elastic/beats/libbeat/monitoring/report"
 )
 
-// MonitoringBeatConfig represents the part of the $BEAT.yml to do with monitoring settings
-type MonitoringBeatConfig struct {
+// BeatConfig represents the part of the $BEAT.yml to do with monitoring settings
+type BeatConfig struct {
 	XPackMonitoring *common.Config `config:"xpack.monitoring"`
 	Monitoring      *common.Config `config:"monitoring"`
 }
@@ -82,7 +82,7 @@ func Clear() error {
 
 // SelectConfig selects the appropriate monitoring configuration based on the user's settings in $BEAT.yml. Users may either
 // use xpack.monitoring.* settings OR monitoring.* settings but not both.
-func SelectConfig(beatCfg MonitoringBeatConfig) (*common.Config, error) {
+func SelectConfig(beatCfg BeatConfig) (*common.Config, error) {
 	switch {
 	case beatCfg.Monitoring.Enabled() && beatCfg.XPackMonitoring.Enabled():
 		errMonitoringBothConfigEnabled := errors.New("both xpack.monitoring.* and monitoring.* cannot be set. Prefer to set monitoring.* and set monitoring.elasticsearch.hosts to monitoring cluster hosts")

--- a/libbeat/monitoring/monitoring.go
+++ b/libbeat/monitoring/monitoring.go
@@ -94,10 +94,10 @@ func SelectConfig(beatCfg BeatConfig) (*common.Config, *report.Settings, error) 
 	case beatCfg.XPackMonitoring.Enabled():
 		cfgwarn.Deprecate("7.0", warnMonitoringDeprecatedConfig)
 		monitoringCfg := beatCfg.XPackMonitoring
-		return monitoringCfg, &report.Settings{Format: report.ReportingFormatXPackMonitoringBulk}, nil
+		return monitoringCfg, &report.Settings{Format: report.FormatXPackMonitoringBulk}, nil
 	case beatCfg.Monitoring.Enabled():
 		monitoringCfg := beatCfg.Monitoring
-		return monitoringCfg, &report.Settings{Format: report.ReportingFormatBulk}, nil
+		return monitoringCfg, &report.Settings{Format: report.FormatBulk}, nil
 	default:
 		return nil, nil, nil
 	}

--- a/libbeat/monitoring/monitoring.go
+++ b/libbeat/monitoring/monitoring.go
@@ -17,7 +17,19 @@
 
 package monitoring
 
-import "errors"
+import (
+	"errors"
+
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
+	"github.com/elastic/beats/libbeat/monitoring/report"
+)
+
+// MonitoringBeatConfig represents the part of the $BEAT.yml to do with monitoring settings
+type MonitoringBeatConfig struct {
+	XPackMonitoring *common.Config `config:"xpack.monitoring"`
+	Monitoring      *common.Config `config:"monitoring"`
+}
 
 type Mode uint8
 
@@ -66,4 +78,26 @@ func Remove(name string) {
 
 func Clear() error {
 	return Default.Clear()
+}
+
+// SelectConfig selects the appropriate monitoring configuration based on the user's settings in $BEAT.yml. Users may either
+// use xpack.monitoring.* settings OR monitoring.* settings but not both.
+func SelectConfig(beatCfg MonitoringBeatConfig) (*common.Config, error) {
+	switch {
+	case beatCfg.Monitoring.Enabled() && beatCfg.XPackMonitoring.Enabled():
+		errMonitoringBothConfigEnabled := errors.New("both xpack.monitoring.* and monitoring.* cannot be set. Prefer to set monitoring.* and set monitoring.elasticsearch.hosts to monitoring cluster hosts")
+		return nil, errMonitoringBothConfigEnabled
+	case beatCfg.XPackMonitoring.Enabled():
+		const warnMonitoringDeprecatedConfig = "xpack.monitoring.* settings are deprecated. Use monitoring.* instead, but set monitoring.elasticsearch.hosts to monitoring cluster hosts"
+		cfgwarn.Deprecate("7.0", warnMonitoringDeprecatedConfig)
+		monitoringCfg := beatCfg.XPackMonitoring
+		monitoringCfg.SetInt("_format", -1, int64(report.ReportingFormatXPackMonitoringBulk))
+		return monitoringCfg, nil
+	case beatCfg.Monitoring.Enabled():
+		monitoringCfg := beatCfg.Monitoring
+		monitoringCfg.SetInt("_format", -1, int64(report.ReportingFormatBulk))
+		return monitoringCfg, nil
+	default:
+		return nil, nil
+	}
 }

--- a/libbeat/monitoring/monitoring.go
+++ b/libbeat/monitoring/monitoring.go
@@ -42,6 +42,11 @@ const (
 	Full
 )
 
+var (
+	errMonitoringBothConfigEnabled = errors.New("both xpack.monitoring.* and monitoring.* cannot be set. Prefer to set monitoring.* and set monitoring.elasticsearch.hosts to monitoring cluster hosts")
+	warnMonitoringDeprecatedConfig = "xpack.monitoring.* settings are deprecated. Use monitoring.* instead, but set monitoring.elasticsearch.hosts to monitoring cluster hosts"
+)
+
 // Default is the global default metrics registry provided by the monitoring package.
 var Default = NewRegistry()
 
@@ -85,10 +90,8 @@ func Clear() error {
 func SelectConfig(beatCfg BeatConfig) (*common.Config, *report.Settings, error) {
 	switch {
 	case beatCfg.Monitoring.Enabled() && beatCfg.XPackMonitoring.Enabled():
-		errMonitoringBothConfigEnabled := errors.New("both xpack.monitoring.* and monitoring.* cannot be set. Prefer to set monitoring.* and set monitoring.elasticsearch.hosts to monitoring cluster hosts")
 		return nil, nil, errMonitoringBothConfigEnabled
 	case beatCfg.XPackMonitoring.Enabled():
-		const warnMonitoringDeprecatedConfig = "xpack.monitoring.* settings are deprecated. Use monitoring.* instead, but set monitoring.elasticsearch.hosts to monitoring cluster hosts"
 		cfgwarn.Deprecate("7.0", warnMonitoringDeprecatedConfig)
 		monitoringCfg := beatCfg.XPackMonitoring
 		return monitoringCfg, &report.Settings{Format: report.ReportingFormatXPackMonitoringBulk}, nil

--- a/libbeat/monitoring/report/elasticsearch/client.go
+++ b/libbeat/monitoring/report/elasticsearch/client.go
@@ -134,7 +134,7 @@ func (c *publishClient) Publish(batch publisher.Batch) error {
 		case report.ReportingFormatXPackMonitoringBulk:
 			err = c.publishXPackBulk(params, event, typ)
 		case report.ReportingFormatBulk:
-			err = c.publishBulk(event)
+			err = c.publishBulk(event, typ)
 		}
 
 		if err != nil {
@@ -179,7 +179,7 @@ func (c *publishClient) publishXPackBulk(params map[string]string, event publish
 	return err
 }
 
-func (c *publishClient) publishBulk(event publisher.Event) error {
+func (c *publishClient) publishBulk(event publisher.Event, typ string) error {
 	meta := common.MapStr{
 		"_index":   getMonitoringIndexName(),
 		"_routing": nil,
@@ -195,17 +195,9 @@ func (c *publishClient) publishBulk(event publisher.Event) error {
 
 	event.Content.Fields.Put("timestamp", event.Content.Timestamp)
 
-	t, err := event.Content.Meta.GetValue("type")
-	if err != nil {
-		return errors.Wrap(err, "could not determine type field")
-	}
-	tStr, ok := t.(string)
-	if !ok {
-		return fmt.Errorf("type is not string")
-	}
 	fields := common.MapStr{
-		"type": tStr,
-		tStr:   event.Content.Fields,
+		"type": typ,
+		typ:    event.Content.Fields,
 	}
 
 	interval, err := event.Content.Meta.GetValue("interval_ms")

--- a/libbeat/monitoring/report/elasticsearch/client.go
+++ b/libbeat/monitoring/report/elasticsearch/client.go
@@ -221,7 +221,7 @@ func (c *publishClient) publishBulk(event publisher.Event, typ string) error {
 	// Currently one request per event is sent. Reason is that each event can contain different
 	// interval params and X-Pack requires to send the interval param.
 	// FIXME: index name (first param below)
-	_, err = c.es.BulkWith(getMonitoringIndexName(), "doc", nil, nil, bulk[:])
+	_, err = c.es.BulkWith(getMonitoringIndexName(), "", nil, nil, bulk[:])
 	return err
 }
 

--- a/libbeat/monitoring/report/elasticsearch/client.go
+++ b/libbeat/monitoring/report/elasticsearch/client.go
@@ -24,8 +24,6 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/pkg/errors"
-
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/monitoring/report"
@@ -167,12 +165,12 @@ func (c *publishClient) publishWithXPackMonitoringBulk(params map[string]string,
 		report.Event{
 			Timestamp: event.Content.Timestamp,
 			Fields:    event.Content.Fields,
-		}
+		},
 	}
 
 	// Currently one request per event is sent. Reason is that each event can contain different
 	// interval params and X-Pack requires to send the interval param.
-	_, err = c.es.SendMonitoringBulk(params, bulk[:])
+	_, err := c.es.SendMonitoringBulk(params, bulk[:])
 	return err
 }
 

--- a/libbeat/monitoring/report/elasticsearch/client.go
+++ b/libbeat/monitoring/report/elasticsearch/client.go
@@ -84,6 +84,8 @@ func (c *publishClient) Connect() error {
 	}
 
 	debugf("XPack monitoring is enabled")
+	debugf("Publishing to %v cluster", c.params["format"])
+
 	return nil
 }
 

--- a/libbeat/monitoring/report/elasticsearch/client.go
+++ b/libbeat/monitoring/report/elasticsearch/client.go
@@ -135,6 +135,7 @@ func (c *publishClient) Publish(batch publisher.Batch) error {
 			continue
 		}
 
+		logp.Info("Sending monitoring data to %s cluster", format)
 		switch format {
 		case report.ReportingFormatProduction:
 			err = c.bulkToProduction(params, event, t)

--- a/libbeat/monitoring/report/elasticsearch/client.go
+++ b/libbeat/monitoring/report/elasticsearch/client.go
@@ -87,7 +87,6 @@ func (c *publishClient) Connect() error {
 	}
 
 	debugf("XPack monitoring is enabled")
-	debugf("Publishing to %v cluster", c.params["_format"])
 
 	return nil
 }

--- a/libbeat/monitoring/report/elasticsearch/client.go
+++ b/libbeat/monitoring/report/elasticsearch/client.go
@@ -226,7 +226,7 @@ func (c *publishClient) publishBulk(event publisher.Event, typ string) error {
 }
 
 func getMonitoringIndexName() string {
-	version := 6
+	version := 7
 	date := time.Now().Format("2006.01.02")
 	return fmt.Sprintf(".monitoring-beats-%v-%s", version, date)
 }

--- a/libbeat/monitoring/report/elasticsearch/client.go
+++ b/libbeat/monitoring/report/elasticsearch/client.go
@@ -35,13 +35,13 @@ import (
 type publishClient struct {
 	es     *esout.Client
 	params map[string]string
-	format report.ReportingFormat
+	format report.Format
 }
 
 func newPublishClient(
 	es *esout.Client,
 	params map[string]string,
-	format report.ReportingFormat,
+	format report.Format,
 ) (*publishClient, error) {
 	p := &publishClient{
 		es:     es,
@@ -131,9 +131,9 @@ func (c *publishClient) Publish(batch publisher.Batch) error {
 		}
 
 		switch c.format {
-		case report.ReportingFormatXPackMonitoringBulk:
+		case report.FormatXPackMonitoringBulk:
 			err = c.publishXPackBulk(params, event, typ)
-		case report.ReportingFormatBulk:
+		case report.FormatBulk:
 			err = c.publishBulk(event, typ)
 		}
 

--- a/libbeat/monitoring/report/elasticsearch/client.go
+++ b/libbeat/monitoring/report/elasticsearch/client.go
@@ -177,11 +177,17 @@ func (c *publishClient) bulkToProduction(params map[string]string, event publish
 func (c *publishClient) bulkToMonitoring(event publisher.Event) error {
 	action := common.MapStr{
 		"index": common.MapStr{
-			"_type":    "doc",
 			"_index":   "monitoring-beats-6-1", // FIXME
 			"_routing": nil,
 		},
 	}
+
+	esVersion := c.es.GetVersion()
+	v7 := common.MustNewVersion("7.0.0")
+	if esVersion.LessThan(v7) {
+		action.Put("index._type", "doc")
+	}
+
 	document := report.Event{
 		Timestamp: event.Content.Timestamp,
 		Fields:    event.Content.Fields,

--- a/libbeat/monitoring/report/elasticsearch/client.go
+++ b/libbeat/monitoring/report/elasticsearch/client.go
@@ -135,7 +135,7 @@ func (c *publishClient) Publish(batch publisher.Batch) error {
 			continue
 		}
 
-		logp.Info("Sending monitoring data to %s cluster", format)
+		logp.Debug("Sending monitoring data to %s cluster", format)
 		switch format {
 		case report.ReportingFormatProduction:
 			err = c.bulkToProduction(params, event, t)

--- a/libbeat/monitoring/report/elasticsearch/client.go
+++ b/libbeat/monitoring/report/elasticsearch/client.go
@@ -180,15 +180,17 @@ func (c *publishClient) publishWithXPackMonitoringBulk(params map[string]string,
 }
 
 func (c *publishClient) publishWithBulk(event publisher.Event) error {
-	action := common.MapStr{
-		"index": common.MapStr{
-			"_index":   getMonitoringIndexName(),
-			"_routing": nil,
-		},
+	meta := common.MapStr{
+		"_index":   getMonitoringIndexName(),
+		"_routing": nil,
 	}
 
 	if c.es.GetVersion().Major < 7 {
-		action.Put("index._type", "doc")
+		meta["_type"] = "doc"
+	}
+
+	action := common.MapStr{
+		"index": meta,
 	}
 
 	event.Content.Fields.Put("timestamp", event.Content.Timestamp)

--- a/libbeat/monitoring/report/elasticsearch/client.go
+++ b/libbeat/monitoring/report/elasticsearch/client.go
@@ -187,9 +187,7 @@ func (c *publishClient) publishWithBulk(event publisher.Event) error {
 		},
 	}
 
-	esVersion := c.es.GetVersion()
-	v7 := common.MustNewVersion("7.0.0")
-	if esVersion.LessThan(v7) {
+	if c.es.GetVersion().Major < 7 {
 		action.Put("index._type", "doc")
 	}
 

--- a/libbeat/monitoring/report/elasticsearch/client.go
+++ b/libbeat/monitoring/report/elasticsearch/client.go
@@ -132,9 +132,9 @@ func (c *publishClient) Publish(batch publisher.Batch) error {
 
 		switch c.format {
 		case report.ReportingFormatXPackMonitoringBulk:
-			err = c.publishWithXPackMonitoringBulk(params, event, typ)
+			err = c.publishXPackBulk(params, event, typ)
 		case report.ReportingFormatBulk:
-			err = c.publishWithBulk(event)
+			err = c.publishBulk(event)
 		}
 
 		if err != nil {
@@ -159,7 +159,7 @@ func (c *publishClient) String() string {
 	return "publish(" + c.es.String() + ")"
 }
 
-func (c *publishClient) publishWithXPackMonitoringBulk(params map[string]string, event publisher.Event, typ string) error {
+func (c *publishClient) publishXPackBulk(params map[string]string, event publisher.Event, typ string) error {
 	meta := common.MapStr{
 		"_index":   "",
 		"_routing": nil,
@@ -179,7 +179,7 @@ func (c *publishClient) publishWithXPackMonitoringBulk(params map[string]string,
 	return err
 }
 
-func (c *publishClient) publishWithBulk(event publisher.Event) error {
+func (c *publishClient) publishBulk(event publisher.Event) error {
 	meta := common.MapStr{
 		"_index":   getMonitoringIndexName(),
 		"_routing": nil,

--- a/libbeat/monitoring/report/elasticsearch/client.go
+++ b/libbeat/monitoring/report/elasticsearch/client.go
@@ -39,12 +39,17 @@ type publishClient struct {
 func newPublishClient(
 	es *esout.Client,
 	params map[string]string,
-) *publishClient {
+) (*publishClient, error) {
+	format := params["_format"]
+	if format != report.ReportingFormatProduction && format != report.ReportingFormatMonitoring {
+		return nil, fmt.Errorf("unsupported reporting format: %v", format)
+	}
+
 	p := &publishClient{
 		es:     es,
 		params: params,
 	}
-	return p
+	return p, nil
 }
 
 func (c *publishClient) Connect() error {
@@ -127,8 +132,6 @@ func (c *publishClient) Publish(batch publisher.Batch) error {
 			err = c.bulkToProduction(params, event, t)
 		case report.ReportingFormatMonitoring:
 			err = c.bulkToMonitoring(event)
-		default:
-			err = fmt.Errorf("unsupported reporting format: %v", params["_format"])
 		}
 
 		if err != nil {

--- a/libbeat/monitoring/report/elasticsearch/client.go
+++ b/libbeat/monitoring/report/elasticsearch/client.go
@@ -84,7 +84,7 @@ func (c *publishClient) Connect() error {
 	}
 
 	debugf("XPack monitoring is enabled")
-	debugf("Publishing to %v cluster", c.params["format"])
+	debugf("Publishing to %v cluster", c.params["_format"])
 
 	return nil
 }
@@ -122,13 +122,13 @@ func (c *publishClient) Publish(batch publisher.Batch) error {
 			}
 		}
 
-		switch params["format"] {
+		switch params["_format"] {
 		case "production":
 			err = c.bulkToProduction(params, event, t)
 		case "monitoring":
 			err = c.bulkToMonitoring(event)
 		default:
-			err = fmt.Errorf("unsupported reporting format: %v", params["format"])
+			err = fmt.Errorf("unsupported reporting format: %v", params["_format"])
 		}
 
 		if err != nil {

--- a/libbeat/monitoring/report/elasticsearch/client.go
+++ b/libbeat/monitoring/report/elasticsearch/client.go
@@ -123,9 +123,9 @@ func (c *publishClient) Publish(batch publisher.Batch) error {
 		}
 
 		switch params["_format"] {
-		case "production":
+		case report.ReportingFormatProduction:
 			err = c.bulkToProduction(params, event, t)
-		case "monitoring":
+		case report.ReportingFormatMonitoring:
 			err = c.bulkToMonitoring(event)
 		default:
 			err = fmt.Errorf("unsupported reporting format: %v", params["_format"])

--- a/libbeat/monitoring/report/elasticsearch/client.go
+++ b/libbeat/monitoring/report/elasticsearch/client.go
@@ -131,17 +131,17 @@ func (c *publishClient) Publish(batch publisher.Batch) error {
 		}
 
 		event.Content.Meta.Delete("format")
-		format, ok := f.(string)
+		format, ok := f.(report.ReportingFormat)
 		if !ok {
 			logp.Err("Format not available in monitoring reported. Please report this error: %s", err)
 			continue
 		}
 
-		logp.Debug("Sending monitoring data to %s cluster", format)
+		logp.Info("Sending monitoring data to %s cluster", getClusterTypeForFormat(format))
 		switch format {
-		case report.ReportingFormatProduction:
+		case report.ReportingFormatBulk:
 			err = c.bulkToProduction(params, event, t)
-		case report.ReportingFormatMonitoring:
+		case report.ReportingFormatXPackMonitoringBulk:
 			err = c.bulkToMonitoring(event)
 		}
 
@@ -245,4 +245,15 @@ func getMonitoringIndexName() string {
 	version := 6
 	date := time.Now().Format("2006.01.02")
 	return fmt.Sprintf(".monitoring-beats-%v-%s", version, date)
+}
+
+func getClusterTypeForFormat(format report.ReportingFormat) string {
+	switch format {
+	case report.ReportingFormatXPackMonitoringBulk:
+		return "monitoring"
+	case report.ReportingFormatBulk:
+		return "production"
+	default:
+		return "invalid"
+	}
 }

--- a/libbeat/monitoring/report/elasticsearch/config.go
+++ b/libbeat/monitoring/report/elasticsearch/config.go
@@ -30,22 +30,22 @@ import (
 type config struct {
 	Hosts            []string
 	Protocol         string
-	Params           map[string]string      `config:"parameters"`
-	Headers          map[string]string      `config:"headers"`
-	Username         string                 `config:"username"`
-	Password         string                 `config:"password"`
-	ProxyURL         string                 `config:"proxy_url"`
-	CompressionLevel int                    `config:"compression_level" validate:"min=0, max=9"`
-	TLS              *tlscommon.Config      `config:"ssl"`
-	MaxRetries       int                    `config:"max_retries"`
-	Timeout          time.Duration          `config:"timeout"`
-	MetricsPeriod    time.Duration          `config:"metrics.period"`
-	StatePeriod      time.Duration          `config:"state.period"`
-	BulkMaxSize      int                    `config:"bulk_max_size" validate:"min=0"`
-	BufferSize       int                    `config:"buffer_size"`
-	Tags             []string               `config:"tags"`
-	Backoff          backoff                `config:"backoff"`
-	Format           report.ReportingFormat `config:"_format"`
+	Params           map[string]string `config:"parameters"`
+	Headers          map[string]string `config:"headers"`
+	Username         string            `config:"username"`
+	Password         string            `config:"password"`
+	ProxyURL         string            `config:"proxy_url"`
+	CompressionLevel int               `config:"compression_level" validate:"min=0, max=9"`
+	TLS              *tlscommon.Config `config:"ssl"`
+	MaxRetries       int               `config:"max_retries"`
+	Timeout          time.Duration     `config:"timeout"`
+	MetricsPeriod    time.Duration     `config:"metrics.period"`
+	StatePeriod      time.Duration     `config:"state.period"`
+	BulkMaxSize      int               `config:"bulk_max_size" validate:"min=0"`
+	BufferSize       int               `config:"buffer_size"`
+	Tags             []string          `config:"tags"`
+	Backoff          backoff           `config:"backoff"`
+	Format           report.Format     `config:"_format"`
 }
 
 type backoff struct {

--- a/libbeat/monitoring/report/elasticsearch/config.go
+++ b/libbeat/monitoring/report/elasticsearch/config.go
@@ -20,6 +20,8 @@ package elasticsearch
 import (
 	"time"
 
+	"github.com/elastic/beats/libbeat/monitoring/report"
+
 	"github.com/elastic/beats/libbeat/common/transport/tlscommon"
 )
 
@@ -28,22 +30,22 @@ import (
 type config struct {
 	Hosts            []string
 	Protocol         string
-	Params           map[string]string `config:"parameters"`
-	Headers          map[string]string `config:"headers"`
-	Username         string            `config:"username"`
-	Password         string            `config:"password"`
-	ProxyURL         string            `config:"proxy_url"`
-	CompressionLevel int               `config:"compression_level" validate:"min=0, max=9"`
-	TLS              *tlscommon.Config `config:"ssl"`
-	MaxRetries       int               `config:"max_retries"`
-	Timeout          time.Duration     `config:"timeout"`
-	MetricsPeriod    time.Duration     `config:"metrics.period"`
-	StatePeriod      time.Duration     `config:"state.period"`
-	BulkMaxSize      int               `config:"bulk_max_size" validate:"min=0"`
-	BufferSize       int               `config:"buffer_size"`
-	Tags             []string          `config:"tags"`
-	Backoff          backoff           `config:"backoff"`
-	Format           string            `config:"_format"`
+	Params           map[string]string      `config:"parameters"`
+	Headers          map[string]string      `config:"headers"`
+	Username         string                 `config:"username"`
+	Password         string                 `config:"password"`
+	ProxyURL         string                 `config:"proxy_url"`
+	CompressionLevel int                    `config:"compression_level" validate:"min=0, max=9"`
+	TLS              *tlscommon.Config      `config:"ssl"`
+	MaxRetries       int                    `config:"max_retries"`
+	Timeout          time.Duration          `config:"timeout"`
+	MetricsPeriod    time.Duration          `config:"metrics.period"`
+	StatePeriod      time.Duration          `config:"state.period"`
+	BulkMaxSize      int                    `config:"bulk_max_size" validate:"min=0"`
+	BufferSize       int                    `config:"buffer_size"`
+	Tags             []string               `config:"tags"`
+	Backoff          backoff                `config:"backoff"`
+	Format           report.ReportingFormat `config:"_format"`
 }
 
 type backoff struct {

--- a/libbeat/monitoring/report/elasticsearch/config.go
+++ b/libbeat/monitoring/report/elasticsearch/config.go
@@ -43,6 +43,7 @@ type config struct {
 	BufferSize       int               `config:"buffer_size"`
 	Tags             []string          `config:"tags"`
 	Backoff          backoff           `config:"backoff"`
+	Format           string            `config:"format"`
 }
 
 type backoff struct {

--- a/libbeat/monitoring/report/elasticsearch/config.go
+++ b/libbeat/monitoring/report/elasticsearch/config.go
@@ -43,7 +43,7 @@ type config struct {
 	BufferSize       int               `config:"buffer_size"`
 	Tags             []string          `config:"tags"`
 	Backoff          backoff           `config:"backoff"`
-	Format           string            `config:"format"`
+	Format           string            `config:"_format"`
 }
 
 type backoff struct {

--- a/libbeat/monitoring/report/elasticsearch/elasticsearch.go
+++ b/libbeat/monitoring/report/elasticsearch/elasticsearch.go
@@ -98,14 +98,14 @@ func defaultConfig(settings report.Settings) config {
 			Init: 1 * time.Second,
 			Max:  60 * time.Second,
 		},
-		Format: report.ReportingFormatXPackMonitoringBulk,
+		Format: report.FormatXPackMonitoringBulk,
 	}
 
 	if settings.DefaultUsername != "" {
 		c.Username = settings.DefaultUsername
 	}
 
-	if settings.Format != report.ReportingFormatUnknown {
+	if settings.Format != report.FormatUnknown {
 		c.Format = settings.Format
 	}
 
@@ -347,7 +347,7 @@ func makeClient(
 		return nil, err
 	}
 
-	if config.Format != report.ReportingFormatXPackMonitoringBulk && config.Format != report.ReportingFormatBulk {
+	if config.Format != report.FormatXPackMonitoringBulk && config.Format != report.FormatBulk {
 		return nil, fmt.Errorf("unknown reporting format: %v", config.Format)
 	}
 

--- a/libbeat/monitoring/report/elasticsearch/elasticsearch.go
+++ b/libbeat/monitoring/report/elasticsearch/elasticsearch.go
@@ -105,6 +105,10 @@ func defaultConfig(settings report.Settings) config {
 		c.Username = settings.DefaultUsername
 	}
 
+	if settings.Format != report.ReportingFormatUnknown {
+		c.Format = settings.Format
+	}
+
 	return c
 }
 

--- a/libbeat/monitoring/report/elasticsearch/elasticsearch.go
+++ b/libbeat/monitoring/report/elasticsearch/elasticsearch.go
@@ -340,7 +340,7 @@ func makeClient(
 		return nil, err
 	}
 
-	return newPublishClient(esClient, params), nil
+	return newPublishClient(esClient, params)
 }
 
 func closing(log *logp.Logger, c io.Closer) {

--- a/libbeat/monitoring/report/elasticsearch/elasticsearch.go
+++ b/libbeat/monitoring/report/elasticsearch/elasticsearch.go
@@ -97,7 +97,7 @@ func defaultConfig(settings report.Settings) config {
 			Init: 1 * time.Second,
 			Max:  60 * time.Second,
 		},
-		Format: report.ReportingFormatProduction,
+		Format: report.ReportingFormatXPackMonitoringBulk,
 	}
 
 	if settings.DefaultUsername != "" {
@@ -261,7 +261,7 @@ func (r *reporter) initLoop(c config) {
 	go r.snapshotLoop("stats", "metrics", c.MetricsPeriod, c.Format)
 }
 
-func (r *reporter) snapshotLoop(namespace, prefix string, period time.Duration, format string) {
+func (r *reporter) snapshotLoop(namespace, prefix string, period time.Duration, format report.ReportingFormat) {
 	ticker := time.NewTicker(period)
 	defer ticker.Stop()
 

--- a/libbeat/monitoring/report/report.go
+++ b/libbeat/monitoring/report/report.go
@@ -25,6 +25,11 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 )
 
+const (
+	ReportingFormatProduction = "production"
+	ReportingFormatMonitoring = "monitoring"
+)
+
 type config struct {
 	// allow for maximum one reporter being configured
 	Reporter common.ConfigNamespace `config:",inline"`

--- a/libbeat/monitoring/report/report.go
+++ b/libbeat/monitoring/report/report.go
@@ -73,10 +73,10 @@ func New(
 }
 
 func getReporterConfig(
-	cfg *common.Config,
+	monitoringConfig *common.Config,
 	outputs common.ConfigNamespace,
 ) (string, *common.Config, error) {
-	cfg = collectSubObject(cfg)
+	cfg := collectSubObject(monitoringConfig)
 	config := defaultConfig
 	if err := cfg.Unpack(&config); err != nil {
 		return "", nil, err
@@ -109,6 +109,12 @@ func getReporterConfig(
 			}
 			rc = merged
 		}
+
+		format, err := monitoringConfig.String("format", -1)
+		if err != nil {
+			return "", nil, err
+		}
+		rc.SetString("parameters.format", -1, format)
 
 		return name, rc, nil
 	}

--- a/libbeat/monitoring/report/report.go
+++ b/libbeat/monitoring/report/report.go
@@ -119,7 +119,7 @@ func getReporterConfig(
 		if err != nil {
 			return "", nil, err
 		}
-		rc.SetString("parameters._format", -1, format)
+		rc.SetString("format", -1, format)
 
 		return name, rc, nil
 	}

--- a/libbeat/monitoring/report/report.go
+++ b/libbeat/monitoring/report/report.go
@@ -115,7 +115,7 @@ func getReporterConfig(
 			}{}
 			rc.Unpack(&hosts)
 
-			if settings.Format == FormatBulk && len(hosts.Hosts) > 0 {
+			if settings.Format == FormatXPackMonitoringBulk && len(hosts.Hosts) > 0 {
 				pathMonHosts := rc.PathOf("hosts")
 				pathOutHost := outCfg.PathOf("hosts")
 				err := fmt.Errorf("'%v' and '%v' are configured", pathMonHosts, pathOutHost)

--- a/libbeat/monitoring/report/report.go
+++ b/libbeat/monitoring/report/report.go
@@ -28,7 +28,7 @@ import (
 type ReportingFormat int
 
 const (
-	ReportingFormatUnknown ReportingFormat = iota
+	ReportingFormatUnknown ReportingFormat = iota // to protect against zero-value errors
 	ReportingFormatXPackMonitoringBulk
 	ReportingFormatBulk
 )

--- a/libbeat/monitoring/report/report.go
+++ b/libbeat/monitoring/report/report.go
@@ -25,7 +25,8 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 )
 
-// Format encodes the type of format to report monitoring data in.
+// Format encodes the type of format to report monitoring data in. This
+// is currently only being used by the elaticsearch reporter.
 type Format int
 
 // Enumerations of various Formats. A reporter can choose whether to

--- a/libbeat/monitoring/report/report.go
+++ b/libbeat/monitoring/report/report.go
@@ -25,8 +25,10 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 )
 
+// ReportingFormat encodes the type of format to report monitoring data in
 type ReportingFormat int
 
+// Enumerations of various ReportingFormats
 const (
 	ReportingFormatUnknown ReportingFormat = iota // to protect against zero-value errors
 	ReportingFormatXPackMonitoringBulk

--- a/libbeat/monitoring/report/report.go
+++ b/libbeat/monitoring/report/report.go
@@ -110,11 +110,11 @@ func getReporterConfig(
 			rc = merged
 		}
 
-		format, err := monitoringConfig.String("format", -1)
+		format, err := monitoringConfig.String("_format", -1)
 		if err != nil {
 			return "", nil, err
 		}
-		rc.SetString("parameters.format", -1, format)
+		rc.SetString("parameters._format", -1, format)
 
 		return name, rc, nil
 	}

--- a/libbeat/monitoring/report/report.go
+++ b/libbeat/monitoring/report/report.go
@@ -25,15 +25,15 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 )
 
-// ReportingFormat encodes the type of format to report monitoring data in.
-type ReportingFormat int
+// Format encodes the type of format to report monitoring data in.
+type Format int
 
-// Enumerations of various ReportingFormats. A reporter can choose whether to
+// Enumerations of various Formats. A reporter can choose whether to
 // interpret this setting or not, and if so, how to interpret it.
 const (
-	ReportingFormatUnknown ReportingFormat = iota // to protect against zero-value errors
-	ReportingFormatXPackMonitoringBulk
-	ReportingFormatBulk
+	FormatUnknown Format = iota // to protect against zero-value errors
+	FormatXPackMonitoringBulk
+	FormatBulk
 )
 
 type config struct {
@@ -43,7 +43,7 @@ type config struct {
 
 type Settings struct {
 	DefaultUsername string
-	Format          ReportingFormat
+	Format          Format
 }
 
 type Reporter interface {
@@ -109,7 +109,7 @@ func getReporterConfig(
 			}{}
 			rc.Unpack(&hosts)
 
-			if settings.Format == ReportingFormatBulk && len(hosts.Hosts) > 0 {
+			if settings.Format == FormatBulk && len(hosts.Hosts) > 0 {
 				pathMonHosts := rc.PathOf("hosts")
 				pathOutHost := outCfg.PathOf("hosts")
 				err := fmt.Errorf("'%v' and '%v' are configured", pathMonHosts, pathOutHost)

--- a/libbeat/monitoring/report/report.go
+++ b/libbeat/monitoring/report/report.go
@@ -27,6 +27,11 @@ import (
 
 // Format encodes the type of format to report monitoring data in. This
 // is currently only being used by the elaticsearch reporter.
+// This is a hack that is necessary so we can map certain monitoring
+// configuration options to certain behaviors in reporters. Depending on
+// the configuration option used, the correct format is set, and reporters
+// that know how to interpret the format use it to choose the appropriate
+// reporting behavior.
 type Format int
 
 // Enumerations of various Formats. A reporter can choose whether to

--- a/libbeat/outputs/elasticsearch/client.go
+++ b/libbeat/outputs/elasticsearch/client.go
@@ -77,7 +77,7 @@ type ClientSettings struct {
 	Observer           outputs.Observer
 }
 
-type connectCallback func(client *Client) error
+type ConnectCallback func(client *Client) error
 
 // Connection manages the connection for a given client.
 type Connection struct {

--- a/libbeat/outputs/elasticsearch/client.go
+++ b/libbeat/outputs/elasticsearch/client.go
@@ -77,6 +77,7 @@ type ClientSettings struct {
 	Observer           outputs.Observer
 }
 
+// ConnectCallback defines the type for the function to be called when the Elasticsearch client successfully connects to the cluster
 type ConnectCallback func(client *Client) error
 
 // Connection manages the connection for a given client.

--- a/libbeat/outputs/elasticsearch/elasticsearch.go
+++ b/libbeat/outputs/elasticsearch/elasticsearch.go
@@ -54,7 +54,7 @@ var (
 // Callbacks must not depend on the result of a previous one,
 // because the ordering is not fixed.
 type callbacksRegistry struct {
-	callbacks map[uuid.UUID]connectCallback
+	callbacks map[uuid.UUID]ConnectCallback
 	mutex     sync.Mutex
 }
 
@@ -88,14 +88,14 @@ func RegisterGlobalCallback(callback connectCallback) (uuid.UUID, error) {
 
 func newCallbacksRegistry() callbacksRegistry {
 	return callbacksRegistry{
-		callbacks: make(map[uuid.UUID]connectCallback),
+		callbacks: make(map[uuid.UUID]ConnectCallback),
 	}
 }
 
 // RegisterConnectCallback registers a callback for the elasticsearch output
 // The callback is called each time the client connects to elasticsearch.
 // It returns the key of the newly added callback, so it can be deregistered later.
-func RegisterConnectCallback(callback connectCallback) (uuid.UUID, error) {
+func RegisterConnectCallback(callback ConnectCallback) (uuid.UUID, error) {
 	connectCallbackRegistry.mutex.Lock()
 	defer connectCallbackRegistry.mutex.Unlock()
 

--- a/libbeat/outputs/elasticsearch/elasticsearch.go
+++ b/libbeat/outputs/elasticsearch/elasticsearch.go
@@ -66,7 +66,7 @@ var connectCallbackRegistry = newCallbacksRegistry()
 var globalCallbackRegistry = newCallbacksRegistry()
 
 // RegisterGlobalCallback register a global callbacks.
-func RegisterGlobalCallback(callback connectCallback) (uuid.UUID, error) {
+func RegisterGlobalCallback(callback ConnectCallback) (uuid.UUID, error) {
 	globalCallbackRegistry.mutex.Lock()
 	defer globalCallbackRegistry.mutex.Unlock()
 

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -221,7 +221,7 @@ system-tests: prepare-tests ${BEAT_NAME}.test python-env
 .PHONY: system-tests-environment
 system-tests-environment:  ## @testing Runs the system tests inside a virtual environment. This can be run on any docker-machine (local, remote)
 system-tests-environment: prepare-tests build-image
-	${DOCKER_COMPOSE} run -e INTEGRATION_TESTS=1 -e TESTING_ENVIRONMENT=${TESTING_ENVIRONMENT} -e DOCKER_COMPOSE_PROJECT_NAME=${DOCKER_COMPOSE_PROJECT_NAME} beat make system-tests
+	${DOCKER_COMPOSE} run -e INTEGRATION_TESTS=1 -e TESTING_ENVIRONMENT=${TESTING_ENVIRONMENT} -e DOCKER_COMPOSE_PROJECT_NAME=${DOCKER_COMPOSE_PROJECT_NAME} beat make system-tests || ${DOCKER_COMPOSE} logs --tail 200
 
 .PHONY: fast-system-tests
 fast-system-tests: ## @testing Runs system tests without coverage reports and in parallel

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -208,7 +208,7 @@ integration-tests-environment: prepare-tests build-image
 	#
 	# This will make docker-compose command to display the logs on stdout on error, It's not enabled
 	# by default because it can create noise if the test inside the container fails.
-	${DOCKER_COMPOSE} run beat make integration-tests RACE_DETECTOR=$(RACE_DETECTOR) DOCKER_COMPOSE_PROJECT_NAME=${DOCKER_COMPOSE_PROJECT_NAME}
+	${DOCKER_COMPOSE} run beat make integration-tests RACE_DETECTOR=$(RACE_DETECTOR) DOCKER_COMPOSE_PROJECT_NAME=${DOCKER_COMPOSE_PROJECT_NAME} || ${DOCKER_COMPOSE} logs --tail 200
 
 # Runs the system tests
 .PHONY: system-tests

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -208,7 +208,7 @@ integration-tests-environment: prepare-tests build-image
 	#
 	# This will make docker-compose command to display the logs on stdout on error, It's not enabled
 	# by default because it can create noise if the test inside the container fails.
-	${DOCKER_COMPOSE} run beat make integration-tests RACE_DETECTOR=$(RACE_DETECTOR) DOCKER_COMPOSE_PROJECT_NAME=${DOCKER_COMPOSE_PROJECT_NAME} || ${DOCKER_COMPOSE} logs --tail 200
+	${DOCKER_COMPOSE} run beat make integration-tests RACE_DETECTOR=$(RACE_DETECTOR) DOCKER_COMPOSE_PROJECT_NAME=${DOCKER_COMPOSE_PROJECT_NAME}
 
 # Runs the system tests
 .PHONY: system-tests
@@ -221,7 +221,7 @@ system-tests: prepare-tests ${BEAT_NAME}.test python-env
 .PHONY: system-tests-environment
 system-tests-environment:  ## @testing Runs the system tests inside a virtual environment. This can be run on any docker-machine (local, remote)
 system-tests-environment: prepare-tests build-image
-	${DOCKER_COMPOSE} run -e INTEGRATION_TESTS=1 -e TESTING_ENVIRONMENT=${TESTING_ENVIRONMENT} -e DOCKER_COMPOSE_PROJECT_NAME=${DOCKER_COMPOSE_PROJECT_NAME} beat make system-tests || ${DOCKER_COMPOSE} logs --tail 200
+	${DOCKER_COMPOSE} run -e INTEGRATION_TESTS=1 -e TESTING_ENVIRONMENT=${TESTING_ENVIRONMENT} -e DOCKER_COMPOSE_PROJECT_NAME=${DOCKER_COMPOSE_PROJECT_NAME} beat make system-tests
 
 .PHONY: fast-system-tests
 fast-system-tests: ## @testing Runs system tests without coverage reports and in parallel

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -221,7 +221,7 @@ system-tests: prepare-tests ${BEAT_NAME}.test python-env
 .PHONY: system-tests-environment
 system-tests-environment:  ## @testing Runs the system tests inside a virtual environment. This can be run on any docker-machine (local, remote)
 system-tests-environment: prepare-tests build-image
-	${DOCKER_COMPOSE} run -e INTEGRATION_TESTS=1 -e TESTING_ENVIRONMENT=${TESTING_ENVIRONMENT} -e DOCKER_COMPOSE_PROJECT_NAME=${DOCKER_COMPOSE_PROJECT_NAME} beat make system-tests || ${DOCKER_COMPOSE} logs --tail 200
+	${DOCKER_COMPOSE} run -e INTEGRATION_TESTS=1 -e TESTING_ENVIRONMENT=${TESTING_ENVIRONMENT} -e DOCKER_COMPOSE_PROJECT_NAME=${DOCKER_COMPOSE_PROJECT_NAME} beat make system-tests
 
 .PHONY: fast-system-tests
 fast-system-tests: ## @testing Runs system tests without coverage reports and in parallel

--- a/libbeat/tests/system/config/mockbeat.yml.j2
+++ b/libbeat/tests/system/config/mockbeat.yml.j2
@@ -109,5 +109,12 @@ xpack.monitoring.elasticsearch.metrics.period: 2s    # to speed up tests
 xpack.monitoring.elasticsearch.state.period: 3s      # to speed up tests
 {% endif -%}
 
+{% if monitoring -%}
+#================================ X-Pack Monitoring (direct) =====================================
+monitoring.elasticsearch.hosts: {{xpack.monitoring.elasticsearch.hosts}}
+monitoring.elasticsearch.metrics.period: 2s    # to speed up tests
+monitoring.elasticsearch.state.period: 3s      # to speed up tests
+{% endif -%}
+
 # vim: set ft=jinja:
 

--- a/libbeat/tests/system/config/mockbeat.yml.j2
+++ b/libbeat/tests/system/config/mockbeat.yml.j2
@@ -111,7 +111,7 @@ xpack.monitoring.elasticsearch.state.period: 3s      # to speed up tests
 
 {% if monitoring -%}
 #================================ X-Pack Monitoring (direct) =====================================
-monitoring.elasticsearch.hosts: {{xpack.monitoring.elasticsearch.hosts}}
+monitoring.elasticsearch.hosts: {{monitoring.elasticsearch.hosts}}
 monitoring.elasticsearch.metrics.period: 2s    # to speed up tests
 monitoring.elasticsearch.state.period: 3s      # to speed up tests
 {% endif -%}

--- a/libbeat/tests/system/test_monitoring.py
+++ b/libbeat/tests/system/test_monitoring.py
@@ -144,7 +144,7 @@ class Test(BaseTest):
 
         proc.check_kill_and_wait()
 
-         # TODO: Get a beats_stats doc
+        # TODO: Get a beats_stats doc
         # TODO: Get a beats_state doc
 
         # TODO: compare the two beats_stats docs, making sure same keys exist under `beats_stats` field

--- a/libbeat/tests/system/test_monitoring.py
+++ b/libbeat/tests/system/test_monitoring.py
@@ -49,6 +49,38 @@ class Test(BaseTest):
             field_names = ['cluster_uuid', 'timestamp', 'interval_ms', 'type', 'source_node', monitoring_doc_type]
             self.assert_monitoring_doc_contains_fields(monitoring_doc_type, field_names)
 
+    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
+    @attr('integration')
+    def test_direct_to_monitoring_cluster(self):
+        """
+        Test shipping monitoring data directly to the monitoring cluster.
+        Make sure expected documents are indexed in monitoring cluster.
+        """
+
+        self.render_config_template(
+            "mockbeat",
+            monitoring={
+                "elasticsearch": {
+                    "hosts": [self.get_elasticsearch_monitoring_url()]
+                }
+            }
+        )
+
+        self.clean()
+
+        proc = self.start_beat(config="mockbeat.yml")
+        self.wait_until(lambda: self.log_contains("mockbeat start running."))
+        self.wait_until(lambda: self.log_contains(re.compile("\[monitoring\].*Publish event")))
+        self.wait_until(lambda: self.log_contains(re.compile(
+            "Connection to .*elasticsearch\("+self.get_elasticsearch_monitoring_url()+"\).* established")))
+        self.wait_until(lambda: self.monitoring_doc_exists('beats_stats'))
+        self.wait_until(lambda: self.monitoring_doc_exists('beats_state'))
+
+        for monitoring_doc_type in ['beats_stats', 'beats_state']:
+            field_names = ['cluster_uuid', 'timestamp', 'interval_ms', 'type', monitoring_doc_type]
+            self.assert_monitoring_doc_contains_fields(monitoring_doc_type, field_names)
+
+
     def monitoring_doc_exists(self, monitoring_type):
         results = self.es_monitoring.search(
             index='.monitoring-beats-*',

--- a/libbeat/tests/system/test_monitoring.py
+++ b/libbeat/tests/system/test_monitoring.py
@@ -16,10 +16,6 @@ class Test(BaseTest):
         self.es = Elasticsearch([self.get_elasticsearch_url()])
         self.es_monitoring = Elasticsearch([self.get_elasticsearch_monitoring_url()])
 
-    def tearDown(self):
-        if self.proc:
-            self.proc.check_kill_and_wait()
-
     @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     @attr('integration')
     def test_via_output_cluster(self):
@@ -42,13 +38,15 @@ class Test(BaseTest):
         self.init_output_cluster()
         self.init_monitoring_cluster()
 
-        self.proc = self.start_beat(config="mockbeat.yml")
+        proc = self.start_beat(config="mockbeat.yml")
         self.wait_until(lambda: self.log_contains("mockbeat start running."))
         self.wait_until(lambda: self.log_contains(re.compile("\[monitoring\].*Publish event")))
         self.wait_until(lambda: self.log_contains(re.compile(
             "Connection to .*elasticsearch\("+self.get_elasticsearch_url()+"\).* established")))
         self.wait_until(lambda: self.monitoring_doc_exists('beats_stats'))
         self.wait_until(lambda: self.monitoring_doc_exists('beats_state'))
+
+        proc.check_kill_and_wait()
 
         for monitoring_doc_type in ['beats_stats', 'beats_state']:
             field_names = ['cluster_uuid', 'timestamp', 'interval_ms', 'type', 'source_node', monitoring_doc_type]
@@ -73,13 +71,15 @@ class Test(BaseTest):
 
         self.init_monitoring_cluster()
 
-        self.proc = self.start_beat(config="mockbeat.yml")
+        proc = self.start_beat(config="mockbeat.yml")
         self.wait_until(lambda: self.log_contains("mockbeat start running."))
         self.wait_until(lambda: self.log_contains(re.compile("\[monitoring\].*Publish event")))
         self.wait_until(lambda: self.log_contains(re.compile(
             "Connection to .*elasticsearch\("+self.get_elasticsearch_monitoring_url()+"\).* established")))
         self.wait_until(lambda: self.monitoring_doc_exists('beats_stats'))
         self.wait_until(lambda: self.monitoring_doc_exists('beats_state'))
+
+        proc.check_kill_and_wait()
 
         for monitoring_doc_type in ['beats_stats', 'beats_state']:
             field_names = ['cluster_uuid', 'timestamp', 'interval_ms', 'type', monitoring_doc_type]
@@ -106,7 +106,7 @@ class Test(BaseTest):
         self.init_output_cluster()
         self.init_monitoring_cluster()
 
-        self.proc = self.start_beat(config="mockbeat.yml")
+        proc = self.start_beat(config="mockbeat.yml")
         self.wait_until(lambda: self.log_contains("mockbeat start running."))
         self.wait_until(lambda: self.log_contains(re.compile("\[monitoring\].*Publish event")))
         self.wait_until(lambda: self.log_contains(re.compile(
@@ -114,10 +114,10 @@ class Test(BaseTest):
         self.wait_until(lambda: self.monitoring_doc_exists('beats_stats'))
         self.wait_until(lambda: self.monitoring_doc_exists('beats_state'))
 
+        proc.check_kill_and_wait()
+
         # TODO: Get a beats_stats doc
         # TODO: Get a beats_state doc
-
-        self.proc.check_kill_and_wait()
 
         self.render_config_template(
             "mockbeat",
@@ -130,13 +130,15 @@ class Test(BaseTest):
 
         self.init_monitoring_cluster()
 
-        self.proc = self.start_beat(config="mockbeat.yml")
+        proc = self.start_beat(config="mockbeat.yml")
         self.wait_until(lambda: self.log_contains("mockbeat start running."))
         self.wait_until(lambda: self.log_contains(re.compile("\[monitoring\].*Publish event")))
         self.wait_until(lambda: self.log_contains(re.compile(
             "Connection to .*elasticsearch\("+self.get_elasticsearch_monitoring_url()+"\).* established")))
         self.wait_until(lambda: self.monitoring_doc_exists('beats_stats'))
         self.wait_until(lambda: self.monitoring_doc_exists('beats_state'))
+
+        proc.check_kill_and_wait()
 
         # TODO: Get a beats_stats doc
         # TODO: Get a beats_state doc

--- a/libbeat/tests/system/test_monitoring.py
+++ b/libbeat/tests/system/test_monitoring.py
@@ -43,7 +43,7 @@ class Test(BaseTest):
         self.wait_until(lambda: self.log_contains("mockbeat start running."))
         self.wait_until(lambda: self.log_contains(re.compile("\[monitoring\].*Publish event")))
         self.wait_until(lambda: self.log_contains(re.compile(
-            "Connection to .*elasticsearch\("+self.     ()+"\).* established")))
+            "Connection to .*elasticsearch\("+self.get_elasticsearch_url()+"\).* established")))
         self.wait_until(lambda: self.monitoring_doc_exists('beats_stats'))
         self.wait_until(lambda: self.monitoring_doc_exists('beats_state'))
 

--- a/libbeat/tests/system/test_monitoring.py
+++ b/libbeat/tests/system/test_monitoring.py
@@ -39,8 +39,8 @@ class Test(BaseTest):
             }
         )
 
-        self.clean_output_cluster()
-        self.clean_monitoring_cluster()
+        self.init_output_cluster()
+        self.init_monitoring_cluster()
 
         self.proc = self.start_beat(config="mockbeat.yml")
         self.wait_until(lambda: self.log_contains("mockbeat start running."))
@@ -71,7 +71,7 @@ class Test(BaseTest):
             }
         )
 
-        self.clean_monitoring_cluster()
+        self.init_monitoring_cluster()
 
         self.proc = self.start_beat(config="mockbeat.yml")
         self.wait_until(lambda: self.log_contains("mockbeat start running."))
@@ -103,8 +103,8 @@ class Test(BaseTest):
             }
         )
 
-        self.clean_output_cluster()
-        self.clean_monitoring_cluster()
+        self.init_output_cluster()
+        self.init_monitoring_cluster()
 
         self.proc = self.start_beat(config="mockbeat.yml")
         self.wait_until(lambda: self.log_contains("mockbeat start running."))
@@ -128,7 +128,7 @@ class Test(BaseTest):
             }
         )
 
-        self.clean_monitoring_cluster()
+        self.init_monitoring_cluster()
 
         self.proc = self.start_beat(config="mockbeat.yml")
         self.wait_until(lambda: self.log_contains("mockbeat start running."))
@@ -165,7 +165,7 @@ class Test(BaseTest):
         for field_name in field_names:
             assert field_name in source
 
-    def clean_output_cluster(self):
+    def init_output_cluster(self):
         # Setup remote exporter
         self.es.cluster.put_settings(body={
             "transient": {
@@ -183,7 +183,7 @@ class Test(BaseTest):
             }
         })
 
-    def clean_monitoring_cluster(self):
+    def init_monitoring_cluster(self):
         # Delete any old beats monitoring data
         self.es_monitoring.indices.delete(index=".monitoring-beats-*", ignore=[404])
 


### PR DESCRIPTION
Currently all beats ship their x-pack monitoring data to the production Elasticsearch cluster by `POST`ing it to the custom `_xpack/monitoring/_bulk` Elasticsearch API endpoint.

In the future we want to support beats shipping their x-pack monitoring data directly to a monitoring Elasticsearch cluster (which _could_ be the same as their production cluster but doesn't necessarily have to be) by `POST`ing it to the regular `_bulk` Elasticsearch API endpoint.

This PR introduces this "direct shipping" feature. Concretely:

* [x] It introduces a new class of settings named `monitoring.*` that will parallel the current `xpack.monitoring.*` settings. If the user has set `xpack.monitoring.*` the beat will continue to ship to the production cluster as it does today (but also emit a deprecation warning about these settings). However, if the user has set the `monitoring.*`, the beat will instead ship directly to the monitoring cluster.

* [x] It modifies the Elastisearch reporter to decide where to ship the data (production cluster, `_xpack/monitoring/_bulk` API endpoint -or- monitoring cluster, `_bulk` API endpoint).

* [x] If data is being shipped directly to the monitoring cluster AND the beat is configured to use an `elasticsearch` output, the Elasticsearch reporter will inject this `cluster_uuid` of the `elasticsearch` output cluster into the monitoring data event before publishing it.

