### PR TITLE
Cherry-pick #9523 to 6.x: Fix flaky ml test by increasing timeout

### DIFF
--- a/filebeat/tests/system/test_ml.py
+++ b/filebeat/tests/system/test_ml.py
@@ -133,6 +133,6 @@ class Test(BaseTest):
         for obj in ["Datafeed", "Job", "Dashboard", "Search", "Visualization"]:
             self.wait_log_contains("{obj} already exists".format(obj=obj),
                                    logfile=output_path,
-                                   max_timeout=30)
+                                   max_timeout=60)
 
         beat.kill()

--- a/x-pack/libbeat/docker-compose.yml
+++ b/x-pack/libbeat/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       kibana: { condition: service_healthy }
     healthcheck:
       interval: 1s
-      retries: 1200
+      retries: 2400
 
   elasticsearch:
     extends:
@@ -30,7 +30,7 @@ services:
       service: elasticsearch
     healthcheck:
       test: ["CMD", "curl", "-u", "elastic:changeme", "-f", "http://localhost:9200"]
-      retries: 300
+      retries: 1200
       interval: 1s
     environment:
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
@@ -47,6 +47,6 @@ services:
       service: kibana
     healthcheck:
       test: ["CMD-SHELL", 'python -c ''import urllib, json; response = urllib.urlopen("http://elastic:changeme@localhost:5601/api/status"); data = json.loads(response.read()); exit(1) if data["status"]["overall"]["state"] != "green" else exit(0);''']
-      retries: 300
+      retries: 1200
       interval: 1s
     command: /usr/local/bin/kibana-docker --xpack.security.enabled=true --elasticsearch.username=elastic --elasticsearch.password=changeme


### PR DESCRIPTION
Cherry-pick of PR #9523 to 6.x branch. Original message: 

The ml tests sometimes fail on Travis or Jenkins but it seems when looking at the output of the files normally all entries are there. As they pass most of the time I assume it is an issue related to the timeout. Increasing the timeout to 60s.