### PR TITLE
Update go-ucfg to 0.7.0

### DIFF
--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -26,3 +26,4 @@ The list below covers the major changes between 7.0.0-alpha2 and master only.
 
 - Allow multiple object type configurations per field. {pull}9772[9772]
 - Move agent metadata addition to a processor. {pull}9952[9952]
+- Add (*common.Config).Has and (*common.Config).Remove. {pull}10363[10363]

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -667,8 +667,8 @@ Apache License 2.0
 
 --------------------------------------------------------------------
 Dependency: github.com/elastic/go-ucfg
-Version: v0.6.5
-Revision: 92d43887f91851c9936621665af7f796f4d03412
+Version: v0.7.0
+Revision: 0539807037ce820e147797f051ff32b05f4f9288
 License type (autodetected): Apache-2.0
 ./vendor/github.com/elastic/go-ucfg/LICENSE:
 --------------------------------------------------------------------

--- a/libbeat/common/config.go
+++ b/libbeat/common/config.go
@@ -188,6 +188,14 @@ func (c *Config) PathOf(field string) string {
 	return c.access().PathOf(field, ".")
 }
 
+func (c *Config) Remove(name string, idx int) (bool, error) {
+	return c.access().Remove(name, idx, configOpts...)
+}
+
+func (c *Config) Has(name string, idx int) (bool, error) {
+	return c.access().Has(name, idx, configOpts...)
+}
+
 func (c *Config) HasField(name string) bool {
 	return c.access().HasField(name)
 }

--- a/vendor/github.com/elastic/go-ucfg/CHANGELOG.md
+++ b/vendor/github.com/elastic/go-ucfg/CHANGELOG.md
@@ -14,6 +14,15 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+## [0.7.0]
+
+### Added
+- Add (*Config).Has. #127
+- Add (*Config).Remove. #126
+
+### Removed
+- Remove CI and support for go versions <1.10. #128
+
 ## [0.6.5]
 
 ### Added
@@ -225,8 +234,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Introduced CHANGELOG.md for documenting changes to ucfg.
 
 
-[Unreleased]: https://github.com/elastic/go-ucfg/compare/v0.6.5...HEAD
-[0.6.4]: https://github.com/elastic/go-ucfg/compare/v0.6.4...v0.6.5
+[Unreleased]: https://github.com/elastic/go-ucfg/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/elastic/go-ucfg/compare/v0.6.5...v0.7.0
+[0.6.5]: https://github.com/elastic/go-ucfg/compare/v0.6.4...v0.6.5
 [0.6.4]: https://github.com/elastic/go-ucfg/compare/v0.6.3...v0.6.4
 [0.6.3]: https://github.com/elastic/go-ucfg/compare/v0.6.2...v0.6.3
 [0.6.2]: https://github.com/elastic/go-ucfg/compare/v0.6.1...v0.6.2

--- a/vendor/github.com/elastic/go-ucfg/README.md
+++ b/vendor/github.com/elastic/go-ucfg/README.md
@@ -89,4 +89,4 @@ The above uses `Counter` as the config variable. ucfg assures that the value is 
 
 ucfg has the following requirements:
 
-* Golang 1.7+
+* Golang 1.10+

