### PR TITLE
Enhance RabbitMQ test to use real data and test with 3.6

### DIFF
--- a/metricbeat/docs/modules/rabbitmq.asciidoc
+++ b/metricbeat/docs/modules/rabbitmq.asciidoc
@@ -14,9 +14,7 @@ If `management.path_prefix` is set in RabbitMQ configuration, `management_path_p
 [float]
 === Compatibility
 
-The rabbitmq module is fully tested with RabbitMQ 3.7.4 and partially tested with 3.6.0, 3.6.5 and 3.7.14 and it should be compatible
-with any version supporting the management plugin. This plugin needs to be
-enabled.
+The rabbitmq module is fully tested with RabbitMQ 3.7.4 and it should be compatible with any version supporting the management plugin (which needs to be installed and enabled). Exchange metricset is also tested with 3.6.0, 3.6.5 and 3.7.14
 
 
 [float]

--- a/metricbeat/docs/modules/rabbitmq.asciidoc
+++ b/metricbeat/docs/modules/rabbitmq.asciidoc
@@ -14,7 +14,7 @@ If `management.path_prefix` is set in RabbitMQ configuration, `management_path_p
 [float]
 === Compatibility
 
-The rabbitmq module is tested with RabbitMQ 3.7.4, and it should be compatible
+The rabbitmq module is fully tested with RabbitMQ 3.7.4 and partially tested with 3.6.0, 3.6.5 and 3.7.14 and it should be compatible
 with any version supporting the management plugin. This plugin needs to be
 enabled.
 

--- a/metricbeat/module/rabbitmq/_meta/docs.asciidoc
+++ b/metricbeat/module/rabbitmq/_meta/docs.asciidoc
@@ -7,6 +7,6 @@ If `management.path_prefix` is set in RabbitMQ configuration, `management_path_p
 [float]
 === Compatibility
 
-The rabbitmq module is tested with RabbitMQ 3.7.4, and it should be compatible
+The rabbitmq module is fully tested with RabbitMQ 3.7.4 and partially tested with 3.6.0, 3.6.5 and 3.7.14 and it should be compatible
 with any version supporting the management plugin. This plugin needs to be
 enabled.

--- a/metricbeat/module/rabbitmq/_meta/docs.asciidoc
+++ b/metricbeat/module/rabbitmq/_meta/docs.asciidoc
@@ -7,6 +7,4 @@ If `management.path_prefix` is set in RabbitMQ configuration, `management_path_p
 [float]
 === Compatibility
 
-The rabbitmq module is fully tested with RabbitMQ 3.7.4 and partially tested with 3.6.0, 3.6.5 and 3.7.14 and it should be compatible
-with any version supporting the management plugin. This plugin needs to be
-enabled.
+The rabbitmq module is fully tested with RabbitMQ 3.7.4 and it should be compatible with any version supporting the management plugin (which needs to be installed and enabled). Exchange metricset is also tested with 3.6.0, 3.6.5 and 3.7.14

