### PR TITLE
Fix flaky x-pack libbeat build

### DIFF
--- a/x-pack/libbeat/docker-compose.yml
+++ b/x-pack/libbeat/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       service: elasticsearch
     healthcheck:
       test: ["CMD", "curl", "-u", "elastic:changeme", "-f", "http://localhost:9200"]
-      retries: 300
+      retries: 600
       interval: 1s
     environment:
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
@@ -47,6 +47,6 @@ services:
       service: kibana
     healthcheck:
       test: ["CMD-SHELL", 'python -c ''import urllib, json; response = urllib.urlopen("http://elastic:changeme@localhost:5601/api/status"); data = json.loads(response.read()); exit(1) if data["status"]["overall"]["state"] != "green" else exit(0);''']
-      retries: 300
+      retries: 600
       interval: 1s
     command: /usr/local/bin/kibana-docker --xpack.security.enabled=true --elasticsearch.username=elastic --elasticsearch.password=changeme


### PR DESCRIPTION
The x-pack libbeat build on travis was flaky. It got stuck when starting up the containers. Comparing it to the non x-pack libbeat build it turns out the timeout for Kibana and Elasticsearch is 600s and not 300s which is probably the reason it timeout. This adjust the timeout for both.