### PR TITLE
Check on ilm-policy setup for Elasticsearch version

### DIFF
--- a/libbeat/cmd/instance/ilm.go
+++ b/libbeat/cmd/instance/ilm.go
@@ -118,6 +118,16 @@ func (b *Beat) loadILMPolicy() error {
 		return err
 	}
 
+	err = checkElasticsearchVersionIlm(esClient)
+	if err != nil {
+		return err
+	}
+
+	err = checkILMFeatureEnabled(esClient)
+	if err != nil {
+		return err
+	}
+
 	_, _, err = esClient.Request("PUT", "/_ilm/policy/"+ILMPolicyName, "", nil, ILMPolicy)
 	return err
 }


### PR DESCRIPTION
So far only when running ILM the checks for the Elasticsearch version and if the ILM feature is available were done. This lead to a not very nice error message when run `metricbeat setup --ilm-policy`. This introduces these checks to return the following two errors:

* `Exiting: ILM requires at least Elasticsearch 6.6.0. Used version: 6.5.3` which is thrown on older ES versions
* `Exiting: ILM feature is not available in this Elasticsearch version` which normally means OSS version is used

Unfortunately I couldn't find an easy way to test this change in an automated way as it would require to spin up 2 additional versions of Elasticsearch for testing.