### PR TITLE
Handle IPv6 zone id in IIS filebeat ingest pipeline

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -53,6 +53,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 *Filebeat*
 
 - Add `convert_timezone` option to Elasticsearch module to convert dates to UTC. {issue}9756[9756] {pull}9761[9761]
+- Support IPv6 addresses with zone id in IIS ingest pipeline. {issue}9836[9836] {pull}9869[9869]
 
 *Heartbeat*
 

--- a/filebeat/module/iis/error/ingest/default.json
+++ b/filebeat/module/iis/error/ingest/default.json
@@ -28,9 +28,23 @@
       "field": "iis.error.time"
     }
   }, {
-    "geoip": {
+    "grok": {
       "field": "iis.error.remote_ip",
+      "patterns": [
+        "%{NOZONEIP:iis.error.remote_ip_geoip}"
+      ],
+      "pattern_definitions": {
+         "NOZONEIP": "[^%]*"
+      }
+    }
+  }, {
+    "geoip": {
+      "field": "iis.error.remote_ip_geoip",
       "target_field": "iis.error.geoip"
+    }
+  }, {
+    "remove": {
+      "field": "iis.error.remote_ip_geoip"
     }
   }],
   "on_failure" : [{

--- a/filebeat/module/iis/error/test/ipv6_zone_id.log
+++ b/filebeat/module/iis/error/test/ipv6_zone_id.log
@@ -1,0 +1,5 @@
+#Software: Microsoft HTTP API 2.0
+#Version: 1.0
+#Date: 2018-12-30 13:48:36
+#Fields: date time c-ip c-port s-ip s-port cs-version cs-method cs-uri streamid sc-status s-siteid s-reason s-queuename
+2018-12-30 14:22:07 ::1%0 49958 ::1%0 80 - - - - - - Timer_ConnectionIdle -

--- a/filebeat/module/iis/error/test/ipv6_zone_id.log-expected.json
+++ b/filebeat/module/iis/error/test/ipv6_zone_id.log-expected.json
@@ -1,0 +1,16 @@
+[
+    {
+        "@timestamp": "2018-12-30T14:22:07.000Z",
+        "ecs.version": "1.0.0-beta2",
+        "event.dataset": "error",
+        "event.module": "iis",
+        "iis.error.queue_name": "-",
+        "iis.error.reason_phrase": "Timer_ConnectionIdle",
+        "iis.error.remote_ip": "::1%0",
+        "iis.error.remote_port": "49958",
+        "iis.error.server_ip": "::1%0",
+        "iis.error.server_port": "80",
+        "input.type": "log",
+        "log.offset": 195
+    }
+]


### PR DESCRIPTION
Possible workaround for #9836, this may be needed in other modules if other services also log IPv6 addresses with zone id.

Wait for https://github.com/elastic/elasticsearch/issues/37107 before deciding what to do about this.