### PR TITLE
Reenable modules tests

### DIFF
--- a/filebeat/module/apache/access/test/ssl-request.log-expected.json
+++ b/filebeat/module/apache/access/test/ssl-request.log-expected.json
@@ -1,6 +1,6 @@
 [
     {
-        "@timestamp": "2018-08-10T07:45:56.000Z",
+        "@timestamp": "2018-08-10T09:45:56.000Z",
         "apache.access.ssl.cipher": "ECDHE-RSA-AES128-GCM-SHA256",
         "apache.access.ssl.protocol": "TLSv1.2",
         "ecs.version": "1.0.0-beta2",

--- a/filebeat/module/elasticsearch/audit/test/test-access.log-expected.json
+++ b/filebeat/module/elasticsearch/audit/test/test-access.log-expected.json
@@ -1,6 +1,5 @@
 [
     {
-        "@timestamp": "2018-06-19T05:16:15.549Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.audit.layer": "rest",
         "event.dataset": "elasticsearch.audit",
@@ -16,7 +15,6 @@
         "user.name": "i030648"
     },
     {
-        "@timestamp": "2018-06-19T05:07:52.304Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.audit.layer": "rest",
         "elasticsearch.node.name": "v_VJhjV",
@@ -33,7 +31,6 @@
         "user.name": "rado"
     },
     {
-        "@timestamp": "2018-06-19T05:00:15.778Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.audit.action": "indices:data/read/scroll/clear",
         "elasticsearch.audit.layer": "transport",
@@ -51,7 +48,6 @@
         "user.name": "_xpack_security"
     },
     {
-        "@timestamp": "2018-06-19T05:07:45.544Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.audit.layer": "rest",
         "elasticsearch.node.name": "v_VJhjV",
@@ -67,7 +63,6 @@
         "url.original": "/_xpack/security/_authenticate"
     },
     {
-        "@timestamp": "2018-06-19T05:26:27.268Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.audit.layer": "rest",
         "event.dataset": "elasticsearch.audit",
@@ -83,7 +78,6 @@
         "user.name": "N078801"
     },
     {
-        "@timestamp": "2018-06-19T05:55:26.898Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.audit.action": "cluster:monitor/main",
         "elasticsearch.audit.layer": "transport",
@@ -101,7 +95,6 @@
         "user.name": "_anonymous"
     },
     {
-        "@timestamp": "2018-06-19T05:24:15.190Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.audit.layer": "rest",
         "elasticsearch.node.name": "v_VJhjV",
@@ -119,7 +112,6 @@
         "user.name": "elastic"
     },
     {
-        "@timestamp": "2019-01-08T14:15:02.011Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.audit.action": "indices:data/read/search[free_context]",
         "elasticsearch.audit.indices": [
@@ -152,7 +144,6 @@
         "user.name": "username"
     },
     {
-        "@timestamp": "2019-01-27T20:04:27.244Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.audit.layer": "rest",
         "elasticsearch.audit.realm": "default_file",

--- a/filebeat/module/elasticsearch/audit/test/test-audit.log-expected.json
+++ b/filebeat/module/elasticsearch/audit/test/test-audit.log-expected.json
@@ -1,6 +1,5 @@
 [
     {
-        "@timestamp": "2018-10-31T09:34:25.109Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.audit.layer": "rest",
         "elasticsearch.audit.origin.type": "rest",
@@ -20,7 +19,6 @@
         "user.name": "elastic"
     },
     {
-        "@timestamp": "2018-10-31T09:34:25.207Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.audit.layer": "rest",
         "elasticsearch.audit.origin.type": "rest",
@@ -40,7 +38,6 @@
         "user.name": "elastic"
     },
     {
-        "@timestamp": "2018-10-31T09:35:11.428Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.audit.action": "cluster:admin/xpack/security/realm/cache/clear",
         "elasticsearch.audit.layer": "transport",
@@ -65,7 +62,6 @@
         "user.name": "_xpack_security"
     },
     {
-        "@timestamp": "2018-10-31T09:35:11.430Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.audit.action": "cluster:admin/xpack/security/realm/cache/clear[n]",
         "elasticsearch.audit.layer": "transport",
@@ -90,7 +86,6 @@
         "user.name": "_xpack_security"
     },
     {
-        "@timestamp": "2018-10-31T09:35:12.303Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.audit.action": "cluster:admin/xpack/security/user/change_password",
         "elasticsearch.audit.layer": "transport",
@@ -115,7 +110,6 @@
         "user.name": "elastic"
     },
     {
-        "@timestamp": "2018-10-31T09:35:12.314Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.audit.action": "indices:admin/create",
         "elasticsearch.audit.indices": [
@@ -143,7 +137,6 @@
         "user.name": "_xpack_security"
     },
     {
-        "@timestamp": "2019-01-27T20:15:10.380Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.audit.layer": "rest",
         "elasticsearch.audit.origin.type": "rest",

--- a/filebeat/module/elasticsearch/deprecation/test/elasticsearch_deprecation.log-expected.json
+++ b/filebeat/module/elasticsearch/deprecation/test/elasticsearch_deprecation.log-expected.json
@@ -1,6 +1,5 @@
 [
     {
-        "@timestamp": "2018-04-23T16:40:13.737Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.component": "o.e.d.a.a.i.t.p.PutIndexTemplateRequest",
         "event.dataset": "elasticsearch.deprecation",
@@ -13,7 +12,6 @@
         "service.type": "elasticsearch"
     },
     {
-        "@timestamp": "2018-04-23T16:40:13.862Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.component": "o.e.d.a.a.i.t.p.PutIndexTemplateRequest",
         "event.dataset": "elasticsearch.deprecation",
@@ -26,7 +24,6 @@
         "service.type": "elasticsearch"
     },
     {
-        "@timestamp": "2018-04-23T16:40:14.792Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.component": "o.e.d.a.a.i.t.p.PutIndexTemplateRequest",
         "event.dataset": "elasticsearch.deprecation",
@@ -39,7 +36,6 @@
         "service.type": "elasticsearch"
     },
     {
-        "@timestamp": "2018-04-23T16:40:15.127Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.component": "o.e.d.a.a.i.t.p.PutIndexTemplateRequest",
         "event.dataset": "elasticsearch.deprecation",

--- a/filebeat/module/elasticsearch/deprecation/test/other_elasticsearch_deprecation.log-expected.json
+++ b/filebeat/module/elasticsearch/deprecation/test/other_elasticsearch_deprecation.log-expected.json
@@ -1,6 +1,5 @@
 [
     {
-        "@timestamp": "2017-11-30T13:38:16.911Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.component": "o.e.d.c.ParseField",
         "event.dataset": "elasticsearch.deprecation",
@@ -13,7 +12,6 @@
         "service.type": "elasticsearch"
     },
     {
-        "@timestamp": "2017-11-30T13:38:16.941Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.component": "o.e.d.c.ParseField",
         "event.dataset": "elasticsearch.deprecation",
@@ -26,7 +24,6 @@
         "service.type": "elasticsearch"
     },
     {
-        "@timestamp": "2017-11-30T13:39:28.986Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.component": "o.e.d.i.m.UidFieldMapper",
         "event.dataset": "elasticsearch.deprecation",
@@ -39,7 +36,6 @@
         "service.type": "elasticsearch"
     },
     {
-        "@timestamp": "2017-11-30T13:39:36.339Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.component": "o.e.d.i.m.UidFieldMapper",
         "event.dataset": "elasticsearch.deprecation",
@@ -52,7 +48,6 @@
         "service.type": "elasticsearch"
     },
     {
-        "@timestamp": "2017-11-30T13:40:49.540Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.component": "o.e.d.i.m.UidFieldMapper",
         "event.dataset": "elasticsearch.deprecation",
@@ -65,7 +60,6 @@
         "service.type": "elasticsearch"
     },
     {
-        "@timestamp": "2017-11-30T14:08:37.413Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.component": "o.e.d.i.m.UidFieldMapper",
         "event.dataset": "elasticsearch.deprecation",
@@ -78,7 +72,6 @@
         "service.type": "elasticsearch"
     },
     {
-        "@timestamp": "2017-11-30T14:08:37.413Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.component": "o.e.d.i.m.UidFieldMapper",
         "event.dataset": "elasticsearch.deprecation",
@@ -91,7 +84,6 @@
         "service.type": "elasticsearch"
     },
     {
-        "@timestamp": "2017-11-30T14:08:46.006Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.component": "o.e.d.i.m.UidFieldMapper",
         "event.dataset": "elasticsearch.deprecation",
@@ -104,7 +96,6 @@
         "service.type": "elasticsearch"
     },
     {
-        "@timestamp": "2017-11-30T14:08:46.006Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.component": "o.e.d.i.m.UidFieldMapper",
         "event.dataset": "elasticsearch.deprecation",
@@ -117,7 +108,6 @@
         "service.type": "elasticsearch"
     },
     {
-        "@timestamp": "2017-12-01T14:05:54.017Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.component": "o.e.d.i.m.AllFieldMapper",
         "event.dataset": "elasticsearch.deprecation",
@@ -130,7 +120,6 @@
         "service.type": "elasticsearch"
     },
     {
-        "@timestamp": "2017-12-01T14:05:54.019Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.component": "o.e.d.i.m.AllFieldMapper",
         "event.dataset": "elasticsearch.deprecation",
@@ -143,7 +132,6 @@
         "service.type": "elasticsearch"
     },
     {
-        "@timestamp": "2017-12-01T14:06:52.059Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.component": "o.e.d.i.m.AllFieldMapper",
         "event.dataset": "elasticsearch.deprecation",
@@ -156,7 +144,6 @@
         "service.type": "elasticsearch"
     },
     {
-        "@timestamp": "2017-12-01T14:46:10.428Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.component": "o.e.d.s.a.InternalOrder$Parser",
         "event.dataset": "elasticsearch.deprecation",
@@ -169,7 +156,6 @@
         "service.type": "elasticsearch"
     },
     {
-        "@timestamp": "2017-12-04T16:17:18.271Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.component": "o.e.d.a.a.i.t.p.PutIndexTemplateRequest",
         "event.dataset": "elasticsearch.deprecation",
@@ -182,7 +168,6 @@
         "service.type": "elasticsearch"
     },
     {
-        "@timestamp": "2017-12-04T16:17:18.282Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.component": "o.e.d.i.m.MapperService",
         "event.dataset": "elasticsearch.deprecation",
@@ -195,7 +180,6 @@
         "service.type": "elasticsearch"
     },
     {
-        "@timestamp": "2017-12-04T16:20:43.248Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.component": "o.e.d.i.m.MapperService",
         "event.dataset": "elasticsearch.deprecation",

--- a/filebeat/module/elasticsearch/deprecation/test/test-json.log-expected.json
+++ b/filebeat/module/elasticsearch/deprecation/test/test-json.log-expected.json
@@ -1,6 +1,5 @@
 [
     {
-        "@timestamp": "2019-01-30T22:16:20.233Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "es1",
         "elasticsearch.cluster.uuid": "S4dWw65ZT1eu3SltmAr84A",
@@ -17,7 +16,6 @@
         "service.type": "elasticsearch"
     },
     {
-        "@timestamp": "2019-01-30T22:16:22.388Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "es1",
         "elasticsearch.cluster.uuid": "S4dWw65ZT1eu3SltmAr84A",
@@ -34,7 +32,6 @@
         "service.type": "elasticsearch"
     },
     {
-        "@timestamp": "2019-01-30T22:16:22.566Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "es1",
         "elasticsearch.cluster.uuid": "S4dWw65ZT1eu3SltmAr84A",
@@ -51,7 +48,6 @@
         "service.type": "elasticsearch"
     },
     {
-        "@timestamp": "2019-01-30T22:16:24.538Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "es1",
         "elasticsearch.cluster.uuid": "S4dWw65ZT1eu3SltmAr84A",
@@ -68,7 +64,6 @@
         "service.type": "elasticsearch"
     },
     {
-        "@timestamp": "2019-01-30T22:16:59.311Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "es1",
         "elasticsearch.cluster.uuid": "S4dWw65ZT1eu3SltmAr84A",
@@ -85,7 +80,6 @@
         "service.type": "elasticsearch"
     },
     {
-        "@timestamp": "2019-01-30T22:16:59.922Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "es1",
         "elasticsearch.cluster.uuid": "S4dWw65ZT1eu3SltmAr84A",
@@ -102,7 +96,6 @@
         "service.type": "elasticsearch"
     },
     {
-        "@timestamp": "2019-01-30T22:17:00.095Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "es1",
         "elasticsearch.cluster.uuid": "S4dWw65ZT1eu3SltmAr84A",
@@ -119,7 +112,6 @@
         "service.type": "elasticsearch"
     },
     {
-        "@timestamp": "2019-01-30T22:17:13.226Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "es1",
         "elasticsearch.cluster.uuid": "S4dWw65ZT1eu3SltmAr84A",
@@ -136,7 +128,6 @@
         "service.type": "elasticsearch"
     },
     {
-        "@timestamp": "2019-01-30T22:17:14.747Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "es1",
         "elasticsearch.cluster.uuid": "S4dWw65ZT1eu3SltmAr84A",
@@ -153,7 +144,6 @@
         "service.type": "elasticsearch"
     },
     {
-        "@timestamp": "2019-01-30T22:17:14.801Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "es1",
         "elasticsearch.cluster.uuid": "S4dWw65ZT1eu3SltmAr84A",
@@ -170,7 +160,6 @@
         "service.type": "elasticsearch"
     },
     {
-        "@timestamp": "2019-01-30T22:17:17.546Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "es1",
         "elasticsearch.cluster.uuid": "S4dWw65ZT1eu3SltmAr84A",
@@ -187,7 +176,6 @@
         "service.type": "elasticsearch"
     },
     {
-        "@timestamp": "2019-01-30T22:18:33.367Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "es1",
         "elasticsearch.cluster.uuid": "S4dWw65ZT1eu3SltmAr84A",
@@ -204,7 +192,6 @@
         "service.type": "elasticsearch"
     },
     {
-        "@timestamp": "2019-01-30T22:18:46.493Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "es1",
         "elasticsearch.cluster.uuid": "S4dWw65ZT1eu3SltmAr84A",

--- a/filebeat/module/elasticsearch/server/test/test.log-expected.json
+++ b/filebeat/module/elasticsearch/server/test/test.log-expected.json
@@ -1,6 +1,5 @@
 [
     {
-        "@timestamp": "2018-05-17T08:29:12.177Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.index.name": "test-filebeat-modules",
         "elasticsearch.node.name": "vWNJsZ3",
@@ -15,7 +14,6 @@
         "service.type": "elasticsearch"
     },
     {
-        "@timestamp": "2018-05-17T08:19:35.939Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.node.name": "",
         "elasticsearch.server.component": "o.e.n.Node",
@@ -29,7 +27,6 @@
         "service.type": "elasticsearch"
     },
     {
-        "@timestamp": "2018-05-17T08:19:36.089Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.node.name": "vWNJsZ3",
         "elasticsearch.server.component": "o.e.e.NodeEnvironment",
@@ -43,7 +40,6 @@
         "service.type": "elasticsearch"
     },
     {
-        "@timestamp": "2018-05-17T08:19:36.090Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.node.name": "vWNJsZ3",
         "elasticsearch.server.component": "o.e.e.NodeEnvironment",
@@ -57,7 +53,6 @@
         "service.type": "elasticsearch"
     },
     {
-        "@timestamp": "2018-05-17T08:19:36.116Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.server.component": "o.e.n.Node",
         "event.dataset": "elasticsearch.server",
@@ -70,7 +65,6 @@
         "service.type": "elasticsearch"
     },
     {
-        "@timestamp": "2018-05-17T08:23:48.941Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.node.name": "vWNJsZ3",
         "elasticsearch.server.component": "o.e.c.r.a.DiskThresholdMonitor",
@@ -84,7 +78,6 @@
         "service.type": "elasticsearch"
     },
     {
-        "@timestamp": "2018-05-17T08:29:09.245Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.index.name": "filebeat-test-input",
         "elasticsearch.node.name": "vWNJsZ3",
@@ -99,7 +92,6 @@
         "service.type": "elasticsearch"
     },
     {
-        "@timestamp": "2018-05-17T08:29:09.576Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.index.id": "aOGgDwbURfCV57AScqbCgw",
         "elasticsearch.index.name": "filebeat-test-input",
@@ -115,7 +107,6 @@
         "service.type": "elasticsearch"
     },
     {
-        "@timestamp": "2018-07-09T12:47:33.959Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.index.id": "3tWftqb4RLKdyCAga9syGA",
         "elasticsearch.index.name": ".kibana",
@@ -131,7 +122,6 @@
         "service.type": "elasticsearch"
     },
     {
-        "@timestamp": "2018-05-17T08:29:25.598Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.node.name": "vWNJsZ3",
         "elasticsearch.server.component": "o.e.n.Node",
@@ -145,7 +135,6 @@
         "service.type": "elasticsearch"
     },
     {
-        "@timestamp": "2018-05-17T08:29:25.612Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.node.name": "vWNJsZ3",
         "elasticsearch.server.component": "o.e.n.Node",
@@ -159,7 +148,6 @@
         "service.type": "elasticsearch"
     },
     {
-        "@timestamp": "2018-07-03T11:45:48.548Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.node.name": "srvmulpvlsk252_md",
         "elasticsearch.server.component": "o.e.d.z.ZenDiscovery",
@@ -173,7 +161,6 @@
         "service.type": "elasticsearch"
     },
     {
-        "@timestamp": "2018-07-03T11:45:48.548Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.node.name": "srvmulpvlsk252_md",
         "elasticsearch.server.component": "o.e.d.z.ZenDiscovery",
@@ -190,7 +177,6 @@
         "service.type": "elasticsearch"
     },
     {
-        "@timestamp": "2018-07-03T11:45:52.666Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.server.component": "r.suppressed",
         "event.dataset": "elasticsearch.server",
@@ -206,7 +192,6 @@
         "service.type": "elasticsearch"
     },
     {
-        "@timestamp": "2018-07-03T11:48:02.552Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.server.component": "r.suppressed",
         "event.dataset": "elasticsearch.server",
@@ -222,7 +207,6 @@
         "service.type": "elasticsearch"
     },
     {
-        "@timestamp": "2018-07-03T11:45:27.896Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.node.name": "srvmulpvlsk252_md",
         "elasticsearch.server.component": "o.e.m.j.JvmGcMonitorService",
@@ -241,7 +225,6 @@
         "service.type": "elasticsearch"
     },
     {
-        "@timestamp": "2018-07-03T11:45:45.604Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.node.name": "srvmulpvlsk252_md",
         "elasticsearch.server.component": "o.e.m.j.JvmGcMonitorService",
@@ -258,7 +241,6 @@
         "service.type": "elasticsearch"
     },
     {
-        "@timestamp": "2018-07-03T11:48:02.541Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.node.name": "srvmulpvlsk252_md",
         "elasticsearch.server.component": "o.e.a.b.TransportShardBulkAction",
@@ -272,7 +254,6 @@
         "service.type": "elasticsearch"
     },
     {
-        "@timestamp": "2018-07-03T20:10:07.376Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.node.name": "srvmulpvlsk252_md",
         "elasticsearch.server.component": "o.e.x.m.MonitoringService",

--- a/filebeat/module/elasticsearch/slowlog/test/auditlog_index_indexing_slowlog.log-expected.json
+++ b/filebeat/module/elasticsearch/slowlog/test/auditlog_index_indexing_slowlog.log-expected.json
@@ -1,6 +1,5 @@
 [
     {
-        "@timestamp": "2018-07-04T21:51:29.536Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.index.id": "VLKxBLvUSYuIMKzpacGjRg",
         "elasticsearch.index.name": "metricbeat-6.3.0-2018.07.04",
@@ -22,7 +21,6 @@
         "service.type": "elasticsearch"
     },
     {
-        "@timestamp": "2018-07-04T21:51:29.537Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.index.id": "VLKxBLvUSYuIMKzpacGjRg",
         "elasticsearch.index.name": "metricbeat-6.3.0-2018.07.04",
@@ -44,7 +42,6 @@
         "service.type": "elasticsearch"
     },
     {
-        "@timestamp": "2018-07-04T21:51:29.538Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.index.id": "VLKxBLvUSYuIMKzpacGjRg",
         "elasticsearch.index.name": "metricbeat-6.3.0-2018.07.04",
@@ -66,7 +63,6 @@
         "service.type": "elasticsearch"
     },
     {
-        "@timestamp": "2018-07-04T21:51:30.411Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.index.id": "VLKxBLvUSYuIMKzpacGjRg",
         "elasticsearch.index.name": "metricbeat-6.3.0-2018.07.04",
@@ -87,7 +83,6 @@
         "service.type": "elasticsearch"
     },
     {
-        "@timestamp": "2018-07-04T21:51:30.963Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.index.id": "VLKxBLvUSYuIMKzpacGjRg",
         "elasticsearch.index.name": "metricbeat-6.3.0-2018.07.04",
@@ -109,7 +104,6 @@
         "service.type": "elasticsearch"
     },
     {
-        "@timestamp": "2018-07-04T21:51:30.965Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.index.id": "VLKxBLvUSYuIMKzpacGjRg",
         "elasticsearch.index.name": "metricbeat-6.3.0-2018.07.04",

--- a/filebeat/module/elasticsearch/slowlog/test/es_index_indexing_slowlog-json.log-expected.json
+++ b/filebeat/module/elasticsearch/slowlog/test/es_index_indexing_slowlog-json.log-expected.json
@@ -1,6 +1,5 @@
 [
     {
-        "@timestamp": "2019-01-29T07:35:54.170Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "distribution_run",
         "elasticsearch.cluster.uuid": "oqKkg2eoQh2P_KrKliI3DA",
@@ -25,7 +24,6 @@
         "service.type": "elasticsearch"
     },
     {
-        "@timestamp": "2019-01-29T07:35:58.359Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "distribution_run",
         "elasticsearch.cluster.uuid": "oqKkg2eoQh2P_KrKliI3DA",

--- a/filebeat/module/elasticsearch/slowlog/test/es_index_search_slowlog-json.log-expected.json
+++ b/filebeat/module/elasticsearch/slowlog/test/es_index_search_slowlog-json.log-expected.json
@@ -1,6 +1,5 @@
 [
     {
-        "@timestamp": "2019-01-29T07:31:40.426Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "distribution_run",
         "elasticsearch.cluster.uuid": "oqKkg2eoQh2P_KrKliI3DA",
@@ -21,7 +20,6 @@
         "service.type": "elasticsearch"
     },
     {
-        "@timestamp": "2019-01-29T07:36:01.675Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "distribution_run",
         "elasticsearch.cluster.uuid": "oqKkg2eoQh2P_KrKliI3DA",
@@ -42,7 +40,6 @@
         "service.type": "elasticsearch"
     },
     {
-        "@timestamp": "2019-01-29T07:36:01.685Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "distribution_run",
         "elasticsearch.cluster.uuid": "oqKkg2eoQh2P_KrKliI3DA",

--- a/filebeat/module/elasticsearch/slowlog/test/test.log-expected.json
+++ b/filebeat/module/elasticsearch/slowlog/test/test.log-expected.json
@@ -1,6 +1,5 @@
 [
     {
-        "@timestamp": "2018-06-29T10:06:14.933Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.index.name": "metricbeat-6.3.0-2018.06.26",
         "elasticsearch.node.name": "v_VJhjV",
@@ -27,7 +26,6 @@
         "service.type": "elasticsearch"
     },
     {
-        "@timestamp": "2018-06-29T10:06:14.943Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.index.name": "metricbeat-6.3.0-2018.06.26",
         "elasticsearch.node.name": "v_VJhjV",
@@ -51,7 +49,6 @@
         "service.type": "elasticsearch"
     },
     {
-        "@timestamp": "2018-06-29T09:01:01.821Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.index.name": "metricbeat-6.3.0-2018.06.26",
         "elasticsearch.node.name": "v_VJhjV",
@@ -75,7 +72,6 @@
         "service.type": "elasticsearch"
     },
     {
-        "@timestamp": "2018-06-29T09:01:01.827Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.index.name": "metricbeat-6.3.0-2018.06.26",
         "elasticsearch.node.name": "v_VJhjV",
@@ -99,7 +95,6 @@
         "service.type": "elasticsearch"
     },
     {
-        "@timestamp": "2018-07-04T13:48:07.452Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.index.id": "VLKxBLvUSYuIMKzpacGjRg",
         "elasticsearch.index.name": "metricbeat-6.3.0-2018.07.04",
@@ -121,7 +116,6 @@
         "service.type": "elasticsearch"
     },
     {
-        "@timestamp": "2018-07-04T21:51:30.411Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.index.id": "VLKxBLvUSYuIMKzpacGjRg",
         "elasticsearch.index.name": "metricbeat-6.3.0-2018.07.04",

--- a/filebeat/module/icinga/debug/test/test.log-expected.json
+++ b/filebeat/module/icinga/debug/test/test.log-expected.json
@@ -1,6 +1,6 @@
 [
     {
-        "@timestamp": "2017-04-04T11:43:09.000Z",
+        "@timestamp": "2017-04-04T13:43:09.000Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "icinga.debug",
         "event.module": "icinga",
@@ -13,7 +13,7 @@
         "service.type": "icinga"
     },
     {
-        "@timestamp": "2017-04-04T11:43:09.000Z",
+        "@timestamp": "2017-04-04T13:43:09.000Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "icinga.debug",
         "event.module": "icinga",
@@ -26,7 +26,7 @@
         "service.type": "icinga"
     },
     {
-        "@timestamp": "2017-04-04T11:43:11.000Z",
+        "@timestamp": "2017-04-04T13:43:11.000Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "icinga.debug",
         "event.module": "icinga",

--- a/filebeat/module/icinga/main/test/test.log-expected.json
+++ b/filebeat/module/icinga/main/test/test.log-expected.json
@@ -1,6 +1,6 @@
 [
     {
-        "@timestamp": "2017-04-04T09:16:34.000Z",
+        "@timestamp": "2017-04-04T11:16:34.000Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "icinga.main",
         "event.module": "icinga",
@@ -13,7 +13,7 @@
         "service.type": "icinga"
     },
     {
-        "@timestamp": "2017-04-04T09:16:34.000Z",
+        "@timestamp": "2017-04-04T11:16:34.000Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "icinga.main",
         "event.module": "icinga",
@@ -29,7 +29,7 @@
         "service.type": "icinga"
     },
     {
-        "@timestamp": "2017-04-04T09:16:48.000Z",
+        "@timestamp": "2017-04-04T11:16:48.000Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "icinga.main",
         "event.module": "icinga",

--- a/filebeat/module/logstash/log/test/logstash-plain.log-expected.json
+++ b/filebeat/module/logstash/log/test/logstash-plain.log-expected.json
@@ -1,6 +1,5 @@
 [
     {
-        "@timestamp": "2017-10-23T14:20:12.046Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "logstash.log",
         "event.module": "logstash",
@@ -13,7 +12,6 @@
         "service.type": "logstash"
     },
     {
-        "@timestamp": "2017-11-20T03:55:00.318Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "logstash.log",
         "event.module": "logstash",

--- a/filebeat/module/logstash/slowlog/test/slowlog-plain.log-expected.json
+++ b/filebeat/module/logstash/slowlog/test/slowlog-plain.log-expected.json
@@ -1,6 +1,5 @@
 [
     {
-        "@timestamp": "2017-10-30T09:57:58.243Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "logstash.slowlog",
         "event.duration": 3027675106,

--- a/filebeat/module/mongodb/log/test/mongodb-debian-3.2.11.log-expected.json
+++ b/filebeat/module/mongodb/log/test/mongodb-debian-3.2.11.log-expected.json
@@ -1,6 +1,6 @@
 [
     {
-        "@timestamp": "2018-02-05T12:44:56.657Z",
+        "@timestamp": "2018-02-05T13:44:56.657Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",
@@ -14,7 +14,7 @@
         "service.type": "mongodb"
     },
     {
-        "@timestamp": "2018-02-05T12:44:56.657Z",
+        "@timestamp": "2018-02-05T13:44:56.657Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",
@@ -28,7 +28,7 @@
         "service.type": "mongodb"
     },
     {
-        "@timestamp": "2018-02-05T12:44:56.657Z",
+        "@timestamp": "2018-02-05T13:44:56.657Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",
@@ -42,7 +42,7 @@
         "service.type": "mongodb"
     },
     {
-        "@timestamp": "2018-02-05T12:44:56.677Z",
+        "@timestamp": "2018-02-05T13:44:56.677Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",
@@ -56,7 +56,7 @@
         "service.type": "mongodb"
     },
     {
-        "@timestamp": "2018-02-05T12:44:56.724Z",
+        "@timestamp": "2018-02-05T13:44:56.724Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",
@@ -70,7 +70,7 @@
         "service.type": "mongodb"
     },
     {
-        "@timestamp": "2018-02-05T12:44:56.724Z",
+        "@timestamp": "2018-02-05T13:44:56.724Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",
@@ -84,7 +84,7 @@
         "service.type": "mongodb"
     },
     {
-        "@timestamp": "2018-02-05T12:44:56.744Z",
+        "@timestamp": "2018-02-05T13:44:56.744Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",
@@ -98,7 +98,7 @@
         "service.type": "mongodb"
     },
     {
-        "@timestamp": "2018-02-05T12:50:55.170Z",
+        "@timestamp": "2018-02-05T13:50:55.170Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",
@@ -112,7 +112,7 @@
         "service.type": "mongodb"
     },
     {
-        "@timestamp": "2018-02-05T12:50:55.487Z",
+        "@timestamp": "2018-02-05T13:50:55.487Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",
@@ -126,7 +126,7 @@
         "service.type": "mongodb"
     },
     {
-        "@timestamp": "2018-02-05T13:49:45.606Z",
+        "@timestamp": "2018-02-05T14:49:45.606Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",
@@ -140,7 +140,7 @@
         "service.type": "mongodb"
     },
     {
-        "@timestamp": "2018-02-05T13:49:45.606Z",
+        "@timestamp": "2018-02-05T14:49:45.606Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",
@@ -154,7 +154,7 @@
         "service.type": "mongodb"
     },
     {
-        "@timestamp": "2018-02-05T13:49:45.606Z",
+        "@timestamp": "2018-02-05T14:49:45.606Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",
@@ -168,7 +168,7 @@
         "service.type": "mongodb"
     },
     {
-        "@timestamp": "2018-02-05T13:49:45.606Z",
+        "@timestamp": "2018-02-05T14:49:45.606Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",
@@ -182,7 +182,7 @@
         "service.type": "mongodb"
     },
     {
-        "@timestamp": "2018-02-05T13:49:45.606Z",
+        "@timestamp": "2018-02-05T14:49:45.606Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",
@@ -196,7 +196,7 @@
         "service.type": "mongodb"
     },
     {
-        "@timestamp": "2018-02-05T13:49:45.688Z",
+        "@timestamp": "2018-02-05T14:49:45.688Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",
@@ -210,7 +210,7 @@
         "service.type": "mongodb"
     },
     {
-        "@timestamp": "2018-02-05T12:44:56.657Z",
+        "@timestamp": "2018-02-05T13:44:56.657Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",
@@ -224,7 +224,7 @@
         "service.type": "mongodb"
     },
     {
-        "@timestamp": "2018-02-05T12:44:56.657Z",
+        "@timestamp": "2018-02-05T13:44:56.657Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",
@@ -238,7 +238,7 @@
         "service.type": "mongodb"
     },
     {
-        "@timestamp": "2018-02-05T12:44:56.657Z",
+        "@timestamp": "2018-02-05T13:44:56.657Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",
@@ -252,7 +252,7 @@
         "service.type": "mongodb"
     },
     {
-        "@timestamp": "2018-02-05T12:44:56.657Z",
+        "@timestamp": "2018-02-05T13:44:56.657Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",
@@ -266,7 +266,7 @@
         "service.type": "mongodb"
     },
     {
-        "@timestamp": "2018-02-05T12:50:55.170Z",
+        "@timestamp": "2018-02-05T13:50:55.170Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",
@@ -280,7 +280,7 @@
         "service.type": "mongodb"
     },
     {
-        "@timestamp": "2018-02-05T12:50:56.180Z",
+        "@timestamp": "2018-02-05T13:50:56.180Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",
@@ -294,7 +294,7 @@
         "service.type": "mongodb"
     },
     {
-        "@timestamp": "2018-02-05T13:15:42.095Z",
+        "@timestamp": "2018-02-05T14:15:42.095Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",
@@ -308,7 +308,7 @@
         "service.type": "mongodb"
     },
     {
-        "@timestamp": "2018-02-05T13:49:45.606Z",
+        "@timestamp": "2018-02-05T14:49:45.606Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",
@@ -322,7 +322,7 @@
         "service.type": "mongodb"
     },
     {
-        "@timestamp": "2018-02-05T13:49:45.606Z",
+        "@timestamp": "2018-02-05T14:49:45.606Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",
@@ -336,7 +336,7 @@
         "service.type": "mongodb"
     },
     {
-        "@timestamp": "2018-02-05T13:49:45.688Z",
+        "@timestamp": "2018-02-05T14:49:45.688Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",
@@ -350,7 +350,7 @@
         "service.type": "mongodb"
     },
     {
-        "@timestamp": "2018-02-05T12:44:56.657Z",
+        "@timestamp": "2018-02-05T13:44:56.657Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",
@@ -364,7 +364,7 @@
         "service.type": "mongodb"
     },
     {
-        "@timestamp": "2018-02-05T12:44:56.657Z",
+        "@timestamp": "2018-02-05T13:44:56.657Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",
@@ -378,7 +378,7 @@
         "service.type": "mongodb"
     },
     {
-        "@timestamp": "2018-02-05T12:44:56.657Z",
+        "@timestamp": "2018-02-05T13:44:56.657Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",
@@ -392,7 +392,7 @@
         "service.type": "mongodb"
     },
     {
-        "@timestamp": "2018-02-05T12:50:55.487Z",
+        "@timestamp": "2018-02-05T13:50:55.487Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",
@@ -406,7 +406,7 @@
         "service.type": "mongodb"
     },
     {
-        "@timestamp": "2018-02-05T12:50:56.180Z",
+        "@timestamp": "2018-02-05T13:50:56.180Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",
@@ -420,7 +420,7 @@
         "service.type": "mongodb"
     },
     {
-        "@timestamp": "2018-02-05T13:11:41.401Z",
+        "@timestamp": "2018-02-05T14:11:41.401Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",
@@ -434,7 +434,7 @@
         "service.type": "mongodb"
     },
     {
-        "@timestamp": "2018-02-05T13:49:45.605Z",
+        "@timestamp": "2018-02-05T14:49:45.605Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",
@@ -448,7 +448,7 @@
         "service.type": "mongodb"
     },
     {
-        "@timestamp": "2018-02-05T13:49:45.605Z",
+        "@timestamp": "2018-02-05T14:49:45.605Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",
@@ -462,7 +462,7 @@
         "service.type": "mongodb"
     },
     {
-        "@timestamp": "2018-02-05T13:49:45.606Z",
+        "@timestamp": "2018-02-05T14:49:45.606Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",

--- a/filebeat/tests/system/test_modules.py
+++ b/filebeat/tests/system/test_modules.py
@@ -87,7 +87,6 @@ class Test(BaseTest):
                      "integration tests are disabled, run with INTEGRATION_TESTS=1 to enable them.")
     @unittest.skipIf(os.getenv("TESTING_ENVIRONMENT") == "2x",
                      "integration test not available on 2.x")
-    @unittest.skip("Skipped because of timestamp and user_agent changes in ES.")
     def test_fileset_file(self, module, fileset, test_file):
         self.init()
 


### PR DESCRIPTION
This reenables the filebeat module tests which were skipped in https://github.com/elastic/beats/pull/10516. The generated files were updated. Two issues:

* Timestamp removal is odd
* User_agent needs fixing

Both of these should happen rather soonish.