### PR TITLE
Fix list formatting in redis key metricset

### DIFF
--- a/metricbeat/module/redis/key/_meta/docs.asciidoc
+++ b/metricbeat/module/redis/key/_meta/docs.asciidoc
@@ -5,6 +5,7 @@ Elasticsearch with information about this key, what includes the type, its
 length when available, and its ttl.
 
 Patterns are configured as a list containing these fields:
+
 * `pattern` (required): pattern for key names, as accepted by the Redis
   `KEYS` or `SCAN` commands.
 * `limit` (optional): safeguard when using patterns with wildcards to avoid


### PR DESCRIPTION
Without an space before the list this is not formatted like that.