### PR TITLE
Run queue unit tests in parallel

### DIFF
--- a/libbeat/publisher/queue/memqueue/queue_test.go
+++ b/libbeat/publisher/queue/memqueue/queue_test.go
@@ -54,9 +54,11 @@ func TestProduceConsumer(t *testing.T) {
 	testWith := func(factory queuetest.QueueFactory) func(t *testing.T) {
 		return func(t *testing.T) {
 			t.Run("single", func(t *testing.T) {
+				t.Parallel()
 				queuetest.TestSingleProducerConsumer(t, events, batchSize, factory)
 			})
 			t.Run("multi", func(t *testing.T) {
+				t.Parallel()
 				queuetest.TestMultiProducerConsumer(t, events, batchSize, factory)
 			})
 		}

--- a/libbeat/publisher/queue/queuetest/log.go
+++ b/libbeat/publisher/queue/queuetest/log.go
@@ -31,6 +31,8 @@ import (
 var debug bool
 var printLog bool
 
+var muStderr sync.Mutex
+
 type TestLogger struct {
 	t *testing.T
 }
@@ -49,8 +51,15 @@ func (w *testLogWriter) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
-func withLogOutput(fn func(*testing.T)) func(*testing.T) {
+func withOptLogOutput(capture bool, fn func(*testing.T)) func(*testing.T) {
+	if !capture {
+		return fn
+	}
+
 	return func(t *testing.T) {
+		// ensure we have only one active test if we capture stderr
+		muStderr.Lock()
+		defer muStderr.Unlock()
 
 		stderr := os.Stderr
 		r, w, err := os.Pipe()

--- a/libbeat/publisher/queue/queuetest/producer_cancel.go
+++ b/libbeat/publisher/queue/queuetest/producer_cancel.go
@@ -34,7 +34,7 @@ import (
 // Note: queues not requiring consumers to ACK a events in order to
 //       return ACKs to the producer are not supported by this test.
 func TestProducerCancelRemovesEvents(t *testing.T, factory QueueFactory) {
-	fn := withLogOutput(func(t *testing.T) {
+	fn := withOptLogOutput(true, func(t *testing.T) {
 		var (
 			i  int
 			N1 = 3

--- a/libbeat/publisher/queue/queuetest/queuetest.go
+++ b/libbeat/publisher/queue/queuetest/queuetest.go
@@ -64,6 +64,8 @@ func TestSingleProducerConsumer(
 
 	for _, test := range tests {
 		t.Run(test.name, withLogOutput(func(t *testing.T) {
+			t.Parallel()
+
 			log := NewTestLogger(t)
 			log.Debug("run test: ", test.name)
 
@@ -207,6 +209,8 @@ func TestMultiProducerConsumer(
 
 	for _, test := range tests {
 		t.Run(test.name, withLogOutput(func(t *testing.T) {
+			t.Parallel()
+
 			log := NewTestLogger(t)
 			log.Debug("run test: ", test.name)
 

--- a/libbeat/publisher/queue/queuetest/queuetest.go
+++ b/libbeat/publisher/queue/queuetest/queuetest.go
@@ -63,8 +63,11 @@ func TestSingleProducerConsumer(
 	}
 
 	for _, test := range tests {
-		t.Run(test.name, withLogOutput(func(t *testing.T) {
-			t.Parallel()
+		verbose := testing.Verbose()
+		t.Run(test.name, withOptLogOutput(verbose, func(t *testing.T) {
+			if !verbose {
+				t.Parallel()
+			}
 
 			log := NewTestLogger(t)
 			log.Debug("run test: ", test.name)
@@ -208,8 +211,11 @@ func TestMultiProducerConsumer(
 	}
 
 	for _, test := range tests {
-		t.Run(test.name, withLogOutput(func(t *testing.T) {
-			t.Parallel()
+		verbose := testing.Verbose()
+		t.Run(test.name, withOptLogOutput(verbose, func(t *testing.T) {
+			if !verbose {
+				t.Parallel()
+			}
 
 			log := NewTestLogger(t)
 			log.Debug("run test: ", test.name)


### PR DESCRIPTION
This reduce test queue test duration by a factor of 4 on my machine.
From 20s to ~5s for memqueue + spool-queue testing.