### PR TITLE
Cherry-pick #9609 to 6.x: Netflow input ECS changes

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -113,6 +113,7 @@ https://github.com/elastic/beats/compare/v6.5.0...6.x[Check the HEAD diff]
 - Add event.dataset to module events. {pull}9457[9457]
 - Add field log.source.address and log.file.path to replace source. {pull}9435[9435]
 - Add support for multi-core thread_id in postgresql module {issue}9156[9156] {pull}9482[9482]
+- Added netflow input type that supports NetFlow v1, v5, v6, v7, v8, v9 and IPFIX. {issue}9399[9399]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Barracuda-extended-uniflow-template-256.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Barracuda-extended-uniflow-template-256.golden.json
@@ -10,13 +10,12 @@
           "locality": "public",
           "port": 443
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2018-04-18T08:16:47Z",
-          "duration": 0
+          "duration": 0,
+          "kind": "event"
         },
         "flow": {
           "id": "xrwrnNR_Xgs",
@@ -58,14 +57,18 @@
           "source_transport_port": 51917,
           "timestamp": 1524039407,
           "traffic_type": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 0,
           "community_id": "1:hxVadzb8UUZ5YGGYtqj+E2mpQe8=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 0,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.236.5.4",
@@ -85,13 +88,12 @@
           "locality": "private",
           "port": 51917
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2018-04-18T08:16:47Z",
-          "duration": 0
+          "duration": 0,
+          "kind": "event"
         },
         "flow": {
           "id": "7BBLL0QpIjw",
@@ -133,14 +135,18 @@
           "source_transport_port": 443,
           "timestamp": 1524039407,
           "traffic_type": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 0,
           "community_id": "1:4oQU8uYa7F7RE/lIflbJOuU8Vc8=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 0,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "64.235.151.76",

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Barracuda-firewall.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Barracuda-firewall.golden.json
@@ -10,13 +10,12 @@
           "locality": "private",
           "port": 53
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2017-06-29T13:58:28Z",
-          "duration": 20269000000
+          "duration": 20269000000,
+          "kind": "event"
         },
         "flow": {
           "id": "iuHn3GlQ8XA",
@@ -46,14 +45,18 @@
           "source_ipv4_address": "10.99.130.239",
           "source_mac_address": "00:00:00:00:00:00",
           "source_transport_port": 65105,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 0,
           "community_id": "1:UAtYiTxp798P/gsK6Pp/IjMZLiU=",
           "direction": "unknown",
+          "iana_number": 17,
           "packets": 0,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.99.130.239",
@@ -73,13 +76,12 @@
           "locality": "private",
           "port": 65105
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2017-06-29T13:58:28Z",
-          "duration": 20269000000
+          "duration": 20269000000,
+          "kind": "event"
         },
         "flow": {
           "id": "SJgQadmL3WE",
@@ -109,14 +111,18 @@
           "source_ipv4_address": "10.99.252.50",
           "source_mac_address": "00:00:00:00:00:00",
           "source_transport_port": 53,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 81,
           "community_id": "1:Z1aQRJ93TBJeX7YDGHG1zysbYVM=",
           "direction": "unknown",
+          "iana_number": 17,
           "packets": 1,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.99.252.50",
@@ -136,13 +142,12 @@
           "locality": "private",
           "port": 53
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2017-06-29T13:58:28Z",
-          "duration": 20306000000
+          "duration": 20306000000,
+          "kind": "event"
         },
         "flow": {
           "id": "iuHn3GlQ8XA",
@@ -172,14 +177,18 @@
           "source_ipv4_address": "10.99.130.239",
           "source_mac_address": "00:00:00:00:00:00",
           "source_transport_port": 65105,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 0,
           "community_id": "1:UAtYiTxp798P/gsK6Pp/IjMZLiU=",
           "direction": "unknown",
+          "iana_number": 17,
           "packets": 0,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.99.130.239",
@@ -199,13 +208,12 @@
           "locality": "private",
           "port": 65105
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2017-06-29T13:58:28Z",
-          "duration": 20306000000
+          "duration": 20306000000,
+          "kind": "event"
         },
         "flow": {
           "id": "eIt31cWru0w",
@@ -235,14 +243,18 @@
           "source_ipv4_address": "10.98.243.20",
           "source_mac_address": "00:00:00:00:00:00",
           "source_transport_port": 53,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 81,
           "community_id": "1:Xb8wZBfARygVu6rohygs9ZhX5Og=",
           "direction": "unknown",
+          "iana_number": 17,
           "packets": 1,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.98.243.20",
@@ -262,13 +274,12 @@
           "locality": "private",
           "port": 53
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2017-06-29T13:58:28Z",
-          "duration": 20317000000
+          "duration": 20317000000,
+          "kind": "event"
         },
         "flow": {
           "id": "MNe2gxAuU4I",
@@ -298,14 +309,18 @@
           "source_ipv4_address": "10.99.168.140",
           "source_mac_address": "00:00:00:00:00:00",
           "source_transport_port": 52344,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 0,
           "community_id": "1:ElddGTwZIDATUPp6inGMG4Ii4Xw=",
           "direction": "unknown",
+          "iana_number": 17,
           "packets": 0,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.99.168.140",
@@ -325,13 +340,12 @@
           "locality": "private",
           "port": 52344
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2017-06-29T13:58:28Z",
-          "duration": 20317000000
+          "duration": 20317000000,
+          "kind": "event"
         },
         "flow": {
           "id": "Fm5S3cg6Lcw",
@@ -361,14 +375,18 @@
           "source_ipv4_address": "10.98.243.20",
           "source_mac_address": "00:00:00:00:00:00",
           "source_transport_port": 53,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 113,
           "community_id": "1:+74AKYSI83q3lzZWoLzV4bxxCfU=",
           "direction": "unknown",
+          "iana_number": 17,
           "packets": 1,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.98.243.20",
@@ -388,13 +406,12 @@
           "locality": "private",
           "port": 53
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2017-06-29T13:58:28Z",
-          "duration": 20368000000
+          "duration": 20368000000,
+          "kind": "event"
         },
         "flow": {
           "id": "1srU81eLhhw",
@@ -424,14 +441,18 @@
           "source_ipv4_address": "10.99.168.140",
           "source_mac_address": "00:00:00:00:00:00",
           "source_transport_port": 50294,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 0,
           "community_id": "1:r8af+dFTXsLQoTuHm+3HOu/Gpzc=",
           "direction": "unknown",
+          "iana_number": 17,
           "packets": 0,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.99.168.140",
@@ -451,13 +472,12 @@
           "locality": "private",
           "port": 50294
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2017-06-29T13:58:28Z",
-          "duration": 20368000000
+          "duration": 20368000000,
+          "kind": "event"
         },
         "flow": {
           "id": "b-peOmD4XyI",
@@ -487,14 +507,18 @@
           "source_ipv4_address": "10.98.243.20",
           "source_mac_address": "00:00:00:00:00:00",
           "source_transport_port": 53,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 113,
           "community_id": "1:yBQpMR0U13RQyD1dOmOn6u8mts0=",
           "direction": "unknown",
+          "iana_number": 17,
           "packets": 1,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.98.243.20",

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Mikrotik-RouterOS-6.39.2.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Mikrotik-RouterOS-6.39.2.golden.json
@@ -10,12 +10,11 @@
           "locality": "private",
           "port": 123
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-07-19T16:18:08Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-07-19T16:18:08Z",
+          "kind": "event"
         },
         "flow": {
           "id": "qKMtgI7Ed9s",
@@ -45,14 +44,18 @@
           "source_ipv4_address": "10.10.8.197",
           "source_transport_port": 123,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 152,
           "community_id": "1:o4guLY2bL+DOHtQO9gHFEbXsEQ0=",
           "direction": "unknown",
+          "iana_number": 17,
           "packets": 2,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.10.8.197",
@@ -71,12 +74,11 @@
           "locality": "private",
           "port": 82
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-07-19T16:18:08Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-07-19T16:18:08Z",
+          "kind": "event"
         },
         "flow": {
           "id": "5FNp7ndavXc",
@@ -106,14 +108,18 @@
           "source_ipv4_address": "192.168.35.143",
           "source_transport_port": 46518,
           "tcp_control_bits": 2,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 502,
           "community_id": "1:dff66BxOHH2oQ2rp9q6L5XAyxUw=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 8,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.35.143",
@@ -132,12 +138,11 @@
           "locality": "private",
           "port": 46518
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-07-19T16:18:08Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-07-19T16:18:08Z",
+          "kind": "event"
         },
         "flow": {
           "id": "5dxciNWUCt0",
@@ -167,14 +172,18 @@
           "source_ipv4_address": "10.10.6.11",
           "source_transport_port": 80,
           "tcp_control_bits": 18,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 2233,
           "community_id": "1:r27Ws33L+xEVSg9VX0zVJ9MNKwA=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 8,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.10.6.11",
@@ -193,12 +202,11 @@
           "locality": "private",
           "port": 123
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-07-19T16:18:08Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-07-19T16:18:08Z",
+          "kind": "event"
         },
         "flow": {
           "id": "TJxuTh4pSgE",
@@ -228,14 +236,18 @@
           "source_ipv4_address": "192.168.128.17",
           "source_transport_port": 123,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 152,
           "community_id": "1:vzzwAshWVAvuWES5NyhLy1GLPAY=",
           "direction": "unknown",
+          "iana_number": 17,
           "packets": 2,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.128.17",
@@ -254,12 +266,11 @@
           "locality": "private",
           "port": 42502
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-07-19T16:18:08Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-07-19T16:18:08Z",
+          "kind": "event"
         },
         "flow": {
           "id": "eVcvPUJANB4",
@@ -289,14 +300,18 @@
           "source_ipv4_address": "10.10.8.220",
           "source_transport_port": 80,
           "tcp_control_bits": 18,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 79724,
           "community_id": "1:1LnuPKitmhDRXGMc7PEKYVnKHqs=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 57,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.10.8.220",
@@ -315,12 +330,11 @@
           "locality": "private",
           "port": 53
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-07-19T16:18:08Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-07-19T16:18:08Z",
+          "kind": "event"
         },
         "flow": {
           "id": "Dr8WeOCZm_4",
@@ -350,14 +364,18 @@
           "source_ipv4_address": "172.20.4.199",
           "source_transport_port": 10240,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 161,
           "community_id": "1:xCTumK0k/psyvuepNPEIbpQ8Iy4=",
           "direction": "unknown",
+          "iana_number": 17,
           "packets": 3,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "172.20.4.199",
@@ -376,12 +394,11 @@
           "locality": "private",
           "port": 10240
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-07-19T16:18:08Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-07-19T16:18:08Z",
+          "kind": "event"
         },
         "flow": {
           "id": "P7HJmFBUOa8",
@@ -411,14 +428,18 @@
           "source_ipv4_address": "172.20.4.1",
           "source_transport_port": 53,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 245,
           "community_id": "1:z+7+u9s7BqnBecKTeXOc7Esh+mM=",
           "direction": "unknown",
+          "iana_number": 17,
           "packets": 3,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "172.20.4.1",
@@ -437,12 +458,11 @@
           "locality": "private",
           "port": 0
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-07-19T16:18:08Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-07-19T16:18:08Z",
+          "kind": "event"
         },
         "flow": {
           "id": "E6FN06gC8JE",
@@ -472,14 +492,18 @@
           "source_ipv4_address": "172.20.4.30",
           "source_transport_port": 0,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 504,
           "community_id": "1:AB9PVU/9h10nCsljEg6e5LXF1dA=",
           "direction": "unknown",
+          "iana_number": 1,
           "packets": 6,
-          "protocol": "icmp"
+          "transport": "icmp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "172.20.4.30",
@@ -498,12 +522,11 @@
           "locality": "private",
           "port": 59571
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-07-19T16:18:08Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-07-19T16:18:08Z",
+          "kind": "event"
         },
         "flow": {
           "id": "D9tiVWmcw2o",
@@ -533,14 +556,18 @@
           "source_ipv4_address": "10.10.8.105",
           "source_transport_port": 22,
           "tcp_control_bits": 18,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 784,
           "community_id": "1:KXMvvH/BLW4/w8E/y+y2Q/SCK98=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 6,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.10.8.105",
@@ -559,12 +586,11 @@
           "locality": "private",
           "port": 22
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-07-19T16:18:08Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-07-19T16:18:08Z",
+          "kind": "event"
         },
         "flow": {
           "id": "ZNd__DyTXzg",
@@ -594,14 +620,18 @@
           "source_ipv4_address": "172.20.4.30",
           "source_transport_port": 59571,
           "tcp_control_bits": 2,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 433,
           "community_id": "1:Ijd9IXUQpbZAEGLrnnoGfaBS1Ag=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 8,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "172.20.4.30",
@@ -620,12 +650,11 @@
           "locality": "private",
           "port": 6667
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-07-19T16:18:08Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-07-19T16:18:08Z",
+          "kind": "event"
         },
         "flow": {
           "id": "r4pPq83nIfU",
@@ -655,14 +684,18 @@
           "source_ipv4_address": "10.10.7.11",
           "source_transport_port": 48378,
           "tcp_control_bits": 24,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 196,
           "community_id": "1:CYX4DREl+BdwaoOD2Loh6qciwxU=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 3,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.10.7.11",
@@ -681,12 +714,11 @@
           "locality": "private",
           "port": 48378
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-07-19T16:18:08Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-07-19T16:18:08Z",
+          "kind": "event"
         },
         "flow": {
           "id": "W0ydMavNfpM",
@@ -716,14 +748,18 @@
           "source_ipv4_address": "192.168.183.199",
           "source_transport_port": 6667,
           "tcp_control_bits": 16,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 206,
           "community_id": "1:18lbeqRsrUgxd8UtlYpuACgLqzY=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 3,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.183.199",
@@ -742,12 +778,11 @@
           "locality": "private",
           "port": 0
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-07-19T16:18:08Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-07-19T16:18:08Z",
+          "kind": "event"
         },
         "flow": {
           "id": "euOQwbFToDs",
@@ -777,14 +812,18 @@
           "source_ipv4_address": "10.10.8.34",
           "source_transport_port": 0,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 504,
           "community_id": "1:qqXQzadVXO6y385wBBFibOAWjO4=",
           "direction": "unknown",
+          "iana_number": 1,
           "packets": 6,
-          "protocol": "icmp"
+          "transport": "icmp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.10.8.34",
@@ -803,12 +842,11 @@
           "locality": "private",
           "port": 80
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-07-19T16:18:08Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-07-19T16:18:08Z",
+          "kind": "event"
         },
         "flow": {
           "id": "vtn0fYyiQAs",
@@ -838,14 +876,18 @@
           "source_ipv4_address": "172.20.5.191",
           "source_transport_port": 42502,
           "tcp_control_bits": 2,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 3539,
           "community_id": "1:wac990UkZPCjIeHvh0HL/Xpni2I=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 58,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "172.20.5.191",
@@ -864,12 +906,11 @@
           "locality": "private",
           "port": 5678
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-07-19T16:18:08Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-07-19T16:18:08Z",
+          "kind": "event"
         },
         "flow": {
           "id": "kgBNXXN8ed4",
@@ -899,14 +940,18 @@
           "source_ipv4_address": "172.20.4.1",
           "source_transport_port": 33332,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 495,
           "community_id": "1:CAn4DeDPy+T2ErchwToc81lqPQU=",
           "direction": "unknown",
+          "iana_number": 17,
           "packets": 3,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "172.20.4.1",
@@ -925,12 +970,11 @@
           "locality": "private",
           "port": 5678
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-07-19T16:18:08Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-07-19T16:18:08Z",
+          "kind": "event"
         },
         "flow": {
           "id": "kgBNXXN8ed4",
@@ -960,14 +1004,18 @@
           "source_ipv4_address": "172.20.4.1",
           "source_transport_port": 33332,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 330,
           "community_id": "1:CAn4DeDPy+T2ErchwToc81lqPQU=",
           "direction": "unknown",
+          "iana_number": 17,
           "packets": 2,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "172.20.4.1",
@@ -986,12 +1034,11 @@
           "locality": "private",
           "port": 5678
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-07-19T16:18:08Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-07-19T16:18:08Z",
+          "kind": "event"
         },
         "flow": {
           "id": "AYD5HyisGMY",
@@ -1021,14 +1068,18 @@
           "source_ipv4_address": "172.30.0.1",
           "source_transport_port": 53298,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 435,
           "community_id": "1:ECc+OoQ/d54eyjdC2O/nZlxXu5U=",
           "direction": "unknown",
+          "iana_number": 17,
           "packets": 3,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "172.30.0.1",
@@ -1047,12 +1098,11 @@
           "locality": "private",
           "port": 5678
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-07-19T16:18:08Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-07-19T16:18:08Z",
+          "kind": "event"
         },
         "flow": {
           "id": "AYD5HyisGMY",
@@ -1082,14 +1132,18 @@
           "source_ipv4_address": "172.30.0.1",
           "source_transport_port": 53298,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 290,
           "community_id": "1:ECc+OoQ/d54eyjdC2O/nZlxXu5U=",
           "direction": "unknown",
+          "iana_number": 17,
           "packets": 2,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "172.30.0.1",
@@ -1108,12 +1162,11 @@
           "locality": "private",
           "port": 5678
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-07-19T16:18:08Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-07-19T16:18:08Z",
+          "kind": "event"
         },
         "flow": {
           "id": "he8fZsMllBk",
@@ -1143,14 +1196,18 @@
           "source_ipv4_address": "10.10.6.1",
           "source_transport_port": 48172,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 495,
           "community_id": "1:7z8BCaKj9NKuV5cTZ/0iho+mq8g=",
           "direction": "unknown",
+          "iana_number": 17,
           "packets": 3,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.10.6.1",
@@ -1169,12 +1226,11 @@
           "locality": "private",
           "port": 5678
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-07-19T16:18:08Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-07-19T16:18:08Z",
+          "kind": "event"
         },
         "flow": {
           "id": "he8fZsMllBk",
@@ -1204,14 +1260,18 @@
           "source_ipv4_address": "10.10.6.1",
           "source_transport_port": 48172,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 330,
           "community_id": "1:7z8BCaKj9NKuV5cTZ/0iho+mq8g=",
           "direction": "unknown",
+          "iana_number": 17,
           "packets": 2,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.10.6.1",
@@ -1230,12 +1290,11 @@
           "locality": "private",
           "port": 5678
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-07-19T16:18:08Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-07-19T16:18:08Z",
+          "kind": "event"
         },
         "flow": {
           "id": "fanKYX35CDM",
@@ -1265,14 +1324,18 @@
           "source_ipv4_address": "10.10.7.1",
           "source_transport_port": 48935,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 495,
           "community_id": "1:Kkf8y7Ployk+ad0kqHGs5DfAD2I=",
           "direction": "unknown",
+          "iana_number": 17,
           "packets": 3,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.10.7.1",
@@ -1291,12 +1354,11 @@
           "locality": "private",
           "port": 5678
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-07-19T16:18:08Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-07-19T16:18:08Z",
+          "kind": "event"
         },
         "flow": {
           "id": "fanKYX35CDM",
@@ -1326,14 +1388,18 @@
           "source_ipv4_address": "10.10.7.1",
           "source_transport_port": 48935,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 330,
           "community_id": "1:Kkf8y7Ployk+ad0kqHGs5DfAD2I=",
           "direction": "unknown",
+          "iana_number": 17,
           "packets": 2,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.10.7.1",
@@ -1352,12 +1418,11 @@
           "locality": "private",
           "port": 5678
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-07-19T16:18:08Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-07-19T16:18:08Z",
+          "kind": "event"
         },
         "flow": {
           "id": "1I_ey2YYTSM",
@@ -1387,14 +1452,18 @@
           "source_ipv4_address": "10.10.8.1",
           "source_transport_port": 51931,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 495,
           "community_id": "1:NSreojKsVnKur/rcYCbfJyvxowQ=",
           "direction": "unknown",
+          "iana_number": 17,
           "packets": 3,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.10.8.1",
@@ -1413,12 +1482,11 @@
           "locality": "private",
           "port": 5678
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-07-19T16:18:08Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-07-19T16:18:08Z",
+          "kind": "event"
         },
         "flow": {
           "id": "1I_ey2YYTSM",
@@ -1448,14 +1516,18 @@
           "source_ipv4_address": "10.10.8.1",
           "source_transport_port": 51931,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 330,
           "community_id": "1:NSreojKsVnKur/rcYCbfJyvxowQ=",
           "direction": "unknown",
+          "iana_number": 17,
           "packets": 2,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.10.8.1",
@@ -1474,12 +1546,11 @@
           "locality": "private",
           "port": 5678
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-07-19T16:18:08Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-07-19T16:18:08Z",
+          "kind": "event"
         },
         "flow": {
           "id": "P7bcxAuBWAY",
@@ -1509,14 +1580,18 @@
           "source_ipv4_address": "10.20.0.1",
           "source_transport_port": 43454,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 495,
           "community_id": "1:U63dC2bH5aZryJEt2eamKMKzoug=",
           "direction": "unknown",
+          "iana_number": 17,
           "packets": 3,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.20.0.1",
@@ -1535,12 +1610,11 @@
           "locality": "private",
           "port": 5678
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-07-19T16:18:08Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-07-19T16:18:08Z",
+          "kind": "event"
         },
         "flow": {
           "id": "P7bcxAuBWAY",
@@ -1570,14 +1644,18 @@
           "source_ipv4_address": "10.20.0.1",
           "source_transport_port": 43454,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 330,
           "community_id": "1:U63dC2bH5aZryJEt2eamKMKzoug=",
           "direction": "unknown",
+          "iana_number": 17,
           "packets": 2,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.20.0.1",
@@ -1596,12 +1674,11 @@
           "locality": "private",
           "port": 5678
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-07-19T16:18:08Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-07-19T16:18:08Z",
+          "kind": "event"
         },
         "flow": {
           "id": "rBSLKqUfMAo",
@@ -1631,14 +1708,18 @@
           "source_ipv4_address": "10.10.10.1",
           "source_transport_port": 52837,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 495,
           "community_id": "1:zLCNgJ9Rr55+Kd5OAB4CQOgTQBY=",
           "direction": "unknown",
+          "iana_number": 17,
           "packets": 3,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.10.10.1",
@@ -1657,12 +1738,11 @@
           "locality": "private",
           "port": 5678
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-07-19T16:18:08Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-07-19T16:18:08Z",
+          "kind": "event"
         },
         "flow": {
           "id": "rBSLKqUfMAo",
@@ -1692,14 +1772,18 @@
           "source_ipv4_address": "10.10.10.1",
           "source_transport_port": 52837,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 330,
           "community_id": "1:zLCNgJ9Rr55+Kd5OAB4CQOgTQBY=",
           "direction": "unknown",
+          "iana_number": 17,
           "packets": 2,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.10.10.1",
@@ -1716,12 +1800,11 @@
         "destination": {
           "port": 5678
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-07-19T16:18:08Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-07-19T16:18:08Z",
+          "kind": "event"
         },
         "flow": {
           "id": "RlrAo_U1Y14",
@@ -1749,14 +1832,18 @@
           "source_ipv6_address": "fe80::ff:fe00:401",
           "source_transport_port": 5678,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 555,
           "community_id": "1:I4DlCbWgyxRiNPVj5ntu1L7Z0hw=",
           "direction": "unknown",
+          "iana_number": 17,
           "packets": 3,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "port": 5678
@@ -1771,12 +1858,11 @@
         "destination": {
           "port": 5678
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-07-19T16:18:08Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-07-19T16:18:08Z",
+          "kind": "event"
         },
         "flow": {
           "id": "RlrAo_U1Y14",
@@ -1804,14 +1890,18 @@
           "source_ipv6_address": "fe80::ff:fe00:401",
           "source_transport_port": 5678,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 370,
           "community_id": "1:I4DlCbWgyxRiNPVj5ntu1L7Z0hw=",
           "direction": "unknown",
+          "iana_number": 17,
           "packets": 2,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "port": 5678
@@ -1826,12 +1916,11 @@
         "destination": {
           "port": 5678
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-07-19T16:18:08Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-07-19T16:18:08Z",
+          "kind": "event"
         },
         "flow": {
           "id": "RlrAo_U1Y14",
@@ -1859,14 +1948,18 @@
           "source_ipv6_address": "fe80::ff:fe00:501",
           "source_transport_port": 5678,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 495,
           "community_id": "1:I4DlCbWgyxRiNPVj5ntu1L7Z0hw=",
           "direction": "unknown",
+          "iana_number": 17,
           "packets": 3,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "port": 5678
@@ -1881,12 +1974,11 @@
         "destination": {
           "port": 5678
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-07-19T16:18:08Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-07-19T16:18:08Z",
+          "kind": "event"
         },
         "flow": {
           "id": "RlrAo_U1Y14",
@@ -1914,14 +2006,18 @@
           "source_ipv6_address": "fe80::ff:fe00:501",
           "source_transport_port": 5678,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 330,
           "community_id": "1:I4DlCbWgyxRiNPVj5ntu1L7Z0hw=",
           "direction": "unknown",
+          "iana_number": 17,
           "packets": 2,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "port": 5678
@@ -1936,12 +2032,11 @@
         "destination": {
           "port": 5678
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-07-19T16:18:08Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-07-19T16:18:08Z",
+          "kind": "event"
         },
         "flow": {
           "id": "RlrAo_U1Y14",
@@ -1969,14 +2064,18 @@
           "source_ipv6_address": "fe80::ff:fe00:601",
           "source_transport_port": 5678,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 555,
           "community_id": "1:I4DlCbWgyxRiNPVj5ntu1L7Z0hw=",
           "direction": "unknown",
+          "iana_number": 17,
           "packets": 3,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "port": 5678
@@ -1991,12 +2090,11 @@
         "destination": {
           "port": 5678
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-07-19T16:18:08Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-07-19T16:18:08Z",
+          "kind": "event"
         },
         "flow": {
           "id": "RlrAo_U1Y14",
@@ -2024,14 +2122,18 @@
           "source_ipv6_address": "fe80::ff:fe00:601",
           "source_transport_port": 5678,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 370,
           "community_id": "1:I4DlCbWgyxRiNPVj5ntu1L7Z0hw=",
           "direction": "unknown",
+          "iana_number": 17,
           "packets": 2,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "port": 5678
@@ -2046,12 +2148,11 @@
         "destination": {
           "port": 5678
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-07-19T16:18:08Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-07-19T16:18:08Z",
+          "kind": "event"
         },
         "flow": {
           "id": "RlrAo_U1Y14",
@@ -2079,14 +2180,18 @@
           "source_ipv6_address": "fe80::ff:fe00:701",
           "source_transport_port": 5678,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 555,
           "community_id": "1:I4DlCbWgyxRiNPVj5ntu1L7Z0hw=",
           "direction": "unknown",
+          "iana_number": 17,
           "packets": 3,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "port": 5678
@@ -2101,12 +2206,11 @@
         "destination": {
           "port": 5678
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-07-19T16:18:08Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-07-19T16:18:08Z",
+          "kind": "event"
         },
         "flow": {
           "id": "RlrAo_U1Y14",
@@ -2134,14 +2238,18 @@
           "source_ipv6_address": "fe80::ff:fe00:701",
           "source_transport_port": 5678,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 370,
           "community_id": "1:I4DlCbWgyxRiNPVj5ntu1L7Z0hw=",
           "direction": "unknown",
+          "iana_number": 17,
           "packets": 2,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "port": 5678
@@ -2156,12 +2264,11 @@
         "destination": {
           "port": 5678
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-07-19T16:18:08Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-07-19T16:18:08Z",
+          "kind": "event"
         },
         "flow": {
           "id": "RlrAo_U1Y14",
@@ -2189,14 +2296,18 @@
           "source_ipv6_address": "fe80::ff:fe00:801",
           "source_transport_port": 5678,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 555,
           "community_id": "1:I4DlCbWgyxRiNPVj5ntu1L7Z0hw=",
           "direction": "unknown",
+          "iana_number": 17,
           "packets": 3,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "port": 5678
@@ -2211,12 +2322,11 @@
         "destination": {
           "port": 5678
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-07-19T16:18:08Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-07-19T16:18:08Z",
+          "kind": "event"
         },
         "flow": {
           "id": "RlrAo_U1Y14",
@@ -2244,14 +2354,18 @@
           "source_ipv6_address": "fe80::ff:fe00:801",
           "source_transport_port": 5678,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 370,
           "community_id": "1:I4DlCbWgyxRiNPVj5ntu1L7Z0hw=",
           "direction": "unknown",
+          "iana_number": 17,
           "packets": 2,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "port": 5678
@@ -2266,12 +2380,11 @@
         "destination": {
           "port": 5678
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-07-19T16:18:08Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-07-19T16:18:08Z",
+          "kind": "event"
         },
         "flow": {
           "id": "RlrAo_U1Y14",
@@ -2299,14 +2412,18 @@
           "source_ipv6_address": "fe80::ff:fe00:901",
           "source_transport_port": 5678,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 555,
           "community_id": "1:I4DlCbWgyxRiNPVj5ntu1L7Z0hw=",
           "direction": "unknown",
+          "iana_number": 17,
           "packets": 3,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "port": 5678
@@ -2321,12 +2438,11 @@
         "destination": {
           "port": 5678
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-07-19T16:18:08Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-07-19T16:18:08Z",
+          "kind": "event"
         },
         "flow": {
           "id": "RlrAo_U1Y14",
@@ -2354,14 +2470,18 @@
           "source_ipv6_address": "fe80::ff:fe00:901",
           "source_transport_port": 5678,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 370,
           "community_id": "1:I4DlCbWgyxRiNPVj5ntu1L7Z0hw=",
           "direction": "unknown",
+          "iana_number": 17,
           "packets": 2,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "port": 5678
@@ -2376,12 +2496,11 @@
         "destination": {
           "port": 5678
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-07-19T16:18:08Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-07-19T16:18:08Z",
+          "kind": "event"
         },
         "flow": {
           "id": "RlrAo_U1Y14",
@@ -2409,14 +2528,18 @@
           "source_ipv6_address": "fe80::ff:fe00:1001",
           "source_transport_port": 5678,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 555,
           "community_id": "1:I4DlCbWgyxRiNPVj5ntu1L7Z0hw=",
           "direction": "unknown",
+          "iana_number": 17,
           "packets": 3,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "port": 5678
@@ -2431,12 +2554,11 @@
         "destination": {
           "port": 5678
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-07-19T16:18:08Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-07-19T16:18:08Z",
+          "kind": "event"
         },
         "flow": {
           "id": "RlrAo_U1Y14",
@@ -2464,14 +2586,18 @@
           "source_ipv6_address": "fe80::ff:fe00:1001",
           "source_transport_port": 5678,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 370,
           "community_id": "1:I4DlCbWgyxRiNPVj5ntu1L7Z0hw=",
           "direction": "unknown",
+          "iana_number": 17,
           "packets": 2,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "port": 5678
@@ -2486,12 +2612,11 @@
         "destination": {
           "port": 5678
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-07-19T16:18:08Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-07-19T16:18:08Z",
+          "kind": "event"
         },
         "flow": {
           "id": "RlrAo_U1Y14",
@@ -2519,14 +2644,18 @@
           "source_ipv6_address": "fe80::ff:fe00:1101",
           "source_transport_port": 5678,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 555,
           "community_id": "1:I4DlCbWgyxRiNPVj5ntu1L7Z0hw=",
           "direction": "unknown",
+          "iana_number": 17,
           "packets": 3,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "port": 5678
@@ -2541,12 +2670,11 @@
         "destination": {
           "port": 5678
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-07-19T16:18:08Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-07-19T16:18:08Z",
+          "kind": "event"
         },
         "flow": {
           "id": "RlrAo_U1Y14",
@@ -2574,14 +2702,18 @@
           "source_ipv6_address": "fe80::ff:fe00:1101",
           "source_transport_port": 5678,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 370,
           "community_id": "1:I4DlCbWgyxRiNPVj5ntu1L7Z0hw=",
           "direction": "unknown",
+          "iana_number": 17,
           "packets": 2,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "port": 5678
@@ -2596,12 +2728,11 @@
         "destination": {
           "port": 5678
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-07-19T16:18:08Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-07-19T16:18:08Z",
+          "kind": "event"
         },
         "flow": {
           "id": "RlrAo_U1Y14",
@@ -2629,14 +2760,18 @@
           "source_ipv6_address": "fe80::ff:fe00:1201",
           "source_transport_port": 5678,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 555,
           "community_id": "1:I4DlCbWgyxRiNPVj5ntu1L7Z0hw=",
           "direction": "unknown",
+          "iana_number": 17,
           "packets": 3,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "port": 5678
@@ -2651,12 +2786,11 @@
         "destination": {
           "port": 5678
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-07-19T16:18:08Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-07-19T16:18:08Z",
+          "kind": "event"
         },
         "flow": {
           "id": "RlrAo_U1Y14",
@@ -2684,14 +2818,18 @@
           "source_ipv6_address": "fe80::ff:fe00:1201",
           "source_transport_port": 5678,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 370,
           "community_id": "1:I4DlCbWgyxRiNPVj5ntu1L7Z0hw=",
           "direction": "unknown",
+          "iana_number": 17,
           "packets": 2,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "port": 5678

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Netscaler-with-variable-length-fields.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Netscaler-with-variable-length-fields.golden.json
@@ -10,12 +10,11 @@
           "locality": "private",
           "port": 443
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2016-11-11T12:09:19Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2016-11-11T12:09:19Z",
+          "kind": "event"
         },
         "flow": {
           "id": "urCm_V5Qsz0",
@@ -68,14 +67,18 @@
           "source_ipv4_address": "192.168.0.1",
           "source_transport_port": 51053,
           "tcp_control_bits": 16,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 40,
           "community_id": "1:VtyB9RHgAkNqVk0mIUunFcpOSfk=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 1,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.0.1",
@@ -94,12 +97,11 @@
           "locality": "private",
           "port": 51053
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2016-11-11T12:09:19Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2016-11-11T12:09:19Z",
+          "kind": "event"
         },
         "flow": {
           "id": "1fCxVMA_rD0",
@@ -140,14 +142,18 @@
           "source_ipv4_address": "10.0.0.1",
           "source_transport_port": 443,
           "tcp_control_bits": 24,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 1525,
           "community_id": "1:mUmoe1yk2N8K21TGbG3DxjqkRYg=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 2,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.0.0.1",
@@ -166,12 +172,11 @@
           "locality": "private",
           "port": 443
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2016-11-11T12:09:19Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2016-11-11T12:09:19Z",
+          "kind": "event"
         },
         "flow": {
           "id": "urCm_V5Qsz0",
@@ -224,14 +229,18 @@
           "source_ipv4_address": "192.168.0.1",
           "source_transport_port": 51053,
           "tcp_control_bits": 24,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 1541,
           "community_id": "1:VtyB9RHgAkNqVk0mIUunFcpOSfk=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 2,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.0.1",

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Nokia-BRAS.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Nokia-BRAS.golden.json
@@ -10,12 +10,11 @@
           "locality": "private",
           "port": 80
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-12-14T07:23:45Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-12-14T07:23:45Z",
+          "kind": "event"
         },
         "flow": {
           "id": "VHOuRvMCrLs",
@@ -40,12 +39,16 @@
           "protocol_identifier": 6,
           "source_ipv4_address": "10.0.1.228",
           "source_transport_port": 5878,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "community_id": "1:JOQeKrnZDhP8AqJv8DtyiRwHnek=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.0.1.228",

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-OpenBSD-pflow.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-OpenBSD-pflow.golden.json
@@ -10,12 +10,11 @@
           "locality": "private",
           "port": 80
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2016-07-21T13:30:37Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2016-07-21T13:30:37Z",
+          "kind": "event"
         },
         "flow": {
           "id": "2h9znuMUydg",
@@ -41,14 +40,18 @@
           "protocol_identifier": 6,
           "source_ipv4_address": "192.168.0.17",
           "source_transport_port": 64020,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 373,
           "community_id": "1:UJAZQmO+yNpnLE1k+ZOTE4hajps=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 7,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.0.17",
@@ -67,12 +70,11 @@
           "locality": "private",
           "port": 64020
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2016-07-21T13:30:37Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2016-07-21T13:30:37Z",
+          "kind": "event"
         },
         "flow": {
           "id": "C82X98Ss6VM",
@@ -98,14 +100,18 @@
           "protocol_identifier": 6,
           "source_ipv4_address": "192.168.0.1",
           "source_transport_port": 80,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 6634,
           "community_id": "1:UqXVzZedUC3xywY5ipESqIoQsEo=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 8,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.0.1",
@@ -124,12 +130,11 @@
           "locality": "private",
           "port": 80
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2016-07-21T13:30:37Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2016-07-21T13:30:37Z",
+          "kind": "event"
         },
         "flow": {
           "id": "a2WjJB6_nU0",
@@ -155,14 +160,18 @@
           "protocol_identifier": 6,
           "source_ipv4_address": "192.168.0.17",
           "source_transport_port": 64021,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 453,
           "community_id": "1:0ISi0EM/A6gaKAZZqNA4s0Mg7yU=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 9,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.0.17",
@@ -181,12 +190,11 @@
           "locality": "private",
           "port": 64021
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2016-07-21T13:30:37Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2016-07-21T13:30:37Z",
+          "kind": "event"
         },
         "flow": {
           "id": "m58nw4UHNJY",
@@ -212,14 +220,18 @@
           "protocol_identifier": 6,
           "source_ipv4_address": "192.168.0.1",
           "source_transport_port": 80,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 10893,
           "community_id": "1:glKlzvj2Hw5JD4VDyjboFxA0jMs=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 11,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.0.1",
@@ -238,12 +250,11 @@
           "locality": "private",
           "port": 80
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2016-07-21T13:30:37Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2016-07-21T13:30:37Z",
+          "kind": "event"
         },
         "flow": {
           "id": "a2WjJB6_nU0",
@@ -269,14 +280,18 @@
           "protocol_identifier": 6,
           "source_ipv4_address": "192.168.0.17",
           "source_transport_port": 64021,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 453,
           "community_id": "1:0ISi0EM/A6gaKAZZqNA4s0Mg7yU=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 9,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.0.17",
@@ -295,12 +310,11 @@
           "locality": "private",
           "port": 64021
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2016-07-21T13:30:37Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2016-07-21T13:30:37Z",
+          "kind": "event"
         },
         "flow": {
           "id": "m58nw4UHNJY",
@@ -326,14 +340,18 @@
           "protocol_identifier": 6,
           "source_ipv4_address": "192.168.0.1",
           "source_transport_port": 80,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 10893,
           "community_id": "1:glKlzvj2Hw5JD4VDyjboFxA0jMs=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 11,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.0.1",
@@ -352,12 +370,11 @@
           "locality": "private",
           "port": 80
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2016-07-21T13:30:37Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2016-07-21T13:30:37Z",
+          "kind": "event"
         },
         "flow": {
           "id": "7dX_2AbqEVc",
@@ -383,14 +400,18 @@
           "protocol_identifier": 6,
           "source_ipv4_address": "192.168.0.17",
           "source_transport_port": 64022,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 373,
           "community_id": "1:sqB23dG2s8pdp8UJ3tDiPppa1IU=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 7,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.0.17",
@@ -409,12 +430,11 @@
           "locality": "private",
           "port": 64022
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2016-07-21T13:30:37Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2016-07-21T13:30:37Z",
+          "kind": "event"
         },
         "flow": {
           "id": "n2aEU3BSI4E",
@@ -440,14 +460,18 @@
           "protocol_identifier": 6,
           "source_ipv4_address": "192.168.0.1",
           "source_transport_port": 80,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 6780,
           "community_id": "1:a/hRDAyfEZg4KZOTAdJv3xeDwgQ=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 8,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.0.1",
@@ -466,12 +490,11 @@
           "locality": "private",
           "port": 80
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2016-07-21T13:30:37Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2016-07-21T13:30:37Z",
+          "kind": "event"
         },
         "flow": {
           "id": "7dX_2AbqEVc",
@@ -497,14 +520,18 @@
           "protocol_identifier": 6,
           "source_ipv4_address": "192.168.0.17",
           "source_transport_port": 64022,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 373,
           "community_id": "1:sqB23dG2s8pdp8UJ3tDiPppa1IU=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 7,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.0.17",
@@ -523,12 +550,11 @@
           "locality": "private",
           "port": 64022
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2016-07-21T13:30:37Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2016-07-21T13:30:37Z",
+          "kind": "event"
         },
         "flow": {
           "id": "n2aEU3BSI4E",
@@ -554,14 +580,18 @@
           "protocol_identifier": 6,
           "source_ipv4_address": "192.168.0.1",
           "source_transport_port": 80,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 6780,
           "community_id": "1:a/hRDAyfEZg4KZOTAdJv3xeDwgQ=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 8,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.0.1",
@@ -580,12 +610,11 @@
           "locality": "private",
           "port": 80
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2016-07-21T13:30:37Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2016-07-21T13:30:37Z",
+          "kind": "event"
         },
         "flow": {
           "id": "cKtQJlqfWKs",
@@ -611,14 +640,18 @@
           "protocol_identifier": 6,
           "source_ipv4_address": "192.168.0.17",
           "source_transport_port": 64023,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 373,
           "community_id": "1:yiSn+h79Umz3bFmTmeESFhm5404=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 7,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.0.17",
@@ -637,12 +670,11 @@
           "locality": "private",
           "port": 64023
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2016-07-21T13:30:37Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2016-07-21T13:30:37Z",
+          "kind": "event"
         },
         "flow": {
           "id": "MguWi5iQ0x8",
@@ -668,14 +700,18 @@
           "protocol_identifier": 6,
           "source_ipv4_address": "192.168.0.1",
           "source_transport_port": 80,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 7319,
           "community_id": "1:vZF2uyiEOE/tq2ixGkt58g4TzYE=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 9,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.0.1",
@@ -694,12 +730,11 @@
           "locality": "private",
           "port": 80
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2016-07-21T13:30:37Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2016-07-21T13:30:37Z",
+          "kind": "event"
         },
         "flow": {
           "id": "cKtQJlqfWKs",
@@ -725,14 +760,18 @@
           "protocol_identifier": 6,
           "source_ipv4_address": "192.168.0.17",
           "source_transport_port": 64023,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 373,
           "community_id": "1:yiSn+h79Umz3bFmTmeESFhm5404=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 7,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.0.17",
@@ -751,12 +790,11 @@
           "locality": "private",
           "port": 64023
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2016-07-21T13:30:37Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2016-07-21T13:30:37Z",
+          "kind": "event"
         },
         "flow": {
           "id": "MguWi5iQ0x8",
@@ -782,14 +820,18 @@
           "protocol_identifier": 6,
           "source_ipv4_address": "192.168.0.1",
           "source_transport_port": 80,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 7319,
           "community_id": "1:vZF2uyiEOE/tq2ixGkt58g4TzYE=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 9,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.0.1",
@@ -808,12 +850,11 @@
           "locality": "private",
           "port": 80
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2016-07-21T13:30:37Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2016-07-21T13:30:37Z",
+          "kind": "event"
         },
         "flow": {
           "id": "_ozB47fTdyc",
@@ -839,14 +880,18 @@
           "protocol_identifier": 6,
           "source_ipv4_address": "192.168.0.17",
           "source_transport_port": 64024,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 333,
           "community_id": "1:rnxpvb+Sa3z3ZTUsHla872/PPNY=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 6,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.0.17",
@@ -865,12 +910,11 @@
           "locality": "private",
           "port": 64024
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2016-07-21T13:30:37Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2016-07-21T13:30:37Z",
+          "kind": "event"
         },
         "flow": {
           "id": "1qsG5DGX-3k",
@@ -896,14 +940,18 @@
           "protocol_identifier": 6,
           "source_ipv4_address": "192.168.0.1",
           "source_transport_port": 80,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 1833,
           "community_id": "1:h33RWeSLni6vfVlgFQBkRGQ0ZDQ=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 5,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.0.1",
@@ -922,12 +970,11 @@
           "locality": "private",
           "port": 80
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2016-07-21T13:30:37Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2016-07-21T13:30:37Z",
+          "kind": "event"
         },
         "flow": {
           "id": "_ozB47fTdyc",
@@ -953,14 +1000,18 @@
           "protocol_identifier": 6,
           "source_ipv4_address": "192.168.0.17",
           "source_transport_port": 64024,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 333,
           "community_id": "1:rnxpvb+Sa3z3ZTUsHla872/PPNY=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 6,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.0.17",
@@ -979,12 +1030,11 @@
           "locality": "private",
           "port": 64024
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2016-07-21T13:30:37Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2016-07-21T13:30:37Z",
+          "kind": "event"
         },
         "flow": {
           "id": "1qsG5DGX-3k",
@@ -1010,14 +1060,18 @@
           "protocol_identifier": 6,
           "source_ipv4_address": "192.168.0.1",
           "source_transport_port": 80,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 1833,
           "community_id": "1:h33RWeSLni6vfVlgFQBkRGQ0ZDQ=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 5,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.0.1",
@@ -1036,12 +1090,11 @@
           "locality": "private",
           "port": 80
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2016-07-21T13:30:37Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2016-07-21T13:30:37Z",
+          "kind": "event"
         },
         "flow": {
           "id": "nzEWA7mEeQw",
@@ -1067,14 +1120,18 @@
           "protocol_identifier": 6,
           "source_ipv4_address": "192.168.0.17",
           "source_transport_port": 64025,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 453,
           "community_id": "1:ZpG4aa8BJ2zIJbtgKxuRmefVfLw=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 9,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.0.17",
@@ -1093,12 +1150,11 @@
           "locality": "private",
           "port": 64025
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2016-07-21T13:30:37Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2016-07-21T13:30:37Z",
+          "kind": "event"
         },
         "flow": {
           "id": "5Dss0hKgBfg",
@@ -1124,14 +1180,18 @@
           "protocol_identifier": 6,
           "source_ipv4_address": "192.168.0.1",
           "source_transport_port": 80,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 10550,
           "community_id": "1:VtXZCiwUjAo0CYNoq6to3RH0SDo=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 11,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.0.1",
@@ -1150,12 +1210,11 @@
           "locality": "private",
           "port": 80
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2016-07-21T13:30:37Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2016-07-21T13:30:37Z",
+          "kind": "event"
         },
         "flow": {
           "id": "nzEWA7mEeQw",
@@ -1181,14 +1240,18 @@
           "protocol_identifier": 6,
           "source_ipv4_address": "192.168.0.17",
           "source_transport_port": 64025,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 453,
           "community_id": "1:ZpG4aa8BJ2zIJbtgKxuRmefVfLw=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 9,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.0.17",
@@ -1207,12 +1270,11 @@
           "locality": "private",
           "port": 64025
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2016-07-21T13:30:37Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2016-07-21T13:30:37Z",
+          "kind": "event"
         },
         "flow": {
           "id": "5Dss0hKgBfg",
@@ -1238,14 +1300,18 @@
           "protocol_identifier": 6,
           "source_ipv4_address": "192.168.0.1",
           "source_transport_port": 80,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 10550,
           "community_id": "1:VtXZCiwUjAo0CYNoq6to3RH0SDo=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 11,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.0.1",
@@ -1264,12 +1330,11 @@
           "locality": "private",
           "port": 80
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2016-07-21T13:30:37Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2016-07-21T13:30:37Z",
+          "kind": "event"
         },
         "flow": {
           "id": "3ZIZbhFW0h0",
@@ -1295,14 +1360,18 @@
           "protocol_identifier": 6,
           "source_ipv4_address": "192.168.0.17",
           "source_transport_port": 64026,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 373,
           "community_id": "1:xosr4vj7ubH8+n3LgR04NAKyTSo=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 7,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.0.17",
@@ -1321,12 +1390,11 @@
           "locality": "private",
           "port": 64026
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2016-07-21T13:30:37Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2016-07-21T13:30:37Z",
+          "kind": "event"
         },
         "flow": {
           "id": "PXoRY8uUukM",
@@ -1352,14 +1420,18 @@
           "protocol_identifier": 6,
           "source_ipv4_address": "192.168.0.1",
           "source_transport_port": 80,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 6425,
           "community_id": "1:FXizUy6YctpVTvg8A6VIG+Yx7+0=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 8,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.0.1",
@@ -1378,12 +1450,11 @@
           "locality": "private",
           "port": 80
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2016-07-21T13:30:37Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2016-07-21T13:30:37Z",
+          "kind": "event"
         },
         "flow": {
           "id": "3ZIZbhFW0h0",
@@ -1409,14 +1480,18 @@
           "protocol_identifier": 6,
           "source_ipv4_address": "192.168.0.17",
           "source_transport_port": 64026,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 373,
           "community_id": "1:xosr4vj7ubH8+n3LgR04NAKyTSo=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 7,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.0.17",
@@ -1435,12 +1510,11 @@
           "locality": "private",
           "port": 64026
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2016-07-21T13:30:37Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2016-07-21T13:30:37Z",
+          "kind": "event"
         },
         "flow": {
           "id": "PXoRY8uUukM",
@@ -1466,14 +1540,18 @@
           "protocol_identifier": 6,
           "source_ipv4_address": "192.168.0.1",
           "source_transport_port": 80,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 6425,
           "community_id": "1:FXizUy6YctpVTvg8A6VIG+Yx7+0=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 8,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.0.1",

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Procera.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Procera.golden.json
@@ -10,12 +10,11 @@
           "locality": "public",
           "port": 47838
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2018-04-15T03:30:00Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2018-04-15T03:30:00Z",
+          "kind": "event"
         },
         "flow": {
           "id": "q-trxhRGXW0",
@@ -52,12 +51,16 @@
           "source_ipv4_address": "181.214.87.71",
           "source_ipv6_address": "::",
           "source_transport_port": 53787,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "community_id": "1:pMbHu2KSX2ETGFunUYvRZUVwkDA=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "181.214.87.71",
@@ -76,12 +79,11 @@
           "locality": "private",
           "port": 135
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2018-04-15T03:30:00Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2018-04-15T03:30:00Z",
+          "kind": "event"
         },
         "flow": {
           "id": "GYmhjYyvaAI",
@@ -118,12 +120,16 @@
           "source_ipv4_address": "0.0.0.0",
           "source_ipv6_address": "2001:388:cf0a:6::1",
           "source_transport_port": 136,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "community_id": "1:vK+Zeop1Y3GHxfFGVF2/COcNBWw=",
           "direction": "unknown",
-          "protocol": "ipv6-icmp"
+          "iana_number": 58,
+          "transport": "ipv6-icmp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "0.0.0.0",
@@ -142,12 +148,11 @@
           "locality": "public",
           "port": 22252
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2018-04-15T03:30:00Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2018-04-15T03:30:00Z",
+          "kind": "event"
         },
         "flow": {
           "id": "s0UY7AEXtbs",
@@ -184,12 +189,16 @@
           "source_ipv4_address": "5.188.11.35",
           "source_ipv6_address": "::",
           "source_transport_port": 44155,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "community_id": "1:K4/7oSyucHcfZAc5dWGMTB7XWGw=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "5.188.11.35",
@@ -208,12 +217,11 @@
           "locality": "public",
           "port": 8
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2018-04-15T03:30:00Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2018-04-15T03:30:00Z",
+          "kind": "event"
         },
         "flow": {
           "id": "r-qsT9TbSHw",
@@ -250,12 +258,16 @@
           "source_ipv4_address": "206.117.25.89",
           "source_ipv6_address": "::",
           "source_transport_port": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "community_id": "1:yBV3/K+LwXqfvm3nlYaqIPtS6UQ=",
           "direction": "unknown",
-          "protocol": "icmp"
+          "iana_number": 1,
+          "transport": "icmp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "206.117.25.89",
@@ -274,12 +286,11 @@
           "locality": "private",
           "port": 135
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2018-04-15T03:30:00Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2018-04-15T03:30:00Z",
+          "kind": "event"
         },
         "flow": {
           "id": "GYmhjYyvaAI",
@@ -316,12 +327,16 @@
           "source_ipv4_address": "0.0.0.0",
           "source_ipv6_address": "2001:388:cf0a:6::1",
           "source_transport_port": 136,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "community_id": "1:vK+Zeop1Y3GHxfFGVF2/COcNBWw=",
           "direction": "unknown",
-          "protocol": "ipv6-icmp"
+          "iana_number": 58,
+          "transport": "ipv6-icmp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "0.0.0.0",
@@ -340,12 +355,11 @@
           "locality": "public",
           "port": 7451
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2018-04-15T03:30:00Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2018-04-15T03:30:00Z",
+          "kind": "event"
         },
         "flow": {
           "id": "dF2yRC2ldzk",
@@ -382,12 +396,16 @@
           "source_ipv4_address": "185.232.29.199",
           "source_ipv6_address": "::",
           "source_transport_port": 55869,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "community_id": "1:/Nqnh+qS63xOcLeH1LsIVNCCpvc=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "185.232.29.199",
@@ -406,12 +424,11 @@
           "locality": "public",
           "port": 2000
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2018-04-15T03:30:00Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2018-04-15T03:30:00Z",
+          "kind": "event"
         },
         "flow": {
           "id": "Nv4c6iSK_5U",
@@ -448,12 +465,16 @@
           "source_ipv4_address": "177.188.228.137",
           "source_ipv6_address": "::",
           "source_transport_port": 9430,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "community_id": "1:3qkFUQpCFoQLLRqciw3v0aXVkvk=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "177.188.228.137",
@@ -472,12 +493,11 @@
           "locality": "public",
           "port": 179
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2018-04-15T03:30:00Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2018-04-15T03:30:00Z",
+          "kind": "event"
         },
         "flow": {
           "id": "PhIIQeuDikc",
@@ -514,12 +534,16 @@
           "source_ipv4_address": "138.44.161.14",
           "source_ipv6_address": "::",
           "source_transport_port": 33689,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "community_id": "1:v9ASezXn5L0vAVcmj8jxybrYJ6I=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "138.44.161.14",

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-VMware-virtual-distributed-switch.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-VMware-virtual-distributed-switch.golden.json
@@ -10,12 +10,11 @@
           "locality": "private",
           "port": 5985
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2016-12-22T12:17:52Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2016-12-22T12:17:52Z",
+          "kind": "event"
         },
         "flow": {
           "id": "p2ZChbTH1YU",
@@ -47,7 +46,7 @@
           "source_ipv4_address": "172.18.65.21",
           "source_transport_port": 61209,
           "tcp_control_bits": 2,
-          "type": "netflow",
+          "type": "netflow_flow",
           "vmware_egress_interface_attr": 2,
           "vmware_ingress_interface_attr": 1,
           "vmware_vxlan_export_role": 0
@@ -56,8 +55,12 @@
           "bytes": 100,
           "community_id": "1:Rs7Lnh/lOTiJTtqZqBdEOBbKchs=",
           "direction": "outbound",
+          "iana_number": 6,
           "packets": 2,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "172.18.65.21",
@@ -76,12 +79,11 @@
           "locality": "private",
           "port": 138
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2016-12-22T12:17:56Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2016-12-22T12:17:56Z",
+          "kind": "event"
         },
         "flow": {
           "id": "J4VOqDnsqno",
@@ -113,7 +115,7 @@
           "source_ipv4_address": "172.18.65.91",
           "source_transport_port": 138,
           "tcp_control_bits": 0,
-          "type": "netflow",
+          "type": "netflow_flow",
           "vmware_egress_interface_attr": 2,
           "vmware_ingress_interface_attr": 1,
           "vmware_vxlan_export_role": 0
@@ -122,8 +124,12 @@
           "bytes": 229,
           "community_id": "1:dfYpWxplvmUP34MWL1A0xpN2SRw=",
           "direction": "outbound",
+          "iana_number": 17,
           "packets": 1,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "172.18.65.91",
@@ -142,12 +148,11 @@
           "locality": "private",
           "port": 138
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2016-12-22T12:17:56Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2016-12-22T12:17:56Z",
+          "kind": "event"
         },
         "flow": {
           "id": "J4VOqDnsqno",
@@ -179,7 +184,7 @@
           "source_ipv4_address": "172.18.65.91",
           "source_transport_port": 138,
           "tcp_control_bits": 0,
-          "type": "netflow",
+          "type": "netflow_flow",
           "vmware_egress_interface_attr": 2,
           "vmware_ingress_interface_attr": 1,
           "vmware_vxlan_export_role": 0
@@ -188,8 +193,12 @@
           "bytes": 229,
           "community_id": "1:dfYpWxplvmUP34MWL1A0xpN2SRw=",
           "direction": "outbound",
+          "iana_number": 17,
           "packets": 1,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "172.18.65.91",
@@ -208,12 +217,11 @@
           "locality": "private",
           "port": 5355
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2016-12-22T12:26:04Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2016-12-22T12:26:04Z",
+          "kind": "event"
         },
         "flow": {
           "id": "iPG_hIy8oDM",
@@ -245,7 +253,7 @@
           "source_ipv4_address": "172.18.65.21",
           "source_transport_port": 61329,
           "tcp_control_bits": 0,
-          "type": "netflow",
+          "type": "netflow_flow",
           "vmware_egress_interface_attr": 2,
           "vmware_ingress_interface_attr": 1,
           "vmware_vxlan_export_role": 0
@@ -254,8 +262,12 @@
           "bytes": 104,
           "community_id": "1:ZPVVwcy+Kfw9UUtwR8lyWYv8htU=",
           "direction": "outbound",
+          "iana_number": 17,
           "packets": 2,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "172.18.65.21",
@@ -272,12 +284,11 @@
         "destination": {
           "port": 5355
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2016-12-22T12:26:04Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2016-12-22T12:26:04Z",
+          "kind": "event"
         },
         "flow": {
           "id": "y_Vml2vPNtw",
@@ -309,7 +320,7 @@
           "source_ipv6_address": "fe80::5187:5cd8:d750:cdc9",
           "source_transport_port": 61329,
           "tcp_control_bits": 0,
-          "type": "netflow",
+          "type": "netflow_flow",
           "vmware_egress_interface_attr": 2,
           "vmware_ingress_interface_attr": 1,
           "vmware_vxlan_export_role": 0
@@ -318,8 +329,12 @@
           "bytes": 144,
           "community_id": "1:Nl0K3f1AqKrkGYEhoNHcgFAr/EY=",
           "direction": "outbound",
+          "iana_number": 17,
           "packets": 2,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "port": 61329

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-YAF-basic-with-applabel.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-YAF-basic-with-applabel.golden.json
@@ -12,12 +12,11 @@
           "packets": 2,
           "port": 53
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2016-12-25T13:03:38Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2016-12-25T13:03:38Z",
+          "kind": "event"
         },
         "flow": {
           "id": "_tbAAnwoAu8",
@@ -50,15 +49,19 @@
           "silk_app_label": 53,
           "source_ipv4_address": "172.16.32.201",
           "source_transport_port": 46086,
-          "type": "netflow",
+          "type": "netflow_flow",
           "vlan_id": 0
         },
         "network": {
           "bytes": 532,
           "community_id": "1:gQfwC1pqdEJoyqjxe8la2a1bW6g=",
           "direction": "unknown",
+          "iana_number": 17,
           "packets": 6,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "bytes": 132,
@@ -81,12 +84,11 @@
           "packets": 2,
           "port": 9997
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2016-12-25T12:58:38Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2016-12-25T12:58:38Z",
+          "kind": "event"
         },
         "flow": {
           "id": "qznEzwF6uiM",
@@ -124,7 +126,7 @@
           "source_ipv4_address": "172.16.32.100",
           "source_transport_port": 63499,
           "tcp_sequence_number": 340533701,
-          "type": "netflow",
+          "type": "netflow_flow",
           "union_tcfp_lags": 17,
           "vlan_id": 0
         },
@@ -132,8 +134,12 @@
           "bytes": 356,
           "community_id": "1:/MUy9fW9u7vMDGqxcZLVrZX0ARU=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 8,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "bytes": 172,
@@ -149,12 +155,11 @@
       "Timestamp": "2016-12-25T13:03:33Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
           "action": "netflow_options",
-          "created": "2016-12-25T13:03:33Z"
+          "category": "network_traffic",
+          "created": "2016-12-25T13:03:33Z",
+          "kind": "event"
         },
         "netflow": {
           "exporter": {
@@ -183,6 +188,9 @@
             "system_init_time_milliseconds": "2016-12-25T12:58:32Z"
           },
           "type": "netflow_options"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         }
       },
       "Private": null

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-configured-with-include_flowset_id.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-configured-with-include_flowset_id.golden.json
@@ -10,12 +10,11 @@
           "locality": "private",
           "port": 443
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2016-11-11T12:09:19Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2016-11-11T12:09:19Z",
+          "kind": "event"
         },
         "flow": {
           "id": "urCm_V5Qsz0",
@@ -68,14 +67,18 @@
           "source_ipv4_address": "192.168.0.1",
           "source_transport_port": 51053,
           "tcp_control_bits": 16,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 40,
           "community_id": "1:VtyB9RHgAkNqVk0mIUunFcpOSfk=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 1,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.0.1",
@@ -94,12 +97,11 @@
           "locality": "private",
           "port": 51053
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2016-11-11T12:09:19Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2016-11-11T12:09:19Z",
+          "kind": "event"
         },
         "flow": {
           "id": "1fCxVMA_rD0",
@@ -140,14 +142,18 @@
           "source_ipv4_address": "10.0.0.1",
           "source_transport_port": 443,
           "tcp_control_bits": 24,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 1525,
           "community_id": "1:mUmoe1yk2N8K21TGbG3DxjqkRYg=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 2,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.0.0.1",
@@ -166,12 +172,11 @@
           "locality": "private",
           "port": 443
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2016-11-11T12:09:19Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2016-11-11T12:09:19Z",
+          "kind": "event"
         },
         "flow": {
           "id": "urCm_V5Qsz0",
@@ -224,14 +229,18 @@
           "source_ipv4_address": "192.168.0.1",
           "source_transport_port": 51053,
           "tcp_control_bits": 24,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 1541,
           "community_id": "1:VtyB9RHgAkNqVk0mIUunFcpOSfk=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 2,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.0.1",

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-options-template-from-Juniper-MX240-JunOS-15.1-R6-S3.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-options-template-from-Juniper-MX240-JunOS-15.1-R6-S3.golden.json
@@ -5,12 +5,11 @@
       "Timestamp": "2018-06-01T15:11:53Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
           "action": "netflow_options",
-          "created": "2018-06-01T15:11:53Z"
+          "category": "network_traffic",
+          "created": "2018-06-01T15:11:53Z",
+          "kind": "event"
         },
         "netflow": {
           "exporter": {
@@ -36,6 +35,9 @@
             "exporting_process_id": 2
           },
           "type": "netflow_options"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         }
       },
       "Private": null

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-vIPtela-with-VPN-id.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-vIPtela-with-VPN-id.golden.json
@@ -10,12 +10,11 @@
           "locality": "private",
           "port": 443
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-11-21T14:32:15Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-11-21T14:32:15Z",
+          "kind": "event"
         },
         "flow": {
           "id": "5qh7ipMbBV0",
@@ -52,15 +51,19 @@
           "source_ipv4_address": "10.113.7.54",
           "source_transport_port": 41717,
           "tcp_control_bits": 16,
-          "type": "netflow",
+          "type": "netflow_flow",
           "viptela_vpin_d": 100
         },
         "network": {
           "bytes": 775,
           "community_id": "1:+fvsmN9SnAg8yt/KBn6yA19IrXE=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 8,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.113.7.54",

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX.golden.json
@@ -5,12 +5,11 @@
       "Timestamp": "2015-05-13T11:20:26Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
           "action": "netflow_options",
-          "created": "2015-05-13T11:20:26Z"
+          "category": "network_traffic",
+          "created": "2015-05-13T11:20:26Z",
+          "kind": "event"
         },
         "netflow": {
           "exporter": {
@@ -30,6 +29,9 @@
             "metering_process_id": 2679
           },
           "type": "netflow_options"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         }
       },
       "Private": null
@@ -43,12 +45,11 @@
           "locality": "private",
           "port": 22
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2015-05-13T11:20:26Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2015-05-13T11:20:26Z",
+          "kind": "event"
         },
         "flow": {
           "id": "5dY_LIjk4jM",
@@ -77,15 +78,19 @@
           "source_ipv4_address": "192.168.253.1",
           "source_transport_port": 60560,
           "tcp_control_bits": 16,
-          "type": "netflow",
+          "type": "netflow_flow",
           "vlan_id": 0
         },
         "network": {
           "bytes": 260,
           "community_id": "1:5zkwPg6j1HR922PEK8GyaxzrFwQ=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 5,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.253.1",
@@ -104,12 +109,11 @@
           "locality": "private",
           "port": 60560
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2015-05-13T11:20:26Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2015-05-13T11:20:26Z",
+          "kind": "event"
         },
         "flow": {
           "id": "D9c6mFRsdDc",
@@ -138,15 +142,19 @@
           "source_ipv4_address": "192.168.253.128",
           "source_transport_port": 22,
           "tcp_control_bits": 24,
-          "type": "netflow",
+          "type": "netflow_flow",
           "vlan_id": 0
         },
         "network": {
           "bytes": 1000,
           "community_id": "1:US3awEhv6suG72vxm+M1HkgqctM=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 6,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.253.128",
@@ -165,12 +173,11 @@
           "locality": "private",
           "port": 35262
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2015-05-13T11:20:26Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2015-05-13T11:20:26Z",
+          "kind": "event"
         },
         "flow": {
           "id": "Htn9CGiiIcE",
@@ -199,15 +206,19 @@
           "source_ipv4_address": "192.168.253.2",
           "source_transport_port": 53,
           "tcp_control_bits": 0,
-          "type": "netflow",
+          "type": "netflow_flow",
           "vlan_id": 0
         },
         "network": {
           "bytes": 601,
           "community_id": "1:ASd6tw0cxo+COe02J7RUWx1Zpz0=",
           "direction": "unknown",
+          "iana_number": 17,
           "packets": 2,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.253.2",
@@ -226,12 +237,11 @@
           "locality": "private",
           "port": 53
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2015-05-13T11:20:26Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2015-05-13T11:20:26Z",
+          "kind": "event"
         },
         "flow": {
           "id": "zasoUAZZ0VY",
@@ -260,15 +270,19 @@
           "source_ipv4_address": "192.168.253.132",
           "source_transport_port": 35262,
           "tcp_control_bits": 0,
-          "type": "netflow",
+          "type": "netflow_flow",
           "vlan_id": 0
         },
         "network": {
           "bytes": 148,
           "community_id": "1:wys1qTextK4PoWX8LNF3Ftn2XGU=",
           "direction": "unknown",
+          "iana_number": 17,
           "packets": 2,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.253.132",
@@ -287,12 +301,11 @@
           "locality": "private",
           "port": 49935
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2015-05-13T11:20:26Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2015-05-13T11:20:26Z",
+          "kind": "event"
         },
         "flow": {
           "id": "S1-OrWp2NPk",
@@ -321,15 +334,19 @@
           "source_ipv4_address": "54.214.9.161",
           "source_transport_port": 443,
           "tcp_control_bits": 26,
-          "type": "netflow",
+          "type": "netflow_flow",
           "vlan_id": 0
         },
         "network": {
           "bytes": 5946,
           "community_id": "1:l7BnKMlyrD4MPxU3tD15rivudaU=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 14,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "54.214.9.161",
@@ -348,12 +365,11 @@
           "locality": "public",
           "port": 443
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2015-05-13T11:20:26Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2015-05-13T11:20:26Z",
+          "kind": "event"
         },
         "flow": {
           "id": "KbgtQk9RbTg",
@@ -382,15 +398,19 @@
           "source_ipv4_address": "192.168.253.132",
           "source_transport_port": 49935,
           "tcp_control_bits": 26,
-          "type": "netflow",
+          "type": "netflow_flow",
           "vlan_id": 0
         },
         "network": {
           "bytes": 2608,
           "community_id": "1:LHK7P1y0Hk2e91GsVeb/Y2Ka9x4=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 13,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.253.132",
@@ -409,12 +429,11 @@
           "locality": "private",
           "port": 9200
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2015-05-13T11:20:26Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2015-05-13T11:20:26Z",
+          "kind": "event"
         },
         "flow": {
           "id": "aMDg_zpGiEg",
@@ -443,15 +462,19 @@
           "source_ipv4_address": "192.168.253.130",
           "source_transport_port": 38254,
           "tcp_control_bits": 2,
-          "type": "netflow",
+          "type": "netflow_flow",
           "vlan_id": 0
         },
         "network": {
           "bytes": 60,
           "community_id": "1:3JM19rLv8Up/ifiBcncNv9+u1ac=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 1,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.253.130",
@@ -470,12 +493,11 @@
           "locality": "private",
           "port": 22
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2015-05-13T11:20:28Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2015-05-13T11:20:28Z",
+          "kind": "event"
         },
         "flow": {
           "id": "5dY_LIjk4jM",
@@ -504,15 +526,19 @@
           "source_ipv4_address": "192.168.253.1",
           "source_transport_port": 60560,
           "tcp_control_bits": 24,
-          "type": "netflow",
+          "type": "netflow_flow",
           "vlan_id": 0
         },
         "network": {
           "bytes": 256,
           "community_id": "1:5zkwPg6j1HR922PEK8GyaxzrFwQ=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 4,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.253.1",
@@ -531,12 +557,11 @@
           "locality": "private",
           "port": 60560
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2015-05-13T11:20:28Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2015-05-13T11:20:28Z",
+          "kind": "event"
         },
         "flow": {
           "id": "D9c6mFRsdDc",
@@ -565,15 +590,19 @@
           "source_ipv4_address": "192.168.253.128",
           "source_transport_port": 22,
           "tcp_control_bits": 24,
-          "type": "netflow",
+          "type": "netflow_flow",
           "vlan_id": 0
         },
         "network": {
           "bytes": 1916,
           "community_id": "1:US3awEhv6suG72vxm+M1HkgqctM=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 3,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.253.128",
@@ -592,12 +621,11 @@
           "locality": "private",
           "port": 22
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2015-05-13T11:20:28Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2015-05-13T11:20:28Z",
+          "kind": "event"
         },
         "flow": {
           "id": "5rzmeAVHDXo",
@@ -626,15 +654,19 @@
           "source_ipv4_address": "192.168.253.1",
           "source_transport_port": 65308,
           "tcp_control_bits": 24,
-          "type": "netflow",
+          "type": "netflow_flow",
           "vlan_id": 0
         },
         "network": {
           "bytes": 168,
           "community_id": "1:Qil1AUeHYTzgVk9ced1uu+tH7xQ=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 2,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.253.1",
@@ -653,12 +685,11 @@
           "locality": "private",
           "port": 65308
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2015-05-13T11:20:28Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2015-05-13T11:20:28Z",
+          "kind": "event"
         },
         "flow": {
           "id": "yZq2BehxSew",
@@ -687,15 +718,19 @@
           "source_ipv4_address": "192.168.253.128",
           "source_transport_port": 22,
           "tcp_control_bits": 24,
-          "type": "netflow",
+          "type": "netflow_flow",
           "vlan_id": 0
         },
         "network": {
           "bytes": 84,
           "community_id": "1:0XgIQvzxYzeiJ3zUXDK29zsihcI=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 1,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.253.128",
@@ -714,12 +749,11 @@
           "locality": "private",
           "port": 5353
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2015-05-13T11:20:28Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2015-05-13T11:20:28Z",
+          "kind": "event"
         },
         "flow": {
           "id": "Ft-4Om5rIsk",
@@ -748,15 +782,19 @@
           "source_ipv4_address": "192.168.253.1",
           "source_transport_port": 5353,
           "tcp_control_bits": 0,
-          "type": "netflow",
+          "type": "netflow_flow",
           "vlan_id": 0
         },
         "network": {
           "bytes": 232,
           "community_id": "1:l3uSgEhzehRFeZ+njR5WuFsGEr8=",
           "direction": "unknown",
+          "iana_number": 17,
           "packets": 1,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.253.1",

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-1941-K9-release-15.1.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-1941-K9-release-15.1.golden.json
@@ -10,12 +10,11 @@
           "locality": "public",
           "port": 53
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-10-03T17:03:39Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-10-03T17:03:39Z",
+          "kind": "event"
         },
         "flow": {
           "id": "tNbQulf11TU",
@@ -44,14 +43,18 @@
           "source_mac_address": "ec:1f:72:11:9f:c1",
           "source_transport_port": 37301,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 75,
           "community_id": "1:bRyQGyObIc1D2o7DkHSOKH8tsio=",
           "direction": "inbound",
+          "iana_number": 17,
           "packets": 1,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.0.111",
@@ -71,12 +74,11 @@
           "locality": "public",
           "port": 53
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-10-03T17:03:39Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-10-03T17:03:39Z",
+          "kind": "event"
         },
         "flow": {
           "id": "wplOqUGEvng",
@@ -105,14 +107,18 @@
           "source_mac_address": "ec:1f:72:11:9f:c1",
           "source_transport_port": 58411,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 75,
           "community_id": "1:wbdTe6mwksAQ9lGcVDaWyoOTmhk=",
           "direction": "inbound",
+          "iana_number": 17,
           "packets": 1,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.0.111",
@@ -132,12 +138,11 @@
           "locality": "public",
           "port": 53
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-10-03T17:03:39Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-10-03T17:03:39Z",
+          "kind": "event"
         },
         "flow": {
           "id": "MGp1pcAULtY",
@@ -166,14 +171,18 @@
           "source_mac_address": "ec:1f:72:11:9f:c1",
           "source_transport_port": 37661,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 75,
           "community_id": "1:jP1p/7/u4HsUidwYdywfdEpcPKQ=",
           "direction": "inbound",
+          "iana_number": 17,
           "packets": 1,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.0.111",
@@ -193,12 +202,11 @@
           "locality": "public",
           "port": 53
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-10-03T17:03:39Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-10-03T17:03:39Z",
+          "kind": "event"
         },
         "flow": {
           "id": "BVWdRT29zFQ",
@@ -227,14 +235,18 @@
           "source_mac_address": "ec:1f:72:11:9f:c1",
           "source_transport_port": 60212,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 75,
           "community_id": "1:kKLFvXJJaQi9kI42KQJ2v2corCE=",
           "direction": "inbound",
+          "iana_number": 17,
           "packets": 1,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.0.111",
@@ -254,12 +266,11 @@
           "locality": "private",
           "port": 37450
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-10-03T17:03:39Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-10-03T17:03:39Z",
+          "kind": "event"
         },
         "flow": {
           "id": "yT-AD8ZRSJo",
@@ -288,14 +299,18 @@
           "source_mac_address": "00:23:04:18:ef:40",
           "source_transport_port": 5222,
           "tcp_control_bits": 29,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 964,
           "community_id": "1:34znV7gBt2utWJHrTSPMwhTz2Eg=",
           "direction": "outbound",
+          "iana_number": 6,
           "packets": 10,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "158.85.58.115",
@@ -315,12 +330,11 @@
           "locality": "public",
           "port": 443
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-10-03T17:03:39Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-10-03T17:03:39Z",
+          "kind": "event"
         },
         "flow": {
           "id": "hxO6SQDKQVY",
@@ -349,14 +363,18 @@
           "source_mac_address": "a4:d1:8c:e9:30:2c",
           "source_transport_port": 61490,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 2748,
           "community_id": "1:iXnrRyr8wo26XN0Ph22X++rTZeo=",
           "direction": "inbound",
+          "iana_number": 17,
           "packets": 8,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.0.88",
@@ -376,12 +394,11 @@
           "locality": "private",
           "port": 61490
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-10-03T17:03:39Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-10-03T17:03:39Z",
+          "kind": "event"
         },
         "flow": {
           "id": "0-orkNwXKfY",
@@ -410,14 +427,18 @@
           "source_mac_address": "00:23:04:18:ef:40",
           "source_transport_port": 443,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 2023,
           "community_id": "1:HD2M0NX2rS6y8B3MY+Iwv+XHRRI=",
           "direction": "outbound",
+          "iana_number": 17,
           "packets": 9,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "216.58.212.195",
@@ -437,12 +458,11 @@
           "locality": "public",
           "port": 443
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-10-03T17:03:39Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-10-03T17:03:39Z",
+          "kind": "event"
         },
         "flow": {
           "id": "wlxoX3Rml10",
@@ -471,14 +491,18 @@
           "source_mac_address": "98:01:a7:9f:8d:5f",
           "source_transport_port": 50299,
           "tcp_control_bits": 24,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 2180,
           "community_id": "1:uCD3Q6u5DuWp4BBrNuh08puZY6U=",
           "direction": "inbound",
+          "iana_number": 6,
           "packets": 9,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.1.201",
@@ -498,12 +522,11 @@
           "locality": "private",
           "port": 50299
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-10-03T17:03:39Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-10-03T17:03:39Z",
+          "kind": "event"
         },
         "flow": {
           "id": "Em0tsl0c_AI",
@@ -532,14 +555,18 @@
           "source_mac_address": "00:23:04:18:ef:40",
           "source_transport_port": 443,
           "tcp_control_bits": 24,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 700,
           "community_id": "1:pbgT4RHa3Pkj4VUsV2ZuAXb7NJc=",
           "direction": "outbound",
+          "iana_number": 6,
           "packets": 9,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "216.58.201.106",
@@ -559,12 +586,11 @@
           "locality": "private",
           "port": 61353
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-10-03T17:03:39Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-10-03T17:03:39Z",
+          "kind": "event"
         },
         "flow": {
           "id": "XDiXRMEwAoI",
@@ -593,14 +619,18 @@
           "source_mac_address": "00:23:04:18:ef:40",
           "source_transport_port": 443,
           "tcp_control_bits": 24,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 161,
           "community_id": "1:3UJAXfwRkrqnjorLTDfwA2lIK5o=",
           "direction": "outbound",
+          "iana_number": 6,
           "packets": 2,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "52.236.33.163",
@@ -620,12 +650,11 @@
           "locality": "public",
           "port": 443
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-10-03T17:03:39Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-10-03T17:03:39Z",
+          "kind": "event"
         },
         "flow": {
           "id": "GyvkHwTpOVU",
@@ -654,14 +683,18 @@
           "source_mac_address": "1c:5c:f2:07:0f:2a",
           "source_transport_port": 61674,
           "tcp_control_bits": 27,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 1764,
           "community_id": "1:mshcMglow3GUvCItk1pK74FLkzM=",
           "direction": "inbound",
+          "iana_number": 6,
           "packets": 21,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.3.34",
@@ -681,12 +714,11 @@
           "locality": "private",
           "port": 61672
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-10-03T17:03:39Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-10-03T17:03:39Z",
+          "kind": "event"
         },
         "flow": {
           "id": "IKnO36OYWBE",
@@ -715,14 +747,18 @@
           "source_mac_address": "00:23:04:18:ef:40",
           "source_transport_port": 443,
           "tcp_control_bits": 31,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 13811,
           "community_id": "1:sCy/9s7UF0Bv1dEJGaPKptRstZA=",
           "direction": "outbound",
+          "iana_number": 6,
           "packets": 30,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "209.197.3.19",
@@ -742,12 +778,11 @@
           "locality": "private",
           "port": 61674
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-10-03T17:03:39Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-10-03T17:03:39Z",
+          "kind": "event"
         },
         "flow": {
           "id": "l6f_GDBq5e4",
@@ -776,14 +811,18 @@
           "source_mac_address": "00:23:04:18:ef:40",
           "source_transport_port": 443,
           "tcp_control_bits": 27,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 4717,
           "community_id": "1:zoZ7/PcKboOk3QEq0Jc4k12H7AI=",
           "direction": "outbound",
+          "iana_number": 6,
           "packets": 16,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "52.216.130.237",
@@ -803,12 +842,11 @@
           "locality": "public",
           "port": 443
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-10-03T17:03:39Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-10-03T17:03:39Z",
+          "kind": "event"
         },
         "flow": {
           "id": "xSntjtbHvZ8",
@@ -837,14 +875,18 @@
           "source_mac_address": "b0:34:95:0d:d2:5d",
           "source_transport_port": 51209,
           "tcp_control_bits": 26,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 2419,
           "community_id": "1:m9W66mSxsAZlmvM70NmJT4nlrkk=",
           "direction": "inbound",
+          "iana_number": 6,
           "packets": 13,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.0.157",
@@ -864,12 +906,11 @@
           "locality": "private",
           "port": 51209
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-10-03T17:03:39Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-10-03T17:03:39Z",
+          "kind": "event"
         },
         "flow": {
           "id": "7ZMa49AANa4",
@@ -898,14 +939,18 @@
           "source_mac_address": "00:23:04:18:ef:40",
           "source_transport_port": 443,
           "tcp_control_bits": 26,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 5551,
           "community_id": "1:GIrBDC9vXe7Zm4DMPiPtmJVTls4=",
           "direction": "outbound",
+          "iana_number": 6,
           "packets": 10,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "172.217.23.232",
@@ -925,12 +970,11 @@
           "locality": "private",
           "port": 45584
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-10-03T17:03:39Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-10-03T17:03:39Z",
+          "kind": "event"
         },
         "flow": {
           "id": "TanHDUIaXUc",
@@ -959,14 +1003,18 @@
           "source_mac_address": "00:23:04:18:ef:40",
           "source_transport_port": 443,
           "tcp_control_bits": 25,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 187,
           "community_id": "1:P9h6YFje9lqATAkmHYS9HVVWzFY=",
           "direction": "outbound",
+          "iana_number": 6,
           "packets": 3,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "107.21.232.174",
@@ -986,12 +1034,11 @@
           "locality": "public",
           "port": 443
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-10-03T17:03:39Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-10-03T17:03:39Z",
+          "kind": "event"
         },
         "flow": {
           "id": "6udpjf64Fpg",
@@ -1020,14 +1067,18 @@
           "source_mac_address": "dc:ef:ca:4c:da:57",
           "source_transport_port": 45584,
           "tcp_control_bits": 17,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 104,
           "community_id": "1:nJc3Pe5SE+C0yRtf3IBstM2/wf8=",
           "direction": "inbound",
+          "iana_number": 6,
           "packets": 2,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.3.178",
@@ -1047,12 +1098,11 @@
           "locality": "public",
           "port": 2222
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-10-03T17:03:39Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-10-03T17:03:39Z",
+          "kind": "event"
         },
         "flow": {
           "id": "zT9kcrkDd6s",
@@ -1081,14 +1131,18 @@
           "source_mac_address": "70:18:8b:5c:c9:b5",
           "source_transport_port": 64233,
           "tcp_control_bits": 27,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 4050,
           "community_id": "1:O5rmXSFSnlff9/cA9+155LFPgBM=",
           "direction": "inbound",
+          "iana_number": 6,
           "packets": 72,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.2.118",
@@ -1108,12 +1162,11 @@
           "locality": "private",
           "port": 64233
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-10-03T17:03:39Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-10-03T17:03:39Z",
+          "kind": "event"
         },
         "flow": {
           "id": "lSjcB0XXRjo",
@@ -1142,14 +1195,18 @@
           "source_mac_address": "00:23:04:18:ef:40",
           "source_transport_port": 2222,
           "tcp_control_bits": 27,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 3719,
           "community_id": "1:nVIdFfXErPGzJhGjTgW3gNk911I=",
           "direction": "outbound",
+          "iana_number": 6,
           "packets": 72,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "95.0.145.242",
@@ -1169,12 +1226,11 @@
           "locality": "public",
           "port": 443
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-10-03T17:03:39Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-10-03T17:03:39Z",
+          "kind": "event"
         },
         "flow": {
           "id": "ib00xbCp9fc",
@@ -1203,14 +1259,18 @@
           "source_mac_address": "8c:29:37:7a:28:c0",
           "source_transport_port": 54275,
           "tcp_control_bits": 26,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 1402,
           "community_id": "1:90Ag0hFjWyN3t7gH9CqeM/did5s=",
           "direction": "inbound",
+          "iana_number": 6,
           "packets": 16,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.0.79",
@@ -1230,12 +1290,11 @@
           "locality": "public",
           "port": 443
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-10-03T17:03:39Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-10-03T17:03:39Z",
+          "kind": "event"
         },
         "flow": {
           "id": "KkgiVld-pKQ",
@@ -1264,14 +1323,18 @@
           "source_mac_address": "8c:29:37:7a:28:c0",
           "source_transport_port": 54276,
           "tcp_control_bits": 26,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 1538,
           "community_id": "1:NFDWVYhuGdQEmetBlCYqKsa3FxE=",
           "direction": "inbound",
+          "iana_number": 6,
           "packets": 17,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.0.79",
@@ -1291,12 +1354,11 @@
           "locality": "private",
           "port": 54276
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-10-03T17:03:39Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-10-03T17:03:39Z",
+          "kind": "event"
         },
         "flow": {
           "id": "O105la3nsXk",
@@ -1325,14 +1387,18 @@
           "source_mac_address": "00:23:04:18:ef:40",
           "source_transport_port": 443,
           "tcp_control_bits": 26,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 13002,
           "community_id": "1:e26MIMDFVFBLLY7E0XTRE10o3Kw=",
           "direction": "outbound",
+          "iana_number": 6,
           "packets": 14,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "23.5.100.66",
@@ -1352,12 +1418,11 @@
           "locality": "private",
           "port": 57007
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-10-03T17:03:39Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-10-03T17:03:39Z",
+          "kind": "event"
         },
         "flow": {
           "id": "zN13t8qHEGY",
@@ -1386,14 +1451,18 @@
           "source_mac_address": "00:23:04:18:ef:40",
           "source_transport_port": 443,
           "tcp_control_bits": 24,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 1194,
           "community_id": "1:WFh30fi4saQVTIGUy+aRRPLprpI=",
           "direction": "outbound",
+          "iana_number": 6,
           "packets": 4,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "170.251.180.15",
@@ -1413,12 +1482,11 @@
           "locality": "public",
           "port": 443
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-10-03T17:03:39Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-10-03T17:03:39Z",
+          "kind": "event"
         },
         "flow": {
           "id": "jhDgPTAZ-Pc",
@@ -1447,14 +1515,18 @@
           "source_mac_address": "90:61:ae:76:e5:e9",
           "source_transport_port": 57007,
           "tcp_control_bits": 24,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 682,
           "community_id": "1:ZGG4Abe/Pqdj+7pSlunbDP7c/m4=",
           "direction": "inbound",
+          "iana_number": 6,
           "packets": 2,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.0.61",
@@ -1474,12 +1546,11 @@
           "locality": "public",
           "port": 443
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-10-03T17:03:39Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-10-03T17:03:39Z",
+          "kind": "event"
         },
         "flow": {
           "id": "e12qk7vuXjM",
@@ -1508,14 +1579,18 @@
           "source_mac_address": "1c:5c:f2:07:0f:2a",
           "source_transport_port": 61694,
           "tcp_control_bits": 26,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 1804,
           "community_id": "1:baiOQuB0TgMwKAioqCp4nnOKOoQ=",
           "direction": "inbound",
+          "iana_number": 6,
           "packets": 11,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.3.34",
@@ -1535,12 +1610,11 @@
           "locality": "private",
           "port": 59459
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-10-03T17:03:39Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-10-03T17:03:39Z",
+          "kind": "event"
         },
         "flow": {
           "id": "98RPS4e6CzA",
@@ -1569,14 +1643,18 @@
           "source_mac_address": "00:23:04:18:ef:40",
           "source_transport_port": 443,
           "tcp_control_bits": 26,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 4774,
           "community_id": "1:kNqglsjDg0pb/geatAIkiyIYjyE=",
           "direction": "outbound",
+          "iana_number": 6,
           "packets": 9,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "185.60.218.19",
@@ -1596,12 +1674,11 @@
           "locality": "public",
           "port": 443
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-10-03T17:03:39Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-10-03T17:03:39Z",
+          "kind": "event"
         },
         "flow": {
           "id": "A34Tj8bruZ4",
@@ -1630,14 +1707,18 @@
           "source_mac_address": "18:20:32:bb:1d:62",
           "source_transport_port": 64493,
           "tcp_control_bits": 24,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 135,
           "community_id": "1:G9f5HTVvI5bDlLshQnVxCbSm9eE=",
           "direction": "inbound",
+          "iana_number": 6,
           "packets": 2,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.3.200",
@@ -1657,12 +1738,11 @@
           "locality": "private",
           "port": 64493
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-10-03T17:03:39Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-10-03T17:03:39Z",
+          "kind": "event"
         },
         "flow": {
           "id": "uz-rc_F3l2I",
@@ -1691,14 +1771,18 @@
           "source_mac_address": "00:23:04:18:ef:40",
           "source_transport_port": 443,
           "tcp_control_bits": 24,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 135,
           "community_id": "1:F6zH8IWQqM0vi7PdOT+JZyFBYeA=",
           "direction": "outbound",
+          "iana_number": 6,
           "packets": 2,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "185.60.218.15",
@@ -1718,12 +1802,11 @@
           "locality": "public",
           "port": 5222
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-10-03T17:03:39Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-10-03T17:03:39Z",
+          "kind": "event"
         },
         "flow": {
           "id": "NXlrUC3DXDQ",
@@ -1752,14 +1835,18 @@
           "source_mac_address": "a0:39:f7:4d:49:d5",
           "source_transport_port": 35053,
           "tcp_control_bits": 24,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 194,
           "community_id": "1:+Xmm3JdD6oj+iaOxonwDPgB2lVY=",
           "direction": "inbound",
+          "iana_number": 6,
           "packets": 3,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.0.95",

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-ASA-2.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-ASA-2.golden.json
@@ -10,12 +10,11 @@
           "locality": "private",
           "port": 80
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2016-07-21T13:50:37Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2016-07-21T13:50:37Z",
+          "kind": "event"
         },
         "flow": {
           "id": "4FwX8zOnzn4",
@@ -48,12 +47,16 @@
           "responder_octets": 763,
           "source_ipv4_address": "192.168.0.2",
           "source_transport_port": 61775,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "community_id": "1:I8h+Rnj88f03jgEHLyfcKOzLI6M=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.0.2",
@@ -72,12 +75,11 @@
           "locality": "private",
           "port": 80
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2016-07-21T13:50:37Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2016-07-21T13:50:37Z",
+          "kind": "event"
         },
         "flow": {
           "id": "Ad8vSa7issI",
@@ -110,12 +112,16 @@
           "responder_octets": 6207,
           "source_ipv4_address": "192.168.0.2",
           "source_transport_port": 61776,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "community_id": "1:mKvuBb1HFV3U0+pj/F7eH/SPOyc=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.0.2",
@@ -134,12 +140,11 @@
           "locality": "private",
           "port": 80
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2016-07-21T13:50:37Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2016-07-21T13:50:37Z",
+          "kind": "event"
         },
         "flow": {
           "id": "Ad8vSa7issI",
@@ -172,12 +177,16 @@
           "responder_octets": 6207,
           "source_ipv4_address": "192.168.0.2",
           "source_transport_port": 61776,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "community_id": "1:mKvuBb1HFV3U0+pj/F7eH/SPOyc=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.0.2",
@@ -196,12 +205,11 @@
           "locality": "private",
           "port": 80
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2016-07-21T13:50:37Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2016-07-21T13:50:37Z",
+          "kind": "event"
         },
         "flow": {
           "id": "1W6ybGAqMAo",
@@ -234,12 +242,16 @@
           "responder_octets": 9075,
           "source_ipv4_address": "192.168.0.1",
           "source_transport_port": 56635,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "community_id": "1:i5nSykRXJvquvIuEibM9evNxo8o=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.0.1",
@@ -258,12 +270,11 @@
           "locality": "private",
           "port": 80
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2016-07-21T13:50:37Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2016-07-21T13:50:37Z",
+          "kind": "event"
         },
         "flow": {
           "id": "1W6ybGAqMAo",
@@ -296,12 +307,16 @@
           "responder_octets": 9075,
           "source_ipv4_address": "192.168.0.1",
           "source_transport_port": 56635,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "community_id": "1:i5nSykRXJvquvIuEibM9evNxo8o=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.0.1",
@@ -320,12 +335,11 @@
           "locality": "private",
           "port": 80
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2016-07-21T13:50:37Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2016-07-21T13:50:37Z",
+          "kind": "event"
         },
         "flow": {
           "id": "VQT0jF243AA",
@@ -358,12 +372,16 @@
           "responder_octets": 5536,
           "source_ipv4_address": "192.168.0.2",
           "source_transport_port": 61773,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "community_id": "1:4lrT4glskPfI8xSnnz83yjpF3/8=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.0.2",
@@ -382,12 +400,11 @@
           "locality": "private",
           "port": 80
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2016-07-21T13:50:37Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2016-07-21T13:50:37Z",
+          "kind": "event"
         },
         "flow": {
           "id": "VQT0jF243AA",
@@ -420,12 +437,16 @@
           "responder_octets": 5536,
           "source_ipv4_address": "192.168.0.2",
           "source_transport_port": 61773,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "community_id": "1:4lrT4glskPfI8xSnnz83yjpF3/8=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.0.2",
@@ -444,12 +465,11 @@
           "locality": "private",
           "port": 80
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2016-07-21T13:50:37Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2016-07-21T13:50:37Z",
+          "kind": "event"
         },
         "flow": {
           "id": "RA26743dDmc",
@@ -480,12 +500,16 @@
           "protocol_identifier": 6,
           "source_ipv4_address": "192.168.0.1",
           "source_transport_port": 56649,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "community_id": "1:gbcWcUcNt3ZRqBN2uzykEEbA2+U=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.0.1",
@@ -504,12 +528,11 @@
           "locality": "private",
           "port": 80
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2016-07-21T13:50:37Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2016-07-21T13:50:37Z",
+          "kind": "event"
         },
         "flow": {
           "id": "RA26743dDmc",
@@ -542,12 +565,16 @@
           "responder_octets": 14179,
           "source_ipv4_address": "192.168.0.1",
           "source_transport_port": 56649,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "community_id": "1:gbcWcUcNt3ZRqBN2uzykEEbA2+U=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.0.1",
@@ -566,12 +593,11 @@
           "locality": "private",
           "port": 80
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2016-07-21T13:50:37Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2016-07-21T13:50:37Z",
+          "kind": "event"
         },
         "flow": {
           "id": "RA26743dDmc",
@@ -604,12 +630,16 @@
           "responder_octets": 14179,
           "source_ipv4_address": "192.168.0.1",
           "source_transport_port": 56649,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "community_id": "1:gbcWcUcNt3ZRqBN2uzykEEbA2+U=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.0.1",
@@ -628,12 +658,11 @@
           "locality": "private",
           "port": 80
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2016-07-21T13:50:37Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2016-07-21T13:50:37Z",
+          "kind": "event"
         },
         "flow": {
           "id": "bQYn_AhcGkw",
@@ -664,12 +693,16 @@
           "protocol_identifier": 6,
           "source_ipv4_address": "192.168.0.2",
           "source_transport_port": 61777,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "community_id": "1:dMCFJEm0lrPr+fKgCpIef5eiFLk=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.0.2",
@@ -688,12 +721,11 @@
           "locality": "private",
           "port": 80
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2016-07-21T13:50:37Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2016-07-21T13:50:37Z",
+          "kind": "event"
         },
         "flow": {
           "id": "bQYn_AhcGkw",
@@ -726,12 +758,16 @@
           "responder_octets": 14178,
           "source_ipv4_address": "192.168.0.2",
           "source_transport_port": 61777,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "community_id": "1:dMCFJEm0lrPr+fKgCpIef5eiFLk=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.0.2",
@@ -750,12 +786,11 @@
           "locality": "private",
           "port": 80
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2016-07-21T13:50:37Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2016-07-21T13:50:37Z",
+          "kind": "event"
         },
         "flow": {
           "id": "bQYn_AhcGkw",
@@ -788,12 +823,16 @@
           "responder_octets": 14178,
           "source_ipv4_address": "192.168.0.2",
           "source_transport_port": 61777,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "community_id": "1:dMCFJEm0lrPr+fKgCpIef5eiFLk=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.0.2",
@@ -812,12 +851,11 @@
           "locality": "private",
           "port": 80
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2016-07-21T13:50:37Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2016-07-21T13:50:37Z",
+          "kind": "event"
         },
         "flow": {
           "id": "gx9XsEXj188",
@@ -848,12 +886,16 @@
           "protocol_identifier": 6,
           "source_ipv4_address": "192.168.0.1",
           "source_transport_port": 56650,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "community_id": "1:ehXkRqqxuigy8ra+qE/GuJchCA4=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.0.1",
@@ -872,12 +914,11 @@
           "locality": "private",
           "port": 80
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2016-07-21T13:50:37Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2016-07-21T13:50:37Z",
+          "kind": "event"
         },
         "flow": {
           "id": "gx9XsEXj188",
@@ -910,12 +951,16 @@
           "responder_octets": 881,
           "source_ipv4_address": "192.168.0.1",
           "source_transport_port": 56650,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "community_id": "1:ehXkRqqxuigy8ra+qE/GuJchCA4=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.0.1",
@@ -934,12 +979,11 @@
           "locality": "private",
           "port": 80
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2016-07-21T13:50:37Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2016-07-21T13:50:37Z",
+          "kind": "event"
         },
         "flow": {
           "id": "gx9XsEXj188",
@@ -972,12 +1016,16 @@
           "responder_octets": 881,
           "source_ipv4_address": "192.168.0.1",
           "source_transport_port": 56650,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "community_id": "1:ehXkRqqxuigy8ra+qE/GuJchCA4=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.0.1",
@@ -996,12 +1044,11 @@
           "locality": "private",
           "port": 80
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2016-07-21T13:50:37Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2016-07-21T13:50:37Z",
+          "kind": "event"
         },
         "flow": {
           "id": "4JJK6i2GTfU",
@@ -1032,12 +1079,16 @@
           "protocol_identifier": 6,
           "source_ipv4_address": "192.168.0.1",
           "source_transport_port": 56651,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "community_id": "1:xKQan2kd1NgxMAX7DUOk/URZAno=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.0.1",
@@ -1056,12 +1107,11 @@
           "locality": "private",
           "port": 80
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2016-07-21T13:50:37Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2016-07-21T13:50:37Z",
+          "kind": "event"
         },
         "flow": {
           "id": "4JJK6i2GTfU",
@@ -1094,12 +1144,16 @@
           "responder_octets": 14178,
           "source_ipv4_address": "192.168.0.1",
           "source_transport_port": 56651,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "community_id": "1:xKQan2kd1NgxMAX7DUOk/URZAno=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.0.1",
@@ -1118,12 +1172,11 @@
           "locality": "private",
           "port": 80
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2016-07-21T13:50:37Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2016-07-21T13:50:37Z",
+          "kind": "event"
         },
         "flow": {
           "id": "4JJK6i2GTfU",
@@ -1156,12 +1209,16 @@
           "responder_octets": 14178,
           "source_ipv4_address": "192.168.0.1",
           "source_transport_port": 56651,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "community_id": "1:xKQan2kd1NgxMAX7DUOk/URZAno=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.0.1",

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-ASA.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-ASA.golden.json
@@ -10,12 +10,11 @@
           "locality": "public",
           "port": 17549
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2015-10-09T09:47:51Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2015-10-09T09:47:51Z",
+          "kind": "event"
         },
         "flow": {
           "id": "4sqHgIUNdhc",
@@ -42,13 +41,17 @@
           "protocol_identifier": 1,
           "source_ipv4_address": "192.168.14.1",
           "source_transport_port": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 56,
           "community_id": "1:SmwvOXNzqf078/v4Sdnv4cSsPEI=",
           "direction": "unknown",
-          "protocol": "icmp"
+          "iana_number": 1,
+          "transport": "icmp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.14.1",
@@ -67,12 +70,11 @@
           "locality": "public",
           "port": 0
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2015-10-09T09:47:51Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2015-10-09T09:47:51Z",
+          "kind": "event"
         },
         "flow": {
           "id": "3zooPayCX08",
@@ -99,13 +101,17 @@
           "protocol_identifier": 1,
           "source_ipv4_address": "192.168.23.22",
           "source_transport_port": 17549,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 56,
           "community_id": "1:ze3NNjzfiQKBNJMVnoVNEOJInGg=",
           "direction": "unknown",
-          "protocol": "icmp"
+          "iana_number": 1,
+          "transport": "icmp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.23.22",
@@ -124,12 +130,11 @@
           "locality": "private",
           "port": 17549
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2015-10-09T09:47:51Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2015-10-09T09:47:51Z",
+          "kind": "event"
         },
         "flow": {
           "id": "rjHIoePwVUY",
@@ -156,13 +161,17 @@
           "protocol_identifier": 1,
           "source_ipv4_address": "164.164.37.11",
           "source_transport_port": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 56,
           "community_id": "1:xvskJWklV13yhdmqo/CeIyXRtsY=",
           "direction": "unknown",
-          "protocol": "icmp"
+          "iana_number": 1,
+          "transport": "icmp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "164.164.37.11",
@@ -181,12 +190,11 @@
           "locality": "public",
           "port": 0
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2015-10-09T09:47:51Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2015-10-09T09:47:51Z",
+          "kind": "event"
         },
         "flow": {
           "id": "kTUBU9vFxdg",
@@ -213,13 +221,17 @@
           "protocol_identifier": 1,
           "source_ipv4_address": "192.168.23.20",
           "source_transport_port": 17805,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 56,
           "community_id": "1:RThhKEIaevWgAeGJidFNVthplto=",
           "direction": "unknown",
-          "protocol": "icmp"
+          "iana_number": 1,
+          "transport": "icmp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.23.20",
@@ -238,12 +250,11 @@
           "locality": "private",
           "port": 17805
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2015-10-09T09:47:51Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2015-10-09T09:47:51Z",
+          "kind": "event"
         },
         "flow": {
           "id": "xPJhkFDpNiU",
@@ -270,13 +281,17 @@
           "protocol_identifier": 1,
           "source_ipv4_address": "164.164.37.11",
           "source_transport_port": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 56,
           "community_id": "1:xvskJWklV13yhdmqo/CeIyXRtsY=",
           "direction": "unknown",
-          "protocol": "icmp"
+          "iana_number": 1,
+          "transport": "icmp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "164.164.37.11",
@@ -295,12 +310,11 @@
           "locality": "public",
           "port": 0
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2015-10-09T09:47:51Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2015-10-09T09:47:51Z",
+          "kind": "event"
         },
         "flow": {
           "id": "AxuXms6GBGk",
@@ -327,13 +341,17 @@
           "protocol_identifier": 1,
           "source_ipv4_address": "192.168.14.11",
           "source_transport_port": 17805,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 56,
           "community_id": "1:u/b3SLdlsknqQeCYLejlqwSewgo=",
           "direction": "unknown",
-          "protocol": "icmp"
+          "iana_number": 1,
+          "transport": "icmp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.14.11",
@@ -352,12 +370,11 @@
           "locality": "private",
           "port": 17805
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2015-10-09T09:47:51Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2015-10-09T09:47:51Z",
+          "kind": "event"
         },
         "flow": {
           "id": "gFKfPBsWfLM",
@@ -384,13 +401,17 @@
           "protocol_identifier": 1,
           "source_ipv4_address": "2.2.2.11",
           "source_transport_port": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 56,
           "community_id": "1:kS6rsnr70uQ6xFsuYMkvCKSdW8k=",
           "direction": "unknown",
-          "protocol": "icmp"
+          "iana_number": 1,
+          "transport": "icmp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "2.2.2.11",
@@ -409,12 +430,11 @@
           "locality": "private",
           "port": 0
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2015-10-09T09:47:51Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2015-10-09T09:47:51Z",
+          "kind": "event"
         },
         "flow": {
           "id": "eHdG6rUdn28",
@@ -441,13 +461,17 @@
           "protocol_identifier": 1,
           "source_ipv4_address": "2.2.2.11",
           "source_transport_port": 17805,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 56,
           "community_id": "1:kS6rsnr70uQ6xFsuYMkvCKSdW8k=",
           "direction": "unknown",
-          "protocol": "icmp"
+          "iana_number": 1,
+          "transport": "icmp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "2.2.2.11",
@@ -466,12 +490,11 @@
           "locality": "public",
           "port": 17805
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2015-10-09T09:47:51Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2015-10-09T09:47:51Z",
+          "kind": "event"
         },
         "flow": {
           "id": "JVI-3U3vTiM",
@@ -498,13 +521,17 @@
           "protocol_identifier": 1,
           "source_ipv4_address": "192.168.14.1",
           "source_transport_port": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 56,
           "community_id": "1:SmwvOXNzqf078/v4Sdnv4cSsPEI=",
           "direction": "unknown",
-          "protocol": "icmp"
+          "iana_number": 1,
+          "transport": "icmp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.14.1",
@@ -523,12 +550,11 @@
           "locality": "private",
           "port": 0
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2015-10-09T09:47:51Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2015-10-09T09:47:51Z",
+          "kind": "event"
         },
         "flow": {
           "id": "pc77-XHjAxs",
@@ -555,13 +581,17 @@
           "protocol_identifier": 1,
           "source_ipv4_address": "164.164.37.11",
           "source_transport_port": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 160,
           "community_id": "1:xvskJWklV13yhdmqo/CeIyXRtsY=",
           "direction": "unknown",
-          "protocol": "icmp"
+          "iana_number": 1,
+          "transport": "icmp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "164.164.37.11",
@@ -580,12 +610,11 @@
           "locality": "public",
           "port": 0
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2015-10-09T09:47:51Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2015-10-09T09:47:51Z",
+          "kind": "event"
         },
         "flow": {
           "id": "Qh5mk2U4KjY",
@@ -612,13 +641,17 @@
           "protocol_identifier": 1,
           "source_ipv4_address": "192.168.23.22",
           "source_transport_port": 18061,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 56,
           "community_id": "1:ze3NNjzfiQKBNJMVnoVNEOJInGg=",
           "direction": "unknown",
-          "protocol": "icmp"
+          "iana_number": 1,
+          "transport": "icmp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.23.22",
@@ -637,12 +670,11 @@
           "locality": "private",
           "port": 18061
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2015-10-09T09:47:51Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2015-10-09T09:47:51Z",
+          "kind": "event"
         },
         "flow": {
           "id": "v3tlG0bhLIU",
@@ -669,13 +701,17 @@
           "protocol_identifier": 1,
           "source_ipv4_address": "164.164.37.11",
           "source_transport_port": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 56,
           "community_id": "1:xvskJWklV13yhdmqo/CeIyXRtsY=",
           "direction": "unknown",
-          "protocol": "icmp"
+          "iana_number": 1,
+          "transport": "icmp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "164.164.37.11",
@@ -694,12 +730,11 @@
           "locality": "public",
           "port": 0
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2015-10-09T09:47:51Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2015-10-09T09:47:51Z",
+          "kind": "event"
         },
         "flow": {
           "id": "arIGi4uQChk",
@@ -726,13 +761,17 @@
           "protocol_identifier": 1,
           "source_ipv4_address": "192.168.23.20",
           "source_transport_port": 18061,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 56,
           "community_id": "1:RThhKEIaevWgAeGJidFNVthplto=",
           "direction": "unknown",
-          "protocol": "icmp"
+          "iana_number": 1,
+          "transport": "icmp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.23.20",
@@ -751,12 +790,11 @@
           "locality": "private",
           "port": 18061
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2015-10-09T09:47:51Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2015-10-09T09:47:51Z",
+          "kind": "event"
         },
         "flow": {
           "id": "v3tlG0bhLIU",
@@ -783,13 +821,17 @@
           "protocol_identifier": 1,
           "source_ipv4_address": "164.164.37.11",
           "source_transport_port": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 56,
           "community_id": "1:xvskJWklV13yhdmqo/CeIyXRtsY=",
           "direction": "unknown",
-          "protocol": "icmp"
+          "iana_number": 1,
+          "transport": "icmp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "164.164.37.11",

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-ASR-9000-series-options-template-256.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-ASR-9000-series-options-template-256.golden.json
@@ -5,12 +5,11 @@
       "Timestamp": "2016-12-06T10:09:48Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
           "action": "netflow_options",
-          "created": "2016-12-06T10:09:48Z"
+          "category": "network_traffic",
+          "created": "2016-12-06T10:09:48Z",
+          "kind": "event"
         },
         "netflow": {
           "exporter": {
@@ -28,6 +27,9 @@
             "octet_delta_count": 3250896451
           },
           "type": "netflow_options"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         }
       },
       "Private": null
@@ -36,12 +38,11 @@
       "Timestamp": "2016-12-06T10:09:48Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
           "action": "netflow_options",
-          "created": "2016-12-06T10:09:48Z"
+          "category": "network_traffic",
+          "created": "2016-12-06T10:09:48Z",
+          "kind": "event"
         },
         "netflow": {
           "exporter": {
@@ -59,6 +60,9 @@
             "octet_delta_count": 3250896451
           },
           "type": "netflow_options"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         }
       },
       "Private": null
@@ -67,12 +71,11 @@
       "Timestamp": "2016-12-06T10:09:48Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
           "action": "netflow_options",
-          "created": "2016-12-06T10:09:48Z"
+          "category": "network_traffic",
+          "created": "2016-12-06T10:09:48Z",
+          "kind": "event"
         },
         "netflow": {
           "exporter": {
@@ -90,6 +93,9 @@
             "octet_delta_count": 3250896451
           },
           "type": "netflow_options"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         }
       },
       "Private": null
@@ -98,12 +104,11 @@
       "Timestamp": "2016-12-06T10:09:48Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
           "action": "netflow_options",
-          "created": "2016-12-06T10:09:48Z"
+          "category": "network_traffic",
+          "created": "2016-12-06T10:09:48Z",
+          "kind": "event"
         },
         "netflow": {
           "exporter": {
@@ -121,6 +126,9 @@
             "octet_delta_count": 3250896451
           },
           "type": "netflow_options"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         }
       },
       "Private": null
@@ -129,12 +137,11 @@
       "Timestamp": "2016-12-06T10:09:48Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
           "action": "netflow_options",
-          "created": "2016-12-06T10:09:48Z"
+          "category": "network_traffic",
+          "created": "2016-12-06T10:09:48Z",
+          "kind": "event"
         },
         "netflow": {
           "exporter": {
@@ -152,6 +159,9 @@
             "octet_delta_count": 3250896451
           },
           "type": "netflow_options"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         }
       },
       "Private": null
@@ -160,12 +170,11 @@
       "Timestamp": "2016-12-06T10:09:48Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
           "action": "netflow_options",
-          "created": "2016-12-06T10:09:48Z"
+          "category": "network_traffic",
+          "created": "2016-12-06T10:09:48Z",
+          "kind": "event"
         },
         "netflow": {
           "exporter": {
@@ -183,6 +192,9 @@
             "octet_delta_count": 3250896451
           },
           "type": "netflow_options"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         }
       },
       "Private": null
@@ -191,12 +203,11 @@
       "Timestamp": "2016-12-06T10:09:48Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
           "action": "netflow_options",
-          "created": "2016-12-06T10:09:48Z"
+          "category": "network_traffic",
+          "created": "2016-12-06T10:09:48Z",
+          "kind": "event"
         },
         "netflow": {
           "exporter": {
@@ -214,6 +225,9 @@
             "octet_delta_count": 3250896451
           },
           "type": "netflow_options"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         }
       },
       "Private": null
