### PR TITLE
[Filebeat] Add ecs:false to user_agent processor

### DIFF
--- a/filebeat/module/apache2/access/ingest/default.json
+++ b/filebeat/module/apache2/access/ingest/default.json
@@ -33,7 +33,8 @@
     "user_agent": {
       "field": "apache2.access.agent",
       "target_field": "apache2.access.user_agent",
-      "ignore_failure": true
+      "ignore_failure": true,
+      "ecs": false
     }
   }, {
     "rename": {

--- a/filebeat/module/iis/access/ingest/default.json
+++ b/filebeat/module/iis/access/ingest/default.json
@@ -33,7 +33,8 @@
   }, {
     "user_agent": {
       "field": "iis.access.agent",
-      "target_field": "iis.access.user_agent"
+      "target_field": "iis.access.user_agent",
+      "ecs": false
     }
   }, {
     "rename": {

--- a/filebeat/module/nginx/access/ingest/default.json
+++ b/filebeat/module/nginx/access/ingest/default.json
@@ -73,7 +73,8 @@
         {
             "user_agent": {
                 "field": "nginx.access.agent",
-                "target_field": "nginx.access.user_agent"
+                "target_field": "nginx.access.user_agent",
+                "ecs": false
             }
         },
         {

--- a/filebeat/module/traefik/access/ingest/pipeline.json
+++ b/filebeat/module/traefik/access/ingest/pipeline.json
@@ -46,7 +46,8 @@
             "user_agent": {
                 "field": "traefik.access.agent",
                 "target_field": "traefik.access.user_agent",
-                "ignore_failure": true
+                "ignore_failure": true,
+                "ecs": false
             }
         },
         {

--- a/x-pack/filebeat/module/suricata/eve/ingest/pipeline.json
+++ b/x-pack/filebeat/module/suricata/eve/ingest/pipeline.json
@@ -207,6 +207,7 @@
       { "field": "user_agent.original"
       , "target_field": "user_agent"
       , "ignore_missing": true
+      , "ecs": false
       }
     }
   , { "rename":


### PR DESCRIPTION
To make sure the same data structure is ingested in Elasticsearch 6.7 and 7.0 when running Filebeat 6.7, the user_agent processor flag `ecs: false` must be set. Otherwise the data structure would change and data structure conflicts would happen (see https://github.com/elastic/beats/issues/10650).

This change requires Elasticsearch to support the `ecs: false` flag in 7.x.

Adding the `ecs: flag` will mean Filebeat 6.7 stops working with Elasticsearch 6.5 or older as the flag is not supported.