### PR TITLE
Do not collect files in auditbeat docs collector

### DIFF
--- a/auditbeat/scripts/docs_collector.py
+++ b/auditbeat/scripts/docs_collector.py
@@ -27,7 +27,8 @@ This file is generated! See scripts/docs_collector.py
     for path in base_paths:
         module_dir = os.path.join(path, "module")
         for module_name in os.listdir(module_dir):
-            module_dirs[module_name] = os.path.join(module_dir, module_name)
+            if os.path.isdir(os.path.join(module_dir, module_name)):
+                module_dirs[module_name] = os.path.join(module_dir, module_name)
 
     # Iterate over all modules
     for module in sorted(module_dirs):


### PR DESCRIPTION
The docs_collector script for Auditbeat collected not only directories but also files. This lead to the issue that if a .DS_Store file exists, it was also added to the modules list.