### PR TITLE
[6.x] Allow multiple object types per field. (#9772)

### DIFF
--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -23,3 +23,5 @@ The list below covers the major changes between 6.6.0 and 6.x only.
 ==== Bugfixes
 
 ==== Added
+
+- Allow multiple object type configurations per field. {pull}9772[9772]

--- a/libbeat/common/field.go
+++ b/libbeat/common/field.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/pkg/errors"
+
 	"github.com/elastic/go-ucfg/yaml"
 )
 
@@ -34,25 +36,27 @@ import (
 type Fields []Field
 
 type Field struct {
-	Name                  string      `config:"name"`
-	Type                  string      `config:"type"`
-	Description           string      `config:"description"`
-	Format                string      `config:"format"`
-	ScalingFactor         int         `config:"scaling_factor"`
-	Fields                Fields      `config:"fields"`
-	MultiFields           Fields      `config:"multi_fields"`
-	ObjectType            string      `config:"object_type"`
-	ObjectTypeMappingType string      `config:"object_type_mapping_type"`
-	Enabled               *bool       `config:"enabled"`
-	Analyzer              string      `config:"analyzer"`
-	SearchAnalyzer        string      `config:"search_analyzer"`
-	Norms                 bool        `config:"norms"`
-	Dynamic               DynamicType `config:"dynamic"`
-	Index                 *bool       `config:"index"`
-	DocValues             *bool       `config:"doc_values"`
-	CopyTo                string      `config:"copy_to"`
-	IgnoreAbove           int         `config:"ignore_above"`
-	AliasPath             string      `config:"path"`
+	Name           string      `config:"name"`
+	Type           string      `config:"type"`
+	Description    string      `config:"description"`
+	Format         string      `config:"format"`
+	Fields         Fields      `config:"fields"`
+	MultiFields    Fields      `config:"multi_fields"`
+	Enabled        *bool       `config:"enabled"`
+	Analyzer       string      `config:"analyzer"`
+	SearchAnalyzer string      `config:"search_analyzer"`
+	Norms          bool        `config:"norms"`
+	Dynamic        DynamicType `config:"dynamic"`
+	Index          *bool       `config:"index"`
+	DocValues      *bool       `config:"doc_values"`
+	CopyTo         string      `config:"copy_to"`
+	IgnoreAbove    int         `config:"ignore_above"`
+	AliasPath      string      `config:"path"`
+
+	ObjectType            string          `config:"object_type"`
+	ObjectTypeMappingType string          `config:"object_type_mapping_type"`
+	ScalingFactor         int             `config:"scaling_factor"`
+	ObjectTypeParams      []ObjectTypeCfg `config:"object_type_params"`
 
 	// Kibana specific
 	Analyzed     *bool  `config:"analyzed"`
@@ -72,6 +76,13 @@ type Field struct {
 	Path string
 }
 
+// ObjectTypeCfg defines type and configuration of object attributes
+type ObjectTypeCfg struct {
+	ObjectType            string `config:"object_type"`
+	ObjectTypeMappingType string `config:"object_type_mapping_type"`
+	ScalingFactor         int    `config:"scaling_factor"`
+}
+
 type VersionizedString struct {
 	MinVersion string `config:"min_version"`
 	Value      string `config:"value"`
@@ -89,6 +100,17 @@ func (d *DynamicType) Unpack(s string) error {
 		d.Value = s
 	default:
 		return fmt.Errorf("'%v' is invalid dynamic setting", s)
+	}
+	return nil
+}
+
+// Validate ensures objectTypeParams are not mixed with top level objectType configuration
+func (f *Field) Validate() error {
+	if len(f.ObjectTypeParams) == 0 {
+		return nil
+	}
+	if f.ScalingFactor != 0 || f.ObjectTypeMappingType != "" || f.ObjectType != "" {
+		return errors.New("mixing top level objectType configuration with array of object type configurations is forbidden")
 	}
 	return nil
 }

--- a/libbeat/common/field_test.go
+++ b/libbeat/common/field_test.go
@@ -20,6 +20,8 @@ package common
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/go-ucfg/yaml"
@@ -188,4 +190,60 @@ func TestGetKeys(t *testing.T) {
 	for _, test := range tests {
 		assert.Equal(t, test.keys, test.fields.GetKeys())
 	}
+}
+
+func TestFieldValidate(t *testing.T) {
+	tests := []struct {
+		cfg   MapStr
+		field Field
+		err   bool
+		name  string
+	}{
+		{
+			cfg:   MapStr{"object_type": "scaled_float", "object_type_mapping_type": "float", "scaling_factor": 10},
+			field: Field{ObjectType: "scaled_float", ObjectTypeMappingType: "float", ScalingFactor: 10},
+			err:   false,
+			name:  "top level object type config",
+		}, {
+			cfg: MapStr{"object_type_params": []MapStr{
+				{"object_type": "scaled_float", "object_type_mapping_type": "float", "scaling_factor": 100}}},
+			field: Field{ObjectTypeParams: []ObjectTypeCfg{{ObjectType: "scaled_float", ObjectTypeMappingType: "float", ScalingFactor: 100}}},
+			err:   false,
+			name:  "multiple object type configs",
+		}, {
+			cfg: MapStr{
+				"object_type":        "scaled_float",
+				"object_type_params": []MapStr{{"object_type": "scaled_float", "object_type_mapping_type": "float"}}},
+			err:  true,
+			name: "invalid config mixing object_type and object_type_params",
+		}, {
+			cfg: MapStr{
+				"object_type_mapping_type": "float",
+				"object_type_params":       []MapStr{{"object_type": "scaled_float", "object_type_mapping_type": "float"}}},
+			err:  true,
+			name: "invalid config mixing object_type_mapping_type and object_type_params",
+		}, {
+			cfg: MapStr{
+				"scaling_factor":     100,
+				"object_type_params": []MapStr{{"object_type": "scaled_float", "object_type_mapping_type": "float"}}},
+			err:  true,
+			name: "invalid config mixing scaling_factor and object_type_params",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cfg, err := NewConfigFrom(test.cfg)
+			require.NoError(t, err)
+			var f Field
+			err = cfg.Unpack(&f)
+			if test.err {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, test.field, f)
+			}
+		})
+	}
+
 }


### PR DESCRIPTION
Backports the following commits to 6.x:
 - Allow multiple object types per field.  (#9772)