### PR TITLE
Add `mage fields` to x-pack/libbeat

### DIFF
--- a/x-pack/libbeat/magefile.go
+++ b/x-pack/libbeat/magefile.go
@@ -22,6 +22,11 @@ func Clean() error {
 	return mage.Clean()
 }
 
+// Fields generates a fields.yml for the Beat.
+func Fields() error {
+	return mage.GenerateFieldsYAML()
+}
+
 // GoTestUnit executes the Go unit tests.
 // Use TEST_COVERAGE=true to enable code coverage profiling.
 // Use RACE_DETECTOR=true to enable the race detector.


### PR DESCRIPTION
The `fields` was missing for the x-pack/libbeat build target.

This related to the changed I've made to infra.