### PR TITLE
Set shard count to 1 in all default configs

### DIFF
--- a/auditbeat/_meta/common.p2.yml
+++ b/auditbeat/_meta/common.p2.yml
@@ -1,6 +1,6 @@
 
 #==================== Elasticsearch template setting ==========================
 setup.template.settings:
-  index.number_of_shards: 3
+  index.number_of_shards: 1
   #index.codec: best_compression
   #_source.enabled: false

--- a/auditbeat/auditbeat.yml
+++ b/auditbeat/auditbeat.yml
@@ -50,7 +50,7 @@ auditbeat.modules:
 
 #==================== Elasticsearch template setting ==========================
 setup.template.settings:
-  index.number_of_shards: 3
+  index.number_of_shards: 1
   #index.codec: best_compression
   #_source.enabled: false
 

--- a/filebeat/_meta/common.p2.yml
+++ b/filebeat/_meta/common.p2.yml
@@ -69,6 +69,6 @@ filebeat.config.modules:
 #==================== Elasticsearch template setting ==========================
 
 setup.template.settings:
-  index.number_of_shards: 3
+  index.number_of_shards: 1
   #index.codec: best_compression
   #_source.enabled: false

--- a/filebeat/filebeat.yml
+++ b/filebeat/filebeat.yml
@@ -78,7 +78,7 @@ filebeat.config.modules:
 #==================== Elasticsearch template setting ==========================
 
 setup.template.settings:
-  index.number_of_shards: 3
+  index.number_of_shards: 1
   #index.codec: best_compression
   #_source.enabled: false
 

--- a/journalbeat/_meta/beat.yml
+++ b/journalbeat/_meta/beat.yml
@@ -44,3 +44,9 @@ journalbeat.inputs:
   # Name of the registry file. If a relative path is used, it is considered relative to the
   # data path.
   #registry_file: registry
+
+#==================== Elasticsearch template setting ==========================
+setup.template.settings:
+  index.number_of_shards: 1
+  #index.codec: best_compression
+  #_source.enabled: false

--- a/journalbeat/journalbeat.reference.yml
+++ b/journalbeat/journalbeat.reference.yml
@@ -45,6 +45,12 @@ journalbeat.inputs:
   # data path.
   #registry_file: registry
 
+#==================== Elasticsearch template setting ==========================
+setup.template.settings:
+  index.number_of_shards: 1
+  #index.codec: best_compression
+  #_source.enabled: false
+
 #================================ General ======================================
 
 # The name of the shipper that publishes the network data. It can be used to group

--- a/journalbeat/journalbeat.yml
+++ b/journalbeat/journalbeat.yml
@@ -45,6 +45,12 @@ journalbeat.inputs:
   # data path.
   #registry_file: registry
 
+#==================== Elasticsearch template setting ==========================
+setup.template.settings:
+  index.number_of_shards: 1
+  #index.codec: best_compression
+  #_source.enabled: false
+
 #================================ General =====================================
 
 # The name of the shipper that publishes the network data. It can be used to group

--- a/packetbeat/_meta/beat.yml
+++ b/packetbeat/_meta/beat.yml
@@ -104,6 +104,6 @@ packetbeat.protocols:
 #==================== Elasticsearch template setting ==========================
 
 setup.template.settings:
-  index.number_of_shards: 3
+  index.number_of_shards: 1
   #index.codec: best_compression
   #_source.enabled: false

--- a/packetbeat/packetbeat.yml
+++ b/packetbeat/packetbeat.yml
@@ -104,7 +104,7 @@ packetbeat.protocols:
 #==================== Elasticsearch template setting ==========================
 
 setup.template.settings:
-  index.number_of_shards: 3
+  index.number_of_shards: 1
   #index.codec: best_compression
   #_source.enabled: false
 

--- a/winlogbeat/_meta/beat.yml
+++ b/winlogbeat/_meta/beat.yml
@@ -26,6 +26,6 @@ winlogbeat.event_logs:
 #==================== Elasticsearch template setting ==========================
 
 setup.template.settings:
-  index.number_of_shards: 3
+  index.number_of_shards: 1
   #index.codec: best_compression
   #_source.enabled: false

--- a/winlogbeat/winlogbeat.yml
+++ b/winlogbeat/winlogbeat.yml
@@ -26,7 +26,7 @@ winlogbeat.event_logs:
 #==================== Elasticsearch template setting ==========================
 
 setup.template.settings:
-  index.number_of_shards: 3
+  index.number_of_shards: 1
   #index.codec: best_compression
   #_source.enabled: false
 

--- a/x-pack/auditbeat/auditbeat.yml
+++ b/x-pack/auditbeat/auditbeat.yml
@@ -67,7 +67,7 @@ auditbeat.modules:
 
 #==================== Elasticsearch template setting ==========================
 setup.template.settings:
-  index.number_of_shards: 3
+  index.number_of_shards: 1
   #index.codec: best_compression
   #_source.enabled: false
 

--- a/x-pack/filebeat/filebeat.yml
+++ b/x-pack/filebeat/filebeat.yml
@@ -78,7 +78,7 @@ filebeat.config.modules:
 #==================== Elasticsearch template setting ==========================
 
 setup.template.settings:
-  index.number_of_shards: 3
+  index.number_of_shards: 1
   #index.codec: best_compression
   #_source.enabled: false
 

--- a/x-pack/functionbeat/_meta/beat.yml
+++ b/x-pack/functionbeat/_meta/beat.yml
@@ -144,3 +144,10 @@ functionbeat.provider.aws.functions:
         # Starting position is where to start reading events from the Kinesis stream.
         # Default is trim_horizon.
         #starting_position: "trim_horizon"
+
+#==================== Elasticsearch template setting ==========================
+
+setup.template.settings:
+  index.number_of_shards: 1
+  #index.codec: best_compression
+  #_source.enabled: false

--- a/x-pack/functionbeat/functionbeat.yml
+++ b/x-pack/functionbeat/functionbeat.yml
@@ -145,6 +145,13 @@ functionbeat.provider.aws.functions:
         # Default is trim_horizon.
         #starting_position: "trim_horizon"
 
+#==================== Elasticsearch template setting ==========================
+
+setup.template.settings:
+  index.number_of_shards: 1
+  #index.codec: best_compression
+  #_source.enabled: false
+
 #================================ General =====================================
 
 # The name of the shipper that publishes the network data. It can be used to group


### PR DESCRIPTION
This reimplements #7091.

We already set shards to 1 in our Metricbeat and Heartbeat configurations, but we were
explicitly setting it to 3 in the other configs. I changed to be 1 everywhere. I went
for a change that still contains the number of shards in the Beat config, rather than
just rely on the ES default, so that Beats 7.0 behave the same even when talking to ES 6.x.