### PR TITLE
[Heartbeat] Fix port truncation in new url fields

### DIFF
--- a/heartbeat/monitors/wrappers/util.go
+++ b/heartbeat/monitors/wrappers/util.go
@@ -58,7 +58,7 @@ func URLFields(u *url.URL) common.MapStr {
 	}
 
 	if u.Port() != "" {
-		fields["port"], _ = strconv.ParseUint(u.Port(), 10, 8)
+		fields["port"], _ = strconv.ParseUint(u.Port(), 10, 16)
 	}
 
 	if u.Path != "" {

--- a/heartbeat/monitors/wrappers/util_test.go
+++ b/heartbeat/monitors/wrappers/util_test.go
@@ -63,11 +63,12 @@ func TestURLFields(t *testing.T) {
 		},
 		{
 			"complex",
-			"tcp+ssl://myuser:mypass@elastic.co/foo/bar?q=dosomething&x=y",
+			"tcp+ssl://myuser:mypass@elastic.co:65500/foo/bar?q=dosomething&x=y",
 			common.MapStr{
-				"full":     "tcp+ssl://myuser:%3Chidden%3E@elastic.co/foo/bar?q=dosomething&x=y",
+				"full":     "tcp+ssl://myuser:%3Chidden%3E@elastic.co:65500/foo/bar?q=dosomething&x=y",
 				"scheme":   "tcp+ssl",
 				"domain":   "elastic.co",
+				"port":     uint64(65500),
 				"path":     "/foo/bar",
 				"query":    "q=dosomething&x=y",
 				"username": "myuser",

--- a/libbeat/common/mapval/is_defs.go
+++ b/libbeat/common/mapval/is_defs.go
@@ -126,7 +126,7 @@ func IsDeepEqual(to interface{}) IsDef {
 		return SimpleResult(
 			path,
 			false,
-			fmt.Sprintf("objects not equal: actual(%v) != expected(%v)", v, to),
+			fmt.Sprintf("objects not equal: actual(%T(%v)) != expected(%T(%v))", v, v, to, to),
 		)
 	})
 }


### PR DESCRIPTION
This only affects 7.0. The old code accidentally parsed port numbers as 8 bit leading ports > 255 to but truncated to 255.

This also includes a commit that makes test output clearer when types differ.

Weirdly ParseUint doesn't emit 16 bit uints. There's no reason to try and micro-optimize to a `uint16` here though.

No changelog needed as this was never released in the wild.