### PR TITLE
Cherry-pick #9269 to 6.x: Fix alias field generation in docs

### DIFF
--- a/libbeat/scripts/generate_fields_docs.py
+++ b/libbeat/scripts/generate_fields_docs.py
@@ -39,12 +39,12 @@ def document_fields(output, section, sections, path):
             document_field(output, field, newpath)
 
 
-def document_field(output, field, path):
+def document_field(output, field, field_path):
 
-    if "path" not in field:
-        field["path"] = path
+    if "field_path" not in field:
+        field["field_path"] = field_path
 
-    output.write("*`{}`*::\n+\n--\n".format(field["path"]))
+    output.write("*`{}`*::\n+\n--\n".format(field["field_path"]))
 
     if "deprecated" in field:
         output.write("\ndeprecated[{}]\n\n".format(field["deprecated"]))
@@ -57,7 +57,8 @@ def document_field(output, field, path):
         output.write("format: {}\n\n".format(field["format"]))
     if "required" in field:
         output.write("required: {}\n\n".format(field["required"]))
-
+    if "path" in field:
+        output.write("alias to: {}\n\n".format(field["path"]))
     if "description" in field:
         output.write("{}\n\n".format(field["description"]))
 
@@ -71,7 +72,7 @@ def document_field(output, field, path):
 
     if "multi_fields" in field:
         for subfield in field["multi_fields"]:
-            document_field(output, subfield, path + "." + subfield["name"])
+            document_field(output, subfield, field_path + "." + subfield["name"])
     output.write("--\n\n")
 
 


### PR DESCRIPTION
Cherry-pick of PR #9269 to 6.x branch. Original message: 

Alias fields documented in the fields list were not correct. The reason is that `path` was used in our generation of the docs for a different puprose. This one was renamed and reporting of path was added for field alias.