### PR TITLE
Cherry-pick #10185 to 6.x: Adding fields to achieve parity with internal collection

### DIFF
--- a/metricbeat/module/kibana/stats/data_xpack.go
+++ b/metricbeat/module/kibana/stats/data_xpack.go
@@ -45,6 +45,10 @@ var (
 				"used_in_bytes":  c.Int("used_bytes"),
 			}),
 			"uptime_in_millis": c.Int("uptime_ms"),
+			"distro":           c.Str("distro", s.Optional),
+			"distroRelease":    c.Str("distro_release", s.Optional),
+			"platform":         c.Str("platform", s.Optional),
+			"platformRelease":  c.Str("platform_release", s.Optional),
 		}),
 		"process": c.Dict("process", s.Schema{
 			"event_loop_delay": c.Float("event_loop_delay"),


### PR DESCRIPTION
Cherry-pick of PR #10185 to 6.x branch. Original message: 

Resolves #9985.

This PR teaches the `kibana/stats` x-pack metricset code to ingest four new fields now exposed by the Kibana Stats API (http://localhost:5601/api/stats?extended):

* `os.distro`
* `os.distro_release` (indexed into Kibana monitoring docs as `distroRelease` by internal collection)
* `os.platform`
* `os.platform_release` (indexed into Kibana monitoring docs as `platformRelease` by internal collection)

These fields are being collected by Kibana's internal monitoring collection mechanism so they need to be collected by Metricbeat as well.

Note that the fields are marked as optional since a user could run a version of Metricbeat that has the changes in this PR with an older version of Kibana. Also, the `distro` and `distro_release` fields seem to be absent under certain conditions.

### Testing this PR

1. Setup internal collection/monitoring of Kibana. Easiest way to do this is to click the "Turn on monitoring" button in the Monitoring UI.
2. Wait 20 seconds for internal collection to happen.
3. Grab an internally-collected Kibana monitoring document and notice the fields under the `os` field, particularly the ones added in this PR:
   ```
   GET .monitoring-kibana-6-2*/_search?filter_path=hits.hits._source.kibana_stats.os
   ```
4. Setup Metricbeat collection/monitoring of Kibana. See https://www.elastic.co/guide/en/kibana/current/monitoring-metricbeat.html.
5. Wait 20 seconds for Metricbeat collection to happen.
6. Grab an Metricbeat-collected Kibana monitoring document and notice the fields under the `os` field, particularly the ones added in this PR:
   ```
   GET .monitoring-kibana-6-mb-*/_search?filter_path=hits.hits._source.kibana_stats.os
   ```
7. Compare the fields collected under the `os` field between steps 3 and 6. They should be identical.