### PR TITLE
[Auditbeat] Opt-in to detecting password changes

### DIFF
--- a/x-pack/auditbeat/auditbeat.reference.yml
+++ b/x-pack/auditbeat/auditbeat.reference.yml
@@ -119,6 +119,8 @@ auditbeat.modules:
 
   state.period: 12h
 
+  user.detect_password_changes: false
+
   report_changes: true
 
 

--- a/x-pack/auditbeat/auditbeat.reference.yml
+++ b/x-pack/auditbeat/auditbeat.reference.yml
@@ -119,7 +119,10 @@ auditbeat.modules:
 
   state.period: 12h
 
-  user.detect_password_changes: false
+  # Enabled by default. Auditbeat will read password fields in
+  # /etc/passwd and /etc/shadow and store a hash locally to
+  # detect any changes.
+  user.detect_password_changes: true
 
   report_changes: true
 

--- a/x-pack/auditbeat/auditbeat.yml
+++ b/x-pack/auditbeat/auditbeat.yml
@@ -57,6 +57,8 @@ auditbeat.modules:
 
   state.period: 12h
 
+  user.detect_password_changes: false
+
   report_changes: true
 
 

--- a/x-pack/auditbeat/auditbeat.yml
+++ b/x-pack/auditbeat/auditbeat.yml
@@ -57,7 +57,10 @@ auditbeat.modules:
 
   state.period: 12h
 
-  user.detect_password_changes: false
+  # Enabled by default. Auditbeat will read password fields in
+  # /etc/passwd and /etc/shadow and store a hash locally to
+  # detect any changes.
+  user.detect_password_changes: true
 
   report_changes: true
 

--- a/x-pack/auditbeat/module/system/_meta/config.yml.tmpl
+++ b/x-pack/auditbeat/module/system/_meta/config.yml.tmpl
@@ -15,9 +15,10 @@
   state.period: 12h
 
   {{ if eq .GOOS "linux" -}}
-  # When set to true, detects changes to password fields in
-  # /etc/passwd and /etc/shadow.
-  user.detect_password_changes: false
+  # Enabled by default. Auditbeat will read password fields in
+  # /etc/passwd and /etc/shadow and store a hash locally to
+  # detect any changes.
+  user.detect_password_changes: true
   {{- end }}
 
   report_changes: true

--- a/x-pack/auditbeat/module/system/_meta/config.yml.tmpl
+++ b/x-pack/auditbeat/module/system/_meta/config.yml.tmpl
@@ -14,6 +14,10 @@
 
   state.period: 12h
 
+  {{ if eq .GOOS "linux" -}}
+  user.detect_password_changes: false
+  {{- end }}
+
   report_changes: true
 {{- end }}
 {{ if .Reference }}

--- a/x-pack/auditbeat/module/system/_meta/config.yml.tmpl
+++ b/x-pack/auditbeat/module/system/_meta/config.yml.tmpl
@@ -15,6 +15,8 @@
   state.period: 12h
 
   {{ if eq .GOOS "linux" -}}
+  # When set to true, detects changes to password fields in
+  # /etc/passwd and /etc/shadow.
   user.detect_password_changes: false
   {{- end }}
 

--- a/x-pack/auditbeat/module/system/user/config.go
+++ b/x-pack/auditbeat/module/system/user/config.go
@@ -15,11 +15,6 @@ type config struct {
 	DetectPasswordChanges bool          `config:"user.detect_password_changes"`
 }
 
