### PR TITLE
Fix exclude_labels when there are dotted keys

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -54,6 +54,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 - Enforce validation for the Central Management access token. {issue}9621[9621]
 - Allow to unenroll a Beat from the UI. {issue}9452[9452]
+- Fix exclude_labels when there are dotted keys {pull}10154[10154]
 
 *Auditbeat*
 

--- a/libbeat/common/kubernetes/metadata.go
+++ b/libbeat/common/kubernetes/metadata.go
@@ -87,7 +87,7 @@ func (g *metaGenerator) ResourceMetadata(obj Resource) common.MapStr {
 
 	// Exclude any labels that are present in the exclude_labels config
 	for _, label := range g.ExcludeLabels {
-		delete(labelMap, label)
+		labelMap.Delete(label)
 	}
 
 	annotationsMap := generateMapSubset(objMeta.Annotations, g.IncludeAnnotations, g.AnnotationsDedot)


### PR DESCRIPTION
If there is a label like foo.bar it can't be excluded as we are using `delete` instead of `mapstr.Delete`. This PR addresses that.