### PR TITLE
Cherry-pick #9767 to 6.x: Introduce next Changelog file

### DIFF
--- a/CHANGELOG-developer.asciidoc
+++ b/CHANGELOG-developer.asciidoc
@@ -13,9 +13,9 @@ other Beats should be migrated.
 Note: This changelog was only started after the 6.3 release.
 
 === Beats version HEAD
-https://github.com/elastic/beats/compare/v6.3.0..master[Check the HEAD diff]
+https://github.com/elastic/beats/compare/v6.3.0..v7.0.0-alpha2[Check the HEAD diff]
 
-The list below covers the major changes between 6.3.0 and master only.
+The list below covers the major changes between 6.3.0 and 7.0.0-alpha2 only.
 
 ==== Breaking changes
 

--- a/CHANGELOG-developer.asciidoc
+++ b/CHANGELOG-developer.asciidoc
@@ -13,9 +13,9 @@ other Beats should be migrated.
 Note: This changelog was only started after the 6.3 release.
 
 === Beats version HEAD
-https://github.com/elastic/beats/compare/v6.3.0..v7.0.0-alpha2[Check the HEAD diff]
+https://github.com/elastic/beats/compare/v6.3.0..6.x[Check the HEAD diff]
 
-The list below covers the major changes between 6.3.0 and 7.0.0-alpha2 only.
+The list below covers the major changes between 6.3.0 and HEAD only.
 
 ==== Breaking changes
 

--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -1,0 +1,25 @@
+// Use these for links to issue and pulls. Note issues and pulls redirect one to
+// each other on Github, so don't worry too much on using the right prefix.
+:issue: https://github.com/elastic/beats/issues/
+:pull: https://github.com/elastic/beats/pull/
+
+This changelog is intended for community Beat developers. It covers the major
+breaking changes to the internal APIs in the official Beats and changes related
+to developing a Beat like code generators or `fields.yml`. Only the major
+changes will be covered in this changelog that are expected to affect community
+developers. Each breaking change added here should have an explanation on how
+other Beats should be migrated.
+
+Note: This changelog documents the current changes which are not yet present in
+an actual release.
+
+=== Beats version HEAD
+https://github.com/elastic/beats/compare/v7.0.0-alpha2..master[Check the HEAD diff]
+
+The list below covers the major changes between 7.0.0-alpha2 and master only.
+
+==== Breaking changes
+
+==== Bugfixes
+
+==== Added

--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -14,9 +14,9 @@ Note: This changelog documents the current changes which are not yet present in
 an actual release.
 
 === Beats version HEAD
-https://github.com/elastic/beats/compare/v7.0.0-alpha2..master[Check the HEAD diff]
+https://github.com/elastic/beats/compare/v6.6.0..6.x[Check the HEAD diff]
 
-The list below covers the major changes between 7.0.0-alpha2 and master only.
+The list below covers the major changes between 6.6.0 and 6.x only.
 
 ==== Breaking changes
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -7,7 +7,7 @@
 // Template, add newest changes here
 
 === Beats version HEAD
