### PR TITLE
Update go-sysinfo

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -584,7 +584,7 @@ Apache License 2.0
 
 --------------------------------------------------------------------
 Dependency: github.com/elastic/go-sysinfo
-Revision: 7b021494a9562d0c3f0422d49b9980709c5650e9
+Revision: 59ef8c0eae46c0929e3b219ac86368d4b5934f91
 License type (autodetected): Apache-2.0
 ./vendor/github.com/elastic/go-sysinfo/LICENSE.txt:
 --------------------------------------------------------------------

--- a/vendor/github.com/elastic/go-sysinfo/providers/darwin/host_darwin_amd64.go
+++ b/vendor/github.com/elastic/go-sysinfo/providers/darwin/host_darwin_amd64.go
@@ -218,5 +218,9 @@ func (r *reader) time(h *host) {
 }
 
 func (r *reader) uniqueID(h *host) {
-	// TODO: call gethostuuid(uuid [16]byte, timespec)
+	v, err := MachineID()
+	if r.addErr(err) {
+		return
+	}
+	h.info.UniqueID = v
 }

--- a/vendor/github.com/elastic/go-sysinfo/providers/linux/process_linux.go
+++ b/vendor/github.com/elastic/go-sysinfo/providers/linux/process_linux.go
@@ -22,6 +22,7 @@ import (
 	"io/ioutil"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/prometheus/procfs"
@@ -36,7 +37,6 @@ func (s linuxSystem) Processes() ([]types.Process, error) {
 	if err != nil {
 		return nil, err
 	}
-	s.procFS.Path()
 
 	processes := make([]types.Process, 0, len(procs))
 	for _, proc := range procs {
@@ -69,8 +69,12 @@ type process struct {
 	info *types.ProcessInfo
 }
 
+func (p *process) PID() int {
+	return p.Proc.PID
+}
+
 func (p *process) path(pa ...string) string {
-	return p.fs.Path(append([]string{strconv.Itoa(p.PID)}, pa...)...)
+	return p.fs.Path(append([]string{strconv.Itoa(p.PID())}, pa...)...)
 }
 
 func (p *process) CWD() (string, error) {
@@ -115,7 +119,7 @@ func (p *process) Info() (types.ProcessInfo, error) {
 
 	p.info = &types.ProcessInfo{
 		Name:      stat.Comm,
-		PID:       p.PID,
+		PID:       p.PID(),
 		PPID:      stat.PPID,
 		CWD:       cwd,
 		Exe:       exe,
@@ -202,6 +206,37 @@ func (p *process) Capabilities() (*types.CapabilityInfo, error) {
 	}
 
 	return readCapabilities(content)
+}
+
+func (p *process) User() (types.UserInfo, error) {
+	content, err := ioutil.ReadFile(p.path("status"))
+	if err != nil {
+		return types.UserInfo{}, err
+	}
+
+	var user types.UserInfo
+	err = parseKeyValue(content, ":", func(key, value []byte) error {
+		// See proc(5) for the format of /proc/[pid]/status
+		switch string(key) {
+		case "Uid":
+			ids := strings.Split(string(value), "\t")
+			if len(ids) >= 3 {
+				user.UID = ids[0]
+				user.EUID = ids[1]
+				user.SUID = ids[2]
+			}
+		case "Gid":
+			ids := strings.Split(string(value), "\t")
+			if len(ids) >= 3 {
+				user.GID = ids[0]
+				user.EGID = ids[1]
+				user.SGID = ids[2]
+			}
+		}
+		return nil
+	})
+
+	return user, nil
 }
 
 func ticksToDuration(ticks uint64) time.Duration {

--- a/vendor/github.com/elastic/go-sysinfo/providers/windows/arch_windows.go
+++ b/vendor/github.com/elastic/go-sysinfo/providers/windows/arch_windows.go
@@ -18,7 +18,7 @@
 package windows
 
 import (
-	"github.com/elastic/go-windows"
+	windows "github.com/elastic/go-windows"
 )
 
 func Architecture() (string, error) {

--- a/vendor/github.com/elastic/go-sysinfo/providers/windows/boottime_windows.go
+++ b/vendor/github.com/elastic/go-sysinfo/providers/windows/boottime_windows.go
@@ -20,7 +20,7 @@ package windows
 import (
 	"time"
 
-	"github.com/elastic/go-windows"
+	windows "github.com/elastic/go-windows"
 	"github.com/pkg/errors"
 )
 

--- a/vendor/github.com/elastic/go-sysinfo/providers/windows/host_windows.go
+++ b/vendor/github.com/elastic/go-sysinfo/providers/windows/host_windows.go
@@ -21,7 +21,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/elastic/go-windows"
+	windows "github.com/elastic/go-windows"
 	"github.com/joeshaw/multierror"
 	"github.com/pkg/errors"
 

--- a/vendor/github.com/elastic/go-sysinfo/providers/windows/kernel_windows.go
+++ b/vendor/github.com/elastic/go-sysinfo/providers/windows/kernel_windows.go
@@ -18,7 +18,7 @@
 package windows
 
 import (
-	"github.com/elastic/go-windows"
+	windows "github.com/elastic/go-windows"
 )
 
 const windowsKernelExe = `C:\Windows\System32\ntoskrnl.exe`

--- a/vendor/github.com/elastic/go-sysinfo/providers/windows/os_windows.go
+++ b/vendor/github.com/elastic/go-sysinfo/providers/windows/os_windows.go
@@ -37,6 +37,7 @@ func OperatingSystem() (*types.OSInfo, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, `failed to open HKLM\%v`, path)
 	}
+	defer k.Close()
 
 	osInfo := &types.OSInfo{
 		Family:   "windows",

--- a/vendor/github.com/elastic/go-sysinfo/providers/windows/process_windows.go
+++ b/vendor/github.com/elastic/go-sysinfo/providers/windows/process_windows.go
@@ -26,8 +26,9 @@ import (
 	"unsafe"
 
 	"github.com/pkg/errors"
+	syswin "golang.org/x/sys/windows"
 
-	"github.com/elastic/go-windows"
+	windows "github.com/elastic/go-windows"
 
 	"github.com/elastic/go-sysinfo/types"
 )
@@ -45,6 +46,12 @@ func (s windowsSystem) Processes() (procs []types.Process, err error) {
 	procs = make([]types.Process, 0, len(pids))
 	var proc types.Process
 	for _, pid := range pids {
+		if pid == 0 || pid == 4 {
+			// The Idle and System processes (PIDs 0 and 4) can never be
+			// opened by user-level code (see documentation for OpenProcess).
+			continue
+		}
+
 		if proc, err = s.Process(int(pid)); err == nil {
 			procs = append(procs, proc)
 		}
@@ -66,6 +73,10 @@ func (s windowsSystem) Self() (types.Process, error) {
 type process struct {
 	pid  int
 	info types.ProcessInfo
+}
+
+func (p *process) PID() int {
+	return p.pid
 }
 
 func newProcess(pid int) (*process, error) {
@@ -239,6 +250,45 @@ func (p *process) open() (handle syscall.Handle, err error) {
 
 func (p *process) Info() (types.ProcessInfo, error) {
 	return p.info, nil
+}
+
+func (p *process) User() (types.UserInfo, error) {
+	handle, err := p.open()
+	if err != nil {
+		return types.UserInfo{}, errors.Wrap(err, "OpenProcess failed")
+	}
+	defer syscall.CloseHandle(handle)
+
+	var accessToken syswin.Token
+	err = syswin.OpenProcessToken(syswin.Handle(handle), syscall.TOKEN_QUERY, &accessToken)
+	if err != nil {
+		return types.UserInfo{}, errors.Wrap(err, "OpenProcessToken failed")
+	}
+	defer accessToken.Close()
+
+	tokenUser, err := accessToken.GetTokenUser()
+	if err != nil {
+		return types.UserInfo{}, errors.Wrap(err, "GetTokenUser failed")
+	}
+
+	sid, err := tokenUser.User.Sid.String()
+	if err != nil {
+		return types.UserInfo{}, errors.Wrap(err, "failed to look up user SID")
+	}
+
+	tokenGroup, err := accessToken.GetTokenPrimaryGroup()
+	if err != nil {
+		return types.UserInfo{}, errors.Wrap(err, "GetTokenPrimaryGroup failed")
+	}
+	gsid, err := tokenGroup.PrimaryGroup.String()
+	if err != nil {
+		return types.UserInfo{}, errors.Wrap(err, "failed to look up primary group SID")
+	}
+
+	return types.UserInfo{
+		UID: sid,
+		GID: gsid,
+	}, nil
 }
 
 func (p *process) Memory() (types.MemoryInfo, error) {

--- a/vendor/github.com/elastic/go-sysinfo/types/process.go
+++ b/vendor/github.com/elastic/go-sysinfo/types/process.go
@@ -23,6 +23,8 @@ type Process interface {
 	CPUTimer
 	Info() (ProcessInfo, error)
 	Memory() (MemoryInfo, error)
+	User() (UserInfo, error)
+	PID() int
 }
 
 type ProcessInfo struct {
@@ -33,6 +35,38 @@ type ProcessInfo struct {
 	Exe       string    `json:"exe"`
 	Args      []string  `json:"args"`
 	StartTime time.Time `json:"start_time"`
+}
+
+// UserInfo contains information about the UID and GID
+// values of a process.
+type UserInfo struct {
+	// UID is the user ID.
+	// On Linux and Darwin (macOS) this is the real user ID.
+	// On Windows, this is the security identifier (SID) of the
+	// user account of the process access token.
+	UID string `json:"uid"`
+
+	// On Linux and Darwin (macOS) this is the effective user ID.
+	// On Windows, this is empty.
+	EUID string `json:"euid"`
+
+	// On Linux and Darwin (macOS) this is the saved user ID.
+	// On Windows, this is empty.
+	SUID string `json:"suid"`
+
+	// GID is the primary group ID.
+	// On Linux and Darwin (macOS) this is the real group ID.
+	// On Windows, this is the security identifier (SID) of the
+	// primary group of the process access token.
+	GID string `json:"gid"`
+
+	// On Linux and Darwin (macOS) this is the effective group ID.
+	// On Windows, this is empty.
+	EGID string `json:"egid"`
+
+	// On Linux and Darwin (macOS) this is the saved group ID.
+	// On Windows, this is empty.
+	SGID string `json:"sgid"`
 }
 
 type Environment interface {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -898,44 +898,44 @@
 		{
 			"checksumSHA1": "QhFIpuHPaV6hKejKcc2wm6y4MSQ=",
 			"path": "github.com/elastic/go-sysinfo",
-			"revision": "7b021494a9562d0c3f0422d49b9980709c5650e9",
-			"revisionTime": "2018-09-11T17:37:16Z"
+			"revision": "59ef8c0eae46c0929e3b219ac86368d4b5934f91",
+			"revisionTime": "2019-01-07T12:18:35Z"
 		},
 		{
 			"checksumSHA1": "GiZCjX17K265TtamGZZw4R2Jwbk=",
 			"path": "github.com/elastic/go-sysinfo/internal/registry",
-			"revision": "7b021494a9562d0c3f0422d49b9980709c5650e9",
-			"revisionTime": "2018-09-11T17:37:16Z"
+			"revision": "59ef8c0eae46c0929e3b219ac86368d4b5934f91",
+			"revisionTime": "2019-01-07T12:18:35Z"
 		},
 		{
-			"checksumSHA1": "432ecsMRmLpy5OvXMhQE/k9KWLQ=",
+			"checksumSHA1": "ovafihHzpBx9Y7+lZh9X5KwNCvE=",
 			"path": "github.com/elastic/go-sysinfo/providers/darwin",
-			"revision": "7b021494a9562d0c3f0422d49b9980709c5650e9",
-			"revisionTime": "2018-09-11T17:37:16Z"
+			"revision": "59ef8c0eae46c0929e3b219ac86368d4b5934f91",
+			"revisionTime": "2019-01-07T12:18:35Z"
 		},
 		{
-			"checksumSHA1": "1eCL0MsvmiyjNvh0tcnnR4rmcWk=",
+			"checksumSHA1": "AK76ZxnuvK02Dfpmj7b2TD/aiSI=",
 			"path": "github.com/elastic/go-sysinfo/providers/linux",
-			"revision": "7b021494a9562d0c3f0422d49b9980709c5650e9",
-			"revisionTime": "2018-09-11T17:37:16Z"
+			"revision": "59ef8c0eae46c0929e3b219ac86368d4b5934f91",
+			"revisionTime": "2019-01-07T12:18:35Z"
 		},
 		{
 			"checksumSHA1": "RWLvcP1w9ynKbuCqiW6prwd+EDU=",
 			"path": "github.com/elastic/go-sysinfo/providers/shared",
-			"revision": "7b021494a9562d0c3f0422d49b9980709c5650e9",
-			"revisionTime": "2018-09-11T17:37:16Z"
+			"revision": "59ef8c0eae46c0929e3b219ac86368d4b5934f91",
+			"revisionTime": "2019-01-07T12:18:35Z"
 		},
 		{
-			"checksumSHA1": "lWVD4w1xiAkFZgQPZAYz+fTZsrU=",
+			"checksumSHA1": "aF05MEkMjbRekzHlwFxmd5WBpeY=",
 			"path": "github.com/elastic/go-sysinfo/providers/windows",
-			"revision": "7b021494a9562d0c3f0422d49b9980709c5650e9",
-			"revisionTime": "2018-09-11T17:37:16Z"
+			"revision": "59ef8c0eae46c0929e3b219ac86368d4b5934f91",
+			"revisionTime": "2019-01-07T12:18:35Z"
 		},
 		{
-			"checksumSHA1": "tIqFxnZi9XvC70dMoZDSoUtEVQY=",
+			"checksumSHA1": "MLQioPEjULYbNqqCjfB1/cux08E=",
 			"path": "github.com/elastic/go-sysinfo/types",
-			"revision": "7b021494a9562d0c3f0422d49b9980709c5650e9",
-			"revisionTime": "2018-09-11T17:37:16Z"
+			"revision": "59ef8c0eae46c0929e3b219ac86368d4b5934f91",
+			"revisionTime": "2019-01-07T12:18:35Z"
 		},
 		{
 			"checksumSHA1": "tNszmkpuJYZMX8l8rlnvBDtoc1M=",


### PR DESCRIPTION
Updates `go-sysinfo` to its current master. This will automatically populate the `host.id` on macOS if the `add_host_processor` is being used (the default in 7.0).

It also adds some functionality for processes that is needed in the Auditbeat system module.