### PR TITLE
Cherry-pick 10033 to 6.x: Add grok pattern to support different timestamp fmt in redis log

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -20,6 +20,7 @@ https://github.com/elastic/beats/compare/v6.6.0...6.x[Check the HEAD diff]
 
 - Allow beats to blacklist certain part of the configuration while using Central Management. {pull}9099[9099]
 - Filesets with multiple ingest pipelines added in {pull}8914[8914] only work with Elasticsearch >= 6.5.0 {pull}10001[10001]
+- Add grok pattern to support redis 5.0.3 log timestamp. {issue}9819[9819] {pull}10033[10033]
 
 *Heartbeat*
 

--- a/filebeat/module/redis/log/ingest/pipeline.json
+++ b/filebeat/module/redis/log/ingest/pipeline.json
@@ -5,12 +5,14 @@
             "grok": {
                 "field": "message",
                 "patterns": [
-                    "(%{POSINT:redis.log.pid:long}:%{CHAR:redis.log.role} )?%{REDISTIMESTAMP:redis.log.timestamp} %{REDISLEVEL:redis.log.level} %{GREEDYDATA:redis.log.message}",
+                    "(%{POSINT:redis.log.pid:long}:%{CHAR:redis.log.role} )?(%{REDISTIMESTAMP1:redis.log.timestamp}||%{REDISTIMESTAMP2:redis.log.timestamp}) %{GREEDYDATA:redis.log.message}",
                     "%{POSINT:redis.log.pid:long}:signal-handler \\(%{POSINT:redis.log.timestamp}\\) %{GREEDYDATA:redis.log.message}"
                 ],
                 "pattern_definitions": {
                     "CHAR": "[a-zA-Z]",
-                    "REDISLEVEL": "[.\\-*#]"
+                    "REDISLEVEL": "[.\\-*#]",
+                    "REDISTIMESTAMP1": "%{MONTHDAY} %{MONTH} %{TIME}",
+                    "REDISTIMESTAMP2": "%{MONTHDAY} %{MONTH} %{YEAR} %{TIME}"
                 }
             }
         },
