### PR TITLE
[Docs]Fix Metricbeat docker example

### DIFF
--- a/metricbeat/docs/running-on-docker.asciidoc
+++ b/metricbeat/docs/running-on-docker.asciidoc
@@ -18,8 +18,8 @@ docker run \
   --mount type=bind,source=/proc,target=/hostfs/proc,readonly \ <1>
   --mount type=bind,source=/sys/fs/cgroup,target=/hostfs/sys/fs/cgroup,readonly \ <2>
   --mount type=bind,source=/,target=/hostfs,readonly \ <3>
-  --net=host <4>
-  {dockerimage} -system.hostfs=/hostfs
+  --net=host \ <4>
+  {dockerimage} -e -system.hostfs=/hostfs
 ----
 
 <1> Metricbeat's <<metricbeat-module-system,system module>> collects much of its data through the Linux proc


### PR DESCRIPTION
Added `-e` to docker run example and added missing `\` to **Monitor the host machine** section.

Recommended from:
https://discuss.elastic.co/t/running-metricbeat-in-docker-and-monitoring-the-host-system-does-not-work-with-command-from-documentation/119821

Change should be backported.