### PR TITLE
Enhance dashboard tooling

### DIFF
--- a/dev-tools/cmd/dashboards/export_dashboards.go
+++ b/dev-tools/cmd/dashboards/export_dashboards.go
@@ -23,7 +23,6 @@ import (
 	"io/ioutil"
 	"log"
 	"net/url"
-	"os"
 	"path/filepath"
 	"time"
 
@@ -84,7 +83,7 @@ func main() {
 		if err != nil {
 			log.Fatalf("Failed to export dashboards from YML file: %+v", err)
 		}
-		os.Exit(0)
+		return
 	}
 
 	if len(*dashboard) > 0 {
@@ -95,11 +94,15 @@ func main() {
 		if !quiet {
 			log.Printf("The dashboard %s was exported under '%s'\n", *dashboard, *fileOutput)
 		}
+		return
 	}
 }
 
 func exportDashboardsFromYML(client *kibana.Client, ymlFile string) error {
 	results, info, err := dashboards.ExportAllFromYml(client, ymlFile)
+	if err != nil {
+		return err
+	}
 	for i, r := range results {
 		log.Printf("id=%s, name=%s\n", info.Dashboards[i].ID, info.Dashboards[i].File)
 		r = dashboards.DecodeExported(r)

--- a/dev-tools/cmd/dashboards/export_dashboards.go
+++ b/dev-tools/cmd/dashboards/export_dashboards.go
@@ -57,9 +57,16 @@ func main() {
 		log.Fatalf("Error parsing Kibana URL: %+v", err)
 	}
 
+	var user, pass string
+	if u.User != nil {
+		user = u.User.Username()
+		pass, _ = u.User.Password()
+	}
 	client, err := kibana.NewClientWithConfig(&kibana.ClientConfig{
 		Protocol: u.Scheme,
 		Host:     u.Host,
+		Username: user,
+		Password: pass,
 		SpaceID:  *spaceID,
 		Timeout:  kibanaTimeout,
 	})

--- a/dev-tools/cmd/dashboards/export_dashboards.go
+++ b/dev-tools/cmd/dashboards/export_dashboards.go
@@ -53,7 +53,7 @@ func main() {
 
 	u, err := url.Parse(*kibanaURL)
 	if err != nil {
-		log.Fatalf("Error parsing Kibana URL: %+v", err)
+		log.Fatalf("Error parsing Kibana URL: %v", err)
 	}
 
 	var user, pass string
@@ -70,7 +70,7 @@ func main() {
 		Timeout:  kibanaTimeout,
 	})
 	if err != nil {
-		log.Fatalf("Error while connecting to Kibana: %+v", err)
+		log.Fatalf("Error while connecting to Kibana: %v", err)
 	}
 
 	if len(*ymlFile) == 0 && len(*dashboard) == 0 {
@@ -81,7 +81,7 @@ func main() {
 	if len(*ymlFile) > 0 {
 		err = exportDashboardsFromYML(client, *ymlFile)
 		if err != nil {
-			log.Fatalf("Failed to export dashboards from YML file: %+v", err)
+			log.Fatalf("Failed to export dashboards from YML file: %v", err)
 		}
 		return
 	}
@@ -89,7 +89,7 @@ func main() {
 	if len(*dashboard) > 0 {
 		err = exportSingleDashboard(client, *dashboard, *fileOutput)
 		if err != nil {
-			log.Fatalf("Failed to export the dashboard: %+v", err)
+			log.Fatalf("Failed to export the dashboard: %v", err)
 		}
 		if !quiet {
 			log.Printf("The dashboard %s was exported under '%s'\n", *dashboard, *fileOutput)

--- a/dev-tools/mage/kibana.go
+++ b/dev-tools/mage/kibana.go
@@ -31,6 +31,9 @@ import (
 func KibanaDashboards(moduleDirs ...string) error {
 	var kibanaBuildDir = "build/kibana"
 
+	if err := os.RemoveAll(kibanaBuildDir); err != nil {
+		return err
+	}
 	if err := os.MkdirAll(kibanaBuildDir, 0755); err != nil {
 		return err
 	}

--- a/libbeat/dashboards/export.go
+++ b/libbeat/dashboards/export.go
@@ -18,12 +18,12 @@
 package dashboards
 
 import (
-	"fmt"
 	"io/ioutil"
 	"path/filepath"
 	"strconv"
 
-	yaml "gopkg.in/yaml.v2"
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v2"
 
 	"github.com/elastic/beats/filebeat/generator"
 	"github.com/elastic/beats/libbeat/common"
@@ -57,12 +57,12 @@ func Export(client *kibana.Client, id string) (common.MapStr, error) {
 func ExportAllFromYml(client *kibana.Client, ymlPath string) ([]common.MapStr, ListYML, error) {
 	b, err := ioutil.ReadFile(ymlPath)
 	if err != nil {
-		return nil, ListYML{}, fmt.Errorf("error opening the list of dashboards: %+v", err)
+		return nil, ListYML{}, errors.Wrap(err, "error opening the list of dashboards")
 	}
 	var list ListYML
 	err = yaml.Unmarshal(b, &list)
 	if err != nil {
-		return nil, ListYML{}, fmt.Errorf("error reading the list of dashboards: %+v", err)
+		return nil, ListYML{}, errors.Wrap(err, "error reading the list of dashboards")
 	}
 
 	results, err := ExportAll(client, list)
@@ -76,7 +76,7 @@ func ExportAll(client *kibana.Client, list ListYML) ([]common.MapStr, error) {
 	for _, e := range list.Dashboards {
 		result, err := Export(client, e.ID)
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrapf(err, "failed exporting id=%v", e.ID)
 		}
 		results = append(results, result)
 	}

--- a/libbeat/tests/system/test_dashboard.py
+++ b/libbeat/tests/system/test_dashboard.py
@@ -242,7 +242,8 @@ class Test(BaseTest):
         )
 
         beat.check_wait(exit_code=1)
-        assert self.log_contains("Error getting dashboards from yml: error opening the list of dashboards:") is True
+        assert self.log_contains("Error getting dashboards from yml")
+        assert self.log_contains("error opening the list of dashboards")
 
     @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     @attr('integration')


### PR DESCRIPTION
- Pass URL username and password to Kibana client
  This allows dashboards to be exported from Kibana hosts with X-Pack security.
- Clean the build/kibana dir when running `mage dashboards`
- Improve error reporting when exporting fails