### PR TITLE
Add geo fields to `add_host_metadata` processor.

### DIFF
--- a/libbeat/docs/processors-using.asciidoc
+++ b/libbeat/docs/processors-using.asciidoc
@@ -895,6 +895,14 @@ processors:
 - add_host_metadata:
     netinfo.enabled: false
     cache.ttl: 5m
+    geo:
+      name: nyc-dc1-rack1
+      location: 40.7128, -74.0060
+      continent_name: North America
+      country_iso_code: US
+      region_name: New York
+      region_iso_code: NY
+      city_name: New York
 -------------------------------------------------------------------------------
 
 It has the following settings:
@@ -902,6 +910,23 @@ It has the following settings:
 `netinfo.enabled`:: (Optional) Default false. Include IP addresses and MAC addresses as fields host.ip and host.mac
 
 `cache.ttl`:: (Optional) The processor uses an internal cache for the host metadata. This sets the cache expiration time. The default is 5m, negative values disable caching altogether.
+
+`geo.name`:: User definable token to be used for identifying a discrete location. Frequently a datacenter, rack, or similar.
+
+`geo.location`:: Longitude and latitude in comma separated format.
+
+`geo.continent_name`:: Name of the continent.
+
+`geo.country_name`:: Name of the country.
+
+`geo.region_name`:: Name of the region.
+
+`geo.city_name`:: Name of the city.
+
+`geo.country_iso_code`:: ISO country code.
+
+`geo.region_iso_code`:: ISO region code.
+
 
 The `add_host_metadata` processor annotates each event with relevant metadata from the host machine.
 The fields added to the event are looking as following:
@@ -922,7 +947,16 @@ The fields added to the event are looking as following:
          "name":"Mac OS X"
       },
       "ip": ["192.168.0.1", "10.0.0.1"],
-      "mac": ["00:25:96:12:34:56", "72:00:06:ff:79:f1"]
+      "mac": ["00:25:96:12:34:56", "72:00:06:ff:79:f1"],
+      "geo": {
+          "continent_name": "North America",
+          "country_iso_code": "US",
+          "region_name": "New York",
+          "region_iso_code": "NY",
+          "city_name": "New York",
+          "name": "nyc-dc1-rack1",
+          "location": "40.7128, -74.0060"
+        }
    }
 }
 -------------------------------------------------------------------------------

--- a/libbeat/processors/add_host_metadata/add_host_metadata.go
+++ b/libbeat/processors/add_host_metadata/add_host_metadata.go
@@ -94,8 +94,10 @@ func newHostMetadataProcessor(cfg *common.Config) (processors.Processor, error) 
 			"city_name":        config.Geo.CityName,
 		}
 		// Delete any empty values
+		blankStringMatch := regexp.MustCompile(`^\s*$`)
 		for k, v := range geoFields {
-			if v == "" {
+			vStr := v.(string)
+			if blankStringMatch.MatchString(vStr) {
 				delete(geoFields, k)
 			}
 		}

--- a/libbeat/processors/add_host_metadata/add_host_metadata.go
+++ b/libbeat/processors/add_host_metadata/add_host_metadata.go
@@ -20,6 +20,7 @@ package add_host_metadata
 import (
 	"fmt"
 	"net"
+	"regexp"
 	"sync"
 	"time"
 
@@ -43,8 +44,9 @@ type addHostMetadata struct {
 		time.Time
 		sync.Mutex
 	}
-	data   common.MapStrPointer
-	config Config
+	data    common.MapStrPointer
+	geoData common.MapStr
+	config  Config
 }
 
 const (
@@ -62,6 +64,44 @@ func newHostMetadataProcessor(cfg *common.Config) (processors.Processor, error) 
 		data:   common.NewMapStrPointer(nil),
 	}
 	p.loadData()
+
+	if config.Geo != nil {
+		if len(config.Geo.Location) > 0 {
+			// Regexp matching a number with an optional decimal component
+			// Valid numbers: '123', '123.23', etc.
+			latOrLon := `\-?\d+(\.\d+)?`
+
+			// Regexp matching a pair of lat lon coordinates.
+			// e.g. 40.123, -92.929
+			locRegexp := `^\s*` + // anchor to start of string with optional whitespace
+				latOrLon + // match the latitude
+				`\s*\,\s*` + // match the separator. optional surrounding whitespace
+				latOrLon + // match the longitude
+				`\s*$` //optional whitespace then end anchor
+
+			if m, _ := regexp.MatchString(locRegexp, config.Geo.Location); !m {
+				return nil, errors.New(fmt.Sprintf("Invalid lat,lon  string for add_host_metadata: %s", config.Geo.Location))
+			}
+		}
+
+		geoFields := common.MapStr{
+			"name":             config.Geo.Name,
+			"location":         config.Geo.Location,
+			"continent_name":   config.Geo.ContinentName,
+			"country_iso_code": config.Geo.CountryISOCode,
+			"region_name":      config.Geo.RegionName,
+			"region_iso_code":  config.Geo.RegionISOCode,
+			"city_name":        config.Geo.CityName,
+		}
+		// Delete any empty values
+		for k, v := range geoFields {
+			if v == "" {
+				delete(geoFields, k)
+			}
+		}
+		p.geoData = common.MapStr{"host": common.MapStr{"geo": geoFields}}
+	}
+
 	return p, nil
 }
 
