### PR TITLE
Fix Makefile of generated Beats

### DIFF
--- a/generator/beat/{beat}/Makefile
+++ b/generator/beat/{beat}/Makefile
@@ -4,16 +4,22 @@ BEAT_GOPATH=$(firstword $(subst :, ,${GOPATH}))
 SYSTEM_TESTS=false
 TEST_ENVIRONMENT=false
 ES_BEATS?=./vendor/github.com/elastic/beats
+LIBBEAT_MAKEFILE=$(ES_BEATS)/libbeat/scripts/Makefile
 GOPACKAGES=$(shell govendor list -no-status +local)
 GOBUILD_FLAGS=-i -ldflags "-X $(BEAT_PATH)/vendor/github.com/elastic/beats/libbeat/version.buildTime=$(NOW) -X $(BEAT_PATH)/vendor/github.com/elastic/beats/libbeat/version.commit=$(COMMIT_ID)"
 MAGE_IMPORT_PATH=${BEAT_PATH}/vendor/github.com/magefile/mage
+NO_COLLECT=true
 
 # Path to the libbeat Makefile
--include $(ES_BEATS)/libbeat/scripts/Makefile
+-include $(LIBBEAT_MAKEFILE)
 
 # Initial beat setup
 .PHONY: setup
-setup: copy-vendor git-init update git-add
+setup: pre-setup git-add
+
+pre-setup: copy-vendor git-init
+	$(MAKE) -f $(LIBBEAT_MAKEFILE) mage
+	$(MAKE) -f $(LIBBEAT_MAKEFILE) update BEAT_NAME=$(BEAT_NAME) ES_BEATS=$(ES_BEATS) NO_COLLECT=$(NO_COLLECT)
 
 # Copy beats into vendor directory
 .PHONY: copy-vendor
@@ -32,7 +38,3 @@ git-init:
 git-add:
 	git add -A
 	git commit -m "Add generated {beat} files"
-
-# Collects all dependencies and then calls update
-.PHONY: collect
-collect:

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -455,3 +455,8 @@ release: mage
 .PHONY: snapshot
 snapshot: mage
 	@SNAPSHOT=true mage package
+
+ifdef NO_COLLECT
+.PHONY: collect
+collect:
+endif


### PR DESCRIPTION
Makefile of generated Beats have two issues:

1. It does not install mage which is required for `make update` recipe
2. First run of `make setup` fails due to absence of libbeat [Makefile](https://github.com/elastic/beats/blob/master/generator/beat/%7Bbeat%7D/Makefile#L12) from the desired location (under vendor directory). Second run of `make setup` is successful though because the vendor directory has been filled due to [copy-vendor](https://github.com/elastic/beats/blob/master/generator/beat/%7Bbeat%7D/Makefile#L22) recipe.

Proposed Solution:
1. Use libbeat Makefile's [make mage](https://github.com/elastic/beats/blob/master/libbeat/scripts/Makefile#L444-L449) recipe to install mage
2. Call libbeat Makefile's `make update` recipe explicitly inside make setup because at the first time of calling `make setup` the `-include ...` has [failed silently (due to "-" sign)](https://www.gnu.org/software/make/manual/html_node/Include.html)
3. Introduce empty `make collect` recipe to Makefiles of beats which include libbeat's Makefile. The reason is that `make update` of libbeat's [Makefile](https://github.com/elastic/beats/blob/master/libbeat/scripts/Makefile#L314) requires `make collect` recipe to be found without declaring it

Signed-off-by: Stamatis Katsaounis <katsaouniss@gmail.com>
Co-Authored-By: Michael Katsoulis <michaelkatsoulis88@gmail.com>