### PR TITLE
Mark indices with the beat name

### DIFF
--- a/libbeat/template/template.go
+++ b/libbeat/template/template.go
@@ -46,6 +46,7 @@ type Template struct {
 	name        string
 	pattern     string
 	beatVersion common.Version
+	beatName    string
 	esVersion   common.Version
 	config      TemplateConfig
 	migration   bool
@@ -116,6 +117,7 @@ func New(beatVersion string, beatName string, esVersion common.Version, config T
 		name:        name,
 		beatVersion: *bV,
 		esVersion:   esVersion,
+		beatName:    beatName,
 		config:      config,
 		migration:   migration,
 	}, nil
@@ -189,7 +191,7 @@ func (t *Template) Generate(properties common.MapStr, dynamicTemplates []common.
 		keyPattern: patterns,
 
 		"mappings": buildMappings(
-			t.beatVersion, t.esVersion,
+			t.beatVersion, t.esVersion, t.beatName,
 			properties,
 			append(dynamicTemplates, buildDynTmpl(t.esVersion)),
 			common.MapStr(t.config.Settings.Source),
@@ -215,6 +217,7 @@ func buildPatternSettings(ver common.Version, pattern string) (string, interface
 
 func buildMappings(
 	beatVersion, esVersion common.Version,
+	beatName string,
 	properties common.MapStr,
 	dynTmpls []common.MapStr,
 	source common.MapStr,
@@ -222,6 +225,7 @@ func buildMappings(
 	mapping := common.MapStr{
 		"_meta": common.MapStr{
 			"version": beatVersion.String(),
+			"beat":    beatName,
 		},
 		"date_detection":    defaultDateDetection,
 		"dynamic_templates": dynTmpls,

--- a/libbeat/template/template_test.go
+++ b/libbeat/template/template_test.go
@@ -76,3 +76,17 @@ func TestNumberOfRoutingShardsOverwrite(t *testing.T) {
 
 	assert.Equal(t, 5, shards.(int))
 }
+
+func TestTemplate(t *testing.T) {
+	beatVersion := "6.6.0"
+	beatName := "testbeat"
+	ver := common.MustNewVersion("6.6.0")
+	template, err := New(beatVersion, beatName, *ver, TemplateConfig{}, false)
+	assert.NoError(t, err)
+
+	data := template.Generate(nil, nil)
+	assert.Equal(t, []string{"testbeat-6.6.0-*"}, data["index_patterns"])
+	meta, err := data.GetValue("mappings.doc._meta")
+	assert.NoError(t, err)
+	assert.Equal(t, common.MapStr{"beat": "testbeat", "version": "6.6.0"}, meta)
+}


### PR DESCRIPTION
To facilitate APM re-indexing / migration scripts, it is very convenient to uniquely identify `apm` indices without searching for values in data.
Since everything is configurable by the user, right now we don't have any attribute that we can rely on. 

We have been recommended to put a mark on the `_meta` mapping. This enables us to set it in code without users tampering with it.

