### PR TITLE
Cherry-pick #10258 to 6.x: [Heartbeat] Incorporate factory metadata for autodiscover

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -149,6 +149,7 @@ https://github.com/elastic/beats/compare/v6.6.0...6.x[Check the HEAD diff]
 
 *Heartbeat*
 - Made monitors.d configuration part of the default config. {pull}9004[9004]
+- Autodiscover metadata is now included in events by default. So, if you are using the docker provider for instance, you'll see the correct fields under the `docker` key. {pull}10258[10258]
 
 *Journalbeat*
 

--- a/heartbeat/monitors/factory.go
+++ b/heartbeat/monitors/factory.go
@@ -38,7 +38,7 @@ func NewFactory(sched *scheduler.Scheduler, allowWatches bool) *RunnerFactory {
 
 // Create makes a new Runner for a new monitor with the given Config.
 func (f *RunnerFactory) Create(p beat.Pipeline, c *common.Config, meta *common.MapStrPointer) (cfgfile.Runner, error) {
-	monitor, err := newMonitor(c, globalPluginsReg, p, f.sched, f.allowWatches)
+	monitor, err := newMonitor(c, globalPluginsReg, p, f.sched, f.allowWatches, meta)
 	return monitor, err
 }
 

--- a/heartbeat/monitors/monitor.go
+++ b/heartbeat/monitors/monitor.go
@@ -56,7 +56,8 @@ type Monitor struct {
 
 	// stats is the countersRecorder used to record lifecycle events
 	// for global metrics + telemetry
-	stats registryRecorder
+	stats           registryRecorder
+	factoryMetadata *common.MapStrPointer
 }
 
 // String prints a description of the monitor in a threadsafe way. It is important that this use threadsafe
@@ -66,7 +67,7 @@ func (m *Monitor) String() string {
 }
 
 func checkMonitorConfig(config *common.Config, registrar *pluginsReg, allowWatches bool) error {
-	_, err := newMonitor(config, registrar, nil, nil, allowWatches)
+	_, err := newMonitor(config, registrar, nil, nil, allowWatches, nil)
 	return err
 }
 
@@ -79,6 +80,7 @@ func newMonitor(
 	pipelineConnector beat.PipelineConnector,
 	scheduler *scheduler.Scheduler,
 	allowWatches bool,
+	factoryMetadata *common.MapStrPointer,
 ) (*Monitor, error) {
 	// Extract just the Type and Enabled fields from the config
 	// We'll parse things more precisely later once we know what exact type of
@@ -102,6 +104,7 @@ func newMonitor(
 		internalsMtx:      sync.Mutex{},
 		config:            config,
 		stats:             monitorPlugin.stats,
+		factoryMetadata:   factoryMetadata,
 	}
 
 	jobs, endpoints, err := monitorPlugin.create(config)

--- a/heartbeat/monitors/monitor_test.go
+++ b/heartbeat/monitors/monitor_test.go
@@ -37,7 +37,7 @@ func TestMonitor(t *testing.T) {
 	require.NoError(t, err)
 	defer sched.Stop()
 
-	mon, err := newMonitor(serverMonConf, reg, pipelineConnector, sched, false)
+	mon, err := newMonitor(serverMonConf, reg, pipelineConnector, sched, false, nil)
 	require.NoError(t, err)
 
 	mon.Start()

--- a/heartbeat/monitors/task.go
+++ b/heartbeat/monitors/task.go
@@ -145,10 +145,15 @@ func (t *configuredJob) makeSchedulerTaskFunc() scheduler.TaskFunc {
 func (t *configuredJob) Start() {
 	var err error
 
+	fields := common.MapStr{"event": common.MapStr{"dataset": "uptime"}}
+	if t.monitor.factoryMetadata != nil {
+		fields.DeepUpdate(t.monitor.factoryMetadata.Get())
+	}
+
 	t.client, err = t.monitor.pipelineConnector.ConnectWith(beat.ClientConfig{
 		EventMetadata: t.config.EventMetadata,
 		Processor:     t.processors,
-		Fields:        common.MapStr{"event": common.MapStr{"dataset": "uptime"}},
+		Fields:        fields,
 	})
 	if err != nil {
 		logp.Err("could not start monitor: %v", err)

--- a/heartbeat/tests/system/test_autodiscovery.py
+++ b/heartbeat/tests/system/test_autodiscovery.py
@@ -57,8 +57,8 @@ class TestAutodiscover(BaseTest):
                     port = network_settings['Ports'].keys()[0].split("/")[0]
                     # Check metadata is added
                     expected = 'tcp-tcp@%s:%s' % (host, port)
-                    actual = output[0]['monitor']['id']
-                    if expected == actual:
+                    event = output[0]
+                    if event['monitor']['id'] == expected and event['docker']['container']['id'] is not None:
                         matched = True
 
         assert matched


### PR DESCRIPTION
Cherry-pick of PR #10258 to 6.x branch. Original message: 

Heartbeat factories get metadata from autodiscover and other sources.

This change automatically adds that data to events keeping heartbeat behavior in-line with other beats.