### PR TITLE
Backport to 6.6: [Docs] Add topic about running Journalbeat on docker (#9386)

### DIFF
--- a/journalbeat/docs/getting-started.asciidoc
+++ b/journalbeat/docs/getting-started.asciidoc
@@ -71,6 +71,21 @@ tar xzvf {beatname_lc}-{version}-linux-x86_64.tar.gz
 
 endif::[]
 
+[[docker]]
+*docker:*
+
+ifeval::["{release-state}"=="unreleased"]
+
+Version {stack-version} of {beatname_uc} has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
+
+See <<running-on-docker, Running on Docker>> for deploying Docker containers.
+
+endif::[]
+
 [id="{beatname_lc}-configuration"]
 === Step 2: Configure {beatname_uc}
 

--- a/journalbeat/docs/index.asciidoc
+++ b/journalbeat/docs/index.asciidoc
@@ -16,6 +16,7 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :deb_os:
 :rpm_os:
 :linux_os:
+:docker_platform:
 :no_dashboards:
 
 include::{libbeat-dir}/docs/shared-beats-attributes.asciidoc[]

--- a/journalbeat/docs/setting-up-running.asciidoc
+++ b/journalbeat/docs/setting-up-running.asciidoc
@@ -18,7 +18,7 @@ This section includes additional information on how to set up and run
 * <<keystore>>
 * <<command-line-options>>
 * <<shutdown>>
-
+* <<running-on-docker>>
 
 //MAINTAINERS: If you add a new file to this section, make sure you update the bulleted list ^^ too.
 
@@ -27,5 +27,7 @@ include::{libbeat-dir}/docs/shared-directory-layout.asciidoc[]
 include::{libbeat-dir}/docs/keystore.asciidoc[]
 
 include::{libbeat-dir}/docs/command-reference.asciidoc[]
+
+include::./running-on-docker.asciidoc[]
 
 include::{libbeat-dir}/docs/shared-shutdown.asciidoc[]

--- a/libbeat/docs/shared-docker.asciidoc
+++ b/libbeat/docs/shared-docker.asciidoc
@@ -45,7 +45,7 @@ endif::[]
 Running {beatname_uc} with the setup command will create the index pattern and
 load visualizations, dashboards, and machine learning jobs.  Run this command:
 
-ifeval::[("{beatname_lc}"=="filebeat") or ("{beatname_lc}"=="metricbeat") or ("{beatname_lc}"=="heartbeat")]
+ifeval::[("{beatname_lc}"=="filebeat") or ("{beatname_lc}"=="metricbeat") or ("{beatname_lc}"=="heartbeat") or ("{beatname_lc}"=="journalbeat")]
 ["source", "sh", subs="attributes"]
 --------------------------------------------
 docker run \
@@ -110,16 +110,16 @@ curl -L -O https://raw.githubusercontent.com/elastic/beats/{doc-branch}/deploy/d
 One way to configure {beatname_uc} on Docker is to provide +{beatname_lc}.docker.yml+ via a volume mount.
 With +docker run+, the volume mount can be specified like this:
 
-ifeval::["{beatname_lc}"=="filebeat"]
+ifeval::[("{beatname_lc}"=="filebeat") or ("{beatname_lc}"=="journalbeat")]
 ["source", "sh", subs="attributes"]
 --------------------------------------------
 docker run -d \
-  --name=filebeat \
+  --name={beatname_lc} \
   --user=root \
-  --volume="$(pwd)/{beatname_lc}.docker.yml:/usr/share/filebeat/filebeat.yml:ro" \
+  --volume="$(pwd)/{beatname_lc}.docker.yml:/usr/share/{beatname_lc}/{beatname_lc}.yml:ro" \
   --volume="/var/lib/docker/containers:/var/lib/docker/containers:ro" \
   --volume="/var/run/docker.sock:/var/run/docker.sock:ro" \
-  {dockerimage} filebeat -e -strict.perms=false \
+  {dockerimage} {beatname_lc} -e -strict.perms=false \
   -E output.elasticsearch.hosts=["elasticsearch:9200"] <1> <2>
 --------------------------------------------
 endif::[]


### PR DESCRIPTION
Cherry-picks #9386 into the 6.6 branch.

NOTE: Do not merge before confirming that the docker image is available for download here: https://www.docker.elastic.co/

(cherry picked from commit b882136d0c28d69cbe4c7bd1466692d0c63ae700)