### PR TITLE
Cherry-pick #9624 to 6.6: Be more strict when handling the access token

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -35,6 +35,14 @@ https://github.com/elastic/beats/compare/1035569addc4a3b29ffa14f8a08c27c1ace16ef
 
 *Affecting all Beats*
 
+- Fix autodiscover configurations stopping when metadata is missing. {pull}8851[8851]
+- Log events at the debug level when dropped by encoding problems. {pull}9251[9251]
+- Refresh host metadata in add_host_metadata. {pull}9359[9359]
+- When collecting swap metrics for beats telemetry or system metricbeat module handle cases of free swap being bigger than total swap by assuming no swap is being used. {issue}6271[6271] {pull}9383[9383]
+- Adding logging traces at debug level when the pipeline client receives the following events: onFilteredOut, onDroppedOnPublish. {pull}9016[9016]
+- Ignore non index fields in default_field for Elasticsearch. {pull}9549[9549]
+- Enforce validation for the Central Management access token. {issue}9621[9621]
+
 *Auditbeat*
 
 *Filebeat*


### PR DESCRIPTION
Cherry-pick of PR #9624 to 6.6 branch. Original message: 

Add validations for the Kibana response with the access token,
and enforce that the access token is not empty when unpacking the
configuration. Since the access token in the keystore could be edited.

Fixes: #9621