-// validate validates the host metricset config.
-func (c *config) validate() error {
-	return nil
-}
-
 func (c *config) effectiveStatePeriod() time.Duration {
 	if c.UserStatePeriod != 0 {
 		return c.UserStatePeriod

--- a/x-pack/auditbeat/module/system/user/config.go
+++ b/x-pack/auditbeat/module/system/user/config.go
@@ -8,24 +8,28 @@ import (
 	"time"
 )
 
-// Config defines the metricset's configuration options.
-type Config struct {
-	StatePeriod     time.Duration `config:"state.period"`
-	UserStatePeriod time.Duration `config:"user.state.period"`
+// config defines the metricset's configuration options.
+type config struct {
+	StatePeriod           time.Duration `config:"state.period"`
+	UserStatePeriod       time.Duration `config:"user.state.period"`
+	DetectPasswordChanges bool          `config:"user.detect_password_changes"`
 }
 
-// Validate validates the host metricset config.
-func (c *Config) Validate() error {
+// validate validates the host metricset config.
+func (c *config) validate() error {
 	return nil
 }
 
-func (c *Config) effectiveStatePeriod() time.Duration {
+func (c *config) effectiveStatePeriod() time.Duration {
 	if c.UserStatePeriod != 0 {
 		return c.UserStatePeriod
 	}
 	return c.StatePeriod
 }
 
-var defaultConfig = Config{
-	StatePeriod: 12 * time.Hour,
+func defaultConfig() config {
+	return config{
+		StatePeriod:           12 * time.Hour,
+		DetectPasswordChanges: false,
+	}
 }

--- a/x-pack/auditbeat/module/system/user/user.go
+++ b/x-pack/auditbeat/module/system/user/user.go
@@ -102,7 +102,7 @@ func (user User) Hash() uint64 {
 	h := xxhash.New64()
 	// Use everything except userInfo
 	h.WriteString(user.Name)
-	binary.Write(h, binary.BigEndian, user.PasswordType)
+	binary.Write(h, binary.BigEndian, uint8(user.PasswordType))
 	h.WriteString(user.PasswordChanged.String())
 	h.Write(user.PasswordHashHash)
 	h.WriteString(strconv.Itoa(int(user.UID)))

--- a/x-pack/auditbeat/module/system/user/user.go
+++ b/x-pack/auditbeat/module/system/user/user.go
@@ -54,7 +54,7 @@ const (
 type passwordType uint8
 
 const (
-	detectionDisabled passwordType = iota + 1
+	detectionDisabled passwordType = iota
 	shadowPassword
 	passwordDisabled
 	noPassword

--- a/x-pack/auditbeat/module/system/user/user.go
+++ b/x-pack/auditbeat/module/system/user/user.go
@@ -46,10 +46,35 @@ const (
 	eventActionPasswordChanged = "password_changed"
 )
 
+type passwordType uint8
+
+const (
+	detectionDisabled passwordType = iota + 1
+	shadowPassword
+	passwordDisabled
+	noPassword
+	cryptPassword
+)
+
+func (t passwordType) string() string {
+	switch t {
+	case shadowPassword:
+		return "shadow_password"
+	case passwordDisabled:
+		return "password_disabled"
+	case noPassword:
+		return "no_password"
+	case cryptPassword:
+		return "crypt_password"
+	default:
+		return ""
+	}
+}
+
 // User represents a user. Fields according to getpwent(3).
 type User struct {
 	Name             string
-	PasswordType     string
+	PasswordType     passwordType
 	PasswordChanged  time.Time
 	PasswordHashHash []byte
 	UID              uint32
@@ -72,7 +97,7 @@ func (user User) Hash() uint64 {
 	h := xxhash.New64()
 	// Use everything except userInfo
 	h.WriteString(user.Name)
-	h.WriteString(user.PasswordType)
+	h.WriteString(user.PasswordType.string())
 	h.WriteString(user.PasswordChanged.String())
 	h.Write(user.PasswordHashHash)
 	h.WriteString(strconv.Itoa(int(user.UID)))
@@ -90,10 +115,7 @@ func (user User) Hash() uint64 {
 
 func (user User) toMapStr() common.MapStr {
 	evt := common.MapStr{
-		"name": user.Name,
-		"password": common.MapStr{
-			"type": user.PasswordType,
-		},
+		"name":  user.Name,
 		"uid":   user.UID,
 		"gid":   user.GID,
 		"dir":   user.Dir,
@@ -102,6 +124,10 @@ func (user User) toMapStr() common.MapStr {
 
 	if user.UserInfo != "" {
 		evt.Put("user_information", user.UserInfo)
+	}
+
+	if user.PasswordType != detectionDisabled {
+		evt.Put("password.type", user.PasswordType.string())
 	}
 
 	if !user.PasswordChanged.IsZero() {
@@ -131,7 +157,7 @@ func init() {
 // MetricSet collects data about a system's users.
 type MetricSet struct {
 	mb.BaseMetricSet
-	config     Config
+	config     config
 	log        *logp.Logger
 	cache      *cache.Cache
 	bucket     datastore.Bucket
@@ -146,7 +172,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 		return nil, fmt.Errorf("the %v/%v dataset is only supported on Linux", moduleName, metricsetName)
 	}
 
-	config := defaultConfig
+	config := defaultConfig()
 	if err := base.Module().UnpackConfig(&config); err != nil {
 		return nil, errors.Wrapf(err, "failed to unpack the %v/%v config", moduleName, metricsetName)
 	}
@@ -224,7 +250,7 @@ func (ms *MetricSet) Fetch(report mb.ReporterV2) {
 func (ms *MetricSet) reportState(report mb.ReporterV2) error {
 	ms.lastState = time.Now()
 
-	users, err := GetUsers()
+	users, err := GetUsers(ms.config.DetectPasswordChanges)
 	if err != nil {
 		return errors.Wrap(err, "failed to get users")
 	}
@@ -261,7 +287,7 @@ func (ms *MetricSet) reportState(report mb.ReporterV2) error {
 // reportChanges detects and reports any changes to users on this system since the last call.
 func (ms *MetricSet) reportChanges(report mb.ReporterV2) error {
 	currentTime := time.Now()
-	changed, err := haveFilesChanged(ms.lastChange)
+	changed, err := ms.haveFilesChanged(ms.lastChange)
 	if err != nil {
 		return err
 	}
@@ -270,7 +296,7 @@ func (ms *MetricSet) reportChanges(report mb.ReporterV2) error {
 	}
 	ms.lastChange = currentTime
 
-	users, err := GetUsers()
+	users, err := GetUsers(ms.config.DetectPasswordChanges)
 	if err != nil {
 		return errors.Wrap(err, "failed to get users")
 	}
@@ -287,25 +313,31 @@ func (ms *MetricSet) reportChanges(report mb.ReporterV2) error {
 
 		for _, userFromCache := range newInCache {
 			newUser := userFromCache.(*User)
-			matchingMissingUser, found := missingUserMap[newUser.UID]
+			oldUser, found := missingUserMap[newUser.UID]
 
 			if found {
 				// Report password change separately
-				if newUser.PasswordChanged.Before(matchingMissingUser.PasswordChanged) ||
-					!bytes.Equal(newUser.PasswordHashHash, matchingMissingUser.PasswordHashHash) ||
-					newUser.PasswordType != matchingMissingUser.PasswordType {
-					report.Event(userEvent(newUser, eventTypeEvent, eventActionPasswordChanged))
+				if ms.config.DetectPasswordChanges && newUser.PasswordType != detectionDisabled &&
+					oldUser.PasswordType != detectionDisabled {
+
+					passwordChanged := newUser.PasswordChanged.Before(oldUser.PasswordChanged) ||
+						!bytes.Equal(newUser.PasswordHashHash, oldUser.PasswordHashHash) ||
+						newUser.PasswordType != oldUser.PasswordType
+
+					if passwordChanged {
+						report.Event(userEvent(newUser, eventTypeEvent, eventActionPasswordChanged))
+					}
 				}
 
 				// Hack to check if only the password changed
-				matchingMissingUser.PasswordChanged = newUser.PasswordChanged
-				matchingMissingUser.PasswordHashHash = newUser.PasswordHashHash
-				matchingMissingUser.PasswordType = newUser.PasswordType
-				if newUser.Hash() != matchingMissingUser.Hash() {
+				oldUser.PasswordChanged = newUser.PasswordChanged
+				oldUser.PasswordHashHash = newUser.PasswordHashHash
+				oldUser.PasswordType = newUser.PasswordType
+				if newUser.Hash() != oldUser.Hash() {
 					report.Event(userEvent(newUser, eventTypeEvent, eventActionUserChanged))
 				}
 
-				delete(missingUserMap, matchingMissingUser.UID)
+				delete(missingUserMap, oldUser.UID)
 			} else {
 				report.Event(userEvent(newUser, eventTypeEvent, eventActionUserAdded))
 			}
@@ -411,7 +443,7 @@ func (ms *MetricSet) saveUsersToDisk(users []*User) error {
 
 // haveFilesChanged checks if any of the relevant files (/etc/passwd, /etc/shadow, /etc/group)
 // have changed.
-func haveFilesChanged(since time.Time) (bool, error) {
+func (ms *MetricSet) haveFilesChanged(since time.Time) (bool, error) {
 	const passwdFile = "/etc/passwd"
 	const shadowFile = "/etc/shadow"
 	const groupFile = "/etc/group"
@@ -424,11 +456,13 @@ func haveFilesChanged(since time.Time) (bool, error) {
 		return true, nil
 	}
 
-	if err := syscall.Stat(shadowFile, &stats); err != nil {
-		return true, errors.Wrapf(err, "failed to stat %v", shadowFile)
-	}
-	if since.Before(time.Unix(stats.Ctim.Sec, stats.Ctim.Nsec)) {
-		return true, nil
+	if ms.config.DetectPasswordChanges {
+		if err := syscall.Stat(shadowFile, &stats); err != nil {
+			return true, errors.Wrapf(err, "failed to stat %v", shadowFile)
+		}
+		if since.Before(time.Unix(stats.Ctim.Sec, stats.Ctim.Nsec)) {
+			return true, nil
+		}
 	}
 
 	if err := syscall.Stat(groupFile, &stats); err != nil {

--- a/x-pack/auditbeat/module/system/user/user.go
+++ b/x-pack/auditbeat/module/system/user/user.go
@@ -132,7 +132,7 @@ func (user User) toMapStr() common.MapStr {
 	}
 
 	if user.PasswordType != detectionDisabled {
-		evt.Put("password.type", user.PasswordType.string())
+		evt.Put("password.type", user.PasswordType.String())
 	}
 
 	if !user.PasswordChanged.IsZero() {

--- a/x-pack/auditbeat/module/system/user/user.go
+++ b/x-pack/auditbeat/module/system/user/user.go
@@ -61,7 +61,7 @@ const (
 	cryptPassword
 )
 
-func (t passwordType) string() string {
+func (t passwordType) String() string {
 	switch t {
 	case shadowPassword:
 		return "shadow_password"

--- a/x-pack/auditbeat/module/system/user/users_linux.go
+++ b/x-pack/auditbeat/module/system/user/users_linux.go
@@ -27,8 +27,8 @@ var (
 
 // GetUsers retrieves a list of users using information from
 // /etc/passwd, /etc/group, and - if configured - /etc/shadow.
-func GetUsers(readPassword bool) ([]*User, error) {
-	users, err := readPasswdFile(readPassword)
+func GetUsers(readPasswords bool) ([]*User, error) {
+	users, err := readPasswdFile(readPasswords)
 	if err != nil {
 		return nil, err
 	}
@@ -38,7 +38,7 @@ func GetUsers(readPassword bool) ([]*User, error) {
 		return nil, err
 	}
 
-	if readPassword {
+	if readPasswords {
 		err = enrichWithShadow(users)
 		if err != nil {
 			return nil, err
@@ -48,7 +48,7 @@ func GetUsers(readPassword bool) ([]*User, error) {
 	return users, nil
 }
 
-func readPasswdFile(readPassword bool) ([]*User, error) {
+func readPasswdFile(readPasswords bool) ([]*User, error) {
 	var users []*User
 
 	C.setpwent()
@@ -69,7 +69,7 @@ func readPasswdFile(readPassword bool) ([]*User, error) {
 			Shell:    C.GoString(passwd.pw_shell),
 		}
 
-		if readPassword {
+		if readPasswords {
 			switch C.GoString(passwd.pw_passwd) {
 			case "x":
 				user.PasswordType = shadowPassword
@@ -219,8 +219,8 @@ func readShadowFile() (map[string]shadowFileEntry, error) {
 // multiRoundHash performs 10 rounds of SHA-512 hashing.
 func multiRoundHash(s string) []byte {
 	hash := sha512.Sum512([]byte(s))
-	for i := 9; i > 0; i++ {
-		hash = sha512.Sum512(hash)
+	for i := 0; i < 9; i++ {
+		hash = sha512.Sum512(hash[:])
 	}
 	return hash[:]
 }

--- a/x-pack/auditbeat/module/system/user/users_linux.go
+++ b/x-pack/auditbeat/module/system/user/users_linux.go
@@ -129,7 +129,6 @@ func enrichWithShadow(users []*User) error {
 				} else if strings.HasPrefix(shadow.Password, "!") || strings.HasPrefix(shadow.Password, "*") {
 					user.PasswordType = passwordDisabled
 				} else {
-
 					user.PasswordHashHash = multiRoundHash(shadow.Password)
 				}
 			}


### PR DESCRIPTION
This introduces a `user.detect_password_changes` config parameter to the system module. Its default is `false`, and without it being explicitly turned on, the code will not read the `password` field in `/etc/passwd` nor `/etc/shadow` and so will not emit any `password_changed` events.

In addition, when detecting passwords is turned on, we will now do 10 rounds of SHA-512 hashing before storing a hash of the password field value.