### PR TITLE
Cherry-pick #9770 to 6.x: Parameterizing Painless script literals

### DIFF
--- a/filebeat/module/auditd/log/ingest/pipeline.json
+++ b/filebeat/module/auditd/log/ingest/pipeline.json
@@ -71,7 +71,7 @@
         },
         {
             "convert": {
-                "field" : "auditd.log.sequence",
+                "field": "auditd.log.sequence",
                 "type": "integer",
                 "ignore_missing": true
             }
@@ -79,7 +79,11 @@
         {
             "script": {
                 "lang": "painless",
-                "inline": "    String trimQuotes(def v) {\n        if (v.startsWith(\"'\") || v.startsWith('\"')) {\n          v = v.substring(1, v.length());\n        }\n        if (v.endsWith(\"'\") || v.endsWith('\"')) {\n          v = v.substring(0, v.length()-1);\n        }  \n        return v;\n    }\n    \n    boolean isHexAscii(String v) {\n      def len = v.length();\n      if (len == 0 || len % 2 != 0) {\n        return false; \n      }\n  \n      for (int i = 0 ; i < len ; i++) {\n        if (Character.digit(v.charAt(i), 16) == -1) {\n          return false;\n        }\n      }\n\n      return true;\n    }\n    \n    String convertHexToString(String hex) {\n\t    StringBuilder sb = new StringBuilder();\n\n      for (int i=0; i < hex.length() - 1; i+=2) {\n          String output = hex.substring(i, (i + 2));\n          int decimal = Integer.parseInt(output, 16);\n          sb.append((char)decimal);\n      }\n\n      return sb.toString();\n    }\n    \n    def possibleHexKeys = ['exe', 'cmd'];\n    \n    def audit = ctx.auditd.get(\"log\");\n    Iterator entries = audit.entrySet().iterator();\n    while (entries.hasNext()) {\n      def e = entries.next();\n      def k = e.getKey();\n      def v = e.getValue(); \n\n      // Remove entries whose value is ?\n      if (v == \"?\" || v == \"(null)\" || v == \"\") {\n        entries.remove();\n        continue;\n      }\n      \n      // Convert hex values to ASCII.\n      if (possibleHexKeys.contains(k) && isHexAscii(v)) {\n        v = convertHexToString(v);\n        audit.put(k, v);\n      }\n      \n      // Trim quotes.\n      if (v instanceof String) {\n        v = trimQuotes(v);\n        audit.put(k, v);\n      }\n      \n      // Convert arch.\n      if (k == \"arch\" && v == \"c000003e\") {\n        audit.put(k, \"x86_64\");\n      }\n    }"
+                "source": "    String trimQuotes(def singleQuote, def doubleQuote, def v) {\n        if (v.startsWith(singleQuote) || v.startsWith(doubleQuote)) {\n          v = v.substring(1, v.length());\n        }\n        if (v.endsWith(singleQuote) || v.endsWith(doubleQuote)) {\n          v = v.substring(0, v.length()-1);\n        }  \n        return v;\n    }\n    \n    boolean isHexAscii(String v) {\n      def len = v.length();\n      if (len == 0 || len % 2 != 0) {\n        return false; \n      }\n  \n      for (int i = 0 ; i < len ; i++) {\n        if (Character.digit(v.charAt(i), 16) == -1) {\n          return false;\n        }\n      }\n\n      return true;\n    }\n    \n    String convertHexToString(String hex) {\n\t    StringBuilder sb = new StringBuilder();\n\n      for (int i=0; i < hex.length() - 1; i+=2) {\n          String output = hex.substring(i, (i + 2));\n          int decimal = Integer.parseInt(output, 16);\n          sb.append((char)decimal);\n      }\n\n      return sb.toString();\n    }\n    \n    def possibleHexKeys = ['exe', 'cmd'];\n    \n    def audit = ctx.auditd.get(\"log\");\n    Iterator entries = audit.entrySet().iterator();\n    while (entries.hasNext()) {\n      def e = entries.next();\n      def k = e.getKey();\n      def v = e.getValue(); \n\n      // Remove entries whose value is ?\n      if (v == \"?\" || v == \"(null)\" || v == \"\") {\n        entries.remove();\n        continue;\n      }\n      \n      // Convert hex values to ASCII.\n      if (possibleHexKeys.contains(k) && isHexAscii(v)) {\n        v = convertHexToString(v);\n        audit.put(k, v);\n      }\n      \n      // Trim quotes.\n      if (v instanceof String) {\n        v = trimQuotes(params.single_quote, params.double_quote, v);\n        audit.put(k, v);\n      }\n      \n      // Convert arch.\n      if (k == \"arch\" && v == \"c000003e\") {\n        audit.put(k, \"x86_64\");\n      }\n    }",
+                "params": {
+                    "single_quote": "'",
+                    "double_quote": "\""
+                }
             }
         },
         {

--- a/filebeat/module/nginx/access/ingest/default.json
+++ b/filebeat/module/nginx/access/ingest/default.json
@@ -1,78 +1,139 @@
 {
-  "description": "Pipeline for parsing Nginx access logs. Requires the geoip and user_agent plugins.",
-  "processors": [{
-    "grok": {
-      "field": "message",
-      "patterns":[
-        "\"?%{IP_LIST:nginx.access.remote_ip_list} - %{DATA:nginx.access.user_name} \\[%{HTTPDATE:nginx.access.time}\\] \"%{GREEDYDATA:nginx.access.info}\" %{NUMBER:nginx.access.response_code} %{NUMBER:nginx.access.body_sent.bytes} \"%{DATA:nginx.access.referrer}\" \"%{DATA:nginx.access.agent}\""
-        ],
-      "pattern_definitions": {
-        "IP_LIST": "%{IP}(\"?,?\\s*%{IP})*"
-      },
-      "ignore_missing": true
-    }
-  }, {
-    "grok": {
-      "field": "nginx.access.info",
-      "patterns": [
-          "%{WORD:nginx.access.method} %{DATA:nginx.access.url} HTTP/%{NUMBER:nginx.access.http_version}",
-          ""
-      ],
-      "ignore_missing": true
-    }
-  }, {
-    "remove": {
-      "field": "nginx.access.info"
-    }
-  }, {
-    "split": {
-      "field": "nginx.access.remote_ip_list",
-      "separator": "\"?,?\\s+"
-    }
-  }, {
-    "script": {
-      "lang": "painless",
-      "inline": "boolean isPrivate(def ip) { try { StringTokenizer tok = new StringTokenizer(ip, '.'); int firstByte = Integer.parseInt(tok.nextToken());       int secondByte = Integer.parseInt(tok.nextToken());       if (firstByte == 10) {         return true;       }       if (firstByte == 192 && secondByte == 168) {         return true;       }       if (firstByte == 172 && secondByte >= 16 && secondByte <= 31) {         return true;       }       if (firstByte == 127) {         return true;       }       return false;     } catch (Exception e) {       return false;     }   }   def found = false;   for (def item : ctx.nginx.access.remote_ip_list) {     if (!isPrivate(item)) {       ctx.nginx.access.remote_ip = item;       found = true;       break;     }   }   if (!found) {     ctx.nginx.access.remote_ip = ctx.nginx.access.remote_ip_list[0];   }"
-      }
-  }, {
-    "remove":{
-      "field": "message"
-    }
-  }, {
-    "rename": {
-      "field": "@timestamp",
-      "target_field": "read_timestamp"
-    }
-  }, {
-    "date": {
-      "field": "nginx.access.time",
-      "target_field": "@timestamp",
-      "formats": ["dd/MMM/YYYY:H:m:s Z"]
-    }
-  }, {
-    "remove": {
-      "field": "nginx.access.time"
-    }
-  }, {
-    "user_agent": {
-      "field": "nginx.access.agent",
-      "target_field": "nginx.access.user_agent"
-    }
-  }, {
-    "rename": {
-      "field": "nginx.access.agent",
-      "target_field": "nginx.access.user_agent.original"
-    }
-  }, {
-    "geoip": {
-      "field": "nginx.access.remote_ip",
-      "target_field": "nginx.access.geoip"
-    }
-  }],
-  "on_failure" : [{
-    "set" : {
-      "field" : "error.message",
-      "value" : "{{ _ingest.on_failure_message }}"
-    }
-  }]
+    "description": "Pipeline for parsing Nginx access logs. Requires the geoip and user_agent plugins.",
+    "processors": [
+        {
+            "grok": {
+                "field": "message",
+                "patterns": [
+                    "\"?%{IP_LIST:network.forwarded_ip} - %{DATA:user.name} \\[%{HTTPDATE:nginx.access.time}\\] \"%{GREEDYDATA:nginx.access.info}\" %{NUMBER:http.response.status_code:long} %{NUMBER:nginx.access.body_sent.bytes:long} \"%{DATA:http.request.referrer}\" \"%{DATA:nginx.access.agent}\""
+                ],
+                "pattern_definitions": {
+                    "IP_LIST": "%{IP}(\"?,?\\s*%{IP})*"
+                },
+                "ignore_missing": true
+            }
+        },
+        {
+            "grok": {
+                "field": "nginx.access.info",
+                "patterns": [
+                    "%{WORD:http.request.method} %{DATA:url.original} HTTP/%{NUMBER:http.version}",
+                    ""
+                ],
+                "ignore_missing": true
+            }
+        },
+        {
+            "remove": {
+                "field": "nginx.access.info"
+            }
+        },
+        {
+            "split": {
+                "field": "network.forwarded_ip",
+                "separator": "\"?,?\\s+"
+            }
+        },
+        {
+            "set": {
+                "field": "source.ip",
+                "value": ""
+            }
+        },
+        {
+            "script": {
+                "lang": "painless",
+                "source": "boolean isPrivate(def dot, def ip) { try { StringTokenizer tok = new StringTokenizer(ip, dot); int firstByte = Integer.parseInt(tok.nextToken());       int secondByte = Integer.parseInt(tok.nextToken());       if (firstByte == 10) {         return true;       }       if (firstByte == 192 && secondByte == 168) {         return true;       }       if (firstByte == 172 && secondByte >= 16 && secondByte <= 31) {         return true;       }       if (firstByte == 127) {         return true;       }       return false;     } catch (Exception e) {       return false;     }   }   def found = false;   for (def item : ctx.network.forwarded_ip) {     if (!isPrivate(params.dot, item)) {       ctx.source.ip = item;       found = true;       break;     }   }   if (!found) {     ctx.source.ip = ctx.network.forwarded_ip[0];   }",
+                "params": {
+                    "dot": "."
+                }
+            }
+        },
+        {
+            "remove": {
+                "field": "message"
+            }
+        },
+        {
+            "rename": {
+                "field": "@timestamp",
+                "target_field": "read_timestamp"
+            }
+        },
+        {
+            "date": {
+                "field": "nginx.access.time",
+                "target_field": "@timestamp",
+                "formats": [
+                    "dd/MMM/YYYY:H:m:s Z"
+                ]
+            }
+        },
+        {
+            "remove": {
+                "field": "nginx.access.time"
+            }
+        },
+        {
+            "user_agent": {
+                "field": "nginx.access.agent"
+            }
+        },
+        {
+            "rename": {
+                "field": "nginx.access.agent",
+                "target_field": "user_agent.original"
+            }
+        },
+        {
+            "rename": {
+                "field": "user_agent.os",
+                "target_field": "user_agent.os.full_name",
+                "ignore_missing": true
+            }
+        },
+        {
+            "rename": {
+                "field": "user_agent.os_name",
+                "target_field": "user_agent.os.name",
+                "ignore_missing": true
+            }
+        },
+        {
+            "rename": {
+                "field": "user_agent.os_major",
+                "target_field": "user_agent.os.major",
+                "ignore_missing": true
+            }
+        },
+        {
+            "rename": {
+                "field": "user_agent.os_minor",
+                "target_field": "user_agent.os.minor",
+                "ignore_missing": true
+            }
+        },
+        {
+            "rename": {
+                "field": "user_agent.os_patch",
+                "target_field": "user_agent.os.patch",
+                "ignore_missing": true
+            }
+        },
+        {
+            "geoip": {
+                "field": "source.ip",
+                "target_field": "source.geo",
+                "ignore_missing": true
+            }
+        }
+    ],
+    "on_failure": [
+        {
+            "set": {
+                "field": "error.message",
+                "value": "{{ _ingest.on_failure_message }}"
+            }
+        }
+    ]
 }

--- a/filebeat/module/nginx/access/ingest/default.json
+++ b/filebeat/module/nginx/access/ingest/default.json
@@ -5,7 +5,7 @@
             "grok": {
                 "field": "message",
                 "patterns": [
-                    "\"?%{IP_LIST:network.forwarded_ip} - %{DATA:user.name} \\[%{HTTPDATE:nginx.access.time}\\] \"%{GREEDYDATA:nginx.access.info}\" %{NUMBER:http.response.status_code:long} %{NUMBER:nginx.access.body_sent.bytes:long} \"%{DATA:http.request.referrer}\" \"%{DATA:nginx.access.agent}\""
+                    "\"?%{IP_LIST:nginx.access.remote_ip_list} - %{DATA:nginx.access.user_name} \\[%{HTTPDATE:nginx.access.time}\\] \"%{GREEDYDATA:nginx.access.info}\" %{NUMBER:nginx.access.response_code:long} %{NUMBER:nginx.access.body_sent.bytes:long} \"%{DATA:nginx.access.referrer}\" \"%{DATA:nginx.access.agent}\""
                 ],
                 "pattern_definitions": {
                     "IP_LIST": "%{IP}(\"?,?\\s*%{IP})*"
@@ -17,7 +17,7 @@
             "grok": {
                 "field": "nginx.access.info",
                 "patterns": [
-                    "%{WORD:http.request.method} %{DATA:url.original} HTTP/%{NUMBER:http.version}",
+                    "%{WORD:nginx.access.method} %{DATA:nginx.access.url} HTTP/%{NUMBER:nginx.access.http_version}",
                     ""
                 ],
                 "ignore_missing": true
@@ -30,20 +30,14 @@
         },
         {
             "split": {
-                "field": "network.forwarded_ip",
+                "field": "nginx.access.remote_ip_list",
                 "separator": "\"?,?\\s+"
-            }
-        },
-        {
-            "set": {
-                "field": "source.ip",
-                "value": ""
             }
         },
         {
             "script": {
                 "lang": "painless",
-                "source": "boolean isPrivate(def dot, def ip) { try { StringTokenizer tok = new StringTokenizer(ip, dot); int firstByte = Integer.parseInt(tok.nextToken());       int secondByte = Integer.parseInt(tok.nextToken());       if (firstByte == 10) {         return true;       }       if (firstByte == 192 && secondByte == 168) {         return true;       }       if (firstByte == 172 && secondByte >= 16 && secondByte <= 31) {         return true;       }       if (firstByte == 127) {         return true;       }       return false;     } catch (Exception e) {       return false;     }   }   def found = false;   for (def item : ctx.network.forwarded_ip) {     if (!isPrivate(params.dot, item)) {       ctx.source.ip = item;       found = true;       break;     }   }   if (!found) {     ctx.source.ip = ctx.network.forwarded_ip[0];   }",
+                "source": "boolean isPrivate(def dot, def ip) { try { StringTokenizer tok = new StringTokenizer(ip, dot); int firstByte = Integer.parseInt(tok.nextToken());       int secondByte = Integer.parseInt(tok.nextToken());       if (firstByte == 10) {         return true;       }       if (firstByte == 192 && secondByte == 168) {         return true;       }       if (firstByte == 172 && secondByte >= 16 && secondByte <= 31) {         return true;       }       if (firstByte == 127) {         return true;       }       return false;     } catch (Exception e) {       return false;     }   }   def found = false;   for (def item : ctx.nginx.access.remote_ip_list) {     if (!isPrivate(params.dot, item)) {       ctx.nginx.access.remote_ip = item;       found = true;       break;     }   }   if (!found) {     ctx.nginx.access.remote_ip = ctx.nginx.access.remote_ip_list[0];   }",
                 "params": {
                     "dot": "."
                 }
@@ -76,54 +70,20 @@
         },
         {
             "user_agent": {
-                "field": "nginx.access.agent"
+                "field": "nginx.access.agent",
+                "target_field": "nginx.access.user_agent"
             }
         },
         {
             "rename": {
                 "field": "nginx.access.agent",
-                "target_field": "user_agent.original"
-            }
-        },
-        {
-            "rename": {
-                "field": "user_agent.os",
-                "target_field": "user_agent.os.full_name",
-                "ignore_missing": true
-            }
-        },
-        {
-            "rename": {
-                "field": "user_agent.os_name",
-                "target_field": "user_agent.os.name",
-                "ignore_missing": true
-            }
-        },
-        {
-            "rename": {
-                "field": "user_agent.os_major",
-                "target_field": "user_agent.os.major",
-                "ignore_missing": true
-            }
-        },
-        {
-            "rename": {
-                "field": "user_agent.os_minor",
-                "target_field": "user_agent.os.minor",
-                "ignore_missing": true
-            }
-        },
-        {
-            "rename": {
-                "field": "user_agent.os_patch",
-                "target_field": "user_agent.os.patch",
-                "ignore_missing": true
+                "target_field": "nginx.access.user_agent.original"
             }
         },
         {
             "geoip": {
-                "field": "source.ip",
-                "target_field": "source.geo",
+                "field": "nginx.access.remote_ip",
+                "target_field": "nginx.access.geoip",
                 "ignore_missing": true
             }
         }

--- a/filebeat/module/redis/log/ingest/pipeline.json
+++ b/filebeat/module/redis/log/ingest/pipeline.json
@@ -1,55 +1,82 @@
 {
-  "description": "Pipeline for parsing redis logs",
-  "processors": [
-    {
-      "grok": {
-        "field": "message",
-        "patterns": [
-          "(%{POSINT:redis.log.pid}:%{CHAR:redis.log.role} )?%{REDISTIMESTAMP:redis.log.timestamp} %{REDISLEVEL:redis.log.level} %{GREEDYDATA:redis.log.message}",
-          "%{POSINT:redis.log.pid}:signal-handler \\(%{POSINT:redis.log.timestamp}\\) %{GREEDYDATA:redis.log.message}"
-        ],
-        "pattern_definitions": {
-          "CHAR": "[a-zA-Z]",
-          "REDISLEVEL": "[.\\-*#]"
+    "description": "Pipeline for parsing redis logs",
+    "processors": [
+        {
+            "grok": {
+                "field": "message",
+                "patterns": [
+                    "(%{POSINT:process.pid:long}:%{CHAR:redis.log.role} )?%{REDISTIMESTAMP:redis.log.timestamp} %{REDISLEVEL:log.level} %{GREEDYDATA:message}",
+                    "%{POSINT:process.pid:long}:signal-handler \\(%{POSINT:redis.log.timestamp}\\) %{GREEDYDATA:message}"
+                ],
+                "pattern_definitions": {
+                    "CHAR": "[a-zA-Z]",
+                    "REDISLEVEL": "[.\\-*#]"
+                }
+            }
+        },
+        {
+            "script": {
+                "lang": "painless",
+                "source": "if (ctx.log.level == params.dot) {\n          ctx.log.level = params.debug;\n        } else if (ctx.log.level == params.dash) {\n          ctx.log.level = params.verbose;\n        } else if (ctx.log.level == params.asterisk) {\n          ctx.log.level = params.notice;\n        } else if (ctx.log.level == params.hash) {\n          ctx.log.level = params.warning;\n        }",
+                "params": {
+                    "dot": ".",
+                    "debug": "debug",
+                    "dash": "-",
+                    "verbose": "verbose",
+                    "asterisk": "*",
+                    "notice": "notice",
+                    "hash": "#",
+                    "warning": "warning"
+                }
+            }
+        },
+        {
+            "script": {
+                "lang": "painless",
+                "source": "if (ctx.redis.log.role == params.master_abbrev) {\n          ctx.redis.log.role = params.master;\n        } else if (ctx.redis.log.role == params.slave_abbrev) {\n          ctx.redis.log.role = params.slave;\n        } else if (ctx.redis.log.role == params.child_abbrev) {\n          ctx.redis.log.role = params.child;\n        } else if (ctx.redis.log.role == params.sentinel_abbrev) {\n          ctx.redis.log.role = params.sentinel;\n        }\n        ",
+                "params": {
+                    "master_abbrev": "M",
+                    "master": "master",
+                    "slave_abbrev": "S",
+                    "slave": "slave",
+                    "child_abbrev": "C",
+                    "child": "child",
+                    "sentinel_abbrev": "X",
+                    "sentinel": "sentinel"
+                }
+            }
+        },
+        {
+            "rename": {
+                "field": "@timestamp",
+                "target_field": "read_timestamp"
+            }
+        },
+        {
+            "date": {
+                "field": "redis.log.timestamp",
+                "target_field": "@timestamp",
+                "formats": [
+                    "dd MMM H:m:s.SSS",
+                    "dd MMM H:m:s",
+                    "UNIX"
+                ],
+                "ignore_failure": true
+            }
+        },
+        {
+            "remove": {
+                "field": "redis.log.timestamp",
+                "ignore_failure": true
+            }
         }
-      }
-    }, {
-      "script": {
-        "lang": "painless",
-        "inline": "if (ctx.redis.log.level == '.') {\n          ctx.redis.log.level = 'debug';\n        } else if (ctx.redis.log.level == '-') {\n          ctx.redis.log.level = 'verbose';\n        } else if (ctx.redis.log.level == '*') {\n          ctx.redis.log.level = 'notice';\n        } else if (ctx.redis.log.level == '#') {\n          ctx.redis.log.level = 'warning';\n        }"
-      }
-    }, {
-      "script": {
-        "lang": "painless",
-        "inline": "if (ctx.redis.log.role == 'M') {\n          ctx.redis.log.role = 'master';\n        } else if (ctx.redis.log.role == 'S') {\n          ctx.redis.log.role = 'slave';\n        } else if (ctx.redis.log.role == 'C') {\n          ctx.redis.log.role = 'child';\n        } else if (ctx.redis.log.role == 'X') {\n          ctx.redis.log.role = 'sentinel';\n        }\n        "
-      }
-    }, {
-      "remove": {
-        "field": "message"
-      }
-    }, {
-      "rename": {
-        "field": "@timestamp",
-        "target_field": "read_timestamp"
-      }
-    }, {
-      "date": {
-        "field": "redis.log.timestamp",
-        "target_field": "@timestamp",
-        "formats": ["dd MMM H:m:s.SSS", "dd MMM H:m:s", "UNIX"],
-        "ignore_failure": true
-      }
-    }, {
-      "remove": {
-        "field": "redis.log.timestamp",
-        "ignore_failure": true
-      }
-    }
-  ],
-  "on_failure" : [{
-    "set" : {
-      "field" : "error.message",
-      "value" : "{{ _ingest.on_failure_message }}"
-    }
-  }]
+    ],
+    "on_failure": [
+        {
+            "set": {
+                "field": "error.message",
+                "value": "{{ _ingest.on_failure_message }}"
+            }
+        }
+    ]
 }

--- a/filebeat/module/redis/log/ingest/pipeline.json
+++ b/filebeat/module/redis/log/ingest/pipeline.json
@@ -5,8 +5,8 @@
             "grok": {
                 "field": "message",
                 "patterns": [
-                    "(%{POSINT:process.pid:long}:%{CHAR:redis.log.role} )?%{REDISTIMESTAMP:redis.log.timestamp} %{REDISLEVEL:log.level} %{GREEDYDATA:message}",
-                    "%{POSINT:process.pid:long}:signal-handler \\(%{POSINT:redis.log.timestamp}\\) %{GREEDYDATA:message}"
+                    "(%{POSINT:redis.log.pid:long}:%{CHAR:redis.log.role} )?%{REDISTIMESTAMP:redis.log.timestamp} %{REDISLEVEL:redis.log.level} %{GREEDYDATA:redis.log.message}",
+                    "%{POSINT:redis.log.pid:long}:signal-handler \\(%{POSINT:redis.log.timestamp}\\) %{GREEDYDATA:redis.log.message}"
                 ],
                 "pattern_definitions": {
                     "CHAR": "[a-zA-Z]",
@@ -17,7 +17,7 @@
         {
             "script": {
                 "lang": "painless",
-                "source": "if (ctx.log.level == params.dot) {\n          ctx.log.level = params.debug;\n        } else if (ctx.log.level == params.dash) {\n          ctx.log.level = params.verbose;\n        } else if (ctx.log.level == params.asterisk) {\n          ctx.log.level = params.notice;\n        } else if (ctx.log.level == params.hash) {\n          ctx.log.level = params.warning;\n        }",
+                "source": "if (ctx.redis.log.level == params.dot) {\n          ctx.redis.log.level = params.debug;\n        } else if (ctx.redis.log.level == params.dash) {\n          ctx.redis.log.level = params.verbose;\n        } else if (ctx.redis.log.level == params.asterisk) {\n          ctx.redis.log.level = params.notice;\n        } else if (ctx.redis.log.level == params.hash) {\n          ctx.redis.log.level = params.warning;\n        }",
                 "params": {
                     "dot": ".",
                     "debug": "debug",
@@ -44,6 +44,11 @@
                     "sentinel_abbrev": "X",
                     "sentinel": "sentinel"
                 }
+            }
+        },
+        {
+            "remove": {
+                "field": "message"
             }
         },
         {


### PR DESCRIPTION
Cherry-pick of PR #9770 to 6.x branch. Original message: 

Several Filebeat CI runs are failing like so:

```
05:55:30 ======================================================================
05:55:30 FAIL: test_fileset_file_7_traefik (test_modules.Test)
05:55:30 ----------------------------------------------------------------------
05:55:30 Traceback (most recent call last):
05:55:30   File "/go/src/github.com/elastic/beats/filebeat/build/python-env/local/lib/python2.7/site-packages/parameterized/parameterized.py", line 392, in standalone_func
05:55:30     return func(*(a + p.args), **p.kwargs)
05:55:30   File "/go/src/github.com/elastic/beats/filebeat/tests/system/test_modules.py", line 91, in test_fileset_file
05:55:30     cfgfile=cfgfile)
05:55:30   File "/go/src/github.com/elastic/beats/filebeat/tests/system/test_modules.py", line 140, in run_on_file
05:55:30     obj)
05:55:30 AssertionError: not error expected but got: {u'http': {u'version': u'1.0', u'request': {u'method': u'GET'}, u'response': {u'status_code': 200}}, u'log': {u'file': {u'path': u'/go/src/github.com/elastic/beats/filebeat/module/traefik/access/test/test.log'}, u'offset': 1581}, u'url': {u'original': u'/apache_pb.gif'}, u'traefik': {u'access': {u'body_sent': {u'bytes': 2326}, u'user_identifier': u'-'}}, u'@timestamp': u'2000-10-10T20:55:36.000Z', u'read_timestamp': u'2018-12-22T13:50:36.804Z', u'agent': {u'hostname': u'47c93834e587', u'type': u'filebeat', u'version': u'7.0.0'}, u'source': {u'ip': u'127.0.0.1', u'address': u'127.0.0.1'}, u'host': {u'name': u'47c93834e587'}, u'user': {u'name': u'frank'}, u'error': {u'message': u'[script] Too many dynamic script compilations within, max: [75/5m]; please use indexed, or scripts with parameters instead; this limit can be changed by the [script.max_compilations_rate] setting'}, u'input': {u'type': u'log'}, u'event': {u'module': u'traefik', u'dataset': u'access'}}
05:55:30 -------------------- >> begin captured stdout << ---------------------
05:55:30 Using elasticsearch: http://elasticsearch:9200
05:55:30 Testing traefik/access on /go/src/github.com/elastic/beats/filebeat/tests/system/../../module/traefik/access/test/test.log
05:55:30 
05:55:30 --------------------- >> end captured stdout << ----------------------
05:55:30 
05:55:30 ----------------------------------------------------------------------
```

For example:
* https://beats-ci.elastic.co/job/elastic+beats+pull-request+multijob-linux/2911/beat=filebeat,label=ubuntu/console
* https://beats-ci.elastic.co/job/elastic+beats+pull-request+multijob-linux/2912/beat=filebeat,label=ubuntu/console

This PR tries to parameterize any painless scripts in Filebeat modules' pipelines to see if it helps with the `Too many dynamic script compilations within, max: [75/5m]` error. Specifically, it parameterizes literals that were previous used in painless scripts by the following Filebeat module pipelines:

* `auditd`
* `nginx`
* `redis`
