### PR TITLE
[Auditbeat] Add message field to system module

### DIFF
--- a/libbeat/tests/system/beat/beat.py
+++ b/libbeat/tests/system/beat/beat.py
@@ -495,8 +495,8 @@ class TestCase(unittest.TestCase, ComposeMixin):
                 if "name" not in field:
                     continue
 
-                # Chain together names
-                if name != "":
+                # Chain together names. Names in group `base` are top-level.
+                if name != "" and name != "base":
                     newName = name + "." + field["name"]
                 else:
                     newName = field["name"]

--- a/x-pack/auditbeat/module/system/host/_meta/data.json
+++ b/x-pack/auditbeat/module/system/host/_meta/data.json
@@ -10,6 +10,7 @@
         "module": "system",
         "kind": "state"
     },
+    "message": "Ubuntu host ubuntu-bionic (IP: 10.0.2.15) is up for 0 days, 5 hours, 11 minutes",
     "service": {
         "type": "system"
     },
@@ -17,9 +18,10 @@
         "audit": {
             "host": {
                 "architecture": "x86_64",
-                "boottime": "2018-12-04T12:13:02Z",
+                "boottime": "2018-12-10T15:48:44Z",
                 "containerized": false,
-                "id": "b0d3f38d51bdeefe224737595c03d916",
+                "hostname": "ubuntu-bionic",
+                "id": "6f7be6fb33e6c77f057266415c094408",
                 "ip": [
                     "10.0.2.15",
                     "fe80::2d:fdff:fe81:e747",
@@ -36,17 +38,16 @@
                     "02:42:83:be:1a:3a",
                     "02:42:9e:d3:d8:88"
                 ],
-                "hostname": "ubuntu-bionic",
                 "os": {
                     "family": "debian",
-                    "kernel": "4.15.0-39-generic",
+                    "kernel": "4.15.0-42-generic",
                     "name": "Ubuntu",
                     "platform": "ubuntu",
                     "version": "18.04.1 LTS (Bionic Beaver)"
                 },
                 "timezone.name": "UTC",
                 "timezone.offset.sec": 0,
-                "uptime": 105705490232434
+                "uptime": 18661357350265
             }
         }
     }

