### PR TITLE
Cherry-pick #9658 to 6.6: Add mage target alias for Jenkins compatibility

### DIFF
--- a/x-pack/auditbeat/magefile.go
+++ b/x-pack/auditbeat/magefile.go
@@ -22,6 +22,12 @@ func init() {
 	mage.BeatLicense = "Elastic License"
 }
 
+// Aliases provides compatibility with CI while we transition all Beats
+// to having common testing targets.
+var Aliases = map[string]interface{}{
+	"goTestUnit": GoUnitTest, // dev-tools/jenkins_ci.ps1 uses this.
+}
+
 // Build builds the Beat binary.
 func Build() error {
 	return mage.Build(mage.DefaultBuildArgs())

--- a/x-pack/filebeat/magefile.go
+++ b/x-pack/filebeat/magefile.go
@@ -22,6 +22,12 @@ func init() {
 	mage.BeatLicense = "Elastic License"
 }
 
+// Aliases provides compatibility with CI while we transition all Beats
+// to having common testing targets.
+var Aliases = map[string]interface{}{
+	"goTestUnit": GoUnitTest, // dev-tools/jenkins_ci.ps1 uses this.
+}
+
 // Build builds the Beat binary.
 func Build() error {
 	return mage.Build(mage.DefaultBuildArgs())


### PR DESCRIPTION
Cherry-pick of PR #9658 to 6.6 branch. Original message: 

jenkins_ci.ps1 expects a target named `goTestUnit` but those are being renamed to `goUnitTest` (which aligns better with the related targets `unitTest` and `pythonUnitTest`).