### PR TITLE
[Docs] Update documentation for APM

### DIFF
--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -211,11 +211,21 @@ for more information about the environment variables.
 [[index-option-es]]
 ===== `index`
 
+ifndef::apm-server[]
 The index name to write events to. The default is
 +"{beatname_lc}-%\{[beat.version]\}-%\{+yyyy.MM.dd\}"+ (for example,
 +"{beatname_lc}-{version}-{localdate}"+). If you change this setting, you also
 need to configure the `setup.template.name` and `setup.template.pattern` options
 (see <<configuration-template>>).
+endif::apm-server[]
+
+ifdef::apm-server[]
+The index name to write events to. The default is
++"apm-%\{[beat.version]\}-EVENT_TYPE-%\{+yyyy.MM.dd\}"+ (for example,
++"apm-{version}-transaction-{localdate}"+). If you change this setting, you also
+need to configure the `setup.template.name` and `setup.template.pattern` options
+(see <<configuration-template>>).
+endif::apm-server[]
 
 ifndef::no_dashboards[]
 If you are using the pre-built Kibana

--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -222,9 +222,14 @@ endif::apm-server[]
 ifdef::apm-server[]
 The index name to write events to. The default is
 +"apm-%\{[beat.version]\}-{type\}-%\{+yyyy.MM.dd\}"+ (for example,
-+"apm-{version}-transaction-{localdate}"+). If you change this setting, you also
-need to configure the `setup.template.name` and `setup.template.pattern` options
-(see <<configuration-template>>).
++"apm-{version}-transaction-{localdate}"+). See
+<<exploring-es-data,Exploring data in Elasticsearch>> for more information on
+default index configuration.
+
+IMPORTANT: If you change this setting,
+you need to configure the `setup.template.name` and `setup.template.pattern` options
+(see <<configuration-template>>). You also must set the default index configuration
+in the `apm-server.yml` file.
 
 NOTE: `beat.version` is a field managed by Beats that is added to every document.
 It holds the current version of APM Server.

--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -221,7 +221,7 @@ endif::apm-server[]
 
 ifdef::apm-server[]
 The index name to write events to. The default is
-+"apm-%\{[beat.version]\}-EVENT_TYPE-%\{+yyyy.MM.dd\}"+ (for example,
++"apm-%\{[beat.version]\}-{type\}-%\{+yyyy.MM.dd\}"+ (for example,
 +"apm-{version}-transaction-{localdate}"+). If you change this setting, you also
 need to configure the `setup.template.name` and `setup.template.pattern` options
 (see <<configuration-template>>).

--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -275,8 +275,10 @@ to a new name.
 match.
 
 *`when`*:: A condition that must succeed in order to execute the current rule.
+ifndef::no-processors[]
 All the <<conditions,conditions>> supported by processors are also supported
-here. 
+here.
+endif::no-processors[]
 
 The following example sets the index based on whether the `message` field
 contains the specified string:
@@ -380,8 +382,10 @@ it to a new name.
 match.
 
 *`when`*:: A condition that must succeed in order to execute the current rule.
+ifndef::no-processors[]
 All the <<conditions,conditions>> supported by processors are also supported
-here. 
+here.
+endif::no-processors[]
 
 The following example sends events to a specific pipeline based on whether the
 `message` field contains the specified string:
@@ -864,8 +868,10 @@ to a new name.
 match.
 
 *`when`*:: A condition that must succeed in order to execute the current rule.
+ifndef::no-processors[]
 All the <<conditions,conditions>> supported by processors are also supported
-here. 
+here.
+endif::no-processors[] 
 
 
 ===== `key`
@@ -1089,8 +1095,10 @@ a new name.
 *`default`*:: The default string value to use if `mappings` does not find a match.
 
 *`when`*:: A condition that must succeed in order to execute the current rule.
+ifndef::no-processors[]
 All the <<conditions,conditions>> supported by processors are also supported
-here. 
+here.
+endif::no-processors[]
 
 Example `keys` settings:
 

--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -1388,6 +1388,10 @@ endif::[]
 [[configure-cloud-id]]
 === Configure the output for the Elastic Cloud
 
+ifdef::apm-server[]
+NOTE: This page refers to using a separate instance of APM Server with an existing Elastic Cloud deployment of Elasticsearch and/or Kibana. APM Server is not yet supported on Elastic Cloud.
+endif::apm-server[]
+
 ++++
 <titleabbrev>Cloud</titleabbrev>
 ++++

--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -216,10 +216,14 @@ The index name to write events to. The default is
 +"{beatname_lc}-{version}-{localdate}"+). If you change this setting, you also
 need to configure the `setup.template.name` and `setup.template.pattern` options
 (see <<configuration-template>>).
