### PR TITLE
Cover empty request data, url and version in Apache2 Filebeat module

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -184,6 +184,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix bad bytes count in `docker` input when filtering by stream. {pull}10211[10211]
 - Fixed data types for roles and indices fields in `elasticsearch/audit` fileset {pull}10307[10307]
 - Ensure `source.address` is always populated by the nginx module (ECS). {pull}10418[10418]
+- Cover empty request data, url and version in Apache2 module{pull}10730[10730]
 
 *Heartbeat*
 

--- a/filebeat/module/apache/access/ingest/default.json
+++ b/filebeat/module/apache/access/ingest/default.json
@@ -4,7 +4,7 @@
     "grok": {
       "field": "message",
       "patterns":[
-        "%{IPORHOST:source.address} - %{DATA:user.name} \\[%{HTTPDATE:apache.access.time}\\] \"%{WORD:http.request.method} %{DATA:url.original} HTTP/%{NUMBER:http.version}\" %{NUMBER:http.response.status_code:long} (?:%{NUMBER:http.response.body.bytes:long}|-)( \"%{DATA:http.request.referrer}\")?( \"%{DATA:user_agent.original}\")?",
+        "%{IPORHOST:source.address} - %{DATA:user.name} \\[%{HTTPDATE:apache.access.time}\\] \"(?:%{WORD:http.request.method} %{DATA:url.original} HTTP/%{NUMBER:http.version}|-)?\" %{NUMBER:http.response.status_code:long} (?:%{NUMBER:http.response.body.bytes:long}|-)( \"%{DATA:http.request.referrer}\")?( \"%{DATA:user_agent.original}\")?",
         "%{IPORHOST:source.address} - %{DATA:user.name} \\[%{HTTPDATE:apache.access.time}\\] \"-\" %{NUMBER:http.response.status_code:long} -",
         "\\[%{HTTPDATE:apache.access.time}\\] %{IPORHOST:source.address} %{DATA:apache.access.ssl.protocol} %{DATA:apache.access.ssl.cipher} \"%{WORD:http.request.method} %{DATA:url.original} HTTP/%{NUMBER:http.version}\" %{NUMBER:http.response.body.bytes:long}"
         ],
@@ -31,11 +31,13 @@
     "date": {
       "field": "apache.access.time",
       "target_field": "@timestamp",
-      "formats": ["dd/MMM/yyyy:H:m:s Z"]
+      "formats": ["dd/MMM/yyyy:H:m:s Z"],
+        "ignore_failure": true
     }
   }, {
     "remove": {
-      "field": "apache.access.time"
+      "field": "apache.access.time",
+        "ignore_failure": true
     }
   }, {
     "user_agent": {

--- a/filebeat/module/apache/access/test/ssl-request.log-expected.json
+++ b/filebeat/module/apache/access/test/ssl-request.log-expected.json
@@ -1,6 +1,6 @@
 [
     {
-        "@timestamp": "2018-08-10T09:45:56.000Z",
+        "@timestamp": "2018-08-10T07:45:56.000Z",
         "apache.access.ssl.cipher": "ECDHE-RSA-AES128-GCM-SHA256",
         "apache.access.ssl.protocol": "TLSv1.2",
         "ecs.version": "1.0.0-beta2",

--- a/filebeat/module/apache/access/test/ssl-request.log-expected.json
+++ b/filebeat/module/apache/access/test/ssl-request.log-expected.json
@@ -1,6 +1,6 @@
 [
     {
-        "@timestamp": "2018-08-10T07:45:56.000Z",
+        "@timestamp": "2018-08-10T09:45:56.000Z",
         "apache.access.ssl.cipher": "ECDHE-RSA-AES128-GCM-SHA256",
         "apache.access.ssl.protocol": "TLSv1.2",
         "ecs.version": "1.0.0-beta2",

--- a/filebeat/module/apache/access/test/test.log
+++ b/filebeat/module/apache/access/test/test.log
@@ -3,3 +3,4 @@
 ::1 - - [26/Dec/2016:16:16:48 +0200] "-" 408 -
 172.17.0.1 - - [29/May/2017:19:02:48 +0000] "GET /stringpatch HTTP/1.1" 404 612 "-" "Mozilla/5.0 (Windows NT 6.1; rv:15.0) Gecko/20120716 Firefox/15.0a2" "-"
 monitoring-server - - [29/May/2017:19:02:48 +0000] "GET /status HTTP/1.1" 200 612 "-" "Mozilla/5.0 (Windows NT 6.1; rv:15.0) Gecko/20120716 Firefox/15.0a2" "-"
+127.0.0.1 - - [02/Feb/2019:05:38:45 +0100] "-" 408 152 "-" "-"

--- a/filebeat/module/apache/access/test/test.log-expected.json
+++ b/filebeat/module/apache/access/test/test.log-expected.json
@@ -104,5 +104,24 @@
         "user_agent.original": "Mozilla/5.0 (Windows NT 6.1; rv:15.0) Gecko/20120716 Firefox/15.0a2",
         "user_agent.os.name": "Windows 7",
         "user_agent.version": "15.0.a2"
+    },
+    {
+        "@timestamp": "2019-02-02T05:38:45.000Z",
+        "ecs.version": "1.0.0-beta2",
+        "event.dataset": "apache.access",
+        "event.module": "apache",
+        "fileset.name": "access",
+        "http.request.referrer": "-",
+        "http.response.body.bytes": 152,
+        "http.response.status_code": 408,
+        "input.type": "log",
+        "log.offset": 603,
+        "service.type": "apache",
+        "source.address": "127.0.0.1",
+        "source.ip": "127.0.0.1",
+        "user.name": "-",
+        "user_agent.device.name": "Other",
+        "user_agent.name": "Other",
+        "user_agent.original": "-"
     }
 ]

--- a/filebeat/module/apache/access/test/test.log-expected.json
+++ b/filebeat/module/apache/access/test/test.log-expected.json
@@ -1,6 +1,6 @@
 [
     {
-        "@timestamp": "2016-12-26T14:16:29.000Z",
+        "@timestamp": "2016-12-26T16:16:29.000Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "apache.access",
         "event.module": "apache",
@@ -44,7 +44,7 @@
         "user_agent.version": "50.0"
     },
     {
-        "@timestamp": "2016-12-26T14:16:48.000Z",
+        "@timestamp": "2016-12-26T16:16:48.000Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "apache.access",
         "event.module": "apache",

--- a/filebeat/module/apache/access/test/test.log-expected.json
+++ b/filebeat/module/apache/access/test/test.log-expected.json
@@ -1,6 +1,6 @@
 [
     {
-        "@timestamp": "2016-12-26T16:16:29.000Z",
+        "@timestamp": "2016-12-26T14:16:29.000Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "apache.access",
         "event.module": "apache",
@@ -44,7 +44,7 @@
         "user_agent.version": "50.0"
     },
     {
-        "@timestamp": "2016-12-26T16:16:48.000Z",
+        "@timestamp": "2016-12-26T14:16:48.000Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "apache.access",
         "event.module": "apache",
@@ -106,7 +106,7 @@
         "user_agent.version": "15.0.a2"
     },
     {
-        "@timestamp": "2019-02-02T05:38:45.000Z",
+        "@timestamp": "2019-02-02T04:38:45.000Z",
         "ecs.version": "1.0.0-beta2",
         "event.dataset": "apache.access",
         "event.module": "apache",


### PR DESCRIPTION
Related to this issue https://github.com/elastic/beats/issues/10656 we weren't parsing properly HTTP timeouts where HTTP information from the server isn't received (url, request method and version).

The example line from the issue is included and a slight modification to the existing Grok patterns covers this use case.

Please, take a closer look at this file https://github.com/elastic/beats/compare/master...sayden:bugfix/fb/parse-empty-data-in-apache?expand=1#diff-9c8ecada761029001c82a19f1f2edafe because, for some reason I don't fully understand, the timezone of the "old" lines has changed when regenerating the file.