### PR TITLE
Fix alias field generation in docs

### DIFF
--- a/auditbeat/docs/fields.asciidoc
+++ b/auditbeat/docs/fields.asciidoc
@@ -4679,17 +4679,21 @@ Minor version of the operating system.
 
 --
 
-*`agent.type`*::
+*`beat.name`*::
 +
 --
 type: alias
 
+path: agent.type
+
 --
 
-*`agent.hostname`*::
+*`beat.hostname`*::
 +
 --
 type: alias
+
+path: agent.hostname
 
 --
 

--- a/auditbeat/docs/fields.asciidoc
+++ b/auditbeat/docs/fields.asciidoc
@@ -4684,7 +4684,7 @@ Minor version of the operating system.
 --
 type: alias
 
-path: agent.type
+alias to: agent.type
 
 --
 
@@ -4693,7 +4693,7 @@ path: agent.type
 --
 type: alias
 
-path: agent.hostname
+alias to: agent.hostname
 
 --
 

--- a/filebeat/docs/fields.asciidoc
+++ b/filebeat/docs/fields.asciidoc
@@ -2649,17 +2649,21 @@ Minor version of the operating system.
 
 --
 
-*`agent.type`*::
+*`beat.name`*::
 +
 --
 type: alias
 
+path: agent.type
+
 --
 
-*`agent.hostname`*::
+*`beat.hostname`*::
 +
 --
 type: alias
+
+path: agent.hostname
 
 --
 
@@ -3487,24 +3491,30 @@ If connection is via unix socket, socket path is in this field.
 
 --
 
-*`source.port`*::
+*`haproxy.client.port`*::
 +
 --
 type: alias
 
+path: source.port
+
 --
 
-*`process.name`*::
+*`haproxy.process_name`*::
 +
 --
 type: alias
 
+path: process.name
+
 --
 
-*`process.pid`*::
+*`haproxy.pid`*::
 +
 --
 type: alias
+
+path: process.pid
 
 --
 
@@ -3514,17 +3524,21 @@ type: alias
 Destination information
 
 
-*`destination.port`*::
+*`haproxy.destination.port`*::
 +
 --
 type: alias
 
+path: destination.port
+
 --
 
-*`destination.ip`*::
+*`haproxy.destination.ip`*::
 +
 --
 type: alias
+
+path: destination.ip
 
 --
 
@@ -3535,45 +3549,57 @@ Contains GeoIP information gathered based on the client.ip field. Only present i
 
 
 
-*`source.geo.continent_name`*::
+*`haproxy.geoip.continent_name`*::
 +
 --
 type: alias
 
+path: source.geo.continent_name
+
 --
 
-*`source.geo.country_iso_code`*::
+*`haproxy.geoip.country_iso_code`*::
 +
 --
 type: alias
 
+path: source.geo.country_iso_code
+
 --
 
-*`source.geo.location`*::
+*`haproxy.geoip.location`*::
 +
 --
 type: alias
 
+path: source.geo.location
+
 --
 
-*`source.geo.region_name`*::
+*`haproxy.geoip.region_name`*::
 +
 --
 type: alias
 
+path: source.geo.region_name
+
 --
 
-*`source.geo.city_name`*::
+*`haproxy.geoip.city_name`*::
 +
 --
 type: alias
 
+path: source.geo.city_name
+
 --
 
-*`source.geo.region_iso_code`*::
+*`haproxy.geoip.region_iso_code`*::
 +
 --
 type: alias
+
+path: source.geo.region_iso_code
 
 --
 
@@ -3947,194 +3973,248 @@ The number of bytes of the server request body.
 
 --
 
-*`destination.ip`*::
+*`iis.access.server_ip`*::
 +
 --
 type: alias
 
+path: destination.ip
+
 --
 
-*`http.request.method`*::
+*`iis.access.method`*::
 +
 --
 type: alias
 
+path: http.request.method
+
 --
 
-*`url.path`*::
+*`iis.access.url`*::
 +
 --
 type: alias
 
+path: url.path
+
 --
 
-*`url.query`*::
+*`iis.access.query_string`*::
 +
 --
 type: alias
 
+path: url.query
+
 --
 
-*`destination.port`*::
+*`iis.access.port`*::
 +
 --
 type: alias
 
+path: destination.port
+
 --
 
-*`user.name`*::
+*`iis.access.user_name`*::
 +
 --
 type: alias
 
+path: user.name
+
 --
 
-*`source.ip`*::
+*`iis.access.remote_ip`*::
 +
 --
 type: alias
 
+path: source.ip
+
 --
 
-*`http.request.referrer`*::
+*`iis.access.referrer`*::
 +
 --
 type: alias
 
+path: http.request.referrer
+
 --
 
-*`http.response.status_code`*::
+*`iis.access.response_code`*::
 +
 --
 type: alias
 
+path: http.response.status_code
+
 --
 
-*`http.version`*::
+*`iis.access.http_version`*::
 +
 --
 type: alias
 
+path: http.version
+
 --
 
-*`host.hostname`*::
+*`iis.access.hostname`*::
 +
 --
 type: alias
 
+path: host.hostname
+
 --
 
 
-*`user_agent.device`*::
+*`iis.access.user_agent.device`*::
 +
 --
 type: alias
 
+path: user_agent.device
+
 --
 
-*`user_agent.major`*::
+*`iis.access.user_agent.major`*::
 +
 --
 type: alias
 
+path: user_agent.major
+
 --
 
