### PR TITLE
Enable set syslog host for Filebeat HAProxy module

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -74,6 +74,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha1...master[Check the HEAD d
 
 *Filebeat*
 - Added `detect_null_bytes` selector to detect null bytes from a io.reader. {pull}9210[9210]
+- Added `syslog_host` variable to HAProxy module. {pull}9366[9366]
 
 *Heartbeat*
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -76,7 +76,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha1...master[Check the HEAD d
 *Filebeat*
 
 - Added `detect_null_bytes` selector to detect null bytes from a io.reader. {pull}9210[9210]
-- Added `syslog_host` variable to HAProxy module. {pull}9366[9366]
+- Added `syslog_host` variable to HAProxy module to allow syslog listener to bind to configured host. {pull}9366[9366]
 
 *Heartbeat*
 

--- a/filebeat/module/haproxy/log/config/syslog.yml
+++ b/filebeat/module/haproxy/log/config/syslog.yml
@@ -1,3 +1,3 @@
 type: syslog
 protocol.udp:
-  host: "localhost:{{.syslog_port}}"
+  host: "{{.syslog_host}}:{{.syslog_port}}"

--- a/filebeat/module/haproxy/log/manifest.yml
+++ b/filebeat/module/haproxy/log/manifest.yml
@@ -4,6 +4,8 @@ var:
   - name: paths
     default:
       - /var/log/haproxy.log
+  - name: syslog_host
+    default: localhost
   - name: syslog_port
     default: 9001
   - name: input


### PR DESCRIPTION
The syslog input for the Filebeat HAProxy module binds by default to localhost:9001. It is possible to configure the port through the variable var.syslog_port, but it is not possible for the syslog_host. This can be useful when running Filebeat inside a Docker container. Since it is not easy to forward a port from the host to localhost inside the Docker container, it restricts the ability to use Filebeat in a Docker container to log HAProxy running on a remote instance. With this commit, we make it possible to configure the host that the syslog input for the HAProxy binds to through a variable var.syslog_host. This makes it possible to have HAProxy running on a remote instance (e.g., a FreeBSD 11.2 host), and configure that instance to remote log to a Filebeat instance running inside a Docker container.