### PR TITLE
Cherry-pick #9873 to 6.x: Fix config appender registration

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -51,6 +51,7 @@ https://github.com/elastic/beats/compare/v6.6.0...6.x[Check the HEAD diff]
 - Update Kibana index pattern attributes for objects that are disabled. {pull}9644[9644]
 - Enforce validation for the Central Management access token. {issue}9621[9621]
 - Update Golang to 1.10.7. {pull}9640[9640]
+- Fix config appender registration. {pull}9873[9873]
 
 *Auditbeat*
 

--- a/libbeat/autodiscover/config.go
+++ b/libbeat/autodiscover/config.go
@@ -19,7 +19,6 @@ package autodiscover
 
 import (
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/conditions"
 )
 
 // Config settings for Autodiscover
@@ -39,6 +38,5 @@ type BuilderConfig struct {
 
 // AppenderConfig settings
 type AppenderConfig struct {
-	Type            string             `config:"type"`
-	ConditionConfig *conditions.Config `config:"condition"`
+	Type string `config:"type"`
 }

--- a/libbeat/cmd/instance/imports.go
+++ b/libbeat/cmd/instance/imports.go
@@ -18,6 +18,7 @@
 package instance
 
 import (
+	_ "github.com/elastic/beats/libbeat/autodiscover/appenders/config" // Register autodiscover appenders
 	_ "github.com/elastic/beats/libbeat/autodiscover/providers/docker" // Register autodiscover providers
 	_ "github.com/elastic/beats/libbeat/autodiscover/providers/jolokia"
 	_ "github.com/elastic/beats/libbeat/autodiscover/providers/kubernetes"

--- a/metricbeat/tests/system/test_autodiscover.py
+++ b/metricbeat/tests/system/test_autodiscover.py
@@ -95,3 +95,51 @@ class TestAutodiscover(metricbeat.BaseTest):
         # Check metadata is added
         assert output[0]['docker']['container']['image'] == 'memcached:latest'
         assert 'name' in output[0]['docker']['container']
+
+    @unittest.skipIf(not INTEGRATION_TESTS or
+                     os.getenv("TESTING_ENVIRONMENT") == "2x",
+                     "integration test not available on 2.x")
+    def test_config_appender(self):
+        """
+        Test config appenders correctly updates configs
+        """
+        import docker
+        docker_client = docker.from_env()
+
+        self.render_config_template(
+            autodiscover={
+                'docker': {
+                    'hints.enabled': 'true',
+                    'appenders': '''
+                      - type: config
+                        condition:
+                          equals.docker.container.image: memcached:latest
+                        config:
+                          fields:
+                            foo: bar
+                    ''',
+                },
+            },
+        )
+
+        proc = self.start_beat()
+        docker_client.images.pull('memcached:latest')
+        labels = {
+            'co.elastic.metrics/module': 'memcached',
+            'co.elastic.metrics/period': '1s',
+            'co.elastic.metrics/hosts': "'${data.host}:11211'",
+        }
+        container = docker_client.containers.run('memcached:latest', labels=labels, detach=True)
+
+        self.wait_until(lambda: self.log_contains('Starting runner: memcached'))
+
+        self.wait_until(lambda: self.output_count(lambda x: x >= 1))
+        container.stop()
+
+        self.wait_until(lambda: self.log_contains('Stopping runner: memcached'))
+
+        output = self.read_output_json()
+        proc.check_kill_and_wait()
+
+        # Check field is added
+        assert output[0]['fields']['foo'] == 'bar'


### PR DESCRIPTION
Cherry-pick of PR #9873 to 6.x branch. Original message: 

Autodiscover config wasn't regsistered, this change updates the code,
adds integration tests and makes sure that the appender is correctly
registered and working.

closes elastic/beats#9817