-*`user_agent.minor`*::
+*`iis.access.user_agent.minor`*::
 +
 --
 type: alias
 
+path: user_agent.minor
+
 --
 
-*`user_agent.patch`*::
+*`iis.access.user_agent.patch`*::
 +
 --
 type: alias
 
+path: user_agent.patch
+
 --
 
-*`user_agent.name`*::
+*`iis.access.user_agent.name`*::
 +
 --
 type: alias
 
+path: user_agent.name
+
 --
 
-*`user_agent.os.full_name`*::
+*`iis.access.user_agent.os`*::
 +
 --
 type: alias
 
+path: user_agent.os.full_name
+
 --
 
-*`user_agent.os.major`*::
+*`iis.access.user_agent.os_major`*::
 +
 --
 type: alias
 
+path: user_agent.os.major
+
 --
 
-*`user_agent.os.minor`*::
+*`iis.access.user_agent.os_minor`*::
 +
 --
 type: alias
 
+path: user_agent.os.minor
+
 --
 
-*`user_agent.os.name`*::
+*`iis.access.user_agent.os_name`*::
 +
 --
 type: alias
 
+path: user_agent.os.name
+
 --
 
-*`user_agent.original`*::
+*`iis.access.user_agent.original`*::
 +
 --
 type: alias
 
+path: user_agent.original
+
 --
 
 
-*`source.geo.continent_name`*::
+*`iis.access.geoip.continent_name`*::
 +
 --
 type: alias
 
+path: source.geo.continent_name
+
 --
 
-*`source.geo.country_iso_code`*::
+*`iis.access.geoip.country_iso_code`*::
 +
 --
 type: alias
 
+path: source.geo.country_iso_code
+
 --
 
-*`source.geo.location`*::
+*`iis.access.geoip.location`*::
 +
 --
 type: alias
 
+path: source.geo.location
+
 --
 
-*`source.geo.region_name`*::
+*`iis.access.geoip.region_name`*::
 +
 --
 type: alias
 
+path: source.geo.region_name
+
 --
 
-*`source.geo.city_name`*::
+*`iis.access.geoip.city_name`*::
 +
 --
 type: alias
 
+path: source.geo.city_name
+
 --
 
-*`source.geo.region_iso_code`*::
+*`iis.access.geoip.region_iso_code`*::
 +
 --
 type: alias
+
+path: source.geo.region_iso_code
 
 --
 
@@ -4748,17 +4828,21 @@ Referrer for this HTTP request.
 
 --
 
-*`event.dataset`*::
+*`fileset.name`*::
 +
 --
 type: alias
 
+path: event.dataset
+
 --
 
-*`event.module`*::
+*`fileset.module`*::
 +
 --
 type: alias
+
+path: event.module
 
 --
 
@@ -5206,180 +5290,230 @@ The number of bytes of the server response body.
 
 --
 
-*`network.forwarded_ip`*::
+*`nginx.access.remote_ip_list`*::
 +
 --
 type: alias
 
+path: network.forwarded_ip
+
 --
 
-*`source.ip`*::
+*`nginx.access.remote_ip`*::
 +
 --
 type: alias
 
+path: source.ip
+
 --
 
-*`user.name`*::
+*`nginx.access.user_name`*::
 +
 --
 type: alias
 
+path: user.name
+
 --
 
-*`http.request.method`*::
+*`nginx.access.method`*::
 +
 --
 type: alias
 
+path: http.request.method
+
 --
 
-*`url.original`*::
+*`nginx.access.url`*::
 +
 --
 type: alias
 
+path: url.original
+
 --
 
-*`http.version`*::
+*`nginx.access.http_version`*::
 +
 --
 type: alias
 
+path: http.version
+
 --
 
-*`http.response.status_code`*::
+*`nginx.access.response_code`*::
 +
 --
 type: alias
 
+path: http.response.status_code
+
 --
 
-*`http.request.referrer`*::
+*`nginx.access.referrer`*::
 +
 --
 type: alias
 
+path: http.request.referrer
+
 --
 
-*`user_agent.original`*::
+*`nginx.access.agent`*::
 +
 --
 type: alias
 
+path: user_agent.original
+
 --
 
 
-*`user_agent.device`*::
+*`nginx.access.user_agent.device`*::
 +
 --
 type: alias
 
+path: user_agent.device
+
 --
 
-*`user_agent.major`*::
+*`nginx.access.user_agent.major`*::
 +
 --
 type: alias
 
+path: user_agent.major
+
 --
 
-*`user_agent.minor`*::
+*`nginx.access.user_agent.minor`*::
 +
 --
 type: alias
 
+path: user_agent.minor
+
 --
 
-*`user_agent.patch`*::
+*`nginx.access.user_agent.patch`*::
 +
 --
 type: alias
 
+path: user_agent.patch
+
 --
 
-*`user_agent.name`*::
+*`nginx.access.user_agent.name`*::
 +
 --
 type: alias
 
+path: user_agent.name
+
 --
 
-*`user_agent.os.full_name`*::
+*`nginx.access.user_agent.os`*::
 +
 --
 type: alias
 
+path: user_agent.os.full_name
+
 --
 
-*`user_agent.os.major`*::
+*`nginx.access.user_agent.os_major`*::
 +
 --
 type: alias
 
+path: user_agent.os.major
+
 --
 
-*`user_agent.os.minor`*::
+*`nginx.access.user_agent.os_minor`*::
 +
 --
 type: alias
 
+path: user_agent.os.minor
+
 --
 
-*`user_agent.os.name`*::
+*`nginx.access.user_agent.os_name`*::
 +
 --
 type: alias
 
