### PR TITLE
Cherry-pick #10082 to 6.x: [Heartbeat] Fix NPE in HTTP responses.

### DIFF
--- a/heartbeat/monitors/active/http/simple_transp.go
+++ b/heartbeat/monitors/active/http/simple_transp.go
@@ -184,7 +184,6 @@ func (t *SimpleTransport) readResponse(
 ) (*http.Response, error) {
 	reader := bufio.NewReader(conn)
 	resp, err := http.ReadResponse(reader, req)
-	resp.Body = comboConnReadCloser{conn, resp.Body}
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Cherry-pick of PR #10082 to 6.x branch. Original message: 

This removes an accidentally duplicated line that broke the error check on the following line.

I suspect this was caused by git merging incorrectly.

Fixes https://github.com/elastic/beats/issues/10066