### PR TITLE
Cherry-pick #10486 to 6.6: Migrate registry from previous incorrect path

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -75,6 +75,8 @@ https://github.com/elastic/beats/compare/1035569addc4a3b29ffa14f8a08c27c1ace16ef
 
 *Journalbeat*
 
+- Migrate registry from previously incorrect path. {pull}10486[10486]
+
 *Metricbeat*
 
 *Packetbeat*


### PR DESCRIPTION
Cherry-pick of PR #10486 to 6.6 branch. Original message: 

In 6.x Journalbeat placed its registry file under the wrong path ignoring the data.path settings.
This patch lets users migrate from registries under such paths when upgrading from 6.x to 7.x.