### PR TITLE
Fix missing nodes from Node Listing page when using Metricbeat Elasticsearch module with xpack.enabled: true

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -201,6 +201,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fixed data type for isr field in `kafka/partition` metricset {pull}10307[10307]
 - Fixed data types for various hosts fields in `mongodb/replstatus` metricset {pull}10307[10307]
 - Added function to close sql database connection. {pull}10355[10355]
+- Fix issue with `elasticsearch/node_stats` metricset (x-pack) not indexing `source_node` field. {pull}10639[10639]
 
 *Packetbeat*
 


### PR DESCRIPTION
Starting Metricbeat 6.6.0, if a user uses the `elasticsearch` module for stack monitoring (by setting `xpack.enabled: true` in their `modules.d/elasticsearch.yml`), they will see no nodes in their Elasticsearch Node Listing page. 😮 

<img width="1676" alt="screen shot 2019-02-07 at 10 24 33 am" src="https://user-images.githubusercontent.com/51061/52433739-94cd1100-2ac2-11e9-9ce1-213ae4a13cee.png">

This is because the UI code relies on the `type=nodes_stats` documents in `.monitoring-es-*` to contain a `source_node` property with certain fields in it. The `elasticsearch/node_stats` metricset wasn't indexing this property.

This PR fixes this bug.