### PR TITLE
[Heartbeat] Fix NXDOMAIN errors

### DIFF
--- a/heartbeat/monitors/active/tcp/tcp_test.go
+++ b/heartbeat/monitors/active/tcp/tcp_test.go
@@ -214,9 +214,19 @@ func TestNXDomain(t *testing.T) {
 	mapvaltest.Test(
 		t,
 		mapval.Strict(mapval.Compose(
-			tcpMonitorChecks(host, host, port, "down"),
 			hbtest.ErrorChecks(dialErr, "io"),
-			hbtest.TCPBaseChecks(port),
+			mapval.MustCompile(mapval.Map{
+				"monitor": mapval.Map{
+					"status":   "down",
+					"scheme":   "tcp",
+					"host":     host,
+					"id":       fmt.Sprintf("tcp-tcp@%s:%d", host, port),
+					"duration": mapval.Map{"us": mapval.IsDuration},
+				},
+				"resolve": mapval.Map{
+					"host": host,
+				},
+			}),
 		)),
 		event.Fields,
 	)

--- a/heartbeat/monitors/active/tcp/tcp_test.go
+++ b/heartbeat/monitors/active/tcp/tcp_test.go
@@ -206,15 +206,14 @@ func TestUnreachableEndpointJob(t *testing.T) {
 // TestNXDomain tests that non-existent domains are correctly pinged.
 // Note, this depends on the system having a DNS resolver that doesn't hijack NXDOMAIN Results.
 func TestNXDomain(t *testing.T) {
-	host := "notadomainatallforsure.notadomain.notatldreally"
+	host := "notadomain.notatld"
 	port := uint16(1234)
 	event := testTCPCheck(t, host, port)
 
-	dialErr := fmt.Sprintf("lookup %s", host)
 	mapvaltest.Test(
 		t,
 		mapval.Strict(mapval.Compose(
-			hbtest.ErrorChecks(dialErr, "io"),
+			hbtest.ErrorChecks("no such host", "io"),
 			mapval.MustCompile(mapval.Map{
 				"monitor": mapval.Map{
 					"status":   "down",

--- a/heartbeat/monitors/active/tcp/tcp_test.go
+++ b/heartbeat/monitors/active/tcp/tcp_test.go
@@ -202,3 +202,22 @@ func TestUnreachableEndpointJob(t *testing.T) {
 		event.Fields,
 	)
 }
+
+// TestNXDomain tests that non-existent domains are correctly pinged.
+// Note, this depends on the system having a DNS resolver that doesn't hijack NXDOMAIN Results.
+func TestNXDomain(t *testing.T) {
+	host := "notadomainatallforsure.notadomain.notatldreally"
+	port := uint16(1234)
+	event := testTCPCheck(t, host, port)
+
+	dialErr := fmt.Sprintf("lookup %s", host)
+	mapvaltest.Test(
+		t,
+		mapval.Strict(mapval.Compose(
+			tcpMonitorChecks(host, host, port, "down"),
+			hbtest.ErrorChecks(dialErr, "io"),
+			hbtest.TCPBaseChecks(port),
+		)),
+		event.Fields,
+	)
+}

--- a/heartbeat/monitors/util.go
+++ b/heartbeat/monitors/util.go
@@ -274,8 +274,8 @@ func makeByHostAnyIPJob(
 		resolveStart := time.Now()
 		ip, err := net.ResolveIPAddr(network, host)
 		if err != nil {
-			resolveErr(event, host, err)
-			return nil, nil
+			resolveErr(event, host)
+			return nil, err
 		}
 
 		resolveEnd := time.Now()
@@ -303,8 +303,8 @@ func makeByHostAllIPJob(
 		resolveStart := time.Now()
 		ips, err := net.LookupIP(host)
 		if err != nil {
-			resolveErr(event, host, err)
-			return nil, nil
+			resolveErr(event, host)
+			return nil, err
 		}
 
 		resolveEnd := time.Now()
@@ -316,8 +316,8 @@ func makeByHostAllIPJob(
 
 		if len(ips) == 0 {
 			err := fmt.Errorf("no %v address resolvable for host %v", network, host)
-			resolveErr(event, host, err)
-			return nil, nil
+			resolveErr(event, host)
+			return nil, err
 		}
 
 		// create ip ping tasks
@@ -345,7 +345,7 @@ func resolveIPEvent(host, ip string, rtt time.Duration) common.MapStr {
 	}
 }
 
-func resolveErr(event *beat.Event, host string, err error) {
+func resolveErr(event *beat.Event, host string) {
 	MergeEventFields(event, common.MapStr{
 		"monitor": common.MapStr{
 			"host": host,


### PR DESCRIPTION
Heartbeat 6.7 broke NXDOMAIN errors by accident. This PR adds test coverage for NXDOMAIN issues as well.

Heartbeat 7.0.0 is immune due to a simplified and improved error handling control flow.

Fixes #10734 