### PR TITLE
Cherry-pick #10087 to 6.6: Instead of blacklisting chars in the resource name for cloudformation use whitelisting.

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -28,6 +28,8 @@ https://github.com/elastic/beats/compare/1035569addc4a3b29ffa14f8a08c27c1ace16ef
 
 *Functionbeat*
 
+- Correctly normalize Cloudformation resource name. {issue}10087[10087]
+
 ==== Bugfixes
 
 *Affecting all Beats*

--- a/x-pack/functionbeat/provider/aws/cli_manager_test.go
+++ b/x-pack/functionbeat/provider/aws/cli_manager_test.go
@@ -59,6 +59,11 @@ func TestNormalize(t *testing.T) {
 			candidate: "hello",
 			expected:  "hello",
 		},
+		{
+			title:     "when the string contains underscore",
+			candidate: "/var/log-alpha/tmp:ok_moreok",
+			expected:  "varlogalphatmpokmoreok",
+		},
 	}
 
 	for _, test := range tests {

--- a/x-pack/functionbeat/provider/aws/cloudwatch_logs.go
+++ b/x-pack/functionbeat/provider/aws/cloudwatch_logs.go
@@ -165,7 +165,7 @@ func (r *AWSLogsSubscriptionFilter) AWSCloudFormationType() string {
 // Template returns the cloudformation template for configuring the service with the specified triggers.
 func (c *CloudwatchLogs) Template() *cloudformation.Template {
 	prefix := func(suffix string) string {
-		return "fnb" + c.config.Name + suffix
+		return normalizeResourceName("fnb" + c.config.Name + suffix)
 	}
 
 	template := cloudformation.NewTemplate()
@@ -197,7 +197,7 @@ func (c *CloudwatchLogs) Template() *cloudformation.Template {
 		}
 
 		// doc: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-logs-subscriptionfilter.html
-		template.Resources[prefix("SubscriptionFilter"+normalizeResourceName(string(trigger.LogGroupName)))] = &AWSLogsSubscriptionFilter{
+		template.Resources[prefix("SF")+normalizeResourceName(string(trigger.LogGroupName))] = &AWSLogsSubscriptionFilter{
 			DestinationArn: cloudformation.GetAtt(prefix(""), "Arn"),
 			FilterPattern:  trigger.FilterPattern,
 			LogGroupName:   string(trigger.LogGroupName),

--- a/x-pack/functionbeat/provider/aws/sqs.go
+++ b/x-pack/functionbeat/provider/aws/sqs.go
@@ -87,7 +87,7 @@ func (s *SQS) Template() *cloudformation.Template {
 	template := cloudformation.NewTemplate()
 
 	prefix := func(suffix string) string {
-		return "fnb" + s.config.Name + suffix
+		return normalizeResourceName("fnb" + s.config.Name + suffix)
 	}
 
 	for _, trigger := range s.config.Triggers {


### PR DESCRIPTION
Cherry-pick of PR #10087 to 6.6 branch. Original message: 

Only [a-zA-Z0-9] are permitted as resource name

Fixes: #9420