+path: user_agent.os.name
+
 --
 
-*`user_agent.original`*::
+*`nginx.access.user_agent.original`*::
 +
 --
 type: alias
 
+path: user_agent.original
+
 --
 
 
-*`source.geo.continent_name`*::
+*`nginx.access.geoip.continent_name`*::
 +
 --
 type: alias
 
+path: source.geo.continent_name
+
 --
 
-*`source.geo.country_iso_code`*::
+*`nginx.access.geoip.country_iso_code`*::
 +
 --
 type: alias
 
+path: source.geo.country_iso_code
+
 --
 
-*`source.geo.location`*::
+*`nginx.access.geoip.location`*::
 +
 --
 type: alias
 
+path: source.geo.location
+
 --
 
-*`source.geo.region_name`*::
+*`nginx.access.geoip.region_name`*::
 +
 --
 type: alias
 
+path: source.geo.region_name
+
 --
 
-*`source.geo.city_name`*::
+*`nginx.access.geoip.city_name`*::
 +
 --
 type: alias
 
+path: source.geo.city_name
+
 --
 
-*`source.geo.region_iso_code`*::
+*`nginx.access.geoip.region_iso_code`*::
 +
 --
 type: alias
+
+path: source.geo.region_iso_code
 
 --
 
@@ -5781,45 +5915,57 @@ Fields from the Linux authorization logs.
 
 
 
-*`@timestamp`*::
+*`system.auth.timestamp`*::
 +
 --
 type: alias
 
+path: @timestamp
+
 --
 
-*`host.hostname`*::
+*`system.auth.hostname`*::
 +
 --
 type: alias
 
+path: host.hostname
+
 --
 
-*`process.name`*::
+*`system.auth.program`*::
 +
 --
 type: alias
 
+path: process.name
+
 --
 
-*`process.pid`*::
+*`system.auth.pid`*::
 +
 --
 type: alias
 
+path: process.pid
+
 --
 
-*`message`*::
+*`system.auth.message`*::
 +
 --
 type: alias
 
+path: message
+
 --
 
-*`user.name`*::
+*`system.auth.user`*::
 +
 --
 type: alias
+
+path: user.name
 
 --
 
@@ -5850,67 +5996,85 @@ The client IP from SSH connections that are open and immediately dropped.
 
 --
 
-*`event.action`*::
+*`system.auth.ssh.event`*::
 +
 --
 type: alias
 
+path: event.action
+
 --
 
-*`source.ip`*::
+*`system.auth.ssh.ip`*::
 +
 --
 type: alias
 
+path: source.ip
+
 --
 
-*`source.port`*::
+*`system.auth.ssh.port`*::
 +
 --
 type: alias
 
+path: source.port
+
 --
 
 
-*`source.geo.continent_name`*::
+*`system.auth.ssh.geoip.continent_name`*::
 +
 --
 type: alias
 
+path: source.geo.continent_name
+
 --
 
-*`source.geo.country_iso_code`*::
+*`system.auth.ssh.geoip.country_iso_code`*::
 +
 --
 type: alias
 
+path: source.geo.country_iso_code
+
 --
 
-*`source.geo.location`*::
+*`system.auth.ssh.geoip.location`*::
 +
 --
 type: alias
 
+path: source.geo.location
+
 --
 
-*`source.geo.region_name`*::
+*`system.auth.ssh.geoip.region_name`*::
 +
 --
 type: alias
 
+path: source.geo.region_name
+
 --
 
-*`source.geo.city_name`*::
+*`system.auth.ssh.geoip.city_name`*::
 +
 --
 type: alias
 
+path: source.geo.city_name
+
 --
 
-*`source.geo.region_iso_code`*::
+*`system.auth.ssh.geoip.region_iso_code`*::
 +
 --
 type: alias
+
+path: source.geo.region_iso_code
 
 --
 
@@ -5986,24 +6150,30 @@ The default shell for the new user.
 
 --
 
-*`user.name`*::
+*`system.auth.useradd.name`*::
 +
 --
 type: alias
 
+path: user.name
+
 --
 
-*`user.id`*::
+*`system.auth.useradd.uid`*::
 +
 --
 type: alias
 
+path: user.id
+
 --
 
-*`group.id`*::
+*`system.auth.useradd.gid`*::
 +
 --
 type: alias
+
+path: group.id
 
 --
 
@@ -6014,17 +6184,21 @@ Fields specific to events created by the `groupadd` command.
 
 
 
-*`group.name`*::
+*`system.auth.groupadd.name`*::
 +
 --
 type: alias
 
+path: group.name
+
 --
 
-*`group.id`*::
+*`system.auth.groupadd.gid`*::
 +
 --
 type: alias
+
+path: group.id
 
 --
 
@@ -6035,38 +6209,48 @@ Contains fields from the syslog system logs.
 
 
 
-*`@timestamp`*::
+*`system.syslog.timestamp`*::
 +
 --
 type: alias
 
+path: @timestamp
+
 --
 
-*`host.hostname`*::
+*`system.syslog.hostname`*::
 +
 --
 type: alias
 
+path: host.hostname
+
 --
 
-*`process.name`*::
+*`system.syslog.program`*::
 +
 --
 type: alias
 
+path: process.name
+
 --
 
-*`process.pid`*::
+*`system.syslog.pid`*::
 +
 --
 type: alias
 
+path: process.pid
+
 --
 
-*`message`*::
+*`system.syslog.message`*::
 +
 --
 type: alias
