### PR TITLE
Cherry-pick #9718 to 6.6: Fix ml job because of missing datafeed in the logs

### DIFF
--- a/filebeat/tests/system/test_ml.py
+++ b/filebeat/tests/system/test_ml.py
@@ -93,6 +93,9 @@ class Test(BaseTest):
             "-c", cfgfile
         ]
 
+        # Skipping dashboard loading to speed up tests, unfortunately only works for setup and not --setup
+        cmd += ["-E", "setup.dashboards.enabled=false"]
+
         if setup_flag:
             cmd += ["--setup"]
         else:

--- a/libbeat/ml-importer/importer.go
+++ b/libbeat/ml-importer/importer.go
@@ -228,7 +228,7 @@ func checkResponse(r []byte) error {
 
 	for _, feed := range resp.Datafeeds {
 		if !feed.Success {
-			if strings.HasPrefix(feed.Error.Msg, "[resource_already_exists_exception]") {
+			if strings.HasPrefix(feed.Error.Msg, "[status_exception] A datafeed") || strings.HasPrefix(feed.Error.Msg, "[resource_already_exists_exception]") {
 				logp.Debug("machine-learning", "Datafeed already exists: %s, error: %s", feed.ID, feed.Error.Msg)
 				continue
 			}


### PR DESCRIPTION
Cherry-pick of PR #9718 to 6.6 branch. Original message: 

The log output from ML changed. Because of this the check on the Beats side has to be adjusted. The old check was kept in place for backward compatiblity.

```
2018-12-20T14:11:14.356ZERRORinstance/beat.go:906Exiting: 2 errors: Error setting up ML for apache2: 5 errors: [status_exception] A datafeed [datafeed-filebeat-apache2-access-visitor_rate] already exists for job [filebeat-apache2-access-visitor_rate]; [status_exception] A datafeed [datafeed-filebeat-apache2-access-response_code] already exists for job [filebeat-apache2-access-response_code]; [status_exception] A datafeed [datafeed-filebeat-apache2-access-remote_ip_url_count] already exists for job [filebeat-apache2-access-remote_ip_url_count]; [status_exception] A datafeed [datafeed-filebeat-apache2-access-low_request_rate] already exists for job [filebeat-apache2-access-low_request_rate]; [status_exception] A datafeed [datafeed-filebeat-apache2-access-remote_ip_request_rate] already exists for job [filebeat-apache2-access-remote_ip_request_rate]; Error setting up ML for nginx: 5 errors: [status_exception] A datafeed [datafeed-filebeat-nginx-access-visitor_rate] already exists for job [filebeat-nginx-access-visitor_rate]; [status_exception] A datafeed [datafeed-filebeat-nginx-access-remote_ip_url_count] already exists for job [filebeat-nginx-access-remote_ip_url_count]; [status_exception] A datafeed [datafeed-filebeat-nginx-access-response_code] already exists for job [filebeat-nginx-access-response_code]; [status_exception] A datafeed [datafeed-filebeat-nginx-access-remote_ip_request_rate] already exists for job [filebeat-nginx-access-remote_ip_request_rate]; [status_exception] A datafeed [datafeed-filebeat-nginx-access-low_request_rate] already exists for job [filebeat-nginx-access-low_request_rate]
```