### PR TITLE
Cherry-pick #9737 to 6.6: Fix integTest target by honoring TEST_ENVIRONMENT

### DIFF
--- a/dev-tools/mage/integtest.go
+++ b/dev-tools/mage/integtest.go
@@ -20,9 +20,11 @@ package mage
 import (
 	"fmt"
 	"io/ioutil"
+	"log"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -96,6 +98,10 @@ func StopIntegTestEnv() error {
 		return nil
 	}
 
+	if _, skip := skipIntegTest(); skip {
+		return nil
+	}
+
 	composeEnv, err := integTestDockerComposeEnvVars()
 	if err != nil {
 		return err
@@ -130,6 +136,11 @@ func StopIntegTestEnv() error {
 //
 // Always use this with AddIntegTestUsage() and defer StopIntegTestEnv().
 func RunIntegTest(mageTarget string, test func() error, passThroughEnvVars ...string) error {
+	if reason, skip := skipIntegTest(); skip {
+		fmt.Printf(">> %v: Skipping because %v\n", mageTarget, reason)
+		return nil
+	}
+
 	AddIntegTestUsage()
 	defer StopIntegTestEnv()
 
@@ -230,6 +241,31 @@ func haveIntegTestEnvRequirements() error {
 		return err
 	}
 	return nil
+}
+
+// skipIntegTest returns true if integ tests should be skipped.
+func skipIntegTest() (reason string, skip bool) {
+	if IsInIntegTestEnv() {
+		return "", false
+	}
+
+	// Honor the TEST_ENVIRONMENT value if set.
+	if testEnvVar, isSet := os.LookupEnv("TEST_ENVIRONMENT"); isSet {
+		enabled, err := strconv.ParseBool(testEnvVar)
+		if err != nil {
+			panic(errors.Wrap(err, "failed to parse TEST_ENVIRONMENT value"))
+		}
+		return "TEST_ENVIRONMENT=" + testEnvVar, !enabled
+	}
+
+	// Otherwise skip if we don't have all the right dependencies.
+	if err := haveIntegTestEnvRequirements(); err != nil {
+		// Skip if we don't meet the requirements.
+		log.Println("Skipping integ test because:", err)
+		return "docker is not available", true
+	}
+
+	return "", false
 }
 
 // integTestDockerComposeEnvVars returns the environment variables used for


### PR DESCRIPTION
Cherry-pick of PR #9737 to 6.6 branch. Original message: 

This backports a small portion of #9724.