### PR TITLE
[Auditbeat] Disable user metricset on non-Linux systems

### DIFF
--- a/x-pack/auditbeat/module/system/user/user.go
+++ b/x-pack/auditbeat/module/system/user/user.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+// +build linux,cgo
+
 package user
 
 import (

--- a/x-pack/auditbeat/module/system/user/user_test.go
+++ b/x-pack/auditbeat/module/system/user/user_test.go
@@ -2,6 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+// +build linux,cgo
+
 package user
 
 import (

--- a/x-pack/auditbeat/module/system/user/users_other.go
+++ b/x-pack/auditbeat/module/system/user/users_other.go
@@ -7,10 +7,23 @@
 package user
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
+
+	"github.com/elastic/beats/metricbeat/mb"
 )
 
-// GetUsers is not implemented on all systems.
-func GetUsers() (users []*User, err error) {
-	return nil, errors.New("not implemented")
+const (
+	moduleName    = "system"
+	metricsetName = "user"
+)
+
+func init() {
+	mb.Registry.MustAddMetricSet(moduleName, metricsetName, New,
+		mb.DefaultMetricSet(),
+	)
+}
+
+// New returns an error.
+func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
+	return nil, fmt.Errorf("the %v/%v dataset is only supported on Linux", moduleName, metricsetName)
 }

--- a/x-pack/auditbeat/tests/system/test_metricsets.py
+++ b/x-pack/auditbeat/tests/system/test_metricsets.py
@@ -60,6 +60,7 @@ class Test(AuditbeatXPackTest):
             if "network.type" not in str(e):
                 raise
 
+    @unittest.skipUnless(sys.platform == "linux2", "Only implemented for Linux")
     def test_metricset_user(self):
         """
         user metricset collects information about users on a server.


### PR DESCRIPTION
This adds additional build flags to the new `user` metricset to prevent build failures on non-Linux systems. If it is configured, it will now throw an error and abort the launch.

This is similar to the [what the `socket` metricset does](https://github.com/elastic/beats/blob/feature-auditbeat-host/x-pack/auditbeat/module/system/socket/socket_other.go).