### PR TITLE
Fix RabbitMQ dashboard

### DIFF
--- a/metricbeat/module/rabbitmq/_meta/kibana/7/dashboard/Metricbeat-rabbitmq-overview.json
+++ b/metricbeat/module/rabbitmq/_meta/kibana/7/dashboard/Metricbeat-rabbitmq-overview.json
@@ -8,7 +8,7 @@
                         "filter": []
                     }
                 }, 
-                "savedSearchId": "Metricbeat-Rabbitmq-ecs ECS", 
+                "savedSearchId": "Metricbeat-Rabbitmq-ecs",
                 "title": "Memory Usage [Metricbeat RabbitMQ] ECS", 
                 "uiStateJSON": {}, 
                 "version": 1, 
@@ -86,7 +86,7 @@
                         "filter": []
                     }
                 }, 
-                "savedSearchId": "Metricbeat-Rabbitmq-ecs ECS", 
+                "savedSearchId": "Metricbeat-Rabbitmq-ecs", 
                 "title": "Number of Nodes [Metricbeat RabbitMQ] ECS", 
                 "uiStateJSON": {}, 
                 "version": 1, 
@@ -124,7 +124,7 @@
                         "filter": []
                     }
                 }, 
-                "savedSearchId": "Metricbeat-Rabbitmq-ecs ECS", 
+                "savedSearchId": "Metricbeat-Rabbitmq-ecs", 
                 "title": "Erlang Process Usage [Metricbeat RabbitMQ] ECS", 
                 "uiStateJSON": {}, 
                 "version": 1, 
@@ -201,7 +201,7 @@
                         "filter": []
                     }
                 }, 
-                "savedSearchId": "Metricbeat-Rabbitmq-ecs ECS", 
+                "savedSearchId": "Metricbeat-Rabbitmq-ecs", 
                 "title": "Queue Index Operations [Metricbeat RabbitMQ] ECS", 
                 "uiStateJSON": {}, 
                 "version": 1, 
@@ -370,10 +370,10 @@
                     "@timestamp", 
                     "desc"
                 ], 
-                "title": "Metricbeat-Rabbitmq-ecs ECS", 
+                "title": "Metricbeat Rabbitmq ECS",
                 "version": 1
             }, 
-            "id": "Metricbeat-Rabbitmq-ecs ECS", 
+            "id": "Metricbeat-Rabbitmq-ecs", 
             "type": "search", 
             "version": 1
         }, 

--- a/metricbeat/module/rabbitmq/_meta/kibana/7/dashboard/Metricbeat-rabbitmq-overview.json
+++ b/metricbeat/module/rabbitmq/_meta/kibana/7/dashboard/Metricbeat-rabbitmq-overview.json
@@ -8,8 +8,8 @@
                         "filter": []
                     }
                 }, 
-                "savedSearchId": "Metricbeat-Rabbitmq", 
-                "title": "Memory Usage [Metricbeat RabbitMQ]", 
+                "savedSearchId": "Metricbeat-Rabbitmq-ecs", 
+                "title": "Memory Usage [Metricbeat RabbitMQ] ECS", 
                 "uiStateJSON": {}, 
                 "version": 1, 
                 "visState": {
@@ -70,11 +70,11 @@
                         "times": [], 
                         "yAxis": {}
                     }, 
-                    "title": "RabbitMQ Memory Usage", 
+                    "title": "RabbitMQ Memory Usage ECS", 
                     "type": "line"
                 }
             }, 
-            "id": "RabbitMQ-Memory-Usage", 
+            "id": "RabbitMQ-Memory-Usage-ecs", 
             "type": "visualization", 
             "version": 2
         }, 
@@ -86,8 +86,8 @@
                         "filter": []
                     }
                 }, 
-                "savedSearchId": "Metricbeat-Rabbitmq", 
-                "title": "Number of Nodes [Metricbeat RabbitMQ]", 
+                "savedSearchId": "Metricbeat-Rabbitmq-ecs", 
+                "title": "Number of Nodes [Metricbeat RabbitMQ] ECS", 
                 "uiStateJSON": {}, 
                 "version": 1, 
                 "visState": {
@@ -108,11 +108,11 @@
                         "fontSize": 60, 
                         "handleNoResults": true
                     }, 
