### PR TITLE
[Netflow] Fix flow ID and locality calculation

### DIFF
--- a/x-pack/filebeat/input/netflow/convert.go
+++ b/x-pack/filebeat/input/netflow/convert.go
@@ -198,6 +198,18 @@ func flowToBeatEvent(flow record.Record) (event beat.Event) {
 		ecsSource["mac"] = mac
 	}
 
+	// ECS Fields -- destination
+	if ip, found := getKeyIP(flow.Fields, "destinationIPv4Address"); found {
+		ecsDest["ip"] = ip
+		ecsDest["locality"] = getIPLocality(ip).String()
+	}
+	if destPort, found := getKeyUint64(flow.Fields, "destinationTransportPort"); found {
+		ecsDest["port"] = destPort
+	}
+	if mac, found := getKeyString(flow.Fields, "destinationMacAddress"); found {
+		ecsDest["mac"] = mac
+	}
+
 	// ECS Fields -- Flow
 	ecsFlow := common.MapStr{}
 	var srcIP, dstIP net.IP
@@ -226,18 +238,6 @@ func flowToBeatEvent(flow record.Record) (event beat.Event) {
 	}
 	ecsFlow["id"] = flowID(srcIP, dstIP, srcPort, dstPort, uint8(protocol))
 	ecsFlow["locality"] = getIPLocality(srcIP, dstIP).String()
-
-	// ECS Fields -- destination
-	if ip, found := getKeyIP(flow.Fields, "destinationIPv4Address"); found {
-		ecsDest["ip"] = ip
-		ecsDest["locality"] = getIPLocality(ip).String()
-	}
-	if destPort, found := getKeyUint64(flow.Fields, "destinationTransportPort"); found {
-		ecsDest["port"] = destPort
-	}
-	if mac, found := getKeyString(flow.Fields, "destinationMacAddress"); found {
-		ecsDest["mac"] = mac
-	}
 
 	// ECS Fields -- network
 	ecsNetwork := common.MapStr{}

--- a/x-pack/filebeat/input/netflow/netflow_test.go
+++ b/x-pack/filebeat/input/netflow/netflow_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/x-pack/filebeat/input/netflow/decoder"
 	"github.com/elastic/beats/x-pack/filebeat/input/netflow/decoder/protocol"
+	"github.com/elastic/beats/x-pack/filebeat/input/netflow/decoder/record"
 	"github.com/elastic/beats/x-pack/filebeat/input/netflow/decoder/test"
 )
 
@@ -259,4 +260,86 @@ func readGoldenFile(t testing.TB, file string) TestResult {
 		t.Fatal(err)
 	}
 	return tr
