### PR TITLE
Cherry-pick #9992 to 6.6: Do not configure aliases in unsupported Elasticsearch versions

### DIFF
--- a/libbeat/template/processor.go
+++ b/libbeat/template/processor.go
@@ -249,6 +249,11 @@ func (p *Processor) array(f *common.Field) common.MapStr {
 }
 
 func (p *Processor) alias(f *common.Field) common.MapStr {
+	// Aliases were introduced in Elasticsearch 6.4, ignore if unsupported
+	if p.EsVersion.LessThan(common.MustNewVersion("6.4.0")) {
+		return nil
+	}
+
 	properties := getDefaultProperties(f)
 	properties["type"] = "alias"
 	properties["path"] = f.AliasPath

--- a/libbeat/template/processor_test.go
+++ b/libbeat/template/processor_test.go
@@ -26,13 +26,12 @@ import (
 )
 
 func TestProcessor(t *testing.T) {
-	esVersion2, err := common.NewVersion("2.0.0")
-	assert.NoError(t, err)
-
 	falseVar := false
 	trueVar := true
 	p := &Processor{}
-	pEsVersion2 := &Processor{EsVersion: *esVersion2}
+	pEsVersion2 := &Processor{EsVersion: *common.MustNewVersion("2.0.0")}
+	pEsVersion64 := &Processor{EsVersion: *common.MustNewVersion("6.4.0")}
+	pEsVersion63 := &Processor{EsVersion: *common.MustNewVersion("6.3.6")}
 
 	tests := []struct {
 		output   common.MapStr
@@ -87,8 +86,13 @@ func TestProcessor(t *testing.T) {
 			expected: common.MapStr{"index": false, "type": "keyword"},
 		},
 		{
-			output:   p.alias(&common.Field{Type: "alias", AliasPath: "a.b"}),
+			output:   pEsVersion64.alias(&common.Field{Type: "alias", AliasPath: "a.b"}),
 			expected: common.MapStr{"path": "a.b", "type": "alias"},
+		},
+		{
+			// alias unsupported in ES < 6.4
+			output:   pEsVersion63.alias(&common.Field{Type: "alias", AliasPath: "a.b"}),
+			expected: nil,
 		},
 		{
 			output: p.object(&common.Field{Type: "object", Enabled: &falseVar}),


### PR DESCRIPTION
Cherry-pick of PR #9992 to 6.6 branch. Original message: 

Field aliases[0] were introduced by Elasticsearch 6.4, this change
ensures we don't try to setup field aliases in the template if talking
to a previous version.

[0] https://www.elastic.co/guide/en/elasticsearch/reference/6.4/alias.html

Fixes #9989