### PR TITLE
Allow multiple object types per field.

### DIFF
--- a/libbeat/common/field.go
+++ b/libbeat/common/field.go
@@ -34,25 +34,28 @@ import (
 type Fields []Field
 
 type Field struct {
-	Name                  string      `config:"name"`
-	Type                  string      `config:"type"`
-	Description           string      `config:"description"`
-	Format                string      `config:"format"`
-	ScalingFactor         int         `config:"scaling_factor"`
-	Fields                Fields      `config:"fields"`
-	MultiFields           Fields      `config:"multi_fields"`
-	ObjectType            string      `config:"object_type"`
-	ObjectTypeMappingType string      `config:"object_type_mapping_type"`
-	Enabled               *bool       `config:"enabled"`
-	Analyzer              string      `config:"analyzer"`
-	SearchAnalyzer        string      `config:"search_analyzer"`
-	Norms                 bool        `config:"norms"`
-	Dynamic               DynamicType `config:"dynamic"`
-	Index                 *bool       `config:"index"`
-	DocValues             *bool       `config:"doc_values"`
-	CopyTo                string      `config:"copy_to"`
-	IgnoreAbove           int         `config:"ignore_above"`
-	AliasPath             string      `config:"path"`
+	Name           string      `config:"name"`
+	Type           string      `config:"type"`
+	Description    string      `config:"description"`
+	Format         string      `config:"format"`
+	Fields         Fields      `config:"fields"`
+	MultiFields    Fields      `config:"multi_fields"`
+	Enabled        *bool       `config:"enabled"`
+	Analyzer       string      `config:"analyzer"`
+	SearchAnalyzer string      `config:"search_analyzer"`
+	Norms          bool        `config:"norms"`
+	Dynamic        DynamicType `config:"dynamic"`
+	Index          *bool       `config:"index"`
+	DocValues      *bool       `config:"doc_values"`
+	CopyTo         string      `config:"copy_to"`
+	IgnoreAbove    int         `config:"ignore_above"`
+	AliasPath      string      `config:"path"`
+
+	ScalingFactor         int    `config:"scaling_factor"`
+	ObjectType            string `config:"object_type"`
+	ObjectTypeMappingType string `config:"object_type_mapping_type"`
+
+	ObjectTypeParams []ObjectTypeCfg `config:"object_type_params"`
 
 	// Kibana specific
 	Analyzed     *bool  `config:"analyzed"`
@@ -71,6 +74,12 @@ type Field struct {
 
 	Overwrite bool `config:"overwrite"`
 	Path      string
+}
+
+type ObjectTypeCfg struct {
+	ObjectType            string `config:"object_type"`
+	ObjectTypeMappingType string `config:"object_type_mapping_type"`
+	ScalingFactor         int    `config:"scaling_factor"`
 }
 
 type VersionizedString struct {

--- a/libbeat/template/processor_test.go
+++ b/libbeat/template/processor_test.go
@@ -18,6 +18,7 @@
 package template
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -43,21 +44,21 @@ func TestProcessor(t *testing.T) {
 			expected: common.MapStr{"type": "long"},
 		},
 		{
-			output: p.scaledFloat(&common.Field{Type: "scaled_float"}),
+			output: p.scaledFloat(&common.Field{Type: "scaled_float"}, 0),
 			expected: common.MapStr{
 				"type":           "scaled_float",
 				"scaling_factor": 1000,
 			},
 		},
 		{
-			output: p.scaledFloat(&common.Field{Type: "scaled_float", ScalingFactor: 100}),
+			output: p.scaledFloat(&common.Field{Type: "scaled_float", ScalingFactor: 100}, 10),
 			expected: common.MapStr{
 				"type":           "scaled_float",
-				"scaling_factor": 100,
+				"scaling_factor": 10,
 			},
 		},
 		{
-			output:   pEsVersion2.scaledFloat(&common.Field{Type: "scaled_float"}),
+			output:   pEsVersion2.scaledFloat(&common.Field{Type: "scaled_float"}, 0),
 			expected: common.MapStr{"type": "float"},
 		},
 		{
@@ -264,22 +265,24 @@ func TestProcessor(t *testing.T) {
 	}
 }
 
-func TestDynamicTemplate(t *testing.T) {
+func TestDynamicTemplates(t *testing.T) {
 	p := &Processor{}
 	tests := []struct {
 		field    common.Field
-		expected common.MapStr
+		expected []common.MapStr
 	}{
 		{
 			field: common.Field{
 				Type: "object", ObjectType: "keyword",
 				Name: "context",
 			},
-			expected: common.MapStr{
-				"context": common.MapStr{
-					"mapping":            common.MapStr{"type": "keyword"},
-					"match_mapping_type": "string",
-					"path_match":         "context.*",
+			expected: []common.MapStr{
+				common.MapStr{
+					"context": common.MapStr{
+						"mapping":            common.MapStr{"type": "keyword"},
+						"match_mapping_type": "string",
+						"path_match":         "context.*",
+					},
 				},
 			},
 		},
@@ -288,11 +291,13 @@ func TestDynamicTemplate(t *testing.T) {
 				Type: "object", ObjectType: "long", ObjectTypeMappingType: "futuretype",
 				Path: "language", Name: "english",
 			},
-			expected: common.MapStr{
-				"language.english": common.MapStr{
-					"mapping":            common.MapStr{"type": "long"},
-					"match_mapping_type": "futuretype",
-					"path_match":         "language.english.*",
+			expected: []common.MapStr{
+				common.MapStr{
+					"language.english": common.MapStr{
+						"mapping":            common.MapStr{"type": "long"},
+						"match_mapping_type": "futuretype",
+						"path_match":         "language.english.*",
+					},
 				},
 			},
 		},
@@ -301,11 +306,13 @@ func TestDynamicTemplate(t *testing.T) {
 				Type: "object", ObjectType: "long", ObjectTypeMappingType: "*",
 				Path: "language", Name: "english",
 			},
-			expected: common.MapStr{
-				"language.english": common.MapStr{
-					"mapping":            common.MapStr{"type": "long"},
-					"match_mapping_type": "*",
-					"path_match":         "language.english.*",
+			expected: []common.MapStr{
+				common.MapStr{
+					"language.english": common.MapStr{
+						"mapping":            common.MapStr{"type": "long"},
+						"match_mapping_type": "*",
+						"path_match":         "language.english.*",
+					},
 				},
 			},
 		},
@@ -314,11 +321,13 @@ func TestDynamicTemplate(t *testing.T) {
 				Type: "object", ObjectType: "long",
 				Path: "language", Name: "english",
 			},
-			expected: common.MapStr{
-				"language.english": common.MapStr{
-					"mapping":            common.MapStr{"type": "long"},
-					"match_mapping_type": "long",
-					"path_match":         "language.english.*",
+			expected: []common.MapStr{
+				common.MapStr{
+					"language.english": common.MapStr{
+						"mapping":            common.MapStr{"type": "long"},
+						"match_mapping_type": "long",
+						"path_match":         "language.english.*",
+					},
 				},
 			},
 		},
@@ -327,11 +336,13 @@ func TestDynamicTemplate(t *testing.T) {
 				Type: "object", ObjectType: "text",
 				Path: "language", Name: "english",
 			},
-			expected: common.MapStr{
-				"language.english": common.MapStr{
-					"mapping":            common.MapStr{"type": "text"},
-					"match_mapping_type": "string",
-					"path_match":         "language.english.*",
+			expected: []common.MapStr{
+				common.MapStr{
+					"language.english": common.MapStr{
+						"mapping":            common.MapStr{"type": "text"},
+						"match_mapping_type": "string",
+						"path_match":         "language.english.*",
+					},
 				},
 			},
 		},
@@ -340,14 +351,16 @@ func TestDynamicTemplate(t *testing.T) {
 				Type: "object", ObjectType: "scaled_float",
 				Name: "core.*.pct",
 			},
-			expected: common.MapStr{
-				"core.*.pct": common.MapStr{
-					"mapping": common.MapStr{
-						"type":           "scaled_float",
-						"scaling_factor": defaultScalingFactor,
+			expected: []common.MapStr{
+				common.MapStr{
+					"core.*.pct": common.MapStr{
+						"mapping": common.MapStr{
+							"type":           "scaled_float",
+							"scaling_factor": defaultScalingFactor,
+						},
+						"match_mapping_type": "*",
+						"path_match":         "core.*.pct",
 					},
-					"match_mapping_type": "*",
-					"path_match":         "core.*.pct",
 				},
 			},
 		},
@@ -356,35 +369,72 @@ func TestDynamicTemplate(t *testing.T) {
 				Type: "object", ObjectType: "scaled_float",
 				Name: "core.*.pct", ScalingFactor: 100, ObjectTypeMappingType: "float",
 			},
-			expected: common.MapStr{
-				"core.*.pct": common.MapStr{
-					"mapping": common.MapStr{
-						"type":           "scaled_float",
-						"scaling_factor": 100,
+			expected: []common.MapStr{
+				common.MapStr{
+					"core.*.pct": common.MapStr{
+						"mapping": common.MapStr{
+							"type":           "scaled_float",
+							"scaling_factor": 100,
+						},
+						"match_mapping_type": "float",
+						"path_match":         "core.*.pct",
 					},
-					"match_mapping_type": "float",
-					"path_match":         "core.*.pct",
+				},
+			},
+		},
+		{
+			field: common.Field{
+				Type: "object", ObjectTypeParams: []common.ObjectTypeCfg{
+					{ObjectType: "float", ObjectTypeMappingType: "float"},
+					{ObjectType: "boolean"},
+					{ObjectType: "scaled_float", ScalingFactor: 10000},
+				},
+				Name: "context",
+			},
+			expected: []common.MapStr{
+				common.MapStr{
+					"context": common.MapStr{
+						"mapping":            common.MapStr{"type": "float"},
+						"match_mapping_type": "float",
+						"path_match":         "context.*",
+					},
+				},
+				common.MapStr{
+					"context": common.MapStr{
+						"mapping":            common.MapStr{"type": "boolean"},
+						"match_mapping_type": "boolean",
+						"path_match":         "context.*",
+					},
+				},
+				common.MapStr{
+					"context": common.MapStr{
+						"mapping":            common.MapStr{"type": "scaled_float", "scaling_factor": 10000},
+						"match_mapping_type": "*",
+						"path_match":         "context.*",
+					},
 				},
 			},
 		},
 	}
 
-	for _, numericType := range []string{"byte", "double", "float", "long", "short"} {
+	for _, numericType := range []string{"byte", "double", "float", "long", "short", "boolean"} {
 		gen := struct {
 			field    common.Field
-			expected common.MapStr
+			expected []common.MapStr
 		}{
 			field: common.Field{
 				Type: "object", ObjectType: numericType,
 				Name: "somefield", ObjectTypeMappingType: "long",
 			},
-			expected: common.MapStr{
-				"somefield": common.MapStr{
-					"mapping": common.MapStr{
-						"type": numericType,
+			expected: []common.MapStr{
+				common.MapStr{
+					"somefield": common.MapStr{
+						"mapping": common.MapStr{
+							"type": numericType,
+						},
+						"match_mapping_type": "long",
+						"path_match":         "somefield.*",
 					},
-					"match_mapping_type": "long",
-					"path_match":         "somefield.*",
 				},
 			},
 		}
@@ -394,7 +444,7 @@ func TestDynamicTemplate(t *testing.T) {
 	for _, test := range tests {
 		dynamicTemplates = nil
 		p.object(&test.field)
-		assert.Equal(t, test.expected, dynamicTemplates[0])
+		assert.Equal(t, test.expected, dynamicTemplates)
 	}
 }
 


### PR DESCRIPTION
Allow configuring multiple object types for the same field, to allow creating multiple dynamic templates on dynamic attributes, where keys are unknown. 

Usage:
```
- name: tags
  object_type_params:
  -  object_type: boolean
  -  object_type: scaled_float
      scaling_factor: 1000000
```

precondition for https://github.com/elastic/apm-server/pull/1712