### PR TITLE
[docs][APM] Add apm_user role

### DIFF
--- a/libbeat/docs/security/user-access.asciidoc
+++ b/libbeat/docs/security/user-access.asciidoc
@@ -2,21 +2,32 @@
 [[beats-user-access]]
 === Grant users access to {beatname_uc} indices
 
+:person: user
+:role_name: reader
+
 To enable users to access the indices {beatname_uc} creates, grant them `read`
 and `view_index_metadata` privileges on the {beatname_uc} indices. If they're
 using {kib}, they also need the `kibana_user` role.
 
-. Create a reader role that has the `read` and `view_index_metadata` privileges
+ifdef::apm-server[]
+:person: account
+:role_name: user
+X-Pack security provides a built-in role called `apm_user` that you can explicitly assign to users.
+This role grants them the necessary `read` and `view_index_metadata` privileges on the {beatname_uc} indices.
+endif::apm-server[]
+
+ifndef::apm-server[]
+. Create a {role_name} role that has the `read` and `view_index_metadata` privileges
 on the {beatname_uc} indices.
 +
 You can create roles from the **Management > Roles** UI in {kib} or through the
 `role` API. For example, the following request creates a role named
-++{beat_default_index_prefix}_reader++:
+++{beat_default_index_prefix}_{role_name}++:
 +
 --
 ["source","sh",subs="attributes,callouts"]
 ---------------------------------------------------------------
