### PR TITLE
[Heartbeat] Fixes broken timestamps in monitors with mode: all

### DIFF
--- a/heartbeat/monitors/util.go
+++ b/heartbeat/monitors/util.go
@@ -260,7 +260,7 @@ func MakeByHostJob(
 		return makeByHostAnyIPJob(settings, host, pingFactory), nil
 	}
 
-	return makeByHostAllIPJob(settings, host, pingFactory), nil
+	return TimeAndCheckJob(makeByHostAllIPJob(settings, host, pingFactory)), nil
 }
 
 func makeByHostAnyIPJob(


### PR DESCRIPTION
This broke in e2701baa2d56b147f8f22a17ea0ab07c538485ff

It was patched in master in d60330cd97d1126b3eb23536a4294ca610e5b517 but that cannot be backported to 6.x due to it building off additional work in master. This is a minimal patch, while d60330cd97d1126b3eb23536a4294ca610e5b517 sought to fix the structural issues that led to this being overlooked.

This patch does not contain tests. Normally, that would not be OK, but I think it's appropriate here because d60330cd97d1126b3eb23536a4294ca610e5b517 does indeed contain tests, and the current code structure makes testing complex, especially with mode: all since we'd need to determine a way to fake multiple A records or setup a complex mocking infrastructure. Since this can be easily manually tested, I think we're fine here given that 6.7 is the end of the road for the 6.x series of heartbeat.

To manually test this use the following config:

```yml
- type: http
  urls: ["http://elastic.co"] // has two A records
  mode: all
  schedule: '@every 1s'
```

simply check that in Elasticsearch there is one heartbeat index, not one timestamped at the year 0001.