### PR TITLE
Cherry-pick #9443 to 6.x: Make packetbeat process monitor aware of bound address

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -75,6 +75,8 @@ https://github.com/elastic/beats/compare/v6.5.0...6.x[Check the HEAD diff]
 
 *Packetbeat*
 
+- Fix issue with process monitor associating traffic to the wrong process. {issue}9151[9151] {pull}9443[9443]
+
 *Winlogbeat*
 
 *Functionbeat*

--- a/packetbeat/procs/procs_linux.go
+++ b/packetbeat/procs/procs_linux.go
@@ -53,7 +53,7 @@ var procFiles = map[applayer.Transport]struct {
 
 // GetLocalPortToPIDMapping returns the list of local port numbers and the PID
 // that owns them.
-func (proc *ProcessesWatcher) GetLocalPortToPIDMapping(transport applayer.Transport) (ports map[uint16]int, err error) {
+func (proc *ProcessesWatcher) GetLocalPortToPIDMapping(transport applayer.Transport) (ports map[endpoint]int, err error) {
 	sourceFiles, ok := procFiles[transport]
 	if !ok {
 		return nil, fmt.Errorf("unsupported transport protocol id: %d", transport)
@@ -81,7 +81,7 @@ func (proc *ProcessesWatcher) GetLocalPortToPIDMapping(transport applayer.Transp
 		socksMap[s.inode] = s
 	}
 
-	ports = make(map[uint16]int)
+	ports = make(map[endpoint]int)
 	for _, pid := range pids.List {
 		inodes, err := findSocketsOfPid("", pid)
 		if err != nil {
@@ -91,7 +91,7 @@ func (proc *ProcessesWatcher) GetLocalPortToPIDMapping(transport applayer.Transp
 
 		for _, inode := range inodes {
 			if sockInfo, exists := socksMap[inode]; exists {
-				ports[sockInfo.srcPort] = pid
+				ports[endpoint{address: sockInfo.srcIP.String(), port: sockInfo.srcPort}] = pid
 			}
 		}
 	}

--- a/packetbeat/procs/procs_other.go
+++ b/packetbeat/procs/procs_other.go
@@ -23,6 +23,6 @@ import "github.com/elastic/beats/packetbeat/protos/applayer"
 
 // GetLocalPortToPIDMapping returns the list of local port numbers and the PID
 // that owns them.
-func (proc *ProcessesWatcher) GetLocalPortToPIDMapping(transport applayer.Transport) (ports map[uint16]int, err error) {
+func (proc *ProcessesWatcher) GetLocalPortToPIDMapping(transport applayer.Transport) (ports map[endpoint]int, err error) {
 	return nil, nil
 }


### PR DESCRIPTION
Cherry-pick of PR #9443 to 6.x branch. Original message: 

The current implementation of Packetbeat's process monitor detects the local process by looking at the local port number used. However, different processes can be bound to the same port on different interfaces, causing Packetbeat to associate an event to the wrong process.

This PR fixes the problem by looking up the process by using the tuple (address, port).

There's still a case where Packetbeat can pick the wrong process:

When one process is bound to INADDR_ANY and another to a specific local address. Testing suggests that the last socket to be bound takes precedence over the other. However, I couldn't find this behavior documented anywhere.

As Packetbeat can't tell which socket was bound first, there's no way of telling which process is really receiving the traffic. This PR will give precedence to a socket bound to a local IP-address over a socket bound to INADDR_ANY.

Fixes #9151