### PR TITLE
Cherry-pick #10179 to 6.6: Revert "Skip x-pack libbeat tests again as flaky (#10068)"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
   global:
     # Cross-compile for amd64 only to speed up testing.
     - GOX_FLAGS="-arch amd64"
-    - DOCKER_COMPOSE_VERSION=1.11.1
+    - DOCKER_COMPOSE_VERSION=1.21.0
     - GO_VERSION="$(cat .go-version)"
     # Newer versions of minikube fail on travis, see: https://github.com/kubernetes/minikube/issues/2704
     - TRAVIS_MINIKUBE_VERSION=v0.25.2

--- a/auditbeat/docker-compose.yml
+++ b/auditbeat/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.3'
 services:
   beat:
     build: ${PWD}/.

--- a/filebeat/docker-compose.yml
+++ b/filebeat/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.3'
 services:
   beat:
     build: ${PWD}/.

--- a/heartbeat/docker-compose.yml
+++ b/heartbeat/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.3'
 services:
   beat:
     build: ${PWD}/.

--- a/libbeat/docker-compose.yml
+++ b/libbeat/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.3'
 services:
   beat:
     build: ${PWD}/.

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -197,7 +197,7 @@ integration-tests: prepare-tests
 .PHONY: integration-tests-environment
 integration-tests-environment:  ## @testing Runs the integration inside a virtual environment. This can be run on any docker-machine (local, remote)
 integration-tests-environment: prepare-tests build-image
-	${DOCKER_COMPOSE} run beat make integration-tests RACE_DETECTOR=$(RACE_DETECTOR) DOCKER_COMPOSE_PROJECT_NAME=${DOCKER_COMPOSE_PROJECT_NAME}
+	${DOCKER_COMPOSE} run beat make integration-tests RACE_DETECTOR=$(RACE_DETECTOR) DOCKER_COMPOSE_PROJECT_NAME=${DOCKER_COMPOSE_PROJECT_NAME} || ${DOCKER_COMPOSE} logs --tail 200
 
 # Runs the system tests
 .PHONY: system-tests

--- a/testing/environments/5.x.yml
+++ b/testing/environments/5.x.yml
@@ -1,6 +1,6 @@
 # This is the latest stable 5x release environment.
 
-version: '2.1'
+version: '2.3'
 services:
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:5.6.9

--- a/testing/environments/6.0.yml
+++ b/testing/environments/6.0.yml
@@ -1,6 +1,6 @@
 # This is the latest 6.0 environment.
 
-version: '2.1'
+version: '2.3'
 services:
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch-platinum:6.0.1

--- a/testing/environments/latest.yml
+++ b/testing/environments/latest.yml
@@ -1,6 +1,6 @@
 # This is the latest released environment.
 
-version: '2.1'
+version: '2.3'
 services:
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:6.4.0

--- a/testing/environments/local.yml
+++ b/testing/environments/local.yml
@@ -2,7 +2,7 @@
 # This is useful for testing locally with a full elastic stack setup.
 # All services can be reached through localhost like localhost:5601 for Kibana
 # This is not used for CI as otherwise ports conflicts could happen.
-version: '2.1'
+version: '2.3'
 services:
   kibana:
     ports:

--- a/testing/environments/snapshot-oss.yml
+++ b/testing/environments/snapshot-oss.yml
@@ -1,6 +1,6 @@
 # This should start the environment with the latest snapshots.
 
-version: '2.1'
+version: '2.3'
 services:
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.0.0-alpha1-SNAPSHOT

--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -1,6 +1,6 @@
 # This should start the environment with the latest snapshots.
 
-version: '2.1'
+version: '2.3'
 services:
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:6.6.0-SNAPSHOT

--- a/x-pack/auditbeat/docker-compose.yml
+++ b/x-pack/auditbeat/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.3'
 services:
   beat:
     build: ../../auditbeat

