### PR TITLE
Fix link to developer changelog

### DIFF
--- a/docs/devguide/contributing.asciidoc
+++ b/docs/devguide/contributing.asciidoc
@@ -147,4 +147,4 @@ In most cases `govendor fetch your/dependency@version +out` will get the job don
 
 To keep up to date with changes to the official Beats for community developers,
 follow the developer changelog
- https://github.com/elastic/beats/blob/master/CHANGELOG-developer.asciidoc[here].
+https://github.com/elastic/beats/blob/master/CHANGELOG-developer.asciidoc[here].

--- a/docs/devguide/contributing.asciidoc
+++ b/docs/devguide/contributing.asciidoc
@@ -147,4 +147,4 @@ In most cases `govendor fetch your/dependency@version +out` will get the job don
 
 To keep up to date with changes to the official Beats for community developers,
 follow the developer changelog
-https://raw.githubusercontent.com/elastic/beats/master/CHANGELOG-developer.asciidoc[here].
+ https://github.com/elastic/beats/blob/master/CHANGELOG-developer.asciidoc[here].

--- a/docs/devguide/contributing.asciidoc
+++ b/docs/devguide/contributing.asciidoc
@@ -147,4 +147,4 @@ In most cases `govendor fetch your/dependency@version +out` will get the job don
 
 To keep up to date with changes to the official Beats for community developers,
 follow the developer changelog
-https://github.com/elastic/beats/blob/master/CHANGELOG-developer.md[here].
+https://raw.githubusercontent.com/elastic/beats/master/CHANGELOG-developer.asciidoc[here].


### PR DESCRIPTION
The previous URL was 404ing. :) 