### PR TITLE
Elasticsearch deprecation log fileset: adding expected test files

### DIFF
--- a/filebeat/module/elasticsearch/deprecation/test/elasticsearch_deprecation.log-expected.json
+++ b/filebeat/module/elasticsearch/deprecation/test/elasticsearch_deprecation.log-expected.json
@@ -1,0 +1,46 @@
+[
+    {
+        "@timestamp": "2018-04-23T16:40:13,737", 
+        "elasticsearch.server.component": "o.e.d.a.a.i.t.p.PutIndexTemplateRequest", 
+        "event.dataset": "deprecation", 
+        "event.module": "elasticsearch", 
+        "input.type": "log", 
+        "log.level": "WARN", 
+        "log.offset": 0, 
+        "message": "Deprecated field [template] used, replaced by [index_patterns]", 
+        "service.name": "elasticsearch"
+    }, 
+    {
+        "@timestamp": "2018-04-23T16:40:13,862", 
+        "elasticsearch.server.component": "o.e.d.a.a.i.t.p.PutIndexTemplateRequest", 
+        "event.dataset": "deprecation", 
+        "event.module": "elasticsearch", 
+        "input.type": "log", 
+        "log.level": "WARN", 
+        "log.offset": 137, 
+        "message": "Deprecated field [template] used, replaced by [index_patterns]", 
+        "service.name": "elasticsearch"
+    }, 
+    {
+        "@timestamp": "2018-04-23T16:40:14,792", 
+        "elasticsearch.server.component": "o.e.d.a.a.i.t.p.PutIndexTemplateRequest", 
+        "event.dataset": "deprecation", 
+        "event.module": "elasticsearch", 
+        "input.type": "log", 
+        "log.level": "WARN", 
+        "log.offset": 274, 
+        "message": "Deprecated field [template] used, replaced by [index_patterns]", 
+        "service.name": "elasticsearch"
+    }, 
+    {
+        "@timestamp": "2018-04-23T16:40:15,127", 
+        "elasticsearch.server.component": "o.e.d.a.a.i.t.p.PutIndexTemplateRequest", 
+        "event.dataset": "deprecation", 
+        "event.module": "elasticsearch", 
+        "input.type": "log", 
+        "log.level": "WARN", 
+        "log.offset": 411, 
+        "message": "Deprecated field [template] used, replaced by [index_patterns]", 
+        "service.name": "elasticsearch"
+    }
+]

