### PR TITLE
Skip duplicate flaky tests in journalbeat/checkpoint

### DIFF
--- a/journalbeat/checkpoint/checkpoint_test.go
+++ b/journalbeat/checkpoint/checkpoint_test.go
@@ -57,6 +57,7 @@ func eventually(t *testing.T, predicate func() (bool, error), timeout time.Durat
 
 // Test that a write is triggered when the maximum number of updates is reached.
 func TestWriteMaxUpdates(t *testing.T) {
+	t.Skip("Duplicate of winlogbeat/checkpoint")
 	dir, err := ioutil.TempDir("", "wlb-checkpoint-test")
 	if err != nil {
 		t.Fatal(err)
@@ -110,6 +111,7 @@ func TestWriteMaxUpdates(t *testing.T) {
 // Test that a write is triggered when the maximum time period since the last
 // write is reached.
 func TestWriteTimedFlush(t *testing.T) {
+	t.Skip("Duplicate of winlogbeat/checkpoint")
 	dir, err := ioutil.TempDir("", "wlb-checkpoint-test")
 	if err != nil {
 		t.Fatal(err)
@@ -152,6 +154,7 @@ func TestWriteTimedFlush(t *testing.T) {
 
 // Test that createDir creates the directory with 0750 permissions.
 func TestCreateDir(t *testing.T) {
+	t.Skip("Duplicate of winlogbeat/checkpoint")
 	dir, err := ioutil.TempDir("", "wlb-checkpoint-test")
 	if err != nil {
 		t.Fatal(err)
@@ -191,6 +194,7 @@ func TestCreateDir(t *testing.T) {
 // Test createDir when the directory already exists to verify that no error is
 // returned.
 func TestCreateDirAlreadyExists(t *testing.T) {
+	t.Skip("Duplicate of winlogbeat/checkpoint")
 	dir, err := ioutil.TempDir("", "wlb-checkpoint-test")
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Unit tests in package journalbeat/checkpoint are duplicates of those in Winlogbeat. Thus, there is not any additional information coming from running unit tests in both packages.
I am not removing the tests. So if someone modifies checkpointing in Journalbeat, he/she does not need to write new tests from scratch or copy from Winlogbeat again.