### PR TITLE
Fix log path format in logging example

### DIFF
--- a/libbeat/docs/loggingconfig.asciidoc
+++ b/libbeat/docs/loggingconfig.asciidoc
@@ -19,6 +19,7 @@ ifndef::serverless[]
 The logging system can write logs to the syslog or rotate log files. If logging
 is not explicitly configured the file output is used.
 
+ifndef::win_only[]
 ["source","yaml",subs="attributes"]
 ----
 logging.level: info
@@ -29,6 +30,20 @@ logging.files:
   keepfiles: 7
   permissions: 0644
 ----
+endif::win_only[]
+
+ifdef::win_only[]
+["source","yaml",subs="attributes"]
+----
+logging.level: info
+logging.to_files: true
+logging.files:
+  path: C:{backslash}ProgramData{backslash}{beatname_lc}{backslash}Logs
+  name: {beatname_lc}
+  keepfiles: 7
+  permissions: 0644
+----
+endif::win_only[]
 
 TIP: In addition to setting logging options in the config file, you can modify
 the logging output configuration from the command line. See

--- a/winlogbeat/docs/getting-started.asciidoc
+++ b/winlogbeat/docs/getting-started.asciidoc
@@ -74,7 +74,7 @@ output.elasticsearch:
 
 logging.to_files: true
 logging.files:
-  path: C:/ProgramData/winlogbeat/Logs
+  path: C:\ProgramData\winlogbeat\Logs
 logging.level: info
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #10646 

Doesn't seem to matter if you use forward or backslashes in the config file, but doing so is more intuitive for windows users, so I've changed that, too.