+
+path: message
 
 --
 

--- a/filebeat/docs/fields.asciidoc
+++ b/filebeat/docs/fields.asciidoc
@@ -81,166 +81,212 @@ The number of bytes of the server response body.
 
 --
 
-*`user.name`*::
+*`apache2.access.user_name`*::
 +
 --
 type: alias
 
+alias to: user.name
+
 --
 
-*`http.request.method`*::
+*`apache2.access.method`*::
 +
 --
 type: alias
 
+alias to: http.request.method
+
 --
 
-*`url.original`*::
+*`apache2.access.url`*::
 +
 --
 type: alias
 
+alias to: url.original
+
 --
 
-*`http.version`*::
+*`apache2.access.http_version`*::
 +
 --
 type: alias
 
+alias to: http.version
+
 --
 
-*`http.response.status_code`*::
+*`apache2.access.response_code`*::
 +
 --
 type: alias
 
+alias to: http.response.status_code
+
 --
 
-*`http.request.referrer`*::
+*`apache2.access.referrer`*::
 +
 --
 type: alias
 
+alias to: http.request.referrer
+
 --
 
-*`user_agent.original`*::
+*`apache2.access.agent`*::
 +
 --
 type: alias
 
+alias to: user_agent.original
+
 --
 
 
-*`user_agent.device`*::
+*`apache2.access.user_agent.device`*::
 +
 --
 type: alias
 
+alias to: user_agent.device
+
 --
 
-*`user_agent.major`*::
+*`apache2.access.user_agent.major`*::
 +
 --
 type: alias
 
+alias to: user_agent.major
+
 --
 
-*`user_agent.minor`*::
+*`apache2.access.user_agent.minor`*::
 +
 --
 type: alias
 
+alias to: user_agent.minor
+
 --
 
-*`user_agent.patch`*::
+*`apache2.access.user_agent.patch`*::
 +
 --
 type: alias
 
+alias to: user_agent.patch
+
 --
 
-*`user_agent.name`*::
+*`apache2.access.user_agent.name`*::
 +
 --
 type: alias
 
+alias to: user_agent.name
+
 --
 
-*`user_agent.os.full_name`*::
+*`apache2.access.user_agent.os`*::
 +
 --
 type: alias
 
+alias to: user_agent.os.full_name
+
 --
 
-*`user_agent.os.major`*::
+*`apache2.access.user_agent.os_major`*::
 +
 --
 type: alias
 
+alias to: user_agent.os.major
+
 --
 
-*`user_agent.os.minor`*::
+*`apache2.access.user_agent.os_minor`*::
 +
 --
 type: alias
 
+alias to: user_agent.os.minor
+
 --
 
-*`user_agent.os.name`*::
+*`apache2.access.user_agent.os_name`*::
 +
 --
 type: alias
 
+alias to: user_agent.os.name
+
 --
 
-*`user_agent.original`*::
+*`apache2.access.user_agent.original`*::
 +
 --
 type: alias
 
+alias to: user_agent.original
+
 --
 
 
-*`source.geo.continent_name`*::
+*`apache2.access.geoip.continent_name`*::
 +
 --
 type: alias
 
+alias to: source.geo.continent_name
+
 --
 
-*`source.geo.country_iso_code`*::
+*`apache2.access.geoip.country_iso_code`*::
 +
 --
 type: alias
 
+alias to: source.geo.country_iso_code
+
 --
 
-*`source.geo.location`*::
+*`apache2.access.geoip.location`*::
 +
 --
 type: alias
 
+alias to: source.geo.location
+
 --
 
-*`source.geo.region_name`*::
+*`apache2.access.geoip.region_name`*::
 +
 --
 type: alias
 
+alias to: source.geo.region_name
+
 --
 
-*`source.geo.city_name`*::
+*`apache2.access.geoip.city_name`*::
 +
 --
 type: alias
 
+alias to: source.geo.city_name
+
 --
 
-*`source.geo.region_iso_code`*::
+*`apache2.access.geoip.region_iso_code`*::
 +
 --
 type: alias
+
+alias to: source.geo.region_iso_code
 
 --
 

--- a/filebeat/docs/fields.asciidoc
+++ b/filebeat/docs/fields.asciidoc
@@ -2654,7 +2654,7 @@ Minor version of the operating system.
 --
 type: alias
 
-path: agent.type
+alias to: agent.type
 
 --
 
@@ -2663,7 +2663,7 @@ path: agent.type
 --
 type: alias
 
-path: agent.hostname
+alias to: agent.hostname
 
 --
 
@@ -3496,7 +3496,7 @@ If connection is via unix socket, socket path is in this field.
 --
 type: alias
 
-path: source.port
+alias to: source.port
 
 --
 
@@ -3505,7 +3505,7 @@ path: source.port
 --
 type: alias
 
-path: process.name
+alias to: process.name
 
 --
 
@@ -3514,7 +3514,7 @@ path: process.name
 --
 type: alias
 
-path: process.pid
+alias to: process.pid
 
 --
 
@@ -3529,7 +3529,7 @@ Destination information
 --
 type: alias
 
-path: destination.port
+alias to: destination.port
 
 --
 
@@ -3538,7 +3538,7 @@ path: destination.port
 --
 type: alias
 
-path: destination.ip
+alias to: destination.ip
 
 --
 
@@ -3554,7 +3554,7 @@ Contains GeoIP information gathered based on the client.ip field. Only present i
 --
 type: alias
 
-path: source.geo.continent_name
+alias to: source.geo.continent_name
 
 --
 
