### PR TITLE
Cherry-pick #10003 to 6.5: configure union merge for Changelog*.next.asciidoc

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
-CHANGELOG.md  merge=union
-CHANGELOG.asciidoc  merge=union
+CHANGELOG.next.asciidoc  merge=union
+CHANGELOG-developer.next.asciidoc  merge=union
 
 # Keep these file types as CRLF (Windows).
 *.bat    text eol=crlf


### PR DESCRIPTION
Cherry-pick of PR #10003 to 6.5 branch. Original message: 

This change automatically merges Changelog*.next.asciidoc files when
merging or rebasing via `merge=union`. No more need to fix changelog
files when doing `git rebase master`.

Note: github UI seems to ignore the setting. Convenience will only be improved on command line.