### PR TITLE
Cherry-pick #9567 to 6.x: [Filebeat] Link docs for the NetFlow input

### DIFF
--- a/filebeat/docs/filebeat-options.asciidoc
+++ b/filebeat/docs/filebeat-options.asciidoc
@@ -49,6 +49,7 @@ You can configure {beatname_uc} to use the following inputs:
 * <<{beatname_lc}-input-docker>>
 * <<{beatname_lc}-input-tcp>>
 * <<{beatname_lc}-input-syslog>>
+* <<{beatname_lc}-input-netflow>>
 
 
 
@@ -65,3 +66,5 @@ include::inputs/input-docker.asciidoc[]
 include::inputs/input-tcp.asciidoc[]
 
 include::inputs/input-syslog.asciidoc[]
+
+include::../../x-pack/filebeat/docs/inputs/input-netflow.asciidoc[]


### PR DESCRIPTION
Cherry-pick of PR #9567 to 6.x branch. Original message: 

This PR links the NetFlow docs to the input docs in OSS filebeat.

Needs to be merged after https://github.com/elastic/docs/pull/507 is merged or the docs build will fail.