### PR TITLE
Initialize Paths before loading the keystore

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -29,6 +29,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Move output.elasticsearch.ilm settings to setup.ilm. {pull}10347[10347]
 - ILM will be available by default if Elasticsearch > 7.0 is used. {pull}10347[10347]
 - Allow Central Management to send events back to kibana. {issue}9382[9382]
+- Initialize the Paths before the keystore and save the keystore into `data/{beatname}.keystore`. {pull}10706[10706]
 
 *Auditbeat*
 

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -909,9 +909,9 @@ func initKibanaConfig(beatConfig beatConfig) (*common.Config, error) {
 }
 
 func initPaths(cfg *common.Config) error {
-	// To Fix the chicken-egg problem with the Keystore initial and the loading of the configuration
-	// file we are doing a partial unpack of the configuration file and only take into consideration
-	// the configured path. After we will unpack the complete configuration and keystore reference
+	// To Fix the chicken-egg problem with the Keystore and the loading of the configuration
+	// files we are doing a partial unpack of the configuration file and only take into consideration
+	// the paths field. After we will unpack the complete configuration and keystore reference
 	// will be correctly replaced.
 	partialConfig := struct {
 		Path paths.Path `config:"path"`

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -519,6 +519,10 @@ func (b *Beat) configure(settings Settings) error {
 		return fmt.Errorf("error loading config file: %v", err)
 	}
 
+	if err := initPaths(cfg); err != nil {
+		return err
+	}
+
 	// We have to initialize the keystore before any unpack or merging the cloud
 	// options.
 	store, err := LoadKeystore(cfg, b.Info.Beat)
@@ -549,11 +553,6 @@ func (b *Beat) configure(settings Settings) error {
 
 	if name := b.Config.Name; name != "" {
 		b.Info.Name = name
-	}
-
-	err = paths.InitPaths(&b.Config.Path)
-	if err != nil {
-		return fmt.Errorf("error setting default paths: %v", err)
 	}
 
 	if err := configure.Logging(b.Info.Beat, b.Config.Logging); err != nil {
@@ -907,4 +906,23 @@ func initKibanaConfig(beatConfig beatConfig) (*common.Config, error) {
 		}
 	}
 	return kibanaConfig, nil
+}
+
+func initPaths(cfg *common.Config) error {
+	// To Fix the chicken-egg problem with the Keystore initial and the loading of the configuration
+	// file we are doing a partial unpack of the configuration file and only take into consideration
+	// the configured path. After we will unpack the complete configuration and keystore reference
+	// will be correctly replaced.
+	partialConfig := struct {
+		Path paths.Path `config:"path"`
+	}{}
+
+	if err := cfg.Unpack(&partialConfig); err != nil {
+		return fmt.Errorf("error extracting default paths: %+v", err)
+	}
+
+	if err := paths.InitPaths(&partialConfig.Path); err != nil {
+		return fmt.Errorf("error setting default paths: %v", err)
+	}
+	return nil
 }

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -922,7 +922,7 @@ func initPaths(cfg *common.Config) error {
 	}
 
 	if err := paths.InitPaths(&partialConfig.Path); err != nil {
-		return fmt.Errorf("error setting default paths: %v", err)
+		return fmt.Errorf("error setting default paths: %+v", err)
 	}
 	return nil
 }


### PR DESCRIPTION
The paths were incorrectly initialized meaning that instead of creating
the keystore in the data directory it was created next to the binary.

The problem was the call to `paths.InitPaths()` was done after loading
the keystore, this was causing a chicken and egg situation and
`paths.Resolve(path.Data, "hello")` was returning "hello" instead of
`data/hello`.

To solve that situation we do a partial extract of the configuration,
just enough to initialize the paths and we move on to the keystore and
the complete unpack.