### PR TITLE
Fixes a panic originating from process_test.go

### DIFF
--- a/x-pack/auditbeat/module/system/process/process_test.go
+++ b/x-pack/auditbeat/module/system/process/process_test.go
@@ -22,10 +22,7 @@ func TestData(t *testing.T) {
 		t.Fatal("no events were generated")
 	}
 
-	// The first process (events[0]) is usually something like systemd,
-	// the last few are test processes, so we pick something more interesting
-	// towards the end.
-	fullEvent := mbtest.StandardizeEvent(f, events[len(events)-8], core.AddDatasetToEvent)
+	fullEvent := mbtest.StandardizeEvent(f, events[0], core.AddDatasetToEvent)
 	mbtest.WriteEventToDataJSON(t, fullEvent, "")
 }
 


### PR DESCRIPTION
The test references an index without doing bounds checking. Reverting to just using events[0] for which there is
a bounds check.

    panic: runtime error: index out of range
    /home/vagrant/go/src/github.com/elastic/beats/x-pack/auditbeat/module/system/process/process_test.go:28 +0x4a1