### PR TITLE
[Auditbeat] Cherry-pick #9954 to 6.6: Add Windows to docs for host dataset

### DIFF
--- a/x-pack/auditbeat/module/system/host/_meta/docs.asciidoc
+++ b/x-pack/auditbeat/module/system/host/_meta/docs.asciidoc
@@ -4,4 +4,4 @@ experimental[]
 
 This is the `host` metricset of the system module.
 
-It is implemented for Linux and macOS (Darwin).
+It is implemented for Linux, macOS (Darwin), and Windows.


### PR DESCRIPTION
Cherry-pick of PR #9954 to 6.6 branch. Original message: 

The `host` dataset of the system module works on Windows. Beats-tester [is happy](https://beats-ci.elastic.co/job/elastic+beats-tester+master/217/artifact/logs/auditbeat-x86_64-tester-win12-64/), too. So I think we can say that it is implemented for Windows, same as the `process` dataset.