### PR TITLE
Be more strict when handling the access token

### DIFF
--- a/x-pack/libbeat/management/api/enroll.go
+++ b/x-pack/libbeat/management/api/enroll.go
@@ -8,9 +8,21 @@ import (
 	"net/http"
 
 	"github.com/gofrs/uuid"
+	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/libbeat/common"
 )
+
+type enrollResponse struct {
+	AccessToken string `json:"access_token"`
+}
+
+func (e *enrollResponse) Validate() error {
+	if len(e.AccessToken) == 0 {
+		return errors.New("empty access_token")
+	}
+	return nil
+}
 
 // Enroll a beat in central management, this call returns a valid access token to retrieve configurations
 func (c *Client) Enroll(beatType, beatName, beatVersion, hostname string, beatUUID uuid.UUID, enrollmentToken string) (string, error) {
@@ -21,15 +33,17 @@ func (c *Client) Enroll(beatType, beatName, beatVersion, hostname string, beatUU
 		"host_name": hostname,
 	}
 
-	resp := struct {
-		AccessToken string `json:"access_token"`
-	}{}
+	resp := enrollResponse{}
 
 	headers := http.Header{}
 	headers.Set("kbn-beats-enrollment-token", enrollmentToken)
 
 	_, err := c.request("POST", "/api/beats/agent/"+beatUUID.String(), params, headers, &resp)
 	if err != nil {
+		return "", err
+	}
+
+	if err := resp.Validate(); err != nil {
 		return "", err
 	}
 

--- a/x-pack/libbeat/management/config.go
+++ b/x-pack/libbeat/management/config.go
@@ -5,6 +5,7 @@
 package management
 
 import (
+	"errors"
 	"io"
 	"text/template"
 	"time"
@@ -66,6 +67,8 @@ const ManagedConfigTemplate = `
 #xpack.monitoring.elasticsearch:
 `
 
+var errEmptyAccessToken = errors.New("access_token is empty, you must reenroll your beats")
+
 // Config for central management
 type Config struct {
 	// true when enrolled
@@ -79,6 +82,13 @@ type Config struct {
 	Kibana *kibana.ClientConfig `config:"kibana" yaml:"kibana"`
 
 	Blacklist ConfigBlacklistSettings `config:"blacklist" yaml:"blacklist"`
+}
+
+func (c *Config) Validate() error {
+	if len(c.AccessToken) == 0 {
+		return errEmptyAccessToken
+	}
+	return nil
 }
 
 func defaultConfig() *Config {

--- a/x-pack/libbeat/management/config_test.go
+++ b/x-pack/libbeat/management/config_test.go
@@ -1,0 +1,44 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package management
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/libbeat/common"
+)
+
+func TestConfigValidate(t *testing.T) {
+	tests := []struct {
+		name   string
+		config *common.Config
+		err    bool
+	}{
+		{
+			name:   "missing access_token",
+			config: common.MustNewConfigFrom(map[string]interface{}{}),
+			err:    true,
+		},
+		{
+			name:   "access_token is present",
+			config: common.MustNewConfigFrom(map[string]interface{}{"access_token": "abc1234"}),
+			err:    false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := defaultConfig()
+			err := test.config.Unpack(c)
+			if test.err {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
Add validations for the Kibana response with the access token,
and enforce that the access token is not empty when unpacking the
configuration. Since the access token in the keystore could be edited.

Fixes: #9621