### PR TITLE
Docs: State need to include $GOPATH/bin in PATH

### DIFF
--- a/docs/devguide/newbeat.asciidoc
+++ b/docs/devguide/newbeat.asciidoc
@@ -38,10 +38,10 @@ original Packetbeat authors.
 
 For general information about contributing to Beats, see <<beats-contributing>>.
 
-After you have https://golang.org/doc/install[installed Go] and set up the
+After you have https://golang.org/doc/install[installed Go], set up the
 https://golang.org/doc/code.html#GOPATH[GOPATH] environment variable to point to
-your preferred workspace location, clone the Beats repository in the correct location
-under `GOPATH`:
+your preferred workspace location, and added the `$GOPATH/bin` directory to your
+PATH variable, clone the Beats repository in the correct location under `GOPATH`:
 
 [source,shell]
 ----------------------------------------------------------------------


### PR DESCRIPTION
The makefiles that'll end up in a generated beat assume that $GOPATH/bin is in the PATH variable (at least when invoking mage from vendor/github.com/elastic/beats/libbeat/scripts/Makefile) so we should include this requirement in the documentation.