### PR TITLE
[Auditbeat] Remove exception catching in system module system tests

### DIFF
--- a/x-pack/auditbeat/tests/system/test_metricsets.py
+++ b/x-pack/auditbeat/tests/system/test_metricsets.py
@@ -21,13 +21,7 @@ class Test(AuditbeatXPackTest):
         fields = ["system.audit.host.uptime", "system.audit.host.ip", "system.audit.host.os.name"]
 
         # Metricset is experimental and that generates a warning, TODO: remove later
-        # TODO: Remove try/catch once new fields are in fields.ecs.yml
-        # https://github.com/elastic/beats/issues/9318
-        try:
-            self.check_metricset("system", "host", COMMON_FIELDS + fields, warnings_allowed=True)
-        except Exception as e:
-            if "event.kind" not in str(e):
-                raise
+        self.check_metricset("system", "host", COMMON_FIELDS + fields, warnings_allowed=True)
 
     @unittest.skip("Packages metricset is disabled")
     def test_metricset_packages(self):
@@ -49,13 +43,7 @@ class Test(AuditbeatXPackTest):
         fields = ["process.pid"]
 
         # Metricset is experimental and that generates a warning, TODO: remove later
-        # TODO: Remove try/catch once new fields are in fields.ecs.yml
-        # https://github.com/elastic/beats/issues/9318
-        try:
-            self.check_metricset("system", "process", COMMON_FIELDS + fields, warnings_allowed=True)
-        except Exception as e:
-            if "process.working_directory" not in str(e) and "process.start" not in str(e) and "event.kind" not in str(e):
-                raise
+        self.check_metricset("system", "process", COMMON_FIELDS + fields, warnings_allowed=True)
 
     @unittest.skipUnless(sys.platform == "linux2", "Only implemented for Linux")
     def test_metricset_socket(self):
@@ -66,13 +54,7 @@ class Test(AuditbeatXPackTest):
         fields = ["destination.port"]
 
         # Metricset is experimental and that generates a warning, TODO: remove later
-        # TODO: Remove try/catch once new fields are in fields.ecs.yml
-        # https://github.com/elastic/beats/issues/9318
-        try:
-            self.check_metricset("system", "socket", COMMON_FIELDS + fields, warnings_allowed=True)
-        except Exception as e:
-            if "network.type" not in str(e) and "event.kind" not in str(e):
-                raise
+        self.check_metricset("system", "socket", COMMON_FIELDS + fields, warnings_allowed=True)
 
     @unittest.skipUnless(sys.platform == "linux2", "Only implemented for Linux")
     def test_metricset_user(self):
@@ -83,10 +65,4 @@ class Test(AuditbeatXPackTest):
         fields = ["system.audit.user.name"]
 
         # Metricset is experimental and that generates a warning, TODO: remove later
-        # TODO: Remove try/catch once new fields are in fields.ecs.yml
-        # https://github.com/elastic/beats/issues/9318
-        try:
-            self.check_metricset("system", "user", COMMON_FIELDS + fields, warnings_allowed=True)
-        except Exception as e:
-            if "event.kind" not in str(e):
-                raise
+        self.check_metricset("system", "user", COMMON_FIELDS + fields, warnings_allowed=True)


### PR DESCRIPTION
Now that all ECS fields have landed (https://github.com/elastic/beats/issues/9318) we can remove the exception catching logic around these system tests.