### PR TITLE
skip dashboard unpacking for empty objects

### DIFF
--- a/libbeat/scripts/unpack_dashboards.py
+++ b/libbeat/scripts/unpack_dashboards.py
@@ -6,6 +6,9 @@ import argparse
 
 def transform_data(data, method):
     for obj in data["objects"]:
+        if "attributes" not in obj:
+            continue
+
         if "uiStateJSON" in obj["attributes"]:
             obj["attributes"]["uiStateJSON"] = method(obj["attributes"]["uiStateJSON"])
 


### PR DESCRIPTION
We have removed dashboards completely from APM Server. Unfortunately, people who still have `setup.dashboards.enabled: true` will get an error when APM Servers starts if there's no dashboard file. More details here: https://github.com/elastic/apm-server/issues/1905

There's a way to have an empty dashboard file which works for now, but unfortunately the conversion script breaks with that solution: https://github.com/elastic/apm-server/pull/1917.