### PR TITLE
[7.0] Ensure index pattern version is a string (#10689)

### DIFF
--- a/libbeat/kibana/index_pattern_generator.go
+++ b/libbeat/kibana/index_pattern_generator.go
@@ -84,7 +84,7 @@ func (i *IndexPatternGenerator) generatePattern(attrs common.MapStr) common.MapS
 			common.MapStr{
 				"type":       "index-pattern",
 				"id":         i.indexName,
-				"version":    1,
+				"version":    "1",
 				"attributes": attrs,
 			},
 		},

--- a/libbeat/kibana/index_pattern_generator_test.go
+++ b/libbeat/kibana/index_pattern_generator_test.go
@@ -157,7 +157,7 @@ func testGenerate(t *testing.T, tests []compare, sourceFilters bool) {
 			objExisting := existing["objects"].([]interface{})[0].(map[string]interface{})
 			objCreated := test.created["objects"].([]common.MapStr)[0]
 
-			assert.Equal(t, int(objExisting["version"].(float64)), objCreated["version"])
+			assert.Equal(t, objExisting["version"], objCreated["version"])
 			assert.Equal(t, objExisting["id"], objCreated["id"])
 			assert.Equal(t, objExisting["type"], objCreated["type"])
 

--- a/libbeat/kibana/testdata/beat-6.json
+++ b/libbeat/kibana/testdata/beat-6.json
@@ -10,7 +10,7 @@
       },
       "id": "beat-*",
       "type": "index-pattern",
-      "version": 1
+      "version": "1"
     }
   ],
   "version": "7.0.0-alpha1"

--- a/libbeat/kibana/testdata/extensive/metricbeat-6.json
+++ b/libbeat/kibana/testdata/extensive/metricbeat-6.json
@@ -8,7 +8,7 @@
         "timeFieldName": "@timestamp", 
         "title": "metricbeat-*"
       }, 
-      "version": 1, 
+      "version": "1",
       "type": "index-pattern", 
       "id": "metricbeat-*"
     }


### PR DESCRIPTION
Backports the following commits to 7.0:
 - Ensure index pattern version is a string  (#10689)