### PR TITLE
Cherry-pick #9516 to 6.x: Allow the Host header to be overriden (fixes #9376)

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -72,6 +72,7 @@ https://github.com/elastic/beats/compare/v6.6.0...6.x[Check the HEAD diff]
 *Heartbeat*
 
 - Heartbeat now always downloads the entire body of HTTP endpoints, even if no checks against the body content are declared. This fixes an issue where timing metrics would be incorrect in scenarios where the body wasn't used since the connection would be closed soon after the headers were sent, but before the entire body was. {pull}8894[8894]
+- `Host` header can now be overridden for HTTP requests sent by Heartbeat monitors. {pull}9148[9516]
 
 *Journalbeat*
 

--- a/heartbeat/monitors/active/http/task.go
+++ b/heartbeat/monitors/active/http/task.go
@@ -223,6 +223,11 @@ func buildRequest(addr string, config *Config, enc contentEncoder) (*http.Reques
 		request.SetBasicAuth(config.Username, config.Password)
 	}
 	for k, v := range config.Check.Request.SendHeaders {
+		// defining the Host header isn't enough. See https://github.com/golang/go/issues/7682
+		if k == "Host" {
+			request.Host = v
+		}
+
 		request.Header.Add(k, v)
 	}
 

--- a/heartbeat/monitors/active/http/task_test.go
+++ b/heartbeat/monitors/active/http/task_test.go
@@ -154,3 +154,18 @@ func TestNonZeroRedirect(t *testing.T) {
 	// We are now at the limit, this request should fail
 	assert.Equal(t, http.ErrUseLastResponse, checker(makeTestHTTPRequest(t), via))
 }
+
+func TestRequestBuildingWithCustomHost(t *testing.T) {
+	var config = Config{}
+	var encoder = nilEncoder{}
+
+	config.Check.Request.SendHeaders = make(map[string]string)
+	config.Check.Request.SendHeaders["Host"] = "custom-host"
+
+	request, err := buildRequest("localhost", &config, encoder)
+
+	if assert.Nil(t, err) {
+		assert.Equal(t, "custom-host", request.Host)
+		assert.Equal(t, "custom-host", request.Header.Get("Host"))
+	}
+}


### PR DESCRIPTION
Cherry-pick of PR #9516 to 6.x branch. Original message: 

As explained on [golang's repository](https://github.com/golang/go/issues/7682), adding a *Host* header to the request's headers list isn't enough. So when this header is defined by the configuration, I also explicitly give it to the HTTP request.