### PR TITLE
Remove duplicated content about setting up the dev environment

### DIFF
--- a/docs/devguide/contributing.asciidoc
+++ b/docs/devguide/contributing.asciidoc
@@ -51,9 +51,9 @@ After https://golang.org/doc/install[installing Go], set the
 https://golang.org/doc/code.html#GOPATH[GOPATH] environment variable to point to
 your workspace location, and make sure the Go `bin` directory is in your PATH.
 
-The location where you clone is important. Clone the beats repository under the
-source directory of your `GOPATH`. If you don't have `GOPATH` already set, you
-can set it to the `go` directory in your home (`export GOPATH=$HOME/go`).
+The location where you clone is important. Make a directory structure under
+`GOPATH` that matches the URL used for Elastic repositories, then clone the
+beats repository under the new directory: 
 
 [source,shell]
 ----------------------------------------------------------------------

--- a/docs/devguide/contributing.asciidoc
+++ b/docs/devguide/contributing.asciidoc
@@ -49,7 +49,7 @@ http://golang.org/[Go] which is being used for Beats development.
 
 After https://golang.org/doc/install[installing Go], set the
 https://golang.org/doc/code.html#GOPATH[GOPATH] environment variable to point to
-your workspace location, and make sure the Go `bin` directory is in your PATH.
+your workspace location, and make sure `$GOPATH/bin` is in your PATH.
 
 The location where you clone is important. Make a directory structure under
 `GOPATH` that matches the URL used for Elastic repositories, then clone the

--- a/docs/devguide/contributing.asciidoc
+++ b/docs/devguide/contributing.asciidoc
@@ -47,16 +47,19 @@ Beats].
 The Beats are Go programs, so install the {go-version} version of
 http://golang.org/[Go] which is being used for Beats development.
 
-The location where you clone is important. Please clone under the source
-directory of your `GOPATH`. If you don't have `GOPATH` already set, you can
-simply set it to the `go` directory in your home (`export GOPATH=$HOME/go`).
+After https://golang.org/doc/install[installing Go], set the
+https://golang.org/doc/code.html#GOPATH[GOPATH] environment variable to point to
+your workspace location, and make sure the Go `bin` directory is in your PATH.
+
+The location where you clone is important. Clone the beats repository under the
+source directory of your `GOPATH`. If you don't have `GOPATH` already set, you
+can set it to the `go` directory in your home (`export GOPATH=$HOME/go`).
 
 [source,shell]
---------------------------------------------------------------------------------
+----------------------------------------------------------------------
 mkdir -p ${GOPATH}/src/github.com/elastic
-cd ${GOPATH}/src/github.com/elastic
-git clone https://github.com/elastic/beats.git
---------------------------------------------------------------------------------
+git clone https://github.com/elastic/beats ${GOPATH}/src/github.com/elastic/beats
+----------------------------------------------------------------------
 
 NOTE: If you have multiple go paths, use `${GOPATH%%:*}` instead of `${GOPATH}`.
 

--- a/docs/devguide/newbeat.asciidoc
+++ b/docs/devguide/newbeat.asciidoc
@@ -36,29 +36,17 @@ language, and very few people are experts in it. In fact, several
 people learned Go by contributing to Packetbeat and libbeat, including the
 original Packetbeat authors.
 
-For general information about contributing to Beats, see <<beats-contributing>>.
+*Before you begin:* Set up your Go environment as described under
+<<setting-up-dev-environment>> in <<beats-contributing>>.
 
-After https://golang.org/doc/install[installing Go], set the
-https://golang.org/doc/code.html#GOPATH[GOPATH] environment variable to point to your
-workspace location, and make sure the Go `bin` directory is in your PATH. Then clone
-the Beats repository in the correct location under `GOPATH`.
-
-[source,shell]
-----------------------------------------------------------------------
-mkdir -p ${GOPATH}/src/github.com/elastic
-git clone https://github.com/elastic/beats ${GOPATH}/src/github.com/elastic/beats
-----------------------------------------------------------------------
-
-To build your beat
-on a specific version of libbeat, check out the specific branch ({branch} in the example below):
+To build your Beat on a specific version of libbeat, check out the specific
+branch ({branch} in the example below):
 
 ["source","sh",subs="attributes"]
 ----
-cd ${GOPATH}/src/github.com/elastic/beats
+cd $\{GOPATH\}/src/github.com/elastic/beats
 git checkout {branch}
 ----
-
-NOTE: If you have multiple go paths, use `${GOPATH%%:*}` instead of `${GOPATH}`.
 
 [[newbeat-overview]]
 === Overview
@@ -121,9 +109,9 @@ Now that you have the big picture, let's dig into the code.
 === Generating Your Beat
 
 To generate your own Beat, you use the Beat generator available in the beats repo on GitHub. If you haven't
-downloaded the Beats source code yet, follow the instructions in <<newbeat-getting-ready>>.
+downloaded the Beats source code yet, follow the instructions in <<setting-up-dev-environment>>.
 
-Before running beat generator, you must decide on a name for your beat. The name should be one word with
+Before running the Beat generator, you must decide on a name for your Beat. The name should be one word with
 the first letter capitalized. In our example, we use `Countbeat`.
 
 Now create a directory under $GOPATH for your repository and change to the new directory:

--- a/docs/devguide/newbeat.asciidoc
+++ b/docs/devguide/newbeat.asciidoc
@@ -38,11 +38,10 @@ original Packetbeat authors.
 
 For general information about contributing to Beats, see <<beats-contributing>>.
 
-After you have https://golang.org/doc/install[installed Go] make sure you have set up the
-https://golang.org/doc/code.html#GOPATH[GOPATH] environment variable to point to
-your preferred workspace location and that your Go bin directory is on your PATH.
-Once Go is configured clone the Beats repository in the correct location
-under `GOPATH`:
+After https://golang.org/doc/install[installing Go], set the
+https://golang.org/doc/code.html#GOPATH[GOPATH] environment variable to point to your
+workspace location, and make sure the Go `bin` directory is in your PATH. Then clone
+the Beats repository in the correct location under `GOPATH`.
 
 [source,shell]
 ----------------------------------------------------------------------

--- a/docs/devguide/newbeat.asciidoc
+++ b/docs/devguide/newbeat.asciidoc
@@ -38,9 +38,10 @@ original Packetbeat authors.
 
 For general information about contributing to Beats, see <<beats-contributing>>.
 
-After you have https://golang.org/doc/install[installed Go] and set up the
+After you have https://golang.org/doc/install[installed Go] make sure you have set up the
 https://golang.org/doc/code.html#GOPATH[GOPATH] environment variable to point to
-your preferred workspace location, clone the Beats repository in the correct location
+your preferred workspace location and that your Go bin directory is on your PATH.
+Once Go is configured clone the Beats repository in the correct location
 under `GOPATH`:
 
 [source,shell]


### PR DESCRIPTION
Removes duplicated content about setting up dev environment. Also cherry-picks #8368.