### PR TITLE
Add missing changelog for #9226

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -88,6 +88,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha1...master[Check the HEAD d
 - Add setting to disable docker cpu metrics per core. {pull}9194[9194]
 - The `elasticsearch/node` metricset now reports the Elasticsearch cluster UUID. {pull}8771[8771]
 - Add service.type field to Metricbeat. {pull}8965[8965]
+- Support GET requests in Jolokia module. {issue}8566[8566] {pull}9226[9226]
 
 *Packetbeat*
 


### PR DESCRIPTION
elastic/beats#9226 was merged without changelog entry, but it'd need one.