### PR TITLE
Cherry-pick #9557 to 6.x: Update version of python elasticsearch client to 6.3.1

### DIFF
--- a/libbeat/tests/system/requirements.txt
+++ b/libbeat/tests/system/requirements.txt
@@ -8,7 +8,7 @@ docker-compose==1.23.1
 docker-pycreds==0.3.0
 dockerpty==0.4.1
 docopt==0.6.2
-elasticsearch==6.2.0
+elasticsearch==6.3.1
 enum34==1.1.6
 functools32==3.2.3.post2
 idna==2.6

--- a/metricbeat/tests/system/requirements.txt
+++ b/metricbeat/tests/system/requirements.txt
@@ -1,3 +1,3 @@
 kafka-python==1.4.3
-elasticsearch==6.2.0
+elasticsearch==6.3.1
 semver==2.8.1


### PR DESCRIPTION
Cherry-pick of PR #9557 to 6.x branch. Original message: 

When running `make update` the following error message was shown:

```
elasticsearch 6.2.0 has requirement urllib3<1.23,>=1.21.1, but you'll have urllib3 1.23 which is incompatible.
```

Updating Elasticsearch Python client to 6.3.1 should solve this issue.