### PR TITLE
Fix asset registry slice generation

### DIFF
--- a/libbeat/asset/registry.go
+++ b/libbeat/asset/registry.go
@@ -56,7 +56,7 @@ func GetFields(beat string) ([]byte, error) {
 
 	// Get all priorities and sort them
 	beatRegistry := FieldsRegistry[beat]
-	priorities := make([]int, 0, len(FieldsRegistry))
+	priorities := make([]int, 0, len(beatRegistry))
 	for p := range beatRegistry {
 		priorities = append(priorities, p)
 	}


### PR DESCRIPTION
As found in https://github.com/elastic/beats/pull/9703/files#r246286729 the wrong variable was used for the length check.