### PR TITLE
Update to 7.0 snapshot build and fixes Elasticsearch and Logstash integration test.

### DIFF
--- a/libbeat/outputs/elasticsearch/api.go
+++ b/libbeat/outputs/elasticsearch/api.go
@@ -49,8 +49,14 @@ type SearchResults struct {
 
 // Hits contains the hits.
 type Hits struct {
-	Total int
+	Total Total
 	Hits  []json.RawMessage `json:"hits"`
+}
+
+// Total contains the number of element fetched and the relation.
+type Total struct {
+	Value    int    `json:"value"`
+	Relation string `json:"relation"`
 }
 
 // CountResults contains the count of results.

--- a/libbeat/outputs/elasticsearch/api_integration_test.go
+++ b/libbeat/outputs/elasticsearch/api_integration_test.go
@@ -64,7 +64,7 @@ func TestIndex(t *testing.T) {
 		t.Errorf("SearchUriWithBody() returns an error: %s", err)
 	}
 	if result.Hits.Total != 1 {
-		t.Errorf("Wrong number of search results: %d", result.Hits.Total)
+		t.Errorf("Wrong number of search results: %d", result.Hits.Total.Value)
 	}
 
 	params = map[string]string{
@@ -75,7 +75,7 @@ func TestIndex(t *testing.T) {
 		t.Errorf("SearchUri() returns an error: %s", err)
 	}
 	if result.Hits.Total != 1 {
-		t.Errorf("Wrong number of search results: %d", result.Hits.Total)
+		t.Errorf("Wrong number of search results: %d", result.Hits.Total.Value)
 	}
 
 	_, resp, err = client.Delete(index, "test", "1", nil)

--- a/libbeat/outputs/elasticsearch/api_integration_test.go
+++ b/libbeat/outputs/elasticsearch/api_integration_test.go
@@ -63,7 +63,7 @@ func TestIndex(t *testing.T) {
 	if err != nil {
 		t.Errorf("SearchUriWithBody() returns an error: %s", err)
 	}
-	if result.Hits.Total != 1 {
+	if result.Hits.Total.Value != 1 {
 		t.Errorf("Wrong number of search results: %d", result.Hits.Total.Value)
 	}
 
@@ -74,7 +74,7 @@ func TestIndex(t *testing.T) {
 	if err != nil {
 		t.Errorf("SearchUri() returns an error: %s", err)
 	}
-	if result.Hits.Total != 1 {
+	if result.Hits.Total.Value != 1 {
 		t.Errorf("Wrong number of search results: %d", result.Hits.Total.Value)
 	}
 

--- a/libbeat/outputs/elasticsearch/api_test.go
+++ b/libbeat/outputs/elasticsearch/api_test.go
@@ -59,7 +59,7 @@ func GetValidQueryResult() QueryResult {
 
 func GetValidSearchResults() SearchResults {
 	hits := Hits{
-		Total: 0,
+		Total: Total{Value: 0, Relation: "eq"},
 		Hits:  nil,
 	}
 
@@ -121,7 +121,7 @@ func TestReadSearchResult(t *testing.T) {
     		"successful" : 2,
     		"failed" : 1
   		},
-  		"hits" : {},
+			"hits" : { "total": { "value": 0, "relation": "eq" } },
   		"aggs" : {}
   	}`)
 

--- a/libbeat/outputs/elasticsearch/bulkapi_integration_test.go
+++ b/libbeat/outputs/elasticsearch/bulkapi_integration_test.go
@@ -67,7 +67,7 @@ func TestBulk(t *testing.T) {
 		t.Fatalf("SearchUri() returns an error: %s", err)
 	}
 	if result.Hits.Total != 1 {
-		t.Errorf("Wrong number of search results: %d", result.Hits.Total)
+		t.Errorf("Wrong number of search results: %d", result.Hits.Total.Value)
 	}
 
 	_, _, err = client.Delete(index, "", "", nil)
@@ -168,7 +168,7 @@ func TestBulkMoreOperations(t *testing.T) {
 		t.Fatalf("SearchUri() returns an error: %s", err)
 	}
 	if result.Hits.Total != 1 {
-		t.Errorf("Wrong number of search results: %d", result.Hits.Total)
+		t.Errorf("Wrong number of search results: %d", result.Hits.Total.Value)
 	}
 
 	params = map[string]string{
@@ -179,7 +179,7 @@ func TestBulkMoreOperations(t *testing.T) {
 		t.Fatalf("SearchUri() returns an error: %s", err)
 	}
 	if result.Hits.Total != 1 {
-		t.Errorf("Wrong number of search results: %d", result.Hits.Total)
+		t.Errorf("Wrong number of search results: %d", result.Hits.Total.Value)
 	}
 
 	_, _, err = client.Delete(index, "", "", nil)

--- a/libbeat/outputs/elasticsearch/bulkapi_integration_test.go
+++ b/libbeat/outputs/elasticsearch/bulkapi_integration_test.go
@@ -66,7 +66,7 @@ func TestBulk(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SearchUri() returns an error: %s", err)
 	}
-	if result.Hits.Total != 1 {
+	if result.Hits.Total.Value != 1 {
 		t.Errorf("Wrong number of search results: %d", result.Hits.Total.Value)
 	}
 
@@ -167,7 +167,7 @@ func TestBulkMoreOperations(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SearchUri() returns an error: %s", err)
 	}
-	if result.Hits.Total != 1 {
+	if result.Hits.Total.Value != 1 {
 		t.Errorf("Wrong number of search results: %d", result.Hits.Total.Value)
 	}
 
@@ -178,7 +178,7 @@ func TestBulkMoreOperations(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SearchUri() returns an error: %s", err)
 	}
-	if result.Hits.Total != 1 {
+	if result.Hits.Total.Value != 1 {
 		t.Errorf("Wrong number of search results: %d", result.Hits.Total.Value)
 	}
 

--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 version: '2.1'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.0.0-alpha1-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.0.0-SNAPSHOT
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9200"]
       retries: 300
@@ -16,7 +16,7 @@ services:
     - "xpack.security.enabled=false"
 
   logstash:
-    image: docker.elastic.co/logstash/logstash:7.0.0-alpha1-SNAPSHOT
+    image: docker.elastic.co/logstash/logstash:7.0.0-SNAPSHOT
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9600/_node/stats"]
       retries: 600
@@ -26,7 +26,7 @@ services:
       - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:7.0.0-alpha1-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:7.0.0-SNAPSHOT
     healthcheck:
       test: ["CMD-SHELL", 'python -c ''import urllib, json; response = urllib.urlopen("http://localhost:5601/api/status"); data = json.loads(response.read()); exit(1) if data["status"]["overall"]["state"] != "green" else exit(0);''']
       retries: 600


### PR DESCRIPTION
The integration tests for the LS and ES output were failing because the format for the hits changed in the ES master. Ref elastic/elasticsearch#35849

Elasticsearch will return total hits as an object, e.g.:
```
{
  "hits": {
    "total": {
      "value": 100,
      "relation": "eq"
    }
  }
}
```

But we were assuming the following structure:
```
{
  "hits": {
    "total": 100
  }
}
```