-                    "title": "Rabbitmq Number of Nodes",
+                    "title": "Rabbitmq Number of Nodes ECS",
                     "type": "metric"
                 }
             }, 
-            "id": "Rabbitmq-Number-of-Nodes", 
+            "id": "Rabbitmq-Number-of-Nodes-ecs", 
             "type": "visualization", 
             "version": 2
         }, 
@@ -124,8 +124,8 @@
                         "filter": []
                     }
                 }, 
-                "savedSearchId": "Metricbeat-Rabbitmq", 
-                "title": "Erlang Process Usage [Metricbeat RabbitMQ]", 
+                "savedSearchId": "Metricbeat-Rabbitmq-ecs", 
+                "title": "Erlang Process Usage [Metricbeat RabbitMQ] ECS", 
                 "uiStateJSON": {}, 
                 "version": 1, 
                 "visState": {
@@ -185,11 +185,11 @@
                         "times": [], 
                         "yAxis": {}
                     }, 
-                    "title": "RabbitMQ Erlang Process Usage", 
+                    "title": "RabbitMQ Erlang Process Usage ECS", 
                     "type": "line"
                 }
             }, 
-            "id": "RabbitMQ-Erlang-Process-Usage", 
+            "id": "RabbitMQ-Erlang-Process-Usage-ecs", 
             "type": "visualization", 
             "version": 2
         }, 
@@ -201,8 +201,8 @@
                         "filter": []
                     }
                 }, 
-                "savedSearchId": "Metricbeat-Rabbitmq", 
-                "title": "Queue Index Operations [Metricbeat RabbitMQ]", 
+                "savedSearchId": "Metricbeat-Rabbitmq-ecs", 
+                "title": "Queue Index Operations [Metricbeat RabbitMQ] ECS", 
                 "uiStateJSON": {}, 
                 "version": 1, 
                 "visState": {
@@ -329,11 +329,11 @@
                         ], 
                         "yAxis": {}
                     }, 
-                    "title": "Queue Index Operations [Metricbeat RabbitMQ]", 
+                    "title": "Queue Index Operations [Metricbeat RabbitMQ] ECS", 
                     "type": "line"
                 }
             }, 
-            "id": "RabbitMQ-Queue-Index-Operations", 
+            "id": "RabbitMQ-Queue-Index-Operations-ecs", 
             "type": "visualization", 
             "version": 2
         }, 
@@ -361,7 +361,7 @@
                         "query": {
                             "query_string": {
                                 "analyze_wildcard": true, 
-                                "query": "metricset.module:rabbitmq"
+                                "query": "event.module:rabbitmq"
                             }
                         }
                     }
@@ -370,10 +370,10 @@
                     "@timestamp", 
                     "desc"
                 ], 
-                "title": "Metricbeat Rabbitmq",
+                "title": "Metricbeat Rabbitmq ECS",
                 "version": 1
             }, 
-            "id": "Metricbeat-Rabbitmq", 
+            "id": "Metricbeat-Rabbitmq-ecs", 
             "type": "search", 
             "version": 1
         }, 
@@ -403,7 +403,7 @@
                 "panelsJSON": [
                     {
                         "col": 1, 
-                        "id": "RabbitMQ-Memory-Usage", 
+                        "id": "RabbitMQ-Memory-Usage-ecs", 
                         "panelIndex": 8, 
                         "row": 1, 
                         "size_x": 6, 
@@ -412,7 +412,7 @@
                     }, 
                     {
                         "col": 8, 
-                        "id": "Rabbitmq-Number-of-Nodes", 
+                        "id": "Rabbitmq-Number-of-Nodes-ecs", 
                         "panelIndex": 2, 
                         "row": 1, 
                         "size_x": 3, 
@@ -421,7 +421,7 @@
                     }, 
                     {
                         "col": 1, 
-                        "id": "RabbitMQ-Erlang-Process-Usage", 
+                        "id": "RabbitMQ-Erlang-Process-Usage-ecs", 
                         "panelIndex": 10, 
                         "row": 4, 
                         "size_x": 6, 
@@ -430,7 +430,7 @@
                     }, 
                     {
                         "col": 7, 
-                        "id": "RabbitMQ-Queue-Index-Operations", 
+                        "id": "RabbitMQ-Queue-Index-Operations-ecs", 
                         "panelIndex": 9, 
                         "row": 4, 
                         "size_x": 6, 
@@ -439,7 +439,7 @@
                     }
                 ], 
                 "timeRestore": false, 