+
 ifndef::no_dashboards[]
 If you are using the pre-built Kibana
 dashboards, you also need to set the `setup.dashboards.index` option (see
 <<configuration-dashboards>>).
+ifdef::deprecate_dashboard_loading[]
+deprecated[{deprecate_dashboard_loading}]
+endif::deprecate_dashboard_loading[]
 endif::no_dashboards[]
 
 You can set the index dynamically by using a format string to access any event
@@ -247,12 +251,6 @@ TIP: To learn how to add custom fields to events, see the
 See the <<indices-option-es,`indices`>> setting for other ways to set the index
 dynamically.
 
-
-ifdef::deprecate_dashboard_loading[]
-
-deprecated[{deprecate_dashboard_loading}]
-
-endif::[]
 
 [[indices-option-es]]
 ===== `indices`

--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -1389,7 +1389,8 @@ endif::[]
 === Configure the output for the Elastic Cloud
 
 ifdef::apm-server[]
-NOTE: This page refers to using a separate instance of APM Server with an existing Elastic Cloud deployment of Elasticsearch and/or Kibana. APM Server is not yet supported on Elastic Cloud.
+NOTE: This page refers to using a separate instance of APM Server with an existing Elasticsearch Service deployment.
+APM Server is not yet supported on Elasticsearch Service.
 endif::apm-server[]
 
 ++++

--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -225,6 +225,9 @@ The index name to write events to. The default is
 +"apm-{version}-transaction-{localdate}"+). If you change this setting, you also
 need to configure the `setup.template.name` and `setup.template.pattern` options
 (see <<configuration-template>>).
+
+NOTE: `beat.version` is a field managed by Beats that is added to every document.
+It holds the current version of APM Server.
 endif::apm-server[]
 
 ifndef::no_dashboards[]

--- a/libbeat/docs/shared-beats-attributes.asciidoc
+++ b/libbeat/docs/shared-beats-attributes.asciidoc
@@ -15,6 +15,7 @@
 :dashboards: https://artifacts.elastic.co/downloads/beats/beats-dashboards/beats-dashboards-{stack-version}.zip
 :dockerimage: docker.elastic.co/beats/{beatname_lc}:{version}
 :dockergithub: https://github.com/elastic/beats-docker/tree/{doc-branch}
+:dockerconfig: https://raw.githubusercontent.com/elastic/beats/{doc-branch}/deploy/docker/{beatname_lc}.docker.yml
 :downloads: https://artifacts.elastic.co/downloads/beats
 :ES-version: {stack-version}
 :LS-version: {stack-version}

--- a/libbeat/docs/shared-docker.asciidoc
+++ b/libbeat/docs/shared-docker.asciidoc
@@ -40,12 +40,14 @@ https://www.docker.elastic.co[www.docker.elastic.co].
 
 endif::[]
 
+ifndef::apm-server[]
+
 ==== Run the {beatname_uc} setup
 
 Running {beatname_uc} with the setup command will create the index pattern and
 load visualizations, dashboards, and machine learning jobs.  Run this command:
 
-ifeval::[("{beatname_lc}"=="filebeat") or ("{beatname_lc}"=="metricbeat") or ("{beatname_lc}"=="heartbeat") or ("{beatname_lc}"=="apm-server")]
+ifeval::[("{beatname_lc}"=="filebeat") or ("{beatname_lc}"=="metricbeat") or ("{beatname_lc}"=="heartbeat")]
 ["source", "sh", subs="attributes"]
 --------------------------------------------
 docker run \
@@ -88,6 +90,8 @@ using this syntax:
 -E cloud.id=<Cloud ID from Elasticsearch Service> \
 -E cloud.auth=elastic:<elastic password>
 --------------------------------------------
+
+endif::apm-server[]
 
 ==== Configure {beatname_uc} on Docker
 

--- a/libbeat/docs/shared-docker.asciidoc
+++ b/libbeat/docs/shared-docker.asciidoc
@@ -100,10 +100,23 @@ configuration included.
 
 Download this example configuration file as a starting point:
 
+ifndef::apm-server[]
+
 ["source","sh",subs="attributes,callouts"]
 ------------------------------------------------
 curl -L -O https://raw.githubusercontent.com/elastic/beats/{doc-branch}/deploy/docker/{beatname_lc}.docker.yml
 ------------------------------------------------
+
+endif::apm-server[]
+
+ifdef::apm-server[]
+
+["source","sh",subs="attributes,callouts"]
+------------------------------------------------
+curl -L -O https://raw.githubusercontent.com/elastic/apm-server/{doc-branch}/apm-server.docker.yml
+------------------------------------------------
+
+endif::apm-server[]
 
 ===== Volume-mounted configuration
 

