### PR TITLE
Cherry-pick #9706 to 6.6: Remove the experimental tag from Jolokia autodiscover provider

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -55,6 +55,8 @@ https://github.com/elastic/beats/compare/1035569addc4a3b29ffa14f8a08c27c1ace16ef
 
 *Affecting all Beats*
 
+- Release Jolokia autodiscover as GA. {pull}9706[9706]
+
 *Auditbeat*
 
 *Filebeat*

--- a/libbeat/autodiscover/providers/jolokia/jolokia.go
+++ b/libbeat/autodiscover/providers/jolokia/jolokia.go
@@ -24,7 +24,6 @@ import (
 	"github.com/elastic/beats/libbeat/autodiscover/template"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/bus"
-	"github.com/elastic/beats/libbeat/common/cfgwarn"
 )
 
 func init() {
@@ -51,8 +50,6 @@ type Provider struct {
 // AutodiscoverBuilder builds a Jolokia Discovery autodiscover provider, it fails if
 // there is some problem with the configuration
 func AutodiscoverBuilder(bus bus.Bus, uuid uuid.UUID, c *common.Config) (autodiscover.Provider, error) {
-	cfgwarn.Experimental("The Jolokia Discovery autodiscover is experimental")
-
 	config := defaultConfig()
 	err := c.Unpack(&config)
 	if err != nil {

--- a/libbeat/docs/shared-autodiscover.asciidoc
+++ b/libbeat/docs/shared-autodiscover.asciidoc
@@ -191,7 +191,7 @@ After they are de-duplicated, only one will be used.
 
 ifdef::autodiscoverJolokia[]
 [float]
-===== Jolokia (experimental)
+===== Jolokia
 
 The Jolokia autodiscover provider uses Jolokia Discovery to find agents running
 in your host or your network.


### PR DESCRIPTION
Cherry-pick of PR #9706 to 6.6 branch. Original message: 

I'd say we want to keep Jolokia autodiscover as is, so remove the experimental tag for 7.0. 