### PR TITLE
Cherry-pick #10019 to 6.x: Simple conversion of the format returned by the API

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -14,6 +14,11 @@ https://github.com/elastic/beats/compare/v6.6.0...6.x[Check the HEAD diff]
 - Fix registry handle leak on Windows (https://github.com/elastic/go-sysinfo/pull/33). {pull}9920[9920]
 - Allow to unenroll a Beat from the UI. {issue}9452[9452]
 - Port settings have been deprecated in redis/logstash output and will be removed in 7.0. {pull}9915[9915]
+- Rename `process.exe` to `process.executable` in add_process_metadata to align with ECS. {pull}9949[9949]
+- Import ECS change https://github.com/elastic/ecs/pull/308[ecs#308]:
+  leaf field `user.group` is now the `group` field set. {pull}10275[10275]
+- Update the code of Central Management to align with the new returned format. {pull}10019[10019]
+- Docker and Kubernetes labels/annotations will be "dedoted" by default. {pull}10338[10338]
 
 *Auditbeat*
 

--- a/x-pack/libbeat/management/api/configuration_test.go
+++ b/x-pack/libbeat/management/api/configuration_test.go
@@ -28,7 +28,7 @@ func TestConfiguration(t *testing.T) {
 
 		assert.Equal(t, "false", r.URL.Query().Get("validSetting"))
 
-		fmt.Fprintf(w, `{"configuration_blocks":[{"type":"filebeat.modules","config":{"module":"apache2"}},{"type":"metricbeat.modules","config":{"module":"system","period":"10s"}}]}`)
+		fmt.Fprintf(w, `{"configuration_blocks":[{"type":"filebeat.modules","config":{"_sub_type":"apache2"}},{"type":"metricbeat.modules","config":{"_sub_type":"system","period":"10s"}}]}`)
 	}))
 	defer server.Close()
 

--- a/x-pack/libbeat/management/api/convert.go
+++ b/x-pack/libbeat/management/api/convert.go
@@ -1,0 +1,79 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package api
+
+import (
+	"fmt"
+	"strings"
+)
+
+type converter func(map[string]interface{}) (map[string]interface{}, error)
+
+var mapper = map[string]converter{
+	".inputs":  noopConvert,
+	".modules": convertMultiple,
+	"output":   convertSingle,
+}
+
+var errSubTypeNotFound = fmt.Errorf("'%s' key not found", subTypeKey)
+
+var (
+	subTypeKey = "_sub_type"
+	moduleKey  = "module"
+)
+
+func selectConverter(t string) converter {
+	for k, v := range mapper {
+		if strings.Index(t, k) > -1 {
+			return v
+		}
+	}
+	return noopConvert
+}
+
+func convertSingle(m map[string]interface{}) (map[string]interface{}, error) {
+	subType, err := extractSubType(m)
+	if err != nil {
+		return nil, err
+	}
+
+	delete(m, subTypeKey)
+	newMap := map[string]interface{}{subType: m}
+	return newMap, nil
+}
+
+func convertMultiple(m map[string]interface{}) (map[string]interface{}, error) {
+	subType, err := extractSubType(m)
+	if err != nil {
+		return nil, err
+	}
+
+	v, ok := m[moduleKey]
+
+	if ok && v != subType {
+		return nil, fmt.Errorf("module key already exist in the raw document and doesn't match the 'sub_type', expecting '%s' and received '%s", subType, v)
+	}
+
+	m[moduleKey] = subType
+	delete(m, subTypeKey)
+	return m, nil
+}
+
+func noopConvert(m map[string]interface{}) (map[string]interface{}, error) {
+	return m, nil
+}
+
+func extractSubType(m map[string]interface{}) (string, error) {
+	subType, ok := m[subTypeKey]
+	if !ok {
+		return "", errSubTypeNotFound
+	}
+
+	k, ok := subType.(string)
+	if !ok {
+		return "", fmt.Errorf("invalid type for `sub_type`, expecting a string received %T", subType)
+	}
+	return k, nil
+}

