### PR TITLE
Cherry-pick #9869 to 6.6: Handle IPv6 zone id in IIS filebeat ingest pipeline

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -36,11 +36,14 @@ https://github.com/elastic/beats/compare/1035569addc4a3b29ffa14f8a08c27c1ace16ef
 
 *Filebeat*
 
+- Support IPv6 addresses with zone id in IIS ingest pipeline. {issue}9836[9836] {pull}9869[9869]
+
 *Heartbeat*
 
 *Journalbeat*
 
 *Metricbeat*
+
 - Fix panics in vsphere module when certain values where not returned by the API. {pull}9784[9784]
 
 *Packetbeat*

--- a/filebeat/module/iis/error/ingest/default.json
+++ b/filebeat/module/iis/error/ingest/default.json
@@ -28,9 +28,23 @@
       "field": "iis.error.time"
     }
   }, {
-    "geoip": {
+    "grok": {
       "field": "iis.error.remote_ip",
+      "patterns": [
+        "%{NOZONEIP:iis.error.remote_ip_geoip}"
+      ],
+      "pattern_definitions": {
+         "NOZONEIP": "[^%]*"
+      }
+    }
+  }, {
+    "geoip": {
+      "field": "iis.error.remote_ip_geoip",
       "target_field": "iis.error.geoip"
+    }
+  }, {
+    "remove": {
+      "field": "iis.error.remote_ip_geoip"
     }
   }],
   "on_failure" : [{

--- a/filebeat/module/iis/error/test/ipv6_zone_id.log
+++ b/filebeat/module/iis/error/test/ipv6_zone_id.log
@@ -1,0 +1,5 @@
+#Software: Microsoft HTTP API 2.0
+#Version: 1.0
+#Date: 2018-12-30 13:48:36
+#Fields: date time c-ip c-port s-ip s-port cs-version cs-method cs-uri streamid sc-status s-siteid s-reason s-queuename
+2018-12-30 14:22:07 ::1%0 49958 ::1%0 80 - - - - - - Timer_ConnectionIdle -

--- a/filebeat/module/iis/error/test/ipv6_zone_id.log-expected.json
+++ b/filebeat/module/iis/error/test/ipv6_zone_id.log-expected.json
@@ -1,0 +1,16 @@
+[
+    {
+        "@timestamp": "2018-12-30T14:22:07.000Z",
+        "ecs.version": "1.0.0-beta2",
+        "event.dataset": "error",
+        "event.module": "iis",
+        "iis.error.queue_name": "-",
+        "iis.error.reason_phrase": "Timer_ConnectionIdle",
+        "iis.error.remote_ip": "::1%0",
+        "iis.error.remote_port": "49958",
+        "iis.error.server_ip": "::1%0",
+        "iis.error.server_port": "80",
+        "input.type": "log",
+        "log.offset": 195
+    }
+]

--- a/filebeat/module/iis/error/test/ipv6_zone_id.log-expected.json
+++ b/filebeat/module/iis/error/test/ipv6_zone_id.log-expected.json
@@ -1,16 +1,17 @@
 [
     {
-        "@timestamp": "2018-12-30T14:22:07.000Z",
-        "ecs.version": "1.0.0-beta2",
-        "event.dataset": "error",
-        "event.module": "iis",
-        "iis.error.queue_name": "-",
-        "iis.error.reason_phrase": "Timer_ConnectionIdle",
-        "iis.error.remote_ip": "::1%0",
-        "iis.error.remote_port": "49958",
-        "iis.error.server_ip": "::1%0",
-        "iis.error.server_port": "80",
-        "input.type": "log",
-        "log.offset": 195
+        "@timestamp": "2018-12-30T14:22:07.000Z", 
+        "event.dataset": "iis.error", 
+        "fileset.module": "iis", 
+        "fileset.name": "error", 
+        "iis.error.queue_name": "-", 
+        "iis.error.reason_phrase": "Timer_ConnectionIdle", 
+        "iis.error.remote_ip": "::1%0", 
+        "iis.error.remote_port": "49958", 
+        "iis.error.server_ip": "::1%0", 
+        "iis.error.server_port": "80", 
+        "input.type": "log", 
+        "offset": 195, 
+        "prospector.type": "log"
     }
 ]


### PR DESCRIPTION
Cherry-pick of PR #9869 to 6.6 branch. Original message: 

Possible workaround for #9836, this may be needed in other modules if other services also log IPv6 addresses with zone id.

Wait for https://github.com/elastic/elasticsearch/issues/37107 before deciding what to do about this.