### PR TITLE
Add release tag to metricset templates

### DIFF
--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -33,3 +33,4 @@ The list below covers the major changes between 7.0.0-alpha2 and master only.
 - Introduce ILM and IndexManagment support to beat.Settings. {pull}10347[10347]
 - Introduce ILM and IndexManagement support to beat.Settings. {pull}10347[10347]
 - Generating index pattern on demand instead of shipping them in the packages. {pull}10478[10478]
+- Metricset generator generates beta modules by default now. {pull}10657[10657]

--- a/metricbeat/scripts/module/fields.yml
+++ b/metricbeat/scripts/module/fields.yml
@@ -1,8 +1,7 @@
 - key: {module}
   title: "{module}"
+  release: experimental
   description: >
-    experimental[]
-
     {module} module
   fields:
     - name: {module}

--- a/metricbeat/scripts/module/fields.yml
+++ b/metricbeat/scripts/module/fields.yml
@@ -1,6 +1,6 @@
 - key: {module}
   title: "{module}"
-  release: experimental
+  release: beta
   description: >
     {module} module
   fields:

--- a/metricbeat/scripts/module/metricset/metricset.go.tmpl
+++ b/metricbeat/scripts/module/metricset/metricset.go.tmpl
@@ -26,7 +26,7 @@ type MetricSet struct {
 // New creates a new instance of the MetricSet. New is responsible for unpacking
 // any MetricSet specific configuration options if there are any.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	cfgwarn.Experimental("The {module} {metricset} metricset is experimental.")
+	cfgwarn.Beta("The {module} {metricset} metricset is beta.")
 
 	config := struct{}{}
 	if err := base.Module().UnpackConfig(&config); err != nil {


### PR DESCRIPTION
We were having contributions of metricsets with the release level in
the description, the cause was that our generator scripts did it this
way.

Add release tag to metricset templates instead of using the description
field for this purpouse.

Make beta the release level for new modules by default. Experimental
should be kept just for real experiments or in some corner cases. The
usual level for a new metricset that collects metrics from a known
existing service or technology should be beta (or ga if it is really
complete).