### PR TITLE
Skip event.dataset and service.type if module is empty

### DIFF
--- a/filebeat/channel/factory.go
+++ b/filebeat/channel/factory.go
@@ -104,7 +104,9 @@ func (f *OutletFactory) Create(p beat.Pipeline, cfg *common.Config, dynFields *c
 
 	fields := common.MapStr{}
 	setMeta(fields, "module", config.Module)
-	setMeta(fields, "dataset", config.Module+"."+config.Fileset)
+	if config.Module != "" && config.Fileset != "" {
+		setMeta(fields, "dataset", config.Module+"."+config.Fileset)
+	}
 	if len(fields) > 0 {
 		fields = common.MapStr{
 			"event": fields,
@@ -115,7 +117,7 @@ func (f *OutletFactory) Create(p beat.Pipeline, cfg *common.Config, dynFields *c
 	}
 	if config.ServiceType != "" {
 		fields.Put("service.type", config.ServiceType)
-	} else {
+	} else if config.Module != "" {
 		fields.Put("service.type", config.Module)
 	}
 	if config.Type != "" {


### PR DESCRIPTION
If Filebeat is only used with an input and now module, both event.dataset and service.type were set with a `.` or empty string. This should not be the case and the fields should be just left out. This PR fixes these two issues.