### PR TITLE
Add systemd compatibility statement

### DIFF
--- a/journalbeat/docs/overview.asciidoc
+++ b/journalbeat/docs/overview.asciidoc
@@ -13,3 +13,9 @@ https://www.elastic.co/products/elasticsearch[Elasticsearch] or
 https://www.elastic.co/products/logstash[Logstash].
 
 include::{libbeat-dir}/docs/shared-libbeat-description.asciidoc[]
+
+[float]
+=== Compatibility
+
+{beatname_uc} requires systemd v233 or later. Versions prior to systemd v233
+have a defect that prevents {beatname_uc} from reading rotated journals.


### PR DESCRIPTION
Closes #10700 

@kvch I wanted to provide a little detail without going into a lot of detail. I hope I found the right balance. I think we could put this statement in multiple places, but users might miss it. Can we check the systemd version programmatically and let users know when they are using an unsupported version? If not, is there a symptom that we can describe in the troubleshooting docs that will help users discover the problem more easily?