@@ -222,12 +236,11 @@
       "Timestamp": "2016-12-06T10:09:48Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
           "action": "netflow_options",
-          "created": "2016-12-06T10:09:48Z"
+          "category": "network_traffic",
+          "created": "2016-12-06T10:09:48Z",
+          "kind": "event"
         },
         "netflow": {
           "exporter": {
@@ -245,6 +258,9 @@
             "octet_delta_count": 3250896451
           },
           "type": "netflow_options"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         }
       },
       "Private": null
@@ -253,12 +269,11 @@
       "Timestamp": "2016-12-06T10:09:48Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
           "action": "netflow_options",
-          "created": "2016-12-06T10:09:48Z"
+          "category": "network_traffic",
+          "created": "2016-12-06T10:09:48Z",
+          "kind": "event"
         },
         "netflow": {
           "exporter": {
@@ -276,6 +291,9 @@
             "octet_delta_count": 3250896451
           },
           "type": "netflow_options"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         }
       },
       "Private": null
@@ -284,12 +302,11 @@
       "Timestamp": "2016-12-06T10:09:48Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
           "action": "netflow_options",
-          "created": "2016-12-06T10:09:48Z"
+          "category": "network_traffic",
+          "created": "2016-12-06T10:09:48Z",
+          "kind": "event"
         },
         "netflow": {
           "exporter": {
@@ -307,6 +324,9 @@
             "octet_delta_count": 3250896451
           },
           "type": "netflow_options"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         }
       },
       "Private": null
