### PR TITLE
[Auditbeat] Cherry-pick #9863 to 6.6: Process metricset: Skip permission errors on Windows

### DIFF
--- a/x-pack/auditbeat/docs/modules/system.asciidoc
+++ b/x-pack/auditbeat/docs/modules/system.asciidoc
@@ -14,8 +14,8 @@ a system. All metricsets send both periodic state information (e.g. all currentl
 running processes) and real-time changes (e.g. when a new process starts
 or stops).
 
-The module is fully implemented for Linux, and partially implemented
-for macOS (Darwin).
+The module is fully implemented for Linux. Some metricsets are also available
+for macOS (Darwin) and Windows.
 
 [float]
 === How it works

--- a/x-pack/auditbeat/module/system/_meta/docs.asciidoc
+++ b/x-pack/auditbeat/module/system/_meta/docs.asciidoc
@@ -9,8 +9,8 @@ a system. All metricsets send both periodic state information (e.g. all currentl
 running processes) and real-time changes (e.g. when a new process starts
 or stops).
 
-The module is fully implemented for Linux, and partially implemented
-for macOS (Darwin).
+The module is fully implemented for Linux. Some metricsets are also available
+for macOS (Darwin) and Windows.
 
 [float]
 === How it works

--- a/x-pack/auditbeat/module/system/process/_meta/docs.asciidoc
+++ b/x-pack/auditbeat/module/system/process/_meta/docs.asciidoc
@@ -4,4 +4,4 @@ experimental[]
 
 This is the `process` metricset of the system module.
 
-It is implemented for Linux and macOS (Darwin).
+It is implemented for Linux, macOS (Darwin), and Windows.

--- a/x-pack/auditbeat/module/system/process/process.go
+++ b/x-pack/auditbeat/module/system/process/process.go
@@ -329,6 +329,13 @@ func (ms *MetricSet) getProcesses() ([]*Process, error) {
 				continue
 			}
 
+			if runtime.GOOS == "windows" && (pid == 0 || os.IsPermission(err)) {
+				// On Windows, the call to Process() can fail if Auditbeat does not have
+				// the necessary access rights, while trying to open the System Process (PID: 0)
+				// will always fail.
+				continue
+			}
+
 			// Record what we can and continue
 			process = &Process{
 				Info: types.ProcessInfo{

--- a/x-pack/auditbeat/module/system/process/process_test.go
+++ b/x-pack/auditbeat/module/system/process/process_test.go
@@ -5,7 +5,6 @@
 package process
 
 import (
-	"runtime"
 	"testing"
 
 	"github.com/elastic/beats/auditbeat/core"
@@ -13,9 +12,6 @@ import (
 )
 
 func TestData(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Fails on Windows - https://github.com/elastic/beats/issues/9748")
-	}
 	f := mbtest.NewReportingMetricSetV2(t, getConfig())
 	events, errs := mbtest.ReportingFetchV2(f)
 	if len(errs) > 0 {

--- a/x-pack/auditbeat/tests/system/test_metricsets.py
+++ b/x-pack/auditbeat/tests/system/test_metricsets.py
@@ -22,7 +22,6 @@ class Test(AuditbeatXPackTest):
         self.check_metricset("system", "host", COMMON_FIELDS + fields, warnings_allowed=True)
 
     @unittest.skipIf(sys.platform == "darwin" and os.geteuid != 0, "Requires root on macOS")
-    @unittest.skipIf(sys.platform == "win32", "Fails on Windows - https://github.com/elastic/beats/issues/9748")
     def test_metricset_process(self):
         """
         process metricset collects information about processes running on a system.


### PR DESCRIPTION
Cherry-pick of PR #9863 to 6.6 branch. Original message: 

The `process` metricset tests were failing on Windows because they were trying to open processes that cannot be opened (the System and Idle Processes, and any CSRSS process - see [OpenProcess](https://docs.microsoft.com/en-us/windows/desktop/api/processthreadsapi/nf-processthreadsapi-openprocess)).

This change skips the System Process (PID: 0) as well as any process access has been denied to.

Since the `process` metricset seems to be working well on Windows now, this also adds Windows to the documentation (Note: The system module remains marked as `experimental` for now).

Fixes https://github.com/elastic/beats/issues/9748.