### PR TITLE
Change iis module doc to add iis 7.5 version

### DIFF
--- a/filebeat/docs/modules/iis.asciidoc
+++ b/filebeat/docs/modules/iis.asciidoc
@@ -20,7 +20,7 @@ This module requires the
 {elasticsearch-plugins}/ingest-user-agent.html[ingest-user-agent] and
 {elasticsearch-plugins}/ingest-geoip.html[ingest-geoip] Elasticsearch plugins.
 
-The IIS module was tested with logs from version 10.
+The IIS module was tested with logs from version 7.5 and version 10.
 
 include::../include/running-modules.asciidoc[]
 

--- a/filebeat/module/iis/_meta/docs.asciidoc
+++ b/filebeat/module/iis/_meta/docs.asciidoc
@@ -15,7 +15,7 @@ This module requires the
 {elasticsearch-plugins}/ingest-user-agent.html[ingest-user-agent] and
 {elasticsearch-plugins}/ingest-geoip.html[ingest-geoip] Elasticsearch plugins.
 
-The IIS module was tested with logs from version 10.
+The IIS module was tested with logs from version 7.5 and version 10.
 
 include::../include/running-modules.asciidoc[]
 


### PR DESCRIPTION
This PR is to change iis module doc for https://github.com/elastic/beats/pull/9967 and https://github.com/elastic/beats/pull/9999
Original issue: https://github.com/elastic/beats/issues/9753