### PR TITLE
Skip x-pack libbeat tests again as flaky

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,10 +80,10 @@ jobs:
       env: STRESS_TEST_OPTIONS="-timeout=20m -race -v -parallel 1" TARGETS="-C libbeat stress-tests"
       go: $GO_VERSION
       stage: test
-    - os: linux
-      env: TARGETS="-C x-pack/libbeat testsuite"
-      go: $GO_VERSION
-      stage: test
+    #- os: linux
+    #  env: TARGETS="-C x-pack/libbeat testsuite"
+    #  go: $GO_VERSION
+    #  stage: test
 
     # Metricbeat
     - os: linux


### PR DESCRIPTION
It was tried to fix this in https://github.com/elastic/beats/pull/10043 but it seems it was not successful as it is still flaky. Skipping it again.

See https://github.com/elastic/beats/issues/9690