### PR TITLE
Increate LS test timeouts to 10s

### DIFF
--- a/libbeat/outputs/logstash/client_test.go
+++ b/libbeat/outputs/logstash/client_test.go
@@ -63,10 +63,12 @@ type testDriverCommand struct {
 
 const testMaxWindowSize = 64
 
+const testConnectTimeout = 10 * time.Second
+
 func testSendZero(t *testing.T, factory clientFactory) {
 	enableLogging([]string{"*"})
 
-	server := transptest.NewMockServerTCP(t, 1*time.Second, "", nil)
+	server := transptest.NewMockServerTCP(t, testConnectTimeout, "", nil)
 	defer server.Close()
 
 	sock, transp, err := server.ConnectPair()
@@ -92,7 +94,7 @@ func testSendZero(t *testing.T, factory clientFactory) {
 
 func testSimpleEvent(t *testing.T, factory clientFactory) {
 	enableLogging([]string{"*"})
-	mock := transptest.NewMockServerTCP(t, 1*time.Second, "", nil)
+	mock := transptest.NewMockServerTCP(t, testConnectTimeout, "", nil)
 	server, _ := v2.NewWithListener(mock.Listener)
 	defer server.Close()
 
@@ -126,7 +128,7 @@ func testSimpleEvent(t *testing.T, factory clientFactory) {
 
 func testSimpleEventWithTTL(t *testing.T, factory clientFactory) {
 	enableLogging([]string{"*"})
-	mock := transptest.NewMockServerTCP(t, 1*time.Second, "", nil)
+	mock := transptest.NewMockServerTCP(t, testConnectTimeout, "", nil)
 	server, _ := v2.NewWithListener(mock.Listener)
 	defer server.Close()
 
@@ -178,7 +180,7 @@ func testSimpleEventWithTTL(t *testing.T, factory clientFactory) {
 
 func testStructuredEvent(t *testing.T, factory clientFactory) {
 	enableLogging([]string{"*"})
-	mock := transptest.NewMockServerTCP(t, 1*time.Second, "", nil)
+	mock := transptest.NewMockServerTCP(t, testConnectTimeout, "", nil)
 	server, _ := v2.NewWithListener(mock.Listener)
 	defer server.Close()
 

--- a/libbeat/outputs/logstash/logstash_test.go
+++ b/libbeat/outputs/logstash/logstash_test.go
@@ -41,13 +41,13 @@ const (
 func TestLogstashTCP(t *testing.T) {
 	enableLogging([]string{"*"})
 
-	timeout := 2 * time.Second
+	timeout := testConnectTimeout
 	server := transptest.NewMockServerTCP(t, timeout, "", nil)
 
 	config := map[string]interface{}{
 		"hosts":   []string{server.Addr()},
 		"index":   testLogstashIndex("logstash-conn-tcp"),
-		"timeout": "2s",
+		"timeout": timeout.String(),
 	}
 	testConnectionType(t, server, testOutputerFactory(t, "", config))
 }
@@ -58,7 +58,7 @@ func TestLogstashTLS(t *testing.T) {
 	certName := "ca_test"
 	ip := "127.0.0.1"
 
-	timeout := 2 * time.Second
+	timeout := testConnectTimeout
 	transptest.GenCertForTestingPurpose(t, ip, certName, "")
 	server := transptest.NewMockServerTLS(t, timeout, certName, nil)
 
@@ -66,7 +66,7 @@ func TestLogstashTLS(t *testing.T) {
 	config := map[string]interface{}{
 		"hosts":                       []string{server.Addr()},
 		"index":                       testLogstashIndex("logstash-conn-tls"),
-		"timeout":                     "2s",
+		"timeout":                     timeout.String(),
 		"ssl.certificate_authorities": []string{certName + ".pem"},
 	}
 	testConnectionType(t, server, testOutputerFactory(t, "", config))
@@ -76,14 +76,14 @@ func TestLogstashInvalidTLSInsecure(t *testing.T) {
 	certName := "ca_invalid_test"
 	ip := "1.2.3.4"
 
-	timeout := 2 * time.Second
+	timeout := testConnectTimeout
 	transptest.GenCertForTestingPurpose(t, ip, certName, "")
 	server := transptest.NewMockServerTLS(t, timeout, certName, nil)
 
 	config := map[string]interface{}{
 		"hosts":                       []string{server.Addr()},
 		"index":                       testLogstashIndex("logstash-conn-tls-invalid"),
-		"timeout":                     2,
+		"timeout":                     timeout.String(),
 		"max_retries":                 1,
 		"ssl.verification_mode":       "none",
 		"ssl.certificate_authorities": []string{certName + ".pem"},


### PR DESCRIPTION
Lostash output unit tests failed, due to connection timeouts in CI (CI overloaded?). Increase the timeout to 10s and hope it helps.