### PR TITLE
[Auditbeat] Login: Change event.type to event.kind

### DIFF
--- a/x-pack/auditbeat/module/system/login/_meta/data.json
+++ b/x-pack/auditbeat/module/system/login/_meta/data.json
@@ -10,7 +10,7 @@
         "module": "system",
         "origin": "/var/log/wtmp.1",
         "outcome": "success",
-        "type": "event"
+        "kind": "event"
     },
     "message": "Login by user vagrant (UID: 1000) on pts/1 (PID: 17559) from 10.0.2.2 (IP: 10.0.2.2)",
     "process": {

--- a/x-pack/auditbeat/module/system/login/_meta/data.json
+++ b/x-pack/auditbeat/module/system/login/_meta/data.json
@@ -7,10 +7,10 @@
     "event": {
         "action": "user_login",
         "dataset": "login",
+        "kind": "event",
         "module": "system",
         "origin": "/var/log/wtmp.1",
-        "outcome": "success",
-        "kind": "event"
+        "outcome": "success"
     },
     "message": "Login by user vagrant (UID: 1000) on pts/1 (PID: 17559) from 10.0.2.2 (IP: 10.0.2.2)",
     "process": {

--- a/x-pack/auditbeat/module/system/login/login.go
+++ b/x-pack/auditbeat/module/system/login/login.go
@@ -166,7 +166,7 @@ func (ms *MetricSet) loginEvent(loginRecord *LoginRecord) mb.Event {
 		Timestamp: loginRecord.Timestamp,
 		RootFields: common.MapStr{
 			"event": common.MapStr{
-				"type":   eventTypeEvent,
+				"kind":   eventTypeEvent,
 				"action": loginRecord.Type.string(),
 				"origin": loginRecord.Origin,
 			},


### PR DESCRIPTION
The `login` dataset is still accidentally using `event.type`. This changes to the correct `event.kind`. I fixed it [in the backport](https://github.com/elastic/beats/pull/10509) as well, so no extra backport needed.