### PR TITLE
Squelch duplicate HTTP packet loss error messages

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -210,6 +210,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 - Fix DHCPv4 dashboard that wouldn't load in Kibana. {issue}9850[9850]
 - Fixed a crash when using af_packet capture {pull}10477[10477]
+- Prevent duplicate packet loss error messages in HTTP events. {pull}10709[10709]
 
 *Winlogbeat*
 

--- a/packetbeat/protos/http/http.go
+++ b/packetbeat/protos/http/http.go
@@ -189,9 +189,15 @@ func (http *httpPlugin) messageGap(s *stream, nbytes int) (ok bool, complete boo
 		}
 
 		if m.isRequest {
-			m.notes = append(m.notes, "Packet loss while capturing the request")
+			if !m.packetLossReq {
+				m.packetLossReq = true
+				m.notes = append(m.notes, "Packet loss while capturing the request")
+			}
 		} else {
-			m.notes = append(m.notes, "Packet loss while capturing the response")
+			if !m.packetLossResp {
+				m.packetLossResp = true
+				m.notes = append(m.notes, "Packet loss while capturing the response")
+			}
 		}
 		if !m.hasContentLength && (bytes.Equal(m.connection, constClose) ||
 			(isVersion(m.version, 1, 0) && !bytes.Equal(m.connection, constKeepAlive))) {

--- a/packetbeat/protos/http/http_parser.go
+++ b/packetbeat/protos/http/http_parser.go
@@ -73,7 +73,9 @@ type message struct {
 	saveBody bool
 	body     []byte
 
-	notes []string
+	notes          []string
+	packetLossReq  bool
+	packetLossResp bool
 
 	next *message
 }


### PR DESCRIPTION
Each time a gap is detected a new error message is appended. One message is
sufficient to know that packet loss occurred so stop adding errors after the first.

I was seeing events with many errors.

       "error": {
             "message": [
               "Packet loss while capturing the response",
               "Packet loss while capturing the response",
              ....
              ]
       }