### PR TITLE
[WIP] Fix empty string without error in index selection

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -135,6 +135,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - The backing off now implements jitter to better distribute the load. {issue}10172[10172]
 - Fix TLS certificate DoS vulnerability. {pull}10302[10302]
 - Fix panic and file unlock in spool on atomic operation (arm, x86-32). File lock was not released when panic occurs, leading to the beat deadlocking on startup. {pull}10289[10289]
+- Report error if index selection fails due to a missing field. {pull}10360[10360]
 
 *Auditbeat*
 

--- a/libbeat/common/fmtstr/formatevents.go
+++ b/libbeat/common/fmtstr/formatevents.go
@@ -407,6 +407,9 @@ func parseEventPath(field string) (string, error) {
 func fieldString(event *beat.Event, field string) (string, error) {
 	v, err := event.GetValue(field)
 	if err != nil {
+		if err == common.ErrKeyNotFound {
+			err = fmt.Errorf("event field '%v' not found", field)
+		}
 		return "", err
 	}
 

--- a/libbeat/outputs/elasticsearch/client_test.go
+++ b/libbeat/outputs/elasticsearch/client_test.go
@@ -355,7 +355,7 @@ func TestBulkEncodeEvents(t *testing.T) {
 		events  []common.MapStr
 	}{
 		"Beats 7.x event": {
-			docType: "doc",
+			docType: "",
 			config:  common.MapStr{},
 			events:  []common.MapStr{{"message": "test"}},
 		},

--- a/libbeat/outputs/outil/select.go
+++ b/libbeat/outputs/outil/select.go
@@ -355,8 +355,9 @@ func (s *constSelector) sel(_ *beat.Event) (string, error) {
 func (s *fmtSelector) sel(evt *beat.Event) (string, error) {
 	n, err := s.f.Run(evt)
 	if err != nil {
-		// err will be set if not all keys present in event ->
-		// return empty selector result and ignore error
+		if s.otherwise == "" {
+			return "", err
+		}
 		return s.otherwise, nil
 	}
 

--- a/libbeat/outputs/outil/select.go
+++ b/libbeat/outputs/outil/select.go
@@ -43,6 +43,9 @@ type Settings struct {
 
 	// Fail building selector if `key` and `multiKey` are missing
 	FailEmpty bool
+
+	// Allow selector to ignore errors and return an empty string
+	EmptyOnErr bool
 }
 
 var errNoMatchFound = errors.New("no matching selector for event")
@@ -181,6 +184,10 @@ func BuildSelectorFromConfig(
 
 		return Selector{}, fmt.Errorf("missing required '%v' in %v",
 			multiKey, cfg.Path())
+	}
+
+	if settings.EmptyOnErr && len(sel) > 0 {
+		sel = append(sel, ConstSelectorExpr(""))
 	}
 
 	return MakeSelector(sel...), nil
@@ -338,7 +345,7 @@ func (s *listSelector) sel(evt *beat.Event) (string, error) {
 			err = fail
 		}
 
-		if fail == nil && n != "" {
+		if fail == nil {
 			return n, nil
 		}
 	}

--- a/libbeat/outputs/outil/select_test.go
+++ b/libbeat/outputs/outil/select_test.go
@@ -33,134 +33,135 @@ type node map[string]interface{}
 
 func TestSelector(t *testing.T) {
 	tests := map[string]struct {
-		config string
-		event  common.MapStr
-		want   string
+		config     string
+		event      common.MapStr
+		want       string
+		allowEmpty bool
 	}{
 		"constant key": {
-			`key: value`,
-			common.MapStr{},
-			"value",
+			config: `key: value`,
+			event:  common.MapStr{},
+			want:   "value",
 		},
 		"format string key": {
-			`key: '%{[key]}'`,
-			common.MapStr{"key": "value"},
-			"value",
+			config: `key: '%{[key]}'`,
+			event:  common.MapStr{"key": "value"},
+			want:   "value",
 		},
 		"key with empty keys": {
-			`{key: value, keys: }`,
-			common.MapStr{},
-			"value",
+			config: `{key: value, keys: }`,
+			event:  common.MapStr{},
+			want:   "value",
 		},
 		"constant in multi key": {
-			`keys: [key: 'value']`,
-			common.MapStr{},
-			"value",
+			config: `keys: [key: 'value']`,
+			event:  common.MapStr{},
+			want:   "value",
 		},
 		"format string in multi key": {
-			`keys: [key: '%{[key]}']`,
-			common.MapStr{"key": "value"},
-			"value",
+			config: `keys: [key: '%{[key]}']`,
+			event:  common.MapStr{"key": "value"},
+			want:   "value",
 		},
 		"missing format string key with default in rule": {
-			`keys:
+			config: `keys:
 			        - key: '%{[key]}'
 			          default: value`,
-			common.MapStr{},
-			"value",
+			event: common.MapStr{},
+			want:  "value",
 		},
 		"empty format string key with default in rule": {
-			`keys:
+			config: `keys:
 						        - key: '%{[key]}'
 						          default: value`,
-			common.MapStr{"key": ""},
-			"value",
+			event: common.MapStr{"key": ""},
+			want:  "value",
 		},
 		"missing format string key with constant in next rule": {
-			`keys:
+			config: `keys:
 						        - key: '%{[key]}'
 						        - key: value`,
-			common.MapStr{},
-			"value",
+			event: common.MapStr{},
+			want:  "value",
 		},
 		"missing format string key with constant in top-level rule": {
-			`{ key: value, keys: [key: '%{[key]}']}`,
-			common.MapStr{},
-			"value",
+			config: `{ key: value, keys: [key: '%{[key]}']}`,
+			event:  common.MapStr{},
+			want:   "value",
 		},
 		"apply mapping": {
-			`keys:
+			config: `keys:
 						       - key: '%{[key]}'
 						         mappings:
 						           v: value`,
-			common.MapStr{"key": "v"},
-			"value",
+			event: common.MapStr{"key": "v"},
+			want:  "value",
 		},
 		"apply mapping with default on empty key": {
-			`keys:
+			config: `keys:
 						       - key: '%{[key]}'
 						         default: value
 						         mappings:
 						           v: 'v'`,
-			common.MapStr{"key": ""},
-			"value",
+			event: common.MapStr{"key": ""},
+			want:  "value",
 		},
 		"apply mapping with default on empty lookup": {
-			`keys:
+			config: `keys:
 			       - key: '%{[key]}'
 			         default: value
 			         mappings:
 			           v: ''`,
-			common.MapStr{"key": "v"},
-			"value",
+			event: common.MapStr{"key": "v"},
+			want:  "value",
 		},
 		"apply mapping without match": {
-			`keys:
+			config: `keys:
 						       - key: '%{[key]}'
 						         mappings:
 						           v: ''
 						       - key: value`,
-			common.MapStr{"key": "x"},
-			"value",
+			event: common.MapStr{"key": "x"},
+			want:  "value",
 		},
 		"mapping with constant key": {
-			`keys:
+			config: `keys:
 						       - key: k
 						         mappings:
 						           k: value`,
-			common.MapStr{},
-			"value",
+			event: common.MapStr{},
+			want:  "value",
 		},
 		"mapping with missing constant key": {
-			`keys:
+			config: `keys:
 						       - key: unknown
 						         mappings: {k: wrong}
 						       - key: value`,
-			common.MapStr{},
-			"value",
+			event: common.MapStr{},
+			want:  "value",
 		},
 		"mapping with missing constant key, but default": {
-			`keys:
+			config: `keys:
 						       - key: unknown
 						         default: value
 						         mappings: {k: wrong}`,
-			common.MapStr{},
-			"value",
+			event: common.MapStr{},
+			want:  "value",
 		},
 		"matching condition": {
-			`keys:
+			config: `keys:
 						       - key: value
 						         when.equals.test: test`,
-			common.MapStr{"test": "test"},
-			"value",
+			event: common.MapStr{"test": "test"},
+			want:  "value",
 		},
 		"failing condition": {
-			`keys:
+			config: `keys:
 						       - key: wrong
 						         when.equals.test: test
 						       - key: value`,
-			common.MapStr{"test": "x"},
-			"value",
+			event: common.MapStr{"test": "x"},
+			want:  "value",
 		},
 	}
 
@@ -177,6 +178,7 @@ func TestSelector(t *testing.T) {
 				MultiKey:         "keys",
 				EnableSingleOnly: true,
 				FailEmpty:        true,
+				EmptyOnErr:       test.allowEmpty,
 			})
 			require.NoError(t, err)
 

--- a/libbeat/outputs/outil/select_test.go
+++ b/libbeat/outputs/outil/select_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
@@ -31,74 +32,63 @@ import (
 type node map[string]interface{}
 
 func TestSelector(t *testing.T) {
-	tests := []struct {
-		title    string
-		config   string
-		event    common.MapStr
-		expected string
+	tests := map[string]struct {
+		config string
+		event  common.MapStr
+		want   string
 	}{
-		{
-			"constant key",
+		"constant key": {
 			`key: value`,
 			common.MapStr{},
 			"value",
 		},
-		{
-			"format string key",
+		"format string key": {
 			`key: '%{[key]}'`,
 			common.MapStr{"key": "value"},
 			"value",
 		},
-		{
-			"key with empty keys",
+		"key with empty keys": {
 			`{key: value, keys: }`,
 			common.MapStr{},
 			"value",
 		},
-		{
-			"constant in multi key",
+		"constant in multi key": {
 			`keys: [key: 'value']`,
 			common.MapStr{},
 			"value",
 		},
-		{
-			"format string in multi key",
+		"format string in multi key": {
 			`keys: [key: '%{[key]}']`,
 			common.MapStr{"key": "value"},
 			"value",
 		},
-		{
-			"missing format string key with default in rule",
+		"missing format string key with default in rule": {
 			`keys:
 			        - key: '%{[key]}'
 			          default: value`,
 			common.MapStr{},
 			"value",
 		},
-		{
-			"empty format string key with default in rule",
+		"empty format string key with default in rule": {
 			`keys:
 						        - key: '%{[key]}'
 						          default: value`,
 			common.MapStr{"key": ""},
 			"value",
 		},
-		{
-			"missing format string key with constant in next rule",
+		"missing format string key with constant in next rule": {
 			`keys:
 						        - key: '%{[key]}'
 						        - key: value`,
 			common.MapStr{},
 			"value",
 		},
-		{
-			"missing format string key with constant in top-level rule",
+		"missing format string key with constant in top-level rule": {
 			`{ key: value, keys: [key: '%{[key]}']}`,
 			common.MapStr{},
 			"value",
 		},
-		{
-			"apply mapping",
+		"apply mapping": {
 			`keys:
 						       - key: '%{[key]}'
 						         mappings:
@@ -106,8 +96,7 @@ func TestSelector(t *testing.T) {
 			common.MapStr{"key": "v"},
 			"value",
 		},
-		{
-			"apply mapping with default on empty key",
+		"apply mapping with default on empty key": {
 			`keys:
 						       - key: '%{[key]}'
 						         default: value
@@ -116,8 +105,7 @@ func TestSelector(t *testing.T) {
 			common.MapStr{"key": ""},
 			"value",
 		},
-		{
-			"apply mapping with default on empty lookup",
+		"apply mapping with default on empty lookup": {
 			`keys:
 			       - key: '%{[key]}'
 			         default: value
@@ -126,8 +114,7 @@ func TestSelector(t *testing.T) {
 			common.MapStr{"key": "v"},
 			"value",
 		},
-		{
-			"apply mapping without match",
+		"apply mapping without match": {
 			`keys:
 						       - key: '%{[key]}'
 						         mappings:
@@ -136,8 +123,7 @@ func TestSelector(t *testing.T) {
 			common.MapStr{"key": "x"},
 			"value",
 		},
-		{
-			"mapping with constant key",
+		"mapping with constant key": {
 			`keys:
 						       - key: k
 						         mappings:
@@ -145,8 +131,7 @@ func TestSelector(t *testing.T) {
 			common.MapStr{},
 			"value",
 		},
-		{
-			"mapping with missing constant key",
+		"mapping with missing constant key": {
 			`keys:
 						       - key: unknown
 						         mappings: {k: wrong}
@@ -154,8 +139,7 @@ func TestSelector(t *testing.T) {
 			common.MapStr{},
 			"value",
 		},
-		{
-			"mapping with missing constant key, but default",
+		"mapping with missing constant key, but default": {
 			`keys:
 						       - key: unknown
 						         default: value
@@ -163,16 +147,14 @@ func TestSelector(t *testing.T) {
 			common.MapStr{},
 			"value",
 		},
-		{
-			"matching condition",
+		"matching condition": {
 			`keys:
 						       - key: value
 						         when.equals.test: test`,
 			common.MapStr{"test": "test"},
 			"value",
 		},
-		{
-			"failing condition",
+		"failing condition": {
 			`keys:
 						       - key: wrong
 						         when.equals.test: test
@@ -182,113 +164,93 @@ func TestSelector(t *testing.T) {
 		},
 	}
 
-	for i, test := range tests {
-		t.Logf("run (%v): %v", i, test.title)
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			yaml := strings.Replace(test.config, "\t", "  ", -1)
+			cfg, err := common.NewConfigWithYAML([]byte(yaml), "test")
+			if err != nil {
+				t.Fatalf("YAML parse error: %v\n%v", err, yaml)
+			}
 
-		yaml := strings.Replace(test.config, "\t", "  ", -1)
-		cfg, err := common.NewConfigWithYAML([]byte(yaml), "test")
-		if err != nil {
-			t.Errorf("YAML parse error: %v\n%v", err, yaml)
-			continue
-		}
+			sel, err := BuildSelectorFromConfig(cfg, Settings{
+				Key:              "key",
+				MultiKey:         "keys",
+				EnableSingleOnly: true,
+				FailEmpty:        true,
+			})
+			require.NoError(t, err)
 
-		sel, err := BuildSelectorFromConfig(cfg, Settings{
-			Key:              "key",
-			MultiKey:         "keys",
-			EnableSingleOnly: true,
-			FailEmpty:        true,
+			event := beat.Event{
+				Timestamp: time.Now(),
+				Fields:    test.event,
+			}
+			actual, err := sel.Select(&event)
+			require.NoError(t, err)
+
+			assert.Equal(t, test.want, actual)
 		})
-		if err != nil {
-			t.Error(err)
-			continue
-		}
-
-		event := beat.Event{
-			Timestamp: time.Now(),
-			Fields:    test.event,
-		}
-		actual, err := sel.Select(&event)
-		if err != nil {
-			t.Error(err)
-			continue
-		}
-
-		assert.Equal(t, test.expected, actual)
 	}
 }
 
 func TestSelectorInitFail(t *testing.T) {
-	tests := []struct {
-		title  string
+	tests := map[string]struct {
 		config string
 	}{
-		{
-			"keys missing",
+		"keys missing": {
 			`test: no key`,
 		},
-		{
-			"invalid keys type",
+		"invalid keys type": {
 			`keys: 5`,
 		},
-		{
-			"invaid keys element type",
+		"invaid keys element type": {
 			`keys: [5]`,
 		},
-		{
-			"invalid key type",
+		"invalid key type": {
 			`key: {}`,
 		},
-		{
-			"missing key in list",
+		"missing key in list": {
 			`keys: [default: value]`,
 		},
-		{
-			"invalid key type in list",
+		"invalid key type in list": {
 			`keys: [key: {}]`,
 		},
-		{
-			"fail on invalid format string",
+		"fail on invalid format string": {
 			`key: '%{[abc}'`,
 		},
-		{
-			"fail on invalid format string in list",
+		"fail on invalid format string in list": {
 			`keys: [key: '%{[abc}']`,
 		},
-		{
-			"default value type mismatch",
+		"default value type mismatch": {
 			`keys: [{key: ok, default: {}}]`,
 		},
-		{
-			"mappings type mismatch",
+		"mappings type mismatch": {
 			`keys:
        - key: '%{[k]}'
          mappings: {v: {}}`,
 		},
-		{
-			"condition empty",
+		"condition empty": {
 			`keys:
        - key: value
          when:`,
 		},
 	}
 
-	for i, test := range tests {
-		t.Logf("run (%v): %v", i, test.title)
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			cfg, err := common.NewConfigWithYAML([]byte(test.config), "test")
+			if err != nil {
+				t.Fatal(err)
+			}
 
-		cfg, err := common.NewConfigWithYAML([]byte(test.config), "test")
-		if err != nil {
-			t.Error(err)
-			continue
-		}
+			_, err = BuildSelectorFromConfig(cfg, Settings{
+				Key:              "key",
+				MultiKey:         "keys",
+				EnableSingleOnly: true,
+				FailEmpty:        true,
+			})
 
-		_, err = BuildSelectorFromConfig(cfg, Settings{
-			Key:              "key",
-			MultiKey:         "keys",
-			EnableSingleOnly: true,
-			FailEmpty:        true,
+			assert.Error(t, err)
+			t.Log(err)
 		})
-
-		assert.Error(t, err)
-		t.Log(err)
 	}
 }


### PR DESCRIPTION
This fixes the index selector returning an empty string if a key used in
the pattern is not found. The error has been swallowed by accident,
resuling in the output retrying an event.

The error including the name of the missing key will be reported and
logged by now. The event will be dropped if there is no fallback index
configuration.