### PR TITLE
Metricbeat dashboard for MSSQL transaction log metricset

### DIFF
--- a/x-pack/metricbeat/module/mssql/_meta/kibana/7/dashboard/Metricbeat-mssql-transaction_log.json
+++ b/x-pack/metricbeat/module/mssql/_meta/kibana/7/dashboard/Metricbeat-mssql-transaction_log.json
@@ -470,6 +470,7 @@
             },
             "id": "e9654a40-1fb2-11e9-8a4d-eb34d2834f6b",
             "panelIndex": "1",
+            "title": "Recovery size of transaction log",
             "type": "visualization",
             "version": "7.0.0-alpha2"
           },
@@ -484,6 +485,7 @@
             },
             "id": "1757d530-1fb3-11e9-8a4d-eb34d2834f6b",
             "panelIndex": "2",
+            "title": "Transaction log size since last checkpoint",
             "type": "visualization",
             "version": "7.0.0-alpha2"
           },
@@ -498,6 +500,7 @@
             },
             "id": "a55bb000-1fb2-11e9-8a4d-eb34d2834f6b",
             "panelIndex": "3",
+            "title": "Percentage of used space of transaction log",
             "type": "visualization",
             "version": "7.0.0-alpha2"
           },
@@ -512,6 +515,7 @@
             },
             "id": "edb7a0c0-1f2b-11e9-8a4d-eb34d2834f6b",
             "panelIndex": "4",
+            "title": "Log space size since last backup",
             "type": "visualization",
             "version": "7.0.0-alpha2"
           },
@@ -526,6 +530,7 @@
             },
             "id": "c9ead180-1fb2-11e9-8a4d-eb34d2834f6b",
             "panelIndex": "5",
+            "title": "Active size of transaction log",
             "type": "visualization",
             "version": "7.0.0-alpha2"
           },
@@ -540,6 +545,7 @@
             },
             "id": "68fa61b0-1fb2-11e9-8a4d-eb34d2834f6b",
             "panelIndex": "6",
+            "title": "Used space of transaction log",
             "type": "visualization",
             "version": "7.0.0-alpha2"
           },
@@ -554,6 +560,7 @@
             },
             "id": "6710ff20-1f2c-11e9-8a4d-eb34d2834f6b",
             "panelIndex": "7",
+            "title": "Total log space usage",
             "type": "visualization",
             "version": "7.0.0-alpha2"
           }
@@ -564,8 +571,8 @@
       },
       "id": "18d66970-1fb4-11e9-8a4d-eb34d2834f6b",
       "type": "dashboard",
-      "updated_at": "2019-01-24T08:43:18.278Z",
-      "version": 1
+      "updated_at": "2019-01-24T09:40:34.632Z",
+      "version": 2
     }
   ],
   "version": "7.0.0-alpha2"

