### PR TITLE
[Heartbeat] Cleanup monitors.d sample files

### DIFF
--- a/heartbeat/monitors.d/sample.http.yml.disabled
+++ b/heartbeat/monitors.d/sample.http.yml.disabled
@@ -23,46 +23,38 @@
   ipv6: true
   mode: any
 
-    # Configure file json file to be watched for changes to the monitor:
-    #watch.poll_file:
-    # Path to check for updates.
-    #path:
+  # Optional HTTP proxy url.
+  #proxy_url: ''
 
-    # Interval between file file changed checks.
-    #interval: 5s
+  # Total test connection and data exchange timeout
+  #timeout: 16s
 
-    # Optional HTTP proxy url.
-    #proxy_url: ''
+  # Optional Authentication Credentials
+  #username: ''
+  #password: ''
 
-    # Total test connection and data exchange timeout
-    #timeout: 16s
+  # TLS/SSL connection settings for use with HTTPS endpoint. If not configured
+  # system defaults will be used.
+  #ssl:
+  # Certificate Authorities
+  #certificate_authorities: ['']
 
-    # Optional Authentication Credentials
-    #username: ''
-    #password: ''
+  # Required TLS protocols
+  #supported_protocols: ["TLSv1.0", "TLSv1.1", "TLSv1.2"]
 
-    # TLS/SSL connection settings for use with HTTPS endpoint. If not configured
-    # system defaults will be used.
-    #ssl:
-    # Certificate Authorities
-    #certificate_authorities: ['']
+  # Request settings:
+  #check.request:
+  # Configure HTTP method to use. Only 'HEAD', 'GET' and 'POST' methods are allowed.
+  #method: "GET"
 
-    # Required TLS protocols
-    #supported_protocols: ["TLSv1.0", "TLSv1.1", "TLSv1.2"]
+  # Dictionary of additional HTTP headers to send:
+  #headers:
 
-    # Request settings:
-    #check.request:
-    # Configure HTTP method to use. Only 'HEAD', 'GET' and 'POST' methods are allowed.
-    #method: "GET"
+  # Optional request body content
+  #body:
 
-    # Dictionary of additional HTTP headers to send:
-    #headers:
-
-    # Optional request body content
-    #body:
-
-    # Expected response settings
-    #check.response:
+  # Expected response settings
+  #check.response:
     # Expected status code. If not configured or set to 0 any status code not
     # being 404 is accepted.
     #status: 0
@@ -80,12 +72,18 @@
     #    equals:
     #      myField: expectedValue
 
+  # The tags of the monitors are included in their own field with each
+  # transaction published. Tags make it easy to group servers by different
+  # logical properties.
+  #tags: ["service-X", "web-tier"]
 
-    # NOTE: THIS FEATURE IS DEPRECATED AND WILL BE REMOVED IN A FUTURE RELEASE
-    # Configure file json file to be watched for changes to the monitor:
-    #watch.poll_file:
-    # Path to check for updates.
-    #path:
+  # Optional fields that you can specify to add additional information to the
+  # monitor output. Fields can be scalar values, arrays, dictionaries, or any nested
+  # combination of these.
+  #fields:
+  #  env: staging
 
-    # Interval between file file changed checks.
-  #interval: 5s
+  # If this option is set to true, the custom fields are stored as top-level
+  # fields in the output document instead of being grouped under a fields
+  # sub-dictionary. Default is false.
+  #fields_under_root: false

--- a/heartbeat/monitors.d/sample.icmp.yml.disabled
+++ b/heartbeat/monitors.d/sample.icmp.yml.disabled
@@ -30,38 +30,18 @@
   # Waiting duration until another ICMP Echo Request is emitted.
   wait: 1s
 
-    # The tags of the monitors are included in their own field with each
-    # transaction published. Tags make it easy to group servers by different
-    # logical properties.
-    #tags: ["service-X", "web-tier"]
+  # The tags of the monitors are included in their own field with each
+  # transaction published. Tags make it easy to group servers by different
+  # logical properties.
+  #tags: ["service-X", "web-tier"]
 
-    # Optional fields that you can specify to add additional information to the
-    # monitor output. Fields can be scalar values, arrays, dictionaries, or any nested
-    # combination of these.
-    #fields:
-    #  env: staging
+  # Optional fields that you can specify to add additional information to the
+  # monitor output. Fields can be scalar values, arrays, dictionaries, or any nested
+  # combination of these.
+  #fields:
+  #  env: staging
 