@@ -315,12 +335,11 @@
       "Timestamp": "2016-12-06T10:09:48Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
           "action": "netflow_options",
-          "created": "2016-12-06T10:09:48Z"
+          "category": "network_traffic",
+          "created": "2016-12-06T10:09:48Z",
+          "kind": "event"
         },
         "netflow": {
           "exporter": {
@@ -338,6 +357,9 @@
             "octet_delta_count": 3250896451
           },
           "type": "netflow_options"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         }
       },
       "Private": null
@@ -346,12 +368,11 @@
       "Timestamp": "2016-12-06T10:09:48Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
           "action": "netflow_options",
-          "created": "2016-12-06T10:09:48Z"
+          "category": "network_traffic",
+          "created": "2016-12-06T10:09:48Z",
+          "kind": "event"
         },
         "netflow": {
           "exporter": {
@@ -369,6 +390,9 @@
             "octet_delta_count": 3250896451
           },
           "type": "netflow_options"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         }
       },
       "Private": null
@@ -377,12 +401,11 @@
       "Timestamp": "2016-12-06T10:09:48Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
           "action": "netflow_options",
-          "created": "2016-12-06T10:09:48Z"
+          "category": "network_traffic",
+          "created": "2016-12-06T10:09:48Z",
+          "kind": "event"
         },
         "netflow": {
           "exporter": {
@@ -400,6 +423,9 @@
             "octet_delta_count": 3250896451
           },
           "type": "netflow_options"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         }
       },
       "Private": null
