### PR TITLE
Cherry-pick #9198 to 6.x: Upgrade test Docker images to latest versions

### DIFF
--- a/metricbeat/module/elasticsearch/_meta/Dockerfile
+++ b/metricbeat/module/elasticsearch/_meta/Dockerfile
@@ -1,2 +1,2 @@
 FROM docker.elastic.co/elasticsearch/elasticsearch:6.5.1
-HEALTHCHECK --interval=1s --retries=300 CMD curl -f http://localhost:9200/_cluster/health
+HEALTHCHECK --interval=1s --retries=300 CMD curl -f http://localhost:9200/_xpack/license

--- a/metricbeat/module/elasticsearch/_meta/Dockerfile
+++ b/metricbeat/module/elasticsearch/_meta/Dockerfile
@@ -1,2 +1,2 @@
-FROM docker.elastic.co/elasticsearch/elasticsearch:6.4.3
-HEALTHCHECK --interval=1s --retries=300 CMD curl -f http://localhost:9200
+FROM docker.elastic.co/elasticsearch/elasticsearch:6.5.1
+HEALTHCHECK --interval=1s --retries=300 CMD curl -f http://localhost:9200/_cluster/health

--- a/metricbeat/module/elasticsearch/ccr/_meta/test/test_follower_index.json
+++ b/metricbeat/module/elasticsearch/ccr/_meta/test/test_follower_index.json
@@ -1,0 +1,4 @@
+{
+    "remote_cluster": "same",
+    "leader_index": "pied_piper"
+}

--- a/metricbeat/module/elasticsearch/ccr/_meta/test/test_leader_index.json
+++ b/metricbeat/module/elasticsearch/ccr/_meta/test/test_leader_index.json
@@ -1,0 +1,5 @@
+{
+    "settings": {
+        "soft_deletes.enabled": true
+    }
+}

