### PR TITLE
Change travis.yml to use TRAVIS_GO_VERSION

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,7 @@ env:
     # Cross-compile for amd64 only to speed up testing.
     - GOX_FLAGS="-arch amd64"
     - DOCKER_COMPOSE_VERSION=1.21.0
-    - GO_VERSION=$(cat .go-version)
-    - GIMME_GO_VERSION=$(cat .go-version)
+    - TRAVIS_GO_VERSION=$(cat .go-version)
     # Newer versions of minikube fail on travis, see: https://github.com/kubernetes/minikube/issues/2704
     - TRAVIS_MINIKUBE_VERSION=v0.25.2
 
@@ -23,17 +22,17 @@ jobs:
     # General checks
     - os: linux
       env: TARGETS="check"
-      go: 1.11.5
+      go: $TRAVIS_GO_VERSION
       stage: check
 
     # Filebeat
     - os: linux
       env: TARGETS="-C filebeat testsuite"
-      go: $GIMME_GO_VERSION
+      go: $TRAVIS_GO_VERSION
       stage: test
     - os: osx
       env: TARGETS="TEST_ENVIRONMENT=0 -C filebeat testsuite"
-      go: $GO_VERSION
+      go: $TRAVIS_GO_VERSION
       stage: test
     - os: linux
       env: TARGETS="-C x-pack/filebeat testsuite"
@@ -43,109 +42,109 @@ jobs:
     # Heartbeat
     - os: linux
       env: TARGETS="-C heartbeat testsuite"
-      go: $GO_VERSION
+      go: $TRAVIS_GO_VERSION
       stage: test
     - os: osx
       env: TARGETS="TEST_ENVIRONMENT=0 -C heartbeat testsuite"
-      go: $GO_VERSION
+      go: $TRAVIS_GO_VERSION
       stage: test
 
     # Auditbeat
     - os: linux
       env: TARGETS="-C auditbeat testsuite"
-      go: $GO_VERSION
+      go: $TRAVIS_GO_VERSION
       stage: test
     - os: osx
       env: TARGETS="TEST_ENVIRONMENT=0 -C auditbeat testsuite"
-      go: $GO_VERSION
+      go: $TRAVIS_GO_VERSION
       stage: test
     - os: linux
       env: TARGETS="-C auditbeat crosscompile"
-      go: $GO_VERSION
+      go: $TRAVIS_GO_VERSION
       stage: test
     - os: linux
       env: TARGETS="-C x-pack/auditbeat testsuite"
-      go: $GO_VERSION
+      go: $TRAVIS_GO_VERSION
       stage: test
 
     # Libbeat
     - os: linux
       env: TARGETS="-C libbeat testsuite"
-      go: $GO_VERSION
+      go: $TRAVIS_GO_VERSION
       stage: test
     - os: linux
       env: TARGETS="-C libbeat crosscompile"
-      go: $GO_VERSION
+      go: $TRAVIS_GO_VERSION
       stage: test
     - os: linux
       env: STRESS_TEST_OPTIONS="-timeout=20m -race -v -parallel 1" TARGETS="-C libbeat stress-tests"
-      go: $GO_VERSION
+      go: $TRAVIS_GO_VERSION
       stage: test
     - os: linux
       env: TARGETS="-C x-pack/libbeat testsuite"
-      go: $GO_VERSION
+      go: $TRAVIS_GO_VERSION
       stage: test
 
     # Metricbeat
     - os: linux
       env: TARGETS="-C metricbeat testsuite"
-      go: $GO_VERSION
+      go: $TRAVIS_GO_VERSION
       stage: test
     - os: osx
       env: TARGETS="TEST_ENVIRONMENT=0 -C metricbeat testsuite"
-      go: $GO_VERSION
+      go: $TRAVIS_GO_VERSION
       stage: test
     - os: linux
       env: TARGETS="-C metricbeat crosscompile"
-      go: $GO_VERSION
+      go: $TRAVIS_GO_VERSION
       stage: test
     - os: linux
       env: TARGETS="-C x-pack/metricbeat testsuite"
-      go: $GO_VERSION
+      go: $TRAVIS_GO_VERSION
       stage: test
 
     # Packetbeat
     - os: linux
       env: TARGETS="-C packetbeat testsuite"