+}
+
+// This test converts a flow and its reverse flow to a Beat event
+// to check that they have the same flow.id, locality and community-id.
+func TestReverseFlows(t *testing.T) {
+	parseMAC := func(s string) net.HardwareAddr {
+		addr, err := net.ParseMAC(s)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return addr
+	}
+	flows := []record.Record{
+		{
+			Type: record.Flow,
+			Fields: record.Map{
+				"ingressInterface":         uint64(2),
+				"destinationTransportPort": uint64(50285),
+				"sourceTransportPort":      uint64(993),
+				"packetDeltaCount":         uint64(26),
+				"ipVersion":                uint64(4),
+				"sourceIPv4Address":        net.ParseIP("203.0.113.123").To4(),
+				"deltaFlowCount":           uint64(0),
+				"sourceMacAddress":         parseMAC("10:00:00:00:00:02"),
+				"flowDirection":            uint64(0),
+				"flowEndSysUpTime":         uint64(64526131),
+				"vlanId":                   uint64(0),
+				"ipClassOfService":         uint64(0),
+				"mplsLabelStackLength":     uint64(3),
+				"tcpControlBits":           uint64(27),
+				"egressInterface":          uint64(3),
+				"destinationIPv4Address":   net.ParseIP("10.111.111.96").To4(),
+				"protocolIdentifier":       uint64(6),
+				"flowStartSysUpTime":       uint64(64523806),
+				"destinationMacAddress":    parseMAC("10:00:00:00:00:03"),
+				"octetDeltaCount":          uint64(12852),
+			},
+		},
+		{
+			Type: record.Flow,
+			Fields: record.Map{
+				"ingressInterface":          uint64(3),
+				"destinationTransportPort":  uint64(993),
+				"sourceTransportPort":       uint64(50285),
+				"packetDeltaCount":          uint64(26),
+				"ipVersion":                 uint64(4),
+				"destinationIPv4Address":    net.ParseIP("203.0.113.123").To4(),
+				"deltaFlowCount":            uint64(0),
+				"postDestinationMacAddress": parseMAC("10:00:00:00:00:03"),
+				"flowDirection":             uint64(1),
+				"flowEndSysUpTime":          uint64(64526131),
+				"vlanId":                    uint64(0),
+				"ipClassOfService":          uint64(0),
+				"mplsLabelStackLength":      uint64(3),
+				"tcpControlBits":            uint64(27),
+				"egressInterface":           uint64(3),
+				"sourceIPv4Address":         net.ParseIP("10.111.111.96").To4(),
+				"protocolIdentifier":        uint64(6),
+				"flowStartSysUpTime":        uint64(64523806),
+				"postSourceMacAddress":      parseMAC("10:00:00:00:00:02"),
+				"octetDeltaCount":           uint64(12852),
+			},
+		},
+	}
+
+	var evs []beat.Event
+	for _, f := range flows {
+		evs = append(evs, toBeatEvent(f))
+	}
+	if !assert.Len(t, evs, 2) {
+		t.Fatal()
+	}
+	for _, key := range []string{"flow.id", "flow.locality", "network.community_id"} {
+		var keys [2]interface{}
+		for i := range keys {
+			var err error
+			if keys[i], err = evs[i].Fields.GetValue(key); err != nil {
+				t.Fatal(err, "event num=", i, "key=", key)
+			}
+		}
+		assert.Equal(t, keys[0], keys[1], key)
+	}
 }

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Barracuda-extended-uniflow-template-256.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Barracuda-extended-uniflow-template-256.golden.json
@@ -18,8 +18,8 @@
           "kind": "event"
         },
         "flow": {
-          "id": "xrwrnNR_Xgs",
-          "locality": "private"
+          "id": "kSpZ1WuBhjc",
+          "locality": "public"
         },
         "netflow": {
           "audit_counter": 4157725,
@@ -61,7 +61,7 @@
         },
         "network": {
           "bytes": 0,
-          "community_id": "1:hxVadzb8UUZ5YGGYtqj+E2mpQe8=",
+          "community_id": "1:3g7/10xslZq/7OW7ucdoDYgE3IY=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 0,
@@ -96,7 +96,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "7BBLL0QpIjw",
+          "id": "kSpZ1WuBhjc",
           "locality": "public"
         },
         "netflow": {
@@ -139,7 +139,7 @@
         },
         "network": {
           "bytes": 0,
-          "community_id": "1:4oQU8uYa7F7RE/lIflbJOuU8Vc8=",
+          "community_id": "1:3g7/10xslZq/7OW7ucdoDYgE3IY=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 0,

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Barracuda-firewall.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Barracuda-firewall.golden.json
@@ -18,7 +18,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "iuHn3GlQ8XA",
+          "id": "2vFIarATx_4",
           "locality": "private"
         },
         "netflow": {
@@ -49,7 +49,7 @@
         },
         "network": {
           "bytes": 0,
-          "community_id": "1:UAtYiTxp798P/gsK6Pp/IjMZLiU=",
+          "community_id": "1:hn30QwbDmwNihxKr9rCALGUWPgE=",
           "direction": "unknown",
           "iana_number": 17,
           "packets": 0,
@@ -84,7 +84,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "SJgQadmL3WE",
+          "id": "2vFIarATx_4",
           "locality": "private"
         },
         "netflow": {
@@ -115,7 +115,7 @@
         },
         "network": {
           "bytes": 81,
-          "community_id": "1:Z1aQRJ93TBJeX7YDGHG1zysbYVM=",
+          "community_id": "1:hn30QwbDmwNihxKr9rCALGUWPgE=",
           "direction": "unknown",
           "iana_number": 17,
           "packets": 1,
@@ -150,7 +150,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "iuHn3GlQ8XA",
+          "id": "wU3G8idsscw",
           "locality": "private"
         },
         "netflow": {
@@ -181,7 +181,7 @@
         },
         "network": {
           "bytes": 0,
-          "community_id": "1:UAtYiTxp798P/gsK6Pp/IjMZLiU=",
+          "community_id": "1:ocm1auwAPO+Yk9MSSqJM5efL6qY=",
           "direction": "unknown",
           "iana_number": 17,
           "packets": 0,
@@ -216,7 +216,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "eIt31cWru0w",
+          "id": "wU3G8idsscw",
           "locality": "private"
         },
         "netflow": {
@@ -247,7 +247,7 @@
         },
         "network": {
           "bytes": 81,
-          "community_id": "1:Xb8wZBfARygVu6rohygs9ZhX5Og=",
+          "community_id": "1:ocm1auwAPO+Yk9MSSqJM5efL6qY=",
           "direction": "unknown",
           "iana_number": 17,
           "packets": 1,
@@ -282,7 +282,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "MNe2gxAuU4I",
+          "id": "rOmj8EdZ2dc",
           "locality": "private"
         },
         "netflow": {
@@ -313,7 +313,7 @@
         },
         "network": {
           "bytes": 0,
-          "community_id": "1:ElddGTwZIDATUPp6inGMG4Ii4Xw=",
+          "community_id": "1:bcQGBQMaIVFnAydHjNGt5YPnRAY=",
           "direction": "unknown",
           "iana_number": 17,
           "packets": 0,
@@ -348,7 +348,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "Fm5S3cg6Lcw",
+          "id": "rOmj8EdZ2dc",
           "locality": "private"
         },
         "netflow": {
@@ -379,7 +379,7 @@
         },
         "network": {
           "bytes": 113,
-          "community_id": "1:+74AKYSI83q3lzZWoLzV4bxxCfU=",
+          "community_id": "1:bcQGBQMaIVFnAydHjNGt5YPnRAY=",
           "direction": "unknown",
           "iana_number": 17,
           "packets": 1,
@@ -414,7 +414,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "1srU81eLhhw",
+          "id": "JE7pThaMwJY",
           "locality": "private"
         },
         "netflow": {
@@ -445,7 +445,7 @@
         },
         "network": {
           "bytes": 0,
-          "community_id": "1:r8af+dFTXsLQoTuHm+3HOu/Gpzc=",
+          "community_id": "1:ojn8oXkIUR5w+o320kdpJMiPmmM=",
           "direction": "unknown",
           "iana_number": 17,
           "packets": 0,
@@ -480,7 +480,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "b-peOmD4XyI",
+          "id": "JE7pThaMwJY",
           "locality": "private"
         },
         "netflow": {
@@ -511,7 +511,7 @@
         },
         "network": {
           "bytes": 113,
-          "community_id": "1:yBQpMR0U13RQyD1dOmOn6u8mts0=",
+          "community_id": "1:ojn8oXkIUR5w+o320kdpJMiPmmM=",
           "direction": "unknown",
           "iana_number": 17,
           "packets": 1,

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Mikrotik-RouterOS-6.39.2.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Mikrotik-RouterOS-6.39.2.golden.json
@@ -17,7 +17,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "qKMtgI7Ed9s",
+          "id": "1SREAwMSn_Y",
           "locality": "private"
         },
         "netflow": {
@@ -48,7 +48,7 @@
         },
         "network": {
           "bytes": 152,
-          "community_id": "1:o4guLY2bL+DOHtQO9gHFEbXsEQ0=",
+          "community_id": "1:xhtOANVN9QLWDf3Tox5fsHMf1j4=",
           "direction": "unknown",
           "iana_number": 17,
           "packets": 2,
@@ -81,7 +81,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "5FNp7ndavXc",
+          "id": "-1ecQ0Y-YzY",
           "locality": "private"
         },
         "netflow": {
@@ -112,7 +112,7 @@
         },
         "network": {
           "bytes": 502,
-          "community_id": "1:dff66BxOHH2oQ2rp9q6L5XAyxUw=",
+          "community_id": "1:X9Jzjnw7Bw6phIzn9EyEGGF0sCg=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 8,
@@ -145,7 +145,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "5dxciNWUCt0",
+          "id": "_ztnBsqvzw4",
           "locality": "private"
         },
         "netflow": {
@@ -176,7 +176,7 @@
         },
         "network": {
           "bytes": 2233,
-          "community_id": "1:r27Ws33L+xEVSg9VX0zVJ9MNKwA=",
+          "community_id": "1:pDmVo/Rru0kNar+as9ZR2B9R8ig=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 8,
@@ -209,7 +209,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "TJxuTh4pSgE",
+          "id": "83jerlRbQig",
           "locality": "private"
         },
         "netflow": {
@@ -240,7 +240,7 @@
         },
         "network": {
           "bytes": 152,
-          "community_id": "1:vzzwAshWVAvuWES5NyhLy1GLPAY=",
+          "community_id": "1:XpciCcuce+PqeEptJQCPs7PXDWw=",
           "direction": "unknown",
           "iana_number": 17,
           "packets": 2,
@@ -273,7 +273,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "eVcvPUJANB4",
+          "id": "r6DcuKSlKG8",
           "locality": "private"
         },
         "netflow": {
@@ -304,7 +304,7 @@
         },
         "network": {
           "bytes": 79724,
-          "community_id": "1:1LnuPKitmhDRXGMc7PEKYVnKHqs=",
+          "community_id": "1:mijZXFPsGq/HPIz0GoNycp+l6z4=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 57,
@@ -337,7 +337,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "Dr8WeOCZm_4",
+          "id": "MJV4se1d1EY",
           "locality": "private"
         },
         "netflow": {
@@ -368,7 +368,7 @@
         },
         "network": {
           "bytes": 161,
-          "community_id": "1:xCTumK0k/psyvuepNPEIbpQ8Iy4=",
+          "community_id": "1:1bkChZwKODrxts9j+uOWU8Z71yI=",
           "direction": "unknown",
           "iana_number": 17,
           "packets": 3,
@@ -401,7 +401,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "P7HJmFBUOa8",
+          "id": "MJV4se1d1EY",
           "locality": "private"
         },
         "netflow": {
@@ -432,7 +432,7 @@
         },
         "network": {
           "bytes": 245,
-          "community_id": "1:z+7+u9s7BqnBecKTeXOc7Esh+mM=",
+          "community_id": "1:1bkChZwKODrxts9j+uOWU8Z71yI=",
           "direction": "unknown",
           "iana_number": 17,
           "packets": 3,
@@ -465,7 +465,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "E6FN06gC8JE",
+          "id": "Md4y9RxWsu0",
           "locality": "private"
         },
         "netflow": {
@@ -496,7 +496,7 @@
         },
         "network": {
           "bytes": 504,
-          "community_id": "1:AB9PVU/9h10nCsljEg6e5LXF1dA=",
+          "community_id": "1:R5/ADz+BGeMBuTetWufJMjY3Fp0=",
           "direction": "unknown",
           "iana_number": 1,
           "packets": 6,
@@ -529,7 +529,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "D9tiVWmcw2o",
+          "id": "_XZysP4InTc",
           "locality": "private"
         },
         "netflow": {
@@ -560,7 +560,7 @@
         },
         "network": {
           "bytes": 784,
-          "community_id": "1:KXMvvH/BLW4/w8E/y+y2Q/SCK98=",
+          "community_id": "1:UTPqIKbgBOhUsWyDGwpQ9ybvG1Q=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 6,
@@ -593,7 +593,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "ZNd__DyTXzg",
+          "id": "_XZysP4InTc",
           "locality": "private"
         },
         "netflow": {
@@ -624,7 +624,7 @@
         },
         "network": {
           "bytes": 433,
-          "community_id": "1:Ijd9IXUQpbZAEGLrnnoGfaBS1Ag=",
+          "community_id": "1:UTPqIKbgBOhUsWyDGwpQ9ybvG1Q=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 8,
@@ -657,7 +657,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "r4pPq83nIfU",
+          "id": "5stvUzTWY8c",
           "locality": "private"
         },
         "netflow": {
@@ -688,7 +688,7 @@
         },
         "network": {
           "bytes": 196,
-          "community_id": "1:CYX4DREl+BdwaoOD2Loh6qciwxU=",
+          "community_id": "1:+2FFzJt+KXMsdRFIIwAkTVbJJ3k=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 3,
@@ -721,7 +721,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "W0ydMavNfpM",
+          "id": "VdPCBSYnnS0",
           "locality": "private"
         },
         "netflow": {
@@ -752,7 +752,7 @@
         },
         "network": {
           "bytes": 206,
-          "community_id": "1:18lbeqRsrUgxd8UtlYpuACgLqzY=",
+          "community_id": "1:wUPylJNkPlJks6QXwY7UebXp0Nk=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 3,
@@ -785,7 +785,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "euOQwbFToDs",
+          "id": "asoP1PL3Pao",
           "locality": "private"
         },
         "netflow": {
@@ -816,7 +816,7 @@
         },
         "network": {
           "bytes": 504,
-          "community_id": "1:qqXQzadVXO6y385wBBFibOAWjO4=",
+          "community_id": "1:egGU52actG9xRhZUuYg20CpjWzI=",
           "direction": "unknown",
           "iana_number": 1,
           "packets": 6,
@@ -849,7 +849,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "vtn0fYyiQAs",
+          "id": "r6DcuKSlKG8",
           "locality": "private"
         },
         "netflow": {
@@ -880,7 +880,7 @@
         },
         "network": {
           "bytes": 3539,
-          "community_id": "1:wac990UkZPCjIeHvh0HL/Xpni2I=",
+          "community_id": "1:mijZXFPsGq/HPIz0GoNycp+l6z4=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 58,
@@ -913,7 +913,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "kgBNXXN8ed4",
+          "id": "4AA5ETLDkm0",
           "locality": "private"
         },
         "netflow": {
@@ -944,7 +944,7 @@
         },
         "network": {
           "bytes": 495,
-          "community_id": "1:CAn4DeDPy+T2ErchwToc81lqPQU=",
+          "community_id": "1:4xsmybmBWEF/OhjZe6xnUkZg4O4=",
           "direction": "unknown",
           "iana_number": 17,
           "packets": 3,
@@ -977,7 +977,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "kgBNXXN8ed4",
+          "id": "4AA5ETLDkm0",
           "locality": "private"
         },
         "netflow": {
@@ -1008,7 +1008,7 @@
         },
         "network": {
           "bytes": 330,
-          "community_id": "1:CAn4DeDPy+T2ErchwToc81lqPQU=",
+          "community_id": "1:4xsmybmBWEF/OhjZe6xnUkZg4O4=",
           "direction": "unknown",
           "iana_number": 17,
           "packets": 2,
@@ -1041,7 +1041,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "AYD5HyisGMY",
+          "id": "BaTGW6h8V9s",
           "locality": "private"
         },
         "netflow": {
@@ -1072,7 +1072,7 @@
         },
         "network": {
           "bytes": 435,
-          "community_id": "1:ECc+OoQ/d54eyjdC2O/nZlxXu5U=",
+          "community_id": "1:AK+uc3uJyb6v35G+oeC8Ehp4dOE=",
           "direction": "unknown",
           "iana_number": 17,
           "packets": 3,
@@ -1105,7 +1105,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "AYD5HyisGMY",
+          "id": "BaTGW6h8V9s",
           "locality": "private"
         },
         "netflow": {
@@ -1136,7 +1136,7 @@
         },
         "network": {
           "bytes": 290,
-          "community_id": "1:ECc+OoQ/d54eyjdC2O/nZlxXu5U=",
+          "community_id": "1:AK+uc3uJyb6v35G+oeC8Ehp4dOE=",
           "direction": "unknown",
           "iana_number": 17,
           "packets": 2,
@@ -1169,7 +1169,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "he8fZsMllBk",
+          "id": "a0peNOTOYXA",
           "locality": "private"
         },
         "netflow": {
@@ -1200,7 +1200,7 @@
         },
         "network": {
           "bytes": 495,
-          "community_id": "1:7z8BCaKj9NKuV5cTZ/0iho+mq8g=",
+          "community_id": "1:RAC/9JDBXZ5+D1hZFUTfKaz2ugo=",
           "direction": "unknown",
           "iana_number": 17,
           "packets": 3,
@@ -1233,7 +1233,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "he8fZsMllBk",
+          "id": "a0peNOTOYXA",
           "locality": "private"
         },
         "netflow": {
@@ -1264,7 +1264,7 @@
         },
         "network": {
           "bytes": 330,
-          "community_id": "1:7z8BCaKj9NKuV5cTZ/0iho+mq8g=",
+          "community_id": "1:RAC/9JDBXZ5+D1hZFUTfKaz2ugo=",
           "direction": "unknown",
           "iana_number": 17,
           "packets": 2,
@@ -1297,7 +1297,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "fanKYX35CDM",
+          "id": "rX81_0wnl4c",
           "locality": "private"
         },
         "netflow": {
@@ -1328,7 +1328,7 @@
         },
         "network": {
           "bytes": 495,
-          "community_id": "1:Kkf8y7Ployk+ad0kqHGs5DfAD2I=",
+          "community_id": "1:aBxBvbPn1huzZcWnY6vxAArokoQ=",
           "direction": "unknown",
           "iana_number": 17,
           "packets": 3,
@@ -1361,7 +1361,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "fanKYX35CDM",
+          "id": "rX81_0wnl4c",
           "locality": "private"
         },
         "netflow": {
@@ -1392,7 +1392,7 @@
         },
         "network": {
           "bytes": 330,
-          "community_id": "1:Kkf8y7Ployk+ad0kqHGs5DfAD2I=",
+          "community_id": "1:aBxBvbPn1huzZcWnY6vxAArokoQ=",
           "direction": "unknown",
           "iana_number": 17,
           "packets": 2,
@@ -1425,7 +1425,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "1I_ey2YYTSM",
+          "id": "7EW3D8kjT4Q",
           "locality": "private"
         },
         "netflow": {
@@ -1456,7 +1456,7 @@
         },
         "network": {
           "bytes": 495,
-          "community_id": "1:NSreojKsVnKur/rcYCbfJyvxowQ=",
+          "community_id": "1:OGKDsfaFh3XEKadSh2qUGRfql5E=",
           "direction": "unknown",
           "iana_number": 17,
           "packets": 3,
@@ -1489,7 +1489,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "1I_ey2YYTSM",
+          "id": "7EW3D8kjT4Q",
           "locality": "private"
         },
         "netflow": {
@@ -1520,7 +1520,7 @@
         },
         "network": {
           "bytes": 330,
-          "community_id": "1:NSreojKsVnKur/rcYCbfJyvxowQ=",
+          "community_id": "1:OGKDsfaFh3XEKadSh2qUGRfql5E=",
           "direction": "unknown",
           "iana_number": 17,
           "packets": 2,
@@ -1553,7 +1553,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "P7bcxAuBWAY",
+          "id": "JacJ1_FgpYg",
           "locality": "private"
         },
         "netflow": {
@@ -1584,7 +1584,7 @@
         },
         "network": {
           "bytes": 495,
-          "community_id": "1:U63dC2bH5aZryJEt2eamKMKzoug=",
+          "community_id": "1:SZHwZuTGD4KhA34qOHlPFpIm6O4=",
           "direction": "unknown",
           "iana_number": 17,
           "packets": 3,
@@ -1617,7 +1617,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "P7bcxAuBWAY",
+          "id": "JacJ1_FgpYg",
           "locality": "private"
         },
         "netflow": {
@@ -1648,7 +1648,7 @@
         },
         "network": {
           "bytes": 330,
-          "community_id": "1:U63dC2bH5aZryJEt2eamKMKzoug=",
+          "community_id": "1:SZHwZuTGD4KhA34qOHlPFpIm6O4=",
           "direction": "unknown",
           "iana_number": 17,
           "packets": 2,
@@ -1681,7 +1681,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "rBSLKqUfMAo",
+          "id": "38frmBtEgfI",
           "locality": "private"
         },
         "netflow": {
@@ -1712,7 +1712,7 @@
         },
         "network": {
           "bytes": 495,
-          "community_id": "1:zLCNgJ9Rr55+Kd5OAB4CQOgTQBY=",
+          "community_id": "1:jI3Kb3eebBn6wSG8vdNDd3rT5eY=",
           "direction": "unknown",
           "iana_number": 17,
           "packets": 3,
@@ -1745,7 +1745,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "rBSLKqUfMAo",
+          "id": "38frmBtEgfI",
           "locality": "private"
         },
         "netflow": {
@@ -1776,7 +1776,7 @@
         },
         "network": {
           "bytes": 330,
-          "community_id": "1:zLCNgJ9Rr55+Kd5OAB4CQOgTQBY=",
+          "community_id": "1:jI3Kb3eebBn6wSG8vdNDd3rT5eY=",
           "direction": "unknown",
           "iana_number": 17,
           "packets": 2,

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Netscaler-with-variable-length-fields.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Netscaler-with-variable-length-fields.golden.json
@@ -17,7 +17,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "urCm_V5Qsz0",
+          "id": "8wXIKNz6u_8",
           "locality": "private"
         },
         "netflow": {
@@ -71,7 +71,7 @@
         },
         "network": {
           "bytes": 40,
-          "community_id": "1:VtyB9RHgAkNqVk0mIUunFcpOSfk=",
+          "community_id": "1:vKHRCBsu01Bj9xGu84I60+x4kGg=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 1,
@@ -104,7 +104,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "1fCxVMA_rD0",
+          "id": "8wXIKNz6u_8",
           "locality": "private"
         },
         "netflow": {
@@ -146,7 +146,7 @@
         },
         "network": {
           "bytes": 1525,
-          "community_id": "1:mUmoe1yk2N8K21TGbG3DxjqkRYg=",
+          "community_id": "1:vKHRCBsu01Bj9xGu84I60+x4kGg=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 2,
@@ -179,7 +179,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "urCm_V5Qsz0",
+          "id": "8wXIKNz6u_8",
           "locality": "private"
         },
         "netflow": {
@@ -233,7 +233,7 @@
         },
         "network": {
           "bytes": 1541,
-          "community_id": "1:VtyB9RHgAkNqVk0mIUunFcpOSfk=",
+          "community_id": "1:vKHRCBsu01Bj9xGu84I60+x4kGg=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 2,

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Nokia-BRAS.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Nokia-BRAS.golden.json
@@ -17,7 +17,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "VHOuRvMCrLs",
+          "id": "aVnWxMM8qxI",
           "locality": "private"
         },
         "netflow": {
@@ -42,7 +42,7 @@
           "type": "netflow_flow"
         },
         "network": {
-          "community_id": "1:JOQeKrnZDhP8AqJv8DtyiRwHnek=",
+          "community_id": "1:WBN/ZleczX2flsJWsHfNA7w+NGg=",
           "direction": "unknown",
           "iana_number": 6,
           "transport": "tcp"

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-OpenBSD-pflow.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-OpenBSD-pflow.golden.json
@@ -17,7 +17,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "2h9znuMUydg",
+          "id": "_dzJqQAoWYk",
           "locality": "private"
         },
         "netflow": {
@@ -44,7 +44,7 @@
         },
         "network": {
           "bytes": 373,
-          "community_id": "1:UJAZQmO+yNpnLE1k+ZOTE4hajps=",
+          "community_id": "1:kRyrwhpDMtm6dZyLIZd9TKwNaw4=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 7,
@@ -77,7 +77,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "C82X98Ss6VM",
+          "id": "_dzJqQAoWYk",
           "locality": "private"
         },
         "netflow": {
@@ -104,7 +104,7 @@
         },
         "network": {
           "bytes": 6634,
-          "community_id": "1:UqXVzZedUC3xywY5ipESqIoQsEo=",
+          "community_id": "1:kRyrwhpDMtm6dZyLIZd9TKwNaw4=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 8,
@@ -137,7 +137,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "a2WjJB6_nU0",
+          "id": "iSYE82PBcbQ",
           "locality": "private"
         },
         "netflow": {
@@ -164,7 +164,7 @@
         },
         "network": {
           "bytes": 453,
-          "community_id": "1:0ISi0EM/A6gaKAZZqNA4s0Mg7yU=",
+          "community_id": "1:smEk2vYDQSrIiSeS8YpPeZZRDkI=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 9,
@@ -197,7 +197,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "m58nw4UHNJY",
+          "id": "iSYE82PBcbQ",
           "locality": "private"
         },
         "netflow": {
@@ -224,7 +224,7 @@
         },
         "network": {
           "bytes": 10893,
-          "community_id": "1:glKlzvj2Hw5JD4VDyjboFxA0jMs=",
+          "community_id": "1:smEk2vYDQSrIiSeS8YpPeZZRDkI=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 11,
@@ -257,7 +257,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "a2WjJB6_nU0",
+          "id": "iSYE82PBcbQ",
           "locality": "private"
         },
         "netflow": {
@@ -284,7 +284,7 @@
         },
         "network": {
           "bytes": 453,
-          "community_id": "1:0ISi0EM/A6gaKAZZqNA4s0Mg7yU=",
+          "community_id": "1:smEk2vYDQSrIiSeS8YpPeZZRDkI=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 9,
@@ -317,7 +317,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "m58nw4UHNJY",
+          "id": "iSYE82PBcbQ",
           "locality": "private"
         },
         "netflow": {
@@ -344,7 +344,7 @@
         },
         "network": {
           "bytes": 10893,
-          "community_id": "1:glKlzvj2Hw5JD4VDyjboFxA0jMs=",
+          "community_id": "1:smEk2vYDQSrIiSeS8YpPeZZRDkI=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 11,
@@ -377,7 +377,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "7dX_2AbqEVc",
+          "id": "L_N7tNeOZwc",
           "locality": "private"
         },
         "netflow": {
@@ -404,7 +404,7 @@
         },
         "network": {
           "bytes": 373,
-          "community_id": "1:sqB23dG2s8pdp8UJ3tDiPppa1IU=",
+          "community_id": "1:zsYqw4TFjuNp89C5d7QHyhWZN7g=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 7,
@@ -437,7 +437,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "n2aEU3BSI4E",
+          "id": "L_N7tNeOZwc",
           "locality": "private"
         },
         "netflow": {
@@ -464,7 +464,7 @@
         },
         "network": {
           "bytes": 6780,
-          "community_id": "1:a/hRDAyfEZg4KZOTAdJv3xeDwgQ=",
+          "community_id": "1:zsYqw4TFjuNp89C5d7QHyhWZN7g=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 8,
@@ -497,7 +497,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "7dX_2AbqEVc",
+          "id": "L_N7tNeOZwc",
           "locality": "private"
         },
         "netflow": {
@@ -524,7 +524,7 @@
         },
         "network": {
           "bytes": 373,
-          "community_id": "1:sqB23dG2s8pdp8UJ3tDiPppa1IU=",
+          "community_id": "1:zsYqw4TFjuNp89C5d7QHyhWZN7g=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 7,
@@ -557,7 +557,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "n2aEU3BSI4E",
+          "id": "L_N7tNeOZwc",
           "locality": "private"
         },
         "netflow": {
@@ -584,7 +584,7 @@
         },
         "network": {
           "bytes": 6780,
-          "community_id": "1:a/hRDAyfEZg4KZOTAdJv3xeDwgQ=",
+          "community_id": "1:zsYqw4TFjuNp89C5d7QHyhWZN7g=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 8,
@@ -617,7 +617,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "cKtQJlqfWKs",
+          "id": "Dsp4RZAzcPQ",
           "locality": "private"
         },
         "netflow": {
@@ -644,7 +644,7 @@
         },
         "network": {
           "bytes": 373,
-          "community_id": "1:yiSn+h79Umz3bFmTmeESFhm5404=",
+          "community_id": "1:/JSyWJaYnu0LK3Kp4u7M+1swKeg=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 7,
@@ -677,7 +677,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "MguWi5iQ0x8",
+          "id": "Dsp4RZAzcPQ",
           "locality": "private"
         },
         "netflow": {
@@ -704,7 +704,7 @@
         },
         "network": {
           "bytes": 7319,
-          "community_id": "1:vZF2uyiEOE/tq2ixGkt58g4TzYE=",
+          "community_id": "1:/JSyWJaYnu0LK3Kp4u7M+1swKeg=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 9,
@@ -737,7 +737,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "cKtQJlqfWKs",
+          "id": "Dsp4RZAzcPQ",
           "locality": "private"
         },
         "netflow": {
@@ -764,7 +764,7 @@
         },
         "network": {
           "bytes": 373,
-          "community_id": "1:yiSn+h79Umz3bFmTmeESFhm5404=",
+          "community_id": "1:/JSyWJaYnu0LK3Kp4u7M+1swKeg=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 7,
@@ -797,7 +797,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "MguWi5iQ0x8",
+          "id": "Dsp4RZAzcPQ",
           "locality": "private"
         },
         "netflow": {
@@ -824,7 +824,7 @@
         },
         "network": {
           "bytes": 7319,
-          "community_id": "1:vZF2uyiEOE/tq2ixGkt58g4TzYE=",
+          "community_id": "1:/JSyWJaYnu0LK3Kp4u7M+1swKeg=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 9,
@@ -857,7 +857,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "_ozB47fTdyc",
+          "id": "B9Jsqhany8Q",
           "locality": "private"
         },
         "netflow": {
@@ -884,7 +884,7 @@
         },
         "network": {
           "bytes": 333,
-          "community_id": "1:rnxpvb+Sa3z3ZTUsHla872/PPNY=",
+          "community_id": "1:SvijMnTP+08D8cR3dpIWgVpuahc=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 6,
@@ -917,7 +917,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "1qsG5DGX-3k",
+          "id": "B9Jsqhany8Q",
           "locality": "private"
         },
         "netflow": {
@@ -944,7 +944,7 @@
         },
         "network": {
           "bytes": 1833,
-          "community_id": "1:h33RWeSLni6vfVlgFQBkRGQ0ZDQ=",
+          "community_id": "1:SvijMnTP+08D8cR3dpIWgVpuahc=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 5,
@@ -977,7 +977,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "_ozB47fTdyc",
+          "id": "B9Jsqhany8Q",
           "locality": "private"
         },
         "netflow": {
@@ -1004,7 +1004,7 @@
         },
         "network": {
           "bytes": 333,
-          "community_id": "1:rnxpvb+Sa3z3ZTUsHla872/PPNY=",
+          "community_id": "1:SvijMnTP+08D8cR3dpIWgVpuahc=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 6,
@@ -1037,7 +1037,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "1qsG5DGX-3k",
+          "id": "B9Jsqhany8Q",
           "locality": "private"
         },
         "netflow": {
@@ -1064,7 +1064,7 @@
         },
         "network": {
           "bytes": 1833,
-          "community_id": "1:h33RWeSLni6vfVlgFQBkRGQ0ZDQ=",
+          "community_id": "1:SvijMnTP+08D8cR3dpIWgVpuahc=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 5,
@@ -1097,7 +1097,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "nzEWA7mEeQw",
+          "id": "O7k79Py4ef0",
           "locality": "private"
         },
         "netflow": {
@@ -1124,7 +1124,7 @@
         },
         "network": {
           "bytes": 453,
-          "community_id": "1:ZpG4aa8BJ2zIJbtgKxuRmefVfLw=",
+          "community_id": "1:/Vk3fKGez62RCQgI6iMAXwRZVao=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 9,
@@ -1157,7 +1157,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "5Dss0hKgBfg",
+          "id": "O7k79Py4ef0",
           "locality": "private"
         },
         "netflow": {
@@ -1184,7 +1184,7 @@
         },
         "network": {
           "bytes": 10550,
-          "community_id": "1:VtXZCiwUjAo0CYNoq6to3RH0SDo=",
+          "community_id": "1:/Vk3fKGez62RCQgI6iMAXwRZVao=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 11,
@@ -1217,7 +1217,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "nzEWA7mEeQw",
+          "id": "O7k79Py4ef0",
           "locality": "private"
         },
         "netflow": {
@@ -1244,7 +1244,7 @@
         },
         "network": {
           "bytes": 453,
-          "community_id": "1:ZpG4aa8BJ2zIJbtgKxuRmefVfLw=",
+          "community_id": "1:/Vk3fKGez62RCQgI6iMAXwRZVao=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 9,
@@ -1277,7 +1277,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "5Dss0hKgBfg",
+          "id": "O7k79Py4ef0",
           "locality": "private"
         },
         "netflow": {
@@ -1304,7 +1304,7 @@
         },
         "network": {
           "bytes": 10550,
-          "community_id": "1:VtXZCiwUjAo0CYNoq6to3RH0SDo=",
+          "community_id": "1:/Vk3fKGez62RCQgI6iMAXwRZVao=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 11,
@@ -1337,7 +1337,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "3ZIZbhFW0h0",
+          "id": "T1etbJ4WSI0",
           "locality": "private"
         },
         "netflow": {
@@ -1364,7 +1364,7 @@
         },
         "network": {
           "bytes": 373,
-          "community_id": "1:xosr4vj7ubH8+n3LgR04NAKyTSo=",
+          "community_id": "1:lzzJ0bLmBlhJSD9tpGSy2cP4jIg=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 7,
@@ -1397,7 +1397,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "PXoRY8uUukM",
+          "id": "T1etbJ4WSI0",
           "locality": "private"
         },
         "netflow": {
@@ -1424,7 +1424,7 @@
         },
         "network": {
           "bytes": 6425,
-          "community_id": "1:FXizUy6YctpVTvg8A6VIG+Yx7+0=",
+          "community_id": "1:lzzJ0bLmBlhJSD9tpGSy2cP4jIg=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 8,
@@ -1457,7 +1457,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "3ZIZbhFW0h0",
+          "id": "T1etbJ4WSI0",
           "locality": "private"
         },
         "netflow": {
@@ -1484,7 +1484,7 @@
         },
         "network": {
           "bytes": 373,
-          "community_id": "1:xosr4vj7ubH8+n3LgR04NAKyTSo=",
+          "community_id": "1:lzzJ0bLmBlhJSD9tpGSy2cP4jIg=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 7,
@@ -1517,7 +1517,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "PXoRY8uUukM",
+          "id": "T1etbJ4WSI0",
           "locality": "private"
         },
         "netflow": {
@@ -1544,7 +1544,7 @@
         },
         "network": {
           "bytes": 6425,
-          "community_id": "1:FXizUy6YctpVTvg8A6VIG+Yx7+0=",
+          "community_id": "1:lzzJ0bLmBlhJSD9tpGSy2cP4jIg=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 8,

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Procera.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Procera.golden.json
@@ -17,7 +17,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "q-trxhRGXW0",
+          "id": "gEodlN50y4w",
           "locality": "public"
         },
         "netflow": {
@@ -54,7 +54,7 @@
           "type": "netflow_flow"
         },
         "network": {
-          "community_id": "1:pMbHu2KSX2ETGFunUYvRZUVwkDA=",
+          "community_id": "1:A32CVBRvJG9El+XUJRJpXNzEEJY=",
           "direction": "unknown",
           "iana_number": 6,
           "transport": "tcp"
@@ -155,7 +155,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "s0UY7AEXtbs",
+          "id": "qSSNfC38l0c",
           "locality": "public"
         },
         "netflow": {
@@ -192,7 +192,7 @@
           "type": "netflow_flow"
         },
         "network": {
-          "community_id": "1:K4/7oSyucHcfZAc5dWGMTB7XWGw=",
+          "community_id": "1:zC4ZLN/8rkaEyAGWB7SZsdwZbU8=",
           "direction": "unknown",
           "iana_number": 6,
           "transport": "tcp"
@@ -224,7 +224,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "r-qsT9TbSHw",
+          "id": "Tv1jmZy2vn4",
           "locality": "public"
         },
         "netflow": {
@@ -261,7 +261,7 @@
           "type": "netflow_flow"
         },
         "network": {
-          "community_id": "1:yBV3/K+LwXqfvm3nlYaqIPtS6UQ=",
+          "community_id": "1:JtAapjcKxopGbt4rPXZuNEkoRv8=",
           "direction": "unknown",
           "iana_number": 1,
           "transport": "icmp"
@@ -362,7 +362,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "dF2yRC2ldzk",
+          "id": "JhEHWMX5XwI",
           "locality": "public"
         },
         "netflow": {
@@ -399,7 +399,7 @@
           "type": "netflow_flow"
         },
         "network": {
-          "community_id": "1:/Nqnh+qS63xOcLeH1LsIVNCCpvc=",
+          "community_id": "1:GY1mBBTSNtzeOvb8SNjfw0N/cdk=",
           "direction": "unknown",
           "iana_number": 6,
           "transport": "tcp"
@@ -431,7 +431,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "Nv4c6iSK_5U",
+          "id": "Q_zyIhDZuIo",
           "locality": "public"
         },
         "netflow": {
@@ -468,7 +468,7 @@
           "type": "netflow_flow"
         },
         "network": {
-          "community_id": "1:3qkFUQpCFoQLLRqciw3v0aXVkvk=",
+          "community_id": "1:Xy/0zLI0aRilmkxj3qiB2MT4W1g=",
           "direction": "unknown",
           "iana_number": 6,
           "transport": "tcp"
@@ -500,7 +500,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "PhIIQeuDikc",
+          "id": "pNMKY7O9aVc",
           "locality": "public"
         },
         "netflow": {
@@ -537,7 +537,7 @@
           "type": "netflow_flow"
         },
         "network": {
-          "community_id": "1:v9ASezXn5L0vAVcmj8jxybrYJ6I=",
+          "community_id": "1:dIK+X6e3IIFTqsUMuGz9lAG8Ag8=",
           "direction": "unknown",
           "iana_number": 6,
           "transport": "tcp"

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-VMware-virtual-distributed-switch.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-VMware-virtual-distributed-switch.golden.json
@@ -17,7 +17,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "p2ZChbTH1YU",
+          "id": "-Sv1di8xiKE",
           "locality": "private"
         },
         "netflow": {
@@ -53,7 +53,7 @@
         },
         "network": {
           "bytes": 100,
-          "community_id": "1:Rs7Lnh/lOTiJTtqZqBdEOBbKchs=",
+          "community_id": "1:N7jRolYdcCZxQlKUzhCPw7zSQS0=",
           "direction": "outbound",
           "iana_number": 6,
           "packets": 2,
@@ -86,7 +86,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "J4VOqDnsqno",
+          "id": "OQCLJ5IN83c",
           "locality": "private"
         },
         "netflow": {
@@ -122,7 +122,7 @@
         },
         "network": {
           "bytes": 229,
-          "community_id": "1:dfYpWxplvmUP34MWL1A0xpN2SRw=",
+          "community_id": "1:yfsv6D0WSefvSi1u8ktASD/D4MU=",
           "direction": "outbound",
           "iana_number": 17,
           "packets": 1,
@@ -155,7 +155,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "J4VOqDnsqno",
+          "id": "OQCLJ5IN83c",
           "locality": "private"
         },
         "netflow": {
@@ -191,7 +191,7 @@
         },
         "network": {
           "bytes": 229,
-          "community_id": "1:dfYpWxplvmUP34MWL1A0xpN2SRw=",
+          "community_id": "1:yfsv6D0WSefvSi1u8ktASD/D4MU=",
           "direction": "outbound",
           "iana_number": 17,
           "packets": 1,
@@ -224,7 +224,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "iPG_hIy8oDM",
+          "id": "xcyYrM-QBl0",
           "locality": "private"
         },
         "netflow": {
@@ -260,7 +260,7 @@
         },
         "network": {
           "bytes": 104,
-          "community_id": "1:ZPVVwcy+Kfw9UUtwR8lyWYv8htU=",
+          "community_id": "1:LDWJP/qvMM9zo06ETUUG64DZWhY=",
           "direction": "outbound",
           "iana_number": 17,
           "packets": 2,

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-YAF-basic-with-applabel.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-YAF-basic-with-applabel.golden.json
@@ -19,7 +19,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "_tbAAnwoAu8",
+          "id": "QMH_S2K9KdI",
           "locality": "private"
         },
         "netflow": {
@@ -54,7 +54,7 @@
         },
         "network": {
           "bytes": 532,
-          "community_id": "1:gQfwC1pqdEJoyqjxe8la2a1bW6g=",
+          "community_id": "1:3NQ+f2IICsvUP3F8oQM9Js9FO6Q=",
           "direction": "unknown",
           "iana_number": 17,
           "packets": 6,
@@ -91,7 +91,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "qznEzwF6uiM",
+          "id": "YlvEOsG0NHc",
           "locality": "private"
         },
         "netflow": {
@@ -132,7 +132,7 @@
         },
         "network": {
           "bytes": 356,
-          "community_id": "1:/MUy9fW9u7vMDGqxcZLVrZX0ARU=",
+          "community_id": "1:H1pHO7CtjIP7Q5Rljq4l4EH1wf4=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 8,

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-configured-with-include_flowset_id.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-configured-with-include_flowset_id.golden.json
@@ -17,7 +17,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "urCm_V5Qsz0",
+          "id": "8wXIKNz6u_8",
           "locality": "private"
         },
         "netflow": {
@@ -71,7 +71,7 @@
         },
         "network": {
           "bytes": 40,
-          "community_id": "1:VtyB9RHgAkNqVk0mIUunFcpOSfk=",
+          "community_id": "1:vKHRCBsu01Bj9xGu84I60+x4kGg=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 1,
@@ -104,7 +104,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "1fCxVMA_rD0",
+          "id": "8wXIKNz6u_8",
           "locality": "private"
         },
         "netflow": {
@@ -146,7 +146,7 @@
         },
         "network": {
           "bytes": 1525,
-          "community_id": "1:mUmoe1yk2N8K21TGbG3DxjqkRYg=",
+          "community_id": "1:vKHRCBsu01Bj9xGu84I60+x4kGg=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 2,
@@ -179,7 +179,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "urCm_V5Qsz0",
+          "id": "8wXIKNz6u_8",
           "locality": "private"
         },
         "netflow": {
@@ -233,7 +233,7 @@
         },
         "network": {
           "bytes": 1541,
-          "community_id": "1:VtyB9RHgAkNqVk0mIUunFcpOSfk=",
+          "community_id": "1:vKHRCBsu01Bj9xGu84I60+x4kGg=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 2,

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-vIPtela-with-VPN-id.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-vIPtela-with-VPN-id.golden.json
@@ -17,7 +17,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "5qh7ipMbBV0",
+          "id": "dO-Anbp9xpw",
           "locality": "private"
         },
         "netflow": {
@@ -56,7 +56,7 @@
         },
         "network": {
           "bytes": 775,
-          "community_id": "1:+fvsmN9SnAg8yt/KBn6yA19IrXE=",
+          "community_id": "1:uhU0lSQQ+LoAMve6GxHC0M3nIes=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 8,

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX.golden.json
@@ -52,7 +52,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "5dY_LIjk4jM",
+          "id": "ofdVXz7_x6E",
           "locality": "private"
         },
         "netflow": {
@@ -83,7 +83,7 @@
         },
         "network": {
           "bytes": 260,
-          "community_id": "1:5zkwPg6j1HR922PEK8GyaxzrFwQ=",
+          "community_id": "1:6pzReSc2/Mtd0o91uM5DmacQb0M=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 5,
@@ -116,7 +116,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "D9c6mFRsdDc",
+          "id": "ofdVXz7_x6E",
           "locality": "private"
         },
         "netflow": {
@@ -147,7 +147,7 @@
         },
         "network": {
           "bytes": 1000,
-          "community_id": "1:US3awEhv6suG72vxm+M1HkgqctM=",
+          "community_id": "1:6pzReSc2/Mtd0o91uM5DmacQb0M=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 6,
@@ -180,7 +180,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "Htn9CGiiIcE",
+          "id": "ztL93_3GZNs",
           "locality": "private"
         },
         "netflow": {
@@ -211,7 +211,7 @@
         },
         "network": {
           "bytes": 601,
-          "community_id": "1:ASd6tw0cxo+COe02J7RUWx1Zpz0=",
+          "community_id": "1:cmEHBNcVowAg9a6vEA2mT6qdaEY=",
           "direction": "unknown",
           "iana_number": 17,
           "packets": 2,
@@ -244,7 +244,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "zasoUAZZ0VY",
+          "id": "ztL93_3GZNs",
           "locality": "private"
         },
         "netflow": {
@@ -275,7 +275,7 @@
         },
         "network": {
           "bytes": 148,
-          "community_id": "1:wys1qTextK4PoWX8LNF3Ftn2XGU=",
+          "community_id": "1:cmEHBNcVowAg9a6vEA2mT6qdaEY=",
           "direction": "unknown",
           "iana_number": 17,
           "packets": 2,
@@ -308,7 +308,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "S1-OrWp2NPk",
+          "id": "VANFUe1rklc",
           "locality": "public"
         },
         "netflow": {
@@ -339,7 +339,7 @@
         },
         "network": {
           "bytes": 5946,
-          "community_id": "1:l7BnKMlyrD4MPxU3tD15rivudaU=",
+          "community_id": "1:fXim87AxDxTnzBecrylQnaOWwXs=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 14,
@@ -372,8 +372,8 @@
           "kind": "event"
         },
         "flow": {
-          "id": "KbgtQk9RbTg",
-          "locality": "private"
+          "id": "VANFUe1rklc",
+          "locality": "public"
         },
         "netflow": {
           "destination_ipv4_address": "54.214.9.161",
@@ -403,7 +403,7 @@
         },
         "network": {
           "bytes": 2608,
-          "community_id": "1:LHK7P1y0Hk2e91GsVeb/Y2Ka9x4=",
+          "community_id": "1:fXim87AxDxTnzBecrylQnaOWwXs=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 13,
@@ -436,7 +436,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "aMDg_zpGiEg",
+          "id": "iDHwMSG6faQ",
           "locality": "private"
         },
         "netflow": {
@@ -467,7 +467,7 @@
         },
         "network": {
           "bytes": 60,
-          "community_id": "1:3JM19rLv8Up/ifiBcncNv9+u1ac=",
+          "community_id": "1:TGQXQoBV0v/a8jfzOG4MA7lX628=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 1,
@@ -500,7 +500,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "5dY_LIjk4jM",
+          "id": "ofdVXz7_x6E",
           "locality": "private"
         },
         "netflow": {
@@ -531,7 +531,7 @@
         },
         "network": {
           "bytes": 256,
-          "community_id": "1:5zkwPg6j1HR922PEK8GyaxzrFwQ=",
+          "community_id": "1:6pzReSc2/Mtd0o91uM5DmacQb0M=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 4,
@@ -564,7 +564,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "D9c6mFRsdDc",
+          "id": "ofdVXz7_x6E",
           "locality": "private"
         },
         "netflow": {
@@ -595,7 +595,7 @@
         },
         "network": {
           "bytes": 1916,
-          "community_id": "1:US3awEhv6suG72vxm+M1HkgqctM=",
+          "community_id": "1:6pzReSc2/Mtd0o91uM5DmacQb0M=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 3,
@@ -628,7 +628,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "5rzmeAVHDXo",
+          "id": "WgPN9s2D0jg",
           "locality": "private"
         },
         "netflow": {
@@ -659,7 +659,7 @@
         },
         "network": {
           "bytes": 168,
-          "community_id": "1:Qil1AUeHYTzgVk9ced1uu+tH7xQ=",
+          "community_id": "1:+Mf5R/ZcHy8l33HQh7MUdj1QlUE=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 2,
@@ -692,7 +692,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "yZq2BehxSew",
+          "id": "WgPN9s2D0jg",
           "locality": "private"
         },
         "netflow": {
@@ -723,7 +723,7 @@
         },
         "network": {
           "bytes": 84,
-          "community_id": "1:0XgIQvzxYzeiJ3zUXDK29zsihcI=",
+          "community_id": "1:+Mf5R/ZcHy8l33HQh7MUdj1QlUE=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 1,
@@ -756,7 +756,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "Ft-4Om5rIsk",
+          "id": "PSMPOofjjVU",
           "locality": "private"
         },
         "netflow": {
@@ -787,7 +787,7 @@
         },
         "network": {
           "bytes": 232,
-          "community_id": "1:l3uSgEhzehRFeZ+njR5WuFsGEr8=",
+          "community_id": "1:nyhq/ntQBZPAPfKLfPLpg31+JBs=",
           "direction": "unknown",
           "iana_number": 17,
           "packets": 1,

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-1941-K9-release-15.1.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-1941-K9-release-15.1.golden.json
@@ -17,8 +17,8 @@
           "kind": "event"
         },
         "flow": {
-          "id": "tNbQulf11TU",
-          "locality": "private"
+          "id": "BPlkuHwo9sU",
+          "locality": "public"
         },
         "netflow": {
           "application_id": "BQAASA==",
@@ -47,7 +47,7 @@
         },
         "network": {
           "bytes": 75,
-          "community_id": "1:bRyQGyObIc1D2o7DkHSOKH8tsio=",
+          "community_id": "1:Q0JWoL0pSyHJDJxF9+6Nqpnqn3I=",
           "direction": "inbound",
           "iana_number": 17,
           "packets": 1,
@@ -81,8 +81,8 @@
           "kind": "event"
         },
         "flow": {
-          "id": "wplOqUGEvng",
-          "locality": "private"
+          "id": "-PhJhHv5gvE",
+          "locality": "public"
         },
         "netflow": {
           "application_id": "BQAASA==",
@@ -111,7 +111,7 @@
         },
         "network": {
           "bytes": 75,
-          "community_id": "1:wbdTe6mwksAQ9lGcVDaWyoOTmhk=",
+          "community_id": "1:ixp5Xp0pUmGBy18PlAIUAecp4n4=",
           "direction": "inbound",
           "iana_number": 17,
           "packets": 1,
@@ -145,8 +145,8 @@
           "kind": "event"
         },
         "flow": {
-          "id": "MGp1pcAULtY",
-          "locality": "private"
+          "id": "zTrEnrxMnjo",
+          "locality": "public"
         },
         "netflow": {
           "application_id": "BQAASA==",
@@ -175,7 +175,7 @@
         },
         "network": {
           "bytes": 75,
-          "community_id": "1:jP1p/7/u4HsUidwYdywfdEpcPKQ=",
+          "community_id": "1:uuaH/p8dMr2C7F6OvG7QTwKafoI=",
           "direction": "inbound",
           "iana_number": 17,
           "packets": 1,
@@ -209,8 +209,8 @@
           "kind": "event"
         },
         "flow": {
-          "id": "BVWdRT29zFQ",
-          "locality": "private"
+          "id": "G4AVpSxBAVo",
+          "locality": "public"
         },
         "netflow": {
           "application_id": "BQAASA==",
@@ -239,7 +239,7 @@
         },
         "network": {
           "bytes": 75,
-          "community_id": "1:kKLFvXJJaQi9kI42KQJ2v2corCE=",
+          "community_id": "1:cN6L1398Z+/E9YhZhQQEXXzKWfI=",
           "direction": "inbound",
           "iana_number": 17,
           "packets": 1,
@@ -273,7 +273,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "yT-AD8ZRSJo",
+          "id": "2nQmjOOzSH0",
           "locality": "public"
         },
         "netflow": {
@@ -303,7 +303,7 @@
         },
         "network": {
           "bytes": 964,
-          "community_id": "1:34znV7gBt2utWJHrTSPMwhTz2Eg=",
+          "community_id": "1:Hi/9p/anXVpWlMC/6/k3Zr9I1to=",
           "direction": "outbound",
           "iana_number": 6,
           "packets": 10,
@@ -337,8 +337,8 @@
           "kind": "event"
         },
         "flow": {
-          "id": "hxO6SQDKQVY",
-          "locality": "private"
+          "id": "z7uHiA5SrD0",
+          "locality": "public"
         },
         "netflow": {
           "application_id": "BQAAQg==",
@@ -367,7 +367,7 @@
         },
         "network": {
           "bytes": 2748,
-          "community_id": "1:iXnrRyr8wo26XN0Ph22X++rTZeo=",
+          "community_id": "1:qgStw7dQK+Tl0+hQK5Uq9q42HEM=",
           "direction": "inbound",
           "iana_number": 17,
           "packets": 8,
@@ -401,7 +401,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "0-orkNwXKfY",
+          "id": "z7uHiA5SrD0",
           "locality": "public"
         },
         "netflow": {
@@ -431,7 +431,7 @@
         },
         "network": {
           "bytes": 2023,
-          "community_id": "1:HD2M0NX2rS6y8B3MY+Iwv+XHRRI=",
+          "community_id": "1:qgStw7dQK+Tl0+hQK5Uq9q42HEM=",
           "direction": "outbound",
           "iana_number": 17,
           "packets": 9,
@@ -465,8 +465,8 @@
           "kind": "event"
         },
         "flow": {
-          "id": "wlxoX3Rml10",
-          "locality": "private"
+          "id": "eyNcUtWu34I",
+          "locality": "public"
         },
         "netflow": {
           "application_id": "BQAAAQ==",
@@ -495,7 +495,7 @@
         },
         "network": {
           "bytes": 2180,
-          "community_id": "1:uCD3Q6u5DuWp4BBrNuh08puZY6U=",
+          "community_id": "1:qby1BSw4pTWxwlh6xrXkVFUjmW0=",
           "direction": "inbound",
           "iana_number": 6,
           "packets": 9,
@@ -529,7 +529,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "Em0tsl0c_AI",
+          "id": "eyNcUtWu34I",
           "locality": "public"
         },
         "netflow": {
@@ -559,7 +559,7 @@
         },
         "network": {
           "bytes": 700,
-          "community_id": "1:pbgT4RHa3Pkj4VUsV2ZuAXb7NJc=",
+          "community_id": "1:qby1BSw4pTWxwlh6xrXkVFUjmW0=",
           "direction": "outbound",
           "iana_number": 6,
           "packets": 9,
@@ -593,7 +593,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "XDiXRMEwAoI",
+          "id": "i7e4W23LBGg",
           "locality": "public"
         },
         "netflow": {
@@ -623,7 +623,7 @@
         },
         "network": {
           "bytes": 161,
-          "community_id": "1:3UJAXfwRkrqnjorLTDfwA2lIK5o=",
+          "community_id": "1:TbEdA3tLJqC2kZYCOR3uLDsO9Zs=",
           "direction": "outbound",
           "iana_number": 6,
           "packets": 2,
@@ -657,8 +657,8 @@
           "kind": "event"
         },
         "flow": {
-          "id": "GyvkHwTpOVU",
-          "locality": "private"
+          "id": "ALOJ32qLh_s",
+          "locality": "public"
         },
         "netflow": {
           "application_id": "BQAAEA==",
@@ -687,7 +687,7 @@
         },
         "network": {
           "bytes": 1764,
-          "community_id": "1:mshcMglow3GUvCItk1pK74FLkzM=",
+          "community_id": "1:k+G++HkZbxWsJmSxiwjNGauDdMo=",
           "direction": "inbound",
           "iana_number": 6,
           "packets": 21,
@@ -721,7 +721,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "IKnO36OYWBE",
+          "id": "h9s7TXaoMZw",
           "locality": "public"
         },
         "netflow": {
@@ -751,7 +751,7 @@
         },
         "network": {
           "bytes": 13811,
-          "community_id": "1:sCy/9s7UF0Bv1dEJGaPKptRstZA=",
+          "community_id": "1:/IDNcRrgXRDN+hVYssIa2UWNFFc=",
           "direction": "outbound",
           "iana_number": 6,
           "packets": 30,
@@ -785,7 +785,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "l6f_GDBq5e4",
+          "id": "ALOJ32qLh_s",
           "locality": "public"
         },
         "netflow": {
@@ -815,7 +815,7 @@
         },
         "network": {
           "bytes": 4717,
-          "community_id": "1:zoZ7/PcKboOk3QEq0Jc4k12H7AI=",
+          "community_id": "1:k+G++HkZbxWsJmSxiwjNGauDdMo=",
           "direction": "outbound",
           "iana_number": 6,
           "packets": 16,
@@ -849,8 +849,8 @@
           "kind": "event"
         },
         "flow": {
-          "id": "xSntjtbHvZ8",
-          "locality": "private"
+          "id": "2GPS5gJiF8g",
+          "locality": "public"
         },
         "netflow": {
           "application_id": "BQAAEA==",
@@ -879,7 +879,7 @@
         },
         "network": {
           "bytes": 2419,
-          "community_id": "1:m9W66mSxsAZlmvM70NmJT4nlrkk=",
+          "community_id": "1:oFTpsIQUx9tiU/r2SmwlsJKnuus=",
           "direction": "inbound",
           "iana_number": 6,
           "packets": 13,
@@ -913,7 +913,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "7ZMa49AANa4",
+          "id": "2GPS5gJiF8g",
           "locality": "public"
         },
         "netflow": {
@@ -943,7 +943,7 @@
         },
         "network": {
           "bytes": 5551,
-          "community_id": "1:GIrBDC9vXe7Zm4DMPiPtmJVTls4=",
+          "community_id": "1:oFTpsIQUx9tiU/r2SmwlsJKnuus=",
           "direction": "outbound",
           "iana_number": 6,
           "packets": 10,
@@ -977,7 +977,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "TanHDUIaXUc",
+          "id": "ughO0a0lrBw",
           "locality": "public"
         },
         "netflow": {
@@ -1007,7 +1007,7 @@
         },
         "network": {
           "bytes": 187,
-          "community_id": "1:P9h6YFje9lqATAkmHYS9HVVWzFY=",
+          "community_id": "1:lWK6ttJ9rWv8JtxbOL3hnjCMNMU=",
           "direction": "outbound",
           "iana_number": 6,
           "packets": 3,
@@ -1041,8 +1041,8 @@
           "kind": "event"
         },
         "flow": {
-          "id": "6udpjf64Fpg",
-          "locality": "private"
+          "id": "ughO0a0lrBw",
+          "locality": "public"
         },
         "netflow": {
           "application_id": "BQAAEA==",
@@ -1071,7 +1071,7 @@
         },
         "network": {
           "bytes": 104,
-          "community_id": "1:nJc3Pe5SE+C0yRtf3IBstM2/wf8=",
+          "community_id": "1:lWK6ttJ9rWv8JtxbOL3hnjCMNMU=",
           "direction": "inbound",
           "iana_number": 6,
           "packets": 2,
@@ -1105,8 +1105,8 @@
           "kind": "event"
         },
         "flow": {
-          "id": "zT9kcrkDd6s",
-          "locality": "private"
+          "id": "Ie4W_7Snl8w",
+          "locality": "public"
         },
         "netflow": {
           "application_id": "BQAAAQ==",
@@ -1135,7 +1135,7 @@
         },
         "network": {
           "bytes": 4050,
-          "community_id": "1:O5rmXSFSnlff9/cA9+155LFPgBM=",
+          "community_id": "1:6p8Cv/jo8TMJvy1G2nAPs9x6DFk=",
           "direction": "inbound",
           "iana_number": 6,
           "packets": 72,
@@ -1169,7 +1169,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "lSjcB0XXRjo",
+          "id": "Ie4W_7Snl8w",
           "locality": "public"
         },
         "netflow": {
@@ -1199,7 +1199,7 @@
         },
         "network": {
           "bytes": 3719,
-          "community_id": "1:nVIdFfXErPGzJhGjTgW3gNk911I=",
+          "community_id": "1:6p8Cv/jo8TMJvy1G2nAPs9x6DFk=",
           "direction": "outbound",
           "iana_number": 6,
           "packets": 72,
@@ -1233,8 +1233,8 @@
           "kind": "event"
         },
         "flow": {
-          "id": "ib00xbCp9fc",
-          "locality": "private"
+          "id": "yokq763qB0U",
+          "locality": "public"
         },
         "netflow": {
           "application_id": "BQAAEA==",
@@ -1263,7 +1263,7 @@
         },
         "network": {
           "bytes": 1402,
-          "community_id": "1:90Ag0hFjWyN3t7gH9CqeM/did5s=",
+          "community_id": "1:9vhQhoWddOoV+A74fuYIGy8zA54=",
           "direction": "inbound",
           "iana_number": 6,
           "packets": 16,
@@ -1297,8 +1297,8 @@
           "kind": "event"
         },
         "flow": {
-          "id": "KkgiVld-pKQ",
-          "locality": "private"
+          "id": "DCY-5ocv9ik",
+          "locality": "public"
         },
         "netflow": {
           "application_id": "BQAAEA==",
@@ -1327,7 +1327,7 @@
         },
         "network": {
           "bytes": 1538,
-          "community_id": "1:NFDWVYhuGdQEmetBlCYqKsa3FxE=",
+          "community_id": "1:hbJVG+ljKDlDBqE4TqstvyId5+U=",
           "direction": "inbound",
           "iana_number": 6,
           "packets": 17,
@@ -1361,7 +1361,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "O105la3nsXk",
+          "id": "DCY-5ocv9ik",
           "locality": "public"
         },
         "netflow": {
@@ -1391,7 +1391,7 @@
         },
         "network": {
           "bytes": 13002,
-          "community_id": "1:e26MIMDFVFBLLY7E0XTRE10o3Kw=",
+          "community_id": "1:hbJVG+ljKDlDBqE4TqstvyId5+U=",
           "direction": "outbound",
           "iana_number": 6,
           "packets": 14,
@@ -1425,7 +1425,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "zN13t8qHEGY",
+          "id": "B7rjR_940zU",
           "locality": "public"
         },
         "netflow": {
@@ -1455,7 +1455,7 @@
         },
         "network": {
           "bytes": 1194,
-          "community_id": "1:WFh30fi4saQVTIGUy+aRRPLprpI=",
+          "community_id": "1:usm9s48ZKXop7u60nquyl3OGGmU=",
           "direction": "outbound",
           "iana_number": 6,
           "packets": 4,
@@ -1489,8 +1489,8 @@
           "kind": "event"
         },
         "flow": {
-          "id": "jhDgPTAZ-Pc",
-          "locality": "private"
+          "id": "B7rjR_940zU",
+          "locality": "public"
         },
         "netflow": {
           "application_id": "BQAAEA==",
@@ -1519,7 +1519,7 @@
         },
         "network": {
           "bytes": 682,
-          "community_id": "1:ZGG4Abe/Pqdj+7pSlunbDP7c/m4=",
+          "community_id": "1:usm9s48ZKXop7u60nquyl3OGGmU=",
           "direction": "inbound",
           "iana_number": 6,
           "packets": 2,
@@ -1553,8 +1553,8 @@
           "kind": "event"
         },
         "flow": {
-          "id": "e12qk7vuXjM",
-          "locality": "private"
+          "id": "0RrmR_QtH34",
+          "locality": "public"
         },
         "netflow": {
           "application_id": "BQAAEA==",
@@ -1583,7 +1583,7 @@
         },
         "network": {
           "bytes": 1804,
-          "community_id": "1:baiOQuB0TgMwKAioqCp4nnOKOoQ=",
+          "community_id": "1:/jxDWhvRG2nr/ht0LPbgCBQrKOo=",
           "direction": "inbound",
           "iana_number": 6,
           "packets": 11,
@@ -1617,7 +1617,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "98RPS4e6CzA",
+          "id": "O1-Y9rjVH2A",
           "locality": "public"
         },
         "netflow": {
@@ -1647,7 +1647,7 @@
         },
         "network": {
           "bytes": 4774,
-          "community_id": "1:kNqglsjDg0pb/geatAIkiyIYjyE=",
+          "community_id": "1:ubJyGYO3ADUgo0t/BtTgdjnF4fk=",
           "direction": "outbound",
           "iana_number": 6,
           "packets": 9,
@@ -1681,8 +1681,8 @@
           "kind": "event"
         },
         "flow": {
-          "id": "A34Tj8bruZ4",
-          "locality": "private"
+          "id": "CtFBGbTcLpg",
+          "locality": "public"
         },
         "netflow": {
           "application_id": "BQAAAQ==",
@@ -1711,7 +1711,7 @@
         },
         "network": {
           "bytes": 135,
-          "community_id": "1:G9f5HTVvI5bDlLshQnVxCbSm9eE=",
+          "community_id": "1:q44LzNKb1dp9tu+LzQFSpppE8Gg=",
           "direction": "inbound",
           "iana_number": 6,
           "packets": 2,
@@ -1745,7 +1745,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "uz-rc_F3l2I",
+          "id": "CtFBGbTcLpg",
           "locality": "public"
         },
         "netflow": {
@@ -1775,7 +1775,7 @@
         },
         "network": {
           "bytes": 135,
-          "community_id": "1:F6zH8IWQqM0vi7PdOT+JZyFBYeA=",
+          "community_id": "1:q44LzNKb1dp9tu+LzQFSpppE8Gg=",
           "direction": "outbound",
           "iana_number": 6,
           "packets": 2,
@@ -1809,8 +1809,8 @@
           "kind": "event"
         },
         "flow": {
-          "id": "NXlrUC3DXDQ",
-          "locality": "private"
+          "id": "lT_guTKc7y4",
+          "locality": "public"
         },
         "netflow": {
           "application_id": "BQAAAQ==",
@@ -1839,7 +1839,7 @@
         },
         "network": {
           "bytes": 194,
-          "community_id": "1:+Xmm3JdD6oj+iaOxonwDPgB2lVY=",
+          "community_id": "1:e0AnW/lunIiMyNSi9fNN7W5p7Bg=",
           "direction": "inbound",
           "iana_number": 6,
           "packets": 3,

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-ASA-2.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-ASA-2.golden.json
@@ -17,7 +17,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "4FwX8zOnzn4",
+          "id": "UTkRrDbrhnI",
           "locality": "private"
         },
         "netflow": {
@@ -50,7 +50,7 @@
           "type": "netflow_flow"
         },
         "network": {
-          "community_id": "1:I8h+Rnj88f03jgEHLyfcKOzLI6M=",
+          "community_id": "1:XaNCBbXLPvRPq4YmlYj+3C8LbyE=",
           "direction": "unknown",
           "iana_number": 6,
           "transport": "tcp"
@@ -82,7 +82,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "Ad8vSa7issI",
+          "id": "WQVc0v7217I",
           "locality": "private"
         },
         "netflow": {
@@ -115,7 +115,7 @@
           "type": "netflow_flow"
         },
         "network": {
-          "community_id": "1:mKvuBb1HFV3U0+pj/F7eH/SPOyc=",
+          "community_id": "1:ApLoUXZvqTmJTtS6gao5Sqg0kgQ=",
           "direction": "unknown",
           "iana_number": 6,
           "transport": "tcp"
@@ -147,7 +147,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "Ad8vSa7issI",
+          "id": "WQVc0v7217I",
           "locality": "private"
         },
         "netflow": {
@@ -180,7 +180,7 @@
           "type": "netflow_flow"
         },
         "network": {
-          "community_id": "1:mKvuBb1HFV3U0+pj/F7eH/SPOyc=",
+          "community_id": "1:ApLoUXZvqTmJTtS6gao5Sqg0kgQ=",
           "direction": "unknown",
           "iana_number": 6,
           "transport": "tcp"
@@ -212,7 +212,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "1W6ybGAqMAo",
+          "id": "Nle5z0FLBjA",
           "locality": "private"
         },
         "netflow": {
@@ -245,7 +245,7 @@
           "type": "netflow_flow"
         },
         "network": {
-          "community_id": "1:i5nSykRXJvquvIuEibM9evNxo8o=",
+          "community_id": "1:64faG50xtU56JMAADXSJ0Lro5iE=",
           "direction": "unknown",
           "iana_number": 6,
           "transport": "tcp"
@@ -277,7 +277,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "1W6ybGAqMAo",
+          "id": "Nle5z0FLBjA",
           "locality": "private"
         },
         "netflow": {
@@ -310,7 +310,7 @@
           "type": "netflow_flow"
         },
         "network": {
-          "community_id": "1:i5nSykRXJvquvIuEibM9evNxo8o=",
+          "community_id": "1:64faG50xtU56JMAADXSJ0Lro5iE=",
           "direction": "unknown",
           "iana_number": 6,
           "transport": "tcp"
@@ -342,7 +342,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "VQT0jF243AA",
+          "id": "lfYzCmoZgqo",
           "locality": "private"
         },
         "netflow": {
@@ -375,7 +375,7 @@
           "type": "netflow_flow"
         },
         "network": {
-          "community_id": "1:4lrT4glskPfI8xSnnz83yjpF3/8=",
+          "community_id": "1:8hx//bjfEFu4sYomYN8bh9DeMaQ=",
           "direction": "unknown",
           "iana_number": 6,
           "transport": "tcp"
@@ -407,7 +407,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "VQT0jF243AA",
+          "id": "lfYzCmoZgqo",
           "locality": "private"
         },
         "netflow": {
@@ -440,7 +440,7 @@
           "type": "netflow_flow"
         },
         "network": {
-          "community_id": "1:4lrT4glskPfI8xSnnz83yjpF3/8=",
+          "community_id": "1:8hx//bjfEFu4sYomYN8bh9DeMaQ=",
           "direction": "unknown",
           "iana_number": 6,
           "transport": "tcp"
@@ -472,7 +472,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "RA26743dDmc",
+          "id": "_9ahEyFsD94",
           "locality": "private"
         },
         "netflow": {
@@ -503,7 +503,7 @@
           "type": "netflow_flow"
         },
         "network": {
-          "community_id": "1:gbcWcUcNt3ZRqBN2uzykEEbA2+U=",
+          "community_id": "1:IZ8RrSqt8oeb2F2Rp9296zm54bc=",
           "direction": "unknown",
           "iana_number": 6,
           "transport": "tcp"
@@ -535,7 +535,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "RA26743dDmc",
+          "id": "_9ahEyFsD94",
           "locality": "private"
         },
         "netflow": {
@@ -568,7 +568,7 @@
           "type": "netflow_flow"
         },
         "network": {
-          "community_id": "1:gbcWcUcNt3ZRqBN2uzykEEbA2+U=",
+          "community_id": "1:IZ8RrSqt8oeb2F2Rp9296zm54bc=",
           "direction": "unknown",
           "iana_number": 6,
           "transport": "tcp"
@@ -600,7 +600,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "RA26743dDmc",
+          "id": "_9ahEyFsD94",
           "locality": "private"
         },
         "netflow": {
@@ -633,7 +633,7 @@
           "type": "netflow_flow"
         },
         "network": {
-          "community_id": "1:gbcWcUcNt3ZRqBN2uzykEEbA2+U=",
+          "community_id": "1:IZ8RrSqt8oeb2F2Rp9296zm54bc=",
           "direction": "unknown",
           "iana_number": 6,
           "transport": "tcp"
@@ -665,7 +665,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "bQYn_AhcGkw",
+          "id": "bnG6S7DUlEE",
           "locality": "private"
         },
         "netflow": {
@@ -696,7 +696,7 @@
           "type": "netflow_flow"
         },
         "network": {
-          "community_id": "1:dMCFJEm0lrPr+fKgCpIef5eiFLk=",
+          "community_id": "1:E1vNamQGw5X+X+vT1g7ui6Nc3O0=",
           "direction": "unknown",
           "iana_number": 6,
           "transport": "tcp"
@@ -728,7 +728,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "bQYn_AhcGkw",
+          "id": "bnG6S7DUlEE",
           "locality": "private"
         },
         "netflow": {
@@ -761,7 +761,7 @@
           "type": "netflow_flow"
         },
         "network": {
-          "community_id": "1:dMCFJEm0lrPr+fKgCpIef5eiFLk=",
+          "community_id": "1:E1vNamQGw5X+X+vT1g7ui6Nc3O0=",
           "direction": "unknown",
           "iana_number": 6,
           "transport": "tcp"
@@ -793,7 +793,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "bQYn_AhcGkw",
+          "id": "bnG6S7DUlEE",
           "locality": "private"
         },
         "netflow": {
@@ -826,7 +826,7 @@
           "type": "netflow_flow"
         },
         "network": {
-          "community_id": "1:dMCFJEm0lrPr+fKgCpIef5eiFLk=",
+          "community_id": "1:E1vNamQGw5X+X+vT1g7ui6Nc3O0=",
           "direction": "unknown",
           "iana_number": 6,
           "transport": "tcp"
@@ -858,7 +858,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "gx9XsEXj188",
+          "id": "wuMbsS0oTj4",
           "locality": "private"
         },
         "netflow": {
@@ -889,7 +889,7 @@
           "type": "netflow_flow"
         },
         "network": {
-          "community_id": "1:ehXkRqqxuigy8ra+qE/GuJchCA4=",
+          "community_id": "1:pkwcoe/zjCLerUgj+HGAwwt4wV8=",
           "direction": "unknown",
           "iana_number": 6,
           "transport": "tcp"
@@ -921,7 +921,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "gx9XsEXj188",
+          "id": "wuMbsS0oTj4",
           "locality": "private"
         },
         "netflow": {
@@ -954,7 +954,7 @@
           "type": "netflow_flow"
         },
         "network": {
-          "community_id": "1:ehXkRqqxuigy8ra+qE/GuJchCA4=",
+          "community_id": "1:pkwcoe/zjCLerUgj+HGAwwt4wV8=",
           "direction": "unknown",
           "iana_number": 6,
           "transport": "tcp"
@@ -986,7 +986,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "gx9XsEXj188",
+          "id": "wuMbsS0oTj4",
           "locality": "private"
         },
         "netflow": {
@@ -1019,7 +1019,7 @@
           "type": "netflow_flow"
         },
         "network": {
-          "community_id": "1:ehXkRqqxuigy8ra+qE/GuJchCA4=",
+          "community_id": "1:pkwcoe/zjCLerUgj+HGAwwt4wV8=",
           "direction": "unknown",
           "iana_number": 6,
           "transport": "tcp"
@@ -1051,7 +1051,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "4JJK6i2GTfU",
+          "id": "geQD5O-NWw8",
           "locality": "private"
         },
         "netflow": {
@@ -1082,7 +1082,7 @@
           "type": "netflow_flow"
         },
         "network": {
-          "community_id": "1:xKQan2kd1NgxMAX7DUOk/URZAno=",
+          "community_id": "1:35/w0D/WO1QvBp8O+Vd95Nb+tt4=",
           "direction": "unknown",
           "iana_number": 6,
           "transport": "tcp"
@@ -1114,7 +1114,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "4JJK6i2GTfU",
+          "id": "geQD5O-NWw8",
           "locality": "private"
         },
         "netflow": {
@@ -1147,7 +1147,7 @@
           "type": "netflow_flow"
         },
         "network": {
-          "community_id": "1:xKQan2kd1NgxMAX7DUOk/URZAno=",
+          "community_id": "1:35/w0D/WO1QvBp8O+Vd95Nb+tt4=",
           "direction": "unknown",
           "iana_number": 6,
           "transport": "tcp"
@@ -1179,7 +1179,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "4JJK6i2GTfU",
+          "id": "geQD5O-NWw8",
           "locality": "private"
         },
         "netflow": {
@@ -1212,7 +1212,7 @@
           "type": "netflow_flow"
         },
         "network": {
-          "community_id": "1:xKQan2kd1NgxMAX7DUOk/URZAno=",
+          "community_id": "1:35/w0D/WO1QvBp8O+Vd95Nb+tt4=",
           "direction": "unknown",
           "iana_number": 6,
           "transport": "tcp"

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-ASA.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-ASA.golden.json
@@ -17,8 +17,8 @@
           "kind": "event"
         },
         "flow": {
-          "id": "4sqHgIUNdhc",
-          "locality": "private"
+          "id": "5JpExP8VeSU",
+          "locality": "public"
         },
         "netflow": {
           "destination_ipv4_address": "2.2.2.11",
@@ -45,7 +45,7 @@
         },
         "network": {
           "bytes": 56,
-          "community_id": "1:SmwvOXNzqf078/v4Sdnv4cSsPEI=",
+          "community_id": "1:myH1DIuDZe/vHHCWbrfgfAthgew=",
           "direction": "unknown",
           "iana_number": 1,
           "transport": "icmp"
@@ -77,8 +77,8 @@
           "kind": "event"
         },
         "flow": {
-          "id": "3zooPayCX08",
-          "locality": "private"
+          "id": "MSQgezzAYh0",
+          "locality": "public"
         },
         "netflow": {
           "destination_ipv4_address": "164.164.37.11",
@@ -105,7 +105,7 @@
         },
         "network": {
           "bytes": 56,
-          "community_id": "1:ze3NNjzfiQKBNJMVnoVNEOJInGg=",
+          "community_id": "1:V7bWHU0GRcqdysY463DKjFqxvKI=",
           "direction": "unknown",
           "iana_number": 1,
           "transport": "icmp"
@@ -137,7 +137,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "rjHIoePwVUY",
+          "id": "MSQgezzAYh0",
           "locality": "public"
         },
         "netflow": {
@@ -165,7 +165,7 @@
         },
         "network": {
           "bytes": 56,
-          "community_id": "1:xvskJWklV13yhdmqo/CeIyXRtsY=",
+          "community_id": "1:2DYf0o1HOtKayoor66sl7Vub2Oo=",
           "direction": "unknown",
           "iana_number": 1,
           "transport": "icmp"
@@ -197,8 +197,8 @@
           "kind": "event"
         },
         "flow": {
-          "id": "kTUBU9vFxdg",
-          "locality": "private"
+          "id": "ioGVEAJtaEQ",
+          "locality": "public"
         },
         "netflow": {
           "destination_ipv4_address": "164.164.37.11",
@@ -225,7 +225,7 @@
         },
         "network": {
           "bytes": 56,
-          "community_id": "1:RThhKEIaevWgAeGJidFNVthplto=",
+          "community_id": "1:Zjs1q5mpf5QMXR1tU6wLZdnMtdA=",
           "direction": "unknown",
           "iana_number": 1,
           "transport": "icmp"
@@ -257,7 +257,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "xPJhkFDpNiU",
+          "id": "ioGVEAJtaEQ",
           "locality": "public"
         },
         "netflow": {
@@ -285,7 +285,7 @@
         },
         "network": {
           "bytes": 56,
-          "community_id": "1:xvskJWklV13yhdmqo/CeIyXRtsY=",
+          "community_id": "1:WNySyMxsWxABzgjoEp5ntzEwEgk=",
           "direction": "unknown",
           "iana_number": 1,
           "transport": "icmp"
@@ -317,8 +317,8 @@
           "kind": "event"
         },
         "flow": {
-          "id": "AxuXms6GBGk",
-          "locality": "private"
+          "id": "0xqELVtMeog",
+          "locality": "public"
         },
         "netflow": {
           "destination_ipv4_address": "2.2.2.11",
@@ -345,7 +345,7 @@
         },
         "network": {
           "bytes": 56,
-          "community_id": "1:u/b3SLdlsknqQeCYLejlqwSewgo=",
+          "community_id": "1:PuujUZZmIcmzKkqujVxq5IpNdeM=",
           "direction": "unknown",
           "iana_number": 1,
           "transport": "icmp"
@@ -377,7 +377,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "gFKfPBsWfLM",
+          "id": "0xqELVtMeog",
           "locality": "public"
         },
         "netflow": {
@@ -405,7 +405,7 @@
         },
         "network": {
           "bytes": 56,
-          "community_id": "1:kS6rsnr70uQ6xFsuYMkvCKSdW8k=",
+          "community_id": "1:8u4RQjZfNIm4syRFBIcBDWdPF1Y=",
           "direction": "unknown",
           "iana_number": 1,
           "transport": "icmp"
@@ -437,7 +437,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "eHdG6rUdn28",
+          "id": "LA3WpK17LAw",
           "locality": "public"
         },
         "netflow": {
@@ -465,7 +465,7 @@
         },
         "network": {
           "bytes": 56,
-          "community_id": "1:kS6rsnr70uQ6xFsuYMkvCKSdW8k=",
+          "community_id": "1:4ynMlyrnyCCUUIBjD4py4iLgx6g=",
           "direction": "unknown",
           "iana_number": 1,
           "transport": "icmp"
@@ -497,8 +497,8 @@
           "kind": "event"
         },
         "flow": {
-          "id": "JVI-3U3vTiM",
-          "locality": "private"
+          "id": "LA3WpK17LAw",
+          "locality": "public"
         },
         "netflow": {
           "destination_ipv4_address": "2.2.2.11",
@@ -525,7 +525,7 @@
         },
         "network": {
           "bytes": 56,
-          "community_id": "1:SmwvOXNzqf078/v4Sdnv4cSsPEI=",
+          "community_id": "1:myH1DIuDZe/vHHCWbrfgfAthgew=",
           "direction": "unknown",
           "iana_number": 1,
           "transport": "icmp"
@@ -557,7 +557,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "pc77-XHjAxs",
+          "id": "tBFZO1WrQyk",
           "locality": "public"
         },
         "netflow": {
@@ -585,7 +585,7 @@
         },
         "network": {
           "bytes": 160,
-          "community_id": "1:xvskJWklV13yhdmqo/CeIyXRtsY=",
+          "community_id": "1:R0zsc95RXUvk7jJdJGPDDw/ol88=",
           "direction": "unknown",
           "iana_number": 1,
           "transport": "icmp"
@@ -617,8 +617,8 @@
           "kind": "event"
         },
         "flow": {
-          "id": "Qh5mk2U4KjY",
-          "locality": "private"
+          "id": "oil2JqFPSyE",
+          "locality": "public"
         },
         "netflow": {
           "destination_ipv4_address": "164.164.37.11",
@@ -645,7 +645,7 @@
         },
         "network": {
           "bytes": 56,
-          "community_id": "1:ze3NNjzfiQKBNJMVnoVNEOJInGg=",
+          "community_id": "1:V7bWHU0GRcqdysY463DKjFqxvKI=",
           "direction": "unknown",
           "iana_number": 1,
           "transport": "icmp"
@@ -677,7 +677,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "v3tlG0bhLIU",
+          "id": "oil2JqFPSyE",
           "locality": "public"
         },
         "netflow": {
@@ -705,7 +705,7 @@
         },
         "network": {
           "bytes": 56,
-          "community_id": "1:xvskJWklV13yhdmqo/CeIyXRtsY=",
+          "community_id": "1:2DYf0o1HOtKayoor66sl7Vub2Oo=",
           "direction": "unknown",
           "iana_number": 1,
           "transport": "icmp"
@@ -737,8 +737,8 @@
           "kind": "event"
         },
         "flow": {
-          "id": "arIGi4uQChk",
-          "locality": "private"
+          "id": "Pbk_o-xetL4",
+          "locality": "public"
         },
         "netflow": {
           "destination_ipv4_address": "164.164.37.11",
@@ -765,7 +765,7 @@
         },
         "network": {
           "bytes": 56,
-          "community_id": "1:RThhKEIaevWgAeGJidFNVthplto=",
+          "community_id": "1:Zjs1q5mpf5QMXR1tU6wLZdnMtdA=",
           "direction": "unknown",
           "iana_number": 1,
           "transport": "icmp"
@@ -797,7 +797,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "v3tlG0bhLIU",
+          "id": "Pbk_o-xetL4",
           "locality": "public"
         },
         "netflow": {
@@ -825,7 +825,7 @@
         },
         "network": {
           "bytes": 56,
-          "community_id": "1:xvskJWklV13yhdmqo/CeIyXRtsY=",
+          "community_id": "1:WNySyMxsWxABzgjoEp5ntzEwEgk=",
           "direction": "unknown",
           "iana_number": 1,
           "transport": "icmp"

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-ASR-9000-series-template-260.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-ASR-9000-series-template-260.golden.json
@@ -20,7 +20,7 @@
           "start": "2016-12-06T10:08:53.94Z"
         },
         "flow": {
-          "id": "w6H0EF64-XY",
+          "id": "kkhtKjgAywQ",
           "locality": "private"
         },
         "netflow": {
@@ -57,7 +57,7 @@
         },
         "network": {
           "bytes": 40,
-          "community_id": "1:5QtqbRawFoks19lDT4m84rTIr0I=",
+          "community_id": "1:jsUEjyoUL0jdew76Qup2cksJHew=",
           "direction": "outbound",
           "iana_number": 6,
           "packets": 1,
@@ -93,7 +93,7 @@
           "start": "2016-12-06T10:08:53.942Z"
         },
         "flow": {
-          "id": "_1c-gcbRBYA",
+          "id": "4su7p2nlyno",
           "locality": "private"
         },
         "netflow": {
@@ -130,7 +130,7 @@
         },
         "network": {
           "bytes": 104,
-          "community_id": "1:muIMx0jUR+CvrLTk2GTqhLFI218=",
+          "community_id": "1:yB9jVpYE9MA16LwjBHB/JxibmlM=",
           "direction": "outbound",
           "iana_number": 6,
           "packets": 2,
@@ -166,7 +166,7 @@
           "start": "2016-12-06T10:08:53.945Z"
         },
         "flow": {
-          "id": "c7on4lOqINw",
+          "id": "mfb1_zWayo4",
           "locality": "private"
         },
         "netflow": {
@@ -203,7 +203,7 @@
         },
         "network": {
           "bytes": 52,
-          "community_id": "1:yrHEKmgdX/5y+1OPAM1L9TfAHmg=",
+          "community_id": "1:j/VhXzMy3OPka3ZzEYmVN3xFg8A=",
           "direction": "outbound",
           "iana_number": 6,
           "packets": 1,
@@ -239,7 +239,7 @@
           "start": "2016-12-06T10:08:53.947Z"
         },
         "flow": {
-          "id": "RUvfFagvRcI",
+          "id": "jKhffDbQq0o",
           "locality": "private"
         },
         "netflow": {
@@ -276,7 +276,7 @@
         },
         "network": {
           "bytes": 435,
-          "community_id": "1:YNXtH4EzvqrA3VTktVgq2KF/IOY=",
+          "community_id": "1:V29ruuyp06iZ1oJ8bxJlJiyOfIE=",
           "direction": "outbound",
           "iana_number": 17,
           "packets": 1,
@@ -312,7 +312,7 @@
           "start": "2016-12-06T10:08:53.948Z"
         },
         "flow": {
-          "id": "8rGfuJtEqFQ",
+          "id": "5siGD7iCzo4",
           "locality": "private"
         },
         "netflow": {
@@ -349,7 +349,7 @@
         },
         "network": {
           "bytes": 969,
-          "community_id": "1:lGsIn9YpLf87wszEu0Wkgyjo+JE=",
+          "community_id": "1:BfHR+tAWSW/SqM1Bpdnquzk4AaY=",
           "direction": "inbound",
           "iana_number": 6,
           "packets": 1,
@@ -385,7 +385,7 @@
           "start": "2016-12-06T10:08:53.865Z"
         },
         "flow": {
-          "id": "tH2X1gpW5co",
+          "id": "IyuegsSri_U",
           "locality": "private"
         },
         "netflow": {
@@ -422,7 +422,7 @@
         },
         "network": {
           "bytes": 104,
-          "community_id": "1:JLb431i/0yldNOPSZNi/+HsdWeQ=",
+          "community_id": "1:55fPsAgheYzGZEIJDB/aG35LT7A=",
           "direction": "outbound",
           "iana_number": 6,
           "packets": 2,
@@ -458,7 +458,7 @@
           "start": "2016-12-06T10:08:53.951Z"
         },
         "flow": {
-          "id": "Z7W3qCijE1k",
+          "id": "9JGzjsOdNi4",
           "locality": "private"
         },
         "netflow": {
@@ -495,7 +495,7 @@
         },
         "network": {
           "bytes": 52,
-          "community_id": "1:ofLfvLehVuZ4MV4ox/cH00Pau9E=",
+          "community_id": "1:bN7/YptkJDb0iDXbR5ZC9+2pQ+M=",
           "direction": "inbound",
           "iana_number": 6,
           "packets": 1,
@@ -531,7 +531,7 @@
           "start": "2016-12-06T10:08:53.951Z"
         },
         "flow": {
-          "id": "tw9xgUqsD84",
+          "id": "Y3aiAEAjjys",
           "locality": "private"
         },
         "netflow": {
@@ -568,7 +568,7 @@
         },
         "network": {
           "bytes": 614,
-          "community_id": "1:wT0z6v7CLq3V50tVSNInKNKimHI=",
+          "community_id": "1:VwFIN943tEznAwHJLDmQwQ4IrWc=",
           "direction": "inbound",
           "iana_number": 6,
           "packets": 1,
@@ -604,7 +604,7 @@
           "start": "2016-12-06T10:08:48.534Z"
         },
         "flow": {
-          "id": "bjSOPCYMrLM",
+          "id": "sC3kzwxISec",
           "locality": "private"
         },
         "netflow": {
@@ -641,7 +641,7 @@
         },
         "network": {
           "bytes": 4350,
-          "community_id": "1:vXALsmVaBmWRD8avVYrayx6HUv8=",
+          "community_id": "1:keTU72GjRPvGrcGoAh5kgn7VAyE=",
           "direction": "outbound",
           "iana_number": 6,
           "packets": 3,
@@ -677,7 +677,7 @@
           "start": "2016-12-06T10:08:53.953Z"
         },
         "flow": {
-          "id": "cW2GilRshZ0",
+          "id": "dTmlxL48EoA",
           "locality": "private"
         },
         "netflow": {
@@ -714,7 +714,7 @@
         },
         "network": {
           "bytes": 533,
-          "community_id": "1:LLyIDE1QzpXFudau/pNomJiltZo=",
+          "community_id": "1:BQz6ZQnMAgTy7YLZ0FMc/GX7cYw=",
           "direction": "outbound",
           "iana_number": 6,
           "packets": 2,
@@ -750,7 +750,7 @@
           "start": "2016-12-06T10:08:44.489Z"
         },
         "flow": {
-          "id": "j4xTFnwcWbM",
+          "id": "oMLDxCSgNuA",
           "locality": "private"
         },
         "netflow": {
@@ -787,7 +787,7 @@
         },
         "network": {
           "bytes": 13660,
-          "community_id": "1:IOU7kvx862mNhGLL6I96qC93pSw=",
+          "community_id": "1:ER44La+18pqEeuMQJ9u8Z++LJZ8=",
           "direction": "inbound",
           "iana_number": 6,
           "packets": 325,
@@ -823,7 +823,7 @@
           "start": "2016-12-06T10:08:53.955Z"
         },
         "flow": {
-          "id": "yblfrCeNW2I",
+          "id": "5siGD7iCzo4",
           "locality": "private"
         },
         "netflow": {
@@ -860,7 +860,7 @@
         },
         "network": {
           "bytes": 89,
-          "community_id": "1:rFBXrW2Sphy0zvlWpDk/ruilmEI=",
+          "community_id": "1:BfHR+tAWSW/SqM1Bpdnquzk4AaY=",
           "direction": "outbound",
           "iana_number": 6,
           "packets": 1,
@@ -896,7 +896,7 @@
           "start": "2016-12-06T10:08:53.957Z"
         },
         "flow": {
-          "id": "si1uY_f-7f4",
+          "id": "-IcTJfcRi8w",
           "locality": "private"
         },
         "netflow": {
@@ -933,7 +933,7 @@
         },
         "network": {
           "bytes": 833,
-          "community_id": "1:0DisY80Xle+fnyGNQ/SanRYtGCo=",
+          "community_id": "1:V1uWTuA70EL9Qkn1J6pTFRcuV10=",
           "direction": "outbound",
           "iana_number": 6,
           "packets": 1,
@@ -969,7 +969,7 @@
           "start": "2016-12-06T10:08:53.87Z"
         },
         "flow": {
-          "id": "fwH1X67d6AY",
+          "id": "tyf0jfEIDwM",
           "locality": "private"
         },
         "netflow": {
@@ -1006,7 +1006,7 @@
         },
         "network": {
           "bytes": 1625,
-          "community_id": "1:EfcM0REpWogoxKGBseKUSJ1yplM=",
+          "community_id": "1:bF2alD6RwfO9yf2PNZ0MtP9Cksw=",
           "direction": "inbound",
           "iana_number": 6,
           "packets": 2,
@@ -1042,7 +1042,7 @@
           "start": "2016-12-06T10:08:48.557Z"
         },
         "flow": {
-          "id": "Y1GmiKeQUZ0",
+          "id": "OYKOBQNKdF4",
           "locality": "private"
         },
         "netflow": {
@@ -1079,7 +1079,7 @@
         },
         "network": {
           "bytes": 142184,
-          "community_id": "1:A65k305ssNu+Z+35QQRXUxh0XaY=",
+          "community_id": "1:SgVt9ECKOHEc4InDt5s6nTb2ePs=",
           "direction": "outbound",
           "iana_number": 6,
           "packets": 97,
@@ -1115,7 +1115,7 @@
           "start": "2016-12-06T10:08:53.481Z"
         },
         "flow": {
-          "id": "xxE1JcqC8_Q",
+          "id": "fC6tFjsdK54",
           "locality": "private"
         },
         "netflow": {
@@ -1152,7 +1152,7 @@
         },
         "network": {
           "bytes": 3016,
-          "community_id": "1:0CerJ6Jhsco2s7mtd5SGPCWCTEY=",
+          "community_id": "1:tE2lcbsWsM+Jkv2xskEEX4p0MTY=",
           "direction": "outbound",
           "iana_number": 6,
           "packets": 58,
@@ -1188,7 +1188,7 @@
           "start": "2016-12-06T10:08:53.919Z"
         },
         "flow": {
-          "id": "BY9xdCNkYNY",
+          "id": "Kk4bVU4hDRk",
           "locality": "private"
         },
         "netflow": {
@@ -1225,7 +1225,7 @@
         },
         "network": {
           "bytes": 31500,
-          "community_id": "1:mqnuyu3X21eaFef/WIBwFva8J80=",
+          "community_id": "1:FN3bCIq6MMWqE4Hl49V+atNp0E0=",
           "direction": "inbound",
           "iana_number": 6,
           "packets": 21,
@@ -1261,7 +1261,7 @@
           "start": "2016-12-06T10:08:53.659Z"
         },
         "flow": {
-          "id": "HFvBXzMrYew",
+          "id": "_Fk2ywvptGE",
           "locality": "private"
         },
         "netflow": {
@@ -1298,7 +1298,7 @@
         },
         "network": {
           "bytes": 2919,
-          "community_id": "1:G+m3ET1KdJ48R9N7FqnDLPyhqJA=",
+          "community_id": "1:6drEgbq558Eo9wL0KROAp9Dz/NQ=",
           "direction": "inbound",
           "iana_number": 6,
           "packets": 3,
@@ -1334,7 +1334,7 @@
           "start": "2016-12-06T10:08:52.653Z"
         },
         "flow": {
-          "id": "chZ_nMncgV4",
+          "id": "MrTF7IZhOrg",
           "locality": "private"
         },
         "netflow": {
@@ -1371,7 +1371,7 @@
         },
         "network": {
           "bytes": 4514,
-          "community_id": "1:5v4tKeUjkIP+95cYMeNgtQNz7Ww=",
+          "community_id": "1:3ghkl5QTpPmwGGKHHgAzzui7zEs=",
           "direction": "outbound",
           "iana_number": 6,
           "packets": 5,
@@ -1407,7 +1407,7 @@
           "start": "2016-12-06T10:08:53.964Z"
         },
         "flow": {
-          "id": "LJ6ITsDaFGU",
+          "id": "hUKUTbBVmIY",
           "locality": "private"
         },
         "netflow": {
@@ -1444,7 +1444,7 @@
         },
         "network": {
           "bytes": 326,
-          "community_id": "1:vSLX7ymMN1QGKGi1FUCv+zJsYkA=",
+          "community_id": "1:TMLPL/iKXxIK7QRg4pnHfBsShqg=",
           "direction": "inbound",
           "iana_number": 6,
           "packets": 1,
@@ -1480,7 +1480,7 @@
           "start": "2016-12-06T10:08:52.377Z"
         },
         "flow": {
-          "id": "UIGf2vRMiQY",
+          "id": "IoEUbnBqGXE",
           "locality": "private"
         },
         "netflow": {
@@ -1517,7 +1517,7 @@
         },
         "network": {
           "bytes": 112,
-          "community_id": "1:ILVS4/3klc/+6ukE32uhbsceeks=",
+          "community_id": "1:m0iCo0wGlC3GtERxAISGhJWdUMw=",
           "direction": "outbound",
           "iana_number": 6,
           "packets": 2,

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-ASR1001--X.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-ASR1001--X.golden.json
@@ -17,7 +17,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "QywlgaPnfR4",
+          "id": "_qSyv-Xe8IM",
           "locality": "private"
         },
         "netflow": {
@@ -47,7 +47,7 @@
         },
         "network": {
           "bytes": 965,
-          "community_id": "1:uwFzwI08CvSkNfR/WQPCHwlci6o=",
+          "community_id": "1:yBbu9yh2dR3uiqZZPVQfNvrs/bw=",
           "direction": "outbound",
           "iana_number": 6,
           "packets": 7,
@@ -80,7 +80,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "ltJ6GMeuUh8",
+          "id": "7s_4xBb69Y0",
           "locality": "private"
         },
         "netflow": {
@@ -110,7 +110,7 @@
         },
         "network": {
           "bytes": 284,
-          "community_id": "1:qmozbp1hu1WeZnrgR4YYxZsjeAs=",
+          "community_id": "1:EOGOZKIOsiiliNNjOuZs6sS3z0U=",
           "direction": "inbound",
           "iana_number": 17,
           "packets": 1,
@@ -143,7 +143,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "nCOqAo7Vn1Q",
+          "id": "_qSyv-Xe8IM",
           "locality": "private"
         },
         "netflow": {
@@ -173,7 +173,7 @@
         },
         "network": {
           "bytes": 670,
-          "community_id": "1:u2/sO7a/O64V2snOv776vhfrdaE=",
+          "community_id": "1:yBbu9yh2dR3uiqZZPVQfNvrs/bw=",
           "direction": "inbound",
           "iana_number": 6,
           "packets": 6,
@@ -206,7 +206,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "jxAU9kZfvAY",
+          "id": "jk1T8-P2OHM",
           "locality": "private"
         },
         "netflow": {
@@ -236,7 +236,7 @@
         },
         "network": {
           "bytes": 80,
-          "community_id": "1:3hLCiFejfB8o0F+PtLwpKhO8Gvw=",
+          "community_id": "1:6b7hzb2lupBVrTTBOYzbyljYCzw=",
           "direction": "inbound",
           "iana_number": 6,
           "packets": 2,
@@ -269,7 +269,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "TabPGO2qhbg",
+          "id": "jk1T8-P2OHM",
           "locality": "private"
         },
         "netflow": {
@@ -299,7 +299,7 @@
         },
         "network": {
           "bytes": 80,
-          "community_id": "1:Q4BjTF5X3n7a+Oa2eU4BTat20J0=",
+          "community_id": "1:6b7hzb2lupBVrTTBOYzbyljYCzw=",
           "direction": "outbound",
           "iana_number": 6,
           "packets": 2,
@@ -332,7 +332,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "__Gn3lXREl8",
+          "id": "6AEj_wlzQm4",
           "locality": "private"
         },
         "netflow": {
@@ -362,7 +362,7 @@
         },
         "network": {
           "bytes": 101,
-          "community_id": "1:K39hVsHP9vJZE3HgkNg6IhdmFDI=",
+          "community_id": "1:0nd0je2ss73gC5Cl39GkfxSV1iw=",
           "direction": "outbound",
           "iana_number": 17,
           "packets": 1,
@@ -395,7 +395,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "HgByI6ZN5fI",
+          "id": "MtCuD-nvBTY",
           "locality": "private"
         },
         "netflow": {
@@ -425,7 +425,7 @@
         },
         "network": {
           "bytes": 1134,
-          "community_id": "1:dZjX+9FJFoTQCGnVJYA1D7eCt7E=",
+          "community_id": "1:5j05uMjmLSTBrzv+/f4RzVjsXoM=",
           "direction": "outbound",
           "iana_number": 17,
           "packets": 14,
@@ -458,7 +458,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "NmxbGp3YE2k",
+          "id": "8zAXung0YbA",
           "locality": "public"
         },
         "netflow": {
@@ -488,7 +488,7 @@
         },
         "network": {
           "bytes": 237,
-          "community_id": "1:U+WZT9lvd0sxL1M9hpokk9TXK5w=",
+          "community_id": "1:7lNSpJLSiDjzVjBtiTBatlKGNaQ=",
           "direction": "outbound",
           "iana_number": 6,
           "packets": 4,
@@ -521,7 +521,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "EXuHYVwL-Lg",
+          "id": "5LxKkXX5FfM",
           "locality": "private"
         },
         "netflow": {
@@ -551,7 +551,7 @@
         },
         "network": {
           "bytes": 91,
-          "community_id": "1:wRntrWu6NswQHhEk070T8IeU8Fs=",
+          "community_id": "1:MHSDRtvJ2AI894PO4TVb4PrW/yc=",
           "direction": "inbound",
           "iana_number": 17,
           "packets": 1,
@@ -584,8 +584,8 @@
           "kind": "event"
         },
         "flow": {
-          "id": "B0W49XnPuJI",
-          "locality": "private"
+          "id": "MnDMft-qZjs",
+          "locality": "public"
         },
         "netflow": {
           "application_id": "DQABzg==",
@@ -614,7 +614,7 @@
         },
         "network": {
           "bytes": 41,
-          "community_id": "1:5JEyDFPIh+4ITPosuffRDzSF7Jw=",
+          "community_id": "1:uDd6b2aQtfD8+wElJrQKdgWAP34=",
           "direction": "inbound",
           "iana_number": 6,
           "packets": 1,
@@ -647,7 +647,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "kBEBKXXkEV4",
+          "id": "Ddy-Ii-ZDDI",
           "locality": "private"
         },
         "netflow": {
@@ -677,7 +677,7 @@
         },
         "network": {
           "bytes": 111,
-          "community_id": "1:ARbQv4xDOLQ4HUS3c9oqLlwKGWY=",
+          "community_id": "1:57eQyWSxMRU5bytTSoOoGX5Jnjk=",
           "direction": "outbound",
           "iana_number": 17,
           "packets": 1,
@@ -710,7 +710,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "H_ffU7B_Ols",
+          "id": "Hiy-Ti0eVlY",
           "locality": "private"
         },
         "netflow": {
@@ -740,7 +740,7 @@
         },
         "network": {
           "bytes": 1164,
-          "community_id": "1:y/0+lFjviSxqFw5Ud/Cc1yuBn2c=",
+          "community_id": "1:Ik5zyNApQAmWob0G79V+hMi5+Pg=",
           "direction": "inbound",
           "iana_number": 17,
           "packets": 4,
@@ -773,7 +773,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "z9roObSX0VI",
+          "id": "7iMintjCsaw",
           "locality": "private"
         },
         "netflow": {
@@ -803,7 +803,7 @@
         },
         "network": {
           "bytes": 80,
-          "community_id": "1:N8K6l0F31HluX8vUd+WbE/6iDfk=",
+          "community_id": "1:YHvXfhIeIZEgkebPSsnrYgUJJI0=",
           "direction": "inbound",
           "iana_number": 6,
           "packets": 2,
@@ -836,7 +836,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "pF9IcCI5_TA",
+          "id": "MnDMft-qZjs",
           "locality": "public"
         },
         "netflow": {
@@ -866,7 +866,7 @@
         },
         "network": {
           "bytes": 52,
-          "community_id": "1:XKmRGfkKextNmjU2O+4ubL+2LI4=",
+          "community_id": "1:uDd6b2aQtfD8+wElJrQKdgWAP34=",
           "direction": "outbound",
           "iana_number": 6,
           "packets": 1,
@@ -899,7 +899,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "TabPGO2qhbg",
+          "id": "7iMintjCsaw",
           "locality": "private"
         },
         "netflow": {
@@ -929,7 +929,7 @@
         },
         "network": {
           "bytes": 80,
-          "community_id": "1:Q4BjTF5X3n7a+Oa2eU4BTat20J0=",
+          "community_id": "1:YHvXfhIeIZEgkebPSsnrYgUJJI0=",
           "direction": "outbound",
           "iana_number": 6,
           "packets": 2,
@@ -962,8 +962,8 @@
           "kind": "event"
         },
         "flow": {
-          "id": "SHZ5cKd5_7I",
-          "locality": "private"
+          "id": "hphBugBrKPY",
+          "locality": "public"
         },
         "netflow": {
           "application_id": "DQABxQ==",
@@ -992,7 +992,7 @@
         },
         "network": {
           "bytes": 3088,
-          "community_id": "1:afQ2LcWleivXmSC1cEzrvvoFc4U=",
+          "community_id": "1:Lq6KbJ/pg4WbByH0CvgQv8BHdtA=",
           "direction": "inbound",
           "iana_number": 6,
           "packets": 10,
@@ -1025,7 +1025,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "WqkLxpVBsYc",
+          "id": "gJ7Z20zGGk8",
           "locality": "private"
         },
         "netflow": {
@@ -1055,7 +1055,7 @@
         },
         "network": {
           "bytes": 5306,
-          "community_id": "1:+k9rpD1zFTzj1TzClbQz5xxZSkM=",
+          "community_id": "1:/l55n91lgbmQbHIED/mfpk0OQk4=",
           "direction": "inbound",
           "iana_number": 6,
           "packets": 24,
@@ -1088,7 +1088,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "6oldLw2Mlas",
+          "id": "Ddy-Ii-ZDDI",
           "locality": "private"
         },
         "netflow": {
@@ -1118,7 +1118,7 @@
         },
         "network": {
           "bytes": 116,
-          "community_id": "1:SyYPZ96uUcoS7fqJKZzUOfcLHik=",
+          "community_id": "1:57eQyWSxMRU5bytTSoOoGX5Jnjk=",
           "direction": "inbound",
           "iana_number": 17,
           "packets": 1,
@@ -1151,7 +1151,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "h3rJ4LGMXt4",
+          "id": "gJ7Z20zGGk8",
           "locality": "private"
         },
         "netflow": {
@@ -1181,7 +1181,7 @@
         },
         "network": {
           "bytes": 22764,
-          "community_id": "1:dwhTKtbCkX7Na/7SKnulqsYlD40=",
+          "community_id": "1:/l55n91lgbmQbHIED/mfpk0OQk4=",
           "direction": "inbound",
           "iana_number": 6,
           "packets": 30,
@@ -1214,7 +1214,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "hSj81XiLSw0",
+          "id": "LZaFrMI9jg0",
           "locality": "private"
         },
         "netflow": {
@@ -1244,7 +1244,7 @@
         },
         "network": {
           "bytes": 80,
-          "community_id": "1:z67KRlDvetfiNmjA/1mM7UfiB7s=",
+          "community_id": "1:TswEOa5Y4y+EsDzrSTiDVjn6ljE=",
           "direction": "inbound",
           "iana_number": 6,
           "packets": 2,
@@ -1277,7 +1277,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "mWVfnnlkVzU",
+          "id": "f6pXcQQIzpU",
           "locality": "private"
         },
         "netflow": {
@@ -1307,7 +1307,7 @@
         },
         "network": {
           "bytes": 75,
-          "community_id": "1:AtJByg1SAIkNhDGqD4XhVNAhwc8=",
+          "community_id": "1:6XcNqndTmSsA2vpub5no5PP6x94=",
           "direction": "outbound",
           "iana_number": 17,
           "packets": 1,
@@ -1340,7 +1340,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "-RTReIERjF0",
+          "id": "LZaFrMI9jg0",
           "locality": "private"
         },
         "netflow": {
@@ -1370,7 +1370,7 @@
         },
         "network": {
           "bytes": 80,
-          "community_id": "1:YamB1S9bWGFmqfw7U/M0nG1GUz8=",
+          "community_id": "1:TswEOa5Y4y+EsDzrSTiDVjn6ljE=",
           "direction": "outbound",
           "iana_number": 6,
           "packets": 2,
@@ -1403,7 +1403,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "NmZIPGhxoAc",
+          "id": "gQGJtHjUcB8",
           "locality": "private"
         },
         "netflow": {
@@ -1433,7 +1433,7 @@
         },
         "network": {
           "bytes": 160,
-          "community_id": "1:X+r9a4yHo+YM8PQ6q04bec166gk=",
+          "community_id": "1:JCgVF03O/JPuZMdchkd7MsulFlg=",
           "direction": "outbound",
           "iana_number": 17,
           "packets": 2,
@@ -1466,8 +1466,8 @@
           "kind": "event"
         },
         "flow": {
-          "id": "x8DNo198Zms",
-          "locality": "private"
+          "id": "UHiF_w4I6zM",
+          "locality": "public"
         },
         "netflow": {
           "application_id": "AwAAew==",
@@ -1496,7 +1496,7 @@
         },
         "network": {
           "bytes": 76,
-          "community_id": "1:hmVHHQG4Si4V475TR3gSOjFY4PQ=",
+          "community_id": "1:nx2pvp49/72hmhlz+yyp8IVaZtQ=",
           "direction": "inbound",
           "iana_number": 17,
           "packets": 1,
@@ -1529,7 +1529,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "8UnzkHo8VIQ",
+          "id": "czsFrOKrayM",
           "locality": "private"
         },
         "netflow": {
@@ -1559,7 +1559,7 @@
         },
         "network": {
           "bytes": 1340,
-          "community_id": "1:XTYkQhjrZQKtKSBX3glwTV1hOBc=",
+          "community_id": "1:zuc1AIKuUwVTrtFB2fYRrhsv2Ww=",
           "direction": "inbound",
           "iana_number": 6,
           "packets": 2,

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-NBAR-flowset-262.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-NBAR-flowset-262.golden.json
@@ -21,7 +21,7 @@
           "start": "2017-02-14T11:10:19.368Z"
         },
         "flow": {
-          "id": "uz9_zfua5qU",
+          "id": "Bk-2FcuOyCU",
           "locality": "private"
         },
         "netflow": {
@@ -61,7 +61,7 @@
         },
         "network": {
           "bytes": 44,
-          "community_id": "1:OYl5x6oQNloID/wLIKpFGPIvN/U=",
+          "community_id": "1:8cDBXH9jjYVVde053VC5trU8Cuo=",
           "direction": "inbound",
           "iana_number": 1,
           "packets": 1,
@@ -99,7 +99,7 @@
           "start": "2017-02-14T11:10:19.368Z"
         },
         "flow": {
-          "id": "1w3FDvLEFgo",
+          "id": "4Xk8GtQfUAo",
           "locality": "private"
         },
         "netflow": {
@@ -139,7 +139,7 @@
         },
         "network": {
           "bytes": 106,
-          "community_id": "1:CyRN90AZ56qtzUMojGTJ/nFWLGg=",
+          "community_id": "1:ED1EAUtKZuzVn81q9iThMWwSfPs=",
           "direction": "inbound",
           "iana_number": 17,
           "packets": 1,
@@ -177,7 +177,7 @@
           "start": "2017-02-14T11:10:19.924Z"
         },
         "flow": {
-          "id": "qkbx0XD7pSA",
+          "id": "tfLRXnB6AOA",
           "locality": "private"
         },
         "netflow": {
@@ -217,7 +217,7 @@
         },
         "network": {
           "bytes": 44,
-          "community_id": "1:j8GnMqCJ2VnxNT6ZX5j3wFnLTu0=",
+          "community_id": "1:t8Qd3z3L2lOoZPfQUK+zDeteU2Q=",
           "direction": "inbound",
           "iana_number": 1,
           "packets": 1,
@@ -255,7 +255,7 @@
           "start": "2017-02-14T11:10:19.996Z"
         },
         "flow": {
-          "id": "4c7uUPCsBCk",
+          "id": "1mfP23NPuB8",
           "locality": "private"
         },
         "netflow": {
@@ -295,7 +295,7 @@
         },
         "network": {
           "bytes": 76,
-          "community_id": "1:CWcKykFvy1AWUIQAfWn2UBvkX2c=",
+          "community_id": "1:SGyGFFqT/UM9GzEbSqdVwvFlU/A=",
           "direction": "inbound",
           "iana_number": 17,
           "packets": 1,
@@ -333,7 +333,7 @@
           "start": "2017-02-14T11:10:19.936Z"
         },
         "flow": {
-          "id": "f2adL0TDrgs",
+          "id": "g6a7KlISbtM",
           "locality": "private"
         },
         "netflow": {
@@ -373,7 +373,7 @@
         },
         "network": {
           "bytes": 2794,
-          "community_id": "1:eEsNJGUF4/LfUrgXBt8U4TWBA9M=",
+          "community_id": "1:PmZN9x4ZCYdb226ilwjJYIAdKdY=",
           "direction": "inbound",
           "iana_number": 17,
           "packets": 36,

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Fortigate-FortiOS-5.2.1.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Fortigate-FortiOS-5.2.1.golden.json
@@ -55,8 +55,8 @@
           "kind": "event"
         },
         "flow": {
-          "id": "jJrTIsjNw1M",
-          "locality": "private"
+          "id": "SKsZNpZob60",
+          "locality": "public"
         },
         "netflow": {
           "destination_ipv4_address": "31.13.87.36",
@@ -83,7 +83,7 @@
         },
         "network": {
           "bytes": 152,
-          "community_id": "1:tYgSz6Xox1AUTy0tyztkJXZmiIQ=",
+          "community_id": "1:/WRdjqoOaqvaSKG3KADN7XCzjYI=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 3,

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Fortigate-FortiOS-54x-appid.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Fortigate-FortiOS-54x-appid.golden.json
@@ -20,8 +20,8 @@
           "start": "2018-05-11T00:54:09.58Z"
         },
         "flow": {
-          "id": "FGsJnTnhFRo",
-          "locality": "private"
+          "id": "FfT-8jRRvok",
+          "locality": "public"
         },
         "netflow": {
           "application_id": "FAAAMEQAAI80",
@@ -55,7 +55,7 @@
         },
         "network": {
           "bytes": 748,
-          "community_id": "1:k6fnpZvAP2OCIlBK5wf/n7I33FA=",
+          "community_id": "1:cc44MungwEZdPeddV0yoKBntw9Q=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 6,
@@ -91,7 +91,7 @@
           "start": "2018-05-11T00:54:08.61Z"
         },
         "flow": {
-          "id": "pS0eG-KmtWY",
+          "id": "bZjTG4EkhLs",
           "locality": "public"
         },
         "netflow": {
@@ -126,7 +126,7 @@
         },
         "network": {
           "bytes": 6948,
-          "community_id": "1:xE3FUh+IR1gTSuCWTDkzaMAYppc=",
+          "community_id": "1:pbiS0by8+CypjtPRsL9VZgvpS58=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 10,
@@ -162,8 +162,8 @@
           "start": "2018-05-11T00:54:08.61Z"
         },
         "flow": {
-          "id": "UX9yKGG1l0g",
-          "locality": "private"
+          "id": "bZjTG4EkhLs",
+          "locality": "public"
         },
         "netflow": {
           "application_id": "FAAAMEQAAJ54",
@@ -197,7 +197,7 @@
         },
         "network": {
           "bytes": 1584,
-          "community_id": "1:u8ii7EBbKZETNNHlkdrp9ZdLUKY=",
+          "community_id": "1:pbiS0by8+CypjtPRsL9VZgvpS58=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 14,
@@ -233,7 +233,7 @@
           "start": "2018-05-11T00:54:08.7Z"
         },
         "flow": {
-          "id": "8IX_jKHlTYI",
+          "id": "kZjCeMUhjqE",
           "locality": "public"
         },
         "netflow": {
@@ -268,7 +268,7 @@
         },
         "network": {
           "bytes": 8201,
-          "community_id": "1:Yg7TVkDV8wTyFkiw9HGckHvwQk8=",
+          "community_id": "1:ViaPZHKcEpCQ2WFRPBF0gJ8jknQ=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 11,
@@ -304,8 +304,8 @@
           "start": "2018-05-11T00:54:08.7Z"
         },
         "flow": {
-          "id": "xuTsRrER3sQ",
-          "locality": "private"
+          "id": "kZjCeMUhjqE",
+          "locality": "public"
         },
         "netflow": {
           "application_id": "FAAAMEQAAJ54",
@@ -339,7 +339,7 @@
         },
         "network": {
           "bytes": 1729,
-          "community_id": "1:3nyHi/TSF/vyWaCKPnvrEkWYi98=",
+          "community_id": "1:ViaPZHKcEpCQ2WFRPBF0gJ8jknQ=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 15,
@@ -375,7 +375,7 @@
           "start": "2018-05-11T00:54:08.7Z"
         },
         "flow": {
-          "id": "8jdxbghGmCM",
+          "id": "8PR91KFjFKw",
           "locality": "public"
         },
         "netflow": {
@@ -410,7 +410,7 @@
         },
         "network": {
           "bytes": 1122,
-          "community_id": "1:lDlO+jlvvAqzElOUzFaN0Co6N7o=",
+          "community_id": "1:f1/h2ZMHLBG8+ajVGrPeVdJVklE=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 5,
@@ -446,8 +446,8 @@
           "start": "2018-05-11T00:54:08.7Z"
         },
         "flow": {
-          "id": "cgdcVU_EGQA",
-          "locality": "private"
+          "id": "8PR91KFjFKw",
+          "locality": "public"
         },
         "netflow": {
           "application_id": "FAAAMEQAAGTz",
@@ -481,7 +481,7 @@
         },
         "network": {
           "bytes": 705,
-          "community_id": "1:vMV9tpgckoBsKm14H/aaed9/B6o=",
+          "community_id": "1:f1/h2ZMHLBG8+ajVGrPeVdJVklE=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 5,
@@ -517,7 +517,7 @@
           "start": "2018-05-11T00:54:08.16Z"
         },
         "flow": {
-          "id": "GcDNnOgnA5Q",
+          "id": "O5vacJG8mLQ",
           "locality": "public"
         },
         "netflow": {
@@ -552,7 +552,7 @@
         },
         "network": {
           "bytes": 1123,
-          "community_id": "1:36J0xlj2SLkuRRDG0iOA1rSo7zs=",
+          "community_id": "1:hBHjvmVd13dLnqS0QH+QxbITN4c=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 5,
@@ -588,8 +588,8 @@
           "start": "2018-05-11T00:54:08.16Z"
         },
         "flow": {
-          "id": "O3J0MRnKFRc",
-          "locality": "private"
+          "id": "O5vacJG8mLQ",
+          "locality": "public"
         },
         "netflow": {
           "application_id": "FAAAMEQAAGTz",
@@ -623,7 +623,7 @@
         },
         "network": {
           "bytes": 706,
-          "community_id": "1:DlCfunueLMkCou44xfNagrPPzmI=",
+          "community_id": "1:hBHjvmVd13dLnqS0QH+QxbITN4c=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 5,
@@ -659,7 +659,7 @@
           "start": "2018-05-11T00:51:08.55Z"
         },
         "flow": {
-          "id": "r_38fQYHkQc",
+          "id": "wdz94oax40U",
           "locality": "private"
         },
         "netflow": {
@@ -690,7 +690,7 @@
         },
         "network": {
           "bytes": 74,
-          "community_id": "1:pSB9AhXlD5k2Hgt+G8xWPxJVnPY=",
+          "community_id": "1:JzC4dDg7MOhCNcblNQngjswFxcI=",
           "direction": "unknown",
           "iana_number": 17,
           "packets": 1,
@@ -726,7 +726,7 @@
           "start": "2018-05-11T00:51:08.55Z"
         },
         "flow": {
-          "id": "YROWQT5rfG8",
+          "id": "wdz94oax40U",
           "locality": "private"
         },
         "netflow": {
@@ -757,7 +757,7 @@
         },
         "network": {
           "bytes": 58,
-          "community_id": "1:PKa/AyUMS+3x4M4+GxUIgWRcmnw=",
+          "community_id": "1:JzC4dDg7MOhCNcblNQngjswFxcI=",
           "direction": "unknown",
           "iana_number": 17,
           "packets": 1,
@@ -793,7 +793,7 @@
           "start": "2018-05-11T00:51:08.55Z"
         },
         "flow": {
-          "id": "ahrbxvQPrLM",
+          "id": "KvZZ7LW-Qdc",
           "locality": "private"
         },
         "netflow": {
@@ -824,7 +824,7 @@
         },
         "network": {
           "bytes": 74,
-          "community_id": "1:hVNrF7qc5ABcKevdrl3vPBrP5rQ=",
+          "community_id": "1:RdXZTQrdCN4ZePNUM5WsT+6DRLg=",
           "direction": "unknown",
           "iana_number": 17,
           "packets": 1,
@@ -860,7 +860,7 @@
           "start": "2018-05-11T00:51:08.55Z"
         },
         "flow": {
-          "id": "gvmqdtyoP-k",
+          "id": "KvZZ7LW-Qdc",
           "locality": "private"
         },
         "netflow": {
@@ -891,7 +891,7 @@
         },
         "network": {
           "bytes": 58,
-          "community_id": "1:fuwC0soLNJv3on5fRonxy1NehGk=",
+          "community_id": "1:RdXZTQrdCN4ZePNUM5WsT+6DRLg=",
           "direction": "unknown",
           "iana_number": 17,
           "packets": 1,
@@ -927,7 +927,7 @@
           "start": "2018-05-11T00:54:04.19Z"
         },
         "flow": {
-          "id": "HhwdAeswnyA",
+          "id": "PC3a5T13Dpw",
           "locality": "private"
         },
         "netflow": {
@@ -958,7 +958,7 @@
         },
         "network": {
           "bytes": 1071,
-          "community_id": "1:hiYqfWLht4N9AUGcmXtgZpFVvQQ=",
+          "community_id": "1:jKF2O4oRoWz64BmdyUfdbT1ETWo=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 5,
@@ -994,7 +994,7 @@
           "start": "2018-05-11T00:54:04.19Z"
         },
         "flow": {
-          "id": "RSopBOCi7lM",
+          "id": "PC3a5T13Dpw",
           "locality": "private"
         },
         "netflow": {
@@ -1025,7 +1025,7 @@
         },
         "network": {
           "bytes": 1147,
-          "community_id": "1:YAfTDRm1WGwlR9YYWrgtTsf1DMw=",
+          "community_id": "1:jKF2O4oRoWz64BmdyUfdbT1ETWo=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 6,
@@ -1061,7 +1061,7 @@
           "start": "2018-05-11T00:53:56.19Z"
         },
         "flow": {
-          "id": "egrl1hI_KGo",
+          "id": "zdGWMwGlfsg",
           "locality": "private"
         },
         "netflow": {
@@ -1092,7 +1092,7 @@
         },
         "network": {
           "bytes": 1980,
-          "community_id": "1:22XTyUF19jbjqUU+rs71qD5wnus=",
+          "community_id": "1:VrqZzzFH8uxnbcpqL+bWFsIKuoc=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 6,
@@ -1128,7 +1128,7 @@
           "start": "2018-05-11T00:53:56.19Z"
         },
         "flow": {
-          "id": "uEhXi585RDg",
+          "id": "zdGWMwGlfsg",
           "locality": "private"
         },
         "netflow": {
@@ -1159,7 +1159,7 @@
         },
         "network": {
           "bytes": 2164,
-          "community_id": "1:pfRhf4/ExF5JUU0Tz6ExQQROS+Q=",
+          "community_id": "1:VrqZzzFH8uxnbcpqL+bWFsIKuoc=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 8,

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-H3C-Netstream-with-varstring.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-H3C-Netstream-with-varstring.golden.json
@@ -20,7 +20,7 @@
           "start": "2018-07-18T01:34:33.274Z"
         },
         "flow": {
-          "id": "ZqqgTzKUqi8",
+          "id": "dK1E5m-O-ns",
           "locality": "public"
         },
         "netflow": {
@@ -61,7 +61,7 @@
         },
         "network": {
           "bytes": 702,
-          "community_id": "1:WP3Ss+M/Q16gnXrqnk6fwmPWvWc=",
+          "community_id": "1:H4Lg41gxc8Sb+0ZP09wcnLj0a/Y=",
           "direction": "inbound",
           "iana_number": 17,
           "packets": 9,

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-H3C.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-H3C.golden.json
@@ -20,7 +20,7 @@
           "start": "2018-05-21T09:23:34.158Z"
         },
         "flow": {
-          "id": "o7J27_lfELc",
+          "id": "6gDDasxO-4o",
           "locality": "private"
         },
         "netflow": {
@@ -60,7 +60,7 @@
         },
         "network": {
           "bytes": 1027087,
-          "community_id": "1:qzI1p/DraBlY+q0WoDrEVzXNWYQ=",
+          "community_id": "1:eNQLlW0lcfh1MdwlzdboFVeTFPw=",
           "direction": "inbound",
           "iana_number": 6,
           "packets": 697,
@@ -96,7 +96,7 @@
           "start": "2018-05-21T09:24:03.657Z"
         },
         "flow": {
-          "id": "qrFEiuMtPwY",
+          "id": "RJbWY0zxttI",
           "locality": "private"
         },
         "netflow": {
@@ -136,7 +136,7 @@
         },
         "network": {
           "bytes": 6200,
-          "community_id": "1:GSQ1TrOMr/LW4B81ECw0+kz+2QY=",
+          "community_id": "1:rFVeEEfyW/QNxIVODefqxH2vcCI=",
           "direction": "inbound",
           "iana_number": 6,
           "packets": 6,
@@ -172,7 +172,7 @@
           "start": "2018-05-21T09:24:03.64Z"
         },
         "flow": {
-          "id": "K7Oba1OAPtE",
+          "id": "MfdYhUDA3Y4",
           "locality": "private"
         },
         "netflow": {
@@ -212,7 +212,7 @@
         },
         "network": {
           "bytes": 11896,
-          "community_id": "1:61IryZ4mi1uTBDD5+gOvL97xjLM=",
+          "community_id": "1:916CXqxTbwb6orlTyTE7PhRLUSE=",
           "direction": "inbound",
           "iana_number": 6,
           "packets": 21,
@@ -248,7 +248,7 @@
           "start": "2018-05-21T09:23:33.632Z"
         },
         "flow": {
-          "id": "eQWqY8f8ul4",
+          "id": "_QFogYw9xiY",
           "locality": "private"
         },
         "netflow": {
@@ -288,7 +288,7 @@
         },
         "network": {
           "bytes": 1041,
-          "community_id": "1:NOys+eNAZ2uvD2U8rXFlB0IZQCo=",
+          "community_id": "1:ATN9Q9amiD3qSYMP+k9EmMdOQo8=",
           "direction": "inbound",
           "iana_number": 6,
           "packets": 3,
@@ -324,7 +324,7 @@
           "start": "2018-05-21T09:23:33.629Z"
         },
         "flow": {
-          "id": "0r8CsGps2ro",
+          "id": "-O7eEnuq5LI",
           "locality": "private"
         },
         "netflow": {
@@ -364,7 +364,7 @@
         },
         "network": {
           "bytes": 1740,
-          "community_id": "1:gY528hsPNX6RHS6UXpFnEsjqMY0=",
+          "community_id": "1:Uh1hQvm7B77MqivbmxlOAMomv1Q=",
           "direction": "inbound",
           "iana_number": 6,
           "packets": 20,
@@ -400,7 +400,7 @@
           "start": "2018-05-21T09:23:34.202Z"
         },
         "flow": {
-          "id": "0r8CsGps2ro",
+          "id": "pcgnaJ3iCvI",
           "locality": "private"
         },
         "netflow": {
@@ -440,7 +440,7 @@
         },
         "network": {
           "bytes": 2998,
-          "community_id": "1:gY528hsPNX6RHS6UXpFnEsjqMY0=",
+          "community_id": "1:8L5Jeq2Dap6SaVFyk8CIRCH/U3I=",
           "direction": "inbound",
           "iana_number": 6,
           "packets": 16,
@@ -476,7 +476,7 @@
           "start": "2018-05-21T09:23:34.218Z"
         },
         "flow": {
-          "id": "gRcMm2Ek5c0",
+          "id": "_gbuwRW4AVE",
           "locality": "private"
         },
         "netflow": {
@@ -516,7 +516,7 @@
         },
         "network": {
           "bytes": 55773,
-          "community_id": "1:1l5g2rHaCC2EhYGzWl7jD2jprK8=",
+          "community_id": "1:1eLIKeR0kNtd51Gm9QKpAxDjPUg=",
           "direction": "inbound",
           "iana_number": 6,
           "packets": 37,
@@ -552,7 +552,7 @@
           "start": "2018-05-21T09:23:34.235Z"
         },
         "flow": {
-          "id": "eQWqY8f8ul4",
+          "id": "VOe0rUor-cg",
           "locality": "private"
         },
         "netflow": {
@@ -592,7 +592,7 @@
         },
         "network": {
           "bytes": 3239438,
-          "community_id": "1:NOys+eNAZ2uvD2U8rXFlB0IZQCo=",
+          "community_id": "1:mJOXFnQdKGi0FJX8FtN1mVlaVRo=",
           "direction": "inbound",
           "iana_number": 6,
           "packets": 2135,
@@ -628,7 +628,7 @@
           "start": "2018-05-21T09:23:33.685Z"
         },
         "flow": {
-          "id": "lAaotlLZtjQ",
+          "id": "nkp7tr2MVcs",
           "locality": "private"
         },
         "netflow": {
@@ -668,7 +668,7 @@
         },
         "network": {
           "bytes": 5701,
-          "community_id": "1:u3U5M2TEOv+5aaIvoxAWpZcCwfc=",
+          "community_id": "1:CKdc0BQVlrSUdYIl/rZl5QGwVCA=",
           "direction": "inbound",
           "iana_number": 6,
           "packets": 20,
@@ -704,7 +704,7 @@
           "start": "2018-05-21T09:23:34.3Z"
         },
         "flow": {
-          "id": "IbUUsxYjDko",
+          "id": "WxCFEmsTIh0",
           "locality": "private"
         },
         "netflow": {
@@ -744,7 +744,7 @@
         },
         "network": {
           "bytes": 4255012,
-          "community_id": "1:dsegIlwhvWHFpkKtpDEZ+N3EoXU=",
+          "community_id": "1:YvCd9zipqzFOMrFXl/Spyy0/4sk=",
           "direction": "inbound",
           "iana_number": 6,
           "packets": 2804,
@@ -780,7 +780,7 @@
           "start": "2018-05-21T09:23:34.503Z"
         },
         "flow": {
-          "id": "gRcMm2Ek5c0",
+          "id": "rAIv2psXy74",
           "locality": "private"
         },
         "netflow": {
@@ -820,7 +820,7 @@
         },
         "network": {
           "bytes": 37557,
-          "community_id": "1:1l5g2rHaCC2EhYGzWl7jD2jprK8=",
+          "community_id": "1:GhEcsw3dhL4icOZFUJYc5u6lf58=",
           "direction": "inbound",
           "iana_number": 6,
           "packets": 25,
@@ -856,7 +856,7 @@
           "start": "2018-05-21T09:23:33.753Z"
         },
         "flow": {
-          "id": "bF4sqhkd09c",
+          "id": "lR18K-eSVNM",
           "locality": "private"
         },
         "netflow": {
@@ -896,7 +896,7 @@
         },
         "network": {
           "bytes": 23676,
-          "community_id": "1:5VIwljy0926c8Js5Wsve5fEmSLo=",
+          "community_id": "1:0qcEq1XnhKE12NOUrXbjgRk70E0=",
           "direction": "inbound",
           "iana_number": 6,
           "packets": 68,
@@ -932,7 +932,7 @@
           "start": "2018-05-21T09:23:34.689Z"
         },
         "flow": {
-          "id": "bF4sqhkd09c",
+          "id": "1XCFo-Jv19g",
           "locality": "private"
         },
         "netflow": {
@@ -972,7 +972,7 @@
         },
         "network": {
           "bytes": 22821,
-          "community_id": "1:5VIwljy0926c8Js5Wsve5fEmSLo=",
+          "community_id": "1:djYyh9fkbHyZ086z3anBPgMpvVw=",
           "direction": "inbound",
           "iana_number": 6,
           "packets": 30,
@@ -1008,7 +1008,7 @@
           "start": "2018-05-21T09:23:33.938Z"
         },
         "flow": {
-          "id": "qrFEiuMtPwY",
+          "id": "DkV-9Meb8W8",
           "locality": "private"
         },
         "netflow": {
@@ -1048,7 +1048,7 @@
         },
         "network": {
           "bytes": 526,
-          "community_id": "1:GSQ1TrOMr/LW4B81ECw0+kz+2QY=",
+          "community_id": "1:BbUCV6M75DxtXVLg7BD5cEmQP/4=",
           "direction": "inbound",
           "iana_number": 6,
           "packets": 2,
@@ -1084,7 +1084,7 @@
           "start": "2018-05-21T09:24:03.933Z"
         },
         "flow": {
-          "id": "aDDmhx63tkM",
+          "id": "v1m_MeAqdL4",
           "locality": "private"
         },
         "netflow": {
@@ -1124,7 +1124,7 @@
         },
         "network": {
           "bytes": 33129,
-          "community_id": "1:nSRDOwLgxV6v/8JSi4fU7AKGxd8=",
+          "community_id": "1:YnxrxAyx+D+FJm1W+w8UNgPa2rs=",
           "direction": "inbound",
           "iana_number": 6,
           "packets": 220,
@@ -1160,7 +1160,7 @@
           "start": "2018-05-21T09:24:03.922Z"
         },
         "flow": {
-          "id": "0r8CsGps2ro",
+          "id": "ru0mPvG-tKw",
           "locality": "private"
         },
         "netflow": {
@@ -1200,7 +1200,7 @@
         },
         "network": {
           "bytes": 5092,
-          "community_id": "1:gY528hsPNX6RHS6UXpFnEsjqMY0=",
+          "community_id": "1:DJ1L7SqBOi1rRa0BwHHVoNY4yt0=",
           "direction": "inbound",
           "iana_number": 6,
           "packets": 9,

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Huawei-Netstream.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Huawei-Netstream.golden.json
@@ -20,7 +20,7 @@
           "start": "2018-01-29T02:56:51.94Z"
         },
         "flow": {
-          "id": "edQPxE87Y_A",
+          "id": "d-FUjj8eKi8",
           "locality": "private"
         },
         "netflow": {
@@ -60,7 +60,7 @@
         },
         "network": {
           "bytes": 200,
-          "community_id": "1:UTBimnmI4MzXDTKLW5sOTHaZyKc=",
+          "community_id": "1:0qNFnK0G9V0IPgzhxvf+nGmenME=",
           "direction": "outbound",
           "iana_number": 6,
           "packets": 4,

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-IE150-IE151.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-IE150-IE151.golden.json
@@ -17,7 +17,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "XApOh2nrI60",
+          "id": "X6k2SQeAX5c",
           "locality": "private"
         },
         "netflow": {
@@ -47,7 +47,7 @@
         },
         "network": {
           "bytes": 78,
-          "community_id": "1:exuCftrHyAyRt6vQ7silX0RyM6c=",
+          "community_id": "1:1DzICq61xHbOOLkFA+YUG9pmNpo=",
           "direction": "inbound",
           "iana_number": 17,
           "packets": 1,
@@ -80,7 +80,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "eTDK1gD4I9Y",
+          "id": "XEzNKvE_H1k",
           "locality": "private"
         },
         "netflow": {
@@ -110,7 +110,7 @@
         },
         "network": {
           "bytes": 232,
-          "community_id": "1:0CGjtxAvSJC5Eo2OErzsmgtb9JE=",
+          "community_id": "1:FNxXvGAyYWw3vwZ19uivr2R5TOI=",
           "direction": "outbound",
           "iana_number": 17,
           "packets": 1,

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Palo-Alto-1-flowset-in-large-zero-filled-packet.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Palo-Alto-1-flowset-in-large-zero-filled-packet.golden.json
@@ -20,7 +20,7 @@
           "start": "2018-06-06T13:20:02Z"
         },
         "flow": {
-          "id": "NBJEjpgh6PA",
+          "id": "A-NpGXd6eh4",
           "locality": "public"
         },
         "netflow": {
@@ -53,7 +53,7 @@
         },
         "network": {
           "bytes": 363,
-          "community_id": "1:0PLHlww9zxRlvByabAFlUctNy14=",
+          "community_id": "1:hc80jQer1W3Gz0bQrzvclI7gPC4=",
           "direction": "inbound",
           "iana_number": 6,
           "packets": 3,

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Palo-Alto-PAN--OS-with-app--id.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Palo-Alto-PAN--OS-with-app--id.golden.json
@@ -20,7 +20,7 @@
           "start": "2017-11-13T14:39:31Z"
         },
         "flow": {
-          "id": "TjiJZcm_jfQ",
+          "id": "0HZ2F4aNlps",
           "locality": "public"
         },
         "netflow": {
@@ -53,7 +53,7 @@
         },
         "network": {
           "bytes": 70,
-          "community_id": "1:Z13H6lSO/rT00gPaBd0ePtowUwU=",
+          "community_id": "1:11Kt5B6QyX5pDO/SLJ43Bphmq88=",
           "direction": "inbound",
           "iana_number": 6,
           "packets": 1,
@@ -89,8 +89,8 @@
           "start": "2017-11-13T14:33:52Z"
         },
         "flow": {
-          "id": "EfRDtcx9dGw",
-          "locality": "private"
+          "id": "GTu1zsDt3yw",
+          "locality": "public"
         },
         "netflow": {
           "destination_ipv4_address": "162.115.24.30",
@@ -122,7 +122,7 @@
         },
         "network": {
           "bytes": 111,
-          "community_id": "1:zlR/fdbiNTN7ULEui4bC3qxG1o0=",
+          "community_id": "1:5QI8VSitrcJRweFVICeaszFbRls=",
           "direction": "inbound",
           "iana_number": 6,
           "packets": 1,
@@ -158,8 +158,8 @@
           "start": "2017-11-13T14:39:31Z"
         },
         "flow": {
-          "id": "12DeYybcEdw",
-          "locality": "private"
+          "id": "nUCuFEB8z_c",
+          "locality": "public"
         },
         "netflow": {
           "destination_ipv4_address": "34.202.173.126",
@@ -191,7 +191,7 @@
         },
         "network": {
           "bytes": 70,
-          "community_id": "1:iPZ6IKLg+WRI0x/mfDa2zUl8NWo=",
+          "community_id": "1:vBBJ4SjT7kXd3iaexKMtabgqSCs=",
           "direction": "inbound",
           "iana_number": 6,
           "packets": 1,
@@ -227,7 +227,7 @@
           "start": "2017-11-13T14:39:31Z"
         },
         "flow": {
-          "id": "qVYDELU6018",
+          "id": "inYZm0Y9EVM",
           "locality": "public"
         },
         "netflow": {
@@ -260,7 +260,7 @@
         },
         "network": {
           "bytes": 70,
-          "community_id": "1:DG1OmFpfrDQJaRiR/AiJ0Wn4g34=",
+          "community_id": "1:wTMnIMoRsRJzOmrl2DNxoGTllNw=",
           "direction": "inbound",
           "iana_number": 6,
           "packets": 1,
@@ -296,7 +296,7 @@
           "start": "2017-11-13T14:39:31Z"
         },
         "flow": {
-          "id": "TpoaO_sdw_E",
+          "id": "6vds_sLxXqE",
           "locality": "private"
         },
         "netflow": {
@@ -329,7 +329,7 @@
         },
         "network": {
           "bytes": 78,
-          "community_id": "1:ZZSPPc4xy9dNLn8KxxGBoonV5Q0=",
+          "community_id": "1:Jz7Lbm9U8/7FsldE07RUIDaIwMg=",
           "direction": "inbound",
           "iana_number": 6,
           "packets": 1,
@@ -365,7 +365,7 @@
           "start": "2017-11-13T14:39:31Z"
         },
         "flow": {
-          "id": "6dFcKC1QoJM",
+          "id": "6vds_sLxXqE",
           "locality": "private"
         },
         "netflow": {
@@ -398,7 +398,7 @@
         },
         "network": {
           "bytes": 78,
-          "community_id": "1:Pz3YYp58JIxmcuSHQGGFLeqZuMI=",
+          "community_id": "1:Jz7Lbm9U8/7FsldE07RUIDaIwMg=",
           "direction": "inbound",
           "iana_number": 6,
           "packets": 1,
@@ -434,7 +434,7 @@
           "start": "2017-11-13T14:39:31Z"
         },
         "flow": {
-          "id": "Yz_JFHfclJQ",
+          "id": "v3XVGdLaIe4",
           "locality": "public"
         },
         "netflow": {
@@ -467,7 +467,7 @@
         },
         "network": {
           "bytes": 70,
-          "community_id": "1:d7ZiIN8VXiJ5Z+UQZqEL0dDlUxw=",
+          "community_id": "1:rTQvVbrQGU0Tg6wM++r40r7jciY=",
           "direction": "inbound",
           "iana_number": 6,
           "packets": 1,
@@ -503,8 +503,8 @@
           "start": "2017-11-13T14:39:31Z"
         },
         "flow": {
-          "id": "gK9a_4GC8F8",
-          "locality": "private"
+          "id": "aenMB9Z5Tzc",
+          "locality": "public"
         },
         "netflow": {
           "destination_ipv4_address": "65.52.108.254",
@@ -536,7 +536,7 @@
         },
         "network": {
           "bytes": 70,
-          "community_id": "1:+8F8Whgl7WnEMyWEwtKcn0bQE+I=",
+          "community_id": "1:IZHqRmHtHCL+iLqMZ6Ge76dclyk=",
           "direction": "inbound",
           "iana_number": 6,
           "packets": 1,

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Streamcore.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Streamcore.golden.json
@@ -20,7 +20,7 @@
           "start": "2017-01-11T11:47:22.867Z"
         },
         "flow": {
-          "id": "-6Te1tDf44E",
+          "id": "wdxUeEaOBho",
           "locality": "public"
         },
         "netflow": {
@@ -48,7 +48,7 @@
         },
         "network": {
           "bytes": 128,
-          "community_id": "1:Vq90QiM+mzZbbo5vY5GdjE9OrRc=",
+          "community_id": "1:7MtHGVqegLvVBZnjbdFbAv+jNIM=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 3,
@@ -84,8 +84,8 @@
           "start": "2017-01-11T11:47:22.866Z"
         },
         "flow": {
-          "id": "R1qTxPMgj7U",
-          "locality": "private"
+          "id": "wdxUeEaOBho",
+          "locality": "public"
         },
         "netflow": {
           "destination_ipv4_address": "100.78.40.201",
@@ -112,7 +112,7 @@
         },
         "network": {
           "bytes": 172,
-          "community_id": "1:q9x0h1eGokXApDL651a/13CjP74=",
+          "community_id": "1:7MtHGVqegLvVBZnjbdFbAv+jNIM=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 4,
@@ -148,7 +148,7 @@
           "start": "2017-01-11T11:22:43.939Z"
         },
         "flow": {
-          "id": "99lFCpKjscc",
+          "id": "6_Ia6lqx2cg",
           "locality": "public"
         },
         "netflow": {
@@ -176,7 +176,7 @@
         },
         "network": {
           "bytes": 3943,
-          "community_id": "1:2fY1XMUII4NBiXGj6I6Knj1Kg4A=",
+          "community_id": "1:sO2dc+7dqGsF7s8EIdc2tq1XlhQ=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 10,
@@ -212,8 +212,8 @@
           "start": "2017-01-11T11:22:43.939Z"
         },
         "flow": {
-          "id": "qKNwoK4AM-I",
-          "locality": "private"
+          "id": "6_Ia6lqx2cg",
+          "locality": "public"
         },
         "netflow": {
           "destination_ipv4_address": "100.78.40.201",
@@ -240,7 +240,7 @@
         },
         "network": {
           "bytes": 3052,
-          "community_id": "1:yMe4rLBOcLy4kK6KxECnRMoxH5Y=",
+          "community_id": "1:sO2dc+7dqGsF7s8EIdc2tq1XlhQ=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 11,

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Ubiquiti-Edgerouter-with-MPLS-labels.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Ubiquiti-Edgerouter-with-MPLS-labels.golden.json
@@ -21,7 +21,7 @@
           "start": "2016-09-10T16:17:25.825Z"
         },
         "flow": {
-          "id": "9DIPifkw57g",
+          "id": "KYJ6RiyA5YM",
           "locality": "private"
         },
         "netflow": {
@@ -56,7 +56,7 @@
         },
         "network": {
           "bytes": 174,
-          "community_id": "1:LBCtS/p3ascA03WBOEnBcb1EGoI=",
+          "community_id": "1:NBTWKwdDGkYieqGKPdWehkSsDm4=",
           "direction": "inbound",
           "iana_number": 17,
           "packets": 2,
@@ -94,7 +94,7 @@
           "start": "2016-09-10T16:17:25.825Z"
         },
         "flow": {
-          "id": "FxVLIy8iNbs",
+          "id": "4GHcyowN7sg",
           "locality": "private"
         },
         "netflow": {
@@ -129,7 +129,7 @@
         },
         "network": {
           "bytes": 87,
-          "community_id": "1:vJ5vmvDe5YWGqPYTZi5Sq28Qsds=",
+          "community_id": "1:Dyu6ee2GSLgQQ7vGPNfn9m+ogiM=",
           "direction": "inbound",
           "iana_number": 17,
           "packets": 1,
@@ -167,7 +167,7 @@
           "start": "2016-09-10T15:20:10.664Z"
         },
         "flow": {
-          "id": "wzF3aTW8jDk",
+          "id": "GRn2z1Rao3c",
           "locality": "private"
         },
         "netflow": {
@@ -202,7 +202,7 @@
         },
         "network": {
           "bytes": 1920,
-          "community_id": "1:CFiH8b4XWH4O1l2Sw0q1HH4BB4Q=",
+          "community_id": "1:8fXYyfmQTXQv1A8dwYcRyrZr5bA=",
           "direction": "inbound",
           "iana_number": 6,
           "packets": 15,
@@ -240,7 +240,7 @@
           "start": "2016-09-10T15:20:10.664Z"
         },
         "flow": {
-          "id": "F5Rxx9ksQqg",
+          "id": "iHA6jdIkqjA",
           "locality": "private"
         },
         "netflow": {
@@ -275,7 +275,7 @@
         },
         "network": {
           "bytes": 610,
-          "community_id": "1:P/vFKj652d0ZJNMMgXdjjE27lvY=",
+          "community_id": "1:mNTeyDMHqs2HRwBAdsSLCzMRjjI=",
           "direction": "inbound",
           "iana_number": 6,
           "packets": 8,
@@ -313,7 +313,7 @@
           "start": "2016-09-10T16:17:35.661Z"
         },
         "flow": {
-          "id": "KtWRob72_KI",
+          "id": "cBjtKefzGos",
           "locality": "private"
         },
         "netflow": {
@@ -348,7 +348,7 @@
         },
         "network": {
           "bytes": 2420,
-          "community_id": "1:xKw+VoWL9M7oxnO1UggxTAebwU0=",
+          "community_id": "1:/16s6/4OVEnao8jPez9fez90nkk=",
           "direction": "inbound",
           "iana_number": 6,
           "packets": 21,
@@ -386,7 +386,7 @@
           "start": "2016-09-10T16:17:35.763Z"
         },
         "flow": {
-          "id": "HKh39QAnkVg",
+          "id": "EzT0lQWYBRw",
           "locality": "private"
         },
         "netflow": {
@@ -421,7 +421,7 @@
         },
         "network": {
           "bytes": 10204,
-          "community_id": "1:FfkN6z0DhUrGLn5+zWn/sV0ZniA=",
+          "community_id": "1:6KrMdAfJt1Y285J57/II02tBqvw=",
           "direction": "inbound",
           "iana_number": 6,
           "packets": 30,
@@ -459,7 +459,7 @@
           "start": "2016-09-10T15:22:36.207Z"
         },
         "flow": {
-          "id": "odKR5mjX26E",
+          "id": "TROGwofkmJA",
           "locality": "private"
         },
         "netflow": {
@@ -494,7 +494,7 @@
         },
         "network": {
           "bytes": 216,
-          "community_id": "1:eE3KIQz/eWZHV2I+CCqw4zUkL9g=",
+          "community_id": "1:tqJ7J04mTp1f5t9jqcuGIbqiLM8=",
           "direction": "inbound",
           "iana_number": 6,
           "packets": 4,
@@ -532,7 +532,7 @@
           "start": "2016-09-10T16:17:35.661Z"
         },
         "flow": {
-          "id": "jmSySB9x9F4",
+          "id": "wLclDbADA9s",
           "locality": "private"
         },
         "netflow": {
@@ -567,7 +567,7 @@
         },
         "network": {
           "bytes": 152,
-          "community_id": "1:xG/g/ovBtK1hoaoh6T83Jh/9WKo=",
+          "community_id": "1:qoM8TuOJj+A0BLulnxvxPwcFsfs=",
           "direction": "inbound",
           "iana_number": 17,
           "packets": 1,
@@ -604,7 +604,7 @@
           "start": "2016-09-10T15:23:38.835Z"
         },
         "flow": {
-          "id": "JhG_lEoQYB0",
+          "id": "LpdyE0SSB-o",
           "locality": "private"
         },
         "netflow": {
@@ -639,7 +639,7 @@
         },
         "network": {
           "bytes": 260,
-          "community_id": "1:XjfR484ViCn+jOuZLqYQqjqQtfc=",
+          "community_id": "1:eh+yszc/KHzqQp5jYGjCrbErF5w=",
           "direction": "outbound",
           "iana_number": 6,
           "packets": 5,
@@ -675,7 +675,7 @@
           "start": "2016-09-10T16:18:39.443Z"
         },
         "flow": {
-          "id": "p7SVhtV-_NQ",
+          "id": "32P6av-L8P0",
           "locality": "private"
         },
         "netflow": {
@@ -710,7 +710,7 @@
         },
         "network": {
           "bytes": 32,
-          "community_id": "1:95RXAJ+p7YRmPl3ntaE9GolON50=",
+          "community_id": "1:wuo75Abni2/KMmq9G5RDRtUHum4=",
           "direction": "outbound",
           "iana_number": 17,
           "packets": 1,
@@ -746,7 +746,7 @@
           "start": "2016-09-10T16:18:39.443Z"
         },
         "flow": {
-          "id": "nQrz4FxBtZw",
+          "id": "ft_m5C7Hgpo",
           "locality": "private"
         },
         "netflow": {
@@ -781,7 +781,7 @@
         },
         "network": {
           "bytes": 135,
-          "community_id": "1:RCz/33YJNjlqCsLhJKCpATtxyRs=",
+          "community_id": "1:GCl5GOo95EWKkGa7RwFq6LQyB3I=",
           "direction": "outbound",
           "iana_number": 17,
           "packets": 1,
@@ -817,7 +817,7 @@
           "start": "2016-09-10T16:18:39.443Z"
         },
         "flow": {
-          "id": "sA5GmmWb4JM",
+          "id": "bVX88Ii80AQ",
           "locality": "private"
         },
         "netflow": {
@@ -852,7 +852,7 @@
         },
         "network": {
           "bytes": 135,
-          "community_id": "1:XHp0tgbuHUU5GBjWgwCKVVK7F+k=",
+          "community_id": "1:C7Lu8zD8/tm/pDhREb0JsqNmu3U=",
           "direction": "outbound",
           "iana_number": 17,
           "packets": 1,
@@ -888,7 +888,7 @@
           "start": "2016-09-10T16:18:39.443Z"
         },
         "flow": {
-          "id": "NSg4n2Hl_Zk",
+          "id": "bA4nBN4veuI",
           "locality": "private"
         },
         "netflow": {
@@ -923,7 +923,7 @@
         },
         "network": {
           "bytes": 135,
-          "community_id": "1:WFxjExIXgIuAq+rNDGVQYEnaugA=",
+          "community_id": "1:RxUxXSe/yIC0j4o5I9nZhC1kDXA=",
           "direction": "outbound",
           "iana_number": 17,
           "packets": 1,
@@ -959,7 +959,7 @@
           "start": "2016-09-10T16:18:39.443Z"
         },
         "flow": {
-          "id": "SgT6qnJ1Q7U",
+          "id": "lY5yfRKXE3s",
           "locality": "private"
         },
         "netflow": {
@@ -994,7 +994,7 @@
         },
         "network": {
           "bytes": 135,
-          "community_id": "1:d9brHw1Oz6WSVKR3rJyezHX6DIw=",
+          "community_id": "1:MX45AfOFOz7aFL6GL7Ga9yfeUtY=",
           "direction": "outbound",
           "iana_number": 17,
           "packets": 1,
@@ -1030,7 +1030,7 @@
           "start": "2016-09-10T16:18:39.443Z"
         },
         "flow": {
-          "id": "9KP-X-siVpY",
+          "id": "x3GfEtY3zCQ",
           "locality": "private"
         },
         "netflow": {
@@ -1065,7 +1065,7 @@
         },
         "network": {
           "bytes": 135,
-          "community_id": "1:2nQhV3nUU3v8Zm2yOpGYVOulxsI=",
+          "community_id": "1:ZY/RS9VGxN4ZyVhbQwapnUeJxb4=",
           "direction": "outbound",
           "iana_number": 17,
           "packets": 1,
@@ -1101,7 +1101,7 @@
           "start": "2016-09-10T15:02:53.375Z"
         },
         "flow": {
-          "id": "1FSVPXmZiq4",
+          "id": "bfT831bq5AI",
           "locality": "private"
         },
         "netflow": {
@@ -1136,7 +1136,7 @@
         },
         "network": {
           "bytes": 3668,
-          "community_id": "1:p7mv5aLl7VvnGcnWMhevg6/gYrM=",
+          "community_id": "1:qYI9Y2rQNRYLaB2hC3tf5xtUts0=",
           "direction": "outbound",
           "iana_number": 6,
           "packets": 21,

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-field-layer2segmentid.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-field-layer2segmentid.golden.json
@@ -20,8 +20,8 @@
           "start": "2018-01-16T09:44:47Z"
         },
         "flow": {
-          "id": "sjsTHOXy2lQ",
-          "locality": "private"
+          "id": "tS3zN7t_rFg",
+          "locality": "public"
         },
         "netflow": {
           "destination_ipv4_address": "80.82.237.40",
@@ -52,7 +52,7 @@
         },
         "network": {
           "bytes": 52,
-          "community_id": "1:4iAaWV/HzvAcwggo1MJCfjvj8No=",
+          "community_id": "1:V19XLX+69Hp20cyrswTBva1s5MM=",
           "direction": "inbound",
           "iana_number": 6,
           "packets": 1,

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-ipt_netflow-reduced-size-encoding.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-ipt_netflow-reduced-size-encoding.golden.json
@@ -21,7 +21,7 @@
           "start": "2018-02-18T05:46:45Z"
         },
         "flow": {
-          "id": "e51_HB0pUk0",
+          "id": "XLC-7u3wi0U",
           "locality": "public"
         },
         "netflow": {
@@ -56,7 +56,7 @@
         },
         "network": {
           "bytes": 156,
-          "community_id": "1:6bApwXCshD5rqS4P4mVFwtobnBM=",
+          "community_id": "1:UB3lt1Isf0aF4UrkqLFDFJF9mqs=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 3,
@@ -94,7 +94,7 @@
           "start": "2018-02-18T05:46:53.992Z"
         },
         "flow": {
-          "id": "syYxgsNlkLw",
+          "id": "2mdiEm9z6pA",
           "locality": "public"
         },
         "netflow": {
@@ -129,7 +129,7 @@
         },
         "network": {
           "bytes": 48,
-          "community_id": "1:nHvXTDLBywv91YMJeWrLeJPdWP4=",
+          "community_id": "1:qRS02uGU7DQQhA2eIiypcWW646c=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 1,
@@ -167,8 +167,8 @@
           "start": "2018-02-18T05:46:46.336Z"
         },
         "flow": {
-          "id": "lOA4UGSSPSo",
-          "locality": "private"
+          "id": "IKsDJxZK5UA",
+          "locality": "public"
         },
         "netflow": {
           "destination_ipv4_address": "212.224.113.74",
@@ -202,7 +202,7 @@
         },
         "network": {
           "bytes": 584,
-          "community_id": "1:3gZ5hR1U0fS2hvac/Y9iO8mcFDo=",
+          "community_id": "1:m2CtSpaQp+2xe8gg2IStCRuPvdE=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 11,
@@ -240,7 +240,7 @@
           "start": "2018-02-18T05:46:53.976Z"
         },
         "flow": {
-          "id": "0YHsWqnlq5A",
+          "id": "lfpS1KL7LwI",
           "locality": "public"
         },
         "netflow": {
@@ -275,7 +275,7 @@
         },
         "network": {
           "bytes": 577,
-          "community_id": "1:Uc3mP+7U3dbDz60McoL0jYl+KUQ=",
+          "community_id": "1:qBYG/gPpQslUYq/PoeUvwOTeciI=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 4,
@@ -313,8 +313,8 @@
           "start": "2018-02-18T05:46:52.82Z"
         },
         "flow": {
-          "id": "nVp4utJbp_Q",
-          "locality": "private"
+          "id": "HRyho8QOr5M",
+          "locality": "public"
         },
         "netflow": {
           "destination_ipv4_address": "62.221.115.205",
@@ -348,7 +348,7 @@
         },
         "network": {
           "bytes": 152,
-          "community_id": "1:Wcok2NJh31VgMyBs70twGHpEg7M=",
+          "community_id": "1:IMkMWSeVEQtrGLMvUrWNrRloBnU=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 3,
@@ -386,8 +386,8 @@
           "start": "2018-02-18T05:46:45Z"
         },
         "flow": {
-          "id": "jqJsvE2EmTY",
-          "locality": "private"
+          "id": "jbL3H_oK7ok",
+          "locality": "public"
         },
         "netflow": {
           "destination_ipv4_address": "37.146.125.64",
@@ -421,7 +421,7 @@
         },
         "network": {
           "bytes": 152,
-          "community_id": "1:tfHBMGf05/6z8XXBH1VvTg3Bp4k=",
+          "community_id": "1:x/J1qXHnaUwGcB8zD1GcpV9lWRs=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 3,
@@ -459,8 +459,8 @@
           "start": "2018-02-18T05:46:49.56Z"
         },
         "flow": {
-          "id": "vW9hpco_odQ",
-          "locality": "private"
+          "id": "ayKjfr1z0QU",
+          "locality": "public"
         },
         "netflow": {
           "destination_ipv4_address": "52.198.214.72",
@@ -494,7 +494,7 @@
         },
         "network": {
           "bytes": 1809,
-          "community_id": "1:RkpTZIg7FeOitpZbe0ahhlzx90w=",
+          "community_id": "1:FsZvFeVrzzIyp2g1XhIbWdMJlww=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 15,
@@ -532,8 +532,8 @@
           "start": "2018-02-18T05:46:53.916Z"
         },
         "flow": {
-          "id": "XZPQT-klpQE",
-          "locality": "private"
+          "id": "B15R8wv_tVI",
+          "locality": "public"
         },
         "netflow": {
           "destination_ipv4_address": "64.233.161.188",
@@ -567,7 +567,7 @@
         },
         "network": {
           "bytes": 234,
-          "community_id": "1:QdyoRIMjHbHZz9RohPLNm74w6QE=",
+          "community_id": "1:b6ds1NE3TsQ0PIp+pKuGWaqwsyc=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 3,
@@ -605,8 +605,8 @@
           "start": "2018-02-18T05:46:53.592Z"
         },
         "flow": {
-          "id": "zV8Gq7FFMug",
-          "locality": "private"
+          "id": "oYN-uwp504w",
+          "locality": "public"
         },
         "netflow": {
           "destination_ipv4_address": "185.209.20.240",
@@ -640,7 +640,7 @@
         },
         "network": {
           "bytes": 1681,
-          "community_id": "1:ByBLMidnd0Tua+Vk+59YTRfjE3g=",
+          "community_id": "1:w1ulQqI1NNDG8118wxe2KjecAWs=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 22,
@@ -678,8 +678,8 @@
           "start": "2018-02-18T05:46:44.964Z"
         },
         "flow": {
-          "id": "V-jsfUlFYAA",
-          "locality": "private"
+          "id": "MUPum_LUoxk",
+          "locality": "public"
         },
         "netflow": {
           "destination_ipv4_address": "84.39.245.175",
@@ -713,7 +713,7 @@
         },
         "network": {
           "bytes": 152,
-          "community_id": "1:+8jpPMTlqZM+u9QLxrPyk2/duOY=",
+          "community_id": "1:IQI7c8/Vlpqocm+uFFUkvbXPrIo=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 3,
@@ -751,7 +751,7 @@
           "start": "2018-02-18T05:46:53.932Z"
         },
         "flow": {
-          "id": "kHRVt7VxEJU",
+          "id": "YStkNP0pV1E",
           "locality": "public"
         },
         "netflow": {
@@ -786,7 +786,7 @@
         },
         "network": {
           "bytes": 1866,
-          "community_id": "1:hWEp1AGtGX7I3gL6btUapvplzdk=",
+          "community_id": "1:E4w2M65VHyHNlcgPcdFLuqutRQg=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 3,
@@ -824,7 +824,7 @@
           "start": "2018-02-18T05:46:53.8Z"
         },
         "flow": {
-          "id": "sYQ7ITvYnQw",
+          "id": "nkastJ_vPI4",
           "locality": "public"
         },
         "netflow": {
@@ -859,7 +859,7 @@
         },
         "network": {
           "bytes": 187,
-          "community_id": "1:ujpwO/BObx6DD8oop1f63tSyfcw=",
+          "community_id": "1:Ukfnc8AX67bQypWSmcn5huV+6qI=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 3,

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-macaddress.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-macaddress.golden.json
@@ -51,7 +51,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "owSGnhdQc1k",
+          "id": "zQfsdfKgh-o",
           "locality": "private"
         },
         "netflow": {
@@ -72,7 +72,7 @@
           "type": "netflow_flow"
         },
         "network": {
-          "community_id": "1:tzcqIeMhEvkXA/EBAZraJPCnaN8=",
+          "community_id": "1:xXTn9GECsRXx7t5CqUym4B1cCNU=",
           "direction": "unknown",
           "iana_number": 6,
           "transport": "tcp"
@@ -106,7 +106,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "_cbZpOjyGGQ",
+          "id": "Tw1iOKJ-dfE",
           "locality": "private"
         },
         "netflow": {
@@ -127,7 +127,7 @@
           "type": "netflow_flow"
         },
         "network": {
-          "community_id": "1:mYS5cP5hzhSb8JZH9+2v8+RMJ9g=",
+          "community_id": "1:8JJSV5jQe+UfRnLVV/iA7sy8Nz0=",
           "direction": "unknown",
           "iana_number": 17,
           "transport": "udp"
@@ -161,7 +161,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "i1KQBFMlwFg",
+          "id": "NF1W3jyrHAA",
           "locality": "private"
         },
         "netflow": {
@@ -182,7 +182,7 @@
           "type": "netflow_flow"
         },
         "network": {
-          "community_id": "1:cRrWVwyu9GLZ+aU7qmwhjSdMrpE=",
+          "community_id": "1:8JJSV5jQe+UfRnLVV/iA7sy8Nz0=",
           "direction": "unknown",
           "iana_number": 17,
           "transport": "udp"
@@ -216,7 +216,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "O3ETdQvmCOg",
+          "id": "B-_-kE8PEgA",
           "locality": "private"
         },
         "netflow": {
@@ -237,7 +237,7 @@
           "type": "netflow_flow"
         },
         "network": {
-          "community_id": "1:fVzE/MKEA1VMNMkCvz5NQinQLUI=",
+          "community_id": "1:9a3xSEOGeCOgc8wHkqU7yt3aKi4=",
           "direction": "unknown",
           "iana_number": 6,
           "transport": "tcp"
@@ -271,7 +271,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "GuhchkSUWPk",
+          "id": "B-_-kE8PEgA",
           "locality": "private"
         },
         "netflow": {
@@ -292,7 +292,7 @@
           "type": "netflow_flow"
         },
         "network": {
-          "community_id": "1:LZj70OIhu6ThMyKy7u70cO67FK4=",
+          "community_id": "1:9a3xSEOGeCOgc8wHkqU7yt3aKi4=",
           "direction": "unknown",
           "iana_number": 6,
           "transport": "tcp"
@@ -326,7 +326,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "w09kRuEnun8",
+          "id": "q6jss8DvXWE",
           "locality": "private"
         },
         "netflow": {
@@ -347,7 +347,7 @@
           "type": "netflow_flow"
         },
         "network": {
-          "community_id": "1:DoERidYQAzlwvj5aBo1aEylCHgo=",
+          "community_id": "1:tReeXdYbJqf6jxHsV/6j7S+FoNQ=",
           "direction": "unknown",
           "iana_number": 6,
           "transport": "tcp"
@@ -381,7 +381,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "2TaHSp0QckA",
+          "id": "q6jss8DvXWE",
           "locality": "private"
         },
         "netflow": {
@@ -402,7 +402,7 @@
           "type": "netflow_flow"
         },
         "network": {
-          "community_id": "1:s0N+K6vD3goIH7jZO1SqG58ztGQ=",
+          "community_id": "1:tReeXdYbJqf6jxHsV/6j7S+FoNQ=",
           "direction": "unknown",
           "iana_number": 6,
           "transport": "tcp"
@@ -436,7 +436,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "5DhRBSR-wO8",
+          "id": "3TmuMjQR8Mk",
           "locality": "private"
         },
         "netflow": {
@@ -457,7 +457,7 @@
           "type": "netflow_flow"
         },
         "network": {
-          "community_id": "1:q1r5Q5XRCVvpwYqEkfbN8OxKQuI=",
+          "community_id": "1:cdysWB0MnAlJwcBbj7j+pGVyBGg=",
           "direction": "unknown",
           "iana_number": 6,
           "transport": "tcp"
@@ -491,7 +491,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "In7-hVVW5Rw",
+          "id": "3TmuMjQR8Mk",
           "locality": "private"
         },
         "netflow": {
@@ -512,7 +512,7 @@
           "type": "netflow_flow"
         },
         "network": {
-          "community_id": "1:5idRNtMRt9YwcfftLSQtC72/n6Y=",
+          "community_id": "1:cdysWB0MnAlJwcBbj7j+pGVyBGg=",
           "direction": "unknown",
           "iana_number": 6,
           "transport": "tcp"
@@ -546,7 +546,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "p6xawkqu_zY",
+          "id": "2KDgFVtVKGg",
           "locality": "private"
         },
         "netflow": {
@@ -567,7 +567,7 @@
           "type": "netflow_flow"
         },
         "network": {
-          "community_id": "1:O9wqBh6gPhpzxHuWe7MgCX7Xpc4=",
+          "community_id": "1:6giQWS+fyjMORsdQimfi53pgwMk=",
           "direction": "unknown",
           "iana_number": 6,
           "transport": "tcp"
@@ -601,7 +601,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "JyqRDg0Pe1I",
+          "id": "2KDgFVtVKGg",
           "locality": "private"
         },
         "netflow": {
@@ -622,7 +622,7 @@
           "type": "netflow_flow"
         },
         "network": {
-          "community_id": "1:odq42pEjA7OgeYPh6amRzomwnoM=",
+          "community_id": "1:6giQWS+fyjMORsdQimfi53pgwMk=",
           "direction": "unknown",
           "iana_number": 6,
           "transport": "tcp"
@@ -656,7 +656,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "izkM8H_PkUs",
+          "id": "vwr6dNcr6FE",
           "locality": "private"
         },
         "netflow": {
@@ -677,7 +677,7 @@
           "type": "netflow_flow"
         },
         "network": {
-          "community_id": "1:UUC6Ang4BzxgjeDeSNC8v/53zx4=",
+          "community_id": "1:9TricJ4d/hl365P4avkWHSCNrfs=",
           "direction": "unknown",
           "iana_number": 6,
           "transport": "tcp"
@@ -711,7 +711,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "xQ18aAZ-pr8",
+          "id": "vwr6dNcr6FE",
           "locality": "private"
         },
         "netflow": {
@@ -732,7 +732,7 @@
           "type": "netflow_flow"
         },
         "network": {
-          "community_id": "1:gYnQndK1J0EfqJ6hcON4iV+sV1I=",
+          "community_id": "1:9TricJ4d/hl365P4avkWHSCNrfs=",
           "direction": "unknown",
           "iana_number": 6,
           "transport": "tcp"
@@ -766,7 +766,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "-1gdgg3n334",
+          "id": "tmgCubSF_CU",
           "locality": "private"
         },
         "netflow": {
@@ -787,7 +787,7 @@
           "type": "netflow_flow"
         },
         "network": {
-          "community_id": "1:zppnN171ys38psn8czlt3R0wxe8=",
+          "community_id": "1:6RszvU1rDWXVJ74Ktg0VviC8dHQ=",
           "direction": "unknown",
           "iana_number": 6,
           "transport": "tcp"
@@ -821,7 +821,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "CnVw8CbHrMY",
+          "id": "tmgCubSF_CU",
           "locality": "private"
         },
         "netflow": {
@@ -842,7 +842,7 @@
           "type": "netflow_flow"
         },
         "network": {
-          "community_id": "1:t1KFW03nxtZ2y4JBNbWu3PyDfk8=",
+          "community_id": "1:6RszvU1rDWXVJ74Ktg0VviC8dHQ=",
           "direction": "unknown",
           "iana_number": 6,
           "transport": "tcp"
@@ -876,7 +876,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "_P6iyZeEPpY",
+          "id": "Agzgga7RAr0",
           "locality": "private"
         },
         "netflow": {
@@ -897,7 +897,7 @@
           "type": "netflow_flow"
         },
         "network": {
-          "community_id": "1:cYbvSlVIg8esJzIq2q4ATrJ7+sY=",
+          "community_id": "1:c+E4+ll1WxXDPNDgvxstOuxlZJ8=",
           "direction": "unknown",
           "iana_number": 6,
           "transport": "tcp"
@@ -931,7 +931,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "H8S4xKKvY9c",
+          "id": "Agzgga7RAr0",
           "locality": "private"
         },
         "netflow": {
@@ -952,7 +952,7 @@
           "type": "netflow_flow"
         },
         "network": {
-          "community_id": "1:xw52kFQxAYrEnkCjkJPN4NUZ8WI=",
+          "community_id": "1:c+E4+ll1WxXDPNDgvxstOuxlZJ8=",
           "direction": "unknown",
           "iana_number": 6,
           "transport": "tcp"
@@ -986,7 +986,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "RHnG3UfiYVs",
+          "id": "-cqFlm16mLc",
           "locality": "private"
         },
         "netflow": {
@@ -1007,7 +1007,7 @@
           "type": "netflow_flow"
         },
         "network": {
-          "community_id": "1:nOvjuKIb5reZRRHaoCJRGUw2u2o=",
+          "community_id": "1:4qi27nfOIgyBcA6+RYnuq/tZB/8=",
           "direction": "unknown",
           "iana_number": 6,
           "transport": "tcp"
@@ -1041,7 +1041,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "DCtFd6UwimY",
+          "id": "-cqFlm16mLc",
           "locality": "private"
         },
         "netflow": {
@@ -1062,7 +1062,7 @@
           "type": "netflow_flow"
         },
         "network": {
-          "community_id": "1:iXLOg+5V7xMNbFjb/Fn13WXIwpA=",
+          "community_id": "1:4qi27nfOIgyBcA6+RYnuq/tZB/8=",
           "direction": "unknown",
           "iana_number": 6,
           "transport": "tcp"
@@ -1096,7 +1096,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "S6vU3RZ9qRo",
+          "id": "Txfldw7-948",
           "locality": "private"
         },
         "netflow": {
@@ -1117,7 +1117,7 @@
           "type": "netflow_flow"
         },
         "network": {
-          "community_id": "1:hoCpobmQ1SEqktORR12M8ynuDPI=",
+          "community_id": "1:9grL4uqlG5JP5jXa8hCBLSZ1bAo=",
           "direction": "unknown",
           "iana_number": 6,
           "transport": "tcp"
@@ -1151,7 +1151,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "g5SWzYolCH8",
+          "id": "Txfldw7-948",
           "locality": "private"
         },
         "netflow": {
@@ -1172,7 +1172,7 @@
           "type": "netflow_flow"
         },
         "network": {
-          "community_id": "1:nphrDmJfS2JuUpcSM+E36Xh41ck=",
+          "community_id": "1:9grL4uqlG5JP5jXa8hCBLSZ1bAo=",
           "direction": "unknown",
           "iana_number": 6,
           "transport": "tcp"
@@ -1206,7 +1206,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "Pa6VrN0hfFM",
+          "id": "iaXg6w051Ho",
           "locality": "private"
         },
         "netflow": {
@@ -1227,7 +1227,7 @@
           "type": "netflow_flow"
         },
         "network": {
-          "community_id": "1:andIv3q3a7gqVMMwg+YVAxxbyf8=",
+          "community_id": "1:vY2zU7sBMSQd04PrR2LEa7Q2pFE=",
           "direction": "unknown",
           "iana_number": 6,
           "transport": "tcp"
@@ -1261,7 +1261,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "Ma9Hrn8BuXE",
+          "id": "iaXg6w051Ho",
           "locality": "private"
         },
         "netflow": {
@@ -1282,7 +1282,7 @@
           "type": "netflow_flow"
         },
         "network": {
-          "community_id": "1:3Zpznpp5sA+yxgN2vQONTT4Qtlk=",
+          "community_id": "1:vY2zU7sBMSQd04PrR2LEa7Q2pFE=",
           "direction": "unknown",
           "iana_number": 6,
           "transport": "tcp"
@@ -1316,7 +1316,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "Pol0ObD1Z-8",
+          "id": "cEvEMCFhKJk",
           "locality": "private"
         },
         "netflow": {
@@ -1337,7 +1337,7 @@
           "type": "netflow_flow"
         },
         "network": {
-          "community_id": "1:b/19ZiHUfRjjwT7BRwqUlFnZk30=",
+          "community_id": "1:Cf9adPldvSduPZshQSGGhNsc5PU=",
           "direction": "unknown",
           "iana_number": 6,
           "transport": "tcp"
@@ -1371,7 +1371,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "j3DHUjySbaU",
+          "id": "cEvEMCFhKJk",
           "locality": "private"
         },
         "netflow": {
@@ -1392,7 +1392,7 @@
           "type": "netflow_flow"
         },
         "network": {
-          "community_id": "1:ThxBiPu4noU7F3HVrTJodqLYprw=",
+          "community_id": "1:Cf9adPldvSduPZshQSGGhNsc5PU=",
           "direction": "unknown",
           "iana_number": 6,
           "transport": "tcp"
@@ -1426,7 +1426,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "QEHbEEyzRwc",
+          "id": "DnN0kX-gR3Q",
           "locality": "private"
         },
         "netflow": {
@@ -1447,7 +1447,7 @@
           "type": "netflow_flow"
         },
         "network": {
-          "community_id": "1:PtQEU2tjKLZQ3ulraXStL41RrFw=",
+          "community_id": "1:odV4cLKFeNM7n9PKTb6oi19upi4=",
           "direction": "unknown",
           "iana_number": 6,
           "transport": "tcp"
@@ -1481,7 +1481,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "In_yyQ3MzQ4",
+          "id": "DnN0kX-gR3Q",
           "locality": "private"
         },
         "netflow": {
@@ -1502,7 +1502,7 @@
           "type": "netflow_flow"
         },
         "network": {
-          "community_id": "1:c9aRRsQSCI2QgP+soSkmLeg4eME=",
+          "community_id": "1:odV4cLKFeNM7n9PKTb6oi19upi4=",
           "direction": "unknown",
           "iana_number": 6,
           "transport": "tcp"
@@ -1536,7 +1536,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "b69Xoj2gRmY",
+          "id": "-kLcuxmRzgk",
           "locality": "private"
         },
         "netflow": {
@@ -1557,7 +1557,7 @@
           "type": "netflow_flow"
         },
         "network": {
-          "community_id": "1:pYvqf9IBjYoaWWbRiwE7BvIF0+U=",
+          "community_id": "1:ZRD9IAxw9PMwqFA3PuRYzm0karc=",
           "direction": "unknown",
           "iana_number": 6,
           "transport": "tcp"
@@ -1591,7 +1591,7 @@
           "kind": "event"
         },
         "flow": {
-          "id": "7kt-7t6WhAc",
+          "id": "-kLcuxmRzgk",
           "locality": "private"
         },
         "netflow": {
@@ -1612,7 +1612,7 @@
           "type": "netflow_flow"
         },
         "network": {
-          "community_id": "1:khchUIbdprQL3CvkhqiO+LfVtOQ=",
+          "community_id": "1:ZRD9IAxw9PMwqFA3PuRYzm0karc=",
           "direction": "unknown",
           "iana_number": 6,
           "transport": "tcp"

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-multiple-netflow-exporters.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-multiple-netflow-exporters.golden.json
@@ -53,7 +53,7 @@
           "start": "2015-10-08T19:03:46.14Z"
         },
         "flow": {
-          "id": "i1KQBFMlwFg",
+          "id": "1E-M5OJg_go",
           "locality": "private"
         },
         "netflow": {
@@ -82,7 +82,7 @@
         },
         "network": {
           "bytes": 76,
-          "community_id": "1:cRrWVwyu9GLZ+aU7qmwhjSdMrpE=",
+          "community_id": "1:QKTFMKhaT7j1xLTKOURCTVzbKk8=",
           "direction": "unknown",
           "iana_number": 17,
           "packets": 1,
@@ -118,7 +118,7 @@
           "start": "2015-10-08T19:03:46.14Z"
         },
         "flow": {
-          "id": "0Wj-QgIvFZE",
+          "id": "yMxFd8CW_Ok",
           "locality": "private"
         },
         "netflow": {
@@ -147,7 +147,7 @@
         },
         "network": {
           "bytes": 76,
-          "community_id": "1:wNJjbHYcMj4lBiVWbMHK1JcgsJ8=",
+          "community_id": "1:QKTFMKhaT7j1xLTKOURCTVzbKk8=",
           "direction": "unknown",
           "iana_number": 17,
           "packets": 1,
@@ -183,7 +183,7 @@
           "start": "2015-10-08T19:03:51.813Z"
         },
         "flow": {
-          "id": "i1KQBFMlwFg",
+          "id": "NF1W3jyrHAA",
           "locality": "private"
         },
         "netflow": {
@@ -212,7 +212,7 @@
         },
         "network": {
           "bytes": 76,
-          "community_id": "1:cRrWVwyu9GLZ+aU7qmwhjSdMrpE=",
+          "community_id": "1:8JJSV5jQe+UfRnLVV/iA7sy8Nz0=",
           "direction": "unknown",
           "iana_number": 17,
           "packets": 1,
@@ -248,7 +248,7 @@
           "start": "2015-10-08T19:03:51.813Z"
         },
         "flow": {
-          "id": "_cbZpOjyGGQ",
+          "id": "Tw1iOKJ-dfE",
           "locality": "private"
         },
         "netflow": {
@@ -277,7 +277,7 @@
         },
         "network": {
           "bytes": 76,
-          "community_id": "1:mYS5cP5hzhSb8JZH9+2v8+RMJ9g=",
+          "community_id": "1:8JJSV5jQe+UfRnLVV/iA7sy8Nz0=",
           "direction": "unknown",
           "iana_number": 17,
           "packets": 1,
@@ -313,7 +313,7 @@
           "start": "2015-10-08T19:03:55.958Z"
         },
         "flow": {
-          "id": "i1KQBFMlwFg",
+          "id": "sNF38-obC7k",
           "locality": "private"
         },
         "netflow": {
@@ -342,7 +342,7 @@
         },
         "network": {
           "bytes": 76,
-          "community_id": "1:cRrWVwyu9GLZ+aU7qmwhjSdMrpE=",
+          "community_id": "1:SYyoe1e5BMoo9l35SqJ7wRextZg=",
           "direction": "unknown",
           "iana_number": 17,
           "packets": 1,
@@ -378,7 +378,7 @@
           "start": "2015-10-08T19:03:55.958Z"
         },
         "flow": {
-          "id": "jDcbOcubrco",
+          "id": "458D6voFu3E",
           "locality": "private"
         },
         "netflow": {
@@ -407,7 +407,7 @@
         },
         "network": {
           "bytes": 76,
-          "community_id": "1:Y7cJ9MH0pPXGOYtewjtnB/Xf2Os=",
+          "community_id": "1:SYyoe1e5BMoo9l35SqJ7wRextZg=",
           "direction": "unknown",
           "iana_number": 17,
           "packets": 1,
@@ -504,7 +504,7 @@
           "start": "2015-10-08T19:05:55.01Z"
         },
         "flow": {
-          "id": "74wObESpHnY",
+          "id": "zQfsdfKgh-o",
           "locality": "private"
         },
         "netflow": {
@@ -537,7 +537,7 @@
         },
         "network": {
           "bytes": 200,
-          "community_id": "1:8pI6JBgAyYEKnrTjwzuiAMlElgY=",
+          "community_id": "1:xXTn9GECsRXx7t5CqUym4B1cCNU=",
           "direction": "unknown",
           "iana_number": 6,
           "packets": 2,

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-template-with-0-length-fields.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-template-with-0-length-fields.golden.json
@@ -20,7 +20,7 @@
           "start": "2016-12-23T01:34:48.299Z"
         },
         "flow": {
-          "id": "39W8LA5XBnc",
+          "id": "BSsjrf_TZnk",
           "locality": "public"
         },
         "netflow": {
@@ -53,7 +53,7 @@
         },
         "network": {
           "bytes": 0,
-          "community_id": "1:PrM3BB+zl6s0dy/nMB1KOgnPLyM=",
+          "community_id": "1:ULB1r6mICiBbVy83sLPpCdI1WpE=",
           "direction": "outbound",
           "iana_number": 2,
           "packets": 0,
@@ -89,8 +89,8 @@
           "start": "2016-12-23T01:34:48.299Z"
         },
         "flow": {
-          "id": "BXrAI1HW--A",
-          "locality": "private"
+          "id": "R1Sjz_ITbgo",
+          "locality": "public"
         },
         "netflow": {
           "destination_ipv4_address": "239.255.255.250",
@@ -122,7 +122,7 @@
         },
         "network": {
           "bytes": 0,
-          "community_id": "1:iOW2w0b8tPUYnP8m2LWGTS2Eh7k=",
+          "community_id": "1:ULB1r6mICiBbVy83sLPpCdI1WpE=",
           "direction": "outbound",
           "iana_number": 2,
           "packets": 0,
@@ -158,7 +158,7 @@
           "start": "2016-12-23T01:34:51.469Z"
         },
         "flow": {
-          "id": "39W8LA5XBnc",
+          "id": "FpUgB2PIhjQ",
           "locality": "public"
         },
         "netflow": {
@@ -191,7 +191,7 @@
         },
         "network": {
           "bytes": 0,
-          "community_id": "1:PrM3BB+zl6s0dy/nMB1KOgnPLyM=",
+          "community_id": "1:/vWRin3SqfXQJiLYySDX59nv1RI=",
           "direction": "inbound",
           "iana_number": 2,
           "packets": 0,
@@ -227,8 +227,8 @@
           "start": "2016-12-23T01:34:51.469Z"
         },
         "flow": {
-          "id": "Jx-Zk4nwIkE",
-          "locality": "private"
+          "id": "qN8iQExOvkc",
+          "locality": "public"
         },
         "netflow": {
           "destination_ipv4_address": "239.255.255.250",
@@ -260,7 +260,7 @@
         },
         "network": {
           "bytes": 32,
-          "community_id": "1:COeL8zADqbleGkd4vi2Pz6V+2rc=",
+          "community_id": "1:/vWRin3SqfXQJiLYySDX59nv1RI=",
           "direction": "inbound",
           "iana_number": 2,
           "packets": 1,
@@ -296,7 +296,7 @@
           "start": "2016-12-23T01:34:51.469Z"
         },
         "flow": {
-          "id": "39W8LA5XBnc",
+          "id": "FpUgB2PIhjQ",
           "locality": "public"
         },
         "netflow": {
@@ -329,7 +329,7 @@
         },
         "network": {
           "bytes": 0,
-          "community_id": "1:PrM3BB+zl6s0dy/nMB1KOgnPLyM=",
+          "community_id": "1:/vWRin3SqfXQJiLYySDX59nv1RI=",
           "direction": "outbound",
           "iana_number": 2,
           "packets": 0,
@@ -365,8 +365,8 @@
           "start": "2016-12-23T01:34:51.469Z"
         },
         "flow": {
-          "id": "Jx-Zk4nwIkE",
-          "locality": "private"
+          "id": "qN8iQExOvkc",
+          "locality": "public"
         },
         "netflow": {
           "destination_ipv4_address": "239.255.255.250",
@@ -398,7 +398,7 @@
         },
         "network": {
           "bytes": 0,
-          "community_id": "1:COeL8zADqbleGkd4vi2Pz6V+2rc=",
+          "community_id": "1:/vWRin3SqfXQJiLYySDX59nv1RI=",
           "direction": "outbound",
           "iana_number": 2,
           "packets": 0,
@@ -434,7 +434,7 @@
           "start": "2016-12-23T01:34:51.569Z"
         },
         "flow": {
-          "id": "39W8LA5XBnc",
+          "id": "WuFpyBG1Gt0",
           "locality": "public"
         },
         "netflow": {
@@ -467,7 +467,7 @@
         },
         "network": {
           "bytes": 0,
-          "community_id": "1:PrM3BB+zl6s0dy/nMB1KOgnPLyM=",
+          "community_id": "1:/AXSKRoRIJEcn9AsawscEIuzsn0=",
           "direction": "inbound",
           "iana_number": 2,
           "packets": 0,
@@ -503,8 +503,8 @@
           "start": "2016-12-23T01:34:51.569Z"
         },
         "flow": {
-          "id": "IEwgskWJz00",
-          "locality": "private"
+          "id": "1aysHUs7BpA",
+          "locality": "public"
         },
         "netflow": {
           "destination_ipv4_address": "239.255.255.250",
@@ -536,7 +536,7 @@
         },
         "network": {
           "bytes": 32,
-          "community_id": "1:1EE7w6YWICk3nCsh+iZkgYDDczE=",
+          "community_id": "1:/AXSKRoRIJEcn9AsawscEIuzsn0=",
           "direction": "inbound",
           "iana_number": 2,
           "packets": 1,
@@ -572,7 +572,7 @@
           "start": "2016-12-23T01:34:51.569Z"
         },
         "flow": {
-          "id": "39W8LA5XBnc",
+          "id": "WuFpyBG1Gt0",
           "locality": "public"
         },
         "netflow": {
@@ -605,7 +605,7 @@
         },
         "network": {
           "bytes": 0,
-          "community_id": "1:PrM3BB+zl6s0dy/nMB1KOgnPLyM=",
+          "community_id": "1:/AXSKRoRIJEcn9AsawscEIuzsn0=",
           "direction": "outbound",
           "iana_number": 2,
           "packets": 0,
@@ -641,8 +641,8 @@
           "start": "2016-12-23T01:34:51.569Z"
         },
         "flow": {
-          "id": "IEwgskWJz00",
-          "locality": "private"
+          "id": "1aysHUs7BpA",
+          "locality": "public"
         },
         "netflow": {
           "destination_ipv4_address": "239.255.255.250",
@@ -674,7 +674,7 @@
         },
         "network": {
           "bytes": 0,
-          "community_id": "1:1EE7w6YWICk3nCsh+iZkgYDDczE=",
+          "community_id": "1:/AXSKRoRIJEcn9AsawscEIuzsn0=",
           "direction": "outbound",
           "iana_number": 2,
           "packets": 0,

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-valid-01.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-valid-01.golden.json
@@ -20,7 +20,7 @@
           "start": "2015-10-08T19:03:46.14Z"
         },
         "flow": {
-          "id": "i1KQBFMlwFg",
+          "id": "1E-M5OJg_go",
           "locality": "private"
         },
         "netflow": {
@@ -49,7 +49,7 @@
         },
         "network": {
           "bytes": 76,
-          "community_id": "1:cRrWVwyu9GLZ+aU7qmwhjSdMrpE=",
+          "community_id": "1:QKTFMKhaT7j1xLTKOURCTVzbKk8=",
           "direction": "unknown",
           "iana_number": 17,
           "packets": 1,
@@ -85,7 +85,7 @@
           "start": "2015-10-08T19:03:46.14Z"
         },
         "flow": {
-          "id": "0Wj-QgIvFZE",
+          "id": "yMxFd8CW_Ok",
           "locality": "private"
         },
         "netflow": {
@@ -114,7 +114,7 @@
         },
         "network": {
           "bytes": 76,
-          "community_id": "1:wNJjbHYcMj4lBiVWbMHK1JcgsJ8=",
+          "community_id": "1:QKTFMKhaT7j1xLTKOURCTVzbKk8=",
           "direction": "unknown",
           "iana_number": 17,
           "packets": 1,
@@ -150,7 +150,7 @@
           "start": "2015-10-08T19:03:51.813Z"
         },
         "flow": {
-          "id": "i1KQBFMlwFg",
+          "id": "NF1W3jyrHAA",
           "locality": "private"
         },
         "netflow": {
@@ -179,7 +179,7 @@
         },
         "network": {
           "bytes": 76,
-          "community_id": "1:cRrWVwyu9GLZ+aU7qmwhjSdMrpE=",
+          "community_id": "1:8JJSV5jQe+UfRnLVV/iA7sy8Nz0=",
           "direction": "unknown",
           "iana_number": 17,
           "packets": 1,
@@ -215,7 +215,7 @@
           "start": "2015-10-08T19:03:51.813Z"
         },
         "flow": {
-          "id": "_cbZpOjyGGQ",
+          "id": "Tw1iOKJ-dfE",
           "locality": "private"
         },
         "netflow": {
@@ -244,7 +244,7 @@
         },
         "network": {
           "bytes": 76,
-          "community_id": "1:mYS5cP5hzhSb8JZH9+2v8+RMJ9g=",
+          "community_id": "1:8JJSV5jQe+UfRnLVV/iA7sy8Nz0=",
           "direction": "unknown",
           "iana_number": 17,
           "packets": 1,
@@ -280,7 +280,7 @@
           "start": "2015-10-08T19:03:55.958Z"
         },
         "flow": {
-          "id": "i1KQBFMlwFg",
+          "id": "sNF38-obC7k",
           "locality": "private"
         },
         "netflow": {
@@ -309,7 +309,7 @@
         },
         "network": {
           "bytes": 76,
-          "community_id": "1:cRrWVwyu9GLZ+aU7qmwhjSdMrpE=",
+          "community_id": "1:SYyoe1e5BMoo9l35SqJ7wRextZg=",
           "direction": "unknown",
           "iana_number": 17,
           "packets": 1,
@@ -345,7 +345,7 @@
           "start": "2015-10-08T19:03:55.958Z"
         },
         "flow": {
-          "id": "jDcbOcubrco",
+          "id": "458D6voFu3E",
           "locality": "private"
         },
         "netflow": {
@@ -374,7 +374,7 @@
         },
         "network": {
           "bytes": 76,
-          "community_id": "1:Y7cJ9MH0pPXGOYtewjtnB/Xf2Os=",
+          "community_id": "1:SYyoe1e5BMoo9l35SqJ7wRextZg=",
           "direction": "unknown",
           "iana_number": 17,
           "packets": 1,

--- a/x-pack/filebeat/input/netflow/testdata/golden/netflow9_ubiquiti_edgerouter.pcap.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/netflow9_ubiquiti_edgerouter.pcap.golden.json
@@ -20,8 +20,8 @@
           "start": "2018-08-09T16:43:00.02Z"
         },
         "flow": {
-          "id": "T5g_yptWDLc",
-          "locality": "private"
+          "id": "NPZRWU1oZKQ",
+          "locality": "public"
         },
         "netflow": {
           "delta_flow_count": 0,
@@ -55,7 +55,7 @@
         },
         "network": {
           "bytes": 421,
-          "community_id": "1:c3a8HfldOuX4/xBvf0sHuy38GTk=",
+          "community_id": "1:rmH7wArXzq7zo/3zq3UF3YXPRsQ=",
           "direction": "outbound",
           "iana_number": 6,
           "packets": 6,
@@ -91,8 +91,8 @@
           "start": "2018-08-09T16:42:31.108Z"
         },
         "flow": {
-          "id": "p77rp-QQcy4",
-          "locality": "private"
+          "id": "wMmxEUF-2Sk",
+          "locality": "public"
         },
         "netflow": {
           "delta_flow_count": 0,
@@ -126,7 +126,7 @@
         },
         "network": {
           "bytes": 7621,
-          "community_id": "1:ZNEMnnkXh6LJsCtYCHWkxVCOl9E=",
+          "community_id": "1:a6tg/r6jNtMgP63hJDERGLq5/vY=",
           "direction": "outbound",
           "iana_number": 6,
           "packets": 131,
@@ -162,7 +162,7 @@
           "start": "2018-08-09T16:43:01.41Z"
         },
         "flow": {
-          "id": "yqWGb1dLOqc",
+          "id": "2NG48p7EGpw",
           "locality": "private"
         },
         "netflow": {
@@ -197,7 +197,7 @@
         },
         "network": {
           "bytes": 95,
-          "community_id": "1:XdJd2ziZmmG1mSIxfvlr6ecG4pM=",
+          "community_id": "1:cqOWsgOuN87d75n1EozS3EVeQ3w=",
           "direction": "outbound",
           "iana_number": 17,
           "packets": 1,
@@ -233,8 +233,8 @@
           "start": "2018-08-09T16:42:02.683Z"
         },
         "flow": {
-          "id": "l0jbykreH8E",
-          "locality": "private"
+          "id": "f0LYEiUntL0",
+          "locality": "public"
         },
         "netflow": {
           "delta_flow_count": 0,
@@ -268,7 +268,7 @@
         },
         "network": {
           "bytes": 3162,
-          "community_id": "1:+80+CdeOLSths8RQiqHUoqr8qrU=",
+          "community_id": "1:Sqv4MaFQrlxintsHkBwirPKlFkY=",
           "direction": "outbound",
           "iana_number": 6,
           "packets": 30,
@@ -304,8 +304,8 @@
           "start": "2018-08-09T16:42:22.861Z"
         },
         "flow": {
-          "id": "N1T6lJguTIg",
-          "locality": "private"
+          "id": "9ATz0HlBbIQ",
+          "locality": "public"
         },
         "netflow": {
           "delta_flow_count": 0,
@@ -339,7 +339,7 @@
         },
         "network": {
           "bytes": 2711,
-          "community_id": "1:3s9tK3Ncm1BXFpA8+hBpk22sg0c=",
+          "community_id": "1:mXa8bnzBDCffTQexE2vr+5JpBKI=",
           "direction": "outbound",
           "iana_number": 6,
           "packets": 13,
@@ -375,8 +375,8 @@
           "start": "2018-08-09T16:42:25.309Z"
         },
         "flow": {
-          "id": "5FJxwkuWO2k",
-          "locality": "private"
+          "id": "vueGG5QVS_M",
+          "locality": "public"
         },
         "netflow": {
           "delta_flow_count": 0,
@@ -410,7 +410,7 @@
         },
         "network": {
           "bytes": 20855,
-          "community_id": "1:3w94g30M+cTZZskO9dmazwtDHo8=",
+          "community_id": "1:EpAMGHXZQeADLR0iB3Wnf8ODIno=",
           "direction": "outbound",
           "iana_number": 6,
           "packets": 346,
@@ -446,8 +446,8 @@
           "start": "2018-08-09T16:42:31.108Z"
         },
         "flow": {
-          "id": "J7S4xARTVFk",
-          "locality": "private"
+          "id": "rJySLUBW94Y",
+          "locality": "public"
         },
         "netflow": {
           "delta_flow_count": 0,
@@ -481,7 +481,7 @@
         },
         "network": {
           "bytes": 7495,
-          "community_id": "1:XE7UjW9QNWzM1F452q/jPfC4C90=",
+          "community_id": "1:Y3q5x6CFuoZSG9T1/sWch2r+Z/M=",
           "direction": "outbound",
           "iana_number": 6,
           "packets": 129,
@@ -517,8 +517,8 @@
           "start": "2018-08-09T16:42:31.108Z"
         },
         "flow": {
-          "id": "eSnZLaMkN_I",
-          "locality": "private"
+          "id": "pWQ3ZWUMRfU",
+          "locality": "public"
         },
         "netflow": {
           "delta_flow_count": 0,
@@ -552,7 +552,7 @@
         },
         "network": {
           "bytes": 7049,
-          "community_id": "1:CJ9T/03SqwG5Yy7WmXADUqvvgvw=",
+          "community_id": "1:QznhoMOMy0XGL01aIt45mG93Ahs=",
           "direction": "outbound",
           "iana_number": 6,
           "packets": 119,
@@ -588,8 +588,8 @@
           "start": "2018-08-09T16:42:31.358Z"
         },
         "flow": {
-          "id": "_8K2vONzLd4",
-          "locality": "private"
+          "id": "M0l00u11bWc",
+          "locality": "public"
         },
         "netflow": {
           "delta_flow_count": 0,
@@ -623,7 +623,7 @@
         },
         "network": {
           "bytes": 1348,
-          "community_id": "1:3vSrJV3tnfjnzopvPuRQzt2BDS4=",
+          "community_id": "1:nz3afDxgjd58RBYRFia+GrFAvNE=",
           "direction": "outbound",
           "iana_number": 6,
           "packets": 13,
@@ -659,7 +659,7 @@
           "start": "2018-08-09T16:43:06.28Z"
         },
         "flow": {
-          "id": "brcE2vs5Uso",
+          "id": "lzKTutEyrKA",
           "locality": "private"
         },
         "netflow": {
@@ -694,7 +694,7 @@
         },
         "network": {
           "bytes": 82,
-          "community_id": "1:mjMjtH0BZKCuCmxkZbQyrFDfoI0=",
+          "community_id": "1:HFBHKjXNUjNcb0z2P6sMpROPSq8=",
           "direction": "outbound",
           "iana_number": 17,
           "packets": 1,


### PR DESCRIPTION
Flow ID, Community ID and locality calculation was broken in the NetFlow input. 0.0.0.0 was always used as destination IP.

This caused:
- The wrong flow-id and community-id to be generated
- Different ids for the reverse-flow.
- The wrong locality being assigned to the flow.