--- a/filebeat/module/elasticsearch/deprecation/test/other_elasticsearch_deprecation.log-expected.json
+++ b/filebeat/module/elasticsearch/deprecation/test/other_elasticsearch_deprecation.log-expected.json
@@ -1,0 +1,178 @@
+[
+    {
+        "@timestamp": "2017-11-30T13:38:16,911", 
+        "elasticsearch.server.component": "o.e.d.c.ParseField", 
+        "event.dataset": "deprecation", 
+        "event.module": "elasticsearch", 
+        "input.type": "log", 
+        "log.level": "WARN", 
+        "log.offset": 0, 
+        "message": "Deprecated field [inline] used, expected [source] instead", 
+        "service.name": "elasticsearch"
+    }, 
+    {
+        "@timestamp": "2017-11-30T13:38:16,941", 
+        "elasticsearch.server.component": "o.e.d.c.ParseField", 
+        "event.dataset": "deprecation", 
+        "event.module": "elasticsearch", 
+        "input.type": "log", 
+        "log.level": "WARN", 
+        "log.offset": 118, 
+        "message": "Deprecated field [inline] used, expected [source] instead", 
+        "service.name": "elasticsearch"
+    }, 
+    {
+        "@timestamp": "2017-11-30T13:39:28,986", 
+        "elasticsearch.server.component": "o.e.d.i.m.UidFieldMapper", 
+        "event.dataset": "deprecation", 
+        "event.module": "elasticsearch", 
+        "input.type": "log", 
+        "log.level": "WARN", 
+        "log.offset": 236, 
+        "message": "Fielddata access on the _uid field is deprecated, use _id instead", 
+        "service.name": "elasticsearch"
+    }, 
+    {
+        "@timestamp": "2017-11-30T13:39:36,339", 
+        "elasticsearch.server.component": "o.e.d.i.m.UidFieldMapper", 
+        "event.dataset": "deprecation", 
+        "event.module": "elasticsearch", 
+        "input.type": "log", 
+        "log.level": "WARN", 
+        "log.offset": 362, 
+        "message": "Fielddata access on the _uid field is deprecated, use _id instead", 
+        "service.name": "elasticsearch"
+    }, 
+    {
+        "@timestamp": "2017-11-30T13:40:49,540", 
+        "elasticsearch.server.component": "o.e.d.i.m.UidFieldMapper", 
+        "event.dataset": "deprecation", 
+        "event.module": "elasticsearch", 
+        "input.type": "log", 
+        "log.level": "WARN", 
+        "log.offset": 488, 
+        "message": "Fielddata access on the _uid field is deprecated, use _id instead", 
+        "service.name": "elasticsearch"
+    }, 
+    {
+        "@timestamp": "2017-11-30T14:08:37,413", 
+        "elasticsearch.server.component": "o.e.d.i.m.UidFieldMapper", 
+        "event.dataset": "deprecation", 
+        "event.module": "elasticsearch", 
+        "input.type": "log", 
+        "log.level": "WARN", 
+        "log.offset": 614, 
+        "message": "Fielddata access on the _uid field is deprecated, use _id instead", 
+        "service.name": "elasticsearch"
+    }, 
+    {
+        "@timestamp": "2017-11-30T14:08:37,413", 
+        "elasticsearch.server.component": "o.e.d.i.m.UidFieldMapper", 
+        "event.dataset": "deprecation", 
+        "event.module": "elasticsearch", 
+        "input.type": "log", 
+        "log.level": "WARN", 
+        "log.offset": 740, 
+        "message": "Fielddata access on the _uid field is deprecated, use _id instead", 
+        "service.name": "elasticsearch"
+    }, 
+    {
+        "@timestamp": "2017-11-30T14:08:46,006", 
+        "elasticsearch.server.component": "o.e.d.i.m.UidFieldMapper", 
+        "event.dataset": "deprecation", 
+        "event.module": "elasticsearch", 
+        "input.type": "log", 
+        "log.level": "WARN", 
+        "log.offset": 866, 
+        "message": "Fielddata access on the _uid field is deprecated, use _id instead", 
+        "service.name": "elasticsearch"
+    }, 
+    {
+        "@timestamp": "2017-11-30T14:08:46,006", 
+        "elasticsearch.server.component": "o.e.d.i.m.UidFieldMapper", 
+        "event.dataset": "deprecation", 
+        "event.module": "elasticsearch", 
+        "input.type": "log", 
+        "log.level": "WARN", 
+        "log.offset": 992, 
+        "message": "Fielddata access on the _uid field is deprecated, use _id instead", 
+        "service.name": "elasticsearch"
+    }, 
+    {
+        "@timestamp": "2017-12-01T14:05:54,017", 
+        "elasticsearch.server.component": "o.e.d.i.m.AllFieldMapper", 
+        "event.dataset": "deprecation", 
+        "event.module": "elasticsearch", 
+        "input.type": "log", 
+        "log.level": "WARN", 
+        "log.offset": 1118, 
+        "message": "[_all] is deprecated in 6.0+ and will be removed in 7.0. As a replacement, you can use [copy_to] on mapping fields to create your own catch all field.", 
+        "service.name": "elasticsearch"
+    }, 
+    {
+        "@timestamp": "2017-12-01T14:05:54,019", 
+        "elasticsearch.server.component": "o.e.d.i.m.AllFieldMapper", 
+        "event.dataset": "deprecation", 
+        "event.module": "elasticsearch", 
+        "input.type": "log", 
+        "log.level": "WARN", 
+        "log.offset": 1329, 
+        "message": "[_all] is deprecated in 6.0+ and will be removed in 7.0. As a replacement, you can use [copy_to] on mapping fields to create your own catch all field.", 
+        "service.name": "elasticsearch"
+    }, 
+    {
+        "@timestamp": "2017-12-01T14:06:52,059", 
+        "elasticsearch.server.component": "o.e.d.i.m.AllFieldMapper", 
+        "event.dataset": "deprecation", 
+        "event.module": "elasticsearch", 
+        "input.type": "log", 
+        "log.level": "WARN", 
+        "log.offset": 1540, 
+        "message": "[_all] is deprecated in 6.0+ and will be removed in 7.0. As a replacement, you can use [copy_to] on mapping fields to create your own catch all field.", 
+        "service.name": "elasticsearch"
+    }, 
+    {
+        "@timestamp": "2017-12-01T14:46:10,428", 
+        "elasticsearch.server.component": "o.e.d.s.a.InternalOrder$Parser", 
+        "event.dataset": "deprecation", 
+        "event.module": "elasticsearch", 
+        "input.type": "log", 
+        "log.level": "WARN", 
+        "log.offset": 1751, 
+        "message": "Deprecated aggregation order key [_term] used, replaced by [_key]", 
+        "service.name": "elasticsearch"
+    }, 
+    {
+        "@timestamp": "2017-12-04T16:17:18,271", 
+        "elasticsearch.server.component": "o.e.d.a.a.i.t.p.PutIndexTemplateRequest", 
+        "event.dataset": "deprecation", 
+        "event.module": "elasticsearch", 
+        "input.type": "log", 
+        "log.level": "WARN", 
+        "log.offset": 1882, 
+        "message": "Deprecated field [template] used, replaced by [index_patterns]", 
+        "service.name": "elasticsearch"
+    }, 
+    {
+        "@timestamp": "2017-12-04T16:17:18,282", 
+        "elasticsearch.server.component": "o.e.d.i.m.MapperService", 
+        "event.dataset": "deprecation", 
+        "event.module": "elasticsearch", 
+        "input.type": "log", 
+        "log.level": "WARN", 
+        "log.offset": 2019, 
+        "message": "[_default_] mapping is deprecated since it is not useful anymore now that indexes cannot have more than one type", 
+        "service.name": "elasticsearch"
+    }, 
+    {
+        "@timestamp": "2017-12-04T16:20:43,248", 
+        "elasticsearch.server.component": "o.e.d.i.m.MapperService", 
+        "event.dataset": "deprecation", 
+        "event.module": "elasticsearch", 
+        "input.type": "log", 
+        "log.level": "WARN", 
+        "log.offset": 2192, 
+        "message": "[_default_] mapping is deprecated since it is not useful anymore now that indexes cannot have more than one type", 
+        "service.name": "elasticsearch"
+    }
+]


### PR DESCRIPTION
This PR simply adds expected JSON files for the `elasticsearch/deprecation` fileset's integration tests.