### PR TITLE
Update beats to fpm 1.11.0

### DIFF
--- a/dev-tools/mage/settings.go
+++ b/dev-tools/mage/settings.go
@@ -36,7 +36,7 @@ import (
 )
 
 const (
-	fpmVersion = "1.10.0"
+	fpmVersion = "1.11.0"
 
 	// Docker images. See https://github.com/elastic/golang-crossbuild.
 	beatsFPMImage = "docker.elastic.co/beats-dev/fpm"


### PR DESCRIPTION
Previous version of FPM did not pin to a specific version of
childprocess.

See for details jordansissel/fpm#1592