### PR TITLE
Assume all swap memory is free on values overflow

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -38,6 +38,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha1...master[Check the HEAD d
 - Fix autodiscover configurations stopping when metadata is missing. {pull}8851[8851]
 - Log events at the debug level when dropped by encoding problems. {pull}9251[9251]
 - Refresh host metadata in add_host_metadata. {pull}9359[9359]
+- Handle cases of free swap being bigger than total swap by assuming no swap is being used. {issue}6271[6271] {pull}[]
 
 *Auditbeat*
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -38,7 +38,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha1...master[Check the HEAD d
 - Fix autodiscover configurations stopping when metadata is missing. {pull}8851[8851]
 - Log events at the debug level when dropped by encoding problems. {pull}9251[9251]
 - Refresh host metadata in add_host_metadata. {pull}9359[9359]
-- Handle cases of free swap being bigger than total swap by assuming no swap is being used. {issue}6271[6271] {pull}[]
+- When collecting swap metrics for beats telemetry or system metricbeat module handle cases of free swap being bigger than total swap by assuming no swap is being used. {issue}6271[6271] {pull}9383[9383]
 
 *Auditbeat*
 

--- a/libbeat/metric/system/memory/memory.go
+++ b/libbeat/metric/system/memory/memory.go
@@ -69,6 +69,14 @@ func GetSwap() (*SwapStat, error) {
 		return nil, err
 	}
 
+	// This shouldn't happen, but it has been reported to happen and
+	// this can provoke too big values for used swap.
+	// Workaround this by assuming that all swap is free in that case.
+	if swap.Free > swap.Total || swap.Used > swap.Total {
+		swap.Free = swap.Total
+		swap.Used = 0
+	}
+
 	return &SwapStat{Swap: swap}, nil
 }
 

--- a/libbeat/metric/system/memory/memory.go
+++ b/libbeat/metric/system/memory/memory.go
@@ -21,6 +21,7 @@ package memory
 
 import (
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
 	sigar "github.com/elastic/gosigar"
 )
 
@@ -73,6 +74,9 @@ func GetSwap() (*SwapStat, error) {
 	// this can provoke too big values for used swap.
 	// Workaround this by assuming that all swap is free in that case.
 	if swap.Free > swap.Total || swap.Used > swap.Total {
+		logp.Debug("memory",
+			"Odd values for swap memory, total: %v free: %v used: %v. Assuming all swap is free.",
+			swap.Total, swap.Free, swap.Used)
 		swap.Free = swap.Total
 		swap.Used = 0
 	}

--- a/libbeat/metric/system/memory/memory.go
+++ b/libbeat/metric/system/memory/memory.go
@@ -75,7 +75,7 @@ func GetSwap() (*SwapStat, error) {
 	// Workaround this by assuming that all swap is free in that case.
 	if swap.Free > swap.Total || swap.Used > swap.Total {
 		logp.Debug("memory",
-			"Odd values for swap memory, total: %v free: %v used: %v. Assuming all swap is free.",
+			"Unexpected values for swap memory - total: %v free: %v used: %v.  Setting swap used to 0.",
 			swap.Total, swap.Free, swap.Used)
 		swap.Free = swap.Total
 		swap.Used = 0


### PR DESCRIPTION
There have been reports about user swap memory being a value that looks
like an overflow. At the moment used swap memory is calculated as the
value of total memory minus the free memory, so this means that free
memory is bigger than total in some cases. This isn't possible in
principle. Assume that no swap is being used if that happens.

Closes #6271 