### PR TITLE
[Auditbeat] Cherry-pick #9707 to 6.6: Update auditbeat.reference.yml

### DIFF
--- a/x-pack/auditbeat/auditbeat.reference.yml
+++ b/x-pack/auditbeat/auditbeat.reference.yml
@@ -312,6 +312,7 @@ auditbeat.modules:
 #    match_source_index: 4
 #    match_short_id: false
 #    cleanup_timeout: 60
+#    labels.dedot: false
 #    # To connect to Docker over TLS you must specify a client and CA certificate.
 #    #ssl:
 #    #  certificate_authority: "/etc/pki/root/ca.pem"


### PR DESCRIPTION
Cherry-pick of PR #9707 to 6.6 branch. Original message: 

https://github.com/elastic/beats/pull/9602 did not update `x-pack/auditbeat/auditbeat.reference.yml`. CI is failing, e.g. [here](https://beats-ci.elastic.co/job/elastic+beats+6.x+multijob-linux/259/beat=x-pack%2Fauditbeat,label=linux/console).