### PR TITLE
Cherry-pick #9383 to 6.x: Assume all swap memory is free on values overflow

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -40,6 +40,7 @@ https://github.com/elastic/beats/compare/v6.5.0...6.x[Check the HEAD diff]
 - Propagate Sync error when running SafeFileRotate. {pull}9069[9069]
 - Log events at the debug level when dropped by encoding problems. {pull}9251[9251]
 - Refresh host metadata in add_host_metadata. {pull}9359[9359]
+- When collecting swap metrics for beats telemetry or system metricbeat module handle cases of free swap being bigger than total swap by assuming no swap is being used. {issue}6271[6271] {pull}9383[9383]
 
 *Auditbeat*
 


### PR DESCRIPTION
Cherry-pick of PR #9383 to 6.x branch. Original message: 

There have been reports about user swap memory being a value that looks
like an overflow. At the moment used swap memory is calculated as the
value of total memory minus the free memory, so this means that free
memory is bigger than total in some cases. This isn't possible in
principle. Assume that no swap is being used if that happens.

Closes #6271 