### PR TITLE
Cherry-pick #9367 to 6.x: Add CODEOWNERS to Beats

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,32 @@
+# GitHub CODEOWNERS definition
+# See: https://help.github.com/articles/about-codeowners/
+
+* @elastic/beats
+
+# Auditbeat
+/auditbeat/module/ @elastic/secops
+/x-pack/auditbeat/ @elastic/secops
+
+# Packetbeat
+/packetbeat/protos/ @elastic/secops
+/x-pack/packetbeat/ @elastic/secops
+
+# Filebeat
+/filebeat/module/ @elastic/infrastructure
+/filebeat/module/elasticsearch/ @elastic/stack-monitoring
+/filebeat/module/kibana/ @elastic/stack-monitoring
+/filebeat/module/logstash/ @elastic/stack-monitoring
+/x-pack/filebeat/module/ @elastic/infrastructure
+/x-pack/filebeat/module/suricata/ @elastic/secops
+
+# Metricbeat
+/metricbeat/module/ @elastic/infrastructure
+/metricbeat/module/elasticsearch/ @elastic/stack-monitoring
+/metricbeat/module/kibana/ @elastic/stack-monitoring
+/metricbeat/module/logstash/ @elastic/stack-monitoring
+/x-pack/metricbeat/module/ @elastic/infrastructure
+
+# Heartbeat
+/heartbeat/ @elastic/uptime
+
+


### PR DESCRIPTION
Cherry-pick of PR #9367 to 6.x branch. Original message: 

Add the first draft of CODEOWNERS file to Beats. For more details check: https://help.github.com/articles/about-codeowners/ 

