### PR TITLE
Fixing regression in macOS path

### DIFF
--- a/filebeat/module/elasticsearch/audit/manifest.yml
+++ b/filebeat/module/elasticsearch/audit/manifest.yml
@@ -6,8 +6,8 @@ var:
       - /var/log/elasticsearch/*_access.log
       - /var/log/elasticsearch/*_audit.log
     os.darwin:
-      - /usr/local/elasticsearch/*_access.log
-      - /usr/local/elasticsearch/*_audit.log
+      - /usr/local/var/lib/elasticsearch/*_access.log
+      - /usr/local/var/lib/elasticsearch/*_audit.log
     os.windows:
       - c:/ProgramData/Elastic/Elasticsearch/logs/*_access.log
       - c:/ProgramData/Elastic/Elasticsearch/logs/*_audit.log


### PR DESCRIPTION
In https://github.com/elastic/beats/pull/8978, we fixed the default macOS path for Elasticsearch audit logs. However, in https://github.com/elastic/beats/pull/8852 we accidentally reverted those paths to their original incorrect values, thereby introducing a regression.

This PR fixes the regression.