### PR TITLE
Cherry-pick #9663 to 6.x: Honor TEST_ENVIRONMENT in mage integTest

### DIFF
--- a/dev-tools/mage/integtest.go
+++ b/dev-tools/mage/integtest.go
@@ -20,9 +20,11 @@ package mage
 import (
 	"fmt"
 	"io/ioutil"
+	"log"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -130,6 +132,11 @@ func StopIntegTestEnv() error {
 //
 // Always use this with AddIntegTestUsage() and defer StopIntegTestEnv().
 func RunIntegTest(mageTarget string, test func() error, passThroughEnvVars ...string) error {
+	if reason, skip := skipIntegTest(); skip {
+		fmt.Printf(">> %v: Skipping because %v\n", mageTarget, reason)
+		return nil
+	}
+
 	AddIntegTestUsage()
 	defer StopIntegTestEnv()
 
@@ -230,6 +237,27 @@ func haveIntegTestEnvRequirements() error {
 		return err
 	}
 	return nil
+}
+
+// skipIntegTest returns true if integ tests should be skipped.
+func skipIntegTest() (reason string, skip bool) {
+	// Honor the TEST_ENVIRONMENT value if set.
+	if testEnvVar, isSet := os.LookupEnv("TEST_ENVIRONMENT"); isSet {
+		enabled, err := strconv.ParseBool(testEnvVar)
+		if err != nil {
+			panic(errors.Wrap(err, "failed to parse TEST_ENVIRONMENT value"))
+		}
+		return "TEST_ENVIRONMENT=" + testEnvVar, !enabled
+	}
+
+	// Otherwise skip if we don't have all the right dependencies.
+	if err := haveIntegTestEnvRequirements(); err != nil {
+		// Skip if we don't meet the requirements.
+		log.Println("Skipping integ test because:", err)
+		return "docker is not available", true
+	}
+
+	return "", false
 }
 
 // integTestDockerComposeEnvVars returns the environment variables used for


### PR DESCRIPTION
Cherry-pick of PR #9663 to 6.x branch. Original message: 

If TEST_ENVIRONMENT is set then `mage integTest` will strictly honor its value. If true it will attempt to execute the integration tests and fail with an error if docker is not available. If false it will skip the integTest targets.

Not setting the TEST_ENVIRONMENT value is generally the best option because `mage integTest` will automatically do the right thing. It checks if docker and docker-compose are available and working and then runs the tests. If not available then it will skip the tests (no error, just a notice that they were skipped).

This should fix the failure of x-pack/auditbeat on Jenkins+darwin+master.