### PR TITLE
Add include package to x-pack Metricbeat

### DIFF
--- a/x-pack/metricbeat/cmd/root.go
+++ b/x-pack/metricbeat/cmd/root.go
@@ -7,6 +7,9 @@ package cmd
 import (
 	"github.com/elastic/beats/metricbeat/cmd"
 	xpackcmd "github.com/elastic/beats/x-pack/libbeat/cmd"
+
+	// Register the includes.
+	_ "github.com/elastic/beats/x-pack/metricbeat/include"
 )
 
 // RootCmd to handle beats cli

--- a/x-pack/metricbeat/main_test.go
+++ b/x-pack/metricbeat/main_test.go
@@ -1,0 +1,27 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+package main
+
+// This file is mandatory as otherwise the metricbeat.test binary is not generated correctly.
+import (
+	"flag"
+	"testing"
+
+	"github.com/elastic/beats/metricbeat/cmd"
+)
+
+var systemTest *bool
+
+func init() {
+	systemTest = flag.Bool("systemTest", false, "Set to true when running system tests")
+	cmd.RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("systemTest"))
+	cmd.RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("test.coverprofile"))
+}
+
+// Test started when the test binary is started. Only calls main.
+func TestSystem(t *testing.T) {
+	if *systemTest {
+		main()
+	}
+}


### PR DESCRIPTION
The include package was not loaded so far which means modules were not included in the binary. Also this adds a main_test.go file which is used to build the test binary for the system tests.