### PR TITLE
[Auditbeat] Package: Disable librpm signal handlers

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -172,6 +172,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 *Auditbeat*
 
 - Enable System module config on Windows. {pull}10237[10237]
+- Package: Disable librpm signal handlers. {pull}10694[10694]
 
 *Filebeat*
 

--- a/x-pack/auditbeat/module/system/package/rpm_linux.go
+++ b/x-pack/auditbeat/module/system/package/rpm_linux.go
@@ -12,6 +12,7 @@ import (
 	"unsafe"
 
 	"github.com/coreos/pkg/dlopen"
+	"github.com/joeshaw/multierror"
 )
 
 /*
@@ -103,27 +104,38 @@ my_rpmtsFree(void *f, rpmts ts) {
   rpmtsFree(ts);
 }
 
-// By default, librpm is going to trap SIGINT and SIGTERM,
+// By default, librpm is going to trap various UNIX signals including SIGINT and SIGTERM
 // which will prevent Beats from shutting down correctly.
 //
 // This disables that behavior. We should be very dilligent in
 // cleaning up in our use of librpm.
 //
 // More recent versions of librpm have a new function rpmsqSetInterruptSafety()
-// to do this.
+// to do this, see below.
 //
 // See also:
 // - librpm traps signals and calls exit(1) to terminate the whole process incl. our Go code: https://github.com/rpm-software-management/rpm/blob/rpm-4.11.3-release/lib/rpmdb.c#L640
 // - has caused problems for gdb before, calling rpmsqEnable(_, NULL) is the workaround they also use: https://bugzilla.redhat.com/show_bug.cgi?id=643031
-// - the new rpmsqSetInterruptSafety(), unfortunately only available in librpm>=4.14.2.1 (CentOS 7 has 4.11.3): https://github.com/rpm-software-management/rpm/commit/56f49d7f5af7c1c8a3eb478431356195adbfdd25
+// - the new rpmsqSetInterruptSafety(), unfortunately only available in librpm>=4.14.0 (CentOS 7 has 4.11.3): https://github.com/rpm-software-management/rpm/commit/56f49d7f5af7c1c8a3eb478431356195adbfdd25
 void
 my_disableLibrpmSignalTraps(void *f) {
 	int (*rpmsqEnable)(int, rpmsqAction_t);
 	rpmsqEnable = (int (*)(int, rpmsqAction_t))f;
 
-	// Disable traps
-	rpmsqEnable(-SIGTERM, NULL);
+	// Disable all traps
+	rpmsqEnable(-SIGHUP, NULL);
 	rpmsqEnable(-SIGINT, NULL);
+	rpmsqEnable(-SIGTERM, NULL);
+	rpmsqEnable(-SIGQUIT, NULL);
+	rpmsqEnable(-SIGPIPE, NULL);
+}
+
+void
+my_rpmsqSetInterruptSafety(void *f, int on) {
+	void (*rpmsqSetInterruptSafety)(int);
+	rpmsqSetInterruptSafety = (void (*)(int))f;
+
+	rpmsqSetInterruptSafety(on);
 }
 */
 import "C"
@@ -163,11 +175,6 @@ func dlopenCFunctions() (*cFunctions, error) {
 	var cFun cFunctions
 
 	librpm, err := dlopen.GetHandle(librpmNames)
-	if err != nil {
-		return nil, err
-	}
-
-	cFun.rpmsqEnable, err = librpm.GetSymbolPointer("rpmsqEnable")
 	if err != nil {
 		return nil, err
 	}
@@ -217,6 +224,22 @@ func dlopenCFunctions() (*cFunctions, error) {
 		return nil, err
 	}
 
+	// Only available in librpm>=4.13.0
+	rpmsqSetInterruptSafety, err := librpm.GetSymbolPointer("rpmsqSetInterruptSafety")
+	if err != nil {
+		var err2 error
+		// Only available in librpm<4.14.0
+		cFun.rpmsqEnable, err2 = librpm.GetSymbolPointer("rpmsqEnable")
+		if err2 != nil {
+			var errs multierror.Errors
+			errs = append(errs, err)
+			errs = append(errs, err2)
+			return nil, errs.Err()
+		}
+	} else {
+		C.my_rpmsqSetInterruptSafety(rpmsqSetInterruptSafety, 1)
+	}
+
 	return &cFun, nil
 }
 
