### PR TITLE
Revert "Revert "Bump docs version for 5.6.14 (#9311)" (#9407)"

### DIFF
--- a/libbeat/docs/version.asciidoc
+++ b/libbeat/docs/version.asciidoc
@@ -1,4 +1,4 @@
-:stack-version: 5.6.13
+:stack-version: 5.6.14
 :doc-branch: 5.6
 :go-version: 1.7.6
 :release-state: released


### PR DESCRIPTION
This reverts commit db0f16509a5380e4bf8a60f5e6f7c6d3ed9fb084.