### PR TITLE
Replace missing field names from status Metricset in MongoDB Dashboard

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -34,6 +34,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Metricbeat*
 
+- Fix MongoDB dashboard that had some incorrect field names from `status` Metricset {pull}9795[9795] {issue}9715[9715]
+
 *Packetbeat*
 
 - Adjust Packetbeat `http` fields to ECS Beta 2 {pull}9645[9645]

--- a/metricbeat/module/mongodb/_meta/kibana/6/dashboard/Metricbeat-mongodb-overview.json
+++ b/metricbeat/module/mongodb/_meta/kibana/6/dashboard/Metricbeat-mongodb-overview.json
@@ -37,7 +37,7 @@
                             "enabled": true, 
                             "id": "2", 
                             "params": {
-                                "field": "host.name", 
+                                "field": "metricset.host", 
                                 "order": "desc", 
                                 "orderBy": "1", 
                                 "size": 5
@@ -113,7 +113,7 @@
                             "enabled": true, 
                             "id": "1", 
                             "params": {
-                                "field": "host.name"
+                                "field": "metricset.host"
                             }, 
                             "schema": "metric", 
                             "type": "cardinality"

--- a/metricbeat/module/mongodb/_meta/kibana/6/dashboard/Metricbeat-mongodb-overview.json
+++ b/metricbeat/module/mongodb/_meta/kibana/6/dashboard/Metricbeat-mongodb-overview.json
@@ -37,7 +37,7 @@
                             "enabled": true, 
                             "id": "2", 
                             "params": {
-                                "field": "metricset.host", 
+                                "field": "host.name", 
                                 "order": "desc", 
                                 "orderBy": "1", 
                                 "size": 5
@@ -113,7 +113,7 @@
                             "enabled": true, 
                             "id": "1", 
                             "params": {
-                                "field": "metricset.host"
+                                "field": "host.name"
                             }, 
                             "schema": "metric", 
                             "type": "cardinality"
@@ -180,7 +180,7 @@
                             "id": "1", 
                             "params": {
                                 "customLabel": "command", 
-                                "field": "mongodb.status.opcounters.command"
+                                "field": "mongodb.status.ops.counters.command"
                             }, 
                             "schema": "metric", 
                             "type": "avg"
@@ -203,7 +203,7 @@
                             "id": "3", 
                             "params": {
                                 "customLabel": "delete", 
-                                "field": "mongodb.status.opcounters.delete"
+                                "field": "mongodb.status.ops.counters.delete"
                             }, 
                             "schema": "metric", 
                             "type": "avg"
@@ -213,7 +213,7 @@
                             "id": "4", 
                             "params": {
                                 "customLabel": "getmore", 
-                                "field": "mongodb.status.opcounters.getmore"
+                                "field": "mongodb.status.ops.counters.getmore"
                             }, 
                             "schema": "metric", 
                             "type": "avg"
@@ -223,7 +223,7 @@
                             "id": "5", 
                             "params": {
                                 "customLabel": "insert", 
-                                "field": "mongodb.status.opcounters.insert"
+                                "field": "mongodb.status.ops.counters.insert"
                             }, 
                             "schema": "metric", 
                             "type": "avg"
@@ -233,7 +233,7 @@
                             "id": "6", 
                             "params": {
                                 "customLabel": "query", 
-                                "field": "mongodb.status.opcounters.query"
+                                "field": "mongodb.status.ops.counters.query"
                             }, 
                             "schema": "metric", 
                             "type": "avg"
@@ -243,7 +243,7 @@
                             "id": "7", 
                             "params": {
                                 "customLabel": "update", 
-                                "field": "mongodb.status.opcounters_replicated.update"
+                                "field": "mongodb.status.ops.replicated.update"
                             }, 
                             "schema": "metric", 
                             "type": "avg"


### PR DESCRIPTION
According to issue https://github.com/elastic/beats/issues/9715 it seems that some field names within the MongoDB dashboard were incorrect.

It seems that this commit changed the field names https://github.com/elastic/beats/commit/5544838e2002f6a8bf956bafc25d0df8f34f5437 5 months ago.

In this PR, the _correct_ field names are set. I'm not very experienced with Kibana so I have just modified current dashboard JSON file instead of replacing it with the exported one using [this method](https://www.elastic.co/guide/en/beats/devguide/current/export-dashboards.html).

Working in Kibana 6.5.4