### PR TITLE
Add missing file encodings to readers

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -108,6 +108,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add `agent.id` and `agent.ephemeral_id` fields to all beats. {pull}9404[9404]
 - Add `name` config option to `add_host_metadata` processor. {pull}9943[9943]
 - Add `add_labels` and `add_tags` processors. {pull}9973[9973]
+- Add missing file encoding to readers. {pull}10080[10080]
 
 *Auditbeat*
 

--- a/libbeat/reader/readfile/encoding/encoding.go
+++ b/libbeat/reader/readfile/encoding/encoding.go
@@ -50,6 +50,41 @@ var encodings = map[string]EncodingFactory{
 	"iso8859-8e": enc(charmap.ISO8859_8E),
 	"iso8859-8i": enc(charmap.ISO8859_8I),
 
+	"iso8859-1":  enc(charmap.ISO8859_1),  // latin-1
+	"iso8859-2":  enc(charmap.ISO8859_2),  // latin-2
+	"iso8859-3":  enc(charmap.ISO8859_3),  // latin-3
+	"iso8859-4":  enc(charmap.ISO8859_4),  // latin-4
+	"iso8859-5":  enc(charmap.ISO8859_5),  // latin/cyrillic
+	"iso8859-6":  enc(charmap.ISO8859_6),  // latin/arabic
+	"iso8859-7":  enc(charmap.ISO8859_7),  // latin/greek
+	"iso8859-8":  enc(charmap.ISO8859_8),  // latin/hebrew
+	"iso8859-9":  enc(charmap.ISO8859_9),  // latin-5
+	"iso8859-10": enc(charmap.ISO8859_10), // latin-6
+	"iso8859-13": enc(charmap.ISO8859_13), // latin-7
+	"iso8859-14": enc(charmap.ISO8859_14), // latin-8
+	"iso8859-15": enc(charmap.ISO8859_15), // latin-9
+	"iso8859-16": enc(charmap.ISO8859_16), // latin-10
+
+	// cyrillic
+	"koi8r": enc(charmap.KOI8R),
+	"koi8u": enc(charmap.KOI8U),
+
+	// machintosh
+	"macintosh":          enc(charmap.Macintosh),
+	"macintosh-cyrillic": enc(charmap.MacintoshCyrillic),
+
+	// windows
+	"windows1250": enc(charmap.Windows1250), // central and eastern european
+	"windows1251": enc(charmap.Windows1251), // russian, serbian cyrillic
+	"windows1252": enc(charmap.Windows1252), // legacy
+	"windows1253": enc(charmap.Windows1253), // modern greek
+	"windows1254": enc(charmap.Windows1254), // turkish
+	"windows1255": enc(charmap.Windows1255), // hebrew
+	"windows1256": enc(charmap.Windows1256), // arabic
+	"windows1257": enc(charmap.Windows1257), // estonian, latvian, lithuanian
+	"windows1258": enc(charmap.Windows1258), // vietnamese
+	"windows874":  enc(charmap.Windows874),
+
 	// utf16 bom codecs (seekable data source required)
 	"utf-16-bom":   utf16BOMRequired,
 	"utf-16be-bom": utf16BOMBigEndian,

--- a/libbeat/reader/readfile/encoding/encoding.go
+++ b/libbeat/reader/readfile/encoding/encoding.go
@@ -65,6 +65,21 @@ var encodings = map[string]EncodingFactory{
 	"iso8859-15": enc(charmap.ISO8859_15), // latin-9
 	"iso8859-16": enc(charmap.ISO8859_16), // latin-10
 
+	// ibm codepages
+	"cp437":       enc(charmap.CodePage437),
+	"cp850":       enc(charmap.CodePage850),
+	"cp852":       enc(charmap.CodePage852),
+	"cp855":       enc(charmap.CodePage855),
+	"cp858":       enc(charmap.CodePage858),
+	"cp860":       enc(charmap.CodePage860),
+	"cp862":       enc(charmap.CodePage862),
+	"cp863":       enc(charmap.CodePage863),
+	"cp865":       enc(charmap.CodePage865),
+	"cp866":       enc(charmap.CodePage866),
+	"ebcdic-037":  enc(charmap.CodePage037),
+	"ebcdic-1040": enc(charmap.CodePage1140),
+	"ebcdic-1047": enc(charmap.CodePage1047),
+
 	// cyrillic
 	"koi8r": enc(charmap.KOI8R),
 	"koi8u": enc(charmap.KOI8U),

--- a/libbeat/reader/readfile/encoding/encoding.go
+++ b/libbeat/reader/readfile/encoding/encoding.go
@@ -84,7 +84,7 @@ var encodings = map[string]EncodingFactory{
 	"koi8r": enc(charmap.KOI8R),
 	"koi8u": enc(charmap.KOI8U),
 
-	// machintosh
+	// macintosh
 	"macintosh":          enc(charmap.Macintosh),
 	"macintosh-cyrillic": enc(charmap.MacintoshCyrillic),
 

--- a/libbeat/reader/readfile/line_test.go
+++ b/libbeat/reader/readfile/line_test.go
@@ -43,6 +43,31 @@ var tests = []struct {
 	{"gb18030", []string{"我能吞下玻璃", "而不傷身。體"}},
 	{"euc-kr", []string{" 나는 유리를 먹을 수 있어요.", " 그래도 아프지 않아요"}},
 	{"euc-jp", []string{"私はガラスを食べられます。", "それは私を傷つけません。"}},
+	{"plain", []string{"I can", "eat glass"}},
+	{"iso8859-1", []string{"Filebeat is my favourite"}},
+	{"iso8859-2", []string{"Filebeat je môj obľúbený"}},                          // slovak: filebeat is my favourite
+	{"iso8859-3", []string{"büyükannem Filebeat kullanıyor"}},                    // turkish: my granmother uses filebeat
+	{"iso8859-4", []string{"Filebeat on mõeldud kõigile"}},                       // estonian: filebeat is for everyone
+	{"iso8859-5", []string{"я люблю кодировки"}},                                 // russian: i love encodings
+	{"iso8859-6", []string{"أنا بحاجة إلى المزيد من الترميزات"}},                 // arabic: i need more encodings
+	{"iso8859-7", []string{"όπου μπορώ να αγοράσω περισσότερες κωδικοποιήσεις"}}, // greek: where can i buy more encodings?
+	{"iso8859-8", []string{"אני צריך קידוד אישי"}},                               // hebrew: i need a personal encoding
+	{"iso8859-9", []string{"kodlamaları pişirebilirim"}},                         // turkish: i can cook encodings
+	{"iso8859-10", []string{"koodaukset jäädyttävät nollaan"}},                   // finnish: encodings freeze below zero
+	{"iso8859-13", []string{"mój pies zjada kodowanie"}},                         // polish: my dog eats encodings
+	{"iso8859-14", []string{"An féidir leat cáise a ionchódú?"}},                 // irish: can you encode a cheese?
+	{"iso8859-15", []string{"bedes du kode", "for min €"}},                       // danish: please encode my euro symbol
+	{"iso8859-16", []string{"rossz karakterkódolást", "használsz"}},              // hungarian: you use the wrong character encoding
+	{"koi8r", []string{"я люблю кодировки"}},                                     // russian: i love encodings
+	{"koi8u", []string{"я люблю кодировки"}},                                     // russian: i love encodings
+	{"windows1250", []string{"Filebeat je môj obľúbený"}},                        // slovak: filebeat is my favourite
+	{"windows1251", []string{"я люблю кодировки"}},                               // russian: i love encodings
+	{"windows1252", []string{"what is better than an encoding?", "a legacy encoding"}},
+	{"windows1253", []string{"όπου μπορώ να αγοράσω", "περισσότερες κωδικοποιήσεις"}}, // greek: where can i buy more encodings?
+	{"windows1254", []string{"kodlamaları", "pişirebilirim"}},                         // turkish: i can cook encodings
+	{"windows1255", []string{"אני צריך קידוד אישי"}},                                  // hebrew: i need a personal encoding
+	{"windows1256", []string{"أنا بحاجة إلى المزيد من الترميزات"}},                    // arabic: i need more encodings
+	{"windows1257", []string{"toite", "kodeerijaid"}},                                 // estonian: feed the encoders
 }
 
 func TestReaderEncodings(t *testing.T) {


### PR DESCRIPTION
Missing character encodings are added to `libbeat/reader` package. Thus, it is possible to configure the following encodings in Filebeat:

* `"iso8859-1"`: ISO8859_1
* `"iso8859-2"`: ISO8859_2
* `"iso8859-3"`: ISO8859_3
* `"iso8859-4"`: ISO8859_4
* `"iso8859-5"`: ISO8859_5
* `"iso8859-6"`: ISO8859_6
* `"iso8859-7"`: ISO8859_7
* `"iso8859-8"`: ISO8859_8
* `"iso8859-9"`: ISO8859_9
* `"iso8859-10"`: ISO8859_10
* `"iso8859-13"`: ISO8859_13
* `"iso8859-14"`: ISO8859_14
* `"iso8859-15"`: ISO8859_15
* `"iso8859-16"`: ISO8859_16
* `"cp437"`: CodePage437
* `"cp850"`: CodePage850
* `"cp852"`: CodePage852
* `"cp855"`: CodePage855
* `"cp858"`: CodePage858
* `"cp860"`: CodePage860
* `"cp862"`: CodePage862
* `"cp863"`: CodePage863
* `"cp865"`: CodePage865
* `"cp866"`: CodePage866
* `"ebcdic-037"`: CodePage037
* `"ebcdic-1040"`: CodePage1140
* `"ebcdic-1047"`: CodePage1047
* `"koi8r"`: KOI8R
* `"koi8u"`: KOI8U
* `"macintosh"`: Macintosh
* `"macintosh-cyrillic"`: MacintoshCyrillic
* `"windows1250"`: Windows1250
* `"windows1251"`: Windows1251
* `"windows1252"`: Windows1252
* `"windows1253"`: Windows1253
* `"windows1254"`: Windows1254
* `"windows1255"`: Windows1255
* `"windows1256"`: Windows1256
* `"windows1257"`: Windows1257
* `"windows1258"`: Windows1258
* `"windows874"`: Windows874

Filebeat can be configured using the encoding names between quotation marks.

The sentences I have used in the unit tests are coming from Google Translate. If something is off with those, it's on that program. :D