### PR TITLE
Cherry-pick #9305 to 6.x: Don't generate a config when disabling logs collection with hints

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -48,6 +48,9 @@ https://github.com/elastic/beats/compare/v6.5.0...6.x[Check the HEAD diff]
 - Fix macOS default log path for elasticsearch module based on homebrew paths. {pul}8939[8939]
 - Make sure the Filebeat Elastic licensed packages uses the Elastic binary instead of the OSS. {pull}8836[8836]
 
+- Don't generate incomplete configurations when logs collection is disabled by hints. {pull}9305[9305]
+- Stop runners disabled by hints after previously being started. {pull}9305[9305]
+
 *Heartbeat*
 
 - Heartbeat now always downloads the entire body of HTTP endpoints, even if no checks against the body content are declared. This fixes an issue where timing metrics would be incorrect in scenarios where the body wasn't used since the connection would be closed soon after the headers were sent, but before the entire body was. {pull}8894[8894]

--- a/filebeat/autodiscover/builder/hints/logs.go
+++ b/filebeat/autodiscover/builder/hints/logs.go
@@ -84,8 +84,9 @@ func (l *logHints) CreateConfig(event bus.Event) []*common.Config {
 		hints, _ = hIface.(common.MapStr)
 	}
 
-	if builder.IsNoOp(hints, l.Key) == true {
-		return []*common.Config{config}
+	if builder.IsNoOp(hints, l.Key) {
+		logp.Debug("hints.builder", "disabled config in event: %+v", event)
+		return []*common.Config{}
 	}
 
 	inputConfig := l.getInputs(hints)

--- a/libbeat/autodiscover/builder.go
+++ b/libbeat/autodiscover/builder.go
@@ -89,7 +89,7 @@ func (r *registry) BuildBuilder(c *common.Config) (Builder, error) {
 
 // GetConfig creates configs for all builders initialized.
 func (b Builders) GetConfig(event bus.Event) []*common.Config {
-	var configs []*common.Config
+	configs := []*common.Config{}
 
 	for _, builder := range b {
 		if config := builder.CreateConfig(event); config != nil {

--- a/libbeat/autodiscover/providers/kubernetes/kubernetes_test.go
+++ b/libbeat/autodiscover/providers/kubernetes/kubernetes_test.go
@@ -224,6 +224,7 @@ func TestEmitEvent(t *testing.T) {
 						},
 					},
 				},
+				"config": []*common.Config{},
 			},
 		},
 		{
@@ -282,7 +283,7 @@ func TestEmitEvent(t *testing.T) {
 
 		select {
 		case event := <-listener.Events():
-			assert.Equal(t, test.Expected, event)
+			assert.Equal(t, test.Expected, event, test.Message)
 		case <-time.After(2 * time.Second):
 			if test.Expected != nil {
 				t.Fatal("Timeout while waiting for event")


### PR DESCRIPTION
Cherry-pick of PR #9305 to 6.x branch. Original message: 

When `co.elastic.logs/disable="true"` is used in a container, an
incomplete event is generated, what provokes errors about configurations
with missing fields. Don't generate configs in these cases.

If a builder doesn't generate any configuration it still generates an event
with an empty list of configs instead of an event without a config field.

Seen in discuss:
* https://discuss.elastic.co/t/error-creating-runner-from-config-reading-docker-input-config-missing-field-accessing-containers-ids-0
* https://discuss.elastic.co/t/filebeat-6-4-2-autodiscover-on-kubernetes-missing-field-accessing-containers-ids-0