-https://github.com/elastic/beats/compare/v6.5.0...6.x[Check the HEAD diff]
+https://github.com/elastic/beats/compare/v6.6.0...6.x[Check the HEAD diff]
 
 ==== Breaking changes
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -1,0 +1,120 @@
+// Use these for links to issue and pulls. Note issues and pulls redirect one to
+// each other on Github, so don't worry too much on using the right prefix.
+:issue: https://github.com/elastic/beats/issues/
+:pull: https://github.com/elastic/beats/pull/
+
+=== Beats version HEAD
+https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD diff]
+
+==== Breaking changes
+
+*Affecting all Beats*
+
+- Update add_cloud_metadata fields to adjust to ECS. {pull}9265[9265]
+- Automaticall cap signed integers to 63bits. {pull}8991[8991]
+- Rename beat.timezone to event.timezone. {pull}9458[9458]
+- Use _doc as document type. {pull}9056[9056]{pull}9573[9573]
+- Update to Golang 1.11.3. {pull}9560[9560]
+
+*Auditbeat*
+
+*Filebeat*
+
+- Modify apache/error dataset to follow ECS. {pull}8963[8963]
+- Rename many `traefik.access.*` fields to map to ECS. {pull}9005[9005]
+
+*Heartbeat*
+
+- Remove monitor generator script that was rarely used. {pull}9648[9648]
+
+*Journalbeat*
+
+*Metricbeat*
+
+*Packetbeat*
+
+- Adjust Packetbeat `http` fields to ECS Beta 2 {pull}9645[9645]
+  - `http.request.body` moves to `http.request.body.content`
+  - `http.response.body` moves to `http.response.body.content`
+
+*Winlogbeat*
+
+*Functionbeat*
+
+==== Bugfixes
+
+*Affecting all Beats*
+
+- Enforce validation for the Central Management access token. {issue}9621[9621]
+
+*Auditbeat*
+
+*Filebeat*
+
+*Heartbeat*
+
+- Made monitors.d configuration part of the default config. {pull}9004[9004]
+
+*Journalbeat*
+
+*Metricbeat*
+
+*Packetbeat*
+
+*Winlogbeat*
+
+*Functionbeat*
+
+==== Added
+
+*Affecting all Beats*
+
+- Update field definitions for `http` to ECS Beta 2 {pull}9645[9645]
+
+*Auditbeat*
+
+- Add system module. {pull}9546[9546]
+
+*Filebeat*
+
+- Added module for parsing Google Santa logs. {pull}9540[9540]
+- Added netflow input type that supports NetFlow v1, v5, v6, v7, v8, v9 and IPFIX. {issue}9399[9399]
+- Add option to modules.yml file to indicate that a module has been moved {pull}9432[9432].
+
+*Heartbeat*
+
+- Fixed rare issue where TLS connections to endpoints with x509 certificates missing either notBefore or notAfter would cause the check to fail with a stacktrace.  {pull}9566[9566]
+
+
+*Journalbeat*
+
+*Metricbeat*
+
+- Add `key` metricset to the Redis module. {issue}9582[9582] {pull}9657[9657] {pull}9746[9746]
+- Add `socket_summary` metricset to system defaults, removing experimental tag and supporting Windows {pull}9709[9709]
+
+*Packetbeat*
+
+*Functionbeat*
+
+==== Deprecated
+
+*Affecting all Beats*
+
+*Filebeat*
+
+*Heartbeat*
+
+*Journalbeat*
+
+*Metricbeat*
+
+*Packetbeat*
+
+*Winlogbeat*
+
+*Functionbeat*
+
+==== Known Issue
+
+

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -4,24 +4,19 @@
 :pull: https://github.com/elastic/beats/pull/
 
 === Beats version HEAD
-https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD diff]
+https://github.com/elastic/beats/compare/v6.6.0...6.x[Check the HEAD diff]
 
 ==== Breaking changes
 
 *Affecting all Beats*
 
-- Update add_cloud_metadata fields to adjust to ECS. {pull}9265[9265]
-- Automaticall cap signed integers to 63bits. {pull}8991[8991]
-- Rename beat.timezone to event.timezone. {pull}9458[9458]
-- Use _doc as document type. {pull}9056[9056]{pull}9573[9573]
-- Update to Golang 1.11.3. {pull}9560[9560]
+- Dissect syntax change, use * instead of ? when working with field reference. {issue}8054[8054]
 
 *Auditbeat*
 
 *Filebeat*
 
-- Modify apache/error dataset to follow ECS. {pull}8963[8963]
-- Rename many `traefik.access.*` fields to map to ECS. {pull}9005[9005]
+- Allow beats to blacklist certain part of the configuration while using Central Management. {pull}9099[9099]
 
 *Heartbeat*
 
@@ -31,35 +26,66 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Metricbeat*
 
+- Fix issue preventing diskio metrics collection for idle disks. {issue}9124[9124] {pull}9125[9125]
+- Allow beats to blacklist certain part of the configuration while using Central Management. {pull}9099[9099]
+
 *Packetbeat*
 
-- Adjust Packetbeat `http` fields to ECS Beta 2 {pull}9645[9645]
-  - `http.request.body` moves to `http.request.body.content`
-  - `http.response.body` moves to `http.response.body.content`
+*Packetbeat*
 
 *Winlogbeat*
 
 *Functionbeat*
 
+- The CLI will now log CloudFormation Stack events. {issue}8912[8912]
+
 ==== Bugfixes
 
 *Affecting all Beats*
 
+- Propagate Sync error when running SafeFileRotate. {pull}9069[9069]
+- Fix autodiscover configurations stopping when metadata is missing. {pull}8851[8851]
+- Log events at the debug level when dropped by encoding problems. {pull}9251[9251]
+- Refresh host metadata in add_host_metadata. {pull}9359[9359]
+- When collecting swap metrics for beats telemetry or system metricbeat module handle cases of free swap being bigger than total swap by assuming no swap is being used. {issue}6271[6271] {pull}9383[9383]
+- Ignore non index fields in default_field for Elasticsearch. {pull}9549[9549]
+- Update Kibana index pattern attributes for objects that are disabled. {pull}9644[9644]
 - Enforce validation for the Central Management access token. {issue}9621[9621]
