### PR TITLE
Cherry-pick #10265 to 6.x:  Fix permissions issues for SQS

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -121,6 +121,7 @@ https://github.com/elastic/beats/compare/v6.6.0...6.x[Check the HEAD diff]
 *Functionbeat*
 
 - Ensure that functionbeat is logging at info level not debug. {issue}10262[10262]
+- Add the required permissions to the role when deployment SQS functions. {issue}9152[9152]
 
 ==== Added
 


### PR DESCRIPTION
Cherry-pick of PR #10265 to 6.x branch. Original message: 

**NOTES:**  This PR is based on top of #10116 

Correctly add the permissions to the lambda role when monitoring
SQS queue.

Fixes: #9152

