### PR TITLE
Ignore non index fields in default_field for Elasticsearch

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -52,6 +52,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha1...master[Check the HEAD d
 - Refresh host metadata in add_host_metadata. {pull}9359[9359]
 - When collecting swap metrics for beats telemetry or system metricbeat module handle cases of free swap being bigger than total swap by assuming no swap is being used. {issue}6271[6271] {pull}9383[9383]
 - Adding logging traces at debug level when the pipeline client receives the following events: onFilteredOut, onDroppedOnPublish. {pull}9016[9016]
+- Ignore non index fields in default_field for Elasticsearch. {pull}9549[9549]
 
 *Auditbeat*
 

--- a/libbeat/template/processor.go
+++ b/libbeat/template/processor.go
@@ -167,7 +167,9 @@ func (p *Processor) keyword(f *common.Field) common.MapStr {
 		fullName = f.Path + "." + f.Name
 	}
 
-	defaultFields = append(defaultFields, fullName)
+	if f.Index == nil || (f.Index != nil && *f.Index) {
+		defaultFields = append(defaultFields, fullName)
+	}
 
 	property["type"] = "keyword"
 
@@ -201,7 +203,9 @@ func (p *Processor) text(f *common.Field) common.MapStr {
 		fullName = f.Path + "." + f.Name
 	}
 
-	defaultFields = append(defaultFields, fullName)
+	if f.Index == nil || (f.Index != nil && *f.Index) {
+		defaultFields = append(defaultFields, fullName)
+	}
 
 	properties["type"] = "text"
 


### PR DESCRIPTION
We recently started to use fields with `index: false`. By default all fields are defined as keyword internally which meant these fields were also added to the list of default_fields for Elasticsearch. With this PR these fields are now excluded.