### PR TITLE
Cherry-pick #9589 to 6.x: Add setting to disable cgroup metrics per core

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -121,7 +121,7 @@ https://github.com/elastic/beats/compare/v6.5.0...6.x[Check the HEAD diff]
 
 - Collect custom cluster `display_name` in `elasticsearch/cluster_stats` metricset. {pull}8445[8445]
 - Test etcd module with etcd 3.3. {pull}9068[9068]
-- Add setting to disable docker cpu metrics per core. {pull}9194[9194]
+- Add settings to disable docker and cgroup cpu metrics per core. {issue}9187[9187] {pull}9194[9194] {pull}9589[9589]
 - The `elasticsearch/node` metricset now reports the Elasticsearch cluster UUID. {pull}8771[8771]
 - Support GET requests in Jolokia module. {issue}8566[8566] {pull}9226[9226]
 - Add freebsd support for the uptime metricset. {pull}9413[9413]

--- a/metricbeat/module/system/process/_meta/docs.asciidoc
+++ b/metricbeat/module/system/process/_meta/docs.asciidoc
@@ -77,6 +77,10 @@ metricbeat.modules:
   process.include_cpu_ticks: true
 ----
 
+*`process.include_per_cpu`*:: By default metrics per cpu are reported when
+available. Setting this option to false will disable the reporting of these
+metrics.
+
 *`process.include_top_n`*:: These options allow you to filter out all processes
 that are not in the top N by CPU or memory, in order to reduce the number of
 documents created. If both the `by_cpu` and `by_memory` options are used, the

--- a/metricbeat/module/system/process/config.go
+++ b/metricbeat/module/system/process/config.go
@@ -29,6 +29,7 @@ type Config struct {
 	CacheCmdLine    bool                     `config:"process.cmdline.cache.enabled"`
 	IncludeTop      process.IncludeTopConfig `config:"process.include_top_n"`
 	IncludeCPUTicks bool                     `config:"process.include_cpu_ticks"`
+	IncludePerCPU   bool                     `config:"process.include_per_cpu"`
 	CPUTicks        *bool                    `config:"cpu_ticks"` // Deprecated
 }
 
@@ -47,4 +48,5 @@ var defaultConfig = Config{
 		ByCPU:    0,
 		ByMemory: 0,
 	},
+	IncludePerCPU: true,
 }

--- a/metricbeat/module/system/process/process.go
+++ b/metricbeat/module/system/process/process.go
@@ -46,9 +46,9 @@ func init() {
 // MetricSet that fetches process metrics.
 type MetricSet struct {
 	mb.BaseMetricSet
-	stats        *process.Stats
-	cgroup       *cgroup.Reader
-	cacheCmdLine bool
+	stats  *process.Stats
+	cgroup *cgroup.Reader
+	perCPU bool
 }
 
 // New creates and returns a new MetricSet.
@@ -67,6 +67,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 			CacheCmdLine: config.CacheCmdLine,
 			IncludeTop:   config.IncludeTop,
 		},
+		perCPU: config.IncludePerCPU,
 	}
 	err := m.stats.Init()
 	if err != nil {
@@ -116,7 +117,7 @@ func (m *MetricSet) Fetch() ([]common.MapStr, error) {
 				continue
 			}
 
-			if statsMap := cgroupStatsToMap(stats); statsMap != nil {
+			if statsMap := cgroupStatsToMap(stats, m.perCPU); statsMap != nil {
 				proc["cgroup"] = statsMap
 			}
 		}

--- a/metricbeat/tests/system/test_system.py
+++ b/metricbeat/tests/system/test_system.py
@@ -373,6 +373,9 @@ class Test(metricbeat.BaseTest):
             "extras": {
                 "process.env.whitelist": ["PATH"],
                 "process.include_cpu_ticks": True,
+
+                # Remove 'percpu' prior to checking documented fields because its keys are dynamic.
+                "process.include_per_cpu": False,
             }
         }])
         proc = self.start_beat()
@@ -394,10 +397,6 @@ class Test(metricbeat.BaseTest):
             env = process.pop("env", None)
             if env is not None:
                 found_env = True
-
-            # Remove 'percpu' prior to checking documented fields because its keys are dynamic.
-            if "cgroup" in process and "cpuacct" in process["cgroup"]:
-                del process["cgroup"]["cpuacct"]["percpu"]
 
             self.assert_fields_are_documented(evt)
 


### PR DESCRIPTION
Cherry-pick of PR #9589 to 6.x branch. Original message: 

Cgroup CPU metrics collection per core can create loads of fields in hosts with lots of CPUs, and I am not sure if this is so useful. Add a flag to be able disable them by now on 6.6, and we can consider later to disable them by default on 7.0.

This is the cgroups counterpart for what we already did for docker in #9194.

Fix #9326 