### PR TITLE
Add raw JSON to event.original if parsing fails

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -64,6 +64,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha1...master[Check the HEAD d
 
 *Filebeat*
 - Added `detect_null_bytes` selector to detect null bytes from a io.reader. {pull}9210[9210]
+- Add raw JSON to `event.original` if parsing fails. {pull}9361[9361]
 
 *Heartbeat*
 

--- a/filebeat/input/log/harvester.go
+++ b/filebeat/input/log/harvester.go
@@ -314,6 +314,9 @@ func (h *Harvester) Run() error {
 					},
 				},
 			}
+			if len(message.Raw) > 0 {
+				fields.Put("event.original", string(message.Raw))
+			}
 			fields.DeepUpdate(message.Fields)
 
 			// Check if json fields exist

--- a/filebeat/tests/system/test_json.py
+++ b/filebeat/tests/system/test_json.py
@@ -336,6 +336,7 @@ class Test(BaseTest):
         )
         assert len(output) == 1
         assert output[0]["message"] == message
+        assert output[0]["event.original"] == "invalidjson\n"
         assert True == self.log_contains_count("Error decoding JSON")
 
     def test_with_generic_filtering_remove_headers(self):

--- a/libbeat/reader/message.go
+++ b/libbeat/reader/message.go
@@ -28,6 +28,7 @@ import (
 type Message struct {
 	Ts      time.Time     // timestamp the content was read
 	Content []byte        // actual content read
+	Raw     []byte        // unparsed event read from disk
 	Bytes   int           // total number of bytes read to generate the message
 	Fields  common.MapStr // optional fields that can be added by reader
 }

--- a/libbeat/reader/readjson/docker_json.go
+++ b/libbeat/reader/readjson/docker_json.go
@@ -179,6 +179,7 @@ func (p *DockerJSONReader) Next() (reader.Message, error) {
 		var logLine logLine
 		err = p.parseLine(&message, &logLine)
 		if err != nil {
+			message.Raw = message.Content
 			return message, err
 		}
 

--- a/libbeat/reader/readjson/json_test.go
+++ b/libbeat/reader/readjson/json_test.go
@@ -178,7 +178,7 @@ func TestDecodeJSON(t *testing.T) {
 
 		var p JSONReader
 		p.cfg = &test.Config
-		text, M := p.decode([]byte(test.Text))
+		text, M, _ := p.decode([]byte(test.Text))
 		assert.Equal(t, test.ExpectedText, string(text))
 		assert.Equal(t, test.ExpectedMap, M)
 	}


### PR DESCRIPTION
If parsing a JSON message fails Filebeat adds `"error"` key with the error returned by Go. This PR adds the raw message to help debugging.

Inspired by #9172 