### PR TITLE
[CM] Allow Central management to send errors or events back to the Kibana backend

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -28,6 +28,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Remove --configtest command line flag. {pull}10138[10138]
 - Move output.elasticsearch.ilm settings to setup.ilm. {pull}10347[10347]
 - ILM will be available by default if Elasticsearch > 7.0 is used. {pull}10347[10347]
+- Allow Central Management to send events back to kibana. {issue}9382[9382]
 
 *Auditbeat*
 

--- a/x-pack/libbeat/management/api/auth_client.go
+++ b/x-pack/libbeat/management/api/auth_client.go
@@ -27,7 +27,7 @@ type Event interface {
 // EventRequest is the data send to the CM event endpoint.
 type EventRequest struct {
 	Timestamp time.Time `json:"timestamp"`
-	EventType EventType `json:"event_type"`
+	EventType EventType `json:"type"`
 	Event     Event     `json:"event"`
 }
 
@@ -73,7 +73,7 @@ func (c *AuthClient) SendEvents(requests []EventRequest) error {
 	})
 
 	resp := EventAPIResponse{}
-	url := fmt.Sprintf("/api/beats/agent/%s/events", c.BeatUUID)
+	url := fmt.Sprintf("/api/beats/%s/events", c.BeatUUID)
 	statusCode, err := c.Client.request("POST", url, requests, c.headers(), &resp)
 	if err != nil {
 		return err
@@ -102,7 +102,7 @@ func (c *AuthClient) SendEvents(requests []EventRequest) error {
 	var errors multierror.Errors
 	for _, response := range resp.Response {
 		if !response.Success {
-			errors = append(errors, fmt.Errorf("error sending event %+v", response.Reason))
+			errors = append(errors, fmt.Errorf("error sending event, reason: %+v", response.Reason))
 		}
 	}
 

--- a/x-pack/libbeat/management/api/auth_client.go
+++ b/x-pack/libbeat/management/api/auth_client.go
@@ -38,7 +38,8 @@ type EventAPIResponse struct {
 
 // EventResponse is the indiviual response for each event request.
 type EventResponse struct {
-	Success bool `json:"success"`
+	Success bool   `json:"success"`
+	Reason  string `json:"reason"`
 }
 
 // AuthClienter is the interface exposed by the auth client and is useful for testing without calling
@@ -99,9 +100,9 @@ func (c *AuthClient) SendEvents(requests []EventRequest) error {
 	// We could add logic later to retry them, currently if sending error fails it's probably because
 	// Kibana is not answering and the next fetch will probably fails.
 	var errors multierror.Errors
-	for i, response := range resp.Response {
+	for _, response := range resp.Response {
 		if !response.Success {
-			errors = append(errors, fmt.Errorf("error sending event %+v", requests[i]))
+			errors = append(errors, fmt.Errorf("error sending event %+v", response.Reason))
 		}
 	}
 

--- a/x-pack/libbeat/management/api/auth_client.go
+++ b/x-pack/libbeat/management/api/auth_client.go
@@ -1,0 +1,109 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"time"
+
+	"github.com/gofrs/uuid"
+	"github.com/joeshaw/multierror"
+)
+
+// EventType is the type of event that the events endpoint can understand.
+type EventType string
+
+// Event is the interface for the events to be send to the event endpoint.
+type Event interface {
+	json.Marshaler
+	EventType() EventType
+}
+
+// EventRequest is the data send to the CM event endpoint.
+type EventRequest struct {
+	Timestamp time.Time `json:"timestamp"`
+	EventType EventType `json:"event_type"`
+	Event     Event     `json:"event"`
+}
+
+// EventAPIResponse is the top level response for the events endpoints.
+type EventAPIResponse struct {
+	Response []EventResponse `json:"response"`
+}
+
+// EventResponse is the indiviual response for each event request.
+type EventResponse struct {
+	Success bool `json:"success"`
+}
+
+// AuthClienter is the interface exposed by the auth client and is useful for testing without calling
+// a remote endpoint.
+type AuthClienter interface {
+	// SendEvents takes a slices of event request and send them to the endpoint.
+	SendEvents([]EventRequest) error
+
+	// Configuration retrieves the list of configuration blocks from Kibana
+	Configuration() (ConfigBlocks, error)
+}
+
+// AuthClient is a authenticated client to the CM endpoint and exposes the calls that require
+// the clients to pass credentials (UUID and AccessToken).
+type AuthClient struct {
+	Client      *Client
+	BeatUUID    uuid.UUID
+	AccessToken string
+}
+
+func (c AuthClient) headers() http.Header {
+	headers := http.Header{}
+	headers.Set("kbn-beats-access-token", c.AccessToken)
+	return headers
+}
+
+// SendEvents send a list of events to Kibana.
+func (c *AuthClient) SendEvents(requests []EventRequest) error {
+	sort.SliceStable(requests, func(i, j int) bool {
+		return requests[i].Timestamp.Before(requests[j].Timestamp)
+	})
+
+	resp := EventAPIResponse{}
+	url := fmt.Sprintf("/api/beats/agent/%s/events", c.BeatUUID)
+	statusCode, err := c.Client.request("POST", url, requests, c.headers(), &resp)
+	if err != nil {
+		return err
+	}
+
+	if statusCode != http.StatusOK {
+		return fmt.Errorf(
+			"invalid response code while sending events, expected 200 and received %d",
+			statusCode,
+		)
+	}
+
+	if len(resp.Response) != len(requests) {
+		return fmt.Errorf(
+			"number of response and the request do not match, expecting %d and received %d",
+			len(requests),
+			len(resp.Response),
+		)
+	}
+
+	// Loop through the responses and see if all items are marked as `success` we assume the response
+	// are in the same order as the sending order.
+	//
+	// We could add logic later to retry them, currently if sending error fails it's probably because
+	// Kibana is not answering and the next fetch will probably fails.
+	var errors multierror.Errors
+	for i, response := range resp.Response {
+		if !response.Success {
+			errors = append(errors, fmt.Errorf("error sending event %+v", requests[i]))
+		}
+	}
+
+	return errors.Err()
+}

--- a/x-pack/libbeat/management/api/auth_client_test.go
+++ b/x-pack/libbeat/management/api/auth_client_test.go
@@ -1,0 +1,196 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gofrs/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+var testEventType = EventType("TEST_EVENT")
+
+// Create a custom Event type for testing.
+type testEvent struct {
+	Message string    `json:"message"`
+	Type    EventType `json:"event_type"`
+}
+
+func (er *EventRequest) UnmarshalJSON(b []byte) error {
+	resp := struct {
+		EventType EventType       `json:"event_type"`
+		Event     json.RawMessage `json:"event"`
+	}{}
+
+	if err := json.Unmarshal(b, &resp); err != nil {
+		return err
+	}
+
+	switch resp.EventType {
+	case testEventType:
+		event := &testEvent{}
+		if err := json.Unmarshal(resp.Event, event); err != nil {
+			return err
+		}
+		*er = EventRequest{EventType: resp.EventType, Event: event}
+		return nil
+	}
+	return fmt.Errorf("unknown event type of '%s'", resp.EventType)
+}
+
+func (t *testEvent) EventType() EventType {
+	return t.Type
+}
+func (t *testEvent) MarshalJSON() ([]byte, error) {
+	return json.Marshal(*t)
+}
+
+func (t *testEvent) UnmarshalJSON(b []byte) error {
+	resp := struct {
+		Message string    `json:"message"`
+		Type    EventType `json:"event_type"`
+	}{}
+	if err := json.Unmarshal(b, &resp); err != nil {
+		return err
+	}
+	*t = testEvent{Message: resp.Message}
+	return nil
+}
+
+func TestReportEvents(t *testing.T) {
+	beatUUID, err := uuid.NewV4()
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	accessToken := "my-enroll-token"
+
+	t.Run("successfully send events", func(t *testing.T) {
+		server, client := newServerClientPair(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Check correct path is used
+			assert.Equal(t, "/api/beats/agent/"+beatUUID.String()+"/events", r.URL.Path)
+
+			// Check enrollment token is correct
+			assert.Equal(t, accessToken, r.Header.Get("kbn-beats-access-token"))
+
+			var response []EventRequest
+
+			decoder := json.NewDecoder(r.Body)
+			err := decoder.Decode(&response)
+			if !assert.NoError(t, err) {
+				return
+			}
+
+			if !assert.Equal(t, 1, len(response)) {
+				return
+			}
+
+			expected := &testEvent{Message: "OK"}
+			received := response[0].Event.(*testEvent)
+
+			if !assert.Equal(t, expected.Message, received.Message) {
+				return
+			}
+
+			apiResponse := EventAPIResponse{
+				Response: []EventResponse{EventResponse{Success: true}},
+			}
+
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(apiResponse)
+		}))
+		defer server.Close()
+		auth := &AuthClient{Client: client, AccessToken: accessToken, BeatUUID: beatUUID}
+
+		events := []*testEvent{&testEvent{Message: "OK"}}
+
+		err = reportEvents(auth, events)
+		assert.NoError(t, err)
+	})
+
+	t.Run("bubble up any errors", func(t *testing.T) {
+		server, client := newServerClientPair(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+			response := struct {
+				Message string
+			}{
+				Message: "bad request",
+			}
+			json.NewEncoder(w).Encode(response)
+		}))
+		defer server.Close()
+
+		auth := &AuthClient{Client: client, AccessToken: accessToken, BeatUUID: beatUUID}
+
+		events := []*testEvent{&testEvent{Message: "OK"}}
+
+		err = reportEvents(auth, events)
+		assert.Error(t, err)
+	})
+
+	t.Run("assert the response", func(t *testing.T) {
+		server, client := newServerClientPair(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			apiResponse := EventAPIResponse{
+				Response: []EventResponse{
+					EventResponse{Success: true},
+					EventResponse{Success: false},
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(apiResponse)
+		}))
+		defer server.Close()
+
+		auth := &AuthClient{Client: client, AccessToken: accessToken, BeatUUID: beatUUID}
+
+		events := []*testEvent{
+			&testEvent{Message: "testing-1"},
+			&testEvent{Message: "testing-2"},
+		}
+
+		err = reportEvents(auth, events)
+		assert.Error(t, err)
+	})
+
+	t.Run("enforce the match of response/request", func(t *testing.T) {
+		server, client := newServerClientPair(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			apiResponse := EventAPIResponse{
+				Response: []EventResponse{
+					EventResponse{Success: true},
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(apiResponse)
+		}))
+		defer server.Close()
+
+		auth := &AuthClient{Client: client, AccessToken: accessToken, BeatUUID: beatUUID}
+
+		events := []*testEvent{
+			&testEvent{Message: "testing-1"},
+			&testEvent{Message: "testing-2"},
+		}
+
+		err = reportEvents(auth, events)
+		assert.Error(t, err)
+	})
+}
+
+func reportEvents(client AuthClienter, events []*testEvent) error {
+	requests := make([]EventRequest, len(events))
+	for idx, err := range events {
+		requests[idx] = EventRequest{
+			Timestamp: time.Now(),
+			EventType: testEventType,
+			Event:     err,
+		}
+	}
+	return client.SendEvents(requests)
+}

