### PR TITLE
Cherry-pick #9729 to 6.6: [CM] Allow to unenroll a beats

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -35,6 +35,9 @@ https://github.com/elastic/beats/compare/1035569addc4a3b29ffa14f8a08c27c1ace16ef
 
 *Affecting all Beats*
 
+- Enforce validation for the Central Management access token. {issue}9621[9621]
+- Allow to unenroll a Beat from the UI. {issue}9452[9452]
+
 *Auditbeat*
 
 *Filebeat*

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -35,9 +35,6 @@ https://github.com/elastic/beats/compare/1035569addc4a3b29ffa14f8a08c27c1ace16ef
 
 *Affecting all Beats*
 
-- Enforce validation for the Central Management access token. {issue}9621[9621]
-- Allow to unenroll a Beat from the UI. {issue}9452[9452]
-
 *Auditbeat*
 
 *Filebeat*

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -34,6 +34,7 @@ https://github.com/elastic/beats/compare/1035569addc4a3b29ffa14f8a08c27c1ace16ef
 
 - Fix registry handle leak on Windows (https://github.com/elastic/go-sysinfo/pull/33). {pull}9920[9920]
 - Gracefully handle TLS options when enrolling a Beat. {issue}9129[9129]
+- Allow to unenroll a Beat from the UI. {issue}9452[9452]
 
 *Auditbeat*
 

--- a/x-pack/libbeat/management/api/configuration_test.go
+++ b/x-pack/libbeat/management/api/configuration_test.go
@@ -169,3 +169,24 @@ func TestConfigBlocksEqual(t *testing.T) {
 		})
 	}
 }
+
+func TestUnEnroll(t *testing.T) {
+	beatUUID, err := uuid.NewV4()
+	if err != nil {
+		t.Fatalf("error while generating Beat UUID: %v", err)
+	}
+
+	server, client := newServerClientPair(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Check correct path is used
+		assert.Equal(t, "/api/beats/agent/"+beatUUID.String()+"/configuration", r.URL.Path)
+
+		// Check enrollment token is correct
+		assert.Equal(t, "thisismyenrollmenttoken", r.Header.Get("kbn-beats-access-token"))
+
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	_, err = client.Configuration("thisismyenrollmenttoken", beatUUID, false)
+	assert.True(t, IsConfigurationNotFound(err))
+}

--- a/x-pack/libbeat/management/cache.go
+++ b/x-pack/libbeat/management/cache.go
@@ -61,3 +61,8 @@ func (c *Cache) Save() error {
 	// move temporary file into final location
 	return file.SafeFileRotate(path, tempFile)
 }
+
+// HasConfig returns true if configs are cached.
+func (c *Cache) HasConfig() bool {
+	return len(c.Configs) > 0
+}

--- a/x-pack/libbeat/management/cache_test.go
+++ b/x-pack/libbeat/management/cache_test.go
@@ -1,0 +1,38 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package management
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/x-pack/libbeat/management/api"
+)
+
+func TestHasConfig(t *testing.T) {
+	tests := map[string]struct {
+		configs  api.ConfigBlocks
+		expected bool
+	}{
+		"with config": {
+			configs: api.ConfigBlocks{
+				api.ConfigBlocksWithType{Type: "metricbeat "},
+			},
+			expected: true,
+		},
+		"without config": {
+			configs:  api.ConfigBlocks{},
+			expected: false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			cache := Cache{Configs: test.configs}
+			assert.Equal(t, test.expected, cache.HasConfig())
+		})
+	}
+}


### PR DESCRIPTION
Cherry-pick of PR #9729 to 6.6 branch. Original message: 

When a Beat is unenrolled for CM it will receive a 404. Usually Beats
will threat any errors returned by CM to be transient and will use a
cached version of the configuration, this commit change the logic if a 404 is returned by CM
we will clean the cache and remove any running configuration.

We will log this event as either the beats did not find any
configuration or was unenrolled from CM.

If the error is transient, the Beat will pickup the change on the next
fetch, if its permanent we will log each fetch.

Fixes: #9452 


Need backport to 6.5, 6.6, 6.x