### PR TITLE
Documentation for the NetFlow input

### DIFF
--- a/filebeat/docs/filebeat-options.asciidoc
+++ b/filebeat/docs/filebeat-options.asciidoc
@@ -49,6 +49,7 @@ You can configure {beatname_uc} to use the following inputs:
 * <<{beatname_lc}-input-docker>>
 * <<{beatname_lc}-input-tcp>>
 * <<{beatname_lc}-input-syslog>>
+* <<{beatname_lc}-input-netflow>>
 
 
 
@@ -65,3 +66,5 @@ include::inputs/input-docker.asciidoc[]
 include::inputs/input-tcp.asciidoc[]
 
 include::inputs/input-syslog.asciidoc[]
+
+include::../../x-pack/filebeat/docs/inputs/input-netflow.asciidoc[]

--- a/x-pack/filebeat/docs/inputs/input-netflow.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-netflow.asciidoc
@@ -1,0 +1,65 @@
+[role="xpack"]
+
+:type: netflow
+
+[id="{beatname_lc}-input-{type}"]
+=== NetFlow input
+
+++++
+<titleabbrev>NetFlow</titleabbrev>
+++++
+
+Use the `netflow` input to read NetFlow and IPFIX exported flows
+and options records over UDP.
+
+This input supports NetFlow versions 1, 5, 6, 7, 8 and 9, as well as
+IPFIX. For NetFlow versions older than 9, fields are mapped automatically
+to NetFlow v9.
+
+Example configuration:
+
+["source","yaml",subs="attributes"]
+----
+{beatname_lc}.inputs:
+- type: netflow
+  max_message_size: 10KiB
+  host: "0.0.0.0:2055"
+  protocols: [ v5, v9, ipfix ]
+  expiration_timeout: 30m
+  queue_size: 8192
+----
+
+
+==== Configuration options
+
+The `netflow` input supports the following configuration options plus the
+<<{beatname_lc}-input-{type}-common-options>> described later.
+
+include::../../../../filebeat/docs/inputs/input-common-udp-options.asciidoc[]
+
+[float]
+[[protocols]]
+==== `protocols`
+
+List of enabled protocols.
+Valid values are `v1`, `v5`, `v6`, `v7`, `v8`, `v9` and `ipfix`.
+
+[float]
+[[expiration_timeout]]
+==== `expiration_timeout`
+
+The time before an idle session or unused template is expired.
+Only applicable to v9 and IPFIX protocols. A value of zero disables expiration.
+
+[float]
+[[queue_size]]
+==== `queue_size`
+
+The maximum number of packets that can be queued for processing.
+Use this setting to avoid packet-loss when dealing with occasional bursts
+of traffic.
+
+[id="{beatname_lc}-input-{type}-common-options"]
+include::../../../../filebeat/docs/inputs/input-common-options.asciidoc[]
+
+:type!:

--- a/x-pack/filebeat/docs/inputs/input-netflow.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-netflow.asciidoc
@@ -9,6 +9,8 @@
 <titleabbrev>NetFlow</titleabbrev>
 ++++
 
+beta[]
+
 Use the `netflow` input to read NetFlow and IPFIX exported flows
 and options records over UDP.
 


### PR DESCRIPTION
This adds docs for the new netflow input in x-pack/filebeat.

Documents feature in #9365