### PR TITLE
Refactoring: Using common.Version instead of strings

### DIFF
--- a/libbeat/common/version.go
+++ b/libbeat/common/version.go
@@ -18,6 +18,7 @@
 package common
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -149,4 +150,24 @@ func (v *Version) metaIsLessThanOrEqual(v1 *Version) bool {
 		return true
 	}
 	return v.Meta <= v1.Meta
+}
+
+// UnmarshalJSON unmarshals a JSON string version representation into a Version struct
+// Implements https://golang.org/pkg/encoding/json/#Unmarshaler
+func (v *Version) UnmarshalJSON(version []byte) error {
+	var versionStr string
+	err := json.Unmarshal(version, &versionStr)
+	if err != nil {
+		return err
+	}
+
+	ver, err := NewVersion(versionStr)
+
+	v.version = versionStr
+	v.Major = ver.Major
+	v.Minor = ver.Minor
+	v.Bugfix = ver.Bugfix
+	v.Meta = ver.Meta
+
+	return err
 }

--- a/libbeat/common/version.go
+++ b/libbeat/common/version.go
@@ -162,12 +162,14 @@ func (v *Version) UnmarshalJSON(version []byte) error {
 	}
 
 	ver, err := NewVersion(versionStr)
+	if err != nil {
+		return err
+	}
 
-	v.version = versionStr
-	v.Major = ver.Major
-	v.Minor = ver.Minor
-	v.Bugfix = ver.Bugfix
-	v.Meta = ver.Meta
+	if ver == nil {
+		return fmt.Errorf("could not unmarshal version from JSON")
+	}
 
-	return err
+	*v = *ver
+	return nil
 }

--- a/metricbeat/helper/elastic/elastic.go
+++ b/metricbeat/helper/elastic/elastic.go
@@ -97,18 +97,8 @@ func MakeErrorForMissingField(field string, product Product) error {
 }
 
 // IsFeatureAvailable returns whether a feature is available in the current product version
-func IsFeatureAvailable(currentProductVersion, featureAvailableInProductVersion string) (bool, error) {
-	currentVersion, err := common.NewVersion(currentProductVersion)
-	if err != nil {
-		return false, err
-	}
-
-	wantVersion, err := common.NewVersion(featureAvailableInProductVersion)
-	if err != nil {
-		return false, err
-	}
-
-	return !currentVersion.LessThan(wantVersion), nil
+func IsFeatureAvailable(currentProductVersion, featureAvailableInProductVersion *common.Version) bool {
+	return !currentProductVersion.LessThan(featureAvailableInProductVersion)
 }
 
 // ReportAndLogError reports and logs the given error

--- a/metricbeat/module/elasticsearch/ccr/ccr.go
+++ b/metricbeat/module/elasticsearch/ccr/ccr.go
@@ -81,7 +81,7 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 
 	// CCR is only available in Trial or Platinum license of Elasticsearch. So we check
 	// the license first.
-	ccrUnavailableMessage, err := m.checkCCRAvailability(info.Version)
+	ccrUnavailableMessage, err := m.checkCCRAvailability(info.Version.Number)
 	if err != nil {
 		err = errors.Wrap(err, "error determining if CCR is available")
 		elastic.ReportAndLogError(err, r, m.Log)

--- a/metricbeat/module/elasticsearch/ccr/ccr.go
+++ b/metricbeat/module/elasticsearch/ccr/ccr.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/elastic/beats/libbeat/common"
+
 	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/libbeat/common/cfgwarn"
@@ -77,7 +79,12 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 		return
 	}
 
-	elasticsearchVersion := info.Version.Number
+	elasticsearchVersion, err := info.GetVersion()
+	if err != nil {
+		err = errors.Wrap(err, "error determining Elasticsearch version")
+		elastic.ReportAndLogError(err, r, m.Log)
+		return
+	}
 
 	// CCR is only available in Trial or Platinum license of Elasticsearch. So we check
 	// the license first.
@@ -115,7 +122,7 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 	}
 }
 
