### PR TITLE
Docs: include callouts in ifeval

### DIFF
--- a/libbeat/docs/shared-docker.asciidoc
+++ b/libbeat/docs/shared-docker.asciidoc
@@ -76,12 +76,12 @@ docker run \
   setup -E setup.kibana.host=kibana:5601 \
   -E output.elasticsearch.hosts=["elasticsearch:9200"] <1> <2>
 --------------------------------------------
-endif::[]
 
 <1> Substitute your Kibana and Elasticsearch hosts and ports.
 <2> If you are using the hosted Elasticsearch Service in Elastic Cloud, replace
 the `-E output.elasticsearch.hosts` line with the Cloud ID and elastic password
 using this syntax:
+endif::[]
 
 [source,shell]
 --------------------------------------------
@@ -183,12 +183,12 @@ docker run -d \
   --strict.perms=false -e \
   -E output.elasticsearch.hosts=["elasticsearch:9200"] <1> <2>
 --------------------------------------------
-endif::[]
 
 <1> Substitute your Elasticsearch hosts and ports.
 <2> If you are using the hosted Elasticsearch Service in Elastic Cloud, replace
 the `-E output.elasticsearch.hosts` line with the Cloud ID and elastic password
 using the syntax shown earlier.
+endif::[]
 
 ===== Customize your configuration
 


### PR DESCRIPTION
#9391 introduced new conditional rendering. Some of the `ifeval` blocks include code, but not the callouts that reference the code. If the `ifeval` evaluates to false, the asciidoc build throws `element callout validity` errors. Fixed by moving the `endif::[]` to after the callouts. 