### PR TITLE
Use unix.Dup2 in RedirectStandardError

### DIFF
--- a/libbeat/common/file/stderr_other.go
+++ b/libbeat/common/file/stderr_other.go
@@ -21,11 +21,12 @@ package file
 
 import (
 	"os"
-	"syscall"
+
+	"golang.org/x/sys/unix"
 )
 
 // RedirectStandardError causes all standard error output to be directed to the
 // given file.
 func RedirectStandardError(toFile *os.File) error {
-	return syscall.Dup2(int(toFile.Fd()), 2)
+	return unix.Dup2(int(toFile.Fd()), 2)
 }


### PR DESCRIPTION
The function syscall.Dup2 does not exist for all architectures in the
stdlib, but the unix.Dup2 does. Replace it, so to fix compilation on
other os/arch combinations.