### PR TITLE
[heartbeat] Set IDs explicitly

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -27,6 +27,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 *Heartbeat*
 
 - Remove monitor generator script that was rarely used. {pull}9648[9648]
+- monitor IDs are now configurable. Auto generated monitor IDs now use a different formula based on a hash of their config values. If you wish to have continuity with the old format of monitor IDs you'll need to set the `id` property explicitly. {pull}9697[9697]
 
 *Journalbeat*
 

--- a/heartbeat/beater/heartbeat.go
+++ b/heartbeat/beater/heartbeat.go
@@ -143,7 +143,7 @@ func (bt *Heartbeat) RunCentralMgmtMonitors(b *beat.Beat) {
 func (bt *Heartbeat) RunReloadableMonitors(b *beat.Beat) (err error) {
 	// Check monitor configs
 	if err := bt.monitorReloader.Check(bt.dynamicFactory); err != nil {
-		return err
+		logp.Error(errors.Wrap(err, "error loading reloadable monitors"))
 	}
 
 	// Execute the monitor

--- a/heartbeat/docs/heartbeat-options.asciidoc
+++ b/heartbeat/docs/heartbeat-options.asciidoc
@@ -96,13 +96,26 @@ expected response. See <<monitor-http-options>>.
 The `tcp` and `http` monitor types both support SSL/TLS and some proxy
 settings.
 
+[float]
+[[monitor-name]]
+==== `id`
+
+A unique identifier for this configuration. This should not change with edits to the monitor configuration
+regardless of changes to any config fields. Examples: `uploader-service`, `http://example.net`, `us-west-loadbalancer`.
+
+When querying against indexed monitor data this is the field you will be aggregating with. Appears in the
+<<exported-fields,exported fields>> as `monitor.id`.
+
+If you do not set this explicitly the monitor's config will be hashed and a generated value used. This value will
+change with any options change to this monitor making aggregations over time between changes impossible. For this reason
+it is recommended that you set this manually.
 
 [float]
 [[monitor-name]]
 ==== `name`
 
-The monitor name. This value appears in the <<exported-fields,exported fields>>
-under the `monitor` field as the job name and the `type` field as the job type.
+Optional human readable name for this monitor. This value appears in the <<exported-fields,exported fields>>
+as `monitor.name`.
 
 [float]
 [[monitor-enabled]]

--- a/heartbeat/docs/heartbeat-options.asciidoc
+++ b/heartbeat/docs/heartbeat-options.asciidoc
@@ -97,11 +97,11 @@ The `tcp` and `http` monitor types both support SSL/TLS and some proxy
 settings.
 
 [float]
-[[monitor-name]]
+[[monitor-id]]
 ==== `id`
 
 A unique identifier for this configuration. This should not change with edits to the monitor configuration
-regardless of changes to any config fields. Examples: `uploader-service`, `http://example.net`, `us-west-loadbalancer`.
+regardless of changes to any config fields. Examples: `uploader-service`, `http://example.net`, `us-west-loadbalancer`. Note that this uniqueness is only within a given beat instance. If you want to monitor the same endpoint from multiple locations it is recommended that those heartbeat instances use the same IDs so that their results can be correlated. You can use the `host.geo.name` property to disambiguate them.
 
 When querying against indexed monitor data this is the field you will be aggregating with. Appears in the
 <<exported-fields,exported fields>> as `monitor.id`.

--- a/heartbeat/hbtest/hbtestutil.go
+++ b/heartbeat/hbtest/hbtestutil.go
@@ -95,14 +95,13 @@ func TLSChecks(chainIndex, certIndex int, certificate *x509.Certificate) mapval.
 
 // MonitorChecks creates a skima.Validator that represents the "monitor" field present
 // in all heartbeat events.
-func MonitorChecks(id string, host string, ip string, scheme string, status string) mapval.Validator {
+func MonitorChecks(host string, ip string, scheme string, status string) mapval.Validator {
 	return mapval.MustCompile(mapval.Map{
 		"monitor": mapval.Map{
 			// TODO: This is only optional because, for some reason, TCP returns
 			// this value, but HTTP does not. We should fix this
 			"host":        mapval.Optional(mapval.IsEqual(host)),
 			"duration.us": mapval.IsDuration,
-			"id":          id,
 			"ip":          ip,
 			"scheme":      scheme,
 			"status":      status,

--- a/heartbeat/monitors/active/dialchain/builder.go
+++ b/heartbeat/monitors/active/dialchain/builder.go
@@ -129,14 +129,14 @@ func (b *Builder) Run(
 // correctly resolved endpoint.
 func MakeDialerJobs(
 	b *Builder,
-	typ, scheme string,
+	scheme string,
 	endpoints []Endpoint,
 	mode monitors.IPSettings,
 	fn func(event *beat.Event, dialer transport.Dialer, addr string) error,
 ) ([]monitors.Job, error) {
 	var jobs []monitors.Job
 	for _, endpoint := range endpoints {
-		endpointJobs, err := makeEndpointJobs(b, typ, scheme, endpoint, mode, fn)
+		endpointJobs, err := makeEndpointJobs(b, scheme, endpoint, mode, fn)
 		if err != nil {
 			return nil, err
 		}
@@ -148,7 +148,7 @@ func MakeDialerJobs(
 
 func makeEndpointJobs(
 	b *Builder,
-	typ, scheme string,
+	scheme string,
 	endpoint Endpoint,
 	mode monitors.IPSettings,
 	fn func(*beat.Event, transport.Dialer, string) error,

--- a/heartbeat/monitors/active/dialchain/builder.go
+++ b/heartbeat/monitors/active/dialchain/builder.go
@@ -18,7 +18,6 @@
 package dialchain
 
 import (
-	"fmt"
 	"net"
 	"strconv"
 	"time"
@@ -180,8 +179,7 @@ func makeEndpointJobs(
 
 	// Create job that first resolves one or multiple IP (depending on
 	// config.Mode) in order to create one continuation Task per IP.
-	jobID := jobID(typ, scheme, endpoint.Host, endpoint.Ports)
-	settings := monitors.MakeHostJobSettings(jobID, endpoint.Host, mode)
+	settings := monitors.MakeHostJobSettings(endpoint.Host, mode)
 
 	job, err := monitors.MakeByHostJob(settings,
 		monitors.MakePingAllIPPortFactory(endpoint.Ports,
@@ -199,15 +197,5 @@ func makeEndpointJobs(
 	if err != nil {
 		return nil, err
 	}
-	return []monitors.Job{monitors.WithJobId(jobID, monitors.WithFields(fields, job))}, nil
-}
-
-func jobID(typ, jobType, host string, ports []uint16) string {
-	var h string
-	if len(ports) == 1 {
-		h = fmt.Sprintf("%v:%v", host, ports[0])
-	} else {
-		h = fmt.Sprintf("%v:%v", host, ports)
-	}
-	return fmt.Sprintf("%v-%v@%v", typ, jobType, h)
+	return []monitors.Job{monitors.WithFields(fields, job)}, nil
 }

--- a/heartbeat/monitors/active/http/config.go
+++ b/heartbeat/monitors/active/http/config.go
@@ -31,8 +31,6 @@ import (
 )
 
 type Config struct {
-	Name string `config:"name"`
-
 	URLs         []string      `config:"urls" validate:"required"`
 	ProxyURL     string        `config:"proxy_url"`
 	Timeout      time.Duration `config:"timeout"`
@@ -87,7 +85,6 @@ type compressionConfig struct {
 }
 
 var defaultConfig = Config{
-	Name:         "http",
 	Timeout:      16 * time.Second,
 	MaxRedirects: 10,
 	Mode:         monitors.DefaultIPSettings,

--- a/heartbeat/monitors/active/http/http_test.go
+++ b/heartbeat/monitors/active/http/http_test.go
@@ -67,7 +67,7 @@ func testTLSRequest(t *testing.T, testURL string, extraConfig map[string]interfa
 	job := jobs[0]
 
 	event := &beat.Event{}
-	_, err = job.Run(event)
+	_, err = job(event)
 	require.NoError(t, err)
 
 	require.Equal(t, 1, endpoints)
@@ -239,7 +239,7 @@ func TestLargeResponse(t *testing.T) {
 	job := jobs[0]
 
 	event := &beat.Event{}
-	_, err = job.Run(event)
+	_, err = job(event)
 	require.NoError(t, err)
 
 	port, err := hbtest.ServerPort(server)

--- a/heartbeat/monitors/active/http/http_test.go
+++ b/heartbeat/monitors/active/http/http_test.go
@@ -188,7 +188,7 @@ func TestUpStatuses(t *testing.T) {
 			mapvaltest.Test(
 				t,
 				mapval.Strict(mapval.Compose(
-					hbtest.MonitorChecks("http@"+server.URL, server.URL, "127.0.0.1", "http", "up"),
+					hbtest.MonitorChecks(server.URL, "127.0.0.1", "http", "up"),
 					hbtest.RespondingTCPChecks(port),
 					respondingHTTPChecks(server.URL, status),
 				)),
@@ -209,7 +209,7 @@ func TestDownStatuses(t *testing.T) {
 			mapvaltest.Test(
 				t,
 				mapval.Strict(mapval.Compose(
-					hbtest.MonitorChecks("http@"+server.URL, server.URL, "127.0.0.1", "http", "down"),
+					hbtest.MonitorChecks(server.URL, "127.0.0.1", "http", "down"),
 					hbtest.RespondingTCPChecks(port),
 					respondingHTTPChecks(server.URL, status),
 					hbtest.ErrorChecks(fmt.Sprintf("%d", status), "validate"),
@@ -248,7 +248,7 @@ func TestLargeResponse(t *testing.T) {
 	mapvaltest.Test(
 		t,
 		mapval.Strict(mapval.Compose(
-			hbtest.MonitorChecks("http@"+server.URL, server.URL, "127.0.0.1", "http", "up"),
+			hbtest.MonitorChecks(server.URL, "127.0.0.1", "http", "up"),
 			hbtest.RespondingTCPChecks(port),
 			respondingHTTPChecks(server.URL, 200),
 		)),
@@ -282,7 +282,7 @@ func runHTTPSServerCheck(
 	mapvaltest.Test(
 		t,
 		mapval.Strict(mapval.Compose(
-			hbtest.MonitorChecks("http@"+server.URL, server.URL, "127.0.0.1", "https", "up"),
+			hbtest.MonitorChecks(server.URL, "127.0.0.1", "https", "up"),
 			hbtest.RespondingTCPChecks(port),
 			hbtest.TLSChecks(0, 0, cert),
 			respondingHTTPChecks(server.URL, http.StatusOK),
@@ -347,7 +347,7 @@ func TestConnRefusedJob(t *testing.T) {
 	mapvaltest.Test(
 		t,
 		mapval.Strict(mapval.Compose(
-			hbtest.MonitorChecks("http@"+url, url, ip, "http", "down"),
+			hbtest.MonitorChecks(url, ip, "http", "down"),
 			hbtest.TCPBaseChecks(port),
 			hbtest.ErrorChecks(url, "io"),
 			httpBaseChecks(url),
@@ -369,7 +369,7 @@ func TestUnreachableJob(t *testing.T) {
 	mapvaltest.Test(
 		t,
 		mapval.Strict(mapval.Compose(
-			hbtest.MonitorChecks("http@"+url, url, ip, "http", "down"),
+			hbtest.MonitorChecks(url, ip, "http", "down"),
 			hbtest.TCPBaseChecks(uint16(port)),
 			hbtest.ErrorChecks(url, "io"),
 			httpBaseChecks(url),

--- a/heartbeat/monitors/active/icmp/config.go
+++ b/heartbeat/monitors/active/icmp/config.go
@@ -24,8 +24,6 @@ import (
 )
 
 type Config struct {
-	Name string `config:"name"`
-
 	Hosts []string            `config:"hosts" validate:"required"`
 	Mode  monitors.IPSettings `config:",inline"`
 
@@ -34,7 +32,6 @@ type Config struct {
 }
 
 var DefaultConfig = Config{
-	Name: "icmp",
 	Mode: monitors.DefaultIPSettings,
 
 	Timeout: 16 * time.Second,

--- a/heartbeat/monitors/active/icmp/icmp.go
+++ b/heartbeat/monitors/active/icmp/icmp.go
@@ -78,16 +78,10 @@ func create(
 		return nil, 0, err
 	}
 
-	network := config.Mode.Network()
 	pingFactory := monitors.MakePingIPFactory(createPingIPFactory(&config))
 
 	for _, host := range config.Hosts {
-		jobName := fmt.Sprintf("icmp-%v-host-%v@%v", config.Name, network, host)
-		if ip := net.ParseIP(host); ip != nil {
-			jobName = fmt.Sprintf("icmp-%v-ip@%v", config.Name, ip.String())
-		}
-
-		settings := monitors.MakeHostJobSettings(jobName, host, config.Mode)
+		settings := monitors.MakeHostJobSettings(host, config.Mode)
 		err := addJob(monitors.MakeByHostJob(settings, pingFactory))
 		if err != nil {
 			return nil, 0, err

--- a/heartbeat/monitors/active/tcp/config.go
+++ b/heartbeat/monitors/active/tcp/config.go
@@ -28,8 +28,6 @@ import (
 )
 
 type Config struct {
-	Name string `config:"name"`
-
 	// check all ports if host does not contain port
 	Hosts []string `config:"hosts" validate:"required"`
 	Ports []uint16 `config:"ports"`
@@ -49,7 +47,6 @@ type Config struct {
 }
 
 var DefaultConfig = Config{
-	Name:    "tcp",
 	Timeout: 16 * time.Second,
 	Mode:    monitors.DefaultIPSettings,
 }

--- a/heartbeat/monitors/active/tcp/tcp.go
+++ b/heartbeat/monitors/active/tcp/tcp.go
@@ -68,7 +68,6 @@ func create(
 		return nil, 0, err
 	}
 
-	typ := config.Name
 	timeout := config.Timeout
 	validator := makeValidateConn(&config)
 
@@ -87,7 +86,7 @@ func create(
 			return nil, 0, err
 		}
 
-		epJobs, err := dialchain.MakeDialerJobs(db, typ, scheme, eps, config.Mode,
+		epJobs, err := dialchain.MakeDialerJobs(db, scheme, eps, config.Mode,
 			func(event *beat.Event, dialer transport.Dialer, addr string) error {
 				return pingHost(event, dialer, addr, timeout, validator)
 			})

--- a/heartbeat/monitors/active/tcp/tcp_test.go
+++ b/heartbeat/monitors/active/tcp/tcp_test.go
@@ -51,7 +51,7 @@ func testTCPCheck(t *testing.T, host string, port uint16) *beat.Event {
 	job := jobs[0]
 
 	event := &beat.Event{}
-	_, err = job.Run(event)
+	_, err = job(event)
 	require.NoError(t, err)
 
 	require.Equal(t, 1, endpoints)
@@ -74,7 +74,7 @@ func testTLSTCPCheck(t *testing.T, host string, port uint16, certFileName string
 	job := jobs[0]
 
 	event := &beat.Event{}
-	_, err = job.Run(event)
+	_, err = job(event)
 	require.NoError(t, err)
 
 	require.Equal(t, 1, endpoints)

--- a/heartbeat/monitors/active/tcp/tcp_test.go
+++ b/heartbeat/monitors/active/tcp/tcp_test.go
@@ -92,8 +92,7 @@ func setupServer(t *testing.T, serverCreator func(http.Handler) *httptest.Server
 }
 
 func tcpMonitorChecks(host string, ip string, port uint16, status string) mapval.Validator {
-	id := fmt.Sprintf("tcp-tcp@%s:%d", host, port)
-	return hbtest.MonitorChecks(id, host, ip, "tcp", status)
+	return hbtest.MonitorChecks(host, ip, "tcp", status)
 }
 
 func TestUpEndpointJob(t *testing.T) {
@@ -106,7 +105,6 @@ func TestUpEndpointJob(t *testing.T) {
 		t,
 		mapval.Strict(mapval.Compose(
 			hbtest.MonitorChecks(
-				fmt.Sprintf("tcp-tcp@localhost:%d", port),
 				"localhost",
 				"127.0.0.1",
 				"tcp",
@@ -155,7 +153,6 @@ func TestTLSConnection(t *testing.T) {
 		mapval.Strict(mapval.Compose(
 			hbtest.TLSChecks(0, 0, cert),
 			hbtest.MonitorChecks(
-				fmt.Sprintf("tcp-ssl@%s:%d", ip, port),
 				serverURL.Hostname(),
 				ip,
 				"ssl",

--- a/heartbeat/monitors/job.go
+++ b/heartbeat/monitors/job.go
@@ -28,7 +28,7 @@ type Job interface {
 	Run(event *beat.Event) ([]Job, error)
 }
 
-// NamedJob represents a job with an explicitly specified name.
+// NamedJob represents a job with an explicitly specified pluginName.
 type NamedJob struct {
 	id   string
 	name string
@@ -40,12 +40,12 @@ func CreateNamedJob(id string, name string, run func(event *beat.Event) ([]Job, 
 	return &NamedJob{id, name, run}
 }
 
-// ID returns a unique ID for this Job.
+// ID returns a the configured ID for this Job or "" if none is configured.
 func (f *NamedJob) ID() string {
 	return f.id
 }
 
-// Name returns the name of this job.
+// Name returns the pluginName of this job.
 func (f *NamedJob) Name() string {
 	return f.name
 }
@@ -55,7 +55,7 @@ func (f *NamedJob) Run(event *beat.Event) ([]Job, error) {
 	return f.run(event)
 }
 
-// AnonJob represents a job with no assigned name, backed by just a function.
+// AnonJob represents a job with no assigned pluginName, backed by just a function.
 type AnonJob func(event *beat.Event) ([]Job, error)
 
 // ID returns a unique ID for this Job.
@@ -85,19 +85,6 @@ func AfterJob(j Job, after func(*beat.Event, []Job, error) ([]Job, error)) Job {
 			return after(event, next, err)
 		},
 	)
-}
-
-// AfterJobSuccess creates a wrapped version of the given Job that runs additional
-// code after the original job if the original Job succeeds, possibly altering
-// return values.
-func AfterJobSuccess(j Job, after func(*beat.Event, []Job, error) ([]Job, error)) Job {
-	return AfterJob(j, func(event *beat.Event, cont []Job, err error) ([]Job, error) {
-		if err != nil {
-			return cont, err
-		}
-
-		return after(event, cont, err)
-	})
 }
 
 // MakeSimpleJob creates a new Job from a callback function. The callback should

--- a/heartbeat/monitors/mocks_test.go
+++ b/heartbeat/monitors/mocks_test.go
@@ -19,6 +19,7 @@ package monitors
 
 import (
 	"fmt"
+	"regexp"
 	"sync"
 	"testing"
 
@@ -26,6 +27,7 @@ import (
 
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/mapval"
 	"github.com/elastic/beats/libbeat/monitoring"
 )
 
@@ -89,11 +91,32 @@ func (pc *MockPipelineConnector) ConnectWith(beat.ClientConfig) (beat.Client, er
 	return c, nil
 }
 
+func mockEventMonitorValidator(id string) mapval.Validator {
+	var idMatcher mapval.IsDef
+	if id == "" {
+		idMatcher = mapval.IsStringMatching(regexp.MustCompile(`^auto-test-.*`))
+	} else {
+		idMatcher = mapval.IsEqual(id)
+	}
+	return mapval.Strict(mapval.Compose(
+		mapval.MustCompile(mapval.Map{
+			"monitor": mapval.Map{
+				"id":   idMatcher,
+				"name": "test",
+				"type": "test",
+			},
+		}),
+		mapval.MustCompile(mockEventCustomFields()),
+	))
+}
+
+func mockEventCustomFields() map[string]interface{} {
+	return common.MapStr{"foo": "bar"}
+}
+
 func createMockJob(name string, cfg *common.Config) ([]Job, error) {
 	j := MakeSimpleJob(func(event *beat.Event) error {
-		MergeEventFields(event, common.MapStr{
-			"foo": "bar",
-		})
+		MergeEventFields(event, mockEventCustomFields())
 		return nil
 	})
 
@@ -116,12 +139,18 @@ func mockPluginsReg() *pluginsReg {
 	return reg
 }
 
-func mockPluginConf(t *testing.T, schedule string, url string) *common.Config {
-	conf, err := common.NewConfigFrom(map[string]interface{}{
+func mockPluginConf(t *testing.T, id string, schedule string, url string) *common.Config {
+	confMap := map[string]interface{}{
 		"type":     "test",
 		"urls":     []string{url},
 		"schedule": schedule,
-	})
+	}
+
+	if id != "" {
+		confMap["id"] = id
+	}
+
+	conf, err := common.NewConfigFrom(confMap)
 	require.NoError(t, err)
 
 	return conf

--- a/heartbeat/monitors/mocks_test.go
+++ b/heartbeat/monitors/mocks_test.go
@@ -101,9 +101,9 @@ func mockEventMonitorValidator(id string) mapval.Validator {
 	return mapval.Strict(mapval.Compose(
 		mapval.MustCompile(mapval.Map{
 			"monitor": mapval.Map{
-				"id":   idMatcher,
-				"name": "test",
-				"type": "test",
+				"id":         idMatcher,
+				"pluginName": "test",
+				"type":       "test",
 			},
 		}),
 		mapval.MustCompile(mockEventCustomFields()),

--- a/heartbeat/monitors/mocks_test.go
+++ b/heartbeat/monitors/mocks_test.go
@@ -101,9 +101,9 @@ func mockEventMonitorValidator(id string) mapval.Validator {
 	return mapval.Strict(mapval.Compose(
 		mapval.MustCompile(mapval.Map{
 			"monitor": mapval.Map{
-				"id":         idMatcher,
-				"pluginName": "test",
-				"type":       "test",
+				"id":   idMatcher,
+				"name": "",
+				"type": "test",
 			},
 		}),
 		mapval.MustCompile(mockEventCustomFields()),

--- a/heartbeat/monitors/monitor.go
+++ b/heartbeat/monitors/monitor.go
@@ -38,6 +38,7 @@ import (
 type Monitor struct {
 	id             string
 	name           string
+	pluginName     string
 	config         *common.Config
 	registrar      *pluginsReg
 	uniqueName     string
@@ -64,7 +65,7 @@ type Monitor struct {
 // String prints a description of the monitor in a threadsafe way. It is important that this use threadsafe
 // values because it may be invoked from another thread in cfgfile/runner.
 func (m *Monitor) String() string {
-	return fmt.Sprintf("Monitor<name: %s, enabled: %t>", m.name, m.enabled)
+	return fmt.Sprintf("Monitor<pluginName: %s, enabled: %t>", m.name, m.enabled)
 }
 
 func checkMonitorConfig(config *common.Config, registrar *pluginsReg, allowWatches bool) error {
@@ -108,7 +109,8 @@ func newMonitor(
 
 	m := &Monitor{
 		id:                mpi.ID,
-		name:              monitorPlugin.name,
+		name:              mpi.Name,
+		pluginName:        monitorPlugin.name,
 		scheduler:         scheduler,
 		configuredJobs:    []*configuredJob{},
 		pipelineConnector: pipelineConnector,
@@ -130,7 +132,7 @@ func newMonitor(
 
 		// If they have an explicit ID in the config set it to exactly that
 		idWrapper = func(job Job) Job {
-			return WithID(m.id, job)
+			return WithID(m.id, m.name, job)
 		}
 	} else {
 		// If there's no explicit ID generate one
@@ -139,7 +141,7 @@ func newMonitor(
 			return nil, err
 		}
 		idWrapper = func(job Job) Job {
-			return WithID(fmt.Sprintf("auto-%s-%#X", mpi.Type, hash), job)
+			return WithID(fmt.Sprintf("auto-%s-%#X", m.pluginName, hash), mpi.Name, job)
 		}
 	}
 

--- a/heartbeat/monitors/monitor.go
+++ b/heartbeat/monitors/monitor.go
@@ -132,7 +132,7 @@ func newMonitor(
 
 		// If they have an explicit ID in the config set it to exactly that
 		idWrapper = func(job Job) Job {
-			return WithID(m.id, m.name, job)
+			return WithMonitorMeta(m.id, m.name, m.pluginName, job)
 		}
 	} else {
 		// If there's no explicit ID generate one
@@ -141,7 +141,12 @@ func newMonitor(
 			return nil, err
 		}
 		idWrapper = func(job Job) Job {
-			return WithID(fmt.Sprintf("auto-%s-%#X", m.pluginName, hash), mpi.Name, job)
+			return WithMonitorMeta(
+				fmt.Sprintf("auto-%s-%#X", mpi.Type, hash),
+				mpi.Name,
+				mpi.Type,
+				job,
+			)
 		}
 	}
 
@@ -314,4 +319,17 @@ func (m *Monitor) Stop() {
 	}
 
 	m.stats.stopMonitor(int64(m.endpoints))
+}
+
+// WithMonitorMeta ensures that monitor.{id,name,type} are present.
+func WithMonitorMeta(id string, name string, typ string, origJob Job) Job {
+	return WithFields(
+		common.MapStr{
+			"monitor": common.MapStr{
+				"id":   id,
+				"name": name,
+				"type": typ},
+		},
+		origJob,
+	)
 }

--- a/heartbeat/monitors/monitor.go
+++ b/heartbeat/monitors/monitor.go
@@ -69,7 +69,8 @@ func (m *Monitor) String() string {
 }
 
 func checkMonitorConfig(config *common.Config, registrar *pluginsReg, allowWatches bool) error {
-	_, err := newMonitor(config, registrar, nil, nil, allowWatches)
+	m, err := newMonitor(config, registrar, nil, nil, allowWatches)
+	m.Stop() // Stop the monitor to free up the ID from uniqueness checks
 	return err
 }
 

--- a/heartbeat/monitors/plugin.go
+++ b/heartbeat/monitors/plugin.go
@@ -104,11 +104,11 @@ func RegisterActive(name string, builder PluginBuilder) {
 }
 
 // ErrPluginAlreadyExists is returned when there is an attempt to register two plugins
-// with the same name.
+// with the same pluginName.
 type ErrPluginAlreadyExists pluginBuilder
 
 func (m ErrPluginAlreadyExists) Error() string {
-	return fmt.Sprintf("monitor plugin '%s' already exists", m.name)
+	return fmt.Sprintf("monitor plugin '%s' already exists", m.typ)
 }
 
 func (r *pluginsReg) add(plugin pluginBuilder) error {
@@ -121,7 +121,7 @@ func (r *pluginsReg) add(plugin pluginBuilder) error {
 
 func (r *pluginsReg) register(plugin pluginBuilder) error {
 	if _, found := r.monitors[plugin.name]; found {
-		return fmt.Errorf("monitor type %v already exists", plugin.name)
+		return fmt.Errorf("monitor type %v already exists", plugin.typ)
 	}
 
 	r.monitors[plugin.name] = plugin

--- a/heartbeat/monitors/pluginconf.go
+++ b/heartbeat/monitors/pluginconf.go
@@ -29,7 +29,7 @@ var ErrPluginDisabled = errors.New("Monitor not loaded, plugin is disabled")
 // MonitorPluginInfo represents the generic configuration options around a monitor plugin.
 type MonitorPluginInfo struct {
 	ID      string `config:"id"`
-	Name    string `config:"pluginName"`
+	Name    string `config:"name"`
 	Type    string `config:"type" validate:"required"`
 	Enabled bool   `config:"enabled"`
 }

--- a/heartbeat/monitors/pluginconf.go
+++ b/heartbeat/monitors/pluginconf.go
@@ -28,6 +28,7 @@ var ErrPluginDisabled = errors.New("Monitor not loaded, plugin is disabled")
 
 // MonitorPluginInfo represents the generic configuration options around a monitor plugin.
 type MonitorPluginInfo struct {
+	ID      string `config:"id"`
 	Type    string `config:"type" validate:"required"`
 	Enabled bool   `config:"enabled"`
 }

--- a/heartbeat/monitors/pluginconf.go
+++ b/heartbeat/monitors/pluginconf.go
@@ -29,6 +29,7 @@ var ErrPluginDisabled = errors.New("Monitor not loaded, plugin is disabled")
 // MonitorPluginInfo represents the generic configuration options around a monitor plugin.
 type MonitorPluginInfo struct {
 	ID      string `config:"id"`
+	Name    string `config:"pluginName"`
 	Type    string `config:"type" validate:"required"`
 	Enabled bool   `config:"enabled"`
 }

--- a/heartbeat/monitors/task.go
+++ b/heartbeat/monitors/task.go
@@ -156,7 +156,7 @@ func (t *configuredJob) Start() {
 	}
 
 	tf := t.makeSchedulerTaskFunc()
-	t.cancelFn, err = t.monitor.scheduler.Add(t.config.Schedule, t.job.Name(), tf)
+	t.cancelFn, err = t.monitor.scheduler.Add(t.config.Schedule, t.job.ID(), tf)
 	if err != nil {
 		logp.Err("could not start monitor: %v", err)
 	}

--- a/heartbeat/monitors/task.go
+++ b/heartbeat/monitors/task.go
@@ -66,7 +66,7 @@ func newConfiguredJob(job Job, config jobConfig, monitor *Monitor) (*configuredJ
 
 // jobConfig represents fields needed to execute a single job.
 type jobConfig struct {
-	Name     string             `config:"name"`
+	Name     string             `config:"pluginName"`
 	Type     string             `config:"type"`
 	Schedule *schedule.Schedule `config:"schedule" validate:"required"`
 
@@ -96,7 +96,7 @@ func (t *configuredJob) prepareSchedulerJob(meta common.MapStr, job Job) schedul
 		}
 
 		if event != nil && event.Fields != nil {
-			MergeEventFields(event, meta)
+			event.Fields.DeepUpdate(meta)
 			// If continuations are present we defensively publish a clone of the event
 			// in the chance that the event shares underlying data with the events for continuations
 			// This prevents races where the pipeline publish could accidentally alter multiple events.
@@ -133,8 +133,8 @@ func (t *configuredJob) makeSchedulerTaskFunc() scheduler.TaskFunc {
 
 	meta := common.MapStr{
 		"monitor": common.MapStr{
-			"name": name,
-			"type": t.config.Type,
+			"pluginName": name,
+			"type":       t.config.Type,
 		},
 	}
 

--- a/heartbeat/monitors/task.go
+++ b/heartbeat/monitors/task.go
@@ -83,12 +83,12 @@ func (e ProcessorsError) Error() string {
 	return fmt.Sprintf("could not load monitor processors: %s", e.root)
 }
 
-func (t *configuredJob) prepareSchedulerJob(meta common.MapStr, job Job) scheduler.TaskFunc {
+func (t *configuredJob) prepareSchedulerJob(job Job) scheduler.TaskFunc {
 	return func() []scheduler.TaskFunc {
 		event := &beat.Event{
 			Fields: common.MapStr{},
 		}
-		next, err := job.Run(event)
+		next, err := job(event)
 		hasContinuations := len(next) > 0
 
 		if err != nil {
@@ -96,7 +96,6 @@ func (t *configuredJob) prepareSchedulerJob(meta common.MapStr, job Job) schedul
 		}
 
 		if event != nil && event.Fields != nil {
-			event.Fields.DeepUpdate(meta)
 			// If continuations are present we defensively publish a clone of the event
 			// in the chance that the event shares underlying data with the events for continuations
 			// This prevents races where the pipeline publish could accidentally alter multiple events.
@@ -119,26 +118,14 @@ func (t *configuredJob) prepareSchedulerJob(meta common.MapStr, job Job) schedul
 
 		continuations := make([]scheduler.TaskFunc, len(next))
 		for i, n := range next {
-			continuations[i] = t.prepareSchedulerJob(meta, n)
+			continuations[i] = t.prepareSchedulerJob(n)
 		}
 		return continuations
 	}
 }
 
 func (t *configuredJob) makeSchedulerTaskFunc() scheduler.TaskFunc {
-	name := t.config.Name
-	if name == "" {
-		name = t.config.Type
-	}
-
-	meta := common.MapStr{
-		"monitor": common.MapStr{
-			"pluginName": name,
-			"type":       t.config.Type,
-		},
-	}
-
-	return t.prepareSchedulerJob(meta, t.job)
+	return t.prepareSchedulerJob(t.job)
 }
 
 // Start schedules this configuredJob for execution.
@@ -156,7 +143,7 @@ func (t *configuredJob) Start() {
 	}
 
 	tf := t.makeSchedulerTaskFunc()
-	t.cancelFn, err = t.monitor.scheduler.Add(t.config.Schedule, t.job.ID(), tf)
+	t.cancelFn, err = t.monitor.scheduler.Add(t.config.Schedule, t.monitor.id, tf)
 	if err != nil {
 		logp.Err("could not start monitor: %v", err)
 	}

--- a/heartbeat/tests/system/heartbeat.py
+++ b/heartbeat/tests/system/heartbeat.py
@@ -39,13 +39,14 @@ class BaseTest(TestCase):
         return server
 
     @staticmethod
-    def http_cfg(url):
+    def http_cfg(id, url):
         return """
 - type: http
+  id: "{id}"
   schedule: "@every 1s"
   timeout: 3s
   urls: ["{url}"]
-        """[1:-1].format(url=url)
+        """[1:-1].format(id=id, url=url)
 
     @staticmethod
     def tcp_cfg(*hosts):

--- a/heartbeat/tests/system/test_autodiscovery.py
+++ b/heartbeat/tests/system/test_autodiscovery.py
@@ -28,6 +28,7 @@ class TestAutodiscover(BaseTest):
                           contains.docker.container.image: redis
                         config:
                           - type: tcp
+                            id: myid
                             hosts: ["${data.host}:${data.port}"]
                             schedule: "@every 1s"
                             timeout: 1s
@@ -56,9 +57,7 @@ class TestAutodiscover(BaseTest):
                         0]['IPAddress']
                     port = network_settings['Ports'].keys()[0].split("/")[0]
                     # Check metadata is added
-                    expected = 'tcp-tcp@%s:%s' % (host, port)
-                    actual = output[0]['monitor']['id']
-                    if expected == actual:
+                    if output[0]['monitor']['id'] == 'myid':
                         matched = True
 
         assert matched

--- a/heartbeat/tests/system/test_reload.py
+++ b/heartbeat/tests/system/test_reload.py
@@ -18,14 +18,14 @@ class Test(BaseTest):
             cfg_file = "test.yml"
 
             self.write_dyn_config(
-                cfg_file, self.http_cfg("http://localhost:{}".format(server.server_port)))
+                cfg_file, self.http_cfg("myid", "http://localhost:{}".format(server.server_port)))
 
             self.wait_until(lambda: self.output_has(lines=1))
 
             self.assert_last_status("up")
 
             self.write_dyn_config(
-                cfg_file, self.http_cfg("http://203.0.113.1:8186"))
+                cfg_file, self.http_cfg("myid", "http://203.0.113.1:8186"))
 
             self.wait_until(lambda: self.last_output_line()[
                             "http.url"] == "http://203.0.113.1:8186")
@@ -47,7 +47,7 @@ class Test(BaseTest):
             cfg_file = "test.yml"
 
             self.write_dyn_config(
-                cfg_file, self.http_cfg("http://localhost:{}".format(server.server_port)))
+                cfg_file, self.http_cfg("myid", "http://localhost:{}".format(server.server_port)))
 
             self.wait_until(lambda: self.output_has(lines=2))
 
@@ -55,11 +55,9 @@ class Test(BaseTest):
 
             os.remove(self.monitors_dir() + cfg_file)
 
-            # Ensure the job was removed from the scheduler
-            self.wait_until(lambda: self.log_contains(
-                "Remove scheduler job 'http@http://localhost:{}".format(server.server_port)))
-            self.wait_until(lambda: self.log_contains(
-                "Job 'http@http://localhost:{}' returned".format(server.server_port)))
+            # Ensure the job was removed from the schduler
+            self.wait_until(lambda: self.log_contains("Remove scheduler job 'myid'"))
+            self.wait_until(lambda: self.log_contains("Job 'myid' returned"))
 
             self.proc.check_kill_and_wait()
         finally:
@@ -77,7 +75,7 @@ class Test(BaseTest):
         server = self.start_server("hello world", 200)
         try:
             self.write_dyn_config(
-                "test.yml", self.http_cfg("http://localhost:{}".format(server.server_port)))
+                "test.yml", self.http_cfg("myid", "http://localhost:{}".format(server.server_port)))
 
             self.wait_until(lambda: self.log_contains(
                 "Starting reload procedure, current runners: 1"))

--- a/libbeat/common/mapval/is_defs.go
+++ b/libbeat/common/mapval/is_defs.go
@@ -20,6 +20,7 @@ package mapval
 import (
 	"fmt"
 	"reflect"
+	"regexp"
 	"strings"
 	"time"
 
@@ -204,6 +205,26 @@ var IsNonEmptyString = Is("is a non-empty string", func(path path, v interface{}
 
 	return ValidResult(path)
 })
+
+// IsStringMatching checks whether a value matches the given regexp.
+func IsStringMatching(regexp *regexp.Regexp) IsDef {
+	return Is("is string matching regexp", func(path path, v interface{}) *Results {
+		strV, errorResults := isStrCheck(path, v)
+		if errorResults != nil {
+			return errorResults
+		}
+
+		if !regexp.MatchString(strV) {
+			return SimpleResult(
+				path,
+				false,
+				fmt.Sprintf("String '%s' did not match regexp %s", strV, regexp.String()),
+			)
+		}
+
+		return ValidResult(path)
+	})
+}
 
 // IsStringContaining validates that the the actual value contains the specified substring.
 func IsStringContaining(needle string) IsDef {

--- a/libbeat/common/mapval/is_defs_test.go
+++ b/libbeat/common/mapval/is_defs_test.go
@@ -18,6 +18,7 @@
 package mapval
 
 import (
+	"regexp"
 	"testing"
 	"time"
 
@@ -106,6 +107,13 @@ func TestIsNonEmptyString(t *testing.T) {
 	assertIsDefValid(t, IsNonEmptyString, "abc")
 	assertIsDefValid(t, IsNonEmptyString, "a")
 	assertIsDefInvalid(t, IsNonEmptyString, "")
+}
+
+func TestIsStringMatching(t *testing.T) {
+	id := IsStringMatching(regexp.MustCompile(`^f`))
+
+	assertIsDefValid(t, id, "fall")
+	assertIsDefInvalid(t, id, "potato")
 }
 
 func TestIsStringContaining(t *testing.T) {


### PR DESCRIPTION
This patch lets you set the `monitor.id` field from a monitor's config.

It also redefines the specific meaning of heartbeat's `monitor.id` field. It also tightens up the definition of the `monitor.name` field in events.

Fixes #8862