### PR TITLE
Fix and reenable ml tests

### DIFF
--- a/filebeat/module/iis/error/test/ipv6_zone_id.log-expected.json
+++ b/filebeat/module/iis/error/test/ipv6_zone_id.log-expected.json
@@ -2,8 +2,9 @@
     {
         "@timestamp": "2018-12-30T14:22:07.000Z",
         "ecs.version": "1.0.0-beta2",
-        "event.dataset": "error",
+        "event.dataset": "iis.error",
         "event.module": "iis",
+        "fileset.name": "error",
         "iis.error.queue_name": "-",
         "iis.error.reason_phrase": "Timer_ConnectionIdle",
         "iis.error.remote_ip": "::1%0",

--- a/filebeat/tests/system/test_ml.py
+++ b/filebeat/tests/system/test_ml.py
@@ -23,7 +23,7 @@ class Test(BaseTest):
                                             "/../../../../module")
 
         self.kibana_path = os.path.abspath(self.working_dir +
-                                           "/../../../../_meta/kibana.generated")
+                                           "/../../../../build/kibana")
 
         self.filebeat = os.path.abspath(self.working_dir +
                                         "/../../../../filebeat.test")
@@ -41,7 +41,6 @@ class Test(BaseTest):
     @unittest.skipIf(os.getenv("TESTING_ENVIRONMENT") == "2x",
                      "integration test not available on 2.x")
     @unittest.skipIf(os.name == "nt", "skipped on Windows")
-    @unittest.skip("Skip broken ML support.")
     def test_ml_setup(self, setup_flag, modules_flag):
         """ Test ML are installed in all possible ways """
         self._run_ml_test(setup_flag, modules_flag)


### PR DESCRIPTION
In https://github.com/elastic/beats/pull/9892 the build was broken by removing the symlink to the generated kibana files which broke the ml tests. This fixes the test by pointing to the new directory under build/kibana.

Closes https://github.com/elastic/beats/issues/9938