### PR TITLE
Remove experimental log message when xpack.enabled flag is set

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -196,6 +196,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Release Dropwizard module as GA. {pull}10240[10240]
 - Release Graphite module as GA. {pull}10240[10240]
 - Release http.server metricset as GA. {pull}10240[10240]
+- Making RabbitMQ Metricbeat module GA. {pull}10165[10165]
+- Release use of xpack.enabled: true flag in Elasticsearch and Kibana modules as GA. {pull}10222[10222]
 
 *Packetbeat*
 

--- a/metricbeat/docs/modules/elasticsearch.asciidoc
+++ b/metricbeat/docs/modules/elasticsearch.asciidoc
@@ -42,6 +42,10 @@ metricbeat.modules:
 
   # Set to false to fetch all entries
   #index_recovery.active_only: true
+
+  # Set to true to send data collected by module to X-Pack
+  # Monitoring instead of metricbeat-* indices.
+  #xpack.enabled: false
 ----
 
 This module supports TLS connections when using `ssl` config field, as described in <<configuration-ssl>>.

--- a/metricbeat/docs/modules/kibana.asciidoc
+++ b/metricbeat/docs/modules/kibana.asciidoc
@@ -30,6 +30,10 @@ metricbeat.modules:
   hosts: ["localhost:5601"]
   basepath: ""
   enabled: true
+
+  # Set to true to send data collected by module to X-Pack
+  # Monitoring instead of metricbeat-* indices.
+  #xpack.enabled: false
 ----
 
 This module supports TLS connections when using `ssl` config field, as described in <<configuration-ssl>>.

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -217,6 +217,10 @@ metricbeat.modules:
   # Set to false to fetch all entries
   #index_recovery.active_only: true
 
+  # Set to true to send data collected by module to X-Pack
+  # Monitoring instead of metricbeat-* indices.
+  #xpack.enabled: false
+
 #----------------------------- envoyproxy Module -----------------------------
 - module: envoyproxy
   metricsets: ["server"]
@@ -367,6 +371,10 @@ metricbeat.modules:
   hosts: ["localhost:5601"]
   basepath: ""
   enabled: true
+
+  # Set to true to send data collected by module to X-Pack
+  # Monitoring instead of metricbeat-* indices.
+  #xpack.enabled: false
 
 #----------------------------- Kubernetes Module -----------------------------
 # Node metrics, from kubelet:

--- a/metricbeat/module/elasticsearch/_meta/config.reference.yml
+++ b/metricbeat/module/elasticsearch/_meta/config.reference.yml
@@ -15,3 +15,7 @@
 
   # Set to false to fetch all entries
   #index_recovery.active_only: true
+
+  # Set to true to send data collected by module to X-Pack
+  # Monitoring instead of metricbeat-* indices.
+  #xpack.enabled: false

--- a/metricbeat/module/elasticsearch/metricset.go
+++ b/metricbeat/module/elasticsearch/metricset.go
@@ -18,7 +18,6 @@
 package elasticsearch
 
 import (
-	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/metricbeat/helper"
 	"github.com/elastic/beats/metricbeat/mb"
@@ -63,10 +62,6 @@ func NewMetricSet(base mb.BaseMetricSet, servicePath string) (*MetricSet, error)
 	}
 	if err := base.Module().UnpackConfig(&config); err != nil {
 		return nil, err
-	}
-
-	if config.XPack {
-		cfgwarn.Experimental("The experimental xpack.enabled flag in " + base.FullyQualifiedName() + " metricset is enabled.")
 	}
 
 	ms := &MetricSet{

--- a/metricbeat/module/kibana/_meta/config.reference.yml
+++ b/metricbeat/module/kibana/_meta/config.reference.yml
@@ -4,3 +4,7 @@
   hosts: ["localhost:5601"]
   basepath: ""
   enabled: true
+
+  # Set to true to send data collected by module to X-Pack
+  # Monitoring instead of metricbeat-* indices.
+  #xpack.enabled: false

--- a/metricbeat/module/kibana/metricset.go
+++ b/metricbeat/module/kibana/metricset.go
@@ -18,7 +18,6 @@
 package kibana
 
 import (
-	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/metricbeat/mb"
 )
@@ -36,10 +35,6 @@ func NewMetricSet(base mb.BaseMetricSet) (*MetricSet, error) {
 	config := DefaultConfig()
 	if err := base.Module().UnpackConfig(&config); err != nil {
 		return nil, err
-	}
-
-	if config.XPackEnabled {
-		cfgwarn.Experimental("The experimental xpack.enabled flag in the " + base.FullyQualifiedName() + " metricset is enabled.")
 	}
 
 	return &MetricSet{

--- a/metricbeat/module/kibana/stats/stats.go
+++ b/metricbeat/module/kibana/stats/stats.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/metricbeat/helper"
 	"github.com/elastic/beats/metricbeat/helper/elastic"
 	"github.com/elastic/beats/metricbeat/mb"
@@ -86,16 +85,12 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	}
 
 	if ms.XPackEnabled {
-		cfgwarn.Experimental("The experimental xpack.enabled flag in the " + ms.FullyQualifiedName() + " metricset is enabled.")
-
 		// Use legacy API response so we can passthru usage as-is
 		statsHTTP.SetURI(statsHTTP.GetURI() + "&legacy=true")
 	}
 
 	var settingsHTTP *helper.HTTP
 	if ms.XPackEnabled {
-		cfgwarn.Experimental("The experimental xpack.enabled flag in the " + ms.FullyQualifiedName() + " metricset is enabled.")
-
 		isSettingsAPIAvailable := kibana.IsSettingsAPIAvailable(kibanaVersion)
 		if err != nil {
 			return nil, err

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -226,6 +226,10 @@ metricbeat.modules:
   # Set to false to fetch all entries
   #index_recovery.active_only: true
 
+  # Set to true to send data collected by module to X-Pack
+  # Monitoring instead of metricbeat-* indices.
+  #xpack.enabled: false
+
 #------------------------------ Envoyproxy Module ------------------------------
 - module: envoyproxy
   metricsets: ["server"]
@@ -376,6 +380,10 @@ metricbeat.modules:
   hosts: ["localhost:5601"]
   basepath: ""
   enabled: true
+
+  # Set to true to send data collected by module to X-Pack
+  # Monitoring instead of metricbeat-* indices.
+  #xpack.enabled: false
 
 #------------------------------ Kubernetes Module ------------------------------
 # Node metrics, from kubelet:


### PR DESCRIPTION
The Elasticsearch and Kibana Metricbeat modules support an `xpack.enabled` flag. This flag's value defaults to `false`, causing these modules to index their data into `metricbeat-*` indices, as is normal with all other Metricbeat modules.

However, we want to use these modules for Stack Monitoring as well. Concretely, this means that these modules' data would need to be indexed into `.monitoring-*` indices instead of `metricbeat-*` indices. This change of indexing target is enabled by setting `xpack.enabled: true`.

Until this PR, setting `xpack.enabled: true` and the code path that it enabled was marked as experimental. Log messages in the Metricbeat logs would inform the users as such.

This PR removes these log messages and thus makes the use of this flag as GA. It also documents this flag in the modules' configuration yaml files.