### PR TITLE
Cherry-pick #10443 to 6.x: Allow testing of specific filesets

### DIFF
--- a/filebeat/tests/system/test_modules.py
+++ b/filebeat/tests/system/test_modules.py
@@ -27,6 +27,8 @@ def load_fileset_test_cases():
     else:
         modules = os.listdir(modules_dir)
 
+    filesets_env = os.getenv("TESTING_FILEBEAT_FILESETS")
+
     test_cases = []
 
     for module in modules:
@@ -35,7 +37,12 @@ def load_fileset_test_cases():
         if not os.path.isdir(path):
             continue
 
-        for fileset in os.listdir(path):
+        if filesets_env:
+            filesets = filesets_env.split(",")
+        else:
+            filesets = os.listdir(path)
+
+        for fileset in filesets:
             if not os.path.isdir(os.path.join(path, fileset)):
                 continue
 


### PR DESCRIPTION
Cherry-pick of PR #10443 to 6.x branch. Original message: 

Currently, Filebeat system tests can be filtered to run only on specific modules by specifying the `TESTING_FILEBEAT_MODULES` environment variable. This PR teaches the system tests to also understand an optional `TESTING_FILEBEAT_FILESETS` environment variable, that can be used to run system tests only on specific filesets.