### PR TITLE
Cherry-pick #10081 to 6.6: Fix Pod UID automatic enriching

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -50,6 +50,7 @@ https://github.com/elastic/beats/compare/1035569addc4a3b29ffa14f8a08c27c1ace16ef
 *Metricbeat*
 
 - Fix panics in vsphere module when certain values where not returned by the API. {pull}9784[9784]
+- Fix pod UID metadata enrichment in Kubernetes module. {pull}10081[10081]
 
 *Packetbeat*
 

--- a/metricbeat/module/kubernetes/pod/_meta/data.json
+++ b/metricbeat/module/kubernetes/pod/_meta/data.json
@@ -12,6 +12,7 @@
         },
         "pod": {
             "name": "nginx-3137573019-pcfzh",
+            "uid": "b89a812e-18cd-11e9-b333-080027190d51",
             "network": {
                 "rx": {
                     "bytes": 18999261,

--- a/metricbeat/module/kubernetes/state_pod/_meta/data.json
+++ b/metricbeat/module/kubernetes/state_pod/_meta/data.json
@@ -14,6 +14,7 @@
       "host_ip": "192.168.99.100",
       "ip": "172.17.0.3",
       "name": "tiller-deploy-3067024529-1gp80",
+      "uid": "659419d5-e27a-11e8-98fa-080027190d51",
       "status": {
         "phase": "running",
         "ready": "true",


### PR DESCRIPTION
Cherry-pick of PR #10081 to 6.6 branch. Original message: 

Before this change, Kubernetes Pod events where not being enriched correctly and Pod UID was missing, what caused wrong visualizations in Infrastructure UI.

Metadata was being added at the module level, which is correct
for all metricsets, except `pod` and `state_pod`. For these metricsets
metadata must be added at the root level because we are already under
`kubernetes.pod`. Added metadata was being ignored.

This change takes this special case into account and updates events in
the right place, ensuring the events get the metadata correctly.

Before this change, missing UID caused this:

![image](https://user-images.githubusercontent.com/299804/51186929-0a3a2d00-18db-11e9-84fa-0b1144b0b645.png)

After this change visualizations are correct:

![image](https://user-images.githubusercontent.com/299804/51186568-330df280-18da-11e9-9d81-f79b86bbd46f.png)
