### PR TITLE
Update redis, haproxy and system test files using GENERATE=1

### DIFF
--- a/filebeat/module/haproxy/log/test/default.log-expected.json
+++ b/filebeat/module/haproxy/log/test/default.log-expected.json
@@ -1,6 +1,6 @@
 [
     {
-        "@timestamp": "2018-09-20T15:42:59.000Z",
+        "@timestamp": "2019-09-20T15:42:59.000Z",
         "destination.ip": "1.2.3.4",
         "destination.port": 5000,
         "ecs.version": "1.0.0-beta2",

--- a/filebeat/module/redis/log/test/test.log-expected.json
+++ b/filebeat/module/redis/log/test/test.log-expected.json
@@ -1,6 +1,6 @@
 [
     {
-        "@timestamp": "2018-05-30T12:23:52.442Z",
+        "@timestamp": "2019-05-30T12:23:52.442Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "log",
         "event.module": "redis",
@@ -12,7 +12,7 @@
         "redis.log.role": "master"
     },
     {
-        "@timestamp": "2018-05-30T10:05:20.000Z",
+        "@timestamp": "2019-05-30T10:05:20.000Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "log",
         "event.module": "redis",
@@ -22,7 +22,7 @@
         "message": "0 clients connected (0 slaves), 618932 bytes in use, 0 shared objects."
     },
     {
-        "@timestamp": "2018-05-31T04:32:08.000Z",
+        "@timestamp": "2019-05-31T04:32:08.000Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "log",
         "event.module": "redis",

--- a/filebeat/module/system/auth/test/test.log-expected.json
+++ b/filebeat/module/system/auth/test/test.log-expected.json
@@ -1,6 +1,6 @@
 [
     {
-        "@timestamp": "2018-02-21T21:54:44.000Z",
+        "@timestamp": "2019-02-21T21:54:44.000Z",
         "ecs.version": "1.0.0-beta2",
         "event.action": "Accepted",
         "event.dataset": "auth",
@@ -16,7 +16,7 @@
         "user.name": "vagrant"
     },
     {
-        "@timestamp": "2018-02-23T00:13:35.000Z",
+        "@timestamp": "2019-02-23T00:13:35.000Z",
         "ecs.version": "1.0.0-beta2",
         "event.action": "Accepted",
         "event.dataset": "auth",
@@ -31,7 +31,7 @@
         "user.name": "vagrant"
     },
     {
-        "@timestamp": "2018-02-21T21:56:12.000Z",
+        "@timestamp": "2019-02-21T21:56:12.000Z",
         "ecs.version": "1.0.0-beta2",
         "event.action": "Invalid",
         "event.dataset": "auth",
@@ -44,7 +44,7 @@
         "user.name": "test"
     },
     {
-        "@timestamp": "2018-02-20T08:35:22.000Z",
+        "@timestamp": "2019-02-20T08:35:22.000Z",
         "ecs.version": "1.0.0-beta2",
         "event.action": "Failed",
         "event.dataset": "auth",
@@ -65,7 +65,7 @@
         "user.name": "root"
     },
     {
-        "@timestamp": "2018-02-21T23:35:33.000Z",
+        "@timestamp": "2019-02-21T23:35:33.000Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "auth",
         "event.module": "system",
@@ -79,7 +79,7 @@
         "user.name": "vagrant"
     },
     {
-        "@timestamp": "2018-02-19T15:30:04.000Z",
+        "@timestamp": "2019-02-19T15:30:04.000Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "auth",
         "event.module": "system",
@@ -95,7 +95,7 @@
         "system.auth.ssh.dropped_ip": "123.57.245.163"
     },
     {
-        "@timestamp": "2018-02-23T00:08:48.000Z",
+        "@timestamp": "2019-02-23T00:08:48.000Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "auth",
         "event.module": "system",
@@ -109,7 +109,7 @@
         "user.name": "vagrant"
     },
     {
-        "@timestamp": "2018-02-24T00:13:02.000Z",
+        "@timestamp": "2019-02-24T00:13:02.000Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "auth",
         "event.module": "system",
@@ -124,7 +124,7 @@
         "user.name": "tsg"
     },
     {
-        "@timestamp": "2018-02-22T11:47:05.000Z",
+        "@timestamp": "2019-02-22T11:47:05.000Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "auth",
         "event.module": "system",
@@ -136,7 +136,7 @@
         "process.pid": 6991
     },
     {
-        "@timestamp": "2018-02-22T11:47:05.000Z",
+        "@timestamp": "2019-02-22T11:47:05.000Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "auth",
         "event.module": "system",

--- a/filebeat/module/system/syslog/test/darwin-syslog-sample.log-expected.json
+++ b/filebeat/module/system/syslog/test/darwin-syslog-sample.log-expected.json
@@ -1,6 +1,6 @@
 [
     {
-        "@timestamp": "2018-12-13T11:35:28.000Z",
+        "@timestamp": "2019-12-13T11:35:28.000Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "syslog",
         "event.module": "system",
@@ -15,7 +15,7 @@
         "process.pid": 21412
     },
     {
-        "@timestamp": "2018-12-13T11:35:28.000Z",
+        "@timestamp": "2019-12-13T11:35:28.000Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "syslog",
         "event.module": "system",
@@ -27,7 +27,7 @@
         "process.pid": 21412
     },
     {
-        "@timestamp": "2018-04-04T03:39:57.000Z",
+        "@timestamp": "2019-04-04T03:39:57.000Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "syslog",
         "event.module": "system",


### PR DESCRIPTION
This will change timestamp from 2018 to 2019. Happy New Year!
This PR closes: https://github.com/elastic/beats/issues/9849