### PR TITLE
Cherry-pick #10710 to 6.7: Fix more strict params in docs build

### DIFF
--- a/script/build_docs.sh
+++ b/script/build_docs.sh
@@ -30,11 +30,11 @@ do
   mkdir -p "$dest_dir"
   params="--chunk=1"
   if [ "$PREVIEW" = "1" ]; then
-    params="$params -open"
+    params="$params --open"
   fi
 
   if [ -d "$resource_dir" ]; then
-    params="$params -resource=${resource_dir}"
+    params="$params --resource=${resource_dir}"
   fi
 
   $docs_dir/build_docs.pl $params --doc "$index" -out "$dest_dir"


### PR DESCRIPTION
Cherry-pick of PR #10710 to 6.7 branch. Original message: 

It seems the docs build script has become more strict around params. `--` instead of `-` has to be used.