### PR TITLE
Correctly bubble up errors when an integration test fails in a docker container.

### DIFF
--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -202,7 +202,7 @@ integration-tests: prepare-tests
 .PHONY: integration-tests-environment
 integration-tests-environment:  ## @testing Runs the integration inside a virtual environment. This can be run on any docker-machine (local, remote)
 integration-tests-environment: prepare-tests build-image
-	${DOCKER_COMPOSE} run beat make integration-tests RACE_DETECTOR=$(RACE_DETECTOR) DOCKER_COMPOSE_PROJECT_NAME=${DOCKER_COMPOSE_PROJECT_NAME} || ${DOCKER_COMPOSE} logs --tail 200
+	${DOCKER_COMPOSE} run beat make integration-tests RACE_DETECTOR=$(RACE_DETECTOR) DOCKER_COMPOSE_PROJECT_NAME=${DOCKER_COMPOSE_PROJECT_NAME}
 
 # Runs the system tests
 .PHONY: system-tests

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -202,6 +202,11 @@ integration-tests: prepare-tests
 .PHONY: integration-tests-environment
 integration-tests-environment:  ## @testing Runs the integration inside a virtual environment. This can be run on any docker-machine (local, remote)
 integration-tests-environment: prepare-tests build-image
+	# If you want to get logs on CI when the `docker-compose` fails, you can
+	# add  `|| ${DOCKER_COMPOSE} logs --tail 200` after the command.
+	#
+	# This will make docker-compose command to display the logs on stdout on error, It's not enabled
+	# by default because it can create noise if the test inside the container fails.
 	${DOCKER_COMPOSE} run beat make integration-tests RACE_DETECTOR=$(RACE_DETECTOR) DOCKER_COMPOSE_PROJECT_NAME=${DOCKER_COMPOSE_PROJECT_NAME}
 
 # Runs the system tests


### PR DESCRIPTION
As a retrospect leaving the invocation of `docker-compose logs` was a
bad idea, first it could hide some error in the integration suite and it
could add unnecessary long logs line in the CI job making debugging even harder.
So instead, I've remove it completely and leave up to the person debugging to enabled it back.