### PR TITLE
Only need to install geoip and user-agent plugin when ES < 6.7

### DIFF
--- a/filebeat/docs/modules-getting-started.asciidoc
+++ b/filebeat/docs/modules-getting-started.asciidoc
@@ -28,7 +28,7 @@ Before running {beatname_uc} modules:
 <<filebeat-installation>>. After installing {beatname_uc}, return to this
 quick start page.
 
-* Install the Ingest Node GeoIP and User Agent plugins. These plugins are
+* With Elasticsearch < 6.7, install the Ingest Node GeoIP and User Agent plugins. These plugins are
 required to capture the geographical location and browser information used by
 some of the visualizations available in the sample dashboards. You can install
 these plugins by running the following commands in the {es} home path:

--- a/filebeat/docs/modules/apache2.asciidoc
+++ b/filebeat/docs/modules/apache2.asciidoc
@@ -16,7 +16,7 @@ include::../include/what-happens.asciidoc[]
 [float]
 === Compatibility
 
-This module requires the
+With Elasticsearch < 6.7, this module requires the
 {elasticsearch-plugins}/ingest-user-agent.html[ingest-user-agent] and
 {elasticsearch-plugins}/ingest-geoip.html[ingest-geoip] Elasticsearch plugins.
 

--- a/filebeat/docs/modules/iis.asciidoc
+++ b/filebeat/docs/modules/iis.asciidoc
@@ -16,7 +16,7 @@ include::../include/what-happens.asciidoc[]
 [float]
 === Compatibility
 
-This module requires the
+With Elasticsearch < 6.7, this module requires the
 {elasticsearch-plugins}/ingest-user-agent.html[ingest-user-agent] and
 {elasticsearch-plugins}/ingest-geoip.html[ingest-geoip] Elasticsearch plugins.
 

--- a/filebeat/docs/modules/nginx.asciidoc
+++ b/filebeat/docs/modules/nginx.asciidoc
@@ -17,7 +17,7 @@ include::../include/what-happens.asciidoc[]
 [float]
 === Compatibility
 
-This module requires the
+With Elasticsearch < 6.7, this module requires the
 {elasticsearch-plugins}/ingest-user-agent.html[ingest-user-agent] and
 {elasticsearch-plugins}/ingest-geoip.html[ingest-geoip] Elasticsearch plugins.
 

--- a/filebeat/docs/modules/system.asciidoc
+++ b/filebeat/docs/modules/system.asciidoc
@@ -19,7 +19,7 @@ include::../include/what-happens.asciidoc[]
 This module was tested with logs from OSes like Ubuntu 12.04, Centos 7, and
 macOS Sierra.
 
-This module requires the
+With Elasticsearch < 6.7, this module requires the
 {elasticsearch-plugins}/ingest-user-agent.html[ingest-user-agent] and
 {elasticsearch-plugins}/ingest-geoip.html[ingest-geoip] Elasticsearch plugins.
 

--- a/filebeat/docs/modules/traefik.asciidoc
+++ b/filebeat/docs/modules/traefik.asciidoc
@@ -16,7 +16,7 @@ include::../include/what-happens.asciidoc[]
 [float]
 === Compatibility
 
-This module requires the
+With Elasticsearch < 6.7, this module requires the
 {elasticsearch-plugins}/ingest-user-agent.html[ingest-user-agent] and
 {elasticsearch-plugins}/ingest-geoip.html[ingest-geoip] Elasticsearch plugins.
 

--- a/filebeat/module/apache2/_meta/docs.asciidoc
+++ b/filebeat/module/apache2/_meta/docs.asciidoc
@@ -11,7 +11,7 @@ include::../include/what-happens.asciidoc[]
 [float]
 === Compatibility
 
-This module requires the
+With Elasticsearch < 6.7, this module requires the
 {elasticsearch-plugins}/ingest-user-agent.html[ingest-user-agent] and
 {elasticsearch-plugins}/ingest-geoip.html[ingest-geoip] Elasticsearch plugins.
 

--- a/filebeat/module/iis/_meta/docs.asciidoc
+++ b/filebeat/module/iis/_meta/docs.asciidoc
@@ -11,7 +11,7 @@ include::../include/what-happens.asciidoc[]
 [float]
 === Compatibility
 
-This module requires the
+With Elasticsearch < 6.7, this module requires the
 {elasticsearch-plugins}/ingest-user-agent.html[ingest-user-agent] and
 {elasticsearch-plugins}/ingest-geoip.html[ingest-geoip] Elasticsearch plugins.
 

--- a/filebeat/module/nginx/_meta/docs.asciidoc
+++ b/filebeat/module/nginx/_meta/docs.asciidoc
@@ -12,7 +12,7 @@ include::../include/what-happens.asciidoc[]
 [float]
 === Compatibility
 
-This module requires the
+With Elasticsearch < 6.7, this module requires the
 {elasticsearch-plugins}/ingest-user-agent.html[ingest-user-agent] and
 {elasticsearch-plugins}/ingest-geoip.html[ingest-geoip] Elasticsearch plugins.
 

--- a/filebeat/module/system/_meta/docs.asciidoc
+++ b/filebeat/module/system/_meta/docs.asciidoc
@@ -14,7 +14,7 @@ include::../include/what-happens.asciidoc[]
 This module was tested with logs from OSes like Ubuntu 12.04, Centos 7, and
 macOS Sierra.
 
-This module requires the
+With Elasticsearch < 6.7, this module requires the
 {elasticsearch-plugins}/ingest-user-agent.html[ingest-user-agent] and
 {elasticsearch-plugins}/ingest-geoip.html[ingest-geoip] Elasticsearch plugins.
 

--- a/filebeat/module/traefik/_meta/docs.asciidoc
+++ b/filebeat/module/traefik/_meta/docs.asciidoc
@@ -11,7 +11,7 @@ include::../include/what-happens.asciidoc[]
 [float]
 === Compatibility
 
-This module requires the
+With Elasticsearch < 6.7, this module requires the
 {elasticsearch-plugins}/ingest-user-agent.html[ingest-user-agent] and
 {elasticsearch-plugins}/ingest-geoip.html[ingest-geoip] Elasticsearch plugins.
 

--- a/packetbeat/docs/packetbeat-geoip.asciidoc
+++ b/packetbeat/docs/packetbeat-geoip.asciidoc
@@ -24,7 +24,7 @@ Logstash.
 
 To configure Packetbeat and the ingest geoIP processor plugin:
 
-1. {plugins}/ingest-geoip.html[Install the ingest geoIP processor plugin].
+1. With Elasticsearch < 6.7, {plugins}/ingest-geoip.html[Install the ingest geoIP processor plugin].
 After installing the plugin, remember to restart the node.
 
 2. Define an ingest node pipeline that uses a `geoip` processor to add location


### PR DESCRIPTION
This PR is to add ES version limit in documentations regarding to install ingest-geoip and ingest-user-agent plugins. This is a fix for `6.x` branch for https://github.com/elastic/beats/issues/9771 and https://github.com/elastic/beats/issues/9773