### PR TITLE
Cherry-pick #10262 to 6.x: Ensure that functionbeat is logging at info level not debug

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -111,6 +111,8 @@ https://github.com/elastic/beats/compare/v6.6.0...6.x[Check the HEAD diff]
 
 *Functionbeat*
 
+- Ensure that functionbeat is logging at info level not debug. {issue}10262[10262]
+
 ==== Added
 
 *Affecting all Beats*

--- a/x-pack/functionbeat/config/config.go
+++ b/x-pack/functionbeat/config/config.go
@@ -25,7 +25,6 @@ var ConfigOverrides = common.MustNewConfigFrom(map[string]interface{}{
 	"path.logs":              "/tmp/logs",
 	"logging.to_stderr":      true,
 	"logging.to_files":       false,
-	"logging.level":          "debug",
 	"setup.template.enabled": true,
 	"queue.mem": map[string]interface{}{
 		"events":           "${output.elasticsearch.bulk_max_size}",


### PR DESCRIPTION
Cherry-pick of PR #10262 to 6.x branch. Original message: 

