### PR TITLE
Rename generic variable Name var to beatName

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -65,6 +65,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha1...master[Check the HEAD d
 
 *Auditbeat*
 
+- Renamed auditbeat/cmd/root var `Name` to `beatName `and removed global scope {pull}9329[9329]
+
 *Filebeat*
 - Added `detect_null_bytes` selector to detect null bytes from a io.reader. {pull}9210[9210]
 

--- a/auditbeat/cmd/root.go
+++ b/auditbeat/cmd/root.go
@@ -27,9 +27,6 @@ import (
 	"github.com/elastic/beats/metricbeat/mb/module"
 )
 
-// Name of the beat (auditbeat).
-const Name = "auditbeat"
-
 // RootCmd for running auditbeat.
 var RootCmd *cmd.BeatsRootCmd
 
@@ -40,12 +37,14 @@ var ShowCmd = &cobra.Command{
 }
 
 func init() {
+
+	const beatName = "auditbeat"
 	create := beater.Creator(
 		beater.WithModuleOptions(
 			module.WithEventModifier(core.AddDatasetToEvent),
 		),
 	)
-	var runFlags = pflag.NewFlagSet(Name, pflag.ExitOnError)
-	RootCmd = cmd.GenRootCmdWithRunFlags(Name, "", create, runFlags)
+	var runFlags = pflag.NewFlagSet(beatName, pflag.ExitOnError)
+	RootCmd = cmd.GenRootCmdWithRunFlags(beatName, "", create, runFlags)
 	RootCmd.AddCommand(ShowCmd)
 }


### PR DESCRIPTION
# What does this PR?

This minor PR will reduce the scope of the variable `Name`, which before was exported Var and Global.
WIth the pr we reduce its scope and place it directly to `init` function where it is used.
I also removed the comment because it was not meaningful and was more a sign of a code smell. (var name tot generic). 

## TODOs:

- [x] adapt changelog 

- [ ] discuss to backport the change to other beats via PRs or with one PR ( this one)

### Leftovers:

I did not backported this change to the other beats. I can send different PRs for make the codebase more consistent or doing multiples commits on this pr, as you wish :sunflower: 