### PR TITLE
Add documentation about namespace option in kubernetes

### DIFF
--- a/libbeat/docs/processors-using.asciidoc
+++ b/libbeat/docs/processors-using.asciidoc
@@ -806,7 +806,7 @@ by default.
 cannot be accurately detected, as when running {beatname_lc} in host network
 mode.
 `namespace`:: (Optional) Select the namespace from which to collect the
-metadata, if it is not set, the processor collects metadata from all namespaces.
+metadata. If it is not set, the processor collects metadata from all namespaces.
 It is unset by default.
 `kube_config`:: (Optional) Use given config file as configuration for Kubernetes
 client.

--- a/libbeat/docs/processors-using.asciidoc
+++ b/libbeat/docs/processors-using.asciidoc
@@ -805,6 +805,9 @@ by default.
 `host`:: (Optional) Identify the node where {beatname_lc} is running in case it
 cannot be accurately detected, as when running {beatname_lc} in host network
 mode.
+`namespace`:: (Optional) Select the namespace from which to collect the
+metadata, if it is not set, the processor collects metadata from all namespaces.
+It is unset by default.
 `kube_config`:: (Optional) Use given config file as configuration for Kubernetes
 client.
 `default_indexers.enabled`:: (Optional) Enable/Disable default pod indexers, in

--- a/libbeat/docs/shared-autodiscover.asciidoc
+++ b/libbeat/docs/shared-autodiscover.asciidoc
@@ -180,6 +180,9 @@ The `kubernetes` autodiscover provider has the following configuration settings:
 `host`:: (Optional) Identify the node where {beatname_lc} is running in case it
   cannot be accurately detected, as when running {beatname_lc} in host network
   mode.
+`namespace`:: (Optional) Select the namespace from which to collect the
+  metadata, if it is not set, the processor collects metadata from all
+  namespaces. It is unset by default.
 `kube_config`:: (Optional) Use given config file as configuration for Kubernetes
   client.
 

--- a/libbeat/docs/shared-autodiscover.asciidoc
+++ b/libbeat/docs/shared-autodiscover.asciidoc
@@ -181,7 +181,7 @@ The `kubernetes` autodiscover provider has the following configuration settings:
   cannot be accurately detected, as when running {beatname_lc} in host network
   mode.
 `namespace`:: (Optional) Select the namespace from which to collect the
-  metadata, if it is not set, the processor collects metadata from all
+  metadata. If it is not set, the processor collects metadata from all
   namespaces. It is unset by default.
 `kube_config`:: (Optional) Use given config file as configuration for Kubernetes
   client.


### PR DESCRIPTION
`add_kubernetes_metadata` and kubernetes autodiscover provider
accept a `namespace` option to delimit the resources watched to 
an specific namespace. Add reference documentation for this
option.