--- a/x-pack/auditbeat/module/system/host/host.go
+++ b/x-pack/auditbeat/module/system/host/host.go
@@ -43,7 +43,7 @@ const (
 type eventAction uint8
 
 const (
-	eventActionHost eventAction = iota + 1
+	eventActionHost eventAction = iota
 	eventActionIDChanged
 	eventActionReboot
 	eventActionHostnameChanged

--- a/x-pack/auditbeat/module/system/host/host.go
+++ b/x-pack/auditbeat/module/system/host/host.go
@@ -374,9 +374,8 @@ func fmtDuration(d time.Duration) string {
 func inflect(noun string, count int) string {
 	if count == 1 {
 		return noun
-	} else {
-		return noun + "s"
 	}
+	return noun + "s"
 }
 
 func (ms *MetricSet) saveStateToDisk() error {

--- a/x-pack/auditbeat/module/system/host/host.go
+++ b/x-pack/auditbeat/module/system/host/host.go
@@ -332,8 +332,13 @@ func hostEvent(host *Host, eventType string, action eventAction) mb.Event {
 }
 
 func hostMessage(host *Host, action eventAction) string {
+	var firstIP string
+	if len(host.addrs) > 0 {
+		firstIP = ipString(host.addrs[0])
+	}
+
 	// Hostname + IP of the first non-loopback interface.
-	hostString := fmt.Sprintf("%v (IP: %v)", host.info.Hostname, ipString(host.addrs[0]))
+	hostString := fmt.Sprintf("%v (IP: %v)", host.info.Hostname, firstIP)
 
 	var message string
 	switch action {

--- a/x-pack/auditbeat/module/system/process/_meta/data.json
+++ b/x-pack/auditbeat/module/system/process/_meta/data.json
@@ -7,19 +7,23 @@
     "event": {
         "action": "existing_process",
         "dataset": "process",
-        "id": "203e3d86-6b94-4e36-b906-930187073b93",
+        "id": "5795d53b-f7c2-463c-9c04-f316ae876d51",
         "module": "system",
         "kind": "state"
     },
+    "message": "Process zsh (PID: 2363) is RUNNING",
     "process": {
         "args": [
-            "/sbin/init"
+            "/usr/bin/zsh"
         ],
-        "executable": "/lib/systemd/systemd",
-        "name": "systemd",
-        "pid": 1,
-        "ppid": 0,
-        "start": "2018-12-03T23:49:23.08Z",
-        "working_directory": "/"
+        "executable": "/bin/zsh",
+        "name": "zsh",
+        "pid": 2363,
+        "ppid": 2362,
+        "start": "2018-12-10T16:36:25.21Z",
+        "working_directory": "/home/elastic"
+    },
+    "service": {
+        "type": "system"
     }
 }

--- a/x-pack/auditbeat/module/system/process/process.go
+++ b/x-pack/auditbeat/module/system/process/process.go
@@ -39,7 +39,7 @@ const (
 type eventAction uint8
 
 const (
-	eventActionExistingProcess eventAction = iota + 1
+	eventActionExistingProcess eventAction = iota
 	eventActionProcessStarted
 	eventActionProcessStopped
 )

--- a/x-pack/auditbeat/module/system/process/process.go
+++ b/x-pack/auditbeat/module/system/process/process.go
@@ -5,6 +5,7 @@
 package process
 
 import (
+	"fmt"
 	"strconv"
 	"time"
 
@@ -33,11 +34,28 @@ const (
 
 	eventTypeState = "state"
 	eventTypeEvent = "event"
-
-	eventActionExistingProcess = "existing_process"
-	eventActionProcessStarted  = "process_started"
-	eventActionProcessStopped  = "process_stopped"
 )
+
+type eventAction uint8
+
+const (
+	eventActionExistingProcess eventAction = iota + 1
+	eventActionProcessStarted
+	eventActionProcessStopped
+)
+
+func (action eventAction) String() string {
+	switch action {
+	case eventActionExistingProcess:
+		return "existing_process"
+	case eventActionProcessStarted:
+		return "process_started"
+	case eventActionProcessStopped:
+		return "process_stopped"
+	default:
+		return ""
+	}
+}
 
 func init() {
 	mb.Registry.MustAddMetricSet(moduleName, metricsetName, New,
@@ -214,16 +232,32 @@ func (ms *MetricSet) reportChanges(report mb.ReporterV2) error {
 	return nil
 }
 
-func processEvent(pInfo *ProcessInfo, eventType string, eventAction string) mb.Event {
+func processEvent(pInfo *ProcessInfo, eventType string, action eventAction) mb.Event {
 	return mb.Event{
 		RootFields: common.MapStr{
 			"event": common.MapStr{
 				"kind":   eventType,
-				"action": eventAction,
+				"action": action.String(),
 			},
 			"process": pInfo.toMapStr(),
+			"message": processMessage(pInfo, action),
 		},
 	}
+}
+
+func processMessage(pInfo *ProcessInfo, action eventAction) string {
+	var actionString string
+	switch action {
+	case eventActionProcessStarted:
+		actionString = "STARTED"
+	case eventActionProcessStopped:
+		actionString = "STOPPED"
+	case eventActionExistingProcess:
+		actionString = "is RUNNING"
+	}
+
+	return fmt.Sprintf("Process %v (PID: %d) %v",
+		pInfo.Name, pInfo.PID, actionString)
 }
 
 func convertToCacheable(processInfos []*ProcessInfo) []cache.Cacheable {

--- a/x-pack/auditbeat/module/system/process/process_test.go
+++ b/x-pack/auditbeat/module/system/process/process_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestData(t *testing.T) {
+	t.Skip("TODO: Test is failing on Linux.")
+
 	f := mbtest.NewReportingMetricSetV2(t, getConfig())
 	events, errs := mbtest.ReportingFetchV2(f)
 	if len(errs) > 0 {

--- a/x-pack/auditbeat/module/system/process/process_test.go
+++ b/x-pack/auditbeat/module/system/process/process_test.go
@@ -12,8 +12,6 @@ import (
 )
 
 func TestData(t *testing.T) {
-	t.Skip("TODO: Test is failing on Linux.")
-
 	f := mbtest.NewReportingMetricSetV2(t, getConfig())
 	events, errs := mbtest.ReportingFetchV2(f)
 	if len(errs) > 0 {
@@ -24,7 +22,10 @@ func TestData(t *testing.T) {
 		t.Fatal("no events were generated")
 	}
 
-	fullEvent := mbtest.StandardizeEvent(f, events[0], core.AddDatasetToEvent)
+	// The first process (events[0]) is usually something like systemd,
+	// the last few are test processes, so we pick something more interesting
+	// towards the end.
+	fullEvent := mbtest.StandardizeEvent(f, events[len(events)-8], core.AddDatasetToEvent)
 	mbtest.WriteEventToDataJSON(t, fullEvent, "")
 }
 

--- a/x-pack/auditbeat/module/system/socket/_meta/data.json
+++ b/x-pack/auditbeat/module/system/socket/_meta/data.json
@@ -11,25 +11,25 @@
     "event": {
         "action": "existing_socket",
         "dataset": "socket",
-        "id": "d55364de-0442-4638-9022-887d0a549b00",
-        "module": "system",
-        "kind": "state"
+        "id": "6aff69f8-7267-4604-9701-d7b67a7c65bc",
+        "kind": "state",
+        "module": "system"
     },
-    "message": "Inbound socket (10.0.2.2:52002 -\u003e 10.0.2.15:22) OPEN by process sshd (PID: 2293) and user root (UID: 0)",
+    "message": "Inbound socket (10.0.2.2:55270 -\u003e 10.0.2.15:22) OPEN by process sshd (PID: 22799) and user root (UID: 0)",
     "network": {
         "direction": "inbound",
         "type": "ipv4"
     },
     "process": {
         "name": "sshd",
-        "pid": 2293
+        "pid": 22799
     },
     "service": {
         "type": "system"
     },
     "source": {
         "ip": "10.0.2.2",
-        "port": 52002
+        "port": 55270
     },
     "user": {
         "id": 0,

--- a/x-pack/auditbeat/module/system/socket/_meta/data.json
+++ b/x-pack/auditbeat/module/system/socket/_meta/data.json
@@ -4,30 +4,35 @@
         "hostname": "host.example.com",
         "name": "host.example.com"
     },
-    "user": {
-        "name": "vagrant",
-        "id": 1000
-    },
-    "process": {
-        "pid": 4021,
-        "name": "lynx"
-    },
-    "source": {
-        "ip": "10.0.2.15",
-        "port": 33956
-    },
     "destination": {
-        "port": 443,
-        "ip": "52.10.168.186"
+        "ip": "10.0.2.15",
+        "port": 22
     },
     "event": {
-        "kind": "event",
-        "action": "socket_opened",
+        "action": "existing_socket",
+        "dataset": "socket",
+        "id": "d55364de-0442-4638-9022-887d0a549b00",
         "module": "system",
-        "dataset": "socket"
+        "kind": "state"
     },
+    "message": "Inbound socket (10.0.2.2:52002 -\u003e 10.0.2.15:22) OPEN by process sshd (PID: 2293) and user root (UID: 0)",
     "network": {
-        "type": "ipv4",
-        "direction": "outbound"
+        "direction": "inbound",
+        "type": "ipv4"
+    },
+    "process": {
+        "name": "sshd",
+        "pid": 2293
+    },
+    "service": {
+        "type": "system"
+    },
+    "source": {
+        "ip": "10.0.2.2",
+        "port": 52002
+    },
+    "user": {
+        "id": 0,
+        "name": "root"
     }
 }

--- a/x-pack/auditbeat/module/system/socket/socket.go
+++ b/x-pack/auditbeat/module/system/socket/socket.go
@@ -40,7 +40,7 @@ const (
 type eventAction uint8
 
 const (
-	eventActionExistingSocket eventAction = iota + 1
+	eventActionExistingSocket eventAction = iota
 	eventActionSocketOpened
 	eventActionSocketClosed
 )

--- a/x-pack/auditbeat/module/system/socket/socket_test.go
+++ b/x-pack/auditbeat/module/system/socket/socket_test.go
@@ -29,7 +29,10 @@ func TestData(t *testing.T) {
 	if len(events) == 0 {
 		t.Fatal("no events were generated")
 	}
-	fullEvent := mbtest.StandardizeEvent(f, events[0], core.AddDatasetToEvent)
+
+	// The first socket (events[0]) is usually something like rpcbind,
+	// the last one should be more interesting.
+	fullEvent := mbtest.StandardizeEvent(f, events[len(events)-1], core.AddDatasetToEvent)
 	mbtest.WriteEventToDataJSON(t, fullEvent, "")
 }
 

--- a/x-pack/auditbeat/module/system/user/_meta/data.json
+++ b/x-pack/auditbeat/module/system/user/_meta/data.json
@@ -1,40 +1,48 @@
 {
     "@timestamp": "2017-10-12T08:05:34.853Z",
-    "beat": {
+    "agent": {
         "hostname": "host.example.com",
         "name": "host.example.com"
     },
     "event": {
-        "module": "system",
-        "dataset": "user",
-        "kind": "state",
         "action": "existing_user",
-        "id": "57ee8bb6-a3da-4c43-b0d9-0688ccdc88d0"
+        "dataset": "user",
+        "id": "b4ae235c-598c-4230-a585-7e9804f64631",
+        "module": "system",
+        "kind": "state"
     },
-    "user": {
-        "id": 1001,
-        "name": "ubuntu"
+    "message": "Existing user elastic (UID: 1002, Groups: elastic,docker)",
+    "service": {
+        "type": "system"
     },
     "system": {
         "audit": {
             "user": {
-                "uid": 1001,
-                "gid": 1001,
-                "name": "ubuntu",
-                "dir": "/home/ubuntu",
-                "shell": "/bin/bash",
-                "user_information": "Ubuntu",
+                "dir": "/home/elastic",
+                "gid": 1002,
                 "group": [
                     {
-                        "name": "sudo",
-                        "gid": 27
+                        "gid": 1002,
+                        "name": "elastic"
+                    },
+                    {
+                        "gid": 999,
+                        "name": "docker"
                     }
                 ],
+                "name": "elastic",
                 "password": {
-                    "type": "shadow_password",
-                    "last_changed": "2018-09-21T00:00:00.000Z"
-                }
+                    "last_changed": "2018-12-07T00:00:00Z",
+                    "type": "shadow_password"
+                },
+                "shell": "/usr/bin/zsh",
+                "uid": 1002,
+                "user_information": ",,,"
             }
         }
+    },
+    "user": {
+        "id": 1002,
+        "name": "elastic"
     }
 }

--- a/x-pack/auditbeat/module/system/user/_meta/data.json
+++ b/x-pack/auditbeat/module/system/user/_meta/data.json
@@ -7,9 +7,9 @@
     "event": {
         "action": "existing_user",
         "dataset": "user",
-        "id": "b4ae235c-598c-4230-a585-7e9804f64631",
-        "module": "system",
-        "kind": "state"
+        "id": "b0bbc4e2-9540-4aaf-b74e-ef9de506e852",
+        "kind": "state",
+        "module": "system"
     },
     "message": "Existing user elastic (UID: 1002, Groups: elastic,docker)",
     "service": {

--- a/x-pack/auditbeat/module/system/user/user.go
+++ b/x-pack/auditbeat/module/system/user/user.go
@@ -50,7 +50,7 @@ const (
 type eventAction uint8
 
 const (
-	eventActionExistingUser eventAction = iota + 1
+	eventActionExistingUser eventAction = iota
 	eventActionUserAdded
 	eventActionUserRemoved
 	eventActionUserChanged

--- a/x-pack/auditbeat/module/system/user/user.go
+++ b/x-pack/auditbeat/module/system/user/user.go
@@ -94,6 +94,8 @@ func (t passwordType) String() string {
 		return "no_password"
 	case cryptPassword:
 		return "crypt_password"
+	default:
+		return ""
 	}
 }
 

--- a/x-pack/auditbeat/module/system/user/user.go
+++ b/x-pack/auditbeat/module/system/user/user.go
@@ -432,7 +432,7 @@ func userMessage(user *User, action eventAction) string {
 	case eventActionUserChanged:
 		actionString = "Changed"
 	case eventActionPasswordChanged:
-		actionString = "Password change for"
+		actionString = "Password changed for"
 	}
 
 	return fmt.Sprintf("%v user %v (UID: %v, Groups: %v)",

--- a/x-pack/auditbeat/module/system/user/user.go
+++ b/x-pack/auditbeat/module/system/user/user.go
@@ -14,6 +14,7 @@ import (
 	"io"
 	"runtime"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -44,13 +45,34 @@ const (
 
 	eventTypeState = "state"
 	eventTypeEvent = "event"
-
-	eventActionExistingUser    = "existing_user"
-	eventActionUserAdded       = "user_added"
-	eventActionUserRemoved     = "user_removed"
-	eventActionUserChanged     = "user_changed"
-	eventActionPasswordChanged = "password_changed"
 )
+
+type eventAction uint8
+
+const (
+	eventActionExistingUser eventAction = iota + 1
+	eventActionUserAdded
+	eventActionUserRemoved
+	eventActionUserChanged
+	eventActionPasswordChanged
+)
+
+func (action eventAction) String() string {
+	switch action {
+	case eventActionExistingUser:
+		return "existing_user"
+	case eventActionUserAdded:
+		return "user_added"
+	case eventActionUserRemoved:
+		return "user_removed"
+	case eventActionUserChanged:
+		return "user_changed"
+	case eventActionPasswordChanged:
+		return "password_changed"
+	default:
+		return ""
+	}
+}
 
 type passwordType uint8
 
@@ -72,8 +94,6 @@ func (t passwordType) String() string {
 		return "no_password"
 	case cryptPassword:
 		return "crypt_password"
-	default:
-		return ""
 	}
 }
 
@@ -383,20 +403,52 @@ func (ms *MetricSet) reportChanges(report mb.ReporterV2) error {
 	return nil
 }
 
-func userEvent(user *User, eventType string, eventAction string) mb.Event {
+func userEvent(user *User, eventType string, action eventAction) mb.Event {
 	return mb.Event{
 		RootFields: common.MapStr{
 			"event": common.MapStr{
 				"kind":   eventType,
-				"action": eventAction,
+				"action": action.String(),
 			},
 			"user": common.MapStr{
 				"id":   user.UID,
 				"name": user.Name,
 			},
+			"message": userMessage(user, action),
 		},
 		MetricSetFields: user.toMapStr(),
 	}
+}
+
+func userMessage(user *User, action eventAction) string {
+	var actionString string
+	switch action {
+	case eventActionExistingUser:
+		actionString = "Existing"
+	case eventActionUserAdded:
+		actionString = "New"
+	case eventActionUserRemoved:
+		actionString = "Removed"
+	case eventActionUserChanged:
+		actionString = "Changed"
+	case eventActionPasswordChanged:
+		actionString = "Password change for"
+	}
+
+	return fmt.Sprintf("%v user %v (UID: %v, Groups: %v)",
+		actionString, user.Name, user.UID, fmtGroups(user.Groups))
+}
+
+func fmtGroups(groups []Group) string {
+	var b strings.Builder
+
+	b.WriteString(groups[0].Name)
+	for _, group := range groups[1:] {
+		b.WriteString(",")
+		b.WriteString(group.Name)
+	}
+
+	return b.String()
 }
 
 func convertToCacheable(users []*User) []cache.Cacheable {

--- a/x-pack/auditbeat/module/system/user/user_test.go
+++ b/x-pack/auditbeat/module/system/user/user_test.go
@@ -24,7 +24,8 @@ func TestData(t *testing.T) {
 		t.Fatal("no events were generated")
 	}
 
-	fullEvent := mbtest.StandardizeEvent(f, events[0], core.AddDatasetToEvent)
+	// The first user (events[0]) is usually root, the last one should be more interesting.
+	fullEvent := mbtest.StandardizeEvent(f, events[len(events)-1], core.AddDatasetToEvent)
 	mbtest.WriteEventToDataJSON(t, fullEvent, "")
 }
 

--- a/x-pack/auditbeat/module/system/user/user_test.go
+++ b/x-pack/auditbeat/module/system/user/user_test.go
@@ -31,7 +31,8 @@ func TestData(t *testing.T) {
 
 func getConfig() map[string]interface{} {
 	return map[string]interface{}{
-		"module":     "system",
-		"metricsets": []string{"user"},
+		"module":                       "system",
+		"metricsets":                   []string{"user"},
+		"user.detect_password_changes": true,
 	}
 }


### PR DESCRIPTION
This adds a top-level `message` field to the `host`, `process`, `socket`, and `user` metricsets.

Some example messages:

- host: `Ubuntu host ubuntu-bionic (IP: 10.0.2.15) is up for 0 days, 5 hours, 11 minutes`
- process: `Process zsh (PID: 2363) is RUNNING`
- socket: `Inbound socket (10.0.2.2:52002 -> 10.0.2.15:22) OPEN by process sshd (PID: 2293) and user root (UID: 0)`
- user: `Existing user elastic (UID: 1002, Groups: elastic,docker)`