### PR TITLE
Use packages from x-pack/metricbeat

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,12 +16,12 @@ XPACK_SUFFIX=x-pack/
 # PROJECTS_XPACK_PKG is a list of Beats that have independent packaging support
 # in the x-pack directory (rather than having the OSS build produce both sets
 # of artifacts). This will be removed once we complete the transition.
-PROJECTS_XPACK_PKG=x-pack/auditbeat x-pack/filebeat
+PROJECTS_XPACK_PKG=x-pack/auditbeat x-pack/filebeat x-pack/metricbeat
 # PROJECTS_XPACK_MAGE is a list of Beats whose primary build logic is based in
 # Mage. For compatibility with CI testing these projects support a subset of the
 # makefile targets. After all Beats converge to primarily using Mage we can
 # remove this and treat all sub-projects the same.
-PROJECTS_XPACK_MAGE=x-pack/metricbeat $(PROJECTS_XPACK_PKG)
+PROJECTS_XPACK_MAGE=$(PROJECTS_XPACK_PKG)
 
 #
 # Includes

--- a/metricbeat/magefile.go
+++ b/metricbeat/magefile.go
@@ -47,11 +47,6 @@ func GolangCrossBuild() error {
 	return mage.GolangCrossBuild(mage.DefaultGolangCrossBuildArgs())
 }
 
-// CrossBuildXPack cross-builds the beat with XPack for all target platforms.
-func CrossBuildXPack() error {
-	return mage.CrossBuildXPack()
-}
-
 // BuildGoDaemon builds the go-daemon binary (use crossBuildGoDaemon).
 func BuildGoDaemon() error {
 	return mage.BuildGoDaemon()
@@ -80,11 +75,11 @@ func Package() {
 	start := time.Now()
 	defer func() { fmt.Println("package ran for", time.Since(start)) }()
 
-	mage.UseElasticBeatPackaging()
+	mage.UseElasticBeatOSSPackaging()
 	customizePackaging()
 
 	mg.Deps(Update)
-	mg.Deps(CrossBuild, CrossBuildXPack, CrossBuildGoDaemon)
+	mg.Deps(CrossBuild, CrossBuildGoDaemon)
 	mg.SerialDeps(mage.Package, TestPackages)
 }
 


### PR DESCRIPTION
This changes the metricbeat/ build to not create Elastic licensed packages
any longer because those are being build from x-pack/metricbeat.