### PR TITLE
Cherry-pick #9892 to 6.6: Remove _meta/kibana.generated symlink

### DIFF
--- a/dev-tools/mage/kibana.go
+++ b/dev-tools/mage/kibana.go
@@ -35,11 +35,6 @@ func KibanaDashboards(moduleDirs ...string) error {
 		return err
 	}
 
-	// Create symlink from old directory so `make beats-dashboards` works.
-	if err := os.Symlink(filepath.Join("..", kibanaBuildDir), "_meta/kibana.generated"); err != nil && !os.IsExist(err) && !os.IsNotExist(err) {
-		return err
-	}
-
 	// Copy the OSS Beat's common dashboards if they exist. This assumes that
 	// X-Pack Beats only add dashboards with modules (this will require a
 	// change if we have X-Pack only Beats).

--- a/dev-tools/mage/pkgtypes.go
+++ b/dev-tools/mage/pkgtypes.go
@@ -711,14 +711,7 @@ func addUidGidEnvArgs(args []string) ([]string, error) {
 
 // addFileToZip adds a file (or directory) to a zip archive.
 func addFileToZip(ar *zip.Writer, baseDir string, pkgFile PackageFile) error {
-	// filepath.Walk() does not resolve symlinks, but pkgFile.Source might be one,
-	// see mage.KibanaDashboards().
-	resolvedSource, err := filepath.EvalSymlinks(pkgFile.Source)
-	if err != nil {
-		return err
-	}
-
-	return filepath.Walk(resolvedSource, func(path string, info os.FileInfo, err error) error {
+	return filepath.Walk(pkgFile.Source, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Cherry-pick of PR #9892 to 6.6 branch. Original message: 

https://github.com/elastic/beats/pull/9546 introduced a symlink from `_meta/kibana.generated` to `build/kibana` so Auditbeat remains backwards compatible with the other Beats (Auditbeat is already using the first as a location for all its Kibana objects, while the other Beats are still using the latter).

This introduced a bug, where objects would be included in the dashboard ZIP file with the wrong path (https://github.com/elastic/beats/issues/9785).

One way of fixing this would have been to double down on symlinks and change just one line in `addFileToZip`. But with https://github.com/elastic/beats/pull/9842/ about to change all Beats to use the new `build/kibana` I thought it better to just remove the symlink capability altogether and instead if-else between the two possible locations based on whether they exist or not. https://github.com/elastic/beats/pull/9842/ will then change all of that - at least in `master` - once it's merged.

Fixes https://github.com/elastic/beats/issues/9785.