### PR TITLE
Cherry-pick #9797 to 6.x: Allow users to convert timezone in logstash module filesets

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -77,6 +77,12 @@ https://github.com/elastic/beats/compare/v6.6.0...6.x[Check the HEAD diff]
 *Journalbeat*
 
 - Add missing journalbeat non breaking fixes. {pull}9106[9106]
+- Use `log.source.address` instead of `log.source.ip` for network input sources. {pull}9487[9487]
+- Rename many `redis.log.*` fields to map to ECS. {pull}9315[9315]
+- Rename many `icinga.*` fields to map to ECS. {pull}9294[9294]
+- Rename many `postgresql.log.*` fields to map to ECS. {pull}9303[9303]
+- Rename many `kafka.log.*` fields to map to ECS. {pull}9297[9297]
+- Add `convert_timezone` option to Logstash module to convert dates to UTC. {issue}9756[9756] {pull}9797[9797]
 
 *Metricbeat*
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -69,6 +69,7 @@ https://github.com/elastic/beats/compare/v6.6.0...6.x[Check the HEAD diff]
 - Stop runners disabled by hints after previously being started. {pull}9305[9305]
 - Fix saved objects in filebeat haproxy dashboard. {pull}9417[9417]
 - Fixed a memory leak when harvesters are closed. {pull}7820[7820]
+- Add `convert_timezone` option to Logstash module to convert dates to UTC. {issue}9756[9756] {pull}9797[9797]
 
 *Heartbeat*
 
@@ -77,12 +78,6 @@ https://github.com/elastic/beats/compare/v6.6.0...6.x[Check the HEAD diff]
 *Journalbeat*
 
 - Add missing journalbeat non breaking fixes. {pull}9106[9106]
-- Use `log.source.address` instead of `log.source.ip` for network input sources. {pull}9487[9487]
-- Rename many `redis.log.*` fields to map to ECS. {pull}9315[9315]
-- Rename many `icinga.*` fields to map to ECS. {pull}9294[9294]
-- Rename many `postgresql.log.*` fields to map to ECS. {pull}9303[9303]
-- Rename many `kafka.log.*` fields to map to ECS. {pull}9297[9297]
-- Add `convert_timezone` option to Logstash module to convert dates to UTC. {issue}9756[9756] {pull}9797[9797]
 
 *Metricbeat*
 

--- a/filebeat/module/logstash/_meta/config.yml
+++ b/filebeat/module/logstash/_meta/config.yml
@@ -7,9 +7,15 @@
     # Filebeat will choose the paths depending on your OS.
     #var.paths:
 
+    # Convert the timestamp to UTC. Requires Elasticsearch >= 6.1.
+    #var.convert_timezone: false
+
   # Slow logs
   slowlog:
    enabled: true
     # Set custom paths for the log files. If left empty,
     # Filebeat will choose the paths depending on your OS.
     #var.paths:
+
+    # Convert the timestamp to UTC. Requires Elasticsearch >= 6.1.
+    #var.convert_timezone: false

--- a/filebeat/module/logstash/log/config/log.yml
+++ b/filebeat/module/logstash/log/config/log.yml
@@ -8,3 +8,8 @@ multiline:
   pattern: ^\[[0-9]{4}-[0-9]{2}-[0-9]{2}
   negate: true
   match: after
+
+{{ if .convert_timezone }}
+processors:
+- add_locale: ~
+{{ end }}

--- a/filebeat/module/logstash/log/ingest/pipeline-plain.json
+++ b/filebeat/module/logstash/log/ingest/pipeline-plain.json
@@ -34,9 +34,19 @@
             }
         },
         {
-            "rename": {
+            "date": {
                 "field": "logstash.log.timestamp",
-                "target_field": "@timestamp"
+                "target_field": "@timestamp",
+                "formats": [
+                  "ISO8601"
+              ],
+              {< if .convert_timezone >}"timezone": "{{ event.timezone }}",{< end >}
+              "ignore_failure": true
+            }
+        },
+        {
+            "remove": {
+                "field": "logstash.log.timestamp"
             }
         }
     ]

--- a/filebeat/module/logstash/log/manifest.yml
+++ b/filebeat/module/logstash/log/manifest.yml
@@ -8,6 +8,13 @@ var:
       - /var/log/logstash/logstash-{{.format}}*.log
     os.windows:
       - c:/programdata/logstash/logs/logstash-{{.format}}*.log