-      go: $GO_VERSION
+      go: $TRAVIS_GO_VERSION
       stage: test
 
     # Winlogbeat
     - os: linux
       env: TARGETS="-C winlogbeat crosscompile"
-      go: $GO_VERSION
+      go: $TRAVIS_GO_VERSION
       stage: test
 
     # Functionbeat
     - os: linux
       env: TARGETS="-C x-pack/functionbeat testsuite"
-      go: $GO_VERSION
+      go: $TRAVIS_GO_VERSION
       stage: test
     - os: osx
       env: TARGETS="TEST_ENVIRONMENT=0 -C x-pack/functionbeat testsuite"
-      go: $GO_VERSION
+      go: $TRAVIS_GO_VERSION
       stage: test
 
     # Journalbeat
     - os: linux
       env: TARGETS="-C journalbeat testsuite"
-      go: $GO_VERSION
+      go: $TRAVIS_GO_VERSION
       stage: test
 
     # Generators
     - os: linux
       env: TARGETS="-C generator/metricbeat test"
-      go: $GO_VERSION
+      go: $TRAVIS_GO_VERSION
       stage: test
     - os: linux
       env: TARGETS="-C generator/beat test"
-      go: $GO_VERSION
+      go: $TRAVIS_GO_VERSION
       stage: test
 
     # Docs
     - os: linux
       env: TARGETS="docs"
-      go: $GO_VERSION
+      go: $TRAVIS_GO_VERSION
       stage: test
 
     # Kubernetes

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
     # Cross-compile for amd64 only to speed up testing.
     - GOX_FLAGS="-arch amd64"
     - DOCKER_COMPOSE_VERSION=1.21.0
-    - GO_VERSION="$(cat .go-version)"
+    - GO_VERSION=$(cat .go-version)
     # Newer versions of minikube fail on travis, see: https://github.com/kubernetes/minikube/issues/2704
     - TRAVIS_MINIKUBE_VERSION=v0.25.2
 
@@ -22,7 +22,7 @@ jobs:
     # General checks
     - os: linux
       env: TARGETS="check"
-      go: $GO_VERSION
+      go: ${GO_VERSION}
       stage: check
 
     # Filebeat

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
     # Cross-compile for amd64 only to speed up testing.
     - GOX_FLAGS="-arch amd64"
     - DOCKER_COMPOSE_VERSION=1.21.0
-    - GO_VERSION="1.11.5"
+    - GO_VERSION="$(cat .go-version)"
     # Newer versions of minikube fail on travis, see: https://github.com/kubernetes/minikube/issues/2704
     - TRAVIS_MINIKUBE_VERSION=v0.25.2
 
@@ -22,129 +22,129 @@ jobs:
     # General checks
     - os: linux
       env: TARGETS="check"
-      go: 1.11.5
+      go: $GO_VERSION
       stage: check
 
     # Filebeat
     - os: linux
       env: TARGETS="-C filebeat testsuite"
-      go: 1.11.5
+      go: $GO_VERSION
       stage: test
     - os: osx
       env: TARGETS="TEST_ENVIRONMENT=0 -C filebeat testsuite"
-      go: 1.11.5
+      go: $GO_VERSION
       stage: test
     - os: linux
       env: TARGETS="-C x-pack/filebeat testsuite"
-      go: 1.11.5
+      go: $GO_VERSION
       stage: test
 
     # Heartbeat
     - os: linux
       env: TARGETS="-C heartbeat testsuite"
-      go: 1.11.5
+      go: $GO_VERSION
       stage: test
     - os: osx
       env: TARGETS="TEST_ENVIRONMENT=0 -C heartbeat testsuite"
-      go: 1.11.5
+      go: $GO_VERSION
       stage: test
 
     # Auditbeat
     - os: linux
       env: TARGETS="-C auditbeat testsuite"
-      go: 1.11.5
+      go: $GO_VERSION
       stage: test
     - os: osx
       env: TARGETS="TEST_ENVIRONMENT=0 -C auditbeat testsuite"
-      go: 1.11.5
+      go: $GO_VERSION
       stage: test
     - os: linux
       env: TARGETS="-C auditbeat crosscompile"
-      go: 1.11.5
+      go: $GO_VERSION
       stage: test
     - os: linux
       env: TARGETS="-C x-pack/auditbeat testsuite"
