### PR TITLE
Cherry-pick #8928 to 6.x: Do not panic when no tokenizer string is configured for dissect

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -65,6 +65,7 @@ https://github.com/elastic/beats/compare/v6.6.0...6.x[Check the HEAD diff]
 - The backing off now implements jitter to better distribute the load. {issue}10172[10172]
 - Fix TLS certificate DoS vulnerability. {pull}10303[10303]
 - Fix panic and file unlock in spool on atomic operation (arm, x86-32). File lock was not released when panic occurs, leading to the beat deadlocking on startup. {pull}10289[10289]
+- Do not panic when no tokenizer string is configured for a dissect processor. {issue}8895[8895]
 
 *Auditbeat*
 

--- a/libbeat/processors/dissect/config.go
+++ b/libbeat/processors/dissect/config.go
@@ -18,7 +18,7 @@
 package dissect
 
 type config struct {
-	Tokenizer    *tokenizer `config:"tokenizer"`
+	Tokenizer    *tokenizer `config:"tokenizer" validate:"required"`
 	Field        string     `config:"field"`
 	TargetPrefix string     `config:"target_prefix"`
 }

--- a/libbeat/processors/dissect/config_test.go
+++ b/libbeat/processors/dissect/config_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 )
 
-func TestTokenizerType(t *testing.T) {
+func TestConfig(t *testing.T) {
 	t.Run("valid", func(t *testing.T) {
 		c, err := common.NewConfigFrom(map[string]interface{}{
 			"tokenizer": "%{value1}",
@@ -46,6 +46,49 @@ func TestTokenizerType(t *testing.T) {
 		c, err := common.NewConfigFrom(map[string]interface{}{
 			"tokenizer": "%value1}",
 			"field":     "message",
+		})
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		cfg := config{}
+		err = c.Unpack(&cfg)
+		if !assert.Error(t, err) {
+			return
+		}
+	})
+
+	t.Run("with tokenizer missing", func(t *testing.T) {
+		c, err := common.NewConfigFrom(map[string]interface{}{})
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		cfg := config{}
+		err = c.Unpack(&cfg)
+		if !assert.Error(t, err) {
+			return
+		}
+	})
+
+	t.Run("with empty tokenizer", func(t *testing.T) {
+		c, err := common.NewConfigFrom(map[string]interface{}{
+			"tokenizer": "",
+		})
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		cfg := config{}
+		err = c.Unpack(&cfg)
+		if !assert.Error(t, err) {
+			return
+		}
+	})
+
+	t.Run("tokenizer with no field defined", func(t *testing.T) {
+		c, err := common.NewConfigFrom(map[string]interface{}{
+			"tokenizer": "hello world",
 		})
 		if !assert.NoError(t, err) {
 			return


### PR DESCRIPTION
Cherry-pick of PR #8928 to 6.x branch. Original message: 

Defining a dissect processor without a tokenizer field was making beat
panic, we now make sure the field is _required_ in the configuration and
we added tests for the config struct to make sure that all the scenario
of invalid tokenizer string are catched.

Fixes: #8895 

**NOTES** This will need to be backported in  6.4, 6.5, 6.x and maybe 6.3.