### PR TITLE
Cherry-pick #9900 to 6.x: Refactoring: Using common.Version instead of strings

### DIFF
--- a/libbeat/common/version.go
+++ b/libbeat/common/version.go
@@ -18,6 +18,7 @@
 package common
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -149,4 +150,26 @@ func (v *Version) metaIsLessThanOrEqual(v1 *Version) bool {
 		return true
 	}
 	return v.Meta <= v1.Meta
+}
+
+// UnmarshalJSON unmarshals a JSON string version representation into a Version struct
+// Implements https://golang.org/pkg/encoding/json/#Unmarshaler
+func (v *Version) UnmarshalJSON(version []byte) error {
+	var versionStr string
+	err := json.Unmarshal(version, &versionStr)
+	if err != nil {
+		return err
+	}
+
+	ver, err := NewVersion(versionStr)
+	if err != nil {
+		return err
+	}
+
+	if ver == nil {
+		return fmt.Errorf("could not unmarshal version from JSON")
+	}
+
+	*v = *ver
+	return nil
 }

--- a/metricbeat/helper/elastic/elastic.go
+++ b/metricbeat/helper/elastic/elastic.go
@@ -97,18 +97,8 @@ func MakeErrorForMissingField(field string, product Product) error {
 }
 
 // IsFeatureAvailable returns whether a feature is available in the current product version
-func IsFeatureAvailable(currentProductVersion, featureAvailableInProductVersion string) (bool, error) {
-	currentVersion, err := common.NewVersion(currentProductVersion)
-	if err != nil {
-		return false, err
-	}
-
-	wantVersion, err := common.NewVersion(featureAvailableInProductVersion)
-	if err != nil {
-		return false, err
-	}
-
-	return !currentVersion.LessThan(wantVersion), nil
+func IsFeatureAvailable(currentProductVersion, featureAvailableInProductVersion *common.Version) bool {
+	return !currentProductVersion.LessThan(featureAvailableInProductVersion)
 }
 
 // ReportAndLogError reports and logs the given error

--- a/metricbeat/module/elasticsearch/cluster_stats/data_xpack.go
+++ b/metricbeat/module/elasticsearch/cluster_stats/data_xpack.go
@@ -225,7 +225,7 @@ func eventMappingXPack(r mb.ReporterV2, m *MetricSet, info elasticsearch.Info, c
 		"interval_ms":   m.Module().Config().Period / time.Millisecond,
 		"type":          "cluster_stats",
 		"license":       l,
-		"version":       info.Version.Number,
+		"version":       info.Version.Number.String(),
 		"cluster_stats": clusterStats,
 		"cluster_state": clusterState,
 		"stack_stats":   stackStats,

--- a/metricbeat/module/elasticsearch/elasticsearch.go
+++ b/metricbeat/module/elasticsearch/elasticsearch.go
@@ -33,7 +33,7 @@ import (
 )
 
 // CCRStatsAPIAvailableVersion is the version of Elasticsearch since when the CCR stats API is available.
-const CCRStatsAPIAvailableVersion = "6.5.0"
+var CCRStatsAPIAvailableVersion = common.MustNewVersion("6.5.0")
 
 // Global clusterIdCache. Assumption is that the same node id never can belong to a different cluster id.
 var clusterIDCache = map[string]string{}
@@ -46,7 +46,7 @@ type Info struct {
 	ClusterName string `json:"cluster_name"`
 	ClusterID   string `json:"cluster_uuid"`
 	Version     struct {
-		Number string `json:"number"`
+		Number *common.Version `json:"number"`
 	} `json:"version"`
 }
 
@@ -158,7 +158,10 @@ func GetInfo(http *helper.HTTP, uri string) (*Info, error) {
 	}
 
 	info := &Info{}
-	json.Unmarshal(content, info)
+	err = json.Unmarshal(content, &info)
+	if err != nil {
+		return nil, err
+	}
 
 	return info, nil
 }

--- a/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
+++ b/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
@@ -281,39 +281,37 @@ func checkSkip(t *testing.T, metricset string, host string) {
 		t.Fatal("getting elasticsearch version", err)
 	}
 
-	isCCRStatsAPIAvailable, err := elastic.IsFeatureAvailable(version, elasticsearch.CCRStatsAPIAvailableVersion)
-	if err != nil {
-		t.Fatal("checking if elasticsearch CCR stats API is available", err)
-	}
+	isCCRStatsAPIAvailable := elastic.IsFeatureAvailable(version, elasticsearch.CCRStatsAPIAvailableVersion)
 
 	if !isCCRStatsAPIAvailable {
-		t.Skip("elasticsearch CCR stats API is not available until " + elasticsearch.CCRStatsAPIAvailableVersion)
+		t.Skip("elasticsearch CCR stats API is not available until " + elasticsearch.CCRStatsAPIAvailableVersion.String())
 	}
 }
 
