### PR TITLE
make function to return an error instead of panic

### DIFF
--- a/dev-tools/mage/settings.go
+++ b/dev-tools/mage/settings.go
@@ -265,20 +265,21 @@ func findElasticBeatsDir() (string, error) {
 
 // SetElasticBeatsDir explicitly sets the location of the Elastic Beats
 // directory. If not set then it will attempt to locate it.
-func SetElasticBeatsDir(dir string) {
+func SetElasticBeatsDir(dir string) error {
 	elasticBeatsDirLock.Lock()
 	defer elasticBeatsDirLock.Unlock()
 
 	info, err := os.Stat(dir)
 	if err != nil {
-		panic(errors.Wrapf(err, "failed to read elastic beats dir at %v", dir))
+		return errors.Wrapf(err, "failed to read elastic beats dir at %v", dir)
 	}
 
 	if !info.IsDir() {
-		panic(errors.Errorf("elastic beats dir=%v is not a directory", dir))
+		return errors.Errorf("elastic beats dir=%v is not a directory", dir)
 	}
 
 	elasticBeatsDirValue = filepath.Clean(dir)
+	return nil
 }
 
 var (


### PR DESCRIPTION
Used like this https://github.com/elastic/apm-server/pull/1629/commits/4530fa01b51926388e20a32a8752030cebb842f6#diff-3db01cb68c42f27f6422c65fa1175e23R37, 
needed to find the `_beats` folder from the `x-pack` one.

Let me know if there is a better way to accomplish this!