### PR TITLE
Add note regarding using cross-cluster replication

### DIFF
--- a/libbeat/docs/template-config.asciidoc
+++ b/libbeat/docs/template-config.asciidoc
@@ -69,6 +69,11 @@ setup.template.settings:
   index.number_of_replicas: 1
 ----------------------------------------------------------------------
 
+NOTE: If you want to use {stack-ov}/xpack-ccr.html[{ccr}] to replicate {beatname_uc}
+indices to another cluster, you will need to add additional template settings to
+{stack-ov}/ccr-requirements.html#ccr-overview-beats[enable soft deletes] on the
+underlying indices.
+
 *`setup.template.settings._source`*:: A dictionary of settings for the `_source` field. For the available settings,
 please see the Elasticsearch {elasticsearch}/mapping-source-field.html[reference].
 +


### PR DESCRIPTION
This commit adds a note to the docs template for the index templates that explains that changes are needed if a user wants to replicate an index using cross-cluster replication.

Relates #9427