+- Update Golang to 1.10.7. {pull}9640[9640]
 
 *Auditbeat*
 
 *Filebeat*
+- Correctly parse `December` or `Dec` in the Syslog input. {pull}9349[9349]
+- Fix improperly set config for CRI Flag in Docker Input {pull}8899[8899]
+- Just enabling the `elasticsearch` fileset and starting Filebeat no longer causes an error. {pull}8891[8891]
+- Fix macOS default log path for elasticsearch module based on homebrew paths. {pul}8939[8939]
+- Make sure the Filebeat Elastic licensed packages uses the Elastic binary instead of the OSS. {pull}8836[8836]
+- Fix installation of haproxy dashboard. {issue}9307[9307] {pull}9313[9313]
+- Don't generate incomplete configurations when logs collection is disabled by hints. {pull}9305[9305]
+- Stop runners disabled by hints after previously being started. {pull}9305[9305]
+- Fix saved objects in filebeat haproxy dashboard. {pull}9417[9417]
+- Fixed a memory leak when harvesters are closed. {pull}7820[7820]
 
 *Heartbeat*
 
-- Made monitors.d configuration part of the default config. {pull}9004[9004]
+- Heartbeat now always downloads the entire body of HTTP endpoints, even if no checks against the body content are declared. This fixes an issue where timing metrics would be incorrect in scenarios where the body wasn't used since the connection would be closed soon after the headers were sent, but before the entire body was. {pull}8894[8894]
 
 *Journalbeat*
 
+- Add missing journalbeat non breaking fixes. {pull}9106[9106]
+
 *Metricbeat*
 
+- Add missing namespace field in http server metricset {pull}7890[7890]
+- Fix race condition when enriching events with kubernetes metadata. {issue}9055[9055] {issue}9067[9067]
+- Fix panic on docker healthcheck collection on dockers without healthchecks. {pull}9171[9171]
+- Fix issue with not collecting Elasticsearch cross-cluster replication stats correctly. {pull}9179[9179]
+- The `node.name` field in the `elasticsearch/node` metricset now correctly reports the Elasticsarch node name. Previously this field was incorrectly reporting the node ID instead. {pull}9209[9209]
+
 *Packetbeat*
+
+- Fix issue with process monitor associating traffic to the wrong process. {issue}9151[9151] {pull}9443[9443]
 
 *Winlogbeat*
 
@@ -68,32 +94,54 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 ==== Added
 
 *Affecting all Beats*
+- Unify dashboard exporter tools. {pull}9097[9097]
 
-- Update field definitions for `http` to ECS Beta 2 {pull}9645[9645]
+- Dissect will now flag event on parsing error. {pull}8751[8751]
+- Added the `redirect_stderr` option that allows panics to be logged to log files. {pull}8430[8430]
+- Add cache.ttl to add_host_metadata. {pull}9359[9359]
+- Add support for index lifecycle management (beta). {pull}7963[7963]
+- Always include Pod UID as part of Pod metadata. {pull]9517[9517]
+- Release Jolokia autodiscover as GA. {pull}9706[9706]
 
 *Auditbeat*
 
 - Add system module. {pull}9546[9546]
 
 *Filebeat*
-
-- Added module for parsing Google Santa logs. {pull}9540[9540]
+- Added `detect_null_bytes` selector to detect null bytes from a io.reader. {pull}9210[9210]
+- Added `syslog_host` variable to HAProxy module to allow syslog listener to bind to configured host. {pull}9366[9366]
+- Added support on Traefik for Common Log Format and Combined Log Format mixed which is the default Traefik format {issue}8015[8015] {issue}6111[6111] {pull}8768[8768].
+- Allow to force CRI format parsing for better performance {pull}8424[8424]
+- Add event.dataset to module events. {pull}9457[9457]
+- Add field log.source.address and log.file.path to replace source. {pull}9435[9435]
+- Add support for multi-core thread_id in postgresql module {issue}9156[9156] {pull}9482[9482]
 - Added netflow input type that supports NetFlow v1, v5, v6, v7, v8, v9 and IPFIX. {issue}9399[9399]
-- Add option to modules.yml file to indicate that a module has been moved {pull}9432[9432].
 
 *Heartbeat*
 
-- Fixed rare issue where TLS connections to endpoints with x509 certificates missing either notBefore or notAfter would cause the check to fail with a stacktrace.  {pull}9566[9566]
-
-
 *Journalbeat*
