### PR TITLE
Always _doc if Beats major version is 7 and ES >= 6

### DIFF
--- a/libbeat/outputs/elasticsearch/client.go
+++ b/libbeat/outputs/elasticsearch/client.go
@@ -132,9 +132,7 @@ var (
 )
 
 const (
-	defaultEventTypeES6 = "doc"
-	defaultEventTypeES7 = "_doc"
-	defaultEventType    = defaultEventTypeES7
+	defaultEventType = "_doc"
 )
 
 // NewClient instantiates a new client.
@@ -691,12 +689,7 @@ func (client *Client) Connect() error {
 		return err
 	}
 
-	if client.GetVersion().Major < 7 {
-		client.eventType = defaultEventTypeES6
-	} else {
-		client.eventType = defaultEventType
-	}
-
+	client.eventType = defaultEventType
 	return nil
 }
 

--- a/libbeat/outputs/elasticsearch/client_test.go
+++ b/libbeat/outputs/elasticsearch/client_test.go
@@ -395,12 +395,7 @@ func TestBulkEncodeEvents(t *testing.T) {
 		config  common.MapStr
 		events  []common.MapStr
 	}{
-		"ES 6.x event": {
-			docType: "doc",
-			config:  common.MapStr{},
-			events:  []common.MapStr{{"message": "test"}},
-		},
-		"ES 7.x event": {
+		"Beats 7.x event": {
 			docType: "_doc",
 			config:  common.MapStr{},
 			events:  []common.MapStr{{"message": "test"}},

--- a/libbeat/template/load_integration_test.go
+++ b/libbeat/template/load_integration_test.go
@@ -356,7 +356,7 @@ func TestTemplateWithData(t *testing.T) {
 	assert.True(t, loader.CheckTemplate(tmpl.GetName()))
 
 	for _, test := range dataTests {
-		_, _, err = client.Index(tmpl.GetName(), "doc", "", nil, test.data)
+		_, _, err = client.Index(tmpl.GetName(), "_doc", "", nil, test.data)
 		if test.error {
 			assert.NotNil(t, err)
 
@@ -395,13 +395,7 @@ func getTemplate(t *testing.T, client ESClient, templateName string) testTemplat
 }
 
 func (tt *testTemplate) SourceEnabled() bool {
-	docType := "_doc"
-	major := tt.client.GetVersion().Major
-	if major < 7 {
-		docType = "doc"
-	}
-
-	key := fmt.Sprintf("mappings.%v._source.enabled", docType)
+	key := fmt.Sprintf("mappings._doc._source.enabled")
 
 	// _source.enabled is true if it's missing (default)
 	b, _ := tt.HasKey(key)

--- a/libbeat/template/template.go
+++ b/libbeat/template/template.go
@@ -205,15 +205,12 @@ func (t *Template) Generate(properties common.MapStr, dynamicTemplates []common.
 		indexSettings.Put("number_of_routing_shards", defaultNumberOfRoutingShards)
 	}
 
-	var mappingName string
+	mappingName := "_doc"
 	major := t.esVersion.Major
 	switch {
 	case major < 6:
 		mappingName = "_default_"
-	case major == 6:
-		mappingName = "doc"
 	case major >= 7:
-		mappingName = "_doc"
 		defaultFields = append(defaultFields, "fields.*")
 		indexSettings.Put("query.default_field", defaultFields)
 	}


### PR DESCRIPTION
This only affects master and the Beats 7.x releases.

Testing Beats upgrade with ES master/alpha builds I found one can not create an index by putting an event into an non-existing index if the document type used in the template still states "doc". This could potentially prevent Beats from being able to index, depending on upgrade order (ES issue to be created).
As the index versioning is based on the Beats version, but not the ES version, we want to guarantee some kind of consistency, no matter when Beats or ES is updated and in which order. In case Beats is updated before Elasticsearch, then we want to guarantee the template already uses `_doc`, such that the template would be the same, no matter when Elasticsearch is updated.

With this change the value of type in the template and when indexing will always be (independent of update order):

| | ES 6.x | ES 7.x+ |
|-|-------|--------|
| Beats 6.x |  doc | doc |
| Beats 7.x |  _doc | _doc |