### PR TITLE
[Auditbeat] Set auditbeat.max_start_delay to 0 for system tests

### DIFF
--- a/auditbeat/tests/system/config/auditbeat.yml.j2
+++ b/auditbeat/tests/system/config/auditbeat.yml.j2
@@ -17,6 +17,8 @@ auditbeat.modules:
   {% endif -%}
 {%- endfor %}
 
+auditbeat.max_start_delay: 0
+
 queue.mem:
   events: 4
   flush.min_events: 0


### PR DESCRIPTION
Setting `auditbeat.max_start_delay: 0` for system tests greatly reduces their execution time.

Before:
```
----------------------------------------------------------------------
XML: /home/vagrant/go/src/github.com/elastic/beats/auditbeat/build/TEST-system.xml
[success] 39.25% test_file_integrity.Test.test_recursive: 8.7114s
[success] 30.10% test_show_command.Test.test_show_auditd_rules: 6.6808s
[success] 29.18% test_file_integrity.Test.test_non_recursive: 6.4772s
[success] 0.77% test_base.Test.test_start_stop: 0.1703s
[success] 0.50% test_show_command.Test.test_show_auditd_status: 0.1113s
[success] 0.20% test_show_command.Test.test_show_command: 0.0448s
----------------------------------------------------------------------
Ran 8 tests in 22.204s
```

The time varies since the startup time is random, but it's usually above 10s.

After:
```
----------------------------------------------------------------------
XML: /home/vagrant/go/src/github.com/elastic/beats/auditbeat/build/TEST-system.xml
[success] 42.51% test_file_integrity.Test.test_recursive: 1.3856s
[success] 40.13% test_file_integrity.Test.test_non_recursive: 1.3081s
[success] 10.25% test_show_command.Test.test_show_auditd_rules: 0.3342s
[success] 4.73% test_base.Test.test_start_stop: 0.1543s
[success] 1.21% test_show_command.Test.test_show_auditd_status: 0.0395s
[success] 1.17% test_show_command.Test.test_show_command: 0.0382s
----------------------------------------------------------------------
Ran 8 tests in 3.268s
```