### PR TITLE
Document privileges for ILM

### DIFF
--- a/libbeat/docs/security/basic-auth.asciidoc
+++ b/libbeat/docs/security/basic-auth.asciidoc
@@ -40,6 +40,7 @@ POST _xpack/security/role/{beat_default_index_prefix}_writer
   ]
 }
 ---------------------------------------------------------------
+// CONSOLE
 <1> If you use a custom {beatname_uc} index pattern, specify that pattern
 instead of the default ++{beat_default_index_prefix}-*++ pattern.
 endif::[]
@@ -64,6 +65,34 @@ POST _xpack/security/role/{beat_default_index_prefix}_writer
 instead of the default ++{beat_default_index_prefix}-*++ pattern.
 endif::[]
 --
+
+ifndef::no_ilm[]
+. If you plan to use {ref}/getting-started-index-lifecycle-management.html[index
+lifecycle management], create a role that has the following privileges. These
+privileges are required to load index lifecycle policies and create and manage
+rollover indices:
++
+* *Cluster:* `manage_ilm`
+* *Index:* `write`, `create_index`, `manage`, and `manage_ilm` on the 
+{beatname_uc} indices
++
+--
+["source","sh",subs="attributes"]
+---------------------------------------------------------------
+POST _xpack/security/role/{beatname_lc}_ilm
+{
+  "cluster": ["manage_ilm"],
+  "indices": [
+    {
+      "names": [ "{beatname_lc}-*","shrink-{beatname_lc}-*"],
+      "privileges": ["write","create_index","manage","manage_ilm"]
+    }
+  ]
+}
+---------------------------------------------------------------
+// CONSOLE
+--
+endif::no_ilm[]
 
 . Assign the writer role to the user that {beatname_uc} will use to connect to
 {es}. Make sure you also assign any roles that are required for specific

--- a/libbeat/docs/security/securing-beats.asciidoc
+++ b/libbeat/docs/security/securing-beats.asciidoc
@@ -44,39 +44,43 @@ password, set it up now.
 For more information about {security}, see
 {xpack-ref}/elasticsearch-security.html[Securing the {stack}].
 
-[float]
 [[feature-roles]]
 === {beatname_uc} features that require authorization
 
 After securing {beatname_uc}, make sure your users have the roles (or associated
-privileges) required to use these {beatname_uc} features. You must create the
-++{beat_default_index_prefix}_writer++ and
-++{beat_default_index_prefix}_reader++ roles (see <<beats-basic-auth>> and
-<<beats-user-access>>). The other roles are
-{xpack-ref}/built-in-roles.html[built-in].
+privileges) required to use these {beatname_uc} features. Note that some of the
+roles shown here are {xpack-ref}/built-in-roles.html[built-in], and some
+are user-defined.
 
 [options="header"]
 |=======
 |Feature | Role
-|Send data to a secured cluster   | ++{beat_default_index_prefix}_writer++
+|Send data to a secured cluster   | ++{beat_default_index_prefix}_writer++ footnoteref:[noteA,These roles are user-defined.]
 ifeval::["{beatname_lc}"=="filebeat"]
-|Run Filebeat modules | ++{beat_default_index_prefix}_writer++
+|Run Filebeat modules | ++{beat_default_index_prefix}_writer++ footnoteref:[noteA]
 endif::[]
-|Load index templates | ++{beat_default_index_prefix}_writer++ and `kibana_user`
+|Load index templates | ++{beat_default_index_prefix}_writer++ footnoteref:[noteA] and `kibana_user`
 ifndef::no_dashboards[]
-|Load {beatname_uc} dashboards into {kib} | ++{beat_default_index_prefix}_writer++ and `kibana_user`
+|Load {beatname_uc} dashboards into {kib} | ++{beat_default_index_prefix}_writer++ footnoteref:[noteA] and `kibana_user`
 endif::[]
 ifdef::has_ml_jobs[]
 |Load machine learning jobs | `machine_learning_admin`
 endif::[]
-|Read indices created by {beatname_uc} | ++{beat_default_index_prefix}_reader++ 
+|Read indices created by {beatname_uc} | ++{beat_default_index_prefix}_reader++ footnoteref:[noteA] 
 ifndef::no_dashboards[]
 |View {beatname_uc} dashboards in {kib} | `kibana_user`
 endif::[]
 ifdef::has_central_config[]
 |Store and manage configurations in a central location in {kib} | `beats_admin`
 endif::[]
+ifndef::no_ilm[]
+|Load index lifecycle policies and use index lifecycle management | +{beatname_lc}_ilm+ footnoteref:[noteA]
+endif::[]
 |=======
+
+To create the user-defined roles shown here, see <<beats-basic-auth>> and
+<<beats-user-access>>. You may want to define additional roles to provide more
+restrictive access.
 
 include::basic-auth.asciidoc[]
 


### PR DESCRIPTION
I think it's a little odd that our security docs are so prescriptive wrt the specific roles and users that we want people to create. In the interest of getting this info into the docs quickly (with minimum rework), I'm following the current design and recommending that users create a separate role.

We need to revisit these docs and simplify them (in a later PR) so that we clearly describe what privileges are required to do specific things and then leave it up to users to decide which roles/users to create based on how they want to restrict users.