### PR TITLE
Cherry-pick #9929 to 6.6: Fix beats-dashboards

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -33,11 +33,11 @@ var (
 	Beats = []string{
 		"heartbeat",
 		"journalbeat",
+		"metricbeat",
 		"packetbeat",
 		"winlogbeat",
 		"x-pack/auditbeat",
 		"x-pack/filebeat",
-		"x-pack/metricbeat",
 		"x-pack/functionbeat",
 	}
 )


### PR DESCRIPTION
Cherry-pick of PR #9929 to 6.6 branch. Original message: 

x-pack/metricbeat does not generate dashboards.

Fixes #9928