### PR TITLE
Cherry-pick #9515 to 6.x: Python dep upgrade

### DIFF
--- a/libbeat/tests/system/requirements.txt
+++ b/libbeat/tests/system/requirements.txt
@@ -25,7 +25,7 @@ requests==2.20.0
 six==1.11.0
 termcolor==1.1.0
 texttable==0.9.1
-urllib3==1.22
+urllib3==1.23
 websocket-client==0.47.0
 parameterized==0.6.1
 jsondiff==1.1.2


### PR DESCRIPTION
Cherry-pick of PR #9515 to 6.x branch. Original message: 

Reported by GitHub alert. Only used in some python tests.