### PR TITLE
Increase script.max_compilations_rate to get tests passing

### DIFF
--- a/filebeat/tests/system/test_pipeline.py
+++ b/filebeat/tests/system/test_pipeline.py
@@ -45,6 +45,14 @@ class Test(BaseTest):
             pass
         self.wait_until(lambda: not self.es.indices.exists(index_name))
 
+        body = {
+            "transient": {
+                "script.max_compilations_rate": "100/1m"
+            }
+        }
+
+        self.es.transport.perform_request('PUT', "/_cluster/settings", body=body)
+
         self.render_config_template(
             path=os.path.abspath(self.working_dir) + "/log/*",
             elasticsearch=dict(


### PR DESCRIPTION
This is a temporary fix for https://github.com/elastic/beats/issues/9587. The reason I did not skip the tests instead was that I would still like us to have tests for the pipelines running until we figured out which script is the culprit.