### PR TITLE
Address issue #10505 (add_kubernetes_metadata processor matcher not working)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -28,8 +28,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Rename many `traefik.access.*` fields to map to ECS. {pull}9005[9005]
 - Add module zeek. {issue}9931[9931] {pull}10034[10034]
 - Rename many `kibana.log.*` fields to map to ECS. {pull}9301[9301]
-- Address add_kubernetes_metadata processor issue where old source field is 
-  still used for matcher. {issue}10505[10505] {pull}10506[10506]
 
 *Heartbeat*
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -28,6 +28,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Rename many `traefik.access.*` fields to map to ECS. {pull}9005[9005]
 - Add module zeek. {issue}9931[9931] {pull}10034[10034]
 - Rename many `kibana.log.*` fields to map to ECS. {pull}9301[9301]
+- Address add_kubernetes_metadata processor issue where old source field is 
+  still used for matcher. {issue}10505[10505]
 
 *Heartbeat*
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -29,7 +29,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add module zeek. {issue}9931[9931] {pull}10034[10034]
 - Rename many `kibana.log.*` fields to map to ECS. {pull}9301[9301]
 - Address add_kubernetes_metadata processor issue where old source field is 
-  still used for matcher. {issue}10505[10505]
+  still used for matcher. {issue}10505[10505] {pull}10506[10506]
 
 *Heartbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -77,6 +77,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - The `elasticsearch/deprecation` fileset now indexes the `component` field under `elasticsearch` instead of `elasticsearch.server`. {pull}10445[10445]
 - Remove field `kafka.log.trace.full` from kafka.log fielset. {pull}10398[10398]
 - Change field `kafka.log.class` for kafka.log fileset from text to keyword. {pull}10398[10398]
+- Address add_kubernetes_metadata processor issue where old source field is 
+  still used for matcher. {issue}10505[10505] {pull}10506[10506]
 
 *Heartbeat*
 

--- a/filebeat/processor/add_kubernetes_metadata/matchers.go
+++ b/filebeat/processor/add_kubernetes_metadata/matchers.go
@@ -77,9 +77,9 @@ const containerIdLen = 64
 const podUIDPos = 5
 
 func (f *LogPathMatcher) MetadataIndex(event common.MapStr) string {
-	if value, ok := event["source"]; ok {
+	if value, ok := event["log"].(common.MapStr)["file"].(common.MapStr)["path"]; ok {
 		source := value.(string)
-		logp.Debug("kubernetes", "Incoming source value: %s", source)
+		logp.Debug("kubernetes", "Incoming log.file.path value: %s", source)
 
 		if !strings.Contains(source, f.LogsPath) {
 			logp.Debug("kubernetes", "Error extracting container id - source value does not contain matcher's logs_path '%s'.", f.LogsPath)

--- a/filebeat/processor/add_kubernetes_metadata/matchers_test.go
+++ b/filebeat/processor/add_kubernetes_metadata/matchers_test.go
@@ -108,7 +108,11 @@ func executeTestWithResourceType(t *testing.T, cfgLogsPath string, cfgResourceTy
 	assert.Nil(t, err)
 
 	input := common.MapStr{
-		"source": source,
+		"log": common.MapStr{
+			"file": common.MapStr{
+				"path": source,
+			},
+		},
 	}
 	output := logMatcher.MetadataIndex(input)
 	assert.Equal(t, expectedResult, output)

--- a/libbeat/docs/processors-using.asciidoc
+++ b/libbeat/docs/processors-using.asciidoc
@@ -755,7 +755,8 @@ construct a lookup key with the value of the field `metricset.host`.
 Each Beat can define its own default indexers and matchers which are enabled by
 default. For example, FileBeat enables the `container` indexer, which indexes
 pod metadata based on all container IDs, and a `logs_path` matcher, which takes
-the `source` field, extracts the container ID, and uses it to retrieve metadata.
+the `log.file.path` field, extracts the container ID, and uses it to retrieve 
+metadata.
 
 The configuration below enables the processor when {beatname_lc} is run as a pod in
 Kubernetes.


### PR DESCRIPTION
add_kubernetes_metadata processor is broken because it uses old field source for lookup. Use log.file.path for matcher.