### PR TITLE
Skip flaky x-pack libbeat testsuite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,10 +80,10 @@ jobs:
       env: STRESS_TEST_OPTIONS="-timeout=20m -race -v -parallel 1" TARGETS="-C libbeat stress-tests"
       go: $GO_VERSION
       stage: test
-    - os: linux
-      env: TARGETS="-C x-pack/libbeat testsuite"
-      go: $GO_VERSION
-      stage: test
+    #- os: linux
+    #  env: TARGETS="-C x-pack/libbeat testsuite"
+    #  go: $GO_VERSION
+    #  stage: test
 
     # Metricbeat
     - os: linux


### PR DESCRIPTION
In most cases the x-pack libbeat testsuite fails on Travis. This PR skips it. Will create a follow up issue to make sure we fix this.