### PR TITLE
Make SearchURIWithBody work with both ES 7.0 and ES 6.0

### DIFF
--- a/libbeat/outputs/elasticsearch/api.go
+++ b/libbeat/outputs/elasticsearch/api.go
@@ -19,6 +19,7 @@ package elasticsearch
 
 import (
 	"encoding/json"
+	"fmt"
 	"strconv"
 
 	"github.com/pkg/errors"
@@ -62,22 +63,23 @@ type Total struct {
 
 // UnmarshalJSON correctly unmarshal the hits response between ES 6.0 and ES 7.0.
 func (t *Total) UnmarshalJSON(b []byte) error {
+	value := struct {
+		Value    int    `json:"value"`
+		Relation string `json:"relation"`
+	}{}
+
+	if err := json.Unmarshal(b, &value); err == nil {
+		*t = value
+		return nil
+	}
+
 	// fallback for Elasticsearch < 7
 	if i, err := strconv.Atoi(string(b)); err == nil {
 		*t = Total{Value: i, Relation: "eq"}
 		return nil
 	}
 
-	value := struct {
-		Value    int    `json:"value"`
-		Relation string `json:"relation"`
-	}{}
-
-	if err := json.Unmarshal(b, &value); err != nil {
-		return err
-	}
-	*t = value
-	return nil
+	return fmt.Errorf("could not unmarshal JSON value '%s'", string(b))
 }
 
 // CountResults contains the count of results.

--- a/libbeat/outputs/elasticsearch/api_test.go
+++ b/libbeat/outputs/elasticsearch/api_test.go
@@ -59,7 +59,7 @@ func GetValidQueryResult() QueryResult {
 
 func GetValidSearchResults() SearchResults {
 	hits := Hits{
-		Total: Total{Value: 0, Relation: "eq"},
+		Total: Total{Value: 10, Relation: "eq"},
 		Hits:  nil,
 	}
 
@@ -112,26 +112,49 @@ func TestReadQueryResult_invalid(t *testing.T) {
 }
 
 func TestReadSearchResult(t *testing.T) {
-	resultsObject := GetValidSearchResults()
-
-	json := []byte(`{
+	t.Run("search results response from 7.0", func(t *testing.T) {
+		resultsObject := GetValidSearchResults()
+		json := []byte(`{
   		"took" : 19,
   		"_shards" : {
     		"total" : 3,
     		"successful" : 2,
     		"failed" : 1
   		},
-			"hits" : { "total": { "value": 0, "relation": "eq" } },
+			"hits" : { "total": { "value": 10, "relation": "eq" } },
   		"aggs" : {}
   	}`)
 
-	results, err := readSearchResult(json)
+		results, err := readSearchResult(json)
 
-	assert.Nil(t, err)
-	assert.Equal(t, resultsObject.Took, results.Took)
-	assert.Equal(t, resultsObject.Hits, results.Hits)
-	assert.Equal(t, resultsObject.Shards, results.Shards)
-	assert.Equal(t, resultsObject.Aggs, results.Aggs)
+		assert.Nil(t, err)
+		assert.Equal(t, resultsObject.Took, results.Took)
+		assert.Equal(t, resultsObject.Hits, results.Hits)
+		assert.Equal(t, resultsObject.Shards, results.Shards)
+		assert.Equal(t, resultsObject.Aggs, results.Aggs)
+	})
+
+	t.Run("search results response from 6.0", func(t *testing.T) {
+		resultsObject := GetValidSearchResults()
+		json := []byte(`{
+  		"took" : 19,
+  		"_shards" : {
+    		"total" : 3,
+    		"successful" : 2,
+    		"failed" : 1
+  		},
+			"hits" : { "total": 10 },
+  		"aggs" : {}
+  	}`)
+
+		results, err := readSearchResult(json)
+
+		assert.Nil(t, err)
+		assert.Equal(t, resultsObject.Took, results.Took)
+		assert.Equal(t, resultsObject.Hits, results.Hits)
+		assert.Equal(t, resultsObject.Shards, results.Shards)
+		assert.Equal(t, resultsObject.Aggs, results.Aggs)
+	})
 }
 
 func TestReadSearchResult_empty(t *testing.T) {


### PR DESCRIPTION
The PR #9673 broke the usage of
SearchURIWithBody for ES6.0. This commit make sure it work with both
ES7.0 and ES6.0 when unserializing the hits count from a search results.

Fixes: #9691