--- a/x-pack/filebeat/docker-compose.yml
+++ b/x-pack/filebeat/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.3'
 services:
   beat:
     build: ../../filebeat

--- a/x-pack/functionbeat/docker-compose.yml
+++ b/x-pack/functionbeat/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.3'
 services:
   beat:
     build: ${PWD}/.

--- a/x-pack/libbeat/docker-compose.yml
+++ b/x-pack/libbeat/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.3'
 services:
   beat:
     build: ${PWD}/.
@@ -20,18 +20,16 @@ services:
     depends_on:
       elasticsearch: { condition: service_healthy }
       kibana: { condition: service_healthy }
-    healthcheck:
-      interval: 1s
-      retries: 2400
 
   elasticsearch:
     extends:
       file: ${ES_BEATS}/testing/environments/${TESTING_ENVIRONMENT}.yml
       service: elasticsearch
     healthcheck:
-      test: ["CMD", "curl", "-u", "elastic:changeme", "-f", "http://localhost:9200"]
+      test: ["CMD-SHELL", 'python -c ''import urllib, json; response = urllib.urlopen("http://myelastic:changeme@localhost:9200/_cluster/health"); data = json.loads(response.read()); exit(1) if data["status"] != "green" else exit(0);''']
       retries: 1200
-      interval: 1s
+      interval: 5s
+      start_period: 60s
     environment:
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
       - "network.host="
@@ -39,14 +37,19 @@ services:
       - "http.host=0.0.0.0"
       - "xpack.security.enabled=true"
       - "xpack.license.self_generated.type=trial"
-    command: bash -c "bin/elasticsearch-keystore create && echo changeme | bin/elasticsearch-keystore add --stdin bootstrap.password && /usr/local/bin/docker-entrypoint.sh eswrapper"
+      - "xpack.security.authc.realms.file1.type=file"
+      - "xpack.security.authc.realms.file1.order=0"
+    command: bash -c "bin/elasticsearch-users useradd myelastic -r superuser -p changeme | /usr/local/bin/docker-entrypoint.sh eswrapper"
 
   kibana:
+    depends_on:
+      - elasticsearch
     extends:
       file: ${ES_BEATS}/testing/environments/${TESTING_ENVIRONMENT}.yml
       service: kibana
     healthcheck:
-      test: ["CMD-SHELL", 'python -c ''import urllib, json; response = urllib.urlopen("http://elastic:changeme@localhost:5601/api/status"); data = json.loads(response.read()); exit(1) if data["status"]["overall"]["state"] != "green" else exit(0);''']
+      test: ["CMD-SHELL", 'python -c ''import urllib, json; response = urllib.urlopen("http://myelastic:changeme@localhost:5601/api/status"); data = json.loads(response.read()); exit(1) if data["status"]["overall"]["state"] != "green" else exit(0);''']
       retries: 1200
-      interval: 1s
-    command: /usr/local/bin/kibana-docker --xpack.security.enabled=true --elasticsearch.username=elastic --elasticsearch.password=changeme
+      interval: 5s
+      start_period: 60s
+    command: /usr/local/bin/kibana-docker --xpack.security.enabled=true --elasticsearch.username=myelastic --elasticsearch.password=changeme

--- a/x-pack/libbeat/tests/system/test_management.py
+++ b/x-pack/libbeat/tests/system/test_management.py
@@ -2,21 +2,37 @@ import sys
 import os
 import json
 import requests
+import string
+import random
 import unittest
+from elasticsearch import Elasticsearch
+
 
 from base import BaseTest
 
 
 INTEGRATION_TESTS = os.environ.get('INTEGRATION_TESTS', False)
-KIBANA_PASSWORD = 'changeme'
+TIMEOUT = 5 * 60
 
 
 class TestManagement(BaseTest):
