### PR TITLE
Cherry-pick #9909 to 6.x: Make watcher threadpool stats optional

### DIFF
--- a/metricbeat/module/elasticsearch/node_stats/data_xpack.go
+++ b/metricbeat/module/elasticsearch/node_stats/data_xpack.go
@@ -145,7 +145,7 @@ var (
 			"get":        c.Dict("get", threadPoolStatsSchema),
 			"management": c.Dict("management", threadPoolStatsSchema),
 			"search":     c.Dict("search", threadPoolStatsSchema),
-			"watcher":    c.Dict("watcher", threadPoolStatsSchema),
+			"watcher":    c.Dict("watcher", threadPoolStatsSchema, c.DictOptional),
 		}),
 		"fs": c.Dict("fs", s.Schema{
 			"total": c.Dict("total", s.Schema{


### PR DESCRIPTION
Cherry-pick of PR #9909 to 6.x branch. Original message: 

Resolves #9875.

When Watcher is explicitly disabled in ES, by setting `xpack.watcher.enabled: false` in `elasticsearch.yml`, the Node Stats API does not report Watcher threadpool stats. In the scenario, when using Metricbeat for Elasticsearch Monitoring, users would see an error like so in their Metricbeat logs:

```
2018-12-19T14:42:05.741Z	ERROR	node_stats/data_xpack.go:208	failure to apply node schema: 1 error: key thread_pool.watcher not found
```

This PR removes this error by teaching the `elasticsearch/node_stats` metricset to **optionally** look for Watcher threadpool stats.

### Testing this PR

1. Install ES (with default Basic license).
2. Explicitly disable Watcher in ES, by setting `xpack.watcher.enabled: false` in your `elasticsearch.yml`.
3. Start up ES.
2. Check out this PR and build Metricbeat: `mage build`
3. Enable the elasticsearch Metricbeat module: `metricbeat enable elasticsearch`
4. Configure the Elasticsearch module for X-Pack Monitoring by setting `modules.d/elasticsearch.yml` to the following:

   ```
   - module: elasticsearch
     metricsets:
     - node_stats
     period: 10s
     hosts: ["http://localhost:9200"]
     xpack.enabled: true
   ```
5. Start up Metricbeat: `metricbeat -e`.
6. Ensure that the error mentioned above is not shown in the Metricbeat logs.