### PR TITLE
Fix attribute references to work with non-beats shippers

### DIFF
--- a/libbeat/docs/security/basic-auth.asciidoc
+++ b/libbeat/docs/security/basic-auth.asciidoc
@@ -79,12 +79,12 @@ rollover indices:
 --
 ["source","sh",subs="attributes"]
 ---------------------------------------------------------------
-POST _xpack/security/role/{beatname_lc}_ilm
+POST _xpack/security/role/{beat_default_index_prefix}_ilm
 {
   "cluster": ["manage_ilm"],
   "indices": [
     {
-      "names": [ "{beatname_lc}-*","shrink-{beatname_lc}-*"],
+      "names": [ "{beat_default_index_prefix}-*","shrink-{beat_default_index_prefix}-*"],
       "privileges": ["write","create_index","manage","manage_ilm"]
     }
   ]


### PR DESCRIPTION
Using apm-friendly attributes in case you want to turn on these changes for apm later on. I plan to do some fairly signficant rework of the security topics, but wanted to fix this for now.