### PR TITLE
[Auditbeat] Cherry-pick #10508 to 6.x: System module: Detect package updates

### DIFF
--- a/x-pack/auditbeat/tests/system/test_metricsets.py
+++ b/x-pack/auditbeat/tests/system/test_metricsets.py
@@ -48,7 +48,7 @@ class Test(AuditbeatXPackTest):
         package metricset collects information about installed packages on a system.
         """
 
-        fields = ["system.audit.package.name", "system.audit.package.version", "system.audit.package.installtime"]
+        fields = ["system.audit.package.name", "system.audit.package.version"]
 
         # Metricset is experimental and that generates a warning, TODO: remove later
         self.check_metricset("system", "package", COMMON_FIELDS + fields, warnings_allowed=True)


### PR DESCRIPTION
Cherry-pick of PR #10508 to 6.x branch. Original message: 

Detects package updates by checking if any of the "new" package objects have the same package name as one of the "old" package objects. The event will have `event.action: package_updated`.

Also fixes two issues:

1. Removes `InstallTime` from change detection. It is not set for dpkg, and for Homebrew it is currently the modification time of the package's directory. A `touch` will cause it to be reported as changed. I'm actually wondering if we should not set it for Homebrew at all. For change detection, we now rely on `name`, `version`, `release` (only set for RPM), and `size` - all of which (hopefully) only change when the package has indeed changed.
2. For dpkg, reports packages as removed that have only been removed (`apt-get remove`) but not purged (`apt-get purge`). Removed package stay around in `/var/lib/dpkg/status`, but with a `deinstall` status.

As an urgent follow-up, we should add tests with sample files for at least:

- `/var/lib/dpkg/status` in various stages (no package, installed package, new version, deinstalled package). I wanted to add it here, but we'll need a way to pass the test files to the metricset, and at the moment there is no config value for it (but there probably should be). I didn't want to do that bigger change here.
- `/usr/local/Cellar/{pkg.Name}/INSTALL_RECEIPT.json` (read since https://github.com/elastic/beats/pull/10507), and a Ruby formula file. 