### PR TITLE
Fix typo in "Exporting New and Modified Beat Dashboards" docs

### DIFF
--- a/docs/devguide/newdashboards.asciidoc
+++ b/docs/devguide/newdashboards.asciidoc
@@ -232,7 +232,7 @@ MODULE=redis ID=AV4REOpp5NkDleZmzKkE mage exportDashboard
 
 [source,shell]
 ---------------
-./filebeat export dashboard -id 7fea2930-478e-11e7-b1f0-cb29bac6bf8b >> Filebeat-redis.json
+./filebeat export dashboard -dashboard 7fea2930-478e-11e7-b1f0-cb29bac6bf8b >> Filebeat-redis.json
 ---------------
 
 This generates a `AV4REOpp5NkDleZmzKkE.json` file inside dashboard directory in the redis module.


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4249331/50450311-6a1d6380-092d-11e9-85f3-24af5bcfb57d.png)
Docs says that you should use the `-dashboard` flag when exporting but then, in the example, it's written `-id` (the one that actually works is `-dashboard`.

This PR just changes the example so that the correct used arg is `-dashboard`.

I don't know if this kind of things needs backporting.