### PR TITLE
[Filebeat] Fix user_agent processor issue with 7.0

### DIFF
--- a/filebeat/module/apache2/access/ingest/default.json
+++ b/filebeat/module/apache2/access/ingest/default.json
@@ -1,56 +1,125 @@
 {
-  "description": "Pipeline for parsing Apache2 access logs. Requires the geoip and user_agent plugins.",
-  "processors": [{
-    "grok": {
-      "field": "message",
-      "patterns":[
-          "%{IPORHOST:apache2.access.remote_ip} - %{DATA:apache2.access.user_name} \\[%{HTTPDATE:apache2.access.time}\\] \"%{WORD:apache2.access.method} %{DATA:apache2.access.url} HTTP/%{NUMBER:apache2.access.http_version}\" %{NUMBER:apache2.access.response_code} (?:%{NUMBER:apache2.access.body_sent.bytes}|-)( \"%{DATA:apache2.access.referrer}\")?( \"%{DATA:apache2.access.agent}\")?",
-          "%{IPORHOST:apache2.access.remote_ip} - %{DATA:apache2.access.user_name} \\[%{HTTPDATE:apache2.access.time}\\] \"-\" %{NUMBER:apache2.access.response_code} -",
-        "\\[%{HTTPDATE:apache2.access.time}\\] %{IPORHOST:apache2.access.remote_ip} %{DATA:apache2.access.ssl.protocol} %{DATA:apache2.access.ssl.cipher} \"%{WORD:http.request.method} %{DATA:apache2.access.url} HTTP/%{NUMBER:apache2.access.http_version}\" %{NUMBER:apache2.access.body_sent.bytes}"
-        ],
-      "ignore_missing": true
-    }
-  },{
-    "remove":{
-      "field": "message"
-    }
-  }, {
-    "rename": {
-      "field": "@timestamp",
-      "target_field": "read_timestamp"
-    }
-  }, {
-    "date": {
-      "field": "apache2.access.time",
-      "target_field": "@timestamp",
-      "formats": ["dd/MMM/yyyy:H:m:s Z"]
-    }
-  }, {
-    "remove": {
-      "field": "apache2.access.time"
-    }
-  }, {
-    "user_agent": {
-      "field": "apache2.access.agent",
-      "target_field": "apache2.access.user_agent",
-      "ignore_failure": true
-    }
-  }, {
-    "rename": {
-      "field": "apache2.access.agent",
-      "target_field": "apache2.access.user_agent.original",
-      "ignore_failure": true
-    }
-  }, {
-    "geoip": {
-      "field": "apache2.access.remote_ip",
-      "target_field": "apache2.access.geoip"
-    }
-  }],
-  "on_failure" : [{
-    "set" : {
-      "field" : "error.message",
-      "value" : "{{ _ingest.on_failure_message }}"
-    }
-  }]
+    "description": "Pipeline for parsing Apache2 access logs. Requires the geoip and user_agent plugins.",
+    "processors": [
+        {
+            "grok": {
+                "field": "message",
+                "patterns": [
+                    "%{IPORHOST:apache2.access.remote_ip} - %{DATA:apache2.access.user_name} \\[%{HTTPDATE:apache2.access.time}\\] \"%{WORD:apache2.access.method} %{DATA:apache2.access.url} HTTP/%{NUMBER:apache2.access.http_version}\" %{NUMBER:apache2.access.response_code} (?:%{NUMBER:apache2.access.body_sent.bytes}|-)( \"%{DATA:apache2.access.referrer}\")?( \"%{DATA:apache2.access.agent}\")?",
+                    "%{IPORHOST:apache2.access.remote_ip} - %{DATA:apache2.access.user_name} \\[%{HTTPDATE:apache2.access.time}\\] \"-\" %{NUMBER:apache2.access.response_code} -",
+                    "\\[%{HTTPDATE:apache2.access.time}\\] %{IPORHOST:apache2.access.remote_ip} %{DATA:apache2.access.ssl.protocol} %{DATA:apache2.access.ssl.cipher} \"%{WORD:http.request.method} %{DATA:apache2.access.url} HTTP/%{NUMBER:apache2.access.http_version}\" %{NUMBER:apache2.access.body_sent.bytes}"
+                ],
+                "ignore_missing": true
+            }
+        },
+        {
+            "remove": {
+                "field": "message"
+            }
+        },
+        {
+            "rename": {
+                "field": "@timestamp",
+                "target_field": "read_timestamp"
+            }
+        },
+        {
+            "date": {
+                "field": "apache2.access.time",
+                "target_field": "@timestamp",
+                "formats": [
+                    "dd/MMM/yyyy:H:m:s Z"
+                ]
+            }
+        },
+        {
+            "remove": {
+                "field": "apache2.access.time"
+            }
+        },
+        {
+            "user_agent": {
+                "field": "apache2.access.agent",
+                "target_field": "apache2.access.user_agent",
+                "ignore_failure": true
+            }
+        },
+        {
+            "rename": {
+                "field": "apache2.access.user_agent.device.name",
+                "target_field": "apache2.access.user_agent.device_name",
+                "ignore_failure": true
+            }
+        },
+        {
+            "remove": {
+                "if": "ctx.apache2.access.user_agent.device_name != null",
+                "field": "apache2.access.user_agent.device",
+                "ignore_failure": true
+            }
+        },
+        {
+            "rename": {
+                "field": "apache2.access.user_agent.device_name",
+                "target_field": "apache2.access.user_agent.device",
+                "ignore_failure": true
+            }
+        },
+        {
+            "rename": {
+                "field": "apache2.access.user_agent.os.name",
+                "target_field": "apache2.access.user_agent.os_name",
+                "ignore_failure": true
+            }
+        },
+        {
+            "rename": {
+                "field": "apache2.access.user_agent.os.version",
+                "target_field": "apache2.access.user_agent.os_version",
+                "ignore_failure": true
+            }
+        },
+        {
+            "rename": {
+                "field": "apache2.access.user_agent.os.full",
+                "target_field": "apache2.access.user_agent.os_temp",
+                "ignore_failure": true
+            }
+        },
+        {
+            "remove": {
+                "if": "ctx.apache2.access.user_agent.os_temp != null || ctx.apache2.access.user_agent.os_version != null || ctx.apache2.access.user_agent.os_name != null",
+                "field": "apache2.access.user_agent.os",
+                "ignore_failure": true
+            }
+        },
+        {
+            "rename": {
+                "field": "apache2.access.user_agent.os_temp",
+                "target_field": "apache2.access.user_agent.os",
+                "ignore_failure": true
+            }
+        },
+        {
+            "rename": {
+                "field": "apache2.access.agent",
+                "target_field": "apache2.access.user_agent.original",
+                "ignore_failure": true
+            }
+        },
+        {
+            "geoip": {
+                "field": "apache2.access.remote_ip",
+                "target_field": "apache2.access.geoip"
+            }
+        }
+    ],
+    "on_failure": [
+        {
+            "set": {
+                "field": "error.message",
+                "value": "{{ _ingest.on_failure_message }}"
+            }
+        }
+    ]
 }


### PR DESCRIPTION
This is an attempt to solve https://github.com/elastic/beats/issues/10650

The conflicting fields are

* os.*
* device.*

These fields are renamed to the old fields if they exist and then the generated key is removed. Right now I check if any of the os_* fields exists but it would be nice to check if `os` and `device` are an object but haven't found yet how to do this in painless.

To make this work, all `user_agent` usage in Filebeat needs the additions below.