@@ -408,12 +434,11 @@
       "Timestamp": "2016-12-06T10:09:48Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
           "action": "netflow_options",
-          "created": "2016-12-06T10:09:48Z"
+          "category": "network_traffic",
+          "created": "2016-12-06T10:09:48Z",
+          "kind": "event"
         },
         "netflow": {
           "exporter": {
@@ -431,6 +456,9 @@
             "octet_delta_count": 3250896451
           },
           "type": "netflow_options"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         }
       },
       "Private": null
@@ -439,12 +467,11 @@
       "Timestamp": "2016-12-06T10:09:48Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
           "action": "netflow_options",
-          "created": "2016-12-06T10:09:48Z"
+          "category": "network_traffic",
+          "created": "2016-12-06T10:09:48Z",
+          "kind": "event"
         },
         "netflow": {
           "exporter": {
@@ -462,6 +489,9 @@
             "octet_delta_count": 3250896451
           },
           "type": "netflow_options"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         }
       },
       "Private": null
@@ -470,12 +500,11 @@
       "Timestamp": "2016-12-06T10:09:48Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
           "action": "netflow_options",
-          "created": "2016-12-06T10:09:48Z"
+          "category": "network_traffic",
+          "created": "2016-12-06T10:09:48Z",
+          "kind": "event"
         },
         "netflow": {
           "exporter": {
@@ -493,6 +522,9 @@
             "octet_delta_count": 3250896451
           },
           "type": "netflow_options"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         }
       },
       "Private": null
@@ -501,12 +533,11 @@
       "Timestamp": "2016-12-06T10:09:48Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
           "action": "netflow_options",
-          "created": "2016-12-06T10:09:48Z"
+          "category": "network_traffic",
+          "created": "2016-12-06T10:09:48Z",
+          "kind": "event"
         },
         "netflow": {
           "exporter": {
@@ -524,6 +555,9 @@
             "octet_delta_count": 3250896451
           },
           "type": "netflow_options"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         }
       },
       "Private": null
@@ -532,12 +566,11 @@
       "Timestamp": "2016-12-06T10:09:48Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
           "action": "netflow_options",
-          "created": "2016-12-06T10:09:48Z"
+          "category": "network_traffic",
+          "created": "2016-12-06T10:09:48Z",
+          "kind": "event"
         },
         "netflow": {
           "exporter": {
@@ -555,6 +588,9 @@
             "octet_delta_count": 3250896451
           },
           "type": "netflow_options"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         }
       },
       "Private": null
@@ -563,12 +599,11 @@
       "Timestamp": "2016-12-06T10:09:48Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
           "action": "netflow_options",
-          "created": "2016-12-06T10:09:48Z"
+          "category": "network_traffic",
+          "created": "2016-12-06T10:09:48Z",
+          "kind": "event"
         },
         "netflow": {
           "exporter": {
@@ -586,6 +621,9 @@
             "octet_delta_count": 3250896451
           },
           "type": "netflow_options"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         }
       },
       "Private": null

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-ASR-9000-series-template-260.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-ASR-9000-series-template-260.golden.json
@@ -10,14 +10,13 @@
           "locality": "private",
           "port": 443
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2016-12-06T10:09:24Z",
           "duration": 0,
           "end": "2016-12-06T10:08:53.94Z",
+          "kind": "event",
           "start": "2016-12-06T10:08:53.94Z"
         },
         "flow": {
@@ -54,14 +53,18 @@
           "source_ipv4_prefix_length": 16,
           "source_transport_port": 54017,
           "tcp_control_bits": 16,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 40,
           "community_id": "1:5QtqbRawFoks19lDT4m84rTIr0I=",
           "direction": "outbound",
+          "iana_number": 6,
           "packets": 1,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.0.9.146",
@@ -80,14 +83,13 @@
           "locality": "private",
           "port": 443
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2016-12-06T10:09:24Z",
           "duration": 641000000,
           "end": "2016-12-06T10:08:54.583Z",
+          "kind": "event",
           "start": "2016-12-06T10:08:53.942Z"
         },
         "flow": {
@@ -124,14 +126,18 @@
           "source_ipv4_prefix_length": 21,
           "source_transport_port": 36484,
           "tcp_control_bits": 16,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 104,
           "community_id": "1:muIMx0jUR+CvrLTk2GTqhLFI218=",
           "direction": "outbound",
+          "iana_number": 6,
           "packets": 2,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.0.17.42",
@@ -150,14 +156,13 @@
           "locality": "private",
           "port": 443
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2016-12-06T10:09:24Z",
           "duration": 0,
           "end": "2016-12-06T10:08:53.945Z",
+          "kind": "event",
           "start": "2016-12-06T10:08:53.945Z"
         },
         "flow": {
@@ -194,14 +199,18 @@
           "source_ipv4_prefix_length": 24,
           "source_transport_port": 16814,
           "tcp_control_bits": 17,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 52,
           "community_id": "1:yrHEKmgdX/5y+1OPAM1L9TfAHmg=",
           "direction": "outbound",
+          "iana_number": 6,
           "packets": 1,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.0.22.111",
@@ -220,14 +229,13 @@
           "locality": "private",
           "port": 64812
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2016-12-06T10:09:24Z",
           "duration": 0,
           "end": "2016-12-06T10:08:53.947Z",
+          "kind": "event",
           "start": "2016-12-06T10:08:53.947Z"
         },
         "flow": {
@@ -264,14 +272,18 @@
           "source_ipv4_prefix_length": 25,
           "source_transport_port": 53,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 435,
           "community_id": "1:YNXtH4EzvqrA3VTktVgq2KF/IOY=",
           "direction": "outbound",
+          "iana_number": 17,
           "packets": 1,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.0.23.59",
@@ -290,14 +302,13 @@
           "locality": "private",
           "port": 2013
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2016-12-06T10:09:24Z",
           "duration": 0,
           "end": "2016-12-06T10:08:53.948Z",
+          "kind": "event",
           "start": "2016-12-06T10:08:53.948Z"
         },
         "flow": {
@@ -334,14 +345,18 @@
           "source_ipv4_prefix_length": 16,
           "source_transport_port": 443,
           "tcp_control_bits": 24,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 969,
           "community_id": "1:lGsIn9YpLf87wszEu0Wkgyjo+JE=",
           "direction": "inbound",
+          "iana_number": 6,
           "packets": 1,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.0.34.71",
@@ -360,14 +375,13 @@
           "locality": "private",
           "port": 80
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2016-12-06T10:09:24Z",
           "duration": 83000000,
           "end": "2016-12-06T10:08:53.948Z",
+          "kind": "event",
           "start": "2016-12-06T10:08:53.865Z"
         },
         "flow": {
@@ -404,14 +418,18 @@
           "source_ipv4_prefix_length": 16,
           "source_transport_port": 35273,
           "tcp_control_bits": 16,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 104,
           "community_id": "1:JLb431i/0yldNOPSZNi/+HsdWeQ=",
           "direction": "outbound",
+          "iana_number": 6,
           "packets": 2,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.0.10.133",
@@ -430,14 +448,13 @@
           "locality": "private",
           "port": 56771
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2016-12-06T10:09:24Z",
           "duration": 0,
           "end": "2016-12-06T10:08:53.951Z",
+          "kind": "event",
           "start": "2016-12-06T10:08:53.951Z"
         },
         "flow": {
@@ -474,14 +491,18 @@
           "source_ipv4_prefix_length": 24,
           "source_transport_port": 80,
           "tcp_control_bits": 16,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 52,
           "community_id": "1:ofLfvLehVuZ4MV4ox/cH00Pau9E=",
           "direction": "inbound",
+          "iana_number": 6,
           "packets": 1,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.0.37.29",
@@ -500,14 +521,13 @@
           "locality": "private",
           "port": 56830
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2016-12-06T10:09:24Z",
           "duration": 0,
           "end": "2016-12-06T10:08:53.951Z",
+          "kind": "event",
           "start": "2016-12-06T10:08:53.951Z"
         },
         "flow": {
@@ -544,14 +564,18 @@
           "source_ipv4_prefix_length": 20,
           "source_transport_port": 443,
           "tcp_control_bits": 24,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 614,
           "community_id": "1:wT0z6v7CLq3V50tVSNInKNKimHI=",
           "direction": "inbound",
+          "iana_number": 6,
           "packets": 1,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.0.32.176",
@@ -570,14 +594,13 @@
           "locality": "private",
           "port": 40078
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2016-12-06T10:09:24Z",
           "duration": 5418000000,
           "end": "2016-12-06T10:08:53.952Z",
+          "kind": "event",
           "start": "2016-12-06T10:08:48.534Z"
         },
         "flow": {
@@ -614,14 +637,18 @@
           "source_ipv4_prefix_length": 24,
           "source_transport_port": 443,
           "tcp_control_bits": 16,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 4350,
           "community_id": "1:vXALsmVaBmWRD8avVYrayx6HUv8=",
           "direction": "outbound",
+          "iana_number": 6,
           "packets": 3,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.0.12.21",
@@ -640,14 +667,13 @@
           "locality": "private",
           "port": 443
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2016-12-06T10:09:24Z",
           "duration": 3317000000,
           "end": "2016-12-06T10:08:57.27Z",
+          "kind": "event",
           "start": "2016-12-06T10:08:53.953Z"
         },
         "flow": {
@@ -684,14 +710,18 @@
           "source_ipv4_prefix_length": 16,
           "source_transport_port": 50691,
           "tcp_control_bits": 24,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 533,
           "community_id": "1:LLyIDE1QzpXFudau/pNomJiltZo=",
           "direction": "outbound",
+          "iana_number": 6,
           "packets": 2,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.0.4.212",
@@ -710,14 +740,13 @@
           "locality": "private",
           "port": 80
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2016-12-06T10:09:24Z",
           "duration": 19894000000,
           "end": "2016-12-06T10:09:04.383Z",
+          "kind": "event",
           "start": "2016-12-06T10:08:44.489Z"
         },
         "flow": {
@@ -754,14 +783,18 @@
           "source_ipv4_prefix_length": 21,
           "source_transport_port": 58814,
           "tcp_control_bits": 16,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 13660,
           "community_id": "1:IOU7kvx862mNhGLL6I96qC93pSw=",
           "direction": "inbound",
+          "iana_number": 6,
           "packets": 325,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.0.33.122",
@@ -780,14 +813,13 @@
           "locality": "private",
           "port": 443
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2016-12-06T10:09:24Z",
           "duration": 0,
           "end": "2016-12-06T10:08:53.955Z",
+          "kind": "event",
           "start": "2016-12-06T10:08:53.955Z"
         },
         "flow": {
@@ -824,14 +856,18 @@
           "source_ipv4_prefix_length": 21,
           "source_transport_port": 2013,
           "tcp_control_bits": 24,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 89,
           "community_id": "1:rFBXrW2Sphy0zvlWpDk/ruilmEI=",
           "direction": "outbound",
+          "iana_number": 6,
           "packets": 1,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.0.20.242",
@@ -850,14 +886,13 @@
           "locality": "private",
           "port": 51621
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2016-12-06T10:09:24Z",
           "duration": 0,
           "end": "2016-12-06T10:08:53.957Z",
+          "kind": "event",
           "start": "2016-12-06T10:08:53.957Z"
         },
         "flow": {
@@ -894,14 +929,18 @@
           "source_ipv4_prefix_length": 24,
           "source_transport_port": 443,
           "tcp_control_bits": 24,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 833,
           "community_id": "1:0DisY80Xle+fnyGNQ/SanRYtGCo=",
           "direction": "outbound",
+          "iana_number": 6,
           "packets": 1,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.0.13.25",
@@ -920,14 +959,13 @@
           "locality": "private",
           "port": 62464
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2016-12-06T10:09:24Z",
           "duration": 89000000,
           "end": "2016-12-06T10:08:53.959Z",
+          "kind": "event",
           "start": "2016-12-06T10:08:53.87Z"
         },
         "flow": {
@@ -964,14 +1002,18 @@
           "source_ipv4_prefix_length": 16,
           "source_transport_port": 443,
           "tcp_control_bits": 24,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 1625,
           "community_id": "1:EfcM0REpWogoxKGBseKUSJ1yplM=",
           "direction": "inbound",
+          "iana_number": 6,
           "packets": 2,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.0.25.59",
@@ -990,14 +1032,13 @@
           "locality": "private",
           "port": 465
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2016-12-06T10:09:24Z",
           "duration": 17325000000,
           "end": "2016-12-06T10:09:05.882Z",
+          "kind": "event",
           "start": "2016-12-06T10:08:48.557Z"
         },
         "flow": {
@@ -1034,14 +1075,18 @@
           "source_ipv4_prefix_length": 16,
           "source_transport_port": 60312,
           "tcp_control_bits": 24,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 142184,
           "community_id": "1:A65k305ssNu+Z+35QQRXUxh0XaY=",
           "direction": "outbound",
+          "iana_number": 6,
           "packets": 97,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.0.7.73",
@@ -1060,14 +1105,13 @@
           "locality": "private",
           "port": 995
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2016-12-06T10:09:24Z",
           "duration": 2705000000,
           "end": "2016-12-06T10:08:56.186Z",
+          "kind": "event",
           "start": "2016-12-06T10:08:53.481Z"
         },
         "flow": {
@@ -1104,14 +1148,18 @@
           "source_ipv4_prefix_length": 18,
           "source_transport_port": 34452,
           "tcp_control_bits": 16,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 3016,
           "community_id": "1:0CerJ6Jhsco2s7mtd5SGPCWCTEY=",
           "direction": "outbound",
+          "iana_number": 6,
           "packets": 58,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.0.19.50",
@@ -1130,14 +1178,13 @@
           "locality": "private",
           "port": 49917
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2016-12-06T10:09:24Z",
           "duration": 361000000,
           "end": "2016-12-06T10:08:54.28Z",
+          "kind": "event",
           "start": "2016-12-06T10:08:53.919Z"
         },
         "flow": {
@@ -1174,14 +1221,18 @@
           "source_ipv4_prefix_length": 16,
           "source_transport_port": 443,
           "tcp_control_bits": 16,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 31500,
           "community_id": "1:mqnuyu3X21eaFef/WIBwFva8J80=",
           "direction": "inbound",
+          "iana_number": 6,
           "packets": 21,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.0.28.150",
@@ -1200,14 +1251,13 @@
           "locality": "private",
           "port": 50254
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2016-12-06T10:09:24Z",
           "duration": 378000000,
           "end": "2016-12-06T10:08:54.037Z",
+          "kind": "event",
           "start": "2016-12-06T10:08:53.659Z"
         },
         "flow": {
@@ -1244,14 +1294,18 @@
           "source_ipv4_prefix_length": 16,
           "source_transport_port": 993,
           "tcp_control_bits": 24,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 2919,
           "community_id": "1:G+m3ET1KdJ48R9N7FqnDLPyhqJA=",
           "direction": "inbound",
+          "iana_number": 6,
           "packets": 3,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.0.26.188",
@@ -1270,14 +1324,13 @@
           "locality": "private",
           "port": 35983
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2016-12-06T10:09:24Z",
           "duration": 11106000000,
           "end": "2016-12-06T10:09:03.759Z",
+          "kind": "event",
           "start": "2016-12-06T10:08:52.653Z"
         },
         "flow": {
@@ -1314,14 +1367,18 @@
           "source_ipv4_prefix_length": 24,
           "source_transport_port": 443,
           "tcp_control_bits": 24,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 4514,
           "community_id": "1:5v4tKeUjkIP+95cYMeNgtQNz7Ww=",
           "direction": "outbound",
+          "iana_number": 6,
           "packets": 5,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.0.29.34",
@@ -1340,14 +1397,13 @@
           "locality": "private",
           "port": 51671
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2016-12-06T10:09:24Z",
           "duration": 0,
           "end": "2016-12-06T10:08:53.964Z",
+          "kind": "event",
           "start": "2016-12-06T10:08:53.964Z"
         },
         "flow": {
@@ -1384,14 +1440,18 @@
           "source_ipv4_prefix_length": 16,
           "source_transport_port": 23128,
           "tcp_control_bits": 24,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 326,
           "community_id": "1:vSLX7ymMN1QGKGi1FUCv+zJsYkA=",
           "direction": "inbound",
+          "iana_number": 6,
           "packets": 1,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.0.8.200",
@@ -1410,14 +1470,13 @@
           "locality": "private",
           "port": 52364
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2016-12-06T10:09:24Z",
           "duration": 1587000000,
           "end": "2016-12-06T10:08:53.964Z",
+          "kind": "event",
           "start": "2016-12-06T10:08:52.377Z"
         },
         "flow": {
@@ -1454,14 +1513,18 @@
           "source_ipv4_prefix_length": 24,
           "source_transport_port": 443,
           "tcp_control_bits": 18,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 112,
           "community_id": "1:ILVS4/3klc/+6ukE32uhbsceeks=",
           "direction": "outbound",
+          "iana_number": 6,
           "packets": 2,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.0.29.46",

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-ASR1001--X.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-ASR1001--X.golden.json
@@ -10,12 +10,11 @@
           "locality": "private",
           "port": 53218
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-10-09T20:22:35Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-10-09T20:22:35Z",
+          "kind": "event"
         },
         "flow": {
           "id": "QywlgaPnfR4",
@@ -44,14 +43,18 @@
           "protocol_identifier": 6,
           "source_ipv4_address": "10.111.111.242",
           "source_transport_port": 52444,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 965,
           "community_id": "1:uwFzwI08CvSkNfR/WQPCHwlci6o=",
           "direction": "outbound",
+          "iana_number": 6,
           "packets": 7,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.111.111.242",
@@ -70,12 +73,11 @@
           "locality": "private",
           "port": 41746
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-10-09T20:22:35Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-10-09T20:22:35Z",
+          "kind": "event"
         },
         "flow": {
           "id": "ltJ6GMeuUh8",
@@ -104,14 +106,18 @@
           "protocol_identifier": 17,
           "source_ipv4_address": "10.10.4.29",
           "source_transport_port": 161,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 284,
           "community_id": "1:qmozbp1hu1WeZnrgR4YYxZsjeAs=",
           "direction": "inbound",
+          "iana_number": 17,
           "packets": 1,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.10.4.29",
@@ -130,12 +136,11 @@
           "locality": "private",
           "port": 52444
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-10-09T20:22:35Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-10-09T20:22:35Z",
+          "kind": "event"
         },
         "flow": {
           "id": "nCOqAo7Vn1Q",
@@ -164,14 +169,18 @@
           "protocol_identifier": 6,
           "source_ipv4_address": "10.12.100.13",
           "source_transport_port": 53218,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 670,
           "community_id": "1:u2/sO7a/O64V2snOv776vhfrdaE=",
           "direction": "inbound",
+          "iana_number": 6,
           "packets": 6,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.12.100.13",
@@ -190,12 +199,11 @@
           "locality": "private",
           "port": 61440
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-10-09T20:22:35Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-10-09T20:22:35Z",
+          "kind": "event"
         },
         "flow": {
           "id": "jxAU9kZfvAY",
@@ -224,14 +232,18 @@
           "protocol_identifier": 6,
           "source_ipv4_address": "10.12.104.239",
           "source_transport_port": 1720,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 80,
           "community_id": "1:3hLCiFejfB8o0F+PtLwpKhO8Gvw=",
           "direction": "inbound",
+          "iana_number": 6,
           "packets": 2,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.12.104.239",
@@ -250,12 +262,11 @@
           "locality": "private",
           "port": 1720
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-10-09T20:22:35Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-10-09T20:22:35Z",
+          "kind": "event"
         },
         "flow": {
           "id": "TabPGO2qhbg",
@@ -284,14 +295,18 @@
           "protocol_identifier": 6,
           "source_ipv4_address": "10.10.11.21",
           "source_transport_port": 61440,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 80,
           "community_id": "1:Q4BjTF5X3n7a+Oa2eU4BTat20J0=",
           "direction": "outbound",
+          "iana_number": 6,
           "packets": 2,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.10.11.21",
@@ -310,12 +325,11 @@
           "locality": "private",
           "port": 64400
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-10-09T20:22:35Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-10-09T20:22:35Z",
+          "kind": "event"
         },
         "flow": {
           "id": "__Gn3lXREl8",
@@ -344,14 +358,18 @@
           "protocol_identifier": 17,
           "source_ipv4_address": "10.100.101.45",
           "source_transport_port": 53,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 101,
           "community_id": "1:K39hVsHP9vJZE3HgkNg6IhdmFDI=",
           "direction": "outbound",
+          "iana_number": 17,
           "packets": 1,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.100.101.45",
@@ -370,12 +388,11 @@
           "locality": "private",
           "port": 0
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-10-09T20:22:35Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-10-09T20:22:35Z",
+          "kind": "event"
         },
         "flow": {
           "id": "HgByI6ZN5fI",
@@ -404,14 +421,18 @@
           "protocol_identifier": 17,
           "source_ipv4_address": "10.100.101.43",
           "source_transport_port": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 1134,
           "community_id": "1:dZjX+9FJFoTQCGnVJYA1D7eCt7E=",
           "direction": "outbound",
+          "iana_number": 17,
           "packets": 14,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.100.101.43",
@@ -430,12 +451,11 @@
           "locality": "private",
           "port": 51708
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-10-09T20:22:35Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-10-09T20:22:35Z",
+          "kind": "event"
         },
         "flow": {
           "id": "NmxbGp3YE2k",
@@ -464,14 +484,18 @@
           "protocol_identifier": 6,
           "source_ipv4_address": "31.13.71.7",
           "source_transport_port": 443,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 237,
           "community_id": "1:U+WZT9lvd0sxL1M9hpokk9TXK5w=",
           "direction": "outbound",
+          "iana_number": 6,
           "packets": 4,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "31.13.71.7",
@@ -490,12 +514,11 @@
           "locality": "private",
           "port": 58842
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-10-09T20:22:35Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-10-09T20:22:35Z",
+          "kind": "event"
         },
         "flow": {
           "id": "EXuHYVwL-Lg",
@@ -524,14 +547,18 @@
           "protocol_identifier": 17,
           "source_ipv4_address": "10.11.21.60",
           "source_transport_port": 161,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 91,
           "community_id": "1:wRntrWu6NswQHhEk070T8IeU8Fs=",
           "direction": "inbound",
+          "iana_number": 17,
           "packets": 1,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.11.21.60",
@@ -550,12 +577,11 @@
           "locality": "public",
           "port": 443
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-10-09T20:22:35Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-10-09T20:22:35Z",
+          "kind": "event"
         },
         "flow": {
           "id": "B0W49XnPuJI",
@@ -584,14 +610,18 @@
           "protocol_identifier": 6,
           "source_ipv4_address": "10.12.92.102",
           "source_transport_port": 50766,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 41,
           "community_id": "1:5JEyDFPIh+4ITPosuffRDzSF7Jw=",
           "direction": "inbound",
+          "iana_number": 6,
           "packets": 1,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.12.92.102",
@@ -610,12 +640,11 @@
           "locality": "private",
           "port": 161
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-10-09T20:22:35Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-10-09T20:22:35Z",
+          "kind": "event"
         },
         "flow": {
           "id": "kBEBKXXkEV4",
@@ -644,14 +673,18 @@
           "protocol_identifier": 17,
           "source_ipv4_address": "10.100.105.86",
           "source_transport_port": 58843,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 111,
           "community_id": "1:ARbQv4xDOLQ4HUS3c9oqLlwKGWY=",
           "direction": "outbound",
+          "iana_number": 17,
           "packets": 1,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.100.105.86",
@@ -670,12 +703,11 @@
           "locality": "private",
           "port": 41351
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-10-09T20:22:35Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-10-09T20:22:35Z",
+          "kind": "event"
         },
         "flow": {
           "id": "H_ffU7B_Ols",
@@ -704,14 +736,18 @@
           "protocol_identifier": 17,
           "source_ipv4_address": "10.10.4.234",
           "source_transport_port": 161,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 1164,
           "community_id": "1:y/0+lFjviSxqFw5Ud/Cc1yuBn2c=",
           "direction": "inbound",
+          "iana_number": 17,
           "packets": 4,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.10.4.234",
@@ -730,12 +766,11 @@
           "locality": "private",
           "port": 61440
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-10-09T20:22:35Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-10-09T20:22:35Z",
+          "kind": "event"
         },
         "flow": {
           "id": "z9roObSX0VI",
@@ -764,14 +799,18 @@
           "protocol_identifier": 6,
           "source_ipv4_address": "10.12.106.83",
           "source_transport_port": 1720,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 80,
           "community_id": "1:N8K6l0F31HluX8vUd+WbE/6iDfk=",
           "direction": "inbound",
+          "iana_number": 6,
           "packets": 2,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.12.106.83",
@@ -790,12 +829,11 @@
           "locality": "private",
           "port": 50766
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-10-09T20:22:35Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-10-09T20:22:35Z",
+          "kind": "event"
         },
         "flow": {
           "id": "pF9IcCI5_TA",
@@ -824,14 +862,18 @@
           "protocol_identifier": 6,
           "source_ipv4_address": "172.217.11.5",
           "source_transport_port": 443,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 52,
           "community_id": "1:XKmRGfkKextNmjU2O+4ubL+2LI4=",
           "direction": "outbound",
+          "iana_number": 6,
           "packets": 1,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "172.217.11.5",
@@ -850,12 +892,11 @@
           "locality": "private",
           "port": 1720
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-10-09T20:22:35Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-10-09T20:22:35Z",
+          "kind": "event"
         },
         "flow": {
           "id": "TabPGO2qhbg",
@@ -884,14 +925,18 @@
           "protocol_identifier": 6,
           "source_ipv4_address": "10.10.11.21",
           "source_transport_port": 61440,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 80,
           "community_id": "1:Q4BjTF5X3n7a+Oa2eU4BTat20J0=",
           "direction": "outbound",
+          "iana_number": 6,
           "packets": 2,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.10.11.21",
@@ -910,12 +955,11 @@
           "locality": "public",
           "port": 443
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-10-09T20:22:35Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-10-09T20:22:35Z",
+          "kind": "event"
         },
         "flow": {
           "id": "SHZ5cKd5_7I",
@@ -944,14 +988,18 @@
           "protocol_identifier": 6,
           "source_ipv4_address": "10.12.81.86",
           "source_transport_port": 58657,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 3088,
           "community_id": "1:afQ2LcWleivXmSC1cEzrvvoFc4U=",
           "direction": "inbound",
+          "iana_number": 6,
           "packets": 10,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.12.81.86",
@@ -970,12 +1018,11 @@
           "locality": "private",
           "port": 389
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-10-09T20:22:35Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-10-09T20:22:35Z",
+          "kind": "event"
         },
         "flow": {
           "id": "WqkLxpVBsYc",
@@ -1004,14 +1051,18 @@
           "protocol_identifier": 6,
           "source_ipv4_address": "10.14.121.98",
           "source_transport_port": 50174,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 5306,
           "community_id": "1:+k9rpD1zFTzj1TzClbQz5xxZSkM=",
           "direction": "inbound",
+          "iana_number": 6,
           "packets": 24,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.14.121.98",
@@ -1030,12 +1081,11 @@
           "locality": "private",
           "port": 58843
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-10-09T20:22:35Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-10-09T20:22:35Z",
+          "kind": "event"
         },
         "flow": {
           "id": "6oldLw2Mlas",
@@ -1064,14 +1114,18 @@
           "protocol_identifier": 17,
           "source_ipv4_address": "10.11.21.60",
           "source_transport_port": 161,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 116,
           "community_id": "1:SyYPZ96uUcoS7fqJKZzUOfcLHik=",
           "direction": "inbound",
+          "iana_number": 17,
           "packets": 1,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.11.21.60",
@@ -1090,12 +1144,11 @@
           "locality": "private",
           "port": 50174
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-10-09T20:22:35Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-10-09T20:22:35Z",
+          "kind": "event"
         },
         "flow": {
           "id": "h3rJ4LGMXt4",
@@ -1124,14 +1177,18 @@
           "protocol_identifier": 6,
           "source_ipv4_address": "10.12.100.13",
           "source_transport_port": 389,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 22764,
           "community_id": "1:dwhTKtbCkX7Na/7SKnulqsYlD40=",
           "direction": "inbound",
+          "iana_number": 6,
           "packets": 30,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.12.100.13",
@@ -1150,12 +1207,11 @@
           "locality": "private",
           "port": 61443
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-10-09T20:22:35Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-10-09T20:22:35Z",
+          "kind": "event"
         },
         "flow": {
           "id": "hSj81XiLSw0",
@@ -1184,14 +1240,18 @@
           "protocol_identifier": 6,
           "source_ipv4_address": "10.12.102.125",
           "source_transport_port": 1720,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 80,
           "community_id": "1:z67KRlDvetfiNmjA/1mM7UfiB7s=",
           "direction": "inbound",
+          "iana_number": 6,
           "packets": 2,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.12.102.125",
@@ -1210,12 +1270,11 @@
           "locality": "private",
           "port": 161
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-10-09T20:22:35Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-10-09T20:22:35Z",
+          "kind": "event"
         },
         "flow": {
           "id": "mWVfnnlkVzU",
@@ -1244,14 +1303,18 @@
           "protocol_identifier": 17,
           "source_ipv4_address": "10.100.105.86",
           "source_transport_port": 58844,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 75,
           "community_id": "1:AtJByg1SAIkNhDGqD4XhVNAhwc8=",
           "direction": "outbound",
+          "iana_number": 17,
           "packets": 1,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.100.105.86",
@@ -1270,12 +1333,11 @@
           "locality": "private",
           "port": 1720
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-10-09T20:22:35Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-10-09T20:22:35Z",
+          "kind": "event"
         },
         "flow": {
           "id": "-RTReIERjF0",
@@ -1304,14 +1366,18 @@
           "protocol_identifier": 6,
           "source_ipv4_address": "10.10.11.21",
           "source_transport_port": 61443,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 80,
           "community_id": "1:YamB1S9bWGFmqfw7U/M0nG1GUz8=",
           "direction": "outbound",
+          "iana_number": 6,
           "packets": 2,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.10.11.21",
@@ -1330,12 +1396,11 @@
           "locality": "private",
           "port": 161
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-10-09T20:22:35Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-10-09T20:22:35Z",
+          "kind": "event"
         },
         "flow": {
           "id": "NmZIPGhxoAc",
@@ -1364,14 +1429,18 @@
           "protocol_identifier": 17,
           "source_ipv4_address": "10.100.105.85",
           "source_transport_port": 37265,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 160,
           "community_id": "1:X+r9a4yHo+YM8PQ6q04bec166gk=",
           "direction": "outbound",
+          "iana_number": 17,
           "packets": 2,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.100.105.85",
@@ -1390,12 +1459,11 @@
           "locality": "public",
           "port": 123
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-10-09T20:22:35Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-10-09T20:22:35Z",
+          "kind": "event"
         },
         "flow": {
           "id": "x8DNo198Zms",
@@ -1424,14 +1492,18 @@
           "protocol_identifier": 17,
           "source_ipv4_address": "10.14.25.80",
           "source_transport_port": 62427,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 76,
           "community_id": "1:hmVHHQG4Si4V475TR3gSOjFY4PQ=",
           "direction": "inbound",
+          "iana_number": 17,
           "packets": 1,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.14.25.80",
@@ -1450,12 +1522,11 @@
           "locality": "private",
           "port": 49156
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-10-09T20:22:35Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-10-09T20:22:35Z",
+          "kind": "event"
         },
         "flow": {
           "id": "8UnzkHo8VIQ",
@@ -1484,14 +1555,18 @@
           "protocol_identifier": 6,
           "source_ipv4_address": "10.12.150.13",
           "source_transport_port": 61792,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 1340,
           "community_id": "1:XTYkQhjrZQKtKSBX3glwTV1hOBc=",
           "direction": "inbound",
+          "iana_number": 6,
           "packets": 2,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.12.150.13",

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-NBAR-flowset-262.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-NBAR-flowset-262.golden.json
@@ -11,14 +11,13 @@
           "mac": "1c:df:0f:7e:c3:58",
           "port": 2048
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2017-02-14T11:10:36Z",
           "duration": 0,
           "end": "2017-02-14T11:10:19.368Z",
+          "kind": "event",
           "start": "2017-02-14T11:10:19.368Z"
         },
         "flow": {
@@ -57,15 +56,19 @@
           "source_mac_address": "00:50:56:91:56:86",
           "source_transport_port": 0,
           "tcp_source_port": 0,
-          "type": "netflow",
+          "type": "netflow_flow",
           "udp_destination_port": 0
         },
         "network": {
           "bytes": 44,
           "community_id": "1:OYl5x6oQNloID/wLIKpFGPIvN/U=",
           "direction": "inbound",
+          "iana_number": 1,
           "packets": 1,
-          "protocol": "icmp"
+          "transport": "icmp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.30.18.62",
@@ -86,14 +89,13 @@
           "mac": "1c:df:0f:7e:c3:58",
           "port": 161
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2017-02-14T11:10:36Z",
           "duration": 0,
           "end": "2017-02-14T11:10:19.368Z",
+          "kind": "event",
           "start": "2017-02-14T11:10:19.368Z"
         },
         "flow": {
@@ -132,15 +134,19 @@
           "source_mac_address": "00:50:56:91:56:86",
           "source_transport_port": 34220,
           "tcp_source_port": 0,
-          "type": "netflow",
+          "type": "netflow_flow",
           "udp_destination_port": 161
         },
         "network": {
           "bytes": 106,
           "community_id": "1:CyRN90AZ56qtzUMojGTJ/nFWLGg=",
           "direction": "inbound",
+          "iana_number": 17,
           "packets": 1,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.30.18.62",
@@ -161,14 +167,13 @@
           "mac": "1c:df:0f:7e:c3:58",
           "port": 2048
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2017-02-14T11:10:36Z",
           "duration": 0,
           "end": "2017-02-14T11:10:19.924Z",
+          "kind": "event",
           "start": "2017-02-14T11:10:19.924Z"
         },
         "flow": {
@@ -207,15 +212,19 @@
           "source_mac_address": "00:18:19:9e:6c:01",
           "source_transport_port": 0,
           "tcp_source_port": 0,
-          "type": "netflow",
+          "type": "netflow_flow",
           "udp_destination_port": 0
         },
         "network": {
           "bytes": 44,
           "community_id": "1:j8GnMqCJ2VnxNT6ZX5j3wFnLTu0=",
           "direction": "inbound",
+          "iana_number": 1,
           "packets": 1,
-          "protocol": "icmp"
+          "transport": "icmp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.10.172.60",
@@ -236,14 +245,13 @@
           "mac": "1c:df:0f:7e:c3:58",
           "port": 123
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2017-02-14T11:10:36Z",
           "duration": 0,
           "end": "2017-02-14T11:10:19.996Z",
+          "kind": "event",
           "start": "2017-02-14T11:10:19.996Z"
         },
         "flow": {
@@ -282,15 +290,19 @@
           "source_mac_address": "00:18:19:9e:6c:01",
           "source_transport_port": 123,
           "tcp_source_port": 0,
-          "type": "netflow",
+          "type": "netflow_flow",
           "udp_destination_port": 123
         },
         "network": {
           "bytes": 76,
           "community_id": "1:CWcKykFvy1AWUIQAfWn2UBvkX2c=",
           "direction": "inbound",
+          "iana_number": 17,
           "packets": 1,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.10.172.60",
@@ -311,14 +323,13 @@
           "mac": "1c:df:0f:7e:c3:58",
           "port": 161
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2017-02-14T11:10:36Z",
           "duration": 72000000,
           "end": "2017-02-14T11:10:20.008Z",
+          "kind": "event",
           "start": "2017-02-14T11:10:19.936Z"
         },
         "flow": {
@@ -357,15 +368,19 @@
           "source_mac_address": "00:18:19:9e:6c:01",
           "source_transport_port": 45269,
           "tcp_source_port": 0,
-          "type": "netflow",
+          "type": "netflow_flow",
           "udp_destination_port": 161
         },
         "network": {
           "bytes": 2794,
           "community_id": "1:eEsNJGUF4/LfUrgXBt8U4TWBA9M=",
           "direction": "inbound",
+          "iana_number": 17,
           "packets": 36,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.10.172.60",

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-NBAR-options-template-260.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-NBAR-options-template-260.golden.json
@@ -5,12 +5,11 @@
       "Timestamp": "2017-02-14T11:09:59Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
           "action": "netflow_options",
-          "created": "2017-02-14T11:09:59Z"
+          "category": "network_traffic",
+          "created": "2017-02-14T11:09:59Z",
+          "kind": "event"
         },
         "netflow": {
           "exporter": {
@@ -29,6 +28,9 @@
             "octet_delta_count": 168755571
           },
           "type": "netflow_options"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         }
       },
       "Private": null