--- a/x-pack/metricbeat/module/mssql/_meta/kibana/7/dashboard/Metricbeat-mssql-transaction_log.json
+++ b/x-pack/metricbeat/module/mssql/_meta/kibana/7/dashboard/Metricbeat-mssql-transaction_log.json
@@ -1,0 +1,572 @@
+{
+  "objects": [
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "lucene",
+              "query": ""
+            }
+          }
+        },
+        "title": "Recovery size of transaction log [Metricbeat MSSQL]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "bytes",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Recovery size of transaction log",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "mssql.transaction_log.stats.recovery_size.bytes",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_filters": [
+                  {
+                    "color": "#68BC00",
+                    "id": "de4cb6c0-1fb2-11e9-9c8a-cb3f85dff2a3"
+                  }
+                ],
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "mssql.database.name"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Recovery size of transaction log [Metricbeat MSSQL]",
+          "type": "metrics"
+        }
+      },
+      "id": "e9654a40-1fb2-11e9-8a4d-eb34d2834f6b",
+      "type": "visualization",
+      "updated_at": "2019-01-24T08:34:49.188Z",
+      "version": 1
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "lucene",
+              "query": ""
+            }
+          }
+        },
+        "title": "Transaction log size since last checkpoint [Metricbeat MSSQL]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "bytes",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Transaction log size since last checkpoint",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "mssql.transaction_log.stats.since_last_checkpoint.bytes",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "mssql.database.name"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Transaction log size since last checkpoint [Metricbeat MSSQL]",
+          "type": "metrics"
+        }
+      },
+      "id": "1757d530-1fb3-11e9-8a4d-eb34d2834f6b",
+      "type": "visualization",
+      "updated_at": "2019-01-24T08:36:06.275Z",
+      "version": 1
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "lucene",
+              "query": ""
+            }
+          }
+        },
+        "title": "Percentage of used space of transaction log [Metricbeat MSSQL]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "percent",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Percentage of used space of transaction log",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "mssql.transaction_log.space_usage.used.pct",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "percent",
+                "terms_field": "mssql.database.name"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Percentage of used space of transaction log [Metricbeat MSSQL]",
+          "type": "metrics"
+        }
+      },
+      "id": "a55bb000-1fb2-11e9-8a4d-eb34d2834f6b",
+      "type": "visualization",
+      "updated_at": "2019-01-24T08:32:55.040Z",
+      "version": 1
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "lucene",
+              "query": ""
+            }
+          }
+        },
+        "title": "Log space size since last backup [Metricbeat MSSQL]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "mssql.transaction_log.space_usage.since_last_backup.bytes",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "mssql.database.name"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Log space size since last backup [Metricbeat MSSQL]",
+          "type": "metrics"
+        }
+      },
+      "id": "edb7a0c0-1f2b-11e9-8a4d-eb34d2834f6b",
+      "type": "visualization",
+      "updated_at": "2019-01-23T16:28:34.380Z",
+      "version": 1
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "lucene",
+              "query": ""
+            }
+          }
+        },
+        "title": "Active size of transaction log [Metricbeat MSSQL]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "bytes",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Active size of transaction log",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "mssql.transaction_log.stats.active_size.bytes",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "mssql.database.name"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Active size of transaction log [Metricbeat MSSQL]",
+          "type": "metrics"
+        }
+      },
+      "id": "c9ead180-1fb2-11e9-8a4d-eb34d2834f6b",
+      "type": "visualization",
+      "updated_at": "2019-01-24T08:33:56.376Z",
+      "version": 1
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "lucene",
+              "query": ""
+            }
+          }
+        },
+        "title": "Used space of transaction log [Metricbeat MSSQL]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "bytes",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Used space of transaction log",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "mssql.transaction_log.space_usage.used.bytes",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "mssql.database.name"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Used space of transaction log [Metricbeat MSSQL]",
+          "type": "metrics"
+        }
+      },
+      "id": "68fa61b0-1fb2-11e9-8a4d-eb34d2834f6b",
+      "type": "visualization",
+      "updated_at": "2019-01-24T08:31:13.739Z",
+      "version": 1
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "lucene",
+              "query": ""
+            }
+          }
+        },
+        "title": "Total log space usage [Metricbeat MSSQL]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "bytes",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Total log space usage",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "mssql.transaction_log.space_usage.total.bytes",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "stacked",
+                "terms_field": "mssql.database.name"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Total log space usage [Metricbeat MSSQL]",
+          "type": "metrics"
+        }
+      },
+      "id": "6710ff20-1f2c-11e9-8a4d-eb34d2834f6b",
+      "type": "visualization",
+      "updated_at": "2019-01-23T16:31:57.969Z",
+      "version": 1
+    },
+    {
+      "attributes": {
+        "description": "An overview of the transaction log of each database in a MSSQL instance",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "lucene",
+              "query": ""
+            }
+          }
+        },
+        "optionsJSON": {
+          "darkTheme": false,
+          "hidePanelTitles": false,
+          "useMargins": true
+        },
+        "panelsJSON": [
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "1",
+              "w": 24,
+              "x": 0,
+              "y": 15
+            },
+            "id": "e9654a40-1fb2-11e9-8a4d-eb34d2834f6b",
+            "panelIndex": "1",
+            "type": "visualization",
+            "version": "7.0.0-alpha2"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "2",
+              "w": 24,
+              "x": 24,
+              "y": 30
+            },
+            "id": "1757d530-1fb3-11e9-8a4d-eb34d2834f6b",
+            "panelIndex": "2",
+            "type": "visualization",
+            "version": "7.0.0-alpha2"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "3",
+              "w": 24,
+              "x": 24,
+              "y": 0
+            },
+            "id": "a55bb000-1fb2-11e9-8a4d-eb34d2834f6b",
+            "panelIndex": "3",
+            "type": "visualization",
+            "version": "7.0.0-alpha2"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "4",
+              "w": 24,
+              "x": 0,
+              "y": 30
+            },
+            "id": "edb7a0c0-1f2b-11e9-8a4d-eb34d2834f6b",
+            "panelIndex": "4",
+            "type": "visualization",
+            "version": "7.0.0-alpha2"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "5",
+              "w": 24,
+              "x": 0,
+              "y": 45
+            },
+            "id": "c9ead180-1fb2-11e9-8a4d-eb34d2834f6b",
+            "panelIndex": "5",
+            "type": "visualization",
+            "version": "7.0.0-alpha2"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "6",
+              "w": 24,
+              "x": 24,
+              "y": 15
+            },
+            "id": "68fa61b0-1fb2-11e9-8a4d-eb34d2834f6b",
+            "panelIndex": "6",
+            "type": "visualization",
+            "version": "7.0.0-alpha2"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "7",
+              "w": 24,
+              "x": 0,
+              "y": 0
+            },
+            "id": "6710ff20-1f2c-11e9-8a4d-eb34d2834f6b",
+            "panelIndex": "7",
+            "type": "visualization",
+            "version": "7.0.0-alpha2"
+          }
+        ],
+        "timeRestore": false,
+        "title": "[Metricbeat MSSQL] Transaction log",
+        "version": 1
+      },
+      "id": "18d66970-1fb4-11e9-8a4d-eb34d2834f6b",
+      "type": "dashboard",
+      "updated_at": "2019-01-24T08:43:18.278Z",
+      "version": 1
+    }
+  ],
+  "version": "7.0.0-alpha2"
+}

