### PR TITLE
Backport to 6.5: [Docs] Fix example config download link (#9472)

### DIFF
--- a/libbeat/docs/shared-docker.asciidoc
+++ b/libbeat/docs/shared-docker.asciidoc
@@ -102,7 +102,7 @@ Download this example configuration file as a starting point:
 
 ["source","sh",subs="attributes,callouts"]
 ------------------------------------------------
-curl -L -O https://raw.githubusercontent.com/elastic/beats/deploy/docker/{beatname_lc}.docker.yml
+curl -L -O https://raw.githubusercontent.com/elastic/beats/{doc-branch}/deploy/docker/{beatname_lc}.docker.yml
 ------------------------------------------------
 
 ===== Volume-mounted configuration


### PR DESCRIPTION
Cherrry-picks #9472 into 6.5 branch