@@ -73,6 +113,10 @@ func (p *addHostMetadata) Run(event *beat.Event) (*beat.Event, error) {
 	}
 
 	event.Fields.DeepUpdate(p.data.Get().Clone())
+
+	if len(p.geoData) > 0 {
+		event.Fields.DeepUpdate(p.geoData)
+	}
 	return event, nil
 }
 

--- a/libbeat/processors/add_host_metadata/add_host_metadata_test.go
+++ b/libbeat/processors/add_host_metadata/add_host_metadata_test.go
@@ -18,9 +18,12 @@
 package add_host_metadata
 
 import (
+	"fmt"
 	"runtime"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/stretchr/testify/assert"
 
@@ -111,4 +114,70 @@ func TestConfigNetInfoEnabled(t *testing.T) {
 	v, err = newEvent.GetValue("host.mac")
 	assert.NoError(t, err)
 	assert.NotNil(t, v)
+}
+
+func TestConfigGeoEnabled(t *testing.T) {
+	event := &beat.Event{
+		Fields:    common.MapStr{},
+		Timestamp: time.Now(),
+	}
+
+	config := map[string]interface{}{
+		"geo.name":             "yerevan-am",
+		"geo.location":         "40.177200, 44.503490",
+		"geo.continent_name":   "Asia",
+		"geo.country_iso_code": "AM",
+		"geo.region_name":      "Erevan",
+		"geo.region_iso_code":  "AM-ER",
+		"geo.city_name":        "Yerevan",
+	}
+
+	testConfig, err := common.NewConfigFrom(config)
+	assert.NoError(t, err)
+
+	p, err := newHostMetadataProcessor(testConfig)
+	require.NoError(t, err)
+
+	newEvent, err := p.Run(event)
+	assert.NoError(t, err)
+
+	for configKey, configValue := range config {
+		t.Run(fmt.Sprintf("Check of %s", configKey), func(t *testing.T) {
+			v, err := newEvent.GetValue(fmt.Sprintf("host.%s", configKey))
+			assert.NoError(t, err)
+			assert.Equal(t, configValue, v, "Could not find in %s", newEvent)
+		})
+	}
+}
+
+func TestGeoLocationValidation(t *testing.T) {
+	locations := []struct {
+		str   string
+		valid bool
+	}{
+		{"40.177200, 44.503490", true},
+		{"-40.177200, -44.503490", true},
+		{"garbage", false},
+		{"9999999999", false},
+	}
+
+	for _, location := range locations {
+		t.Run(fmt.Sprintf("Location %s validation should be %t", location.str, location.valid), func(t *testing.T) {
+
+			conf, err := common.NewConfigFrom(map[string]interface{}{
+				"geo": map[string]interface{}{
+					"location": location.str,
+				},
+			})
+			require.NoError(t, err)
+
+			_, err = newHostMetadataProcessor(conf)
+
+			if location.valid {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
+		})
+	}
 }

--- a/libbeat/processors/add_host_metadata/config.go
+++ b/libbeat/processors/add_host_metadata/config.go
@@ -25,6 +25,18 @@ import (
 type Config struct {
 	NetInfoEnabled bool          `config:"netinfo.enabled"` // Add IP and MAC to event
 	CacheTTL       time.Duration `config:"cache.ttl"`
+	Geo            *GeoConfig    `config:"geo"`
+}
+
+// GeoConfig contains geo configuration data.
+type GeoConfig struct {
+	Name           string `config:"name"`
+	Location       string `config:"location"`
+	ContinentName  string `config:"continent_name"`
+	CountryISOCode string `config:"country_iso_code"`
+	RegionName     string `config:"region_name"`
+	RegionISOCode  string `config:"region_iso_code"`
+	CityName       string `config:"city_name"`
 }
 
 func defaultConfig() Config {


### PR DESCRIPTION
** EDIT ** I've left the original issue below the break, but after discussion we added geo fields to the `add_host_metadata` processor instead of a new one. *Original is below*

-----

This carries over from the discussion from https://github.com/elastic/beats/pull/8620 .

This adds a new processor that lets users easily add geo fields associated with the host that created the event.  You would use it like so:

```
processors:
  - add_host_geo:
      name: MN HQ
      location: "44.977753, -93.265015"
```

It's debate-able whether ECS should actually let you put these under perhaps `agent.geo`. That's something we should discuss here.

One other question here, should we just fold this functionality under `add_host_metadata`? I believe that probably makes more sense. We agreed in elastic/beats#8620 to make this a separate processor, but with the data nested under host, that makes less sense IMHO.
