### PR TITLE
[Auditbeat] Cherry-pick #9669 and #9682 to 6.6: Skip processes that do not exist anymore

### DIFF
--- a/x-pack/auditbeat/module/system/process/process.go
+++ b/x-pack/auditbeat/module/system/process/process.go
@@ -287,11 +287,22 @@ func (ms *MetricSet) getProcessInfos() ([]*ProcessInfo, error) {
 	for _, pid := range pids {
 		process, err := sysinfo.Process(pid)
 		if err != nil {
+			if os.IsNotExist(err) {
+				// Skip - process probably just terminated since our call
+				// to Pids()
+				continue
+			}
 			return nil, errors.Wrap(err, "failed to load process")
 		}
 
 		pInfo, err := process.Info()
 		if err != nil {
+			if os.IsNotExist(err) {
+				// Skip - process probably just terminated since our call
+				// to Pids()
+				continue
+			}
+
 			if os.Geteuid() != 0 {
 				if os.IsPermission(err) || runtime.GOOS == "darwin" {
 					/*


### PR DESCRIPTION
Cherry-pick of PR #9669 and #9682 to 6.6 branch. Original message:

A process can exit just after we get a list of PIDs, but before we get around to reading that process. This skips such processes as if we had not seen their PID in the first place.

This should fix [this test failure in Travis](https://travis-ci.org/elastic/beats/jobs/469805046), and hopefully [this one in Jenkins](https://beats-ci.elastic.co/job/elastic+beats+master+multijob-linux/326/beat=x-pack%2Fauditbeat,label=linux/testReport/junit/(root)/process/TestData/). 

And:

Follow-up to https://github.com/elastic/beats/pull/9669. Further skips processes that do not exist anymore.