@@ -3563,7 +3563,7 @@ path: source.geo.continent_name
 --
 type: alias
 
-path: source.geo.country_iso_code
+alias to: source.geo.country_iso_code
 
 --
 
@@ -3572,7 +3572,7 @@ path: source.geo.country_iso_code
 --
 type: alias
 
-path: source.geo.location
+alias to: source.geo.location
 
 --
 
@@ -3581,7 +3581,7 @@ path: source.geo.location
 --
 type: alias
 
-path: source.geo.region_name
+alias to: source.geo.region_name
 
 --
 
@@ -3590,7 +3590,7 @@ path: source.geo.region_name
 --
 type: alias
 
-path: source.geo.city_name
+alias to: source.geo.city_name
 
 --
 
@@ -3599,7 +3599,7 @@ path: source.geo.city_name
 --
 type: alias
 
-path: source.geo.region_iso_code
+alias to: source.geo.region_iso_code
 
 --
 
@@ -3978,7 +3978,7 @@ The number of bytes of the server request body.
 --
 type: alias
 
-path: destination.ip
+alias to: destination.ip
 
 --
 
@@ -3987,7 +3987,7 @@ path: destination.ip
 --
 type: alias
 
-path: http.request.method
+alias to: http.request.method
 
 --
 
@@ -3996,7 +3996,7 @@ path: http.request.method
 --
 type: alias
 
-path: url.path
+alias to: url.path
 
 --
 
@@ -4005,7 +4005,7 @@ path: url.path
 --
 type: alias
 
-path: url.query
+alias to: url.query
 
 --
 
@@ -4014,7 +4014,7 @@ path: url.query
 --
 type: alias
 
-path: destination.port
+alias to: destination.port
 
 --
 
@@ -4023,7 +4023,7 @@ path: destination.port
 --
 type: alias
 
-path: user.name
+alias to: user.name
 
 --
 
@@ -4032,7 +4032,7 @@ path: user.name
 --
 type: alias
 
-path: source.ip
+alias to: source.ip
 
 --
 
@@ -4041,7 +4041,7 @@ path: source.ip
 --
 type: alias
 
-path: http.request.referrer
+alias to: http.request.referrer
 
 --
 
@@ -4050,7 +4050,7 @@ path: http.request.referrer
 --
 type: alias
 
-path: http.response.status_code
+alias to: http.response.status_code
 
 --
 
@@ -4059,7 +4059,7 @@ path: http.response.status_code
 --
 type: alias
 
-path: http.version
+alias to: http.version
 
 --
 
@@ -4068,7 +4068,7 @@ path: http.version
 --
 type: alias
 
-path: host.hostname
+alias to: host.hostname
 
 --
 
@@ -4078,7 +4078,7 @@ path: host.hostname
 --
 type: alias
 
-path: user_agent.device
+alias to: user_agent.device
 
 --
 
@@ -4087,7 +4087,7 @@ path: user_agent.device
 --
 type: alias
 
-path: user_agent.major
+alias to: user_agent.major
 
 --
 
@@ -4096,7 +4096,7 @@ path: user_agent.major
 --
 type: alias
 
-path: user_agent.minor
+alias to: user_agent.minor
 
 --
 
@@ -4105,7 +4105,7 @@ path: user_agent.minor
 --
 type: alias
 
-path: user_agent.patch
+alias to: user_agent.patch
 
 --
 
@@ -4114,7 +4114,7 @@ path: user_agent.patch
 --
 type: alias
 
-path: user_agent.name
+alias to: user_agent.name
 
 --
 
@@ -4123,7 +4123,7 @@ path: user_agent.name
 --
 type: alias
 
-path: user_agent.os.full_name
+alias to: user_agent.os.full_name
 
 --
 
@@ -4132,7 +4132,7 @@ path: user_agent.os.full_name
 --
 type: alias
 
-path: user_agent.os.major
+alias to: user_agent.os.major
 
 --
 
@@ -4141,7 +4141,7 @@ path: user_agent.os.major
 --
 type: alias
 
-path: user_agent.os.minor
+alias to: user_agent.os.minor
 
 --
 
@@ -4150,7 +4150,7 @@ path: user_agent.os.minor
 --
 type: alias
 
-path: user_agent.os.name
+alias to: user_agent.os.name
 
 --
 
@@ -4159,7 +4159,7 @@ path: user_agent.os.name
 --
 type: alias
 
-path: user_agent.original
+alias to: user_agent.original
 
 --
 
@@ -4169,7 +4169,7 @@ path: user_agent.original
 --
 type: alias
 
-path: source.geo.continent_name
+alias to: source.geo.continent_name
 
 --
 
@@ -4178,7 +4178,7 @@ path: source.geo.continent_name
 --
 type: alias
 
-path: source.geo.country_iso_code
+alias to: source.geo.country_iso_code
 
 --
 
@@ -4187,7 +4187,7 @@ path: source.geo.country_iso_code
 --
 type: alias
 
-path: source.geo.location
+alias to: source.geo.location
 
 --
 
@@ -4196,7 +4196,7 @@ path: source.geo.location
 --
 type: alias
 
-path: source.geo.region_name
+alias to: source.geo.region_name
 
 --
 
@@ -4205,7 +4205,7 @@ path: source.geo.region_name
 --
 type: alias
 
-path: source.geo.city_name
+alias to: source.geo.city_name
 
 --
 
@@ -4214,7 +4214,7 @@ path: source.geo.city_name
 --
 type: alias
 
