### PR TITLE
Cherry-pick #10663 to 7.0: Revert changes in timezones in filebeat expected results

### DIFF
--- a/filebeat/module/apache/access/test/ssl-request.log-expected.json
+++ b/filebeat/module/apache/access/test/ssl-request.log-expected.json
@@ -1,6 +1,6 @@
 [
     {
-        "@timestamp": "2018-08-10T09:45:56.000Z",
+        "@timestamp": "2018-08-10T07:45:56.000Z",
         "apache.access.ssl.cipher": "ECDHE-RSA-AES128-GCM-SHA256",
         "apache.access.ssl.protocol": "TLSv1.2",
         "ecs.version": "1.0.0-beta2",

--- a/filebeat/module/apache/access/test/test.log-expected.json
+++ b/filebeat/module/apache/access/test/test.log-expected.json
@@ -1,6 +1,6 @@
 [
     {
-        "@timestamp": "2016-12-26T16:16:29.000Z",
+        "@timestamp": "2016-12-26T14:16:29.000Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "apache.access",
         "event.module": "apache",
@@ -44,7 +44,7 @@
         "user_agent.version": "50.0"
     },
     {
-        "@timestamp": "2016-12-26T16:16:48.000Z",
+        "@timestamp": "2016-12-26T14:16:48.000Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "apache.access",
         "event.module": "apache",

--- a/filebeat/module/icinga/debug/test/test.log-expected.json
+++ b/filebeat/module/icinga/debug/test/test.log-expected.json
@@ -1,6 +1,6 @@
 [
     {
-        "@timestamp": "2017-04-04T13:43:09.000Z",
+        "@timestamp": "2017-04-04T11:43:09.000Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "icinga.debug",
         "event.module": "icinga",
@@ -13,7 +13,7 @@
         "service.type": "icinga"
     },
     {
-        "@timestamp": "2017-04-04T13:43:09.000Z",
+        "@timestamp": "2017-04-04T11:43:09.000Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "icinga.debug",
         "event.module": "icinga",
@@ -26,7 +26,7 @@
         "service.type": "icinga"
     },
     {
-        "@timestamp": "2017-04-04T13:43:11.000Z",
+        "@timestamp": "2017-04-04T11:43:11.000Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "icinga.debug",
         "event.module": "icinga",

--- a/filebeat/module/icinga/main/test/test.log-expected.json
+++ b/filebeat/module/icinga/main/test/test.log-expected.json
@@ -1,6 +1,6 @@
 [
     {
-        "@timestamp": "2017-04-04T11:16:34.000Z",
+        "@timestamp": "2017-04-04T09:16:34.000Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "icinga.main",
         "event.module": "icinga",
@@ -13,7 +13,7 @@
         "service.type": "icinga"
     },
     {
-        "@timestamp": "2017-04-04T11:16:34.000Z",
+        "@timestamp": "2017-04-04T09:16:34.000Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "icinga.main",
         "event.module": "icinga",
@@ -29,7 +29,7 @@
         "service.type": "icinga"
     },
     {
-        "@timestamp": "2017-04-04T11:16:48.000Z",
+        "@timestamp": "2017-04-04T09:16:48.000Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "icinga.main",
         "event.module": "icinga",

--- a/filebeat/module/mongodb/log/test/mongodb-debian-3.2.11.log-expected.json
+++ b/filebeat/module/mongodb/log/test/mongodb-debian-3.2.11.log-expected.json
@@ -1,6 +1,6 @@
 [
     {
-        "@timestamp": "2018-02-05T13:44:56.657Z",
+        "@timestamp": "2018-02-05T12:44:56.657Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",
@@ -14,7 +14,7 @@
         "service.type": "mongodb"
     },
     {
-        "@timestamp": "2018-02-05T13:44:56.657Z",
+        "@timestamp": "2018-02-05T12:44:56.657Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",
@@ -28,7 +28,7 @@
         "service.type": "mongodb"
     },
     {
-        "@timestamp": "2018-02-05T13:44:56.657Z",
+        "@timestamp": "2018-02-05T12:44:56.657Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",
@@ -42,7 +42,7 @@
         "service.type": "mongodb"
     },
     {
-        "@timestamp": "2018-02-05T13:44:56.677Z",
+        "@timestamp": "2018-02-05T12:44:56.677Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",
@@ -56,7 +56,7 @@
         "service.type": "mongodb"
     },
     {
-        "@timestamp": "2018-02-05T13:44:56.724Z",
+        "@timestamp": "2018-02-05T12:44:56.724Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",
@@ -70,7 +70,7 @@
         "service.type": "mongodb"
     },
     {
-        "@timestamp": "2018-02-05T13:44:56.724Z",
+        "@timestamp": "2018-02-05T12:44:56.724Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",
@@ -84,7 +84,7 @@
         "service.type": "mongodb"
     },
     {
-        "@timestamp": "2018-02-05T13:44:56.744Z",
+        "@timestamp": "2018-02-05T12:44:56.744Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",
@@ -98,7 +98,7 @@
         "service.type": "mongodb"
     },
     {
-        "@timestamp": "2018-02-05T13:50:55.170Z",
+        "@timestamp": "2018-02-05T12:50:55.170Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",
@@ -112,7 +112,7 @@
         "service.type": "mongodb"
     },
     {
-        "@timestamp": "2018-02-05T13:50:55.487Z",
+        "@timestamp": "2018-02-05T12:50:55.487Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",
@@ -126,7 +126,7 @@
         "service.type": "mongodb"
     },
     {
-        "@timestamp": "2018-02-05T14:49:45.606Z",
+        "@timestamp": "2018-02-05T13:49:45.606Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",
@@ -140,7 +140,7 @@
         "service.type": "mongodb"
     },
     {
-        "@timestamp": "2018-02-05T14:49:45.606Z",
+        "@timestamp": "2018-02-05T13:49:45.606Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",
@@ -154,7 +154,7 @@
         "service.type": "mongodb"
     },
     {
-        "@timestamp": "2018-02-05T14:49:45.606Z",
+        "@timestamp": "2018-02-05T13:49:45.606Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",
@@ -168,7 +168,7 @@
         "service.type": "mongodb"
     },
     {
-        "@timestamp": "2018-02-05T14:49:45.606Z",
+        "@timestamp": "2018-02-05T13:49:45.606Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",
@@ -182,7 +182,7 @@
         "service.type": "mongodb"
     },
     {
-        "@timestamp": "2018-02-05T14:49:45.606Z",
+        "@timestamp": "2018-02-05T13:49:45.606Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",
@@ -196,7 +196,7 @@
         "service.type": "mongodb"
     },
     {
-        "@timestamp": "2018-02-05T14:49:45.688Z",
+        "@timestamp": "2018-02-05T13:49:45.688Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",
@@ -210,7 +210,7 @@
         "service.type": "mongodb"
     },
     {
-        "@timestamp": "2018-02-05T13:44:56.657Z",
+        "@timestamp": "2018-02-05T12:44:56.657Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",
@@ -224,7 +224,7 @@
         "service.type": "mongodb"
     },
     {
-        "@timestamp": "2018-02-05T13:44:56.657Z",
+        "@timestamp": "2018-02-05T12:44:56.657Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",
@@ -238,7 +238,7 @@
         "service.type": "mongodb"
     },
     {
-        "@timestamp": "2018-02-05T13:44:56.657Z",
+        "@timestamp": "2018-02-05T12:44:56.657Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",
@@ -252,7 +252,7 @@
         "service.type": "mongodb"
     },
     {
-        "@timestamp": "2018-02-05T13:44:56.657Z",
+        "@timestamp": "2018-02-05T12:44:56.657Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",
@@ -266,7 +266,7 @@
         "service.type": "mongodb"
     },
     {
-        "@timestamp": "2018-02-05T13:50:55.170Z",
+        "@timestamp": "2018-02-05T12:50:55.170Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",
@@ -280,7 +280,7 @@
         "service.type": "mongodb"
     },
     {
-        "@timestamp": "2018-02-05T13:50:56.180Z",
+        "@timestamp": "2018-02-05T12:50:56.180Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",
@@ -294,7 +294,7 @@
         "service.type": "mongodb"
     },
     {
-        "@timestamp": "2018-02-05T14:15:42.095Z",
+        "@timestamp": "2018-02-05T13:15:42.095Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",
@@ -308,7 +308,7 @@
         "service.type": "mongodb"
     },
     {
-        "@timestamp": "2018-02-05T14:49:45.606Z",
+        "@timestamp": "2018-02-05T13:49:45.606Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",
@@ -322,7 +322,7 @@
         "service.type": "mongodb"
     },
     {
-        "@timestamp": "2018-02-05T14:49:45.606Z",
+        "@timestamp": "2018-02-05T13:49:45.606Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",
@@ -336,7 +336,7 @@
         "service.type": "mongodb"
     },
     {
-        "@timestamp": "2018-02-05T14:49:45.688Z",
+        "@timestamp": "2018-02-05T13:49:45.688Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",
@@ -350,7 +350,7 @@
         "service.type": "mongodb"
     },
     {
-        "@timestamp": "2018-02-05T13:44:56.657Z",
+        "@timestamp": "2018-02-05T12:44:56.657Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",
@@ -364,7 +364,7 @@
         "service.type": "mongodb"
     },
     {
-        "@timestamp": "2018-02-05T13:44:56.657Z",
+        "@timestamp": "2018-02-05T12:44:56.657Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",
@@ -378,7 +378,7 @@
         "service.type": "mongodb"
     },
     {
-        "@timestamp": "2018-02-05T13:44:56.657Z",
+        "@timestamp": "2018-02-05T12:44:56.657Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",
@@ -392,7 +392,7 @@
         "service.type": "mongodb"
     },
     {
-        "@timestamp": "2018-02-05T13:50:55.487Z",
+        "@timestamp": "2018-02-05T12:50:55.487Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",
@@ -406,7 +406,7 @@
         "service.type": "mongodb"
     },
     {
-        "@timestamp": "2018-02-05T13:50:56.180Z",
+        "@timestamp": "2018-02-05T12:50:56.180Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",
@@ -420,7 +420,7 @@
         "service.type": "mongodb"
     },
     {
-        "@timestamp": "2018-02-05T14:11:41.401Z",
+        "@timestamp": "2018-02-05T13:11:41.401Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",
@@ -434,7 +434,7 @@
         "service.type": "mongodb"
     },
     {
-        "@timestamp": "2018-02-05T14:49:45.605Z",
+        "@timestamp": "2018-02-05T13:49:45.605Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",
@@ -448,7 +448,7 @@
         "service.type": "mongodb"
     },
     {
-        "@timestamp": "2018-02-05T14:49:45.605Z",
+        "@timestamp": "2018-02-05T13:49:45.605Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",
@@ -462,7 +462,7 @@
         "service.type": "mongodb"
     },
     {
-        "@timestamp": "2018-02-05T14:49:45.606Z",
+        "@timestamp": "2018-02-05T13:49:45.606Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "mongodb.log",
         "event.module": "mongodb",

--- a/filebeat/module/nginx/access/test/test.log-expected.json
+++ b/filebeat/module/nginx/access/test/test.log-expected.json
@@ -1,6 +1,6 @@
 [
     {
-        "@timestamp": "2016-12-07T11:05:07.000Z",
+        "@timestamp": "2016-12-07T10:05:07.000Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "nginx.access",
         "event.module": "nginx",
@@ -58,7 +58,7 @@
         "user_agent.version": "15.0.a2"
     },
     {
-        "@timestamp": "2016-12-07T11:05:07.000Z",
+        "@timestamp": "2016-12-07T10:05:07.000Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "nginx.access",
         "event.module": "nginx",
@@ -96,7 +96,7 @@
         "user_agent.version": "49.0"
     },
     {
-        "@timestamp": "2016-12-07T11:05:07.000Z",
+        "@timestamp": "2016-12-07T10:05:07.000Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "nginx.access",
         "event.module": "nginx",
@@ -199,7 +199,7 @@
         "user_agent.version": "1.0"
     },
     {
-        "@timestamp": "2018-04-12T09:48:40.000Z",
+        "@timestamp": "2018-04-12T07:48:40.000Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "nginx.access",
         "event.module": "nginx",

--- a/filebeat/module/traefik/access/test/test.log-expected.json
+++ b/filebeat/module/traefik/access/test/test.log-expected.json
@@ -198,7 +198,7 @@
         "user_agent.os.name": "Android"
     },
     {
-        "@timestamp": "2000-10-10T13:55:36.000Z",
+        "@timestamp": "2000-10-10T20:55:36.000Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "traefik.access",
         "event.module": "traefik",


### PR DESCRIPTION
Cherry-pick of PR #10663 to 7.0 branch. Original message: 

There was a regression in ES snapshots when parsing timezones and we
adapted the expected results to the incorrect values in #10441. Revert
these changes when the fixed ES images are ready.