### PR TITLE
[docs]: Add beat_version_key attribute

### DIFF
--- a/libbeat/docs/config-file-format.asciidoc
+++ b/libbeat/docs/config-file-format.asciidoc
@@ -77,11 +77,11 @@ For example this setting:
 
 output:
   elasticsearch:
-    index: 'beat-%{[agent.version]}-%{+yyyy.MM.dd}'
+    index: 'beat-%{[{beat_version_key}]}-%{+yyyy.MM.dd}'
 
 ------------------------------------------------------------------------------
 
-gets collapsed into `output.elasticsearch.index: 'beat-%{[agent.version]}-%{+yyyy.MM.dd}'`. The
+gets collapsed into +output.elasticsearch.index: \'beat-%{[{beat_version_key}]}-%{+yyyy.MM.dd}\'+. The
 full name of a setting is based on all parent structures involved.
 
 Lists create numeric names starting with 0.

--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -60,7 +60,7 @@ Example configuration:
 
 output.elasticsearch:
   hosts: ["https://localhost:9200"]
-  index: "{beatname_lc}-%{[agent.version]}-%{+yyyy.MM.dd}"
+  index: "{beatname_lc}-%{[{beat_version_key}]}-%{+yyyy.MM.dd}"
   ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
   ssl.certificate: "/etc/pki/client/cert.pem"
   ssl.key: "/etc/pki/client/cert.key"
@@ -217,7 +217,7 @@ for more information about the environment variables.
 
 ifndef::apm-server[]
 The index name to write events to. The default is
