### PR TITLE
Enable test for template setup

### DIFF
--- a/metricbeat/tests/system/test_base.py
+++ b/metricbeat/tests/system/test_base.py
@@ -46,11 +46,11 @@ class Test(BaseTest):
             }],
             elasticsearch={"host": self.get_elasticsearch_url()},
         )
-        #exit_code = self.run_beat(extra_args=["setup", "--template"])
-#
-        #assert exit_code == 0
-        #assert self.log_contains('Loaded index template')
-        #assert len(es.cat.templates(name='metricbeat-*', h='name')) > 0
+        exit_code = self.run_beat(extra_args=["setup", "--template", "-E", "setup.template.overwrite=true"])
+
+        assert exit_code == 0
+        assert self.log_contains('Loaded index template')
+        assert len(es.cat.templates(name='metricbeat-*', h='name')) > 0
 
     @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_dashboards(self):


### PR DESCRIPTION
Reverts part of #9031, and force overwrite in case the test is executed against a running instance.

This should fail till updated with #10224