### PR TITLE
make replaced with "mage build"

### DIFF
--- a/docs/devguide/newbeat.asciidoc
+++ b/docs/devguide/newbeat.asciidoc
@@ -184,7 +184,7 @@ To compile the Beat, make sure you are in the Beat directory (`$GOPATH/src/githu
 
 [source,shell]
 ---------
-make
+mage build
 ---------
 
 NOTE: we don't support the `-j` option for make at the moment.


### PR DESCRIPTION
make should be replaced with mage build, make no longer work.