-func (m *MetricSet) checkCCRAvailability(currentElasticsearchVersion string) (message string, err error) {
+func (m *MetricSet) checkCCRAvailability(currentElasticsearchVersion *common.Version) (message string, err error) {
 	license, err := elasticsearch.GetLicense(m.HTTP, m.GetServiceURI())
 	if err != nil {
 		return "", errors.Wrap(err, "error determining Elasticsearch license")
@@ -128,16 +135,13 @@ func (m *MetricSet) checkCCRAvailability(currentElasticsearchVersion string) (me
 		return
 	}
 
-	isAvailable, err := elastic.IsFeatureAvailable(currentElasticsearchVersion, elasticsearch.CCRStatsAPIAvailableVersion)
-	if err != nil {
-		return "", errors.Wrap(err, "error determining if CCR is available in current Elasticsearch version")
-	}
+	isAvailable := elastic.IsFeatureAvailable(currentElasticsearchVersion, elasticsearch.CCRStatsAPIAvailableVersion)
 
 	if !isAvailable {
 		metricsetName := m.FullyQualifiedName()
 		message = "the " + metricsetName + " is only supported with Elasticsearch >= " +
-			elasticsearch.CCRStatsAPIAvailableVersion + ". " +
-			"You are currently running Elasticsearch " + currentElasticsearchVersion + "."
+			elasticsearch.CCRStatsAPIAvailableVersion.String() + ". " +
+			"You are currently running Elasticsearch " + currentElasticsearchVersion.String() + "."
 		return
 	}
 

--- a/metricbeat/module/elasticsearch/ccr/ccr.go
+++ b/metricbeat/module/elasticsearch/ccr/ccr.go
@@ -79,16 +79,9 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 		return
 	}
 
-	elasticsearchVersion, err := info.GetVersion()
-	if err != nil {
-		err = errors.Wrap(err, "error determining Elasticsearch version")
-		elastic.ReportAndLogError(err, r, m.Log)
-		return
-	}
-
 	// CCR is only available in Trial or Platinum license of Elasticsearch. So we check
 	// the license first.
-	ccrUnavailableMessage, err := m.checkCCRAvailability(elasticsearchVersion)
+	ccrUnavailableMessage, err := m.checkCCRAvailability(info.Version)
 	if err != nil {
 		err = errors.Wrap(err, "error determining if CCR is available")
 		elastic.ReportAndLogError(err, r, m.Log)

--- a/metricbeat/module/elasticsearch/cluster_stats/data_xpack.go
+++ b/metricbeat/module/elasticsearch/cluster_stats/data_xpack.go
@@ -225,7 +225,7 @@ func eventMappingXPack(r mb.ReporterV2, m *MetricSet, info elasticsearch.Info, c
 		"interval_ms":   m.Module().Config().Period / time.Millisecond,
 		"type":          "cluster_stats",
 		"license":       l,
-		"version":       info.Version.Number,
+		"version":       info.Version.String(),
 		"cluster_stats": clusterStats,
 		"cluster_state": clusterState,
 		"stack_stats":   stackStats,

--- a/metricbeat/module/elasticsearch/cluster_stats/data_xpack.go
+++ b/metricbeat/module/elasticsearch/cluster_stats/data_xpack.go
@@ -225,7 +225,7 @@ func eventMappingXPack(r mb.ReporterV2, m *MetricSet, info elasticsearch.Info, c
 		"interval_ms":   m.Module().Config().Period / time.Millisecond,
 		"type":          "cluster_stats",
 		"license":       l,
-		"version":       info.Version.String(),
+		"version":       info.Version.Number.String(),
 		"cluster_stats": clusterStats,
 		"cluster_state": clusterState,
 		"stack_stats":   stackStats,

--- a/metricbeat/module/elasticsearch/elasticsearch.go
+++ b/metricbeat/module/elasticsearch/elasticsearch.go
@@ -43,9 +43,11 @@ const ModuleName = "elasticsearch"
 
 // Info construct contains the data from the Elasticsearch / endpoint
 type Info struct {
-	ClusterName string
-	ClusterID   string
-	Version     *common.Version
+	ClusterName string `json:"cluster_name"`
+	ClusterID   string `json:"cluster_uuid"`
+	Version     struct {
+		Number *common.Version `json:"number"`
+	} `json:"version"`
 }
 
 // NodeInfo struct cotains data about the node.
@@ -155,30 +157,13 @@ func GetInfo(http *helper.HTTP, uri string) (*Info, error) {
 		return nil, err
 	}
 
-	// Info construct contains the data from the Elasticsearch / endpoint
-	var info struct {
-		ClusterName string `json:"cluster_name"`
-		ClusterID   string `json:"cluster_uuid"`
-		Version     struct {
-			Number string `json:"number"`
-		} `json:"version"`
-	}
-
+	info := &Info{}
 	err = json.Unmarshal(content, &info)
 	if err != nil {
 		return nil, err
 	}
 
-	version, err := common.NewVersion(info.Version.Number)
-	if err != nil {
-		return nil, err
-	}
-
-	return &Info{
-		info.ClusterName,
-		info.ClusterID,
-		version,
-	}, nil
+	return info, nil
 }
 
 func fetchPath(http *helper.HTTP, uri, path string, query string) ([]byte, error) {

--- a/metricbeat/module/elasticsearch/elasticsearch.go
+++ b/metricbeat/module/elasticsearch/elasticsearch.go
@@ -33,7 +33,7 @@ import (
 )
 
 // CCRStatsAPIAvailableVersion is the version of Elasticsearch since when the CCR stats API is available.
-const CCRStatsAPIAvailableVersion = "6.5.0"
+var CCRStatsAPIAvailableVersion = common.MustNewVersion("6.5.0")
 
 // Global clusterIdCache. Assumption is that the same node id never can belong to a different cluster id.
 var clusterIDCache = map[string]string{}
@@ -48,6 +48,11 @@ type Info struct {
 	Version     struct {
 		Number string `json:"number"`
 	} `json:"version"`
+}
+
+// GetVersion returns a Version object of the Elasticsearch version
+func (info *Info) GetVersion() (*common.Version, error) {
+	return common.NewVersion(info.Version.Number)
 }
 
 // NodeInfo struct cotains data about the node.

--- a/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
+++ b/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
@@ -289,39 +289,37 @@ func checkSkip(t *testing.T, metricset string, host string) {
 		t.Fatal("getting elasticsearch version", err)
 	}
 
-	isCCRStatsAPIAvailable, err := elastic.IsFeatureAvailable(version, elasticsearch.CCRStatsAPIAvailableVersion)
-	if err != nil {
-		t.Fatal("checking if elasticsearch CCR stats API is available", err)
-	}
+	isCCRStatsAPIAvailable := elastic.IsFeatureAvailable(version, elasticsearch.CCRStatsAPIAvailableVersion)
 
 	if !isCCRStatsAPIAvailable {
-		t.Skip("elasticsearch CCR stats API is not available until " + elasticsearch.CCRStatsAPIAvailableVersion)
+		t.Skip("elasticsearch CCR stats API is not available until " + elasticsearch.CCRStatsAPIAvailableVersion.String())
 	}
 }
 
-func getElasticsearchVersion(elasticsearchHostPort string) (string, error) {
+func getElasticsearchVersion(elasticsearchHostPort string) (*common.Version, error) {
 	resp, err := http.Get("http://" + elasticsearchHostPort + "/")
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	defer resp.Body.Close()
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	var data common.MapStr
 	err = json.Unmarshal(body, &data)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	version, err := data.GetValue("version.number")
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	return version.(string), nil
+
+	return common.NewVersion(version.(string))
 }
 
 func httpPutJSON(host, path string, body []byte) ([]byte, *http.Response, error) {

--- a/metricbeat/module/kibana/kibana.go
+++ b/metricbeat/module/kibana/kibana.go
@@ -57,23 +57,18 @@ func GetVersion(http *helper.HTTP, currentPath string) (*common.Version, error) 
 		return nil, err
 	}
 
-	var data common.MapStr
-	err = json.Unmarshal(content, &data)
+	var status struct {
+		Version struct {
+			Number string `json:"number"`
+		} `json:"version"`
+	}
+
+	err = json.Unmarshal(content, &status)
 	if err != nil {
 		return nil, err
 	}
 
-	versionNumber, err := data.GetValue("version.number")
-	if err != nil {
-		return nil, err
-	}
-
-	versionStr, ok := versionNumber.(string)
-	if !ok {
-		return nil, fmt.Errorf("Could not parse Kibana version in status API response")
-	}
-
-	return common.NewVersion(versionStr)
+	return common.NewVersion(status.Version.Number)
 }
 
 // IsStatsAPIAvailable returns whether the stats API is available in the given version of Kibana

--- a/metricbeat/module/kibana/kibana.go
+++ b/metricbeat/module/kibana/kibana.go
@@ -30,15 +30,15 @@ import (
 	"github.com/elastic/beats/metricbeat/mb"
 )
 
-const (
-	// ModuleName is the name of this module
-	ModuleName = "kibana"
+// ModuleName is the name of this module
+const ModuleName = "kibana"
 
+var (
 	// StatsAPIAvailableVersion is the version of Kibana since when the stats API is available
-	StatsAPIAvailableVersion = "6.4.0"
+	StatsAPIAvailableVersion = common.MustNewVersion("6.4.0")
 
 	// SettingsAPIAvailableVersion is the version of Kibana since when the settings API is available
-	SettingsAPIAvailableVersion = "6.5.0"
+	SettingsAPIAvailableVersion = common.MustNewVersion("6.5.0")
 )
 
 // ReportErrorForMissingField reports and returns an error message for the given
@@ -50,39 +50,39 @@ func ReportErrorForMissingField(field string, r mb.ReporterV2) error {
 }
 
 // GetVersion returns the version of the Kibana instance
-func GetVersion(http *helper.HTTP, currentPath string) (string, error) {
+func GetVersion(http *helper.HTTP, currentPath string) (*common.Version, error) {
 	const statusPath = "api/status"
 	content, err := fetchPath(http, currentPath, statusPath)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	var data common.MapStr
 	err = json.Unmarshal(content, &data)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	version, err := data.GetValue("version.number")
+	versionNumber, err := data.GetValue("version.number")
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	versionStr, ok := version.(string)
+	versionStr, ok := versionNumber.(string)
 	if !ok {
-		return "", fmt.Errorf("Could not parse Kibana version in status API response")
+		return nil, fmt.Errorf("Could not parse Kibana version in status API response")
 	}
 
-	return versionStr, nil
+	return common.NewVersion(versionStr)
 }
 
 // IsStatsAPIAvailable returns whether the stats API is available in the given version of Kibana
-func IsStatsAPIAvailable(currentKibanaVersion string) (bool, error) {
+func IsStatsAPIAvailable(currentKibanaVersion *common.Version) bool {
 	return elastic.IsFeatureAvailable(currentKibanaVersion, StatsAPIAvailableVersion)
 }
 
 // IsSettingsAPIAvailable returns whether the settings API is available in the given version of Kibana
-func IsSettingsAPIAvailable(currentKibanaVersion string) (bool, error) {
+func IsSettingsAPIAvailable(currentKibanaVersion *common.Version) bool {
 	return elastic.IsFeatureAvailable(currentKibanaVersion, SettingsAPIAvailableVersion)
 }
 

--- a/metricbeat/module/kibana/kibana_test.go
+++ b/metricbeat/module/kibana/kibana_test.go
@@ -20,6 +20,8 @@ package kibana
 import (
 	"testing"
 
+	"github.com/elastic/beats/libbeat/common"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -35,8 +37,7 @@ func TestIsStatsAPIAvailable(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		actual, err := IsStatsAPIAvailable(test.input)
-		assert.NoError(t, err)
+		actual := IsStatsAPIAvailable(common.MustNewVersion(test.input))
 		assert.Equal(t, test.expected, actual)
 	}
 }

--- a/metricbeat/module/kibana/stats/stats.go
+++ b/metricbeat/module/kibana/stats/stats.go
@@ -77,7 +77,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 		return nil, err
 	}
 
-	isStatsAPIAvailable, err := kibana.IsStatsAPIAvailable(kibanaVersion)
+	isStatsAPIAvailable := kibana.IsStatsAPIAvailable(kibanaVersion)
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +98,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	if ms.XPackEnabled {
 		cfgwarn.Experimental("The experimental xpack.enabled flag in the " + ms.FullyQualifiedName() + " metricset is enabled.")
 
-		isSettingsAPIAvailable, err := kibana.IsSettingsAPIAvailable(kibanaVersion)
+		isSettingsAPIAvailable := kibana.IsSettingsAPIAvailable(kibanaVersion)
 		if err != nil {
 			return nil, err
 		}

--- a/metricbeat/module/kibana/stats/stats_integration_test.go
+++ b/metricbeat/module/kibana/stats/stats_integration_test.go
@@ -45,7 +45,7 @@ func TestFetch(t *testing.T) {
 		t.Fatal("getting kibana version", err)
 	}
 
-	isStatsAPIAvailable, err := kibana.IsStatsAPIAvailable(version)
+	isStatsAPIAvailable := kibana.IsStatsAPIAvailable(version)
 	if err != nil {
 		t.Fatal("checking if kibana stats API is available", err)
 	}
@@ -76,7 +76,7 @@ func TestData(t *testing.T) {
 		t.Fatal("getting kibana version", err)
 	}
 
-	isStatsAPIAvailable, err := kibana.IsStatsAPIAvailable(version)
+	isStatsAPIAvailable := kibana.IsStatsAPIAvailable(version)
 	if err != nil {
 		t.Fatal("checking if kibana stats API is available", err)
 	}
@@ -92,27 +92,28 @@ func TestData(t *testing.T) {
 	}
 }
 
-func getKibanaVersion(kibanaHostPort string) (string, error) {
+func getKibanaVersion(kibanaHostPort string) (*common.Version, error) {
 	resp, err := http.Get("http://" + kibanaHostPort + "/api/status")
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	defer resp.Body.Close()
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	var data common.MapStr
 	err = json.Unmarshal(body, &data)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	version, err := data.GetValue("version.number")
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	return version.(string), nil
+
+	return common.NewVersion(version.(string))
 }


### PR DESCRIPTION
This PR updates code in the `elasticsearch` and `kibana` Metricbeat modules to use the `common.Version` struct instead of bare strings for product versions.