### PR TITLE
Add initial Jenkinsfile as foundatin for using Jenkins Pipelines

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,86 @@
+#!/usr/bin/env groovy
+
+library identifier: 'apm@master',
+retriever: modernSCM(
+  [$class: 'GitSCMSource',
+  credentialsId: 'f94e9298-83ae-417e-ba91-85c279771570',
+  id: '37cf2c00-2cc7-482e-8c62-7bbffef475e2',
+  remote: 'git@github.com:elastic/apm-pipeline-library.git'])
+
+pipeline {
+  agent none
+  environment {
+    BASE_DIR="src/github.com/elastic/beats"
+  }
+  options {
+    timeout(time: 1, unit: 'HOURS') 
+    buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '20', daysToKeepStr: '30'))
+    timestamps()
+    ansiColor('xterm')
+    disableResume()
+    durabilityHint('PERFORMANCE_OPTIMIZED')
+  }
+  parameters {
+    booleanParam(name: 'Run_As_Master_Branch', defaultValue: false, description: 'Allow to run any steps on a PR, some steps normally only run on master branch.')
+  }
+  stages {
+    /**
+     Checkout the code and stash it, to use it on other stages.
+    */
+    stage('Checkout') {
+      agent { label 'linux && immutable' }
+      environment {
+        PATH = "${env.PATH}:${env.WORKSPACE}/bin"
+        HOME = "${env.WORKSPACE}"
+        GOPATH = "${env.WORKSPACE}"
+      }
+      options { skipDefaultCheckout() }
+      steps {
+        gitCheckout(basedir: "${BASE_DIR}")
+        stash allowEmpty: true, name: 'source', useDefaultExcludes: false
+        script {
+          env.GO_VERSION = readFile("${BASE_DIR}/.go-version")
+        }
+      }
+    }
+    /**
+    Updating generated files for Beat.
+    Checks the GO environment.
+    Checks the Python environment.
+    Checks YAML files are generated. 
+    Validate that all updates were committed.
+    */
+    stage('Intake') { 
+      agent { label 'linux && immutable' }
+      options { skipDefaultCheckout() }
+      environment {
+        PATH = "${env.PATH}:${env.WORKSPACE}/bin"
+        HOME = "${env.WORKSPACE}"
+        GOPATH = "${env.WORKSPACE}"
+      }
+      steps {
+        withEnvWrapper() {
+          unstash 'source'
+          dir("${BASE_DIR}"){
+            sh './dev-tools/jenkins_intake.sh'
+          }
+        }
+      }
+    }
+  }
+  post {
+    success {
+      echoColor(text: '[SUCCESS]', colorfg: 'green', colorbg: 'default')
+    }
+    aborted {
+      echoColor(text: '[ABORTED]', colorfg: 'magenta', colorbg: 'default')
+    }
+    failure { 
+      echoColor(text: '[FAILURE]', colorfg: 'red', colorbg: 'default')
+      //step([$class: 'Mailer', notifyEveryUnstableBuild: true, recipients: "${NOTIFY_TO}", sendToIndividuals: false])
+    }
+    unstable {
+      echoColor(text: '[UNSTABLE]', colorfg: 'yellow', colorbg: 'default')
+    }
+  }
+}


### PR DESCRIPTION
The idea is to move to a Jenkinsfile inside the Beats repository instead of relying in the configs in the JJB files. This should allows us more flexibility in adding / removing jobs directly in PRs to also test new builds. This is inspired / copied from the apm-server Jenkinsfile: https://github.com/elastic/apm-server/blob/master/Jenkinsfile

To make this building a few new minimal JJB files and plugin changes on the Jenkis slave are needed.

This is a very basic Jenkinsfile to get started and only contains the check state. The idea is to first get the setup running and then from there expand the stages we run on Jenkinspipelines. This allows us to test it first without having to run the full test suite always twice. It should also allow a migration step by step by adding a build step to Jenkinsfile and remove it from JJB.