--- a/metricbeat/module/elasticsearch/ccr/_meta/test/test_remote_settings.json
+++ b/metricbeat/module/elasticsearch/ccr/_meta/test/test_remote_settings.json
@@ -1,0 +1,13 @@
+{
+    "transient": {
+        "cluster": {
+            "remote": {
+                "same": {
+                    "seeds": [
+                        "127.0.0.1:9300"
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/metricbeat/module/elasticsearch/test_elasticsearch.py
+++ b/metricbeat/module/elasticsearch/test_elasticsearch.py
@@ -34,12 +34,15 @@ class Test(metricbeat.BaseTest):
         """
         elasticsearch metricset tests
         """
-        self.check_skip(metricset)
-
-        if metricset == "ml_job":
-            self.create_ml_job()
-
         es = Elasticsearch(self.get_hosts())
+        self.check_skip(metricset, es)
+
+        self.start_trial(es)
+        if metricset == "ml_job":
+            self.create_ml_job(es)
+        if metricset == "ccr":
+            self.create_ccr_stats(es)
+
         es.indices.create(index='test-index', ignore=400)
         self.check_metricset("elasticsearch", metricset, self.get_hosts(), self.FIELDS +
                              ["service.name"], extras={"index_recovery.active_only": "false"})
@@ -48,16 +51,7 @@ class Test(metricbeat.BaseTest):
         return [os.getenv('ES_HOST', 'localhost') + ':' +
                 os.getenv('ES_PORT', '9200')]
 
-    def create_ml_job(self):
-        es = Elasticsearch(self.get_hosts())
-
-        # Enable xpack trial
-        try:
-            es.transport.perform_request('POST', "/_xpack/license/start_trial?acknowledge=true")
-        except:
-            e = sys.exc_info()[0]
-            print "Trial already enabled. Error: {}".format(e)
-
+    def create_ml_job(self, es):
         # Check if an ml job already exists
         response = es.transport.perform_request('GET', "/_xpack/ml/anomaly_detectors/_all/")
         if response["count"] > 0:
@@ -72,21 +66,66 @@ class Test(metricbeat.BaseTest):
         path = "/_xpack/ml/anomaly_detectors/test"
         es.transport.perform_request('PUT', path, body=body)
 
-    def check_skip(self, metricset):
+    def create_ccr_stats(self, es):
+        self.setup_ccr_remote(es)
+        self.create_ccr_leader_index(es)
+        self.create_ccr_follower_index(es)
+
+    def setup_ccr_remote(self, es):
+        file = os.path.join(self.beat_path, "module", "elasticsearch", "ccr",
+                            "_meta", "test", "test_remote_settings.json")
+
+        body = {}
+        with open(file, 'r') as f:
+            body = json.load(f)
+
+        path = "/_cluster/settings"
+        es.transport.perform_request('PUT', path, body=body)
+
+    def create_ccr_leader_index(self, es):
+        file = os.path.join(self.beat_path, "module", "elasticsearch", "ccr", "_meta", "test", "test_leader_index.json")
+
+        body = {}
+        with open(file, 'r') as f:
+            body = json.load(f)
+
+        path = "/pied_piper"
+        es.transport.perform_request('PUT', path, body=body)
+
+    def create_ccr_follower_index(self, es):
+        file = os.path.join(self.beat_path, "module", "elasticsearch", "ccr",
+                            "_meta", "test", "test_follower_index.json")
+
+        body = {}
+        with open(file, 'r') as f:
+            body = json.load(f)
+
+        path = "/rats/_ccr/follow"
+        es.transport.perform_request('PUT', path, body=body)
+
+    def start_trial(self, es):
+        # Check if trial is already enabled
+        response = es.transport.perform_request('GET', "/_xpack/license")
+        if response["license"]["type"] == "trial":
+            return
+
+        # Enable xpack trial
+        try:
+            es.transport.perform_request('POST', "/_xpack/license/start_trial?acknowledge=true")
+        except:
+            e = sys.exc_info()[0]
+            print "Trial already enabled. Error: {}".format(e)
+
+    def check_skip(self, metricset, es):
         if metricset != "ccr":
             return
 
-        version = self.get_version()
+        version = self.get_version(es)
         if semver.compare(version, "6.5.0") == -1:
             # Skip CCR metricset system test for Elasticsearch versions < 6.5.0 as CCR Stats
             # API endpoint is not available
             raise SkipTest("elasticsearch/ccr metricset system test only valid with Elasticsearch versions >= 6.5.0")
 
-    def get_version(self):
-        host = self.get_hosts()[0]
-        res = urllib2.urlopen("http://" + host + "/").read()
-
-        body = json.loads(res)
-        version = body["version"]["number"]
-
-        return version
+    def get_version(self, es):
+        response = es.transport.perform_request('GET', "/")
+        return response["version"]["number"]

--- a/metricbeat/module/kibana/_meta/Dockerfile
+++ b/metricbeat/module/kibana/_meta/Dockerfile
@@ -1,2 +1,2 @@
-FROM docker.elastic.co/kibana/kibana:6.4.3
+FROM docker.elastic.co/kibana/kibana:6.5.1
 HEALTHCHECK --interval=1s --retries=300 CMD curl -f http://localhost:5601/api/status | grep '"disconnects"'


### PR DESCRIPTION
Cherry-pick of PR #9198 to 6.x branch. Original message: 

This PR upgrades the Elasticsearch and Kibana Docker images to their latest versions in their respective Metricbeat module tests.

In addition to the actual version upgrade changes, this PR also contains several changes necessary to get the integration and system tests for the `elasticsearch/ccr` metricset passing. These tests existed before this PR but were skipped because:
- the CCR feature only exists in Elasticsearch 6.5.0 onwards,
- the tests had a check to skip if the version of Elasticsearch being used in the tests was < 6.5.0, and
- we were using Elasticsearch 6.4.3 until this PR came along and upgraded it.

