### PR TITLE
[7.0] skip dashboard unpacking for empty objs (#10701)

### DIFF
--- a/libbeat/scripts/unpack_dashboards.py
+++ b/libbeat/scripts/unpack_dashboards.py
@@ -6,6 +6,9 @@ import argparse
 
 def transform_data(data, method):
     for obj in data["objects"]:
+        if "attributes" not in obj:
+            continue
+
         if "uiStateJSON" in obj["attributes"]:
             obj["attributes"]["uiStateJSON"] = method(obj["attributes"]["uiStateJSON"])
 


### PR DESCRIPTION
Backports the following commits to 7.0:
 - skip dashboard unpacking for empty objs  (#10701)