### PR TITLE
Add cache.ttl to add_host_metadata

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -36,6 +36,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha1...master[Check the HEAD d
 
 - Fix autodiscover configurations stopping when metadata is missing. {pull}8851[8851]
 - Log events at the debug level when dropped by encoding problems. {pull}9251[9251]
+- Refresh host metadata in add_host_metadata. {pull}9359[9359]
 
 *Auditbeat*
 
@@ -63,6 +64,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha1...master[Check the HEAD d
 *Affecting all Beats*
 - Unify dashboard exporter tools. {pull}9097[9097]
 - Use _doc as document type of the Elasticsearch major version is 7. {pull}9056[9056]
+- Add cache.ttl to add_host_metadata. {pull}9359[9359]
 
 *Auditbeat*
 

--- a/libbeat/docs/processors-using.asciidoc
+++ b/libbeat/docs/processors-using.asciidoc
@@ -894,11 +894,14 @@ beta[]
 processors:
 - add_host_metadata:
     netinfo.enabled: false
+    cache.ttl: 5m
 -------------------------------------------------------------------------------
 
 It has the following settings:
 
 `netinfo.enabled`:: (Optional) Default false. Include IP addresses and MAC addresses as fields host.ip and host.mac
+
+`cache.ttl`:: (Optional) The processor uses an internal cache for the host metadata. This sets the cache expiration time. The default is 5m, negative values disable caching altogether.
 
 The `add_host_metadata` processor annotates each event with relevant metadata from the host machine.
 The fields added to the event are looking as following:
@@ -922,8 +925,6 @@ The fields added to the event are looking as following:
    }
 }
 -------------------------------------------------------------------------------
-
-NOTE: The host information is refreshed every 5 minutes.
 
 [[dissect]]
 === Dissect strings

--- a/libbeat/processors/add_host_metadata/add_host_metadata.go
+++ b/libbeat/processors/add_host_metadata/add_host_metadata.go
@@ -32,7 +32,6 @@ import (
 	"github.com/elastic/beats/libbeat/metric/system/host"
 	"github.com/elastic/beats/libbeat/processors"
 	"github.com/elastic/go-sysinfo"
-	"github.com/elastic/go-sysinfo/types"
 )
 
 func init() {
@@ -40,7 +39,6 @@ func init() {
 }
 
 type addHostMetadata struct {
-	info       types.HostInfo
 	lastUpdate struct {
 		time.Time
 		sync.Mutex
@@ -60,12 +58,7 @@ func newHostMetadataProcessor(cfg *common.Config) (processors.Processor, error) 
 		return nil, errors.Wrapf(err, "fail to unpack the %v configuration", processorName)
 	}
 
-	h, err := sysinfo.Host()
-	if err != nil {
-		return nil, err
-	}
 	p := &addHostMetadata{
-		info:   h.Info(),
 		config: config,
 		data:   common.NewMapStrPointer(nil),
 	}
@@ -75,7 +68,11 @@ func newHostMetadataProcessor(cfg *common.Config) (processors.Processor, error) 
 
 // Run enriches the given event with the host meta data
 func (p *addHostMetadata) Run(event *beat.Event) (*beat.Event, error) {
-	p.loadData()
+	err := p.loadData()
+	if err != nil {
+		return nil, err
+	}
+
 	event.Fields.DeepUpdate(p.data.Get().Clone())
 	return event, nil
 }
@@ -91,12 +88,17 @@ func (p *addHostMetadata) expired() bool {
 	return true
 }
 
-func (p *addHostMetadata) loadData() {
+func (p *addHostMetadata) loadData() error {
 	if !p.expired() {
-		return
+		return nil
 	}
 
-	data := host.MapHostInfo(p.info)
+	h, err := sysinfo.Host()
+	if err != nil {
+		return err
+	}
+
+	data := host.MapHostInfo(h.Info())
 	if p.config.NetInfoEnabled {
 		// IP-address and MAC-address
 		var ipList, hwList, err = p.getNetInfo()
@@ -113,6 +115,7 @@ func (p *addHostMetadata) loadData() {
 	}
 
 	p.data.Set(data)
+	return nil
 }
 
 func (p *addHostMetadata) getNetInfo() ([]string, []string, error) {

--- a/libbeat/processors/add_host_metadata/config.go
+++ b/libbeat/processors/add_host_metadata/config.go
@@ -17,13 +17,19 @@
 
 package add_host_metadata
 
+import (
+	"time"
+)
+
 // Config for add_host_metadata processor.
 type Config struct {
-	NetInfoEnabled bool `config:"netinfo.enabled"` // Add IP and MAC to event
+	NetInfoEnabled bool          `config:"netinfo.enabled"` // Add IP and MAC to event
+	CacheTTL       time.Duration `config:"cache.ttl"`
 }
 
 func defaultConfig() Config {
 	return Config{
 		NetInfoEnabled: false,
+		CacheTTL:       5 * time.Minute,
 	}
 }


### PR DESCRIPTION
Despite what is says in the documentation (`NOTE: The host information is refreshed every 5 minutes.`) the `add_host_metadata` processor does not actually ever refresh most of its information (it does the IPs and MACs if `netinfo.enabled: true`, but not the base host info).

This PR changes it to call `sysinfo.Host()` every time its cache expires.

It also adds a `cache.ttl` parameter to configure how often that happens. The default stays at `5m`, and negative values disable caching altogether (most likely at some cost to performance).

I did not add the new config parameter to all the `*beat.reference.yml` files - I noticed they didn't contain everything (e.g. `add_kubernetes_metadata`) and I think this parameter is not something most users need to configure. Happy to put it in though if it makes sense.