### PR TITLE
Update golden files for icinga/startup test to exclude timestamp

### DIFF
--- a/filebeat/module/icinga/startup/test/test.log-expected.json
+++ b/filebeat/module/icinga/startup/test/test.log-expected.json
@@ -1,6 +1,5 @@
 [
     {
-        "@timestamp": "2018-11-06T18:29:13.579Z", 
         "event.dataset": "startup", 
         "event.module": "icinga", 
         "icinga.startup.facility": "cli", 
@@ -10,7 +9,6 @@
         "log.offset": 0
     }, 
     {
-        "@timestamp": "2018-11-06T18:29:13.579Z", 
         "event.dataset": "startup", 
         "event.module": "icinga", 
         "icinga.startup.facility": "cli", 

--- a/filebeat/tests/system/test_modules.py
+++ b/filebeat/tests/system/test_modules.py
@@ -159,6 +159,7 @@ class Test(BaseTest):
                 for k, obj in enumerate(objects):
                     objects[k] = self.flatten_object(obj, {}, "")
                     clean_keys(objects[k])
+
                 json.dump(objects, f, indent=4, sort_keys=True)
 
         with open(test_file + "-expected.json", "r") as f:
@@ -174,11 +175,6 @@ class Test(BaseTest):
                 # Flatten objects for easier comparing
                 obj = self.flatten_object(obj, {}, "")
                 clean_keys(obj)
-
-                # Remove timestamp for comparison where timestamp is not part of the log line
-                if obj["event.module"] == "icinga" and obj["event.dataset"] == "startup":
-                    delete_key(obj, "@timestamp")
-                    delete_key(ev, "@timestamp")
 
                 if ev == obj:
                     found = True
@@ -198,6 +194,10 @@ def clean_keys(obj):
 
     for key in host_keys + time_keys + other_keys:
         delete_key(obj, key)
+
+    # Remove timestamp for comparison where timestamp is not part of the log line
+    if obj["event.module"] == "icinga" and obj["event.dataset"] == "startup":
+        delete_key(obj, "@timestamp")
 
 
 def delete_key(obj, key):


### PR DESCRIPTION
The icing/startup log file does not contain a timestamp. Because of this the timestamp from filebeat is taken. During the generation of golden files still a timestamp was added but every skipped on comparison. Instead now the timestamp is not added to the generated file anymore to now show a diff each time GENERATE is run.