### PR TITLE
Cherry-pick #10477 to 6.x: Update vendored tsg/gopacket

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -121,6 +121,7 @@ https://github.com/elastic/beats/compare/v6.6.0...6.x[Check the HEAD diff]
 
 - Fix issue with process monitor associating traffic to the wrong process. {issue}9151[9151] {pull}9443[9443]
 - Fix DHCPv4 dashboard that wouldn't load in Kibana. {issue}9850[9850]
+- Fixed a crash when using af_packet capture {pull}10477[10477]
 
 *Winlogbeat*
 

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -2648,7 +2648,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------
 Dependency: github.com/tsg/gopacket
-Revision: f289b3ea3e41a01b2822be9caf5f40c01fdda05c
+Revision: 7c5392a5f2b5c5fa393c71e1f9064e22b5408995
 License type (autodetected): BSD-3-Clause
 ./vendor/github.com/tsg/gopacket/LICENSE:
 --------------------------------------------------------------------

--- a/vendor/github.com/tsg/gopacket/afpacket/afpacket.go
+++ b/vendor/github.com/tsg/gopacket/afpacket/afpacket.go
@@ -72,6 +72,8 @@ type TPacket struct {
 	pollset C.struct_pollfd
 	// shouldReleasePacket is set to true whenever we return packet data, to make sure we remember to release that data back to the kernel.
 	shouldReleasePacket bool
+	// headerNextNeeded is set to true when header need to move to the next packet. No need to move it case of poll error.
+	headerNextNeeded bool
 	// stats is simple statistics on TPacket's run.
 	stats Stats
 	// tpVersion is the version of TPacket actually in use, set by setRequestedTPacketVersion.
@@ -217,7 +219,7 @@ func (h *TPacket) releaseCurrentPacket() error {
 // TPacket.  Each call to ZeroCopyReadPacketData invalidates any data previously
 // returned by ZeroCopyReadPacketData.  Care must be taken not to keep pointers
 // to old bytes when using ZeroCopyReadPacketData... if you need to keep data past
-// the next time you call ZeroCopyReadPacketData, use ReadPacketDataData, which copies
+// the next time you call ZeroCopyReadPacketData, use ReadPacketData, which copies
 // the bytes into a new buffer for you.
 //  tp, _ := NewTPacket(...)
 //  data1, _, _ := tp.ZeroCopyReadPacketData()
@@ -225,12 +227,13 @@ func (h *TPacket) releaseCurrentPacket() error {
 //  data2, _, _ := tp.ZeroCopyReadPacketData()  // invalidates bytes in data1
 func (h *TPacket) ZeroCopyReadPacketData() (data []byte, ci gopacket.CaptureInfo, err error) {
 	h.mu.Lock()
-	if h.current == nil || !h.current.next() {
+	if h.current == nil || !h.headerNextNeeded || !h.current.next() {
 		if h.shouldReleasePacket {
 			h.releaseCurrentPacket()
 		}
 		h.current = h.getTPacketHeader()
 		if err = h.pollForFirstPacket(h.current); err != nil {
+			h.headerNextNeeded = false
 			h.mu.Unlock()
 			return
 		}
@@ -240,6 +243,7 @@ func (h *TPacket) ZeroCopyReadPacketData() (data []byte, ci gopacket.CaptureInfo
 	ci.CaptureLength = len(data)
 	ci.Length = h.current.getLength()
 	h.stats.Packets++
+	h.headerNextNeeded = true
 	h.mu.Unlock()
 	return
 }
@@ -324,6 +328,7 @@ func (h *TPacket) pollForFirstPacket(hdr header) error {
 			return err
 		}
 	}
+
 	h.shouldReleasePacket = true
 	return nil
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1859,32 +1859,32 @@
 		{
 			"checksumSHA1": "M0S9278lG9Fztu+ZUsLUi40GDJU=",
 			"path": "github.com/tsg/gopacket",
-			"revision": "f289b3ea3e41a01b2822be9caf5f40c01fdda05c",
-			"revisionTime": "2018-03-16T21:03:30Z"
+			"revision": "7c5392a5f2b5c5fa393c71e1f9064e22b5408995",
+			"revisionTime": "2019-01-31T17:02:46Z"
 		},
 		{
-			"checksumSHA1": "STY8i3sZLdZfFcKiyOdpV852nls=",
+			"checksumSHA1": "OQEk9avpNRDRyZVvYy08R+PEuFA=",
 			"path": "github.com/tsg/gopacket/afpacket",
-			"revision": "8e703b9968693c15f25cabb6ba8be4370cf431d0",
-			"revisionTime": "2016-08-17T18:24:57Z"
+			"revision": "7c5392a5f2b5c5fa393c71e1f9064e22b5408995",
+			"revisionTime": "2019-01-31T17:02:46Z"
 		},
 		{
-			"checksumSHA1": "+NwKULkolGgMn67wFYf+n0wz+a8=",
+			"checksumSHA1": "hXo0d2jF8bqVFHq37TfqpKvRO5M=",
 			"path": "github.com/tsg/gopacket/layers",
-			"revision": "8e703b9968693c15f25cabb6ba8be4370cf431d0",
-			"revisionTime": "2016-08-17T18:24:57Z"
+			"revision": "7c5392a5f2b5c5fa393c71e1f9064e22b5408995",
+			"revisionTime": "2019-01-31T17:02:46Z"
 		},
 		{
-			"checksumSHA1": "pDfiWUxZQdXap4CR6ASDvblChLU=",
+			"checksumSHA1": "C1AMG/E1pIW6kHrxi4+iNm1Fa9Y=",
 			"path": "github.com/tsg/gopacket/pcap",
-			"revision": "8e703b9968693c15f25cabb6ba8be4370cf431d0",
-			"revisionTime": "2016-08-17T18:24:57Z"
+			"revision": "7c5392a5f2b5c5fa393c71e1f9064e22b5408995",
+			"revisionTime": "2019-01-31T17:02:46Z"
 		},
 		{
 			"checksumSHA1": "nGCIgH3ohqLru6ivQSSiY6YWEow=",
 			"path": "github.com/tsg/gopacket/pfring",
-			"revision": "8e703b9968693c15f25cabb6ba8be4370cf431d0",
-			"revisionTime": "2016-08-17T18:24:57Z"
+			"revision": "7c5392a5f2b5c5fa393c71e1f9064e22b5408995",
+			"revisionTime": "2019-01-31T17:02:46Z"
 		},
 		{
 			"checksumSHA1": "H7tCgNt2ajKK4FBJIDNlevu9MAc=",


### PR DESCRIPTION
Cherry-pick of PR #10477 to 6.x branch. Original message: 

This fixes a Packetbeat crash under Linux when TPACKET_V3 af_packet interface is used.