@@ -62,6 +64,7 @@
                 "field": "redis.log.timestamp",
                 "target_field": "@timestamp",
                 "formats": [
+                    "dd MMM YYYY H:m:s.SSS",
                     "dd MMM H:m:s.SSS",
                     "dd MMM H:m:s",
                     "UNIX"

--- a/filebeat/module/redis/log/ingest/pipeline.json
+++ b/filebeat/module/redis/log/ingest/pipeline.json
@@ -5,7 +5,7 @@
             "grok": {
                 "field": "message",
                 "patterns": [
-                    "(%{POSINT:redis.log.pid:long}:%{CHAR:redis.log.role} )?(%{REDISTIMESTAMP1:redis.log.timestamp}||%{REDISTIMESTAMP2:redis.log.timestamp}) %{GREEDYDATA:redis.log.message}",
+                    "(%{POSINT:redis.log.pid:long}:%{CHAR:redis.log.role} )?(%{REDISTIMESTAMP1:redis.log.timestamp}||%{REDISTIMESTAMP2:redis.log.timestamp}) %{REDISLEVEL:redis.log.level} %{GREEDYDATA:redis.log.message}",
                     "%{POSINT:redis.log.pid:long}:signal-handler \\(%{POSINT:redis.log.timestamp}\\) %{GREEDYDATA:redis.log.message}"
                 ],
                 "pattern_definitions": {

--- a/filebeat/module/redis/log/test/redis-5.0.3.log
+++ b/filebeat/module/redis/log/test/redis-5.0.3.log
@@ -1,0 +1,1 @@
+26571:M 27 Dec 2018 11:19:18.874 * Synchronization with replica 10.114.208.18:6023 succeeded

--- a/filebeat/module/redis/log/test/redis-5.0.3.log-expected.json
+++ b/filebeat/module/redis/log/test/redis-5.0.3.log-expected.json
@@ -1,0 +1,14 @@
+[
+    {
+        "ecs.version": "1.0.0-beta2",
+        "event.dataset": "redis.log",
+        "event.module": "redis",
+        "fileset.name": "log",
+        "input.type": "log",
+        "log.level": "notice",
+        "log.offset": 0,
+        "message": "Synchronization with replica 10.114.208.18:6023 succeeded",
+        "process.pid": 26571,
+        "redis.log.role": "master"
+    }
+]

--- a/filebeat/module/redis/log/test/redis-5.0.3.log-expected.json
+++ b/filebeat/module/redis/log/test/redis-5.0.3.log-expected.json
@@ -6,7 +6,8 @@
         "input.type": "log",
         "offset": 0,
         "prospector.type": "log",
-        "redis.log.message": "* Synchronization with replica 10.114.208.18:6023 succeeded",
+        "redis.log.level": "notice",
+        "redis.log.message": "Synchronization with replica 10.114.208.18:6023 succeeded",
         "redis.log.pid": "26571",
         "redis.log.role": "master"
     }

--- a/filebeat/module/redis/log/test/redis-5.0.3.log-expected.json
+++ b/filebeat/module/redis/log/test/redis-5.0.3.log-expected.json
@@ -1,14 +1,13 @@
 [
     {
-        "ecs.version": "1.0.0-beta2",
         "event.dataset": "redis.log",
-        "event.module": "redis",
+        "fileset.module": "redis",
         "fileset.name": "log",
         "input.type": "log",
-        "log.level": "notice",
-        "log.offset": 0,
-        "message": "Synchronization with replica 10.114.208.18:6023 succeeded",
-        "process.pid": 26571,
+        "offset": 0,
+        "prospector.type": "log",
+        "redis.log.message": "* Synchronization with replica 10.114.208.18:6023 succeeded",
+        "redis.log.pid": "26571",
         "redis.log.role": "master"
     }
 ]

--- a/filebeat/module/redis/log/test/test.log-expected.json
+++ b/filebeat/module/redis/log/test/test.log-expected.json
@@ -6,8 +6,7 @@
         "input.type": "log",
         "offset": 0,
         "prospector.type": "log",
-        "redis.log.level": "notice",
-        "redis.log.message": "Saving the final RDB snapshot before exiting.",
+        "redis.log.message": "* Saving the final RDB snapshot before exiting.",
         "redis.log.pid": "98738",
         "redis.log.role": "master"
     },
@@ -18,8 +17,7 @@
         "input.type": "log",
         "offset": 76,
         "prospector.type": "log",
-        "redis.log.level": "debug",
-        "redis.log.message": "0 clients connected (0 slaves), 618932 bytes in use, 0 shared objects."
+        "redis.log.message": ". 0 clients connected (0 slaves), 618932 bytes in use, 0 shared objects."
     },
     {
         "event.dataset": "redis.log",
@@ -28,8 +26,7 @@
         "input.type": "log",
         "offset": 165,
         "prospector.type": "log",
-        "redis.log.level": "notice",
-        "redis.log.message": "The server is now ready to accept connections on port 6379\""
+        "redis.log.message": "31 May 04:32:08 * The server is now ready to accept connections on port 6379\""
     },
     {
         "event.dataset": "redis.log",

--- a/filebeat/module/redis/log/test/test.log-expected.json
+++ b/filebeat/module/redis/log/test/test.log-expected.json
@@ -6,7 +6,8 @@
         "input.type": "log",
         "offset": 0,
         "prospector.type": "log",
-        "redis.log.message": "* Saving the final RDB snapshot before exiting.",
+        "redis.log.level": "notice",
+        "redis.log.message": "Saving the final RDB snapshot before exiting.",
         "redis.log.pid": "98738",
         "redis.log.role": "master"
     },
@@ -17,7 +18,8 @@
         "input.type": "log",
         "offset": 76,
         "prospector.type": "log",
-        "redis.log.message": ". 0 clients connected (0 slaves), 618932 bytes in use, 0 shared objects."
+        "redis.log.level": "debug",
+        "redis.log.message": "0 clients connected (0 slaves), 618932 bytes in use, 0 shared objects."
     },
     {
         "event.dataset": "redis.log",
@@ -26,7 +28,8 @@
         "input.type": "log",
         "offset": 165,
         "prospector.type": "log",
-        "redis.log.message": "31 May 04:32:08 * The server is now ready to accept connections on port 6379\""
+        "redis.log.level": "notice",
+        "redis.log.message": "The server is now ready to accept connections on port 6379\""
     },
     {
         "event.dataset": "redis.log",


### PR DESCRIPTION
Original commit message:
* Add grok pattern to support different timestamp fmt in redis log

* Add changelog

* Fix rebase issue

(cherry picked from commit 2ec7b550a523fd4ca9c0b7ef87e6330e8e9b3def)