### PR TITLE
Add support for migration alias in index pattern

### DIFF
--- a/dev-tools/cmd/kibana_index_pattern/kibana_index_pattern.go
+++ b/dev-tools/cmd/kibana_index_pattern/kibana_index_pattern.go
@@ -41,6 +41,7 @@ var (
 	indexPattern   string
 	fieldsYAMLFile string
 	outputDir      string
+	migration      bool
 )
 
 func init() {
@@ -49,6 +50,7 @@ func init() {
 	flag.StringVar(&indexPattern, "index", "", "Kibana index pattern. (Required)")
 	flag.StringVar(&fieldsYAMLFile, "fields", "fields.yml", "fields.yml file containing all fields used by the Beat.")
 	flag.StringVar(&outputDir, "out", "build/kibana", "Output dir.")
+	flag.BoolVar(&migration, "migration", false, "Enable migration fields in index pattern.")
 }
 
 func main() {
@@ -68,11 +70,11 @@ func main() {
 	}
 
 	versions := []string{
-		"6.0.0",
+		"7.0.0",
 	}
 	for _, version := range versions {
 		version, _ := common.NewVersion(version)
-		indexPattern, err := kibana.NewGenerator(indexPattern, beatName, fieldsYAMLFile, outputDir, beatVersion, *version)
+		indexPattern, err := kibana.NewGenerator(indexPattern, beatName, fieldsYAMLFile, outputDir, beatVersion, *version, migration)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/libbeat/kibana/fields_transformer.go
+++ b/libbeat/kibana/fields_transformer.go
@@ -32,9 +32,10 @@ type fieldsTransformer struct {
 	transformedFieldFormatMap common.MapStr
 	version                   *common.Version
 	keys                      map[string]int
+	migration                 bool
 }
 
-func newFieldsTransformer(version *common.Version, fields common.Fields) (*fieldsTransformer, error) {
+func newFieldsTransformer(version *common.Version, fields common.Fields, migration bool) (*fieldsTransformer, error) {
 	if version == nil {
 		return nil, errors.New("Version must be given")
 	}
@@ -44,6 +45,7 @@ func newFieldsTransformer(version *common.Version, fields common.Fields) (*field
 		transformedFields:         []common.MapStr{},
 		transformedFieldFormatMap: common.MapStr{},
 		keys:                      map[string]int{},
+		migration:                 migration,
 	}, nil
 }
 
@@ -87,6 +89,9 @@ func (t *fieldsTransformer) transformFields(commonFields common.Fields, path str
 			}
 		} else {
 			if f.Type == "alias" {
+				if f.MigrationAlias && !t.migration {
+					continue
+				}
 				if t.version.LessThan(v640) {
 					continue
 				}

--- a/libbeat/kibana/index_pattern_generator.go
+++ b/libbeat/kibana/index_pattern_generator.go
@@ -34,10 +34,11 @@ type IndexPatternGenerator struct {
 	version        common.Version
 	targetDir      string
 	targetFilename string
+	migration      bool
 }
 
 // Create an instance of the Kibana Index Pattern Generator
-func NewGenerator(indexName, beatName, fieldsYAMLFile, outputDir, beatVersion string, version common.Version) (*IndexPatternGenerator, error) {
+func NewGenerator(indexName, beatName, fieldsYAMLFile, outputDir, beatVersion string, version common.Version, migration bool) (*IndexPatternGenerator, error) {
 	beatName = clean(beatName)
 
 	if _, err := os.Stat(fieldsYAMLFile); err != nil {
@@ -51,6 +52,7 @@ func NewGenerator(indexName, beatName, fieldsYAMLFile, outputDir, beatVersion st
 		version:        version,
 		targetDir:      createTargetDir(outputDir, version),
 		targetFilename: beatName + ".json",
+		migration:      migration,
 	}, nil
 }
 
@@ -125,7 +127,7 @@ func (i *IndexPatternGenerator) addFieldsSpecific(indexPattern *common.MapStr) e
 	if err != nil {
 		return err
 	}
-	transformer, err := newFieldsTransformer(&i.version, fields)
+	transformer, err := newFieldsTransformer(&i.version, fields, i.migration)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
When generating the index pattern, the migration flag can be passed. If set to true, also migration alias are added to the Kibana index pattern.

The problem at the moment is that the index pattern is shipped as part of the package. Instead it should be generated on demand so it can be adjusted based on the configs like the Elasticsearch index template.