### PR TITLE
Give more times to check for Mockbeat alive

### DIFF
--- a/libbeat/tests/system/test_base.py
+++ b/libbeat/tests/system/test_base.py
@@ -124,7 +124,6 @@ class Test(BaseTest):
             lambda: self.log_contains("Total non-zero metrics"),
             max_timeout=2)
 
-    @unittest.skipIf(sys.platform == 'darwin', 'flaky test https://github.com/elastic/beats/issues/9216')
     def test_persistent_uuid(self):
         self.render_config_template()
 
@@ -133,7 +132,7 @@ class Test(BaseTest):
         def run():
             proc = self.start_beat(extra_args=["-path.home", self.working_dir])
             self.wait_until(lambda: self.log_contains("Mockbeat is alive"),
-                            max_timeout=2)
+                            max_timeout=60)
 
             # open meta file before killing the beat, checking the file being
             # available right after startup


### PR DESCRIPTION
Under darwin that test was flaky, I've ran it a few times locally
without issues. looking at the previous issue we always fails check that
Mockbeat is alived, but since this run on VM, we could hit contention
issues with either disk or cpu. Lets give more time to actually assert
before timeout.

Fixes: #9216