### PR TITLE
Add two migrated fields to ecs-migration.yml from #9645.

### DIFF
--- a/dev-tools/ecs-migration.yml
+++ b/dev-tools/ecs-migration.yml
@@ -54,6 +54,9 @@
   alias6: true
   alias: true
 
+
+# Processor fields
+
 # Docker processor
 - from: docker.container.id
   to: container.id
@@ -74,9 +77,6 @@
   to: container.labels
   alias6: false
   alias: true
-
-
-# Processor fields
 
 # Cloud
 - from: meta.cloud.provider

--- a/dev-tools/ecs-migration.yml
+++ b/dev-tools/ecs-migration.yml
@@ -76,10 +76,6 @@
   alias: true
 
 
-# Filebeat modules
-
-## Suricata module
-
 # Processor fields
 
 # Cloud

--- a/dev-tools/ecs-migration.yml
+++ b/dev-tools/ecs-migration.yml
@@ -79,37 +79,37 @@
 # Processor fields
 
 # Cloud
-- form: meta.cloud.provider
+- from: meta.cloud.provider
   to: cloud.provider
   alias: true
   alias6: true
 
-- form: meta.cloud.instance_id
+- from: meta.cloud.instance_id
   to: cloud.instance.id
   alias: true
   alias6: true
 
-- form: meta.cloud.instance_name
+- from: meta.cloud.instance_name
   to: cloud.instance.name
   alias: true
   alias6: true
 
-- form: meta.cloud.machine_type
+- from: meta.cloud.machine_type
   to: cloud.machine.type
   alias: true
   alias6: true
 
-- form: meta.cloud.availability_zone
+- from: meta.cloud.availability_zone
   to: cloud.availability_zone
   alias: true
   alias6: true
 
-- form: meta.cloud.project_id
+- from: meta.cloud.project_id
   to: cloud.project.id
   alias: true
   alias6: true
 
-- form: meta.cloud.region
+- from: meta.cloud.region
   to: cloud.region
   alias: true
   alias6: true

--- a/dev-tools/ecs-migration.yml
+++ b/dev-tools/ecs-migration.yml
@@ -587,12 +587,27 @@
   to: http.version
   alias: true
 
+
 # Auditbeat
 
 ## From Auditbeat's auditd module.
 - from: source.hostname
   to: source.domain
   alias: true
+
+
+# Packetbeat
+
+- from: http.request.body
+  to: http.request.body.content
+  alias6: false
+  alias: false
+
+- from: http.response.body
+  to: http.response.body.content
+  alias6: false
+  alias: false
+
 
 # Metricbeat
 


### PR DESCRIPTION
Notes:

- Can't be aliased since `body` is moving to `body.content`.
- Currently only affects Packetbeat, so it's been listed only there, even if these are ECS field defs.
- This will affect the ES Filebeat module logs as well. A note as been added to #9293, so it doesn't get forgotten.
- Unrelated file cleanup (fix rebase problems and typos)