### PR TITLE
Cherry-pick #9884 to 6.x: Replace beat binary in Elastic DMG distribution

### DIFF
--- a/dev-tools/packaging/packages.yml
+++ b/dev-tools/packaging/packages.yml
@@ -366,6 +366,10 @@ specs:
       spec:
         <<: *macos_beat_pkg_spec
         <<: *elastic_license_for_macos_pkg
+        files:
+          /Library/Application Support/{{.BeatVendor}}/{{.BeatName}}/bin/{{.BeatName}}{{.BinaryExt}}:
+            mode: 0755
+            source: ../x-pack/{{.BeatName}}/build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
 
     - os: linux
       types: [tgz]


### PR DESCRIPTION
Cherry-pick of PR #9884 to 6.x branch. Original message: 

The oss binary was used for the Elastic-licensed DMG. This replaces it with the binary from x-pack folder.

Fixes #9883