### PR TITLE
Add missing ecs-migration entries for #10043

### DIFF
--- a/dev-tools/ecs-migration.yml
+++ b/dev-tools/ecs-migration.yml
@@ -890,3 +890,12 @@
 - from: tcp.port
   to: url.port
   alias: true
+
+# Journalbeat
+- from: host.name
+  to: host.hostname
+  alias: false
+
+- from: read_timestamp
+  to: event.created
+  alias: true


### PR DESCRIPTION
The migration entries went missing there. No alias is used for `host.name` to `host.hostname` as both are existing fields. Change was missing in https://github.com/elastic/beats/pull/10043