### PR TITLE
[Heartbeat] Alias http.url.raw to url.full

### DIFF
--- a/dev-tools/ecs-migration.yml
+++ b/dev-tools/ecs-migration.yml
@@ -685,6 +685,10 @@
   to: url.full
   alias: true
 
+- from: http.url.raw
+  to: url.full
+  alias: true
+
 - from: tcp.port
   to: url.port
   alias: true

--- a/heartbeat/monitors/active/http/_meta/fields.yml
+++ b/heartbeat/monitors/active/http/_meta/fields.yml
@@ -13,6 +13,12 @@
           migration: true
           description: >
             Service url used by monitor.
+        - name: url.raw
+          type: alias
+          path: url.full
+          migration: true
+          description: >
+            Service url used by monitor.
         - name: rtt
           type: group
           description: >


### PR DESCRIPTION
Continues the work in https://github.com/elastic/beats/pull/9570 , aliasing this field for convenience.
In ECS this field is already a keyword, so this should be fine.