### PR TITLE
Instead of blacklisting chars in the resource name for cloudformation use whitelisting.

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -64,6 +64,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Functionbeat*
 
+- Correctly normalize Cloudformation resource name. {issue}10087[10087]
+
 ==== Bugfixes
 
 *Affecting all Beats*

--- a/x-pack/functionbeat/provider/aws/cli_manager.go
+++ b/x-pack/functionbeat/provider/aws/cli_manager.go
@@ -155,7 +155,7 @@ func (c *CLIManager) template(function installer, name, codeLoc string) *cloudfo
 			Handler:                      handlerName,
 			MemorySize:                   lambdaConfig.MemorySize.Megabytes(),
 			ReservedConcurrentExecutions: lambdaConfig.Concurrency,
-			Timeout: int(lambdaConfig.Timeout.Seconds()),
+			Timeout:                      int(lambdaConfig.Timeout.Seconds()),
 		},
 		DependsOn: []string{prefix("") + "IAMRoleLambdaExecution"},
 	}

--- a/x-pack/functionbeat/provider/aws/cli_manager.go
+++ b/x-pack/functionbeat/provider/aws/cli_manager.go
@@ -9,6 +9,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"regexp"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/external"
@@ -26,13 +27,13 @@ const (
 	// AWS lambda currently support go 1.x as a runtime.
 	runtime     = "go1.x"
 	handlerName = "functionbeat"
-
-	// invalidChars for resource name
-	invalidChars = ":-/"
 )
 
-// AWSLambdaFunction add 'dependsOn' as a serializable parameters, for no good reason it's
-// not supported.
+// Chars for resource name anything else will be replaced.
+var validChars = regexp.MustCompile("[^a-zA-Z0-9]")
+
+// AWSLambdaFunction add 'dependsOn' as a serializable parameters,  goformation doesn't currently
+// serialize this field.
 type AWSLambdaFunction struct {
 	*cloudformation.AWSLambdaFunction
 	DependsOn []string
@@ -71,7 +72,7 @@ func (c *CLIManager) template(function installer, name, codeLoc string) *cloudfo
 	lambdaConfig := function.LambdaConfig()
 
 	prefix := func(s string) string {
-		return "fnb" + name + s
+		return normalizeResourceName("fnb" + name + s)
 	}
 
 	// AWS variables references:.
@@ -86,7 +87,7 @@ func (c *CLIManager) template(function installer, name, codeLoc string) *cloudfo
 	// Create the roles for the lambda.
 	template := cloudformation.NewTemplate()
 	// doc: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html
-	template.Resources["IAMRoleLambdaExecution"] = &cloudformation.AWSIAMRole{
+	template.Resources[prefix("")+"IAMRoleLambdaExecution"] = &cloudformation.AWSIAMRole{
 		AssumeRolePolicyDocument: map[string]interface{}{
 			"Statement": []interface{}{
 				map[string]interface{}{
@@ -149,14 +150,14 @@ func (c *CLIManager) template(function installer, name, codeLoc string) *cloudfo
 			},
 			DeadLetterConfig:             dlc,
 			FunctionName:                 name,
-			Role:                         cloudformation.GetAtt("IAMRoleLambdaExecution", "Arn"),
+			Role:                         cloudformation.GetAtt(prefix("")+"IAMRoleLambdaExecution", "Arn"),
 			Runtime:                      runtime,
 			Handler:                      handlerName,
 			MemorySize:                   lambdaConfig.MemorySize.Megabytes(),
 			ReservedConcurrentExecutions: lambdaConfig.Concurrency,
-			Timeout:                      int(lambdaConfig.Timeout.Seconds()),
+			Timeout: int(lambdaConfig.Timeout.Seconds()),
 		},
-		DependsOn: []string{"IAMRoleLambdaExecution"},
+		DependsOn: []string{prefix("") + "IAMRoleLambdaExecution"},
 	}
 
 	// Create the log group for the specific function lambda.
@@ -366,7 +367,7 @@ func mergeTemplate(to, from *cloudformation.Template) error {
 }
 
 func normalizeResourceName(s string) string {
-	return common.RemoveChars(s, invalidChars)
+	return validChars.ReplaceAllString(s, "")
 }
 
 func checksum(data []byte) string {

--- a/x-pack/functionbeat/provider/aws/cli_manager_test.go
+++ b/x-pack/functionbeat/provider/aws/cli_manager_test.go
@@ -59,6 +59,11 @@ func TestNormalize(t *testing.T) {
 			candidate: "hello",
 			expected:  "hello",
 		},
+		{
+			title:     "when the string contains underscore",
+			candidate: "/var/log-alpha/tmp:ok_moreok",
+			expected:  "varlogalphatmpokmoreok",
+		},
 	}
 
 	for _, test := range tests {

--- a/x-pack/functionbeat/provider/aws/cloudwatch_logs.go
+++ b/x-pack/functionbeat/provider/aws/cloudwatch_logs.go
@@ -165,7 +165,7 @@ func (r *AWSLogsSubscriptionFilter) AWSCloudFormationType() string {
 // Template returns the cloudformation template for configuring the service with the specified triggers.
 func (c *CloudwatchLogs) Template() *cloudformation.Template {
 	prefix := func(suffix string) string {
-		return "fnb" + c.config.Name + suffix
+		return normalizeResourceName("fnb" + c.config.Name + suffix)
 	}
 
 	template := cloudformation.NewTemplate()
@@ -197,7 +197,7 @@ func (c *CloudwatchLogs) Template() *cloudformation.Template {
 		}
 
 		// doc: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-logs-subscriptionfilter.html
-		template.Resources[prefix("SubscriptionFilter"+normalizeResourceName(string(trigger.LogGroupName)))] = &AWSLogsSubscriptionFilter{
+		template.Resources[prefix("SF")+normalizeResourceName(string(trigger.LogGroupName))] = &AWSLogsSubscriptionFilter{
 			DestinationArn: cloudformation.GetAtt(prefix(""), "Arn"),
 			FilterPattern:  trigger.FilterPattern,
 			LogGroupName:   string(trigger.LogGroupName),

--- a/x-pack/functionbeat/provider/aws/sqs.go
+++ b/x-pack/functionbeat/provider/aws/sqs.go
@@ -87,7 +87,7 @@ func (s *SQS) Template() *cloudformation.Template {
 	template := cloudformation.NewTemplate()
 
 	prefix := func(suffix string) string {
-		return "fnb" + s.config.Name + suffix
+		return normalizeResourceName("fnb" + s.config.Name + suffix)
 	}
 
 	for _, trigger := range s.config.Triggers {


### PR DESCRIPTION
Only [a-zA-Z0-9] are permitted as resource name

Fixes: #9420