-    # If this option is set to true, the custom fields are stored as top-level
-    # fields in the output document instead of being grouped under a fields
-    # sub-dictionary. Default is false.
-    #fields_under_root: false
-
-    # NOTE: THIS FEATURE IS DEPRECATED AND WILL BE REMOVED IN A FUTURE RELEASE
-    # Configure file json file to be watched for changes to the monitor:
-    #watch.poll_file:
-    # Path to check for updates.
-    #path:
-
-    # Interval between file file changed checks.
-  #interval: 5s
-
-  # Define a directory to load monitor definitions from. Definitions take the form
-  # of individual yaml files.
-  # heartbeat.config.monitors:
-  # Directory + glob pattern to search for configuration files
-  #path: /path/to/my/monitors.d/*.yml
-  # If enabled, heartbeat will periodically check the config.monitors path for changes
-  #reload.enabled: true
-  # How often to check for changes
-  #reload.period: 1s
-
+  # If this option is set to true, the custom fields are stored as top-level
+  # fields in the output document instead of being grouped under a fields
+  # sub-dictionary. Default is false.
+  #fields_under_root: false

--- a/heartbeat/monitors.d/sample.tcp.yml.disabled
+++ b/heartbeat/monitors.d/sample.tcp.yml.disabled
@@ -39,40 +39,46 @@
   ipv6: true
   mode: any
 
-    # List of ports to ping if host does not contain a port number
-    # ports: [80, 9200, 5044]
+  # List of ports to ping if host does not contain a port number
+  # ports: [80, 9200, 5044]
 
-    # Total test connection and data exchange timeout
-    #timeout: 16s
+  # Total test connection and data exchange timeout
+  #timeout: 16s
 
-    # Optional payload string to send to remote and expected answer. If none is
-    # configured, the endpoint is expected to be up if connection attempt was
-    # successful. If only `send_string` is configured, any response will be
-    # accepted as ok. If only `receive_string` is configured, no payload will be
-    # send, but client expects to receive expected payload on connect.
-    #check:
-    #send: ''
-    #receive: ''
+  # Optional payload string to send to remote and expected answer. If none is
+  # configured, the endpoint is expected to be up if connection attempt was
+  # successful. If only `send_string` is configured, any response will be
+  # accepted as ok. If only `receive_string` is configured, no payload will be
+  # send, but client expects to receive expected payload on connect.
+  #check:
+  #send: ''
+  #receive: ''
 
-    # SOCKS5 proxy url
-    # proxy_url: ''
+  # SOCKS5 proxy url
+  # proxy_url: ''
 
-    # Resolve hostnames locally instead on SOCKS5 server:
-    #proxy_use_local_resolver: false
+  # Resolve hostnames locally instead on SOCKS5 server:
+  #proxy_use_local_resolver: false
 
-    # TLS/SSL connection settings:
-    #ssl:
-    # Certificate Authorities
-    #certificate_authorities: ['']
+  # TLS/SSL connection settings:
+  #ssl:
+  # Certificate Authorities
+  #certificate_authorities: ['']
 
-    # Required TLS protocols
-    #supported_protocols: ["TLSv1.0", "TLSv1.1", "TLSv1.2"]
+  # Required TLS protocols
+  #supported_protocols: ["TLSv1.0", "TLSv1.1", "TLSv1.2"]
+  # The tags of the monitors are included in their own field with each
+  # transaction published. Tags make it easy to group servers by different
+  # logical properties.
+  #tags: ["service-X", "web-tier"]
 
-    # NOTE: THIS FEATURE IS DEPRECATED AND WILL BE REMOVED IN A FUTURE RELEASE
-    # Configure file json file to be watched for changes to the monitor:
-    #watch.poll_file:
-    # Path to check for updates.
-    #path:
+  # Optional fields that you can specify to add additional information to the
+  # monitor output. Fields can be scalar values, arrays, dictionaries, or any nested
+  # combination of these.
+  #fields:
+  #  env: staging
 
-    # Interval between file file changed checks.
-  #interval: 5s
+  # If this option is set to true, the custom fields are stored as top-level
+  # fields in the output document instead of being grouped under a fields
+  # sub-dictionary. Default is false.
+  #fields_under_root: false


### PR DESCRIPTION
A lot of the advanced options in the sample monitors.d files distributed with heartbeat was either wrong or inconsistent. This fixes that. This also removes documentation for the deprecated `watch.poll` option. If you're using monitors.d there's no reason to include that.