### PR TITLE
Fix Pod UID automatic enriching

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -86,7 +86,9 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 *Journalbeat*
 
 *Metricbeat*
+
 - Fix panics in vsphere module when certain values where not returned by the API. {pull}9784[9784]
+- Fix pod UID metadata enrichment in Kubernetes module. {pull}10081[10081]
 
 *Packetbeat*
 

--- a/metricbeat/module/kubernetes/pod/_meta/data.json
+++ b/metricbeat/module/kubernetes/pod/_meta/data.json
@@ -12,6 +12,7 @@
         },
         "pod": {
             "name": "nginx-3137573019-pcfzh",
+            "uid": "b89a812e-18cd-11e9-b333-080027190d51",
             "network": {
                 "rx": {
                     "bytes": 18999261,

--- a/metricbeat/module/kubernetes/state_pod/_meta/data.json
+++ b/metricbeat/module/kubernetes/state_pod/_meta/data.json
@@ -14,6 +14,7 @@
       "host_ip": "192.168.99.100",
       "ip": "172.17.0.3",
       "name": "tiller-deploy-3067024529-1gp80",
+      "uid": "659419d5-e27a-11e8-98fa-080027190d51",
       "status": {
         "phase": "running",
         "ready": "true",

--- a/metricbeat/module/kubernetes/util/kubernetes.go
+++ b/metricbeat/module/kubernetes/util/kubernetes.go
@@ -158,6 +158,8 @@ func NewResourceMetadataEnricher(
 		},
 	)
 
+	// Configure the enricher for Pods, so pod specific metadata ends up in the right place when
+	// calling Enrich
 	if _, ok := res.(*kubernetes.Pod); ok {
 		enricher.isPod = true
 	}

--- a/metricbeat/module/kubernetes/util/kubernetes.go
+++ b/metricbeat/module/kubernetes/util/kubernetes.go
@@ -59,6 +59,7 @@ type enricher struct {
 	watcher            kubernetes.Watcher
 	watcherStarted     bool
 	watcherStartedLock sync.Mutex
+	isPod              bool
 }
 
 // GetWatcher initializes a kubernetes watcher with the given
@@ -157,6 +158,10 @@ func NewResourceMetadataEnricher(
 		},
 	)
 
+	if _, ok := res.(*kubernetes.Pod); ok {
+		enricher.isPod = true
+	}
+
 	return enricher
 }
 
@@ -243,7 +248,7 @@ func buildMetadataEnricher(
 	watcher kubernetes.Watcher,
 	update func(map[string]common.MapStr, kubernetes.Resource),
 	delete func(map[string]common.MapStr, kubernetes.Resource),
-	index func(e common.MapStr) string) Enricher {
+	index func(e common.MapStr) string) *enricher {
 
 	enricher := enricher{
 		metadata: map[string]common.MapStr{},
@@ -298,6 +303,17 @@ func (m *enricher) Enrich(events []common.MapStr) {
 	defer m.RUnlock()
 	for _, event := range events {
 		if meta := m.metadata[m.index(event)]; meta != nil {
+			if m.isPod {
+				// apply pod meta at metricset level
+				if podMeta, ok := meta["pod"].(common.MapStr); ok {
+					event.DeepUpdate(podMeta)
+				}
+
+				// don't apply pod metadata to module level
+				meta = meta.Clone()
+				delete(meta, "pod")
+			}
+
 			event.DeepUpdate(common.MapStr{
 				mb.ModuleDataKey: meta,
 			})


### PR DESCRIPTION
Before this change, Kubernetes Pod events where not being enriched correctly and Pod UID was missing, what caused wrong visualizations in Infrastructure UI.

Metadata was being added at the module level, which is correct
for all metricsets, except `pod` and `state_pod`. For these metricsets
metadata must be added at the root level because we are already under
`kubernetes.pod`. Added metadata was being ignored.

This change takes this special case into account and updates events in
the right place, ensuring the events get the metadata correctly.

Before this change, missing UID caused this:

![image](https://user-images.githubusercontent.com/299804/51186929-0a3a2d00-18db-11e9-84fa-0b1144b0b645.png)

After this change visualizations are correct:

![image](https://user-images.githubusercontent.com/299804/51186568-330df280-18da-11e9-9d81-f79b86bbd46f.png)
