### PR TITLE
[Docs] APM additions and code cleanup

### DIFF
--- a/libbeat/docs/command-reference.asciidoc
+++ b/libbeat/docs/command-reference.asciidoc
@@ -546,6 +546,22 @@ the end of the file is reached. By default harvesters are closed after
 `close_inactive` is reached.
 endif::[]
 
+<<<<<<< HEAD
+=======
+*`--setup`*::
+ifdef::has_ml_jobs[]
+Loads the initial setup, including Elasticsearch template, {kib} index pattern,
+{kib} dashboards (when available), and Machine learning jobs.
+endif::has_ml_jobs[]
+ifdef::no_dashboards[]
+Loads the initial setup, including Elasticsearch template.
+endif::no_dashboards[]
+ifndef::has_ml_jobs,no_dashboards[]
+Loads the initial setup, including Elasticsearch template, {kib} index pattern, and {kib} dashboards (when available).
+endif::has_ml_jobs,no_dashboards[]
+If you want to use the command without running {beatname_uc}, use the <<setup-command,`setup`>> command instead.
+
+>>>>>>> docs: remove kib index pattern
 ifeval::["{beatname_lc}"=="metricbeat"]
 *`--system.hostfs MOUNT_POINT`*::
 

--- a/libbeat/docs/command-reference.asciidoc
+++ b/libbeat/docs/command-reference.asciidoc
@@ -36,7 +36,7 @@ ifdef::has_ml_jobs[]
 endif::[]
 
 ifdef::no_dashboards[]
-:setup-command-short-desc: Sets up the initial environment, including the ES index template.
+:setup-command-short-desc: Sets up the initial environment, including the ES index template
 endif::no_dashboards[]
 
 ifndef::has_ml_jobs,no_dashboards[]

--- a/libbeat/docs/command-reference.asciidoc
+++ b/libbeat/docs/command-reference.asciidoc
@@ -15,7 +15,15 @@
 :global-flags: Also see <<global-flags,Global flags>>.
 
 :deploy-command-short-desc: Deploys the specified function to your serverless environment
+
+ifndef::no_dashboards_apm[]
 :export-command-short-desc: Exports the configuration, index template, or a dashboard to stdout
+endif::no_dashboards_apm[]
+
+ifdef::no_dashboards_apm[]
+:export-command-short-desc: Exports the configuration or index template to stdout
+endif::no_dashboards_apm[]
+
 :help-command-short-desc: Shows help for any command
 :keystore-command-short-desc: Manages the <<keystore,secrets keystore>>
 :modules-command-short-desc: Manages configured modules
@@ -27,11 +35,11 @@ ifdef::has_ml_jobs[]
 :setup-command-short-desc: Sets up the initial environment, including the index template, {kib} dashboards (when available), and machine learning jobs (when available)
 endif::[]
 
-ifdef::no_dashboards[]
+ifdef::no_dashboards_apm[]
 :setup-command-short-desc: Sets up the initial environment, including the ES index template.
-endif::no_dashboards[]
+endif::no_dashboards_apm[]
 
-ifndef::has_ml_jobs,no_dashboards[]
+ifndef::has_ml_jobs,no_dashboards_apm[]
 :setup-command-short-desc: Sets up the initial environment, including the index template and {kib} dashboards (when available)
 endif::[]
 
@@ -47,15 +55,15 @@ endif::[]
 <titleabbrev>Command reference</titleabbrev>
 ++++
 
-ifndef::no_dashboards[]
+ifndef::no_dashboards_apm[]
 {beatname_uc} provides a command-line interface for starting {beatname_uc} and
 performing common tasks, like testing configuration files and loading dashboards.
-endif::[]
+endif::no_dashboards_apm[]
 
-ifdef::no_dashboards[]
+ifdef::no_dashboards_apm[]
 {beatname_uc} provides a command-line interface for starting {beatname_uc} and
 performing common tasks, like testing configuration files.
-endif::[]
+endif::no_dashboards_apm[]
 
 The command-line also supports <<global-flags,global flags>>
 for controlling global behaviors.
@@ -134,9 +142,17 @@ endif::[]
 [[export-command]]
 ==== `export` command
 
+ifndef::no_dashboards_apm[]
 {export-command-short-desc}. You can use this
 command to quickly view your configuration, see the contents of the index
 template, or export a dashboard from {kib}.
