### PR TITLE
Cherry-pick #9896 to 6.x: Refactoring: Elasticsearch metricbeat module

### DIFF
--- a/metricbeat/module/elasticsearch/ccr/ccr.go
+++ b/metricbeat/module/elasticsearch/ccr/ccr.go
@@ -58,7 +58,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 
 // Fetch gathers stats for each follower shard from the _ccr/stats API
 func (m *MetricSet) Fetch(r mb.ReporterV2) {
-	isMaster, err := elasticsearch.IsMaster(m.HTTP, m.getServiceURI())
+	isMaster, err := elasticsearch.IsMaster(m.HTTP, m.GetServiceURI())
 	if err != nil {
 		err = errors.Wrap(err, "error determining if connected Elasticsearch node is master")
 		elastic.ReportAndLogError(err, r, m.Log)
@@ -71,7 +71,7 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 		return
 	}
 
-	info, err := elasticsearch.GetInfo(m.HTTP, m.getServiceURI())
+	info, err := elasticsearch.GetInfo(m.HTTP, m.GetServiceURI())
 	if err != nil {
 		elastic.ReportAndLogError(err, r, m.Log)
 		return
@@ -116,7 +116,7 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 }
 
 func (m *MetricSet) checkCCRAvailability(currentElasticsearchVersion string) (message string, err error) {
-	license, err := elasticsearch.GetLicense(m.HTTP, m.getServiceURI())
+	license, err := elasticsearch.GetLicense(m.HTTP, m.GetServiceURI())
 	if err != nil {
 		return "", errors.Wrap(err, "error determining Elasticsearch license")
 	}
@@ -142,9 +142,4 @@ func (m *MetricSet) checkCCRAvailability(currentElasticsearchVersion string) (me
 	}
 
 	return "", nil
-}
-
-func (m *MetricSet) getServiceURI() string {
-	return m.HostData().SanitizedURI + ccrStatsPath
-
 }

--- a/metricbeat/module/elasticsearch/index_recovery/index_recovery.go
+++ b/metricbeat/module/elasticsearch/index_recovery/index_recovery.go
@@ -40,7 +40,6 @@ const (
 // MetricSet type defines all fields of the MetricSet
 type MetricSet struct {
 	*elasticsearch.MetricSet
-	recoveryPath string
 }
 
 // New create a new instance of the MetricSet
@@ -67,12 +66,12 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &MetricSet{MetricSet: ms, recoveryPath: localRecoveryPath}, nil
+	return &MetricSet{MetricSet: ms}, nil
 }
 
 // Fetch gathers stats for each index from the _stats API
 func (m *MetricSet) Fetch(r mb.ReporterV2) {
-	isMaster, err := elasticsearch.IsMaster(m.HTTP, m.getServiceURI())
+	isMaster, err := elasticsearch.IsMaster(m.HTTP, m.GetServiceURI())
 	if err != nil {
 		err = errors.Wrap(err, "error determining if connected Elasticsearch node is master")
 		elastic.ReportAndLogError(err, r, m.Log)
@@ -85,7 +84,7 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 		return
 	}
 
-	info, err := elasticsearch.GetInfo(m.HTTP, m.getServiceURI())
+	info, err := elasticsearch.GetInfo(m.HTTP, m.GetServiceURI())
 	if err != nil {
 		elastic.ReportAndLogError(err, r, m.Log)
 		return
@@ -107,9 +106,4 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 		m.Log.Error(err)
 		return
 	}
-}
-
-func (m *MetricSet) getServiceURI() string {
-	return m.HostData().SanitizedURI + m.recoveryPath
-
 }

--- a/metricbeat/module/elasticsearch/ml_job/ml_job.go
+++ b/metricbeat/module/elasticsearch/ml_job/ml_job.go
@@ -58,7 +58,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // Fetch methods implements the data gathering and data conversion to the right format
 func (m *MetricSet) Fetch(r mb.ReporterV2) {
 
-	isMaster, err := elasticsearch.IsMaster(m.HTTP, m.getServiceURI())
+	isMaster, err := elasticsearch.IsMaster(m.HTTP, m.GetServiceURI())
 	if err != nil {
 		err = errors.Wrap(err, "error determining if connected Elasticsearch node is master")
 		elastic.ReportAndLogError(err, r, m.Log)
@@ -71,7 +71,7 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 		return
 	}
 
-	info, err := elasticsearch.GetInfo(m.HTTP, m.getServiceURI())
+	info, err := elasticsearch.GetInfo(m.HTTP, m.GetServiceURI())
 	if err != nil {
 		elastic.ReportAndLogError(err, r, m.Log)
 		return
@@ -93,8 +93,4 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 		m.Log.Error(err)
 		return
 	}
-}
-
-func (m *MetricSet) getServiceURI() string {
-	return m.HostData().SanitizedURI + jobPath
 }

--- a/metricbeat/module/elasticsearch/node_stats/node_stats.go
+++ b/metricbeat/module/elasticsearch/node_stats/node_stats.go
@@ -63,7 +63,7 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 		return
 	}
 
-	info, err := elasticsearch.GetInfo(m.HTTP, m.getServiceURI())
+	info, err := elasticsearch.GetInfo(m.HTTP, m.GetServiceURI())
 	if err != nil {
 		elastic.ReportAndLogError(err, r, m.Log)
 		return
@@ -82,8 +82,4 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 			return
 		}
 	}
-}
-
-func (m *MetricSet) getServiceURI() string {
-	return m.HostData().SanitizedURI + nodeStatsPath
 }

--- a/metricbeat/module/elasticsearch/pending_tasks/pending_tasks.go
+++ b/metricbeat/module/elasticsearch/pending_tasks/pending_tasks.go
@@ -63,7 +63,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 
 // Fetch methods implements the data gathering and data conversion to the right format
 func (m *MetricSet) Fetch(r mb.ReporterV2) {
-	isMaster, err := elasticsearch.IsMaster(m.HTTP, m.getServiceURI())
+	isMaster, err := elasticsearch.IsMaster(m.HTTP, m.GetServiceURI())
 	if err != nil {
 		err := errors.Wrap(err, "error determining if connected Elasticsearch node is master")
 		elastic.ReportAndLogError(err, r, m.Log)
@@ -76,7 +76,7 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 		return
 	}
 
-	info, err := elasticsearch.GetInfo(m.HTTP, m.getServiceURI())
+	info, err := elasticsearch.GetInfo(m.HTTP, m.GetServiceURI())
 	if err != nil {
 		elastic.ReportAndLogError(err, r, m.Log)
 		return
@@ -93,8 +93,4 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 		m.Log.Error(err)
 		return
 	}
-}
-
-func (m *MetricSet) getServiceURI() string {
-	return m.HostData().SanitizedURI + pendingTasksPath
 }


### PR DESCRIPTION
Cherry-pick of PR #9896 to 6.x branch. Original message: 

Previously some metricsets in the Elasticsearch module each defined a `getServiceURI` method. This PR pulls up that method into the common `elasticsearch.MetricSet` struct.