### PR TITLE
Cherry-pick #10473 to 6.6: Add documentation about namespace option in kubernetes

### DIFF
--- a/libbeat/docs/processors-using.asciidoc
+++ b/libbeat/docs/processors-using.asciidoc
@@ -805,6 +805,9 @@ by default.
 `host`:: (Optional) Identify the node where {beatname_lc} is running in case it
 cannot be accurately detected, as when running {beatname_lc} in host network
 mode.
+`namespace`:: (Optional) Select the namespace from which to collect the
+metadata. If it is not set, the processor collects metadata from all namespaces.
+It is unset by default.
 `kube_config`:: (Optional) Use given config file as configuration for Kubernetes
 client.
 `default_indexers.enabled`:: (Optional) Enable/Disable default pod indexers, in

--- a/libbeat/docs/shared-autodiscover.asciidoc
+++ b/libbeat/docs/shared-autodiscover.asciidoc
@@ -168,6 +168,9 @@ The `kubernetes` autodiscover provider has the following configuration settings:
 `host`:: (Optional) Identify the node where {beatname_lc} is running in case it
   cannot be accurately detected, as when running {beatname_lc} in host network
   mode.
+`namespace`:: (Optional) Select the namespace from which to collect the
+  metadata. If it is not set, the processor collects metadata from all
+  namespaces. It is unset by default.
 `kube_config`:: (Optional) Use given config file as configuration for Kubernetes
   client.
 


### PR DESCRIPTION
Cherry-pick of PR #10473 to 6.6 branch. Original message: 

`add_kubernetes_metadata` and kubernetes autodiscover provider
accept a `namespace` option to delimit the resources watched to 
an specific namespace. Add reference documentation for this
option.