--- a/x-pack/libbeat/management/api/convert_test.go
+++ b/x-pack/libbeat/management/api/convert_test.go
@@ -1,0 +1,111 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package api
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConvertAPI(t *testing.T) {
+	tests := map[string]struct {
+		t        string
+		config   map[string]interface{}
+		expected map[string]interface{}
+		err      bool
+	}{
+		"output": {
+			t: "output",
+			config: map[string]interface{}{
+				"_sub_type": "elasticsearch",
+				"username":  "foobar",
+			},
+			expected: map[string]interface{}{
+				"elasticsearch": map[string]interface{}{
+					"username": "foobar",
+				},
+			},
+		},
+		"filebeat inputs": {
+			t: "filebeat.inputs",
+			config: map[string]interface{}{
+				"type": "log",
+				"paths": []string{
+					"/var/log/message.log",
+					"/var/log/system.log",
+				},
+			},
+			expected: map[string]interface{}{
+				"type": "log",
+				"paths": []string{
+					"/var/log/message.log",
+					"/var/log/system.log",
+				},
+			},
+		},
+		"filebeat modules": {
+			t: "filebeat.modules",
+			config: map[string]interface{}{
+				"_sub_type": "system",
+			},
+			expected: map[string]interface{}{
+				"module": "system",
+			},
+		},
+		"metricbeat modules": {
+			t: "metricbeat.modules",
+			config: map[string]interface{}{
+				"_sub_type": "logstash",
+			},
+			expected: map[string]interface{}{
+				"module": "logstash",
+			},
+		},
+		"badly formed output": {
+			err: true,
+			t:   "output",
+			config: map[string]interface{}{
+				"nosubtype": "logstash",
+			},
+		},
+		"badly formed filebeat module": {
+			err: true,
+			t:   "filebeat.modules",
+			config: map[string]interface{}{
+				"nosubtype": "logstash",
+			},
+		},
+		"badly formed metricbeat module": {
+			err: true,
+			t:   "metricbeat.modules",
+			config: map[string]interface{}{
+				"nosubtype": "logstash",
+			},
+		},
+		"unknown type is passthrough": {
+			t: "unkown",
+			config: map[string]interface{}{
+				"nosubtype": "logstash",
+			},
+			expected: map[string]interface{}{
+				"nosubtype": "logstash",
+			},
+		},
+	}
+
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			converter := selectConverter(test.t)
+			newMap, err := converter(test.config)
+			if !assert.Equal(t, test.err, err != nil) {
+				return
+			}
+			assert.True(t, reflect.DeepEqual(newMap, test.expected))
+		})
+	}
+}

--- a/x-pack/libbeat/management/api/doc.go
+++ b/x-pack/libbeat/management/api/doc.go
@@ -1,0 +1,69 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+/*
+The Kibana CM Api returns a configuration format which cannot be ingested directly by our
+configuration parser, it need to be transformed from the generic format into an adapted format
+which is dependant on the type of configuration.
+
+
+Translations:
+
+Type: output
+
+{
+    "configuration_blocks": [
+
+        {
+            "config": {
+              "_sub_type": "elasticsearch"
+              "_id": "12312341231231"
+              "hosts": [ "localhost" ],
+              "password": "foobar"
+              "username": "elastic"
+            },
+            "type": "output"
+        }
+    ]
+}
+
+YAML representation:
+
+{
+	"elasticsearch": {
+		"hosts": [ "localhost" ],
+		"password": "foobar"
+		"username": "elastic"
+	}
+}
+
+
+Type: *.modules
+
+{
+    "configuration_blocks": [
+
+        {
+            "config": {
+              "_sub_type": "system"
+              "_id": "12312341231231"
+							"path" "foobar"
+            },
+            "type": "filebeat.module"
+        }
+    ]
+}
+
+YAML representation:
+
+[
+{
+	"module": "system"
+	"path": "foobar"
+}
+]
+
+*/
+
+package api


### PR DESCRIPTION
Cherry-pick of PR #10019 to 6.x branch. Original message: 

## DO NOT MERGE REQUIRE CODE CHANGE IN KIBANA
---

The Kibana API for CM is undergoing internal changes to better allow
future scalability of the configurations, one of the requirements for
this move was to flatten as much as possible the configuration file so
the format would be the same independant of the key that need to
received ot the configuration. It will be up to the manager to take the
JSON format and convert it into something that our Configuration can
understand.

ref: https://github.com/elastic/kibana/pull/27717


---

Details about the implementation:

Sorry, It took much longer than I thought it would, and I initially wanted to do it more cleanly and allow the reloadable registry to tells us what it actually needed. I was actually pretty far into it but after taking a step back I was anxious about my strategy and the number of required changes and the implication in review that I've decided to go for a simple take on it instead.

Right now the registry as two concepts a `Single` and `List`, I think we should uniform them into a single `Reloable` and let the implementation details manage how a reload is happening and we also need better feedback from the reload part.
