### PR TITLE
Cherry-pick #9767 to 6.5: Introduce next Changelog file

### DIFF
--- a/CHANGELOG-developer.asciidoc
+++ b/CHANGELOG-developer.asciidoc
@@ -13,9 +13,9 @@ other Beats should be migrated.
 Note: This changelog was only started after the 6.3 release.
 
 === Beats version HEAD
-https://github.com/elastic/beats/compare/v6.3.0..master[Check the HEAD diff]
+https://github.com/elastic/beats/compare/v6.3.0..v7.0.0-alpha2[Check the HEAD diff]
 
-The list below covers the major changes between 6.3.0 and master only.
+The list below covers the major changes between 6.3.0 and 7.0.0-alpha2 only.
 
 ==== Breaking changes
 

--- a/CHANGELOG-developer.asciidoc
+++ b/CHANGELOG-developer.asciidoc
@@ -13,9 +13,9 @@ other Beats should be migrated.
 Note: This changelog was only started after the 6.3 release.
 
 === Beats version HEAD
-https://github.com/elastic/beats/compare/v6.3.0..v7.0.0-alpha2[Check the HEAD diff]
+https://github.com/elastic/beats/compare/v6.3.0..master[Check the HEAD diff]
 
-The list below covers the major changes between 6.3.0 and 7.0.0-alpha2 only.
+The list below covers the major changes between 6.3.0 and master only.
 
 ==== Breaking changes
 

--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -1,0 +1,25 @@
+// Use these for links to issue and pulls. Note issues and pulls redirect one to
+// each other on Github, so don't worry too much on using the right prefix.
+:issue: https://github.com/elastic/beats/issues/
+:pull: https://github.com/elastic/beats/pull/
+
+This changelog is intended for community Beat developers. It covers the major
+breaking changes to the internal APIs in the official Beats and changes related
+to developing a Beat like code generators or `fields.yml`. Only the major
+changes will be covered in this changelog that are expected to affect community
+developers. Each breaking change added here should have an explanation on how
+other Beats should be migrated.
+
+Note: This changelog documents the current changes which are not yet present in
+an actual release.
+
+=== Beats version HEAD
+https://github.com/elastic/beats/compare/v7.0.0-alpha2..master[Check the HEAD diff]
+
+The list below covers the major changes between 7.0.0-alpha2 and master only.
+
+==== Breaking changes
+
+==== Bugfixes
+
+==== Added

--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -14,9 +14,9 @@ Note: This changelog documents the current changes which are not yet present in
 an actual release.
 
 === Beats version HEAD
-https://github.com/elastic/beats/compare/v7.0.0-alpha2..master[Check the HEAD diff]
+https://github.com/elastic/beats/compare/6.5.4..6.5[Check the HEAD diff]
 
