### PR TITLE
Add ECS fields to libbeat/fields.yml

### DIFF
--- a/libbeat/generator/fields/fields.go
+++ b/libbeat/generator/fields/fields.go
@@ -32,12 +32,11 @@ type YmlFile struct {
 }
 
 func collectCommonFiles(esBeatsPath, beatPath string, fieldFiles []*YmlFile) ([]*YmlFile, error) {
-	var commonFields []string
 	var libbeatFieldFiles []*YmlFile
 	var err error
+	commonFields := []string{filepath.Join(esBeatsPath, "libbeat/_meta/fields.ecs.yml")}
 	if !isLibbeat(beatPath) {
 		commonFields = append(commonFields,
-			filepath.Join(esBeatsPath, "libbeat/_meta/fields.ecs.yml"),
 			filepath.Join(esBeatsPath, "libbeat/_meta/fields.common.yml"),
 		)
 


### PR DESCRIPTION
This adds the fields from ECS also to the libbeat/fields.yml. This is needed to have template tests with ECS fields inside.

This is only relevant for testing and makes no difference to the Beats.