### PR TITLE
Close handle on signalEvent

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -121,6 +121,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Winlogbeat*
 
+- Close handle on signalEvent. {pull}9838[9838]
+
 *Functionbeat*
 
 ==== Known Issue

--- a/winlogbeat/eventlog/wineventlog.go
+++ b/winlogbeat/eventlog/wineventlog.go
@@ -126,6 +126,7 @@ func (l *winEventLog) Open(state checkpoint.EventLogState) error {
 	if err != nil {
 		return nil
 	}
+	defer windows.CloseHandle(signalEvent)
 
 	debugf("%s using subscription query=%s", l.logPrefix, l.query)
 	subscriptionHandle, err := win.Subscribe(


### PR DESCRIPTION
hi!
signalEvent not be closed,  handle leak might happen when calling Open()func a lot,
it seems not hard to recurrent such issue, 
and as discuss on https://discuss.elastic.co/t/signalevent-not-be-closed/157966 
signalEvent  actually not work as same function in microsoft docs,
so I just add "defer" here to free the handle, which works in my test env

I'm confused that is it necessary  to add any test cases or comments for the Fix, since it's sample ... 
thanks !
