### PR TITLE
Cherry-pick to 6.x: Add Dedot for Kubernetes labels and annotations (#9939)

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -155,6 +155,7 @@ https://github.com/elastic/beats/compare/v6.6.0...6.x[Check the HEAD diff]
 - Add more TCP statuses to `socket_summary` metricset. {pull}9430[9430]
 - Remove experimental tag from ceph metricsets. {pull}9708[9708]
 - Add `key` metricset to the Redis module. {issue}9582[9582] {pull}9657[9657]
+- Add DeDot for kubernetes labels and annotations. {issue}9860[9860] {pull}9939[9939]
 
 *Packetbeat*
 

--- a/libbeat/common/kubernetes/metadata_test.go
+++ b/libbeat/common/kubernetes/metadata_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 )
 
-func TestPodMetadataDeDot(t *testing.T) {
+func TestPodMetadata(t *testing.T) {
 	UID := "005f3b90-4b9d-12f8-acf0-31020a840133"
 	Deployment := "Deployment"
 	test := "test"
@@ -98,6 +98,91 @@ func TestPodMetadataDeDot(t *testing.T) {
 
 	for _, test := range tests {
 		metaGen, err := NewMetaGenerator(test.config)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, metaGen.PodMetadata(test.pod), test.meta)
+	}
+}
+
+func TestPodMetadataDeDot(t *testing.T) {
+	UID := "005f3b90-4b9d-12f8-acf0-31020a840133"
+	Deployment := "Deployment"
+	test := "test"
+	ReplicaSet := "ReplicaSet"
+	True := true
+	False := false
+	tests := []struct {
+		pod    *Pod
+		meta   common.MapStr
+		config *common.Config
+	}{
+		{
+			pod: &Pod{
+				Metadata: &metav1.ObjectMeta{
+					Labels:      map[string]string{"a.key": "foo", "a": "bar"},
+					Uid:         &UID,
+					Namespace:   &test,
+					Annotations: map[string]string{"b.key": "foo", "b": "bar"},
+				},
+				Spec: &v1.PodSpec{
+					NodeName: &test,
+				},
+			},
+			meta: common.MapStr{
+				"pod": common.MapStr{
+					"name": "",
+					"uid":  "005f3b90-4b9d-12f8-acf0-31020a840133",
+				},
+				"node":        common.MapStr{"name": "test"},
+				"namespace":   "test",
+				"labels":      common.MapStr{"a": "bar", "a_key": "foo"},
+				"annotations": common.MapStr{"b": "bar", "b_key": "foo"},
+			},
+			config: common.NewConfig(),
+		},
+		{
+			pod: &Pod{
+				Metadata: &metav1.ObjectMeta{
+					Labels: map[string]string{"a.key": "foo", "a": "bar"},
+					Uid:    &UID,
+					OwnerReferences: []*metav1.OwnerReference{
+						{
+							Kind:       &Deployment,
+							Name:       &test,
+							Controller: &True,
+						},
+						{
+							Kind:       &ReplicaSet,
+							Name:       &ReplicaSet,
+							Controller: &False,
+						},
+					},
+				},
+				Spec: &v1.PodSpec{
+					NodeName: &test,
+				},
+			},
+			meta: common.MapStr{
+				"pod": common.MapStr{
+					"name": "",
+					"uid":  "005f3b90-4b9d-12f8-acf0-31020a840133",
+				},
+				"node":       common.MapStr{"name": "test"},
+				"labels":     common.MapStr{"a": "bar", "a_key": "foo"},
+				"deployment": common.MapStr{"name": "test"},
+			},
+			config: common.NewConfig(),
+		},
+	}
+
+	for _, test := range tests {
+		config, err := common.NewConfigFrom(map[string]interface{}{
+			"labels.dedot":        true,
+			"annotations.dedot":   true,
+			"include_annotations": []string{"b", "b.key"},
+		})
+		metaGen, err := NewMetaGenerator(config)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/libbeat/docs/shared-autodiscover.asciidoc
+++ b/libbeat/docs/shared-autodiscover.asciidoc
@@ -130,6 +130,18 @@ event:
 If the `include_annotations` config is added to the provider config, then the list of annotations present in the config
 are added to the event.
 
+If the `include_labels` config is added to the provider config, then the list of labels present in the config
+will be added to the event.
+
+If the `exclude_labels` config is added to the provider config, then the list of labels present in the config
+will be excluded from the event.
+
+if the `labels.dedot` config is set to be `true` in the provider config, then `.` in labels will be replaced with `_`.
+
+if the `annotations.dedot` config is set to be `true` in the provider config, then `.` in annotations will be replaced
+with `_`.
+
+
 For example:
 
 [source,yaml]

--- a/metricbeat/module/kubernetes/_meta/config.yml
+++ b/metricbeat/module/kubernetes/_meta/config.yml
@@ -17,6 +17,8 @@
   # Enriching parameters:
   #add_metadata: true
   #in_cluster: true
+  #labels.dedot: false
+  #annotations.dedot: false
   # When used outside the cluster:
   #in_cluster: false
   #host: node_name

--- a/metricbeat/module/kubernetes/event/config.go
+++ b/metricbeat/module/kubernetes/event/config.go
@@ -23,10 +23,12 @@ import (
 )
 
 type kubeEventsConfig struct {
-	InCluster  bool          `config:"in_cluster"`
-	KubeConfig string        `config:"kube_config"`
-	Namespace  string        `config:"namespace"`
-	SyncPeriod time.Duration `config:"sync_period"`
+	InCluster        bool          `config:"in_cluster"`
+	KubeConfig       string        `config:"kube_config"`
+	Namespace        string        `config:"namespace"`
+	SyncPeriod       time.Duration `config:"sync_period"`
+	LabelsDedot      bool          `config:"labels.dedot"`
+	AnnotationsDedot bool          `config:"annotations.dedot"`
 }
 
 type Enabled struct {
@@ -35,8 +37,10 @@ type Enabled struct {
 
 func defaultKubernetesEventsConfig() kubeEventsConfig {
 	return kubeEventsConfig{
-		InCluster:  true,
-		SyncPeriod: 1 * time.Second,
+		InCluster:        true,
+		SyncPeriod:       1 * time.Second,
+		LabelsDedot:      false,
+		AnnotationsDedot: false,
 	}
 }
 

--- a/metricbeat/module/kubernetes/event/event_test.go
+++ b/metricbeat/module/kubernetes/event/event_test.go
@@ -1,0 +1,154 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package event
+
+import (
+	"testing"
+
+	"github.com/ericchiang/k8s/apis/core/v1"
+	k8s_io_apimachinery_pkg_apis_meta_v1 "github.com/ericchiang/k8s/apis/meta/v1"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/libbeat/common"
+)
+
+func TestGenerateMapStrFromEvent(t *testing.T) {
+	labels := map[string]string{
+		"app.kubernetes.io/name":      "mysql",
+		"app.kubernetes.io/version":   "5.7.21",
+		"app.kubernetes.io/component": "database",
+	}
+
+	annotations := map[string]string{
+		"prometheus.io/path":   "/metrics",
+		"prometheus.io/port":   "9102",
+		"prometheus.io/scheme": "http",
+		"prometheus.io/scrape": "false",
+	}
+
+	expectedLabelsMapStrWithDot := common.MapStr{
+		"app": common.MapStr{
+			"kubernetes": common.MapStr{
+				"io/version":   "5.7.21",
+				"io/component": "database",
+				"io/name":      "mysql",
+			},
+		},
+	}
+
+	expectedLabelsMapStrWithDeDot := common.MapStr{
+		"app_kubernetes_io/name":      "mysql",
+		"app_kubernetes_io/version":   "5.7.21",
+		"app_kubernetes_io/component": "database",
+	}
+
+	expectedAnnotationsMapStrWithDot := common.MapStr{
+		"prometheus": common.MapStr{
+			"io/path":   "/metrics",
+			"io/port":   "9102",
+			"io/scheme": "http",
+			"io/scrape": "false",
+		},
+	}
+
+	expectedAnnotationsMapStrWithDeDot := common.MapStr{
+		"prometheus_io/path":   "/metrics",
+		"prometheus_io/port":   "9102",
+		"prometheus_io/scheme": "http",
+		"prometheus_io/scrape": "false",
+	}
+
+	testCases := map[string]struct {
+		mockEvent        v1.Event
+		expectedMetadata common.MapStr
+		dedotConfig      dedotConfig
+	}{
+		"no dedots": {
+			mockEvent: v1.Event{
+				Metadata: &k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{
+					Labels:      labels,
+					Annotations: annotations,
+				},
+			},
+			expectedMetadata: common.MapStr{
+				"labels":      expectedLabelsMapStrWithDot,
+				"annotations": expectedAnnotationsMapStrWithDot,
+			},
+			dedotConfig: dedotConfig{
+				LabelsDedot:      false,
+				AnnotationsDedot: false,
+			},
+		},
+		"dedot labels": {
+			mockEvent: v1.Event{
+				Metadata: &k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{
+					Labels:      labels,
+					Annotations: annotations,
+				},
+			},
+			expectedMetadata: common.MapStr{
+				"labels":      expectedLabelsMapStrWithDeDot,
+				"annotations": expectedAnnotationsMapStrWithDot,
+			},
+			dedotConfig: dedotConfig{
+				LabelsDedot:      true,
+				AnnotationsDedot: false,
+			},
+		},
+		"dedot annotatoins": {
+			mockEvent: v1.Event{
+				Metadata: &k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{
+					Labels:      labels,
+					Annotations: annotations,
+				},
+			},
+			expectedMetadata: common.MapStr{
+				"labels":      expectedLabelsMapStrWithDot,
+				"annotations": expectedAnnotationsMapStrWithDeDot,
+			},
+			dedotConfig: dedotConfig{
+				LabelsDedot:      false,
+				AnnotationsDedot: true,
+			},
+		},
+		"dedot both labels and annotations": {
+			mockEvent: v1.Event{
+				Metadata: &k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{
+					Labels:      labels,
+					Annotations: annotations,
+				},
+			},
+			expectedMetadata: common.MapStr{
+				"labels":      expectedLabelsMapStrWithDeDot,
+				"annotations": expectedAnnotationsMapStrWithDeDot,
+			},
+			dedotConfig: dedotConfig{
+				LabelsDedot:      true,
+				AnnotationsDedot: true,
+			},
+		},
+	}
+
+	for name, test := range testCases {
+		t.Run(name, func(t *testing.T) {
+			mapStrOutput := generateMapStrFromEvent(&test.mockEvent, test.dedotConfig)
+			assert.Equal(t, test.expectedMetadata["labels"], mapStrOutput["metadata"].(common.MapStr)["labels"])
+			assert.Equal(t, test.expectedMetadata["annotations"], mapStrOutput["metadata"].(common.MapStr)["annotations"])
+		})
+	}
+}

--- a/metricbeat/modules.d/kubernetes.yml.disabled
+++ b/metricbeat/modules.d/kubernetes.yml.disabled
@@ -20,6 +20,8 @@
   # Enriching parameters:
   #add_metadata: true
   #in_cluster: true
+  #labels.dedot: false
+  #annotations.dedot: false
   # When used outside the cluster:
   #in_cluster: false
   #host: node_name


### PR DESCRIPTION
Original commit message:
* Add Dedot for Kubernetes labels and annotations

* Add dedot options in libbeat kubernetes metadata

* Update changelog

* Refactor TestGenerateMapStrFromEvent

* Update shared-autodiscover.asciidoc with dedot params

* Add names for each unit test case in event_test.go

* Fix rebase errors

(cherry picked from commit d5bda769e4eed723fe79d1209959ae15e8c691b4)