### PR TITLE
Remove obsolete "make simplify" references

### DIFF
--- a/generator/beat/{beat}/README.md
+++ b/generator/beat/{beat}/README.md
@@ -79,11 +79,10 @@ make update
 
 ### Cleanup
 
-To clean  {Beat} source code, run the following commands:
+To clean  {Beat} source code, run the following command:
 
 ```
 make fmt
-make simplify
 ```
 
 To clean up the build directory and generated artifacts, run:

--- a/heartbeat/README.md
+++ b/heartbeat/README.md
@@ -44,11 +44,10 @@ make update
 
 ### Cleanup
 
-To clean  Heartbeat source code, run the following commands:
+To clean  Heartbeat source code, run the following command:
 
 ```
 make fmt
-make simplify
 ```
 
 To clean up the build directory and generated artifacts, run:


### PR DESCRIPTION
The "simplify" make goal was removed in commit bb8301b (#3464) so remove the lingering documentation references.