### PR TITLE
Cherry-pick #9413 to 6.x: Add freebsd support for the uptime metricset

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -122,6 +122,7 @@ https://github.com/elastic/beats/compare/v6.5.0...6.x[Check the HEAD diff]
 - Add setting to disable docker cpu metrics per core. {pull}9194[9194]
 - The `elasticsearch/node` metricset now reports the Elasticsearch cluster UUID. {pull}8771[8771]
 - Support GET requests in Jolokia module. {issue}8566[8566] {pull}9226[9226]
+- Add freebsd support for the uptime metricset. {pull}9413[9413]
 - Add `host.os.name` field to add_host_metadata processor. {issue}8948[8948] {pull}9405[9405]
 - Add field `event.dataset` which is `{module}.{metricset).
 

--- a/metricbeat/module/system/uptime/_meta/docs.asciidoc
+++ b/metricbeat/module/system/uptime/_meta/docs.asciidoc
@@ -5,6 +5,7 @@ This metricset is available on:
 - Linux
 - macOS
 - OpenBSD
+- FreeBSD
 - Windows
 
 [float]

--- a/metricbeat/module/system/uptime/metricset.go
+++ b/metricbeat/module/system/uptime/metricset.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// +build darwin linux openbsd windows
+// +build darwin linux openbsd windows freebsd,cgo
 
 package uptime
 

--- a/metricbeat/module/system/uptime/metricset_test.go
+++ b/metricbeat/module/system/uptime/metricset_test.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// +build darwin linux openbsd windows
+// +build darwin linux openbsd windows freebsd,cgo
 
 package uptime
 


### PR DESCRIPTION
Cherry-pick of PR #9413 to 6.x branch. Original message: 

The metric is available in the gosigar library.

See:
* https://discuss.elastic.co/t/freebsd-version-of-the-system-module-has-the-uptime-metricset-disabled/159437
* https://github.com/elastic/beats/pull/4887#discussion_r238974879