### PR TITLE
Cherry-pick #9617 to 6.x: Fix issue with ILM that write index was created before template was loaded

### DIFF
--- a/libbeat/mock/mockbeat.go
+++ b/libbeat/mock/mockbeat.go
@@ -49,14 +49,25 @@ func (mb *Mockbeat) Run(b *beat.Beat) error {
 		return err
 	}
 
-	// Wait until mockbeat is done
-	go client.Publish(beat.Event{
-		Timestamp: time.Now(),
-		Fields: common.MapStr{
-			"type":    "mock",
-			"message": "Mockbeat is alive!",
-		},
-	})
+	ticker := time.NewTicker(1 * time.Second)
+	go func() {
+		for {
+			select {
+			case <-ticker.C:
+				client.Publish(beat.Event{
+					Timestamp: time.Now(),
+					Fields: common.MapStr{
+						"type":    "mock",
+						"message": "Mockbeat is alive!",
+					},
+				})
+			case <-mb.done:
+				ticker.Stop()
+				return
+			}
+		}
+	}()
+
 	<-mb.done
 	return nil
 }

--- a/libbeat/tests/system/test_ilm.py
+++ b/libbeat/tests/system/test_ilm.py
@@ -198,6 +198,7 @@ class Test(BaseTest):
         policy = self.es.transport.perform_request('GET', "/_ilm/policy/" + self.policy_name)
         assert self.policy_name in policy
 
+    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     @attr('integration')
     def test_export_ilm_policy(self):
         """


### PR DESCRIPTION
Cherry-pick of PR #9617 to 6.x branch. Original message: 

The write index for ILM was created before the template was loaded. This meant the first template did not contain all the mappings and policy for ILM so was never rolled over. This change makes sure the template is loaded for ILM is setup up and adds a test to confirm it.

Further ILM was not respected when running `metricbeat setup --template`. This is now changed too.

mockbeat was modified to send multiple events instead of just one to allow the new tests.