### PR TITLE
[Auditbeat] Fix linux/386 mage package

### DIFF
--- a/x-pack/auditbeat/module/system/user/user.go
+++ b/x-pack/auditbeat/module/system/user/user.go
@@ -522,7 +522,7 @@ func (ms *MetricSet) haveFilesChanged() (bool, error) {
 			return true, errors.Wrapf(err, "failed to stat %v", path)
 		}
 
-		ctime := time.Unix(stats.Ctim.Sec, stats.Ctim.Nsec)
+		ctime := time.Unix(int64(stats.Ctim.Sec), int64(stats.Ctim.Nsec))
 		if ms.lastRead.Before(ctime) {
 			ms.log.Debugf("File changed: %v (lastRead=%v, ctime=%v)", path, ms.lastRead, ctime)
 


### PR DESCRIPTION
`mage package` in `x-pack/auditbeat` fails for `linux/386`:
```
$ PLATFORMS=linux/386 mage package
[...]
>> buildGoDaemon: Building for linux/386
>> golangCrossBuild: Building for linux/386
>> Building using: cmd='build/mage-linux-amd64 golangCrossBuild', env=[CC=gcc, CXX=g++, GOARCH=386, GOARM=, GOOS=linux, PLATFORM_ID=linux-386]
>> Building using: cmd='build/mage-linux-amd64 buildGoDaemon', env=[CC=gcc, CXX=g++, GOARCH=386, GOARM=, GOOS=linux, PLATFORM_ID=linux-386]
# github.com/elastic/beats/x-pack/auditbeat/module/system/user
module/system/user/user.go:525:32: cannot use stats.Ctim.Sec (type int32) as type int64 in argument to time.Unix
module/system/user/user.go:525:48: cannot use stats.Ctim.Nsec (type int32) as type int64 in argument to time.Unix
Error: running "go build -o build/golang-crossbuild/auditbeat-linux-386 -ldflags -X github.com/elastic/beats/libbeat/version.buildTime=2018-12-18T14:21:35Z -X github.com/elastic/beats/libbeat/version.commit=8eff2a8c504d41cd931ab0db9dd80ebf1c580702" failed with exit code 2
Error: failed building for linux/386: exit status 2
failed building for linux/386: exit status 2
package ran for 1m17.72865377s
Error: running "docker run --env EXEC_UID=501 --env EXEC_GID=20 --rm --env MAGEFILE_VERBOSE= --env MAGEFILE_TIMEOUT= -v /Users/cwurm/go/src/github.com/elastic/beats:/go/src/github.com/elastic/beats -w /go/src/github.com/elastic/beats/x-pack/auditbeat docker.elastic.co/beats-dev/golang-crossbuild:1.11.3-main-debian7 --build-cmd build/mage-linux-amd64 golangCrossBuild -p linux/386" failed with exit code 1
```

The reason is that on 32-bit systems `stats.Ctim.sec` and `stats.Ctim.nsec` is an `int32`. This adds an explicit cast to `int64` that will be ignored on 64-bit systems but is necessary on 32-bit.