-+"{beatname_lc}-%\{[agent.version]\}-%\{+yyyy.MM.dd\}"+ (for example,
++"{beatname_lc}-%\{[{beat_version_key}]\}-%\{+yyyy.MM.dd\}"+ (for example,
 +"{beatname_lc}-{version}-{localdate}"+). If you change this setting, you also
 need to configure the `setup.template.name` and `setup.template.pattern` options
 (see <<configuration-template>>).
@@ -225,7 +225,7 @@ endif::apm-server[]
 
 ifdef::apm-server[]
 The index name to write events to. The default is
-+"apm-%\{[agent.version]\}-{type\}-%\{+yyyy.MM.dd\}"+ (for example,
++"apm-%\{[{beat_version_key}]\}-{type\}-%\{+yyyy.MM.dd\}"+ (for example,
 +"apm-{version}-transaction-{localdate}"+). See
 <<exploring-es-data,Exploring data in Elasticsearch>> for more information on
 default index configuration.
@@ -235,7 +235,7 @@ you need to configure the `setup.template.name` and `setup.template.pattern` opt
 (see <<configuration-template>>). You also must set the default index configuration
 in the `apm-server.yml` file.
 
-NOTE: `agent.version` is a field managed by Beats that is added to every document.
+NOTE: +{beat_version_key}+ is a field managed by Beats that is added to every document.
 It holds the current version of APM Server.
 endif::apm-server[]
 
@@ -256,10 +256,10 @@ to set the index:
 ------------------------------------------------------------------------------
 output.elasticsearch:
   hosts: ["http://localhost:9200"]
-  index: "%\{[fields.log_type]\}-%\{[agent.version]\}-%\{+yyyy.MM.dd}\" <1>
+  index: "%\{[fields.log_type]\}-%\{[{beat_version_key}]\}-%\{+yyyy.MM.dd}\" <1>
 ------------------------------------------------------------------------------
 
-<1> We recommend including `agent.version` in the name to avoid mapping issues
+<1> We recommend including +{beat_version_key}+ in the name to avoid mapping issues
 when you upgrade.
 
 With this configuration, all events with `log_type: normal` are sent to an 
@@ -303,15 +303,15 @@ endif::no-processors[]
 The following example sets the index based on whether the `message` field
 contains the specified string:
 
-["source","yaml"]
+["source","yaml",subs="attributes"]
 ------------------------------------------------------------------------------
 output.elasticsearch:
   hosts: ["http://localhost:9200"]
   indices:
-    - index: "warning-%{[agent.version]}-%{+yyyy.MM.dd}"
+    - index: "warning-%{[{beat_version_key}]}-%{+yyyy.MM.dd}"
       when.contains:
         message: "WARN"
-    - index: "error-%{[agent.version]}-%{+yyyy.MM.dd}"
+    - index: "error-%{[{beat_version_key}]}-%{+yyyy.MM.dd}"
       when.contains:
         message: "ERR"
 ------------------------------------------------------------------------------

--- a/libbeat/docs/shared-beats-attributes.asciidoc
+++ b/libbeat/docs/shared-beats-attributes.asciidoc
@@ -25,3 +25,4 @@
 :beat_monitoring_user: beats_system
 :beat_monitoring_user_version: 6.3.0
 :beat_monitoring_version: 6.2
+:beat_version_key: agent.version

--- a/libbeat/docs/shared-ilm.asciidoc
+++ b/libbeat/docs/shared-ilm.asciidoc
@@ -35,9 +35,9 @@ template to use the correct settings for index lifecycle management.
 NOTE: If you've previously loaded the index template for this version into {es}, 
 you must overwrite the template by setting `setup.template.overwrite: true`.
 
-The rollover alias is set to +{beatname_lc}-\{agent.version\}+ by default. You
+The rollover alias is set to +{beatname_lc}-\{{beat_version_key}\}+ by default. You
 can change the prefix used in the alias by setting `ilm.rollover_alias`, but you
-can't remove `{agent.version}` from the rollover alias name. The default pattern
+can't remove +{beat_version_key}+ from the rollover alias name. The default pattern
 used for the rollover index is `%{now/d}-000001`. You can change the
 pattern by setting `ilm.pattern`. For example:
 

--- a/libbeat/docs/shared-template-load.asciidoc
+++ b/libbeat/docs/shared-template-load.asciidoc
@@ -75,7 +75,7 @@ date information. You also need to configure the `setup.template.name` and
 +
 ["source","sh",subs="attributes,callouts"]
 -----
-output.elasticsearch.index: "customname-%{[agent.version]}-%{+yyyy.MM.dd}"
+output.elasticsearch.index: "customname-%{[{beat_version_key}]}-%{+yyyy.MM.dd}"
 setup.template.name: "customname"
 setup.template.pattern: "customname-*"
 -----

--- a/libbeat/docs/template-config.asciidoc
+++ b/libbeat/docs/template-config.asciidoc
@@ -24,18 +24,18 @@ you must <<load-template-manually,load the template manually>>.
 
 *`setup.template.name`*:: The name of the template. The default is
 +{beatname_lc}+. The {beatname_uc} version is always appended to the given
-name, so the final name is +{beatname_lc}-%\{[agent.version]\}+.
+name, so the final name is +{beatname_lc}-%\{[{beat_version_key}]\}+.
 
 // Maintainers: a backslash character is required to escape curly braces and
 // asterisks in inline code examples that contain asciidoc attributes. You'll
 // note that a backslash does not appear before the asterisk
-// in +{beatname_lc}-%\{[agent.version]\}-*+. This is intentional and formats
+// in +{beatname_lc}-%\{[{beat_version_key}]\}-*+. This is intentional and formats
 // the example as expected.
 
 *`setup.template.pattern`*:: The template pattern to apply to the default index
 settings. The default pattern is +{beat_default_index_prefix}-\*+. The {beatname_uc} version is always
 included in the pattern, so the final pattern is
-+{beat_default_index_prefix}-%\{[agent.version]\}-*+. The wildcard character `-*` is used to
++{beat_default_index_prefix}-%\{[{beat_version_key}]\}-*+. The wildcard character `-*` is used to
 match all daily indices.
 +
 Example:


### PR DESCRIPTION
elastic/beats#10078 renamed `beat.version` to `agent.version` in the docs. Problem is, `agent` means something different in APM land, so we decided to go with the name `observer.version`. This PR removes hard-coding of `agent.version` in the docs and replaces it with the `{beat_version_key}` attribute.

I've built the beat docs and confirmed everything still renders the same on your end.

This change persists the PR in the apm-server repo: elastic/apm-server/pull/1848