### PR TITLE
[6.x] Changing version fields/vars datatypes from string to common.Version

### DIFF
--- a/filebeat/fileset/fileset.go
+++ b/filebeat/fileset/fileset.go
@@ -33,6 +33,8 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/pkg/errors"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	mlimporter "github.com/elastic/beats/libbeat/ml-importer"
@@ -192,15 +194,14 @@ func (fs *Fileset) evaluateVars() (map[string]interface{}, error) {
 
 // turnOffElasticsearchVars re-evaluates the variables that have `min_elasticsearch_version`
 // set.
-func (fs *Fileset) turnOffElasticsearchVars(vars map[string]interface{}, esVersion string) (map[string]interface{}, error) {
+func (fs *Fileset) turnOffElasticsearchVars(vars map[string]interface{}, esVersion common.Version) (map[string]interface{}, error) {
 	retVars := map[string]interface{}{}
 	for key, val := range vars {
 		retVars[key] = val
 	}
 
-	haveVersion, err := common.NewVersion(esVersion)
-	if err != nil {
-		return vars, fmt.Errorf("Error parsing version %s: %v", esVersion, err)
+	if !esVersion.IsValid() {
+		return vars, errors.New("Unknown Elasticsearch version")
 	}
 
 	for _, vals := range fs.manifest.Vars {
@@ -217,11 +218,11 @@ func (fs *Fileset) turnOffElasticsearchVars(vars map[string]interface{}, esVersi
 				return vars, fmt.Errorf("Error parsing version %s: %v", minESVersion["version"].(string), err)
 			}
 
-			logp.Debug("fileset", "Comparing ES version %s with requirement of %s", haveVersion, minVersion)
+			logp.Debug("fileset", "Comparing ES version %s with requirement of %s", esVersion.String(), minVersion)
 
-			if haveVersion.LessThan(minVersion) {
+			if esVersion.LessThan(minVersion) {
 				retVars[name] = minESVersion["value"]
-				logp.Info("Setting var %s (%s) to %v because Elasticsearch version is %s", name, fs, minESVersion["value"], haveVersion)
+				logp.Info("Setting var %s (%s) to %v because Elasticsearch version is %s", name, fs, minESVersion["value"], esVersion.String())
 			}
 		}
 	}
@@ -358,7 +359,7 @@ func (fs *Fileset) getPipelineID(beatVersion string) (string, error) {
 }
 
 // GetPipeline returns the JSON content of the Ingest Node pipeline that parses the logs.
-func (fs *Fileset) GetPipeline(esVersion string) (pipelineID string, content map[string]interface{}, err error) {
+func (fs *Fileset) GetPipeline(esVersion common.Version) (pipelineID string, content map[string]interface{}, err error) {
 	path, err := applyTemplate(fs.vars, fs.manifest.IngestPipeline, false)
 	if err != nil {
 		return "", nil, fmt.Errorf("Error expanding vars on the ingest pipeline path: %v", err)

--- a/filebeat/fileset/fileset.go
+++ b/filebeat/fileset/fileset.go
@@ -25,6 +25,7 @@ package fileset
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -32,8 +33,6 @@ import (
 	"runtime"
 	"strings"
 	"text/template"
-
-	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"

--- a/filebeat/fileset/modules_integration_test.go
+++ b/filebeat/fileset/modules_integration_test.go
@@ -22,7 +22,6 @@ package fileset
 import (
 	"encoding/json"
 	"path/filepath"
-	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -142,11 +141,5 @@ func TestAvailableProcessors(t *testing.T) {
 
 func hasIngest(client *elasticsearch.Client) bool {
 	v := client.GetVersion()
-	majorVersion := string(v[0])
-	version, err := strconv.Atoi(majorVersion)
-	if err != nil {
-		return true
-	}
-
-	return version >= 5
+	return v.Major >= 5
 }

--- a/filebeat/fileset/pipelines.go
+++ b/filebeat/fileset/pipelines.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 )
 
@@ -33,7 +34,7 @@ type PipelineLoaderFactory func() (PipelineLoader, error)
 type PipelineLoader interface {
 	LoadJSON(path string, json map[string]interface{}) ([]byte, error)
 	Request(method, path string, pipeline string, params map[string]string, body interface{}) (int, []byte, error)
-	GetVersion() string
+	GetVersion() common.Version
 }
 
 // LoadPipelines loads the pipelines for each configured fileset.

--- a/libbeat/cmd/export/template.go
+++ b/libbeat/cmd/export/template.go
@@ -57,7 +57,16 @@ func GenTemplateConfigCmd(settings instance.Settings, name, idxPrefix, beatVersi
 				}
 			}
 
-			tmpl, err := template.New(b.Info.Version, index, version, cfg)
+			if version == "" {
+				version = b.Info.Version
+			}
+
+			esVersion, err := common.NewVersion(version)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Invalid Elasticsearch version: %s\n", err)
+			}
+
+			tmpl, err := template.New(b.Info.Version, index, *esVersion, cfg)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Error generating template: %+v", err)
 				os.Exit(1)

--- a/libbeat/cmd/instance/ilm.go
+++ b/libbeat/cmd/instance/ilm.go
@@ -154,10 +154,9 @@ func loadConfigWithDefaults(config *ilmConfig, b *Beat) {
 }
 
 func checkElasticsearchVersionIlm(client *elasticsearch.Client) error {
-	esVer := client.GetVersion()
-	esV, err := common.NewVersion(esVer)
-	if err != nil {
-		return err
+	esVersion := client.GetVersion()
+	if !esVersion.IsValid() {
+		return errors.New("Unknown Elasticsearch version")
 	}
 
 	requiredVersion, err := common.NewVersion("6.6.0")
@@ -165,8 +164,8 @@ func checkElasticsearchVersionIlm(client *elasticsearch.Client) error {
 		return err
 	}
 
-	if esV.LessThan(requiredVersion) {
-		return fmt.Errorf("ILM requires at least Elasticsearch 6.6.0. Used version: %s", esV.String())
+	if esVersion.LessThan(requiredVersion) {
+		return fmt.Errorf("ILM requires at least Elasticsearch 6.6.0. Used version: %s", esVersion.String())
 	}
 
 	return nil

--- a/libbeat/common/version.go
+++ b/libbeat/common/version.go
@@ -31,6 +31,16 @@ type Version struct {
 	Meta    string
 }
 
+// MustNewVersion creates a version from the given version string.
+// If the version string is invalid, MustNewVersion panics.
+func MustNewVersion(version string) *Version {
+	v, err := NewVersion(version)
+	if err != nil {
+		panic(err)
+	}
+	return v
+}
+
 // NewVersion expects a string in the format:
 // major.minor.bugfix(-meta)
 func NewVersion(version string) (*Version, error) {
@@ -67,6 +77,11 @@ func NewVersion(version string) (*Version, error) {
 	}
 
 	return &v, nil
+}
+
+// IsValid returns true if the version object stores a successfully parsed version number.
+func (v *Version) IsValid() bool {
+	return v.version != ""
 }
 
 func (v *Version) IsMajor(major int) bool {

--- a/libbeat/dashboards/es_loader.go
+++ b/libbeat/dashboards/es_loader.go
@@ -19,6 +19,7 @@ package dashboards
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"path"
@@ -33,7 +34,7 @@ import (
 type ElasticsearchLoader struct {
 	client       *elasticsearch.Client
 	config       *Config
-	version      string
+	version      common.Version
 	msgOutputter MessageOutputter
 }
 
@@ -48,6 +49,9 @@ func NewElasticsearchLoader(cfg *common.Config, dashboardsConfig *Config, msgOut
 	}
 
 	version := esClient.GetVersion()
+	if !version.IsValid() {
+		return nil, errors.New("No valid Elasticsearch version available")
+	}
 
 	loader := ElasticsearchLoader{
 		client:       esClient,
@@ -56,7 +60,7 @@ func NewElasticsearchLoader(cfg *common.Config, dashboardsConfig *Config, msgOut
 		msgOutputter: msgOutputter,
 	}
 
-	loader.statusMsg("Initialize the Elasticsearch %s loader", version)
+	loader.statusMsg("Initialize the Elasticsearch %s loader", version.String())
 
 	return &loader, nil
 }

--- a/libbeat/dashboards/es_loader_test.go
+++ b/libbeat/dashboards/es_loader_test.go
@@ -20,7 +20,6 @@
 package dashboards
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -40,8 +39,9 @@ func TestImporter(t *testing.T) {
 	}
 
 	client := estest.GetTestingElasticsearch(t)
-	if strings.HasPrefix(client.Connection.GetVersion(), "6.") ||
-		strings.HasPrefix(client.Connection.GetVersion(), "7.") {
+	major := client.GetVersion().Major
+
+	if major == 6 || major == 7 {
 		t.Skip("Skipping tests for Elasticsearch 6.x releases")
 	}
 
@@ -76,8 +76,8 @@ func TestImporterEmptyBeat(t *testing.T) {
 	}
 
 	client := estest.GetTestingElasticsearch(t)
-	if strings.HasPrefix(client.Connection.GetVersion(), "6.") ||
-		strings.HasPrefix(client.Connection.GetVersion(), "7.") {
+	major := client.GetVersion().Major
+	if major == 6 || major == 7 {
 		t.Skip("Skipping tests for Elasticsearch 6.x releases")
 	}
 

--- a/libbeat/dashboards/export.go
+++ b/libbeat/dashboards/export.go
@@ -84,14 +84,9 @@ func ExportAll(client *kibana.Client, list ListYML) ([]common.MapStr, error) {
 }
 
 // SaveToFile creates the required directories if needed and saves dashboard.
-func SaveToFile(dashboard common.MapStr, filename, root, versionStr string) error {
-	version, err := common.NewVersion(versionStr)
-	if err != nil {
-		return err
-	}
-
+func SaveToFile(dashboard common.MapStr, filename, root string, version common.Version) error {
 	dashboardsPath := "_meta/kibana/" + strconv.Itoa(version.Major) + "/dashboard"
-	err = generator.CreateDirectories(root, dashboardsPath)
+	err := generator.CreateDirectories(root, dashboardsPath)
 	if err != nil {
 		return err
 	}

--- a/libbeat/dashboards/kibana_loader.go
+++ b/libbeat/dashboards/kibana_loader.go
@@ -35,7 +35,7 @@ var importAPI = "/api/kibana/dashboards/import"
 type KibanaLoader struct {
 	client       *kibana.Client
 	config       *Config
-	version      string
+	version      common.Version
 	hostname     string
 	msgOutputter MessageOutputter
 }
@@ -59,7 +59,8 @@ func NewKibanaLoader(ctx context.Context, cfg *common.Config, dashboardsConfig *
 		msgOutputter: msgOutputter,
 	}
 
-	loader.statusMsg("Initialize the Kibana %s loader", client.GetVersion())
+	version := client.GetVersion()
+	loader.statusMsg("Initialize the Kibana %s loader", version.String())
 
 	return &loader, nil
 }

--- a/libbeat/outputs/elasticsearch/api_integration_test.go
+++ b/libbeat/outputs/elasticsearch/api_integration_test.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -105,8 +104,8 @@ func TestIngest(t *testing.T) {
 	}
 
 	client := getTestingElasticsearch(t)
-	if strings.HasPrefix(client.Connection.version, "2.") {
-		t.Skip("Skipping tests as pipeline not available in 2.x releases")
+	if client.Connection.version.Major < 5 {
+		t.Skip("Skipping tests as pipeline not available in <5.x releases")
 	}
 
 	status, _, err := client.DeletePipeline(pipeline, nil)

--- a/libbeat/outputs/elasticsearch/client_integration_test.go
+++ b/libbeat/outputs/elasticsearch/client_integration_test.go
@@ -21,7 +21,6 @@ package elasticsearch
 
 import (
 	"math/rand"
-	"strings"
 	"testing"
 	"time"
 
@@ -92,8 +91,8 @@ func TestClientPublishEventWithPipeline(t *testing.T) {
 	client.Delete(index, "", "", nil)
 
 	// Check version
-	if strings.HasPrefix(client.Connection.version, "2.") {
-		t.Skip("Skipping tests as pipeline not available in 2.x releases")
+	if client.Connection.version.Major < 5 {
+		t.Skip("Skipping tests as pipeline not available in <5.x releases")
 	}
 
 	publish := func(event beat.Event) {
@@ -173,8 +172,8 @@ func TestClientBulkPublishEventsWithPipeline(t *testing.T) {
 	})
 	client.Delete(index, "", "", nil)
 
-	if strings.HasPrefix(client.Connection.version, "2.") {
-		t.Skip("Skipping tests as pipeline not available in 2.x releases")
+	if client.Connection.version.Major < 5 {
+		t.Skip("Skipping tests as pipeline not available in <5.x releases")
 	}
 
 	publish := func(events ...beat.Event) {

--- a/libbeat/template/load.go
+++ b/libbeat/template/load.go
@@ -34,7 +34,7 @@ import (
 type ESClient interface {
 	LoadJSON(path string, json map[string]interface{}) ([]byte, error)
 	Request(method, path string, pipeline string, params map[string]string, body interface{}) (int, []byte, error)
-	GetVersion() string
+	GetVersion() common.Version
 }
 
 type Loader struct {
@@ -79,7 +79,8 @@ func (l *Loader) Load() error {
 	exists := l.CheckTemplate(templateName)
 	if !exists || l.config.Overwrite {
 
-		logp.Info("Loading template for Elasticsearch version: %s", l.client.GetVersion())
+		version := l.client.GetVersion()
+		logp.Info("Loading template for Elasticsearch version: %s", version.String())
 		if l.config.Overwrite {
 			logp.Info("Existing template will be overwritten, as overwrite is enabled.")
 		}

--- a/libbeat/template/template.go
+++ b/libbeat/template/template.go
@@ -22,11 +22,12 @@ import (
 	"sync"
 	"time"
 
+	"github.com/elastic/go-ucfg/yaml"
+
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/libbeat/common/fmtstr"
-	"github.com/elastic/go-ucfg/yaml"
 )
 
 var (
@@ -51,7 +52,7 @@ type Template struct {
 }
 
 // New creates a new template instance
-func New(beatVersion string, beatName string, esVersion string, config TemplateConfig) (*Template, error) {
+func New(beatVersion string, beatName string, esVersion common.Version, config TemplateConfig) (*Template, error) {
 	bV, err := common.NewVersion(beatVersion)
 	if err != nil {
 		return nil, err
@@ -95,21 +96,15 @@ func New(beatVersion string, beatName string, esVersion string, config TemplateC
 		return nil, err
 	}
 
-	// In case no esVersion is set, it is assumed the same as beat version
-	if esVersion == "" {
-		esVersion = beatVersion
-	}
-
-	esV, err := common.NewVersion(esVersion)
-	if err != nil {
-		return nil, err
+	if !esVersion.IsValid() {
+		esVersion = *bV
 	}
 
 	return &Template{
 		pattern:     pattern,
 		name:        name,
 		beatVersion: *bV,
-		esVersion:   *esV,
+		esVersion:   esVersion,
 		config:      config,
 	}, nil
 }

--- a/libbeat/template/template_test.go
+++ b/libbeat/template/template_test.go
@@ -34,7 +34,8 @@ func TestNumberOfRoutingShards(t *testing.T) {
 	config := TemplateConfig{}
 
 	// Test it exists in 6.1
-	template, err := New(beatVersion, beatName, "6.1.0", config)
+	ver := common.MustNewVersion("6.1.0")
+	template, err := New(beatVersion, beatName, *ver, config)
 	assert.NoError(t, err)
 
 	data := template.Generate(nil, nil)
@@ -44,7 +45,8 @@ func TestNumberOfRoutingShards(t *testing.T) {
 	assert.Equal(t, 30, shards.(int))
 
 	// Test it does not exist in 6.0
-	template, err = New(beatVersion, beatName, "6.0.0", config)
+	ver = common.MustNewVersion("6.0.0")
+	template, err = New(beatVersion, beatName, *ver, config)
 	assert.NoError(t, err)
 
 	data = template.Generate(nil, nil)
@@ -64,7 +66,8 @@ func TestNumberOfRoutingShardsOverwrite(t *testing.T) {
 	}
 
 	// Test it exists in 6.1
-	template, err := New(beatVersion, beatName, "6.1.0", config)
+	ver := common.MustNewVersion("6.1.0")
+	template, err := New(beatVersion, beatName, *ver, config)
 	assert.NoError(t, err)
 
 	data := template.Generate(nil, nil)


### PR DESCRIPTION
Partial backport of #9056 — only the code changes related to changing the datatype of version fields/variables from `string` to `common.Version`.