### PR TITLE
[Auditbeat] Skip processes that do not exist anymore - Part 2

### DIFF
--- a/x-pack/auditbeat/module/system/process/process.go
+++ b/x-pack/auditbeat/module/system/process/process.go
@@ -297,6 +297,12 @@ func (ms *MetricSet) getProcessInfos() ([]*ProcessInfo, error) {
 
 		pInfo, err := process.Info()
 		if err != nil {
+			if os.IsNotExist(err) {
+				// Skip - process probably just terminated since our call
+				// to Pids()
+				continue
+			}
+
 			if os.Geteuid() != 0 {
 				if os.IsPermission(err) || runtime.GOOS == "darwin" {
 					/*


### PR DESCRIPTION
Follow-up to https://github.com/elastic/beats/pull/9669. Further skips processes that do not exist anymore.