### PR TITLE
Cherry-pick #9784 to 6.6: Vsphere nil pointers access in Metricbeat module

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -41,6 +41,7 @@ https://github.com/elastic/beats/compare/1035569addc4a3b29ffa14f8a08c27c1ace16ef
 *Journalbeat*
 
 *Metricbeat*
+- Fix panics in vsphere module when certain values where not returned by the API. {pull}9784[9784]
 
 *Packetbeat*
 

--- a/metricbeat/module/vsphere/virtualmachine/virtualmachine.go
+++ b/metricbeat/module/vsphere/virtualmachine/virtualmachine.go
@@ -39,6 +39,8 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 )
 
+var logger = logp.NewLogger("vsphere")
+
 func init() {
 	mb.Registry.MustAddMetricSet("vsphere", "virtualmachine", New,
 		mb.DefaultMetricSet(),
@@ -138,49 +140,40 @@ func (m *MetricSet) Fetch() ([]common.MapStr, error) {
 
 			freeMemory := (int64(vm.Summary.Config.MemorySizeMB) * 1024 * 1024) - (int64(vm.Summary.QuickStats.GuestMemoryUsage) * 1024 * 1024)
 
-			event := common.MapStr{
-				"host": vm.Summary.Runtime.Host.Value,
-				"name": vm.Summary.Config.Name,
-				"cpu": common.MapStr{
-					"used": common.MapStr{
-						"mhz": vm.Summary.QuickStats.OverallCpuUsage,
-					},
-				},
-				"memory": common.MapStr{
-					"used": common.MapStr{
-						"guest": common.MapStr{
-							"bytes": (int64(vm.Summary.QuickStats.GuestMemoryUsage) * 1024 * 1024),
-						},
-						"host": common.MapStr{
-							"bytes": (int64(vm.Summary.QuickStats.HostMemoryUsage) * 1024 * 1024),
-						},
-					},
-					"total": common.MapStr{
-						"guest": common.MapStr{
-							"bytes": (int64(vm.Summary.Config.MemorySizeMB) * 1024 * 1024),
-						},
-					},
-					"free": common.MapStr{
-						"guest": common.MapStr{
-							"bytes": freeMemory,
-						},
-					},
-				},
+			event := common.MapStr{}
+
+			event["name"] = vm.Summary.Config.Name
+			event.Put("cpu.used.mhz", vm.Summary.QuickStats.OverallCpuUsage)
+			event.Put("memory.used.guest.bytes", int64(vm.Summary.QuickStats.GuestMemoryUsage)*1024*1024)
+			event.Put("memory.used.host.bytes", int64(vm.Summary.QuickStats.HostMemoryUsage)*1024*1024)
+			event.Put("memory.total.guest.bytes", int64(vm.Summary.Config.MemorySizeMB)*1024*1024)
+			event.Put("memory.free.guest.bytes", freeMemory)
+
+			if vm.Summary.Runtime.Host != nil {
+				event["host"] = vm.Summary.Runtime.Host.Value
+			} else {
+				logger.Debug("'Host', 'Runtime' or 'Summary' data not found. This is either a parsing error " +
+					"from vsphere library, an error trying to reach host/guest or incomplete information returned " +
+					"from host/guest")
 			}
 
 			// Get custom fields (attributes) values if get_custom_fields is true.
-			if m.GetCustomFields {
+			if m.GetCustomFields && vm.Summary.CustomValue != nil {
 				customFields := getCustomFields(vm.Summary.CustomValue, customFieldsMap)
 
 				if len(customFields) > 0 {
 					event["custom_fields"] = customFields
 				}
+			} else {
+				logger.Debug("custom fields not activated or custom values not found/parse in Summary data. This " +
+					"is either a parsing error from vsphere library, an error trying to reach host/guest or incomplete " +
+					"information returned from host/guest")
 			}
 
 			if vm.Summary.Vm != nil {
 				networkNames, err := getNetworkNames(c, vm.Summary.Vm.Reference())
 				if err != nil {
-					logp.Debug("vsphere", err.Error())
+					logger.Debug(err.Error())
 				} else {
 					if len(networkNames) > 0 {
 						event["network_names"] = networkNames


### PR DESCRIPTION
Cherry-pick of PR #9784 to 6.6 branch. Original message: 

It seems that some fields within the vsphere module on Metricbeat are pointers where the `nil` check access is not being done. This can cause panics that are not easy to reproduce.

This PR checks every pointer that acces a pointer from the `gvmomi` library which is used to access vsphere data.

Initially, we only know about panics in the `virtualmachine` metricset but I have seen that the `host` metricset could potentially have the same problem