### PR TITLE
[Heartbeat] Increase Test Timeouts

### DIFF
--- a/heartbeat/monitors/active/http/http_test.go
+++ b/heartbeat/monitors/active/http/http_test.go
@@ -50,7 +50,7 @@ func testRequest(t *testing.T, testURL string) *beat.Event {
 func testTLSRequest(t *testing.T, testURL string, extraConfig map[string]interface{}) *beat.Event {
 	configSrc := map[string]interface{}{
 		"urls":    testURL,
-		"timeout": "1s",
+		"timeout": "2s",
 	}
 
 	if extraConfig != nil {
@@ -231,7 +231,7 @@ func TestLargeResponse(t *testing.T) {
 
 	configSrc := map[string]interface{}{
 		"urls":                server.URL,
-		"timeout":             "1s",
+		"timeout":             "2s",
 		"check.response.body": "x",
 	}
 

--- a/heartbeat/monitors/active/http/http_test.go
+++ b/heartbeat/monitors/active/http/http_test.go
@@ -50,7 +50,7 @@ func testRequest(t *testing.T, testURL string) *beat.Event {
 func testTLSRequest(t *testing.T, testURL string, extraConfig map[string]interface{}) *beat.Event {
 	configSrc := map[string]interface{}{
 		"urls":    testURL,
-		"timeout": "2s",
+		"timeout": "5s",
 	}
 
 	if extraConfig != nil {
@@ -231,7 +231,7 @@ func TestLargeResponse(t *testing.T) {
 
 	configSrc := map[string]interface{}{
 		"urls":                server.URL,
-		"timeout":             "2s",
+		"timeout":             "5s",
 		"check.response.body": "x",
 	}
 

--- a/heartbeat/monitors/active/tcp/tcp_test.go
+++ b/heartbeat/monitors/active/tcp/tcp_test.go
@@ -41,7 +41,7 @@ func testTCPCheck(t *testing.T, host string, port uint16) *beat.Event {
 	config, err := common.NewConfigFrom(common.MapStr{
 		"hosts":   host,
 		"ports":   port,
-		"timeout": "1s",
+		"timeout": "2s",
 	})
 	require.NoError(t, err)
 
@@ -64,7 +64,7 @@ func testTLSTCPCheck(t *testing.T, host string, port uint16, certFileName string
 		"hosts":   host,
 		"ports":   int64(port),
 		"ssl":     common.MapStr{"certificate_authorities": certFileName},
-		"timeout": "1s",
+		"timeout": "2s",
 	})
 	require.NoError(t, err)
 

--- a/heartbeat/monitors/active/tcp/tcp_test.go
+++ b/heartbeat/monitors/active/tcp/tcp_test.go
@@ -41,7 +41,7 @@ func testTCPCheck(t *testing.T, host string, port uint16) *beat.Event {
 	config, err := common.NewConfigFrom(common.MapStr{
 		"hosts":   host,
 		"ports":   port,
-		"timeout": "2s",
+		"timeout": "5s",
 	})
 	require.NoError(t, err)
 
@@ -64,7 +64,7 @@ func testTLSTCPCheck(t *testing.T, host string, port uint16, certFileName string
 		"hosts":   host,
 		"ports":   int64(port),
 		"ssl":     common.MapStr{"certificate_authorities": certFileName},
-		"timeout": "2s",
+		"timeout": "5s",
 	})
 	require.NoError(t, err)
 


### PR DESCRIPTION
We are seeing some failures where tests against go httptest servers are failing due to timeouts. These could just be slow servers not working well with our aggressive timeout settings. This PR experiments with doubling those timeouts