### PR TITLE
Allow specifying Kibana URL for mage ExportDashboard

### DIFF
--- a/dev-tools/cmd/dashboards/export_dashboards.go
+++ b/dev-tools/cmd/dashboards/export_dashboards.go
@@ -66,6 +66,7 @@ func main() {
 		Host:     u.Host,
 		Username: user,
 		Password: pass,
+		Path:     u.Path,
 		SpaceID:  *spaceID,
 		Timeout:  kibanaTimeout,
 	})

--- a/dev-tools/mage/dashboard.go
+++ b/dev-tools/mage/dashboard.go
@@ -36,6 +36,8 @@ func ExportDashboard() error {
 		return fmt.Errorf("Dashboad ID must be specified")
 	}
 
+	kibanaUrl := EnvOr("KIBANA", "")
+
 	beatsDir, err := ElasticBeatsDir()
 	if err != nil {
 		return err
@@ -49,5 +51,9 @@ func ExportDashboard() error {
 		"-output", file, "-dashboard", id,
 	)
 
-	return dashboardCmd()
+	if kibanaUrl != "" {
+		return dashboardCmd("-kibana", kibanaUrl)
+	} else {
+		return dashboardCmd()
+	}
 }

--- a/dev-tools/mage/dashboard.go
+++ b/dev-tools/mage/dashboard.go
@@ -36,7 +36,7 @@ func ExportDashboard() error {
 		return fmt.Errorf("Dashboad ID must be specified")
 	}
 
-	kibanaURL := EnvOr("KIBANA", "")
+	kibanaURL := EnvOr("KIBANA_URL", "")
 
 	beatsDir, err := ElasticBeatsDir()
 	if err != nil {

--- a/dev-tools/mage/dashboard.go
+++ b/dev-tools/mage/dashboard.go
@@ -36,7 +36,7 @@ func ExportDashboard() error {
 		return fmt.Errorf("Dashboad ID must be specified")
 	}
 
-	kibanaUrl := EnvOr("KIBANA", "")
+	kibanaURL := EnvOr("KIBANA", "")
 
 	beatsDir, err := ElasticBeatsDir()
 	if err != nil {
@@ -51,8 +51,8 @@ func ExportDashboard() error {
 		"-output", file, "-dashboard", id,
 	)
 
-	if kibanaUrl != "" {
-		return dashboardCmd("-kibana", kibanaUrl)
+	if kibanaURL != "" {
+		return dashboardCmd("-kibana", kibanaURL)
 	} else {
 		return dashboardCmd()
 	}

--- a/libbeat/kibana/client.go
+++ b/libbeat/kibana/client.go
@@ -217,8 +217,8 @@ func (client *Client) readVersion() error {
 
 	code, result, err := client.Connection.Request("GET", "/api/status", nil, nil, nil)
 	if err != nil || code >= 400 {
-		return fmt.Errorf("HTTP GET request to /api/status fails: %v. Response: %s.",
-			err, truncateString(result))
+		return fmt.Errorf("HTTP GET request to %s/api/status fails: %v. Response: %s.",
+			client.Connection.URL, err, truncateString(result))
 	}
 
 	var versionString string


### PR DESCRIPTION
When running Kibana from source (maybe also in other cases) Kibana will run under a URL like `http://localhost:5603/kva` (note the `kva` at the end).

This changes the `mage ExportDashboard` command to take into account a `KIBANA` environment variable that allows specifying a custom Kibana URL like that to allow exporting dashboards.

Also improves a log message.