### PR TITLE
Add time encoders to disk spool

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -154,6 +154,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - The backing off now implements jitter to better distribute the load. {issue}10172[10172]
 - Fix TLS certificate DoS vulnerability. {pull}10302[10302]
 - Fix panic and file unlock in spool on atomic operation (arm, x86-32). File lock was not released when panic occurs, leading to the beat deadlocking on startup. {pull}10289[10289]
+- Fix encoding of timestamps when using disk spool. {issue}10099[10099]
 
 *Auditbeat*
 

--- a/libbeat/publisher/queue/spool/codec.go
+++ b/libbeat/publisher/queue/spool/codec.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/outputs/codec"
 	"github.com/elastic/beats/libbeat/publisher"
 	"github.com/elastic/go-structform"
 	"github.com/elastic/go-structform/cborl"
@@ -95,7 +96,12 @@ func (e *encoder) reset() {
 		panic("no codec configured")
 	}
 
-	folder, err := gotype.NewIterator(visitor)
+	folder, err := gotype.NewIterator(visitor,
+		gotype.Folders(
+			codec.MakeTimestampEncoder(),
+			codec.MakeBCTimestampEncoder(),
+		),
+	)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Register encoders for time.Time and common.Time so that events containing timestamps
can be serialized.

Fixes #10099