### PR TITLE
Add description into AWS EC2 dashboard

### DIFF
--- a/x-pack/metricbeat/module/aws/_meta/kibana/7/dashboard/Metricbeat-aws-ec2-overview.json
+++ b/x-pack/metricbeat/module/aws/_meta/kibana/7/dashboard/Metricbeat-aws-ec2-overview.json
@@ -478,7 +478,7 @@
     },
     {
       "attributes": {
-        "description": "",
+        "description": "Overview of AWS EC2 Metrics",
         "hits": 0,
         "kibanaSavedObjectMeta": {
           "searchSourceJSON": {


### PR DESCRIPTION
Just realized there is no description for AWS EC2 dashboard. This pr is to simply add that.