### PR TITLE
Fix issue with ILM that write index was created before template was loaded

### DIFF
--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -456,6 +456,20 @@ func (b *Beat) Setup(bt beat.Creator, template, setupDashboards, machineLearning
 				return fmt.Errorf("Template loading requested but the Elasticsearch output is not configured/enabled")
 			}
 
+			if b.Config.ILM.Enabled() {
+				cfgwarn.Beta("Index lifecycle management is enabled which is in beta.")
+
+				ilmCfg, err := getILMConfig(b)
+				if err != nil {
+					return err
+				}
+
+				err = b.prepareILMTemplate(ilmCfg)
+				if err != nil {
+					return err
+				}
+			}
+
 			esConfig := outCfg.Config()
 			if tmplCfg := b.Config.Template; tmplCfg == nil || tmplCfg.Enabled() {
 				loadCallback, err := b.templateLoadingCallback()
@@ -757,6 +771,19 @@ func (b *Beat) registerTemplateLoading() error {
 			return errors.New("setup.template.name and setup.template.pattern have to be set if index name is modified")
 		}
 
+		if b.Config.Template == nil || (b.Config.Template != nil && b.Config.Template.Enabled()) {
+
+			// load template through callback to make sure it is also loaded
+			// on reconnecting
+			callback, err := b.templateLoadingCallback()
+			if err != nil {
+				return err
+			}
+			elasticsearch.RegisterConnectCallback(callback)
+		} else if b.Config.ILM.Enabled() {
+			return errors.New("templates cannot be disable when using ILM")
+		}
+
 		if b.Config.ILM.Enabled() {
 			cfgwarn.Beta("Index lifecycle management is enabled which is in beta.")
 
@@ -765,33 +792,9 @@ func (b *Beat) registerTemplateLoading() error {
 				return err
 			}
 
-			// In case no template settings are set, config must be created
-			if b.Config.Template == nil {
-				b.Config.Template = common.NewConfig()
-			}
-			// Template name and pattern can't be configure when using ILM
-			logp.Info("Set setup.template.name to '%s' as ILM is enabled.", ilmCfg.RolloverAlias)
-			err = b.Config.Template.SetString("name", -1, ilmCfg.RolloverAlias)
+			err = b.prepareILMTemplate(ilmCfg)
 			if err != nil {
-				return errw.Wrap(err, "error setting setup.template.name")
-			}
-			pattern := fmt.Sprintf("%s-*", ilmCfg.RolloverAlias)
-			logp.Info("Set setup.template.pattern to '%s' as ILM is enabled.", pattern)
-			err = b.Config.Template.SetString("pattern", -1, pattern)
-			if err != nil {
-				return errw.Wrap(err, "error setting setup.template.pattern")
-			}
-
-			// rollover_alias and lifecycle.name can't be configured and will be overwritten
-			logp.Info("Set settings.index.lifecycle.rollover_alias in template to %s as ILM is enabled.", ilmCfg.RolloverAlias)
-			err = b.Config.Template.SetString("settings.index.lifecycle.rollover_alias", -1, ilmCfg.RolloverAlias)
-			if err != nil {
-				return errw.Wrap(err, "error setting settings.index.lifecycle.rollover_alias")
-			}
-			logp.Info("Set settings.index.lifecycle.name in template to %s as ILM is enabled.", ILMPolicyName)
-			err = b.Config.Template.SetString("settings.index.lifecycle.name", -1, ILMPolicyName)
-			if err != nil {
-				return errw.Wrap(err, "error setting settings.index.lifecycle.name")
+				return err
 			}
 
 			// Set the ingestion index to the rollover alias
@@ -828,19 +831,39 @@ func (b *Beat) registerTemplateLoading() error {
 
 			elasticsearch.RegisterConnectCallback(writeAliasCallback)
 		}
+	}
 
-		if b.Config.Template == nil || (b.Config.Template != nil && b.Config.Template.Enabled()) {
+	return nil
+}
 
-			// load template through callback to make sure it is also loaded
-			// on reconnecting
-			callback, err := b.templateLoadingCallback()
-			if err != nil {
-				return err
-			}
-			elasticsearch.RegisterConnectCallback(callback)
-		} else if b.Config.ILM.Enabled() {
-			return errors.New("templates cannot be disable when using ILM")
-		}
+func (b *Beat) prepareILMTemplate(ilmCfg *ilmConfig) error {
+	// In case no template settings are set, config must be created
+	if b.Config.Template == nil {
+		b.Config.Template = common.NewConfig()
+	}
+	// Template name and pattern can't be configure when using ILM
+	logp.Info("Set setup.template.name to '%s' as ILM is enabled.", ilmCfg.RolloverAlias)
+	err := b.Config.Template.SetString("name", -1, ilmCfg.RolloverAlias)
+	if err != nil {
+		return errw.Wrap(err, "error setting setup.template.name")
+	}
+	pattern := fmt.Sprintf("%s-*", ilmCfg.RolloverAlias)
+	logp.Info("Set setup.template.pattern to '%s' as ILM is enabled.", pattern)
+	err = b.Config.Template.SetString("pattern", -1, pattern)
+	if err != nil {
+		return errw.Wrap(err, "error setting setup.template.pattern")
+	}
+
+	// rollover_alias and lifecycle.name can't be configured and will be overwritten
+	logp.Info("Set settings.index.lifecycle.rollover_alias in template to %s as ILM is enabled.", ilmCfg.RolloverAlias)
+	err = b.Config.Template.SetString("settings.index.lifecycle.rollover_alias", -1, ilmCfg.RolloverAlias)
+	if err != nil {
+		return errw.Wrap(err, "error setting settings.index.lifecycle.rollover_alias")
+	}
+	logp.Info("Set settings.index.lifecycle.name in template to %s as ILM is enabled.", ILMPolicyName)
+	err = b.Config.Template.SetString("settings.index.lifecycle.name", -1, ILMPolicyName)
+	if err != nil {
+		return errw.Wrap(err, "error setting settings.index.lifecycle.name")
 	}
 
 	return nil
@@ -862,6 +885,8 @@ func (b *Beat) templateLoadingCallback() (func(esClient *elasticsearch.Client) e
 		if err != nil {
 			return fmt.Errorf("Error loading Elasticsearch template: %v", err)
 		}
+
+		logp.Info("Template successfully loaded.")
 
 		return nil
 	}

--- a/libbeat/mock/mockbeat.go
+++ b/libbeat/mock/mockbeat.go
@@ -49,14 +49,25 @@ func (mb *Mockbeat) Run(b *beat.Beat) error {
 		return err
 	}
 
-	// Wait until mockbeat is done
-	go client.Publish(beat.Event{
-		Timestamp: time.Now(),
-		Fields: common.MapStr{
-			"type":    "mock",
-			"message": "Mockbeat is alive!",
-		},
-	})
+	ticker := time.NewTicker(1 * time.Second)
+	go func() {
+		for {
+			select {
+			case <-ticker.C:
+				client.Publish(beat.Event{
+					Timestamp: time.Now(),
+					Fields: common.MapStr{
+						"type":    "mock",
+						"message": "Mockbeat is alive!",
+					},
+				})
+			case <-mb.done:
+				ticker.Stop()
+				return
+			}
+		}
+	}()
+
 	<-mb.done
 	return nil
 }

