### PR TITLE
Add username password into kibana config before calling NewKibanaClient

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -168,6 +168,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix encoding of timestamps when using disk spool. {issue}10099[10099]
 - Fix stopping of modules started by kubernetes autodiscover. {pull}10476[10476]
 - Fix a issue when remote and local configuration didn't match when fetching configuration from Central Management. {issue}10587[10587]
+- Fix unauthorized error when loading dashboards by adding username and password into kibana config. {issue}10513[10513] {pull}10675[10675]
 
 *Auditbeat*
 

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -690,6 +690,8 @@ func (b *Beat) loadDashboards(ctx context.Context, force bool) error {
 			withMigration = sub.Enabled()
 		}
 
+		// Initialize kibana config. If username and password is set in elasticsearch output config but not in kibana,
+		// initKibanaConfig will attach the ussername and password into kibana config as a part of the initialization.
 		kibanaConfig, err := initKibanaConfig(b.Config)
 		if err != nil {
 			return fmt.Errorf("error initKibanaConfig: %v", err)

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -701,6 +701,18 @@ func (b *Beat) loadDashboards(ctx context.Context, force bool) error {
 			kibanaConfig = common.NewConfig()
 		}
 
+		if esConfig.Enabled() {
+			username, _ := esConfig.String("username", -1)
+			password, _ := esConfig.String("password", -1)
+
+			if !kibanaConfig.HasField("username") && username != "" {
+				kibanaConfig.SetString("username", -1, username)
+			}
+			if !kibanaConfig.HasField("password") && password != "" {
+				kibanaConfig.SetString("password", -1, password)
+			}
+		}
+
 		client, err := kibana.NewKibanaClient(kibanaConfig)
 		if err != nil {
 			return fmt.Errorf("error connecting to Kibana: %v", err)
@@ -720,7 +732,7 @@ func (b *Beat) loadDashboards(ctx context.Context, force bool) error {
 		}
 
 		err = dashboards.ImportDashboards(ctx, b.Info, paths.Resolve(paths.Home, ""),
-			kibanaConfig, esConfig, b.Config.Dashboards, nil, pattern)
+			kibanaConfig, b.Config.Dashboards, nil, pattern)
 		if err != nil {
 			return errw.Wrap(err, "Error importing Kibana dashboards")
 		}

--- a/libbeat/cmd/instance/beat_test.go
+++ b/libbeat/cmd/instance/beat_test.go
@@ -20,8 +20,9 @@
 package instance
 
 import (
-	"github.com/elastic/beats/libbeat/cfgfile"
 	"testing"
+
+	"github.com/elastic/beats/libbeat/cfgfile"
 
 	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/assert"

--- a/libbeat/cmd/instance/beat_test.go
+++ b/libbeat/cmd/instance/beat_test.go
@@ -20,6 +20,7 @@
 package instance
 
 import (
+	"github.com/elastic/beats/libbeat/cfgfile"
 	"testing"
 
 	"github.com/gofrs/uuid"
@@ -62,4 +63,31 @@ func TestNewInstanceUUID(t *testing.T) {
 		t.Fatalf("error while generating ID: %v", err)
 	}
 	assert.NotEqual(t, b.Info.ID, differentUUID)
+}
+
+func TestInitKibanaConfig(t *testing.T) {
+	b, err := NewBeat("filebeat", "testidx", "0.9")
+	if err != nil {
+		panic(err)
+	}
+
+	assert.Equal(t, "filebeat", b.Info.Beat)
+	assert.Equal(t, "testidx", b.Info.IndexPrefix)
+	assert.Equal(t, "0.9", b.Info.Version)
+
+	cfg, err := cfgfile.Load("../test/filebeat_test.yml", nil)
+	err = cfg.Unpack(&b.Config)
+	assert.NoError(t, err)
+
+	kibanaConfig, err := initKibanaConfig(b.Config)
+	assert.NoError(t, err)
+	username, err := kibanaConfig.String("username", -1)
+	password, err := kibanaConfig.String("password", -1)
+	protocol, err := kibanaConfig.String("protocol", -1)
+	host, err := kibanaConfig.String("host", -1)
+
+	assert.Equal(t, "elastic-test-username", username)
+	assert.Equal(t, "elastic-test-password", password)
+	assert.Equal(t, "https", protocol)
+	assert.Equal(t, "127.0.0.1:5601", host)
 }

--- a/libbeat/cmd/test/filebeat_test.yml
+++ b/libbeat/cmd/test/filebeat_test.yml
@@ -1,0 +1,26 @@
+#============================== Kibana =====================================
+
+# Starting with Beats version 6.0.0, the dashboards are loaded via the Kibana API.
+# This requires a Kibana endpoint configuration.
+setup.kibana:
+
+  # Kibana Host
+  # Scheme and port can be left out and will be set to the default (http and 5601)
+  # In case you specify and additional path, the scheme is required: http://localhost:5601/path
+  # IPv6 addresses should always be defined as: https://[2001:db8::1]:5601
+  host: "127.0.0.1:5601"
+  protocol: https
+
+#================================ Outputs =====================================
+
+# Configure what output to use when sending the data collected by the beat.
+
+#-------------------------- Elasticsearch output ------------------------------
+output.elasticsearch:
+  # Array of hosts to connect to.
+  hosts: ["127.0.0.1:9200"]
+
+  # Optional protocol and basic auth credentials.
+  username: "elastic-test-username"
+  password: "elastic-test-password"
+  protocal: "https"

--- a/libbeat/dashboards/dashboards.go
+++ b/libbeat/dashboards/dashboards.go
@@ -33,7 +33,7 @@ import (
 func ImportDashboards(
 	ctx context.Context,
 	beatInfo beat.Info, homePath string,
-	kibanaConfig, esConfig, dashboardsConfig *common.Config,
+	kibanaConfig, dashboardsConfig *common.Config,
 	msgOutputter MessageOutputter,
 	pattern common.MapStr,
 ) error {
@@ -48,18 +48,6 @@ func ImportDashboards(
 	err := dashboardsConfig.Unpack(&dashConfig)
 	if err != nil {
 		return err
-	}
-
-	if esConfig.Enabled() {
-		username, _ := esConfig.String("username", -1)
-		password, _ := esConfig.String("password", -1)
-
-		if !kibanaConfig.HasField("username") && username != "" {
-			kibanaConfig.SetString("username", -1, username)
-		}
-		if !kibanaConfig.HasField("password") && password != "" {
-			kibanaConfig.SetString("password", -1, password)
-		}
 	}
 
 	if !kibanaConfig.Enabled() {


### PR DESCRIPTION
Turned out the fix in https://github.com/elastic/beats/pull/10553 won't solve the issue because `kibana.NewKibanaClient(kibanaConfig)` is called before `dashboards.ImportDashboards`, which already requires the correct config including password and username as input. So moving the same code upfront before `kibana.NewKibanaClient` is called solves this issue. 