-                "title": "[Metricbeat RabbitMQ] Overview", 
+                "title": "[Metricbeat RabbitMQ] Overview ECS", 
                 "uiStateJSON": {
                     "P-2": {
                         "vis": {
@@ -451,7 +451,7 @@
                 }, 
                 "version": 1
             }, 
-            "id": "AV4YobKIge1VCbKU_qVo", 
+            "id": "AV4YobKIge1VCbKU_qVo-ecs", 
             "type": "dashboard", 
             "version": 2
         }

--- a/metricbeat/module/rabbitmq/_meta/kibana/7/dashboard/Metricbeat-rabbitmq-overview.json
+++ b/metricbeat/module/rabbitmq/_meta/kibana/7/dashboard/Metricbeat-rabbitmq-overview.json
@@ -8,8 +8,8 @@
                         "filter": []
                     }
                 }, 
-                "savedSearchId": "Metricbeat-Rabbitmq-ecs",
-                "title": "Memory Usage [Metricbeat RabbitMQ] ECS", 
+                "savedSearchId": "Metricbeat-Rabbitmq", 
+                "title": "Memory Usage [Metricbeat RabbitMQ]", 
                 "uiStateJSON": {}, 
                 "version": 1, 
                 "visState": {
@@ -70,11 +70,11 @@
                         "times": [], 
                         "yAxis": {}
                     }, 
-                    "title": "RabbitMQ Memory Usage ECS", 
+                    "title": "RabbitMQ Memory Usage", 
                     "type": "line"
                 }
             }, 
-            "id": "RabbitMQ-Memory-Usage-ecs", 
+            "id": "RabbitMQ-Memory-Usage", 
             "type": "visualization", 
             "version": 2
         }, 
@@ -86,8 +86,8 @@
                         "filter": []
                     }
                 }, 
-                "savedSearchId": "Metricbeat-Rabbitmq-ecs", 
-                "title": "Number of Nodes [Metricbeat RabbitMQ] ECS", 
+                "savedSearchId": "Metricbeat-Rabbitmq", 
+                "title": "Number of Nodes [Metricbeat RabbitMQ]", 
                 "uiStateJSON": {}, 
                 "version": 1, 
                 "visState": {
@@ -108,11 +108,11 @@
                         "fontSize": 60, 
                         "handleNoResults": true
                     }, 
-                    "title": "Rabbitmq-Number-of-Nodes-ecs ECS", 
+                    "title": "Rabbitmq Number of Nodes",
                     "type": "metric"
                 }
             }, 
-            "id": "Rabbitmq-Number-of-Nodes-ecs ECS", 
+            "id": "Rabbitmq-Number-of-Nodes", 
             "type": "visualization", 
             "version": 2
         }, 
@@ -124,8 +124,8 @@
                         "filter": []
                     }
                 }, 
-                "savedSearchId": "Metricbeat-Rabbitmq-ecs", 
-                "title": "Erlang Process Usage [Metricbeat RabbitMQ] ECS", 
+                "savedSearchId": "Metricbeat-Rabbitmq", 
+                "title": "Erlang Process Usage [Metricbeat RabbitMQ]", 
                 "uiStateJSON": {}, 
                 "version": 1, 
                 "visState": {
@@ -185,11 +185,11 @@
                         "times": [], 
                         "yAxis": {}
                     }, 
-                    "title": "RabbitMQ Erlang Process Usage ECS", 
+                    "title": "RabbitMQ Erlang Process Usage", 
                     "type": "line"
                 }
             }, 
