### PR TITLE
Update configs for old beat.* fields

### DIFF
--- a/libbeat/docs/generalconfig.asciidoc
+++ b/libbeat/docs/generalconfig.asciidoc
@@ -29,7 +29,7 @@ tags: ["service-X", "web-tier"]
 ==== `name`
 
 The name of the Beat. If this option is empty, the `hostname` of the server is
-used. The name is included as the `beat.name` field in each published transaction. You can
+used. The name is included as the `agent.name` field in each published transaction. You can
 use the name to group all transactions sent by a single Beat.
 
 Example:

--- a/libbeat/docs/shared-config-ingest.asciidoc
+++ b/libbeat/docs/shared-config-ingest.asciidoc
@@ -42,7 +42,7 @@ named `pipeline.json`:
     "processors": [
         {
             "lowercase": {
-                "field": "beat.name"
+                "field": "agent.name"
             }
         }
     ]
@@ -65,7 +65,7 @@ output.elasticsearch:
   pipeline: "test-pipeline"
 ------------------------------------------------------------------------------
 
-When you run {beatname_uc}, the value of `beat.name` is converted to lowercase before indexing.
+When you run {beatname_uc}, the value of `agent.name` is converted to lowercase before indexing.
 
 For more information about defining a pre-processing pipeline, see the
 {elasticsearch}/ingest.html[Ingest Node] documentation.

--- a/libbeat/docs/shared-ilm.asciidoc
+++ b/libbeat/docs/shared-ilm.asciidoc
@@ -35,9 +35,9 @@ template to use the correct settings for index lifecycle management.
 NOTE: If you've previously loaded the index template for this version into {es}, 
 you must overwrite the template by setting `setup.template.overwrite: true`.
 
-The rollover alias is set to +{beatname_lc}-\{beat.version\}+ by default. You
+The rollover alias is set to +{beatname_lc}-\{agent.version\}+ by default. You
 can change the prefix used in the alias by setting `ilm.rollover_alias`, but you
-can't remove `{beat.version}` from the rollover alias name. The default pattern
+can't remove `{agent.version}` from the rollover alias name. The default pattern
 used for the rollover index is `%{now/d}-000001`. You can change the
 pattern by setting `ilm.pattern`. For example:
 

--- a/libbeat/docs/shared-template-load.asciidoc
+++ b/libbeat/docs/shared-template-load.asciidoc
@@ -75,7 +75,7 @@ date information. You also need to configure the `setup.template.name` and
 +
 ["source","sh",subs="attributes,callouts"]
 -----
-output.elasticsearch.index: "customname-%{[beat.version]}-%{+yyyy.MM.dd}"
+output.elasticsearch.index: "customname-%{[agent.version]}-%{+yyyy.MM.dd}"
 setup.template.name: "customname"
 setup.template.pattern: "customname-*"
 -----

--- a/metricbeat/docs/how-metricbeat-works.asciidoc
+++ b/metricbeat/docs/how-metricbeat-works.asciidoc
@@ -46,12 +46,10 @@ For more about the benefits of using Metricbeat, see <<key-features>>.
 Every event sent by Metricbeat has the same basic structure. It contains the following fields:
 
 *`@timestamp`*:: Time when the event was captured
-*`beat.hostname`*:: Hostname of the server on which the Beat is running
-*`beat.name`*:: Name given to the Beat
-*`metricset.module`*:: Name of the module that the data is from
-*`metricset.name`*:: Name of the metricset that the data is from
-*`metricset.rtt`*:: Round trip time of the request in microseconds
-*`type`*:: This is always "metricsets"
+*`host.hostname`*:: Hostname of the server on which the Beat is running
+*`agent.type`*:: Name given to the Beat
+*`event.module`*:: Name of the module that the data is from
+*`event.dataset`*:: Name of the module that the data is from
 
 For example:
 
@@ -59,14 +57,15 @@ For example:
 ----
 {
   "@timestamp": "2016-06-22T22:05:53.291Z",
-  "beat": {
-    "hostname": "host.example.com",
-    "name": "host.example.com"
+  "agent": {
+    "type": "metricbeat"
   },
-  "metricset": {
-    "module": "system",
-    "name": "process",
-    "rtt": 7419
+  "host": {
+     "hostname": "host.example.com",
+   },
+  "event": {
+    "dataset": "system.process",
+    "module": process
   },
   .
   .

--- a/metricbeat/docs/metricbeat-filtering.asciidoc
+++ b/metricbeat/docs/metricbeat-filtering.asciidoc
@@ -4,13 +4,13 @@
 include::{libbeat-dir}/docs/processors.asciidoc[]
 
 For example, the following configuration reduces the exported fields by
-dropping the `beat.name` and `beat.hostname` fields under `beat` from all documents.
+dropping the `agent.name` and `agent.version` fields under `beat` from all documents.
 
 [source, yaml]
 ----
 processors:
  - drop_fields:
-    fields: ['beat']
+    fields: ['agent']
 ----
 
 include::{libbeat-dir}/docs/processors-using.asciidoc[]


### PR DESCRIPTION
Replace mentions of beat.name, beat.hostname, beat.version from the docs and replace it with the related fields.

In addition search was done for old fileset.* and metricset.* fields but nothing was found in the docs.