### PR TITLE
Cherry-pick #9649 to 6.x:  Add go vet to mage check

### DIFF
--- a/dev-tools/mage/check.go
+++ b/dev-tools/mage/check.go
@@ -39,11 +39,12 @@ import (
 // if it finds any modifications. If executed in in verbose mode it will write
 // the results of 'git diff' to stdout to indicate what changes have been made.
 //
-// It also checks the file permissions of nosetests test cases and YAML files.
+// It checks the file permissions of nosetests test cases and YAML files.
+// It checks .go source files using 'go vet'.
 func Check() error {
-	fmt.Println(">> check: Checking for modified files or incorrect permissions")
+	fmt.Println(">> check: Checking source code for common problems")
 
-	mg.Deps(CheckNosetestsNotExecutable, CheckYAMLNotExecutable)
+	mg.Deps(GoVet, CheckNosetestsNotExecutable, CheckYAMLNotExecutable)
 
 	changes, err := GitDiffIndex()
 	if err != nil {
@@ -177,4 +178,10 @@ func CheckYAMLNotExecutable() error {
 
 	}
 	return nil
+}
+
+// GoVet vets the .go source code using 'go vet'.
+func GoVet() error {
+	err := sh.RunV("go", "vet", "./...")
+	return errors.Wrap(err, "failed running go vet, please fix the issues reported")
 }

--- a/x-pack/filebeat/input/netflow/decoder/v9/v9_test.go
+++ b/x-pack/filebeat/input/netflow/decoder/v9/v9_test.go
@@ -159,7 +159,7 @@ func TestSessionReset(t *testing.T) {
 	}
 	t.Run("Reset disabled", func(t *testing.T) {
 		cfg := config.Defaults()
-		cfg.WithSequenceResetEnabled(false).WithLogOutput(test.TestLogWriter{t})
+		cfg.WithSequenceResetEnabled(false).WithLogOutput(test.TestLogWriter{TB: t})
 		proto := New(cfg)
 		flows, err := proto.OnPacket(test.MakePacket(templatePacket), addr)
 		assert.NoError(t, err)
@@ -170,7 +170,7 @@ func TestSessionReset(t *testing.T) {
 	})
 	t.Run("Reset enabled", func(t *testing.T) {
 		cfg := config.Defaults()
-		cfg.WithSequenceResetEnabled(true).WithLogOutput(test.TestLogWriter{t})
+		cfg.WithSequenceResetEnabled(true).WithLogOutput(test.TestLogWriter{TB: t})
 		proto := New(cfg)
 		flows, err := proto.OnPacket(test.MakePacket(templatePacket), addr)
 		assert.NoError(t, err)

--- a/x-pack/filebeat/input/netflow/netflow_test.go
+++ b/x-pack/filebeat/input/netflow/netflow_test.go
@@ -154,7 +154,7 @@ func getFlowsFromDat(t testing.TB, name string, datFiles ...string) TestResult {
 		WithProtocols(protocol.Registry.All()...).
 		WithSequenceResetEnabled(false).
 		WithExpiration(0).
-		WithLogOutput(test.TestLogWriter{t})
+		WithLogOutput(test.TestLogWriter{TB: t})
 
 	decoder, err := decoder.NewDecoder(config)
 	if !assert.NoError(t, err) {
@@ -205,7 +205,7 @@ func getFlowsFromPCAP(t testing.TB, name, pcapFile string) TestResult {
 		WithProtocols(protocol.Registry.All()...).
 		WithSequenceResetEnabled(false).
 		WithExpiration(0).
-		WithLogOutput(test.TestLogWriter{t})
+		WithLogOutput(test.TestLogWriter{TB: t})
 
 	decoder, err := decoder.NewDecoder(config)
 	if !assert.NoError(t, err) {


### PR DESCRIPTION
Cherry-pick of PR #9649 to 6.x branch. Original message: 

Improve `mage check` by adding a `go vet` check.

Then fix the `go vet` warnings it catches.