+endif::no_dashboards_apm[]
+
+ifdef::no_dashboards_apm[]
+{export-command-short-desc}. You can use this
+command to quickly view your configuration or see the contents of the index
+template.
+endif::no_dashboards_apm[]
 
 *SYNOPSIS*
 
@@ -151,6 +167,7 @@ template, or export a dashboard from {kib}.
 Exports the current configuration to stdout. If you use the `-c` flag, this
 command exports the configuration that's defined in the specified file.
 
+ifndef::no_dashboards_apm[]
 [[dashboard-subcommand]]*`dashboard`*::
 Exports a dashboard. You can use this option to store a dashboard on disk in a
 module and load it automatically. For example, to export the dashboard to a JSON
@@ -173,6 +190,7 @@ To load the dashboard, copy the generated `dashboard.json` file into the
 +
 If {kib} is not running on `localhost:5061`, you must also adjust the
 {beatname_uc} configuration under `setup.kibana`.
+endif::no_dashboards_apm[]
 
 [[template-subcommand]]*`template`*::
 Exports the index template to stdout. You can specify the `--es.version` and
@@ -196,20 +214,31 @@ When used with <<template-subcommand,`template`>>, sets the base name to use for
 the index template. If this flag is not specified, the default base name is
 +{beatname_lc}+.
 
+ifndef::no_dashboards_apm[]
 *`--id DASHBOARD_ID`*::
 When used with <<dashboard-subcommand,`dashboard`>>, specifies the dashboard ID.
+endif::no_dashboards_apm[]
 
 {global-flags}
 
 *EXAMPLES*
 
+ifndef::no_dashboards_apm[]
 ["source","sh",subs="attributes"]
 -----
 {beatname_lc} export config
 {beatname_lc} export template --es.version {stack-version} --index myindexname
 {beatname_lc} export dashboard --id="a7b35890-8baa-11e8-9676-ef67484126fb" > dashboard.json
 -----
+endif::no_dashboards_apm[]
 
+ifdef::no_dashboards_apm[]
+["source","sh",subs="attributes"]
+-----
+{beatname_lc} export config
+{beatname_lc} export template --es.version {stack-version} --index myindexname
+-----
+endif::no_dashboards_apm[]
 
 [[help-command]]
 ==== `help` command
@@ -554,8 +583,10 @@ Or:
 
 * The index template ensures that fields are mapped correctly in Elasticsearch.
 
+ifndef::no_dashboards[]
 * The {kib} dashboards make it easier for you to visualize {beatname_uc} data
 in {kib}.
+endif::no_dashboards[]
 
 ifdef::has_ml_jobs[]
 * The machine learning jobs contain the configuration information and metadata

--- a/libbeat/docs/command-reference.asciidoc
+++ b/libbeat/docs/command-reference.asciidoc
@@ -23,22 +23,16 @@
 :remove-command-short-desc: Removes the specified function from your serverless environment
 :run-command-short-desc: Runs {beatname_uc}. This command is used by default if you start {beatname_uc} without specifying a command
 
-ifndef::deprecate_dashboard_loading[]
-
 ifdef::has_ml_jobs[]
 :setup-command-short-desc: Sets up the initial environment, including the index template, {kib} dashboards (when available), and machine learning jobs (when available)
 endif::[]
 
-ifndef::has_ml_jobs[]
+ifdef::no_dashboards[]
+:setup-command-short-desc: Sets up the initial environment, including the ES index template.
+endif::no_dashboards[]
+
+ifndef::has_ml_jobs,no_dashboards[]
 :setup-command-short-desc: Sets up the initial environment, including the index template and {kib} dashboards (when available)
-endif::[]
-
-endif::[]
-
-ifdef::deprecate_dashboard_loading[]
-
-:setup-command-short-desc: Sets up the initial environment, including the ES index template and {kib} dashboards (deprecated).
-
 endif::[]
 
 :update-command-short-desc: Updates the specified function
@@ -53,12 +47,12 @@ endif::[]
 <titleabbrev>Command reference</titleabbrev>
 ++++
 
-ifndef::deprecate_dashboard_loading[]
+ifndef::no_dashboards[]
 {beatname_uc} provides a command-line interface for starting {beatname_uc} and
 performing common tasks, like testing configuration files and loading dashboards.
 endif::[]
 
-ifdef::deprecate_dashboard_loading[]
+ifdef::no_dashboards[]
 {beatname_uc} provides a command-line interface for starting {beatname_uc} and
 performing common tasks, like testing configuration files.
 endif::[]
