### PR TITLE
[Metricbeat] Modify system.process metricset to use reporter interface

### DIFF
--- a/metricbeat/module/system/process/_meta/data.json
+++ b/metricbeat/module/system/process/_meta/data.json
@@ -17,28 +17,29 @@
     },
     "system": {
         "process": {
+            "cmdline": "/var/folders/k3/xlwbcsmj6dd7vjv2tg1d7c_40000gn/T/go-build019306533/b001/process.test -data",
             "cpu": {
-                "start_time": "2018-12-12T08:05:53.748Z",
+                "start_time": "2019-01-23T13:12:46.639Z",
                 "total": {
                     "norm": {
-                        "pct": 0
+                        "pct": 0.0087
                     },
-                    "pct": 0,
-                    "value": 60
+                    "pct": 0.0692,
+                    "value": 239
                 }
             },
             "memory": {
                 "rss": {
-                    "bytes": 0,
-                    "pct": 0
+                    "bytes": 49573888,
+                    "pct": 0.0029
                 },
                 "share": 0,
-                "size": 8192
+                "size": 4515098624
             },
-            "name": "go",
-            "pgid": 53737,
-            "pid": 53883,
-            "ppid": 53737,
+            "name": "process.test",
+            "pgid": 40547,
+            "pid": 40583,
+            "ppid": 40547,
             "state": "running",
             "username": "ruflin"
         }

--- a/metricbeat/module/system/process/process_test.go
+++ b/metricbeat/module/system/process/process_test.go
@@ -23,17 +23,31 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
 )
 
+func TestFetch(t *testing.T) {
+	f := mbtest.NewReportingMetricSetV2(t, getConfig())
+	events, errs := mbtest.ReportingFetchV2(f)
+
+	assert.Empty(t, errs)
+	if !assert.NotEmpty(t, events) {
+		t.FailNow()
+	}
+	t.Logf("%s/%s event: %+v", f.Module().Name(), f.Name(),
+		events[0].BeatEvent("system", "process").Fields.StringToPrint())
+}
+
 func TestData(t *testing.T) {
-	f := mbtest.NewEventsFetcher(t, getConfig())
+	f := mbtest.NewReportingMetricSetV2(t, getConfig())
 
 	// Do a first fetch to have percentages
-	f.Fetch()
+	mbtest.ReportingFetchV2(f)
 	time.Sleep(1 * time.Second)
 
-	err := mbtest.WriteEvents(f, t)
+	err := mbtest.WriteEventsReporterV2(f, t, ".")
 	if err != nil {
 		t.Fatal("write", err)
 	}


### PR DESCRIPTION
This change is necessary to use ECS fields. Test and data generation were also updated for the new interface.