### PR TITLE
Cherry-pick #10587 to 6.7: Fix an issue where ConfigBlocksEqual was returning false

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -71,6 +71,7 @@ https://github.com/elastic/beats/compare/v6.6.0...6.x[Check the HEAD diff]
 - Fix panic and file unlock in spool on atomic operation (arm, x86-32). File lock was not released when panic occurs, leading to the beat deadlocking on startup. {pull}10289[10289]
 - Adding logging traces at debug level when the pipeline client receives the following events: onFilteredOut, onDroppedOnPublish. {pull}9016[9016]
 - Do not panic when no tokenizer string is configured for a dissect processor. {issue}8895[8895]
+- Fix a issue when remote and local configuration didn't match when fetching configuration from Central Management. {issue}10587[10587]
 
 *Auditbeat*
 

--- a/x-pack/libbeat/management/api/configuration_test.go
+++ b/x-pack/libbeat/management/api/configuration_test.go
@@ -99,6 +99,34 @@ func TestConfigBlocksEqual(t *testing.T) {
 			equal: true,
 		},
 		{
+			name: "single element with slices",
+			a: ConfigBlocks{
+				ConfigBlocksWithType{
+					Type: "metricbeat.modules",
+					Blocks: []*ConfigBlock{
+						&ConfigBlock{
+							Raw: map[string]interface{}{
+								"foo": []string{"foo", "bar"},
+							},
+						},
+					},
+				},
+			},
+			b: ConfigBlocks{
+				ConfigBlocksWithType{
+					Type: "metricbeat.modules",
+					Blocks: []*ConfigBlock{
+						&ConfigBlock{
+							Raw: map[string]interface{}{
+								"foo": []string{"foo", "bar"},
+							},
+						},
+					},
+				},
+			},
+			equal: true,
+		},
+		{
 			name: "different number of blocks",
 			a: ConfigBlocks{
 				ConfigBlocksWithType{
@@ -137,7 +165,6 @@ func TestConfigBlocksEqual(t *testing.T) {
 				ConfigBlocksWithType{
 					Type: "metricbeat.modules",
 					Blocks: []*ConfigBlock{
-
 						&ConfigBlock{
 							Raw: map[string]interface{}{
 								"baz": "buzz",
@@ -150,7 +177,6 @@ func TestConfigBlocksEqual(t *testing.T) {
 				ConfigBlocksWithType{
 					Type: "metricbeat.modules",
 					Blocks: []*ConfigBlock{
-
 						&ConfigBlock{
 							Raw: map[string]interface{}{
 								"foo": "bar",
@@ -165,7 +191,11 @@ func TestConfigBlocksEqual(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			assert.Equal(t, test.equal, ConfigBlocksEqual(test.a, test.b))
+			check, err := ConfigBlocksEqual(test.a, test.b)
+			if !assert.NoError(t, err) {
+				return
+			}
+			assert.Equal(t, test.equal, check)
 		})
 	}
 }

--- a/x-pack/libbeat/management/manager.go
+++ b/x-pack/libbeat/management/manager.go
@@ -225,7 +225,13 @@ func (cm *ConfigManager) fetch() bool {
 		return false
 	}
 
-	if api.ConfigBlocksEqual(configs, cm.cache.Configs) {
+	equal, err := api.ConfigBlocksEqual(configs, cm.cache.Configs)
+	if err != nil {
+		cm.logger.Errorf("error comparing the configurations, will use cached ones: %s", err)
+		return false
+	}
+
+	if equal {
 		cm.logger.Debug("configuration didn't change, sleeping")
 		return false
 	}


### PR DESCRIPTION
Cherry-pick of PR #10587 to 6.7 branch. Original message: 

The ordering was not preserved when comparing the values for conflict
blocks which result in multiple reload on each fetch even if the
configuration didn't change.