### PR TITLE
Cherry-pick #9855 to 6.5: Ignore timestamp in redis, haproxy and system filebeat module

### DIFF
--- a/filebeat/module/haproxy/log/test/default.log-expected.json
+++ b/filebeat/module/haproxy/log/test/default.log-expected.json
@@ -1,6 +1,5 @@
 [
     {
-        "@timestamp": "2018-09-20T15:42:59.000Z", 
         "fileset.module": "haproxy", 
         "fileset.name": "log", 
         "haproxy.client.ip": "1.2.3.4", 

--- a/filebeat/module/haproxy/log/test/haproxy.log-expected.json
+++ b/filebeat/module/haproxy/log/test/haproxy.log-expected.json
@@ -1,6 +1,5 @@
 [
     {
-        "@timestamp": "2018-07-30T09:03:52.726Z", 
         "fileset.module": "haproxy", 
         "fileset.name": "log", 
         "haproxy.backend_name": "docs_microservice", 

--- a/filebeat/module/haproxy/log/test/tcplog.log-expected.json
+++ b/filebeat/module/haproxy/log/test/tcplog.log-expected.json
@@ -1,6 +1,5 @@
 [
     {
-        "@timestamp": "2018-09-20T15:44:23.285Z", 
         "fileset.module": "haproxy", 
         "fileset.name": "log", 
         "haproxy.backend_name": "app", 

--- a/filebeat/module/icinga/startup/test/test.log-expected.json
+++ b/filebeat/module/icinga/startup/test/test.log-expected.json
@@ -1,6 +1,5 @@
 [
     {
-        "@timestamp": "2018-07-24T21:15:27.590Z", 
         "fileset.module": "icinga", 
         "fileset.name": "startup", 
         "icinga.startup.facility": "cli", 
@@ -11,7 +10,6 @@
         "prospector.type": "log"
     }, 
     {
-        "@timestamp": "2018-07-24T21:15:27.590Z", 
         "fileset.module": "icinga", 
         "fileset.name": "startup", 
         "icinga.startup.facility": "cli", 

--- a/filebeat/module/redis/log/test/test.log-expected.json
+++ b/filebeat/module/redis/log/test/test.log-expected.json
@@ -1,6 +1,5 @@
 [
     {
-        "@timestamp": "2018-05-30T12:23:52.442Z", 
         "fileset.module": "redis", 
         "fileset.name": "log", 
         "input.type": "log", 
@@ -12,7 +11,6 @@
         "redis.log.role": "master"
     }, 
     {
-        "@timestamp": "2018-05-30T10:05:20.000Z", 
         "fileset.module": "redis", 
         "fileset.name": "log", 
         "input.type": "log", 
@@ -22,7 +20,6 @@
         "redis.log.message": "0 clients connected (0 slaves), 618932 bytes in use, 0 shared objects."
     }, 
     {
-        "@timestamp": "2018-05-31T04:32:08.000Z", 
         "fileset.module": "redis", 
         "fileset.name": "log", 
         "input.type": "log", 
@@ -32,7 +29,6 @@
         "redis.log.message": "The server is now ready to accept connections on port 6379\""
     }, 
     {
-        "@timestamp": "2017-05-30T10:57:24.000Z", 
         "fileset.module": "redis", 
         "fileset.name": "log", 
         "input.type": "log", 

--- a/filebeat/module/system/auth/test/test.log-expected.json
+++ b/filebeat/module/system/auth/test/test.log-expected.json
@@ -1,6 +1,5 @@
 [
     {
-        "@timestamp": "2018-02-21T21:54:44.000Z", 
         "fileset.module": "system", 
         "fileset.name": "auth", 
         "input.type": "log", 
@@ -17,7 +16,6 @@
         "system.auth.user": "vagrant"
     }, 
     {
-        "@timestamp": "2018-02-23T00:13:35.000Z", 
         "fileset.module": "system", 
         "fileset.name": "auth", 
         "input.type": "log", 
@@ -33,7 +31,6 @@
         "system.auth.user": "vagrant"
     }, 
     {
-        "@timestamp": "2018-02-21T21:56:12.000Z", 
         "fileset.module": "system", 
         "fileset.name": "auth", 
         "input.type": "log", 
@@ -47,7 +44,6 @@
         "system.auth.user": "test"
     }, 
     {
-        "@timestamp": "2018-02-20T08:35:22.000Z", 
         "fileset.module": "system", 
         "fileset.name": "auth", 
         "input.type": "log", 
@@ -69,7 +65,6 @@
         "system.auth.user": "root"
     }, 
     {
-        "@timestamp": "2018-02-21T23:35:33.000Z", 
         "fileset.module": "system", 
         "fileset.name": "auth", 
         "input.type": "log", 
@@ -84,7 +79,6 @@
         "system.auth.user": "vagrant"
     }, 
     {
-        "@timestamp": "2018-02-19T15:30:04.000Z", 
         "fileset.module": "system", 
         "fileset.name": "auth", 
         "input.type": "log", 
@@ -96,7 +90,6 @@
         "system.auth.timestamp": "Feb 19 15:30:04"
     }, 
     {
-        "@timestamp": "2018-02-23T00:08:48.000Z", 
         "fileset.module": "system", 
         "fileset.name": "auth", 
         "input.type": "log", 
@@ -111,7 +104,6 @@
         "system.auth.user": "vagrant"
     }, 
     {
-        "@timestamp": "2018-02-24T00:13:02.000Z", 
         "fileset.module": "system", 
         "fileset.name": "auth", 
         "input.type": "log", 
@@ -127,7 +119,6 @@
         "system.auth.user": "tsg"
     }, 
     {
-        "@timestamp": "2018-02-22T11:47:05.000Z", 
         "fileset.module": "system", 
         "fileset.name": "auth", 
         "input.type": "log", 
@@ -140,7 +131,6 @@
         "system.auth.timestamp": "Feb 22 11:47:05"
     }, 
     {
-        "@timestamp": "2018-02-22T11:47:05.000Z", 
         "fileset.module": "system", 
         "fileset.name": "auth", 
         "input.type": "log", 

--- a/filebeat/module/system/syslog/test/darwin-syslog-sample.log-expected.json
+++ b/filebeat/module/system/syslog/test/darwin-syslog-sample.log-expected.json
@@ -1,6 +1,5 @@
 [
     {
-        "@timestamp": "2018-12-13T11:35:28.000Z", 
         "fileset.module": "system", 
         "fileset.name": "syslog", 
         "input.type": "log", 
@@ -16,7 +15,6 @@
         "system.syslog.timestamp": "Dec 13 11:35:28"
     }, 
     {
-        "@timestamp": "2018-12-13T11:35:28.000Z", 
         "fileset.module": "system", 
         "fileset.name": "syslog", 
         "input.type": "log", 
@@ -29,7 +27,6 @@
         "system.syslog.timestamp": "Dec 13 11:35:28"
     }, 
     {
-        "@timestamp": "2018-04-04T03:39:57.000Z", 
         "fileset.module": "system", 
         "fileset.name": "syslog", 
         "input.type": "log", 

--- a/filebeat/tests/system/test_modules.py
+++ b/filebeat/tests/system/test_modules.py
@@ -159,6 +159,7 @@ class Test(BaseTest):
                 for k, obj in enumerate(objects):
                     objects[k] = self.flatten_object(obj, {}, "")
                     clean_keys(objects[k])
+
                 json.dump(objects, f, indent=4, sort_keys=True)
 
         with open(test_file + "-expected.json", "r") as f:
@@ -174,11 +175,6 @@ class Test(BaseTest):
                 # Flatten objects for easier comparing
                 obj = self.flatten_object(obj, {}, "")
                 clean_keys(obj)
-
-                # Remove timestamp for comparison where timestamp is not part of the log line
-                if obj["fileset.module"] == "icinga" and obj["fileset.name"] == "startup":
-                    delete_key(obj, "@timestamp")
-                    delete_key(ev, "@timestamp")
 
                 if ev == obj:
                     found = True
@@ -198,6 +194,11 @@ def clean_keys(obj):
 
     for key in host_keys + time_keys + other_keys:
         delete_key(obj, key)
+
+    # Remove timestamp for comparison where timestamp is not part of the log line
+    dataset = "%s.%s" % (obj['fileset.module'], obj['fileset.name'])
+    if dataset in ["icinga.startup", "redis.log", "haproxy.log", "system.auth", "system.syslog"]:
+        delete_key(obj, "@timestamp")
 
 
 def delete_key(obj, key):


### PR DESCRIPTION
Cherry-pick of PR #9855 to 6.5 branch. Original message: 

Another way to solve this issue https://github.com/elastic/beats/issues/9849 is to ignore timestamp in test_modules.py for redis, haproxy and system filebeat module.