--- a/metricbeat/module/rabbitmq/exchange/_meta/data.json
+++ b/metricbeat/module/rabbitmq/exchange/_meta/data.json
@@ -1,9 +1,5 @@
 {
-    "@timestamp": "2017-10-12T08:05:34.853Z",
-    "agent": {
-        "hostname": "host.example.com",
-        "name": "host.example.com"
-    },
+    "@timestamp": "2019-03-01T08:05:34.853Z",
     "event": {
         "dataset": "rabbitmq.exchange",
         "duration": 115000,
@@ -38,7 +34,7 @@
         "vhost": "/"
     },
     "service": {
-        "address": "127.0.0.1:53926",
+        "address": "127.0.0.1:55555",
         "type": "rabbitmq"
     },
     "user": {

--- a/metricbeat/module/rabbitmq/exchange/_meta/testdata/docs.json
+++ b/metricbeat/module/rabbitmq/exchange/_meta/testdata/docs.json
@@ -1,0 +1,22 @@
+[
+    {
+        "message_stats": {
+            "publish_in": 100,
+            "publish_in_details": {
+                "rate": 0.5
+            },
+            "publish_out": 99,
+            "publish_out_details": {
+                "rate": 0.9
+            }
+        },
+        "user_who_performed_action": "guest",
+        "name": "exchange.name",
+        "vhost": "/",
+        "type": "fanout",
+        "durable": true,
+        "auto_delete": false,
+        "internal": false,
+        "arguments": {}
+    }
+]

--- a/metricbeat/module/rabbitmq/exchange/_meta/testdata/docs.json-expected.json
+++ b/metricbeat/module/rabbitmq/exchange/_meta/testdata/docs.json-expected.json
@@ -1,0 +1,44 @@
+[
+    {
+        "event": {
+            "dataset": "rabbitmq.exchange",
+            "duration": 115000,
+            "module": "rabbitmq"
+        },
+        "metricset": {
+            "name": "exchange"
+        },
+        "rabbitmq": {
+            "exchange": {
+                "arguments": {},
+                "auto_delete": false,
+                "durable": true,
+                "internal": false,
+                "messages": {
+                    "publish_in": {
+                        "count": 100,
+                        "details": {
+                            "rate": 0.5
+                        }
+                    },
+                    "publish_out": {
+                        "count": 99,
+                        "details": {
+                            "rate": 0.9
+                        }
+                    }
+                },
+                "name": "exchange.name",
+                "type": "fanout"
+            },
+            "vhost": "/"
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "rabbitmq"
+        },
+        "user": {
+            "name": "guest"
+        }
+    }
+]

--- a/metricbeat/module/rabbitmq/exchange/_meta/testdata/exchange-3.6.0.json
+++ b/metricbeat/module/rabbitmq/exchange/_meta/testdata/exchange-3.6.0.json
@@ -1,0 +1,74 @@
+[
+    {
+        "name": "",
+        "vhost": "/",
+        "type": "direct",
+        "durable": true,
+        "auto_delete": false,
+        "internal": false,
+        "arguments": {}
+    },
+    {
+        "name": "amq.direct",
+        "vhost": "/",
+        "type": "direct",
+        "durable": true,
+        "auto_delete": false,
+        "internal": false,
+        "arguments": {}
+    },
+    {
+        "name": "amq.fanout",
+        "vhost": "/",
+        "type": "fanout",
+        "durable": true,
+        "auto_delete": false,
+        "internal": false,
+        "arguments": {}
+    },
+    {
+        "name": "amq.headers",
+        "vhost": "/",
+        "type": "headers",
+        "durable": true,
+        "auto_delete": false,
+        "internal": false,
+        "arguments": {}
+    },
+    {
+        "name": "amq.match",
+        "vhost": "/",
+        "type": "headers",
+        "durable": true,
+        "auto_delete": false,
+        "internal": false,
+        "arguments": {}
+    },
+    {
+        "name": "amq.rabbitmq.log",
+        "vhost": "/",
+        "type": "topic",
+        "durable": true,
+        "auto_delete": false,
+        "internal": true,
+        "arguments": {}
+    },
+    {
+        "name": "amq.rabbitmq.trace",
+        "vhost": "/",
+        "type": "topic",
+        "durable": true,
+        "auto_delete": false,
+        "internal": true,
+        "arguments": {}
+    },
+    {
+        "name": "amq.topic",
+        "vhost": "/",
+        "type": "topic",
+        "durable": true,
+        "auto_delete": false,
+        "internal": false,
+        "arguments": {}
+    }
+]

--- a/metricbeat/module/rabbitmq/exchange/_meta/testdata/exchange-3.6.0.json-expected.json
+++ b/metricbeat/module/rabbitmq/exchange/_meta/testdata/exchange-3.6.0.json-expected.json
@@ -1,0 +1,202 @@
+[
+    {
+        "event": {
+            "dataset": "rabbitmq.exchange",
+            "duration": 115000,
+            "module": "rabbitmq"
+        },
+        "metricset": {
+            "name": "exchange"
+        },
+        "rabbitmq": {
+            "exchange": {
+                "arguments": {},
+                "auto_delete": false,
+                "durable": true,
+                "internal": false,
+                "name": "amq.fanout",
+                "type": "fanout"
+            },
+            "vhost": "/"
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "rabbitmq"
+        }
+    },
+    {
+        "event": {
+            "dataset": "rabbitmq.exchange",
+            "duration": 115000,
+            "module": "rabbitmq"
+        },
+        "metricset": {
+            "name": "exchange"
+        },
+        "rabbitmq": {
+            "exchange": {
+                "arguments": {},
+                "auto_delete": false,
+                "durable": true,
+                "internal": true,
+                "name": "amq.rabbitmq.trace",
+                "type": "topic"
+            },
+            "vhost": "/"
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "rabbitmq"
+        }
+    },
+    {
+        "event": {
+            "dataset": "rabbitmq.exchange",
+            "duration": 115000,
+            "module": "rabbitmq"
+        },
+        "metricset": {
+            "name": "exchange"
+        },
+        "rabbitmq": {
+            "exchange": {
+                "arguments": {},
+                "auto_delete": false,
+                "durable": true,
+                "internal": false,
+                "name": "amq.match",
+                "type": "headers"
+            },
+            "vhost": "/"
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "rabbitmq"
+        }
+    },
+    {
+        "event": {
+            "dataset": "rabbitmq.exchange",
+            "duration": 115000,
+            "module": "rabbitmq"
+        },
+        "metricset": {
+            "name": "exchange"
+        },
+        "rabbitmq": {
+            "exchange": {
+                "arguments": {},
+                "auto_delete": false,
+                "durable": true,
+                "internal": true,
+                "name": "amq.rabbitmq.log",
+                "type": "topic"
+            },
+            "vhost": "/"
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "rabbitmq"
+        }
+    },
+    {
+        "event": {
+            "dataset": "rabbitmq.exchange",
+            "duration": 115000,
+            "module": "rabbitmq"
+        },
+        "metricset": {
+            "name": "exchange"
+        },
+        "rabbitmq": {
+            "exchange": {
+                "arguments": {},
+                "auto_delete": false,
+                "durable": true,
+                "internal": false,
+                "name": "amq.topic",
+                "type": "topic"
+            },
+            "vhost": "/"
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "rabbitmq"
+        }
+    },
+    {
+        "event": {
+            "dataset": "rabbitmq.exchange",
+            "duration": 115000,
+            "module": "rabbitmq"
+        },
+        "metricset": {
+            "name": "exchange"
+        },
+        "rabbitmq": {
+            "exchange": {
+                "arguments": {},
+                "auto_delete": false,
+                "durable": true,
+                "internal": false,
+                "name": "amq.headers",
+                "type": "headers"
+            },
+            "vhost": "/"
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "rabbitmq"
+        }
+    },
+    {
+        "event": {
+            "dataset": "rabbitmq.exchange",
+            "duration": 115000,
+            "module": "rabbitmq"
+        },
+        "metricset": {
+            "name": "exchange"
+        },
+        "rabbitmq": {
+            "exchange": {
+                "arguments": {},
+                "auto_delete": false,
+                "durable": true,
+                "internal": false,
+                "name": "",
+                "type": "direct"
+            },
+            "vhost": "/"
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "rabbitmq"
+        }
+    },
+    {
+        "event": {
+            "dataset": "rabbitmq.exchange",
+            "duration": 115000,
+            "module": "rabbitmq"
+        },
+        "metricset": {
+            "name": "exchange"
+        },
+        "rabbitmq": {
+            "exchange": {
+                "arguments": {},
+                "auto_delete": false,
+                "durable": true,
+                "internal": false,
+                "name": "amq.direct",
+                "type": "direct"
+            },
+            "vhost": "/"
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "rabbitmq"
+        }
+    }
+]

--- a/metricbeat/module/rabbitmq/exchange/_meta/testdata/exchange-3.6.5.json
+++ b/metricbeat/module/rabbitmq/exchange/_meta/testdata/exchange-3.6.5.json
@@ -1,0 +1,74 @@
+[
+    {
+        "name": "",
+        "vhost": "/",
+        "type": "direct",
+        "durable": true,
+        "auto_delete": false,
+        "internal": false,
+        "arguments": {}
+    },
+    {
+        "name": "amq.direct",
+        "vhost": "/",
+        "type": "direct",
+        "durable": true,
+        "auto_delete": false,
+        "internal": false,
+        "arguments": {}
+    },
+    {
+        "name": "amq.fanout",
+        "vhost": "/",
+        "type": "fanout",
+        "durable": true,
+        "auto_delete": false,
+        "internal": false,
+        "arguments": {}
+    },
+    {
+        "name": "amq.headers",
+        "vhost": "/",
+        "type": "headers",
+        "durable": true,
+        "auto_delete": false,
+        "internal": false,
+        "arguments": {}
+    },
+    {
+        "name": "amq.match",
+        "vhost": "/",
+        "type": "headers",
+        "durable": true,
+        "auto_delete": false,
+        "internal": false,
+        "arguments": {}
+    },
+    {
+        "name": "amq.rabbitmq.log",
+        "vhost": "/",
+        "type": "topic",
+        "durable": true,
+        "auto_delete": false,
+        "internal": true,
+        "arguments": {}
+    },
+    {
+        "name": "amq.rabbitmq.trace",
+        "vhost": "/",
+        "type": "topic",
+        "durable": true,
+        "auto_delete": false,
+        "internal": true,
+        "arguments": {}
+    },
+    {
+        "name": "amq.topic",
+        "vhost": "/",
+        "type": "topic",
+        "durable": true,
+        "auto_delete": false,
+        "internal": false,
+        "arguments": {}
+    }
+]

--- a/metricbeat/module/rabbitmq/exchange/_meta/testdata/exchange-3.6.5.json-expected.json
+++ b/metricbeat/module/rabbitmq/exchange/_meta/testdata/exchange-3.6.5.json-expected.json
@@ -1,0 +1,202 @@
+[
+    {
+        "event": {
+            "dataset": "rabbitmq.exchange",
+            "duration": 115000,
+            "module": "rabbitmq"
+        },
+        "metricset": {
+            "name": "exchange"
+        },
+        "rabbitmq": {
+            "exchange": {
+                "arguments": {},
+                "auto_delete": false,
+                "durable": true,
+                "internal": false,
+                "name": "amq.fanout",
+                "type": "fanout"
+            },
+            "vhost": "/"
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "rabbitmq"
+        }
+    },
+    {
+        "event": {
+            "dataset": "rabbitmq.exchange",
+            "duration": 115000,
+            "module": "rabbitmq"
+        },
+        "metricset": {
+            "name": "exchange"
+        },
+        "rabbitmq": {
+            "exchange": {
+                "arguments": {},
+                "auto_delete": false,
+                "durable": true,
+                "internal": true,
+                "name": "amq.rabbitmq.trace",
+                "type": "topic"
+            },
+            "vhost": "/"
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "rabbitmq"
+        }
+    },
+    {
+        "event": {
+            "dataset": "rabbitmq.exchange",
+            "duration": 115000,
+            "module": "rabbitmq"
+        },
+        "metricset": {
+            "name": "exchange"
+        },
+        "rabbitmq": {
+            "exchange": {
+                "arguments": {},
+                "auto_delete": false,
+                "durable": true,
+                "internal": false,
+                "name": "amq.match",
+                "type": "headers"
+            },
+            "vhost": "/"
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "rabbitmq"
+        }
+    },
+    {
+        "event": {
+            "dataset": "rabbitmq.exchange",
+            "duration": 115000,
+            "module": "rabbitmq"
+        },
+        "metricset": {
+            "name": "exchange"
+        },
+        "rabbitmq": {
+            "exchange": {
+                "arguments": {},
+                "auto_delete": false,
+                "durable": true,
+                "internal": true,
+                "name": "amq.rabbitmq.log",
+                "type": "topic"
+            },
+            "vhost": "/"
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "rabbitmq"
+        }
+    },
+    {
+        "event": {
+            "dataset": "rabbitmq.exchange",
+            "duration": 115000,
+            "module": "rabbitmq"
+        },
+        "metricset": {
+            "name": "exchange"
+        },
+        "rabbitmq": {
+            "exchange": {
+                "arguments": {},
+                "auto_delete": false,
+                "durable": true,
+                "internal": false,
+                "name": "amq.topic",
+                "type": "topic"
+            },
+            "vhost": "/"
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "rabbitmq"
+        }
+    },
+    {
+        "event": {
+            "dataset": "rabbitmq.exchange",
+            "duration": 115000,
+            "module": "rabbitmq"
+        },
+        "metricset": {
+            "name": "exchange"
+        },
+        "rabbitmq": {
+            "exchange": {
+                "arguments": {},
+                "auto_delete": false,
+                "durable": true,
+                "internal": false,
+                "name": "amq.headers",
+                "type": "headers"
+            },
+            "vhost": "/"
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "rabbitmq"
+        }
+    },
+    {
+        "event": {
+            "dataset": "rabbitmq.exchange",
+            "duration": 115000,
+            "module": "rabbitmq"
+        },
+        "metricset": {
+            "name": "exchange"
+        },
+        "rabbitmq": {
+            "exchange": {
+                "arguments": {},
+                "auto_delete": false,
+                "durable": true,
+                "internal": false,
+                "name": "",
+                "type": "direct"
+            },
+            "vhost": "/"
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "rabbitmq"
+        }
+    },
+    {
+        "event": {
+            "dataset": "rabbitmq.exchange",
+            "duration": 115000,
+            "module": "rabbitmq"
+        },
+        "metricset": {
+            "name": "exchange"
+        },
+        "rabbitmq": {
+            "exchange": {
+                "arguments": {},
+                "auto_delete": false,
+                "durable": true,
+                "internal": false,
+                "name": "amq.direct",
+                "type": "direct"
+            },
+            "vhost": "/"
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "rabbitmq"
+        }
+    }
+]

--- a/metricbeat/module/rabbitmq/exchange/_meta/testdata/exchange-3.7.14.json
+++ b/metricbeat/module/rabbitmq/exchange/_meta/testdata/exchange-3.7.14.json
@@ -1,0 +1,72 @@
+[
+    {
+        "arguments": {},
+        "auto_delete": false,
+        "durable": true,
+        "internal": false,
+        "name": "",
+        "type": "direct",
+        "user_who_performed_action": "rmq-internal",
+        "vhost": "/"
+    },
+    {
+        "arguments": {},
+        "auto_delete": false,
+        "durable": true,
+        "internal": false,
+        "name": "amq.direct",
+        "type": "direct",
+        "user_who_performed_action": "rmq-internal",
+        "vhost": "/"
+    },
+    {
+        "arguments": {},
+        "auto_delete": false,
+        "durable": true,
+        "internal": false,
+        "name": "amq.fanout",
+        "type": "fanout",
+        "user_who_performed_action": "rmq-internal",
+        "vhost": "/"
+    },
+    {
+        "arguments": {},
+        "auto_delete": false,
+        "durable": true,
+        "internal": false,
+        "name": "amq.headers",
+        "type": "headers",
+        "user_who_performed_action": "rmq-internal",
+        "vhost": "/"
+    },
+    {
+        "arguments": {},
+        "auto_delete": false,
+        "durable": true,
+        "internal": false,
+        "name": "amq.match",
+        "type": "headers",
+        "user_who_performed_action": "rmq-internal",
+        "vhost": "/"
+    },
+    {
+        "arguments": {},
+        "auto_delete": false,
+        "durable": true,
+        "internal": true,
+        "name": "amq.rabbitmq.trace",
+        "type": "topic",
+        "user_who_performed_action": "rmq-internal",
+        "vhost": "/"
+    },
+    {
+        "arguments": {},
+        "auto_delete": false,
+        "durable": true,
+        "internal": false,
+        "name": "amq.topic",
+        "type": "topic",
+        "user_who_performed_action": "rmq-internal",
+        "vhost": "/"
+    }
+]

--- a/metricbeat/module/rabbitmq/exchange/_meta/testdata/exchange-3.7.14.json-expected.json
+++ b/metricbeat/module/rabbitmq/exchange/_meta/testdata/exchange-3.7.14.json-expected.json
@@ -1,0 +1,198 @@
+[
+    {
+        "event": {
+            "dataset": "rabbitmq.exchange",
+            "duration": 115000,
+            "module": "rabbitmq"
+        },
+        "metricset": {
+            "name": "exchange"
+        },
+        "rabbitmq": {
+            "exchange": {
+                "arguments": {},
+                "auto_delete": false,
+                "durable": true,
+                "internal": false,
+                "name": "amq.topic",
+                "type": "topic"
+            },
+            "vhost": "/"
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "rabbitmq"
+        },
+        "user": {
+            "name": "rmq-internal"
+        }
+    },
+    {
+        "event": {
+            "dataset": "rabbitmq.exchange",
+            "duration": 115000,
+            "module": "rabbitmq"
+        },
+        "metricset": {
+            "name": "exchange"
+        },
+        "rabbitmq": {
+            "exchange": {
+                "arguments": {},
+                "auto_delete": false,
+                "durable": true,
+                "internal": false,
+                "name": "amq.match",
+                "type": "headers"
+            },
+            "vhost": "/"
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "rabbitmq"
+        },
+        "user": {
+            "name": "rmq-internal"
+        }
+    },
+    {
+        "event": {
+            "dataset": "rabbitmq.exchange",
+            "duration": 115000,
+            "module": "rabbitmq"
+        },
+        "metricset": {
+            "name": "exchange"
+        },
+        "rabbitmq": {
+            "exchange": {
+                "arguments": {},
+                "auto_delete": false,
+                "durable": true,
+                "internal": false,
+                "name": "amq.fanout",
+                "type": "fanout"
+            },
+            "vhost": "/"
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "rabbitmq"
+        },
+        "user": {
+            "name": "rmq-internal"
+        }
+    },
+    {
+        "event": {
+            "dataset": "rabbitmq.exchange",
+            "duration": 115000,
+            "module": "rabbitmq"
+        },
+        "metricset": {
+            "name": "exchange"
+        },
+        "rabbitmq": {
+            "exchange": {
+                "arguments": {},
+                "auto_delete": false,
+                "durable": true,
+                "internal": true,
+                "name": "amq.rabbitmq.trace",
+                "type": "topic"
+            },
+            "vhost": "/"
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "rabbitmq"
+        },
+        "user": {
+            "name": "rmq-internal"
+        }
+    },
+    {
+        "event": {
+            "dataset": "rabbitmq.exchange",
+            "duration": 115000,
+            "module": "rabbitmq"
+        },
+        "metricset": {
+            "name": "exchange"
+        },
+        "rabbitmq": {
+            "exchange": {
+                "arguments": {},
+                "auto_delete": false,
+                "durable": true,
+                "internal": false,
+                "name": "amq.direct",
+                "type": "direct"
+            },
+            "vhost": "/"
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "rabbitmq"
+        },
+        "user": {
+            "name": "rmq-internal"
+        }
+    },
+    {
+        "event": {
+            "dataset": "rabbitmq.exchange",
+            "duration": 115000,
+            "module": "rabbitmq"
+        },
+        "metricset": {
+            "name": "exchange"
+        },
+        "rabbitmq": {
+            "exchange": {
+                "arguments": {},
+                "auto_delete": false,
+                "durable": true,
+                "internal": false,
+                "name": "amq.headers",
+                "type": "headers"
+            },
+            "vhost": "/"
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "rabbitmq"
+        },
+        "user": {
+            "name": "rmq-internal"
+        }
+    },
+    {
+        "event": {
+            "dataset": "rabbitmq.exchange",
+            "duration": 115000,
+            "module": "rabbitmq"
+        },
+        "metricset": {
+            "name": "exchange"
+        },
+        "rabbitmq": {
+            "exchange": {
+                "arguments": {},
+                "auto_delete": false,
+                "durable": true,
+                "internal": false,
+                "name": "",
+                "type": "direct"
+            },
+            "vhost": "/"
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "rabbitmq"
+        },
+        "user": {
+            "name": "rmq-internal"
+        }
+    }
+]

--- a/metricbeat/module/rabbitmq/exchange/_meta/testdata/exchange-3.7.4.json
+++ b/metricbeat/module/rabbitmq/exchange/_meta/testdata/exchange-3.7.4.json
@@ -1,0 +1,72 @@
+[
+    {
+        "user_who_performed_action": "rmq-internal",
+        "arguments": {},
+        "internal": false,
+        "auto_delete": false,
+        "durable": true,
+        "type": "direct",
+        "vhost": "/",
+        "name": ""
+    },
+    {
+        "user_who_performed_action": "rmq-internal",
+        "arguments": {},
+        "internal": false,
+        "auto_delete": false,
+        "durable": true,
+        "type": "direct",
+        "vhost": "/",
+        "name": "amq.direct"
+    },
+    {
+        "user_who_performed_action": "rmq-internal",
+        "arguments": {},
+        "internal": false,
+        "auto_delete": false,
+        "durable": true,
+        "type": "fanout",
+        "vhost": "/",
+        "name": "amq.fanout"
+    },
+    {
+        "user_who_performed_action": "rmq-internal",
+        "arguments": {},
+        "internal": false,
+        "auto_delete": false,
+        "durable": true,
+        "type": "headers",
+        "vhost": "/",
+        "name": "amq.headers"
+    },
+    {
+        "user_who_performed_action": "rmq-internal",
+        "arguments": {},
+        "internal": false,
+        "auto_delete": false,
+        "durable": true,
+        "type": "headers",
+        "vhost": "/",
+        "name": "amq.match"
+    },
+    {
+        "user_who_performed_action": "rmq-internal",
+        "arguments": {},
+        "internal": true,
+        "auto_delete": false,
+        "durable": true,
+        "type": "topic",
+        "vhost": "/",
+        "name": "amq.rabbitmq.trace"
+    },
+    {
+        "user_who_performed_action": "rmq-internal",
+        "arguments": {},
+        "internal": false,
+        "auto_delete": false,
+        "durable": true,
+        "type": "topic",
+        "vhost": "/",
+        "name": "amq.topic"
+    }
+]

--- a/metricbeat/module/rabbitmq/exchange/_meta/testdata/exchange-3.7.4.json-expected.json
+++ b/metricbeat/module/rabbitmq/exchange/_meta/testdata/exchange-3.7.4.json-expected.json
@@ -1,0 +1,198 @@
+[
+    {
+        "event": {
+            "dataset": "rabbitmq.exchange",
+            "duration": 115000,
+            "module": "rabbitmq"
+        },
+        "metricset": {
+            "name": "exchange"
+        },
+        "rabbitmq": {
+            "exchange": {
+                "arguments": {},
+                "auto_delete": false,
+                "durable": true,
+                "internal": false,
+                "name": "amq.topic",
+                "type": "topic"
+            },
+            "vhost": "/"
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "rabbitmq"
+        },
+        "user": {
+            "name": "rmq-internal"
+        }
+    },
+    {
+        "event": {
+            "dataset": "rabbitmq.exchange",
+            "duration": 115000,
+            "module": "rabbitmq"
+        },
+        "metricset": {
+            "name": "exchange"
+        },
+        "rabbitmq": {
+            "exchange": {
+                "arguments": {},
+                "auto_delete": false,
+                "durable": true,
+                "internal": false,
+                "name": "amq.match",
+                "type": "headers"
+            },
+            "vhost": "/"
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "rabbitmq"
+        },
+        "user": {
+            "name": "rmq-internal"
+        }
+    },
+    {
+        "event": {
+            "dataset": "rabbitmq.exchange",
+            "duration": 115000,
+            "module": "rabbitmq"
+        },
+        "metricset": {
+            "name": "exchange"
+        },
+        "rabbitmq": {
+            "exchange": {
+                "arguments": {},
+                "auto_delete": false,
+                "durable": true,
+                "internal": false,
+                "name": "amq.fanout",
+                "type": "fanout"
+            },
+            "vhost": "/"
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "rabbitmq"
+        },
+        "user": {
+            "name": "rmq-internal"
+        }
+    },
+    {
+        "event": {
+            "dataset": "rabbitmq.exchange",
+            "duration": 115000,
+            "module": "rabbitmq"
+        },
+        "metricset": {
+            "name": "exchange"
+        },
+        "rabbitmq": {
+            "exchange": {
+                "arguments": {},
+                "auto_delete": false,
+                "durable": true,
+                "internal": true,
+                "name": "amq.rabbitmq.trace",
+                "type": "topic"
+            },
+            "vhost": "/"
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "rabbitmq"
+        },
+        "user": {
+            "name": "rmq-internal"
+        }
+    },
+    {
+        "event": {
+            "dataset": "rabbitmq.exchange",
+            "duration": 115000,
+            "module": "rabbitmq"
+        },
+        "metricset": {
+            "name": "exchange"
+        },
+        "rabbitmq": {
+            "exchange": {
+                "arguments": {},
+                "auto_delete": false,
+                "durable": true,
+                "internal": false,
+                "name": "amq.direct",
+                "type": "direct"
+            },
+            "vhost": "/"
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "rabbitmq"
+        },
+        "user": {
+            "name": "rmq-internal"
+        }
+    },
+    {
+        "event": {
+            "dataset": "rabbitmq.exchange",
+            "duration": 115000,
+            "module": "rabbitmq"
+        },
+        "metricset": {
+            "name": "exchange"
+        },
+        "rabbitmq": {
+            "exchange": {
+                "arguments": {},
+                "auto_delete": false,
+                "durable": true,
+                "internal": false,
+                "name": "amq.headers",
+                "type": "headers"
+            },
+            "vhost": "/"
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "rabbitmq"
+        },
+        "user": {
+            "name": "rmq-internal"
+        }
+    },
+    {
+        "event": {
+            "dataset": "rabbitmq.exchange",
+            "duration": 115000,
+            "module": "rabbitmq"
+        },
+        "metricset": {
+            "name": "exchange"
+        },
+        "rabbitmq": {
+            "exchange": {
+                "arguments": {},
+                "auto_delete": false,
+                "durable": true,
+                "internal": false,
+                "name": "",
+                "type": "direct"
+            },
+            "vhost": "/"
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "rabbitmq"
+        },
+        "user": {
+            "name": "rmq-internal"
+        }
+    }
+]

--- a/metricbeat/module/rabbitmq/exchange/exchange_test.go
+++ b/metricbeat/module/rabbitmq/exchange/exchange_test.go
@@ -34,7 +34,8 @@ func TestFetchEventContents(t *testing.T) {
 	reporter := &mbtest.CapturingReporterV2{}
 
 	metricSet := mbtest.NewReportingMetricSetV2Error(t, getConfig(server.URL))
-	metricSet.Fetch(reporter)
+	err := metricSet.Fetch(reporter)
+	assert.NoError(t, err)
 
 	e := mbtest.StandardizeEvent(metricSet, reporter.GetEvents()[0])
 	t.Logf("%s/%s event: %+v", metricSet.Module().Name(), metricSet.Name(), e.Fields.StringToPrint())

--- a/metricbeat/module/rabbitmq/node/_meta/data.json
+++ b/metricbeat/module/rabbitmq/node/_meta/data.json
@@ -1,9 +1,5 @@
 {
     "@timestamp": "2017-10-12T08:05:34.853Z",
-    "agent": {
-        "hostname": "host.example.com",
-        "name": "host.example.com"
-    },
     "event": {
         "dataset": "rabbitmq.node",
         "duration": 115000,
@@ -16,7 +12,7 @@
         "node": {
             "disk": {
                 "free": {
-                    "bytes": 51687411712,
+                    "bytes": 485213712384,
                     "limit": {
                         "bytes": 50000000
                     }
@@ -24,14 +20,14 @@
             },
             "fd": {
                 "total": 1048576,
-                "used": 25
+                "used": 54
             },
             "gc": {
                 "num": {
-                    "count": 7153
+                    "count": 5724
                 },
                 "reclaimed": {
-                    "bytes": 454566560
+                    "bytes": 294021640
                 }
             },
             "io": {
@@ -75,21 +71,21 @@
             },
             "mem": {
                 "limit": {
-                    "bytes": 2498702540
+                    "bytes": 13340778496
                 },
                 "used": {
-                    "bytes": 91295744
+                    "bytes": 71448312
                 }
             },
             "mnesia": {
                 "disk": {
                     "tx": {
-                        "count": 12
+                        "count": 0
                     }
                 },
                 "ram": {
                     "tx": {
-                        "count": 9
+                        "count": 43
                     }
                 }
             },
@@ -101,12 +97,12 @@
                     "count": 0
                 }
             },
-            "name": "rabbit@d7a26155daf9",
+            "name": "rabbit@my-rabbit",
             "proc": {
                 "total": 1048576,
-                "used": 367
+                "used": 234
             },
-            "processors": 4,
+            "processors": 12,
             "queue": {
                 "index": {
                     "journal_write": {
@@ -128,11 +124,11 @@
                 "used": 0
             },
             "type": "disc",
-            "uptime": 758100
+            "uptime": 155275
         }
     },
     "service": {
-        "address": "localhost:15672",
+        "address": "172.17.0.2:15672",
         "type": "rabbitmq"
     }
 }

--- a/metricbeat/module/rabbitmq/node/node_integration_test.go
+++ b/metricbeat/module/rabbitmq/node/node_integration_test.go
@@ -20,8 +20,9 @@
 package node
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/beats/libbeat/tests/compose"
 	mbtest "github.com/elastic/beats/metricbeat/mb/testing"

--- a/metricbeat/module/rabbitmq/node/node_integration_test.go
+++ b/metricbeat/module/rabbitmq/node/node_integration_test.go
@@ -20,6 +20,7 @@
 package node
 
 import (
+	"github.com/stretchr/testify/assert"
 	"testing"
 
 	"github.com/elastic/beats/libbeat/tests/compose"
@@ -42,7 +43,8 @@ func TestFetch(t *testing.T) {
 	reporter := &mbtest.CapturingReporterV2{}
 
 	metricSet := mbtest.NewReportingMetricSetV2Error(t, getConfig())
-	metricSet.Fetch(reporter)
+	err := metricSet.Fetch(reporter)
+	assert.NoError(t, err)
 
 	e := mbtest.StandardizeEvent(metricSet, reporter.GetEvents()[0])
 	t.Logf("%s/%s event: %+v", metricSet.Module().Name(), metricSet.Name(), e.Fields.StringToPrint())

--- a/metricbeat/module/rabbitmq/queue/_meta/data.json
+++ b/metricbeat/module/rabbitmq/queue/_meta/data.json
@@ -1,9 +1,5 @@
 {
-    "@timestamp": "2017-10-12T08:05:34.853Z",
-    "agent": {
-        "hostname": "host.example.com",
-        "name": "host.example.com"
-    },
+    "@timestamp": "2019-03-01T08:05:34.853Z",
     "event": {
         "dataset": "rabbitmq.queue",
         "duration": 115000,
@@ -69,7 +65,7 @@
         "vhost": "/"
     },
     "service": {
-        "address": "127.0.0.1:53995",
+        "address": "127.0.0.1:55555",
         "type": "rabbitmq"
     }
 }

--- a/metricbeat/module/rabbitmq/queue/_meta/testdata/docs.json
+++ b/metricbeat/module/rabbitmq/queue/_meta/testdata/docs.json
@@ -1,0 +1,145 @@
+[
+    {
+        "memory": 232720,
+        "message_stats": {
+            "disk_reads": 212,
+            "disk_reads_details": {
+                "rate": 0
+            },
+            "disk_writes": 121,
+            "disk_writes_details": {
+                "rate": 0
+            },
+            "deliver": 15,
+            "deliver_details": {
+                "rate": 0
+            },
+            "deliver_no_ack": 0,
+            "deliver_no_ack_details": {
+                "rate": 0
+            },
+            "get": 0,
+            "get_details": {
+                "rate": 0
+            },
+            "get_no_ack": 38,
+            "get_no_ack_details": {
+                "rate": 0
+            },
+            "publish": 121,
+            "publish_details": {
+                "rate": 0
+            },
+            "publish_in": 0,
+            "publish_in_details": {
+                "rate": 0
+            },
+            "publish_out": 0,
+            "publish_out_details": {
+                "rate": 0
+            },
+            "ack": 9,
+            "ack_details": {
+                "rate": 0
+            },
+            "deliver_get": 53,
+            "deliver_get_details": {
+                "rate": 0
+            },
+            "confirm": 0,
+            "confirm_details": {
+                "rate": 0
+            },
+            "return_unroutable": 0,
+            "return_unroutable_details": {
+                "rate": 0
+            },
+            "redeliver": 3,
+            "redeliver_details": {
+                "rate": 0
+            }
+        },
+        "reductions": 787128,
+        "reductions_details": {
+            "rate": 0
+        },
+        "messages": 74,
+        "messages_details": {
+            "rate": 2.2
+        },
+        "messages_ready": 71,
+        "messages_ready_details": {
+            "rate": 0
+        },
+        "messages_unacknowledged": 3,
+        "messages_unacknowledged_details": {
+            "rate": 0.5
+        },
+        "idle_since": "2017-07-28 23:45:52",
+        "consumer_utilisation": 0.7,
+        "policy": null,
+        "exclusive_consumer_tag": null,
+        "consumers": 3,
+        "recoverable_slaves": null,
+        "state": "running",
+        "garbage_collection": {
+            "min_bin_vheap_size": 46422,
+            "min_heap_size": 233,
+            "fullsweep_after": 65535,
+            "minor_gcs": 0
+        },
+        "messages_ram": 74,
+        "messages_ready_ram": 71,
+        "messages_unacknowledged_ram": 3,
+        "messages_persistent": 73,
+        "message_bytes": 101824,
+        "message_bytes_ready": 97696,
+        "message_bytes_unacknowledged": 4128,
+        "message_bytes_ram": 101824,
+        "message_bytes_persistent": 101824,
+        "head_message_timestamp": 1501250275,
+        "disk_reads": 212,
+        "disk_writes": 121,
+        "backing_queue_status": {
+            "priority_lengths": {
+                "0": 0,
+                "1": 71,
+                "2": 0,
+                "3": 0,
+                "4": 0,
+                "5": 0,
+                "6": 0,
+                "7": 0,
+                "8": 0,
+                "9": 0
+            },
+            "mode": "default",
+            "q1": 0,
+            "q2": 0,
+            "delta": [
+                "delta",
+                "todo",
+                "todo",
+                "todo"
+            ],
+            "q3": 0,
+            "q4": 71,
+            "len": 71,
+            "target_ram_count": "infinity",
+            "next_seq_id": 121,
+            "avg_ingress_rate": 0,
+            "avg_egress_rate": 0.00019793395296866087,
+            "avg_ack_ingress_rate": 0.00019793395296866087,
+            "avg_ack_egress_rate": 0.00019793395296866087
+        },
+        "node": "rabbit@localhost",
+        "arguments": {
+            "x-max-priority": 9
+        },
+        "exclusive": false,
+        "auto_delete": false,
+        "durable": true,
+        "vhost": "/",
+        "name": "queuenamehere"
+    }
+]

--- a/metricbeat/module/rabbitmq/queue/_meta/testdata/docs.json-expected.json
+++ b/metricbeat/module/rabbitmq/queue/_meta/testdata/docs.json-expected.json
@@ -1,0 +1,72 @@
+[
+    {
+        "event": {
+            "dataset": "rabbitmq.queue",
+            "duration": 115000,
+            "module": "rabbitmq"
+        },
+        "metricset": {
+            "name": "queue"
+        },
+        "rabbitmq": {
+            "node": {
+                "name": "rabbit@localhost"
+            },
+            "queue": {
+                "arguments": {
+                    "max_priority": 9
+                },
+                "auto_delete": false,
+                "consumers": {
+                    "count": 3,
+                    "utilisation": {
+                        "pct": 0
+                    }
+                },
+                "disk": {
+                    "reads": {
+                        "count": 212
+                    },
+                    "writes": {
+                        "count": 121
+                    }
+                },
+                "durable": true,
+                "exclusive": false,
+                "memory": {
+                    "bytes": 232720
+                },
+                "messages": {
+                    "persistent": {
+                        "count": 73
+                    },
+                    "ready": {
+                        "count": 71,
+                        "details": {
+                            "rate": 0
+                        }
+                    },
+                    "total": {
+                        "count": 74,
+                        "details": {
+                            "rate": 2.2
+                        }
+                    },
+                    "unacknowledged": {
+                        "count": 3,
+                        "details": {
+                            "rate": 0.5
+                        }
+                    }
+                },
+                "name": "queuenamehere",
+                "state": "running"
+            },
+            "vhost": "/"
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "rabbitmq"
+        }
+    }
+]

--- a/metricbeat/module/rabbitmq/queue/queue_test.go
+++ b/metricbeat/module/rabbitmq/queue/queue_test.go
@@ -34,7 +34,8 @@ func TestFetchEventContents(t *testing.T) {
 	reporter := &mbtest.CapturingReporterV2{}
 
 	metricSet := mbtest.NewReportingMetricSetV2Error(t, getConfig(server.URL))
-	metricSet.Fetch(reporter)
+	err := metricSet.Fetch(reporter)
+	assert.NoError(t, err)
 
 	e := mbtest.StandardizeEvent(metricSet, reporter.GetEvents()[0])
 	t.Logf("%s/%s event: %+v", metricSet.Module().Name(), metricSet.Name(), e.Fields.StringToPrint())


### PR DESCRIPTION
"Fixes" this issue https://github.com/elastic/beats/issues/10014 by:

* Using data returned from an instance
* The instance is version 3.6

Currently, RabbitMQ module uses local data stored [here](https://github.com/elastic/beats/tree/master/metricbeat/module/rabbitmq/_meta/testdata) to mock responses from the server during tests. This also generates file `data.json` which is not very nice.

AFAIK, the "missing data" reported in the issue are some fields that aren't parsed by design.

Current PR uses _exchange_ Metricset to actively send messages and consume them from a RabbitMQ instance, to later produce a real `data.json` file.

My main concern about this PR are:

* Now we need a third party library (https://github.com/streadway/amqp) althought as it's only used on tests, it's not shipped with the release binary.
* "Missing fields" reported in the issue and the discuss forum aren't being parsed yet. So, that problem isn't solved anyways.

Comments welcome :)

EDIT: 
Finally I added some version specific tests using the new framework and updated to_error V2_ interface_. I couldn't update Metricset `node` to use the new testing framework because it needs 2 HTTP calls to fetch metrics (and the testing framework it only with single HTTP calls at the moment)