### PR TITLE
[Auditbeat] Make user.group.name optional in system test on Windows

### DIFF
--- a/x-pack/auditbeat/tests/system/test_metricsets.py
+++ b/x-pack/auditbeat/tests/system/test_metricsets.py
@@ -41,12 +41,12 @@ class Test(AuditbeatXPackTest):
         """
 
         fields = ["process.pid", "process.ppid", "process.name", "process.executable", "process.args",
-                  "process.start", "process.working_directory", "user.id", "user.group.id", "user.group.name"]
+                  "process.start", "process.working_directory", "user.id", "user.group.id"]
 
         # Windows does not have effective and saved IDs, and user.name is not always filled for system processes.
         if sys.platform != "win32":
             fields.extend(["user.effective.id", "user.saved.id", "user.effective.group.id", "user.saved.group.id",
-                           "user.name"])
+                           "user.name", "user.group.name"])
 
         # Metricset is experimental and that generates a warning, TODO: remove later
         self.check_metricset("system", "process", COMMON_FIELDS + fields, warnings_allowed=True)


### PR DESCRIPTION
On Windows, `user.group.name` might not necessarily be filled in CI, so let's make it optional.

https://beats-ci.elastic.co/job/elastic+beats+pull-request+multijob-windows/4287/beat=x-pack%2Fauditbeat,label=windows/console:
```
13:02:23 >> go test: Unit Test Passed
13:02:23 System testing x-pack/auditbeat
13:02:37 .ESS
13:02:37 ======================================================================
13:02:37 ERROR: process metricset collects information about processes running on a system.
13:02:37 ----------------------------------------------------------------------
13:02:37 Traceback (most recent call last):
13:02:37   File "C:\Users\jenkins\workspace\elastic+beats+pull-request+multijob-windows\beat\x-pack\auditbeat\label\windows\src\github.com\elastic\beats\x-pack\auditbeat\tests\system\test_metricsets.py", line 38, in test_metricset_process
13:02:37     self.check_metricset("system", "process", COMMON_FIELDS + fields, warnings_allowed=True)
13:02:37   File "C:\Users\jenkins\workspace\elastic+beats+pull-request+multijob-windows\beat\x-pack\auditbeat\label\windows\src\github.com\elastic\beats\x-pack\auditbeat\tests\system\auditbeat_xpack.py", line 56, in check_metricset
13:02:37     raise Exception("Field '{}' not found in event.".format(f))
13:02:37 Exception: Field 'user.group.name' not found in event.
13:02:37 -------------------- >> begin captured stdout << ---------------------
13:02:37 {u'process': {u'executable': u'C:\\Windows\\System32\\smss.exe', u'name': u'smss.exe', u'args': [], u'pid': 280, u'start': u'2019-01-23T05:37:28.109Z', u'working_directory': u'', u'ppid': 4}, u'@timestamp': u'2019-01-29T13:02:36.033Z', u'beat': {u'hostname': u'beats-ci-windows-2016-worker-9vrm', u'name': u'beats-ci-windows-2016-worker-9vrm', u'version': u'6.7.0'}, u'host': {u'name': u'beats-ci-windows-2016-worker-9vrm'}, u'user': {u'group': {u'id': u'S-1-5-18'}, u'id': u'S-1-5-18'}, u'message': u'Process smss.exe (PID: 280) is RUNNING', u'event': {u'action': u'existing_process', u'kind': u'state', u'id': u'10a8b7b2-542b-4f01-8299-fed0bbb63298', u'module': u'system', u'dataset': u'process'}}
```

This does not need a backport, the CI failure happened in 6.x for https://github.com/elastic/beats/pull/10395 and I've already included this change there.