### PR TITLE
Cherry-pick #10436 to 6.x: Use lowercase pattern for years parsing in filebeat pipelines

### DIFF
--- a/filebeat/module/apache2/access/ingest/default.json
+++ b/filebeat/module/apache2/access/ingest/default.json
@@ -23,7 +23,7 @@
     "date": {
       "field": "apache2.access.time",
       "target_field": "@timestamp",
-      "formats": ["dd/MMM/YYYY:H:m:s Z"]
+      "formats": ["dd/MMM/yyyy:H:m:s Z"]
     }
   }, {
     "remove": {

--- a/filebeat/module/apache2/error/ingest/pipeline.json
+++ b/filebeat/module/apache2/error/ingest/pipeline.json
@@ -30,7 +30,7 @@
       "date": {
         "field": "apache2.error.timestamp",
         "target_field": "@timestamp",
-        "formats": ["EEE MMM dd H:m:s YYYY", "EEE MMM dd H:m:s.SSSSSS YYYY"],
+        "formats": ["EEE MMM dd H:m:s yyyy", "EEE MMM dd H:m:s.SSSSSS yyyy"],
         "ignore_failure": true
       }
     },

--- a/filebeat/module/mysql/error/ingest/pipeline.json
+++ b/filebeat/module/mysql/error/ingest/pipeline.json
@@ -36,7 +36,7 @@
         "target_field": "@timestamp",
         "formats": [
           "ISO8601",
-          "YYMMdd H:m:s"
+          "yyMMdd H:m:s"
         ],
         "ignore_failure": true
       }

--- a/filebeat/module/nginx/access/ingest/default.json
+++ b/filebeat/module/nginx/access/ingest/default.json
@@ -59,7 +59,7 @@
                 "field": "nginx.access.time",
                 "target_field": "@timestamp",
                 "formats": [
-                    "dd/MMM/YYYY:H:m:s Z"
+                    "dd/MMM/yyyy:H:m:s Z"
                 ],
                 {< if .convert_timezone >}"timezone": "{{ event.timezone }}",{< end >}
                 "ignore_failure": true

--- a/filebeat/module/nginx/error/ingest/pipeline.json
+++ b/filebeat/module/nginx/error/ingest/pipeline.json
@@ -21,7 +21,7 @@
     "date": {
       "field": "nginx.error.time",
       "target_field": "@timestamp",
-      "formats": ["YYYY/MM/dd H:m:s"],
+      "formats": ["yyyy/MM/dd H:m:s"],
       {< if .convert_timezone >}"timezone": "{{ event.timezone }}",{< end >}
       "ignore_failure": true
     }

--- a/filebeat/module/redis/log/ingest/pipeline.json
+++ b/filebeat/module/redis/log/ingest/pipeline.json
@@ -64,7 +64,7 @@
                 "field": "redis.log.timestamp",
                 "target_field": "@timestamp",
                 "formats": [
-                    "dd MMM YYYY H:m:s.SSS",
+                    "dd MMM yyyy H:m:s.SSS",
                     "dd MMM H:m:s.SSS",
                     "dd MMM H:m:s",
                     "UNIX"

--- a/filebeat/module/traefik/access/ingest/pipeline.json
+++ b/filebeat/module/traefik/access/ingest/pipeline.json
@@ -33,7 +33,7 @@
                 "field": "traefik.access.time",
                 "target_field": "@timestamp",
                 "formats": [
-                    "dd/MMM/YYYY:H:m:s Z"
+                    "dd/MMM/yyyy:H:m:s Z"
                 ]
             }
         },


### PR DESCRIPTION
Cherry-pick of PR #10436 to 6.x branch. Original message: 

Elasticsearch 7.0 will change the date formatter and parser implementation
to use Java formatter instead of the Joda one.
After this change parsing years with `YYYY` no longer works as expected, leading
to incorrectly parsed dates.
`yyyy` works as expected on both implementations, so use it instead.

Fixes #10433.