### PR TITLE
Enable Docker and Kubernetes labels dedot by default

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -21,6 +21,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Rename `process.exe` to `process.executable` in add_process_metadata to align with ECS. {pull}9949[9949]
 - Import ECS change https://github.com/elastic/ecs/pull/308[ecs#308]:
   leaf field `user.group` is now the `group` field set. {pull}10275[10275]
+- Docker and Kubernetes labels/annotations will be "dedoted" by default. {pull}10338[10338]
 
 *Auditbeat*
 - Rename `process.exe` to `process.executable` in auditd module to align with ECS. {pull}9949[9949]

--- a/libbeat/common/kubernetes/metadata.go
+++ b/libbeat/common/kubernetes/metadata.go
@@ -55,8 +55,8 @@ func NewMetaGenerator(cfg *common.Config) (MetaGenerator, error) {
 	// default settings:
 	generator := metaGenerator{
 		IncludeCreatorMetadata: true,
-		LabelsDedot:            false,
-		AnnotationsDedot:       false,
+		LabelsDedot:            true,
+		AnnotationsDedot:       true,
 	}
 
 	err := cfg.Unpack(&generator)

--- a/libbeat/common/kubernetes/metadata_test.go
+++ b/libbeat/common/kubernetes/metadata_test.go
@@ -35,9 +35,8 @@ func TestPodMetadata(t *testing.T) {
 	True := true
 	False := false
 	tests := []struct {
-		pod    *Pod
-		meta   common.MapStr
-		config *common.Config
+		pod  *Pod
+		meta common.MapStr
 	}{
 		{
 			pod: &Pod{
@@ -59,7 +58,6 @@ func TestPodMetadata(t *testing.T) {
 				"namespace": "test",
 				"labels":    common.MapStr{"a": common.MapStr{"value": "bar", "key": "foo"}},
 			},
-			config: common.NewConfig(),
 		},
 		{
 			pod: &Pod{
@@ -92,12 +90,17 @@ func TestPodMetadata(t *testing.T) {
 				"labels":     common.MapStr{"a": common.MapStr{"value": "bar", "key": "foo"}},
 				"deployment": common.MapStr{"name": "test"},
 			},
-			config: common.NewConfig(),
 		},
 	}
 
 	for _, test := range tests {
-		metaGen, err := NewMetaGenerator(test.config)
+		config, err := common.NewConfigFrom(map[string]interface{}{
+			"labels.dedot":        false,
+			"annotations.dedot":   false,
+			"include_annotations": []string{"b", "b.key"},
+		})
+
+		metaGen, err := NewMetaGenerator(config)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -113,9 +116,8 @@ func TestPodMetadataDeDot(t *testing.T) {
 	True := true
 	False := false
 	tests := []struct {
-		pod    *Pod
-		meta   common.MapStr
-		config *common.Config
+		pod  *Pod
+		meta common.MapStr
 	}{
 		{
 			pod: &Pod{
@@ -139,7 +141,6 @@ func TestPodMetadataDeDot(t *testing.T) {
 				"labels":      common.MapStr{"a": "bar", "a_key": "foo"},
 				"annotations": common.MapStr{"b": "bar", "b_key": "foo"},
 			},
-			config: common.NewConfig(),
 		},
 		{
 			pod: &Pod{
@@ -172,14 +173,11 @@ func TestPodMetadataDeDot(t *testing.T) {
 				"labels":     common.MapStr{"a": "bar", "a_key": "foo"},
 				"deployment": common.MapStr{"name": "test"},
 			},
-			config: common.NewConfig(),
 		},
 	}
 
 	for _, test := range tests {
 		config, err := common.NewConfigFrom(map[string]interface{}{
-			"labels.dedot":        true,
-			"annotations.dedot":   true,
 			"include_annotations": []string{"b", "b.key"},
 		})
 		metaGen, err := NewMetaGenerator(config)

--- a/libbeat/processors/add_docker_metadata/add_docker_metadata_test.go
+++ b/libbeat/processors/add_docker_metadata/add_docker_metadata_test.go
@@ -104,6 +104,7 @@ func TestMatchNoContainer(t *testing.T) {
 func TestMatchContainer(t *testing.T) {
 	testConfig, err := common.NewConfigFrom(map[string]interface{}{
 		"match_fields": []string{"foo"},
+		"labels.dedot": false,
 	})
 	assert.NoError(t, err)
 
@@ -152,7 +153,6 @@ func TestMatchContainer(t *testing.T) {
 func TestMatchContainerWithDedot(t *testing.T) {
 	testConfig, err := common.NewConfigFrom(map[string]interface{}{
 		"match_fields": []string{"foo"},
-		"labels.dedot": true,
 	})
 	assert.NoError(t, err)
 

--- a/libbeat/processors/add_docker_metadata/config.go
+++ b/libbeat/processors/add_docker_metadata/config.go
@@ -46,6 +46,6 @@ func defaultConfig() Config {
 		MatchSource: true,
 		SourceIndex: 4, // Use 4 to match the CID in /var/lib/docker/containers/<container_id>/*.log.
 		MatchPIDs:   []string{"process.pid", "process.ppid"},
-		DeDot:       false,
+		DeDot:       true,
 	}
 }

--- a/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
+++ b/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
@@ -130,9 +130,9 @@ func getEnvPort() string {
 // GetConfig returns config for elasticsearch module
 func getConfig(metricset string) map[string]interface{} {
 	return map[string]interface{}{
-		"module":     elasticsearch.ModuleName,
-		"metricsets": []string{metricset},
-		"hosts":      []string{getEnvHost() + ":" + getEnvPort()},
+		"module":                     elasticsearch.ModuleName,
+		"metricsets":                 []string{metricset},
+		"hosts":                      []string{getEnvHost() + ":" + getEnvPort()},
 		"index_recovery.active_only": false,
 	}
 }

--- a/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
+++ b/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
@@ -130,9 +130,9 @@ func getEnvPort() string {
 // GetConfig returns config for elasticsearch module
 func getConfig(metricset string) map[string]interface{} {
 	return map[string]interface{}{
-		"module":                     elasticsearch.ModuleName,
-		"metricsets":                 []string{metricset},
-		"hosts":                      []string{getEnvHost() + ":" + getEnvPort()},
+		"module":     elasticsearch.ModuleName,
+		"metricsets": []string{metricset},
+		"hosts":      []string{getEnvHost() + ":" + getEnvPort()},
 		"index_recovery.active_only": false,
 	}
 }

--- a/metricbeat/module/kubernetes/_meta/config.yml
+++ b/metricbeat/module/kubernetes/_meta/config.yml
@@ -17,8 +17,8 @@
   # Enriching parameters:
   #add_metadata: true
   #in_cluster: true
-  #labels.dedot: false
-  #annotations.dedot: false
+  #labels.dedot: true
+  #annotations.dedot: true
   # When used outside the cluster:
   #in_cluster: false
   #host: node_name

--- a/metricbeat/module/kubernetes/event/config.go
+++ b/metricbeat/module/kubernetes/event/config.go
@@ -39,8 +39,8 @@ func defaultKubernetesEventsConfig() kubeEventsConfig {
 	return kubeEventsConfig{
 		InCluster:        true,
 		SyncPeriod:       1 * time.Second,
-		LabelsDedot:      false,
-		AnnotationsDedot: false,
+		LabelsDedot:      true,
+		AnnotationsDedot: true,
 	}
 }
 

--- a/metricbeat/module/kubernetes/event/event.go
+++ b/metricbeat/module/kubernetes/event/event.go
@@ -46,7 +46,8 @@ type MetricSet struct {
 }
 
 // dedotConfig defines LabelsDedot and AnnotationsDedot.
-// Default to be false. If set to true, replace dots in labels with `_`.
+// If set to true, replace dots in labels with `_`.
+// Default to be true.
 type dedotConfig struct {
 	LabelsDedot      bool `config:"labels.dedot"`
 	AnnotationsDedot bool `config:"annotations.dedot"`

--- a/metricbeat/modules.d/kubernetes.yml.disabled
+++ b/metricbeat/modules.d/kubernetes.yml.disabled
@@ -20,8 +20,8 @@
   # Enriching parameters:
   #add_metadata: true
   #in_cluster: true
-  #labels.dedot: false
-  #annotations.dedot: false
+  #labels.dedot: true
+  #annotations.dedot: true
   # When used outside the cluster:
   #in_cluster: false
   #host: node_name


### PR DESCRIPTION
Starting with 7.0 we want to make sure all container (both docker & kubernetes) labels and annotations are dedoted by default. This PR updates default settings to do so.