-    @unittest.skip('Skipped because of issue: https://github.com/elastic/beats/issues/9597')
+
+    def setUp(self):
+        super(TestManagement, self).setUp()
+        # NOTES: Theses options are linked to the specific of the docker compose environment for
+        # CM.
+        self.es_host = os.getenv('ES_HOST', 'localhost') + ":" + os.getenv('ES_POST', '9200')
+        self.es_user = "myelastic"
+        self.es_pass = "changeme"
+        self.es = Elasticsearch([self.get_elasticsearch_url()], verify_certs=True)
+
+    @unittest.skipIf(not INTEGRATION_TESTS,
+                     "integration tests are disabled, run with INTEGRATION_TESTS=1 to enable them.")
     def test_enroll(self):
         """
         Enroll the beat in Kibana Central Management
         """
+
         # We don't care about this as it will be replaced by enrollment
         # process:
         config_path = os.path.join(self.working_dir, "mockbeat.yml")
@@ -24,9 +40,10 @@ class TestManagement(BaseTest):
 
         config_content = open(config_path, 'r').read()
 
-        exit_code = self.enroll(KIBANA_PASSWORD)
+        exit_code = self.enroll(self.es_user, self.es_pass)
 
         assert exit_code == 0
+
         assert self.log_contains("Enrolled and ready to retrieve settings")
 
         # Enroll creates a keystore (to store access token)
@@ -43,7 +60,8 @@ class TestManagement(BaseTest):
         backup_content = open(config_path + ".bak", 'r').read()
         assert config_content == backup_content
 
-    @unittest.skip('Skipped because of issue: https://github.com/elastic/beats/issues/9597')
+    @unittest.skipIf(not INTEGRATION_TESTS,
+                     "integration tests are disabled, run with INTEGRATION_TESTS=1 to enable them.")
     def test_enroll_bad_pw(self):
         """
         Try to enroll the beat in Kibana Central Management with a bad password
@@ -55,7 +73,7 @@ class TestManagement(BaseTest):
 
         config_content = open(config_path, 'r').read()
 
-        exit_code = self.enroll('wrong password')
+        exit_code = self.enroll("not", 'wrong password')
 
         assert exit_code == 1
 
@@ -67,7 +85,8 @@ class TestManagement(BaseTest):
         new_content = open(config_path, 'r').read()
         assert config_content == new_content
 
-    @unittest.skip('Skipped because of issue: https://github.com/elastic/beats/issues/9597')
+    @unittest.skipIf(not INTEGRATION_TESTS,
+                     "integration tests are disabled, run with INTEGRATION_TESTS=1 to enable them.")
     def test_fetch_configs(self):
         """
         Config is retrieved from Central Management and updates are applied
@@ -75,9 +94,10 @@ class TestManagement(BaseTest):
         # Enroll the beat
         config_path = os.path.join(self.working_dir, "mockbeat.yml")
         self.render_config_template("mockbeat", config_path)
-        exit_code = self.enroll(KIBANA_PASSWORD)
+        exit_code = self.enroll(self.es_user, self.es_pass)
         assert exit_code == 0
 
