### PR TITLE
Inserts natsbeat in the community beats list

### DIFF
--- a/libbeat/docs/communitybeats.asciidoc
+++ b/libbeat/docs/communitybeats.asciidoc
@@ -71,6 +71,7 @@ https://github.com/scottcrespo/mongobeat[mongobeat]:: Monitors MongoDB instances
 https://github.com/nathan-K-/mqttbeat[mqttbeat]:: Add messages from mqtt topics to Elasticsearch.
 https://github.com/adibendahan/mysqlbeat[mysqlbeat]:: Run any query on MySQL and send results to Elasticsearch.
 https://github.com/PhaedrusTheGreek/nagioscheckbeat[nagioscheckbeat]:: For Nagios checks and performance data.
+https://github.com/nfvsap/natsbeat[natsbeat]:: Collects data from NATS monitoring endpoints
 https://github.com/mrkschan/nginxbeat[nginxbeat]:: Reads status from Nginx.
 https://github.com/2Fast2BCn/nginxupstreambeat[nginxupstreambeat]:: Reads upstream status from nginx upstream module.
 https://github.com/mschneider82/nsqbeat[nsqbeat]:: Reads data from a NSQ topic.


### PR DESCRIPTION
This PR aims to add Natsbeat in the community beats list.

Natsbeat is an elastic Beat that collects metrics from NATS monitoring endpoints and indexes them into Elasticsearch database.

In addition we provide a basic Kibana dashboard for metrics visualization.

Co-Authored-By: Stamatis Katsaounis <katsaouniss@gmail.com>
Co-Authored-By: Christos Markou <chrismarkou92@gmail.com>