### PR TITLE
Cherry-pick #9575 to 6.x: [Docs] Remove incorrect note

### DIFF
--- a/libbeat/docs/shared-central-management.asciidoc
+++ b/libbeat/docs/shared-central-management.asciidoc
@@ -121,10 +121,7 @@ During the enrollment process:
  for configuration polling
  . The enroll command creates a backup of your configuration and then
  **overwrites the current settings** so they can be managed centrally
- 
-IMPORTANT: When a Beat is enrolled in central management, it ignores all
-settings specified in local configuration files.
- 
+
 To enroll {beats}, use either <<token-based-enrollment,token-based>>
 or <<username-password-enrollment,username and password-based>> enrollment.
 


### PR DESCRIPTION
Cherry-pick of PR #9575 to 6.x branch. Original message: 

Removed note because it was not true. I've added some clarification to the Kibana Reference in https://github.com/elastic/kibana/pull/27275 so users will know what's supported by central management, and what they can define in the local yaml.