-path: source.geo.region_iso_code
+alias to: source.geo.region_iso_code
 
 --
 
@@ -4833,7 +4833,7 @@ Referrer for this HTTP request.
 --
 type: alias
 
-path: event.dataset
+alias to: event.dataset
 
 --
 
@@ -4842,7 +4842,7 @@ path: event.dataset
 --
 type: alias
 
-path: event.module
+alias to: event.module
 
 --
 
@@ -5295,7 +5295,7 @@ The number of bytes of the server response body.
 --
 type: alias
 
-path: network.forwarded_ip
+alias to: network.forwarded_ip
 
 --
 
@@ -5304,7 +5304,7 @@ path: network.forwarded_ip
 --
 type: alias
 
-path: source.ip
+alias to: source.ip
 
 --
 
@@ -5313,7 +5313,7 @@ path: source.ip
 --
 type: alias
 
-path: user.name
+alias to: user.name
 
 --
 
@@ -5322,7 +5322,7 @@ path: user.name
 --
 type: alias
 
-path: http.request.method
+alias to: http.request.method
 
 --
 
@@ -5331,7 +5331,7 @@ path: http.request.method
 --
 type: alias
 
-path: url.original
+alias to: url.original
 
 --
 
@@ -5340,7 +5340,7 @@ path: url.original
 --
 type: alias
 
-path: http.version
+alias to: http.version
 
 --
 
@@ -5349,7 +5349,7 @@ path: http.version
 --
 type: alias
 
-path: http.response.status_code
+alias to: http.response.status_code
 
 --
 
@@ -5358,7 +5358,7 @@ path: http.response.status_code
 --
 type: alias
 
-path: http.request.referrer
+alias to: http.request.referrer
 
 --
 
@@ -5367,7 +5367,7 @@ path: http.request.referrer
 --
 type: alias
 
-path: user_agent.original
+alias to: user_agent.original
 
 --
 
@@ -5377,7 +5377,7 @@ path: user_agent.original
 --
 type: alias
 
-path: user_agent.device
+alias to: user_agent.device
 
 --
 
@@ -5386,7 +5386,7 @@ path: user_agent.device
 --
 type: alias
 
-path: user_agent.major
+alias to: user_agent.major
 
 --
 
@@ -5395,7 +5395,7 @@ path: user_agent.major
 --
 type: alias
 
-path: user_agent.minor
+alias to: user_agent.minor
 
 --
 
@@ -5404,7 +5404,7 @@ path: user_agent.minor
 --
 type: alias
 
-path: user_agent.patch
+alias to: user_agent.patch
 
 --
 
@@ -5413,7 +5413,7 @@ path: user_agent.patch
 --
 type: alias
 
-path: user_agent.name
+alias to: user_agent.name
 
 --
 
@@ -5422,7 +5422,7 @@ path: user_agent.name
 --
 type: alias
 
-path: user_agent.os.full_name
+alias to: user_agent.os.full_name
 
 --
 
@@ -5431,7 +5431,7 @@ path: user_agent.os.full_name
 --
 type: alias
 
-path: user_agent.os.major
+alias to: user_agent.os.major
 
 --
 
@@ -5440,7 +5440,7 @@ path: user_agent.os.major
 --
 type: alias
 
-path: user_agent.os.minor
+alias to: user_agent.os.minor
 
 --
 
@@ -5449,7 +5449,7 @@ path: user_agent.os.minor
 --
 type: alias
 
-path: user_agent.os.name
+alias to: user_agent.os.name
 
 --
 
@@ -5458,7 +5458,7 @@ path: user_agent.os.name
 --
 type: alias
 
-path: user_agent.original
+alias to: user_agent.original
 
 --
 
@@ -5468,7 +5468,7 @@ path: user_agent.original
 --
 type: alias
 
-path: source.geo.continent_name
+alias to: source.geo.continent_name
 
 --
 
@@ -5477,7 +5477,7 @@ path: source.geo.continent_name
 --
 type: alias
 
-path: source.geo.country_iso_code
+alias to: source.geo.country_iso_code
 
 --
 
@@ -5486,7 +5486,7 @@ path: source.geo.country_iso_code
 --
 type: alias
 
-path: source.geo.location
+alias to: source.geo.location
 
 --
 
@@ -5495,7 +5495,7 @@ path: source.geo.location
 --
 type: alias
 
-path: source.geo.region_name
+alias to: source.geo.region_name
 
 --
 
@@ -5504,7 +5504,7 @@ path: source.geo.region_name
 --
 type: alias
 
-path: source.geo.city_name
+alias to: source.geo.city_name
 
 --
 
@@ -5513,7 +5513,7 @@ path: source.geo.city_name
 --
 type: alias
 
-path: source.geo.region_iso_code
+alias to: source.geo.region_iso_code
 
 --
 
@@ -5920,7 +5920,7 @@ Fields from the Linux authorization logs.
 --
 type: alias
 
-path: @timestamp
+alias to: @timestamp
 
 --
 
@@ -5929,7 +5929,7 @@ path: @timestamp
 --
 type: alias
 
-path: host.hostname
+alias to: host.hostname
 
 --
 
@@ -5938,7 +5938,7 @@ path: host.hostname
 --
 type: alias
 
-path: process.name
+alias to: process.name
 
 --
 
@@ -5947,7 +5947,7 @@ path: process.name
 --
 type: alias
 
-path: process.pid
+alias to: process.pid
 
 --
 
@@ -5956,7 +5956,7 @@ path: process.pid
 --
 type: alias
 