--- a/x-pack/metricbeat/module/mssql/_meta/kibana/7/dashboard/Metricbeat-mssql-transaction_log.json
+++ b/x-pack/metricbeat/module/mssql/_meta/kibana/7/dashboard/Metricbeat-mssql-transaction_log.json
@@ -64,8 +64,11 @@
         }
       },
       "id": "e9654a40-1fb2-11e9-8a4d-eb34d2834f6b",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
       "type": "visualization",
-      "updated_at": "2019-01-24T08:34:49.188Z",
+      "updated_at": "2019-02-01T10:13:18.406Z",
       "version": 1
     },
     {
@@ -126,8 +129,11 @@
         }
       },
       "id": "1757d530-1fb3-11e9-8a4d-eb34d2834f6b",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
       "type": "visualization",
-      "updated_at": "2019-01-24T08:36:06.275Z",
+      "updated_at": "2019-02-01T10:13:18.406Z",
       "version": 1
     },
     {
@@ -188,8 +194,11 @@
         }
       },
       "id": "a55bb000-1fb2-11e9-8a4d-eb34d2834f6b",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
       "type": "visualization",
-      "updated_at": "2019-01-24T08:32:55.040Z",
+      "updated_at": "2019-02-01T10:13:18.406Z",
       "version": 1
     },
     {
@@ -250,8 +259,11 @@
         }
       },
       "id": "edb7a0c0-1f2b-11e9-8a4d-eb34d2834f6b",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
       "type": "visualization",
-      "updated_at": "2019-01-23T16:28:34.380Z",
+      "updated_at": "2019-02-01T10:13:18.406Z",
       "version": 1
     },
     {
@@ -312,8 +324,11 @@
         }
       },
       "id": "c9ead180-1fb2-11e9-8a4d-eb34d2834f6b",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
       "type": "visualization",
-      "updated_at": "2019-01-24T08:33:56.376Z",
+      "updated_at": "2019-02-01T10:13:18.406Z",
       "version": 1
     },
     {
@@ -374,8 +389,11 @@
         }
       },
       "id": "68fa61b0-1fb2-11e9-8a4d-eb34d2834f6b",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
       "type": "visualization",
-      "updated_at": "2019-01-24T08:31:13.739Z",
+      "updated_at": "2019-02-01T10:13:18.406Z",
       "version": 1
     },
     {
@@ -436,8 +454,62 @@
         }
       },
       "id": "6710ff20-1f2c-11e9-8a4d-eb34d2834f6b",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
       "type": "visualization",