@@ -581,21 +575,13 @@ Use this command if you want to set up the environment without actually running
 
 *FLAGS*
 
-ifndef::deprecate_dashboard_loading[]
+ifndef::no_dashboards[]
 *`--dashboards`*::
 Sets up the {kib} dashboards (when available). This option loads the dashboards
 from the {beatname_uc} package. For more options, such as loading customized
 dashboards, see {beatsdevguide}/import-dashboards.html[Importing Existing Beat
 Dashboards] in the _Beats Developer Guide_.
-endif::[]
-
-ifdef::deprecate_dashboard_loading[]
-*`--dashboards`*::
-
-deprecated[{deprecate_dashboard_loading}]
-+
-Sets up the {kib} dashboards only.
-endif::[]
+endif::no_dashboards[]
 
 *`-h, --help`*::
 Shows help for the `setup` command.

--- a/libbeat/docs/command-reference.asciidoc
+++ b/libbeat/docs/command-reference.asciidoc
@@ -16,13 +16,13 @@
 
 :deploy-command-short-desc: Deploys the specified function to your serverless environment
 
-ifndef::no_dashboards_apm[]
+ifndef::no_dashboards[]
 :export-command-short-desc: Exports the configuration, index template, or a dashboard to stdout
-endif::no_dashboards_apm[]
+endif::no_dashboards[]
 
-ifdef::no_dashboards_apm[]
+ifdef::no_dashboards[]
 :export-command-short-desc: Exports the configuration or index template to stdout
-endif::no_dashboards_apm[]
+endif::no_dashboards[]
 
 :help-command-short-desc: Shows help for any command
 :keystore-command-short-desc: Manages the <<keystore,secrets keystore>>
@@ -35,11 +35,11 @@ ifdef::has_ml_jobs[]
 :setup-command-short-desc: Sets up the initial environment, including the index template, {kib} dashboards (when available), and machine learning jobs (when available)
 endif::[]
 
-ifdef::no_dashboards_apm[]
+ifdef::no_dashboards[]
 :setup-command-short-desc: Sets up the initial environment, including the ES index template.
-endif::no_dashboards_apm[]
+endif::no_dashboards[]
 
-ifndef::has_ml_jobs,no_dashboards_apm[]
+ifndef::has_ml_jobs,no_dashboards[]
 :setup-command-short-desc: Sets up the initial environment, including the index template and {kib} dashboards (when available)
 endif::[]
 
@@ -55,15 +55,15 @@ endif::[]
 <titleabbrev>Command reference</titleabbrev>
 ++++
 
-ifndef::no_dashboards_apm[]
+ifndef::no_dashboards[]
 {beatname_uc} provides a command-line interface for starting {beatname_uc} and
 performing common tasks, like testing configuration files and loading dashboards.
-endif::no_dashboards_apm[]
+endif::no_dashboards[]
 
-ifdef::no_dashboards_apm[]
+ifdef::no_dashboards[]
 {beatname_uc} provides a command-line interface for starting {beatname_uc} and
 performing common tasks, like testing configuration files.
-endif::no_dashboards_apm[]
+endif::no_dashboards[]
 
 The command-line also supports <<global-flags,global flags>>
 for controlling global behaviors.
@@ -142,17 +142,17 @@ endif::[]
 [[export-command]]
 ==== `export` command
 
-ifndef::no_dashboards_apm[]
+ifndef::no_dashboards[]
 {export-command-short-desc}. You can use this
 command to quickly view your configuration, see the contents of the index
 template, or export a dashboard from {kib}.
-endif::no_dashboards_apm[]
+endif::no_dashboards[]
 
-ifdef::no_dashboards_apm[]
+ifdef::no_dashboards[]
 {export-command-short-desc}. You can use this
 command to quickly view your configuration or see the contents of the index
 template.
-endif::no_dashboards_apm[]
+endif::no_dashboards[]
 
 *SYNOPSIS*
 
@@ -167,7 +167,7 @@ endif::no_dashboards_apm[]
 Exports the current configuration to stdout. If you use the `-c` flag, this
 command exports the configuration that's defined in the specified file.
 
-ifndef::no_dashboards_apm[]
+ifndef::no_dashboards[]
 [[dashboard-subcommand]]*`dashboard`*::
 Exports a dashboard. You can use this option to store a dashboard on disk in a
 module and load it automatically. For example, to export the dashboard to a JSON
