### PR TITLE
[Auditbeat] Cherry-pick #9705 to 6.x: Skip user system test

### DIFF
--- a/x-pack/auditbeat/tests/system/test_metricsets.py
+++ b/x-pack/auditbeat/tests/system/test_metricsets.py
@@ -46,6 +46,7 @@ class Test(AuditbeatXPackTest):
         self.check_metricset("system", "socket", COMMON_FIELDS + fields, warnings_allowed=True)
 
     @unittest.skipUnless(sys.platform == "linux2", "Only implemented for Linux")
+    @unittest.skip("Test is failing in CI")  # https://github.com/elastic/beats/issues/9679
     def test_metricset_user(self):
         """
         user metricset collects information about users on a server.


### PR DESCRIPTION
Cherry-pick of PR #9705 to 6.x branch. Original message: 

Skipping because of https://github.com/elastic/beats/issues/9679. CI failing e.g. [here](https://beats-ci.elastic.co/job/elastic+beats+master+multijob-linux/334/beat=x-pack%2Fauditbeat,label=linux/console).