### PR TITLE
Cherry-pick to 7.0: Remove filter in DescribeInstances (#10628)

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -133,6 +133,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Update a few kibana.* fields to map to ECS. {pull}10350[10350]
 - Update rabbitmq.* fields to map to ECS. {pull}10563[10563]
 - Update haproxy.* fields to map to ECS. {pull}10558[10558] {pull}10568[10568]
+- Collect all EC2 meta data from all instances in all states. {pull}10628[10628]
 
 *Packetbeat*
 

--- a/x-pack/metricbeat/module/aws/ec2/ec2.go
+++ b/x-pack/metricbeat/module/aws/ec2/ec2.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"time"
 
-	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/cloudwatchiface"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -232,15 +231,7 @@ func getInstancesPerRegion(svc ec2iface.EC2API) (instanceIDs []string, instances
 	init := true
 	for init || output.NextToken != nil {
 		init = false
-		describeInstanceInput := &ec2.DescribeInstancesInput{
-			Filters: []ec2.Filter{
-				{
-					Name:   awssdk.String("instance-state-name"),
-					Values: []string{"running"},
-				},
-			},
-		}
-
+		describeInstanceInput := &ec2.DescribeInstancesInput{}
 		req := svc.DescribeInstancesRequest(describeInstanceInput)
 		output, err := req.Send()
 		if err != nil {


### PR DESCRIPTION
Original commit message:
In ec2 metricset, there is `instance.state.name` and `instance.state.code`, DescribeInstances filter should be removed so instances that are in pending state and all the other states will be collected as well.

* Remove filter DescribeInstances

* Add changelog

(cherry picked from commit 5fb40dd92267f24963572616e1518414422137e9)