### PR TITLE
Cherry-pick #9940 to 6.x: [Docs] Remove duplicate metricset pages

### DIFF
--- a/metricbeat/module/elasticsearch/ml_job/_meta/docs.asciidoc
+++ b/metricbeat/module/elasticsearch/ml_job/_meta/docs.asciidoc
@@ -1,3 +1,3 @@
-=== elasticsearch ml_job MetricSet
-
-This is the ml_job metricset of the module Elasticsearch. This metricset requires https://www.elastic.co/products/x-pack/machine-learning[Machine Learning] to be enabled.
+This is the `ml_job` metricset of the Elasticsearch module. This metricset
+requires https://www.elastic.co/products/x-pack/machine-learning[Machine Learning]
+to be enabled.

--- a/metricbeat/module/elasticsearch/pending_tasks/_meta/docs.asciidoc
+++ b/metricbeat/module/elasticsearch/pending_tasks/_meta/docs.asciidoc
@@ -1,3 +1,1 @@
-=== elasticsearch pending_tasks MetricSet
-
-This is the pending_tasks metricset of the module elasticsearch.
+This is the `pending_tasks` metricset of the Elasticsearch module.


### PR DESCRIPTION
Cherry-pick of PR #9940 to 6.x branch. Original message: 

Closes #9880. Also fixes a similar issue in the pending_tasks metricset.