### PR TITLE
[Heartbeat] Populate url.port field for http(s) fields.

### DIFF
--- a/heartbeat/monitors/wrappers/util.go
+++ b/heartbeat/monitors/wrappers/util.go
@@ -58,7 +58,14 @@ func URLFields(u *url.URL) common.MapStr {
 	}
 
 	if u.Port() != "" {
-		fields["port"], _ = strconv.ParseUint(u.Port(), 10, 16)
+		val, _ := strconv.ParseUint(u.Port(), 10, 16)
+		fields["port"] = uint16(val) // Just use an int for simplicity
+	} else {
+		if u.Scheme == "http" {
+			fields["port"] = uint16(80)
+		} else if u.Scheme == "https" {
+			fields["port"] = uint16(443)
+		}
 	}
 
 	if u.Path != "" {

--- a/heartbeat/monitors/wrappers/util.go
+++ b/heartbeat/monitors/wrappers/util.go
@@ -58,8 +58,9 @@ func URLFields(u *url.URL) common.MapStr {
 	}
 
 	if u.Port() != "" {
+		// Returns a uint64 believe it or not.
 		val, _ := strconv.ParseUint(u.Port(), 10, 16)
-		fields["port"] = uint16(val) // Just use an int for simplicity
+		fields["port"] = uint16(val)
 	} else {
 		if u.Scheme == "http" {
 			fields["port"] = uint16(80)

--- a/heartbeat/monitors/wrappers/util_test.go
+++ b/heartbeat/monitors/wrappers/util_test.go
@@ -41,6 +41,7 @@ func TestURLFields(t *testing.T) {
 				"full":   "http://elastic.co",
 				"scheme": "http",
 				"domain": "elastic.co",
+				"port":   uint16(80),
 			},
 		},
 		{
@@ -50,15 +51,17 @@ func TestURLFields(t *testing.T) {
 				"full":   "https://elastic.co",
 				"scheme": "https",
 				"domain": "elastic.co",
+				"port":   uint16(443),
 			},
 		},
 		{
 			"fancy-proto",
-			"tcp+ssl://elastic.co",
+			"tcp+ssl://elastic.co:1234",
 			common.MapStr{
-				"full":   "tcp+ssl://elastic.co",
+				"full":   "tcp+ssl://elastic.co:1234",
 				"scheme": "tcp+ssl",
 				"domain": "elastic.co",
+				"port":   uint16(1234),
 			},
 		},
 		{
@@ -68,7 +71,7 @@ func TestURLFields(t *testing.T) {
 				"full":     "tcp+ssl://myuser:%3Chidden%3E@elastic.co:65500/foo/bar?q=dosomething&x=y",
 				"scheme":   "tcp+ssl",
 				"domain":   "elastic.co",
-				"port":     uint64(65500),
+				"port":     uint16(65500),
 				"path":     "/foo/bar",
 				"query":    "q=dosomething&x=y",
 				"username": "myuser",


### PR DESCRIPTION
The url.* ECS fields are used for all sorts of stuff. The golang `url` package doesn't infer the URL for URLs with the http(s) schemes, which means that there will be no port value for url.port for these common URLs. This patch explicitly fills in the value in these situations.

This change also fixes some other tests by using an explicit port for TCP which is required in heartbeat. Additionally, it standardizes on the `uint16` type for port values which is common in the go ecosystem.

No Changelog necessary since this is for 7.0 only and does not affect 6.x