### PR TITLE
[Heartbeat] Incorporate factory metadata for autodiscover

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -112,6 +112,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 *Heartbeat*
 
 - Made monitors.d configuration part of the default config. {pull}9004[9004]
+- Fixed rare issue where TLS connections to endpoints with x509 certificates missing either notBefore or notAfter would cause the check to fail with a stacktrace.  {pull}9566[9566]
 
 *Journalbeat*
 
@@ -166,7 +167,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Heartbeat*
 
-- Fixed rare issue where TLS connections to endpoints with x509 certificates missing either notBefore or notAfter would cause the check to fail with a stacktrace.  {pull}9566[9566]
+- Autodiscover metadata is now included in events by default. So, if you are using the docker provider for instance, you'll see the correct fields under the `docker` key. {pull}10258[10258]
 
 *Journalbeat*
 

--- a/heartbeat/monitors/factory.go
+++ b/heartbeat/monitors/factory.go
@@ -38,7 +38,7 @@ func NewFactory(sched *scheduler.Scheduler, allowWatches bool) *RunnerFactory {
 
 // Create makes a new Runner for a new monitor with the given Config.
 func (f *RunnerFactory) Create(p beat.Pipeline, c *common.Config, meta *common.MapStrPointer) (cfgfile.Runner, error) {
-	monitor, err := newMonitor(c, globalPluginsReg, p, f.sched, f.allowWatches)
+	monitor, err := newMonitor(c, globalPluginsReg, p, f.sched, f.allowWatches, meta)
 	return monitor, err
 }
 

--- a/heartbeat/monitors/monitor.go
+++ b/heartbeat/monitors/monitor.go
@@ -62,7 +62,8 @@ type Monitor struct {
 
 	// stats is the countersRecorder used to record lifecycle events
 	// for global metrics + telemetry
-	stats registryRecorder
+	stats           registryRecorder
+	factoryMetadata *common.MapStrPointer
 }
 
 // String prints a description of the monitor in a threadsafe way. It is important that this use threadsafe
@@ -72,7 +73,7 @@ func (m *Monitor) String() string {
 }
 
 func checkMonitorConfig(config *common.Config, registrar *pluginsReg, allowWatches bool) error {
-	m, err := newMonitor(config, registrar, nil, nil, allowWatches)
+	m, err := newMonitor(config, registrar, nil, nil, allowWatches, nil)
 	m.Stop() // Stop the monitor to free up the ID from uniqueness checks
 	return err
 }
@@ -97,6 +98,7 @@ func newMonitor(
 	pipelineConnector beat.PipelineConnector,
 	scheduler *scheduler.Scheduler,
 	allowWatches bool,
+	factoryMetadata *common.MapStrPointer,
 ) (*Monitor, error) {
 	// Extract just the Id, Type, and Enabled fields from the config
 	// We'll parse things more precisely later once we know what exact type of
@@ -123,6 +125,7 @@ func newMonitor(
 		internalsMtx:      sync.Mutex{},
 		config:            config,
 		stats:             monitorPlugin.stats,
+		factoryMetadata:   factoryMetadata,
 	}
 
 	if m.id != "" {

--- a/heartbeat/monitors/monitor_test.go
+++ b/heartbeat/monitors/monitor_test.go
@@ -38,7 +38,7 @@ func TestMonitor(t *testing.T) {
 	require.NoError(t, err)
 	defer sched.Stop()
 
-	mon, err := newMonitor(serverMonConf, reg, pipelineConnector, sched, false)
+	mon, err := newMonitor(serverMonConf, reg, pipelineConnector, sched, false, nil)
 	require.NoError(t, err)
 
 	mon.Start()
@@ -86,7 +86,7 @@ func TestDuplicateMonitorIDs(t *testing.T) {
 	defer sched.Stop()
 
 	makeTestMon := func() (*Monitor, error) {
-		return newMonitor(serverMonConf, reg, pipelineConnector, sched, false)
+		return newMonitor(serverMonConf, reg, pipelineConnector, sched, false, nil)
 	}
 
 	m1, m1Err := makeTestMon()

--- a/heartbeat/monitors/task.go
+++ b/heartbeat/monitors/task.go
@@ -133,10 +133,15 @@ func (t *configuredJob) makeSchedulerTaskFunc() scheduler.TaskFunc {
 func (t *configuredJob) Start() {
 	var err error
 
+	fields := common.MapStr{"event": common.MapStr{"dataset": "uptime"}}
+	if t.monitor.factoryMetadata != nil {
+		fields.DeepUpdate(t.monitor.factoryMetadata.Get())
+	}
+
 	t.client, err = t.monitor.pipelineConnector.ConnectWith(beat.ClientConfig{
 		EventMetadata: t.config.EventMetadata,
 		Processor:     t.processors,
-		Fields:        common.MapStr{"event": common.MapStr{"dataset": "uptime"}},
+		Fields:        fields,
 	})
 	if err != nil {
 		logp.Err("could not start monitor: %v", err)

--- a/heartbeat/tests/system/test_autodiscovery.py
+++ b/heartbeat/tests/system/test_autodiscovery.py
@@ -56,8 +56,11 @@ class TestAutodiscover(BaseTest):
                     host = network_settings['Networks'].values()[
                         0]['IPAddress']
                     port = network_settings['Ports'].keys()[0].split("/")[0]
-                    # Check metadata is added
-                    if output[0]['monitor']['id'] == 'myid':
+                    # Check metadata and docker fields are added
+                    # We don't check all the docker fields because this is really the responsibility
+                    # of libbeat's autodiscovery code.
+                    event = output[0]
+                    if event['monitor']['id'] == 'myid' and event['docker']['container']['id'] is not None:
                         matched = True
 
         assert matched


### PR DESCRIPTION
Heartbeat factories get metadata from autodiscover and other sources.

This change automatically adds that data to events keeping heartbeat behavior in-line with other beats.