--- a/libbeat/docs/shared-docker.asciidoc
+++ b/libbeat/docs/shared-docker.asciidoc
@@ -104,23 +104,10 @@ configuration included.
 
 Download this example configuration file as a starting point:
 
-ifndef::apm-server[]
-
 ["source","sh",subs="attributes,callouts"]
 ------------------------------------------------
-curl -L -O https://raw.githubusercontent.com/elastic/beats/{doc-branch}/deploy/docker/{beatname_lc}.docker.yml
+curl -L -O {dockerconfig}
 ------------------------------------------------
-
-endif::apm-server[]
-
-ifdef::apm-server[]
-
-["source","sh",subs="attributes,callouts"]
-------------------------------------------------
-curl -L -O https://raw.githubusercontent.com/elastic/apm-server/{doc-branch}/apm-server.docker.yml
-------------------------------------------------
-
-endif::apm-server[]
 
 ===== Volume-mounted configuration
 

--- a/libbeat/docs/shared-docker.asciidoc
+++ b/libbeat/docs/shared-docker.asciidoc
@@ -45,7 +45,7 @@ endif::[]
 Running {beatname_uc} with the setup command will create the index pattern and
 load visualizations, dashboards, and machine learning jobs.  Run this command:
 
-ifeval::[("{beatname_lc}"=="filebeat") or ("{beatname_lc}"=="metricbeat") or ("{beatname_lc}"=="heartbeat")]
+ifeval::[("{beatname_lc}"=="filebeat") or ("{beatname_lc}"=="metricbeat") or ("{beatname_lc}"=="heartbeat") or ("{beatname_lc}"=="apm-server")]
 ["source", "sh", subs="attributes"]
 --------------------------------------------
 docker run \
@@ -172,7 +172,7 @@ docker run -d \
 --------------------------------------------
 endif::[]
 
-ifeval::["{beatname_lc}"=="heartbeat"]
+ifeval::[("{beatname_lc}"=="heartbeat") or ("{beatname_lc}"=="apm-server")]
 ["source", "sh", subs="attributes"]
 --------------------------------------------
 docker run -d \

--- a/libbeat/docs/shared-logstash-config.asciidoc
+++ b/libbeat/docs/shared-logstash-config.asciidoc
@@ -40,9 +40,16 @@ For this configuration, you must <<load-template-manually,load the index templat
 because the options for auto loading the template are only available for the Elasticsearch output.
 
 ifndef::win-only[]
+ifndef::apm-server[]
 
 include::../../libbeat/docs/step-test-config.asciidoc[]
 
+endif::apm-server[]
+ifdef::apm-server[]
+
+include::./step-test-config.asciidoc[]
+
+endif::apm-server[]
 endif::win-only[]
 
 ifdef::win-only[]

--- a/libbeat/docs/shared-path-config.asciidoc
+++ b/libbeat/docs/shared-path-config.asciidoc
@@ -86,7 +86,7 @@ Example:
 path.data: /var/lib/beats
 ------------------------------------------------------------------------------
 
-TIP: When running multiple Beat instances on the same host, make sure they
+TIP: When running multiple {beatname_uc} instances on the same host, make sure they
 each have a distinct `path.data` value.
 
 [float]

--- a/libbeat/docs/shared-ssl-config.asciidoc
+++ b/libbeat/docs/shared-ssl-config.asciidoc
@@ -4,7 +4,9 @@
 You can specify SSL options when you configure:
 
 * <<configuring-output,outputs>> that support SSL
+ifeval::["{beatname_lc}"!="apm-server"]
 * the <<setup-kibana-endpoint,Kibana endpoint>>
+endif::["{beatname_lc}"!="apm-server"]
 ifeval::["{beatname_lc}"=="heartbeat"]
 * <<configuration-heartbeat-options,{beatname_uc} monitors>> that support SSL
 endif::[]


### PR DESCRIPTION
Getting the Beats + APM docs in sync!

* 729d36f - Remove processors links (not supported in APM)
* a16dc94 - Include `step-test-config.asciidoc` from the shared folder
* 6d7585b - Update setup command and config
* 4f7462f - Update 404 `docker.yml` file
* b82cb71 - Moved deprecate tag to match content
    * Over time the deprecated tag has been accidentally moved away from what it was intending to reference.
* 7a29c40 - Updated TIP to use `{beatname_uc}` instead of BEAT
    * Does this mess anything up on your end?
* f8a5334 / 61f3ea8 / f1f259c - Updated to correct APM Server index name default.
    * Adds note about beat.version elastic/apm-server/issues/948.
    * Adds note about `apm-server.yml` config https://github.com/elastic/apm-server/issues/1230#issuecomment-448137366
* 7122f50 - elastic/apm-server/issues/1714

Related PR: elastic/apm-server/pull/1634