### PR TITLE
Rename host.name to host.hostname and add config option for name

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -81,6 +81,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 - Update field definitions for `http` to ECS Beta 2 {pull}9645[9645]
 - Add `agent.id` and `agent.ephemeral_id` fields to all beats. {pull}9404[9404]
+- Add `name` config option to `add_host_metadata` processor. {pull}9943[9943]
 
 *Auditbeat*
 

--- a/libbeat/metric/system/host/host.go
+++ b/libbeat/metric/system/host/host.go
@@ -28,7 +28,7 @@ import (
 func MapHostInfo(info types.HostInfo) common.MapStr {
 	data := common.MapStr{
 		"host": common.MapStr{
-			"name":         info.Hostname,
+			"hostname":     info.Hostname,
 			"architecture": info.Architecture,
 			"os": common.MapStr{
 				"platform": info.OS.Platform,
@@ -68,7 +68,7 @@ func ReportInfo(_ monitoring.Mode, V monitoring.Visitor) {
 	}
 	info := h.Info()
 
-	monitoring.ReportString(V, "name", info.Hostname)
+	monitoring.ReportString(V, "hostname", info.Hostname)
 	monitoring.ReportString(V, "architecture", info.Architecture)
 	monitoring.ReportNamespace(V, "os", func() {
 		monitoring.ReportString(V, "platform", info.OS.Platform)

--- a/libbeat/processors/add_host_metadata/add_host_metadata.go
+++ b/libbeat/processors/add_host_metadata/add_host_metadata.go
@@ -163,6 +163,9 @@ func (p *addHostMetadata) loadData() error {
 		}
 	}
 
+	if p.config.Name != "" {
+		data.Put("host.name", p.config.Name)
+	}
 	p.data.Set(data)
 	return nil
 }

--- a/libbeat/processors/add_host_metadata/add_host_metadata_test.go
+++ b/libbeat/processors/add_host_metadata/add_host_metadata_test.go
@@ -116,6 +116,34 @@ func TestConfigNetInfoEnabled(t *testing.T) {
 	assert.NotNil(t, v)
 }
 
+func TestConfigName(t *testing.T) {
+	event := &beat.Event{
+		Fields:    common.MapStr{},
+		Timestamp: time.Now(),
+	}
+
+	config := map[string]interface{}{
+		"name": "my-host",
+	}
+
+	testConfig, err := common.NewConfigFrom(config)
+	assert.NoError(t, err)
+
+	p, err := newHostMetadataProcessor(testConfig)
+	require.NoError(t, err)
+
+	newEvent, err := p.Run(event)
+	assert.NoError(t, err)
+
+	for configKey, configValue := range config {
+		t.Run(fmt.Sprintf("Check of %s", configKey), func(t *testing.T) {
+			v, err := newEvent.GetValue(fmt.Sprintf("host.%s", configKey))
+			assert.NoError(t, err)
+			assert.Equal(t, configValue, v, "Could not find in %s", newEvent)
+		})
+	}
+}
+
 func TestConfigGeoEnabled(t *testing.T) {
 	event := &beat.Event{
 		Fields:    common.MapStr{},

--- a/libbeat/processors/add_host_metadata/config.go
+++ b/libbeat/processors/add_host_metadata/config.go
@@ -26,6 +26,7 @@ type Config struct {
 	NetInfoEnabled bool          `config:"netinfo.enabled"` // Add IP and MAC to event
 	CacheTTL       time.Duration `config:"cache.ttl"`
 	Geo            *GeoConfig    `config:"geo"`
+	Name           string        `config:"name"`
 }
 
 // GeoConfig contains geo configuration data.


### PR DESCRIPTION
Currently by default the hostname of the host on which the Beat is running is fed into host.name. Based on ECS this is now changed to `host.hostname`: https://github.com/elastic/ecs#-host-fields By default `host.name` stays the hostname of the host for backward compatibility. It is not set by the processor but by the pipeline.

If the config option `name` is changed in the Beat config, `host.name` will be set to this value as before. In addition a new config option was added to `add_host_metadata`:

```
processors:
  - add_host_metadata:
      name: foo
```

`name` for the host metadata processor can be set and will overwrite the current value of `host.name`.

It is also possible to set both config options as below:

```
name: bar

processors:
  - add_host_metadata:
      name: foo
```

The outcome event will contain the following two fields:

```
agent.name: bar
host.name: foo
```

Overall if nothing is configured, the behavior stays the same as before but allows additional options.