### PR TITLE
Cherry-pick #9392 to 6.x: Add geo fields to `add_host_metadata` processor.

### DIFF
--- a/libbeat/docs/processors-using.asciidoc
+++ b/libbeat/docs/processors-using.asciidoc
@@ -895,6 +895,14 @@ processors:
 - add_host_metadata:
     netinfo.enabled: false
     cache.ttl: 5m
+    geo:
+      name: nyc-dc1-rack1
+      location: 40.7128, -74.0060
+      continent_name: North America
+      country_iso_code: US
+      region_name: New York
+      region_iso_code: NY
+      city_name: New York
 -------------------------------------------------------------------------------
 
 It has the following settings:
@@ -902,6 +910,23 @@ It has the following settings:
 `netinfo.enabled`:: (Optional) Default false. Include IP addresses and MAC addresses as fields host.ip and host.mac
 
 `cache.ttl`:: (Optional) The processor uses an internal cache for the host metadata. This sets the cache expiration time. The default is 5m, negative values disable caching altogether.
+
+`geo.name`:: User definable token to be used for identifying a discrete location. Frequently a datacenter, rack, or similar.
+
+`geo.location`:: Longitude and latitude in comma separated format.
+
+`geo.continent_name`:: Name of the continent.
+
+`geo.country_name`:: Name of the country.
+
+`geo.region_name`:: Name of the region.
+
+`geo.city_name`:: Name of the city.
+
+`geo.country_iso_code`:: ISO country code.
+
+`geo.region_iso_code`:: ISO region code.
+
 
 The `add_host_metadata` processor annotates each event with relevant metadata from the host machine.
 The fields added to the event are looking as following:
@@ -921,7 +946,16 @@ The fields added to the event are looking as following:
          "name":"Mac OS X"
       },
       "ip": ["192.168.0.1", "10.0.0.1"],
-      "mac": ["00:25:96:12:34:56", "72:00:06:ff:79:f1"]
+      "mac": ["00:25:96:12:34:56", "72:00:06:ff:79:f1"],
+      "geo": {
+          "continent_name": "North America",
+          "country_iso_code": "US",
+          "region_name": "New York",
+          "region_iso_code": "NY",
+          "city_name": "New York",
+          "name": "nyc-dc1-rack1",
+          "location": "40.7128, -74.0060"
+        }
    }
 }
 -------------------------------------------------------------------------------

--- a/libbeat/processors/add_host_metadata/config.go
+++ b/libbeat/processors/add_host_metadata/config.go
@@ -25,6 +25,18 @@ import (
 type Config struct {
 	NetInfoEnabled bool          `config:"netinfo.enabled"` // Add IP and MAC to event
 	CacheTTL       time.Duration `config:"cache.ttl"`
+	Geo            *GeoConfig    `config:"geo"`
+}
+
+// GeoConfig contains geo configuration data.
+type GeoConfig struct {
+	Name           string `config:"name"`
+	Location       string `config:"location"`
+	ContinentName  string `config:"continent_name"`
+	CountryISOCode string `config:"country_iso_code"`
+	RegionName     string `config:"region_name"`
+	RegionISOCode  string `config:"region_iso_code"`
+	CityName       string `config:"city_name"`
 }
 
 func defaultConfig() Config {


### PR DESCRIPTION
Cherry-pick of PR #9392 to 6.x branch. Original message: 

** EDIT ** I've left the original issue below the break, but after discussion we added geo fields to the `add_host_metadata` processor instead of a new one. *Original is below*

-----

This carries over from the discussion from https://github.com/elastic/beats/pull/8620 .

This adds a new processor that lets users easily add geo fields associated with the host that created the event.  You would use it like so:

```
processors:
  - add_host_geo:
      name: MN HQ
      location: "44.977753, -93.265015"
```

It's debate-able whether ECS should actually let you put these under perhaps `agent.geo`. That's something we should discuss here.

One other question here, should we just fold this functionality under `add_host_metadata`? I believe that probably makes more sense. We agreed in elastic/beats#8620 to make this a separate processor, but with the data nested under host, that makes less sense IMHO.