@@ -37,12 +39,11 @@
       "Timestamp": "2017-02-14T11:09:59Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
           "action": "netflow_options",
-          "created": "2017-02-14T11:09:59Z"
+          "category": "network_traffic",
+          "created": "2017-02-14T11:09:59Z",
+          "kind": "event"
         },
         "netflow": {
           "exporter": {
@@ -61,6 +62,9 @@
             "octet_delta_count": 168755571
           },
           "type": "netflow_options"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         }
       },
       "Private": null
@@ -69,12 +73,11 @@
       "Timestamp": "2017-02-14T11:09:59Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
           "action": "netflow_options",
-          "created": "2017-02-14T11:09:59Z"
+          "category": "network_traffic",
+          "created": "2017-02-14T11:09:59Z",
+          "kind": "event"
         },
         "netflow": {
           "exporter": {
@@ -93,6 +96,9 @@
             "octet_delta_count": 168755571
           },
           "type": "netflow_options"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         }
       },
       "Private": null
@@ -101,12 +107,11 @@
       "Timestamp": "2017-02-14T11:09:59Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
           "action": "netflow_options",
-          "created": "2017-02-14T11:09:59Z"
+          "category": "network_traffic",
+          "created": "2017-02-14T11:09:59Z",
+          "kind": "event"
         },
         "netflow": {
           "exporter": {
@@ -125,6 +130,9 @@
             "octet_delta_count": 168755571
           },
           "type": "netflow_options"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         }
       },
       "Private": null
@@ -133,12 +141,11 @@
       "Timestamp": "2017-02-14T11:09:59Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
           "action": "netflow_options",
-          "created": "2017-02-14T11:09:59Z"
+          "category": "network_traffic",
+          "created": "2017-02-14T11:09:59Z",
+          "kind": "event"
         },
         "netflow": {
           "exporter": {
@@ -157,6 +164,9 @@
             "octet_delta_count": 168755571
           },
           "type": "netflow_options"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         }
       },
       "Private": null
@@ -165,12 +175,11 @@
       "Timestamp": "2017-02-14T11:09:59Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
           "action": "netflow_options",
-          "created": "2017-02-14T11:09:59Z"
+          "category": "network_traffic",
+          "created": "2017-02-14T11:09:59Z",
+          "kind": "event"
         },
         "netflow": {
           "exporter": {
@@ -189,6 +198,9 @@
             "octet_delta_count": 168755571
           },
           "type": "netflow_options"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         }
       },
       "Private": null
@@ -197,12 +209,11 @@
       "Timestamp": "2017-02-14T11:09:59Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
           "action": "netflow_options",
-          "created": "2017-02-14T11:09:59Z"
+          "category": "network_traffic",
+          "created": "2017-02-14T11:09:59Z",
+          "kind": "event"
         },
         "netflow": {
           "exporter": {
@@ -221,6 +232,9 @@
             "octet_delta_count": 168755571
           },
           "type": "netflow_options"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         }
       },
       "Private": null
@@ -229,12 +243,11 @@
       "Timestamp": "2017-02-14T11:09:59Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
           "action": "netflow_options",
-          "created": "2017-02-14T11:09:59Z"
+          "category": "network_traffic",
+          "created": "2017-02-14T11:09:59Z",
+          "kind": "event"
         },
         "netflow": {
           "exporter": {
@@ -253,6 +266,9 @@
             "octet_delta_count": 168755571
           },
           "type": "netflow_options"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         }
       },
       "Private": null
@@ -261,12 +277,11 @@
       "Timestamp": "2017-02-14T11:09:59Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
           "action": "netflow_options",
-          "created": "2017-02-14T11:09:59Z"
+          "category": "network_traffic",
+          "created": "2017-02-14T11:09:59Z",
+          "kind": "event"
         },
         "netflow": {
           "exporter": {
@@ -285,6 +300,9 @@
             "octet_delta_count": 168755571
           },
           "type": "netflow_options"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         }
       },
       "Private": null
@@ -293,12 +311,11 @@
       "Timestamp": "2017-02-14T11:09:59Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
           "action": "netflow_options",
-          "created": "2017-02-14T11:09:59Z"
+          "category": "network_traffic",
+          "created": "2017-02-14T11:09:59Z",
+          "kind": "event"
         },
         "netflow": {
           "exporter": {
@@ -317,6 +334,9 @@
             "octet_delta_count": 168755571
           },
           "type": "netflow_options"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         }
       },
       "Private": null
@@ -325,12 +345,11 @@
       "Timestamp": "2017-02-14T11:09:59Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
           "action": "netflow_options",
-          "created": "2017-02-14T11:09:59Z"
+          "category": "network_traffic",
+          "created": "2017-02-14T11:09:59Z",
+          "kind": "event"
         },
         "netflow": {
           "exporter": {
@@ -349,6 +368,9 @@
             "octet_delta_count": 168755571
           },
           "type": "netflow_options"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         }
       },
       "Private": null
@@ -357,12 +379,11 @@
       "Timestamp": "2017-02-14T11:09:59Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
           "action": "netflow_options",
-          "created": "2017-02-14T11:09:59Z"
+          "category": "network_traffic",
+          "created": "2017-02-14T11:09:59Z",
+          "kind": "event"
         },
         "netflow": {
           "exporter": {
@@ -381,6 +402,9 @@
             "octet_delta_count": 168755571
           },
           "type": "netflow_options"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         }
       },
       "Private": null
@@ -389,12 +413,11 @@
       "Timestamp": "2017-02-14T11:09:59Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
           "action": "netflow_options",
-          "created": "2017-02-14T11:09:59Z"
+          "category": "network_traffic",
+          "created": "2017-02-14T11:09:59Z",
+          "kind": "event"
         },
         "netflow": {
           "exporter": {
@@ -413,6 +436,9 @@
             "octet_delta_count": 168755571
           },
           "type": "netflow_options"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         }
       },
       "Private": null
@@ -421,12 +447,11 @@
       "Timestamp": "2017-02-14T11:09:59Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
           "action": "netflow_options",
-          "created": "2017-02-14T11:09:59Z"
+          "category": "network_traffic",
+          "created": "2017-02-14T11:09:59Z",
+          "kind": "event"
         },
         "netflow": {
           "exporter": {
@@ -445,6 +470,9 @@
             "octet_delta_count": 168755571
           },
           "type": "netflow_options"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         }
       },
       "Private": null
@@ -453,12 +481,11 @@
       "Timestamp": "2017-02-14T11:09:59Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
           "action": "netflow_options",
-          "created": "2017-02-14T11:09:59Z"
+          "category": "network_traffic",
+          "created": "2017-02-14T11:09:59Z",
+          "kind": "event"
         },
         "netflow": {
           "exporter": {
@@ -477,6 +504,9 @@
             "octet_delta_count": 168755571
           },
           "type": "netflow_options"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         }
       },
       "Private": null

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-WLC.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-WLC.golden.json
@@ -8,12 +8,11 @@
         "destination": {
           "mac": "00:f6:63:cc:80:60"
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-06-22T06:31:14Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-06-22T06:31:14Z",
+          "kind": "event"
         },
         "flow": {
           "id": "lTcFptYSabQ",
@@ -35,7 +34,7 @@
           "post_ip_diff_serv_code_point": 0,
           "sta_ipv4_address": "192.168.20.121",
           "sta_mac_address": "34:02:86:75:c0:51",
-          "type": "netflow",
+          "type": "netflow_flow",
           "wlan_ssid": "Test-env",
           "wtp_mac_address": "00:f6:63:cc:80:60"
         },
@@ -45,6 +44,9 @@
           "direction": "inbound",
           "name": "Test-env",
           "packets": 83
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.20.121",
@@ -63,12 +65,11 @@
           "locality": "private",
           "mac": "34:02:86:75:c0:51"
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-06-22T06:31:14Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-06-22T06:31:14Z",
+          "kind": "event"
         },
         "flow": {
           "id": "Q1JIGzkHw0I",
@@ -90,7 +91,7 @@
           "post_ip_diff_serv_code_point": 0,
           "sta_ipv4_address": "192.168.20.121",
           "sta_mac_address": "34:02:86:75:c0:51",
-          "type": "netflow",
+          "type": "netflow_flow",
           "wlan_ssid": "Test-env",
           "wtp_mac_address": "00:f6:63:cc:80:60"
         },
@@ -100,6 +101,9 @@
           "direction": "outbound",
           "name": "Test-env",
           "packets": 83
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "mac": "00:f6:63:cc:80:60"
@@ -114,12 +118,11 @@
         "destination": {
           "mac": "00:f6:63:cc:80:60"
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-06-22T06:31:14Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-06-22T06:31:14Z",
+          "kind": "event"
         },
         "flow": {
           "id": "lTcFptYSabQ",
@@ -141,7 +144,7 @@
           "post_ip_diff_serv_code_point": 0,
           "sta_ipv4_address": "192.168.20.121",
           "sta_mac_address": "34:02:86:75:c0:51",
-          "type": "netflow",
+          "type": "netflow_flow",
           "wlan_ssid": "Test-env",
           "wtp_mac_address": "00:f6:63:cc:80:60"
         },
@@ -151,6 +154,9 @@
           "direction": "inbound",
           "name": "Test-env",
           "packets": 69
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.20.121",
@@ -169,12 +175,11 @@
           "locality": "private",
           "mac": "34:02:86:75:c0:51"
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-06-22T06:31:14Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-06-22T06:31:14Z",
+          "kind": "event"
         },
         "flow": {
           "id": "Q1JIGzkHw0I",
@@ -196,7 +201,7 @@
           "post_ip_diff_serv_code_point": 0,
           "sta_ipv4_address": "192.168.20.121",
           "sta_mac_address": "34:02:86:75:c0:51",
-          "type": "netflow",
+          "type": "netflow_flow",
           "wlan_ssid": "Test-env",
           "wtp_mac_address": "00:f6:63:cc:80:60"
         },
@@ -206,6 +211,9 @@
           "direction": "outbound",
           "name": "Test-env",
           "packets": 69
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "mac": "00:f6:63:cc:80:60"
@@ -220,12 +228,11 @@
         "destination": {
           "mac": "00:f6:63:cc:80:60"
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-06-22T06:31:14Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-06-22T06:31:14Z",
+          "kind": "event"
         },
         "flow": {
           "id": "lTcFptYSabQ",
@@ -247,7 +254,7 @@
           "post_ip_diff_serv_code_point": 0,
           "sta_ipv4_address": "192.168.20.121",
           "sta_mac_address": "34:02:86:75:c0:51",
-          "type": "netflow",
+          "type": "netflow_flow",
           "wlan_ssid": "Test-env",
           "wtp_mac_address": "00:f6:63:cc:80:60"
         },
@@ -257,6 +264,9 @@
           "direction": "inbound",
           "name": "Test-env",
           "packets": 1
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.20.121",
@@ -273,12 +283,11 @@
         "destination": {
           "mac": "00:f6:63:cc:80:60"
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-06-22T06:31:14Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-06-22T06:31:14Z",
+          "kind": "event"
         },
         "flow": {
           "id": "lTcFptYSabQ",
@@ -300,7 +309,7 @@
           "post_ip_diff_serv_code_point": 0,
           "sta_ipv4_address": "192.168.20.121",
           "sta_mac_address": "34:02:86:75:c0:51",
-          "type": "netflow",
+          "type": "netflow_flow",
           "wlan_ssid": "Test-env",
           "wtp_mac_address": "00:f6:63:cc:80:60"
         },
@@ -310,6 +319,9 @@
           "direction": "inbound",
           "name": "Test-env",
           "packets": 225
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.20.121",
@@ -328,12 +340,11 @@
           "locality": "private",
           "mac": "34:02:86:75:c0:51"
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-06-22T06:31:14Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-06-22T06:31:14Z",
+          "kind": "event"
         },
         "flow": {
           "id": "Q1JIGzkHw0I",
@@ -355,7 +366,7 @@
           "post_ip_diff_serv_code_point": 0,
           "sta_ipv4_address": "192.168.20.121",
           "sta_mac_address": "34:02:86:75:c0:51",
-          "type": "netflow",
+          "type": "netflow_flow",
           "wlan_ssid": "Test-env",
           "wtp_mac_address": "00:f6:63:cc:80:60"
         },
@@ -365,6 +376,9 @@
           "direction": "outbound",
           "name": "Test-env",
           "packets": 154
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "mac": "00:f6:63:cc:80:60"
@@ -379,12 +393,11 @@
         "destination": {
           "mac": "00:f6:63:cc:80:60"
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-06-22T06:31:14Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-06-22T06:31:14Z",
+          "kind": "event"
         },
         "flow": {
           "id": "lTcFptYSabQ",
@@ -406,7 +419,7 @@
           "post_ip_diff_serv_code_point": 0,
           "sta_ipv4_address": "192.168.20.121",
           "sta_mac_address": "34:02:86:75:c0:51",
-          "type": "netflow",
+          "type": "netflow_flow",
           "wlan_ssid": "Test-env",
           "wtp_mac_address": "00:f6:63:cc:80:60"
         },
@@ -416,6 +429,9 @@
           "direction": "inbound",
           "name": "Test-env",
           "packets": 63
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.20.121",
@@ -434,12 +450,11 @@
           "locality": "private",
           "mac": "34:02:86:75:c0:51"
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-06-22T06:31:14Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-06-22T06:31:14Z",
+          "kind": "event"
         },
         "flow": {
           "id": "Q1JIGzkHw0I",
@@ -461,7 +476,7 @@
           "post_ip_diff_serv_code_point": 0,
           "sta_ipv4_address": "192.168.20.121",
           "sta_mac_address": "34:02:86:75:c0:51",
-          "type": "netflow",
+          "type": "netflow_flow",
           "wlan_ssid": "Test-env",
           "wtp_mac_address": "00:f6:63:cc:80:60"
         },
@@ -471,6 +486,9 @@
           "direction": "outbound",
           "name": "Test-env",
           "packets": 61
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "mac": "00:f6:63:cc:80:60"
@@ -485,12 +503,11 @@
         "destination": {
           "mac": "00:f6:63:cc:80:60"
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-06-22T06:31:14Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-06-22T06:31:14Z",
+          "kind": "event"
         },
         "flow": {
           "id": "lTcFptYSabQ",
@@ -512,7 +529,7 @@
           "post_ip_diff_serv_code_point": 0,
           "sta_ipv4_address": "192.168.20.121",
           "sta_mac_address": "34:02:86:75:c0:51",
-          "type": "netflow",
+          "type": "netflow_flow",
           "wlan_ssid": "Test-env",
           "wtp_mac_address": "00:f6:63:cc:80:60"
         },
@@ -522,6 +539,9 @@
           "direction": "inbound",
           "name": "Test-env",
           "packets": 773
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.20.121",
@@ -540,12 +560,11 @@
           "locality": "private",
           "mac": "34:02:86:75:c0:51"
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-06-22T06:31:14Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-06-22T06:31:14Z",
+          "kind": "event"
         },
         "flow": {
           "id": "Q1JIGzkHw0I",
@@ -567,7 +586,7 @@
           "post_ip_diff_serv_code_point": 0,
           "sta_ipv4_address": "192.168.20.121",
           "sta_mac_address": "34:02:86:75:c0:51",
-          "type": "netflow",
+          "type": "netflow_flow",
           "wlan_ssid": "Test-env",
           "wtp_mac_address": "00:f6:63:cc:80:60"
         },
@@ -577,6 +596,9 @@
           "direction": "outbound",
           "name": "Test-env",
           "packets": 1379
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "mac": "00:f6:63:cc:80:60"
@@ -591,12 +613,11 @@
         "destination": {
           "mac": "00:f6:63:cc:80:60"
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-06-22T06:31:14Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-06-22T06:31:14Z",
+          "kind": "event"
         },
         "flow": {
           "id": "lTcFptYSabQ",
@@ -618,7 +639,7 @@
           "post_ip_diff_serv_code_point": 0,
           "sta_ipv4_address": "192.168.20.121",
           "sta_mac_address": "34:02:86:75:c0:51",
-          "type": "netflow",
+          "type": "netflow_flow",
           "wlan_ssid": "Test-env",
           "wtp_mac_address": "00:f6:63:cc:80:60"
         },
@@ -628,6 +649,9 @@
           "direction": "inbound",
           "name": "Test-env",
           "packets": 26
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.20.121",
@@ -646,12 +670,11 @@
           "locality": "private",
           "mac": "34:02:86:75:c0:51"
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-06-22T06:31:14Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-06-22T06:31:14Z",
+          "kind": "event"
         },
         "flow": {
           "id": "Q1JIGzkHw0I",
@@ -673,7 +696,7 @@
           "post_ip_diff_serv_code_point": 0,
           "sta_ipv4_address": "192.168.20.121",
           "sta_mac_address": "34:02:86:75:c0:51",
-          "type": "netflow",
+          "type": "netflow_flow",
           "wlan_ssid": "Test-env",
           "wtp_mac_address": "00:f6:63:cc:80:60"
         },
@@ -683,6 +706,9 @@
           "direction": "outbound",
           "name": "Test-env",
           "packets": 26
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "mac": "00:f6:63:cc:80:60"
@@ -697,12 +723,11 @@
         "destination": {
           "mac": "00:f6:63:cc:80:60"
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-06-22T06:31:14Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-06-22T06:31:14Z",
+          "kind": "event"
         },
         "flow": {
           "id": "lTcFptYSabQ",
@@ -724,7 +749,7 @@
           "post_ip_diff_serv_code_point": 0,
           "sta_ipv4_address": "192.168.20.121",
           "sta_mac_address": "34:02:86:75:c0:51",
-          "type": "netflow",
+          "type": "netflow_flow",
           "wlan_ssid": "Test-env",
           "wtp_mac_address": "00:f6:63:cc:80:60"
         },
@@ -734,6 +759,9 @@
           "direction": "inbound",
           "name": "Test-env",
           "packets": 20434
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.20.121",
@@ -752,12 +780,11 @@
           "locality": "private",
           "mac": "34:02:86:75:c0:51"
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-06-22T06:31:14Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-06-22T06:31:14Z",
+          "kind": "event"
         },
         "flow": {
           "id": "Q1JIGzkHw0I",
@@ -779,7 +806,7 @@
           "post_ip_diff_serv_code_point": 0,
           "sta_ipv4_address": "192.168.20.121",
           "sta_mac_address": "34:02:86:75:c0:51",
-          "type": "netflow",
+          "type": "netflow_flow",
           "wlan_ssid": "Test-env",
           "wtp_mac_address": "00:f6:63:cc:80:60"
         },
@@ -789,6 +816,9 @@
           "direction": "outbound",
           "name": "Test-env",
           "packets": 40726
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "mac": "00:f6:63:cc:80:60"
@@ -803,12 +833,11 @@
         "destination": {
           "mac": "00:f6:63:cc:80:60"
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-06-22T06:31:14Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-06-22T06:31:14Z",
+          "kind": "event"
         },
         "flow": {
           "id": "lTcFptYSabQ",
@@ -830,7 +859,7 @@
           "post_ip_diff_serv_code_point": 0,
           "sta_ipv4_address": "192.168.20.121",
           "sta_mac_address": "34:02:86:75:c0:51",
-          "type": "netflow",
+          "type": "netflow_flow",
           "wlan_ssid": "Test-env",
           "wtp_mac_address": "00:f6:63:cc:80:60"
         },
@@ -840,6 +869,9 @@
           "direction": "inbound",
           "name": "Test-env",
           "packets": 15
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.20.121",
@@ -858,12 +890,11 @@
           "locality": "private",
           "mac": "34:02:86:75:c0:51"
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-06-22T06:31:14Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-06-22T06:31:14Z",
+          "kind": "event"
         },
         "flow": {
           "id": "Q1JIGzkHw0I",
@@ -885,7 +916,7 @@
           "post_ip_diff_serv_code_point": 0,
           "sta_ipv4_address": "192.168.20.121",
           "sta_mac_address": "34:02:86:75:c0:51",
-          "type": "netflow",
+          "type": "netflow_flow",
           "wlan_ssid": "Test-env",
           "wtp_mac_address": "00:f6:63:cc:80:60"
         },
@@ -895,6 +926,9 @@
           "direction": "outbound",
           "name": "Test-env",
           "packets": 14
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "mac": "00:f6:63:cc:80:60"
@@ -909,12 +943,11 @@
         "destination": {
           "mac": "00:f6:63:cc:80:60"
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-06-22T06:31:14Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-06-22T06:31:14Z",
+          "kind": "event"
         },
         "flow": {
           "id": "lTcFptYSabQ",
@@ -936,7 +969,7 @@
           "post_ip_diff_serv_code_point": 0,
           "sta_ipv4_address": "192.168.20.121",
           "sta_mac_address": "34:02:86:75:c0:51",
-          "type": "netflow",
+          "type": "netflow_flow",
           "wlan_ssid": "Test-env",
           "wtp_mac_address": "00:f6:63:cc:80:60"
         },
@@ -946,6 +979,9 @@
           "direction": "inbound",
           "name": "Test-env",
           "packets": 16145
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.20.121",
@@ -964,12 +1000,11 @@
           "locality": "private",
           "mac": "34:02:86:75:c0:51"
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-06-22T06:31:14Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-06-22T06:31:14Z",
+          "kind": "event"
         },
         "flow": {
           "id": "Q1JIGzkHw0I",
@@ -991,7 +1026,7 @@
           "post_ip_diff_serv_code_point": 0,
           "sta_ipv4_address": "192.168.20.121",
           "sta_mac_address": "34:02:86:75:c0:51",
-          "type": "netflow",
+          "type": "netflow_flow",
           "wlan_ssid": "Test-env",
           "wtp_mac_address": "00:f6:63:cc:80:60"
         },
@@ -1001,6 +1036,9 @@
           "direction": "outbound",
           "name": "Test-env",
           "packets": 53362
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "mac": "00:f6:63:cc:80:60"

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Fortigate-FortiOS-5.2.1.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Fortigate-FortiOS-5.2.1.golden.json
@@ -5,12 +5,11 @@
       "Timestamp": "2017-07-18T05:42:14Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
           "action": "netflow_options",
-          "created": "2017-07-18T05:42:14Z"
+          "category": "network_traffic",
+          "created": "2017-07-18T05:42:14Z",
+          "kind": "event"
         },
         "netflow": {
           "exporter": {
@@ -33,6 +32,9 @@
             "octet_delta_count": 1
           },
           "type": "netflow_options"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         }
       },
       "Private": null
