### PR TITLE
Add syslog support for ISO8601 format timestamp

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -274,6 +274,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - New iptables module that receives iptables/ip6tables logs over syslog or file. Supports Ubiquiti Firewall extensions. {issue}8781[8781] {pull}10176[10176]
 - Added support for ingesting structured Elasticsearch server logs {pull}10428[10428]
 - Populate more ECS fields in the Suricata module. {pull}10006[10006]
+- Add ISO8601 timestamp support in syslog metricset. {issue}8716[8716] {pull}10736[10736]
 
 *Heartbeat*
 

--- a/filebeat/module/system/syslog/ingest/pipeline.json
+++ b/filebeat/module/system/syslog/ingest/pipeline.json
@@ -6,7 +6,8 @@
                 "field": "message",
                 "patterns": [
                     "%{SYSLOGTIMESTAMP:system.syslog.timestamp} %{SYSLOGHOST:host.hostname} %{DATA:process.name}(?:\\[%{POSINT:process.pid:long}\\])?: %{GREEDYMULTILINE:system.syslog.message}",
-                    "%{SYSLOGTIMESTAMP:system.syslog.timestamp} %{GREEDYMULTILINE:system.syslog.message}"
+                    "%{SYSLOGTIMESTAMP:system.syslog.timestamp} %{GREEDYMULTILINE:system.syslog.message}",
+                    "%{TIMESTAMP_ISO8601:system.syslog.timestamp} %{SYSLOGHOST:host.hostname} %{DATA:process.name}(?:\\[%{POSINT:process.pid:long}\\])?: %{GREEDYMULTILINE:system.syslog.message}"
                 ],
                 "pattern_definitions" : {
                     "GREEDYMULTILINE" : "(.|\n)*"
@@ -32,7 +33,8 @@
                 "target_field": "@timestamp",
                 "formats": [
                     "MMM  d HH:mm:ss",
-                    "MMM dd HH:mm:ss"
+                    "MMM dd HH:mm:ss",
+                    "YYYY MM dd HH:mm:ss.SSSSSSZZ"
                 ],
                 {< if .convert_timezone >}"timezone": "{{ beat.timezone }}",{< end >}
                 "ignore_failure": true

--- a/filebeat/module/system/syslog/ingest/pipeline.json
+++ b/filebeat/module/system/syslog/ingest/pipeline.json
@@ -34,7 +34,7 @@
                 "formats": [
                     "MMM  d HH:mm:ss",
                     "MMM dd HH:mm:ss",
-                    "YYYY MM dd HH:mm:ss.SSSSSSZZ"
+                    "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZZ"
                 ],
                 {< if .convert_timezone >}"timezone": "{{ beat.timezone }}",{< end >}
                 "ignore_failure": true

--- a/filebeat/module/system/syslog/test/suse-syslog.log
+++ b/filebeat/module/system/syslog/test/suse-syslog.log
@@ -1,0 +1,2 @@
+2018-08-14T14:30:02.203151+02:00 linux-sqrz systemd[4179]: Stopped target Basic System.
+2018-08-14T14:30:02.203251+02:00 linux-sqrz systemd[4179]: Stopped target Paths.

--- a/filebeat/module/system/syslog/test/suse-syslog.log-expected.json
+++ b/filebeat/module/system/syslog/test/suse-syslog.log-expected.json
@@ -1,0 +1,28 @@
+[
+    {
+        "ecs.version": "1.0.0-beta2",
+        "event.dataset": "system.syslog",
+        "event.module": "system",
+        "fileset.name": "syslog",
+        "host.hostname": "linux-sqrz",
+        "input.type": "log",
+        "log.offset": 0,
+        "message": "Stopped target Basic System.",
+        "process.name": "systemd",
+        "process.pid": 4179,
+        "service.type": "system"
+    },
+    {
+        "ecs.version": "1.0.0-beta2",
+        "event.dataset": "system.syslog",
+        "event.module": "system",
+        "fileset.name": "syslog",
+        "host.hostname": "linux-sqrz",
+        "input.type": "log",
+        "log.offset": 88,
+        "message": "Stopped target Paths.",
+        "process.name": "systemd",
+        "process.pid": 4179,
+        "service.type": "system"
+    }
+]


### PR DESCRIPTION
This PR is to add support for syslog which has ISO8601 format timestamps. For example:
Suse Format:

2018-08-14T14:30:02.203151+02:00 linux-sqrz systemd[4179]: Stopped target Basic System.
2018-08-14T14:30:02.203251+02:00 linux-sqrz systemd[4179]: Stopped target Paths.

closes https://github.com/elastic/beats/issues/8716