-path: message
+alias to: message
 
 --
 
@@ -5965,7 +5965,7 @@ path: message
 --
 type: alias
 
-path: user.name
+alias to: user.name
 
 --
 
@@ -6001,7 +6001,7 @@ The client IP from SSH connections that are open and immediately dropped.
 --
 type: alias
 
-path: event.action
+alias to: event.action
 
 --
 
@@ -6010,7 +6010,7 @@ path: event.action
 --
 type: alias
 
-path: source.ip
+alias to: source.ip
 
 --
 
@@ -6019,7 +6019,7 @@ path: source.ip
 --
 type: alias
 
-path: source.port
+alias to: source.port
 
 --
 
@@ -6029,7 +6029,7 @@ path: source.port
 --
 type: alias
 
-path: source.geo.continent_name
+alias to: source.geo.continent_name
 
 --
 
@@ -6038,7 +6038,7 @@ path: source.geo.continent_name
 --
 type: alias
 
-path: source.geo.country_iso_code
+alias to: source.geo.country_iso_code
 
 --
 
@@ -6047,7 +6047,7 @@ path: source.geo.country_iso_code
 --
 type: alias
 
-path: source.geo.location
+alias to: source.geo.location
 
 --
 
@@ -6056,7 +6056,7 @@ path: source.geo.location
 --
 type: alias
 
-path: source.geo.region_name
+alias to: source.geo.region_name
 
 --
 
@@ -6065,7 +6065,7 @@ path: source.geo.region_name
 --
 type: alias
 
-path: source.geo.city_name
+alias to: source.geo.city_name
 
 --
 
@@ -6074,7 +6074,7 @@ path: source.geo.city_name
 --
 type: alias
 
-path: source.geo.region_iso_code
+alias to: source.geo.region_iso_code
 
 --
 
@@ -6155,7 +6155,7 @@ The default shell for the new user.
 --
 type: alias
 
-path: user.name
+alias to: user.name
 
 --
 
@@ -6164,7 +6164,7 @@ path: user.name
 --
 type: alias
 
-path: user.id
+alias to: user.id
 
 --
 
@@ -6173,7 +6173,7 @@ path: user.id
 --
 type: alias
 
-path: group.id
+alias to: group.id
 
 --
 
@@ -6189,7 +6189,7 @@ Fields specific to events created by the `groupadd` command.
 --
 type: alias
 
-path: group.name
+alias to: group.name
 
 --
 
@@ -6198,7 +6198,7 @@ path: group.name
 --
 type: alias
 
-path: group.id
+alias to: group.id
 
 --
 
@@ -6214,7 +6214,7 @@ Contains fields from the syslog system logs.
 --
 type: alias
 
-path: @timestamp
+alias to: @timestamp
 
 --
 
@@ -6223,7 +6223,7 @@ path: @timestamp
 --
 type: alias
 
-path: host.hostname
+alias to: host.hostname
 
 --
 
@@ -6232,7 +6232,7 @@ path: host.hostname
 --
 type: alias
 
-path: process.name
+alias to: process.name
 
 --
 
@@ -6241,7 +6241,7 @@ path: process.name
 --
 type: alias
 
-path: process.pid
+alias to: process.pid
 
 --
 
@@ -6250,7 +6250,7 @@ path: process.pid
 --
 type: alias
 
-path: message
+alias to: message
 
 --
 

--- a/heartbeat/docs/fields.asciidoc
+++ b/heartbeat/docs/fields.asciidoc
@@ -2271,17 +2271,21 @@ Minor version of the operating system.
 
 --
 
-*`agent.type`*::
+*`beat.name`*::
 +
 --
 type: alias
 
+path: agent.type
+
 --
 
-*`agent.hostname`*::
+*`beat.hostname`*::
 +
 --
 type: alias
+
+path: agent.hostname
 
 --
 

--- a/heartbeat/docs/fields.asciidoc
+++ b/heartbeat/docs/fields.asciidoc
@@ -2276,7 +2276,7 @@ Minor version of the operating system.
 --
 type: alias
 
-path: agent.type
+alias to: agent.type
 
 --
 
@@ -2285,7 +2285,7 @@ path: agent.type
 --
 type: alias
 
-path: agent.hostname
+alias to: agent.hostname
 
 --
 

--- a/journalbeat/docs/fields.asciidoc
+++ b/journalbeat/docs/fields.asciidoc
@@ -2564,17 +2564,21 @@ Minor version of the operating system.
 
 --
 
-*`agent.type`*::
+*`beat.name`*::
 +
 --
 type: alias
 
+path: agent.type
+
 --
 
-*`agent.hostname`*::
+*`beat.hostname`*::
 +
 --
 type: alias
+
+path: agent.hostname
 
 --
 

--- a/journalbeat/docs/fields.asciidoc
+++ b/journalbeat/docs/fields.asciidoc
@@ -2569,7 +2569,7 @@ Minor version of the operating system.
 --
 type: alias
 
-path: agent.type
+alias to: agent.type
 
 --
 
@@ -2578,7 +2578,7 @@ path: agent.type
 --
 type: alias
 
-path: agent.hostname
+alias to: agent.hostname
 
 --
 

--- a/libbeat/scripts/generate_fields_docs.py
+++ b/libbeat/scripts/generate_fields_docs.py
@@ -60,7 +60,7 @@ def document_field(output, field, field_path):
     if "required" in field:
         output.write("required: {}\n\n".format(field["required"]))
     if "path" in field:
