### PR TITLE
New functions to close a mysql connection.

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -128,6 +128,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fixed data type for tags field in `docker/image` metricset {pull}10307[10307]
 - Fixed data type for isr field in `kafka/partition` metricset {pull}10307[10307]
 - Fixed data types for various hosts fields in `mongodb/replstatus` metricset {pull}10307[10307]
+- Added function to close sql database connection.{pull}10355[10355]
 
 *Packetbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -128,7 +128,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fixed data type for tags field in `docker/image` metricset {pull}10307[10307]
 - Fixed data type for isr field in `kafka/partition` metricset {pull}10307[10307]
 - Fixed data types for various hosts fields in `mongodb/replstatus` metricset {pull}10307[10307]
-- Added function to close sql database connection.{pull}10355[10355]
+- Added function to close sql database connection. {pull}10355[10355]
 
 *Packetbeat*
 

--- a/metricbeat/module/mysql/galera_status/status.go
+++ b/metricbeat/module/mysql/galera_status/status.go
@@ -111,7 +111,7 @@ func (m *MetricSet) loadStatus(db *sql.DB) (map[string]string, error) {
 // Close closes the database connection and prevents future queries.
 func (m *MetricSet) Close() error {
 	if m.db == nil {
-		return errors.New("invalid database handle")
+		return nil
 	}
 	return errors.Wrap(m.db.Close(), "failed to close mysql database client")
 }

--- a/metricbeat/module/mysql/galera_status/status.go
+++ b/metricbeat/module/mysql/galera_status/status.go
@@ -107,3 +107,11 @@ func (m *MetricSet) loadStatus(db *sql.DB) (map[string]string, error) {
 
 	return galeraStatus, nil
 }
+
+// Close closes the database connection and prevents future queries.
+func (m *MetricSet) Close() error {
+	if m.db == nil {
+		return errors.New("invalid database handle")
+	}
+	return errors.Wrap(m.db.Close(), "failed to close mysql database client")
+}

--- a/metricbeat/module/mysql/mysql.go
+++ b/metricbeat/module/mysql/mysql.go
@@ -106,3 +106,12 @@ func NewDB(dsn string) (*sql.DB, error) {
 	}
 	return db, nil
 }
+
+// CloseDB uses the database handle to close the connection and prevents future queries.
+func CloseDB(db *sql.DB) error {
+	err := db.Close()
+	if err != nil {
+		return errors.Wrap(err, "sql close failed")
+	}
+	return nil
+}

--- a/metricbeat/module/mysql/mysql.go
+++ b/metricbeat/module/mysql/mysql.go
@@ -106,12 +106,3 @@ func NewDB(dsn string) (*sql.DB, error) {
 	}
 	return db, nil
 }
-
-// CloseDB uses the database handle to close the connection and prevents future queries.
-func CloseDB(db *sql.DB) error {
-	err := db.Close()
-	if err != nil {
-		return errors.Wrap(err, "sql close failed")
-	}
-	return nil
-}

--- a/metricbeat/module/mysql/status/status.go
+++ b/metricbeat/module/mysql/status/status.go
@@ -108,7 +108,7 @@ func (m *MetricSet) loadStatus(db *sql.DB) (map[string]string, error) {
 // Close closes the database connection and prevents future queries.
 func (m *MetricSet) Close() error {
 	if m.db == nil {
-		return errors.New("invalid database handle")
+		return nil
 	}
 	return errors.Wrap(m.db.Close(), "failed to close mysql database client")
 }

--- a/metricbeat/module/mysql/status/status.go
+++ b/metricbeat/module/mysql/status/status.go
@@ -107,10 +107,8 @@ func (m *MetricSet) loadStatus(db *sql.DB) (map[string]string, error) {
 
 // Close closes the database connection and prevents future queries.
 func (m *MetricSet) Close() error {
-	err := m.db.Close()
-	if err != nil {
-		return errors.Wrap(err, "mysql-status close failed")
+	if m.db == nil {
+		return errors.New("invalid database handle")
 	}
-
-	return nil
+	return errors.Wrap(m.db.Close(), "failed to close mysql database client")
 }

--- a/metricbeat/module/mysql/status/status.go
+++ b/metricbeat/module/mysql/status/status.go
@@ -104,3 +104,13 @@ func (m *MetricSet) loadStatus(db *sql.DB) (map[string]string, error) {
 
 	return mysqlStatus, nil
 }
+
+// Close closes the database connection and prevents future queries.
+func (m *MetricSet) Close() error {
+	err := m.db.Close()
+	if err != nil {
+		return errors.Wrap(err, "mysql-status close failed")
+	}
+
+	return nil
+}


### PR DESCRIPTION
This is a possible fix for issue #9415. Added a function in the mysql file and
a method for the metricset to close the db too.

I wanted to give it a shot since the last update was done more than 1 month ago. After researching the issue and feedback I thought about this possible solution. Is my approach good or do you prefer the metricset method doing all the work without calling to a function in the mysql file?

Let me know if there's a specific place where these functions should be called.

Also,
[https://github.com/elastic/beats/blob/824d443bc182a12f30859667da4739beef9c8606/metricbeat/mb/module/wrapper_test.go#L66](url)
is empty. Should it call these new functions for assertion? Just thinking of a possible new commit.