### PR TITLE
Update FPM to 1.11.0

### DIFF
--- a/dev-tools/packer/docker/fpm-image/Dockerfile
+++ b/dev-tools/packer/docker/fpm-image/Dockerfile
@@ -8,4 +8,4 @@ RUN \
     apt-get install -y --no-install-recommends \
         autoconf build-essential libffi-dev ruby-dev rpm zip dos2unix libgmp3-dev
 
-RUN gem install fpm -v 1.9.2
+RUN gem install fpm -v 1.11.0


### PR DESCRIPTION
Previous version of FPM did not pin to a specific version of
childprocess.

See for details https://github.com/jordansissel/fpm/issues/1592

I've used `make package` to test it locally.