### PR TITLE
Add docs build to Jenkinsfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -141,12 +141,6 @@ jobs:
       go: $GO_VERSION
       stage: test
 
-    # Docs
-    - os: linux
-      env: TARGETS="docs"
-      go: $GO_VERSION
-      stage: test
-
     # Kubernetes
     - os: linux
       install: deploy/kubernetes/.travis/setup.sh

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -106,23 +106,89 @@ pipeline {
     Finally archive the results.
     */
     stage('Documentation') {
-      agent { label 'linux && immutable' }
-      options { skipDefaultCheckout() }
-      environment {
-        PATH = "${env.PATH}:${env.WORKSPACE}/bin"
-        HOME = "${env.WORKSPACE}"
-        GOPATH = "${env.WORKSPACE}"
-      }
-      steps {
-        withEnvWrapper() {
-          unstash 'source'
-          dir("${BASE_DIR}"){
-            sh """#!/bin/bash
-            set -euxo pipefail
-            make docs
-            """
+      failFast true
+      parallel {
+        stage('Libbeat docs') {
+          agent { label 'linux && immutable' }
+          options { skipDefaultCheckout() }
+          environment {
+            PATH = "${env.PATH}:${env.WORKSPACE}/bin"
+            HOME = "${env.WORKSPACE}"
+            GOPATH = "${env.WORKSPACE}"
+          }
+          steps {
+            withEnvWrapper() {
+              unstash 'source'
+              dir("${BASE_DIR}"){
+                sh """#!/bin/bash
+                set -euxo pipefail
+                make -C libbeat docs
+                """
+              }
+            }
           }
         }
+
+        stage('Filebeat docs') {
+          agent { label 'linux && immutable' }
+          options { skipDefaultCheckout() }
+          environment {
+            PATH = "${env.PATH}:${env.WORKSPACE}/bin"
+            HOME = "${env.WORKSPACE}"
+            GOPATH = "${env.WORKSPACE}"
+          }
+          steps {
+            withEnvWrapper() {
+              unstash 'source'
+              dir("${BASE_DIR}"){
+                sh """#!/bin/bash
+                set -euxo pipefail
+                make -C filebeat docs
+                """
+              }
+            }
+          }
+        }
+
+        stage('Metricbeat docs') {
+          agent { label 'linux && immutable' }
+          options { skipDefaultCheckout() }
+          environment {
+            PATH = "${env.PATH}:${env.WORKSPACE}/bin"
+            HOME = "${env.WORKSPACE}"
+            GOPATH = "${env.WORKSPACE}"
+          }
+          steps {
+            withEnvWrapper() {
+              unstash 'source'
+              dir("${BASE_DIR}"){
+                sh """#!/bin/bash
+                set -euxo pipefail
+                make -C  metricbeat docs
+                """
+              }
+            }
+          }
+        }
+
+        stage('Dev guide docs') {
+          agent { label 'linux && immutable' }
+          options { skipDefaultCheckout() }
+          environment {
+            PATH = "${env.PATH}:${env.WORKSPACE}/bin"
+            HOME = "${env.WORKSPACE}"
+            GOPATH = "${env.WORKSPACE}"
+          }
+          steps {
+            withEnvWrapper() {
+              unstash 'source'
+              dir("${BASE_DIR}"){
+                sh "./script/build_docs.sh dev-guide github.com/elastic/beats/docs/devguide ./build"
+              }
+            }
+          }
+        }
+
       }
       post{
         success {

--- a/filebeat/scripts/jenkins/unit-test.sh
+++ b/filebeat/scripts/jenkins/unit-test.sh
@@ -5,4 +5,4 @@ source ./dev-tools/common.bash
 
 jenkins_setup
 
-mage GoUnitTest || echo -e "\033[31;49mTests FAILED\033[0m"
+mage integTest || echo -e "\033[31;49mTests FAILED\033[0m"


### PR DESCRIPTION
Remove docs build from Travis. This reduces the number of builds needed on Travis so we can have Travis for the things we do not have on Jenkins more effective.