### PR TITLE
Cherry-pick #9892 to 6.x: Remove _meta/kibana.generated symlink

### DIFF
--- a/dev-tools/mage/kibana.go
+++ b/dev-tools/mage/kibana.go
@@ -35,11 +35,6 @@ func KibanaDashboards(moduleDirs ...string) error {
 		return err
 	}
 
-	// Create symlink from old directory so `make beats-dashboards` works.
-	if err := os.Symlink(filepath.Join("..", kibanaBuildDir), "_meta/kibana.generated"); err != nil && !os.IsExist(err) && !os.IsNotExist(err) {
-		return err
-	}
-
 	// Copy the OSS Beat's common dashboards if they exist. This assumes that
 	// X-Pack Beats only add dashboards with modules (this will require a
 	// change if we have X-Pack only Beats).

--- a/dev-tools/mage/pkgtypes.go
+++ b/dev-tools/mage/pkgtypes.go
@@ -711,14 +711,7 @@ func addUidGidEnvArgs(args []string) ([]string, error) {
 
 // addFileToZip adds a file (or directory) to a zip archive.
 func addFileToZip(ar *zip.Writer, baseDir string, pkgFile PackageFile) error {
-	// filepath.Walk() does not resolve symlinks, but pkgFile.Source might be one,
-	// see mage.KibanaDashboards().
-	resolvedSource, err := filepath.EvalSymlinks(pkgFile.Source)
-	if err != nil {
-		return err
-	}
-
-	return filepath.Walk(resolvedSource, func(path string, info os.FileInfo, err error) error {
+	return filepath.Walk(pkgFile.Source, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}

--- a/magefile.go
+++ b/magefile.go
@@ -20,7 +20,10 @@
 package main
 
 import (
+	"os"
 	"path/filepath"
+
+	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/dev-tools/mage"
 )
@@ -28,13 +31,13 @@ import (
 var (
 	// Beats is a list of Beats to collect dashboards from.
 	Beats = []string{
-		"auditbeat",
-		"filebeat",
 		"heartbeat",
 		"journalbeat",
-		"metricbeat",
 		"packetbeat",
 		"winlogbeat",
+		"x-pack/auditbeat",
+		"x-pack/filebeat",
+		"x-pack/metricbeat",
 		"x-pack/functionbeat",
 	}
 )
@@ -59,9 +62,19 @@ func PackageBeatDashboards() error {
 		OutputFile: "build/distributions/dashboards/{{.Name}}-{{.Version}}{{if .Snapshot}}-SNAPSHOT{{end}}",
 	}
 
-	for _, beat := range Beats {
-		spec.Files[beat] = mage.PackageFile{
-			Source: filepath.Join(beat, "_meta/kibana.generated"),
+	for _, beatDir := range Beats {
+		// The generated dashboard content is moving in the build dir, but
+		// not all projects have been updated so detect which dir to use.
+		dashboardDir := filepath.Join(beatDir, "build/kibana")
+		legacyDir := filepath.Join(beatDir, "_meta/kibana.generated")
+		beatName := filepath.Base(beatDir)
+
+		if _, err := os.Stat(dashboardDir); err == nil {
+			spec.Files[beatName] = mage.PackageFile{Source: dashboardDir}
+		} else if _, err := os.Stat(legacyDir); err == nil {
+			spec.Files[beatName] = mage.PackageFile{Source: legacyDir}
+		} else {
+			return errors.Errorf("no dashboards found for %v", beatDir)
 		}
 	}
 


### PR DESCRIPTION
Cherry-pick of PR #9892 to 6.x branch. Original message: 

https://github.com/elastic/beats/pull/9546 introduced a symlink from `_meta/kibana.generated` to `build/kibana` so Auditbeat remains backwards compatible with the other Beats (Auditbeat is already using the first as a location for all its Kibana objects, while the other Beats are still using the latter).

This introduced a bug, where objects would be included in the dashboard ZIP file with the wrong path (https://github.com/elastic/beats/issues/9785).

One way of fixing this would have been to double down on symlinks and change just one line in `addFileToZip`. But with https://github.com/elastic/beats/pull/9842/ about to change all Beats to use the new `build/kibana` I thought it better to just remove the symlink capability altogether and instead if-else between the two possible locations based on whether they exist or not. https://github.com/elastic/beats/pull/9842/ will then change all of that - at least in `master` - once it's merged.

Fixes https://github.com/elastic/beats/issues/9785.