### PR TITLE
Remove dissect tokenizing from Traefik Filebeat Access Fileset

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -228,6 +228,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add convert_timezone to nginx module. {issue}9839[9839] {pull}10148[10148]
 - Add support for Percona in the `slowlog` fileset of `mysql` module. {issue}6665[6665] {pull}10227[10227]
 - Added support for ingesting structured Elasticsearch audit logs {pull}10352[10352]
+- Remove dissect tokenizing from Filebeat Traefik 'access' Fileset. {pull}10442[10442]
 
 *Heartbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -72,6 +72,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Migrate Elasticsearch audit logs fields to ECS {pull}10352[10352]
 - Several text fields in the Logstash module are now indexed as `keyword` fields with `text` multi-fields (ECS). {pull}10417[10417]
 - Several text fields in the Elasticsearch module are now indexed as `keyword` fields with `text` multi-fields (ECS). {pull}10414[10414]
+- Move dissect pattern for traefik.access fileset from Filbeat to Elasticsearch. {pull}10442[10442]
 
 *Heartbeat*
 
@@ -228,7 +229,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add convert_timezone to nginx module. {issue}9839[9839] {pull}10148[10148]
 - Add support for Percona in the `slowlog` fileset of `mysql` module. {issue}6665[6665] {pull}10227[10227]
 - Added support for ingesting structured Elasticsearch audit logs {pull}10352[10352]
-- Remove dissect tokenizing from Filebeat Traefik 'access' Fileset. {pull}10442[10442]
 
 *Heartbeat*
 

--- a/filebeat/module/traefik/access/config/traefik-access.yml
+++ b/filebeat/module/traefik/access/config/traefik-access.yml
@@ -4,12 +4,3 @@ paths:
  - {{$path}}
 {{ end }}
 exclude_files: [".gz$"]
-
-processors:
-- dissect:
-    tokenizer: '%{source.address} %{traefik.access.user_identifier} %{user.name} [%{traefik.access.time}]
-    "%{http.request.method} %{url.original} HTTP/%{http.version}"
-    %{http.response.status_code} %{traefik.access.message}'
-
-    field: "message"
-    target_prefix: ""

--- a/filebeat/module/traefik/access/ingest/pipeline.json
+++ b/filebeat/module/traefik/access/ingest/pipeline.json
@@ -2,10 +2,16 @@
     "description": "Pipeline for parsing Traefik access logs. Requires the geoip and user_agent plugins.",
     "processors": [
         {
-            "grok": {
+            "dissect": {
                 "field": "message",
+                "pattern": "%{source.address} %{traefik.access.user_identifier} %{user.name} [%{traefik.access.time}] \"%{http.request.method} %{url.original} HTTP/%{http.version}\" %{http.response.status_code} %{traefik.access.message}"
+            }
+        },
+        {
+            "grok": {
+                "field": "traefik.access.message",
                 "patterns": [
-                    "%{IPORHOST:source.address} %{GREEDYDATA:traefik.access.user_identifier} %{GREEDYDATA:user.name} \\[%{HTTPDATE:traefik.access.time}\\] \"%{WORD:http.request.method} %{DATA:url.original} HTTP/%{NUMBER:http.version}\" %{NUMBER:http.response.status_code:long} (?:%{NUMBER:http.response.body.bytes:long}|-)?( (?:\"%{DATA:http.request.referrer}\"|-)? (?:\"%{DATA:traefik.access.agent}\"|-)? (?:%{NUMBER:traefik.access.request_count:long}|-)? (?:\"%{DATA:traefik.access.frontend_name}\"|-)? (?:\"%{DATA:traefik.access.backend_url}\"|-)?( %{NUMBER:temp.duration:long}ms|-)?)?"
+                    "(?:%{NUMBER:http.response.body.bytes:long}|-)( (?:\"%{DATA:http.request.referrer}\"|-)?( (?:\"%{DATA:traefik.access.agent}\"|-)?)?( (?:%{NUMBER:traefik.access.request_count:long}|-)?)?( (?:\"%{DATA:traefik.access.frontend_name}\"|-)?)?( \"%{DATA:traefik.access.backend_url}\")?( %{NUMBER:temp.duration:long}ms)?)?"
                 ],
                 "ignore_missing": true
             }
@@ -13,6 +19,12 @@
         {
             "remove": {
                 "field": "message",
+                "ignore_missing": true
+            }
+        },
+        {
+            "remove": {
+                "field": "traefik.access.message",
                 "ignore_missing": true
             }
         },

--- a/filebeat/module/traefik/access/ingest/pipeline.json
+++ b/filebeat/module/traefik/access/ingest/pipeline.json
@@ -3,9 +3,9 @@
     "processors": [
         {
             "grok": {
-                "field": "traefik.access.message",
+                "field": "message",
                 "patterns": [
-                    "(?:%{NUMBER:http.response.body.bytes:long}|-)( (?:\"%{DATA:http.request.referrer}\"|-)?( (?:\"%{DATA:traefik.access.agent}\"|-)?)?( (?:%{NUMBER:traefik.access.request_count:long}|-)?)?( (?:\"%{DATA:traefik.access.frontend_name}\"|-)?)?( \"%{DATA:traefik.access.backend_url}\")?( %{NUMBER:temp.duration:long}ms)?)?"
+                    "%{IPORHOST:source.address} %{GREEDYDATA:traefik.access.user_identifier} %{GREEDYDATA:user.name} \\[%{HTTPDATE:traefik.access.time}\\] \"%{WORD:http.request.method} %{DATA:url.original} HTTP/%{NUMBER:http.version}\" %{NUMBER:http.response.status_code:long} (?:%{NUMBER:http.response.body.bytes:long}|-)?( (?:\"%{DATA:http.request.referrer}\"|-)? (?:\"%{DATA:traefik.access.agent}\"|-)? (?:%{NUMBER:traefik.access.request_count:long}|-)? (?:\"%{DATA:traefik.access.frontend_name}\"|-)? (?:\"%{DATA:traefik.access.backend_url}\"|-)?( %{NUMBER:temp.duration:long}ms|-)?)?"
                 ],
                 "ignore_missing": true
             }
@@ -13,12 +13,6 @@
         {
             "remove": {
                 "field": "message",
-                "ignore_missing": true
-            }
-        },
-        {
-            "remove": {
-                "field": "traefik.access.message",
                 "ignore_missing": true
             }
         },


### PR DESCRIPTION
Solves: https://github.com/elastic/beats/issues/9434

I had a problem as I couldn't make it work with ES7 and I struggling to make it work in ES6 because in ES6 we use `int` as type for many Grok patterns but in ES7 we use `long`. It seems that `long` is detected as a `string` in ES6 and it was giving many troubles.

The problem trying to test this in ES7 is that it just gets frozen and, reviewing logs the only clue is a message saying: `Malformed [mappings] section for type [date_detection], should include an inner object describing the mapping`