### PR TITLE
Cherry-pick #9258 to 6.x: Unify heartbeat jobs and tasks for simplicity

### DIFF
--- a/heartbeat/monitors/active/dialchain/net.go
+++ b/heartbeat/monitors/active/dialchain/net.go
@@ -24,6 +24,8 @@ import (
 	"time"
 
 	"github.com/elastic/beats/heartbeat/look"
+	"github.com/elastic/beats/heartbeat/monitors"
+	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/outputs/transport"
@@ -64,7 +66,7 @@ func UDPDialer(to time.Duration) NetDialer {
 }
 
 func netDialer(timeout time.Duration) NetDialer {
-	return func(event common.MapStr) (transport.Dialer, error) {
+	return func(event *beat.Event) (transport.Dialer, error) {
 		return makeDialer(func(network, address string) (net.Conn, error) {
 			namespace := ""
 
@@ -86,7 +88,7 @@ func netDialer(timeout time.Duration) NetDialer {
 			if err != nil || portNum < 0 || portNum > (1<<16) {
 				return nil, fmt.Errorf("invalid port number '%v' used", port)
 			}
-			event.DeepUpdate(common.MapStr{
+			monitors.MergeEventFields(event, common.MapStr{
 				namespace: common.MapStr{
 					"port": uint16(portNum),
 				},
@@ -108,7 +110,7 @@ func netDialer(timeout time.Duration) NetDialer {
 			}
 
 			end := time.Now()
-			event.DeepUpdate(common.MapStr{
+			monitors.MergeEventFields(event, common.MapStr{
 				namespace: common.MapStr{
 					"rtt": common.MapStr{
 						"connect": look.RTT(end.Sub(start)),

--- a/heartbeat/monitors/active/dialchain/socks5.go
+++ b/heartbeat/monitors/active/dialchain/socks5.go
@@ -21,7 +21,7 @@ import (
 	"net"
 
 	"github.com/elastic/beats/heartbeat/look"
-	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/outputs/transport"
 )
 
@@ -35,7 +35,7 @@ import (
 //    }
 //  }
 func SOCKS5Layer(config *transport.ProxyConfig) Layer {
-	return func(event common.MapStr, next transport.Dialer) (transport.Dialer, error) {
+	return func(event *beat.Event, next transport.Dialer) (transport.Dialer, error) {
 		var timer timer
 
 		dialer, err := transport.ProxyDialer(config, startTimerAfterDial(&timer, next))
@@ -48,7 +48,7 @@ func SOCKS5Layer(config *transport.ProxyConfig) Layer {
 			// TODO: add proxy url to event?
 
 			timer.stop()
-			event.Put("socks5.rtt.connect", look.RTT(timer.duration()))
+			event.Fields.Put("socks5.rtt.connect", look.RTT(timer.duration()))
 			return conn, nil
 		}), nil
 	}

--- a/heartbeat/monitors/active/dialchain/tls.go
+++ b/heartbeat/monitors/active/dialchain/tls.go
@@ -24,7 +24,7 @@ import (
 	"time"
 
 	"github.com/elastic/beats/heartbeat/look"
-	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/outputs/transport"
 )
 
@@ -38,7 +38,7 @@ import (
 //    }
 //  }
 func TLSLayer(cfg *transport.TLSConfig, to time.Duration) Layer {
-	return func(event common.MapStr, next transport.Dialer) (transport.Dialer, error) {
+	return func(event *beat.Event, next transport.Dialer) (transport.Dialer, error) {
 		var timer timer
 
 		// Wrap next dialer so to start the timer when 'next' returns.
@@ -58,7 +58,7 @@ func TLSLayer(cfg *transport.TLSConfig, to time.Duration) Layer {
 
 			// TODO: extract TLS connection parameters from connection object.
 			timer.stop()
-			event.Put("tls.rtt.handshake", look.RTT(timer.duration()))
+			event.PutValue("tls.rtt.handshake", look.RTT(timer.duration()))
 
 			// Pointers because we need a nil value
 			var chainNotValidBefore *time.Time
@@ -80,8 +80,8 @@ func TLSLayer(cfg *transport.TLSConfig, to time.Duration) Layer {
 				}
 			}
 
-			event.Put("tls.certificate_not_valid_before", *chainNotValidBefore)
-			event.Put("tls.certificate_not_valid_after", *chainNotValidAfter)
+			event.PutValue("tls.certificate_not_valid_before", *chainNotValidBefore)
+			event.PutValue("tls.certificate_not_valid_after", *chainNotValidAfter)
 
 			return conn, nil
 		}), nil

--- a/heartbeat/monitors/active/dialchain/util.go
+++ b/heartbeat/monitors/active/dialchain/util.go
@@ -21,7 +21,7 @@ import (
 	"net"
 	"time"
 
-	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/outputs/transport"
 )
 
@@ -34,7 +34,7 @@ func IDLayer() Layer {
 	return _idLayer
 }
 
-var _idLayer = Layer(func(event common.MapStr, next transport.Dialer) (transport.Dialer, error) {
+var _idLayer = Layer(func(event *beat.Event, next transport.Dialer) (transport.Dialer, error) {
 	return next, nil
 })
 
@@ -43,7 +43,7 @@ var _idLayer = Layer(func(event common.MapStr, next transport.Dialer) (transport
 func ConstAddrLayer(address string) Layer {
 	build := constAddr(address)
 
-	return func(event common.MapStr, next transport.Dialer) (transport.Dialer, error) {
+	return func(event *beat.Event, next transport.Dialer) (transport.Dialer, error) {
 		return build(next), nil
 	}
 }
@@ -108,7 +108,7 @@ func constAddr(addr string) func(transport.Dialer) transport.Dialer {
 }
 
 func withNetDialer(layer NetDialer, fn func(transport.Dialer) transport.Dialer) NetDialer {
-	return func(event common.MapStr) (transport.Dialer, error) {
+	return func(event *beat.Event) (transport.Dialer, error) {
 		origDialer, err := layer.build(event)
 		if err != nil {
 			return nil, err
@@ -118,7 +118,7 @@ func withNetDialer(layer NetDialer, fn func(transport.Dialer) transport.Dialer) 
 }
 
 func withLayerDialer(layer Layer, fn func(transport.Dialer) transport.Dialer) Layer {
-	return func(event common.MapStr, next transport.Dialer) (transport.Dialer, error) {
+	return func(event *beat.Event, next transport.Dialer) (transport.Dialer, error) {
 		origDialer, err := layer.build(event, next)
 		if err != nil {
 			return nil, err

--- a/heartbeat/monitors/active/http/http.go
+++ b/heartbeat/monitors/active/http/http.go
@@ -36,6 +36,7 @@ func init() {
 
 var debugf = logp.MakeDebug("http")
 
+// Create makes a new HTTP monitor
 func create(
 	name string,
 	cfg *common.Config,
@@ -98,7 +99,8 @@ func create(
 		}
 	}
 
-	return jobs, len(config.URLs), nil
+	errWrappedJobs := monitors.WrapAll(jobs, monitors.WithErrAsField)
+	return errWrappedJobs, len(config.URLs), nil
 }
 
 func newRoundTripper(config *Config, tls *transport.TLSConfig) (*http.Transport, error) {

--- a/heartbeat/monitors/active/http/http_test.go
+++ b/heartbeat/monitors/active/http/http_test.go
@@ -40,13 +40,13 @@ import (
 	"github.com/elastic/beats/libbeat/testing/mapvaltest"
 )
 
-func testRequest(t *testing.T, testURL string) beat.Event {
+func testRequest(t *testing.T, testURL string) *beat.Event {
 	return testTLSRequest(t, testURL, nil)
 }
 
 // testTLSRequest tests the given request. certPath is optional, if given
 // an empty string no cert will be set.
-func testTLSRequest(t *testing.T, testURL string, extraConfig map[string]interface{}) beat.Event {
+func testTLSRequest(t *testing.T, testURL string, extraConfig map[string]interface{}) *beat.Event {
 	configSrc := map[string]interface{}{
 		"urls":    testURL,
 		"timeout": "1s",
@@ -66,7 +66,8 @@ func testTLSRequest(t *testing.T, testURL string, extraConfig map[string]interfa
 
 	job := jobs[0]
 
-	event, _, err := job.Run()
+	event := &beat.Event{}
+	_, err = job.Run(event)
 	require.NoError(t, err)
 
 	require.Equal(t, 1, endpoints)
@@ -74,7 +75,7 @@ func testTLSRequest(t *testing.T, testURL string, extraConfig map[string]interfa
 	return event
 }
 
-func checkServer(t *testing.T, handlerFunc http.HandlerFunc) (*httptest.Server, beat.Event) {
+func checkServer(t *testing.T, handlerFunc http.HandlerFunc) (*httptest.Server, *beat.Event) {
 	server := httptest.NewServer(handlerFunc)
 	defer server.Close()
 	event := testRequest(t, server.URL)
@@ -237,7 +238,8 @@ func TestLargeResponse(t *testing.T) {
 
 	job := jobs[0]
 
-	event, _, err := job.Run()
+	event := &beat.Event{}
+	_, err = job.Run(event)
 	require.NoError(t, err)
 
 	port, err := hbtest.ServerPort(server)

--- a/heartbeat/monitors/active/icmp/icmp.go
+++ b/heartbeat/monitors/active/icmp/icmp.go
@@ -21,11 +21,12 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/beat"
 
 	"github.com/elastic/beats/heartbeat/look"
 	"github.com/elastic/beats/heartbeat/monitors"
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
 )
 
 func init() {
@@ -93,19 +94,23 @@ func create(
 		}
 	}
 
-	return jobs, len(config.Hosts), nil
+	errWrappedJobs := monitors.WrapAll(jobs, monitors.WithErrAsField)
+	return errWrappedJobs, len(config.Hosts), nil
 }
 
-func createPingIPFactory(config *Config) func(*net.IPAddr) (common.MapStr, error) {
-	return func(ip *net.IPAddr) (common.MapStr, error) {
+func createPingIPFactory(config *Config) func(*beat.Event, *net.IPAddr) error {
+	return func(event *beat.Event, ip *net.IPAddr) error {
 		rtt, n, err := loop.ping(ip, config.Timeout, config.Wait)
-
-		fields := common.MapStr{"requests": n}
-		if err == nil {
-			fields["rtt"] = look.RTT(rtt)
+		if err != nil {
+			return err
 		}
 
-		event := common.MapStr{"icmp": fields}
-		return event, err
+		icmpFields := common.MapStr{"requests": n}
+		if err == nil {
+			icmpFields["rtt"] = look.RTT(rtt)
+			monitors.MergeEventFields(event, icmpFields)
+		}
+
+		return nil
 	}
 }

--- a/heartbeat/monitors/active/tcp/task.go
+++ b/heartbeat/monitors/active/tcp/task.go
@@ -20,55 +20,58 @@ package tcp
 import (
 	"time"
 
-	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/outputs/transport"
+	"github.com/elastic/beats/heartbeat/monitors"
 
 	"github.com/elastic/beats/heartbeat/look"
 	"github.com/elastic/beats/heartbeat/reason"
+	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/outputs/transport"
 )
 
 func pingHost(
+	event *beat.Event,
 	dialer transport.Dialer,
 	host string,
 	timeout time.Duration,
 	validator ConnCheck,
-) (common.MapStr, error) {
+) error {
 	start := time.Now()
 	deadline := start.Add(timeout)
 
 	conn, err := dialer.Dial("tcp", host)
 	if err != nil {
 		debugf("dial failed with: %v", err)
-		return nil, reason.IOFailed(err)
+		return reason.IOFailed(err)
 	}
 	defer conn.Close()
 	if validator == nil {
 		// no additional validation step => ping success
-		return common.MapStr{}, nil
+		return nil
 	}
 
 	if err := conn.SetDeadline(deadline); err != nil {
 		debugf("setting connection deadline failed with: %v", err)
-		return nil, reason.IOFailed(err)
+		return reason.IOFailed(err)
 	}
 
 	validateStart := time.Now()
 	err = validator.Validate(conn)
 	if err != nil && err != errRecvMismatch {
 		debugf("check failed with: %v", err)
-		return nil, reason.IOFailed(err)
+		return reason.IOFailed(err)
 	}
 
 	end := time.Now()
-	event := common.MapStr{
+	monitors.MergeEventFields(event, common.MapStr{
 		"tcp": common.MapStr{
 			"rtt": common.MapStr{
 				"validate": look.RTT(end.Sub(validateStart)),
 			},
 		},
-	}
+	})
 	if err != nil {
-		event["error"] = reason.FailValidate(err)
+		event.PutValue("error", reason.FailValidate(err))
 	}
-	return event, nil
+	return nil
 }

--- a/heartbeat/monitors/active/tcp/tcp_test.go
+++ b/heartbeat/monitors/active/tcp/tcp_test.go
@@ -50,12 +50,13 @@ func testTCPCheck(t *testing.T, host string, port uint16) *beat.Event {
 
 	job := jobs[0]
 
-	event, _, err := job.Run()
+	event := &beat.Event{}
+	_, err = job.Run(event)
 	require.NoError(t, err)
 
 	require.Equal(t, 1, endpoints)
 
-	return &event
+	return event
 }
 
 func testTLSTCPCheck(t *testing.T, host string, port uint16, certFileName string) *beat.Event {
@@ -72,12 +73,13 @@ func testTLSTCPCheck(t *testing.T, host string, port uint16, certFileName string
 
 	job := jobs[0]
 
-	event, _, err := job.Run()
+	event := &beat.Event{}
+	_, err = job.Run(event)
 	require.NoError(t, err)
 
 	require.Equal(t, 1, endpoints)
 
-	return &event
+	return event
 }
 
 func setupServer(t *testing.T, serverCreator func(http.Handler) *httptest.Server) (*httptest.Server, uint16) {

--- a/heartbeat/monitors/job.go
+++ b/heartbeat/monitors/job.go
@@ -21,10 +21,89 @@ import (
 	"github.com/elastic/beats/libbeat/beat"
 )
 
-// Job represents the work done by a single check by a given Monitor.
+// A Job represents a unit of execution, and may return multiple continuation jobs.
 type Job interface {
 	Name() string
-	Run() (beat.Event, []jobRunner, error)
+	Run(event *beat.Event) ([]Job, error)
 }
 
-type jobRunner func() (beat.Event, []jobRunner, error)
+// NamedJob represents a job with an explicitly specified name.
+type NamedJob struct {
+	name string
+	run  func(event *beat.Event) ([]Job, error)
+}
+
+// CreateNamedJob makes a new NamedJob.
+func CreateNamedJob(name string, run func(event *beat.Event) ([]Job, error)) *NamedJob {
+	return &NamedJob{name, run}
+}
+
+// Name returns the name of this job.
+func (f *NamedJob) Name() string {
+	return f.name
+}
+
+// Run executes the job.
+func (f *NamedJob) Run(event *beat.Event) ([]Job, error) {
+	return f.run(event)
+}
+
+// AnonJob represents a job with no assigned name, backed by just a function.
+type AnonJob func(event *beat.Event) ([]Job, error)
+
+// Name returns "" for AnonJob values.
+func (aj AnonJob) Name() string {
+	return ""
+}
+
+// Run executes the function.
+func (aj AnonJob) Run(event *beat.Event) ([]Job, error) {
+	return aj(event)
+}
+
+// AfterJob creates a wrapped version of the given Job that runs additional
+// code after the original Job, possibly altering return values.
+func AfterJob(j Job, after func(*beat.Event, []Job, error) ([]Job, error)) Job {
+
+	return CreateNamedJob(
+		j.Name(),
+		func(event *beat.Event) ([]Job, error) {
+			next, err := j.Run(event)
+
+			return after(event, next, err)
+		},
+	)
+}
+
+// AfterJobSuccess creates a wrapped version of the given Job that runs additional
+// code after the original job if the original Job succeeds, possibly altering
+// return values.
+func AfterJobSuccess(j Job, after func(*beat.Event, []Job, error) ([]Job, error)) Job {
+	return AfterJob(j, func(event *beat.Event, cont []Job, err error) ([]Job, error) {
+		if err != nil {
+			return cont, err
+		}
+
+		return after(event, cont, err)
+	})
+}
+
+// MakeSimpleJob creates a new Job from a callback function. The callback should
+// return an valid event and can not create any sub-tasks to be executed after
+// completion.
+func MakeSimpleJob(f func(*beat.Event) error) Job {
+	return AnonJob(func(event *beat.Event) ([]Job, error) {
+		err := f(event)
+		return nil, err
+	})
+}
+
+// WrapAll takes a list of jobs and wraps them all with the provided Job wrapping
+// function.
+func WrapAll(jobs []Job, fn func(Job) Job) []Job {
+	var wrapped []Job
+	for _, j := range jobs {
+		wrapped = append(wrapped, fn(j))
+	}
+	return wrapped
+}

--- a/heartbeat/monitors/mocks_test.go
+++ b/heartbeat/monitors/mocks_test.go
@@ -90,10 +90,11 @@ func (pc *MockPipelineConnector) ConnectWith(beat.ClientConfig) (beat.Client, er
 }
 
 func createMockJob(name string, cfg *common.Config) ([]Job, error) {
-	j := MakeSimpleJob(JobSettings{}, func() (common.MapStr, error) {
-		return common.MapStr{
+	j := MakeSimpleJob(func(event *beat.Event) error {
+		MergeEventFields(event, common.MapStr{
 			"foo": "bar",
-		}, nil
+		})
+		return nil
 	})
 
 	return []Job{j}, nil


### PR DESCRIPTION
Cherry-pick of PR #9258 to 6.x branch. Original message: 

In heartbeat we have separate notions of jobs and tasks.

One thing that's hard to do today is to invoke one monitor from another due to the distinction. A monitor has a top-level `job` that spawns many `tasks`. For a task to spawn a `job` without this patch would require an awkward and confusing unwrap / rewrap. This paves the way for enhanced multi-part jobs like elastic/beats#9122 . The other thing this does is move the hoisting of errors from Job return values to fields up into the highest level creation functions. This was required for the composition of jobs as in #9122. It's also cleaner, since we use the `error` return value for errors up until we no longer can.

Just as important as the composition benefits are the code readibility benefits. This patch makes the code easier to follow. By removing these different notions of Job and Task navigating the execution of a monitor is made simpler since there are fewer types to reason about. 

There is probably a tiny amount of extra execution overhead. Tasks only passed a single `common.MapStr`, where we now pass a `*beat.Event`, however, the benefit is that we have a more consistent and simple codebase.