### PR TITLE
Cherry-pick #10579 to 6.x: Fix missing CHANGELOG for #10006

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -174,6 +174,7 @@ https://github.com/elastic/beats/compare/v6.6.0...6.x[Check the HEAD diff]
 - Teach elasticsearch/audit fileset to parse out some more fields. {issue}10134[10134] {pull}10137[10137]
 - Added support for ingesting structured Elasticsearch audit logs {pull}8852[8852]
 - New iptables module that receives iptables/ip6tables logs over syslog or file. Supports Ubiquiti Firewall extensions. {issue}8781[8781] {pull}10176[10176]
+- Populate more ECS fields in the Suricata module. {pull}10006[10006]
 
 *Heartbeat*
 - Made monitors.d configuration part of the default config. {pull}9004[9004]


### PR DESCRIPTION
Cherry-pick of PR #10579 to 6.x branch. Original message: 

Previous PR (#10565) put this entry in the wrong section.
It's an added feature, not a breaking change.