@@ -46,12 +48,11 @@
           "locality": "public",
           "port": 443
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-07-18T05:41:59Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-07-18T05:41:59Z",
+          "kind": "event"
         },
         "flow": {
           "id": "jJrTIsjNw1M",
@@ -78,14 +79,18 @@
           "protocol_identifier": 6,
           "source_ipv4_address": "192.168.99.7",
           "source_transport_port": 61910,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 152,
           "community_id": "1:tYgSz6Xox1AUTy0tyztkJXZmiIQ=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 3,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.99.7",

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Fortigate-FortiOS-54x-appid.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Fortigate-FortiOS-54x-appid.golden.json
@@ -10,14 +10,13 @@
           "locality": "public",
           "port": 80
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2018-05-11T00:54:11Z",
           "duration": 410000000,
           "end": "2018-05-11T00:54:09.99Z",
+          "kind": "event",
           "start": "2018-05-11T00:54:09.58Z"
         },
         "flow": {
@@ -52,14 +51,18 @@
           "protocol_identifier": 6,
           "source_ipv4_address": "192.168.100.151",
           "source_transport_port": 45380,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 748,
           "community_id": "1:k6fnpZvAP2OCIlBK5wf/n7I33FA=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 6,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.100.151",
@@ -78,14 +81,13 @@
           "locality": "private",
           "port": 44778
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2018-05-11T00:54:11Z",
           "duration": 1130000000,
           "end": "2018-05-11T00:54:09.74Z",
+          "kind": "event",
           "start": "2018-05-11T00:54:08.61Z"
         },
         "flow": {
@@ -120,14 +122,18 @@
           "protocol_identifier": 6,
           "source_ipv4_address": "208.100.17.187",
           "source_transport_port": 443,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 6948,
           "community_id": "1:xE3FUh+IR1gTSuCWTDkzaMAYppc=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 10,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "208.100.17.187",
@@ -146,14 +152,13 @@
           "locality": "public",
           "port": 443
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2018-05-11T00:54:11Z",
           "duration": 1130000000,
           "end": "2018-05-11T00:54:09.74Z",
+          "kind": "event",
           "start": "2018-05-11T00:54:08.61Z"
         },
         "flow": {
@@ -188,14 +193,18 @@
           "protocol_identifier": 6,
           "source_ipv4_address": "192.168.100.151",
           "source_transport_port": 44778,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 1584,
           "community_id": "1:u8ii7EBbKZETNNHlkdrp9ZdLUKY=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 14,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.100.151",
@@ -214,14 +223,13 @@
           "locality": "private",
           "port": 50618
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2018-05-11T00:54:11Z",
           "duration": 1040000000,
           "end": "2018-05-11T00:54:09.74Z",
+          "kind": "event",
           "start": "2018-05-11T00:54:08.7Z"
         },
         "flow": {
@@ -256,14 +264,18 @@
           "protocol_identifier": 6,
           "source_ipv4_address": "208.100.17.189",
           "source_transport_port": 443,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 8201,
           "community_id": "1:Yg7TVkDV8wTyFkiw9HGckHvwQk8=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 11,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "208.100.17.189",
@@ -282,14 +294,13 @@
           "locality": "public",
           "port": 443
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2018-05-11T00:54:11Z",
           "duration": 1040000000,
           "end": "2018-05-11T00:54:09.74Z",
+          "kind": "event",
           "start": "2018-05-11T00:54:08.7Z"
         },
         "flow": {
@@ -324,14 +335,18 @@
           "protocol_identifier": 6,
           "source_ipv4_address": "192.168.100.151",
           "source_transport_port": 50618,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 1729,
           "community_id": "1:3nyHi/TSF/vyWaCKPnvrEkWYi98=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 15,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.100.151",
@@ -350,14 +365,13 @@
           "locality": "private",
           "port": 33660
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2018-05-11T00:54:11Z",
           "duration": 410000000,
           "end": "2018-05-11T00:54:09.11Z",
+          "kind": "event",
           "start": "2018-05-11T00:54:08.7Z"
         },
         "flow": {
@@ -392,14 +406,18 @@
           "protocol_identifier": 6,
           "source_ipv4_address": "178.255.83.1",
           "source_transport_port": 80,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 1122,
           "community_id": "1:lDlO+jlvvAqzElOUzFaN0Co6N7o=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 5,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "178.255.83.1",
@@ -418,14 +436,13 @@
           "locality": "public",
           "port": 80
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2018-05-11T00:54:11Z",
           "duration": 410000000,
           "end": "2018-05-11T00:54:09.11Z",
+          "kind": "event",
           "start": "2018-05-11T00:54:08.7Z"
         },
         "flow": {
@@ -460,14 +477,18 @@
           "protocol_identifier": 6,
           "source_ipv4_address": "192.168.100.151",
           "source_transport_port": 33660,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 705,
           "community_id": "1:vMV9tpgckoBsKm14H/aaed9/B6o=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 5,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.100.151",
@@ -486,14 +507,13 @@
           "locality": "private",
           "port": 33646
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2018-05-11T00:54:11Z",
           "duration": 370000000,
           "end": "2018-05-11T00:54:08.53Z",
+          "kind": "event",
           "start": "2018-05-11T00:54:08.16Z"
         },
         "flow": {
@@ -528,14 +548,18 @@
           "protocol_identifier": 6,
           "source_ipv4_address": "178.255.83.1",
           "source_transport_port": 80,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 1123,
           "community_id": "1:36J0xlj2SLkuRRDG0iOA1rSo7zs=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 5,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "178.255.83.1",
@@ -554,14 +578,13 @@
           "locality": "public",
           "port": 80
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2018-05-11T00:54:11Z",
           "duration": 370000000,
           "end": "2018-05-11T00:54:08.53Z",
+          "kind": "event",
           "start": "2018-05-11T00:54:08.16Z"
         },
         "flow": {
@@ -596,14 +619,18 @@
           "protocol_identifier": 6,
           "source_ipv4_address": "192.168.100.151",
           "source_transport_port": 33646,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 706,
           "community_id": "1:DlCfunueLMkCou44xfNagrPPzmI=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 5,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.100.151",
@@ -622,14 +649,13 @@
           "locality": "private",
           "port": 52970
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2018-05-11T00:54:11Z",
           "duration": 80000000,
           "end": "2018-05-11T00:51:08.63Z",
+          "kind": "event",
           "start": "2018-05-11T00:51:08.55Z"
         },
         "flow": {
@@ -660,14 +686,18 @@
           "protocol_identifier": 17,
           "source_ipv4_address": "192.168.100.111",
           "source_transport_port": 53,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 74,
           "community_id": "1:pSB9AhXlD5k2Hgt+G8xWPxJVnPY=",
           "direction": "unknown",
+          "iana_number": 17,
           "packets": 1,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.100.111",
@@ -686,14 +716,13 @@
           "locality": "private",
           "port": 53
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2018-05-11T00:54:11Z",
           "duration": 80000000,
           "end": "2018-05-11T00:51:08.63Z",
+          "kind": "event",
           "start": "2018-05-11T00:51:08.55Z"
         },
         "flow": {
@@ -724,14 +753,18 @@
           "protocol_identifier": 17,
           "source_ipv4_address": "192.168.100.150",
           "source_transport_port": 52970,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 58,
           "community_id": "1:PKa/AyUMS+3x4M4+GxUIgWRcmnw=",
           "direction": "unknown",
+          "iana_number": 17,
           "packets": 1,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.100.150",
@@ -750,14 +783,13 @@
           "locality": "private",
           "port": 49311
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2018-05-11T00:54:11Z",
           "duration": 80000000,
           "end": "2018-05-11T00:51:08.63Z",
+          "kind": "event",
           "start": "2018-05-11T00:51:08.55Z"
         },
         "flow": {
@@ -788,14 +820,18 @@
           "protocol_identifier": 17,
           "source_ipv4_address": "192.168.100.111",
           "source_transport_port": 53,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 74,
           "community_id": "1:hVNrF7qc5ABcKevdrl3vPBrP5rQ=",
           "direction": "unknown",
+          "iana_number": 17,
           "packets": 1,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.100.111",
@@ -814,14 +850,13 @@
           "locality": "private",
           "port": 53
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2018-05-11T00:54:11Z",
           "duration": 80000000,
           "end": "2018-05-11T00:51:08.63Z",
+          "kind": "event",
           "start": "2018-05-11T00:51:08.55Z"
         },
         "flow": {
@@ -852,14 +887,18 @@
           "protocol_identifier": 17,
           "source_ipv4_address": "192.168.100.150",
           "source_transport_port": 49311,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 58,
           "community_id": "1:fuwC0soLNJv3on5fRonxy1NehGk=",
           "direction": "unknown",
+          "iana_number": 17,
           "packets": 1,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.100.150",
@@ -878,14 +917,13 @@
           "locality": "private",
           "port": 51746
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2018-05-11T00:54:11Z",
           "duration": 2020000000,
           "end": "2018-05-11T00:54:06.21Z",
+          "kind": "event",
           "start": "2018-05-11T00:54:04.19Z"
         },
         "flow": {
@@ -916,14 +954,18 @@
           "protocol_identifier": 6,
           "source_ipv4_address": "192.168.100.111",
           "source_transport_port": 80,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 1071,
           "community_id": "1:hiYqfWLht4N9AUGcmXtgZpFVvQQ=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 5,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.100.111",
@@ -942,14 +984,13 @@
           "locality": "private",
           "port": 80
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2018-05-11T00:54:11Z",
           "duration": 2020000000,
           "end": "2018-05-11T00:54:06.21Z",
+          "kind": "event",
           "start": "2018-05-11T00:54:04.19Z"
         },
         "flow": {
@@ -980,14 +1021,18 @@
           "protocol_identifier": 6,
           "source_ipv4_address": "192.168.100.150",
           "source_transport_port": 51746,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 1147,
           "community_id": "1:YAfTDRm1WGwlR9YYWrgtTsf1DMw=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 6,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.100.150",
@@ -1006,14 +1051,13 @@
           "locality": "private",
           "port": 51745
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2018-05-11T00:54:11Z",
           "duration": 4000000000,
           "end": "2018-05-11T00:54:00.19Z",
+          "kind": "event",
           "start": "2018-05-11T00:53:56.19Z"
         },
         "flow": {
@@ -1044,14 +1088,18 @@
           "protocol_identifier": 6,
           "source_ipv4_address": "192.168.100.111",
           "source_transport_port": 80,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 1980,
           "community_id": "1:22XTyUF19jbjqUU+rs71qD5wnus=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 6,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.100.111",
@@ -1070,14 +1118,13 @@
           "locality": "private",
           "port": 80
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2018-05-11T00:54:11Z",
           "duration": 4000000000,
           "end": "2018-05-11T00:54:00.19Z",
+          "kind": "event",
           "start": "2018-05-11T00:53:56.19Z"
         },
         "flow": {
@@ -1108,14 +1155,18 @@
           "protocol_identifier": 6,
           "source_ipv4_address": "192.168.100.150",
           "source_transport_port": 51745,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 2164,
           "community_id": "1:pfRhf4/ExF5JUU0Tz6ExQQROS+Q=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 8,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.100.150",

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-H3C-Netstream-with-varstring.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-H3C-Netstream-with-varstring.golden.json
@@ -10,14 +10,13 @@
           "locality": "public",
           "port": 137
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2018-07-18T01:35:35Z",
           "duration": 29695000000,
           "end": "2018-07-18T01:35:02.969Z",
+          "kind": "event",
           "start": "2018-07-18T01:34:33.274Z"
         },
         "flow": {
@@ -57,15 +56,19 @@
           "source_transport_port": 137,
           "src_traffic_index": 0,
           "tcp_control_bits": 0,
-          "type": "netflow",
+          "type": "netflow_flow",
           "vr_fname": ""
         },
         "network": {
           "bytes": 702,
           "community_id": "1:WP3Ss+M/Q16gnXrqnk6fwmPWvWc=",
           "direction": "inbound",
+          "iana_number": 17,
           "packets": 9,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "20.20.20.20",

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-H3C.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-H3C.golden.json
@@ -10,14 +10,13 @@
           "locality": "private",
           "port": 0
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2018-05-21T09:25:04Z",
           "duration": 89519000000,
           "end": "2018-05-21T09:25:03.677Z",
+          "kind": "event",
           "start": "2018-05-21T09:23:34.158Z"
         },
         "flow": {
@@ -57,14 +56,18 @@
           "source_transport_port": 0,
           "src_traffic_index": 0,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 1027087,
           "community_id": "1:qzI1p/DraBlY+q0WoDrEVzXNWYQ=",
           "direction": "inbound",
+          "iana_number": 6,
           "packets": 697,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.22.166.30",
@@ -83,14 +86,13 @@
           "locality": "private",
           "port": 0
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2018-05-21T09:25:04Z",
           "duration": 60005000000,
           "end": "2018-05-21T09:25:03.662Z",
+          "kind": "event",
           "start": "2018-05-21T09:24:03.657Z"
         },
         "flow": {
@@ -130,14 +132,18 @@
           "source_transport_port": 0,
           "src_traffic_index": 0,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 6200,
           "community_id": "1:GSQ1TrOMr/LW4B81ECw0+kz+2QY=",
           "direction": "inbound",
+          "iana_number": 6,
           "packets": 6,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.22.166.12",
@@ -156,14 +162,13 @@
           "locality": "private",
           "port": 0
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2018-05-21T09:25:04Z",
           "duration": 60016000000,
           "end": "2018-05-21T09:25:03.656Z",
+          "kind": "event",
           "start": "2018-05-21T09:24:03.64Z"
         },
         "flow": {
@@ -203,14 +208,18 @@
           "source_transport_port": 0,
           "src_traffic_index": 0,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 11896,
           "community_id": "1:61IryZ4mi1uTBDD5+gOvL97xjLM=",
           "direction": "inbound",
+          "iana_number": 6,
           "packets": 21,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.22.166.33",
@@ -229,14 +238,13 @@
           "locality": "private",
           "port": 0
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2018-05-21T09:25:04Z",
           "duration": 90011000000,
           "end": "2018-05-21T09:25:03.643Z",
+          "kind": "event",
           "start": "2018-05-21T09:23:33.632Z"
         },
         "flow": {
@@ -276,14 +284,18 @@
           "source_transport_port": 0,
           "src_traffic_index": 0,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 1041,
           "community_id": "1:NOys+eNAZ2uvD2U8rXFlB0IZQCo=",
           "direction": "inbound",
+          "iana_number": 6,
           "packets": 3,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.22.166.35",
@@ -302,14 +314,13 @@
           "locality": "private",
           "port": 0
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2018-05-21T09:25:04Z",
           "duration": 30000000000,
           "end": "2018-05-21T09:24:03.629Z",
+          "kind": "event",
           "start": "2018-05-21T09:23:33.629Z"
         },
         "flow": {
@@ -349,14 +360,18 @@
           "source_transport_port": 0,
           "src_traffic_index": 0,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 1740,
           "community_id": "1:gY528hsPNX6RHS6UXpFnEsjqMY0=",
           "direction": "inbound",
+          "iana_number": 6,
           "packets": 20,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.22.166.36",
@@ -375,14 +390,13 @@
           "locality": "private",
           "port": 0
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2018-05-21T09:25:04Z",
           "duration": 29467000000,
           "end": "2018-05-21T09:24:03.669Z",
+          "kind": "event",
           "start": "2018-05-21T09:23:34.202Z"
         },
         "flow": {
@@ -422,14 +436,18 @@
           "source_transport_port": 0,
           "src_traffic_index": 0,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 2998,
           "community_id": "1:gY528hsPNX6RHS6UXpFnEsjqMY0=",
           "direction": "inbound",
+          "iana_number": 6,
           "packets": 16,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.22.166.36",
@@ -448,14 +466,13 @@
           "locality": "private",
           "port": 0
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2018-05-21T09:25:04Z",
           "duration": 29452000000,
           "end": "2018-05-21T09:24:03.67Z",
+          "kind": "event",
           "start": "2018-05-21T09:23:34.218Z"
         },
         "flow": {
@@ -495,14 +512,18 @@
           "source_transport_port": 0,
           "src_traffic_index": 0,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 55773,
           "community_id": "1:1l5g2rHaCC2EhYGzWl7jD2jprK8=",
           "direction": "inbound",
+          "iana_number": 6,
           "packets": 37,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.22.166.28",
@@ -521,14 +542,13 @@
           "locality": "private",
           "port": 0
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2018-05-21T09:25:04Z",
           "duration": 29449000000,
           "end": "2018-05-21T09:24:03.684Z",
+          "kind": "event",
           "start": "2018-05-21T09:23:34.235Z"
         },
         "flow": {
@@ -568,14 +588,18 @@
           "source_transport_port": 0,
           "src_traffic_index": 0,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 3239438,
           "community_id": "1:NOys+eNAZ2uvD2U8rXFlB0IZQCo=",
           "direction": "inbound",
+          "iana_number": 6,
           "packets": 2135,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.22.166.35",
@@ -594,14 +618,13 @@
           "locality": "private",
           "port": 0
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2018-05-21T09:25:04Z",
           "duration": 30000000000,
           "end": "2018-05-21T09:24:03.685Z",
+          "kind": "event",
           "start": "2018-05-21T09:23:33.685Z"
         },
         "flow": {
@@ -641,14 +664,18 @@
           "source_transport_port": 0,
           "src_traffic_index": 0,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 5701,
           "community_id": "1:u3U5M2TEOv+5aaIvoxAWpZcCwfc=",
           "direction": "inbound",
+          "iana_number": 6,
           "packets": 20,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.22.166.15",
@@ -667,14 +694,13 @@
           "locality": "private",
           "port": 0
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2018-05-21T09:25:04Z",
           "duration": 29391000000,
           "end": "2018-05-21T09:24:03.691Z",
+          "kind": "event",
           "start": "2018-05-21T09:23:34.3Z"
         },
         "flow": {
@@ -714,14 +740,18 @@
           "source_transport_port": 0,
           "src_traffic_index": 0,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 4255012,
           "community_id": "1:dsegIlwhvWHFpkKtpDEZ+N3EoXU=",
           "direction": "inbound",
+          "iana_number": 6,
           "packets": 2804,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.22.166.2",
@@ -740,14 +770,13 @@
           "locality": "private",
           "port": 0
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2018-05-21T09:25:04Z",
           "duration": 29196000000,
           "end": "2018-05-21T09:24:03.699Z",
+          "kind": "event",
           "start": "2018-05-21T09:23:34.503Z"
         },
         "flow": {
@@ -787,14 +816,18 @@
           "source_transport_port": 0,
           "src_traffic_index": 0,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 37557,
           "community_id": "1:1l5g2rHaCC2EhYGzWl7jD2jprK8=",
           "direction": "inbound",
+          "iana_number": 6,
           "packets": 25,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.22.166.28",
@@ -813,14 +846,13 @@
           "locality": "private",
           "port": 0
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2018-05-21T09:25:04Z",
           "duration": 30000000000,
           "end": "2018-05-21T09:24:03.753Z",
+          "kind": "event",
           "start": "2018-05-21T09:23:33.753Z"
         },
         "flow": {
@@ -860,14 +892,18 @@
           "source_transport_port": 0,
           "src_traffic_index": 0,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 23676,
           "community_id": "1:5VIwljy0926c8Js5Wsve5fEmSLo=",
           "direction": "inbound",
+          "iana_number": 6,
           "packets": 68,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.22.166.25",
@@ -886,14 +922,13 @@
           "locality": "private",
           "port": 0
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2018-05-21T09:25:04Z",
           "duration": 89282000000,
           "end": "2018-05-21T09:25:03.971Z",
+          "kind": "event",
           "start": "2018-05-21T09:23:34.689Z"
         },
         "flow": {
@@ -933,14 +968,18 @@
           "source_transport_port": 0,
           "src_traffic_index": 0,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 22821,
           "community_id": "1:5VIwljy0926c8Js5Wsve5fEmSLo=",
           "direction": "inbound",
+          "iana_number": 6,
           "packets": 30,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.22.166.25",
@@ -959,14 +998,13 @@
           "locality": "private",
           "port": 0
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2018-05-21T09:25:04Z",
           "duration": 90012000000,
           "end": "2018-05-21T09:25:03.95Z",
+          "kind": "event",
           "start": "2018-05-21T09:23:33.938Z"
         },
         "flow": {
@@ -1006,14 +1044,18 @@
           "source_transport_port": 0,
           "src_traffic_index": 0,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 526,
           "community_id": "1:GSQ1TrOMr/LW4B81ECw0+kz+2QY=",
           "direction": "inbound",
+          "iana_number": 6,
           "packets": 2,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.22.166.12",
@@ -1032,14 +1074,13 @@
           "locality": "private",
           "port": 0
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2018-05-21T09:25:04Z",
           "duration": 60005000000,
           "end": "2018-05-21T09:25:03.938Z",
+          "kind": "event",
           "start": "2018-05-21T09:24:03.933Z"
         },
         "flow": {
@@ -1079,14 +1120,18 @@
           "source_transport_port": 0,
           "src_traffic_index": 0,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 33129,
           "community_id": "1:nSRDOwLgxV6v/8JSi4fU7AKGxd8=",
           "direction": "inbound",
+          "iana_number": 6,
           "packets": 220,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.22.166.17",
@@ -1105,14 +1150,13 @@
           "locality": "private",
           "port": 0
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2018-05-21T09:25:04Z",
           "duration": 60006000000,
           "end": "2018-05-21T09:25:03.928Z",
+          "kind": "event",
           "start": "2018-05-21T09:24:03.922Z"
         },
         "flow": {
@@ -1152,14 +1196,18 @@
           "source_transport_port": 0,
           "src_traffic_index": 0,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 5092,
           "community_id": "1:gY528hsPNX6RHS6UXpFnEsjqMY0=",
           "direction": "inbound",
+          "iana_number": 6,
           "packets": 9,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.22.166.36",

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Huawei-Netstream.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Huawei-Netstream.golden.json
@@ -10,14 +10,13 @@
           "locality": "private",
           "port": 2598
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2018-01-29T03:02:20Z",
           "duration": 327060000000,
           "end": "2018-01-29T03:02:19Z",
+          "kind": "event",
           "start": "2018-01-29T02:56:51.94Z"
         },
         "flow": {
@@ -56,15 +55,19 @@
           "source_ipv4_prefix_length": 24,
           "source_transport_port": 45587,
           "tcp_control_bits": 24,
-          "type": "netflow",
+          "type": "netflow_flow",
           "vlan_id": 0
         },
         "network": {
           "bytes": 200,
           "community_id": "1:UTBimnmI4MzXDTKLW5sOTHaZyKc=",
           "direction": "outbound",
+          "iana_number": 6,
           "packets": 4,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.108.219.53",

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-IE150-IE151.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-IE150-IE151.golden.json
@@ -10,12 +10,11 @@
           "locality": "private",
           "port": 137
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-12-01T17:04:39Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-12-01T17:04:39Z",
+          "kind": "event"
         },
         "flow": {
           "id": "XApOh2nrI60",
@@ -44,14 +43,18 @@
           "sampler_id": 1,
           "source_ipv4_address": "192.168.0.3",
           "source_transport_port": 137,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 78,
           "community_id": "1:exuCftrHyAyRt6vQ7silX0RyM6c=",
           "direction": "inbound",
+          "iana_number": 17,
           "packets": 1,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.0.3",
@@ -70,12 +73,11 @@
           "locality": "private",
           "port": 6343
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2017-12-01T17:04:39Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2017-12-01T17:04:39Z",
+          "kind": "event"
         },
         "flow": {
           "id": "eTDK1gD4I9Y",
@@ -104,14 +106,18 @@
           "sampler_id": 1,
           "source_ipv4_address": "192.168.0.4",
           "source_transport_port": 58130,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 232,
           "community_id": "1:0CGjtxAvSJC5Eo2OErzsmgtb9JE=",
           "direction": "outbound",
+          "iana_number": 17,
           "packets": 1,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.0.4",

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Palo-Alto-1-flowset-in-large-zero-filled-packet.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Palo-Alto-1-flowset-in-large-zero-filled-packet.golden.json
@@ -10,14 +10,13 @@
           "locality": "public",
           "port": 50234
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2018-06-06T13:20:17Z",
           "duration": 0,
           "end": "2018-06-06T13:20:02Z",
+          "kind": "event",
           "start": "2018-06-06T13:20:02Z"
         },
         "flow": {
@@ -50,14 +49,18 @@
           "source_ipv4_address": "134.220.2.6",
           "source_transport_port": 88,
           "tcp_control_bits": 94,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 363,
           "community_id": "1:0PLHlww9zxRlvByabAFlUctNy14=",
           "direction": "inbound",
+          "iana_number": 6,
           "packets": 3,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "134.220.2.6",

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Palo-Alto-PAN--OS-with-app--id.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Palo-Alto-PAN--OS-with-app--id.golden.json
@@ -10,14 +10,13 @@
           "locality": "private",
           "port": 49519
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2017-11-13T14:39:31Z",
           "duration": 0,
           "end": "2017-11-13T14:39:31Z",
+          "kind": "event",
           "start": "2017-11-13T14:39:31Z"
         },
         "flow": {
@@ -50,14 +49,18 @@
           "source_ipv4_address": "23.35.171.27",
           "source_transport_port": 80,
           "tcp_control_bits": 18,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 70,
           "community_id": "1:Z13H6lSO/rT00gPaBd0ePtowUwU=",
           "direction": "inbound",
+          "iana_number": 6,
           "packets": 1,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "23.35.171.27",
@@ -76,14 +79,13 @@
           "locality": "public",
           "port": 443
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2017-11-13T14:39:31Z",
           "duration": 339000000000,
           "end": "2017-11-13T14:39:31Z",
+          "kind": "event",
           "start": "2017-11-13T14:33:52Z"
         },
         "flow": {
@@ -116,14 +118,18 @@
           "source_ipv4_address": "10.32.105.103",
           "source_transport_port": 39702,
           "tcp_control_bits": 26,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 111,
           "community_id": "1:zlR/fdbiNTN7ULEui4bC3qxG1o0=",
           "direction": "inbound",
+          "iana_number": 6,
           "packets": 1,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.32.105.103",
@@ -142,14 +148,13 @@
           "locality": "public",
           "port": 443
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2017-11-13T14:39:31Z",
           "duration": 0,
           "end": "2017-11-13T14:39:31Z",
+          "kind": "event",
           "start": "2017-11-13T14:39:31Z"
         },
         "flow": {
@@ -182,14 +187,18 @@
           "source_ipv4_address": "10.32.144.145",
           "source_transport_port": 52069,
           "tcp_control_bits": 2,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 70,
           "community_id": "1:iPZ6IKLg+WRI0x/mfDa2zUl8NWo=",
           "direction": "inbound",
+          "iana_number": 6,
           "packets": 1,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.32.144.145",
@@ -208,14 +217,13 @@
           "locality": "private",
           "port": 49449
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2017-11-13T14:39:31Z",
           "duration": 0,
           "end": "2017-11-13T14:39:31Z",
+          "kind": "event",
           "start": "2017-11-13T14:39:31Z"
         },
         "flow": {
@@ -248,14 +256,18 @@
           "source_ipv4_address": "23.209.52.99",
           "source_transport_port": 443,
           "tcp_control_bits": 18,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 70,
           "community_id": "1:DG1OmFpfrDQJaRiR/AiJ0Wn4g34=",
           "direction": "inbound",
+          "iana_number": 6,
           "packets": 1,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "23.209.52.99",
@@ -274,14 +286,13 @@
           "locality": "private",
           "port": 5432
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2017-11-13T14:39:31Z",
           "duration": 0,
           "end": "2017-11-13T14:39:31Z",
+          "kind": "event",
           "start": "2017-11-13T14:39:31Z"
         },
         "flow": {
@@ -314,14 +325,18 @@
           "source_ipv4_address": "10.50.97.57",
           "source_transport_port": 55481,
           "tcp_control_bits": 2,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 78,
           "community_id": "1:ZZSPPc4xy9dNLn8KxxGBoonV5Q0=",
           "direction": "inbound",
+          "iana_number": 6,
           "packets": 1,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.50.97.57",
@@ -340,14 +355,13 @@
           "locality": "private",
           "port": 55481
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2017-11-13T14:39:31Z",
           "duration": 0,
           "end": "2017-11-13T14:39:31Z",
+          "kind": "event",
           "start": "2017-11-13T14:39:31Z"
         },
         "flow": {
@@ -380,14 +394,18 @@
           "source_ipv4_address": "10.50.96.20",
           "source_transport_port": 5432,
           "tcp_control_bits": 18,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 78,
           "community_id": "1:Pz3YYp58JIxmcuSHQGGFLeqZuMI=",
           "direction": "inbound",
+          "iana_number": 6,
           "packets": 1,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.50.96.20",
@@ -406,14 +424,13 @@
           "locality": "private",
           "port": 60068
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2017-11-13T14:39:31Z",
           "duration": 0,
           "end": "2017-11-13T14:39:31Z",
+          "kind": "event",
           "start": "2017-11-13T14:39:31Z"
         },
         "flow": {
@@ -446,14 +463,18 @@
           "source_ipv4_address": "34.234.173.147",
           "source_transport_port": 443,
           "tcp_control_bits": 18,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 70,
           "community_id": "1:d7ZiIN8VXiJ5Z+UQZqEL0dDlUxw=",
           "direction": "inbound",
+          "iana_number": 6,
           "packets": 1,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "34.234.173.147",
@@ -472,14 +493,13 @@
           "locality": "public",
           "port": 443
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2017-11-13T14:39:31Z",
           "duration": 0,
           "end": "2017-11-13T14:39:31Z",
+          "kind": "event",
           "start": "2017-11-13T14:39:31Z"
         },
         "flow": {
@@ -512,14 +532,18 @@
           "source_ipv4_address": "10.130.167.43",
           "source_transport_port": 62196,
           "tcp_control_bits": 2,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 70,
           "community_id": "1:+8F8Whgl7WnEMyWEwtKcn0bQE+I=",
           "direction": "inbound",
+          "iana_number": 6,
           "packets": 1,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.130.167.43",

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Streamcore.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Streamcore.golden.json
@@ -10,14 +10,13 @@
           "locality": "private",
           "port": 50073
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2017-01-11T11:48:15Z",
           "duration": 6012000000,
           "end": "2017-01-11T11:47:28.879Z",
+          "kind": "event",
           "start": "2017-01-11T11:47:22.867Z"
         },
         "flow": {
@@ -45,14 +44,18 @@
           "source_ipv4_address": "100.78.40.201",
           "source_transport_port": 8080,
           "tcp_control_bits": 19,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 128,
           "community_id": "1:Vq90QiM+mzZbbo5vY5GdjE9OrRc=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 3,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "100.78.40.201",
@@ -71,14 +74,13 @@
           "locality": "public",
           "port": 8080
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2017-01-11T11:48:15Z",
           "duration": 6020000000,
           "end": "2017-01-11T11:47:28.886Z",
+          "kind": "event",
           "start": "2017-01-11T11:47:22.866Z"
         },
         "flow": {
@@ -106,14 +108,18 @@
           "source_ipv4_address": "10.231.128.150",
           "source_transport_port": 50073,
           "tcp_control_bits": 19,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 172,
           "community_id": "1:q9x0h1eGokXApDL651a/13CjP74=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 4,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.231.128.150",
@@ -132,14 +138,13 @@
           "locality": "private",
           "port": 53483
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2017-01-11T11:23:51Z",
           "duration": 50997000000,
           "end": "2017-01-11T11:23:34.936Z",
+          "kind": "event",
           "start": "2017-01-11T11:22:43.939Z"
         },
         "flow": {
@@ -167,14 +172,18 @@
           "source_ipv4_address": "100.78.40.201",
           "source_transport_port": 8080,
           "tcp_control_bits": 26,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 3943,
           "community_id": "1:2fY1XMUII4NBiXGj6I6Knj1Kg4A=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 10,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "100.78.40.201",
@@ -193,14 +202,13 @@
           "locality": "public",
           "port": 8080
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2017-01-11T11:23:51Z",
           "duration": 51015000000,
           "end": "2017-01-11T11:23:34.954Z",
+          "kind": "event",
           "start": "2017-01-11T11:22:43.939Z"
         },
         "flow": {
@@ -228,14 +236,18 @@
           "source_ipv4_address": "10.27.8.20",
           "source_transport_port": 53483,
           "tcp_control_bits": 26,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 3052,
           "community_id": "1:yMe4rLBOcLy4kK6KxECnRMoxH5Y=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 11,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.27.8.20",

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Ubiquiti-Edgerouter-with-MPLS-labels.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Ubiquiti-Edgerouter-with-MPLS-labels.golden.json
@@ -11,14 +11,13 @@
           "mac": "44:d9:e7:be:ef:89",
           "port": 17232
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2016-09-10T16:23:30Z",
           "duration": 0,
           "end": "2016-09-10T16:17:25.825Z",
+          "kind": "event",
           "start": "2016-09-10T16:17:25.825Z"
         },
         "flow": {
@@ -52,15 +51,19 @@
           "source_mac_address": "06:be:ef:be:ef:4f",
           "source_transport_port": 53,
           "tcp_control_bits": 0,
-          "type": "netflow",
+          "type": "netflow_flow",
           "vlan_id": 0
         },
         "network": {
           "bytes": 174,
           "community_id": "1:LBCtS/p3ascA03WBOEnBcb1EGoI=",
           "direction": "inbound",
+          "iana_number": 17,
           "packets": 2,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.1.0.135",
@@ -81,14 +84,13 @@
           "mac": "44:d9:e7:be:ef:89",
           "port": 17232
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2016-09-10T16:23:30Z",
           "duration": 0,
           "end": "2016-09-10T16:17:25.825Z",
+          "kind": "event",
           "start": "2016-09-10T16:17:25.825Z"
         },
         "flow": {
@@ -122,15 +124,19 @@
           "source_mac_address": "06:be:ef:be:ef:4f",
           "source_transport_port": 53,
           "tcp_control_bits": 0,
-          "type": "netflow",
+          "type": "netflow_flow",
           "vlan_id": 0
         },
         "network": {
           "bytes": 87,
           "community_id": "1:vJ5vmvDe5YWGqPYTZi5Sq28Qsds=",
           "direction": "inbound",
+          "iana_number": 17,
           "packets": 1,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.1.0.136",
@@ -151,14 +157,13 @@
           "mac": "44:d9:e7:be:ef:89",
           "port": 51369
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2016-09-10T16:23:30Z",
           "duration": 140227000000,
           "end": "2016-09-10T15:22:30.891Z",
+          "kind": "event",
           "start": "2016-09-10T15:20:10.664Z"
         },
         "flow": {
@@ -192,15 +197,19 @@
           "source_mac_address": "06:be:ef:be:ef:4f",
           "source_transport_port": 443,
           "tcp_control_bits": 27,
-          "type": "netflow",
+          "type": "netflow_flow",
           "vlan_id": 0
         },
         "network": {
           "bytes": 1920,
           "community_id": "1:CFiH8b4XWH4O1l2Sw0q1HH4BB4Q=",
           "direction": "inbound",
+          "iana_number": 6,
           "packets": 15,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.1.0.232",
@@ -221,14 +230,13 @@
           "mac": "44:d9:e7:be:ef:89",
           "port": 51370
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2016-09-10T16:23:30Z",
           "duration": 140227000000,
           "end": "2016-09-10T15:22:30.891Z",
+          "kind": "event",
           "start": "2016-09-10T15:20:10.664Z"
         },
         "flow": {
@@ -262,15 +270,19 @@
           "source_mac_address": "06:be:ef:be:ef:4f",
           "source_transport_port": 443,
           "tcp_control_bits": 27,
-          "type": "netflow",
+          "type": "netflow_flow",
           "vlan_id": 0
         },
         "network": {
           "bytes": 610,
           "community_id": "1:P/vFKj652d0ZJNMMgXdjjE27lvY=",
           "direction": "inbound",
+          "iana_number": 6,
           "packets": 8,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.1.0.232",
@@ -291,14 +303,13 @@
           "mac": "44:d9:e7:be:ef:89",
           "port": 44006
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2016-09-10T16:23:30Z",
           "duration": 177102000000,
           "end": "2016-09-10T16:20:32.763Z",
+          "kind": "event",
           "start": "2016-09-10T16:17:35.661Z"
         },
         "flow": {
@@ -332,15 +343,19 @@
           "source_mac_address": "06:be:ef:be:ef:4f",
           "source_transport_port": 443,
           "tcp_control_bits": 31,
-          "type": "netflow",
+          "type": "netflow_flow",
           "vlan_id": 0
         },
         "network": {
           "bytes": 2420,
           "community_id": "1:xKw+VoWL9M7oxnO1UggxTAebwU0=",
           "direction": "inbound",
+          "iana_number": 6,
           "packets": 21,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.5.0.91",
@@ -361,14 +376,13 @@
           "mac": "44:d9:e7:be:ef:89",
           "port": 33282
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2016-09-10T16:23:30Z",
           "duration": 176903000000,
           "end": "2016-09-10T16:20:32.666Z",
+          "kind": "event",
           "start": "2016-09-10T16:17:35.763Z"
         },
         "flow": {
@@ -402,15 +416,19 @@
           "source_mac_address": "06:be:ef:be:ef:4f",
           "source_transport_port": 443,
           "tcp_control_bits": 31,
-          "type": "netflow",
+          "type": "netflow_flow",
           "vlan_id": 0
         },
         "network": {
           "bytes": 10204,
           "community_id": "1:FfkN6z0DhUrGLn5+zWn/sV0ZniA=",
           "direction": "inbound",
+          "iana_number": 6,
           "packets": 30,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.1.0.30",
@@ -431,14 +449,13 @@
           "mac": "44:d9:e7:be:ef:89",
           "port": 64642
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2016-09-10T16:23:30Z",
           "duration": 0,
           "end": "2016-09-10T15:22:36.207Z",
+          "kind": "event",
           "start": "2016-09-10T15:22:36.207Z"
         },
         "flow": {
@@ -472,15 +489,19 @@
           "source_mac_address": "06:be:ef:be:ef:4f",
           "source_transport_port": 443,
           "tcp_control_bits": 27,
-          "type": "netflow",
+          "type": "netflow_flow",
           "vlan_id": 0
         },
         "network": {
           "bytes": 216,
           "community_id": "1:eE3KIQz/eWZHV2I+CCqw4zUkL9g=",
           "direction": "inbound",
+          "iana_number": 6,
           "packets": 4,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.3.0.100",
@@ -501,14 +522,13 @@
           "mac": "44:d9:e7:be:ef:89",
           "port": 9497
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2016-09-10T16:23:30Z",
           "duration": 0,
           "end": "2016-09-10T16:17:35.661Z",
+          "kind": "event",
           "start": "2016-09-10T16:17:35.661Z"
         },
         "flow": {
@@ -542,15 +562,19 @@
           "source_mac_address": "06:be:ef:be:ef:4f",
           "source_transport_port": 53,
           "tcp_control_bits": 0,
-          "type": "netflow",
+          "type": "netflow_flow",
           "vlan_id": 0
         },
         "network": {
           "bytes": 152,
           "community_id": "1:xG/g/ovBtK1hoaoh6T83Jh/9WKo=",
           "direction": "inbound",
+          "iana_number": 17,
           "packets": 1,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.1.0.135",
@@ -570,14 +594,13 @@
           "locality": "private",
           "port": 443
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2016-09-10T16:24:08Z",
           "duration": 116000000,
           "end": "2016-09-10T15:23:38.951Z",
+          "kind": "event",
           "start": "2016-09-10T15:23:38.835Z"
         },
         "flow": {
@@ -612,14 +635,18 @@
           "source_ipv4_address": "192.168.1.98",
           "source_transport_port": 55105,
           "tcp_control_bits": 27,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 260,
           "community_id": "1:XjfR484ViCn+jOuZLqYQqjqQtfc=",
           "direction": "outbound",
+          "iana_number": 6,
           "packets": 5,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.1.98",
@@ -638,14 +665,13 @@
           "locality": "private",
           "port": 10001
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2016-09-10T16:24:08Z",
           "duration": 0,
           "end": "2016-09-10T16:18:39.443Z",
+          "kind": "event",
           "start": "2016-09-10T16:18:39.443Z"
         },
         "flow": {
@@ -680,14 +706,18 @@
           "source_ipv4_address": "10.4.0.251",
           "source_transport_port": 42506,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 32,
           "community_id": "1:95RXAJ+p7YRmPl3ntaE9GolON50=",
           "direction": "outbound",
+          "iana_number": 17,
           "packets": 1,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.4.0.251",
@@ -706,14 +736,13 @@
           "locality": "private",
           "port": 37868
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2016-09-10T16:24:08Z",
           "duration": 0,
           "end": "2016-09-10T16:18:39.443Z",
+          "kind": "event",
           "start": "2016-09-10T16:18:39.443Z"
         },
         "flow": {
@@ -748,14 +777,18 @@
           "source_ipv4_address": "10.4.0.251",
           "source_transport_port": 40295,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 135,
           "community_id": "1:RCz/33YJNjlqCsLhJKCpATtxyRs=",
           "direction": "outbound",
+          "iana_number": 17,
           "packets": 1,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.4.0.251",
@@ -774,14 +807,13 @@
           "locality": "private",
           "port": 56911
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2016-09-10T16:24:08Z",
           "duration": 0,
           "end": "2016-09-10T16:18:39.443Z",
+          "kind": "event",
           "start": "2016-09-10T16:18:39.443Z"
         },
         "flow": {
@@ -816,14 +848,18 @@
           "source_ipv4_address": "10.4.0.251",
           "source_transport_port": 36071,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 135,
           "community_id": "1:XHp0tgbuHUU5GBjWgwCKVVK7F+k=",
           "direction": "outbound",
+          "iana_number": 17,
           "packets": 1,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.4.0.251",
@@ -842,14 +878,13 @@
           "locality": "private",
           "port": 56327
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2016-09-10T16:24:08Z",
           "duration": 0,
           "end": "2016-09-10T16:18:39.443Z",
+          "kind": "event",
           "start": "2016-09-10T16:18:39.443Z"
         },
         "flow": {
@@ -884,14 +919,18 @@
           "source_ipv4_address": "10.4.0.251",
           "source_transport_port": 49829,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 135,
           "community_id": "1:WFxjExIXgIuAq+rNDGVQYEnaugA=",
           "direction": "outbound",
+          "iana_number": 17,
           "packets": 1,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.4.0.251",
@@ -910,14 +949,13 @@
           "locality": "private",
           "port": 56239
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2016-09-10T16:24:08Z",
           "duration": 0,
           "end": "2016-09-10T16:18:39.443Z",
+          "kind": "event",
           "start": "2016-09-10T16:18:39.443Z"
         },
         "flow": {
@@ -952,14 +990,18 @@
           "source_ipv4_address": "10.4.0.251",
           "source_transport_port": 35059,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 135,
           "community_id": "1:d9brHw1Oz6WSVKR3rJyezHX6DIw=",
           "direction": "outbound",
+          "iana_number": 17,
           "packets": 1,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.4.0.251",
@@ -978,14 +1020,13 @@
           "locality": "private",
           "port": 39832
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2016-09-10T16:24:08Z",
           "duration": 0,
           "end": "2016-09-10T16:18:39.443Z",
+          "kind": "event",
           "start": "2016-09-10T16:18:39.443Z"
         },
         "flow": {
@@ -1020,14 +1061,18 @@
           "source_ipv4_address": "10.4.0.251",
           "source_transport_port": 38231,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 135,
           "community_id": "1:2nQhV3nUU3v8Zm2yOpGYVOulxsI=",
           "direction": "outbound",
+          "iana_number": 17,
           "packets": 1,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.4.0.251",
@@ -1046,14 +1091,13 @@
           "locality": "private",
           "port": 443
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2016-09-10T16:24:08Z",
           "duration": 1250988000000,
           "end": "2016-09-10T15:23:44.363Z",
+          "kind": "event",
           "start": "2016-09-10T15:02:53.375Z"
         },
         "flow": {
@@ -1088,14 +1132,18 @@
           "source_ipv4_address": "192.168.1.102",
           "source_transport_port": 47690,
           "tcp_control_bits": 27,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 3668,
           "community_id": "1:p7mv5aLl7VvnGcnWMhevg6/gYrM=",
           "direction": "outbound",
+          "iana_number": 6,
           "packets": 21,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.1.102",

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-field-layer2segmentid.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-field-layer2segmentid.golden.json
@@ -10,14 +10,13 @@
           "locality": "public",
           "port": 445
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2018-01-16T09:45:02Z",
           "duration": 0,
           "end": "2018-01-16T09:44:47Z",
+          "kind": "event",
           "start": "2018-01-16T09:44:47Z"
         },
         "flow": {
@@ -48,15 +47,19 @@
           "sampler_id": 98,
           "source_ipv4_address": "192.168.200.136",
           "source_transport_port": 61926,
-          "type": "netflow",
+          "type": "netflow_flow",
           "vlan_id": 3174
         },
         "network": {
           "bytes": 52,
           "community_id": "1:4iAaWV/HzvAcwggo1MJCfjvj8No=",
           "direction": "inbound",
+          "iana_number": 6,
           "packets": 1,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.200.136",

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-ipt_netflow-reduced-size-encoding.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-ipt_netflow-reduced-size-encoding.golden.json
@@ -11,14 +11,13 @@
           "mac": "00:1b:21:bc:24:dd",
           "port": 36025
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2018-02-18T05:47:09Z",
           "duration": 8996000000,
           "end": "2018-02-18T05:46:53.996Z",
+          "kind": "event",
           "start": "2018-02-18T05:46:45Z"
         },
         "flow": {
@@ -53,14 +52,18 @@
           "source_transport_port": 27622,
           "tcp_control_bits": 2,
           "tcp_options": 4026531840,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 156,
           "community_id": "1:6bApwXCshD5rqS4P4mVFwtobnBM=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 3,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "37.122.1.226",
@@ -81,14 +84,13 @@
           "mac": "00:1b:21:bc:24:dd",
           "port": 29598
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2018-02-18T05:47:09Z",
           "duration": 0,
           "end": "2018-02-18T05:46:53.992Z",
+          "kind": "event",
           "start": "2018-02-18T05:46:53.992Z"
         },
         "flow": {
@@ -123,14 +125,18 @@
           "source_transport_port": 31178,
           "tcp_control_bits": 2,
           "tcp_options": 3489660928,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 48,
           "community_id": "1:nHvXTDLBywv91YMJeWrLeJPdWP4=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 1,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "5.141.231.166",
@@ -151,14 +157,13 @@
           "mac": "00:1b:21:bc:24:dc",
           "port": 443
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2018-02-18T05:47:09Z",
           "duration": 7652000000,
           "end": "2018-02-18T05:46:53.988Z",
+          "kind": "event",
           "start": "2018-02-18T05:46:46.336Z"
         },
         "flow": {
@@ -193,14 +198,18 @@
           "source_transport_port": 53688,
           "tcp_control_bits": 211,
           "tcp_options": 4043309057,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 584,
           "community_id": "1:3gZ5hR1U0fS2hvac/Y9iO8mcFDo=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 11,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.233.128.4",
@@ -221,14 +230,13 @@
           "mac": "00:1b:21:bc:24:dc",
           "port": 51549
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2018-02-18T05:47:09Z",
           "duration": 16000000,
           "end": "2018-02-18T05:46:53.992Z",
+          "kind": "event",
           "start": "2018-02-18T05:46:53.976Z"
         },
         "flow": {
@@ -263,14 +271,18 @@
           "source_transport_port": 80,
           "tcp_control_bits": 27,
           "tcp_options": 4043309056,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 577,
           "community_id": "1:Uc3mP+7U3dbDz60McoL0jYl+KUQ=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 4,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "193.151.192.46",
@@ -291,14 +303,13 @@
           "mac": "00:1b:21:bc:24:dc",
           "port": 1024
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2018-02-18T05:47:09Z",
           "duration": 1168000000,
           "end": "2018-02-18T05:46:53.988Z",
+          "kind": "event",
           "start": "2018-02-18T05:46:52.82Z"
         },
         "flow": {
@@ -333,14 +344,18 @@
           "source_transport_port": 57505,
           "tcp_control_bits": 2,
           "tcp_options": 4026531840,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 152,
           "community_id": "1:Wcok2NJh31VgMyBs70twGHpEg7M=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 3,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.235.197.6",
@@ -361,14 +376,13 @@
           "mac": "00:1b:21:bc:24:dc",
           "port": 3237
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2018-02-18T05:47:09Z",
           "duration": 8992000000,
           "end": "2018-02-18T05:46:53.992Z",
+          "kind": "event",
           "start": "2018-02-18T05:46:45Z"
         },
         "flow": {
@@ -403,14 +417,18 @@
           "source_transport_port": 61471,
           "tcp_control_bits": 2,
           "tcp_options": 4026531840,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 152,
           "community_id": "1:tfHBMGf05/6z8XXBH1VvTg3Bp4k=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 3,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.236.31.7",
@@ -431,14 +449,13 @@
           "mac": "00:1b:21:bc:24:dc",
           "port": 443
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2018-02-18T05:47:09Z",
           "duration": 4432000000,
           "end": "2018-02-18T05:46:53.992Z",
+          "kind": "event",
           "start": "2018-02-18T05:46:49.56Z"
         },
         "flow": {
@@ -473,14 +490,18 @@
           "source_transport_port": 58044,
           "tcp_control_bits": 31,
           "tcp_options": 4177526784,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 1809,
           "community_id": "1:RkpTZIg7FeOitpZbe0ahhlzx90w=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 15,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.233.151.8",
@@ -501,14 +522,13 @@
           "mac": "00:1b:21:bc:24:dc",
           "port": 5228
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2018-02-18T05:47:09Z",
           "duration": 80000000,
           "end": "2018-02-18T05:46:53.996Z",
+          "kind": "event",
           "start": "2018-02-18T05:46:53.916Z"
         },
         "flow": {
@@ -543,14 +563,18 @@
           "source_transport_port": 60583,
           "tcp_control_bits": 24,
           "tcp_options": 2164260864,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 234,
           "community_id": "1:QdyoRIMjHbHZz9RohPLNm74w6QE=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 3,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.234.22.4",
@@ -571,14 +595,13 @@
           "mac": "00:1b:21:bc:24:dc",
           "port": 80
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2018-02-18T05:47:09Z",
           "duration": 400000000,
           "end": "2018-02-18T05:46:53.992Z",
+          "kind": "event",
           "start": "2018-02-18T05:46:53.592Z"
         },
         "flow": {
@@ -613,14 +636,18 @@
           "source_transport_port": 51399,
           "tcp_control_bits": 27,
           "tcp_options": 4043309056,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 1681,
           "community_id": "1:ByBLMidnd0Tua+Vk+59YTRfjE3g=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 22,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.233.36.7",
@@ -641,14 +668,13 @@
           "mac": "00:1b:21:bc:24:dc",
           "port": 18580
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2018-02-18T05:47:09Z",
           "duration": 9024000000,
           "end": "2018-02-18T05:46:53.988Z",
+          "kind": "event",
           "start": "2018-02-18T05:46:44.964Z"
         },
         "flow": {
@@ -683,14 +709,18 @@
           "source_transport_port": 61820,
           "tcp_control_bits": 2,
           "tcp_options": 4026531840,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 152,
           "community_id": "1:+8jpPMTlqZM+u9QLxrPyk2/duOY=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 3,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "10.233.200.7",
@@ -711,14 +741,13 @@
           "mac": "00:1b:21:bc:24:dd",
           "port": 56257
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2018-02-18T05:47:09Z",
           "duration": 60000000,
           "end": "2018-02-18T05:46:53.992Z",
+          "kind": "event",
           "start": "2018-02-18T05:46:53.932Z"
         },
         "flow": {
@@ -753,14 +782,18 @@
           "source_transport_port": 80,
           "tcp_control_bits": 26,
           "tcp_options": 4026531840,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 1866,
           "community_id": "1:hWEp1AGtGX7I3gL6btUapvplzdk=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 3,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "23.43.139.27",
@@ -781,14 +814,13 @@
           "mac": "00:1b:21:bc:24:dd",
           "port": 38164
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2018-02-18T05:47:09Z",
           "duration": 192000000,
           "end": "2018-02-18T05:46:53.992Z",
+          "kind": "event",
           "start": "2018-02-18T05:46:53.8Z"
         },
         "flow": {
@@ -823,14 +855,18 @@
           "source_transport_port": 443,
           "tcp_control_bits": 25,
           "tcp_options": 2164260864,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 187,
           "community_id": "1:ujpwO/BObx6DD8oop1f63tSyfcw=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 3,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "2.17.140.47",

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-macaddress.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-macaddress.golden.json
@@ -5,12 +5,11 @@
       "Timestamp": "2015-10-10T08:46:56Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
           "action": "netflow_options",
-          "created": "2015-10-10T08:46:56Z"
+          "category": "network_traffic",
+          "created": "2015-10-10T08:46:56Z",
+          "kind": "event"
         },
         "netflow": {
           "exporter": {
@@ -28,6 +27,9 @@
             "octet_delta_count": 0
           },
           "type": "netflow_options"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         }
       },
       "Private": null
