### PR TITLE
[Auditbeat] Cherry-pick #10018 to 6.x: Change module configuration from "metricsets" to "datasets"

### DIFF
--- a/auditbeat/tests/system/config/auditbeat.yml.j2
+++ b/auditbeat/tests/system/config/auditbeat.yml.j2
@@ -1,10 +1,10 @@
 auditbeat.modules:
 {% for m in modules -%}
 - module: {{ m.name }}
-  {% if m.metricsets -%}
-  metricsets:
-    {% for ms in m.metricsets -%}
-    - {{ ms }}
+  {% if m.datasets -%}
+  datasets:
+    {% for ds in m.datasets -%}
+    - {{ ds }}
     {% endfor %}
   {% endif -%}
   {% if m.extras -%}

--- a/x-pack/auditbeat/auditbeat.reference.yml
+++ b/x-pack/auditbeat/auditbeat.reference.yml
@@ -106,22 +106,22 @@ auditbeat.modules:
   recursive: false
 
 # The system module collects security related information about a host.
-# All metricsets send both periodic state information (e.g. all currently
+# All datasets send both periodic state information (e.g. all currently
 # running processes) and real-time changes (e.g. when a new process starts
 # or stops).
 - module: system
-  metricsets:
+  datasets:
     - host    # General host information, e.g. uptime, IPs
     - process # Started and stopped processes
     - socket  # Opened and closed sockets
     - user    # User information
 
-  # How often metricsets send state updates with the
+  # How often datasets send state updates with the
   # current state of the system (e.g. all currently
   # running processes, all open sockets).
   state.period: 12h
 
-  # The state.period can be overridden for any metricset.
+  # The state.period can be overridden for any dataset.
   # host.state.period: 12h
   # process.state.period: 12h
   # socket.state.period: 12h

--- a/x-pack/auditbeat/auditbeat.yml
+++ b/x-pack/auditbeat/auditbeat.yml
@@ -48,13 +48,13 @@ auditbeat.modules:
   - /etc
 
 - module: system
-  metricsets:
+  datasets:
     - host    # General host information, e.g. uptime, IPs
     - process # Started and stopped processes
     - socket  # Opened and closed sockets
     - user    # User information
 
-  # How often metricsets send state updates with the
+  # How often datasets send state updates with the
   # current state of the system (e.g. all currently
   # running processes, all open sockets).
   state.period: 12h

--- a/x-pack/auditbeat/docs/modules/system.asciidoc
+++ b/x-pack/auditbeat/docs/modules/system.asciidoc
@@ -108,13 +108,13 @@ is an example configuration:
 ----
 auditbeat.modules:
 - module: system
-  metricsets:
+  datasets:
     - host    # General host information, e.g. uptime, IPs
     - process # Started and stopped processes
     - socket  # Opened and closed sockets
     - user    # User information
 
-  # How often metricsets send state updates with the
+  # How often datasets send state updates with the
   # current state of the system (e.g. all currently
   # running processes, all open sockets).
   state.period: 12h

--- a/x-pack/auditbeat/module/system/_meta/config.yml.tmpl
+++ b/x-pack/auditbeat/module/system/_meta/config.yml.tmpl
@@ -1,12 +1,12 @@
 {{ if ne .GOOS "windows" -}}
 {{ if .Reference -}}
 # The system module collects security related information about a host.
-# All metricsets send both periodic state information (e.g. all currently
+# All datasets send both periodic state information (e.g. all currently
 # running processes) and real-time changes (e.g. when a new process starts
 # or stops).
 {{ end -}}
 - module: system
-  metricsets:
+  datasets:
     - host    # General host information, e.g. uptime, IPs
     {{ if false -}}
     - packages # Installed packages
@@ -17,12 +17,12 @@
     - user    # User information
     {{- end }}
 
-  # How often metricsets send state updates with the
+  # How often datasets send state updates with the
   # current state of the system (e.g. all currently
   # running processes, all open sockets).
   state.period: 12h
 {{ if .Reference }}
-  # The state.period can be overridden for any metricset.
+  # The state.period can be overridden for any dataset.
   # host.state.period: 12h
   # process.state.period: 12h
   # socket.state.period: 12h

--- a/x-pack/auditbeat/module/system/system.go
+++ b/x-pack/auditbeat/module/system/system.go
@@ -1,0 +1,49 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package system
+
+import (
+	"github.com/elastic/beats/metricbeat/mb"
+)
+
+func init() {
+	// Register the custom ModuleFactory function for the system module.
+	if err := mb.Registry.AddModule("system", NewModule); err != nil {
+		panic(err)
+	}
+}
+
+// SystemModuleConfig contains the configuration specific to the system module.
+type SystemModuleConfig struct {
+	// In Auditbeat, sub-modules are called datasets. This extends the module
+	// configuration to allow specifying them under "datasets" rather than
+	// "metricsets".
+	DataSets []string `config:"datasets"`
+}
+
+// SystemModule extends the Metricbeat BaseModule. The purpose is to allow
+// configuring sub-modules as "datasets" rather than "metricsets".
+type SystemModule struct {
+	mb.BaseModule
+	config SystemModuleConfig
+}
+
+// Config returns the ModuleConfig used to create the Module.
+// It overwrites MetricSets with the configured datasets.
+func (m *SystemModule) Config() mb.ModuleConfig {
+	config := m.BaseModule.Config()
+	config.MetricSets = m.config.DataSets
+	return config
+}
+
+// NewModule creates a new mb.Module instance.
+func NewModule(base mb.BaseModule) (mb.Module, error) {
+	var config SystemModuleConfig
+	if err := base.UnpackConfig(&config); err != nil {
+		return nil, err
+	}
+
+	return &SystemModule{BaseModule: base, config: config}, nil
+}

--- a/x-pack/auditbeat/tests/system/auditbeat_xpack.py
+++ b/x-pack/auditbeat/tests/system/auditbeat_xpack.py
@@ -35,7 +35,7 @@ class AuditbeatXPackTest(MetricbeatTest):
         """
         self.render_config_template(modules=[{
             "name": module,
-            "metricsets": [metricset],
+            "datasets": [metricset],
             "period": "10s",
         }])
         proc = self.start_beat()


### PR DESCRIPTION
Cherry-pick of PR #10018 to 6.x branch. Original message: 

This changes the Auditbeat system module configuration to use "datasets" rather than "metricsets" to configure its sub-modules:
```
- module: system
  datasets:
    - host
    - process
    [...]
```

It simply overwrites the `MetricSets` field in the default Metricbeat configuration with the value of the `datasets` configuration.

@andrewkroh We talked about the difficulty of making changes to `go-ucfg` or to the Metricbeat code. Turns out there is no need to change anything under `metricbeat/`, so I think this might be ok? What do you think? I think in the long term we might still want to change to a fileset-like configuration, but for now this would avoid having a mix of "dataset" and "metricset" in anything user-facing, i.e. documentation or configuration.

Follow-up:

1. Change documentation and other places where "metricset(s)" is used