--- a/x-pack/libbeat/management/api/auth_client_test.go
+++ b/x-pack/libbeat/management/api/auth_client_test.go
@@ -25,7 +25,7 @@ type testEvent struct {
 
 func (er *EventRequest) UnmarshalJSON(b []byte) error {
 	resp := struct {
-		EventType EventType       `json:"event_type"`
+		EventType EventType       `json:"type"`
 		Event     json.RawMessage `json:"event"`
 	}{}
 
@@ -55,7 +55,7 @@ func (t *testEvent) MarshalJSON() ([]byte, error) {
 func (t *testEvent) UnmarshalJSON(b []byte) error {
 	resp := struct {
 		Message string    `json:"message"`
-		Type    EventType `json:"event_type"`
+		Type    EventType `json:"type"`
 	}{}
 	if err := json.Unmarshal(b, &resp); err != nil {
 		return err
@@ -75,7 +75,7 @@ func TestReportEvents(t *testing.T) {
 	t.Run("successfully send events", func(t *testing.T) {
 		server, client := newServerClientPair(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// Check correct path is used
-			assert.Equal(t, "/api/beats/agent/"+beatUUID.String()+"/events", r.URL.Path)
+			assert.Equal(t, "/api/beats/"+beatUUID.String()+"/events", r.URL.Path)
 
 			// Check enrollment token is correct
 			assert.Equal(t, accessToken, r.Header.Get("kbn-beats-access-token"))

--- a/x-pack/libbeat/management/api/client.go
+++ b/x-pack/libbeat/management/api/client.go
@@ -84,6 +84,7 @@ func (c *Client) request(method, extraPath string,
 	if err != nil {
 		return statusCode, err
 	}
+
 	if statusCode >= 300 {
 		err = extractError(result)
 	} else {

--- a/x-pack/libbeat/management/api/client.go
+++ b/x-pack/libbeat/management/api/client.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/kibana"
 )
 
@@ -67,18 +66,23 @@ func NewClient(cfg *kibana.ClientConfig) (*Client, error) {
 
 // do a request to the API and unmarshall the message, error if anything fails
 func (c *Client) request(method, extraPath string,
-	params common.MapStr, headers http.Header, message interface{}) (int, error) {
+	body interface{}, headers http.Header, message interface{}) (int, error) {
 
-	paramsJSON, err := json.Marshal(params)
+	bodyJSON, err := json.Marshal(body)
 	if err != nil {
 		return 400, err
 	}
 
-	statusCode, result, err := c.client.Request(method, extraPath, nil, headers, bytes.NewBuffer(paramsJSON))
+	statusCode, result, err := c.client.Request(
+		method,
+		extraPath,
+		nil,
+		headers,
+		bytes.NewBuffer(bodyJSON),
+	)
 	if err != nil {
 		return statusCode, err
 	}
-
 	if statusCode >= 300 {
 		err = extractError(result)
 	} else {

--- a/x-pack/libbeat/management/api/client.go
+++ b/x-pack/libbeat/management/api/client.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/kibana"
 )
 

--- a/x-pack/libbeat/management/api/client.go
+++ b/x-pack/libbeat/management/api/client.go
@@ -66,7 +66,7 @@ func NewClient(cfg *kibana.ClientConfig) (*Client, error) {
 
 // do a request to the API and unmarshall the message, error if anything fails
 func (c *Client) request(method, extraPath string,
-	body interface{}, headers http.Header, message interface{}) (int, error) {
+	body interface{}, headers http.Header, resp interface{}) (int, error) {
 
 	bodyJSON, err := json.Marshal(body)
 	if err != nil {
@@ -86,7 +86,7 @@ func (c *Client) request(method, extraPath string,
 	if statusCode >= 300 {
 		err = extractError(result)
 	} else {
-		if err = json.Unmarshal(result, message); err != nil {
+		if err = json.Unmarshal(result, resp); err != nil {
 			return statusCode, errors.Wrap(err, "error unmarshaling Kibana response")
 		}
 	}

--- a/x-pack/libbeat/management/api/configuration.go
+++ b/x-pack/libbeat/management/api/configuration.go
@@ -14,8 +14,6 @@ import (
 
 	"github.com/elastic/beats/libbeat/common/reload"
 
-	"github.com/gofrs/uuid"
-
 	"github.com/elastic/beats/libbeat/common"
 )
 
@@ -79,15 +77,12 @@ func (c *configResponse) UnmarshalJSON(b []byte) error {
 }
 
 // Configuration retrieves the list of configuration blocks from Kibana
-func (c *Client) Configuration(accessToken string, beatUUID uuid.UUID, configOK bool) (ConfigBlocks, error) {
-	headers := http.Header{}
-	headers.Set("kbn-beats-access-token", accessToken)
-
+func (c *AuthClient) Configuration() (ConfigBlocks, error) {
 	resp := struct {
 		ConfigBlocks []*configResponse `json:"configuration_blocks"`
 	}{}
-	url := fmt.Sprintf("/api/beats/agent/%s/configuration?validSetting=%t", beatUUID, configOK)
-	statusCode, err := c.request("GET", url, nil, headers, &resp)
+	url := fmt.Sprintf("/api/beats/agent/%s/configuration", c.BeatUUID)
+	statusCode, err := c.Client.request("GET", url, nil, c.headers(), &resp)
 	if statusCode == http.StatusNotFound {
 		return nil, errConfigurationNotFound
 	}

--- a/x-pack/libbeat/management/api/configuration_test.go
+++ b/x-pack/libbeat/management/api/configuration_test.go
@@ -26,13 +26,13 @@ func TestConfiguration(t *testing.T) {
 		// Check enrollment token is correct
 		assert.Equal(t, "thisismyenrollmenttoken", r.Header.Get("kbn-beats-access-token"))
 
-		assert.Equal(t, "false", r.URL.Query().Get("validSetting"))
-
 		fmt.Fprintf(w, `{"configuration_blocks":[{"type":"filebeat.modules","config":{"_sub_type":"apache2"}},{"type":"metricbeat.modules","config":{"_sub_type":"system","period":"10s"}}]}`)
 	}))
 	defer server.Close()
 
-	configs, err := client.Configuration("thisismyenrollmenttoken", beatUUID, false)
+	auth := AuthClient{Client: client, AccessToken: "thisismyenrollmenttoken", BeatUUID: beatUUID}
+
+	configs, err := auth.Configuration()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -187,6 +187,7 @@ func TestUnEnroll(t *testing.T) {
 	}))
 	defer server.Close()
 
-	_, err = client.Configuration("thisismyenrollmenttoken", beatUUID, false)
+	auth := AuthClient{Client: client, AccessToken: "thisismyenrollmenttoken", BeatUUID: beatUUID}
+	_, err = auth.Configuration()
 	assert.True(t, IsConfigurationNotFound(err))
 }

--- a/x-pack/libbeat/management/api/event_reporter.go
+++ b/x-pack/libbeat/management/api/event_reporter.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 package api
 
 import (

--- a/x-pack/libbeat/management/api/event_reporter.go
+++ b/x-pack/libbeat/management/api/event_reporter.go
@@ -85,8 +85,7 @@ func (e *EventReporter) reportEvents(events []Event) {
 	if len(events) == 0 {
 		return
 	}
-	e.logger.Debug("Reporting %d events to Kibana", len(events))
-
+	e.logger.Debugf("Reporting %d events to Kibana", len(events))
 	if err := e.sendBatchEvents(events); err != nil {
 		e.logger.Errorf("could not send events, error: %+v", err)
 	}

--- a/x-pack/libbeat/management/api/event_reporter.go
+++ b/x-pack/libbeat/management/api/event_reporter.go
@@ -1,0 +1,127 @@
+package api
+
+import (
+	"sync"
+	"time"
+
+	"github.com/joeshaw/multierror"
+
+	"github.com/elastic/beats/libbeat/logp"
+)
+
+var debugK = "event_reporter"
+
+// EventReporter is an object that will periodically send asyncronously events to the
+// CM events endpoints.
+type EventReporter struct {
+	logger       *logp.Logger
+	client       AuthClienter
+	wg           sync.WaitGroup
+	events       chan Event
+	period       time.Duration
+	maxBatchSize int
+}
+
+// NewEventReporter returns a new event reporter
+func NewEventReporter(
+	logger *logp.Logger,
+	client AuthClienter,
+	period time.Duration,
+	maxBatchSize int,
+) *EventReporter {
+	log := logger.Named(debugK)
+	return &EventReporter{
+		logger:       log,
+		client:       client,
+		period:       period,
+		events:       make(chan Event),
+		maxBatchSize: maxBatchSize,
+	}
+}
+
+// Start starts the event reported and wait for new events.
+func (e *EventReporter) Start() {
+	e.wg.Add(1)
+	go e.worker()
+
+	e.logger.Info("Starting event reporter service")
+}
+
+// Stop stops the reporting events to the endpoint.
+func (e *EventReporter) Stop() {
+	e.logger.Info("Stopping event reporter service")
+	close(e.events)
+	e.wg.Wait()
+}
+
+func (e *EventReporter) worker() {
+	defer e.wg.Done()
+
+	ticker := time.NewTicker(e.period)
+	defer ticker.Stop()
+
+	var buffer []Event
+	for {
+		select {
+		case event, ok := <-e.events:
+			if !ok {
+				e.reportEvents(buffer)
+				return
+			}
+			buffer = append(buffer, event)
+		case <-ticker.C:
+			e.reportEvents(buffer)
+			buffer = nil
+		}
+	}
+}
+
+func (e *EventReporter) reportEvents(events []Event) {
+	if len(events) == 0 {
+		return
+	}
+	e.logger.Debug("Reporting %d events to Kibana", len(events))
+
+	// NOTE: Should we retry here? or do X attempts.
+	if err := e.sendBatchEvents(events); err != nil {
+		e.logger.Errorf("could not send events, error: %+v", err)
+	}
+}
+
+func (e *EventReporter) sendBatchEvents(events []Event) error {
+	var errors multierror.Errors
+	for pos := 0; pos < len(events); pos += e.maxBatchSize {
+		j := pos + e.maxBatchSize
+		if j > len(events) {
+			j = len(events)
+		}
+		if err := e.sendEvents(events[pos:j]); err != nil {
+			errors = append(errors, err)
+		}
+	}
+	return errors.Err()
+}
+
+func (e *EventReporter) sendEvents(events []Event) error {
+	requests := make([]EventRequest, len(events))
+	for i, event := range events {
+		requests[i] = EventRequest{
+			Timestamp: time.Now(),
+			EventType: event.EventType(),
+			Event:     event,
+		}
+	}
+	return e.client.SendEvents(requests)
+}
+
+// AddEvents add an event to be send on the next tick.
+func (e *EventReporter) AddEvents(events ...Event) {
+	for _, event := range events {
+		e.events <- event
+	}
+}
+
+// AddEvent adds an event to be send on the next tick.
+func (e *EventReporter) AddEvent(event Event) {
+	e.events <- event
+}

--- a/x-pack/libbeat/management/api/event_reporter_test.go
+++ b/x-pack/libbeat/management/api/event_reporter_test.go
@@ -57,7 +57,7 @@ func testBatch(numberOfEvents, maxBatchSize int) func(*testing.T) {
 
 		go func() {
 			for i := 0; i < numberOfEvents; i++ {
-				reporter.AddEvents(event)
+				reporter.AddEvent(event)
 			}
 		}()
 

--- a/x-pack/libbeat/management/api/event_reporter_test.go
+++ b/x-pack/libbeat/management/api/event_reporter_test.go
@@ -1,0 +1,74 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package api
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/libbeat/logp"
+)
+
+type memoryAuthClient struct {
+	Requests chan []EventRequest
+	Err      error
+}
+
+func (m *memoryAuthClient) SendEvents(requests []EventRequest) error {
+	if m.Err != nil {
+		return m.Err
+	}
+
+	m.Requests <- requests
+	return nil
+}
+
+func (m *memoryAuthClient) Close() {
+	close(m.Requests)
+}
+
+func (m *memoryAuthClient) Configuration() (ConfigBlocks, error) {
+	return ConfigBlocks{}, nil
+}
+
+func newMemoryAuthClient() *memoryAuthClient {
+	return &memoryAuthClient{Requests: make(chan []EventRequest)}
+}
+
+func TestReporterReportEvents(t *testing.T) {
+	t.Run("single request", testBatch(1, 100))
+	t.Run("receive all events when the requests size is exactly the batch size", testBatch(100, 100))
+	t.Run("receive all events when events are send in multiple batch", testBatch(1234, 25))
+}
+
+func testBatch(numberOfEvents, maxBatchSize int) func(*testing.T) {
+	return func(t *testing.T) {
+		event := &testEvent{Message: "OK"}
+		client := newMemoryAuthClient()
+		defer client.Close()
+		reporter := NewEventReporter(logp.NewLogger(""), client, 1*time.Second, maxBatchSize)
+		reporter.Start()
+		defer reporter.Stop()
+
+		go func() {
+			for i := 0; i < numberOfEvents; i++ {
+				reporter.AddEvents(event)
+			}
+		}()
+
+		var receivedEvents int
+		expectedbatch := int(math.Ceil(float64(numberOfEvents) / float64(maxBatchSize)))
+
+		for receivedBatchs := 0; receivedBatchs < expectedbatch; receivedBatchs++ {
+			requests := <-client.Requests
+			receivedEvents += len(requests)
+		}
+
+		assert.Equal(t, numberOfEvents, receivedEvents)
+	}
+}

--- a/x-pack/libbeat/management/blacklist_test.go
+++ b/x-pack/libbeat/management/blacklist_test.go
@@ -273,8 +273,8 @@ func TestConfigBlacklist(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			err = bl.Filter(test.blocks)
-			assert.Equal(t, test.blacklisted, err != nil)
+			errs := bl.Detect(test.blocks)
+			assert.Equal(t, test.blacklisted, !errs.IsEmpty())
 		})
 	}
 }

--- a/x-pack/libbeat/management/cache.go
+++ b/x-pack/libbeat/management/cache.go
@@ -19,9 +19,7 @@ import (
 
 // Cache keeps a copy of configs provided by Kibana, it's used when Kibana is down
 type Cache struct {
-	// ConfigOK is true if last config update was successful
-	ConfigOK bool
-	Configs  api.ConfigBlocks
+	Configs api.ConfigBlocks
 }
 
 // Load settings from its source file

--- a/x-pack/libbeat/management/config.go
+++ b/x-pack/libbeat/management/config.go
@@ -74,6 +74,8 @@ type Config struct {
 	// Poll configs period
 	Period time.Duration `config:"period" yaml:"period"`
 
+	EventsReporter EventReporterConfig `config:"events_reporter" yaml:"events_reporter"`
+
 	AccessToken string `config:"access_token" yaml:"access_token"`
 
 	Kibana *kibana.ClientConfig `config:"kibana" yaml:"kibana"`
@@ -81,9 +83,19 @@ type Config struct {
 	Blacklist ConfigBlacklistSettings `config:"blacklist" yaml:"blacklist"`
 }
 
+// EventReporterConfig configuration of the events reporter.
+type EventReporterConfig struct {
+	Period       time.Duration `config:"period" yaml:"period"`
+	MaxBatchSize int           `config:"max_batch_size" yaml:"max_batch_size" validate:"nonzero,positive"`
+}
+
 func defaultConfig() *Config {
 	return &Config{
 		Period: 60 * time.Second,
+		EventsReporter: EventReporterConfig{
+			Period:       30 * time.Second,
+			MaxBatchSize: 1000,
+		},
 		Blacklist: ConfigBlacklistSettings{
 			Patterns: map[string]string{
 				"output": "console|file",

--- a/x-pack/libbeat/management/error.go
+++ b/x-pack/libbeat/management/error.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 package management
 
 import (

--- a/x-pack/libbeat/management/error.go
+++ b/x-pack/libbeat/management/error.go
@@ -1,0 +1,104 @@
+package management
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+
+	"github.com/gofrs/uuid"
+	"github.com/pkg/errors"
+
+	"github.com/elastic/beats/x-pack/libbeat/management/api"
+)
+
+// ErrorType is type of error that the events endpoint understand.
+type ErrorType string
+
+// ConfigError is the type of error send when an unpack or a blacklist happen.
+var ConfigError = ErrorType("CONFIG")
+
+// ErrorEvent is the event type when an error happen.
+var ErrorEvent = api.EventType("ERROR")
+
+// Error is a config error to be reported to kibana.
+type Error struct {
+	Type ErrorType
+	UUID uuid.UUID
+	Err  error
+}
+
+// EventType returns a ErrorEvent.
+func (e *Error) EventType() api.EventType {
+	return ErrorEvent
+}
+
+// MarshalJSON transform an error into a JSON document.
+func (e *Error) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&struct {
+		UUID    string `json:"uuid"`
+		Type    string `json:"type"`
+		Message string `json:"message"`
+	}{
+		UUID:    e.UUID.String(),
+		Type:    string(e.Type),
+		Message: e.Err.Error(),
+	})
+}
+
+// UnmarshalJSON unmarshals a event of the type Error.
+func (e *Error) UnmarshalJSON(b []byte) error {
+	res := &struct {
+		UUID    string `json:"uuid,omitempty"`
+		Type    string `json:"type"`
+		Message string `json:"message"`
+	}{}
+
+	if err := json.Unmarshal(b, res); err != nil {
+		return err
+	}
+
+	uuid, err := uuid.FromString(res.UUID)
+	if err != nil {
+		return err
+	}
+	*e = Error{
+		Type: ErrorType(res.Type),
+		UUID: uuid,
+		Err:  errors.New(res.Message),
+	}
+	return nil
+}
+
+func (e *Error) Error() string {
+	return e.Err.Error()
+}
+
+// Errors contains mutiples config error.
+type Errors []*Error
+
+// Errors makes sure we can display the error in the logger.
+func (er *Errors) Error() string {
+	var s strings.Builder
+	if len(*er) == 1 {
+		s.WriteString("1 error: ")
+	} else {
+		s.WriteString(strconv.Itoa(len(*er)))
+		s.WriteString(" errors: ")
+	}
+	for idx, err := range *er {
+		if idx != 0 {
+			s.WriteString("; ")
+		}
+		s.WriteString(err.Error())
+	}
+	return s.String()
+}
+
+// IsEmpty returns true when we don't have any errors.
+func (er *Errors) IsEmpty() bool {
+	return len(*er) == 0
+}
+
+func newConfigError(err error) *Error {
+	return &Error{Type: ConfigError, Err: err}
+}

--- a/x-pack/libbeat/management/error_test.go
+++ b/x-pack/libbeat/management/error_test.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 package management
 
 import (

--- a/x-pack/libbeat/management/error_test.go
+++ b/x-pack/libbeat/management/error_test.go
@@ -1,0 +1,64 @@
+package management
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/gofrs/uuid"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/x-pack/libbeat/management/api"
+)
+
+func TestErrorSerialization(t *testing.T) {
+	id, _ := uuid.NewV4()
+	t.Run("serialize ok", func(t *testing.T) {
+		e := Error{
+			Type: ConfigError,
+			Err:  errors.New("hello world"),
+			UUID: id,
+		}
+
+		b, err := json.Marshal(&e)
+		if assert.NoError(t, err) {
+			return
+		}
+
+		resp := &struct {
+			UUID    string `json:"uuid"`
+			Message string `json:"message"`
+			Type    string `json:"type"`
+		}{}
+
+		err = json.Unmarshal(b, resp)
+		if assert.NoError(t, err) {
+			return
+		}
+
+		assert.Equal(t, e.UUID.String(), resp.UUID)
+		assert.Equal(t, e.Err.Error(), resp.Message)
+		assert.Equal(t, e.Type, api.EventType(resp.Type))
+	})
+
+	t.Run("ensure that json general fields are present", ensureJSONhasGeneralfield(t, &Error{
+		Type: ConfigError,
+		Err:  errors.New("hello world"),
+		UUID: id,
+	}))
+}
+
+func TestErrors(t *testing.T) {
+	t.Run("single error", func(t *testing.T) {
+		errors := Errors{newConfigError(errors.New("error1"))}
+		assert.Equal(t, "1 error: error1", errors.Error())
+	})
+
+	t.Run("multiple errors", func(t *testing.T) {
+		errors := Errors{
+			newConfigError(errors.New("error1")),
+			newConfigError(errors.New("error2")),
+		}
+		assert.Equal(t, "2 errors: error1; error2", errors.Error())
+	})
+}

--- a/x-pack/libbeat/management/manager.go
+++ b/x-pack/libbeat/management/manager.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/elastic/beats/libbeat/common/reload"
+	"github.com/elastic/beats/libbeat/feature"
 
 	"github.com/gofrs/uuid"
 
@@ -26,6 +27,7 @@ import (
 var errEmptyAccessToken = errors.New("access_token is empty, you must reenroll your Beat")
 
 func init() {
+	management.Register("x-pack", NewConfigManager, feature.Beta)
 }
 
 // ConfigManager handles internal config updates. By retrieving

--- a/x-pack/libbeat/management/manager.go
+++ b/x-pack/libbeat/management/manager.go
@@ -16,7 +16,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/libbeat/common/cfgwarn"
-	"github.com/elastic/beats/libbeat/feature"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/x-pack/libbeat/management/api"
 
@@ -27,7 +26,6 @@ import (
 var errEmptyAccessToken = errors.New("access_token is empty, you must reenroll your Beat")
 
 func init() {
-	management.Register("x-pack", NewConfigManager, feature.Beta)
 }
 
 // ConfigManager handles internal config updates. By retrieving
@@ -36,12 +34,15 @@ type ConfigManager struct {
 	config    *Config
 	cache     *Cache
 	logger    *logp.Logger
-	client    *api.Client
+	client    api.AuthClienter
 	beatUUID  uuid.UUID
 	done      chan struct{}
 	registry  *reload.Registry
 	wg        sync.WaitGroup
 	blacklist *ConfigBlacklist
+	reporter  *api.EventReporter
+	state     *State
+	mux       sync.RWMutex
 }
 
 // NewConfigManager returns a X-Pack Beats Central Management manager
@@ -75,9 +76,7 @@ func NewConfigManagerWithConfig(c *Config, registry *reload.Registry, beatUUID u
 		}
 
 		// Initialize central management settings cache
-		cache = &Cache{
-			ConfigOK: true,
-		}
+		cache = &Cache{}
 		if err := cache.Load(); err != nil {
 			return nil, errors.Wrap(err, "reading central management internal cache")
 		}
@@ -89,18 +88,26 @@ func NewConfigManagerWithConfig(c *Config, registry *reload.Registry, beatUUID u
 		if err != nil {
 			return nil, errors.Wrap(err, "initializing kibana client")
 		}
-
 	}
+
+	authClient := &api.AuthClient{Client: client, AccessToken: c.AccessToken, BeatUUID: beatUUID}
+	log := logp.NewLogger(management.DebugK)
 
 	return &ConfigManager{
 		config:    c,
 		cache:     cache,
 		blacklist: blacklist,
-		logger:    logp.NewLogger(management.DebugK),
-		client:    client,
+		logger:    log,
+		client:    authClient,
 		done:      make(chan struct{}),
 		beatUUID:  beatUUID,
 		registry:  registry,
+		reporter: api.NewEventReporter(
+			log,
+			authClient,
+			c.EventsReporter.Period,
+			c.EventsReporter.MaxBatchSize,
+		),
 	}, nil
 }
 
@@ -117,6 +124,7 @@ func (cm *ConfigManager) Start() {
 	cfgwarn.Beta("Central management is enabled")
 	cm.logger.Info("Starting central management service")
 
+	cm.reporter.Start()
 	cm.wg.Add(1)
 	go cm.worker()
 }
@@ -126,9 +134,15 @@ func (cm *ConfigManager) Stop() {
 	if !cm.Enabled() {
 		return
 	}
+
+	// stop collecting configuration
 	cm.logger.Info("Stopping central management service")
 	close(cm.done)
 	cm.wg.Wait()
+
+	// report last state and stop reporting.
+	cm.updateState(Stopped)
+	cm.reporter.Stop()
 }
 
 // CheckRawConfig check settings are correct to start the beat. This method
@@ -146,6 +160,8 @@ func (cm *ConfigManager) worker() {
 	firstRun := true
 	period := 0 * time.Second
 
+	cm.updateState(Starting)
+
 	// Start worker loop: fetch + apply + cache new settings
 	for {
 		select {
@@ -156,9 +172,16 @@ func (cm *ConfigManager) worker() {
 
 		changed := cm.fetch()
 		if changed || firstRun {
+			cm.updateState(InProgress)
 			// configs changed, apply changes
 			// TODO only reload the blocks that changed
-			cm.apply()
+			if errs := cm.apply(); !errs.IsEmpty() {
+				cm.reportErrors(errs)
+				cm.updateState(Failed)
+				cm.logger.Errorf("Could not apply the configuration, error: %+v", errs)
+			} else {
+				cm.updateState(Running)
+			}
 		}
 
 		if changed {
@@ -176,10 +199,16 @@ func (cm *ConfigManager) worker() {
 	}
 }
 
+func (cm *ConfigManager) reportErrors(errs Errors) {
+	for _, err := range errs {
+		cm.reporter.AddEvent(err)
+	}
+}
+
 // fetch configurations from kibana, return true if they changed
 func (cm *ConfigManager) fetch() bool {
 	cm.logger.Debug("Retrieving new configurations from Kibana")
-	configs, err := cm.client.Configuration(cm.config.AccessToken, cm.beatUUID, cm.cache.ConfigOK)
+	configs, err := cm.client.Configuration()
 
 	if api.IsConfigurationNotFound(err) {
 		if cm.cache.HasConfig() {
@@ -205,52 +234,47 @@ func (cm *ConfigManager) fetch() bool {
 	return true
 }
 
-func (cm *ConfigManager) apply() {
-	configOK := true
-
+func (cm *ConfigManager) apply() Errors {
+	var errors Errors
 	missing := map[string]bool{}
 	for _, name := range cm.registry.GetRegisteredNames() {
 		missing[name] = true
 	}
 
-	// Filter unwanted configs from the list
-	errors := cm.blacklist.Filter(cm.cache.Configs)
-	if errors != nil {
-		cm.logger.Error(errors)
-		return
+	// Detect unwanted configs from the list
+	if errs := cm.blacklist.Detect(cm.cache.Configs); !errs.IsEmpty() {
+		errors = append(errors, errs...)
+		return errors
 	}
 
 	// Reload configs
 	for _, b := range cm.cache.Configs {
-		err := cm.reload(b.Type, b.Blocks)
-		configOK = configOK && err == nil
+		if err := cm.reload(b.Type, b.Blocks); err != nil {
+			errors = append(errors, err)
+		}
 		missing[b.Type] = false
 	}
 
 	// Unset missing configs
 	for name := range missing {
 		if missing[name] {
-			cm.reload(name, []*api.ConfigBlock{})
+			if err := cm.reload(name, []*api.ConfigBlock{}); err != nil {
+				errors = append(errors, err)
+			}
 		}
 	}
 
-	if !configOK {
-		cm.logger.Info("Failed to apply settings, reporting error on next fetch")
-	}
-
-	// Update configOK flag with the result of this apply
-	cm.cache.ConfigOK = configOK
+	return errors
 }
 
-func (cm *ConfigManager) reload(t string, blocks []*api.ConfigBlock) error {
+func (cm *ConfigManager) reload(t string, blocks []*api.ConfigBlock) *Error {
 	cm.logger.Infof("Applying settings for %s", t)
-
 	if obj := cm.registry.GetReloadable(t); obj != nil {
 		// Single object
 		if len(blocks) > 1 {
 			err := fmt.Errorf("got an invalid number of configs for %s: %d, expected: 1", t, len(blocks))
 			cm.logger.Error(err)
-			return err
+			return newConfigError(err)
 		}
 
 		var config *reload.ConfigWithMeta
@@ -259,13 +283,13 @@ func (cm *ConfigManager) reload(t string, blocks []*api.ConfigBlock) error {
 			config, err = blocks[0].ConfigWithMeta()
 			if err != nil {
 				cm.logger.Error(err)
-				return err
+				return newConfigError(err)
 			}
 		}
 
 		if err := obj.Reload(config); err != nil {
 			cm.logger.Error(err)
-			return err
+			return newConfigError(err)
 		}
 	} else if obj := cm.registry.GetReloadableList(t); obj != nil {
 		// List
@@ -274,18 +298,26 @@ func (cm *ConfigManager) reload(t string, blocks []*api.ConfigBlock) error {
 			config, err := block.ConfigWithMeta()
 			if err != nil {
 				cm.logger.Error(err)
-				continue
+				return newConfigError(err)
 			}
 			configs = append(configs, config)
 		}
 
 		if err := obj.Reload(configs); err != nil {
 			cm.logger.Error(err)
-			return err
+			return newConfigError(err)
 		}
 	}
 
 	return nil
+}
+
+func (cm *ConfigManager) updateState(state State) {
+	cm.mux.Lock()
+	defer cm.mux.Unlock()
+	cm.state = &state
+	cm.reporter.AddEvent(&state)
+	cm.logger.Infof("Updating state to '%s'", state)
 }
 
 func validateConfig(config *Config) error {

--- a/x-pack/libbeat/management/manager_test.go
+++ b/x-pack/libbeat/management/manager_test.go
@@ -277,9 +277,9 @@ func TestBadConfig(t *testing.T) {
 	mux := http.NewServeMux()
 	i := 0
 	responses := []http.HandlerFunc{ // Initial load
-		responseText(`{"configuration_blocks":[{"type":"output","config":{"console": { "path": "/tmp/bad"}}}]}`),
+		responseText(`{"configuration_blocks":[{"type":"output","config":{"_sub_type": "console", "path": "/tmp/bad"}}]}`),
 		// will not resend new events
-		responseText(`{"configuration_blocks":[{"type":"output","config":{"console": { "path": "/tmp/bad"}}}]}`),
+		responseText(`{"configuration_blocks":[{"type":"output","config":{"_sub_type": "console", "path": "/tmp/bad"}}]}`),
 		// recover on call
 		http.NotFound,
 	}
@@ -347,7 +347,7 @@ type testEventRequest struct {
 
 func (er *testEventRequest) UnmarshalJSON(b []byte) error {
 	resp := struct {
-		EventType api.EventType   `json:"event_type"`
+		EventType api.EventType   `json:"type"`
 		Event     json.RawMessage `json:"event"`
 	}{}
 
@@ -394,7 +394,7 @@ func (r *collectEventRequest) Add(requests ...testEventRequest) {
 
 func addEventsReporterHandle(mux *http.ServeMux, uuid uuid.UUID) *collectEventRequest {
 	reporter := &collectEventRequest{}
-	path := "/api/beats/agent/" + uuid.String() + "/events"
+	path := "/api/beats/" + uuid.String() + "/events"
 	fn := func(w http.ResponseWriter, r *http.Request) {
 		var requests []testEventRequest
 		decoder := json.NewDecoder(r.Body)

--- a/x-pack/libbeat/management/manager_test.go
+++ b/x-pack/libbeat/management/manager_test.go
@@ -292,7 +292,7 @@ func TestBadConfig(t *testing.T) {
 	reporter := addEventsReporterHandle(mux, id)
 	server := httptest.NewServer(mux)
 
-	c, err := api.ConfigFromURL(server.URL)
+	c, err := api.ConfigFromURL(server.URL, common.NewConfig())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -417,7 +417,7 @@ func addEventsReporterHandle(mux *http.ServeMux, uuid uuid.UUID) *collectEventRe
 
 func assertEvents(t *testing.T, events []api.Event, reporter *collectEventRequest) {
 	requests := reporter.Requests()
-	if assert.Equal(t, len(events), len(requests)) {
+	if !assert.Equal(t, len(events), len(requests)) {
 		return
 	}
 

--- a/x-pack/libbeat/management/manager_test.go
+++ b/x-pack/libbeat/management/manager_test.go
@@ -5,14 +5,17 @@
 package management
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/gofrs/uuid"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/beats/libbeat/common"
@@ -54,11 +57,12 @@ func TestConfigManager(t *testing.T) {
 		// Changed, reload
 		`{"configuration_blocks":[{"type":"test.block","config":{"module":"system"}}]}`,
 	}
-	mux.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, fmt.Sprintf("/api/beats/agent/%s/configuration?validSetting=true", id), r.RequestURI)
+	mux.Handle(fmt.Sprintf("/api/beats/agent/%s/configuration", id), http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, responses[i])
 		i++
 	}))
+
+	reporter := addEventsReporterHandle(mux, id)
 
 	server := httptest.NewServer(mux)
 
@@ -72,6 +76,10 @@ func TestConfigManager(t *testing.T) {
 		Period:      100 * time.Millisecond,
 		Kibana:      c,
 		AccessToken: accessToken,
+		EventsReporter: EventReporterConfig{
+			Period:       50 * time.Millisecond,
+			MaxBatchSize: 1,
+		},
 	}
 
 	manager, err := NewConfigManagerWithConfig(config, registry, id)
@@ -99,6 +107,9 @@ func TestConfigManager(t *testing.T) {
 	// Cleanup
 	manager.Stop()
 	os.Remove(paths.Resolve(paths.Data, "management.yml"))
+
+	events := []api.Event{&Starting, &InProgress, &Running, &InProgress, &Running, &Stopped}
+	assertEvents(t, events, reporter)
 }
 
 func TestRemoveItems(t *testing.T) {
@@ -122,11 +133,12 @@ func TestRemoveItems(t *testing.T) {
 		// Return no blocks
 		`{"configuration_blocks":[]}`,
 	}
-	mux.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	mux.Handle(fmt.Sprintf("/api/beats/agent/%s/configuration", id), http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, responses[i])
 		i++
 	}))
 
+	reporter := addEventsReporterHandle(mux, id)
 	server := httptest.NewServer(mux)
 
 	c, err := api.ConfigFromURL(server.URL, common.NewConfig())
@@ -139,6 +151,10 @@ func TestRemoveItems(t *testing.T) {
 		Period:      100 * time.Millisecond,
 		Kibana:      c,
 		AccessToken: accessToken,
+		EventsReporter: EventReporterConfig{
+			Period:       50 * time.Millisecond,
+			MaxBatchSize: 1,
+		},
 	}
 
 	manager, err := NewConfigManagerWithConfig(config, registry, id)
@@ -164,6 +180,9 @@ func TestRemoveItems(t *testing.T) {
 	// Cleanup
 	manager.Stop()
 	os.Remove(paths.Resolve(paths.Data, "management.yml"))
+
+	events := []api.Event{&Starting, &InProgress, &Running, &InProgress, &Running, &Stopped}
+	assertEvents(t, events, reporter)
 }
 
 func responseText(s string) http.HandlerFunc {
@@ -190,11 +209,13 @@ func TestUnEnroll(t *testing.T) {
 		responseText(`{"configuration_blocks":[{"type":"test.blocks","config":{"module":"apache2"}}]}`),
 		http.NotFound,
 	}
-	mux.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+	mux.Handle(fmt.Sprintf("/api/beats/agent/%s/configuration", id), http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		responses[i](w, r)
 		i++
 	}))
 
+	reporter := addEventsReporterHandle(mux, id)
 	server := httptest.NewServer(mux)
 
 	c, err := api.ConfigFromURL(server.URL, common.NewConfig())
@@ -207,6 +228,10 @@ func TestUnEnroll(t *testing.T) {
 		Period:      100 * time.Millisecond,
 		Kibana:      c,
 		AccessToken: accessToken,
+		EventsReporter: EventReporterConfig{
+			Period:       50 * time.Millisecond,
+			MaxBatchSize: 1,
+		},
 	}
 
 	manager, err := NewConfigManagerWithConfig(config, registry, id)
@@ -232,6 +257,181 @@ func TestUnEnroll(t *testing.T) {
 	// Cleanup
 	manager.Stop()
 	os.Remove(paths.Resolve(paths.Data, "management.yml"))
+
+	events := []api.Event{&Starting, &InProgress, &Running, &InProgress, &Running, &Stopped}
+	assertEvents(t, events, reporter)
+}
+
+func TestBadConfig(t *testing.T) {
+	registry := reload.NewRegistry()
+	id, err := uuid.NewV4()
+	if err != nil {
+		t.Fatalf("error while generating id: %v", err)
+	}
+	accessToken := "footoken"
+	reloadable := reloadable{
+		reloaded: make(chan *reload.ConfigWithMeta, 1),
+	}
+	registry.MustRegister("test.blocks", &reloadable)
+
+	mux := http.NewServeMux()
+	i := 0
+	responses := []http.HandlerFunc{ // Initial load
+		responseText(`{"configuration_blocks":[{"type":"output","config":{"console": { "path": "/tmp/bad"}}}]}`),
+		// will not resend new events
+		responseText(`{"configuration_blocks":[{"type":"output","config":{"console": { "path": "/tmp/bad"}}}]}`),
+		// recover on call
+		http.NotFound,
+	}
+
+	mux.Handle(fmt.Sprintf("/api/beats/agent/%s/configuration", id), http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		responses[i](w, r)
+		i++
+	}))
+
+	reporter := addEventsReporterHandle(mux, id)
+	server := httptest.NewServer(mux)
+
+	c, err := api.ConfigFromURL(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	config := &Config{
+		Enabled:     true,
+		Period:      100 * time.Millisecond,
+		Kibana:      c,
+		AccessToken: accessToken,
+		EventsReporter: EventReporterConfig{
+			Period:       50 * time.Millisecond,
+			MaxBatchSize: 1,
+		},
+		Blacklist: ConfigBlacklistSettings{
+			Patterns: map[string]string{
+				"output": "console|file",
+			},
+		},
+	}
+
+	manager, err := NewConfigManagerWithConfig(config, registry, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	manager.Start()
+
+	// On first reload we will get apache2 module
+	config1 := <-reloadable.reloaded
+	assert.Nil(t, config1)
+
+	// Cleanup
+	manager.Stop()
+	os.Remove(paths.Resolve(paths.Data, "management.yml"))
+
+	events := []api.Event{
+		&Starting,
+		&InProgress,
+		&Error{Type: ConfigError, Err: errors.New("Config for 'output' is blacklisted")},
+		&Failed,
+		&InProgress, // recovering on NotFound, to get out of the blocking.
+		&Running,
+		&Stopped,
+	}
+	assertEvents(t, events, reporter)
+}
+
+type testEventRequest struct {
+	EventType api.EventType
+	Event     api.Event
+}
+
+func (er *testEventRequest) UnmarshalJSON(b []byte) error {
+	resp := struct {
+		EventType api.EventType   `json:"event_type"`
+		Event     json.RawMessage `json:"event"`
+	}{}
+
+	if err := json.Unmarshal(b, &resp); err != nil {
+		return err
+	}
+
+	switch resp.EventType {
+	case ErrorEvent:
+		event := &Error{}
+		if err := json.Unmarshal(resp.Event, event); err != nil {
+			return err
+		}
+		*er = testEventRequest{EventType: resp.EventType, Event: event}
+		return nil
+	case StateEvent:
+		event := State("")
+		if err := json.Unmarshal(resp.Event, &event); err != nil {
+			return err
+		}
+		*er = testEventRequest{EventType: resp.EventType, Event: &event}
+		return nil
+	}
+	return fmt.Errorf("unknown event type of '%s'", resp.EventType)
+}
+
+// collect in the background any events generated from the managers.
+type collectEventRequest struct {
+	sync.Mutex
+	requests []testEventRequest
+}
+
+func (r *collectEventRequest) Requests() []testEventRequest {
+	r.Lock()
+	defer r.Unlock()
+	return r.requests
+}
+
+func (r *collectEventRequest) Add(requests ...testEventRequest) {
+	r.Lock()
+	defer r.Unlock()
+	r.requests = append(r.requests, requests...)
+}
+
+func addEventsReporterHandle(mux *http.ServeMux, uuid uuid.UUID) *collectEventRequest {
+	reporter := &collectEventRequest{}
+	path := "/api/beats/agent/" + uuid.String() + "/events"
+	fn := func(w http.ResponseWriter, r *http.Request) {
+		var requests []testEventRequest
+		decoder := json.NewDecoder(r.Body)
+		if err := decoder.Decode(&requests); err != nil {
+			http.Error(w, "could not decode JSON", 500)
+		}
+
+		reporter.Add(requests...)
+		resp := api.EventAPIResponse{Response: make([]api.EventResponse, len(requests))}
+
+		for i := 0; i < len(requests); i++ {
+			resp.Response[i] = api.EventResponse{Success: true}
+		}
+
+		json.NewEncoder(w).Encode(resp)
+	}
+	mux.Handle(path, http.HandlerFunc(fn))
+	return reporter
+}
+
+func assertEvents(t *testing.T, events []api.Event, reporter *collectEventRequest) {
+	requests := reporter.Requests()
+	if assert.Equal(t, len(events), len(requests)) {
+		return
+	}
+
+	for i := 0; i < len(events); i++ {
+		switch v := requests[i].Event.(type) {
+		case *State:
+			assert.Equal(t, events[i], requests[i].Event)
+		case *Error:
+			comparable := events[i].(*Error)
+			assert.Error(t, comparable.Err, v.Err)
+		default:
+			t.Fatalf("cannot assert unknown type: %T", requests[i].Event)
+		}
+	}
 }
 
 func TestConfigValidate(t *testing.T) {

--- a/x-pack/libbeat/management/state.go
+++ b/x-pack/libbeat/management/state.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 package management
 
 import (

--- a/x-pack/libbeat/management/state.go
+++ b/x-pack/libbeat/management/state.go
@@ -1,0 +1,78 @@
+package management
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/elastic/beats/x-pack/libbeat/management/api"
+)
+
+// StateEvent is a state change notification.
+var StateEvent = api.EventType("STATE")
+
+var (
+	// Starting is when the Manager is created and no config are currently active.
+	Starting = State("STARTING")
+	// InProgress we have received a new config from the Remote endpoint and we are trying to apply it.
+	InProgress = State("IN_PROGRESS")
+	// Running is set when all the config are successfully applied.
+	Running = State("RUNNING")
+	// Failed is set if an unpack failed, a a blacklisted option is set or when a reload fails.
+	Failed = State("FAILED")
+	// Stopped is set when CM is shutting down, on close the event reported will flush any pending states.
+	Stopped = State("STOPPED")
+)
+
+var translateState = map[string]State{
+	"STARTING":    Starting,
+	"IN_PROGRESS": InProgress,
+	"RUNNING":     Running,
+	"FAILED":      Failed,
+	"STOPPED":     Stopped,
+}
+
+// State represents the internal State of the CM Manager, it does not yet represent
+// the full status of beats, because if the manager is marked as Failed it is possible that
+// Beat is in fact partially working. A failed state represents an error while unpacking the config
+// or when a module failed to reload.
+type State string
+
+// MarshalJSON marshals a status into a valid JSON document.
+func (s *State) MarshalJSON() ([]byte, error) {
+	res := struct {
+		Type    string `json:"type"`
+		Message string `json:"message"`
+	}{
+		Type:    string(*s),
+		Message: fmt.Sprintf("State change: %s", *s),
+	}
+	return json.Marshal(&res)
+}
+
+// EventType returns the type of event.
+func (s *State) EventType() api.EventType {
+	return StateEvent
+}
+
+// UnmarshalJSON unmarshals the State.
+func (s *State) UnmarshalJSON(b []byte) error {
+	raw := struct {
+		Type string `json:"type"`
+	}{}
+
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+
+	v, ok := translateState[raw.Type]
+	if !ok {
+		return fmt.Errorf("unknown state %s", raw.Type)
+	}
+
+	*s = v
+	return nil
+}
+
+func (s *State) String() string {
+	return string(*s)
+}

--- a/x-pack/libbeat/management/state_test.go
+++ b/x-pack/libbeat/management/state_test.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 package management
 
 import (

--- a/x-pack/libbeat/management/state_test.go
+++ b/x-pack/libbeat/management/state_test.go
@@ -1,0 +1,54 @@
+package management
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSerializationOfState(t *testing.T) {
+	t.Run("serialize ok", func(t *testing.T) {
+		e := &Starting
+
+		b, err := json.Marshal(&e)
+		if assert.NoError(t, err) {
+			return
+		}
+
+		resp := &struct {
+			Message string `json:"message"`
+			Type    string `json:"type"`
+		}{}
+
+		err = json.Unmarshal(b, resp)
+		if assert.NoError(t, err) {
+			return
+		}
+
+		assert.Equal(t, e.String(), resp.Type)
+		assert.NotEmpty(t, resp.Message)
+	})
+	t.Run("ensure that json general fields are present", ensureJSONhasGeneralfield(t, &Starting))
+}
+
+// Ensure that all events have a Message key that can by used by the GUI.
+func ensureJSONhasGeneralfield(t *testing.T, obj json.Marshaler) func(*testing.T) {
+	return func(t *testing.T) {
+		serialized, err := json.Marshal(obj)
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		message := struct {
+			Message string `json:"message"`
+		}{}
+
+		err = json.Unmarshal(serialized, &message)
+
+		if !assert.NoError(t, err) {
+			return
+		}
+		assert.NotEmpty(t, message)
+	}
+}


### PR DESCRIPTION
# NOTES: DO NOT MERGE IT DEPENDS ON FEATURE OF KIBANA

Motivation: Currently CM  send on the next tick a ConfigOK => true if the previous config was successfully applied, the problem is this information is just 0 or 1 and in the context of beat we need a bit more details to make correct decision.


## Changes:

This PR do the following thing:

1. Add a AuthClient that wraps a Client but make sure that all calls are authenticated using the defined UUID and the AccessToken.

2. Add an EventsReporter as part of the `api` package that will send asynchrously api.Event to the CM backend. The reporter is started and closed at the same time of the Manager, on close events are flushed to the backend.

3. Events are send in batch of a 1000 to the Kibana endpoint. (configurable)

5. Any errors from `BlackList` or `Reload` are send as Event.

6. Introduce Manager's State with the following: STARTING, IN_PROGRESS, RUNNING, FAILED, STOPPED and will be send to the event endpoints.

7. Events are send by default every 30 sec. (configurable)



## Requests:

PATH: /api/beats/{UUID}/events exist
Verb used: "POST"
*uuid could be omnitted*

Request example:
```json
[
{"type": "STATE", "timestamp": "2019-01-04T14:32:03.36764-05:00", "event": { "type": "STARTING", "message": "State change: STARTING"}},
{"type": "STATE", "timestamp": "2019-01-04T14:32:03.36764-05:00", "event": { "type": "In_PROGRESS", "message": "State change: IN_PROGRESS"}},
{"type": "ERROR", "timestamp": "2019-01-04T14:32:03.36764-05:00", "event": { "type": "CONFIG", "message": "a bad error", "uuid": "xxxxxxxxxxxxx"}} 
{"type": "ERROR", "timestamp": "2019-01-04T14:32:03.36764-05:00", "event": { "type": "CONFIG", "message": "another bad error", "uuid": "xxxxxxxxxxxxx"}}
{"type": "STATE", "timestamp": "2019-01-04T14:32:03.36764-05:00", "event": { "type": "FAILED", "message": "State change: FAILED"}},
{"type": "STATE", "timestamp": "2019-01-04T14:32:03.36764-05:00", "event": { "type": "STOPPED", "message": "State change: STOPPED"}},
]
```

Expected response:
Status code : 200
```json
{
"response": [
  { "success": true }
  { "success": true }
  { "success": true }
  { "success": true }
  { "success": true }
  { "success": true }
]
}
```
## TODO:
- [ ] Add the UUID from the API, waiting on api implementation to do that / review.
- [ ] Add Severity to the `ERROR`, "Fatal" or "Transient"


## Questions
- [ ] Should we create a UUID for each events and send them as part of the response?
- [ ] The above could allow us to ACK a batch of events.

Fixes: #9382
