### PR TITLE
Allow to remove setup cmd flags from beats.

### DIFF
--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -68,6 +68,19 @@ import (
 	ucfg "github.com/elastic/go-ucfg"
 )
 
+const (
+	//TemplateKey used for defining template in setup cmd
+	TemplateKey = "template"
+	//DashboardKey used for registering dashboards in setup cmd
+	DashboardKey = "dashboards"
+	//MachineLearningKey used for registering ml jobs in setup cmd
+	MachineLearningKey = "machineLearning"
+	//PipelineKey used for registering pipelines in setup cmd
+	PipelineKey = "pipelines"
+	//ILMPolicyKey used for registering ilm in setup cmd
+	ILMPolicyKey = "ilm-policy"
+)
+
 // Beat provides the runnable and configurable instance of a beat.
 type Beat struct {
 	beat.Beat
@@ -435,7 +448,7 @@ func (b *Beat) TestConfig(bt beat.Creator) error {
 }
 
 // Setup registers ES index template, kibana dashboards, ml jobs and pipelines.
-func (b *Beat) Setup(bt beat.Creator, template, setupDashboards, machineLearning, pipelines, policy bool) error {
+func (b *Beat) Setup(bt beat.Creator, flags map[string]bool) error {
 	return handleError(func() error {
 		err := b.Init()
 		if err != nil {
@@ -451,7 +464,7 @@ func (b *Beat) Setup(bt beat.Creator, template, setupDashboards, machineLearning
 			return err
 		}
 
-		if template {
+		if v, ok := flags[TemplateKey]; ok && v {
 			outCfg := b.Config.Output
 
 			if outCfg.Name() != "elasticsearch" {
@@ -494,7 +507,7 @@ func (b *Beat) Setup(bt beat.Creator, template, setupDashboards, machineLearning
 			fmt.Println("Loaded index template")
 		}
 
-		if setupDashboards {
+		if v, ok := flags[DashboardKey]; ok && v {
 			fmt.Println("Loading dashboards (Kibana must be running and reachable)")
 			err = b.loadDashboards(context.Background(), true)
 
@@ -510,7 +523,7 @@ func (b *Beat) Setup(bt beat.Creator, template, setupDashboards, machineLearning
 			}
 		}
 
-		if machineLearning && b.SetupMLCallback != nil {
+		if v, ok := flags[MachineLearningKey]; ok && v && b.SetupMLCallback != nil {
 			err = b.SetupMLCallback(&b.Beat, b.Config.Kibana)
 			if err != nil {
 				return err
@@ -518,7 +531,7 @@ func (b *Beat) Setup(bt beat.Creator, template, setupDashboards, machineLearning
 			fmt.Println("Loaded machine learning job configurations")
 		}
 
-		if pipelines && b.OverwritePipelinesCallback != nil {
+		if v, ok := flags[PipelineKey]; ok && v && b.OverwritePipelinesCallback != nil {
 			esConfig := b.Config.Output.Config()
 			err = b.OverwritePipelinesCallback(esConfig)
 			if err != nil {
@@ -528,7 +541,7 @@ func (b *Beat) Setup(bt beat.Creator, template, setupDashboards, machineLearning
 			fmt.Println("Loaded Ingest pipelines")
 		}
 
-		if policy {
+		if v, ok := flags[ILMPolicyKey]; ok && v {
 			if err := b.loadILMPolicy(); err != nil {
 				return err
 			}


### PR DESCRIPTION
This PR allows to remove flags form the setup command, if they are not available in the specific beat. This helps to clean up the `setup` cmd. 

Example Use Case: https://github.com/elastic/apm-server/pull/1815/files#diff-ff7686b39bf90dc2520886fb874371a4