-      "updated_at": "2019-01-23T16:31:57.969Z",
+      "updated_at": "2019-02-01T10:13:18.406Z",
+      "version": 1
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "lucene",
+              "query": ""
+            }
+          }
+        },
+        "title": "Database selector [Metricbeat MSSQL]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "controls": [
+              {
+                "fieldName": "mssql.database.name",
+                "id": "1549016598264",
+                "indexPattern": "metricbeat-*",
+                "label": "",
+                "options": {
+                  "dynamicOptions": true,
+                  "multiselect": true,
+                  "order": "desc",
+                  "size": 5,
+                  "type": "terms"
+                },
+                "parent": "",
+                "type": "list"
+              }
+            ],
+            "pinFilters": false,
+            "updateFiltersOnChange": false,
+            "useTimeFilter": false
+          },
+          "title": "Database selector [Metricbeat MSSQL]",
+          "type": "input_control_vis"
+        }
+      },
+      "id": "82bf9480-260b-11e9-a46a-471d2a76b305",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "type": "visualization",
+      "updated_at": "2019-02-01T10:24:09.159Z",
       "version": 1
     },
     {
@@ -462,11 +534,11 @@
           {
             "embeddableConfig": {},
             "gridData": {
-              "h": 15,
+              "h": 12,
               "i": "1",
               "w": 24,
               "x": 0,
-              "y": 15
+              "y": 12
             },
             "id": "e9654a40-1fb2-11e9-8a4d-eb34d2834f6b",
             "panelIndex": "1",
@@ -477,11 +549,11 @@
           {
             "embeddableConfig": {},
             "gridData": {
-              "h": 15,
+              "h": 13,
               "i": "2",
               "w": 24,
               "x": 24,
-              "y": 30
+              "y": 24
             },
             "id": "1757d530-1fb3-11e9-8a4d-eb34d2834f6b",
             "panelIndex": "2",
@@ -492,10 +564,10 @@
           {
             "embeddableConfig": {},
             "gridData": {
-              "h": 15,
+              "h": 12,
               "i": "3",
-              "w": 24,
-              "x": 24,
+              "w": 18,
+              "x": 30,
               "y": 0
             },
             "id": "a55bb000-1fb2-11e9-8a4d-eb34d2834f6b",
@@ -507,11 +579,11 @@
           {
             "embeddableConfig": {},
             "gridData": {
-              "h": 15,
+              "h": 13,
               "i": "4",
               "w": 24,
               "x": 0,
-              "y": 30
+              "y": 37
             },
             "id": "edb7a0c0-1f2b-11e9-8a4d-eb34d2834f6b",
             "panelIndex": "4",
@@ -522,11 +594,11 @@
           {
             "embeddableConfig": {},
             "gridData": {
-              "h": 15,
+              "h": 13,
               "i": "5",
               "w": 24,
               "x": 0,
-              "y": 45
+              "y": 24
             },
             "id": "c9ead180-1fb2-11e9-8a4d-eb34d2834f6b",
             "panelIndex": "5",
@@ -537,11 +609,11 @@
           {
             "embeddableConfig": {},
             "gridData": {
-              "h": 15,
+              "h": 12,
               "i": "6",
               "w": 24,
               "x": 24,
-              "y": 15
+              "y": 12
             },
             "id": "68fa61b0-1fb2-11e9-8a4d-eb34d2834f6b",
             "panelIndex": "6",
@@ -552,10 +624,10 @@
           {
             "embeddableConfig": {},
             "gridData": {
-              "h": 15,
+              "h": 12,
               "i": "7",
-              "w": 24,
-              "x": 0,
+              "w": 18,
+              "x": 12,
               "y": 0
             },
             "id": "6710ff20-1f2c-11e9-8a4d-eb34d2834f6b",
@@ -563,6 +635,20 @@
             "title": "Total log space usage",
             "type": "visualization",
             "version": "7.0.0-alpha2"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 12,
+              "i": "8",
+              "w": 12,
+              "x": 0,
+              "y": 0
+            },
+            "id": "82bf9480-260b-11e9-a46a-471d2a76b305",
+            "panelIndex": "8",
+            "type": "visualization",
+            "version": "7.0.0-SNAPSHOT"
           }
         ],
         "timeRestore": false,
@@ -571,9 +657,9 @@
       },
       "id": "18d66970-1fb4-11e9-8a4d-eb34d2834f6b",
       "type": "dashboard",
-      "updated_at": "2019-01-24T09:40:34.632Z",
-      "version": 2
+      "updated_at": "2019-02-01T10:39:36.585Z",
+      "version": 3
     }
   ],
-  "version": "7.0.0-alpha2"
+  "version": "7.0.0-SNAPSHOT"
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4249331/51669345-8e1fa380-1fc4-11e9-979e-3960944fb1c8.png)

Just one thing is "missing". I think there's a bug in the PR of the transaction log because the backup time. It is recognized as `string` inside the index pattern while in the `fields.yml` file is a `date` https://github.com/elastic/beats/blob/master/x-pack/metricbeat/module/mssql/transaction_log/_meta/fields.yml#L45.

![image](https://user-images.githubusercontent.com/4249331/51669128-118cc500-1fc4-11e9-8438-5218d4c98d81.png)

The value is correct, it's just that not backup have been done yet so the database returns its "zero value" but I think it will be nice that it has some formatting or something similar.

By the way, regarding the question about the _@ timestamp per 30 seconds` I did here https://github.com/elastic/beats/pull/10076#issuecomment-456007897 the answer was the visual builder. If you build the dashboard with the visual builder, it appears as _per 10 seconds_