### PR TITLE
Give more time to Mac's test VM

### DIFF
--- a/filebeat/tests/system/test_crawler.py
+++ b/filebeat/tests/system/test_crawler.py
@@ -392,7 +392,7 @@ class Test(BaseTest):
 
             self.wait_until(
                 lambda: self.output_has(1),
-                max_timeout=15)
+                max_timeout=60, poll_interval=1)
 
         lines_written = 0
 
@@ -407,7 +407,7 @@ class Test(BaseTest):
 
                 self.wait_until(
                     lambda: self.output_has(lines_written + 1),
-                    max_timeout=15)
+                    max_timeout=60, poll_interval=1)
 
         filebeat.check_kill_and_wait()
 


### PR DESCRIPTION
Everytime that you assert content from disk, you are at the mercy of the
FS speed, on VM especially on our mac runner disk access can be slow,
there is no need to have low timeout values for theses tests and we do
not need to poll the disk on every 0.1s. Let's give more times for data
to be flushed to disk and make sure we hit the fresh data instead of
cached values.

Fixes: #7687