### PR TITLE
Update Kibana and Elasticsearch to 6.4.3 for testing in Metricbeat

### DIFF
--- a/metricbeat/module/elasticsearch/_meta/Dockerfile
+++ b/metricbeat/module/elasticsearch/_meta/Dockerfile
@@ -1,2 +1,2 @@
-FROM docker.elastic.co/elasticsearch/elasticsearch:6.3.0
+FROM docker.elastic.co/elasticsearch/elasticsearch:6.4.3
 HEALTHCHECK --interval=1s --retries=300 CMD curl -f http://localhost:9200

--- a/metricbeat/module/kibana/_meta/Dockerfile
+++ b/metricbeat/module/kibana/_meta/Dockerfile
@@ -1,2 +1,2 @@
-FROM docker.elastic.co/kibana/kibana:6.3.0
+FROM docker.elastic.co/kibana/kibana:6.4.3
 HEALTHCHECK --interval=1s --retries=300 CMD curl -f http://localhost:5601/api/status | grep '"disconnects"'


### PR DESCRIPTION
In a follow up PR support for alias fields is needed. Picking 6.4.3 as it seems some tests in Metricbeat are failing with 6.5.1 (most recent) and I leave it to the stack-monitoring team to fix these.