### PR TITLE
Adding back missing `@timestamp` fields to golden files

### DIFF
--- a/filebeat/module/elasticsearch/audit/test/test-access.log-expected.json
+++ b/filebeat/module/elasticsearch/audit/test/test-access.log-expected.json
@@ -1,5 +1,6 @@
 [
     {
+        "@timestamp": "2018-06-19T05:16:15.549Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.audit.layer": "rest",
         "event.dataset": "elasticsearch.audit",
@@ -15,6 +16,7 @@
         "user.name": "i030648"
     },
     {
+        "@timestamp": "2018-06-19T05:07:52.304Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.audit.layer": "rest",
         "elasticsearch.node.name": "v_VJhjV",
@@ -31,6 +33,7 @@
         "user.name": "rado"
     },
     {
+        "@timestamp": "2018-06-19T05:00:15.778Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.audit.action": "indices:data/read/scroll/clear",
         "elasticsearch.audit.layer": "transport",
@@ -48,6 +51,7 @@
         "user.name": "_xpack_security"
     },
     {
+        "@timestamp": "2018-06-19T05:07:45.544Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.audit.layer": "rest",
         "elasticsearch.node.name": "v_VJhjV",
@@ -63,6 +67,7 @@
         "url.original": "/_xpack/security/_authenticate"
     },
     {
+        "@timestamp": "2018-06-19T05:26:27.268Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.audit.layer": "rest",
         "event.dataset": "elasticsearch.audit",
@@ -78,6 +83,7 @@
         "user.name": "N078801"
     },
     {
+        "@timestamp": "2018-06-19T05:55:26.898Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.audit.action": "cluster:monitor/main",
         "elasticsearch.audit.layer": "transport",
@@ -95,6 +101,7 @@
         "user.name": "_anonymous"
     },
     {
+        "@timestamp": "2018-06-19T05:24:15.190Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.audit.layer": "rest",
         "elasticsearch.node.name": "v_VJhjV",
@@ -112,6 +119,7 @@
         "user.name": "elastic"
     },
     {
+        "@timestamp": "2019-01-08T14:15:02.011Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.audit.action": "indices:data/read/search[free_context]",
         "elasticsearch.audit.indices": [
@@ -144,6 +152,7 @@
         "user.name": "username"
     },
     {
+        "@timestamp": "2019-01-27T20:04:27.244Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.audit.layer": "rest",
         "elasticsearch.audit.realm": "default_file",

--- a/filebeat/module/elasticsearch/audit/test/test-audit.log-expected.json
+++ b/filebeat/module/elasticsearch/audit/test/test-audit.log-expected.json
@@ -1,5 +1,6 @@
 [
     {
+        "@timestamp": "2018-10-31T09:34:25.109Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.audit.layer": "rest",
         "elasticsearch.audit.origin.type": "rest",
@@ -19,6 +20,7 @@
         "user.name": "elastic"
     },
     {
+        "@timestamp": "2018-10-31T09:34:25.207Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.audit.layer": "rest",
         "elasticsearch.audit.origin.type": "rest",
@@ -38,6 +40,7 @@
         "user.name": "elastic"
     },
     {
+        "@timestamp": "2018-10-31T09:35:11.428Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.audit.action": "cluster:admin/xpack/security/realm/cache/clear",
         "elasticsearch.audit.layer": "transport",
@@ -62,6 +65,7 @@
         "user.name": "_xpack_security"
     },
     {
+        "@timestamp": "2018-10-31T09:35:11.430Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.audit.action": "cluster:admin/xpack/security/realm/cache/clear[n]",
         "elasticsearch.audit.layer": "transport",
@@ -86,6 +90,7 @@
         "user.name": "_xpack_security"
     },
     {
+        "@timestamp": "2018-10-31T09:35:12.303Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.audit.action": "cluster:admin/xpack/security/user/change_password",
         "elasticsearch.audit.layer": "transport",
@@ -110,6 +115,7 @@
         "user.name": "elastic"
     },
     {
+        "@timestamp": "2018-10-31T09:35:12.314Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.audit.action": "indices:admin/create",
         "elasticsearch.audit.indices": [
@@ -137,6 +143,7 @@
         "user.name": "_xpack_security"
     },
     {
+        "@timestamp": "2019-01-27T20:15:10.380Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.audit.layer": "rest",
         "elasticsearch.audit.origin.type": "rest",

--- a/filebeat/module/elasticsearch/deprecation/test/elasticsearch_deprecation.log-expected.json
+++ b/filebeat/module/elasticsearch/deprecation/test/elasticsearch_deprecation.log-expected.json
@@ -1,5 +1,6 @@
 [
     {
+        "@timestamp": "2018-04-23T16:40:13.737Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.component": "o.e.d.a.a.i.t.p.PutIndexTemplateRequest",
         "event.dataset": "elasticsearch.deprecation",
@@ -12,6 +13,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2018-04-23T16:40:13.862Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.component": "o.e.d.a.a.i.t.p.PutIndexTemplateRequest",
         "event.dataset": "elasticsearch.deprecation",
@@ -24,6 +26,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2018-04-23T16:40:14.792Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.component": "o.e.d.a.a.i.t.p.PutIndexTemplateRequest",
         "event.dataset": "elasticsearch.deprecation",
@@ -36,6 +39,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2018-04-23T16:40:15.127Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.component": "o.e.d.a.a.i.t.p.PutIndexTemplateRequest",
         "event.dataset": "elasticsearch.deprecation",

--- a/filebeat/module/elasticsearch/deprecation/test/other_elasticsearch_deprecation.log-expected.json
+++ b/filebeat/module/elasticsearch/deprecation/test/other_elasticsearch_deprecation.log-expected.json
@@ -1,5 +1,6 @@
 [
     {
+        "@timestamp": "2017-11-30T13:38:16.911Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.component": "o.e.d.c.ParseField",
         "event.dataset": "elasticsearch.deprecation",
@@ -12,6 +13,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2017-11-30T13:38:16.941Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.component": "o.e.d.c.ParseField",
         "event.dataset": "elasticsearch.deprecation",
@@ -24,6 +26,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2017-11-30T13:39:28.986Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.component": "o.e.d.i.m.UidFieldMapper",
         "event.dataset": "elasticsearch.deprecation",
@@ -36,6 +39,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2017-11-30T13:39:36.339Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.component": "o.e.d.i.m.UidFieldMapper",
         "event.dataset": "elasticsearch.deprecation",
@@ -48,6 +52,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2017-11-30T13:40:49.540Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.component": "o.e.d.i.m.UidFieldMapper",
         "event.dataset": "elasticsearch.deprecation",
@@ -60,6 +65,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2017-11-30T14:08:37.413Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.component": "o.e.d.i.m.UidFieldMapper",
         "event.dataset": "elasticsearch.deprecation",
@@ -72,6 +78,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2017-11-30T14:08:37.413Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.component": "o.e.d.i.m.UidFieldMapper",
         "event.dataset": "elasticsearch.deprecation",
@@ -84,6 +91,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2017-11-30T14:08:46.006Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.component": "o.e.d.i.m.UidFieldMapper",
         "event.dataset": "elasticsearch.deprecation",
@@ -96,6 +104,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2017-11-30T14:08:46.006Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.component": "o.e.d.i.m.UidFieldMapper",
         "event.dataset": "elasticsearch.deprecation",
@@ -108,6 +117,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2017-12-01T14:05:54.017Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.component": "o.e.d.i.m.AllFieldMapper",
         "event.dataset": "elasticsearch.deprecation",
@@ -120,6 +130,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2017-12-01T14:05:54.019Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.component": "o.e.d.i.m.AllFieldMapper",
         "event.dataset": "elasticsearch.deprecation",
@@ -132,6 +143,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2017-12-01T14:06:52.059Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.component": "o.e.d.i.m.AllFieldMapper",
         "event.dataset": "elasticsearch.deprecation",
@@ -144,6 +156,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2017-12-01T14:46:10.428Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.component": "o.e.d.s.a.InternalOrder$Parser",
         "event.dataset": "elasticsearch.deprecation",
@@ -156,6 +169,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2017-12-04T16:17:18.271Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.component": "o.e.d.a.a.i.t.p.PutIndexTemplateRequest",
         "event.dataset": "elasticsearch.deprecation",
@@ -168,6 +182,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2017-12-04T16:17:18.282Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.component": "o.e.d.i.m.MapperService",
         "event.dataset": "elasticsearch.deprecation",
@@ -180,6 +195,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2017-12-04T16:20:43.248Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.component": "o.e.d.i.m.MapperService",
         "event.dataset": "elasticsearch.deprecation",

--- a/filebeat/module/elasticsearch/deprecation/test/test-json.log-expected.json
+++ b/filebeat/module/elasticsearch/deprecation/test/test-json.log-expected.json
@@ -1,5 +1,6 @@
 [
     {
+        "@timestamp": "2019-01-30T22:16:20.233Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "es1",
         "elasticsearch.cluster.uuid": "S4dWw65ZT1eu3SltmAr84A",
@@ -16,6 +17,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-30T22:16:22.388Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "es1",
         "elasticsearch.cluster.uuid": "S4dWw65ZT1eu3SltmAr84A",
@@ -32,6 +34,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-30T22:16:22.566Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "es1",
         "elasticsearch.cluster.uuid": "S4dWw65ZT1eu3SltmAr84A",
@@ -48,6 +51,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-30T22:16:24.538Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "es1",
         "elasticsearch.cluster.uuid": "S4dWw65ZT1eu3SltmAr84A",
@@ -64,6 +68,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-30T22:16:59.311Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "es1",
         "elasticsearch.cluster.uuid": "S4dWw65ZT1eu3SltmAr84A",
@@ -80,6 +85,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-30T22:16:59.922Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "es1",
         "elasticsearch.cluster.uuid": "S4dWw65ZT1eu3SltmAr84A",
@@ -96,6 +102,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-30T22:17:00.095Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "es1",
         "elasticsearch.cluster.uuid": "S4dWw65ZT1eu3SltmAr84A",
@@ -112,6 +119,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-30T22:17:13.226Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "es1",
         "elasticsearch.cluster.uuid": "S4dWw65ZT1eu3SltmAr84A",
@@ -128,6 +136,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-30T22:17:14.747Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "es1",
         "elasticsearch.cluster.uuid": "S4dWw65ZT1eu3SltmAr84A",
@@ -144,6 +153,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-30T22:17:14.801Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "es1",
         "elasticsearch.cluster.uuid": "S4dWw65ZT1eu3SltmAr84A",
@@ -160,6 +170,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-30T22:17:17.546Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "es1",
         "elasticsearch.cluster.uuid": "S4dWw65ZT1eu3SltmAr84A",
@@ -176,6 +187,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-30T22:18:33.367Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "es1",
         "elasticsearch.cluster.uuid": "S4dWw65ZT1eu3SltmAr84A",
@@ -192,6 +204,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-30T22:18:46.493Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "es1",
         "elasticsearch.cluster.uuid": "S4dWw65ZT1eu3SltmAr84A",

--- a/filebeat/module/elasticsearch/server/test/test-json.log-expected.json
+++ b/filebeat/module/elasticsearch/server/test/test-json.log-expected.json
@@ -1,5 +1,6 @@
 [
     {
+        "@timestamp": "2019-01-18T07:55:08.159Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "distribution_run",
         "elasticsearch.component": "o.e.e.NodeEnvironment",
@@ -14,6 +15,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-18T07:55:08.163Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "distribution_run",
         "elasticsearch.component": "o.e.e.NodeEnvironment",
@@ -28,6 +30,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-18T07:55:08.165Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "distribution_run",
         "elasticsearch.component": "o.e.n.Node",
@@ -42,6 +45,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-18T07:55:08.166Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "distribution_run",
         "elasticsearch.component": "o.e.n.Node",
@@ -56,6 +60,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-18T07:55:08.166Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "distribution_run",
         "elasticsearch.component": "o.e.n.Node",
@@ -70,6 +75,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-18T07:55:08.167Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "distribution_run",
         "elasticsearch.component": "o.e.n.Node",
@@ -84,6 +90,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-18T07:55:09.492Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "distribution_run",
         "elasticsearch.component": "o.e.p.PluginsService",
@@ -98,6 +105,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-18T07:55:09.493Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "distribution_run",
         "elasticsearch.component": "o.e.p.PluginsService",
@@ -112,6 +120,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-18T07:55:09.493Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "distribution_run",
         "elasticsearch.component": "o.e.p.PluginsService",
@@ -126,6 +135,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-18T07:55:09.493Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "distribution_run",
         "elasticsearch.component": "o.e.p.PluginsService",
@@ -140,6 +150,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-18T07:55:09.494Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "distribution_run",
         "elasticsearch.component": "o.e.p.PluginsService",
@@ -154,6 +165,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-18T07:55:09.494Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "distribution_run",
         "elasticsearch.component": "o.e.p.PluginsService",
@@ -168,6 +180,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-18T07:55:09.494Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "distribution_run",
         "elasticsearch.component": "o.e.p.PluginsService",
@@ -182,6 +195,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-18T07:55:09.495Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "distribution_run",
         "elasticsearch.component": "o.e.p.PluginsService",
@@ -196,6 +210,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-18T07:55:09.495Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "distribution_run",
         "elasticsearch.component": "o.e.p.PluginsService",
@@ -210,6 +225,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-18T07:55:09.495Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "distribution_run",
         "elasticsearch.component": "o.e.p.PluginsService",
@@ -224,6 +240,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-18T07:55:09.495Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "distribution_run",
         "elasticsearch.component": "o.e.p.PluginsService",
@@ -238,6 +255,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-18T07:55:09.496Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "distribution_run",
         "elasticsearch.component": "o.e.p.PluginsService",
@@ -252,6 +270,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-18T07:55:09.496Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "distribution_run",
         "elasticsearch.component": "o.e.p.PluginsService",
@@ -266,6 +285,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-18T07:55:09.496Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "distribution_run",
         "elasticsearch.component": "o.e.p.PluginsService",
@@ -280,6 +300,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-18T07:55:09.497Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "distribution_run",
         "elasticsearch.component": "o.e.p.PluginsService",
@@ -294,6 +315,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-18T07:55:09.497Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "distribution_run",
         "elasticsearch.component": "o.e.p.PluginsService",
@@ -308,6 +330,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-18T07:55:09.497Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "distribution_run",
         "elasticsearch.component": "o.e.p.PluginsService",
@@ -322,6 +345,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-18T07:55:09.498Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "distribution_run",
         "elasticsearch.component": "o.e.p.PluginsService",
@@ -336,6 +360,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-18T07:55:09.498Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "distribution_run",
         "elasticsearch.component": "o.e.p.PluginsService",
@@ -350,6 +375,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-18T07:55:09.498Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "distribution_run",
         "elasticsearch.component": "o.e.p.PluginsService",
@@ -364,6 +390,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-18T07:55:09.498Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "distribution_run",
         "elasticsearch.component": "o.e.p.PluginsService",
@@ -378,6 +405,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-18T07:55:09.499Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "distribution_run",
         "elasticsearch.component": "o.e.p.PluginsService",
@@ -392,6 +420,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-18T07:55:09.499Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "distribution_run",
         "elasticsearch.component": "o.e.p.PluginsService",
@@ -406,6 +435,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-18T07:55:09.499Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "distribution_run",
         "elasticsearch.component": "o.e.p.PluginsService",
@@ -420,6 +450,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-18T07:55:09.499Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "distribution_run",
         "elasticsearch.component": "o.e.p.PluginsService",
@@ -434,6 +465,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-18T07:55:09.500Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "distribution_run",
         "elasticsearch.component": "o.e.p.PluginsService",
@@ -448,6 +480,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-18T07:55:09.500Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "distribution_run",
         "elasticsearch.component": "o.e.p.PluginsService",
@@ -462,6 +495,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-18T07:55:09.500Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "distribution_run",
         "elasticsearch.component": "o.e.p.PluginsService",
@@ -476,6 +510,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-18T07:55:09.501Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "distribution_run",
         "elasticsearch.component": "o.e.p.PluginsService",
@@ -490,6 +525,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-18T07:55:12.057Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "distribution_run",
         "elasticsearch.component": "o.e.x.s.a.s.FileRolesStore",
@@ -504,6 +540,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-18T07:55:12.426Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "distribution_run",
         "elasticsearch.component": "o.e.x.m.p.l.CppLogMessageHandler",
@@ -520,6 +557,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-18T07:55:12.709Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "distribution_run",
         "elasticsearch.component": "o.e.a.ActionModule",
@@ -534,6 +572,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-18T07:55:12.922Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "distribution_run",
         "elasticsearch.component": "o.e.d.DiscoveryModule",
@@ -548,6 +587,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-18T07:55:13.507Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "distribution_run",
         "elasticsearch.component": "o.e.n.Node",
@@ -562,6 +602,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-18T07:55:13.508Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "distribution_run",
         "elasticsearch.component": "o.e.n.Node",
@@ -576,6 +617,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-18T07:55:13.642Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "distribution_run",
         "elasticsearch.component": "o.e.t.TransportService",
@@ -590,6 +632,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-18T07:55:13.675Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "distribution_run",
         "elasticsearch.component": "o.e.d.z.FileBasedUnicastHostsProvider",
@@ -604,6 +647,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-18T07:55:13.796Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "distribution_run",
         "elasticsearch.component": "o.e.c.s.MasterService",
@@ -618,6 +662,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-18T07:55:13.871Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "distribution_run",
         "elasticsearch.component": "o.e.c.s.ClusterApplierService",
@@ -632,6 +677,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-18T07:55:13.922Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "distribution_run",
         "elasticsearch.cluster.uuid": "GmvrbHlNTiSVYiPf8kxg9g",
@@ -648,6 +694,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-18T07:55:13.923Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "distribution_run",
         "elasticsearch.cluster.uuid": "GmvrbHlNTiSVYiPf8kxg9g",
@@ -664,6 +711,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-18T07:55:14.105Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "distribution_run",
         "elasticsearch.cluster.uuid": "GmvrbHlNTiSVYiPf8kxg9g",
@@ -680,6 +728,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-18T07:55:14.134Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "distribution_run",
         "elasticsearch.cluster.uuid": "GmvrbHlNTiSVYiPf8kxg9g",
@@ -696,6 +745,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-18T07:55:51.725Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "distribution_run",
         "elasticsearch.cluster.uuid": "GmvrbHlNTiSVYiPf8kxg9g",
@@ -712,6 +762,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-18T07:55:51.726Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "distribution_run",
         "elasticsearch.cluster.uuid": "GmvrbHlNTiSVYiPf8kxg9g",
@@ -728,6 +779,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-18T07:55:51.739Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "distribution_run",
         "elasticsearch.cluster.uuid": "GmvrbHlNTiSVYiPf8kxg9g",
@@ -744,6 +796,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-18T07:55:52.141Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "distribution_run",
         "elasticsearch.cluster.uuid": "GmvrbHlNTiSVYiPf8kxg9g",
@@ -760,6 +813,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-18T07:55:52.141Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "distribution_run",
         "elasticsearch.cluster.uuid": "GmvrbHlNTiSVYiPf8kxg9g",
@@ -776,6 +830,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-18T07:55:52.150Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "distribution_run",
         "elasticsearch.cluster.uuid": "GmvrbHlNTiSVYiPf8kxg9g",
@@ -792,6 +847,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-10T10:18:58.523Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "elasticsearch",
         "elasticsearch.component": "test",
@@ -858,6 +914,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-10T10:18:58.537Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "elasticsearch",
         "elasticsearch.component": "o.e.c.l.JsonLoggerTests",
@@ -872,6 +929,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-10T10:18:58.560Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "elasticsearch",
         "elasticsearch.component": "test",

--- a/filebeat/module/elasticsearch/server/test/test.log-expected.json
+++ b/filebeat/module/elasticsearch/server/test/test.log-expected.json
@@ -1,5 +1,6 @@
 [
     {
+        "@timestamp": "2018-05-17T08:29:12.177Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.component": "o.e.c.m.MetaDataCreateIndexService",
         "elasticsearch.index.name": "test-filebeat-modules",
@@ -14,6 +15,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2018-05-17T08:19:35.939Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.component": "o.e.n.Node",
         "elasticsearch.node.name": "",
@@ -27,6 +29,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2018-05-17T08:19:36.089Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.component": "o.e.e.NodeEnvironment",
         "elasticsearch.node.name": "vWNJsZ3",
@@ -40,6 +43,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2018-05-17T08:19:36.090Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.component": "o.e.e.NodeEnvironment",
         "elasticsearch.node.name": "vWNJsZ3",
@@ -53,6 +57,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2018-05-17T08:19:36.116Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.component": "o.e.n.Node",
         "event.dataset": "elasticsearch.server",
@@ -65,6 +70,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2018-05-17T08:23:48.941Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.component": "o.e.c.r.a.DiskThresholdMonitor",
         "elasticsearch.node.name": "vWNJsZ3",
@@ -78,6 +84,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2018-05-17T08:29:09.245Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.component": "o.e.c.m.MetaDataCreateIndexService",
         "elasticsearch.index.name": "filebeat-test-input",
@@ -92,6 +99,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2018-05-17T08:29:09.576Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.component": "o.e.c.m.MetaDataMappingService",
         "elasticsearch.index.id": "aOGgDwbURfCV57AScqbCgw",
@@ -107,6 +115,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2018-07-09T12:47:33.959Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.component": "o.e.c.m.MetaDataMappingService",
         "elasticsearch.index.id": "3tWftqb4RLKdyCAga9syGA",
@@ -122,6 +131,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2018-05-17T08:29:25.598Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.component": "o.e.n.Node",
         "elasticsearch.node.name": "vWNJsZ3",
@@ -135,6 +145,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2018-05-17T08:29:25.612Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.component": "o.e.n.Node",
         "elasticsearch.node.name": "vWNJsZ3",
@@ -148,6 +159,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2018-07-03T11:45:48.548Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.component": "o.e.d.z.ZenDiscovery",
         "elasticsearch.node.name": "srvmulpvlsk252_md",
@@ -161,6 +173,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2018-07-03T11:45:48.548Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.component": "o.e.d.z.ZenDiscovery",
         "elasticsearch.node.name": "srvmulpvlsk252_md",
@@ -177,6 +190,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2018-07-03T11:45:52.666Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.component": "r.suppressed",
         "event.dataset": "elasticsearch.server",
@@ -192,6 +206,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2018-07-03T11:48:02.552Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.component": "r.suppressed",
         "event.dataset": "elasticsearch.server",
@@ -207,6 +222,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2018-07-03T11:45:27.896Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.component": "o.e.m.j.JvmGcMonitorService",
         "elasticsearch.node.name": "srvmulpvlsk252_md",
@@ -225,6 +241,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2018-07-03T11:45:45.604Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.component": "o.e.m.j.JvmGcMonitorService",
         "elasticsearch.node.name": "srvmulpvlsk252_md",
@@ -241,6 +258,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2018-07-03T11:48:02.541Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.component": "o.e.a.b.TransportShardBulkAction",
         "elasticsearch.node.name": "srvmulpvlsk252_md",
@@ -254,6 +272,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2018-07-03T20:10:07.376Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.component": "o.e.x.m.MonitoringService",
         "elasticsearch.node.name": "srvmulpvlsk252_md",

--- a/filebeat/module/elasticsearch/slowlog/test/auditlog_index_indexing_slowlog.log-expected.json
+++ b/filebeat/module/elasticsearch/slowlog/test/auditlog_index_indexing_slowlog.log-expected.json
@@ -1,5 +1,6 @@
 [
     {
+        "@timestamp": "2018-07-04T21:51:29.536Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.index.id": "VLKxBLvUSYuIMKzpacGjRg",
         "elasticsearch.index.name": "metricbeat-6.3.0-2018.07.04",
@@ -21,6 +22,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2018-07-04T21:51:29.537Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.index.id": "VLKxBLvUSYuIMKzpacGjRg",
         "elasticsearch.index.name": "metricbeat-6.3.0-2018.07.04",
@@ -42,6 +44,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2018-07-04T21:51:29.538Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.index.id": "VLKxBLvUSYuIMKzpacGjRg",
         "elasticsearch.index.name": "metricbeat-6.3.0-2018.07.04",
@@ -63,6 +66,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2018-07-04T21:51:30.411Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.index.id": "VLKxBLvUSYuIMKzpacGjRg",
         "elasticsearch.index.name": "metricbeat-6.3.0-2018.07.04",
@@ -83,6 +87,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2018-07-04T21:51:30.963Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.index.id": "VLKxBLvUSYuIMKzpacGjRg",
         "elasticsearch.index.name": "metricbeat-6.3.0-2018.07.04",
@@ -104,6 +109,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2018-07-04T21:51:30.965Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.index.id": "VLKxBLvUSYuIMKzpacGjRg",
         "elasticsearch.index.name": "metricbeat-6.3.0-2018.07.04",

--- a/filebeat/module/elasticsearch/slowlog/test/es_index_indexing_slowlog-json.log-expected.json
+++ b/filebeat/module/elasticsearch/slowlog/test/es_index_indexing_slowlog-json.log-expected.json
@@ -1,5 +1,6 @@
 [
     {
+        "@timestamp": "2019-01-29T07:35:54.170Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "distribution_run",
         "elasticsearch.cluster.uuid": "oqKkg2eoQh2P_KrKliI3DA",
@@ -24,6 +25,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-29T07:35:58.359Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "distribution_run",
         "elasticsearch.cluster.uuid": "oqKkg2eoQh2P_KrKliI3DA",

--- a/filebeat/module/elasticsearch/slowlog/test/es_index_search_slowlog-json.log-expected.json
+++ b/filebeat/module/elasticsearch/slowlog/test/es_index_search_slowlog-json.log-expected.json
@@ -1,5 +1,6 @@
 [
     {
+        "@timestamp": "2019-01-29T07:31:40.426Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "distribution_run",
         "elasticsearch.cluster.uuid": "oqKkg2eoQh2P_KrKliI3DA",
@@ -20,6 +21,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-29T07:36:01.675Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "distribution_run",
         "elasticsearch.cluster.uuid": "oqKkg2eoQh2P_KrKliI3DA",
@@ -40,6 +42,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2019-01-29T07:36:01.685Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.cluster.name": "distribution_run",
         "elasticsearch.cluster.uuid": "oqKkg2eoQh2P_KrKliI3DA",

--- a/filebeat/module/elasticsearch/slowlog/test/test.log-expected.json
+++ b/filebeat/module/elasticsearch/slowlog/test/test.log-expected.json
@@ -1,5 +1,6 @@
 [
     {
+        "@timestamp": "2018-06-29T10:06:14.933Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.index.name": "metricbeat-6.3.0-2018.06.26",
         "elasticsearch.node.name": "v_VJhjV",
@@ -26,6 +27,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2018-06-29T10:06:14.943Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.index.name": "metricbeat-6.3.0-2018.06.26",
         "elasticsearch.node.name": "v_VJhjV",
@@ -49,6 +51,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2018-06-29T09:01:01.821Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.index.name": "metricbeat-6.3.0-2018.06.26",
         "elasticsearch.node.name": "v_VJhjV",
@@ -72,6 +75,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2018-06-29T09:01:01.827Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.index.name": "metricbeat-6.3.0-2018.06.26",
         "elasticsearch.node.name": "v_VJhjV",
@@ -95,6 +99,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2018-07-04T13:48:07.452Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.index.id": "VLKxBLvUSYuIMKzpacGjRg",
         "elasticsearch.index.name": "metricbeat-6.3.0-2018.07.04",
@@ -116,6 +121,7 @@
         "service.type": "elasticsearch"
     },
     {
+        "@timestamp": "2018-07-04T21:51:30.411Z",
         "ecs.version": "1.0.0-beta2",
         "elasticsearch.index.id": "VLKxBLvUSYuIMKzpacGjRg",
         "elasticsearch.index.name": "metricbeat-6.3.0-2018.07.04",

--- a/filebeat/module/logstash/log/test/logstash-plain.log-expected.json
+++ b/filebeat/module/logstash/log/test/logstash-plain.log-expected.json
@@ -1,5 +1,6 @@
 [
     {
+        "@timestamp": "2017-10-23T14:20:12.046Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "logstash.log",
         "event.module": "logstash",
@@ -12,6 +13,7 @@
         "service.type": "logstash"
     },
     {
+        "@timestamp": "2017-11-20T03:55:00.318Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "logstash.log",
         "event.module": "logstash",

--- a/filebeat/module/logstash/slowlog/test/slowlog-plain.log-expected.json
+++ b/filebeat/module/logstash/slowlog/test/slowlog-plain.log-expected.json
@@ -1,5 +1,6 @@
 [
     {
+        "@timestamp": "2017-10-30T09:57:58.243Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "logstash.slowlog",
         "event.duration": 3027675106,


### PR DESCRIPTION
Resolves #10668.

In #10441, `@timestamp` fields from a number of Filebeat modules' golden test files were removed to account for a regression in Elasticsearch date parsing. This regression will be fixed in https://github.com/elastic/elasticsearch/pull/38434. Once that PR is merged, this PR can be merged as well.