### PR TITLE
fix #9866: remove elasticsearch override

### DIFF
--- a/x-pack/functionbeat/config/config.go
+++ b/x-pack/functionbeat/config/config.go
@@ -32,7 +32,6 @@ var ConfigOverrides = common.MustNewConfigFrom(map[string]interface{}{
 		"flush.min_events": 10,
 		"flush.timeout":    "0.01s",
 	},
-	"output.elasticsearch.bulk_max_size": 50,
 })
 
 // Config default configuration for Functionbeat.

--- a/x-pack/functionbeat/config/config.go
+++ b/x-pack/functionbeat/config/config.go
@@ -28,7 +28,6 @@ var ConfigOverrides = common.MustNewConfigFrom(map[string]interface{}{
 	"logging.level":          "debug",
 	"setup.template.enabled": true,
 	"queue.mem": map[string]interface{}{
-		"events":           "${output.elasticsearch.bulk_max_size}",
 		"flush.min_events": 10,
 		"flush.timeout":    "0.01s",
 	},

--- a/x-pack/functionbeat/functionbeat.reference.yml
+++ b/x-pack/functionbeat/functionbeat.reference.yml
@@ -117,14 +117,14 @@ functionbeat.provider.aws.functions:
 #fields_under_root: false
 
 # Internal queue configuration for buffering events to be published.
-#queue:
+queue:
   # Queue type by name (default 'mem')
   # The memory queue will present all available events (up to the outputs
   # bulk_max_size) to the output, the moment the output is ready to server
   # another batch of events.
-  #mem:
+  mem:
     # Max number of events the queue can buffer.
-    #events: 4096
+    events: 50
 
     # Hints the minimum number of events stored in the queue,
     # before providing a batch of events to the outputs.

--- a/x-pack/functionbeat/functionbeat.yml
+++ b/x-pack/functionbeat/functionbeat.yml
@@ -105,6 +105,14 @@ functionbeat.provider.aws.functions:
 #fields:
 #  env: staging
 
+queue:
+  # Queue type by name (default 'mem')
+  # The memory queue will present all available events (up to the outputs
+  # bulk_max_size) to the output, the moment the output is ready to server
+  # another batch of events.
+  mem:
+    # Max number of events the queue can buffer.
+    events: 50
 
 #============================== Dashboards =====================================
 # These settings control loading the sample dashboards to the Kibana index. Loading


### PR DESCRIPTION
I don't see any reason why this should be forced like this, and it also unfortunately forces one to use elasticsearch as output.