### PR TITLE
Add cache.ttl to add_host_metadata (#9359)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -38,6 +38,7 @@ https://github.com/elastic/beats/compare/v6.5.0...6.x[Check the HEAD diff]
 *Affecting all Beats*
 
 - Propagate Sync error when running SafeFileRotate. {pull}9069[9069]
+- Refresh host metadata in add_host_metadata. {pull}9359[9359]
 
 *Auditbeat*
 
@@ -81,6 +82,7 @@ https://github.com/elastic/beats/compare/v6.5.0...6.x[Check the HEAD diff]
 
 - Dissect will now flag event on parsing error. {pull}8751[8751]
 - Added the `redirect_stderr` option that allows panics to be logged to log files. {pull}8430[8430]
+- Add cache.ttl to add_host_metadata. {pull}9359[9359]
 
 *Auditbeat*
 

--- a/libbeat/docs/processors-using.asciidoc
+++ b/libbeat/docs/processors-using.asciidoc
@@ -894,11 +894,14 @@ beta[]
 processors:
 - add_host_metadata:
     netinfo.enabled: false
+    cache.ttl: 5m
 -------------------------------------------------------------------------------
 
 It has the following settings:
 
 `netinfo.enabled`:: (Optional) Default false. Include IP addresses and MAC addresses as fields host.ip and host.mac
+
+`cache.ttl`:: (Optional) The processor uses an internal cache for the host metadata. This sets the cache expiration time. The default is 5m, negative values disable caching altogether.
 
 The `add_host_metadata` processor annotates each event with relevant metadata from the host machine.
 The fields added to the event are looking as following:
@@ -921,8 +924,6 @@ The fields added to the event are looking as following:
    }
 }
 -------------------------------------------------------------------------------
-
-NOTE: The host information is refreshed every 5 minutes.
 
 [[dissect]]
 === Dissect strings

--- a/libbeat/processors/add_host_metadata/config.go
+++ b/libbeat/processors/add_host_metadata/config.go
@@ -17,13 +17,19 @@
 
 package add_host_metadata
 
+import (
+	"time"
+)
+
 // Config for add_host_metadata processor.
 type Config struct {
-	NetInfoEnabled bool `config:"netinfo.enabled"` // Add IP and MAC to event
+	NetInfoEnabled bool          `config:"netinfo.enabled"` // Add IP and MAC to event
+	CacheTTL       time.Duration `config:"cache.ttl"`
 }
 
 func defaultConfig() Config {
 	return Config{
 		NetInfoEnabled: false,
+		CacheTTL:       5 * time.Minute,
 	}
 }


### PR DESCRIPTION
Fix: Refresh host info when cache expires.

Add config parameter `cache.ttl` to control cache expiration (default 5m).

(cherry picked from commit 30dfa052aa1b0ba6fc63271869b7567f6e3370d0)