### PR TITLE
Fix typo in the field name `container.id_truncated`

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -86,6 +86,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 - Rename read_timestamp to event.created to align with ECS. {pull}10043[10043], {pull}10139[10139]
 - Rename host.name to host.hostname to align with ECS. {pull}10043[10043]
+- Fix typo in field name. {pull}10525[10525]
 
 *Metricbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -86,7 +86,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 - Rename read_timestamp to event.created to align with ECS. {pull}10043[10043], {pull}10139[10139]
 - Rename host.name to host.hostname to align with ECS. {pull}10043[10043]
-- Fix typo in field name. {pull}10525[10525]
+- Fix typo in the field name `container.id_truncated`. {pull}10525[10525]
 
 *Metricbeat*
 

--- a/journalbeat/reader/fields.go
+++ b/journalbeat/reader/fields.go
@@ -80,7 +80,7 @@ var (
 		sdjournal.SD_JOURNAL_FIELD_UID:               fieldConversion{"process.uid", true, false},
 
 		// docker journald fields from: https://docs.docker.com/config/containers/logging/journald/
-		"CONTAINER_ID":              fieldConversion{"conatiner.id_truncated", false, false},
+		"CONTAINER_ID":              fieldConversion{"container.id_truncated", false, false},
 		"CONTAINER_ID_FULL":         fieldConversion{"container.id", false, false},
 		"CONTAINER_NAME":            fieldConversion{"container.name", false, false},
 		"CONTAINER_TAG":             fieldConversion{"container.image.tag", false, false},


### PR DESCRIPTION
Closes #10519 