### PR TITLE
Disable ilm policy loading by default in setup

### DIFF
--- a/libbeat/cmd/setup.go
+++ b/libbeat/cmd/setup.go
@@ -58,7 +58,7 @@ func genSetupCmd(name, idxPrefix, version string, beatCreator beat.Creator) *cob
 				dashboards = true
 				machineLearning = true
 				pipelines = true
-				policy = true
+				policy = false
 			}
 
 			if err = beat.Setup(beatCreator, template, dashboards, machineLearning, pipelines, policy); err != nil {


### PR DESCRIPTION
As the ILM policy was loaded by default when run `*beat setup` it required additional permissions to previous versions of Beats. To no require additional permissions now loading the ILM policy is disabled when running `setup`. To load the policy `beat setup --ilm-policy` has to be run.