### PR TITLE
Metricbeat MSSQL module: Fix for Transaction log flaky test that was sometimes failing

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -170,7 +170,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fixed data type for isr field in `kafka/partition` metricset {pull}10307[10307]
 - Fixed data types for various hosts fields in `mongodb/replstatus` metricset {pull}10307[10307]
 - Added function to close sql database connection. {pull}10355[10355]
-- Fix flaky test of the transaction field on 'transaction_log' Metricset from MSSQL Metricbeat module {pull}10480[10480]
 
 *Packetbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -170,6 +170,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fixed data type for isr field in `kafka/partition` metricset {pull}10307[10307]
 - Fixed data types for various hosts fields in `mongodb/replstatus` metricset {pull}10307[10307]
 - Added function to close sql database connection. {pull}10355[10355]
+- Fix flaky test of the transaction field on 'transaction_log' Metricset from MSSQL Metricbeat module {pull}10480[10480]
 
 *Packetbeat*
 

--- a/x-pack/metricbeat/module/mssql/performance/performance_integration_test.go
+++ b/x-pack/metricbeat/module/mssql/performance/performance_integration_test.go
@@ -60,6 +60,10 @@ func TestFetch(t *testing.T) {
 		return v > 0
 	}
 
+	int64EqualOrHigherThanZero := func(v int64) bool {
+		return v >= 0
+	}
+
 	int64EqualZero := func(v int64) bool {
 		return v == 0
 	}
@@ -73,7 +77,7 @@ func TestFetch(t *testing.T) {
 		{key: "buffer.page_life_expectancy.sec", assertion: int64Assertion(int64HigherThanZero)},
 		{key: "lock_waits_per_sec", assertion: int64Assertion(int64HigherThanZero)},
 		{key: "user_connections", assertion: int64Assertion(int64HigherThanZero)},
-		{key: "transactions", assertion: int64Assertion(int64EqualZero)},
+		{key: "transactions", assertion: int64Assertion(int64EqualOrHigherThanZero)},
 		{key: "active_temp_tables", assertion: int64Assertion(int64EqualZero)},
 		{key: "connections_reset_per_sec", assertion: int64Assertion(int64HigherThanZero)},
 		{key: "logouts_per_sec", assertion: int64Assertion(int64HigherThanZero)},


### PR DESCRIPTION
We have a flaky test failing sometimes on the `transaction_log` Metricset of MSSQL Metricbeat mndule: https://travis-ci.org/elastic/beats/jobs/487174767#L681

This PR should solve it