--- a/libbeat/tests/system/test_ilm.py
+++ b/libbeat/tests/system/test_ilm.py
@@ -6,6 +6,7 @@ import unittest
 import shutil
 import logging
 import datetime
+import time
 
 INTEGRATION_TESTS = os.environ.get('INTEGRATION_TESTS', False)
 
@@ -198,6 +199,7 @@ class Test(BaseTest):
         policy = self.es.transport.perform_request('GET', "/_ilm/policy/" + self.policy_name)
         assert self.policy_name in policy
 
+    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     @attr('integration')
     def test_export_ilm_policy(self):
         """
@@ -222,6 +224,58 @@ class Test(BaseTest):
 
         assert self.log_contains('"max_age": "30d"')
         assert self.log_contains('"max_size": "50gb"')
+
+    @attr('integration')
+    def test_ilm_rollover(self):
+        """
+        Test ilm rollover
+        """
+
+        self.clean()
+
+        self.render_config_template(
+            elasticsearch={
+                "hosts": self.get_elasticsearch_url(),
+                "ilm.enabled": True,
+            },
+        )
+
+        body = {
+            "transient": {
+                "indices.lifecycle.poll_interval": "200ms"
+            }
+        }
+        self.es.transport.perform_request('PUT', "/_cluster/settings", body=body)
+
+        policy = {
+            "policy": {
+                "phases": {
+                    "hot": {
+                        "actions": {
+                            "rollover": {
+                                "max_docs": "1"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        self.es.transport.perform_request('PUT', "/_ilm/policy/" + self.policy_name, body=policy)
+
+        proc = self.start_beat()
+        self.wait_until(lambda: self.log_contains("mockbeat start running."))
+        self.wait_until(lambda: self.log_contains("Set setup.template.name"))
+        self.wait_until(lambda: self.log_contains_count("PublishEvents: 1 events have been published") > 4)
+        proc.check_kill_and_wait()
+
+        # Give time to do the rollovers
+        time.sleep(2)
+        indices = self.es.transport.perform_request('GET', '/_alias/mockbeat-9.9.9')
+
+        print indices
+        # Checks that at least 2 indices were created through rollover
+        assert len(indices) > 1
 
     def clean(self, alias_name=""):
 

--- a/libbeat/tests/system/test_ilm.py
+++ b/libbeat/tests/system/test_ilm.py
@@ -269,13 +269,8 @@ class Test(BaseTest):
         self.wait_until(lambda: self.log_contains_count("PublishEvents: 1 events have been published") > 4)
         proc.check_kill_and_wait()
 
-        # Give time to do the rollovers
-        time.sleep(2)
-        indices = self.es.transport.perform_request('GET', '/_alias/mockbeat-9.9.9')
-
-        print indices
         # Checks that at least 2 indices were created through rollover
-        assert len(indices) > 1
+        self.wait_until(lambda: len(self.es.transport.perform_request('GET', '/_alias/mockbeat-9.9.9')) > 1)
 
     def clean(self, alias_name=""):
 


### PR DESCRIPTION
The write index for ILM was created before the template was loaded. This meant the first template did not contain all the mappings and policy for ILM so was never rolled over. This change makes sure the template is loaded for ILM is setup up and adds a test to confirm it.

Further ILM was not respected when running `metricbeat setup --template`. This is now changed too.

mockbeat was modified to send multiple events instead of just one to allow the new tests.