### PR TITLE
[Docs] Improve description of paths option and add examples

### DIFF
--- a/filebeat/docs/include/var-paths.asciidoc
+++ b/filebeat/docs/include/var-paths.asciidoc
@@ -1,4 +1,9 @@
 *`var.paths`*::
 
-An array of paths that specify where to look for the log files. If left empty,
-Filebeat will choose the paths depending on your operating systems.
+An array of glob-based paths that specify where to look for the log files. All
+patterns supported by https://golang.org/pkg/path/filepath/#Glob[Go Glob]
+are also supported here. For example, you can use wildcards to fetch all files
+from a predefined level of subdirectories: `/path/to/log/*/*.log`. This
+fetches all `.log` files from the subfolders of `/path/to/log`. It does not
+fetch log files from the `/path/to/log` folder itself. If this setting is left
+empty, {beatname_uc} will choose log paths based on your operating system.

--- a/filebeat/docs/modules/elasticsearch.asciidoc
+++ b/filebeat/docs/modules/elasticsearch.asciidoc
@@ -33,26 +33,74 @@ include::../include/config-option-intro.asciidoc[]
 ==== `server` log fileset settings
 
 include::../include/var-paths.asciidoc[]
++
+Example config:
++
+[source,yaml]
+----
+  server:
+    enabled: true
+    var.paths:
+      - /var/log/elasticsearch/*.log
+----
 
 [float]
 ==== `gc` log fileset settings
 
 include::../include/var-paths.asciidoc[]
++
+Example config:
++
+[source,yaml]
+----
+  gc:
+    var.paths:
+      - /var/log/elasticsearch/gc.log.[0-9]*
+      - /var/log/elasticsearch/gc.log
+----
 
 [float]
 ==== `audit` log fileset settings
 
 include::../include/var-paths.asciidoc[]
++
+Example config:
++
+[source,yaml]
+----
+  audit:
+    var.paths:
+      - /var/log/elasticsearch/*_access.log
+----
 
 [float]
 ==== `slowlog` log fileset settings
 
 include::../include/var-paths.asciidoc[]
++
+Example config:
++
+[source,yaml]
+----
+  slowlog:
+    var.paths:
+      - /var/log/elasticsearch/*_index_search_slowlog.log
+      - /var/log/elasticsearch/*_index_indexing_slowlog.log
+----
 
 [float]
 ==== `deprecation` log fileset settings
 
 include::../include/var-paths.asciidoc[]
++
+Example config:
++
+[source,yaml]
+----
+  deprecation:
+    var.paths:
+      - /var/log/elasticsearch/*_deprecation.log
+----
 
 :has-dashboards!:
 

--- a/filebeat/module/elasticsearch/_meta/docs.asciidoc
+++ b/filebeat/module/elasticsearch/_meta/docs.asciidoc
@@ -28,26 +28,74 @@ include::../include/config-option-intro.asciidoc[]
 ==== `server` log fileset settings
 
 include::../include/var-paths.asciidoc[]
++
+Example config:
++
+[source,yaml]
+----
+  server:
+    enabled: true
+    var.paths:
+      - /var/log/elasticsearch/*.log
+----
 
 [float]
 ==== `gc` log fileset settings
 
 include::../include/var-paths.asciidoc[]
++
+Example config:
++
+[source,yaml]
+----
+  gc:
+    var.paths:
+      - /var/log/elasticsearch/gc.log.[0-9]*
+      - /var/log/elasticsearch/gc.log
+----
 
 [float]
 ==== `audit` log fileset settings
 
 include::../include/var-paths.asciidoc[]
++
+Example config:
++
+[source,yaml]
+----
+  audit:
+    var.paths:
+      - /var/log/elasticsearch/*_access.log
+----
 
 [float]
 ==== `slowlog` log fileset settings
 
 include::../include/var-paths.asciidoc[]
++
+Example config:
++
+[source,yaml]
+----
+  slowlog:
+    var.paths:
+      - /var/log/elasticsearch/*_index_search_slowlog.log
+      - /var/log/elasticsearch/*_index_indexing_slowlog.log
+----
 
 [float]
 ==== `deprecation` log fileset settings
 
 include::../include/var-paths.asciidoc[]
++
+Example config:
++
+[source,yaml]
+----
+  deprecation:
+    var.paths:
+      - /var/log/elasticsearch/*_deprecation.log
+----
 
 :has-dashboards!:
 


### PR DESCRIPTION
Closes #9450.

Improves description of `paths` variable to indicate that it's a blob path. I took some of the language from the description of the input `paths` options, which I'm *assuming* behaves the same, but I did not test the possible variations. Let me know if I need to test this to confirm that the wildcards behave as described.

I need to add examples for all the modules, but if this looks good, let's get it merged so the shared description gets updated.

TODO (after merging):

- [ ] Add examples to other module docs (this PR only covers the shared description and examples for the elasticsearch module). 