### PR TITLE
Cherry-pick #9624 to 6.5: Be more strict when handling the access token

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -33,12 +33,6 @@ https://github.com/elastic/beats/compare/v6.5.4...6.5[Check the HEAD diff]
 
 *Affecting all Beats*
 
-- Fix autodiscover configurations stopping when metadata is missing. {pull}8851[8851]
-- Log events at the debug level when dropped by encoding problems. {pull}9251[9251]
-- Refresh host metadata in add_host_metadata. {pull}9359[9359]
-- When collecting swap metrics for beats telemetry or system metricbeat module handle cases of free swap being bigger than total swap by assuming no swap is being used. {issue}6271[6271] {pull}9383[9383]
-- Adding logging traces at debug level when the pipeline client receives the following events: onFilteredOut, onDroppedOnPublish. {pull}9016[9016]
-- Ignore non index fields in default_field for Elasticsearch. {pull}9549[9549]
 - Enforce validation for the Central Management access token. {issue}9621[9621]
 
 *Auditbeat*

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -33,6 +33,14 @@ https://github.com/elastic/beats/compare/v6.5.4...6.5[Check the HEAD diff]
 
 *Affecting all Beats*
 
+- Fix autodiscover configurations stopping when metadata is missing. {pull}8851[8851]
+- Log events at the debug level when dropped by encoding problems. {pull}9251[9251]
+- Refresh host metadata in add_host_metadata. {pull}9359[9359]
+- When collecting swap metrics for beats telemetry or system metricbeat module handle cases of free swap being bigger than total swap by assuming no swap is being used. {issue}6271[6271] {pull}9383[9383]
+- Adding logging traces at debug level when the pipeline client receives the following events: onFilteredOut, onDroppedOnPublish. {pull}9016[9016]
+- Ignore non index fields in default_field for Elasticsearch. {pull}9549[9549]
+- Enforce validation for the Central Management access token. {issue}9621[9621]
+
 *Auditbeat*
 
 *Filebeat*

--- a/x-pack/libbeat/management/api/enroll.go
+++ b/x-pack/libbeat/management/api/enroll.go
@@ -8,9 +8,21 @@ import (
 	"net/http"
 
 	"github.com/gofrs/uuid"
+	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/libbeat/common"
 )
+
+type enrollResponse struct {
+	AccessToken string `json:"access_token"`
+}
+
+func (e *enrollResponse) Validate() error {
+	if len(e.AccessToken) == 0 {
+		return errors.New("empty access_token")
+	}
+	return nil
+}
 
 // Enroll a beat in central management, this call returns a valid access token to retrieve configurations
 func (c *Client) Enroll(beatType, beatName, beatVersion, hostname string, beatUUID uuid.UUID, enrollmentToken string) (string, error) {
@@ -21,15 +33,17 @@ func (c *Client) Enroll(beatType, beatName, beatVersion, hostname string, beatUU
 		"host_name": hostname,
 	}
 
-	resp := struct {
-		AccessToken string `json:"access_token"`
-	}{}
+	resp := enrollResponse{}
 
 	headers := http.Header{}
 	headers.Set("kbn-beats-enrollment-token", enrollmentToken)
 
 	_, err := c.request("POST", "/api/beats/agent/"+beatUUID.String(), params, headers, &resp)
 	if err != nil {
+		return "", err
+	}
+
+	if err := resp.Validate(); err != nil {
 		return "", err
 	}
 

--- a/x-pack/libbeat/management/api/enroll.go
+++ b/x-pack/libbeat/management/api/enroll.go
@@ -5,10 +5,10 @@
 package api
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/gofrs/uuid"
-	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/libbeat/common"
 )

--- a/x-pack/libbeat/management/api/enroll_test.go
+++ b/x-pack/libbeat/management/api/enroll_test.go
@@ -62,18 +62,46 @@ func TestEnrollValid(t *testing.T) {
 }
 
 func TestEnrollError(t *testing.T) {
-	beatUUID, err := uuid.NewV4()
-	if err != nil {
-		t.Fatal(err)
+	tests := map[string]struct {
+		body         string
+		responseCode int
+	}{
+		"invalid enrollment token": {
+			body:         `{"message": "Invalid enrollment token"}`,
+			responseCode: 400,
+		},
+		"invalid token response": {
+			body:         `{"access_token": ""}`,
+			responseCode: 200,
+		},
 	}
 
-	server, client := newServerClientPair(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.Error(w, `{"message": "Invalid enrollment token"}`, 400)
-	}))
-	defer server.Close()
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			beatUUID, err := uuid.NewV4()
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	accessToken, err := client.Enroll("metricbeat", "beatname", "6.3.0", "myhostname.lan", beatUUID, "thisismyenrollmenttoken")
+			server, client := newServerClientPair(t, http.HandlerFunc(func(
+				w http.ResponseWriter,
+				r *http.Request,
+			) {
+				http.Error(w, test.body, test.responseCode)
+			}))
+			defer server.Close()
 
-	assert.NotNil(t, err)
-	assert.Equal(t, "", accessToken)
+			accessToken, err := client.Enroll(
+				"metricbeat",
+				"beatname",
+				"6.3.0",
+				"myhostname.lan",
+				beatUUID,
+				"thisismyenrollmenttoken",
+			)
+
+			assert.NotNil(t, err)
+			assert.Equal(t, "", accessToken)
+		})
+	}
 }

--- a/x-pack/libbeat/management/config.go
+++ b/x-pack/libbeat/management/config.go
@@ -5,6 +5,7 @@
 package management
 
 import (
+	"errors"
 	"io"
 	"text/template"
 	"time"
@@ -66,6 +67,8 @@ const ManagedConfigTemplate = `
 #xpack.monitoring.elasticsearch:
 `
 
+var errEmptyAccessToken = errors.New("access_token is empty, you must reenroll your Beat")
+
 // Config for central management
 type Config struct {
 	// true when enrolled
@@ -77,6 +80,14 @@ type Config struct {
 	AccessToken string `config:"access_token" yaml:"access_token"`
 
 	Kibana *kibana.ClientConfig `config:"kibana" yaml:"kibana"`
+}
+
+// Validate validates the fields in the config.
+func (c *Config) Validate() error {
+	if len(c.AccessToken) == 0 {
+		return errEmptyAccessToken
+	}
+	return nil
 }
 
 func defaultConfig() *Config {

--- a/x-pack/libbeat/management/config_test.go
+++ b/x-pack/libbeat/management/config_test.go
@@ -1,0 +1,41 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package management
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/libbeat/common"
+)
+
+func TestConfigValidate(t *testing.T) {
+	tests := map[string]struct {
+		config *common.Config
+		err    bool
+	}{
+		"missing access_token": {
+			config: common.MustNewConfigFrom(map[string]interface{}{}),
+			err:    true,
+		},
+		"access_token is present": {
+			config: common.MustNewConfigFrom(map[string]interface{}{"access_token": "abc1234"}),
+			err:    false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			c := defaultConfig()
+			err := test.config.Unpack(c)
+			if test.err {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
Cherry-pick of PR #9624 to 6.5 branch. Original message: 

Add validations for the Kibana response with the access token,
and enforce that the access token is not empty when unpacking the
configuration. Since the access token in the keystore could be edited.

Fixes: #9621