### PR TITLE
[Auditbeat] Fix process metricset when not root

### DIFF
--- a/x-pack/auditbeat/module/system/process/process.go
+++ b/x-pack/auditbeat/module/system/process/process.go
@@ -6,6 +6,7 @@ package process
 
 import (
 	"fmt"
+	"os"
 	"strconv"
 	"time"
 
@@ -288,6 +289,11 @@ func (ms *MetricSet) getProcessInfos() ([]*ProcessInfo, error) {
 
 		pInfo, err := process.Info()
 		if err != nil {
+			if os.IsPermission(err) && os.Geteuid() != 0 {
+				// Running as non-root, so we have no access to other user's processes.
+				continue
+			}
+
 			return nil, errors.Wrap(err, "failed to load process information")
 		}
 

--- a/x-pack/auditbeat/module/system/process/process_test.go
+++ b/x-pack/auditbeat/module/system/process/process_test.go
@@ -12,8 +12,6 @@ import (
 )
 
 func TestData(t *testing.T) {
-	t.Skip("TODO: Test is failing on Linux.")
-
 	f := mbtest.NewReportingMetricSetV2(t, getConfig())
 	events, errs := mbtest.ReportingFetchV2(f)
 	if len(errs) > 0 {

--- a/x-pack/auditbeat/tests/system/test_metricsets.py
+++ b/x-pack/auditbeat/tests/system/test_metricsets.py
@@ -41,7 +41,6 @@ class Test(AuditbeatXPackTest):
         self.check_metricset("system", "packages", COMMON_FIELDS + fields, warnings_allowed=True)
 
     @unittest.skipIf(sys.platform == "darwin" and os.geteuid != 0, "Requires root on macOS")
-    @unittest.skip("Test is failing on CI")
     def test_metricset_process(self):
         """
         process metricset collects information about processes running on a system.


### PR DESCRIPTION
The `process` metricset did not behave very well when being run as a user other than root. It would try to read the private process information of all processes on a system, and output the resulting permission errors.

This changes it to catch permission errors to allow running it as any user. It will only report on processes that are readable.

This should also allow re-enabling the unit and system test that were failing in CI.