### PR TITLE
Fix server_integration_test.go version_date

### DIFF
--- a/metricbeat/module/zookeeper/server/server_integration_test.go
+++ b/metricbeat/module/zookeeper/server/server_integration_test.go
@@ -48,7 +48,7 @@ func TestFetch(t *testing.T) {
 		metricsetFields := event.MetricSetFields
 
 		// Check values
-		assert.Equal(t, "06/29/2018 04:05 GMT", metricsetFields["version_date"])
+		assert.Equal(t, "02/06/2016 03:18 GMT", metricsetFields["version_date"])
 
 		received := metricsetFields["received"].(int64)
 		assert.True(t, received >= 0)


### PR DESCRIPTION
> --- FAIL: TestFetch (2.03s)
    server_integration_test.go:47: zookeeper/server event: {RootFields:{"service":{"version":"3.4.8--1"}} ModuleFields:null MetricSetFields:{"connections":1,"count":0,"epoch":0,"latency":{"avg":0,"max":0,"min":0},"mode":"standalone","node_count":4,"outstanding":0,"received":1,"sent":0,"version_date":"02/06/2016 03:18 GMT","zxid":"0x0"} Index: ID: Namespace: Timestamp:0001-01-01 00:00:00 +0000 UTC Error:<nil> Host: Service: Took:0s}
    server_integration_test.go:51: 
            Error Trace:    server_integration_test.go:51
            Error:          Not equal: 
                            expected: "06/29/2018 04:05 GMT"
                            actual  : "02/06/2016 03:18 GMT"
                            
                            Diff:
                            --- Expected
                            +++ Actual
                            @@ -1 +1 @@
                            -06/29/2018 04:05 GMT
                            +02/06/2016 03:18 GMT
            Test:           TestFetch