### PR TITLE
Rename id of Kafka overview dashboard

### DIFF
--- a/filebeat/module/kafka/_meta/kibana/6/dashboard/Filebeat-Kafka-overview.json
+++ b/filebeat/module/kafka/_meta/kibana/6/dashboard/Filebeat-Kafka-overview.json
@@ -121,7 +121,7 @@
                     "type": "histogram"
                 }
             }, 
-            "id": "Number of Kafka stracktraces by class", 
+            "id": "number-of-kafka-stracktraces-by-class",
             "type": "visualization", 
             "version": 2
         }, 
@@ -389,7 +389,7 @@
                 "panelsJSON": [
                     {
                         "col": 1, 
-                        "id": "Number of Kafka stracktraces by class", 
+                        "id": "number-of-kafka-stracktraces-by-class",
                         "panelIndex": 1, 
                         "row": 1, 
                         "size_x": 6, 


### PR DESCRIPTION
The Kafka had the same id as the title which complicates the automatic conversion to 7.x dashboards, see https://github.com/elastic/beats/pull/9998. This is extracted from the migration PR to be able to easily reset the other data again when needed.