### PR TITLE
enforcing init.sh.tmpl in  filebeat to run on the background using start-stop-daemon --background

### DIFF
--- a/dev-tools/packaging/templates/deb/init.sh.tmpl
+++ b/dev-tools/packaging/templates/deb/init.sh.tmpl
@@ -65,7 +65,7 @@ do_start()
 	#   0 if daemon has been started
 	#   1 if daemon was already running
 	#   2 if daemon could not be started
-	start-stop-daemon --start \
+	start-stop-daemon --start --background \
                 --pidfile $PIDFILE  \
 		--exec $WRAPPER -- $WRAPPER_ARGS -- $DAEMON $DAEMON_ARGS \
 		|| return 2


### PR DESCRIPTION
Closes elastic/beats#9774 