-The list below covers the major changes between 7.0.0-alpha2 and master only.
+The list below covers the major changes between 6.5.4 and 6.5.5 only.
 
 ==== Breaking changes
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -1,0 +1,120 @@
+// Use these for links to issue and pulls. Note issues and pulls redirect one to
+// each other on Github, so don't worry too much on using the right prefix.
+:issue: https://github.com/elastic/beats/issues/
+:pull: https://github.com/elastic/beats/pull/
+
+=== Beats version HEAD
+https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD diff]
+
+==== Breaking changes
+
+*Affecting all Beats*
+
+- Update add_cloud_metadata fields to adjust to ECS. {pull}9265[9265]
+- Automaticall cap signed integers to 63bits. {pull}8991[8991]
+- Rename beat.timezone to event.timezone. {pull}9458[9458]
+- Use _doc as document type. {pull}9056[9056]{pull}9573[9573]
+- Update to Golang 1.11.3. {pull}9560[9560]
+
+*Auditbeat*
+
+*Filebeat*
+
+- Modify apache/error dataset to follow ECS. {pull}8963[8963]
+- Rename many `traefik.access.*` fields to map to ECS. {pull}9005[9005]
+
+*Heartbeat*
+
+- Remove monitor generator script that was rarely used. {pull}9648[9648]
+
+*Journalbeat*
+
+*Metricbeat*
+
+*Packetbeat*
+
+- Adjust Packetbeat `http` fields to ECS Beta 2 {pull}9645[9645]
+  - `http.request.body` moves to `http.request.body.content`
+  - `http.response.body` moves to `http.response.body.content`
+
+*Winlogbeat*
+
+*Functionbeat*
+
+==== Bugfixes
+
+*Affecting all Beats*
+
+- Enforce validation for the Central Management access token. {issue}9621[9621]
+
+*Auditbeat*
+
+*Filebeat*
+
+*Heartbeat*
+
+- Made monitors.d configuration part of the default config. {pull}9004[9004]
+
+*Journalbeat*
+
+*Metricbeat*
+
+*Packetbeat*
+
+*Winlogbeat*
+
+*Functionbeat*
+
+==== Added
+
+*Affecting all Beats*
+
+- Update field definitions for `http` to ECS Beta 2 {pull}9645[9645]
+
+*Auditbeat*
+
+- Add system module. {pull}9546[9546]
+
+*Filebeat*
+
+- Added module for parsing Google Santa logs. {pull}9540[9540]
+- Added netflow input type that supports NetFlow v1, v5, v6, v7, v8, v9 and IPFIX. {issue}9399[9399]
+- Add option to modules.yml file to indicate that a module has been moved {pull}9432[9432].
+
+*Heartbeat*
+
+- Fixed rare issue where TLS connections to endpoints with x509 certificates missing either notBefore or notAfter would cause the check to fail with a stacktrace.  {pull}9566[9566]
+
+
+*Journalbeat*
+
+*Metricbeat*
+
+- Add `key` metricset to the Redis module. {issue}9582[9582] {pull}9657[9657] {pull}9746[9746]
+- Add `socket_summary` metricset to system defaults, removing experimental tag and supporting Windows {pull}9709[9709]
+
+*Packetbeat*
+
+*Functionbeat*
+
+==== Deprecated
+
+*Affecting all Beats*
+
+*Filebeat*
+
+*Heartbeat*
+
+*Journalbeat*
+
+*Metricbeat*
+
+*Packetbeat*
+
+*Winlogbeat*
+
+*Functionbeat*
+
+==== Known Issue
+
+

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -4,28 +4,17 @@
 :pull: https://github.com/elastic/beats/pull/
 
 === Beats version HEAD
-https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD diff]
+https://github.com/elastic/beats/compare/v6.5.4...6.5[Check the HEAD diff]
 
 ==== Breaking changes
 
 *Affecting all Beats*
 
-- Update add_cloud_metadata fields to adjust to ECS. {pull}9265[9265]
-- Automaticall cap signed integers to 63bits. {pull}8991[8991]
-- Rename beat.timezone to event.timezone. {pull}9458[9458]
-- Use _doc as document type. {pull}9056[9056]{pull}9573[9573]
-- Update to Golang 1.11.3. {pull}9560[9560]
-
 *Auditbeat*
 
 *Filebeat*
 
-- Modify apache/error dataset to follow ECS. {pull}8963[8963]
-- Rename many `traefik.access.*` fields to map to ECS. {pull}9005[9005]
-
 *Heartbeat*
-
-- Remove monitor generator script that was rarely used. {pull}9648[9648]
 
 *Journalbeat*
 
@@ -33,27 +22,21 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Packetbeat*
 
-- Adjust Packetbeat `http` fields to ECS Beta 2 {pull}9645[9645]
-  - `http.request.body` moves to `http.request.body.content`
-  - `http.response.body` moves to `http.response.body.content`
-
 *Winlogbeat*
 
 *Functionbeat*
 
+- The CLI will now log CloudFormation Stack events. {issue}8912[8912]
+
 ==== Bugfixes
 
 *Affecting all Beats*
