### PR TITLE
[6.x] update object enabled:false index pattern attribs (#9644)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -51,6 +51,7 @@ https://github.com/elastic/beats/compare/v6.5.0...6.x[Check the HEAD diff]
 - When collecting swap metrics for beats telemetry or system metricbeat module handle cases of free swap being bigger than total swap by assuming no swap is being used. {issue}6271[6271] {pull}9383[9383]
 - Ignore non index fields in default_field for Elasticsearch. {pull}9549[9549]
 - Update Golang to 1.10.6. {pull}9563[9563]
+- Update Kibana index pattern attributes for objects that are disabled. {pull}9644[9644]
 - Enforce validation for the Central Management access token. {issue}9621[9621]
 
 *Auditbeat*

--- a/libbeat/kibana/fields_transformer.go
+++ b/libbeat/kibana/fields_transformer.go
@@ -137,6 +137,18 @@ func transformField(version *common.Version, f common.Field) (common.MapStr, com
 		field["searchable"] = false
 	}
 
+	if f.Type == "object" && f.Enabled != nil {
+		enabled := getVal(f.Enabled, true)
+		field["enabled"] = enabled
+		if !enabled {
+			field["aggregatable"] = false
+			field["analyzed"] = false
+			field["doc_values"] = false
+			field["indexed"] = false
+			field["searchable"] = false
+		}
+	}
+
 	if f.Type == "text" {
 		field["aggregatable"] = false
 	}

--- a/libbeat/kibana/fields_transformer_test.go
+++ b/libbeat/kibana/fields_transformer_test.go
@@ -242,6 +242,13 @@ func TestTransformMisc(t *testing.T) {
 		{commonField: common.Field{Type: "binary"}, expected: false, attr: "doc_values"},
 		{commonField: common.Field{DocValues: &truthy, Type: "binary"}, expected: true, attr: "doc_values"},
 
+		// enabled - only applies to objects (and only if set)
+		{commonField: common.Field{Type: "binary", Enabled: &falsy}, expected: nil, attr: "enabled"},
+		{commonField: common.Field{Type: "binary", Enabled: &truthy}, expected: nil, attr: "enabled"},
+		{commonField: common.Field{Type: "object", Enabled: &truthy}, expected: true, attr: "enabled"},
+		{commonField: common.Field{Type: "object", Enabled: &falsy}, expected: false, attr: "enabled"},
+		{commonField: common.Field{Type: "object", Enabled: &falsy}, expected: false, attr: "doc_values"},
+
 		// indexed
 		{commonField: common.Field{Type: "binary"}, expected: false, attr: "indexed"},
 		{commonField: common.Field{Index: &truthy, Type: "binary"}, expected: false, attr: "indexed"},


### PR DESCRIPTION
Backports the following commits to 6.x:
 - update object enabled:false index pattern attribs  (#9644)