### PR TITLE
Test x-pack/filebeat on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,10 @@ jobs:
       env: TARGETS="TEST_ENVIRONMENT=0 -C filebeat testsuite"
       go: $GO_VERSION
       stage: test
+    - os: linux
+      env: TARGETS="-C x-pack/filebeat unit"
+      go: $GO_VERSION
+      stage: test
 
     # Heartbeat
     - os: linux


### PR DESCRIPTION
Execute unit tests for x-pack/filebeat on 6.x.

This will fail until #9611 is merged.

This is the short version of #9184 to act as a stopgap until I can backport and test the build changes from master to 6.x.