--- a/vendor/github.com/elastic/go-ucfg/error.go
+++ b/vendor/github.com/elastic/go-ucfg/error.go
@@ -61,6 +61,8 @@ type criticalError struct {
 var (
 	ErrMissing = errors.New("missing field")
 
+	ErrNoParse = errors.New("parsing dynamic configs is disabled")
+
 	ErrCyclicReference = errors.New("cyclic reference detected")
 
 	ErrDuplicateValidator = errors.New("validator already registered")
@@ -257,6 +259,11 @@ func raiseUnsupportedInputType(ctx context, meta *Meta, v reflect.Value) Error {
 		v.Type(), v)
 
 	return raiseCritical(reason, messagePath(reason, meta, message, ctx.path(".")))
+}
+
+func raiseNoParse(ctx context, meta *Meta) Error {
+	reason := ErrNoParse
+	return raisePathErr(reason, meta, "", ctx.path("."))
 }
 
 func raiseNil(reason error) Error {

--- a/vendor/github.com/elastic/go-ucfg/fieldset.go
+++ b/vendor/github.com/elastic/go-ucfg/fieldset.go
@@ -22,7 +22,7 @@ type fieldSet struct {
 	parent *fieldSet
 }
 
-func NewFieldSet(parent *fieldSet) *fieldSet {
+func newFieldSet(parent *fieldSet) *fieldSet {
 	return &fieldSet{
 		fields: map[string]struct{}{},
 		parent: parent,

--- a/vendor/github.com/elastic/go-ucfg/flag/file.go
+++ b/vendor/github.com/elastic/go-ucfg/flag/file.go
@@ -24,8 +24,17 @@ import (
 	"github.com/elastic/go-ucfg"
 )
 
+// FileLoader is used by NewFlagFiles to define customer file loading functions
+// for different file extensions.
 type FileLoader func(name string, opts ...ucfg.Option) (*ucfg.Config, error)
 
+// NewFlagFiles create a new flag, that will load external configurations file
+// when being used. Configurations loaded from multiple files will be merged
+// into one common Config object.  If cfg is not nil, then the loaded
+// configurations will be merged into cfg.
+// The extensions parameter define custom file loaders for different file
+// extensions. If extensions contains an entry with key "", then this loader
+// will be used as default fallback.
 func NewFlagFiles(
 	cfg *ucfg.Config,
 	extensions map[string]FileLoader,

--- a/vendor/github.com/elastic/go-ucfg/json/json.go
+++ b/vendor/github.com/elastic/go-ucfg/json/json.go
@@ -24,6 +24,7 @@ import (
 	"github.com/elastic/go-ucfg"
 )
 
+// NewConfig creates a new configuration object from the JSON string passed via in.
 func NewConfig(in []byte, opts ...ucfg.Option) (*ucfg.Config, error) {
 	var m interface{}
 	if err := json.Unmarshal(in, &m); err != nil {
@@ -32,12 +33,15 @@ func NewConfig(in []byte, opts ...ucfg.Option) (*ucfg.Config, error) {
 	return ucfg.NewFrom(m, opts...)
 }
 
+// NewConfigWithFile loads a new configuration object from an external JSON file.
 func NewConfigWithFile(name string, opts ...ucfg.Option) (*ucfg.Config, error) {
 	input, err := ioutil.ReadFile(name)
 	if err != nil {
 		return nil, err
 	}
 
-	opts = append([]ucfg.Option{ucfg.MetaData(ucfg.Meta{name})}, opts...)
+	opts = append([]ucfg.Option{
+		ucfg.MetaData(ucfg.Meta{Source: name}),
+	}, opts...)
 	return NewConfig(input, opts...)
 }

--- a/vendor/github.com/elastic/go-ucfg/opts.go
+++ b/vendor/github.com/elastic/go-ucfg/opts.go
@@ -33,6 +33,7 @@ type options struct {
 	env          []*Config
 	resolvers    []func(name string) (string, error)
 	varexp       bool
+	noParse      bool
 
 	configValueHandling configHandling
 
@@ -137,7 +138,7 @@ func doResolveNOOP(o *options) {
 }
 
 var (
-	// ReplacesValues option configures all merging and unpacking operations to
+	// ReplaceValues option configures all merging and unpacking operations to
 	// replace old dictionaries and arrays while merging. Value merging can be
 	// overwritten in unpack by using struct tags.
 	ReplaceValues = makeOptValueHandling(cfgReplaceValue)
@@ -170,7 +171,7 @@ func makeOptions(opts []Option) *options {
 		validatorTag: "validate",
 		pathSep:      "", // no separator by default
 		parsed:       map[string]spliceValue{},
-		activeFields: NewFieldSet(nil),
+		activeFields: newFieldSet(nil),
 	}
 	for _, opt := range opts {
 		opt(&o)

--- a/vendor/github.com/elastic/go-ucfg/reify.go
+++ b/vendor/github.com/elastic/go-ucfg/reify.go
@@ -189,7 +189,7 @@ func reifyMap(opts *options, to reflect.Value, from *Config) Error {
 		to.Set(reflect.MakeMap(to.Type()))
 	}
 	for k, value := range fields {
-		opts.activeFields = NewFieldSet(parentFields)
+		opts.activeFields = newFieldSet(parentFields)
 		key := reflect.ValueOf(k)
 
 		old := to.MapIndex(key)
@@ -249,7 +249,7 @@ func reifyStruct(opts *options, orig reflect.Value, cfg *Config) Error {
 				opts = tmp
 			}
 
-			opts.activeFields = NewFieldSet(parentFields)
+			opts.activeFields = newFieldSet(parentFields)
 
 			vField := to.Field(i)
 			validators, err := parseValidatorTags(stField.Tag.Get(opts.validatorTag))
@@ -656,7 +656,7 @@ func doReifyPrimitive(
 	}
 
 	previous := opts.opts.activeFields
-	opts.opts.activeFields = NewFieldSet(previous)
+	opts.opts.activeFields = newFieldSet(previous)
 	valT, err := val.typ(opts.opts)
 	if err != nil {
 		ctx := val.Context()

--- a/vendor/github.com/elastic/go-ucfg/types.go
+++ b/vendor/github.com/elastic/go-ucfg/types.go
@@ -377,7 +377,7 @@ func (c cfgSub) reify(opts *options) (interface{}, error) {
 	case len(fields) > 0 && len(arr) == 0:
 		m := make(map[string]interface{})
 		for k, v := range fields {
-			opts.activeFields = NewFieldSet(parentFields)
+			opts.activeFields = newFieldSet(parentFields)
 			var err error
 			if m[k], err = v.reify(opts); err != nil {
 				return nil, err
@@ -387,7 +387,7 @@ func (c cfgSub) reify(opts *options) (interface{}, error) {
 	case len(fields) == 0 && len(arr) > 0:
 		m := make([]interface{}, len(arr))
 		for i, v := range arr {
-			opts.activeFields = NewFieldSet(parentFields)
+			opts.activeFields = newFieldSet(parentFields)
 			var err error
 			if m[i], err = v.reify(opts); err != nil {
 				return nil, err
@@ -397,14 +397,14 @@ func (c cfgSub) reify(opts *options) (interface{}, error) {
 	default:
 		m := make(map[string]interface{})
 		for k, v := range fields {
-			opts.activeFields = NewFieldSet(parentFields)
+			opts.activeFields = newFieldSet(parentFields)
 			var err error
 			if m[k], err = v.reify(opts); err != nil {
 				return nil, err
 			}
 		}
 		for i, v := range arr {
-			opts.activeFields = NewFieldSet(parentFields)
+			opts.activeFields = newFieldSet(parentFields)
 			var err error
 			m[fmt.Sprintf("%d", i)], err = v.reify(opts)
 			if err != nil {
@@ -554,6 +554,10 @@ func (s spliceDynValue) String() string {
 }
 
 func parseValue(p *cfgPrimitive, opts *options, str string) (value, error) {
+	if opts.noParse {
+		return nil, raiseNoParse(p.ctx, p.meta())
+	}
+
 	ifc, err := parse.Value(str)
 	if err != nil {
 		return nil, err

--- a/vendor/github.com/elastic/go-ucfg/ucfg.go
+++ b/vendor/github.com/elastic/go-ucfg/ucfg.go
@@ -83,7 +83,7 @@ func New() *Config {
 	}
 }
 
-// NustNewFrom creates a new config object normalizing and copying from into the new
+// MustNewFrom creates a new config object normalizing and copying from into the new
 // Config object. MustNewFrom uses Merge to copy from.
 //
 // MustNewFrom supports the options: PathSep, MetaData, StructTag, VarExp
@@ -126,10 +126,48 @@ func (c *Config) GetFields() []string {
 	return names
 }
 
+// Has checks if a field by the given path+idx configuration exists.
+// Has returns an error if the path can not be resolved because a primitive
+// value is found in the middle of the traversal.
+func (c *Config) Has(name string, idx int, options ...Option) (bool, error) {
+	opts := makeOptions(options)
+	p := parsePathIdx(name, opts.pathSep, idx)
+	return p.Has(c, opts)
+}
+
 // HasField checks if c has a top-level named key name.
 func (c *Config) HasField(name string) bool {
 	_, ok := c.fields.get(name)
 	return ok
+}
+
+// Remove removes a setting from the config. If the configuration references
+// another configuration namespace, then the setting will be removed from the
+// linked reference.
+// Remove returns true if the setting was removed. If the path can't be
+// resolved (e.g. due to type mismatch) Remove will return an error.
+//
+// Settings can be created on Unpack via Env, Resolve, and ResolveEnv. Settings
+// generated dynamically on Unpack can not be removed. Remove ignores any
+// configured environments and will return an error if a value can not be
+// removed for this reason.
+//
+// The setting path is constructed from name and idx. If name is set and idx is -1,
+// only the name is used to access the setting by name. If name is empty, idx
+// must be >= 0, assuming the Config is a list. If both name and idx are set,
+// the name must point to a list.
+//
+// Remove supports the options: PathSep
+func (c *Config) Remove(name string, idx int, options ...Option) (bool, error) {
+	opts := makeOptions(options)
+
+	// ignore environments
+	opts.env = nil
+	opts.resolvers = nil
+	opts.noParse = true
+
+	p := parsePathIdx(name, opts.pathSep, idx)
+	return p.Remove(c, opts)
 }
 
 // Path gets the absolute path of c separated by sep. If c is a root-Config an
@@ -217,6 +255,26 @@ func (f *fields) dict() map[string]value {
 
 func (f *fields) array() []value {
 	return f.a
+}
+
+func (f *fields) del(name string) bool {
+	_, exists := f.d[name]
+	if exists {
+		delete(f.d, name)
+	}
+	return exists
+}
+
+func (f *fields) delAt(i int) bool {
+	a := f.a
+	if i < 0 || len(a) <= i {
+		return false
+	}
+
+	copy(a[i:], a[i+1:])
+	a[len(a)-1] = nil
+	f.a = a[:len(a)-1]
+	return true
 }
 
 func (f *fields) set(name string, v value) {

--- a/vendor/github.com/elastic/go-ucfg/unpack.go
+++ b/vendor/github.com/elastic/go-ucfg/unpack.go
@@ -155,12 +155,7 @@ func implementsUnpacker(t reflect.Type) bool {
 
 	// method receiver is known, check config parameters being compatible
 	tIn := method.Type.In(1)
-	acceptsConfig := tConfig.ConvertibleTo(tIn) || tConfigPtr.ConvertibleTo(tIn)
-	if !acceptsConfig {
-		return false
-	}
-
-	return true
+	return tConfig.ConvertibleTo(tIn) || tConfigPtr.ConvertibleTo(tIn)
 }
 
 func unpackWith(opts *options, v reflect.Value, with value) Error {

--- a/vendor/github.com/elastic/go-ucfg/yaml/yaml.go
+++ b/vendor/github.com/elastic/go-ucfg/yaml/yaml.go
@@ -25,6 +25,7 @@ import (
 	"github.com/elastic/go-ucfg"
 )
 
+// NewConfig creates a new configuration object from the YAML string passed via in.
 func NewConfig(in []byte, opts ...ucfg.Option) (*ucfg.Config, error) {
 	var m interface{}
 	if err := yaml.Unmarshal(in, &m); err != nil {
@@ -34,12 +35,15 @@ func NewConfig(in []byte, opts ...ucfg.Option) (*ucfg.Config, error) {
 	return ucfg.NewFrom(m, opts...)
 }
 
+// NewConfigWithFile loads a new configuration object from an external JSON file.
 func NewConfigWithFile(name string, opts ...ucfg.Option) (*ucfg.Config, error) {
 	input, err := ioutil.ReadFile(name)
 	if err != nil {
 		return nil, err
 	}
 
-	opts = append([]ucfg.Option{ucfg.MetaData(ucfg.Meta{name})}, opts...)
+	opts = append([]ucfg.Option{
+		ucfg.MetaData(ucfg.Meta{Source: name}),
+	}, opts...)
 	return NewConfig(input, opts...)
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1109,52 +1109,52 @@
 			"versionExact": "v0.0.6"
 		},
 		{
-			"checksumSHA1": "Yb61Nqnh+3igFci61hv9WYgk/hc=",
+			"checksumSHA1": "b91TSC0atoGVSMZdKuWTYsMOGiM=",
 			"path": "github.com/elastic/go-ucfg",
-			"revision": "92d43887f91851c9936621665af7f796f4d03412",
-			"revisionTime": "2018-10-26T17:42:06Z",
-			"version": "v0.6.5",
-			"versionExact": "v0.6.5"
+			"revision": "0539807037ce820e147797f051ff32b05f4f9288",
+			"revisionTime": "2019-01-28T11:18:48Z",
+			"version": "v0.7.0",
+			"versionExact": "v0.7.0"
 		},
 		{
 			"checksumSHA1": "X+R/CD8SokJrmlxFTx2nSevRDhQ=",
 			"path": "github.com/elastic/go-ucfg/cfgutil",
-			"revision": "581f7b1fe9d84f4c18ef0694d6e0eb944a925dae",
-			"revisionTime": "2018-07-13T14:04:29Z",
-			"version": "v0.6.1",
-			"versionExact": "v0.6.1"
+			"revision": "0539807037ce820e147797f051ff32b05f4f9288",
+			"revisionTime": "2019-01-28T11:18:48Z",
+			"version": "v0.7.0",
+			"versionExact": "v0.7.0"
 		},
 		{
-			"checksumSHA1": "zC8mCPW/pPPNcuHQOc/B/Ej1W1U=",
+			"checksumSHA1": "/pq8HNEdzHmky9S9HSo1WofXQ4Y=",
 			"path": "github.com/elastic/go-ucfg/flag",
-			"revision": "581f7b1fe9d84f4c18ef0694d6e0eb944a925dae",
-			"revisionTime": "2018-07-13T14:04:29Z",
-			"version": "v0.6.1",
-			"versionExact": "v0.6.1"
+			"revision": "0539807037ce820e147797f051ff32b05f4f9288",
+			"revisionTime": "2019-01-28T11:18:48Z",
+			"version": "v0.7.0",
+			"versionExact": "v0.7.0"
 		},
 		{
 			"checksumSHA1": "esXpiQlEvTOUwsE0nNesso8albo=",
 			"path": "github.com/elastic/go-ucfg/internal/parse",
-			"revision": "581f7b1fe9d84f4c18ef0694d6e0eb944a925dae",
-			"revisionTime": "2018-07-13T14:04:29Z",
-			"version": "v0.6.1",
-			"versionExact": "v0.6.1"
+			"revision": "0539807037ce820e147797f051ff32b05f4f9288",
+			"revisionTime": "2019-01-28T11:18:48Z",
+			"version": "v0.7.0",
+			"versionExact": "v0.7.0"
 		},
 		{
-			"checksumSHA1": "5mXUhhlPdvcAFKiQENInTJWrtQM=",
+			"checksumSHA1": "cfMNsyQm0gZOV0hRJrBSdKDQSBo=",
 			"path": "github.com/elastic/go-ucfg/json",
-			"revision": "581f7b1fe9d84f4c18ef0694d6e0eb944a925dae",
-			"revisionTime": "2018-07-13T14:04:29Z",
-			"version": "v0.6.1",
-			"versionExact": "v0.6.1"
+			"revision": "0539807037ce820e147797f051ff32b05f4f9288",
+			"revisionTime": "2019-01-28T11:18:48Z",
+			"version": "v0.7.0",
+			"versionExact": "v0.7.0"
 		},
 		{
-			"checksumSHA1": "Bg6vistPQLftv2fEYB7GWwSExv8=",
+			"checksumSHA1": "PJCBACDGPhnRAEqjGPMPCMjbj4o=",
 			"path": "github.com/elastic/go-ucfg/yaml",
-			"revision": "581f7b1fe9d84f4c18ef0694d6e0eb944a925dae",
-			"revisionTime": "2018-07-13T14:04:29Z",
-			"version": "v0.6.1",
-			"versionExact": "v0.6.1"
+			"revision": "0539807037ce820e147797f051ff32b05f4f9288",
+			"revisionTime": "2019-01-28T11:18:48Z",
+			"version": "v0.7.0",
+			"versionExact": "v0.7.0"
 		},
 		{
 			"checksumSHA1": "rnd3qf1FE22X3MxXWbetqq6EoBk=",


### PR DESCRIPTION
This introduces:
- (*common.Config).Has: check for setting or namespace by path (can walk
  a configuration)
- (*common.Config).Remove: remove a configuration.

Note: removing from dynamically parsed objects (e.g. parsed objects by
  splicing in a custom string via environment variable) is not possible.