### PR TITLE
Cherry-pick #9680 to 6.x: [Auditbeat] Skip flaky user test

### DIFF
--- a/x-pack/auditbeat/module/system/user/user_test.go
+++ b/x-pack/auditbeat/module/system/user/user_test.go
@@ -14,6 +14,8 @@ import (
 )
 
 func TestData(t *testing.T) {
+	t.Skip("test is failing in CI")
+
 	f := mbtest.NewReportingMetricSetV2(t, getConfig())
 	events, errs := mbtest.ReportingFetchV2(f)
 	if len(errs) > 0 {


### PR DESCRIPTION
Cherry-pick of PR #9680 to 6.x branch. Original message: 

Disabling this test because of https://github.com/elastic/beats/issues/9679.