-            "id": "RabbitMQ-Erlang-Process-Usage-ecs", 
+            "id": "RabbitMQ-Erlang-Process-Usage", 
             "type": "visualization", 
             "version": 2
         }, 
@@ -201,8 +201,8 @@
                         "filter": []
                     }
                 }, 
-                "savedSearchId": "Metricbeat-Rabbitmq-ecs", 
-                "title": "Queue Index Operations [Metricbeat RabbitMQ] ECS", 
+                "savedSearchId": "Metricbeat-Rabbitmq", 
+                "title": "Queue Index Operations [Metricbeat RabbitMQ]", 
                 "uiStateJSON": {}, 
                 "version": 1, 
                 "visState": {
@@ -329,11 +329,11 @@
                         ], 
                         "yAxis": {}
                     }, 
-                    "title": "Queue Index Operations [Metricbeat RabbitMQ] ECS", 
+                    "title": "Queue Index Operations [Metricbeat RabbitMQ]", 
                     "type": "line"
                 }
             }, 
-            "id": "RabbitMQ-Queue-Index-Operations-ecs", 
+            "id": "RabbitMQ-Queue-Index-Operations", 
             "type": "visualization", 
             "version": 2
         }, 
@@ -361,7 +361,7 @@
                         "query": {
                             "query_string": {
                                 "analyze_wildcard": true, 
-                                "query": "event.module:rabbitmq"
+                                "query": "metricset.module:rabbitmq"
                             }
                         }
                     }
@@ -370,10 +370,10 @@
                     "@timestamp", 
                     "desc"
                 ], 
-                "title": "Metricbeat Rabbitmq ECS",
+                "title": "Metricbeat Rabbitmq",
                 "version": 1
             }, 
-            "id": "Metricbeat-Rabbitmq-ecs", 
+            "id": "Metricbeat-Rabbitmq", 
             "type": "search", 
             "version": 1
         }, 
@@ -403,7 +403,7 @@
                 "panelsJSON": [
                     {
                         "col": 1, 
-                        "id": "RabbitMQ-Memory-Usage-ecs", 
+                        "id": "RabbitMQ-Memory-Usage", 
                         "panelIndex": 8, 
                         "row": 1, 
                         "size_x": 6, 
@@ -412,7 +412,7 @@
                     }, 
                     {
                         "col": 8, 
-                        "id": "Rabbitmq-Number-of-Nodes-ecs ECS", 
+                        "id": "Rabbitmq-Number-of-Nodes", 
                         "panelIndex": 2, 
                         "row": 1, 
                         "size_x": 3, 
@@ -421,7 +421,7 @@
                     }, 
                     {
                         "col": 1, 
-                        "id": "RabbitMQ-Erlang-Process-Usage-ecs", 
+                        "id": "RabbitMQ-Erlang-Process-Usage", 
                         "panelIndex": 10, 
                         "row": 4, 
                         "size_x": 6, 
@@ -430,7 +430,7 @@
                     }, 
                     {
                         "col": 7, 
-                        "id": "RabbitMQ-Queue-Index-Operations-ecs", 
+                        "id": "RabbitMQ-Queue-Index-Operations", 
                         "panelIndex": 9, 
                         "row": 4, 
                         "size_x": 6, 
@@ -439,7 +439,7 @@
                     }
                 ], 
                 "timeRestore": false, 
-                "title": "[Metricbeat RabbitMQ] Overview ECS", 
+                "title": "[Metricbeat RabbitMQ] Overview", 
                 "uiStateJSON": {
                     "P-2": {
                         "vis": {
@@ -451,7 +451,7 @@
                 }, 
                 "version": 1
             }, 
-            "id": "AV4YobKIge1VCbKU_qVo-ecs", 
+            "id": "AV4YobKIge1VCbKU_qVo", 
             "type": "dashboard", 
             "version": 2
         }


### PR DESCRIPTION
During the migration to 7.0 the RabbitMQ dashboard broke. The reason is that one of the titles was identical to the id's and the migration script could not deal with this. This PR changes the title and reapply the migration on the dashboard which was reset.