### PR TITLE
[Auditbeat] Fix skipping processes on permission error

### DIFF
--- a/x-pack/auditbeat/module/system/process/process.go
+++ b/x-pack/auditbeat/module/system/process/process.go
@@ -376,7 +376,7 @@ func (ms *MetricSet) getProcesses() ([]*Process, error) {
 							ms.suppressPermissionWarnings = true
 						}
 
-						//continue
+						continue
 					}
 				}
 


### PR DESCRIPTION
A `continue` statement was accidentally commented out that skipped processes when a permission error occurred. This is common when running as non-root, and not skipping them will lead to the output of a lot of process error documents.