### PR TITLE
Add required permission for EC2 metricset

### DIFF
--- a/x-pack/metricbeat/module/aws/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/aws/_meta/docs.asciidoc
@@ -24,6 +24,9 @@ see https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html[Te
 aws> sts get-session-token --serial-number arn:aws:iam::1234:mfa/test@elastic.co --token-code 456789 --duration-seconds 129600
 ----
 
+Specific permissions needs to be added into the IAM user's policy to allow Metricbeat collecting AWS monitoring metrics. Please
+see documentation under each metric set for required permissions.
+
 By default, Amazon EC2 sends metric data to CloudWatch every 5 minutes. With this basic monitoring, `period` in aws module
 configuration should be larger or equal than `300s`. If `period` is set to be less than `300s`, the same cloudwatch metrics
 will be collected more than once which will cause extra fees without getting more granular metrics. For example, in `US East (N. Virginia)` region, it costs

--- a/x-pack/metricbeat/module/aws/ec2/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/aws/ec2/_meta/docs.asciidoc
@@ -2,6 +2,14 @@ The ec2 metricset of aws module allows you to monitor your AWS EC2 instances,
 including `cpu`, `network`, `disk` and `status`. `ec2` metricset fetches a set of values from
 https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/viewing_metrics_with_cloudwatch.html#ec2-cloudwatch-metrics[Cloudwatch AWS EC2 Metrics].
 
+=== AWS Permissions
+Some specific AWS permissions are required for IAM user to collect AWS EC2 metrics.
+----
+ec2:DescribeInstances
+cloudwatch:GetMetricData
+ec2:DescribeRegions
+----
+
 === Dashboard
 
 The aws ec2 metricset comes with a predefined dashboard. For example:


### PR DESCRIPTION
This PR is to document what are the required permissions for collecting AWS EC2 metrics.