### PR TITLE
Add support for CRI-O based logs autodiscover

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -273,6 +273,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...v7.0.0-beta1[Check the 
 - Added support for ingesting structured Elasticsearch server logs {pull}10428[10428]
 - Populate more ECS fields in the Suricata module. {pull}10006[10006]
 - Add module zeek. {issue}9931[9931] {pull}10034[10034]
+- Add support for CRI-O based logs autodiscover {pull}10687[10687]
 
 *Heartbeat*
 

--- a/filebeat/autodiscover/builder/hints/config.go
+++ b/filebeat/autodiscover/builder/hints/config.go
@@ -28,8 +28,8 @@ func defaultConfig() config {
 	rawCfg := map[string]interface{}{
 		"type": "docker",
 		"containers": map[string]interface{}{
-			"ids": []string{
-				"${data.container.id}",
+			"paths": []string{
+				"/var/log/containers/${data.kubernetes.pod.name}_${data.kubernetes.namespace}_${data.container.name}-${data.container.id}.log",
 			},
 		},
 	}

--- a/filebeat/autodiscover/builder/hints/config.go
+++ b/filebeat/autodiscover/builder/hints/config.go
@@ -31,7 +31,7 @@ func defaultConfig() config {
 			"paths": []string{
 				// To be able to use this builder with CRI-O replace paths with:
 				// /var/log/pods/${data.kubernetes.pod.uid}/${data.kubernetes.container.name}/*.log
-				"/var/lib/docker/containers/${data.kubernetes.container.id}/*-json.log",
+				"/var/lib/docker/containers/${data.container.id}/*-json.log",
 			},
 		},
 	}

--- a/filebeat/autodiscover/builder/hints/config.go
+++ b/filebeat/autodiscover/builder/hints/config.go
@@ -29,7 +29,7 @@ func defaultConfig() config {
 		"type": "docker",
 		"containers": map[string]interface{}{
 			"paths": []string{
-				"/var/log/containers/${data.kubernetes.pod.name}_${data.kubernetes.namespace}_${data.container.name}-${data.container.id}.log",
+				"/var/log/pods/${data.kubernetes.pod.uid}/${data.kubernetes.container.name}/*.log",
 			},
 		},
 	}

--- a/filebeat/autodiscover/builder/hints/config.go
+++ b/filebeat/autodiscover/builder/hints/config.go
@@ -29,7 +29,9 @@ func defaultConfig() config {
 		"type": "docker",
 		"containers": map[string]interface{}{
 			"paths": []string{
-				"/var/log/pods/${data.kubernetes.pod.uid}/${data.kubernetes.container.name}/*.log",
+				// To be able to use this builder with CRI-O replace paths with:
+				// /var/log/pods/${data.kubernetes.pod.uid}/${data.kubernetes.container.name}/*.log
+				"/var/lib/docker/containers/${data.kubernetes.container.id}/*-json.log",
 			},
 		},
 	}

--- a/filebeat/autodiscover/builder/hints/logs_test.go
+++ b/filebeat/autodiscover/builder/hints/logs_test.go
@@ -32,7 +32,6 @@ func TestGenerateHints(t *testing.T) {
 	tests := []struct {
 		msg    string
 		event  bus.Event
-		path   string
 		len    int
 		result common.MapStr
 	}{
@@ -45,10 +44,370 @@ func TestGenerateHints(t *testing.T) {
 					},
 				},
 			},
-			path:   "/var/lib/docker/containers/${data.kubernetes.container.id}/*-json.log",
 			len:    0,
 			result: common.MapStr{},
 		},
+		{
+			msg: "Empty event hints should return default config",
+			event: bus.Event{
+				"host": "1.2.3.4",
+				"kubernetes": common.MapStr{
+					"container": common.MapStr{
+						"name": "foobar",
+						"id":   "abc",
+					},
+				},
+				"container": common.MapStr{
+					"name": "foobar",
+					"id":   "abc",
+				},
+			},
+			len: 1,
+			result: common.MapStr{
+				"type": "docker",
+				"containers": map[string]interface{}{
+					"ids": []interface{}{"abc"},
+				},
+				"close_timeout": "true",
+			},
+		},
+		{
+			msg: "Hint with include|exclude_lines must be part of the input config",
+			event: bus.Event{
+				"host": "1.2.3.4",
+				"kubernetes": common.MapStr{
+					"container": common.MapStr{
+						"name": "foobar",
+						"id":   "abc",
+					},
+				},
+				"container": common.MapStr{
+					"name": "foobar",
+					"id":   "abc",
+				},
+				"hints": common.MapStr{
+					"logs": common.MapStr{
+						"include_lines": "^test, ^test1",
+						"exclude_lines": "^test2, ^test3",
+					},
+				},
+			},
+			len: 1,
+			result: common.MapStr{
+				"type": "docker",
+				"containers": map[string]interface{}{
+					"ids": []interface{}{"abc"},
+				},
+				"include_lines": []interface{}{"^test", "^test1"},
+				"exclude_lines": []interface{}{"^test2", "^test3"},
+				"close_timeout": "true",
+			},
+		},
+		{
+			msg: "Hint with multiline config must have a multiline in the input config",
+			event: bus.Event{
+				"host": "1.2.3.4",
+				"kubernetes": common.MapStr{
+					"container": common.MapStr{
+						"name": "foobar",
+						"id":   "abc",
+					},
+				},
+				"container": common.MapStr{
+					"name": "foobar",
+					"id":   "abc",
+				},
+				"hints": common.MapStr{
+					"logs": common.MapStr{
+						"multiline": common.MapStr{
+							"pattern": "^test",
+							"negate":  "true",
+						},
+					},
+				},
+			},
+			len: 1,
+			result: common.MapStr{
+				"type": "docker",
+				"containers": map[string]interface{}{
+					"ids": []interface{}{"abc"},
+				},
+				"multiline": map[string]interface{}{
+					"pattern": "^test",
+					"negate":  "true",
+				},
+				"close_timeout": "true",
+			},
+		},
+		{
+			msg: "Hint with inputs config as json must be accepted",
+			event: bus.Event{
+				"host": "1.2.3.4",
+				"kubernetes": common.MapStr{
+					"container": common.MapStr{
+						"name": "foobar",
+						"id":   "abc",
+					},
+				},
+				"container": common.MapStr{
+					"name": "foobar",
+					"id":   "abc",
+				},
+				"hints": common.MapStr{
+					"logs": common.MapStr{
+						"raw": "[{\"containers\":{\"ids\":[\"${data.container.id}\"]},\"multiline\":{\"negate\":\"true\",\"pattern\":\"^test\"},\"type\":\"docker\"}]",
+					},
+				},
+			},
+			len: 1,
+			result: common.MapStr{
+				"type": "docker",
+				"containers": map[string]interface{}{
+					"ids": []interface{}{"abc"},
+				},
+				"multiline": map[string]interface{}{
+					"pattern": "^test",
+					"negate":  "true",
+				},
+			},
+		},
+		{
+			msg: "Hint with processors config must have a processors in the input config",
+			event: bus.Event{
+				"host": "1.2.3.4",
+				"kubernetes": common.MapStr{
+					"container": common.MapStr{
+						"name": "foobar",
+						"id":   "abc",
+					},
+				},
+				"container": common.MapStr{
+					"name": "foobar",
+					"id":   "abc",
+				},
+				"hints": common.MapStr{
+					"logs": common.MapStr{
+						"processors": common.MapStr{
+							"1": common.MapStr{
+								"dissect": common.MapStr{
+									"tokenizer": "%{key1} %{key2}",
+								},
+							},
+							"drop_event": common.MapStr{},
+						},
+					},
+				},
+			},
+			len: 1,
+			result: common.MapStr{
+				"type": "docker",
+				"containers": map[string]interface{}{
+					"ids": []interface{}{"abc"},
+				},
+				"close_timeout": "true",
+				"processors": []interface{}{
+					map[string]interface{}{
+						"dissect": map[string]interface{}{
+							"tokenizer": "%{key1} %{key2}",
+						},
+					},
+					map[string]interface{}{
+						"drop_event": nil,
+					},
+				},
+			},
+		},
+		{
+			msg: "Hint with module should attach input to its filesets",
+			event: bus.Event{
+				"host": "1.2.3.4",
+				"kubernetes": common.MapStr{
+					"container": common.MapStr{
+						"name": "foobar",
+						"id":   "abc",
+					},
+				},
+				"container": common.MapStr{
+					"name": "foobar",
+					"id":   "abc",
+				},
+				"hints": common.MapStr{
+					"logs": common.MapStr{
+						"module": "apache2",
+					},
+				},
+			},
+			len: 1,
+			result: common.MapStr{
+				"module": "apache2",
+				"error": map[string]interface{}{
+					"enabled": true,
+					"input": map[string]interface{}{
+						"type": "docker",
+						"containers": map[string]interface{}{
+							"stream": "all",
+							"ids":    []interface{}{"abc"},
+						},
+						"close_timeout": "true",
+					},
+				},
+				"access": map[string]interface{}{
+					"enabled": true,
+					"input": map[string]interface{}{
+						"type": "docker",
+						"containers": map[string]interface{}{
+							"stream": "all",
+							"ids":    []interface{}{"abc"},
+						},
+						"close_timeout": "true",
+					},
+				},
+			},
+		},
+		{
+			msg: "Hint with module should honor defined filesets",
+			event: bus.Event{
+				"host": "1.2.3.4",
+				"kubernetes": common.MapStr{
+					"container": common.MapStr{
+						"name": "foobar",
+						"id":   "abc",
+					},
+				},
+				"container": common.MapStr{
+					"name": "foobar",
+					"id":   "abc",
+				},
+				"hints": common.MapStr{
+					"logs": common.MapStr{
+						"module":  "apache2",
+						"fileset": "access",
+					},
+				},
+			},
+			len: 1,
+			result: common.MapStr{
+				"module": "apache2",
+				"access": map[string]interface{}{
+					"enabled": true,
+					"input": map[string]interface{}{
+						"type": "docker",
+						"containers": map[string]interface{}{
+							"stream": "all",
+							"ids":    []interface{}{"abc"},
+						},
+						"close_timeout": "true",
+					},
+				},
+				"error": map[string]interface{}{
+					"enabled": false,
+					"input": map[string]interface{}{
+						"type": "docker",
+						"containers": map[string]interface{}{
+							"stream": "all",
+							"ids":    []interface{}{"abc"},
+						},
+						"close_timeout": "true",
+					},
+				},
+			},
+		},
+		{
+			msg: "Hint with module should honor defined filesets with streams",
+			event: bus.Event{
+				"host": "1.2.3.4",
+				"kubernetes": common.MapStr{
+					"container": common.MapStr{
+						"name": "foobar",
+						"id":   "abc",
+					},
+				},
+				"container": common.MapStr{
+					"name": "foobar",
+					"id":   "abc",
+				},
+				"hints": common.MapStr{
+					"logs": common.MapStr{
+						"module":         "apache2",
+						"fileset.stdout": "access",
+						"fileset.stderr": "error",
+					},
+				},
+			},
+			len: 1,
+			result: common.MapStr{
+				"module": "apache2",
+				"access": map[string]interface{}{
+					"enabled": true,
+					"input": map[string]interface{}{
+						"type": "docker",
+						"containers": map[string]interface{}{
+							"stream": "stdout",
+							"ids":    []interface{}{"abc"},
+						},
+						"close_timeout": "true",
+					},
+				},
+				"error": map[string]interface{}{
+					"enabled": true,
+					"input": map[string]interface{}{
+						"type": "docker",
+						"containers": map[string]interface{}{
+							"stream": "stderr",
+							"ids":    []interface{}{"abc"},
+						},
+						"close_timeout": "true",
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		cfg, _ := common.NewConfigFrom(map[string]interface{}{
+			"config": map[string]interface{}{
+				"type": "docker",
+				"containers": map[string]interface{}{
+					"ids": []string{
+						"${data.container.id}",
+					},
+				},
+				"close_timeout": "true",
+			},
+		})
+
+		// Configure path for modules access
+		abs, _ := filepath.Abs("../../..")
+		err := paths.InitPaths(&paths.Path{
+			Home: abs,
+		})
+
+		l, err := NewLogHints(cfg)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		cfgs := l.CreateConfig(test.event)
+		assert.Equal(t, len(cfgs), test.len, test.msg)
+		if test.len != 0 {
+			config := common.MapStr{}
+			err := cfgs[0].Unpack(&config)
+			assert.Nil(t, err, test.msg)
+
+			assert.Equal(t, test.result, config, test.msg)
+		}
+
+	}
+}
+
+func TestGenerateHintsWithPaths(t *testing.T) {
+	tests := []struct {
+		msg    string
+		event  bus.Event
+		path   string
+		len    int
+		result common.MapStr
+	}{
 		{
 			msg: "Empty event hints should return default config",
 			event: bus.Event{
@@ -76,119 +435,6 @@ func TestGenerateHints(t *testing.T) {
 					"paths": []interface{}{"/var/lib/docker/containers/abc/*-json.log"},
 				},
 				"close_timeout": "true",
-			},
-		},
-		{
-			msg: "Hint with include|exclude_lines must be part of the input config",
-			event: bus.Event{
-				"host": "1.2.3.4",
-				"kubernetes": common.MapStr{
-					"container": common.MapStr{
-						"name": "foobar",
-						"id":   "abc",
-					},
-					"pod": common.MapStr{
-						"name": "pod",
-						"uid":  "12345",
-					},
-				},
-				"container": common.MapStr{
-					"name": "foobar",
-					"id":   "abc",
-				},
-				"hints": common.MapStr{
-					"logs": common.MapStr{
-						"include_lines": "^test, ^test1",
-						"exclude_lines": "^test2, ^test3",
-					},
-				},
-			},
-			len:  1,
-			path: "/var/lib/docker/containers/${data.kubernetes.container.id}/*-json.log",
-			result: common.MapStr{
-				"type": "docker",
-				"containers": map[string]interface{}{
-					"paths": []interface{}{"/var/lib/docker/containers/abc/*-json.log"},
-				},
-				"include_lines": []interface{}{"^test", "^test1"},
-				"exclude_lines": []interface{}{"^test2", "^test3"},
-				"close_timeout": "true",
-			},
-		},
-		{
-			msg: "Hint with multiline config must have a multiline in the input config",
-			event: bus.Event{
-				"host": "1.2.3.4",
-				"kubernetes": common.MapStr{
-					"container": common.MapStr{
-						"name": "foobar",
-						"uid":  "12345",
-					},
-					"pod": common.MapStr{
-						"name": "pod",
-						"uid":  "12345",
-					},
-				},
-				"container": common.MapStr{
-					"name": "foobar",
-					"id":   "abc",
-				},
-				"hints": common.MapStr{
-					"logs": common.MapStr{
-						"multiline": common.MapStr{
-							"pattern": "^test",
-							"negate":  "true",
-						},
-					},
-				},
-			},
-			len:  1,
-			path: "/var/log/pods/${data.kubernetes.pod.uid}/${data.kubernetes.container.name}/*.log",
-			result: common.MapStr{
-				"type": "docker",
-				"containers": map[string]interface{}{
-					"paths": []interface{}{"/var/log/pods/12345/foobar/*.log"},
-				},
-				"multiline": map[string]interface{}{
-					"pattern": "^test",
-					"negate":  "true",
-				},
-				"close_timeout": "true",
-			},
-		},
-		{
-			msg: "Hint with inputs config as json must be accepted",
-			event: bus.Event{
-				"host": "1.2.3.4",
-				"kubernetes": common.MapStr{
-					"container": common.MapStr{
-						"name": "foobar",
-					},
-					"pod": common.MapStr{
-						"name": "pod",
-					},
-				},
-				"container": common.MapStr{
-					"name": "foobar",
-					"id":   "abc",
-				},
-				"hints": common.MapStr{
-					"logs": common.MapStr{
-						"raw": "[{\"containers\":{\"ids\":[\"${data.container.id}\"]},\"multiline\":{\"negate\":\"true\",\"pattern\":\"^test\"},\"type\":\"docker\"}]",
-					},
-				},
-			},
-			len:  1,
-			path: "",
-			result: common.MapStr{
-				"type": "docker",
-				"containers": map[string]interface{}{
-					"ids": []interface{}{"abc"},
-				},
-				"multiline": map[string]interface{}{
-					"pattern": "^test",
-					"negate":  "true",
-				},
 			},
 		},
 		{
@@ -340,60 +586,6 @@ func TestGenerateHints(t *testing.T) {
 						"type": "docker",
 						"containers": map[string]interface{}{
 							"stream": "all",
-							"paths":  []interface{}{"/var/log/pods/12345/foobar/*.log"},
-						},
-						"close_timeout": "true",
-					},
-				},
-			},
-		},
-		{
-			msg: "Hint with module should honor defined filesets with streams",
-			event: bus.Event{
-				"host": "1.2.3.4",
-				"kubernetes": common.MapStr{
-					"container": common.MapStr{
-						"name": "foobar",
-						"id":   "abc",
-					},
-					"pod": common.MapStr{
-						"name": "pod",
-						"uid":  "12345",
-					},
-				},
-				"container": common.MapStr{
-					"name": "foobar",
-					"id":   "abc",
-				},
-				"hints": common.MapStr{
-					"logs": common.MapStr{
-						"module":         "apache2",
-						"fileset.stdout": "access",
-						"fileset.stderr": "error",
-					},
-				},
-			},
-			len:  1,
-			path: "/var/log/pods/${data.kubernetes.pod.uid}/${data.kubernetes.container.name}/*.log",
-			result: common.MapStr{
-				"module": "apache2",
-				"access": map[string]interface{}{
-					"enabled": true,
-					"input": map[string]interface{}{
-						"type": "docker",
-						"containers": map[string]interface{}{
-							"stream": "stdout",
-							"paths":  []interface{}{"/var/log/pods/12345/foobar/*.log"},
-						},
-						"close_timeout": "true",
-					},
-				},
-				"error": map[string]interface{}{
-					"enabled": true,
-					"input": map[string]interface{}{
-						"type": "docker",
-						"containers": map[string]interface{}{
-							"stream": "stderr",
 							"paths":  []interface{}{"/var/log/pods/12345/foobar/*.log"},
 						},
 						"close_timeout": "true",

--- a/filebeat/autodiscover/builder/hints/logs_test.go
+++ b/filebeat/autodiscover/builder/hints/logs_test.go
@@ -58,8 +58,8 @@ func TestGenerateHints(t *testing.T) {
 					},
 					"pod": common.MapStr{
 						"name": "pod",
+						"uid":  "12345",
 					},
-					"namespace": "ns",
 				},
 				"container": common.MapStr{
 					"name": "foobar",
@@ -70,7 +70,7 @@ func TestGenerateHints(t *testing.T) {
 			result: common.MapStr{
 				"type": "docker",
 				"containers": map[string]interface{}{
-					"paths": []interface{}{"/var/log/containers/pod_ns_foobar-abc.log"},
+					"paths": []interface{}{"/var/log/pods/12345/foobar/*.log"},
 				},
 				"close_timeout": "true",
 			},
@@ -86,8 +86,8 @@ func TestGenerateHints(t *testing.T) {
 					},
 					"pod": common.MapStr{
 						"name": "pod",
+						"uid":  "12345",
 					},
-					"namespace": "ns",
 				},
 				"container": common.MapStr{
 					"name": "foobar",
@@ -104,7 +104,7 @@ func TestGenerateHints(t *testing.T) {
 			result: common.MapStr{
 				"type": "docker",
 				"containers": map[string]interface{}{
-					"paths": []interface{}{"/var/log/containers/pod_ns_foobar-abc.log"},
+					"paths": []interface{}{"/var/log/pods/12345/foobar/*.log"},
 				},
 				"include_lines": []interface{}{"^test", "^test1"},
 				"exclude_lines": []interface{}{"^test2", "^test3"},
@@ -118,12 +118,12 @@ func TestGenerateHints(t *testing.T) {
 				"kubernetes": common.MapStr{
 					"container": common.MapStr{
 						"name": "foobar",
-						"id":   "abc",
+						"uid":  "12345",
 					},
 					"pod": common.MapStr{
 						"name": "pod",
+						"uid":  "12345",
 					},
-					"namespace": "ns",
 				},
 				"container": common.MapStr{
 					"name": "foobar",
@@ -142,7 +142,7 @@ func TestGenerateHints(t *testing.T) {
 			result: common.MapStr{
 				"type": "docker",
 				"containers": map[string]interface{}{
-					"paths": []interface{}{"/var/log/containers/pod_ns_foobar-abc.log"},
+					"paths": []interface{}{"/var/log/pods/12345/foobar/*.log"},
 				},
 				"multiline": map[string]interface{}{
 					"pattern": "^test",
@@ -158,12 +158,10 @@ func TestGenerateHints(t *testing.T) {
 				"kubernetes": common.MapStr{
 					"container": common.MapStr{
 						"name": "foobar",
-						"id":   "abc",
 					},
 					"pod": common.MapStr{
 						"name": "pod",
 					},
-					"namespace": "ns",
 				},
 				"container": common.MapStr{
 					"name": "foobar",
@@ -198,8 +196,8 @@ func TestGenerateHints(t *testing.T) {
 					},
 					"pod": common.MapStr{
 						"name": "pod",
+						"uid":  "12345",
 					},
-					"namespace": "ns",
 				},
 				"container": common.MapStr{
 					"name": "foobar",
@@ -222,7 +220,7 @@ func TestGenerateHints(t *testing.T) {
 			result: common.MapStr{
 				"type": "docker",
 				"containers": map[string]interface{}{
-					"paths": []interface{}{"/var/log/containers/pod_ns_foobar-abc.log"},
+					"paths": []interface{}{"/var/log/pods/12345/foobar/*.log"},
 				},
 				"close_timeout": "true",
 				"processors": []interface{}{
@@ -248,8 +246,8 @@ func TestGenerateHints(t *testing.T) {
 					},
 					"pod": common.MapStr{
 						"name": "pod",
+						"uid":  "12345",
 					},
-					"namespace": "ns",
 				},
 				"container": common.MapStr{
 					"name": "foobar",
@@ -270,7 +268,7 @@ func TestGenerateHints(t *testing.T) {
 						"type": "docker",
 						"containers": map[string]interface{}{
 							"stream": "all",
-							"paths":  []interface{}{"/var/log/containers/pod_ns_foobar-abc.log"},
+							"paths":  []interface{}{"/var/log/pods/12345/foobar/*.log"},
 						},
 						"close_timeout": "true",
 					},
@@ -281,7 +279,7 @@ func TestGenerateHints(t *testing.T) {
 						"type": "docker",
 						"containers": map[string]interface{}{
 							"stream": "all",
-							"paths":  []interface{}{"/var/log/containers/pod_ns_foobar-abc.log"},
+							"paths":  []interface{}{"/var/log/pods/12345/foobar/*.log"},
 						},
 						"close_timeout": "true",
 					},
@@ -299,8 +297,8 @@ func TestGenerateHints(t *testing.T) {
 					},
 					"pod": common.MapStr{
 						"name": "pod",
+						"uid":  "12345",
 					},
-					"namespace": "ns",
 				},
 				"container": common.MapStr{
 					"name": "foobar",
@@ -322,7 +320,7 @@ func TestGenerateHints(t *testing.T) {
 						"type": "docker",
 						"containers": map[string]interface{}{
 							"stream": "all",
-							"paths":  []interface{}{"/var/log/containers/pod_ns_foobar-abc.log"},
+							"paths":  []interface{}{"/var/log/pods/12345/foobar/*.log"},
 						},
 						"close_timeout": "true",
 					},
@@ -333,7 +331,7 @@ func TestGenerateHints(t *testing.T) {
 						"type": "docker",
 						"containers": map[string]interface{}{
 							"stream": "all",
-							"paths":  []interface{}{"/var/log/containers/pod_ns_foobar-abc.log"},
+							"paths":  []interface{}{"/var/log/pods/12345/foobar/*.log"},
 						},
 						"close_timeout": "true",
 					},
@@ -351,8 +349,8 @@ func TestGenerateHints(t *testing.T) {
 					},
 					"pod": common.MapStr{
 						"name": "pod",
+						"uid":  "12345",
 					},
-					"namespace": "ns",
 				},
 				"container": common.MapStr{
 					"name": "foobar",
@@ -375,7 +373,7 @@ func TestGenerateHints(t *testing.T) {
 						"type": "docker",
 						"containers": map[string]interface{}{
 							"stream": "stdout",
-							"paths":  []interface{}{"/var/log/containers/pod_ns_foobar-abc.log"},
+							"paths":  []interface{}{"/var/log/pods/12345/foobar/*.log"},
 						},
 						"close_timeout": "true",
 					},
@@ -386,7 +384,7 @@ func TestGenerateHints(t *testing.T) {
 						"type": "docker",
 						"containers": map[string]interface{}{
 							"stream": "stderr",
-							"paths":  []interface{}{"/var/log/containers/pod_ns_foobar-abc.log"},
+							"paths":  []interface{}{"/var/log/pods/12345/foobar/*.log"},
 						},
 						"close_timeout": "true",
 					},
@@ -401,7 +399,7 @@ func TestGenerateHints(t *testing.T) {
 				"type": "docker",
 				"containers": map[string]interface{}{
 					"paths": []string{
-						"/var/log/containers/${data.kubernetes.pod.name}_${data.kubernetes.namespace}_${data.container.name}-${data.container.id}.log",
+						"/var/log/pods/${data.kubernetes.pod.uid}/${data.container.name}/*.log",
 					},
 				},
 				"close_timeout": "true",

--- a/filebeat/autodiscover/builder/hints/logs_test.go
+++ b/filebeat/autodiscover/builder/hints/logs_test.go
@@ -32,6 +32,7 @@ func TestGenerateHints(t *testing.T) {
 	tests := []struct {
 		msg    string
 		event  bus.Event
+		path   string
 		len    int
 		result common.MapStr
 	}{
@@ -44,6 +45,7 @@ func TestGenerateHints(t *testing.T) {
 					},
 				},
 			},
+			path:   "/var/lib/docker/containers/${data.kubernetes.container.id}/*-json.log",
 			len:    0,
 			result: common.MapStr{},
 		},
@@ -66,11 +68,12 @@ func TestGenerateHints(t *testing.T) {
 					"id":   "abc",
 				},
 			},
-			len: 1,
+			path: "/var/lib/docker/containers/${data.kubernetes.container.id}/*-json.log",
+			len:  1,
 			result: common.MapStr{
 				"type": "docker",
 				"containers": map[string]interface{}{
-					"paths": []interface{}{"/var/log/pods/12345/foobar/*.log"},
+					"paths": []interface{}{"/var/lib/docker/containers/abc/*-json.log"},
 				},
 				"close_timeout": "true",
 			},
@@ -100,11 +103,12 @@ func TestGenerateHints(t *testing.T) {
 					},
 				},
 			},
-			len: 1,
+			len:  1,
+			path: "/var/lib/docker/containers/${data.kubernetes.container.id}/*-json.log",
 			result: common.MapStr{
 				"type": "docker",
 				"containers": map[string]interface{}{
-					"paths": []interface{}{"/var/log/pods/12345/foobar/*.log"},
+					"paths": []interface{}{"/var/lib/docker/containers/abc/*-json.log"},
 				},
 				"include_lines": []interface{}{"^test", "^test1"},
 				"exclude_lines": []interface{}{"^test2", "^test3"},
@@ -138,7 +142,8 @@ func TestGenerateHints(t *testing.T) {
 					},
 				},
 			},
-			len: 1,
+			len:  1,
+			path: "/var/log/pods/${data.kubernetes.pod.uid}/${data.kubernetes.container.name}/*.log",
 			result: common.MapStr{
 				"type": "docker",
 				"containers": map[string]interface{}{
@@ -173,7 +178,8 @@ func TestGenerateHints(t *testing.T) {
 					},
 				},
 			},
-			len: 1,
+			len:  1,
+			path: "",
 			result: common.MapStr{
 				"type": "docker",
 				"containers": map[string]interface{}{
@@ -216,7 +222,8 @@ func TestGenerateHints(t *testing.T) {
 					},
 				},
 			},
-			len: 1,
+			len:  1,
+			path: "/var/log/pods/${data.kubernetes.pod.uid}/${data.kubernetes.container.name}/*.log",
 			result: common.MapStr{
 				"type": "docker",
 				"containers": map[string]interface{}{
@@ -259,7 +266,8 @@ func TestGenerateHints(t *testing.T) {
 					},
 				},
 			},
-			len: 1,
+			len:  1,
+			path: "/var/log/pods/${data.kubernetes.pod.uid}/${data.kubernetes.container.name}/*.log",
 			result: common.MapStr{
 				"module": "apache2",
 				"error": map[string]interface{}{
@@ -311,7 +319,8 @@ func TestGenerateHints(t *testing.T) {
 					},
 				},
 			},
-			len: 1,
+			len:  1,
+			path: "/var/log/pods/${data.kubernetes.pod.uid}/${data.kubernetes.container.name}/*.log",
 			result: common.MapStr{
 				"module": "apache2",
 				"access": map[string]interface{}{
@@ -364,7 +373,8 @@ func TestGenerateHints(t *testing.T) {
 					},
 				},
 			},
-			len: 1,
+			len:  1,
+			path: "/var/log/pods/${data.kubernetes.pod.uid}/${data.kubernetes.container.name}/*.log",
 			result: common.MapStr{
 				"module": "apache2",
 				"access": map[string]interface{}{
@@ -399,7 +409,7 @@ func TestGenerateHints(t *testing.T) {
 				"type": "docker",
 				"containers": map[string]interface{}{
 					"paths": []string{
-						"/var/log/pods/${data.kubernetes.pod.uid}/${data.container.name}/*.log",
+						test.path,
 					},
 				},
 				"close_timeout": "true",

--- a/filebeat/autodiscover/builder/hints/logs_test.go
+++ b/filebeat/autodiscover/builder/hints/logs_test.go
@@ -56,6 +56,10 @@ func TestGenerateHints(t *testing.T) {
 						"name": "foobar",
 						"id":   "abc",
 					},
+					"pod": common.MapStr{
+						"name": "pod",
+					},
+					"namespace": "ns",
 				},
 				"container": common.MapStr{
 					"name": "foobar",
@@ -66,7 +70,7 @@ func TestGenerateHints(t *testing.T) {
 			result: common.MapStr{
 				"type": "docker",
 				"containers": map[string]interface{}{
-					"ids": []interface{}{"abc"},
+					"paths": []interface{}{"/var/log/containers/pod_ns_foobar-abc.log"},
 				},
 				"close_timeout": "true",
 			},
@@ -80,6 +84,10 @@ func TestGenerateHints(t *testing.T) {
 						"name": "foobar",
 						"id":   "abc",
 					},
+					"pod": common.MapStr{
+						"name": "pod",
+					},
+					"namespace": "ns",
 				},
 				"container": common.MapStr{
 					"name": "foobar",
@@ -96,7 +104,7 @@ func TestGenerateHints(t *testing.T) {
 			result: common.MapStr{
 				"type": "docker",
 				"containers": map[string]interface{}{
-					"ids": []interface{}{"abc"},
+					"paths": []interface{}{"/var/log/containers/pod_ns_foobar-abc.log"},
 				},
 				"include_lines": []interface{}{"^test", "^test1"},
 				"exclude_lines": []interface{}{"^test2", "^test3"},
@@ -112,6 +120,10 @@ func TestGenerateHints(t *testing.T) {
 						"name": "foobar",
 						"id":   "abc",
 					},
+					"pod": common.MapStr{
+						"name": "pod",
+					},
+					"namespace": "ns",
 				},
 				"container": common.MapStr{
 					"name": "foobar",
@@ -130,7 +142,7 @@ func TestGenerateHints(t *testing.T) {
 			result: common.MapStr{
 				"type": "docker",
 				"containers": map[string]interface{}{
-					"ids": []interface{}{"abc"},
+					"paths": []interface{}{"/var/log/containers/pod_ns_foobar-abc.log"},
 				},
 				"multiline": map[string]interface{}{
 					"pattern": "^test",
@@ -148,6 +160,10 @@ func TestGenerateHints(t *testing.T) {
 						"name": "foobar",
 						"id":   "abc",
 					},
+					"pod": common.MapStr{
+						"name": "pod",
+					},
+					"namespace": "ns",
 				},
 				"container": common.MapStr{
 					"name": "foobar",
@@ -180,6 +196,10 @@ func TestGenerateHints(t *testing.T) {
 						"name": "foobar",
 						"id":   "abc",
 					},
+					"pod": common.MapStr{
+						"name": "pod",
+					},
+					"namespace": "ns",
 				},
 				"container": common.MapStr{
 					"name": "foobar",
@@ -202,7 +222,7 @@ func TestGenerateHints(t *testing.T) {
 			result: common.MapStr{
 				"type": "docker",
 				"containers": map[string]interface{}{
-					"ids": []interface{}{"abc"},
+					"paths": []interface{}{"/var/log/containers/pod_ns_foobar-abc.log"},
 				},
 				"close_timeout": "true",
 				"processors": []interface{}{
@@ -226,6 +246,10 @@ func TestGenerateHints(t *testing.T) {
 						"name": "foobar",
 						"id":   "abc",
 					},
+					"pod": common.MapStr{
+						"name": "pod",
+					},
+					"namespace": "ns",
 				},
 				"container": common.MapStr{
 					"name": "foobar",
@@ -246,7 +270,7 @@ func TestGenerateHints(t *testing.T) {
 						"type": "docker",
 						"containers": map[string]interface{}{
 							"stream": "all",
-							"ids":    []interface{}{"abc"},
+							"paths":  []interface{}{"/var/log/containers/pod_ns_foobar-abc.log"},
 						},
 						"close_timeout": "true",
 					},
@@ -257,7 +281,7 @@ func TestGenerateHints(t *testing.T) {
 						"type": "docker",
 						"containers": map[string]interface{}{
 							"stream": "all",
-							"ids":    []interface{}{"abc"},
+							"paths":  []interface{}{"/var/log/containers/pod_ns_foobar-abc.log"},
 						},
 						"close_timeout": "true",
 					},
@@ -273,6 +297,10 @@ func TestGenerateHints(t *testing.T) {
 						"name": "foobar",
 						"id":   "abc",
 					},
+					"pod": common.MapStr{
+						"name": "pod",
+					},
+					"namespace": "ns",
 				},
 				"container": common.MapStr{
 					"name": "foobar",
@@ -294,7 +322,7 @@ func TestGenerateHints(t *testing.T) {
 						"type": "docker",
 						"containers": map[string]interface{}{
 							"stream": "all",
-							"ids":    []interface{}{"abc"},
+							"paths":  []interface{}{"/var/log/containers/pod_ns_foobar-abc.log"},
 						},
 						"close_timeout": "true",
 					},
@@ -305,7 +333,7 @@ func TestGenerateHints(t *testing.T) {
 						"type": "docker",
 						"containers": map[string]interface{}{
 							"stream": "all",
-							"ids":    []interface{}{"abc"},
+							"paths":  []interface{}{"/var/log/containers/pod_ns_foobar-abc.log"},
 						},
 						"close_timeout": "true",
 					},
@@ -321,6 +349,10 @@ func TestGenerateHints(t *testing.T) {
 						"name": "foobar",
 						"id":   "abc",
 					},
+					"pod": common.MapStr{
+						"name": "pod",
+					},
+					"namespace": "ns",
 				},
 				"container": common.MapStr{
 					"name": "foobar",
@@ -343,7 +375,7 @@ func TestGenerateHints(t *testing.T) {
 						"type": "docker",
 						"containers": map[string]interface{}{
 							"stream": "stdout",
-							"ids":    []interface{}{"abc"},
+							"paths":  []interface{}{"/var/log/containers/pod_ns_foobar-abc.log"},
 						},
 						"close_timeout": "true",
 					},
@@ -354,7 +386,7 @@ func TestGenerateHints(t *testing.T) {
 						"type": "docker",
 						"containers": map[string]interface{}{
 							"stream": "stderr",
-							"ids":    []interface{}{"abc"},
+							"paths":  []interface{}{"/var/log/containers/pod_ns_foobar-abc.log"},
 						},
 						"close_timeout": "true",
 					},
@@ -368,8 +400,8 @@ func TestGenerateHints(t *testing.T) {
 			"config": map[string]interface{}{
 				"type": "docker",
 				"containers": map[string]interface{}{
-					"ids": []string{
-						"${data.container.id}",
+					"paths": []string{
+						"/var/log/containers/${data.kubernetes.pod.name}_${data.kubernetes.namespace}_${data.container.name}-${data.container.id}.log",
 					},
 				},
 				"close_timeout": "true",

--- a/filebeat/input/docker/config.go
+++ b/filebeat/input/docker/config.go
@@ -27,6 +27,7 @@ var defaultConfig = config{
 }
 
 type config struct {
+	// List of containers' log files to tail
 	Containers containers `config:"containers"`
 
 	// Partial configures the input to join partial lines
@@ -40,8 +41,11 @@ type config struct {
 }
 
 type containers struct {
+	// IDs + Path to be removed in 8.0 in favor of Paths.
 	IDs  []string `config:"ids"`
 	Path string   `config:"path"`
+
+	Paths []string `config:"paths"`
 
 	// Stream can be all, stdout or stderr
 	Stream string `config:"stream"`

--- a/filebeat/input/docker/config.go
+++ b/filebeat/input/docker/config.go
@@ -41,7 +41,6 @@ type config struct {
 }
 
 type containers struct {
-	// IDs + Path to be removed in 8.0 in favor of Paths.
 	IDs  []string `config:"ids"`
 	Path string   `config:"path"`
 

--- a/filebeat/input/docker/input.go
+++ b/filebeat/input/docker/input.go
@@ -111,6 +111,11 @@ func NewInput(
 		return nil, errors.Wrap(err, "update input config")
 	}
 
+	// Set symlinks to true as CRI-O paths could point to symlinks instead of the actual path.
+	if err := cfg.SetBool("symlinks", -1, true); err != nil {
+		return nil, errors.Wrap(err, "update input config")
+	}
+
 	// Add stream to meta to ensure different state per stream
 	if config.Containers.Stream != "all" {
 		if context.Meta == nil {

--- a/filebeat/input/docker/input.go
+++ b/filebeat/input/docker/input.go
@@ -77,6 +77,7 @@ func NewInput(
 		return nil, errors.New("Docker input requires at least one entry under 'containers.ids' or 'containers.paths'")
 	}
 
+	// IDs + Path and Paths are mutually exclusive. Ensure that only one of them are set in a given configuration
 	if len(ids) != 0 && len(paths) != 0 {
 		return nil, errors.New("can not provide both 'containers.ids' and 'containers.paths' in the same input config")
 	}
@@ -111,9 +112,11 @@ func NewInput(
 		return nil, errors.Wrap(err, "update input config")
 	}
 
-	// Set symlinks to true as CRI-O paths could point to symlinks instead of the actual path.
-	if err := cfg.SetBool("symlinks", -1, true); err != nil {
-		return nil, errors.Wrap(err, "update input config")
+	if len(paths) != 0 {
+		// Set symlinks to true as CRI-O paths could point to symlinks instead of the actual path.
+		if err := cfg.SetBool("symlinks", -1, true); err != nil {
+			return nil, errors.Wrap(err, "update input config")
+		}
 	}
 
 	// Add stream to meta to ensure different state per stream

--- a/filebeat/input/docker/input.go
+++ b/filebeat/input/docker/input.go
@@ -51,10 +51,19 @@ func NewInput(
 		return nil, errors.Wrap(err, "reading docker input config")
 	}
 
-	// Docker input should make sure that no callers should ever pass empty strings as container IDs
+	// Docker input should make sure that no callers should ever pass empty strings as container IDs or paths
 	// Hence we explicitly make sure that we catch such things and print stack traces in the event of
 	// an invocation so that it can be fixed.
-	var ids []string
+	var ids, paths []string
+	for _, p := range config.Containers.Paths {
+		if p != "" {
+			paths = append(paths, p)
+		} else {
+			logger.Error("Docker paths can't be empty for Docker input config")
+			logger.Debugw("Empty path for Docker logfile was received", logp.Stack("stacktrace"))
+		}
+	}
+
 	for _, containerID := range config.Containers.IDs {
 		if containerID != "" {
 			ids = append(ids, containerID)
@@ -64,12 +73,22 @@ func NewInput(
 		}
 	}
 
-	if len(ids) == 0 {
-		return nil, errors.New("Docker input requires at least one entry under 'containers.ids'")
+	if len(ids) == 0 && len(paths) == 0 {
+		return nil, errors.New("Docker input requires at least one entry under 'containers.ids' or 'containers.paths'")
 	}
 
-	for idx, containerID := range ids {
-		cfg.SetString("paths", idx, path.Join(config.Containers.Path, containerID, "*.log"))
+	if len(ids) != 0 && len(paths) != 0 {
+		return nil, errors.New("can not provide both 'containers.ids' and 'containers.paths' in the same input config")
+	}
+
+	if len(ids) != 0 {
+		for idx, containerID := range ids {
+			cfg.SetString("paths", idx, path.Join(config.Containers.Path, containerID, "*.log"))
+		}
+	} else {
+		for idx, p := range paths {
+			cfg.SetString("paths", idx, p)
+		}
 	}
 
 	if err := checkStream(config.Containers.Stream); err != nil {


### PR DESCRIPTION
This PR attempts to do two things:
* Allow docker input to be used generically for file paths instead of explicitly using container names.
* Make autodiscover generate CRI-O paths by default. 