-        output.write("path: {}\n\n".format(field["path"]))
+        output.write("alias to: {}\n\n".format(field["path"]))
     if "description" in field:
         output.write("{}\n\n".format(field["description"]))
 

--- a/libbeat/scripts/generate_fields_docs.py
+++ b/libbeat/scripts/generate_fields_docs.py
@@ -41,12 +41,12 @@ def document_fields(output, section, sections, path):
             document_field(output, field, newpath)
 
 
-def document_field(output, field, path):
+def document_field(output, field, field_path):
 
-    if "path" not in field:
-        field["path"] = path
+    if "field_path" not in field:
+        field["field_path"] = field_path
 
-    output.write("*`{}`*::\n+\n--\n".format(field["path"]))
+    output.write("*`{}`*::\n+\n--\n".format(field["field_path"]))
 
     if "deprecated" in field:
         output.write("\ndeprecated[{}]\n\n".format(field["deprecated"]))
@@ -59,7 +59,8 @@ def document_field(output, field, path):
         output.write("format: {}\n\n".format(field["format"]))
     if "required" in field:
         output.write("required: {}\n\n".format(field["required"]))
-
+    if "path" in field:
+        output.write("path: {}\n\n".format(field["path"]))
     if "description" in field:
         output.write("{}\n\n".format(field["description"]))
 
@@ -73,7 +74,7 @@ def document_field(output, field, path):
 
     if "multi_fields" in field:
         for subfield in field["multi_fields"]:
-            document_field(output, subfield, path + "." + subfield["name"])
+            document_field(output, subfield, field_path + "." + subfield["name"])
     output.write("--\n\n")
 
 

--- a/metricbeat/docs/fields.asciidoc
+++ b/metricbeat/docs/fields.asciidoc
@@ -5329,7 +5329,7 @@ Minor version of the operating system.
 --
 type: alias
 
-path: agent.type
+alias to: agent.type
 
 --
 
@@ -5338,7 +5338,7 @@ path: agent.type
 --
 type: alias
 
-path: agent.hostname
+alias to: agent.hostname
 
 --
 

--- a/metricbeat/docs/fields.asciidoc
+++ b/metricbeat/docs/fields.asciidoc
@@ -5324,17 +5324,21 @@ Minor version of the operating system.
 
 --
 
-*`agent.type`*::
+*`beat.name`*::
 +
 --
 type: alias
 
+path: agent.type
+
 --
 
-*`agent.hostname`*::
+*`beat.hostname`*::
 +
 --
 type: alias
+
+path: agent.hostname
 
 --
 

--- a/packetbeat/docs/fields.asciidoc
+++ b/packetbeat/docs/fields.asciidoc
@@ -4207,17 +4207,21 @@ Minor version of the operating system.
 
 --
 
-*`agent.type`*::
+*`beat.name`*::
 +
 --
 type: alias
 
+path: agent.type
+
 --
 
-*`agent.hostname`*::
+*`beat.hostname`*::
 +
 --
 type: alias
+
+path: agent.hostname
 
 --
 

--- a/packetbeat/docs/fields.asciidoc
+++ b/packetbeat/docs/fields.asciidoc
@@ -4212,7 +4212,7 @@ Minor version of the operating system.
 --
 type: alias
 
-path: agent.type
+alias to: agent.type
 
 --
 
@@ -4221,7 +4221,7 @@ path: agent.type
 --
 type: alias
 
-path: agent.hostname
+alias to: agent.hostname
 
 --
 

--- a/winlogbeat/docs/fields.asciidoc
+++ b/winlogbeat/docs/fields.asciidoc
@@ -2189,7 +2189,7 @@ Minor version of the operating system.
 --
 type: alias
 
-path: agent.type
+alias to: agent.type
 
 --
 
@@ -2198,7 +2198,7 @@ path: agent.type
 --
 type: alias
 
-path: agent.hostname
+alias to: agent.hostname
 
 --
 

--- a/winlogbeat/docs/fields.asciidoc
+++ b/winlogbeat/docs/fields.asciidoc
@@ -2184,17 +2184,21 @@ Minor version of the operating system.
 
 --
 
-*`agent.type`*::
+*`beat.name`*::
 +
 --
 type: alias
 
+path: agent.type
+
 --
 
-*`agent.hostname`*::
+*`beat.hostname`*::
 +
 --
 type: alias
+
+path: agent.hostname
 
 --
 

--- a/x-pack/functionbeat/docs/fields.asciidoc
+++ b/x-pack/functionbeat/docs/fields.asciidoc
@@ -2170,7 +2170,7 @@ Minor version of the operating system.
 --
 type: alias
 
-path: agent.type
+alias to: agent.type
 
 --
 
@@ -2179,7 +2179,7 @@ path: agent.type
 --
 type: alias
 
-path: agent.hostname
+alias to: agent.hostname
 
 --
 

--- a/x-pack/functionbeat/docs/fields.asciidoc
+++ b/x-pack/functionbeat/docs/fields.asciidoc
@@ -2165,17 +2165,21 @@ Minor version of the operating system.
 
 --
 
-*`agent.type`*::
+*`beat.name`*::
 +
 --
 type: alias
 
+path: agent.type
+
 --
 
-*`agent.hostname`*::
+*`beat.hostname`*::
 +
 --
 type: alias
+
+path: agent.hostname
 
 --
 


### PR DESCRIPTION
Alias fields documented in the fields list were not correct. The reason is that `path` was used in our generation of the docs for a different puprose. This one was renamed and reporting of path was added for field alias.