### PR TITLE
[Libbeat] Gracefully shut down on SIGHUP

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -239,7 +239,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add `community_id` processor for computing network flow hashes. {pull}10745[10745]
 - Add output test to kafka output {pull}10834[10834]
 - Add ip fields to default_field in Elasticsearch template. {pull}11035[11035]
-
 - Gracefully shut down on SIGHUP {pull}10704[10704]
 
 *Auditbeat*

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -240,6 +240,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add output test to kafka output {pull}10834[10834]
 - Add ip fields to default_field in Elasticsearch template. {pull}11035[11035]
 
+- Gracefully shut down on SIGHUP {pull}10704[10704]
 
 *Auditbeat*
 

--- a/libbeat/service/service.go
+++ b/libbeat/service/service.go
@@ -42,7 +42,7 @@ import (
 func HandleSignals(stopFunction func(), cancel context.CancelFunc) {
 	var callback sync.Once
 
-	// On ^C or SIGTERM, gracefully stop the sniffer
+	// On termination signals, gracefully stop the Beat
 	sigc := make(chan os.Signal, 1)
 	signal.Notify(sigc, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
 	go func() {

--- a/libbeat/tests/system/test_base.py
+++ b/libbeat/tests/system/test_base.py
@@ -23,7 +23,7 @@ class Test(BaseTest):
         proc.check_kill_and_wait()
         assert self.log_contains("mockbeat stopped.")
 
-    @unittest.skipIf(sys.platform.startswith("win"), "SIGHUP is not available on Windows"')
+    @unittest.skipIf(sys.platform.startswith("win"), "SIGHUP is not available on Windows")
     def test_sighup(self):
         """
         Basic test with exiting Mockbeat because of SIGHUP

--- a/libbeat/tests/system/test_base.py
+++ b/libbeat/tests/system/test_base.py
@@ -3,6 +3,7 @@ from base import BaseTest
 import json
 import os
 import shutil
+import signal
 import subprocess
 import sys
 import unittest
@@ -20,6 +21,21 @@ class Test(BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.log_contains("mockbeat start running."))
         proc.check_kill_and_wait()
+        assert self.log_contains("mockbeat stopped.")
+
+    @unittest.skipIf(sys.platform.startswith("win"), "SIGHUP is not available on Windows"'
+    def test_sighup(self):
+        """
+        Basic test with exiting Mockbeat because of SIGHUP
+        """
+        self.render_config_template(
+        )
+
+        proc = self.start_beat()
+        self.wait_until(lambda: self.log_contains("mockbeat start running."))
+        proc.proc.send_signal(signal.SIGHUP)
+        proc.check_wait()
+        assert self.log_contains("mockbeat stopped.")
 
     def test_no_config(self):
         """

--- a/libbeat/tests/system/test_base.py
+++ b/libbeat/tests/system/test_base.py
@@ -23,7 +23,7 @@ class Test(BaseTest):
         proc.check_kill_and_wait()
         assert self.log_contains("mockbeat stopped.")
 
-    @unittest.skipIf(sys.platform.startswith("win"), "SIGHUP is not available on Windows"'
+    @unittest.skipIf(sys.platform.startswith("win"), "SIGHUP is not available on Windows"')
     def test_sighup(self):
         """
         Basic test with exiting Mockbeat because of SIGHUP


### PR DESCRIPTION
`SIGHUP` is sent to a process if the user's terminal is disconnected. It is one of the five [termination signals](https://www.gnu.org/software/libc/manual/html_node/Termination-Signals.html#Termination-Signals). Currently, Beats is going to terminate suddenly, i.e. the log will cut off, no shutdown actions are going to be run, etc.

As we handle more and more state (e.g. writing state to `beat.db` files) it becomes more important to gracefully shutdown in "less than ideal" situations. Beats should probably not be run directly from a terminal or a terminal multiplexer, but it probably happens, and if so the consequences of a network disconnect or clumsy fingers (I forget the number of times I've hit the wrong key when using shortcuts in tmux/screen) should not be severe if we can help it.

This change catches `SIGHUP` as it already does `SIGINT/SIGTERM` and runs the usual shutdown actions. This can include waiting for a period of time specified using the `shutdown_timeout` option [Filebeat](https://www.elastic.co/guide/en/beats/filebeat/6.6/configuration-general-options.html#shutdown-timeout) and [Packetbeat](https://www.elastic.co/guide/en/beats/packetbeat/6.6/configuration-processes.html#shutdown-timeout) support.

I thought we might want to exit with a non-zero exit code if we receive this unexpected signal, but I don't see a good way to specifiy the exit code in Libbeat at the moment.