### PR TITLE
Cherry-pick #9517 to 6.x: Always include Pod UID as part of Pod metadata

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -97,6 +97,7 @@ https://github.com/elastic/beats/compare/v6.5.0...6.x[Check the HEAD diff]
 - Added the `redirect_stderr` option that allows panics to be logged to log files. {pull}8430[8430]
 - Add cache.ttl to add_host_metadata. {pull}9359[9359]
 - Add support for index lifecycle management (beta). {pull}7963[7963]
+- Always include Pod UID as part of Pod metadata. {pull]9517[9517]
 
 *Auditbeat*
 

--- a/libbeat/autodiscover/providers/kubernetes/kubernetes_test.go
+++ b/libbeat/autodiscover/providers/kubernetes/kubernetes_test.go
@@ -157,6 +157,7 @@ func TestEmitEvent(t *testing.T) {
 	namespace := "default"
 	podIP := "127.0.0.1"
 	containerID := "docker://foobar"
+	uid := "005f3b90-4b9d-12f8-acf0-31020a840133"
 	containerImage := "elastic/filebeat:6.3.0"
 	node := "node"
 	UUID, err := uuid.NewV4()
@@ -176,6 +177,7 @@ func TestEmitEvent(t *testing.T) {
 			Pod: &v1.Pod{
 				Metadata: &metav1.ObjectMeta{
 					Name:        &name,
+					Uid:         &uid,
 					Namespace:   &namespace,
 					Labels:      map[string]string{},
 					Annotations: map[string]string{},
@@ -213,6 +215,7 @@ func TestEmitEvent(t *testing.T) {
 					},
 					"pod": common.MapStr{
 						"name": "filebeat",
+						"uid":  "005f3b90-4b9d-12f8-acf0-31020a840133",
 					},
 					"node": common.MapStr{
 						"name": "node",
@@ -227,6 +230,7 @@ func TestEmitEvent(t *testing.T) {
 							"name": "filebeat",
 						}, "pod": common.MapStr{
 							"name": "filebeat",
+							"uid":  "005f3b90-4b9d-12f8-acf0-31020a840133",
 						}, "node": common.MapStr{
 							"name": "node",
 						},
@@ -241,6 +245,7 @@ func TestEmitEvent(t *testing.T) {
 			Pod: &v1.Pod{
 				Metadata: &metav1.ObjectMeta{
 					Name:        &name,
+					Uid:         &uid,
 					Namespace:   &namespace,
 					Labels:      map[string]string{},
 					Annotations: map[string]string{},

--- a/libbeat/common/kubernetes/metadata.go
+++ b/libbeat/common/kubernetes/metadata.go
@@ -43,7 +43,6 @@ type MetaGeneratorConfig struct {
 	IncludeAnnotations []string `config:"include_annotations"`
 
 	// Undocumented settings, to be deprecated in favor of `drop_fields` processor:
-	IncludePodUID          bool `config:"include_pod_uid"`
 	IncludeCreatorMetadata bool `config:"include_creator_metadata"`
 }
 
@@ -118,11 +117,7 @@ func (g *metaGenerator) ResourceMetadata(obj Resource) common.MapStr {
 func (g *metaGenerator) PodMetadata(pod *Pod) common.MapStr {
 	podMeta := g.ResourceMetadata(pod)
 
-	// Add UID metadata if enabled
-	if g.IncludePodUID {
-		safemapstr.Put(podMeta, "pod.uid", pod.GetMetadata().GetUid())
-	}
-
+	safemapstr.Put(podMeta, "pod.uid", pod.GetMetadata().GetUid())
 	safemapstr.Put(podMeta, "pod.name", pod.GetMetadata().GetName())
 	safemapstr.Put(podMeta, "node.name", pod.Spec.GetNodeName())
 

--- a/libbeat/common/kubernetes/metadata_test.go
+++ b/libbeat/common/kubernetes/metadata_test.go
@@ -28,8 +28,6 @@ import (
 )
 
 func TestPodMetadataDeDot(t *testing.T) {
-	withUID, _ := common.NewConfigFrom(map[string]interface{}{"include_pod_uid": true})
-
 	UID := "005f3b90-4b9d-12f8-acf0-31020a840133"
 	Deployment := "Deployment"
 	test := "test"
@@ -53,32 +51,15 @@ func TestPodMetadataDeDot(t *testing.T) {
 				},
 			},
 			meta: common.MapStr{
-				"pod":       common.MapStr{"name": ""},
+				"pod": common.MapStr{
+					"name": "",
+					"uid":  "005f3b90-4b9d-12f8-acf0-31020a840133",
+				},
 				"node":      common.MapStr{"name": "test"},
 				"namespace": "test",
 				"labels":    common.MapStr{"a": common.MapStr{"value": "bar", "key": "foo"}},
 			},
 			config: common.NewConfig(),
-		},
-		{
-			pod: &Pod{
-				Metadata: &metav1.ObjectMeta{
-					Labels: map[string]string{"a.key": "foo", "a": "bar"},
-					Uid:    &UID,
-				},
-				Spec: &v1.PodSpec{
-					NodeName: &test,
-				},
-			},
-			meta: common.MapStr{
-				"pod": common.MapStr{
-					"name": "",
-					"uid":  "005f3b90-4b9d-12f8-acf0-31020a840133",
-				},
-				"node":   common.MapStr{"name": "test"},
-				"labels": common.MapStr{"a": common.MapStr{"value": "bar", "key": "foo"}},
-			},
-			config: withUID,
 		},
 		{
 			pod: &Pod{
@@ -103,7 +84,10 @@ func TestPodMetadataDeDot(t *testing.T) {
 				},
 			},
 			meta: common.MapStr{
-				"pod":        common.MapStr{"name": ""},
+				"pod": common.MapStr{
+					"name": "",
+					"uid":  "005f3b90-4b9d-12f8-acf0-31020a840133",
+				},
 				"node":       common.MapStr{"name": "test"},
 				"labels":     common.MapStr{"a": common.MapStr{"value": "bar", "key": "foo"}},
 				"deployment": common.MapStr{"name": "test"},

--- a/libbeat/docs/processors-using.asciidoc
+++ b/libbeat/docs/processors-using.asciidoc
@@ -735,6 +735,7 @@ metadata based on which Kubernetes pod the event originated from. Each event is
 annotated with:
 
 * Pod Name
+* Pod UID
 * Namespace
 * Labels
 

--- a/libbeat/docs/shared-autodiscover.asciidoc
+++ b/libbeat/docs/shared-autodiscover.asciidoc
@@ -125,6 +125,7 @@ event:
   * kubernetes.namespace
   * kubernetes.node.name
   * kubernetes.pod.name
+  * kubernetes.pod.uid
 
 If the `include_annotations` config is added to the provider config, then the list of annotations present in the config
 are added to the event.

--- a/libbeat/processors/add_kubernetes_metadata/indexers_test.go
+++ b/libbeat/processors/add_kubernetes_metadata/indexers_test.go
@@ -38,11 +38,13 @@ func TestPodIndexer(t *testing.T) {
 	assert.Nil(t, err)
 
 	podName := "testpod"
+	uid := "005f3b90-4b9d-12f8-acf0-31020a840133"
 	ns := "testns"
 	nodeName := "testnode"
 	pod := kubernetes.Pod{
 		Metadata: &metav1.ObjectMeta{
 			Name:      &podName,
+			Uid:       &uid,
 			Namespace: &ns,
 			Labels: map[string]string{
 				"labelkey": "labelvalue",
@@ -60,6 +62,7 @@ func TestPodIndexer(t *testing.T) {
 	expected := common.MapStr{
 		"pod": common.MapStr{
 			"name": "testpod",
+			"uid":  "005f3b90-4b9d-12f8-acf0-31020a840133",
 		},
 		"namespace": "testns",
 		"labels": common.MapStr{
@@ -111,6 +114,7 @@ func TestPodUIDIndexer(t *testing.T) {
 	expected := common.MapStr{
 		"pod": common.MapStr{
 			"name": "testpod",
+			"uid":  "005f3b90-4b9d-12f8-acf0-31020a840133",
 		},
 		"namespace": "testns",
 		"labels": common.MapStr{
@@ -136,6 +140,7 @@ func TestContainerIndexer(t *testing.T) {
 
 	podName := "testpod"
 	ns := "testns"
+	uid := "005f3b90-4b9d-12f8-acf0-31020a840133"
 	container := "container"
 	initContainer := "initcontainer"
 	nodeName := "testnode"
@@ -143,6 +148,7 @@ func TestContainerIndexer(t *testing.T) {
 	pod := kubernetes.Pod{
 		Metadata: &metav1.ObjectMeta{
 			Name:      &podName,
+			Uid:       &uid,
 			Namespace: &ns,
 			Labels: map[string]string{
 				"labelkey": "labelvalue",
@@ -162,6 +168,7 @@ func TestContainerIndexer(t *testing.T) {
 	expected := common.MapStr{
 		"pod": common.MapStr{
 			"name": "testpod",
+			"uid":  "005f3b90-4b9d-12f8-acf0-31020a840133",
 		},
 		"namespace": "testns",
 		"labels": common.MapStr{
@@ -340,12 +347,14 @@ func TestIpPortIndexer(t *testing.T) {
 
 	podName := "testpod"
 	ns := "testns"
+	uid := "005f3b90-4b9d-12f8-acf0-31020a840133"
 	container := "container"
 	ip := "1.2.3.4"
 	port := int32(80)
 	pod := kubernetes.Pod{
 		Metadata: &metav1.ObjectMeta{
 			Name:      &podName,
+			Uid:       &uid,
 			Namespace: &ns,
 			Labels: map[string]string{
 				"labelkey": "labelvalue",
@@ -375,6 +384,7 @@ func TestIpPortIndexer(t *testing.T) {
 	expected := common.MapStr{
 		"pod": common.MapStr{
 			"name": "testpod",
+			"uid":  "005f3b90-4b9d-12f8-acf0-31020a840133",
 		},
 		"namespace": "testns",
 		"labels": common.MapStr{


### PR DESCRIPTION
Cherry-pick of PR #9517 to 6.x branch. Original message: 

We realized Pod UID is a really useful info to have around so we are
always including it.

Users wanted to opt-out from this can use the `drop_fields` processor
like this:

```
processors:
  - drop_fields:
      fields: ["kubernetes.pod.uid"]
```

closes #9360