@@ -190,7 +190,7 @@ To load the dashboard, copy the generated `dashboard.json` file into the
 +
 If {kib} is not running on `localhost:5061`, you must also adjust the
 {beatname_uc} configuration under `setup.kibana`.
-endif::no_dashboards_apm[]
+endif::no_dashboards[]
 
 [[template-subcommand]]*`template`*::
 Exports the index template to stdout. You can specify the `--es.version` and
@@ -214,31 +214,31 @@ When used with <<template-subcommand,`template`>>, sets the base name to use for
 the index template. If this flag is not specified, the default base name is
 +{beatname_lc}+.
 
-ifndef::no_dashboards_apm[]
+ifndef::no_dashboards[]
 *`--id DASHBOARD_ID`*::
 When used with <<dashboard-subcommand,`dashboard`>>, specifies the dashboard ID.
-endif::no_dashboards_apm[]
+endif::no_dashboards[]
 
 {global-flags}
 
 *EXAMPLES*
 
-ifndef::no_dashboards_apm[]
+ifndef::no_dashboards[]
 ["source","sh",subs="attributes"]
 -----
 {beatname_lc} export config
 {beatname_lc} export template --es.version {stack-version} --index myindexname
 {beatname_lc} export dashboard --id="a7b35890-8baa-11e8-9676-ef67484126fb" > dashboard.json
 -----
-endif::no_dashboards_apm[]
+endif::no_dashboards[]
 
-ifdef::no_dashboards_apm[]
+ifdef::no_dashboards[]
 ["source","sh",subs="attributes"]
 -----
 {beatname_lc} export config
 {beatname_lc} export template --es.version {stack-version} --index myindexname
 -----
-endif::no_dashboards_apm[]
+endif::no_dashboards[]
 
 [[help-command]]
 ==== `help` command
@@ -549,16 +549,17 @@ endif::[]
 <<<<<<< HEAD
 =======
 *`--setup`*::
+Loads the initial setup, including: 
+
+* Elasticsearch template
 ifdef::has_ml_jobs[]
-Loads the initial setup, including Elasticsearch template, {kib} index pattern,
-{kib} dashboards (when available), and Machine learning jobs.
+* Machine learning jobs
 endif::has_ml_jobs[]
-ifdef::no_dashboards[]
-Loads the initial setup, including Elasticsearch template.
+ifndef::no_dashboards[]
+* {kib} index pattern
+* {kib} dashboards
 endif::no_dashboards[]
-ifndef::has_ml_jobs,no_dashboards[]
-Loads the initial setup, including Elasticsearch template, {kib} index pattern, and {kib} dashboards (when available).
-endif::has_ml_jobs,no_dashboards[]
+
 If you want to use the command without running {beatname_uc}, use the <<setup-command,`setup`>> command instead.
 
 >>>>>>> docs: remove kib index pattern

--- a/libbeat/docs/command-reference.asciidoc
+++ b/libbeat/docs/command-reference.asciidoc
@@ -546,23 +546,6 @@ the end of the file is reached. By default harvesters are closed after
 `close_inactive` is reached.
 endif::[]
 
-<<<<<<< HEAD
-=======
-*`--setup`*::
-Loads the initial setup, including: 
-
-* Elasticsearch template
-ifdef::has_ml_jobs[]
-* Machine learning jobs
-endif::has_ml_jobs[]
-ifndef::no_dashboards[]
-* {kib} index pattern
-* {kib} dashboards
-endif::no_dashboards[]
-
-If you want to use the command without running {beatname_uc}, use the <<setup-command,`setup`>> command instead.
-
->>>>>>> docs: remove kib index pattern
 ifeval::["{beatname_lc}"=="metricbeat"]
 *`--system.hostfs MOUNT_POINT`*::
 

--- a/libbeat/docs/command-reference.asciidoc
+++ b/libbeat/docs/command-reference.asciidoc
@@ -60,7 +60,7 @@ endif::[]
 
 ifdef::deprecate_dashboard_loading[]
 {beatname_uc} provides a command-line interface for starting {beatname_uc} and
-performing common tasks, like testing configuration files and loading dashboards (deprecated).
+performing common tasks, like testing configuration files.
 endif::[]
 
 The command-line also supports <<global-flags,global flags>>

--- a/libbeat/docs/dashboardsconfig.asciidoc
+++ b/libbeat/docs/dashboardsconfig.asciidoc
@@ -11,11 +11,6 @@
 
 [[configuration-dashboards]]
 == Load the Kibana dashboards