-
-- Enforce validation for the Central Management access token. {issue}9621[9621]
 
 *Auditbeat*
 
 *Filebeat*
 
 *Heartbeat*
-
-- Made monitors.d configuration part of the default config. {pull}9004[9004]
 
 *Journalbeat*
 
@@ -69,37 +52,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Affecting all Beats*
 
-- Update field definitions for `http` to ECS Beta 2 {pull}9645[9645]
-
 *Auditbeat*
-
-- Add system module. {pull}9546[9546]
-
-*Filebeat*
-
-- Added module for parsing Google Santa logs. {pull}9540[9540]
-- Added netflow input type that supports NetFlow v1, v5, v6, v7, v8, v9 and IPFIX. {issue}9399[9399]
-- Add option to modules.yml file to indicate that a module has been moved {pull}9432[9432].
-
-*Heartbeat*
-
-- Fixed rare issue where TLS connections to endpoints with x509 certificates missing either notBefore or notAfter would cause the check to fail with a stacktrace.  {pull}9566[9566]
-
-
-*Journalbeat*
-
-*Metricbeat*
-
-- Add `key` metricset to the Redis module. {issue}9582[9582] {pull}9657[9657] {pull}9746[9746]
-- Add `socket_summary` metricset to system defaults, removing experimental tag and supporting Windows {pull}9709[9709]
-
-*Packetbeat*
-
-*Functionbeat*
-
-==== Deprecated
-
-*Affecting all Beats*
 
 *Filebeat*
 
@@ -113,8 +66,25 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Winlogbeat*
 
+*Heartbeat*
+
+*Functionbeat*
+
+==== Deprecated
+
+*Affecting all Beats*
+
+*Filebeat*
+
+*Heartbeat*
+
+*Journalbeat*
+
+*Packetbeat*
+
+*Winlogbeat*
+
 *Functionbeat*
 
 ==== Known Issue
-
 

--- a/docs/devguide/contributing.asciidoc
+++ b/docs/devguide/contributing.asciidoc
@@ -27,7 +27,7 @@ You only need to sign the CLA once.
 https://help.github.com/articles/using-pull-requests[submit a pull request]. In
 the pull request, describe what your changes do and mention any bugs/issues
 related to the pull request. Please also add a changelog entry to
-https://github.com/elastic/beats/blob/master/CHANGELOG.asciidoc[CHANGELOG.asciidoc].
+https://github.com/elastic/beats/blob/master/CHANGELOG.next.asciidoc[CHANGELOG.next.asciidoc].
 
 [float]
 [[adding-new-beat]]
@@ -147,4 +147,4 @@ In most cases `govendor fetch your/dependency@version +out` will get the job don
 
 To keep up to date with changes to the official Beats for community developers,
 follow the developer changelog
-https://github.com/elastic/beats/blob/master/CHANGELOG-developer.asciidoc[here].
+https://github.com/elastic/beats/blob/master/CHANGELOG-developer.next.asciidoc[here].


### PR DESCRIPTION
Cherry-pick of PR #9767 to 6.5 branch. Original message: 

This introduces CHANGELOG.next.asciidoc and
CHANGELOG-developer.next.asciidoc. These changelog files will document
yet unreleased changes.

Having a separate changelog file reduces the work required to cleanup
the changelog, as rebasing and cherry-picking on backports sometimes
moves changelog entries into the wrong place.

I don't mean all PRs to be updated/changed to use the CHANGELOG.next.asciidoc yet. We will continue cleaning up the changelog, until things eventually get more stabilisied by everyone using CHANGELOG.next.asciidoc in the future. In order to reduce some friction for other PRs we still have the current changelog entries in CHANGELOG.asciidoc. We will remove the template from CHANGELOG.asciidoc during the next releases.

Note: the developers changelog requires quite some cleanup. Switching to CHANGELOG-developer.next.asciidoc will make our lives easier here as well.