+
+- Add the ability to check against JSON HTTP bodies with conditions. {pull}8667[8667]
+- Add cursor_seek_fallback option. {pull}9234[9234]
 
 *Metricbeat*
 
-- Add `key` metricset to the Redis module. {issue}9582[9582] {pull}9657[9657] {pull}9746[9746]
-- Add `socket_summary` metricset to system defaults, removing experimental tag and supporting Windows {pull}9709[9709]
+- Collect custom cluster `display_name` in `elasticsearch/cluster_stats` metricset. {pull}8445[8445]
+- Test etcd module with etcd 3.3. {pull}9068[9068]
+- All `elasticsearch` metricsets now have module-level `cluster.id` and `cluster.name` fields. {pull}8770[8770] {pull}8771[8771] {pull}9164[9164] {pull}9165[9165] {pull}9166[9166] {pull}9168[9168]
+- All `elasticsearch` node-level metricsets now have `node.id` and `node.name` fields. {pull}9168[9168] {pull}9209[9209]
+- Add settings to disable docker and cgroup cpu metrics per core. {issue}9187[9187] {pull}9194[9194] {pull}9589[9589]
+- The `elasticsearch/node` metricset now reports the Elasticsearch cluster UUID. {pull}8771[8771]
+- Support GET requests in Jolokia module. {issue}8566[8566] {pull}9226[9226]
+- Add freebsd support for the uptime metricset. {pull}9413[9413]
+- Add `host.os.name` field to add_host_metadata processor. {issue}8948[8948] {pull}9405[9405]
+- Add field `event.dataset` which is `{module}.{metricset).
+- Add more TCP statuses to `socket_summary` metricset. {pull}9430[9430]
+- Remove experimental tag from ceph metricsets. {pull}9708[9708]
 
 *Packetbeat*
+
+*Winlogbeat*
 
 *Functionbeat*
 
@@ -102,6 +150,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 *Affecting all Beats*
 
 *Filebeat*
+- Deprecate field source. Will be replaced by log.source.address and log.file.path in 7.0. {pull}9435[9435]
 
 *Heartbeat*
 
@@ -109,12 +158,15 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Metricbeat*
 
+- Deprecate field `metricset.rtt`. Replaced by `event.duration` which is in nano instead of micro seconds.
+
 *Packetbeat*
+
+- Support new TLS version negotiation introduced in TLS 1.3. {issue}8647[8647].
 
 *Winlogbeat*
 
 *Functionbeat*
 
 ==== Known Issue
-
 

--- a/docs/devguide/contributing.asciidoc
+++ b/docs/devguide/contributing.asciidoc
@@ -27,7 +27,7 @@ You only need to sign the CLA once.
 https://help.github.com/articles/using-pull-requests[submit a pull request]. In
 the pull request, describe what your changes do and mention any bugs/issues
 related to the pull request. Please also add a changelog entry to
-https://github.com/elastic/beats/blob/master/CHANGELOG.asciidoc[CHANGELOG.asciidoc].
+https://github.com/elastic/beats/blob/master/CHANGELOG.next.asciidoc[CHANGELOG.next.asciidoc].
 
 [float]
 [[adding-new-beat]]
@@ -147,4 +147,4 @@ In most cases `govendor fetch your/dependency@version +out` will get the job don
 
 To keep up to date with changes to the official Beats for community developers,
 follow the developer changelog
-https://github.com/elastic/beats/blob/master/CHANGELOG-developer.asciidoc[here].
+https://github.com/elastic/beats/blob/master/CHANGELOG-developer.next.asciidoc[here].


### PR DESCRIPTION
Cherry-pick of PR #9767 to 6.x branch. Original message: 

This introduces CHANGELOG.next.asciidoc and
CHANGELOG-developer.next.asciidoc. These changelog files will document
yet unreleased changes.

Having a separate changelog file reduces the work required to cleanup
the changelog, as rebasing and cherry-picking on backports sometimes
moves changelog entries into the wrong place.

I don't mean all PRs to be updated/changed to use the CHANGELOG.next.asciidoc yet. We will continue cleaning up the changelog, until things eventually get more stabilisied by everyone using CHANGELOG.next.asciidoc in the future. In order to reduce some friction for other PRs we still have the current changelog entries in CHANGELOG.asciidoc. We will remove the template from CHANGELOG.asciidoc during the next releases.

Note: the developers changelog requires quite some cleanup. Switching to CHANGELOG-developer.next.asciidoc will make our lives easier here as well.