### PR TITLE
[Auditbeat] Auditd: Check all fields are in fields.yml in unit test

### DIFF
--- a/auditbeat/magefile.go
+++ b/auditbeat/magefile.go
@@ -175,6 +175,7 @@ func UnitTest() {
 // Use TEST_COVERAGE=true to enable code coverage profiling.
 // Use RACE_DETECTOR=true to enable the race detector.
 func GoUnitTest(ctx context.Context) error {
+	mg.Deps(Fields)
 	return mage.GoTest(ctx, mage.DefaultGoTestUnitArgs())
 }
 
@@ -182,6 +183,7 @@ func GoUnitTest(ctx context.Context) error {
 // Use TEST_COVERAGE=true to enable code coverage profiling.
 // Use RACE_DETECTOR=true to enable the race detector.
 func GoIntegTest(ctx context.Context) error {
+	mg.Deps(Fields)
 	return mage.RunIntegTest("goIntegTest", func() error {
 		return mage.GoTest(ctx, mage.DefaultGoTestIntegrationArgs())
 	})

--- a/auditbeat/module/auditd/audit_linux_test.go
+++ b/auditbeat/module/auditd/audit_linux_test.go
@@ -117,6 +117,7 @@ func assertFieldsAreDocumented(t *testing.T, events []mb.Event) {
 				// to auditd.paths which does not exist in fields.yml.
 				if strings.HasPrefix(documentedFieldName, eventFieldName) {
 					found = true
+					break
 				}
 			}
 			if !found {

--- a/auditbeat/module/auditd/audit_linux_test.go
+++ b/auditbeat/module/auditd/audit_linux_test.go
@@ -110,7 +110,7 @@ func assertFieldsAreDocumented(t *testing.T, events []mb.Event) {
 
 	for _, e := range events {
 		beatEvent := e.BeatEvent(moduleName, metricsetName, core.AddDatasetToEvent)
-		for eventFieldName, _ := range beatEvent.Fields.Flatten() {
+		for eventFieldName := range beatEvent.Fields.Flatten() {
 			found := false
 			for _, documentedFieldName := range documentedFields {
 				// Have to use HasPrefix and not "==" since fields in auditd.paths.* get flattened

--- a/auditbeat/module/auditd/audit_linux_test.go
+++ b/auditbeat/module/auditd/audit_linux_test.go
@@ -24,6 +24,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"strings"
 	"testing"
 	"time"
 
@@ -32,6 +33,7 @@ import (
 	"github.com/prometheus/procfs"
 
 	"github.com/elastic/beats/auditbeat/core"
+	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/metricbeat/mb"
 	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
@@ -76,7 +78,9 @@ func TestData(t *testing.T) {
 		// Send expected ACKs for initialization
 		returnACK().returnACK().returnACK().returnACK().returnACK().
 		// Send a single audit message from the kernel.
-		returnMessage(userLoginMsg)
+		returnMessage(userLoginMsg).
+		returnMessage(execveMsgs...).
+		returnMessage(acceptMsgs...)
 
 	// Replace the default AuditClient with a mock.
 	ms := mbtest.NewPushMetricSetV2(t, getConfig())
@@ -84,14 +88,42 @@ func TestData(t *testing.T) {
 	auditMetricSet.client.Close()
 	auditMetricSet.client = &libaudit.AuditClient{Netlink: mock}
 
-	events := mbtest.RunPushMetricSetV2(10*time.Second, 1, ms)
-	if len(events) == 0 {
-		t.Fatal("received no events")
+	events := mbtest.RunPushMetricSetV2(10*time.Second, 3, ms)
+	if len(events) != 3 {
+		t.Fatalf("expected 3 events, but received %d", len(events))
 	}
 	assertNoErrors(t, events)
 
+	assertFieldsAreDocumented(t, events)
+
 	beatEvent := mbtest.StandardizeEvent(ms, events[0], core.AddDatasetToEvent)
 	mbtest.WriteEventToDataJSON(t, beatEvent, "")
+}
+
+// assertFieldsAreDocumented mimics assert_fields_are_documented in Python system tests.
+func assertFieldsAreDocumented(t *testing.T, events []mb.Event) {
+	fieldsYml, err := common.LoadFieldsYaml("../../fields.yml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	documentedFields := fieldsYml.GetKeys()
+
+	for _, e := range events {
+		beatEvent := e.BeatEvent(moduleName, metricsetName, core.AddDatasetToEvent)
+		for eventFieldName, _ := range beatEvent.Fields.Flatten() {
+			found := false
+			for _, documentedFieldName := range documentedFields {
+				// Have to use HasPrefix and not "==" since fields in auditd.paths.* get flattened
+				// to auditd.paths which does not exist in fields.yml.
+				if strings.HasPrefix(documentedFieldName, eventFieldName) {
+					found = true
+				}
+			}
+			if !found {
+				assert.Fail(t, "Field not documented", "Key '%v' found in event is not documented.", eventFieldName)
+			}
+		}
+	}
 }
 
 func getConfig() map[string]interface{} {


### PR DESCRIPTION
Similar to how Python system tests in Metricbeat and Auditbeat call an `assert_fields_are_documented` function to check if all produced fields are in `fields.yml` this does the same in Go code for the `auditd` module where we don't have a Python system test.

I've built it while adding user fields in https://github.com/elastic/beats/pull/10456 and it was quite helpful to make sure I didn't miss anything.

The code is surprisingly simple and calls a lot of the "authoritative" code in Libbeat rather than try to replicate things like fields.yml parsing in Python. It makes me muse about moving the checks from Python to Go in other places as well.