-POST _security/role/{beat_default_index_prefix}_reader
+POST _xpack/security/role/{beat_default_index_prefix}_{role_name}
 {
   "indices": [
     {
@@ -30,40 +41,43 @@ POST _security/role/{beat_default_index_prefix}_reader
 <1> If you use a custom {beatname_uc} index pattern, specify that pattern
 instead of the default ++{beat_default_index_prefix}-*++ pattern.
 --
+endif::apm-server[]
 
-. Assign your users the reader role so they can access the {beatname_uc}
-indices. For {kib} users who need to visualize the data, also assign the
-`kibana_user` role:
+. Assign your users the ++{beat_default_index_prefix}_{role_name}++
+role so they can access the {beatname_uc} indices.
+For {kib} users who need to visualize the data,
+also assign the `kibana_user` role:
 
 .. If you're using the `native` realm, you can assign roles with the
 **Management > Users** UI in {kib} or through the `user` API. For example, the
-following request grants ++{beat_default_index_prefix}_user++ the
-++{beat_default_index_prefix}_reader++ and `kibana_user` roles:
+following request grants ++{beat_default_index_prefix}_{person}++ the
+++{beat_default_index_prefix}_{role_name}++ and `kibana_user` roles:
 +
 --
 ["source", "sh", subs="attributes,callouts"]
 ---------------------------------------------------------------
-POST /_security/user/{beat_default_index_prefix}_user
+POST /_xpack/security/user/{beat_default_index_prefix}_{person}
 {
   "password" : "{pwd}",
-  "roles" : [ "{beat_default_index_prefix}_reader","kibana_user"],
-  "full_name" : "{beatname_uc} User"
+  "roles" : [ "{beat_default_index_prefix}_{role_name}","kibana_user"],
+  "full_name" : "{beatname_uc} {person}"
 }
 ---------------------------------------------------------------
 // CONSOLE
 --
-.. If you're using the LDAP, Active Directory, or PKI realms, you assign the
-roles in the `role_mapping.yml` configuration file. For example, the following
-snippet grants ++{beatname_uc} User++ the ++{beat_default_index_prefix}_reader++
-and `kibana_user` roles:
+.. If you're using the LDAP, Active Directory, or PKI realms,
+you assign the roles in the `role_mapping.yml` configuration file.
+For example, the following snippet grants
+++{beat_default_index_prefix} {person}++ the
+++{beat_default_index_prefix}_{role_name}++ and `kibana_user` roles:
 +
 --
 ["source", "yaml", subs="attributes,callouts"]
 ---------------------------------------------------------------
-{beat_default_index_prefix}_reader:
-  - "cn={beatname_uc} User,dc=example,dc=com"
+{beat_default_index_prefix}_{role_name}:
+  - "cn={beatname_uc} {person},dc=example,dc=com"
 kibana_user:
-  - "cn={beatname_uc} User,dc=example,dc=com"
+  - "cn={beatname_uc} {person},dc=example,dc=com"
 ---------------------------------------------------------------
 
 For more information, see

--- a/libbeat/docs/security/user-access.asciidoc
+++ b/libbeat/docs/security/user-access.asciidoc
@@ -25,7 +25,7 @@ You can create roles from the **Management > Roles** UI in {kib} or through the
 --
 ["source","sh",subs="attributes,callouts"]
 ---------------------------------------------------------------
-POST _xpack/security/role/{beat_default_index_prefix}_{role_name}
+POST _security/role/{beat_default_index_prefix}_{role_name}
 {
   "indices": [
     {
@@ -54,7 +54,7 @@ following request grants ++{beat_default_index_prefix}_account++ the
 --
 ["source", "sh", subs="attributes,callouts"]
 ---------------------------------------------------------------
-POST /_xpack/security/user/{beat_default_index_prefix}_account
+POST /_security/user/{beat_default_index_prefix}_account
 {
   "password" : "{pwd}",
   "roles" : [ "{beat_default_index_prefix}_{role_name}","kibana_user"],

--- a/libbeat/docs/security/user-access.asciidoc
+++ b/libbeat/docs/security/user-access.asciidoc
@@ -2,7 +2,6 @@
 [[beats-user-access]]
 === Grant users access to {beatname_uc} indices
 
-:person: user
 :role_name: reader
 
 To enable users to access the indices {beatname_uc} creates, grant them `read`
@@ -10,7 +9,6 @@ and `view_index_metadata` privileges on the {beatname_uc} indices. If they're
 using {kib}, they also need the `kibana_user` role.
 
 ifdef::apm-server[]
-:person: account
 :role_name: user
 X-Pack security provides a built-in role called `apm_user` that you can explicitly assign to users.
 This role grants them the necessary `read` and `view_index_metadata` privileges on the {beatname_uc} indices.
@@ -50,17 +48,17 @@ also assign the `kibana_user` role:
 
 .. If you're using the `native` realm, you can assign roles with the
 **Management > Users** UI in {kib} or through the `user` API. For example, the
-following request grants ++{beat_default_index_prefix}_{person}++ the
+following request grants ++{beat_default_index_prefix}_account++ the
 ++{beat_default_index_prefix}_{role_name}++ and `kibana_user` roles:
 +
 --
 ["source", "sh", subs="attributes,callouts"]
 ---------------------------------------------------------------
-POST /_xpack/security/user/{beat_default_index_prefix}_{person}
+POST /_xpack/security/user/{beat_default_index_prefix}_account
 {
   "password" : "{pwd}",
   "roles" : [ "{beat_default_index_prefix}_{role_name}","kibana_user"],
-  "full_name" : "{beatname_uc} {person}"
+  "full_name" : "{beatname_uc} account"
 }
 ---------------------------------------------------------------
 // CONSOLE
@@ -68,16 +66,16 @@ POST /_xpack/security/user/{beat_default_index_prefix}_{person}
 .. If you're using the LDAP, Active Directory, or PKI realms,
 you assign the roles in the `role_mapping.yml` configuration file.
 For example, the following snippet grants
-++{beat_default_index_prefix} {person}++ the
+++{beat_default_index_prefix} account++ the
 ++{beat_default_index_prefix}_{role_name}++ and `kibana_user` roles:
 +
 --
 ["source", "yaml", subs="attributes,callouts"]
 ---------------------------------------------------------------
 {beat_default_index_prefix}_{role_name}:
-  - "cn={beatname_uc} {person},dc=example,dc=com"
+  - "cn={beatname_uc} account,dc=example,dc=com"
 kibana_user:
-  - "cn={beatname_uc} {person},dc=example,dc=com"
+  - "cn={beatname_uc} account,dc=example,dc=com"
 ---------------------------------------------------------------
 
 For more information, see

--- a/libbeat/docs/security/user-access.asciidoc
+++ b/libbeat/docs/security/user-access.asciidoc
@@ -2,30 +2,27 @@
 [[beats-user-access]]
 === Grant users access to {beatname_uc} indices
 
-:role_name: reader
-
 To enable users to access the indices {beatname_uc} creates, grant them `read`
 and `view_index_metadata` privileges on the {beatname_uc} indices. If they're
 using {kib}, they also need the `kibana_user` role.
 
 ifdef::apm-server[]
-:role_name: user
 X-Pack security provides a built-in role called `apm_user` that you can explicitly assign to users.
 This role grants them the necessary `read` and `view_index_metadata` privileges on the {beatname_uc} indices.
 endif::apm-server[]
 
 ifndef::apm-server[]
-. Create a {role_name} role that has the `read` and `view_index_metadata` privileges
+. Create a role that has the `read` and `view_index_metadata` privileges
 on the {beatname_uc} indices.
 +
 You can create roles from the **Management > Roles** UI in {kib} or through the
 `role` API. For example, the following request creates a role named
-++{beat_default_index_prefix}_{role_name}++:
+++{access_role}++:
 +
 --
 ["source","sh",subs="attributes,callouts"]
 ---------------------------------------------------------------
-POST _security/role/{beat_default_index_prefix}_{role_name}
+POST _security/role/{access_role}
 {
   "indices": [
     {
@@ -41,7 +38,7 @@ instead of the default ++{beat_default_index_prefix}-*++ pattern.
 --
 endif::apm-server[]
 
-. Assign your users the ++{beat_default_index_prefix}_{role_name}++
+. Assign your users the ++{access_role}++
 role so they can access the {beatname_uc} indices.
 For {kib} users who need to visualize the data,
 also assign the `kibana_user` role:
@@ -49,7 +46,7 @@ also assign the `kibana_user` role:
 .. If you're using the `native` realm, you can assign roles with the
 **Management > Users** UI in {kib} or through the `user` API. For example, the
 following request grants ++{beat_default_index_prefix}_account++ the
-++{beat_default_index_prefix}_{role_name}++ and `kibana_user` roles:
+++{access_role}++ and `kibana_user` roles:
 +
 --
 ["source", "sh", subs="attributes,callouts"]
@@ -57,7 +54,7 @@ following request grants ++{beat_default_index_prefix}_account++ the
 POST /_security/user/{beat_default_index_prefix}_account
 {
   "password" : "{pwd}",
-  "roles" : [ "{beat_default_index_prefix}_{role_name}","kibana_user"],
+  "roles" : [ "{access_role}","kibana_user"],
   "full_name" : "{beatname_uc} account"
 }
 ---------------------------------------------------------------
@@ -66,16 +63,16 @@ POST /_security/user/{beat_default_index_prefix}_account
 .. If you're using the LDAP, Active Directory, or PKI realms,
 you assign the roles in the `role_mapping.yml` configuration file.
 For example, the following snippet grants
-++{beat_default_index_prefix} account++ the
-++{beat_default_index_prefix}_{role_name}++ and `kibana_user` roles:
+++{beat_default_index_prefix}_account++ the
+++{access_role}++ and `kibana_user` roles:
 +
 --
 ["source", "yaml", subs="attributes,callouts"]
 ---------------------------------------------------------------
-{beat_default_index_prefix}_{role_name}:
-  - "cn={beatname_uc} account,dc=example,dc=com"
+{access_role}:
+  - "cn={beat_default_index_prefix}_account,dc=example,dc=com"
 kibana_user:
-  - "cn={beatname_uc} account,dc=example,dc=com"
+  - "cn={beat_default_index_prefix}_account,dc=example,dc=com"
 ---------------------------------------------------------------
 
 For more information, see

--- a/libbeat/docs/shared-beats-attributes.asciidoc
+++ b/libbeat/docs/shared-beats-attributes.asciidoc
@@ -26,3 +26,4 @@
 :beat_monitoring_user_version: 6.3.0
 :beat_monitoring_version: 6.2
 :beat_version_key: agent.version
+:access_role: {beat_default_index_prefix}_reader


### PR DESCRIPTION
This PR adds the new reserved roll `apm_user` to the documentation. See https://github.com/elastic/elasticsearch/pull/38206 for more details.

A few things:
1) Naming the role the way we did (`apm_user`) complicates things a lot. The documentation refers to a _user_ as both the _user_ and the _role_. To clarify, I swapped the use of _user_ for _account_ where applicable.
2) ~The `{beatname}_reader` example no longer applies to APM. I cut this step out, but it meant I had to introduce a new attribute for this page called `:role_name:`. This maintains the use of "reader" for the beats examples, but swaps to "user" for the APM example.~ (fixed by simitt [here](https://github.com/elastic/beats/pull/10683#discussion_r256734645))