### PR TITLE
Split up Metricbeat tests into 3 builds on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,9 +87,18 @@ jobs:
 
     # Metricbeat
     - os: linux
-      env: TARGETS="-C metricbeat testsuite"
+      env: TARGETS="-C metricbeat unit-tests coverage-report"
       go: $TRAVIS_GO_VERSION
       stage: test
+    - os: linux
+      env: TARGETS="-C metricbeat integration-tests-environment coverage-report"
+      go: $TRAVIS_GO_VERSION
+      stage: test
+    - os: linux
+      env: TARGETS="-C metricbeat system-tests-environment coverage-report"
+      go: $TRAVIS_GO_VERSION
+      stage: test
+
     - os: osx
       env: TARGETS="TEST_ENVIRONMENT=0 -C metricbeat testsuite"
       go: $TRAVIS_GO_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -95,7 +95,7 @@ jobs:
       go: $TRAVIS_GO_VERSION
       stage: test
     - os: linux
-      env: TARGETS="-C metricbeat system-tests-environment coverage-report"
+      env: TARGETS="-C metricbeat update system-tests-environment coverage-report"
       go: $TRAVIS_GO_VERSION
       stage: test
 


### PR DESCRIPTION
The builds on travis for metricbeat exceeded 60min. This splits up the tests into 3 parts.