@@ -243,7 +266,9 @@ func listRPMPackages() ([]*Package, error) {
 	if mi == nil {
 		return nil, fmt.Errorf("Failed to get match iterator")
 	}
-	C.my_disableLibrpmSignalTraps(cFun.rpmsqEnable)
+	if cFun.rpmsqEnable != nil {
+		C.my_disableLibrpmSignalTraps(cFun.rpmsqEnable)
+	}
 	defer C.my_rpmdbFreeIterator(cFun.rpmdbFreeIterator, mi)
 
 	var packages []*Package

--- a/x-pack/auditbeat/module/system/package/rpm_linux.go
+++ b/x-pack/auditbeat/module/system/package/rpm_linux.go
@@ -232,8 +232,7 @@ func dlopenCFunctions() (*cFunctions, error) {
 		cFun.rpmsqEnable, err2 = librpm.GetSymbolPointer("rpmsqEnable")
 		if err2 != nil {
 			var errs multierror.Errors
-			errs = append(errs, err)
-			errs = append(errs, err2)
+			errs = append(errs, err, err2)
 			return nil, errs.Err()
 		}
 	} else {

--- a/x-pack/auditbeat/module/system/package/rpm_linux.go
+++ b/x-pack/auditbeat/module/system/package/rpm_linux.go
@@ -22,6 +22,7 @@ import (
 #include <rpm/header.h>
 #include <rpm/rpmts.h>
 #include <rpm/rpmdb.h>
+#include <rpm/rpmsq.h>
 
 rpmts
 my_rpmtsCreate(void *f) {
@@ -100,7 +101,31 @@ my_rpmtsFree(void *f, rpmts ts) {
   rpmtsFree = (rpmts (*)(rpmts))f;
 
   rpmtsFree(ts);
-}*/
+}
+
+// By default, librpm is going to trap SIGINT and SIGTERM,
+// which will prevent Beats from shutting down correctly.
+//
+// This disables that behavior. We should be very dilligent in
+// cleaning up in our use of librpm.
+//
+// More recent versions of librpm have a new function rpmsqSetInterruptSafety()
+// to do this.
+//
+// See also:
+// - librpm traps signals and calls exit(1) to terminate the whole process incl. our Go code: https://github.com/rpm-software-management/rpm/blob/rpm-4.11.3-release/lib/rpmdb.c#L640
+// - has caused problems for gdb before, calling rpmsqEnable(_, NULL) is the workaround they also use: https://bugzilla.redhat.com/show_bug.cgi?id=643031
+// - the new rpmsqSetInterruptSafety(), unfortunately only available in librpm>=4.14.2.1 (CentOS 7 has 4.11.3): https://github.com/rpm-software-management/rpm/commit/56f49d7f5af7c1c8a3eb478431356195adbfdd25
+void
+my_disableLibrpmSignalTraps(void *f) {
+	int (*rpmsqEnable)(int, rpmsqAction_t);
+	rpmsqEnable = (int (*)(int, rpmsqAction_t))f;
+
+	// Disable traps
+	rpmsqEnable(-SIGTERM, NULL);
+	rpmsqEnable(-SIGINT, NULL);
+}
+*/
 import "C"
 
 // Constants in sync with /usr/include/rpm/rpmtag.h
@@ -126,6 +151,7 @@ type cFunctions struct {
 	headerFree         unsafe.Pointer
 	rpmdbFreeIterator  unsafe.Pointer
 	rpmtsFree          unsafe.Pointer
+	rpmsqEnable        unsafe.Pointer
 }
 
 var cFun *cFunctions
@@ -137,6 +163,11 @@ func dlopenCFunctions() (*cFunctions, error) {
 	var cFun cFunctions
 
 	librpm, err := dlopen.GetHandle(librpmNames)
+	if err != nil {
+		return nil, err
+	}
+
+	cFun.rpmsqEnable, err = librpm.GetSymbolPointer("rpmsqEnable")
 	if err != nil {
 		return nil, err
 	}
@@ -212,6 +243,7 @@ func listRPMPackages() ([]*Package, error) {
 	if mi == nil {
 		return nil, fmt.Errorf("Failed to get match iterator")
 	}
+	C.my_disableLibrpmSignalTraps(cFun.rpmsqEnable)
 	defer C.my_rpmdbFreeIterator(cFun.rpmdbFreeIterator, mi)
 
 	var packages []*Package

--- a/x-pack/auditbeat/module/system/package/rpm_linux.go
+++ b/x-pack/auditbeat/module/system/package/rpm_linux.go
@@ -236,7 +236,7 @@ func dlopenCFunctions() (*cFunctions, error) {
 			return nil, errs.Err()
 		}
 	} else {
-		C.my_rpmsqSetInterruptSafety(rpmsqSetInterruptSafety, 1)
+		C.my_rpmsqSetInterruptSafety(rpmsqSetInterruptSafety, 0)
 	}
 
 	return &cFun, nil

--- a/x-pack/auditbeat/tests/system/test_metricsets.py
+++ b/x-pack/auditbeat/tests/system/test_metricsets.py
@@ -41,7 +41,6 @@ class Test(AuditbeatXPackTest):
         # Metricset is experimental and that generates a warning, TODO: remove later
         self.check_metricset("system", "login", COMMON_FIELDS + fields, config, warnings_allowed=True)
 
-    @unittest.skip("Flaky test, see https://github.com/elastic/beats/issues/10633")
     @unittest.skipIf(sys.platform == "win32", "Not implemented for Windows")
     @unittest.skipIf(sys.platform == "linux2" and not (os.path.isdir("/var/lib/dpkg") or os.path.isdir("/var/lib/rpm")),
                      "Only implemented for dpkg and rpm")


### PR DESCRIPTION
Librpm installs its own signal handlers, preventing Beats from running its own Go handlers and causing an unclean shutdown. This summarily disables librpm's signal handlers. See https://github.com/elastic/beats/issues/10633#issuecomment-461830679 for a detailed description of what is happening.

Resolves https://github.com/elastic/beats/issues/10633.