### PR TITLE
Revert "Bump docs version for 5.6.14"

### DIFF
--- a/libbeat/docs/version.asciidoc
+++ b/libbeat/docs/version.asciidoc
@@ -1,4 +1,4 @@
-:stack-version: 5.6.14
+:stack-version: 5.6.13
 :doc-branch: 5.6
 :go-version: 1.7.6
 :release-state: released


### PR DESCRIPTION
Reverts elastic/beats#9311

Need to revert because 5.6.14 did not go out today.