### PR TITLE
[Auditbeat] System module: Detect package updates

### DIFF
--- a/x-pack/auditbeat/module/system/package/package.go
+++ b/x-pack/auditbeat/module/system/package/package.go
@@ -114,7 +114,6 @@ func (pkg Package) Hash() uint64 {
 	h.WriteString(pkg.Name)
 	h.WriteString(pkg.Version)
 	h.WriteString(pkg.Release)
-	h.WriteString(pkg.InstallTime.String())
 	binary.Write(h, binary.LittleEndian, pkg.Size)
 	return h.Sum64()
 }

--- a/x-pack/auditbeat/module/system/package/package.go
+++ b/x-pack/auditbeat/module/system/package/package.go
@@ -312,18 +312,18 @@ func (ms *MetricSet) reportChanges(report mb.ReporterV2) error {
 	ms.log.Debugf("Found %v packages", len(packages))
 
 	newInCache, missingFromCache := ms.cache.DiffAndUpdateCache(convertToCacheable(packages))
-	new := convertToPackage(newInCache)
-	missing := convertToPackage(missingFromCache)
+	newPackages := convertToPackage(newInCache)
+	missingPackages := convertToPackage(missingFromCache)
 
 	// Package names of updated packages
 	updated := make(map[string]struct{})
 
-	for _, missingPkg := range missing {
+	for _, missingPkg := range missingPackages {
 		found := false
 
 		// Using an inner loop is less efficient than using a map, but in this case
 		// we do not expect a lot of installed or removed packages all at once.
-		for _, newPkg := range new {
+		for _, newPkg := range newPackages {
 			if missingPkg.Name == newPkg.Name {
 				found = true
 				updated[newPkg.Name] = struct{}{}
@@ -337,13 +337,13 @@ func (ms *MetricSet) reportChanges(report mb.ReporterV2) error {
 		}
 	}
 
-	for _, newPkg := range new {
+	for _, newPkg := range newPackages {
 		if _, contains := updated[newPkg.Name]; !contains {
 			report.Event(packageEvent(newPkg, eventTypeEvent, eventActionPackageInstalled))
 		}
 	}
 
-	if len(new) > 0 || len(missing) > 0 {
+	if len(newPackages) > 0 || len(missingPackages) > 0 {
 		return ms.savePackagesToDisk(packages)
 	}
 

--- a/x-pack/auditbeat/module/system/package/package.go
+++ b/x-pack/auditbeat/module/system/package/package.go
@@ -9,6 +9,7 @@ package pkg
 import (
 	"bufio"
 	"bytes"
+	"encoding/binary"
 	"encoding/gob"
 	"fmt"
 	"io"
@@ -57,6 +58,7 @@ const (
 	eventActionExistingPackage eventAction = iota
 	eventActionPackageInstalled
 	eventActionPackageRemoved
+	eventActionPackageUpdated
 )
 
 func (action eventAction) String() string {
@@ -67,6 +69,8 @@ func (action eventAction) String() string {
 		return "package_installed"
 	case eventActionPackageRemoved:
 		return "package_removed"
+	case eventActionPackageUpdated:
+		return "package_updated"
 	default:
 		return ""
 	}
@@ -109,7 +113,9 @@ func (pkg Package) Hash() uint64 {
 	h := xxhash.New64()
 	h.WriteString(pkg.Name)
 	h.WriteString(pkg.Version)
+	h.WriteString(pkg.Release)
 	h.WriteString(pkg.InstallTime.String())
+	binary.Write(h, binary.LittleEndian, pkg.Size)
 	return h.Sum64()
 }
 
@@ -306,14 +312,36 @@ func (ms *MetricSet) reportChanges(report mb.ReporterV2) error {
 	}
 	ms.log.Debugf("Found %v packages", len(packages))
 
-	installed, removed := ms.cache.DiffAndUpdateCache(convertToCacheable(packages))
+	newInCache, missingFromCache := ms.cache.DiffAndUpdateCache(convertToCacheable(packages))
+	installed := convertToPackage(newInCache)
+	removed := convertToPackage(missingFromCache)
 
-	for _, cacheValue := range installed {
-		report.Event(packageEvent(cacheValue.(*Package), eventTypeEvent, eventActionPackageInstalled))
+	// Package names of updated packages
+	updated := make(map[string]struct{})
+
+	for _, removedPkg := range removed {
+		found := false
+
+		// Using an inner loop is less efficient than using a map, but in this case
+		// we do not expect a lot of installed or removed packages all at once.
+		for _, installedPkg := range installed {
+			if removedPkg.Name == installedPkg.Name {
+				found = true
+				updated[installedPkg.Name] = struct{}{}
+				report.Event(packageEvent(installedPkg, eventTypeEvent, eventActionPackageUpdated))
+				break
+			}
+		}
+
+		if !found {
+			report.Event(packageEvent(removedPkg, eventTypeEvent, eventActionPackageRemoved))
+		}
 	}
 
-	for _, cacheValue := range removed {
-		report.Event(packageEvent(cacheValue.(*Package), eventTypeEvent, eventActionPackageRemoved))
+	for _, installedPkg := range installed {
+		if _, contains := updated[installedPkg.Name]; !contains {
+			report.Event(packageEvent(installedPkg, eventTypeEvent, eventActionPackageInstalled))
+		}
 	}
 
 	if len(installed) > 0 || len(removed) > 0 {
@@ -321,6 +349,16 @@ func (ms *MetricSet) reportChanges(report mb.ReporterV2) error {
 	}
 
 	return nil
+}
+
+func convertToPackage(cacheValues []interface{}) []*Package {
+	packages := make([]*Package, 0, len(cacheValues))
+
+	for _, c := range cacheValues {
+		packages = append(packages, c.(*Package))
+	}
+
+	return packages
 }
 
 func packageEvent(pkg *Package, eventType string, action eventAction) mb.Event {
@@ -351,6 +389,8 @@ func packageMessage(pkg *Package, action eventAction) string {
 		actionString = "installed"
 	case eventActionPackageRemoved:
 		actionString = "removed"
+	case eventActionPackageUpdated:
+		actionString = "updated"
 	}
 
 	return fmt.Sprintf("Package %v (%v) %v",

--- a/x-pack/auditbeat/module/system/package/package.go
+++ b/x-pack/auditbeat/module/system/package/package.go
@@ -108,15 +108,19 @@ type Package struct {
 func (pkg Package) Hash() uint64 {
 	h := xxhash.New64()
 	h.WriteString(pkg.Name)
+	h.WriteString(pkg.Version)
 	h.WriteString(pkg.InstallTime.String())
 	return h.Sum64()
 }
 
 func (pkg Package) toMapStr() common.MapStr {
 	mapstr := common.MapStr{
-		"name":        pkg.Name,
-		"version":     pkg.Version,
-		"installtime": pkg.InstallTime,
+		"name":    pkg.Name,
+		"version": pkg.Version,
+	}
+
+	if pkg.Release != "" {
+		mapstr.Put("release", pkg.Release)
 	}
 
 	if pkg.Arch != "" {
@@ -127,8 +131,8 @@ func (pkg Package) toMapStr() common.MapStr {
 		mapstr.Put("license", pkg.License)
 	}
 
-	if pkg.Release != "" {
-		mapstr.Put("release", pkg.Release)
+	if !pkg.InstallTime.IsZero() {
+		mapstr.Put("installtime", pkg.InstallTime)
 	}
 
 	if pkg.Size != 0 {

--- a/x-pack/auditbeat/tests/system/test_metricsets.py
+++ b/x-pack/auditbeat/tests/system/test_metricsets.py
@@ -48,7 +48,7 @@ class Test(AuditbeatXPackTest):
         package metricset collects information about installed packages on a system.
         """
 
-        fields = ["system.audit.package.name", "system.audit.package.version", "system.audit.package.installtime"]
+        fields = ["system.audit.package.name", "system.audit.package.version"]
 
         # Metricset is experimental and that generates a warning, TODO: remove later
         self.check_metricset("system", "package", COMMON_FIELDS + fields, warnings_allowed=True)


### PR DESCRIPTION
Detects package updates by checking if any of the "new" package objects have the same package name as one of the "old" package objects. The event will have `event.action: package_updated`.

Also fixes two issues:

1. Removes `InstallTime` from change detection. It is not set for dpkg, and for Homebrew it is currently the modification time of the package's directory. A `touch` will cause it to be reported as changed. I'm actually wondering if we should not set it for Homebrew at all. For change detection, we now rely on `name`, `version`, `release` (only set for RPM), and `size` - all of which (hopefully) only change when the package has indeed changed.
2. For dpkg, reports packages as removed that have only been removed (`apt-get remove`) but not purged (`apt-get purge`). Removed package stay around in `/var/lib/dpkg/status`, but with a `deinstall` status.

As an urgent follow-up, we should add tests with sample files for at least:

- `/var/lib/dpkg/status` in various stages (no package, installed package, new version, deinstalled package). I wanted to add it here, but we'll need a way to pass the test files to the metricset, and at the moment there is no config value for it (but there probably should be). I didn't want to do that bigger change here.
- `/usr/local/Cellar/{pkg.Name}/INSTALL_RECEIPT.json` (read since https://github.com/elastic/beats/pull/10507), and a Ruby formula file. 