@@ -42,12 +44,11 @@
           "mac": "00:0c:29:70:86:09",
           "port": 22
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2015-10-10T08:47:01Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2015-10-10T08:47:01Z",
+          "kind": "event"
         },
         "flow": {
           "id": "owSGnhdQc1k",
@@ -68,12 +69,16 @@
           "source_ipv4_address": "172.16.32.1",
           "source_mac_address": "00:50:56:c0:00:01",
           "source_transport_port": 65058,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "community_id": "1:tzcqIeMhEvkXA/EBAZraJPCnaN8=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "172.16.32.1",
@@ -94,12 +99,11 @@
           "mac": "00:0c:29:8d:af:c3",
           "port": 123
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2015-10-10T08:47:01Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2015-10-10T08:47:01Z",
+          "kind": "event"
         },
         "flow": {
           "id": "_cbZpOjyGGQ",
@@ -120,12 +124,16 @@
           "source_ipv4_address": "172.16.32.201",
           "source_mac_address": "00:0c:29:70:86:09",
           "source_transport_port": 123,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "community_id": "1:mYS5cP5hzhSb8JZH9+2v8+RMJ9g=",
           "direction": "unknown",
-          "protocol": "udp"
+          "iana_number": 17,
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "172.16.32.201",
@@ -146,12 +154,11 @@
           "mac": "00:0c:29:70:86:09",
           "port": 123
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2015-10-10T08:47:01Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2015-10-10T08:47:01Z",
+          "kind": "event"
         },
         "flow": {
           "id": "i1KQBFMlwFg",
@@ -172,12 +179,16 @@
           "source_ipv4_address": "172.16.32.100",
           "source_mac_address": "00:0c:29:8d:af:c3",
           "source_transport_port": 123,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "community_id": "1:cRrWVwyu9GLZ+aU7qmwhjSdMrpE=",
           "direction": "unknown",
-          "protocol": "udp"
+          "iana_number": 17,
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "172.16.32.100",
@@ -198,12 +209,11 @@
           "mac": "00:0c:29:70:86:09",
           "port": 80
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2015-10-10T08:47:01Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2015-10-10T08:47:01Z",
+          "kind": "event"
         },
         "flow": {
           "id": "O3ETdQvmCOg",
@@ -224,12 +234,16 @@
           "source_ipv4_address": "172.16.32.1",
           "source_mac_address": "00:50:56:c0:00:01",
           "source_transport_port": 59157,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "community_id": "1:fVzE/MKEA1VMNMkCvz5NQinQLUI=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "172.16.32.1",
@@ -250,12 +264,11 @@
           "mac": "00:50:56:c0:00:01",
           "port": 59157
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2015-10-10T08:47:01Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2015-10-10T08:47:01Z",
+          "kind": "event"
         },
         "flow": {
           "id": "GuhchkSUWPk",
@@ -276,12 +289,16 @@
           "source_ipv4_address": "172.16.32.201",
           "source_mac_address": "00:0c:29:70:86:09",
           "source_transport_port": 80,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "community_id": "1:LZj70OIhu6ThMyKy7u70cO67FK4=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "172.16.32.201",
@@ -302,12 +319,11 @@
           "mac": "00:0c:29:70:86:09",
           "port": 443
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2015-10-10T08:47:01Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2015-10-10T08:47:01Z",
+          "kind": "event"
         },
         "flow": {
           "id": "w09kRuEnun8",
@@ -328,12 +344,16 @@
           "source_ipv4_address": "172.16.32.1",
           "source_mac_address": "00:50:56:c0:00:01",
           "source_transport_port": 59158,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "community_id": "1:DoERidYQAzlwvj5aBo1aEylCHgo=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "172.16.32.1",
@@ -354,12 +374,11 @@
           "mac": "00:50:56:c0:00:01",
           "port": 59158
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2015-10-10T08:47:01Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2015-10-10T08:47:01Z",
+          "kind": "event"
         },
         "flow": {
           "id": "2TaHSp0QckA",
@@ -380,12 +399,16 @@
           "source_ipv4_address": "172.16.32.201",
           "source_mac_address": "00:0c:29:70:86:09",
           "source_transport_port": 443,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "community_id": "1:s0N+K6vD3goIH7jZO1SqG58ztGQ=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "172.16.32.201",
@@ -406,12 +429,11 @@
           "mac": "00:0c:29:70:86:09",
           "port": 139
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2015-10-10T08:47:01Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2015-10-10T08:47:01Z",
+          "kind": "event"
         },
         "flow": {
           "id": "5DhRBSR-wO8",
@@ -432,12 +454,16 @@
           "source_ipv4_address": "172.16.32.1",
           "source_mac_address": "00:50:56:c0:00:01",
           "source_transport_port": 59159,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "community_id": "1:q1r5Q5XRCVvpwYqEkfbN8OxKQuI=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "172.16.32.1",
@@ -458,12 +484,11 @@
           "mac": "00:50:56:c0:00:01",
           "port": 59159
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2015-10-10T08:47:01Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2015-10-10T08:47:01Z",
+          "kind": "event"
         },
         "flow": {
           "id": "In7-hVVW5Rw",
@@ -484,12 +509,16 @@
           "source_ipv4_address": "172.16.32.201",
           "source_mac_address": "00:0c:29:70:86:09",
           "source_transport_port": 139,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "community_id": "1:5idRNtMRt9YwcfftLSQtC72/n6Y=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "172.16.32.201",
@@ -510,12 +539,11 @@
           "mac": "00:0c:29:70:86:09",
           "port": 23
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2015-10-10T08:47:01Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2015-10-10T08:47:01Z",
+          "kind": "event"
         },
         "flow": {
           "id": "p6xawkqu_zY",
@@ -536,12 +564,16 @@
           "source_ipv4_address": "172.16.32.1",
           "source_mac_address": "00:50:56:c0:00:01",
           "source_transport_port": 59160,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "community_id": "1:O9wqBh6gPhpzxHuWe7MgCX7Xpc4=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "172.16.32.1",
@@ -562,12 +594,11 @@
           "mac": "00:50:56:c0:00:01",
           "port": 59160
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2015-10-10T08:47:01Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2015-10-10T08:47:01Z",
+          "kind": "event"
         },
         "flow": {
           "id": "JyqRDg0Pe1I",
@@ -588,12 +619,16 @@
           "source_ipv4_address": "172.16.32.201",
           "source_mac_address": "00:0c:29:70:86:09",
           "source_transport_port": 23,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "community_id": "1:odq42pEjA7OgeYPh6amRzomwnoM=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "172.16.32.201",
@@ -614,12 +649,11 @@
           "mac": "00:0c:29:70:86:09",
           "port": 995
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2015-10-10T08:47:01Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2015-10-10T08:47:01Z",
+          "kind": "event"
         },
         "flow": {
           "id": "izkM8H_PkUs",
@@ -640,12 +674,16 @@
           "source_ipv4_address": "172.16.32.1",
           "source_mac_address": "00:50:56:c0:00:01",
           "source_transport_port": 59161,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "community_id": "1:UUC6Ang4BzxgjeDeSNC8v/53zx4=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "172.16.32.1",
@@ -666,12 +704,11 @@
           "mac": "00:50:56:c0:00:01",
           "port": 59161
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2015-10-10T08:47:01Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2015-10-10T08:47:01Z",
+          "kind": "event"
         },
         "flow": {
           "id": "xQ18aAZ-pr8",
@@ -692,12 +729,16 @@
           "source_ipv4_address": "172.16.32.201",
           "source_mac_address": "00:0c:29:70:86:09",
           "source_transport_port": 995,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "community_id": "1:gYnQndK1J0EfqJ6hcON4iV+sV1I=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "172.16.32.201",
@@ -718,12 +759,11 @@
           "mac": "00:0c:29:70:86:09",
           "port": 443
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2015-10-10T08:47:01Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2015-10-10T08:47:01Z",
+          "kind": "event"
         },
         "flow": {
           "id": "-1gdgg3n334",
@@ -744,12 +784,16 @@
           "source_ipv4_address": "172.16.32.1",
           "source_mac_address": "00:50:56:c0:00:01",
           "source_transport_port": 59162,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "community_id": "1:zppnN171ys38psn8czlt3R0wxe8=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "172.16.32.1",
@@ -770,12 +814,11 @@
           "mac": "00:50:56:c0:00:01",
           "port": 59162
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2015-10-10T08:47:01Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2015-10-10T08:47:01Z",
+          "kind": "event"
         },
         "flow": {
           "id": "CnVw8CbHrMY",
@@ -796,12 +839,16 @@
           "source_ipv4_address": "172.16.32.201",
           "source_mac_address": "00:0c:29:70:86:09",
           "source_transport_port": 443,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "community_id": "1:t1KFW03nxtZ2y4JBNbWu3PyDfk8=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "172.16.32.201",
@@ -822,12 +869,11 @@
           "mac": "00:0c:29:70:86:09",
           "port": 135
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2015-10-10T08:47:01Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2015-10-10T08:47:01Z",
+          "kind": "event"
         },
         "flow": {
           "id": "_P6iyZeEPpY",
@@ -848,12 +894,16 @@
           "source_ipv4_address": "172.16.32.1",
           "source_mac_address": "00:50:56:c0:00:01",
           "source_transport_port": 59163,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "community_id": "1:cYbvSlVIg8esJzIq2q4ATrJ7+sY=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "172.16.32.1",
@@ -874,12 +924,11 @@
           "mac": "00:50:56:c0:00:01",
           "port": 59163
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2015-10-10T08:47:01Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2015-10-10T08:47:01Z",
+          "kind": "event"
         },
         "flow": {
           "id": "H8S4xKKvY9c",
@@ -900,12 +949,16 @@
           "source_ipv4_address": "172.16.32.201",
           "source_mac_address": "00:0c:29:70:86:09",
           "source_transport_port": 135,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "community_id": "1:xw52kFQxAYrEnkCjkJPN4NUZ8WI=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "172.16.32.201",
@@ -926,12 +979,11 @@
           "mac": "00:0c:29:70:86:09",
           "port": 110
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2015-10-10T08:47:01Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2015-10-10T08:47:01Z",
+          "kind": "event"
         },
         "flow": {
           "id": "RHnG3UfiYVs",
@@ -952,12 +1004,16 @@
           "source_ipv4_address": "172.16.32.1",
           "source_mac_address": "00:50:56:c0:00:01",
           "source_transport_port": 59164,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "community_id": "1:nOvjuKIb5reZRRHaoCJRGUw2u2o=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "172.16.32.1",
@@ -978,12 +1034,11 @@
           "mac": "00:50:56:c0:00:01",
           "port": 59164
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2015-10-10T08:47:01Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2015-10-10T08:47:01Z",
+          "kind": "event"
         },
         "flow": {
           "id": "DCtFd6UwimY",
@@ -1004,12 +1059,16 @@
           "source_ipv4_address": "172.16.32.201",
           "source_mac_address": "00:0c:29:70:86:09",
           "source_transport_port": 110,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "community_id": "1:iXLOg+5V7xMNbFjb/Fn13WXIwpA=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "172.16.32.201",
@@ -1030,12 +1089,11 @@
           "mac": "00:0c:29:70:86:09",
           "port": 111
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2015-10-10T08:47:01Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2015-10-10T08:47:01Z",
+          "kind": "event"
         },
         "flow": {
           "id": "S6vU3RZ9qRo",
@@ -1056,12 +1114,16 @@
           "source_ipv4_address": "172.16.32.1",
           "source_mac_address": "00:50:56:c0:00:01",
           "source_transport_port": 59165,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "community_id": "1:hoCpobmQ1SEqktORR12M8ynuDPI=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "172.16.32.1",
@@ -1082,12 +1144,11 @@
           "mac": "00:50:56:c0:00:01",
           "port": 59165
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2015-10-10T08:47:01Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2015-10-10T08:47:01Z",
+          "kind": "event"
         },
         "flow": {
           "id": "g5SWzYolCH8",
@@ -1108,12 +1169,16 @@
           "source_ipv4_address": "172.16.32.201",
           "source_mac_address": "00:0c:29:70:86:09",
           "source_transport_port": 111,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "community_id": "1:nphrDmJfS2JuUpcSM+E36Xh41ck=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "172.16.32.201",
@@ -1134,12 +1199,11 @@
           "mac": "00:0c:29:70:86:09",
           "port": 143
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2015-10-10T08:47:01Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2015-10-10T08:47:01Z",
+          "kind": "event"
         },
         "flow": {
           "id": "Pa6VrN0hfFM",
@@ -1160,12 +1224,16 @@
           "source_ipv4_address": "172.16.32.1",
           "source_mac_address": "00:50:56:c0:00:01",
           "source_transport_port": 59166,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "community_id": "1:andIv3q3a7gqVMMwg+YVAxxbyf8=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "172.16.32.1",
@@ -1186,12 +1254,11 @@
           "mac": "00:50:56:c0:00:01",
           "port": 59166
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2015-10-10T08:47:01Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2015-10-10T08:47:01Z",
+          "kind": "event"
         },
         "flow": {
           "id": "Ma9Hrn8BuXE",
@@ -1212,12 +1279,16 @@
           "source_ipv4_address": "172.16.32.201",
           "source_mac_address": "00:0c:29:70:86:09",
           "source_transport_port": 143,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "community_id": "1:3Zpznpp5sA+yxgN2vQONTT4Qtlk=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "172.16.32.201",
@@ -1238,12 +1309,11 @@
           "mac": "00:0c:29:70:86:09",
           "port": 3389
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2015-10-10T08:47:01Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2015-10-10T08:47:01Z",
+          "kind": "event"
         },
         "flow": {
           "id": "Pol0ObD1Z-8",
@@ -1264,12 +1334,16 @@
           "source_ipv4_address": "172.16.32.1",
           "source_mac_address": "00:50:56:c0:00:01",
           "source_transport_port": 59167,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "community_id": "1:b/19ZiHUfRjjwT7BRwqUlFnZk30=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "172.16.32.1",
@@ -1290,12 +1364,11 @@
           "mac": "00:50:56:c0:00:01",
           "port": 59167
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2015-10-10T08:47:01Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2015-10-10T08:47:01Z",
+          "kind": "event"
         },
         "flow": {
           "id": "j3DHUjySbaU",
@@ -1316,12 +1389,16 @@
           "source_ipv4_address": "172.16.32.201",
           "source_mac_address": "00:0c:29:70:86:09",
           "source_transport_port": 3389,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "community_id": "1:ThxBiPu4noU7F3HVrTJodqLYprw=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "172.16.32.201",
@@ -1342,12 +1419,11 @@
           "mac": "00:0c:29:70:86:09",
           "port": 80
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2015-10-10T08:47:01Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2015-10-10T08:47:01Z",
+          "kind": "event"
         },
         "flow": {
           "id": "QEHbEEyzRwc",
@@ -1368,12 +1444,16 @@
           "source_ipv4_address": "172.16.32.1",
           "source_mac_address": "00:50:56:c0:00:01",
           "source_transport_port": 59168,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "community_id": "1:PtQEU2tjKLZQ3ulraXStL41RrFw=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "172.16.32.1",
@@ -1394,12 +1474,11 @@
           "mac": "00:50:56:c0:00:01",
           "port": 59168
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2015-10-10T08:47:01Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2015-10-10T08:47:01Z",
+          "kind": "event"
         },
         "flow": {
           "id": "In_yyQ3MzQ4",
@@ -1420,12 +1499,16 @@
           "source_ipv4_address": "172.16.32.201",
           "source_mac_address": "00:0c:29:70:86:09",
           "source_transport_port": 80,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "community_id": "1:c9aRRsQSCI2QgP+soSkmLeg4eME=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "172.16.32.201",
@@ -1446,12 +1529,11 @@
           "mac": "00:0c:29:70:86:09",
           "port": 25
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2015-10-10T08:47:01Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2015-10-10T08:47:01Z",
+          "kind": "event"
         },
         "flow": {
           "id": "b69Xoj2gRmY",
@@ -1472,12 +1554,16 @@
           "source_ipv4_address": "172.16.32.1",
           "source_mac_address": "00:50:56:c0:00:01",
           "source_transport_port": 59169,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "community_id": "1:pYvqf9IBjYoaWWbRiwE7BvIF0+U=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "172.16.32.1",
@@ -1498,12 +1584,11 @@
           "mac": "00:50:56:c0:00:01",
           "port": 59169
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2015-10-10T08:47:01Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2015-10-10T08:47:01Z",
+          "kind": "event"
         },
         "flow": {
           "id": "7kt-7t6WhAc",
@@ -1524,12 +1609,16 @@
           "source_ipv4_address": "172.16.32.201",
           "source_mac_address": "00:0c:29:70:86:09",
           "source_transport_port": 25,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "community_id": "1:khchUIbdprQL3CvkhqiO+LfVtOQ=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "172.16.32.201",

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-multiple-netflow-exporters.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-multiple-netflow-exporters.golden.json
@@ -5,12 +5,11 @@
       "Timestamp": "2015-10-08T19:06:29Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
           "action": "netflow_options",
-          "created": "2015-10-08T19:06:29Z"
+          "category": "network_traffic",
+          "created": "2015-10-08T19:06:29Z",
+          "kind": "event"
         },
         "netflow": {
           "exporter": {
@@ -28,6 +27,9 @@
             "octet_delta_count": 0
           },
           "type": "netflow_options"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         }
       },
       "Private": null
@@ -41,14 +43,13 @@
           "locality": "private",
           "port": 123
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2015-10-08T19:04:30Z",
           "duration": 1000000,
           "end": "2015-10-08T19:03:46.141Z",
+          "kind": "event",
           "start": "2015-10-08T19:03:46.14Z"
         },
         "flow": {
@@ -77,14 +78,18 @@
           "source_ipv4_address": "172.16.32.100",
           "source_transport_port": 123,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 76,
           "community_id": "1:cRrWVwyu9GLZ+aU7qmwhjSdMrpE=",
           "direction": "unknown",
+          "iana_number": 17,
           "packets": 1,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "172.16.32.100",
@@ -103,14 +108,13 @@
           "locality": "private",
           "port": 123
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2015-10-08T19:04:30Z",
           "duration": 1000000,
           "end": "2015-10-08T19:03:46.141Z",
+          "kind": "event",
           "start": "2015-10-08T19:03:46.14Z"
         },
         "flow": {
@@ -139,14 +143,18 @@
           "source_ipv4_address": "172.16.32.248",
           "source_transport_port": 123,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 76,
           "community_id": "1:wNJjbHYcMj4lBiVWbMHK1JcgsJ8=",
           "direction": "unknown",
+          "iana_number": 17,
           "packets": 1,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "172.16.32.248",
@@ -165,14 +173,13 @@
           "locality": "private",
           "port": 123
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2015-10-08T19:04:30Z",
           "duration": 1000000,
           "end": "2015-10-08T19:03:51.814Z",
+          "kind": "event",
           "start": "2015-10-08T19:03:51.813Z"
         },
         "flow": {
@@ -201,14 +208,18 @@
           "source_ipv4_address": "172.16.32.100",
           "source_transport_port": 123,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 76,
           "community_id": "1:cRrWVwyu9GLZ+aU7qmwhjSdMrpE=",
           "direction": "unknown",
+          "iana_number": 17,
           "packets": 1,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "172.16.32.100",
@@ -227,14 +238,13 @@
           "locality": "private",
           "port": 123
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2015-10-08T19:04:30Z",
           "duration": 1000000,
           "end": "2015-10-08T19:03:51.814Z",
+          "kind": "event",
           "start": "2015-10-08T19:03:51.813Z"
         },
         "flow": {
@@ -263,14 +273,18 @@
           "source_ipv4_address": "172.16.32.201",
           "source_transport_port": 123,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 76,
           "community_id": "1:mYS5cP5hzhSb8JZH9+2v8+RMJ9g=",
           "direction": "unknown",
+          "iana_number": 17,
           "packets": 1,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "172.16.32.201",
@@ -289,14 +303,13 @@
           "locality": "private",
           "port": 123
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2015-10-08T19:04:30Z",
           "duration": 0,
           "end": "2015-10-08T19:03:55.958Z",
+          "kind": "event",
           "start": "2015-10-08T19:03:55.958Z"
         },
         "flow": {
@@ -325,14 +338,18 @@
           "source_ipv4_address": "172.16.32.100",
           "source_transport_port": 123,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 76,
           "community_id": "1:cRrWVwyu9GLZ+aU7qmwhjSdMrpE=",
           "direction": "unknown",
+          "iana_number": 17,
           "packets": 1,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "172.16.32.100",
@@ -351,14 +368,13 @@
           "locality": "private",
           "port": 123
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2015-10-08T19:04:30Z",
           "duration": 0,
           "end": "2015-10-08T19:03:55.958Z",
+          "kind": "event",
           "start": "2015-10-08T19:03:55.958Z"
         },
         "flow": {
@@ -387,14 +403,18 @@
           "source_ipv4_address": "172.16.32.202",
           "source_transport_port": 123,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 76,
           "community_id": "1:Y7cJ9MH0pPXGOYtewjtnB/Xf2Os=",
           "direction": "unknown",
+          "iana_number": 17,
           "packets": 1,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "172.16.32.202",
@@ -411,14 +431,13 @@
         "destination": {
           "port": 34304
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2015-10-08T19:04:30Z",
           "duration": 38081000000,
           "end": "2015-10-08T19:04:25.9Z",
+          "kind": "event",
           "start": "2015-10-08T19:03:47.819Z"
         },
         "flow": {
@@ -447,14 +466,18 @@
           "source_ipv6_address": "fe80::20c:29ff:fe83:3b6e",
           "source_transport_port": 0,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 672,
           "community_id": "1:vK+Zeop1Y3GHxfFGVF2/COcNBWw=",
           "direction": "unknown",
+          "iana_number": 58,
           "packets": 7,
-          "protocol": "ipv6-icmp"
+          "transport": "ipv6-icmp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "port": 0
@@ -471,14 +494,13 @@
           "locality": "private",
           "port": 65058
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2015-10-08T19:06:29Z",
           "duration": 5000000,
           "end": "2015-10-08T19:05:55.015Z",
+          "kind": "event",
           "start": "2015-10-08T19:05:55.01Z"
         },
         "flow": {
@@ -511,14 +533,18 @@
           "source_ipv4_prefix_length": 0,
           "source_transport_port": 22,
           "tcp_control_bits": 24,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 200,
           "community_id": "1:8pI6JBgAyYEKnrTjwzuiAMlElgY=",
           "direction": "unknown",
+          "iana_number": 6,
           "packets": 2,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "172.16.32.201",

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-nprobe-DPI-L7.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-nprobe-DPI-L7.golden.json
@@ -10,12 +10,11 @@
           "locality": "private",
           "port": 0
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
-          "created": "1970-01-01T00:08:22Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "1970-01-01T00:08:22Z",
+          "kind": "event"
         },
         "flow": {
           "id": "oFN7CMNpOLQ",
@@ -40,14 +39,18 @@
           "protocol_identifier": 0,
           "source_ipv4_address": "0.0.0.0",
           "source_transport_port": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 82,
           "community_id": "1:LFE/FJ5zfsQGP8HTeu6b6rxLS78=",
           "direction": "unknown",
+          "iana_number": 0,
           "packets": 1,
-          "protocol": "unknown (0)"
+          "transport": "unknown (0)"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "0.0.0.0",

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-options-template-with-scope-fields.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-options-template-with-scope-fields.golden.json
@@ -5,12 +5,11 @@
       "Timestamp": "2015-10-08T19:06:29Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
           "action": "netflow_options",
-          "created": "2015-10-08T19:06:29Z"
+          "category": "network_traffic",
+          "created": "2015-10-08T19:06:29Z",
+          "kind": "event"
         },
         "netflow": {
           "exporter": {
@@ -28,6 +27,9 @@
             "octet_delta_count": 0
           },
           "type": "netflow_options"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         }
       },
       "Private": null

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-template-with-0-length-fields.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-template-with-0-length-fields.golden.json
@@ -10,14 +10,13 @@
           "locality": "private",
           "port": 0
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2016-12-23T01:35:31Z",
           "duration": 0,
           "end": "2016-12-23T01:34:48.299Z",