-ifdef::deprecate_dashboard_loading[]
-
-deprecated[{deprecate_dashboard_loading}]
-
-endif::[]
 
 {beatname_uc} comes packaged with example Kibana dashboards, visualizations,
 and searches for visualizing {beatname_uc} data in Kibana.

--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -243,9 +243,6 @@ ifndef::no_dashboards[]
 If you are using the pre-built Kibana
 dashboards, you also need to set the `setup.dashboards.index` option (see
 <<configuration-dashboards>>).
-ifdef::deprecate_dashboard_loading[]
-deprecated[{deprecate_dashboard_loading}]
-endif::deprecate_dashboard_loading[]
 endif::no_dashboards[]
 
 You can set the index dynamically by using a format string to access any event

--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -92,10 +92,12 @@ output.elasticsearch:
 For more information about securing {beatname_uc}, see
 <<securing-{beatname_lc}>>.
 
+ifndef::no_ilm[]
 If you are indexing large amounts of time-series data, you might also want to
 configure {beatname_uc} to use index lifecycle management. For more information
 about configuring and using index lifecycle management with {beatname_uc}, see
 <<ilm>>.
+endif::no_ilm[]
 
 ==== Compatibility
 
@@ -339,6 +341,20 @@ This configuration results in indices named `sev1`, `sev2`, and `sev3`.
 The `mappings` setting simplifies the configuration, but is limited to string
 values. You cannot specify format strings within the mapping pairs.
 
+<<<<<<< HEAD
+=======
+//TODO: MOVE ILM OPTIONS TO APPEAR LOGICALLY BASED ON LOCATION IN THE YAML FILE.
+
+ifndef::no_ilm[]
+[[ilm-es]]
+===== `ilm`
+
+Configuration options for index lifecycle management. 
+
+See <<ilm>> for more information.
+endif::no_ilm[]
+
+>>>>>>> docs: add no_ilm attribute
 ifndef::no-pipeline[]
 [[pipeline-option-es]]
 ===== `pipeline`

--- a/libbeat/docs/shared-kibana-config.asciidoc
+++ b/libbeat/docs/shared-kibana-config.asciidoc
@@ -11,22 +11,9 @@
 
 [[setup-kibana-endpoint]]
 == Set up the Kibana endpoint
-ifdef::deprecate_dashboard_loading[]
 
-deprecated[{deprecate_dashboard_loading}]
-
-endif::[]
-
-ifeval::["{beatname_lc}" == "apm-server"]
-The Kibana dashboards are loaded into Kibana via the Kibana API.
-This requires a Kibana endpoint configuration.
-endif::[]
-
-ifeval::["{beatname_lc}" != "apm-server"]
 Starting with {beatname_uc} 6.0.0, the Kibana dashboards are loaded into Kibana
 via the Kibana API. This requires a Kibana endpoint configuration.
-endif::[]
-
 
 You configure the endpoint in the `setup.kibana` section of the
 +{beatname_lc}.yml+ config file.

--- a/libbeat/docs/shared-template-load.asciidoc
+++ b/libbeat/docs/shared-template-load.asciidoc
@@ -79,7 +79,7 @@ output.elasticsearch.index: "customname-%{[{beat_version_key}]}-%{+yyyy.MM.dd}"
 setup.template.name: "customname"
 setup.template.pattern: "customname-*"
 -----
-ifndef::deprecate_dashboard_loading,no_dashboards[]
+ifndef::no_dashboards[]
 +
 If you're using pre-built Kibana dashboards, also set the
 `setup.dashboards.index` option. For example: 
@@ -88,12 +88,11 @@ If you're using pre-built Kibana dashboards, also set the
 ----
 setup.dashboards.index: "customname-*"
 ----
-endif::[]
+endif::no_dashboards[]
 
-ifdef::deprecate_dashboard_loading[]
-+
+ifdef::no_dashboards[]
 Remember to change the index name when you load dashboards via the Kibana UI.
-endif::[]
+endif::no_dashboards[]
 
 See <<configuration-template>> for the full list of configuration options.
 


### PR DESCRIPTION
This PR attempts to accomplish four things:

* Removes unused APM conditionals
* Removes the now outdated `deprecate_dashboards` attribute. Switches to `no_dashboards` attribute (currently used by x-pack and journalbeat).
* Fix "triple conditional" formatting by removing nested conditionals and replacing with easier to read code.
* Removes new ILM links for APM

Changes mirrored in apm-server repo: https://github.com/elastic/apm-server/pull/1791