### PR TITLE
Cherry-pick #9056 to 6.x: Use _doc if ES major version is 7

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -79,6 +79,7 @@ https://github.com/elastic/beats/compare/v6.5.0...6.x[Check the HEAD diff]
 
 *Affecting all Beats*
 - Unify dashboard exporter tools. {pull}9097[9097]
+- Use _doc as document type of the Elasticsearch major version is 7. {pull}9056[9056]
 
 - Dissect will now flag event on parsing error. {pull}8751[8751]
 - Added the `redirect_stderr` option that allows panics to be logged to log files. {pull}8430[8430]

--- a/filebeat/fileset/modules_integration_test.go
+++ b/filebeat/fileset/modules_integration_test.go
@@ -22,7 +22,6 @@ package fileset
 import (
 	"encoding/json"
 	"path/filepath"
-	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -142,11 +141,5 @@ func TestAvailableProcessors(t *testing.T) {
 
 func hasIngest(client *elasticsearch.Client) bool {
 	v := client.GetVersion()
-	majorVersion := string(v[0])
-	version, err := strconv.Atoi(majorVersion)
-	if err != nil {
-		return true
-	}
-
-	return version >= 5
+	return v.Major >= 5
 }

--- a/filebeat/fileset/pipelines.go
+++ b/filebeat/fileset/pipelines.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 )
 
@@ -33,7 +34,7 @@ type PipelineLoaderFactory func() (PipelineLoader, error)
 type PipelineLoader interface {
 	LoadJSON(path string, json map[string]interface{}) ([]byte, error)
 	Request(method, path string, pipeline string, params map[string]string, body interface{}) (int, []byte, error)
-	GetVersion() string
+	GetVersion() common.Version
 }
 
 // LoadPipelines loads the pipelines for each configured fileset.

--- a/filebeat/scripts/tester/main.go
+++ b/filebeat/scripts/tester/main.go
@@ -264,7 +264,7 @@ func runSimulate(url string, pipeline map[string]interface{}, logs []string, ver
 	for _, s := range sources {
 		d := common.MapStr{
 			"_index":  "index",
-			"_type":   "doc",
+			"_type":   "_doc",
 			"_id":     "id",
 			"_source": s,
 		}

--- a/libbeat/cmd/export/dashboard.go
+++ b/libbeat/cmd/export/dashboard.go
@@ -73,6 +73,7 @@ func GenDashboardCmd(name, idxPrefix, beatVersion string) *cobra.Command {
 					if decode {
 						r = dashboards.DecodeExported(r)
 					}
+
 					err = dashboards.SaveToFile(r, info.Dashboards[i].File, filepath.Dir(yml), client.GetVersion())
 					if err != nil {
 						fmt.Fprintf(os.Stderr, "Error saving dashboard '%s' to file '%s' : %+v\n",

--- a/libbeat/cmd/export/template.go
+++ b/libbeat/cmd/export/template.go
@@ -57,7 +57,16 @@ func GenTemplateConfigCmd(settings instance.Settings, name, idxPrefix, beatVersi
 				}
 			}
 
-			tmpl, err := template.New(b.Info.Version, index, version, cfg)
+			if version == "" {
+				version = b.Info.Version
+			}
+
+			esVersion, err := common.NewVersion(version)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Invalid Elasticsearch version: %s\n", err)
+			}
+
+			tmpl, err := template.New(b.Info.Version, index, *esVersion, cfg)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Error generating template: %+v", err)
 				os.Exit(1)

--- a/libbeat/common/version.go
+++ b/libbeat/common/version.go
@@ -31,6 +31,16 @@ type Version struct {
 	Meta    string
 }
 
+// MustNewVersion creates a version from the given version string.
+// If the version string is invalid, MustNewVersion panics.
+func MustNewVersion(version string) *Version {
+	v, err := NewVersion(version)
+	if err != nil {
+		panic(err)
+	}
+	return v
+}
+
 // NewVersion expects a string in the format:
 // major.minor.bugfix(-meta)
 func NewVersion(version string) (*Version, error) {
@@ -67,6 +77,11 @@ func NewVersion(version string) (*Version, error) {
 	}
 
 	return &v, nil
+}
+
+// IsValid returns true if the version object stores a successfully parsed version number.
+func (v *Version) IsValid() bool {
+	return v.version != ""
 }
 
 func (v *Version) IsMajor(major int) bool {

--- a/libbeat/dashboards/dashboards.go
+++ b/libbeat/dashboards/dashboards.go
@@ -22,8 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
-	"strconv"
-	"strings"
 
 	errw "github.com/pkg/errors"
 
@@ -106,12 +104,7 @@ func ImportDashboards(
 
 		esLoader.statusMsg("Elasticsearch URL %v", esLoader.client.Connection.URL)
 
-		majorVersion, _, err := getMajorAndMinorVersion(esLoader.version)
-		if err != nil {
-			return fmt.Errorf("wrong Elasticsearch version: %v", err)
-		}
-
-		if majorVersion < 6 {
+		if esLoader.version.Major < 6 {
 			importVia = importViaES
 		} else {
 			importVia = useKibana
@@ -145,17 +138,16 @@ func setupAndImportDashboardsViaKibana(ctx context.Context, hostname string, kib
 }
 
 func ImportDashboardsViaKibana(kibanaLoader *KibanaLoader) error {
+	version := kibanaLoader.version
+	if !version.IsValid() {
+		return errors.New("No valid kibana version available")
+	}
 
 	if !isKibanaAPIavailable(kibanaLoader.version) {
-		return fmt.Errorf("Kibana API is not available in Kibana version %s", kibanaLoader.version)
+		return fmt.Errorf("Kibana API is not available in Kibana version %s", kibanaLoader.version.String())
 	}
 
-	version, err := common.NewVersion(kibanaLoader.version)
-	if err != nil {
-		return fmt.Errorf("Invalid Kibana version: %s", kibanaLoader.version)
-	}
-
-	importer, err := NewImporter(*version, kibanaLoader.config, kibanaLoader)
+	importer, err := NewImporter(version, kibanaLoader.config, kibanaLoader)
 	if err != nil {
 		return fmt.Errorf("fail to create a Kibana importer for loading the dashboards: %v", err)
 	}
@@ -187,40 +179,6 @@ func ImportDashboardsViaElasticsearch(esLoader *ElasticsearchLoader) error {
 	return nil
 }
 
-func getMajorAndMinorVersion(version string) (int, int, error) {
-	fields := strings.Split(version, ".")
-	if len(fields) != 3 {
-		return 0, 0, fmt.Errorf("wrong version %s", version)
-	}
-	majorVersion := fields[0]
-	minorVersion := fields[1]
-
-	majorVersionInt, err := strconv.Atoi(majorVersion)
-	if err != nil {
-		return 0, 0, err
-	}
-
-	minorVersionInt, err := strconv.Atoi(minorVersion)
-	if err != nil {
-		return 0, 0, err
-	}
-
-	return majorVersionInt, minorVersionInt, nil
-}
-
-func isKibanaAPIavailable(version string) bool {
-	majorVersion, minorVersion, err := getMajorAndMinorVersion(version)
-	if err != nil {
-		return false
-	}
-
-	if majorVersion == 5 && minorVersion >= 6 {
-		return true
-	}
-
-	if majorVersion >= 6 {
-		return true
-	}
-
-	return false
+func isKibanaAPIavailable(version common.Version) bool {
+	return (version.Major == 5 && version.Minor >= 6) || version.Major >= 6
 }

--- a/libbeat/dashboards/es_loader.go
+++ b/libbeat/dashboards/es_loader.go
@@ -19,6 +19,7 @@ package dashboards
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"path"
@@ -33,7 +34,7 @@ import (
 type ElasticsearchLoader struct {
 	client       *elasticsearch.Client
 	config       *Config
-	version      string
+	version      common.Version
 	msgOutputter MessageOutputter
 }
 
@@ -48,6 +49,9 @@ func NewElasticsearchLoader(cfg *common.Config, dashboardsConfig *Config, msgOut
 	}
 
 	version := esClient.GetVersion()
+	if !version.IsValid() {
+		return nil, errors.New("No valid Elasticsearch version available")
+	}
 
 	loader := ElasticsearchLoader{
 		client:       esClient,
@@ -56,7 +60,7 @@ func NewElasticsearchLoader(cfg *common.Config, dashboardsConfig *Config, msgOut
 		msgOutputter: msgOutputter,
 	}
 
-	loader.statusMsg("Initialize the Elasticsearch %s loader", version)
+	loader.statusMsg("Initialize the Elasticsearch %s loader", version.String())
 
 	return &loader, nil
 }

--- a/libbeat/dashboards/es_loader_test.go
+++ b/libbeat/dashboards/es_loader_test.go
@@ -20,7 +20,6 @@
 package dashboards
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -40,8 +39,9 @@ func TestImporter(t *testing.T) {
 	}
 
 	client := estest.GetTestingElasticsearch(t)
-	if strings.HasPrefix(client.Connection.GetVersion(), "6.") ||
-		strings.HasPrefix(client.Connection.GetVersion(), "7.") {
+	major := client.GetVersion().Major
+
+	if major == 6 || major == 7 {
 		t.Skip("Skipping tests for Elasticsearch 6.x releases")
 	}
 
@@ -76,8 +76,8 @@ func TestImporterEmptyBeat(t *testing.T) {
 	}
 
 	client := estest.GetTestingElasticsearch(t)
-	if strings.HasPrefix(client.Connection.GetVersion(), "6.") ||
-		strings.HasPrefix(client.Connection.GetVersion(), "7.") {
+	major := client.GetVersion().Major
+	if major == 6 || major == 7 {
 		t.Skip("Skipping tests for Elasticsearch 6.x releases")
 	}
 

--- a/libbeat/dashboards/export.go
+++ b/libbeat/dashboards/export.go
@@ -84,14 +84,9 @@ func ExportAll(client *kibana.Client, list ListYML) ([]common.MapStr, error) {
 }
 
 // SaveToFile creates the required directories if needed and saves dashboard.
-func SaveToFile(dashboard common.MapStr, filename, root, versionStr string) error {
-	version, err := common.NewVersion(versionStr)
-	if err != nil {
-		return err
-	}
-
+func SaveToFile(dashboard common.MapStr, filename, root string, version common.Version) error {
 	dashboardsPath := "_meta/kibana/" + strconv.Itoa(version.Major) + "/dashboard"
-	err = generator.CreateDirectories(root, dashboardsPath)
+	err := generator.CreateDirectories(root, dashboardsPath)
 	if err != nil {
 		return err
 	}

--- a/libbeat/dashboards/kibana_loader.go
+++ b/libbeat/dashboards/kibana_loader.go
@@ -35,7 +35,7 @@ var importAPI = "/api/kibana/dashboards/import"
 type KibanaLoader struct {
 	client       *kibana.Client
 	config       *Config
-	version      string
+	version      common.Version
 	hostname     string
 	msgOutputter MessageOutputter
 }
@@ -59,7 +59,8 @@ func NewKibanaLoader(ctx context.Context, cfg *common.Config, dashboardsConfig *
 		msgOutputter: msgOutputter,
 	}
 
-	loader.statusMsg("Initialize the Kibana %s loader", client.GetVersion())
+	version := client.GetVersion()
+	loader.statusMsg("Initialize the Kibana %s loader", version.String())
 
 	return &loader, nil
 }

--- a/libbeat/outputs/codec/json/event.go
+++ b/libbeat/outputs/codec/json/event.go
@@ -46,7 +46,7 @@ func makeEvent(index, version string, in *beat.Event) event {
 		Meta: meta{
 			Beat:    index,
 			Version: version,
-			Type:    "doc",
+			Type:    "_doc",
 			Fields:  in.Meta,
 		},
 		Fields: in.Fields,

--- a/libbeat/outputs/codec/json/json_test.go
+++ b/libbeat/outputs/codec/json/json_test.go
@@ -35,7 +35,7 @@ func TestJsonCodec(t *testing.T) {
 		"default json": testCase{
 			config:   defaultConfig,
 			in:       common.MapStr{"msg": "message"},
-			expected: `{"@timestamp":"0001-01-01T00:00:00.000Z","@metadata":{"beat":"test","type":"doc","version":"1.2.3"},"msg":"message"}`,
+			expected: `{"@timestamp":"0001-01-01T00:00:00.000Z","@metadata":{"beat":"test","type":"_doc","version":"1.2.3"},"msg":"message"}`,
 		},
 		"pretty enabled": testCase{
 			config: config{Pretty: true},
@@ -44,7 +44,7 @@ func TestJsonCodec(t *testing.T) {
   "@timestamp": "0001-01-01T00:00:00.000Z",
   "@metadata": {
     "beat": "test",
-    "type": "doc",
+    "type": "_doc",
     "version": "1.2.3"
   },
   "msg": "message"
@@ -53,12 +53,12 @@ func TestJsonCodec(t *testing.T) {
 		"html escaping enabled": testCase{
 			config:   config{EscapeHTML: true},
 			in:       common.MapStr{"msg": "<hello>world</hello>"},
-			expected: `{"@timestamp":"0001-01-01T00:00:00.000Z","@metadata":{"beat":"test","type":"doc","version":"1.2.3"},"msg":"\u003chello\u003eworld\u003c/hello\u003e"}`,
+			expected: `{"@timestamp":"0001-01-01T00:00:00.000Z","@metadata":{"beat":"test","type":"_doc","version":"1.2.3"},"msg":"\u003chello\u003eworld\u003c/hello\u003e"}`,
 		},
 		"html escaping disabled": testCase{
 			config:   config{EscapeHTML: false},
 			in:       common.MapStr{"msg": "<hello>world</hello>"},
-			expected: `{"@timestamp":"0001-01-01T00:00:00.000Z","@metadata":{"beat":"test","type":"doc","version":"1.2.3"},"msg":"<hello>world</hello>"}`,
+			expected: `{"@timestamp":"0001-01-01T00:00:00.000Z","@metadata":{"beat":"test","type":"_doc","version":"1.2.3"},"msg":"<hello>world</hello>"}`,
 		},
 	}
 

--- a/libbeat/outputs/console/console_test.go
+++ b/libbeat/outputs/console/console_test.go
@@ -82,7 +82,7 @@ func TestConsoleOutput(t *testing.T) {
 			[]beat.Event{
 				{Fields: event("field", "value")},
 			},
-			"{\"@timestamp\":\"0001-01-01T00:00:00.000Z\",\"@metadata\":{\"beat\":\"test\",\"type\":\"doc\",\"version\":\"1.2.3\"},\"field\":\"value\"}\n",
+			"{\"@timestamp\":\"0001-01-01T00:00:00.000Z\",\"@metadata\":{\"beat\":\"test\",\"type\":\"_doc\",\"version\":\"1.2.3\"},\"field\":\"value\"}\n",
 		},
 		{
 			"single json event (pretty=true)",
@@ -90,7 +90,7 @@ func TestConsoleOutput(t *testing.T) {
 			[]beat.Event{
 				{Fields: event("field", "value")},
 			},
-			"{\n  \"@timestamp\": \"0001-01-01T00:00:00.000Z\",\n  \"@metadata\": {\n    \"beat\": \"test\",\n    \"type\": \"doc\",\n    \"version\": \"1.2.3\"\n  },\n  \"field\": \"value\"\n}\n",
+			"{\n  \"@timestamp\": \"0001-01-01T00:00:00.000Z\",\n  \"@metadata\": {\n    \"beat\": \"test\",\n    \"type\": \"_doc\",\n    \"version\": \"1.2.3\"\n  },\n  \"field\": \"value\"\n}\n",
 		},
 		// TODO: enable test after update fmtstr support to beat.Event
 		{

--- a/libbeat/outputs/elasticsearch/api_integration_test.go
+++ b/libbeat/outputs/elasticsearch/api_integration_test.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -105,8 +104,8 @@ func TestIngest(t *testing.T) {
 	}
 
 	client := getTestingElasticsearch(t)
-	if strings.HasPrefix(client.Connection.version, "2.") {
-		t.Skip("Skipping tests as pipeline not available in 2.x releases")
+	if client.Connection.version.Major < 5 {
+		t.Skip("Skipping tests as pipeline not available in <5.x releases")
 	}
 
 	status, _, err := client.DeletePipeline(pipeline, nil)

--- a/libbeat/outputs/elasticsearch/client.go
+++ b/libbeat/outputs/elasticsearch/client.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/outputs"
 	"github.com/elastic/beats/libbeat/outputs/outil"
@@ -42,10 +43,11 @@ type Client struct {
 	Connection
 	tlsConfig *transport.TLSConfig
 
-	index    outil.Selector
-	pipeline *outil.Selector
-	params   map[string]string
-	timeout  time.Duration
+	index     outil.Selector
+	pipeline  *outil.Selector
+	params    map[string]string
+	timeout   time.Duration
+	eventType string
 
 	// buffered bulk requests
 	bulkRequ *bulkRequest
@@ -89,7 +91,7 @@ type Connection struct {
 	onConnectCallback func() error
 
 	encoder bodyEncoder
-	version string
+	version common.Version
 }
 
 type bulkIndexAction struct {
@@ -129,7 +131,9 @@ var (
 )
 
 const (
-	eventType = "doc"
+	defaultEventTypeES6 = "doc"
+	defaultEventTypeES7 = "_doc"
+	defaultEventType    = defaultEventTypeES7
 )
 
 // NewClient instantiates a new client.
@@ -214,6 +218,7 @@ func NewClient(
 		pipeline:  pipeline,
 		params:    params,
 		timeout:   s.Timeout,
+		eventType: defaultEventType,
 
 		bulkRequ: bulkRequ,
 
@@ -301,7 +306,7 @@ func (client *Client) publishEvents(
 	// events slice
 
 	origCount := len(data)
-	data = bulkEncodePublishRequest(body, client.index, client.pipeline, data)
+	data = bulkEncodePublishRequest(body, client.index, client.pipeline, client.eventType, data)
 	newCount := len(data)
 	if st != nil && origCount > newCount {
 		st.Dropped(origCount - newCount)
@@ -360,12 +365,13 @@ func bulkEncodePublishRequest(
 	body bulkWriter,
 	index outil.Selector,
 	pipeline *outil.Selector,
+	eventType string,
 	data []publisher.Event,
 ) []publisher.Event {
 	okEvents := data[:0]
 	for i := range data {
 		event := &data[i].Content
-		meta, err := createEventBulkMeta(index, pipeline, event)
+		meta, err := createEventBulkMeta(index, pipeline, eventType, event)
 		if err != nil {
 			logp.Err("Failed to encode event meta data: %s", err)
 			continue
@@ -382,6 +388,7 @@ func bulkEncodePublishRequest(
 func createEventBulkMeta(
 	indexSel outil.Selector,
 	pipelineSel *outil.Selector,
+	eventType string,
 	event *beat.Event,
 ) (interface{}, error) {
 	pipeline, err := getPipeline(event, pipelineSel)
@@ -627,8 +634,8 @@ func (client *Client) LoadJSON(path string, json map[string]interface{}) ([]byte
 	return body, nil
 }
 
-// GetVersion returns the elasticsearch version the client is connected to
-func (client *Client) GetVersion() string {
+// GetVersion returns the elasticsearch version the client is connected to.
+func (client *Client) GetVersion() common.Version {
 	return client.Connection.version
 }
 
@@ -660,7 +667,7 @@ func (client *Client) Test(d testing.Driver) {
 
 		err = client.Connect()
 		d.Fatal("talk to server", err)
-		d.Info("version", client.version)
+		d.Info("version", client.version.String())
 	})
 }
 
@@ -668,12 +675,38 @@ func (client *Client) String() string {
 	return "elasticsearch(" + client.Connection.URL + ")"
 }
 
-// Connect connects the client.
-func (conn *Connection) Connect() error {
-	var err error
-	conn.version, err = conn.Ping()
+// Connect connects the client. It runs a GET request against the root URL of
+// the configured host, updates the known Elasticsearch version and calls
+// globally configured handlers.
+func (client *Client) Connect() error {
+	err := client.Connection.Connect()
 	if err != nil {
 		return err
+	}
+
+	if client.GetVersion().Major < 7 {
+		client.eventType = defaultEventTypeES6
+	} else {
+		client.eventType = defaultEventType
+	}
+
+	return nil
+}
+
+// Connect connects the client. It runs a GET request against the root URL of
+// the configured host, updates the known Elasticsearch version and calls
+// globally configured handlers.
+func (conn *Connection) Connect() error {
+	versionString, err := conn.Ping()
+	if err != nil {
+		return err
+	}
+
+	if version, err := common.NewVersion(versionString); err != nil {
+		logp.Err("Invalid version from Elasticsearch: %v", versionString)
+		conn.version = common.Version{}
+	} else {
+		conn.version = *version
 	}
 
 	err = conn.onConnectCallback()
@@ -802,7 +835,9 @@ func (conn *Connection) execHTTPRequest(req *http.Request) (int, []byte, error) 
 	return status, obj, err
 }
 
-func (conn *Connection) GetVersion() string {
+// GetVersion returns the elasticsearch version the client is connected to.
+// The version is read and updated on 'Connect'.
+func (conn *Connection) GetVersion() common.Version {
 	return conn.version
 }
 

--- a/libbeat/outputs/elasticsearch/client_integration_test.go
+++ b/libbeat/outputs/elasticsearch/client_integration_test.go
@@ -21,7 +21,6 @@ package elasticsearch
 
 import (
 	"math/rand"
-	"strings"
 	"testing"
 	"time"
 
@@ -92,8 +91,8 @@ func TestClientPublishEventWithPipeline(t *testing.T) {
 	client.Delete(index, "", "", nil)
 
 	// Check version
-	if strings.HasPrefix(client.Connection.version, "2.") {
-		t.Skip("Skipping tests as pipeline not available in 2.x releases")
+	if client.Connection.version.Major < 5 {
+		t.Skip("Skipping tests as pipeline not available in <5.x releases")
 	}
 
 	publish := func(event beat.Event) {
@@ -173,8 +172,8 @@ func TestClientBulkPublishEventsWithPipeline(t *testing.T) {
 	})
 	client.Delete(index, "", "", nil)
 
-	if strings.HasPrefix(client.Connection.version, "2.") {
-		t.Skip("Skipping tests as pipeline not available in 2.x releases")
+	if client.Connection.version.Major < 5 {
+		t.Skip("Skipping tests as pipeline not available in <5.x releases")
 	}
 
 	publish := func(events ...beat.Event) {

--- a/libbeat/outputs/elasticsearch/client_test.go
+++ b/libbeat/outputs/elasticsearch/client_test.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
@@ -36,6 +37,7 @@ import (
 	"github.com/elastic/beats/libbeat/outputs/outest"
 	"github.com/elastic/beats/libbeat/outputs/outil"
 	"github.com/elastic/beats/libbeat/publisher"
+	"github.com/elastic/beats/libbeat/version"
 )
 
 func readStatusItem(in []byte) (int, string, error) {
@@ -378,4 +380,90 @@ func TestAddToURL(t *testing.T) {
 		url := addToURL(test.url, test.path, test.pipeline, test.params)
 		assert.Equal(t, url, test.expected)
 	}
+}
+
+type testBulkRecorder struct {
+	data     []interface{}
+	inAction bool
+}
+
+func TestBulkEncodeEvents(t *testing.T) {
+	cases := map[string]struct {
+		docType string
+		config  common.MapStr
+		events  []common.MapStr
+	}{
+		"ES 6.x event": {
+			docType: "doc",
+			config:  common.MapStr{},
+			events:  []common.MapStr{{"message": "test"}},
+		},
+		"ES 7.x event": {
+			docType: "_doc",
+			config:  common.MapStr{},
+			events:  []common.MapStr{{"message": "test"}},
+		},
+	}
+
+	for name, test := range cases {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			cfg := common.MustNewConfigFrom(test.config)
+
+			index, pipeline, err := buildSelectors(beat.Info{
+				IndexPrefix: "test",
+				Version:     version.GetDefaultVersion(),
+			}, cfg)
+			require.NoError(t, err)
+
+			events := make([]publisher.Event, len(test.events))
+			for i, fields := range test.events {
+				events[i] = publisher.Event{
+					Content: beat.Event{
+						Timestamp: time.Now(),
+						Fields:    fields,
+					},
+				}
+			}
+
+			recorder := &testBulkRecorder{}
+
+			encoded := bulkEncodePublishRequest(recorder, index, pipeline, test.docType, events)
+			assert.Equal(t, len(events), len(encoded), "all events should have been encoded")
+			assert.False(t, recorder.inAction, "incomplete bulk")
+
+			// check meta-data for each event
+			for i := 0; i < len(recorder.data); i += 2 {
+				var meta bulkEventMeta
+				switch v := recorder.data[i].(type) {
+				case bulkCreateAction:
+					meta = v.Create
+				case bulkIndexAction:
+					meta = v.Index
+				default:
+					panic("unknown type")
+				}
+
+				assert.NotEqual(t, "", meta.Index)
+				assert.Equal(t, test.docType, meta.DocType)
+			}
+
+			// TODO: customer per test case validation
+		})
+	}
+}
+
+func (r *testBulkRecorder) Add(meta, obj interface{}) error {
+	if r.inAction {
+		panic("can not add a new action if other action is active")
+	}
+
+	r.data = append(r.data, meta, obj)
+	return nil
+}
+
+func (r *testBulkRecorder) AddRaw(raw interface{}) error {
+	r.data = append(r.data)
+	r.inAction = !r.inAction
+	return nil
 }

--- a/libbeat/template/load.go
+++ b/libbeat/template/load.go
@@ -34,7 +34,7 @@ import (
 type ESClient interface {
 	LoadJSON(path string, json map[string]interface{}) ([]byte, error)
 	Request(method, path string, pipeline string, params map[string]string, body interface{}) (int, []byte, error)
-	GetVersion() string
+	GetVersion() common.Version
 }
 
 type Loader struct {
@@ -79,7 +79,8 @@ func (l *Loader) Load() error {
 	exists := l.CheckTemplate(templateName)
 	if !exists || l.config.Overwrite {
 
-		logp.Info("Loading template for Elasticsearch version: %s", l.client.GetVersion())
+		version := l.client.GetVersion()
+		logp.Info("Loading template for Elasticsearch version: %s", version.String())
 		if l.config.Overwrite {
 			logp.Info("Existing template will be overwritten, as overwrite is enabled.")
 		}

--- a/libbeat/template/template.go
+++ b/libbeat/template/template.go
@@ -51,7 +51,7 @@ type Template struct {
 }
 
 // New creates a new template instance
-func New(beatVersion string, beatName string, esVersion string, config TemplateConfig) (*Template, error) {
+func New(beatVersion string, beatName string, esVersion common.Version, config TemplateConfig) (*Template, error) {
 	bV, err := common.NewVersion(beatVersion)
 	if err != nil {
 		return nil, err
@@ -96,20 +96,15 @@ func New(beatVersion string, beatName string, esVersion string, config TemplateC
 	}
 
 	// In case no esVersion is set, it is assumed the same as beat version
-	if esVersion == "" {
-		esVersion = beatVersion
-	}
-
-	esV, err := common.NewVersion(esVersion)
-	if err != nil {
-		return nil, err
+	if !esVersion.IsValid() {
+		esVersion = *bV
 	}
 
 	return &Template{
 		pattern:     pattern,
 		name:        name,
 		beatVersion: *bV,
-		esVersion:   *esV,
+		esVersion:   esVersion,
 		config:      config,
 	}, nil
 }
@@ -210,19 +205,20 @@ func (t *Template) Generate(properties common.MapStr, dynamicTemplates []common.
 		indexSettings.Put("number_of_routing_shards", defaultNumberOfRoutingShards)
 	}
 
-	if t.esVersion.IsMajor(7) {
+	var mappingName string
+	major := t.esVersion.Major
+	switch {
+	case major < 6:
+		mappingName = "_default_"
+	case major == 6:
+		mappingName = "doc"
+	case major >= 7:
+		mappingName = "_doc"
 		defaultFields = append(defaultFields, "fields.*")
 		indexSettings.Put("query.default_field", defaultFields)
 	}
 
 	indexSettings.DeepUpdate(t.config.Settings.Index)
-
-	var mappingName string
-	if t.esVersion.Major >= 6 {
-		mappingName = "doc"
-	} else {
-		mappingName = "_default_"
-	}
 
 	// Load basic structure
 	basicStructure := common.MapStr{

--- a/libbeat/template/template_test.go
+++ b/libbeat/template/template_test.go
@@ -34,7 +34,8 @@ func TestNumberOfRoutingShards(t *testing.T) {
 	config := TemplateConfig{}
 
 	// Test it exists in 6.1
-	template, err := New(beatVersion, beatName, "6.1.0", config)
+	ver := common.MustNewVersion("6.1.0")
+	template, err := New(beatVersion, beatName, *ver, config)
 	assert.NoError(t, err)
 
 	data := template.Generate(nil, nil)
@@ -44,7 +45,8 @@ func TestNumberOfRoutingShards(t *testing.T) {
 	assert.Equal(t, 30, shards.(int))
 
 	// Test it does not exist in 6.0
-	template, err = New(beatVersion, beatName, "6.0.0", config)
+	ver = common.MustNewVersion("6.0.0")
+	template, err = New(beatVersion, beatName, *ver, config)
 	assert.NoError(t, err)
 
 	data = template.Generate(nil, nil)
@@ -64,7 +66,8 @@ func TestNumberOfRoutingShardsOverwrite(t *testing.T) {
 	}
 
 	// Test it exists in 6.1
-	template, err := New(beatVersion, beatName, "6.1.0", config)
+	ver := common.MustNewVersion("6.1.0")
+	template, err := New(beatVersion, beatName, *ver, config)
 	assert.NoError(t, err)
 
 	data := template.Generate(nil, nil)

--- a/metricbeat/mb/module/example_test.go
+++ b/metricbeat/mb/module/example_test.go
@@ -86,7 +86,7 @@ func ExampleWrapper() {
 	// {
 	//   "@metadata": {
 	//     "beat": "noindex",
-	//     "type": "doc",
+	//     "type": "_doc",
 	//     "version": "1.2.3"
 	//   },
 	//   "@timestamp": "2016-05-10T23:27:58.485Z",

--- a/metricbeat/tests/system/test_template.py
+++ b/metricbeat/tests/system/test_template.py
@@ -42,7 +42,7 @@ class Test(metricbeat.BaseTest):
 
         t = json.loads(template_content)
 
-        properties = t["mappings"]["doc"]["properties"]
+        properties = t["mappings"]["_doc"]["properties"]
 
         # Check libbeat fields
         assert properties["@timestamp"] == {"type": "date"}


### PR DESCRIPTION
Cherry-pick of PR #9056 to 6.x branch. Original message: 

Update the Elasticsearch output and template generator to set the type
to _doc if Elasticsearch major version is 7.