### PR TITLE
Fix apache fields config for ECS migration

### DIFF
--- a/dev-tools/ecs-migration.yml
+++ b/dev-tools/ecs-migration.yml
@@ -254,11 +254,11 @@
   alias: true
 
 ### Error fileset
-- from: apache.error.message
+- from: apache2.error.message
   to: message
   alias: true
 
-- from: apache.error.level
+- from: apache2.error.level
   to: log.level
   alias: true
 


### PR DESCRIPTION
Fields refering to `apache` module should refer to `apache2` instead.

This config was added in #8963