### PR TITLE
[Auditbeat] Cherry-pick #9750 to 6.x: Fix/Skip Windows x-pack/auditbeat tests

### DIFF
--- a/metricbeat/tests/system/metricbeat.py
+++ b/metricbeat/tests/system/metricbeat.py
@@ -2,7 +2,7 @@ import re
 import sys
 import os
 
-sys.path.append(os.path.join(os.path.dirname(__file__), '../../../libbeat/tests/system'))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../libbeat/tests/system')))
 
 from beat.beat import TestCase
 

--- a/x-pack/auditbeat/module/system/process/process_test.go
+++ b/x-pack/auditbeat/module/system/process/process_test.go
@@ -5,6 +5,7 @@
 package process
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/elastic/beats/auditbeat/core"
@@ -12,6 +13,9 @@ import (
 )
 
 func TestData(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Fails on Windows - https://github.com/elastic/beats/issues/9748")
+	}
 	f := mbtest.NewReportingMetricSetV2(t, getConfig())
 	events, errs := mbtest.ReportingFetchV2(f)
 	if len(errs) > 0 {

--- a/x-pack/auditbeat/tests/system/auditbeat_xpack.py
+++ b/x-pack/auditbeat/tests/system/auditbeat_xpack.py
@@ -1,10 +1,13 @@
 import jinja2
 import os
+import sys
 
-from auditbeat import BaseTest as AuditbeatTest
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../../metricbeat/tests/system')))
+
+from metricbeat import BaseTest as MetricbeatTest
 
 
-class AuditbeatXPackTest(AuditbeatTest):
+class AuditbeatXPackTest(MetricbeatTest):
 
     @classmethod
     def setUpClass(self):
@@ -12,10 +15,10 @@ class AuditbeatXPackTest(AuditbeatTest):
         self.beat_path = os.path.abspath(
             os.path.join(os.path.dirname(__file__), "../../"))
 
-        super(AuditbeatTest, self).setUpClass()
+        super(MetricbeatTest, self).setUpClass()
 
     def setUp(self):
-        super(AuditbeatTest, self).setUp()
+        super(MetricbeatTest, self).setUp()
 
         # Hack to make jinja2 have the right paths
         self.template_env = jinja2.Environment(

--- a/x-pack/auditbeat/tests/system/test_metricsets.py
+++ b/x-pack/auditbeat/tests/system/test_metricsets.py
@@ -4,8 +4,6 @@ import sys
 import time
 import unittest
 
-sys.path.append(os.path.join(os.path.dirname(__file__), '../../../../auditbeat/tests/system'))
-
 from auditbeat_xpack import *
 
 COMMON_FIELDS = ["@timestamp", "host.name", "event.module", "event.dataset"]
@@ -24,6 +22,7 @@ class Test(AuditbeatXPackTest):
         self.check_metricset("system", "host", COMMON_FIELDS + fields, warnings_allowed=True)
 
     @unittest.skipIf(sys.platform == "darwin" and os.geteuid != 0, "Requires root on macOS")
+    @unittest.skipIf(sys.platform == "win32", "Fails on Windows - https://github.com/elastic/beats/issues/9748")
     def test_metricset_process(self):
         """
         process metricset collects information about processes running on a system.


### PR DESCRIPTION
Cherry-pick of PR #9750 to 6.x branch. Original message: 

Tries to address https://github.com/elastic/beats/issues/9748 by skipping the `process` unit test on Windows, and changing the inheritance of `AuditbeatXPackTest` for system tests.