### PR TITLE
Add event.kind and event.category

### DIFF
--- a/packetbeat/flows/worker.go
+++ b/packetbeat/flows/worker.go
@@ -212,6 +212,9 @@ func createEvent(
 		"end":      common.Time(f.ts),
 		"duration": f.ts.Sub(f.createTS),
 		"dataset":  "flow",
+		"kind":     "event",
+		"category": "network_traffic",
+		"action":   "network_flow",
 	}
 	flow := common.MapStr{
 		"id":    common.NetString(f.id.Serialize()),

--- a/packetbeat/pb/event_test.go
+++ b/packetbeat/pb/event_test.go
@@ -38,7 +38,13 @@ func TestMarshalMapStr(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assert.Equal(t, common.MapStr{"source": common.MapStr{"ip": "127.0.0.1"}}, m)
+	assert.Equal(t, common.MapStr{
+		"event": common.MapStr{
+			"kind":     "event",
+			"category": "network_traffic",
+		},
+		"source": common.MapStr{"ip": "127.0.0.1"},
+	}, m)
 }
 
 func TestComputeValues(t *testing.T) {

--- a/packetbeat/protos/amqp/amqp.go
+++ b/packetbeat/protos/amqp/amqp.go
@@ -437,6 +437,7 @@ func (amqp *amqpPlugin) publishTransaction(t *amqpTransaction) {
 	pbf.Event.Dataset = "amqp"
 	pbf.Network.Protocol = pbf.Event.Dataset
 	pbf.Network.Transport = "tcp"
+	pbf.Error.Message = t.notes
 
 	fields := evt.Fields
 	fields["type"] = pbf.Event.Dataset
@@ -488,12 +489,6 @@ func (amqp *amqpPlugin) publishTransaction(t *amqpTransaction) {
 		} else {
 			fields["response"] = t.response
 		}
-	}
-
-	if len(t.notes) == 1 {
-		evt.PutValue("error.message", t.notes[0])
-	} else if len(t.notes) > 1 {
-		evt.PutValue("error.message", t.notes)
 	}
 
 	amqp.results(evt)

--- a/packetbeat/protos/amqp/amqp_test.go
+++ b/packetbeat/protos/amqp/amqp_test.go
@@ -28,8 +28,8 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 
-	"github.com/elastic/beats/packetbeat/pb"
 	"github.com/elastic/beats/packetbeat/protos"
+	"github.com/elastic/beats/packetbeat/publish"
 )
 
 type eventStore struct {
@@ -37,18 +37,7 @@ type eventStore struct {
 }
 
 func (e *eventStore) publish(event beat.Event) {
-	pbf, err := pb.GetFields(event.Fields)
-	if err != nil || pbf == nil {
-		panic("_packetbeat not found")
-	}
-	delete(event.Fields, pb.FieldsKey)
-	if err = pbf.ComputeValues(nil); err != nil {
-		panic(err)
-	}
-	if err = pbf.MarshalMapStr(event.Fields); err != nil {
-		panic(err)
-	}
-
+	publish.MarshalPacketbeatFields(&event, nil)
 	e.events = append(e.events, event)
 }
 

--- a/packetbeat/protos/applayer/applayer.go
+++ b/packetbeat/protos/applayer/applayer.go
@@ -223,7 +223,7 @@ func (t *Transaction) InitWithMsg(
 func (t *Transaction) Event(event *beat.Event) error {
 	event.Timestamp = t.Ts.Ts
 
-	pbf := &pb.Fields{}
+	pbf := pb.NewFields()
 	pbf.SetSource(&t.Src)
 	pbf.SetDestination(&t.Dst)
 	pbf.Source.Bytes = int64(t.BytesIn)
@@ -233,16 +233,12 @@ func (t *Transaction) Event(event *beat.Event) error {
 	pbf.Event.End = t.EndTime
 	pbf.Network.Transport = t.Transport.String()
 	pbf.Network.Protocol = pbf.Event.Dataset
+	pbf.Error.Message = t.Notes
 
 	fields := event.Fields
 	fields[pb.FieldsKey] = pbf
 	fields["type"] = pbf.Event.Dataset
 	fields["status"] = t.Status
-	if len(t.Notes) == 1 {
-		event.PutValue("error.message", t.Notes[0])
-	} else if len(t.Notes) > 1 {
-		event.PutValue("error.message", t.Notes)
-	}
 	return nil
 }
 

--- a/packetbeat/protos/cassandra/pub.go
+++ b/packetbeat/protos/cassandra/pub.go
@@ -79,13 +79,12 @@ func (pub *transPub) createEvent(requ, resp *message) beat.Event {
 
 	cassandra := common.MapStr{}
 	status := common.OK_STATUS
-	var notes []string
 
 	//requ can be null, if the message is a PUSHed message
 	if requ != nil {
 		pbf.Source.Bytes = int64(requ.Size)
 		pbf.Event.Start = requ.Ts
-		notes = append(notes, requ.Notes...)
+		pbf.Error.Message = requ.Notes
 
 		if pub.sendRequest {
 			if pub.sendRequestHeader {
@@ -107,7 +106,7 @@ func (pub *transPub) createEvent(requ, resp *message) beat.Event {
 	if resp != nil {
 		pbf.Destination.Bytes = int64(resp.Size)
 		pbf.Event.End = resp.Ts
-		notes = append(notes, resp.Notes...)
+		pbf.Error.Message = append(pbf.Error.Message, resp.Notes...)
 
 		if resp.failed {
 			status = common.ERROR_STATUS
@@ -131,12 +130,6 @@ func (pub *transPub) createEvent(requ, resp *message) beat.Event {
 
 	if len(cassandra) > 0 {
 		fields["cassandra"] = cassandra
-	}
-
-	if len(notes) == 1 {
-		fields.Put("error.message", notes[0])
-	} else if len(notes) > 1 {
-		fields.Put("error.message", notes)
 	}
 
 	return evt

--- a/packetbeat/protos/dns/dns.go
+++ b/packetbeat/protos/dns/dns.go
@@ -370,15 +370,11 @@ func (dns *dnsPlugin) publishTransaction(t *dnsTransaction) {
 	pbf.SetDestination(&t.dst)
 	pbf.Network.Transport = t.transport.String()
 	pbf.Network.Protocol = "dns"
+	pbf.Error.Message = t.notes
 
 	fields := evt.Fields
 	fields["type"] = "dns"
 	fields["status"] = common.ERROR_STATUS
-	if len(t.notes) == 1 {
-		fields.Put("error.message", t.notes[0])
-	} else if len(t.notes) > 1 {
-		fields.Put("error.message", t.notes)
-	}
 
 	dnsEvent := common.MapStr{}
 	fields["dns"] = dnsEvent

--- a/packetbeat/protos/dns/dns_test.go
+++ b/packetbeat/protos/dns/dns_test.go
@@ -34,8 +34,8 @@ import (
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
-	"github.com/elastic/beats/packetbeat/pb"
 	"github.com/elastic/beats/packetbeat/protos"
+	"github.com/elastic/beats/packetbeat/publish"
 )
 
 // Test Constants
@@ -79,18 +79,7 @@ type eventStore struct {
 }
 
 func (e *eventStore) publish(event beat.Event) {
-	pbf, err := pb.GetFields(event.Fields)
-	if err != nil || pbf == nil {
-		panic("_packetbeat not found")
-	}
-	delete(event.Fields, pb.FieldsKey)
-	if err = pbf.ComputeValues(nil); err != nil {
-		panic(err)
-	}
-	if err = pbf.MarshalMapStr(event.Fields); err != nil {
-		panic(err)
-	}
-
+	publish.MarshalPacketbeatFields(&event, nil)
 	e.events = append(e.events, event)
 }
 

--- a/packetbeat/protos/http/http.go
+++ b/packetbeat/protos/http/http.go
@@ -559,6 +559,7 @@ func (http *httpPlugin) newTransaction(requ, resp *message) beat.Event {
 		if http.sendRequest {
 			fields["request"] = string(http.makeRawMessage(requ))
 		}
+		fields["method"] = httpFields.RequestMethod
 		fields["query"] = fmt.Sprintf("%s %s", requ.method, path)
 	}
 

--- a/packetbeat/protos/http/http_test.go
+++ b/packetbeat/protos/http/http_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/packetbeat/protos"
+	"github.com/elastic/beats/packetbeat/publish"
 )
 
 type testParser struct {
@@ -49,6 +50,7 @@ type eventStore struct {
 }
 
 func (e *eventStore) publish(event beat.Event) {
+	publish.MarshalPacketbeatFields(&event, nil)
 	e.events = append(e.events, event)
 }
 

--- a/packetbeat/protos/icmp/icmp.go
+++ b/packetbeat/protos/icmp/icmp.go
@@ -288,6 +288,7 @@ func (icmp *icmpPlugin) publishTransaction(trans *icmpTransaction) {
 	pbf.Source = &ecs.Source{IP: trans.tuple.srcIP.String()}
 	pbf.Destination = &ecs.Destination{IP: trans.tuple.dstIP.String()}
 	pbf.Event.Dataset = "icmp"
+	pbf.Error.Message = trans.notes
 
 	// common fields - group "event"
 	fields := evt.Fields
@@ -339,12 +340,6 @@ func (icmp *icmpPlugin) publishTransaction(trans *icmpTransaction) {
 			pbf.ICMPType = trans.response.Type
 			pbf.ICMPCode = trans.response.code
 		}
-	}
-
-	if len(trans.notes) == 1 {
-		evt.PutValue("error.message", trans.notes[0])
-	} else if len(trans.notes) > 1 {
-		evt.PutValue("error.message", trans.notes)
 	}
 
 	icmp.results(evt)

--- a/packetbeat/protos/mysql/mysql.go
+++ b/packetbeat/protos/mysql/mysql.go
@@ -1164,6 +1164,7 @@ func (mysql *mysqlPlugin) publishTransaction(t *mysqlTransaction) {
 	pbf.Event.End = t.endTime
 	pbf.Network.Transport = "tcp"
 	pbf.Network.Protocol = "mysql"
+	pbf.Error.Message = t.notes
 
 	fields := evt.Fields
 	fields["type"] = pbf.Event.Dataset
@@ -1188,12 +1189,6 @@ func (mysql *mysqlPlugin) publishTransaction(t *mysqlTransaction) {
 	}
 	if mysql.sendResponse {
 		fields["response"] = t.responseRaw
-	}
-
-	if len(t.notes) == 1 {
-		evt.PutValue("error.message", t.notes[0])
-	} else if len(t.notes) > 1 {
-		evt.PutValue("error.message", t.notes)
 	}
 
 	mysql.results(evt)

--- a/packetbeat/protos/mysql/mysql_test.go
+++ b/packetbeat/protos/mysql/mysql_test.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/elastic/beats/packetbeat/protos"
 	"github.com/elastic/beats/packetbeat/protos/tcp"
+	"github.com/elastic/beats/packetbeat/publish"
 )
 
 const serverPort = 3306
@@ -42,6 +43,7 @@ type eventStore struct {
 }
 
 func (e *eventStore) publish(event beat.Event) {
+	publish.MarshalPacketbeatFields(&event, nil)
 	e.events = append(e.events, event)
 }
 

--- a/packetbeat/protos/pgsql/pgsql.go
+++ b/packetbeat/protos/pgsql/pgsql.go
@@ -467,6 +467,7 @@ func (pgsql *pgsqlPlugin) publishTransaction(t *pgsqlTransaction) {
 	pbf.Event.Dataset = "pgsql"
 	pbf.Network.Transport = "tcp"
 	pbf.Network.Protocol = pbf.Event.Dataset
+	pbf.Error.Message = t.notes
 
 	fields := evt.Fields
 	fields["type"] = pbf.Event.Dataset
@@ -484,12 +485,6 @@ func (pgsql *pgsqlPlugin) publishTransaction(t *pgsqlTransaction) {
 	}
 	if pgsql.sendResponse {
 		fields["response"] = t.responseRaw
-	}
-
-	if len(t.notes) == 1 {
-		evt.PutValue("error.message", t.notes[0])
-	} else if len(t.notes) > 1 {
-		evt.PutValue("error.message", t.notes)
 	}
 
 	pgsql.results(evt)

--- a/packetbeat/protos/pgsql/pgsql_test.go
+++ b/packetbeat/protos/pgsql/pgsql_test.go
@@ -31,8 +31,8 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 
-	"github.com/elastic/beats/packetbeat/pb"
 	"github.com/elastic/beats/packetbeat/protos"
+	"github.com/elastic/beats/packetbeat/publish"
 )
 
 type eventStore struct {
@@ -40,18 +40,7 @@ type eventStore struct {
 }
 
 func (e *eventStore) publish(event beat.Event) {
-	pbf, err := pb.GetFields(event.Fields)
-	if err != nil || pbf == nil {
-		panic("_packetbeat not found")
-	}
-	delete(event.Fields, pb.FieldsKey)
-	if err = pbf.ComputeValues(nil); err != nil {
-		panic(err)
-	}
-	if err = pbf.MarshalMapStr(event.Fields); err != nil {
-		panic(err)
-	}
-
+	publish.MarshalPacketbeatFields(&event, nil)
 	e.events = append(e.events, event)
 }
 

--- a/packetbeat/protos/thrift/thrift.go
+++ b/packetbeat/protos/thrift/thrift.go
@@ -1137,11 +1137,8 @@ func (thrift *thriftPlugin) publishTransactions() {
 						t.reply.exceptions)
 				}
 			}
-			if len(t.reply.notes) == 1 {
-				evt.PutValue("error.message", t.reply.notes[0])
-			} else if len(t.reply.notes) > 1 {
-				evt.PutValue("error.message", t.reply.notes)
-			}
+
+			pbf.Error.Message = t.reply.notes
 		}
 
 		if thrift.results != nil {

--- a/packetbeat/protos/tls/tls_test.go
+++ b/packetbeat/protos/tls/tls_test.go
@@ -30,8 +30,8 @@ import (
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
-	"github.com/elastic/beats/packetbeat/pb"
 	"github.com/elastic/beats/packetbeat/protos"
+	"github.com/elastic/beats/packetbeat/publish"
 )
 
 type eventStore struct {
@@ -39,7 +39,7 @@ type eventStore struct {
 }
 
 const (
-	expectedClientHello = `{"client":{"ip":"192.168.0.1","port":6512},"destination":{"domain":"example.org","ip":"192.168.0.2","port":27017},"event":{"dataset":"tls"},"network":{"community_id":"1:jKfewJN/czjTuEpVvsKdYXXiMzs=","protocol":"tls","transport":"tcp","type":"ipv4"},"server":{"domain":"example.org","ip":"192.168.0.2","port":27017},"source":{"ip":"192.168.0.1","port":6512},"status":"Error","tls":{"client_certificate_requested":false,"client_hello":{"extensions":{"_unparsed_":["renegotiation_info","23","status_request","18","30032"],"application_layer_protocol_negotiation":["h2","http/1.1"],"ec_points_formats":["uncompressed"],"server_name_indication":["example.org"],"session_ticket":"","signature_algorithms":["ecdsa_secp256r1_sha256","rsa_pss_sha256","rsa_pkcs1_sha256","ecdsa_secp384r1_sha384","rsa_pss_sha384","rsa_pkcs1_sha384","rsa_pss_sha512","rsa_pkcs1_sha512","rsa_pkcs1_sha1"],"supported_groups":["x25519","secp256r1","secp384r1"]},"supported_ciphers":["TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256","TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256","TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384","TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384","TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256","TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256","TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA","TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA","TLS_RSA_WITH_AES_128_GCM_SHA256","TLS_RSA_WITH_AES_256_GCM_SHA384","TLS_RSA_WITH_AES_128_CBC_SHA","TLS_RSA_WITH_AES_256_CBC_SHA","TLS_RSA_WITH_3DES_EDE_CBC_SHA"],"supported_compression_methods":["NULL"],"version":"3.3"},"fingerprints":{"ja3":{"hash":"94c485bca29d5392be53f2b8cf7f4304","str":"771,49195-49199-49196-49200-52393-52392-49171-49172-156-157-47-53-10,65281-0-23-35-13-5-18-16-30032-11-10,29-23-24,0"}},"handshake_completed":false,"resumed":false},"type":"tls"}`
+	expectedClientHello = `{"client":{"ip":"192.168.0.1","port":6512},"destination":{"domain":"example.org","ip":"192.168.0.2","port":27017},"event":{"category":"network_traffic","dataset":"tls","kind":"event"},"network":{"community_id":"1:jKfewJN/czjTuEpVvsKdYXXiMzs=","protocol":"tls","transport":"tcp","type":"ipv4"},"server":{"domain":"example.org","ip":"192.168.0.2","port":27017},"source":{"ip":"192.168.0.1","port":6512},"status":"Error","tls":{"client_certificate_requested":false,"client_hello":{"extensions":{"_unparsed_":["renegotiation_info","23","status_request","18","30032"],"application_layer_protocol_negotiation":["h2","http/1.1"],"ec_points_formats":["uncompressed"],"server_name_indication":["example.org"],"session_ticket":"","signature_algorithms":["ecdsa_secp256r1_sha256","rsa_pss_sha256","rsa_pkcs1_sha256","ecdsa_secp384r1_sha384","rsa_pss_sha384","rsa_pkcs1_sha384","rsa_pss_sha512","rsa_pkcs1_sha512","rsa_pkcs1_sha1"],"supported_groups":["x25519","secp256r1","secp384r1"]},"supported_ciphers":["TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256","TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256","TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384","TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384","TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256","TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256","TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA","TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA","TLS_RSA_WITH_AES_128_GCM_SHA256","TLS_RSA_WITH_AES_256_GCM_SHA384","TLS_RSA_WITH_AES_128_CBC_SHA","TLS_RSA_WITH_AES_256_CBC_SHA","TLS_RSA_WITH_3DES_EDE_CBC_SHA"],"supported_compression_methods":["NULL"],"version":"3.3"},"fingerprints":{"ja3":{"hash":"94c485bca29d5392be53f2b8cf7f4304","str":"771,49195-49199-49196-49200-52393-52392-49171-49172-156-157-47-53-10,65281-0-23-35-13-5-18-16-30032-11-10,29-23-24,0"}},"handshake_completed":false,"resumed":false},"type":"tls"}`
 	expectedServerHello = `{"extensions":{"_unparsed_":["renegotiation_info","status_request"],"application_layer_protocol_negotiation":["h2"],"ec_points_formats":["uncompressed","ansiX962_compressed_prime","ansiX962_compressed_char2"],"session_ticket":""},"selected_cipher":"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256","selected_compression_method":"NULL","version":"3.3"}`
 	rawClientHello      = "16030100c2010000be03033367dfae0d46ec0651e49cca2ae47317e8989df710" +
 		"ee7570a88b9a7d5d56b3af00001c3a3ac02bc02fc02cc030cca9cca8c013c014" +
@@ -56,18 +56,7 @@ const (
 )
 
 func (e *eventStore) publish(event beat.Event) {
-	pbf, err := pb.GetFields(event.Fields)
-	if err != nil || pbf == nil {
-		panic("_packetbeat not found")
-	}
-	delete(event.Fields, pb.FieldsKey)
-	if err = pbf.ComputeValues(nil); err != nil {
-		panic(err)
-	}
-	if err = pbf.MarshalMapStr(event.Fields); err != nil {
-		panic(err)
-	}
-
+	publish.MarshalPacketbeatFields(&event, nil)
 	e.events = append(e.events, event)
 }
 

--- a/packetbeat/publish/publish_test.go
+++ b/packetbeat/publish/publish_test.go
@@ -20,6 +20,7 @@
 package publish
 
 import (
+	"net"
 	"testing"
 	"time"
 
@@ -27,6 +28,8 @@ import (
 
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/packetbeat/pb"
+	"github.com/elastic/ecs/code/go/ecs"
 )
 
 func testEvent() beat.Event {
@@ -88,125 +91,98 @@ func TestFilterEvent(t *testing.T) {
 	}
 }
 
-func TestDirectionOut(t *testing.T) {
-	processor := transProcessor{
-		localIPStrings: []string{"192.145.2.4"},
-		ignoreOutgoing: false,
-		name:           "test",
-	}
+func TestPublish(t *testing.T) {
+	var srcIP, dstIP = "192.145.2.4", "192.145.2.5"
 
-	event := beat.Event{
-		Timestamp: time.Now(),
-		Fields: common.MapStr{
-			"type": "test",
-			"src": &common.Endpoint{
-				IP:     "192.145.2.4",
-				Port:   3267,
-				Domain: "server1",
-				Process: common.Process{
-					Args: []string{"proc1", "start"},
-					Name: "proc1",
+	event := func() *beat.Event {
+		return &beat.Event{
+			Timestamp: time.Now(),
+			Fields: common.MapStr{
+				"type": "test",
+				"_packetbeat": &pb.Fields{
+					Source: &ecs.Source{
+						IP:   srcIP,
+						Port: 3267,
+					},
+					Destination: &ecs.Destination{
+						IP:   dstIP,
+						Port: 32232,
+					},
 				},
 			},
-			"dst": &common.Endpoint{
-				IP:     "192.145.2.5",
-				Port:   32232,
-				Domain: "server2",
-				Process: common.Process{
-					Args: []string{"proc2", "start"},
-					Name: "proc2",
-				},
-			},
-		},
+		}
 	}
 
-	if res, _ := processor.Run(&event); res == nil {
-		t.Fatalf("event has been filtered out")
-	}
-	clientIP, _ := event.GetValue("client.ip")
-	assert.Equal(t, "192.145.2.4", clientIP)
-	dir, _ := event.GetValue("network.direction")
-	assert.Equal(t, "outgoing", dir)
-}
+	t.Run("direction/inbound", func(t *testing.T) {
+		processor := transProcessor{
+			localIPs: []net.IP{net.ParseIP(dstIP)},
+			name:     "test",
+		}
 
-func TestDirectionIn(t *testing.T) {
-	processor := transProcessor{
-		localIPStrings: []string{"192.145.2.5"},
-		ignoreOutgoing: false,
-		name:           "test",
-	}
+		res, _ := processor.Run(event())
+		if res == nil {
+			t.Fatalf("event has been filtered out")
+		}
 
-	event := beat.Event{
-		Timestamp: time.Now(),
-		Fields: common.MapStr{
-			"type": "test",
-			"src": &common.Endpoint{
-				IP:     "192.145.2.4",
-				Port:   3267,
-				Domain: "server1",
-				Process: common.Process{
-					Args: []string{"proc1", "start"},
-					Name: "proc1",
-				},
-			},
-			"dst": &common.Endpoint{
-				IP:     "192.145.2.5",
-				Port:   32232,
-				Domain: "server2",
-				Process: common.Process{
-					Args: []string{"proc2", "start"},
-					Name: "proc2",
-				},
-			},
-		},
-	}
+		dir, _ := res.GetValue("network.direction")
+		assert.Equal(t, "inbound", dir)
+	})
 
-	if res, _ := processor.Run(&event); res == nil {
-		t.Fatalf("event has been filtered out")
-	}
-	clientIP, _ := event.GetValue("client.ip")
-	assert.Equal(t, "192.145.2.4", clientIP)
-	dir, _ := event.GetValue("network.direction")
-	assert.Equal(t, "incoming", dir)
-}
+	t.Run("direction/outbound", func(t *testing.T) {
+		processor := transProcessor{
+			localIPs: []net.IP{net.ParseIP(srcIP)},
+			name:     "test",
+		}
 
-func TestNoDirection(t *testing.T) {
-	processor := transProcessor{
-		localIPStrings: []string{"192.145.2.6"},
-		ignoreOutgoing: false,
-		name:           "test",
-	}
+		res, _ := processor.Run(event())
+		if res == nil {
+			t.Fatalf("event has been filtered out")
+		}
 
-	event := beat.Event{
-		Timestamp: time.Now(),
-		Fields: common.MapStr{
-			"type": "test",
-			"src": &common.Endpoint{
-				IP:     "192.145.2.4",
-				Port:   3267,
-				Domain: "server1",
-				Process: common.Process{
-					Args: []string{"proc1", "start"},
-					Name: "proc1",
-				},
-			},
-			"dst": &common.Endpoint{
-				IP:     "192.145.2.5",
-				Port:   32232,
-				Domain: "server2",
-				Process: common.Process{
-					Args: []string{"proc2", "start"},
-					Name: "proc2",
-				},
-			},
-		},
-	}
+		dir, _ := res.GetValue("network.direction")
+		assert.Equal(t, "outbound", dir)
+	})
 
-	if res, _ := processor.Run(&event); res == nil {
-		t.Fatalf("event has been filtered out")
-	}
-	clientIP, _ := event.GetValue("client.ip")
-	assert.Equal(t, "192.145.2.4", clientIP)
-	dir, _ := event.GetValue("network.direction")
-	assert.Nil(t, dir)
+	t.Run("direction/internal", func(t *testing.T) {
+		processor := transProcessor{
+			localIPs: []net.IP{net.ParseIP(srcIP), net.ParseIP(dstIP)},
+			name:     "test",
+		}
+
+		res, _ := processor.Run(event())
+		if res == nil {
+			t.Fatalf("event has been filtered out")
+		}
+
+		dir, _ := res.GetValue("network.direction")
+		assert.Equal(t, "internal", dir)
+	})
+
+	t.Run("direction/none", func(t *testing.T) {
+		processor := transProcessor{
+			localIPs: []net.IP{net.ParseIP(dstIP + "1")},
+			name:     "test",
+		}
+
+		res, _ := processor.Run(event())
+		if res == nil {
+			t.Fatalf("event has been filtered out")
+		}
+
+		dir, _ := res.GetValue("network.direction")
+		assert.Nil(t, dir)
+	})
+
+	t.Run("ignore_outgoing", func(t *testing.T) {
+		processor := transProcessor{
+			localIPs:       []net.IP{net.ParseIP(srcIP)},
+			ignoreOutgoing: true,
+			name:           "test",
+		}
+
+		res, err := processor.Run(event())
+		if assert.NoError(t, err) {
+			assert.Nil(t, res)
+		}
+	})
 }

--- a/packetbeat/tests/system/packetbeat.py
+++ b/packetbeat/tests/system/packetbeat.py
@@ -10,7 +10,7 @@ from beat.beat import Proc
 
 TRANS_REQUIRED_FIELDS = ["@timestamp", "type", "status",
                          "agent.type", "agent.hostname", "agent.version",
-                         "event.dataset", "event.start",
+                         "event.kind", "event.category", "event.dataset", "event.start",
                          "source.ip", "destination.ip",
                          "client.ip", "server.ip",
                          "network.type", "network.transport", "network.community_id",
@@ -18,7 +18,7 @@ TRANS_REQUIRED_FIELDS = ["@timestamp", "type", "status",
 
 FLOWS_REQUIRED_FIELDS = ["@timestamp", "type",
                          "agent.type", "agent.hostname", "agent.version",
-                         "event.dataset", "event.start", "event.end", "event.duration",
+                         "event.kind", "event.category", "event.dataset", "event.action", "event.start", "event.end", "event.duration",
                          "source.ip", "destination.ip",
                          "flow.id",
                          "network.type", "network.transport", "network.community_id",


### PR DESCRIPTION
Part of #7968

Adds `event.kind = event` and `event.category = network_traffic` to all Packetbeat events.
Packetbeat flow events will additional have `event.action = network_flow` (same as Filebeat
netflow).

This also does some cleanup of redundant and unused code that resulted from the ECS
migration.