### PR TITLE
[Auditbeat] Enable System module config on Windows

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -93,6 +93,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Auditbeat*
 
+- Enable System module config on Windows. {pull}10237[10237]
+
 *Filebeat*
 
 - Add `convert_timezone` option to Elasticsearch module to convert dates to UTC. {issue}9756[9756] {pull}9761[9761]

--- a/x-pack/auditbeat/module/system/_meta/config.yml.tmpl
+++ b/x-pack/auditbeat/module/system/_meta/config.yml.tmpl
@@ -1,4 +1,3 @@
-{{ if ne .GOOS "windows" -}}
 {{ if .Reference -}}
 # The system module collects security related information about a host.
 # All datasets send both periodic state information (e.g. all currently
@@ -34,8 +33,3 @@
   # detect any changes.
   user.detect_password_changes: true
   {{- end }}
-  {{- if false -}}
-  {{/* Only remaining use in packages, to be removed completely. */}}
-  report_changes: true
-  {{- end -}}
-{{- end }}

--- a/x-pack/auditbeat/module/system/_meta/config.yml.tmpl
+++ b/x-pack/auditbeat/module/system/_meta/config.yml.tmpl
@@ -24,8 +24,10 @@
   # The state.period can be overridden for any dataset.
   # host.state.period: 12h
   # process.state.period: 12h
+  {{ if eq .GOOS "linux" -}}
   # socket.state.period: 12h
   # user.state.period: 12h
+  {{- end }}
 {{ end }}
   {{ if eq .GOOS "linux" -}}
   # Enabled by default. Auditbeat will read password fields in


### PR DESCRIPTION
This should have actually been part of https://github.com/elastic/beats/pull/9954 or even previous PRs.

The `host` and `process` datasets are implemented for Windows, and the docs now say so, but unfortunately I missed that the config we ship for Windows has the whole system module disabled. It can still be configured manually, of course, but with this change it will show up in the reference files as well.