### PR TITLE
[Heartbeat] Add fields to example heartbeat autodiscover usage.

### DIFF
--- a/heartbeat/docs/autodiscover-docker-config.asciidoc
+++ b/heartbeat/docs/autodiscover-docker-config.asciidoc
@@ -14,6 +14,10 @@ heartbeat.autodiscover:
               hosts: ["${data.host}:${data.port}"]
               schedule: "@every 1s"
               timeout: 1s
+              fields:
+                container_id: "${data.docker.container.id}"
+                container_image: "${data.docker.container.image}"
+                container_name: "${data.docker.container.name}"
 -------------------------------------------------------------------------------------
 
 This configuration launches a `redis` monitor for all containers running an image with `redis` in the name.

--- a/heartbeat/docs/autodiscover-docker-config.asciidoc
+++ b/heartbeat/docs/autodiscover-docker-config.asciidoc
@@ -15,9 +15,11 @@ heartbeat.autodiscover:
               schedule: "@every 1s"
               timeout: 1s
               fields:
-                container_id: "${data.docker.container.id}"
-                container_image: "${data.docker.container.image}"
-                container_name: "${data.docker.container.name}"
+                container.runtime: "docker"
+                container.id: "${data.docker.container.id}"
+                container.name: "${data.docker.container.name}"
+                container.image.image.name: "${data.docker.container.image}"
+              fields_as_root: true
 -------------------------------------------------------------------------------------
 
 This configuration launches a `redis` monitor for all containers running an image with `redis` in the name.


### PR DESCRIPTION
It's useful when using autodiscovered endpoints to have container metadata. It's not obvious how to do this, so we document some of the fields one might use here in the docs.

This addresses a comment brought up on discuss in https://discuss.elastic.co/t/autodiscover-and-metadata/162980/1