### PR TITLE
Mark redis/logstash port settings as deprecated

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -13,6 +13,7 @@ https://github.com/elastic/beats/compare/v6.6.0...6.x[Check the HEAD diff]
 - Dissect syntax change, use * instead of ? when working with field reference. {issue}8054[8054]
 - Fix registry handle leak on Windows (https://github.com/elastic/go-sysinfo/pull/33). {pull}9920[9920]
 - Allow to unenroll a Beat from the UI. {issue}9452[9452]
+- Port settings have been deprecated in redis/logstash output and will be removed in 7.0. {pull}9915[9915]
 
 *Auditbeat*
 

--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -727,10 +727,6 @@ output.elasticsearch:
   # unreachable, the events are distributed to the reachable servers only.
   #hosts: ["localhost:6379"]
 
-  # The Redis port to use if hosts does not contain a port number. The default
-  # is 6379.
-  #port: 6379
-
   # The name of the Redis list or channel the events are published to. The
   # default is auditbeat.
   #key: auditbeat

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -1419,10 +1419,6 @@ output.elasticsearch:
   # unreachable, the events are distributed to the reachable servers only.
   #hosts: ["localhost:6379"]
 
-  # The Redis port to use if hosts does not contain a port number. The default
-  # is 6379.
-  #port: 6379
-
   # The name of the Redis list or channel the events are published to. The
   # default is filebeat.
   #key: filebeat

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -876,10 +876,6 @@ output.elasticsearch:
   # unreachable, the events are distributed to the reachable servers only.
   #hosts: ["localhost:6379"]
 
-  # The Redis port to use if hosts does not contain a port number. The default
-  # is 6379.
-  #port: 6379
-
   # The name of the Redis list or channel the events are published to. The
   # default is heartbeat.
   #key: heartbeat

--- a/journalbeat/journalbeat.reference.yml
+++ b/journalbeat/journalbeat.reference.yml
@@ -678,10 +678,6 @@ output.elasticsearch:
   # unreachable, the events are distributed to the reachable servers only.
   #hosts: ["localhost:6379"]
 
-  # The Redis port to use if hosts does not contain a port number. The default
-  # is 6379.
-  #port: 6379
-
   # The name of the Redis list or channel the events are published to. The
   # default is journalbeat.
   #key: journalbeat

--- a/libbeat/_meta/config.reference.yml
+++ b/libbeat/_meta/config.reference.yml
@@ -620,10 +620,6 @@ output.elasticsearch:
   # unreachable, the events are distributed to the reachable servers only.
   #hosts: ["localhost:6379"]
 
-  # The Redis port to use if hosts does not contain a port number. The default
-  # is 6379.
-  #port: 6379
-
   # The name of the Redis list or channel the events are published to. The
   # default is beatname.
   #key: beatname

--- a/libbeat/outputs/logstash/logstash.go
+++ b/libbeat/outputs/logstash/logstash.go
@@ -20,6 +20,7 @@ package logstash
 import (
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/libbeat/common/transport/tlscommon"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/outputs"
@@ -49,6 +50,10 @@ func makeLogstash(
 	config := newConfig()
 	if err := cfg.Unpack(config); err != nil {
 		return outputs.Fail(err)
+	}
+
+	if cfg.HasField("port") {
+		cfgwarn.Deprecate("7.0.0", "The Logstash outputs port setting")
 	}
 
 	hosts, err := outputs.ReadHostList(cfg)

--- a/libbeat/outputs/redis/redis.go
+++ b/libbeat/outputs/redis/redis.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/libbeat/common/transport/tlscommon"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/outputs"
@@ -54,6 +55,10 @@ func makeRedis(
 
 	if !cfg.HasField("index") {
 		cfg.SetString("index", -1, beat.Beat)
+	}
+
+	if cfg.HasField("port") {
+		cfgwarn.Deprecate("7.0.0", "The Redis outputs port setting")
 	}
 
 	// ensure we have a `key` field in settings

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -1306,10 +1306,6 @@ output.elasticsearch:
   # unreachable, the events are distributed to the reachable servers only.
   #hosts: ["localhost:6379"]
 
-  # The Redis port to use if hosts does not contain a port number. The default
-  # is 6379.
-  #port: 6379
-
   # The name of the Redis list or channel the events are published to. The
   # default is metricbeat.
   #key: metricbeat

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -1101,10 +1101,6 @@ output.elasticsearch:
   # unreachable, the events are distributed to the reachable servers only.
   #hosts: ["localhost:6379"]
 
-  # The Redis port to use if hosts does not contain a port number. The default
-  # is 6379.
-  #port: 6379
-
   # The name of the Redis list or channel the events are published to. The
   # default is packetbeat.
   #key: packetbeat

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -649,10 +649,6 @@ output.elasticsearch:
   # unreachable, the events are distributed to the reachable servers only.
   #hosts: ["localhost:6379"]
 
-  # The Redis port to use if hosts does not contain a port number. The default
-  # is 6379.
-  #port: 6379
-
   # The name of the Redis list or channel the events are published to. The
   # default is winlogbeat.
   #key: winlogbeat

--- a/x-pack/auditbeat/auditbeat.reference.yml
+++ b/x-pack/auditbeat/auditbeat.reference.yml
@@ -753,10 +753,6 @@ output.elasticsearch:
   # unreachable, the events are distributed to the reachable servers only.
   #hosts: ["localhost:6379"]
 
-  # The Redis port to use if hosts does not contain a port number. The default
-  # is 6379.
-  #port: 6379
-
   # The name of the Redis list or channel the events are published to. The
   # default is auditbeat.
   #key: auditbeat

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -1453,10 +1453,6 @@ output.elasticsearch:
   # unreachable, the events are distributed to the reachable servers only.
   #hosts: ["localhost:6379"]
 
-  # The Redis port to use if hosts does not contain a port number. The default
-  # is 6379.
-  #port: 6379
-
   # The name of the Redis list or channel the events are published to. The
   # default is filebeat.
   #key: filebeat

--- a/x-pack/functionbeat/functionbeat.reference.yml
+++ b/x-pack/functionbeat/functionbeat.reference.yml
@@ -714,10 +714,6 @@ output.elasticsearch:
   # unreachable, the events are distributed to the reachable servers only.
   #hosts: ["localhost:6379"]
 
-  # The Redis port to use if hosts does not contain a port number. The default
-  # is 6379.
-  #port: 6379
-
   # The name of the Redis list or channel the events are published to. The
   # default is functionbeat.
   #key: functionbeat


### PR DESCRIPTION
The port settigns for redis/logstash have been marked as deprecated since 5.0. This change will print a deprecation warning if the settings are used. We will remove the setting in 7.0.