### PR TITLE
Cherry-pick #9802 to 6.6: Remove X-Pack foo Metricbeat module from reference file

### DIFF
--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -227,14 +227,6 @@ metricbeat.modules:
   period: 10s
   hosts: ["localhost:2379"]
 
-#--------------------------------- Foo Module ---------------------------------
-- module: foo
-  metricsets: ["bar"]
-  enabled: false
-  period: 10s
-  hosts: ["localhost"]
-
-
 #-------------------------------- Golang Module --------------------------------
 - module: golang
   #metricsets:


### PR DESCRIPTION
Cherry-pick of PR #9802 to 6.6 branch. Original message: 

The purpose of the `foo` module in Metricbeat X-Pack was to test the new build and test system within the `x-pack/metricbeat` folder.

After [merging](https://github.com/elastic/beats/commit/49660170a8da223044c36f227f61a9bc4cec942e) MS SQL module in X-Pack, we can already remove this dummy module.

Things that have been removed:
* module folder and all its contents `module/foo`
* References to the module and metricset in `include/list.go` file
* Reference in the `metricbeat.reference.yml` file.