+          "kind": "event",
           "start": "2016-12-23T01:34:48.299Z"
         },
         "flow": {
@@ -50,14 +49,18 @@
           "source_ipv4_prefix_length": 32,
           "source_transport_port": 0,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 0,
           "community_id": "1:PrM3BB+zl6s0dy/nMB1KOgnPLyM=",
           "direction": "outbound",
+          "iana_number": 2,
           "packets": 0,
-          "protocol": "unknown (2)"
+          "transport": "unknown (2)"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "239.255.255.250",
@@ -76,14 +79,13 @@
           "locality": "public",
           "port": 0
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2016-12-23T01:35:31Z",
           "duration": 0,
           "end": "2016-12-23T01:34:48.299Z",
+          "kind": "event",
           "start": "2016-12-23T01:34:48.299Z"
         },
         "flow": {
@@ -116,14 +118,18 @@
           "source_ipv4_prefix_length": 32,
           "source_transport_port": 0,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 0,
           "community_id": "1:iOW2w0b8tPUYnP8m2LWGTS2Eh7k=",
           "direction": "outbound",
+          "iana_number": 2,
           "packets": 0,
-          "protocol": "unknown (2)"
+          "transport": "unknown (2)"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.1.80",
@@ -142,14 +148,13 @@
           "locality": "private",
           "port": 0
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2016-12-23T01:35:31Z",
           "duration": 0,
           "end": "2016-12-23T01:34:51.469Z",
+          "kind": "event",
           "start": "2016-12-23T01:34:51.469Z"
         },
         "flow": {
@@ -182,14 +187,18 @@
           "source_ipv4_prefix_length": 32,
           "source_transport_port": 0,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 0,
           "community_id": "1:PrM3BB+zl6s0dy/nMB1KOgnPLyM=",
           "direction": "inbound",
+          "iana_number": 2,
           "packets": 0,
-          "protocol": "unknown (2)"
+          "transport": "unknown (2)"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "239.255.255.250",
@@ -208,14 +217,13 @@
           "locality": "public",
           "port": 0
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2016-12-23T01:35:31Z",
           "duration": 0,
           "end": "2016-12-23T01:34:51.469Z",
+          "kind": "event",
           "start": "2016-12-23T01:34:51.469Z"
         },
         "flow": {
@@ -248,14 +256,18 @@
           "source_ipv4_prefix_length": 32,
           "source_transport_port": 0,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 32,
           "community_id": "1:COeL8zADqbleGkd4vi2Pz6V+2rc=",
           "direction": "inbound",
+          "iana_number": 2,
           "packets": 1,
-          "protocol": "unknown (2)"
+          "transport": "unknown (2)"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.1.95",
@@ -274,14 +286,13 @@
           "locality": "private",
           "port": 0
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2016-12-23T01:35:31Z",
           "duration": 0,
           "end": "2016-12-23T01:34:51.469Z",
+          "kind": "event",
           "start": "2016-12-23T01:34:51.469Z"
         },
         "flow": {
@@ -314,14 +325,18 @@
           "source_ipv4_prefix_length": 32,
           "source_transport_port": 0,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 0,
           "community_id": "1:PrM3BB+zl6s0dy/nMB1KOgnPLyM=",
           "direction": "outbound",
+          "iana_number": 2,
           "packets": 0,
-          "protocol": "unknown (2)"
+          "transport": "unknown (2)"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "239.255.255.250",
@@ -340,14 +355,13 @@
           "locality": "public",
           "port": 0
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2016-12-23T01:35:31Z",
           "duration": 0,
           "end": "2016-12-23T01:34:51.469Z",
+          "kind": "event",
           "start": "2016-12-23T01:34:51.469Z"
         },
         "flow": {
@@ -380,14 +394,18 @@
           "source_ipv4_prefix_length": 32,
           "source_transport_port": 0,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 0,
           "community_id": "1:COeL8zADqbleGkd4vi2Pz6V+2rc=",
           "direction": "outbound",
+          "iana_number": 2,
           "packets": 0,
-          "protocol": "unknown (2)"
+          "transport": "unknown (2)"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.1.95",
@@ -406,14 +424,13 @@
           "locality": "private",
           "port": 0
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2016-12-23T01:35:31Z",
           "duration": 0,
           "end": "2016-12-23T01:34:51.569Z",
+          "kind": "event",
           "start": "2016-12-23T01:34:51.569Z"
         },
         "flow": {
@@ -446,14 +463,18 @@
           "source_ipv4_prefix_length": 32,
           "source_transport_port": 0,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 0,
           "community_id": "1:PrM3BB+zl6s0dy/nMB1KOgnPLyM=",
           "direction": "inbound",
+          "iana_number": 2,
           "packets": 0,
-          "protocol": "unknown (2)"
+          "transport": "unknown (2)"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "239.255.255.250",
@@ -472,14 +493,13 @@
           "locality": "public",
           "port": 0
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2016-12-23T01:35:31Z",
           "duration": 0,
           "end": "2016-12-23T01:34:51.569Z",
+          "kind": "event",
           "start": "2016-12-23T01:34:51.569Z"
         },
         "flow": {
@@ -512,14 +532,18 @@
           "source_ipv4_prefix_length": 32,
           "source_transport_port": 0,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 32,
           "community_id": "1:1EE7w6YWICk3nCsh+iZkgYDDczE=",
           "direction": "inbound",
+          "iana_number": 2,
           "packets": 1,
-          "protocol": "unknown (2)"
+          "transport": "unknown (2)"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.1.33",
@@ -538,14 +562,13 @@
           "locality": "private",
           "port": 0
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2016-12-23T01:35:31Z",
           "duration": 0,
           "end": "2016-12-23T01:34:51.569Z",
+          "kind": "event",
           "start": "2016-12-23T01:34:51.569Z"
         },
         "flow": {
@@ -578,14 +601,18 @@
           "source_ipv4_prefix_length": 32,
           "source_transport_port": 0,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 0,
           "community_id": "1:PrM3BB+zl6s0dy/nMB1KOgnPLyM=",
           "direction": "outbound",
+          "iana_number": 2,
           "packets": 0,
-          "protocol": "unknown (2)"
+          "transport": "unknown (2)"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "239.255.255.250",
@@ -604,14 +631,13 @@
           "locality": "public",
           "port": 0
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2016-12-23T01:35:31Z",
           "duration": 0,
           "end": "2016-12-23T01:34:51.569Z",
+          "kind": "event",
           "start": "2016-12-23T01:34:51.569Z"
         },
         "flow": {
@@ -644,14 +670,18 @@
           "source_ipv4_prefix_length": 32,
           "source_transport_port": 0,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 0,
           "community_id": "1:1EE7w6YWICk3nCsh+iZkgYDDczE=",
           "direction": "outbound",
+          "iana_number": 2,
           "packets": 0,
-          "protocol": "unknown (2)"
+          "transport": "unknown (2)"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "192.168.1.33",

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-valid-01.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-valid-01.golden.json
@@ -10,14 +10,13 @@
           "locality": "private",
           "port": 123
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2015-10-08T19:04:30Z",
           "duration": 1000000,
           "end": "2015-10-08T19:03:46.141Z",
+          "kind": "event",
           "start": "2015-10-08T19:03:46.14Z"
         },
         "flow": {
@@ -46,14 +45,18 @@
           "source_ipv4_address": "172.16.32.100",
           "source_transport_port": 123,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 76,
           "community_id": "1:cRrWVwyu9GLZ+aU7qmwhjSdMrpE=",
           "direction": "unknown",
+          "iana_number": 17,
           "packets": 1,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "172.16.32.100",
@@ -72,14 +75,13 @@
           "locality": "private",
           "port": 123
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2015-10-08T19:04:30Z",
           "duration": 1000000,
           "end": "2015-10-08T19:03:46.141Z",
+          "kind": "event",
           "start": "2015-10-08T19:03:46.14Z"
         },
         "flow": {
@@ -108,14 +110,18 @@
           "source_ipv4_address": "172.16.32.248",
           "source_transport_port": 123,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 76,
           "community_id": "1:wNJjbHYcMj4lBiVWbMHK1JcgsJ8=",
           "direction": "unknown",
+          "iana_number": 17,
           "packets": 1,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "172.16.32.248",
@@ -134,14 +140,13 @@
           "locality": "private",
           "port": 123
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2015-10-08T19:04:30Z",
           "duration": 1000000,
           "end": "2015-10-08T19:03:51.814Z",
+          "kind": "event",
           "start": "2015-10-08T19:03:51.813Z"
         },
         "flow": {
@@ -170,14 +175,18 @@
           "source_ipv4_address": "172.16.32.100",
           "source_transport_port": 123,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 76,
           "community_id": "1:cRrWVwyu9GLZ+aU7qmwhjSdMrpE=",
           "direction": "unknown",
+          "iana_number": 17,
           "packets": 1,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "172.16.32.100",
@@ -196,14 +205,13 @@
           "locality": "private",
           "port": 123
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2015-10-08T19:04:30Z",
           "duration": 1000000,
           "end": "2015-10-08T19:03:51.814Z",
+          "kind": "event",
           "start": "2015-10-08T19:03:51.813Z"
         },
         "flow": {
@@ -232,14 +240,18 @@
           "source_ipv4_address": "172.16.32.201",
           "source_transport_port": 123,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 76,
           "community_id": "1:mYS5cP5hzhSb8JZH9+2v8+RMJ9g=",
           "direction": "unknown",
+          "iana_number": 17,
           "packets": 1,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "172.16.32.201",
@@ -258,14 +270,13 @@
           "locality": "private",
           "port": 123
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2015-10-08T19:04:30Z",
           "duration": 0,
           "end": "2015-10-08T19:03:55.958Z",
+          "kind": "event",
           "start": "2015-10-08T19:03:55.958Z"
         },
         "flow": {
@@ -294,14 +305,18 @@
           "source_ipv4_address": "172.16.32.100",
           "source_transport_port": 123,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 76,
           "community_id": "1:cRrWVwyu9GLZ+aU7qmwhjSdMrpE=",
           "direction": "unknown",
+          "iana_number": 17,
           "packets": 1,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "172.16.32.100",
@@ -320,14 +335,13 @@
           "locality": "private",
           "port": 123
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2015-10-08T19:04:30Z",
           "duration": 0,
           "end": "2015-10-08T19:03:55.958Z",
+          "kind": "event",
           "start": "2015-10-08T19:03:55.958Z"
         },
         "flow": {
@@ -356,14 +370,18 @@
           "source_ipv4_address": "172.16.32.202",
           "source_transport_port": 123,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 76,
           "community_id": "1:Y7cJ9MH0pPXGOYtewjtnB/Xf2Os=",
           "direction": "unknown",
+          "iana_number": 17,
           "packets": 1,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "ip": "172.16.32.202",
@@ -380,14 +398,13 @@
         "destination": {
           "port": 34304
         },
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2015-10-08T19:04:30Z",
           "duration": 38081000000,
           "end": "2015-10-08T19:04:25.9Z",
+          "kind": "event",
           "start": "2015-10-08T19:03:47.819Z"
         },
         "flow": {
@@ -416,14 +433,18 @@
           "source_ipv6_address": "fe80::20c:29ff:fe83:3b6e",
           "source_transport_port": 0,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 672,
           "community_id": "1:vK+Zeop1Y3GHxfFGVF2/COcNBWw=",
           "direction": "unknown",
+          "iana_number": 58,
           "packets": 7,
-          "protocol": "ipv6-icmp"
+          "transport": "ipv6-icmp"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         },
         "source_ecs": {
           "port": 0

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow9-Juniper-SRX-options-template-with-0-scope-field-length.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow9-Juniper-SRX-options-template-with-0-scope-field-length.golden.json
@@ -5,12 +5,11 @@
       "Timestamp": "2016-11-29T00:21:56Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "192.0.2.1"
-        },
         "event": {
           "action": "netflow_options",
-          "created": "2016-11-29T00:21:56Z"
+          "category": "network_traffic",
+          "created": "2016-11-29T00:21:56Z",
+          "kind": "event"
         },
         "netflow": {
           "exporter": {
@@ -26,6 +25,9 @@
           },
           "scope": {},
           "type": "netflow_options"
+        },
+        "observer": {
+          "ip": "192.0.2.1"
         }
       },
       "Private": null

--- a/x-pack/filebeat/input/netflow/testdata/golden/ipfix_cisco.pcap.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/ipfix_cisco.pcap.golden.json
@@ -5,12 +5,11 @@
       "Timestamp": "2018-07-03T10:47:00Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "10.101.255.2"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2018-07-03T10:47:00Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2018-07-03T10:47:00Z",
+          "kind": "event"
         },
         "flow": {
           "id": "Vhs9T5k296w",
@@ -52,14 +51,18 @@
           "protocol_identifier": 6,
           "responder_octets": 0,
           "responder_packets": 0,
-          "type": "netflow",
+          "type": "netflow_flow",
           "vlan_id": 0,
           "waasoptimization_segment": 16
         },
         "network": {
           "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "10.101.255.2"
         }
       },
       "Private": null
@@ -68,12 +71,11 @@
       "Timestamp": "2018-07-03T10:47:00Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "10.101.255.2"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2018-07-03T10:47:00Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2018-07-03T10:47:00Z",
+          "kind": "event"
         },
         "flow": {
           "id": "Vhs9T5k296w",
@@ -115,14 +117,18 @@
           "protocol_identifier": 6,
           "responder_octets": 0,
           "responder_packets": 0,
-          "type": "netflow",
+          "type": "netflow_flow",
           "vlan_id": 0,
           "waasoptimization_segment": 16
         },
         "network": {
           "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "10.101.255.2"
         }
       },
       "Private": null
@@ -131,12 +137,11 @@
       "Timestamp": "2018-07-03T10:47:00Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "10.101.255.2"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2018-07-03T10:47:00Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2018-07-03T10:47:00Z",
+          "kind": "event"
         },
         "flow": {
           "id": "Vhs9T5k296w",
@@ -178,14 +183,18 @@
           "protocol_identifier": 6,
           "responder_octets": 0,
           "responder_packets": 1,
-          "type": "netflow",
+          "type": "netflow_flow",
           "vlan_id": 290,
           "waasoptimization_segment": 16
         },
         "network": {
           "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "10.101.255.2"
         }
       },
       "Private": null
@@ -194,12 +203,11 @@
       "Timestamp": "2018-07-03T10:47:00Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "10.101.255.2"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2018-07-03T10:47:00Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2018-07-03T10:47:00Z",
+          "kind": "event"
         },
         "flow": {
           "id": "Vhs9T5k296w",
@@ -241,14 +249,18 @@
           "protocol_identifier": 6,
           "responder_octets": 0,
           "responder_packets": 0,
-          "type": "netflow",
+          "type": "netflow_flow",
           "vlan_id": 0,
           "waasoptimization_segment": 16
         },
         "network": {
           "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "10.101.255.2"
         }
       },
       "Private": null
@@ -257,12 +269,11 @@
       "Timestamp": "2018-07-03T10:47:00Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "10.101.255.2"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2018-07-03T10:47:00Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2018-07-03T10:47:00Z",
+          "kind": "event"
         },
         "flow": {
           "id": "Vhs9T5k296w",
@@ -304,14 +315,18 @@
           "protocol_identifier": 6,
           "responder_octets": 0,
           "responder_packets": 0,
-          "type": "netflow",
+          "type": "netflow_flow",
           "vlan_id": 0,
           "waasoptimization_segment": 16
         },
         "network": {
           "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "10.101.255.2"
         }
       },
       "Private": null
@@ -320,12 +335,11 @@
       "Timestamp": "2018-07-03T10:47:00Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "10.101.255.2"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2018-07-03T10:47:00Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2018-07-03T10:47:00Z",
+          "kind": "event"
         },
         "flow": {
           "id": "Vhs9T5k296w",
@@ -367,14 +381,18 @@
           "protocol_identifier": 6,
           "responder_octets": 9437,
           "responder_packets": 18,
-          "type": "netflow",
+          "type": "netflow_flow",
           "vlan_id": 290,
           "waasoptimization_segment": 16
         },
         "network": {
           "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "10.101.255.2"
         }
       },
       "Private": null
@@ -383,12 +401,11 @@
       "Timestamp": "2018-07-03T10:47:00Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "10.101.255.2"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2018-07-03T10:47:00Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2018-07-03T10:47:00Z",
+          "kind": "event"
         },
         "flow": {
           "id": "Vhs9T5k296w",
@@ -430,14 +447,18 @@
           "protocol_identifier": 6,
           "responder_octets": 0,
           "responder_packets": 0,
-          "type": "netflow",
+          "type": "netflow_flow",
           "vlan_id": 0,
           "waasoptimization_segment": 16
         },
         "network": {
           "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "10.101.255.2"
         }
       },
       "Private": null
@@ -446,12 +467,11 @@
       "Timestamp": "2018-07-03T10:47:00Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "10.101.255.2"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2018-07-03T10:47:00Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2018-07-03T10:47:00Z",
+          "kind": "event"
         },
         "flow": {
           "id": "Vhs9T5k296w",
@@ -493,14 +513,18 @@
           "protocol_identifier": 6,
           "responder_octets": 36894,
           "responder_packets": 47,
-          "type": "netflow",
+          "type": "netflow_flow",
           "vlan_id": 290,
           "waasoptimization_segment": 16
         },
         "network": {
           "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "10.101.255.2"
         }
       },
       "Private": null
@@ -509,12 +533,11 @@
       "Timestamp": "2018-07-03T10:47:00Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "10.101.255.2"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2018-07-03T10:47:00Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2018-07-03T10:47:00Z",
+          "kind": "event"
         },
         "flow": {
           "id": "Vhs9T5k296w",
@@ -556,14 +579,18 @@
           "protocol_identifier": 6,
           "responder_octets": 6533,
           "responder_packets": 14,
-          "type": "netflow",
+          "type": "netflow_flow",
           "vlan_id": 0,
           "waasoptimization_segment": 16
         },
         "network": {
           "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "10.101.255.2"
         }
       },
       "Private": null
@@ -572,12 +599,11 @@
       "Timestamp": "2018-07-03T10:47:00Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "10.101.255.2"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2018-07-03T10:47:00Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2018-07-03T10:47:00Z",
+          "kind": "event"
         },
         "flow": {
           "id": "Vhs9T5k296w",
@@ -619,14 +645,18 @@
           "protocol_identifier": 6,
           "responder_octets": 0,
           "responder_packets": 0,
-          "type": "netflow",
+          "type": "netflow_flow",
           "vlan_id": 290,
           "waasoptimization_segment": 16
         },
         "network": {
           "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "10.101.255.2"
         }
       },
       "Private": null
@@ -635,12 +665,11 @@
       "Timestamp": "2018-07-03T10:47:00Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "10.101.255.2"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2018-07-03T10:47:00Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2018-07-03T10:47:00Z",
+          "kind": "event"
         },
         "flow": {
           "id": "Vhs9T5k296w",
@@ -682,14 +711,18 @@
           "protocol_identifier": 6,
           "responder_octets": 0,
           "responder_packets": 0,
-          "type": "netflow",
+          "type": "netflow_flow",
           "vlan_id": 290,
           "waasoptimization_segment": 16
         },
         "network": {
           "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "10.101.255.2"
         }
       },
       "Private": null
@@ -698,12 +731,11 @@
       "Timestamp": "2018-07-03T10:47:00Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "10.101.255.2"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2018-07-03T10:47:00Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2018-07-03T10:47:00Z",
+          "kind": "event"
         },
         "flow": {
           "id": "Vhs9T5k296w",
@@ -745,14 +777,18 @@
           "protocol_identifier": 6,
           "responder_octets": 138,
           "responder_packets": 4,
-          "type": "netflow",
+          "type": "netflow_flow",
           "vlan_id": 0,
           "waasoptimization_segment": 16
         },
         "network": {
           "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "10.101.255.2"
         }
       },
       "Private": null
@@ -761,12 +797,11 @@
       "Timestamp": "2018-07-03T10:47:00Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "10.101.255.2"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2018-07-03T10:47:00Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2018-07-03T10:47:00Z",
+          "kind": "event"
         },
         "flow": {
           "id": "Vhs9T5k296w",
@@ -808,14 +843,18 @@
           "protocol_identifier": 6,
           "responder_octets": 0,
           "responder_packets": 0,
-          "type": "netflow",
+          "type": "netflow_flow",
           "vlan_id": 290,
           "waasoptimization_segment": 16
         },
         "network": {
           "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "10.101.255.2"
         }
       },
       "Private": null
@@ -824,12 +863,11 @@
       "Timestamp": "2018-07-03T10:47:00Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "10.101.255.2"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2018-07-03T10:47:00Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2018-07-03T10:47:00Z",
+          "kind": "event"
         },
         "flow": {
           "id": "Vhs9T5k296w",
@@ -871,14 +909,18 @@
           "protocol_identifier": 6,
           "responder_octets": 6079,
           "responder_packets": 10,
-          "type": "netflow",
+          "type": "netflow_flow",
           "vlan_id": 0,
           "waasoptimization_segment": 16
         },
         "network": {
           "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "10.101.255.2"
         }
       },
       "Private": null
@@ -887,12 +929,11 @@
       "Timestamp": "2018-07-03T10:47:00Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "10.101.255.2"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2018-07-03T10:47:00Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2018-07-03T10:47:00Z",
+          "kind": "event"
         },
         "flow": {
           "id": "Vhs9T5k296w",
@@ -934,14 +975,18 @@
           "protocol_identifier": 6,
           "responder_octets": 0,
           "responder_packets": 0,
-          "type": "netflow",
+          "type": "netflow_flow",
           "vlan_id": 0,
           "waasoptimization_segment": 16
         },
         "network": {
           "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "10.101.255.2"
         }
       },
       "Private": null
@@ -950,12 +995,11 @@
       "Timestamp": "2018-07-03T10:47:00Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "10.101.255.2"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2018-07-03T10:47:00Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2018-07-03T10:47:00Z",
+          "kind": "event"
         },
         "flow": {
           "id": "Vhs9T5k296w",
@@ -997,14 +1041,18 @@
           "protocol_identifier": 6,
           "responder_octets": 0,
           "responder_packets": 0,
-          "type": "netflow",
+          "type": "netflow_flow",
           "vlan_id": 0,
           "waasoptimization_segment": 16
         },
         "network": {
           "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "10.101.255.2"
         }
       },
       "Private": null
@@ -1013,12 +1061,11 @@
       "Timestamp": "2018-07-03T10:47:00Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "10.101.255.2"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2018-07-03T10:47:00Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2018-07-03T10:47:00Z",
+          "kind": "event"
         },
         "flow": {
           "id": "Vhs9T5k296w",
@@ -1060,14 +1107,18 @@
           "protocol_identifier": 6,
           "responder_octets": 3409,
           "responder_packets": 7,
-          "type": "netflow",
+          "type": "netflow_flow",
           "vlan_id": 290,
           "waasoptimization_segment": 16
         },
         "network": {
           "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "10.101.255.2"
         }
       },
       "Private": null
@@ -1076,12 +1127,11 @@
       "Timestamp": "2018-07-03T10:47:00Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "10.101.255.2"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2018-07-03T10:47:00Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2018-07-03T10:47:00Z",
+          "kind": "event"
         },
         "flow": {
           "id": "Vhs9T5k296w",
@@ -1123,14 +1173,18 @@
           "protocol_identifier": 6,
           "responder_octets": 0,
           "responder_packets": 0,
-          "type": "netflow",
+          "type": "netflow_flow",
           "vlan_id": 0,
           "waasoptimization_segment": 16
         },
         "network": {
           "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "10.101.255.2"
         }
       },
       "Private": null
@@ -1139,12 +1193,11 @@
       "Timestamp": "2018-07-03T10:47:00Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "10.101.255.2"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2018-07-03T10:47:00Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2018-07-03T10:47:00Z",
+          "kind": "event"
         },
         "flow": {
           "id": "Vhs9T5k296w",
@@ -1186,14 +1239,18 @@
           "protocol_identifier": 6,
           "responder_octets": 0,
           "responder_packets": 0,
-          "type": "netflow",
+          "type": "netflow_flow",
           "vlan_id": 0,
           "waasoptimization_segment": 16
         },
         "network": {
           "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "10.101.255.2"
         }
       },
       "Private": null
@@ -1202,12 +1259,11 @@
       "Timestamp": "2018-07-03T10:47:00Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "10.101.255.2"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2018-07-03T10:47:00Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2018-07-03T10:47:00Z",
+          "kind": "event"
         },
         "flow": {
           "id": "Vhs9T5k296w",
@@ -1249,14 +1305,18 @@
           "protocol_identifier": 6,
           "responder_octets": 6305,
           "responder_packets": 15,
-          "type": "netflow",
+          "type": "netflow_flow",
           "vlan_id": 290,
           "waasoptimization_segment": 16
         },
         "network": {
           "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "10.101.255.2"
         }
       },
       "Private": null
@@ -1265,12 +1325,11 @@
       "Timestamp": "2018-07-03T10:47:00Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "10.101.255.2"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2018-07-03T10:47:00Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2018-07-03T10:47:00Z",
+          "kind": "event"
         },
         "flow": {
           "id": "Vhs9T5k296w",
@@ -1312,14 +1371,18 @@
           "protocol_identifier": 6,
           "responder_octets": 3110,
           "responder_packets": 7,
-          "type": "netflow",
+          "type": "netflow_flow",
           "vlan_id": 0,
           "waasoptimization_segment": 16
         },
         "network": {
           "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "10.101.255.2"
         }
       },
       "Private": null
@@ -1328,12 +1391,11 @@
       "Timestamp": "2018-07-03T10:47:00Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "10.101.255.2"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2018-07-03T10:47:00Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2018-07-03T10:47:00Z",
+          "kind": "event"
         },
         "flow": {
           "id": "Vhs9T5k296w",
@@ -1375,14 +1437,18 @@
           "protocol_identifier": 6,
           "responder_octets": 2,
           "responder_packets": 4,
-          "type": "netflow",
+          "type": "netflow_flow",
           "vlan_id": 0,
           "waasoptimization_segment": 16
         },
         "network": {
           "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "10.101.255.2"
         }
       },
       "Private": null
@@ -1391,12 +1457,11 @@
       "Timestamp": "2018-07-03T10:47:00Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "10.101.255.2"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2018-07-03T10:47:00Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2018-07-03T10:47:00Z",
+          "kind": "event"
         },
         "flow": {
           "id": "Vhs9T5k296w",
@@ -1438,14 +1503,18 @@
           "protocol_identifier": 6,
           "responder_octets": 0,
           "responder_packets": 2,
-          "type": "netflow",
+          "type": "netflow_flow",
           "vlan_id": 290,
           "waasoptimization_segment": 16
         },
         "network": {
           "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "10.101.255.2"
         }
       },
       "Private": null
@@ -1454,12 +1523,11 @@
       "Timestamp": "2018-07-03T10:47:00Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "10.101.255.2"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2018-07-03T10:47:00Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2018-07-03T10:47:00Z",
+          "kind": "event"
         },
         "flow": {
           "id": "Vhs9T5k296w",
@@ -1501,14 +1569,18 @@
           "protocol_identifier": 6,
           "responder_octets": 0,
           "responder_packets": 2,
-          "type": "netflow",
+          "type": "netflow_flow",
           "vlan_id": 290,
           "waasoptimization_segment": 16
         },
         "network": {
           "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "10.101.255.2"
         }
       },
       "Private": null
@@ -1517,12 +1589,11 @@
       "Timestamp": "2018-07-03T10:47:00Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "10.101.255.2"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2018-07-03T10:47:00Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2018-07-03T10:47:00Z",
+          "kind": "event"
         },
         "flow": {
           "id": "Vhs9T5k296w",
@@ -1564,14 +1635,18 @@
           "protocol_identifier": 6,
           "responder_octets": 174,
           "responder_packets": 3,
-          "type": "netflow",
+          "type": "netflow_flow",
           "vlan_id": 290,
           "waasoptimization_segment": 16
         },
         "network": {
           "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "10.101.255.2"
         }
       },
       "Private": null
@@ -1580,12 +1655,11 @@
       "Timestamp": "2018-07-03T10:47:00Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "10.101.255.2"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2018-07-03T10:47:00Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2018-07-03T10:47:00Z",
+          "kind": "event"
         },
         "flow": {
           "id": "Vhs9T5k296w",
@@ -1627,14 +1701,18 @@
           "protocol_identifier": 6,
           "responder_octets": 138,
           "responder_packets": 4,
-          "type": "netflow",
+          "type": "netflow_flow",
           "vlan_id": 0,
           "waasoptimization_segment": 16
         },
         "network": {
           "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "10.101.255.2"
         }
       },
       "Private": null
@@ -1643,12 +1721,11 @@
       "Timestamp": "2018-07-03T10:47:00Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "10.101.255.2"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2018-07-03T10:47:00Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2018-07-03T10:47:00Z",
+          "kind": "event"
         },
         "flow": {
           "id": "Vhs9T5k296w",
@@ -1690,14 +1767,18 @@
           "protocol_identifier": 6,
           "responder_octets": 31,
           "responder_packets": 2,
-          "type": "netflow",
+          "type": "netflow_flow",
           "vlan_id": 0,
           "waasoptimization_segment": 16
         },
         "network": {
           "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "10.101.255.2"
         }
       },
       "Private": null
@@ -1706,12 +1787,11 @@
       "Timestamp": "2018-07-03T10:47:00Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "10.101.255.2"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2018-07-03T10:47:00Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2018-07-03T10:47:00Z",
+          "kind": "event"
         },
         "flow": {
           "id": "Vhs9T5k296w",
@@ -1753,14 +1833,18 @@
           "protocol_identifier": 6,
           "responder_octets": 13482,
           "responder_packets": 17,
-          "type": "netflow",
+          "type": "netflow_flow",
           "vlan_id": 0,
           "waasoptimization_segment": 16
         },
         "network": {
           "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "10.101.255.2"
         }
       },
       "Private": null
@@ -1769,12 +1853,11 @@
       "Timestamp": "2018-07-03T10:47:00Z",
       "Meta": null,
       "Fields": {
-        "device": {
-          "ip": "10.101.255.2"
-        },
         "event": {
-          "action": "netflow",
-          "created": "2018-07-03T10:47:00Z"
+          "action": "netflow_flow",
+          "category": "network_traffic",
+          "created": "2018-07-03T10:47:00Z",
+          "kind": "event"
         },
         "flow": {
           "id": "Vhs9T5k296w",
@@ -1816,14 +1899,18 @@
           "protocol_identifier": 6,
           "responder_octets": 28373,
           "responder_packets": 133,
-          "type": "netflow",
+          "type": "netflow_flow",
           "vlan_id": 0,
           "waasoptimization_segment": 16
         },
         "network": {
           "community_id": "1:idwO/QHAjbcGlF1bfQE9dPuu7T0=",
           "direction": "unknown",
-          "protocol": "tcp"
+          "iana_number": 6,
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "10.101.255.2"
         }
       },
       "Private": null

--- a/x-pack/filebeat/input/netflow/testdata/golden/netflow9_ubiquiti_edgerouter.pcap.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/netflow9_ubiquiti_edgerouter.pcap.golden.json
@@ -10,14 +10,13 @@
           "locality": "public",
           "port": 80
         },
-        "device": {
-          "ip": "10.100.4.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2018-08-09T16:49:04Z",
           "duration": 287000000,
           "end": "2018-08-09T16:43:00.307Z",
+          "kind": "event",
           "start": "2018-08-09T16:43:00.02Z"
         },
         "flow": {
@@ -52,14 +51,18 @@
           "source_ipv4_address": "10.100.5.2",
           "source_transport_port": 43376,
           "tcp_control_bits": 27,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 421,
           "community_id": "1:c3a8HfldOuX4/xBvf0sHuy38GTk=",
           "direction": "outbound",
+          "iana_number": 6,
           "packets": 6,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "10.100.4.1"
         },
         "source_ecs": {
           "ip": "10.100.5.2",
@@ -78,14 +81,13 @@
           "locality": "public",
           "port": 443
         },
-        "device": {
-          "ip": "10.100.4.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2018-08-09T16:49:04Z",
           "duration": 30209000000,
           "end": "2018-08-09T16:43:01.317Z",
+          "kind": "event",
           "start": "2018-08-09T16:42:31.108Z"
         },
         "flow": {
@@ -120,14 +122,18 @@
           "source_ipv4_address": "10.100.6.93",
           "source_transport_port": 54520,
           "tcp_control_bits": 27,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 7621,
           "community_id": "1:ZNEMnnkXh6LJsCtYCHWkxVCOl9E=",
           "direction": "outbound",
+          "iana_number": 6,
           "packets": 131,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "10.100.4.1"
         },
         "source_ecs": {
           "ip": "10.100.6.93",
@@ -146,14 +152,13 @@
           "locality": "private",
           "port": 62323
         },
-        "device": {
-          "ip": "10.100.4.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2018-08-09T16:49:04Z",
           "duration": 0,
           "end": "2018-08-09T16:43:01.41Z",
+          "kind": "event",
           "start": "2018-08-09T16:43:01.41Z"
         },
         "flow": {
@@ -188,14 +193,18 @@
           "source_ipv4_address": "10.100.4.1",
           "source_transport_port": 53,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 95,
           "community_id": "1:XdJd2ziZmmG1mSIxfvlr6ecG4pM=",
           "direction": "outbound",
+          "iana_number": 17,
           "packets": 1,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "10.100.4.1"
         },
         "source_ecs": {
           "ip": "10.100.4.1",
@@ -214,14 +223,13 @@
           "locality": "public",
           "port": 443
         },
-        "device": {
-          "ip": "10.100.4.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2018-08-09T16:49:04Z",
           "duration": 59651000000,
           "end": "2018-08-09T16:43:02.334Z",
+          "kind": "event",
           "start": "2018-08-09T16:42:02.683Z"
         },
         "flow": {
@@ -256,14 +264,18 @@
           "source_ipv4_address": "10.100.6.93",
           "source_transport_port": 54497,
           "tcp_control_bits": 27,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 3162,
           "community_id": "1:+80+CdeOLSths8RQiqHUoqr8qrU=",
           "direction": "outbound",
+          "iana_number": 6,
           "packets": 30,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "10.100.4.1"
         },
         "source_ecs": {
           "ip": "10.100.6.93",
@@ -282,14 +294,13 @@
           "locality": "public",
           "port": 443
         },
-        "device": {
-          "ip": "10.100.4.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2018-08-09T16:49:04Z",
           "duration": 40015000000,
           "end": "2018-08-09T16:43:02.876Z",
+          "kind": "event",
           "start": "2018-08-09T16:42:22.861Z"
         },
         "flow": {
@@ -324,14 +335,18 @@
           "source_ipv4_address": "10.100.6.80",
           "source_transport_port": 50030,
           "tcp_control_bits": 27,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 2711,
           "community_id": "1:3s9tK3Ncm1BXFpA8+hBpk22sg0c=",
           "direction": "outbound",
+          "iana_number": 6,
           "packets": 13,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "10.100.4.1"
         },
         "source_ecs": {
           "ip": "10.100.6.80",
@@ -350,14 +365,13 @@
           "locality": "public",
           "port": 443
         },
-        "device": {
-          "ip": "10.100.4.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2018-08-09T16:49:04Z",
           "duration": 37121000000,
           "end": "2018-08-09T16:43:02.43Z",
+          "kind": "event",
           "start": "2018-08-09T16:42:25.309Z"
         },
         "flow": {
@@ -392,14 +406,18 @@
           "source_ipv4_address": "10.100.6.93",
           "source_transport_port": 54517,
           "tcp_control_bits": 27,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 20855,
           "community_id": "1:3w94g30M+cTZZskO9dmazwtDHo8=",
           "direction": "outbound",
+          "iana_number": 6,
           "packets": 346,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "10.100.4.1"
         },
         "source_ecs": {
           "ip": "10.100.6.93",
@@ -418,14 +436,13 @@
           "locality": "public",
           "port": 443
         },
-        "device": {
-          "ip": "10.100.4.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2018-08-09T16:49:04Z",
           "duration": 31322000000,
           "end": "2018-08-09T16:43:02.43Z",
+          "kind": "event",
           "start": "2018-08-09T16:42:31.108Z"
         },
         "flow": {
@@ -460,14 +477,18 @@
           "source_ipv4_address": "10.100.6.93",
           "source_transport_port": 54518,
           "tcp_control_bits": 27,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 7495,
           "community_id": "1:XE7UjW9QNWzM1F452q/jPfC4C90=",
           "direction": "outbound",
+          "iana_number": 6,
           "packets": 129,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "10.100.4.1"
         },
         "source_ecs": {
           "ip": "10.100.6.93",
@@ -486,14 +507,13 @@
           "locality": "public",
           "port": 443
         },
-        "device": {
-          "ip": "10.100.4.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2018-08-09T16:49:04Z",
           "duration": 31226000000,
           "end": "2018-08-09T16:43:02.334Z",
+          "kind": "event",
           "start": "2018-08-09T16:42:31.108Z"
         },
         "flow": {
@@ -528,14 +548,18 @@
           "source_ipv4_address": "10.100.6.93",
           "source_transport_port": 54519,
           "tcp_control_bits": 27,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 7049,
           "community_id": "1:CJ9T/03SqwG5Yy7WmXADUqvvgvw=",
           "direction": "outbound",
+          "iana_number": 6,
           "packets": 119,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "10.100.4.1"
         },
         "source_ecs": {
           "ip": "10.100.6.93",
@@ -554,14 +578,13 @@
           "locality": "public",
           "port": 443
         },
-        "device": {
-          "ip": "10.100.4.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2018-08-09T16:49:04Z",
           "duration": 30976000000,
           "end": "2018-08-09T16:43:02.334Z",
+          "kind": "event",
           "start": "2018-08-09T16:42:31.358Z"
         },
         "flow": {
@@ -596,14 +619,18 @@
           "source_ipv4_address": "10.100.6.93",
           "source_transport_port": 54521,
           "tcp_control_bits": 27,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 1348,
           "community_id": "1:3vSrJV3tnfjnzopvPuRQzt2BDS4=",
           "direction": "outbound",
+          "iana_number": 6,
           "packets": 13,
-          "protocol": "tcp"
+          "transport": "tcp"
+        },
+        "observer": {
+          "ip": "10.100.4.1"
         },
         "source_ecs": {
           "ip": "10.100.6.93",
@@ -622,14 +649,13 @@
           "locality": "private",
           "port": 53
         },
-        "device": {
-          "ip": "10.100.4.1"
-        },
         "event": {
-          "action": "netflow",
+          "action": "netflow_flow",
+          "category": "network_traffic",
           "created": "2018-08-09T16:49:04Z",
           "duration": 0,
           "end": "2018-08-09T16:43:06.28Z",
+          "kind": "event",
           "start": "2018-08-09T16:43:06.28Z"
         },
         "flow": {
@@ -664,14 +690,18 @@
           "source_ipv4_address": "192.168.1.4",
           "source_transport_port": 57253,
           "tcp_control_bits": 0,
-          "type": "netflow"
+          "type": "netflow_flow"
         },
         "network": {
           "bytes": 82,
           "community_id": "1:mjMjtH0BZKCuCmxkZbQyrFDfoI0=",
           "direction": "outbound",
+          "iana_number": 17,
           "packets": 1,
-          "protocol": "udp"
+          "transport": "udp"
+        },
+        "observer": {
+          "ip": "10.100.4.1"
         },
         "source_ecs": {
           "ip": "192.168.1.4",


### PR DESCRIPTION
Cherry-pick of PR #9609 to 6.x branch. Original message: 

This makes changes to several fields to more closely align with ECS.

- Set event.category and event.action and event.kind.
- Replace device with observer
- Add network.iana_number
- Change network.protocol to network.transport
- Set client/server for bidirectional flows.

Meta: https://github.com/elastic/beats/issues/9399