### PR TITLE
Log events with logs in mysql 8 flaky tests

### DIFF
--- a/metricbeat/tests/system/test_mysql.py
+++ b/metricbeat/tests/system/test_mysql.py
@@ -34,7 +34,7 @@ class Test(metricbeat.BaseTest):
         self.assertEqual(len(output), 1)
         evt = output[0]
 
-        self.assertItemsEqual(self.de_dot(MYSQL_FIELDS), evt.keys())
+        self.assertItemsEqual(self.de_dot(MYSQL_FIELDS), evt.keys(), evt)
 
         status = evt["mysql"]["status"]
         assert status["connections"] > 0
@@ -46,7 +46,6 @@ class Test(metricbeat.BaseTest):
         return ['root:test@tcp({}:3306)/'.format(self.compose_hosts()[0])]
 
 
-@unittest.skip("Flaky test, see https://github.com/elastic/beats/issues/10608")
 class TestMysql80(Test):
     COMPOSE_SERVICES = ['mysql_8_0']
 
@@ -55,7 +54,6 @@ class TestPercona57(Test):
     COMPOSE_SERVICES = ['percona_5_7']
 
 
-@unittest.skip("Flaky test, see https://github.com/elastic/beats/issues/10608")
 class TestPercona80(Test):
     COMPOSE_SERVICES = ['percona_8_0']
 


### PR DESCRIPTION
I cannot reproduce #10608 locally or after many CI builds.
Make the assert log the event in case of failure so we have more
info when it happens.

Tests were skipped in #10609