+  - name: convert_timezone
+    default: false
+    # if ES < 6.1.0, this flag switches to false automatically when evaluating the
+    # pipeline
+    min_elasticsearch_version:
+      version: 6.1.0
+      value: false
 
 ingest_pipeline: ingest/pipeline-{{.format}}.json
 input: config/log.yml

--- a/filebeat/module/logstash/log/test/logstash-plain.log-expected.json
+++ b/filebeat/module/logstash/log/test/logstash-plain.log-expected.json
@@ -1,6 +1,6 @@
 [
     {
-        "@timestamp": "2017-10-23T14:20:12,046",
+        "@timestamp": "2017-10-23T14:20:12.046Z",
         "event.dataset": "logstash.log",
         "fileset.module": "logstash",
         "fileset.name": "log",
@@ -12,7 +12,7 @@
         "prospector.type": "log"
     },
     {
-        "@timestamp": "2017-11-20T03:55:00,318",
+        "@timestamp": "2017-11-20T03:55:00.318Z",
         "event.dataset": "logstash.log",
         "fileset.module": "logstash",
         "fileset.name": "log",

--- a/filebeat/module/logstash/slowlog/config/slowlog.yml
+++ b/filebeat/module/logstash/slowlog/config/slowlog.yml
@@ -4,3 +4,8 @@ paths:
  - {{$path}}
 {{ end }}
 exclude_files: [".gz$"]
+
+{{ if .convert_timezone }}
+processors:
+- add_locale: ~
+{{ end }}

--- a/filebeat/module/logstash/slowlog/ingest/pipeline-plain.json
+++ b/filebeat/module/logstash/slowlog/ingest/pipeline-plain.json
@@ -49,9 +49,19 @@
             }
         },
         {
-            "rename": {
+            "date": {
                 "field": "logstash.slowlog.timestamp",
-                "target_field": "@timestamp"
+                "target_field": "@timestamp",
+                "formats": [
+                  "ISO8601"
+              ],
+              {< if .convert_timezone >}"timezone": "{{ event.timezone }}",{< end >}
+              "ignore_failure": true
+            }
+        },
+        {
+            "remove": {
+                "field": "logstash.slowlog.timestamp"
             }
         },
         {

--- a/filebeat/module/logstash/slowlog/manifest.yml
+++ b/filebeat/module/logstash/slowlog/manifest.yml
@@ -8,6 +8,13 @@ var:
       - /var/log/logstash/logstash-slowlog-{{.format}}*.log
     os.windows:
       - c:/programdata/logstash/logs/logstash-slowlog-{{.format}}*.log
+  - name: convert_timezone
+    default: false
+    # if ES < 6.1.0, this flag switches to false automatically when evaluating the
+    # pipeline
+    min_elasticsearch_version:
+      version: 6.1.0
+      value: false
 
 ingest_pipeline: ingest/pipeline-{{.format}}.json
 input: config/slowlog.yml

--- a/filebeat/module/logstash/slowlog/test/slowlog-plain.log-expected.json
+++ b/filebeat/module/logstash/slowlog/test/slowlog-plain.log-expected.json
@@ -1,6 +1,6 @@
 [
     {
-        "@timestamp": "2017-10-30T09:57:58,243",
+        "@timestamp": "2017-10-30T09:57:58.243Z",
         "event.dataset": "logstash.slowlog",
         "fileset.module": "logstash",
         "fileset.name": "slowlog",

--- a/filebeat/modules.d/logstash.yml.disabled
+++ b/filebeat/modules.d/logstash.yml.disabled
@@ -7,9 +7,15 @@
     # Filebeat will choose the paths depending on your OS.
     #var.paths:
 
+    # Convert the timestamp to UTC. Requires Elasticsearch >= 6.1.
+    #var.convert_timezone: false
+
   # Slow logs
   slowlog:
    enabled: true
     # Set custom paths for the log files. If left empty,
     # Filebeat will choose the paths depending on your OS.
     #var.paths:
+
+    # Convert the timestamp to UTC. Requires Elasticsearch >= 6.1.
+    #var.convert_timezone: false


### PR DESCRIPTION
Cherry-pick of PR #9797 to 6.x branch. Original message: 

This PR updates the following filesets in the `logstash` Filebeat module to accept a `var.convert_timezone` configuration setting:

* [x] log
* [x] slowlog

Fixes partially #9756. Related: #9761