### PR TITLE
Cherry-pick #10237 to 6.x: [Auditbeat] Enable System module config on Windows

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -65,6 +65,8 @@ https://github.com/elastic/beats/compare/v6.6.0...6.x[Check the HEAD diff]
 
 *Auditbeat*
 
+- Enable System module config on Windows. {pull}10237[10237]
+
 *Filebeat*
 
 - Correctly parse `December` or `Dec` in the Syslog input. {pull}9349[9349]

--- a/x-pack/auditbeat/module/system/_meta/config.yml.tmpl
+++ b/x-pack/auditbeat/module/system/_meta/config.yml.tmpl
@@ -1,4 +1,3 @@
-{{ if ne .GOOS "windows" -}}
 {{ if .Reference -}}
 # The system module collects security related information about a host.
 # All datasets send both periodic state information (e.g. all currently
@@ -25,8 +24,10 @@
   # The state.period can be overridden for any dataset.
   # host.state.period: 12h
   # process.state.period: 12h
+  {{ if eq .GOOS "linux" -}}
   # socket.state.period: 12h
   # user.state.period: 12h
+  {{- end }}
 {{ end }}
   {{ if eq .GOOS "linux" -}}
   # Enabled by default. Auditbeat will read password fields in
@@ -34,8 +35,3 @@
   # detect any changes.
   user.detect_password_changes: true
   {{- end }}
-  {{- if false -}}
-  {{/* Only remaining use in packages, to be removed completely. */}}
-  report_changes: true
-  {{- end -}}
-{{- end }}


### PR DESCRIPTION
Cherry-pick of PR #10237 to 6.x branch. Original message: 

This should have actually been part of https://github.com/elastic/beats/pull/9954 or even previous PRs.

The `host` and `process` datasets are implemented for Windows, and the docs now say so, but unfortunately I missed that the config we ship for Windows has the whole system module disabled. It can still be configured manually, of course, but with this change it will show up in the reference files as well.