### PR TITLE
Cherry-pick #9234 to 6.x: Add cursor_seek_fallback option

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -89,6 +89,7 @@ https://github.com/elastic/beats/compare/v6.5.0...6.x[Check the HEAD diff]
 *Journalbeat*
 
 - Add the ability to check against JSON HTTP bodies with conditions. {pull}8667[8667]
+- Add cursor_seek_fallback option. {pull}9234[9234]
 
 *Metricbeat*
 

--- a/journalbeat/_meta/beat.yml
+++ b/journalbeat/_meta/beat.yml
@@ -25,6 +25,8 @@ journalbeat.inputs:
 
   # Position to start reading from journal. Valid values: head, tail, cursor
   seek: cursor
+  # Fallback position if no cursor data is available.
+  #cursor_seek_fallback: head
 
   # Exact matching for field values of events.
   # Matching for nginx entries: "systemd.unit=nginx"

--- a/journalbeat/input/config.go
+++ b/journalbeat/input/config.go
@@ -30,14 +30,14 @@ type Config struct {
 	// Paths stores the paths to the journal files to be read.
 	Paths []string `config:"paths"`
 	// MaxBackoff is the limit of the backoff time.
-	Backoff time.Duration `config:"backoff" validate:"min=0,nonzero"`
+	MaxBackoff time.Duration `config:"max_backoff" validate:"min=0,nonzero"`
 	// Backoff is the current interval to wait before
 	// attemting to read again from the journal.
-	BackoffFactor int `config:"backoff_factor" validate:"min=1"`
-	// BackoffFactor is the multiplier of Backoff.
-	MaxBackoff time.Duration `config:"max_backoff" validate:"min=0,nonzero"`
+	Backoff time.Duration `config:"backoff" validate:"min=0,nonzero"`
 	// Seek is the method to read from journals.
 	Seek config.SeekMode `config:"seek"`
+	// CursorSeekFallback sets where to seek if registry file is not available.
+	CursorSeekFallback config.SeekMode `config:"cursor_seek_fallback"`
 	// Matches store the key value pairs to match entries.
 	Matches []string `config:"include_matches"`
 
@@ -50,9 +50,9 @@ type Config struct {
 var (
 	// DefaultConfig is the defaults for an inputs
 	DefaultConfig = Config{
-		Backoff:       1 * time.Second,
-		BackoffFactor: 2,
-		MaxBackoff:    60 * time.Second,
-		Seek:          config.SeekCursor,
+		Backoff:            1 * time.Second,
+		MaxBackoff:         60 * time.Second,
+		Seek:               config.SeekCursor,
+		CursorSeekFallback: config.SeekHead,
 	}
 )

--- a/journalbeat/input/input.go
+++ b/journalbeat/input/input.go
@@ -67,11 +67,12 @@ func New(
 	var readers []*reader.Reader
 	if len(config.Paths) == 0 {
 		cfg := reader.Config{
-			Path:       reader.LocalSystemJournalID, // used to identify the state in the registry
-			Backoff:    config.Backoff,
-			MaxBackoff: config.MaxBackoff,
-			Seek:       config.Seek,
-			Matches:    config.Matches,
+			Path:               reader.LocalSystemJournalID, // used to identify the state in the registry
+			Backoff:            config.Backoff,
+			MaxBackoff:         config.MaxBackoff,
+			Seek:               config.Seek,
+			CursorSeekFallback: config.CursorSeekFallback,
+			Matches:            config.Matches,
 		}
 
 		state := states[reader.LocalSystemJournalID]
@@ -84,11 +85,12 @@ func New(
 
 	for _, p := range config.Paths {
 		cfg := reader.Config{
-			Path:       p,
-			Backoff:    config.Backoff,
-			MaxBackoff: config.MaxBackoff,
-			Seek:       config.Seek,
-			Matches:    config.Matches,
+			Path:               p,
+			Backoff:            config.Backoff,
+			MaxBackoff:         config.MaxBackoff,
+			Seek:               config.Seek,
+			CursorSeekFallback: config.CursorSeekFallback,
+			Matches:            config.Matches,
 		}
 		state := states[p]
 		r, err := reader.New(cfg, done, state, logger)

--- a/journalbeat/journalbeat.reference.yml
+++ b/journalbeat/journalbeat.reference.yml
@@ -25,6 +25,8 @@ journalbeat.inputs:
 
   # Position to start reading from journal. Valid values: head, tail, cursor
   seek: cursor
+  # Fallback position if no cursor data is available.
+  #cursor_seek_fallback: head
 
   # Exact matching for field values of events.
   # Matching for nginx entries: "systemd.unit=nginx"

--- a/journalbeat/journalbeat.yml
+++ b/journalbeat/journalbeat.yml
@@ -25,6 +25,8 @@ journalbeat.inputs:
 
   # Position to start reading from journal. Valid values: head, tail, cursor
   seek: cursor
+  # Fallback position if no cursor data is available.
+  #cursor_seek_fallback: head
 
   # Exact matching for field values of events.
   # Matching for nginx entries: "systemd.unit=nginx"

--- a/journalbeat/reader/config.go
+++ b/journalbeat/reader/config.go
@@ -30,6 +30,8 @@ type Config struct {
 	// Seek specifies the seeking stategy.
 	// Possible values: head, tail, cursor.
 	Seek config.SeekMode
+	// CursorSeekFallback sets where to seek if registry file is not available.
+	CursorSeekFallback config.SeekMode
 	// MaxBackoff is the limit of the backoff time.
 	MaxBackoff time.Duration
 	// Backoff is the current interval to wait before

--- a/journalbeat/reader/journal.go
+++ b/journalbeat/reader/journal.go
@@ -146,8 +146,16 @@ func (r *Reader) seek(cursor string) {
 	switch r.config.Seek {
 	case config.SeekCursor:
 		if cursor == "" {
-			r.journal.SeekHead()
-			r.logger.Debug("Seeking method set to cursor, but no state is saved for reader. Starting to read from the beginning")
+			switch r.config.CursorSeekFallback {
+			case config.SeekHead:
+				r.journal.SeekHead()
+				r.logger.Debug("Seeking method set to cursor, but no state is saved for reader. Starting to read from the beginning")
+			case config.SeekTail:
+				r.journal.SeekTail()
+				r.logger.Debug("Seeking method set to cursor, but no state is saved for reader. Starting to read from the end")
+			default:
+				r.logger.Error("Invalid option for cursor_seek_fallback")
+			}
 			return
 		}
 		r.journal.SeekCursor(cursor)

--- a/journalbeat/tests/system/config/journalbeat.yml.j2
+++ b/journalbeat/tests/system/config/journalbeat.yml.j2
@@ -2,9 +2,12 @@
 journalbeat.inputs:
 - paths: [{{ journal_path }}]
   seek: {{ seek_method }}
-  matches: [{{ matches }}]
+  {% if cursor_seek_fallback %}
+  cursor_seek_fallback: {{ cursor_seek_fallback }}
+  {% endif %}
+  include_matches: [{{ matches }}]
 
-journalbeat.registry: {{ registry_file }}
+journalbeat.registry_file: {{ registry_file }}
 
 ############################# Output ##########################################
 


### PR DESCRIPTION
Cherry-pick of PR #9234 to 6.x branch. Original message: 

New option is introduced to configure the fallback method of seek mode `"cursor"`. The option is named `cursor_seek_fallback`. The name is taken from the community Journalbeat: https://github.com/mheese/journalbeat/blob/master/config/journalbeat.yml#L3

By default it seeks to the beginning as before. But from now on it is possible to configure it to start reading from the end of the journal.