### PR TITLE
[Auditbeat] Set up and remove data dir in all unit tests

### DIFF
--- a/auditbeat/module/file_integrity/metricset_test.go
+++ b/auditbeat/module/file_integrity/metricset_test.go
@@ -29,12 +29,12 @@ import (
 
 	"github.com/elastic/beats/auditbeat/core"
 	"github.com/elastic/beats/auditbeat/datastore"
-	"github.com/elastic/beats/libbeat/paths"
+	abtest "github.com/elastic/beats/auditbeat/testing"
 	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
 )
 
 func TestData(t *testing.T) {
-	defer setup(t)()
+	defer abtest.SetupDataDir(t)()
 
 	dir, err := ioutil.TempDir("", "audit-file")
 	if err != nil {
@@ -61,7 +61,7 @@ func TestData(t *testing.T) {
 }
 
 func TestActions(t *testing.T) {
-	defer setup(t)()
+	defer abtest.SetupDataDir(t)()
 
 	bucket, err := datastore.OpenBucket(bucketName)
 	if err != nil {
@@ -170,7 +170,7 @@ func TestActions(t *testing.T) {
 }
 
 func TestExcludedFiles(t *testing.T) {
-	defer setup(t)()
+	defer abtest.SetupDataDir(t)()
 
 	bucket, err := datastore.OpenBucket(bucketName)
 	if err != nil {
@@ -224,7 +224,7 @@ func TestExcludedFiles(t *testing.T) {
 }
 
 func TestIncludedExcludedFiles(t *testing.T) {
-	defer setup(t)()
+	defer abtest.SetupDataDir(t)()
 
 	bucket, err := datastore.OpenBucket(bucketName)
 	if err != nil {
@@ -286,16 +286,6 @@ func TestIncludedExcludedFiles(t *testing.T) {
 			assert.True(t, ok)
 		}
 	}
-}
-
-func setup(t testing.TB) func() {
-	// path.data should be set so that the DB is written to a predictable location.
-	var err error
-	paths.Paths.Data, err = ioutil.TempDir("", "beat-data-dir")
-	if err != nil {
-		t.Fatal()
-	}
-	return func() { os.RemoveAll(paths.Paths.Data) }
 }
 
 func getConfig(path ...string) map[string]interface{} {

--- a/auditbeat/testing/setup.go
+++ b/auditbeat/testing/setup.go
@@ -1,0 +1,37 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package testing
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/elastic/beats/libbeat/paths"
+)
+
+// SetupDataDir sets up a temporary data directory to use for testing.
+func SetupDataDir(t testing.TB) func() {
+	// path.data should be set so that the DB is written to a predictable location.
+	var err error
+	paths.Paths.Data, err = ioutil.TempDir("", "beat-data-dir")
+	if err != nil {
+		t.Fatal()
+	}
+	return func() { os.RemoveAll(paths.Paths.Data) }
+}

--- a/x-pack/auditbeat/module/system/host/host_test.go
+++ b/x-pack/auditbeat/module/system/host/host_test.go
@@ -8,10 +8,13 @@ import (
 	"testing"
 
 	"github.com/elastic/beats/auditbeat/core"
+	abtest "github.com/elastic/beats/auditbeat/testing"
 	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
 )
 
 func TestData(t *testing.T) {
+	defer abtest.SetupDataDir(t)()
+
 	f := mbtest.NewReportingMetricSetV2(t, getConfig())
 	events, errs := mbtest.ReportingFetchV2(f)
 	if len(errs) > 0 {

--- a/x-pack/auditbeat/module/system/login/login_test.go
+++ b/x-pack/auditbeat/module/system/login/login_test.go
@@ -8,12 +8,10 @@ package login
 
 import (
 	"encoding/binary"
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/elastic/beats/auditbeat/core"
-	"github.com/elastic/beats/libbeat/paths"
+	abtest "github.com/elastic/beats/auditbeat/testing"
 	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
 )
 
@@ -22,7 +20,7 @@ func TestData(t *testing.T) {
 		t.Skip("Test only works on little-endian systems - skipping.")
 	}
 
-	defer setup(t)()
+	defer abtest.SetupDataDir(t)()
 
 	f := mbtest.NewReportingMetricSetV2(t, getConfig())
 
@@ -48,16 +46,4 @@ func getConfig() map[string]interface{} {
 		"login.wtmp_file_pattern": "../../../tests/files/wtmp",
 		"login.btmp_file_pattern": "",
 	}
-}
-
-// setup is copied from file_integrity/metricset_test.go.
-// TODO: Move to shared location and use in all unit tests.
-func setup(t testing.TB) func() {
-	// path.data should be set so that the DB is written to a predictable location.
-	var err error
-	paths.Paths.Data, err = ioutil.TempDir("", "beat-data-dir")
-	if err != nil {
-		t.Fatal()
-	}
-	return func() { os.RemoveAll(paths.Paths.Data) }
 }

--- a/x-pack/auditbeat/module/system/package/package_test.go
+++ b/x-pack/auditbeat/module/system/package/package_test.go
@@ -10,10 +10,13 @@ import (
 	"testing"
 
 	"github.com/elastic/beats/auditbeat/core"
+	abtest "github.com/elastic/beats/auditbeat/testing"
 	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
 )
 
 func TestData(t *testing.T) {
+	defer abtest.SetupDataDir(t)()
+
 	f := mbtest.NewReportingMetricSetV2(t, getConfig())
 	events, errs := mbtest.ReportingFetchV2(f)
 	if len(errs) > 0 {

--- a/x-pack/auditbeat/module/system/process/process_test.go
+++ b/x-pack/auditbeat/module/system/process/process_test.go
@@ -12,12 +12,15 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/beats/auditbeat/core"
+	abtest "github.com/elastic/beats/auditbeat/testing"
 	"github.com/elastic/beats/libbeat/common"
 	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
 	"github.com/elastic/go-sysinfo/types"
 )
 
 func TestData(t *testing.T) {
+	defer abtest.SetupDataDir(t)()
+
 	f := mbtest.NewReportingMetricSetV2(t, getConfig())
 	events, errs := mbtest.ReportingFetchV2(f)
 	if len(errs) > 0 {

--- a/x-pack/auditbeat/module/system/socket/socket_test.go
+++ b/x-pack/auditbeat/module/system/socket/socket_test.go
@@ -16,11 +16,14 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/beats/auditbeat/core"
+	abtest "github.com/elastic/beats/auditbeat/testing"
 	"github.com/elastic/beats/metricbeat/mb"
 	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
 )
 
 func TestData(t *testing.T) {
+	defer abtest.SetupDataDir(t)()
+
 	f := mbtest.NewReportingMetricSetV2(t, getConfig())
 	events, errs := mbtest.ReportingFetchV2(f)
 	if len(errs) > 0 {
@@ -37,6 +40,8 @@ func TestData(t *testing.T) {
 }
 
 func TestFetch(t *testing.T) {
+	defer abtest.SetupDataDir(t)()
+
 	// Consume first event: list of all currently open sockets
 	ms := mbtest.NewReportingMetricSetV2(t, getConfig())
 	events, errs := mbtest.ReportingFetchV2(ms)

--- a/x-pack/auditbeat/module/system/user/user_test.go
+++ b/x-pack/auditbeat/module/system/user/user_test.go
@@ -10,10 +10,13 @@ import (
 	"testing"
 
 	"github.com/elastic/beats/auditbeat/core"
+	abtest "github.com/elastic/beats/auditbeat/testing"
 	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
 )
 
 func TestData(t *testing.T) {
+	defer abtest.SetupDataDir(t)()
+
 	f := mbtest.NewReportingMetricSetV2(t, getConfig())
 	events, errs := mbtest.ReportingFetchV2(f)
 	if len(errs) > 0 {


### PR DESCRIPTION
Most of the unit tests in the Auditbeat system module were not deleting `beat.db` after they had run. This would lead to an error when trying to run any unit test twice without deleting it in other ways in between. For the login dataset this led to CI errors which is why it already has a copy of the `setup` method.

This PR now takes the `setup` method from `file_integrity/metricset_test.go` that creates and removes the data directory, moves it to a new `auditbeat/testing` package and uses it in all relevant unit tests.