### PR TITLE
Fix failing template tests based on doc type change in Elasticsearch

### DIFF
--- a/libbeat/template/load_integration_test.go
+++ b/libbeat/template/load_integration_test.go
@@ -395,7 +395,7 @@ func getTemplate(t *testing.T, client ESClient, templateName string) testTemplat
 }
 
 func (tt *testTemplate) SourceEnabled() bool {
-	key := fmt.Sprintf("mappings._doc._source.enabled")
+	key := fmt.Sprintf("mappings._source.enabled")
 
 	// _source.enabled is true if it's missing (default)
 	b, _ := tt.HasKey(key)

--- a/libbeat/tests/files/template.json
+++ b/libbeat/tests/files/template.json
@@ -4,18 +4,16 @@
         "number_of_shards": 1
     },
     "mappings": {
-        "example": {
-            "_source": {
-                "enabled": false
+        "_source": {
+            "enabled": false
+        },
+        "properties": {
+            "host_name": {
+                "type": "keyword"
             },
-            "properties": {
-                "host_name": {
-                    "type": "keyword"
-                },
-                "created_at": {
-                    "type": "date",
-                    "format": "EEE MMM dd HH:mm:ss Z YYYY"
-                }
+            "created_at": {
+                "type": "date",
+                "format": "EEE MMM dd HH:mm:ss Z YYYY"
             }
         }
     }


### PR DESCRIPTION
Elasticsearch just remove the types from the mappings. This PR fixes the broken integration tests by removing the type.

Further work to remove it in other parts is probably needed.