### PR TITLE
Cherry-pick to 6.x: Add OS Name into add-host-metadata (#9405)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -109,6 +109,7 @@ https://github.com/elastic/beats/compare/v6.5.0...6.x[Check the HEAD diff]
 - Test etcd module with etcd 3.3. {pull}9068[9068]
 - Add setting to disable docker cpu metrics per core. {pull}9194[9194]
 - The `elasticsearch/node` metricset now reports the Elasticsearch cluster UUID. {pull}8771[8771]
+- Add `host.os.name` field to add_host_metadata processor. {issue}8948[8948] {pull}9405[9405]
 
 *Packetbeat*
 

--- a/libbeat/docs/processors-using.asciidoc
+++ b/libbeat/docs/processors-using.asciidoc
@@ -917,7 +917,8 @@ The fields added to the event are looking as following:
          "family":"darwin",
          "build":"16G1212",
          "platform":"darwin",
-         "version":"10.12.6"
+         "version":"10.12.6",
+         "name":"Mac OS X"
       },
       "ip": ["192.168.0.1", "10.0.0.1"],
       "mac": ["00:25:96:12:34:56", "72:00:06:ff:79:f1"]

--- a/libbeat/metric/system/host/host.go
+++ b/libbeat/metric/system/host/host.go
@@ -34,6 +34,7 @@ func MapHostInfo(info types.HostInfo) common.MapStr {
 				"platform": info.OS.Platform,
 				"version":  info.OS.Version,
 				"family":   info.OS.Family,
+				"name":     info.OS.Name,
 			},
 		},
 	}
@@ -72,6 +73,7 @@ func ReportInfo(_ monitoring.Mode, V monitoring.Visitor) {
 		monitoring.ReportString(V, "platform", info.OS.Platform)
 		monitoring.ReportString(V, "version", info.OS.Version)
 		monitoring.ReportString(V, "family", info.OS.Family)
+		monitoring.ReportString(V, "name", info.OS.Name)
 
 		if info.OS.Codename != "" {
 			monitoring.ReportString(V, "codename", info.OS.Codename)

--- a/libbeat/processors/add_host_metadata/add_host_metadata_test.go
+++ b/libbeat/processors/add_host_metadata/add_host_metadata_test.go
@@ -51,6 +51,10 @@ func TestConfigDefault(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, v)
 
+	v, err = newEvent.GetValue("host.os.name")
+	assert.NoError(t, err)
+	assert.NotNil(t, v)
+
 	v, err = newEvent.GetValue("host.ip")
 	assert.Error(t, err)
 	assert.Nil(t, v)
@@ -81,6 +85,10 @@ func TestConfigNetInfoEnabled(t *testing.T) {
 	assert.NoError(t, err)
 
 	v, err := newEvent.GetValue("host.os.family")
+	assert.NoError(t, err)
+	assert.NotNil(t, v)
+
+	v, err = newEvent.GetValue("host.os.name")
 	assert.NoError(t, err)
 	assert.NotNil(t, v)
 


### PR DESCRIPTION
* Add OS Name into add-host-metadat

* Run gofmt

* Add changelog and update documentation

* Update changelog

(cherry picked from commit 2a9c2178d51721be310bf39ae71112d85a87272c)