### PR TITLE
Cherry-pick #9029 to 6.x: Make conditions in autodiscovery configs optional

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -226,6 +226,7 @@ https://github.com/elastic/beats/compare/v6.4.0...v6.5.0[View commits]
 - Add Beats Central Management {pull}8559[8559]
 - Report configured queue type. {pull}8091[8091]
 - Enable `host` and `cloud` metadata processors by default. {pull}8596[8596]
+- Autodiscovery no longer requires that the `condition` field be set. If left unset all configs will be matched. {pull}9029[9029]
 
 *Filebeat*
 

--- a/libbeat/autodiscover/providers/docker/docker.go
+++ b/libbeat/autodiscover/providers/docker/docker.go
@@ -40,7 +40,7 @@ type Provider struct {
 	builders      autodiscover.Builders
 	appenders     autodiscover.Appenders
 	watcher       docker.Watcher
-	templates     *template.Mapper
+	templates     template.Mapper
 	stop          chan interface{}
 	startListener bus.Listener
 	stopListener  bus.Listener

--- a/libbeat/autodiscover/providers/jolokia/jolokia.go
+++ b/libbeat/autodiscover/providers/jolokia/jolokia.go
@@ -42,7 +42,7 @@ type Provider struct {
 	bus       bus.Bus
 	builders  autodiscover.Builders
 	appenders autodiscover.Appenders
-	templates *template.Mapper
+	templates template.Mapper
 	discovery DiscoveryProber
 }
 

--- a/libbeat/autodiscover/providers/kubernetes/kubernetes.go
+++ b/libbeat/autodiscover/providers/kubernetes/kubernetes.go
@@ -41,7 +41,7 @@ type Provider struct {
 	bus       bus.Bus
 	watcher   kubernetes.Watcher
 	metagen   kubernetes.MetaGenerator
-	templates *template.Mapper
+	templates template.Mapper
 	builders  autodiscover.Builders
 	appenders autodiscover.Appenders
 }

--- a/libbeat/autodiscover/template/config_test.go
+++ b/libbeat/autodiscover/template/config_test.go
@@ -60,6 +60,16 @@ func TestConfigsMapping(t *testing.T) {
 			},
 			expected: []*common.Config{config},
 		},
+		// No condition
+		{
+			mapping: `
+- config:
+    - correct: config`,
+			event: bus.Event{
+				"foo": 3,
+			},
+			expected: []*common.Config{config},
+		},
 	}
 
 	for _, test := range tests {
@@ -98,5 +108,6 @@ func TestNilConditionConfig(t *testing.T) {
 	}
 
 	_, err = NewConfigMapper(mappings)
-	assert.Error(t, err)
+	assert.NoError(t, err)
+	assert.Nil(t, mappings[0].ConditionConfig)
 }

--- a/libbeat/docs/shared-autodiscover.asciidoc
+++ b/libbeat/docs/shared-autodiscover.asciidoc
@@ -12,8 +12,8 @@ config file. To enable autodiscover, you specify a list of providers.
 === Providers
 
 Autodiscover providers work by watching for events on the system and translating those events into internal autodiscover
-events with a common format. When you configure the provider, you can use fields from the autodiscover event to set
-conditions that, when met, launch specific configurations.
+events with a common format. When you configure the provider, you can optionally use fields from the autodiscover event
+to set conditions that, when met, launch specific configurations.
 
 On start, {beatname_uc} will scan existing containers and launch the proper configs for them. Then it will watch for new
 start/stop events. This ensures you don't need to worry about state, but only define your desired configs.


### PR DESCRIPTION
Cherry-pick of PR #9029 to 6.x branch. Original message: 

This change lets users leave the `condition` option undeclared when writing autodiscover configurations. When not declared all configurations will match all events.

This also changes the type of the autodiscovery `Mapper` from `*Mapper` to `Mapper`. Since this type is backed by a slice, which is internally a pointer, there's no need to make it a pointer type, as it it makes the append operation awkward. If we internally mutated the slice via method's it'd make sense to keep the pointer, but we don't.

This takes over from elastic/beats#8897 .