+        index = self.random_index()
         # Configure an output
         self.create_and_assing_tag([
             {
@@ -86,9 +106,10 @@ class TestManagement(BaseTest):
                     {
                         "output": "elasticsearch",
                         "elasticsearch": {
-                            "hosts": ["localhost:9200"],
-                            "username":"elastic",
-                            "password": KIBANA_PASSWORD,
+                            "hosts": [self.es_host],
+                            "username": self.es_user,
+                            "password": self.es_pass,
+                            "index": index,
                         }
                     }
                 ]
@@ -98,12 +119,16 @@ class TestManagement(BaseTest):
         # Start beat
         proc = self.start_beat(extra_args=[
             "-E", "management.period=1s",
-            # do not blacklist file/elasticsearch outputs
-            "-E", "management.blacklist.output='foo'",
         ])
 
         # Wait for beat to apply new conf
         self.wait_log_contains("Applying settings for output")
+
+        self.wait_until(lambda: self.log_contains("PublishEvents: "))
+
+        self.wait_documents(index, 1)
+
+        index2 = self.random_index()
 
         # Update output configuration
         self.create_and_assing_tag([
@@ -111,25 +136,24 @@ class TestManagement(BaseTest):
                 "type": "output",
                 "configs": [
                     {
-                        "output": "file",
-                        "file": {
-                            "path": os.path.join(self.working_dir, "output"),
-                            "filename": "mockbeat",
+                        "output": "elasticsearch",
+                        "elasticsearch": {
+                            "hosts": [self.es_host],
+                            "username": self.es_user,
+                            "password": self.es_pass,
+                            "index": index2,
                         }
                     }
                 ]
             }
         ])
-
-        # Wait for beat to apply new conf, now it logs to console
-        self.wait_until(
-            cond=lambda: self.log_contains_count("Applying settings for output") == 2)
-
-        self.wait_until(cond=lambda: self.output_has(1))
+        self.wait_until(lambda: self.log_contains("PublishEvents: "))
+        self.wait_documents(index2, 1)
 
         proc.check_kill_and_wait()
 
-    @unittest.skip('Skipped because of issue: https://github.com/elastic/beats/issues/9597')
+    @unittest.skipIf(not INTEGRATION_TESTS,
+                     "integration tests are disabled, run with INTEGRATION_TESTS=1 to enable them.")
     def test_configs_cache(self):
         """
         Config cache is used if Kibana is not available
@@ -137,8 +161,10 @@ class TestManagement(BaseTest):
         # Enroll the beat
         config_path = os.path.join(self.working_dir, "mockbeat.yml")
         self.render_config_template("mockbeat", config_path)
-        exit_code = self.enroll(KIBANA_PASSWORD)
+        exit_code = self.enroll(self.es_user, self.es_pass)
         assert exit_code == 0
+
+        index = self.random_index()
 
         # Update output configuration
         self.create_and_assing_tag([
@@ -146,86 +172,62 @@ class TestManagement(BaseTest):
                 "type": "output",
                 "configs": [
                     {
-                        "output": "file",
-                        "file": {
-                            "path": os.path.join(self.working_dir, "output"),
-                            "filename": "mockbeat_managed",
+
+                        "output": "elasticsearch",
+                        "elasticsearch": {
+                            "hosts": [self.es_host],
+                            "username": self.es_user,
+                            "password": self.es_pass,
+                            "index": index,
                         }
                     }
                 ]
             }
         ])
 
-        output_file = os.path.join("output", "mockbeat_managed")
-
         # Start beat
         proc = self.start_beat(extra_args=[
-            # do not blacklist file output
-            "-E", "management.blacklist.output='elasticsearch'",
+            "-E", "management.period=1s",
         ])
-        self.wait_until(cond=lambda: self.output_has(
-            1, output_file=output_file))
+
+        self.wait_until(lambda: self.log_contains("PublishEvents: "), )
+        self.wait_documents(index, 1)
         proc.check_kill_and_wait()
 
-        # Remove output file
-        os.remove(os.path.join(self.working_dir, output_file))
+        # Remove the index
+        self.es.indices.delete(index)
 
         # Cache should exists already, start with wrong kibana settings:
         proc = self.start_beat(extra_args=[
+            "-E", "management.period=1s",
             "-E", "management.kibana.host=wronghost",
             "-E", "management.kibana.timeout=0.5s",
-            # do not blacklist file output
-            "-E", "management.blacklist.output='elasticsearch'",
-        ])
-        self.wait_until(cond=lambda: self.output_has(
-            1, output_file=output_file))
-        proc.check_kill_and_wait()
-
-    @unittest.skip('Skipped because of issue: https://github.com/elastic/beats/issues/9597')
-    def test_blacklist(self):
-        """
-        Blacklist blocks bad configs
-        """
-        # Enroll the beat
-        config_path = os.path.join(self.working_dir, "mockbeat.yml")
-        self.render_config_template("mockbeat", config_path)
-        exit_code = self.enroll(KIBANA_PASSWORD)
-        assert exit_code == 0
-
-        # Update output configuration
-        self.create_and_assing_tag([
-            {
-                "type": "output",
-                "configs": [
-                    {
-                        "output": "file",
-                        "file": {
-                            "path": os.path.join(self.working_dir, "output"),
-                            "filename": "mockbeat_managed",
-                        }
-                    }
-                ]
-            }
         ])
 
-        output_file = os.path.join("output", "mockbeat_managed")
-
-        # Start beat
-        proc = self.start_beat()
-
-        self.wait_until(
-            cond=lambda: self.log_contains("Config for 'output' is blacklisted"))
+        self.wait_until(lambda: self.log_contains("PublishEvents: "))
+        self.wait_documents(index, 1)
         proc.check_kill_and_wait()
-        assert not os.path.isfile(os.path.join(self.working_dir, output_file))
 
-    def enroll(self, password):
+    def enroll(self, user, password):
         return self.run_beat(
             extra_args=["enroll", self.get_kibana_url(),
-                        "--password", "env:PASS", "--force"],
+                        "--password", "env:PASS", "--username", user, "--force"],
             logging_args=["-v", "-d", "*"],
             env={
                 'PASS': password,
             })
+
+    def check_kibana_status(self):
+        headers = {
+            "kbn-xsrf": "1"
+        }
+
+        # Create tag
+        url = self.get_kibana_url() + "/api/status"
+
+        r = requests.get(url, headers=headers,
+                         auth=(self.es_user, self.es_pass))
+        print(r.text)
 
     def create_and_assing_tag(self, blocks):
         tag_name = "test"
@@ -241,10 +243,10 @@ class TestManagement(BaseTest):
         }
 
         r = requests.put(url, json=data, headers=headers,
-                         auth=('elastic', KIBANA_PASSWORD))
+                         auth=(self.es_user, self.es_pass))
         assert r.status_code in (200, 201)
 
-        # Retrieve beat UUID
+        # Retrieve beat ID
         meta = json.loads(
             open(os.path.join(self.working_dir, 'data', 'meta.json'), 'r').read())
 
@@ -252,8 +254,23 @@ class TestManagement(BaseTest):
         data = {"assignments": [{"beatId": meta["uuid"], "tag": tag_name}]}
         url = self.get_kibana_url() + "/api/beats/agents_tags/assignments"
         r = requests.post(url, json=data, headers=headers,
-                          auth=('elastic', KIBANA_PASSWORD))
+                          auth=(self.es_user, self.es_pass))
         assert r.status_code == 200
+
+    def get_elasticsearch_url(self):
+        return 'http://' + self.es_user + ":" + self.es_pass + '@' + os.getenv('ES_HOST', 'localhost') + ':' + os.getenv('ES_PORT', '5601')
 
     def get_kibana_url(self):
         return 'http://' + os.getenv('KIBANA_HOST', 'kibana') + ':' + os.getenv('KIBANA_PORT', '5601')
+
+    def random_index(self):
+        return ''.join(random.choice(string.ascii_lowercase) for i in range(10))
+
+    def check_document_count(self, index, count):
+        try:
+            return self.es.search(index=index, body={"query": {"match_all": {}}})['hits']['total'] >= count
+        except:
+            return False
+
+    def wait_documents(self, index, count):
+        self.wait_until(lambda: self.check_document_count(index, count), max_timeout=TIMEOUT)


### PR DESCRIPTION
Cherry-pick of PR #10179 to 6.6 branch. Original message: 

This reverts commit edeed0972eae1a12740cbb2344b6821cfe6e04c6.


Looking at this with a fresh eyes, I am not sure its flakyness, we should get log from the docker containers on failures.