### PR TITLE
Add XpackDir variable and Beats search path for apm-server

### DIFF
--- a/dev-tools/mage/settings.go
+++ b/dev-tools/mage/settings.go
@@ -53,6 +53,7 @@ var (
 	GOARM        = EnvOr("GOARM", "")
 	Platform     = MakePlatformAttributes(GOOS, GOARCH, GOARM)
 	BinaryExt    = ""
+	XPackDir     = "../x-pack"
 	RaceDetector = false
 	TestCoverage = false
 
@@ -128,6 +129,7 @@ func varMap(args ...map[string]interface{}) map[string]interface{} {
 		"GOARM":           GOARM,
 		"Platform":        Platform,
 		"BinaryExt":       BinaryExt,
+		"XPackDir":        XPackDir,
 		"BeatName":        BeatName,
 		"BeatServiceName": BeatServiceName,
 		"BeatIndexPrefix": BeatIndexPrefix,
@@ -157,6 +159,7 @@ GOARCH           = {{.GOARCH}}
 GOARM            = {{.GOARM}}
 Platform         = {{.Platform}}
 BinaryExt        = {{.BinaryExt}}
+XPackDir         = {{.XPackDir}}
 BeatName         = {{.BeatName}}
 BeatServiceName  = {{.BeatServiceName}}
 BeatIndexPrefix  = {{.BeatIndexPrefix}}
@@ -248,8 +251,10 @@ func findElasticBeatsDir() (string, error) {
 
 	const devToolsImportPath = elasticBeatsImportPath + "/dev-tools/mage"
 
-	// Search in project vendor directories.
+	// Search in project vendor directories. Order is relevant
 	searchPaths := []string{
+		// beats directory of apm-server
+		filepath.Join(repo.RootDir, "_beats/dev-tools/vendor"),
 		filepath.Join(repo.RootDir, repo.SubDir, "vendor", devToolsImportPath),
 		filepath.Join(repo.RootDir, "vendor", devToolsImportPath),
 	}
@@ -261,24 +266,6 @@ func findElasticBeatsDir() (string, error) {
 	}
 
 	return "", errors.Errorf("failed to find %v in the project's vendor", devToolsImportPath)
-}
-
-// SetElasticBeatsDir explicitly sets the location of the Elastic Beats
-// directory. If not set then it will attempt to locate it.
-func SetElasticBeatsDir(dir string) {
-	elasticBeatsDirLock.Lock()
-	defer elasticBeatsDirLock.Unlock()
-
-	info, err := os.Stat(dir)
-	if err != nil {
-		panic(errors.Wrapf(err, "failed to read elastic beats dir at %v", dir))
-	}
-
-	if !info.IsDir() {
-		panic(errors.Errorf("elastic beats dir=%v is not a directory", dir))
-	}
-
-	elasticBeatsDirValue = filepath.Clean(dir)
 }
 
 var (

--- a/dev-tools/packaging/packages.yml
+++ b/dev-tools/packaging/packages.yml
@@ -395,7 +395,7 @@ specs:
         <<: *elastic_license_for_binaries
         files:
           '{{.BeatName}}{{.BinaryExt}}':
-            source: ../x-pack/{{.BeatName}}/build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
+            source: ./{{.XPackDir}}/{{.BeatName}}/build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
 
     - os: darwin
       types: [tgz]
@@ -404,7 +404,7 @@ specs:
         <<: *elastic_license_for_binaries
         files:
           '{{.BeatName}}{{.BinaryExt}}':
-            source: ../x-pack/{{.BeatName}}/build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
+            source: ./{{.XPackDir}}/{{.BeatName}}/build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
 
     - os: darwin
       types: [dmg]
@@ -419,7 +419,7 @@ specs:
         <<: *elastic_license_for_binaries
         files:
           '{{.BeatName}}{{.BinaryExt}}':
-            source: ../x-pack/{{.BeatName}}/build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
+            source: ./{{.XPackDir}}/{{.BeatName}}/build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
 
     - os: linux
       types: [deb, rpm]
@@ -428,7 +428,7 @@ specs:
         <<: *elastic_license_for_deb_rpm
         files:
           /usr/share/{{.BeatName}}/bin/{{.BeatName}}{{.BinaryExt}}:
-            source: ../x-pack/{{.BeatName}}/build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
+            source: ./{{.XPackDir}}/{{.BeatName}}/build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
 
     - os: linux
       types: [docker]
@@ -438,4 +438,4 @@ specs:
         <<: *elastic_license_for_binaries
         files:
           '{{.BeatName}}{{.BinaryExt}}':
-            source: ../x-pack/{{.BeatName}}/build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
+            source: ./{{.XPackDir}}/{{.BeatName}}/build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}


### PR DESCRIPTION

Alternative approach to https://github.com/elastic/beats/pull/9426 
We also need the right path in the `packages.yml` file

Used: https://github.com/jalvz/apm-server/commit/9f2f7907e5e8b8a21f9227c9dfebfbe22d6c2ecc
