### PR TITLE
[WIP] Expose the tls.Config's KeyLogWriter option

### DIFF
--- a/libbeat/common/transport/tlscommon/tls_config.go
+++ b/libbeat/common/transport/tlscommon/tls_config.go
@@ -20,6 +20,7 @@ package tlscommon
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"io"
 
 	"github.com/elastic/beats/libbeat/logp"
 )
@@ -64,6 +65,10 @@ type TLSConfig struct {
 	// ClientAuth controls how we want to verify certificate from a client, `none`, `optional` and
 	// `required`, default to required. Do not affect TCP client.
 	ClientAuth tls.ClientAuthType
+
+	// KeyLogWriter allows to save key exchange information to a file allow the decryption of the
+	// communication with wireshark useful for debugging network issues.
+	KeyLogWriter io.Writer
 }
 
 // BuildModuleConfig takes the TLSConfig and transform it into a `tls.Config`.
@@ -90,5 +95,6 @@ func (c *TLSConfig) BuildModuleConfig(host string) *tls.Config {
 		CipherSuites:       c.CipherSuites,
 		CurvePreferences:   c.CurvePreferences,
 		ClientAuth:         c.ClientAuth,
+		KeyLogWriter:       c.KeyLogWriter,
 	}
 }


### PR DESCRIPTION
When you are using any part of beats that support TLS options you can
now add allow the connection to write the exchange keys details in the
NSS Log format to a file on disk. This file can be use afterward with a
wireshark recording to actually decode the communication.

Fixes: #10378


## TODO:

- [ ] Add to the documentation
- [ ] Add to the YAML config
- [ ] Testing? system test maybe?

## HOW TO TEST

I am assuming a central management context for simplicity.

- Setup Kibana with TLS
- Create an Enrollment token 
- Start Wireshark to record traffic on the localhost
- Start beats with the following command:
```
 ./filebeat enroll https://localhost:5601 a374fd0e340d4d479a374cf641615770  -E "management.kibana.ssl.certificate_authorities=/tmp/security.crt" -E "management.kibana.ssl.key_log.enabled=true" -E "management.kibana.ssl.key_log.path=/tmp/nss.log" -v -d "*" -e
```
- Filter with the dump with `tcp.port==5601`
- Right click on the TLS stream, `Protocol Preferences/(Pre)-master-secret logfilename` Use the the log generated from the enrollment.
- You should see decrypted communication.