### PR TITLE
Do not read last entry when falling back to tail

### DIFF
--- a/journalbeat/reader/journal.go
+++ b/journalbeat/reader/journal.go
@@ -160,6 +160,7 @@ func (r *Reader) seek(cursor string) {
 				r.logger.Debug("Seeking method set to cursor, but no state is saved for reader. Starting to read from the beginning")
 			case config.SeekTail:
 				r.journal.SeekTail()
+				r.journal.Next()
 				r.logger.Debug("Seeking method set to cursor, but no state is saved for reader. Starting to read from the end")
 			default:
 				r.logger.Error("Invalid option for cursor_seek_fallback")


### PR DESCRIPTION
Previously, when falling back to `tail` seeking mode, the last entry was read by Journalbeat. This could lead to unwanted events being read, when a user simply wants to read new entries.
It was already fixed in case of `tail` seek mode.

This feature hasn't been released yet, so I am not adding a new changelog entry.