-func getElasticsearchVersion(elasticsearchHostPort string) (string, error) {
+func getElasticsearchVersion(elasticsearchHostPort string) (*common.Version, error) {
 	resp, err := http.Get("http://" + elasticsearchHostPort + "/")
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	defer resp.Body.Close()
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	var data common.MapStr
 	err = json.Unmarshal(body, &data)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	version, err := data.GetValue("version.number")
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	return version.(string), nil
+
+	return common.NewVersion(version.(string))
 }
 
 func httpPutJSON(host, path string, body []byte) ([]byte, *http.Response, error) {

--- a/metricbeat/module/kibana/kibana_test.go
+++ b/metricbeat/module/kibana/kibana_test.go
@@ -20,6 +20,8 @@ package kibana
 import (
 	"testing"
 
+	"github.com/elastic/beats/libbeat/common"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -35,8 +37,7 @@ func TestIsStatsAPIAvailable(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		actual, err := IsStatsAPIAvailable(test.input)
-		assert.NoError(t, err)
+		actual := IsStatsAPIAvailable(common.MustNewVersion(test.input))
 		assert.Equal(t, test.expected, actual)
 	}
 }

--- a/metricbeat/module/kibana/stats/stats.go
+++ b/metricbeat/module/kibana/stats/stats.go
@@ -77,7 +77,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 		return nil, err
 	}
 
-	isStatsAPIAvailable, err := kibana.IsStatsAPIAvailable(kibanaVersion)
+	isStatsAPIAvailable := kibana.IsStatsAPIAvailable(kibanaVersion)
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +98,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	if ms.XPackEnabled {
 		cfgwarn.Experimental("The experimental xpack.enabled flag in the " + ms.FullyQualifiedName() + " metricset is enabled.")
 
-		isSettingsAPIAvailable, err := kibana.IsSettingsAPIAvailable(kibanaVersion)
+		isSettingsAPIAvailable := kibana.IsSettingsAPIAvailable(kibanaVersion)
 		if err != nil {
 			return nil, err
 		}

--- a/metricbeat/module/kibana/stats/stats_integration_test.go
+++ b/metricbeat/module/kibana/stats/stats_integration_test.go
@@ -45,7 +45,7 @@ func TestFetch(t *testing.T) {
 		t.Fatal("getting kibana version", err)
 	}
 
-	isStatsAPIAvailable, err := kibana.IsStatsAPIAvailable(version)
+	isStatsAPIAvailable := kibana.IsStatsAPIAvailable(version)
 	if err != nil {
 		t.Fatal("checking if kibana stats API is available", err)
 	}
@@ -76,7 +76,7 @@ func TestData(t *testing.T) {
 		t.Fatal("getting kibana version", err)
 	}
 
-	isStatsAPIAvailable, err := kibana.IsStatsAPIAvailable(version)
+	isStatsAPIAvailable := kibana.IsStatsAPIAvailable(version)
 	if err != nil {
 		t.Fatal("checking if kibana stats API is available", err)
 	}
@@ -92,27 +92,28 @@ func TestData(t *testing.T) {
 	}
 }
 
-func getKibanaVersion(kibanaHostPort string) (string, error) {
+func getKibanaVersion(kibanaHostPort string) (*common.Version, error) {
 	resp, err := http.Get("http://" + kibanaHostPort + "/api/status")
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	defer resp.Body.Close()
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	var data common.MapStr
 	err = json.Unmarshal(body, &data)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	version, err := data.GetValue("version.number")
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	return version.(string), nil
+
+	return common.NewVersion(version.(string))
 }


### PR DESCRIPTION
Cherry-pick of PR #9900 to 6.x branch. Original message: 

This PR updates code in the `elasticsearch` and `kibana` Metricbeat modules to use the `common.Version` struct instead of bare strings for product versions.