### PR TITLE
Cherry-pick #9642 to 6.x: Export field for xpack.enabled setting

### DIFF
--- a/metricbeat/module/kibana/metricset.go
+++ b/metricbeat/module/kibana/metricset.go
@@ -33,23 +33,18 @@ type MetricSet struct {
 // NewMetricSet creates a metricset that can be used to build other metricsets
 // within the Kibana module.
 func NewMetricSet(base mb.BaseMetricSet) (*MetricSet, error) {
-	config := struct {
-		xPackEnabled bool `config:"xpack.enabled"`
-	}{
-		xPackEnabled: false,
-	}
-
+	config := DefaultConfig()
 	if err := base.Module().UnpackConfig(&config); err != nil {
 		return nil, err
 	}
 
-	if config.xPackEnabled {
+	if config.XPackEnabled {
 		cfgwarn.Experimental("The experimental xpack.enabled flag in the " + base.FullyQualifiedName() + " metricset is enabled.")
 	}
 
 	return &MetricSet{
 		base,
-		config.xPackEnabled,
+		config.XPackEnabled,
 		logp.NewLogger(ModuleName),
 	}, nil
 }


### PR DESCRIPTION
Cherry-pick of PR #9642 to 6.x branch. Original message: 

The cleanup in https://github.com/elastic/beats/pull/8308 introduced a regression which caused the `xpack.enabled` flag in the `kibana` module to stop having any effect.

This PR fixes that issue by reverting the troublesome bits from #8308, ensuring that the struct field for the parsed configuration setting is exported.