-      go: 1.11.5
+      go: $GO_VERSION
       stage: test
 
     # Libbeat
     - os: linux
       env: TARGETS="-C libbeat testsuite"
-      go: 1.11.5
+      go: $GO_VERSION
       stage: test
     - os: linux
       env: TARGETS="-C libbeat crosscompile"
-      go: 1.11.5
+      go: $GO_VERSION
       stage: test
     - os: linux
       env: STRESS_TEST_OPTIONS="-timeout=20m -race -v -parallel 1" TARGETS="-C libbeat stress-tests"
-      go: 1.11.5
+      go: $GO_VERSION
       stage: test
     - os: linux
       env: TARGETS="-C x-pack/libbeat testsuite"
-      go: 1.11.5
+      go: $GO_VERSION
       stage: test
 
     # Metricbeat
     - os: linux
       env: TARGETS="-C metricbeat testsuite"
-      go: 1.11.5
+      go: $GO_VERSION
       stage: test
     - os: osx
       env: TARGETS="TEST_ENVIRONMENT=0 -C metricbeat testsuite"
-      go: 1.11.5
+      go: $GO_VERSION
       stage: test
     - os: linux
       env: TARGETS="-C metricbeat crosscompile"
-      go: 1.11.5
+      go: $GO_VERSION
       stage: test
     - os: linux
       env: TARGETS="-C x-pack/metricbeat testsuite"
-      go: 1.11.5
+      go: $GO_VERSION
       stage: test
 
     # Packetbeat
     - os: linux
       env: TARGETS="-C packetbeat testsuite"
-      go: 1.11.5
+      go: $GO_VERSION
       stage: test
 
     # Winlogbeat
     - os: linux
       env: TARGETS="-C winlogbeat crosscompile"
-      go: 1.11.5
+      go: $GO_VERSION
       stage: test
 
     # Functionbeat
     - os: linux
       env: TARGETS="-C x-pack/functionbeat testsuite"
-      go: 1.11.5
+      go: $GO_VERSION
       stage: test
     - os: osx
       env: TARGETS="TEST_ENVIRONMENT=0 -C x-pack/functionbeat testsuite"
-      go: 1.11.5
+      go: $GO_VERSION
       stage: test
 
     # Journalbeat
     - os: linux
       env: TARGETS="-C journalbeat testsuite"
-      go: 1.11.5
+      go: $GO_VERSION
       stage: test
 
     # Generators
     - os: linux
       env: TARGETS="-C generator/metricbeat test"
-      go: 1.11.5
+      go: $GO_VERSION
       stage: test
     - os: linux
       env: TARGETS="-C generator/beat test"
-      go: 1.11.5
+      go: $GO_VERSION
       stage: test
 
     # Docs
     - os: linux
       env: TARGETS="docs"
-      go: 1.11.5
+      go: $GO_VERSION
       stage: test
 
     # Kubernetes

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
     - GOX_FLAGS="-arch amd64"
     - DOCKER_COMPOSE_VERSION=1.21.0
     - GO_VERSION=$(cat .go-version)
+    - GIMME_GO_VERSION=$(cat .go-version)
     # Newer versions of minikube fail on travis, see: https://github.com/kubernetes/minikube/issues/2704
     - TRAVIS_MINIKUBE_VERSION=v0.25.2
 
@@ -22,13 +23,13 @@ jobs:
     # General checks
     - os: linux
       env: TARGETS="check"
-      go: ${GO_VERSION}
+      go: 1.11.5
       stage: check
 
     # Filebeat
     - os: linux
       env: TARGETS="-C filebeat testsuite"
-      go: $GO_VERSION
+      go: $GIMME_GO_VERSION
       stage: test
     - os: osx
       env: TARGETS="TEST_ENVIRONMENT=0 -C filebeat testsuite"
@@ -36,7 +37,7 @@ jobs:
       stage: test
     - os: linux
       env: TARGETS="-C x-pack/filebeat testsuite"
-      go: $GO_VERSION
+      go: $(GO_VERSION)
       stage: test
 
     # Heartbeat


### PR DESCRIPTION
This change is based on https://travis-ci.community/t/go-version-as-environment-variable-stopped-working/2171