### PR TITLE
Cherry-pick #9873 to 6.6: Fix config appender registration

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -35,6 +35,7 @@ https://github.com/elastic/beats/compare/1035569addc4a3b29ffa14f8a08c27c1ace16ef
 - Fix registry handle leak on Windows (https://github.com/elastic/go-sysinfo/pull/33). {pull}9920[9920]
 - Gracefully handle TLS options when enrolling a Beat. {issue}9129[9129]
 - Allow to unenroll a Beat from the UI. {issue}9452[9452]
+- Fix config appender registration. {pull}9873[9873]
 
 *Auditbeat*
 

--- a/libbeat/autodiscover/appenders/config/config.go
+++ b/libbeat/autodiscover/appenders/config/config.go
@@ -20,6 +20,8 @@ package config
 import (
 	"fmt"
 
+	"github.com/pkg/errors"
+
 	"github.com/elastic/beats/libbeat/autodiscover"
 	"github.com/elastic/beats/libbeat/autodiscover/template"
 	"github.com/elastic/beats/libbeat/common"
@@ -38,51 +40,37 @@ type config struct {
 	Config          *common.Config     `config:"config"`
 }
 
-type configs []config
-
-type configMap struct {
+type configAppender struct {
 	condition conditions.Condition
 	config    common.MapStr
-}
-
-type configAppender struct {
-	configMaps []configMap
 }
 
 // NewConfigAppender creates a configAppender that can append templatized configs into built configs
 func NewConfigAppender(cfg *common.Config) (autodiscover.Appender, error) {
 	cfgwarn.Beta("The config appender is beta")
 
-	confs := configs{}
-	err := cfg.Unpack(&confs)
+	config := config{}
+	err := cfg.Unpack(&config)
 	if err != nil {
 		return nil, fmt.Errorf("unable to unpack config appender due to error: %v", err)
 	}
 
-	var configMaps []configMap
-	for _, conf := range confs {
-		var cond conditions.Condition
-
-		if conf.ConditionConfig != nil {
-			cond, err = conditions.NewCondition(conf.ConditionConfig)
-			if err != nil {
-				logp.Warn("config", "unable to create condition due to error: %v", err)
-				continue
-			}
-		}
-		cm := configMap{condition: cond}
-
-		// Unpack the config
-		cf := common.MapStr{}
-		err = conf.Config.Unpack(&cf)
+	var cond conditions.Condition
+	if config.ConditionConfig != nil {
+		cond, err = conditions.NewCondition(config.ConditionConfig)
 		if err != nil {
-			logp.Warn("config", "unable to unpack config due to error: %v", err)
-			continue
+			return nil, errors.Wrap(err, "unable to create condition due to error")
 		}
-		cm.config = cf
-		configMaps = append(configMaps, cm)
 	}
-	return &configAppender{configMaps: configMaps}, nil
+
+	// Unpack the config
+	cf := common.MapStr{}
+	err = config.Config.Unpack(&cf)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to unpack config due to error")
+	}
+
+	return &configAppender{condition: cond, config: cf}, nil
 }
 
 // Append adds configuration into configs built by builds/templates. It applies conditions to filter out
@@ -99,25 +87,23 @@ func (c *configAppender) Append(event bus.Event) {
 	if !ok {
 		return
 	}
-	for _, configMap := range c.configMaps {
-		if configMap.condition == nil || configMap.condition.Check(common.MapStr(event)) == true {
-			// Merge the template with all the configs
-			for _, cfg := range cfgs {
-				cf := common.MapStr{}
-				err := cfg.Unpack(&cf)
-				if err != nil {
-					logp.Debug("config", "unable to unpack config due to error: %v", err)
-					continue
-				}
-				err = cfg.Merge(&configMap.config)
-				if err != nil {
-					logp.Debug("config", "unable to merge configs due to error: %v", err)
-				}
+	if c.condition == nil || c.condition.Check(common.MapStr(event)) == true {
+		// Merge the template with all the configs
+		for _, cfg := range cfgs {
+			cf := common.MapStr{}
+			err := cfg.Unpack(&cf)
+			if err != nil {
+				logp.Debug("config", "unable to unpack config due to error: %v", err)
+				continue
 			}
-
-			// Apply the template
-			template.ApplyConfigTemplate(event, cfgs)
+			err = cfg.Merge(&c.config)
+			if err != nil {
+				logp.Debug("config", "unable to merge configs due to error: %v", err)
+			}
 		}
+
+		// Apply the template
+		template.ApplyConfigTemplate(event, cfgs)
 	}
 
 	// Replace old config with newly appended configs

--- a/libbeat/autodiscover/config.go
+++ b/libbeat/autodiscover/config.go
@@ -19,7 +19,6 @@ package autodiscover
 
 import (
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/conditions"
 )
 
 // Config settings for Autodiscover
@@ -39,6 +38,5 @@ type BuilderConfig struct {
 
 // AppenderConfig settings
 type AppenderConfig struct {
-	Type            string             `config:"type"`
-	ConditionConfig *conditions.Config `config:"condition"`
+	Type string `config:"type"`
 }

--- a/libbeat/cmd/instance/imports.go
+++ b/libbeat/cmd/instance/imports.go
@@ -18,6 +18,7 @@
 package instance
 
 import (
+	_ "github.com/elastic/beats/libbeat/autodiscover/appenders/config" // Register autodiscover appenders
 	_ "github.com/elastic/beats/libbeat/autodiscover/providers/docker" // Register autodiscover providers
 	_ "github.com/elastic/beats/libbeat/autodiscover/providers/jolokia"
 	_ "github.com/elastic/beats/libbeat/autodiscover/providers/kubernetes"

--- a/metricbeat/tests/system/test_autodiscover.py
+++ b/metricbeat/tests/system/test_autodiscover.py
@@ -95,3 +95,51 @@ class TestAutodiscover(metricbeat.BaseTest):
         # Check metadata is added
         assert output[0]['docker']['container']['image'] == 'memcached:latest'
         assert 'name' in output[0]['docker']['container']
+
+    @unittest.skipIf(not INTEGRATION_TESTS or
+                     os.getenv("TESTING_ENVIRONMENT") == "2x",
+                     "integration test not available on 2.x")
+    def test_config_appender(self):
+        """
+        Test config appenders correctly updates configs
+        """
+        import docker
+        docker_client = docker.from_env()
+
+        self.render_config_template(
+            autodiscover={
+                'docker': {
+                    'hints.enabled': 'true',
+                    'appenders': '''
+                      - type: config
+                        condition:
+                          equals.docker.container.image: memcached:latest
+                        config:
+                          fields:
+                            foo: bar
+                    ''',
+                },
+            },
+        )
+
+        proc = self.start_beat()
+        docker_client.images.pull('memcached:latest')
+        labels = {
+            'co.elastic.metrics/module': 'memcached',
+            'co.elastic.metrics/period': '1s',
+            'co.elastic.metrics/hosts': "'${data.host}:11211'",
+        }
+        container = docker_client.containers.run('memcached:latest', labels=labels, detach=True)
+
+        self.wait_until(lambda: self.log_contains('Starting runner: memcached'))
+
+        self.wait_until(lambda: self.output_count(lambda x: x >= 1))
+        container.stop()
+
+        self.wait_until(lambda: self.log_contains('Stopping runner: memcached'))
+
+        output = self.read_output_json()
+        proc.check_kill_and_wait()
+
+        # Check field is added
+        assert output[0]['fields']['foo'] == 'bar'


### PR DESCRIPTION
Cherry-pick of PR #9873 to 6.6 branch. Original message: 

Autodiscover config wasn't regsistered, this change updates the code,
adds integration tests and makes sure that the appender is correctly
registered and working.

closes elastic/beats#9817