### PR TITLE
Cherry-pick #9888 to 6.x: Minor fixes to error handling

### DIFF
--- a/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
+++ b/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
@@ -180,6 +180,14 @@ func enableTrialLicense(host string) error {
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode != 200 {
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+		return fmt.Errorf("could not enable trial license, response = %v", string(body))
+	}
+
 	return nil
 }
 
@@ -199,7 +207,7 @@ func createMLJob(host string) error {
 	body, resp, err := httpPutJSON(host, jobURL, mlJob)
 
 	if resp.StatusCode != 200 {
-		return fmt.Errorf("HTTP error loading ml job %d: %s, %s", resp.StatusCode, resp.Status, body)
+		return fmt.Errorf("HTTP error loading ml job %d: %s, %s", resp.StatusCode, resp.Status, string(body))
 	}
 
 	return nil


### PR DESCRIPTION
Cherry-pick of PR #9888 to 6.x branch. Original message: 

This PR fixes a couple of small issues in the metricbeat elasticsearch module's integration tests:

* The `enableTrialLicense` function returns an error if the "start trial" ES API returned a non-200 response code

* Converts response body to a string in an error returned by the `createMLJob` fucnction