### PR TITLE
Add if/then/else support to processors

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -239,6 +239,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add `overwrite` and `check_exists` settings to ILM support. {pull}10347[10347]
 - Generate Kibana index pattern on demand instead of using a local file. {pull}10478[10478]
 - Calls to Elasticsearch X-Pack APIs made by Beats won't cause deprecation logs in Elasticsearch logs. {9656}9656[9656]
+- Add if/then/else support to processors. {pull}10744[10744]
 
 *Auditbeat*
 

--- a/libbeat/conditions/conditions.go
+++ b/libbeat/conditions/conditions.go
@@ -86,7 +86,7 @@ func NewCondition(config *Config) (Condition, error) {
 			condition, err = NewNotCondition(inner)
 		}
 	default:
-		err = errors.New("missing condition")
+		err = errors.New("missing or invalid condition")
 	}
 	if err != nil {
 		return nil, err

--- a/libbeat/docs/processors-using.asciidoc
+++ b/libbeat/docs/processors-using.asciidoc
@@ -31,6 +31,32 @@ condition is present, then the action is executed only if the condition is
 fulfilled. If no condition is passed, then the action is always executed.
 * `<parameters>` is the list of parameters to pass to the processor.
 
+More complex conditional processing can be accomplished by using the
+if-then-else processor configuration. This allows multiple processors to be
+executed based on a single condition.
+
+[source,yaml]
+----
+processors:
+- if:
+    <condition>
+  then: <1>
+    - <processor_name>:
+        <parameters>
+    - <processor_name>:
+        <parameters>
+    ...
+  else: <2>
+    - <processor_name>:
+        <parameters>
+    - <processor_name>:
+        <parameters>
+    ...
+----
+<1> `then` must contain a single processor or a list of one or more processors
+to execute when the condition evaluates to true.
+<2> `else` is optional. It can contain a single processor or a list of
+processors to execute when the conditional evaluate to false.
 
 [[where-valid]]
 ==== Where are processors valid?

--- a/libbeat/processors/actions/common_test.go
+++ b/libbeat/processors/actions/common_test.go
@@ -44,12 +44,7 @@ func testProcessors(t *testing.T, cases map[string]testCase) {
 					t.Fatalf("Failed to create config(%v): %+v", i, err)
 				}
 
-				var plugin map[string]*common.Config
-				if err := config.Unpack(&plugin); err != nil {
-					t.Fatalf("Failed to unpack config: %+v", err)
-				}
-
-				ps[i], err = processors.New(processors.PluginConfig{plugin})
+				ps[i], err = processors.New([]*common.Config{config})
 				if err != nil {
 					t.Fatalf("Failed to create add_tags processor(%v): %+v", i, err)
 				}
@@ -57,7 +52,11 @@ func testProcessors(t *testing.T, cases map[string]testCase) {
 
 			current := &beat.Event{Fields: test.event.Clone()}
 			for i, processor := range ps {
-				current = processor.Run(current)
+				var err error
+				current, err = processor.Run(current)
+				if err != nil {
+					t.Fatal(err)
+				}
 				if current == nil {
 					t.Fatalf("Event dropped(%v)", i)
 				}

--- a/libbeat/processors/conditionals_test.go
+++ b/libbeat/processors/conditionals_test.go
@@ -122,3 +122,92 @@ func TestConditionRuleInitErrorPropagates(t *testing.T) {
 	assert.Equal(t, testErr, err)
 	assert.Nil(t, filter)
 }
+
+type testCase struct {
+	event common.MapStr
+	want  common.MapStr
+	cfg   string
+}
+
+func testProcessors(t *testing.T, cases map[string]testCase) {
+	for name, test := range cases {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			c, err := common.NewConfigWithYAML([]byte(test.cfg), "test "+name)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var pluginConfig PluginConfig
+			if err = c.Unpack(&pluginConfig); err != nil {
+				t.Fatal(err)
+			}
+
+			processor, err := New(pluginConfig)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			result, err := processor.Run(&beat.Event{Fields: test.event.Clone()})
+			if err != nil {
+				t.Fatal(err)
+			}
+			assert.Equal(t, test.want, result.Fields)
+		})
+	}
+}
+
+func TestIfElseThenProcessor(t *testing.T) {
+	const ifThen = `
+- if:
+    range.uid.lt: 500
+  then:
+    - add_fields: {target: "", fields: {uid_type: reserved}}
+`
+
+	const ifThenElse = `
+- if:
+    range.uid.lt: 500
+  then:
+    - add_fields: {target: "", fields: {uid_type: reserved}}
+  else:
+    - add_fields: {target: "", fields: {uid_type: user}}
+`
+
+	const ifThenElseSingleProcessor = `
+- if:
+    range.uid.lt: 500
+  then:
+    add_fields: {target: "", fields: {uid_type: reserved}}
+  else:
+    add_fields: {target: "", fields: {uid_type: user}}
+`
+
+	testProcessors(t, map[string]testCase{
+		"if-then-true": {
+			event: common.MapStr{"uid": 411},
+			want:  common.MapStr{"uid": 411, "uid_type": "reserved"},
+			cfg:   ifThen,
+		},
+		"if-then-false": {
+			event: common.MapStr{"uid": 500},
+			want:  common.MapStr{"uid": 500},
+			cfg:   ifThen,
+		},
+		"if-then-else-true": {
+			event: common.MapStr{"uid": 411},
+			want:  common.MapStr{"uid": 411, "uid_type": "reserved"},
+			cfg:   ifThenElse,
+		},
+		"if-then-else-false": {
+			event: common.MapStr{"uid": 500},
+			want:  common.MapStr{"uid": 500, "uid_type": "user"},
+			cfg:   ifThenElse,
+		},
+		"if-then-else-false-single-processor": {
+			event: common.MapStr{"uid": 500},
+			want:  common.MapStr{"uid": 500, "uid_type": "user"},
+			cfg:   ifThenElseSingleProcessor,
+		},
+	})
+}

--- a/libbeat/processors/conditionals_test.go
+++ b/libbeat/processors/conditionals_test.go
@@ -183,6 +183,20 @@ func TestIfElseThenProcessor(t *testing.T) {
     add_fields: {target: "", fields: {uid_type: user}}
 `
 
+	const ifThenElseIf = `
+- if:
+    range.uid.lt: 500
+  then:
+    - add_fields: {target: "", fields: {uid_type: reserved}}
+  else:
+    if:
+      equals.uid: 500
+    then:
+      add_fields: {target: "", fields: {uid_type: "eq_500"}}
+    else:
+      add_fields: {target: "", fields: {uid_type: "gt_500"}}
+`
+
 	testProcessors(t, map[string]testCase{
 		"if-then-true": {
 			event: common.MapStr{"uid": 411},
@@ -208,6 +222,11 @@ func TestIfElseThenProcessor(t *testing.T) {
 			event: common.MapStr{"uid": 500},
 			want:  common.MapStr{"uid": 500, "uid_type": "user"},
 			cfg:   ifThenElseSingleProcessor,
+		},
+		"if-then-else-if": {
+			event: common.MapStr{"uid": 500},
+			want:  common.MapStr{"uid": 500, "uid_type": "eq_500"},
+			cfg:   ifThenElseIf,
 		},
 	})
 }

--- a/libbeat/processors/config.go
+++ b/libbeat/processors/config.go
@@ -21,7 +21,8 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 )
 
-type PluginConfig []map[string]*common.Config
+// PluginConfig represents the list of processors.
+type PluginConfig []*common.Config
 
 // fields that should be always exported
 var MandatoryExportedFields = []string{"type"}

--- a/libbeat/processors/namespace.go
+++ b/libbeat/processors/namespace.go
@@ -18,9 +18,10 @@
 package processors
 
 import (
-	"errors"
 	"fmt"
 	"strings"
+
+	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/libbeat/common"
 )
@@ -58,7 +59,7 @@ func (ns *Namespace) add(names []string, p pluginer) error {
 	// register plugin if intermediate node in path being processed
 	if len(names) == 1 {
 		if _, found := ns.reg[name]; found {
-			return errors.New("exists already")
+			return errors.Errorf("%v exists already", name)
 		}
 
 		ns.reg[name] = p
@@ -94,20 +95,20 @@ func (ns *Namespace) Plugin() Constructor {
 			}
 
 			if section != "" {
-				return nil, fmt.Errorf("Too many lookup modules configured (%v, %v)",
-					section, name)
+				return nil, errors.Errorf("too many lookup modules "+
+					"configured (%v, %v)", section, name)
 			}
 
 			section = name
 		}
 
 		if section == "" {
-			return nil, errors.New("No lookup module configured")
+			return nil, errors.New("no lookup module configured")
 		}
 
 		backend, found := ns.reg[section]
 		if !found {
-			return nil, fmt.Errorf("Unknown lookup module: %v", section)
+			return nil, errors.Errorf("unknown lookup module: %v", section)
 		}
 
 		config, err := cfg.Child(section, -1)

--- a/libbeat/processors/processor.go
+++ b/libbeat/processors/processor.go
@@ -123,6 +123,9 @@ func (procs *Processors) All() []beat.Processor {
 	return ret
 }
 
+// Run executes the all processors serially and returns the event and possibly
+// an error. If the event has been dropped (canceled) by a processor in the
+// list then a nil event is returned.
 func (procs *Processors) Run(event *beat.Event) (*beat.Event, error) {
 	var err error
 	for _, p := range procs.List {

--- a/libbeat/processors/processor.go
+++ b/libbeat/processors/processor.go
@@ -18,16 +18,21 @@
 package processors
 
 import (
-	"fmt"
 	"strings"
+
+	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 )
 
+const logName = "processors"
+
+// Processors is
 type Processors struct {
 	List []Processor
+	log  *logp.Logger
 }
 
 type Processor interface {
@@ -36,35 +41,53 @@ type Processor interface {
 }
 
 func New(config PluginConfig) (*Processors, error) {
-	procs := Processors{}
-
-	for _, processor := range config {
-
-		if len(processor) != 1 {
-			return nil, fmt.Errorf("each processor needs to have exactly one action, but found %d actions",
-				len(processor))
-		}
-
-		for processorName, cfg := range processor {
-
-			gen, exists := registry.reg[processorName]
-			if !exists {
-				return nil, fmt.Errorf("the processor %s doesn't exist", processorName)
-			}
-
-			cfg.PrintDebugf("Configure processor '%v' with:", processorName)
-			constructor := gen.Plugin()
-			plugin, err := constructor(cfg)
-			if err != nil {
-				return nil, err
-			}
-
-			procs.add(plugin)
-		}
+	procs := &Processors{
+		log: logp.NewLogger(logName),
 	}
 
-	logp.Debug("processors", "Processors: %v", procs)
-	return &procs, nil
+	for _, procConfig := range config {
+		// Handle if/then/else processor which has multiple top-level keys.
+		if procConfig.HasField("if") {
+			p, err := NewIfElseThenProcessor(procConfig)
+			if err != nil {
+				return nil, errors.Wrap(err, "failed to make if/then/else processor")
+			}
+			procs.add(p)
+			continue
+		}
+
+		if len(procConfig.GetFields()) != 1 {
+			return nil, errors.Errorf("each processor must have exactly one "+
+				"action, but found %d actions (%v)",
+				len(procConfig.GetFields()),
+				strings.Join(procConfig.GetFields(), ","))
+		}
+
+		actionName := procConfig.GetFields()[0]
+		actionCfg, err := procConfig.Child(actionName, -1)
+		if err != nil {
+			return nil, err
+		}
+
+		gen, exists := registry.reg[actionName]
+		if !exists {
+			return nil, errors.Errorf("the processor action %s does not exist", actionName)
+		}
+
+		actionCfg.PrintDebugf("Configure processor action '%v' with:", actionName)
+		constructor := gen.Plugin()
+		plugin, err := constructor(actionCfg)
+		if err != nil {
+			return nil, err
+		}
+
+		procs.add(plugin)
+	}
+
+	if len(procs.List) > 0 {
+		procs.log.Debugf("Generated new processors: %v", procs)
+	}
+	return procs, nil
 }
 
 func (procs *Processors) add(p Processor) {
@@ -78,7 +101,10 @@ func (procs *Processors) add(p Processor) {
 // Note: this method will be removed, when the publisher pipeline BC-API is to
 //       be removed.
 func (procs *Processors) RunBC(event common.MapStr) common.MapStr {
-	ret := procs.Run(&beat.Event{Fields: event})
+	ret, err := procs.Run(&beat.Event{Fields: event})
+	if err != nil {
+		procs.log.Debugw("Error in processor pipeline", "error", err)
+	}
 	if ret == nil {
 		return nil
 	}
@@ -97,32 +123,19 @@ func (procs *Processors) All() []beat.Processor {
 	return ret
 }
 
-// Applies a sequence of processing rules and returns the filtered event
-func (procs *Processors) Run(event *beat.Event) *beat.Event {
-	// Check if processors are set, just return event if not
-	if len(procs.List) == 0 {
-		return event
-	}
-
+func (procs *Processors) Run(event *beat.Event) (*beat.Event, error) {
+	var err error
 	for _, p := range procs.List {
-		var err error
 		event, err = p.Run(event)
 		if err != nil {
-			// XXX: We don't drop the event, but continue filtering here iff the most
-			//      recent processor did return an event.
-			//      We want processors having this kind of implicit behavior
-			//      on errors?
-
-			logp.Debug("filter", "fail to apply processor %s: %s", p, err)
+			return event, errors.Wrapf(err, "failed applying processor %v", p)
 		}
-
 		if event == nil {
-			// drop event
-			return nil
+			// Drop.
+			return nil, nil
 		}
 	}
-
-	return event
+	return event, nil
 }
 
 func (procs Processors) String() string {

--- a/libbeat/processors/processor_test.go
+++ b/libbeat/processors/processor_test.go
@@ -31,26 +31,29 @@ import (
 	_ "github.com/elastic/beats/libbeat/processors/add_cloud_metadata"
 )
 
-func GetProcessors(t *testing.T, yml []map[string]interface{}) *processors.Processors {
-	config := processors.PluginConfig{}
-
-	for _, action := range yml {
-		c := map[string]*common.Config{}
-
-		for name, actionYml := range action {
-			actionConfig, err := common.NewConfigFrom(actionYml)
-			assert.Nil(t, err)
-
-			c[name] = actionConfig
-		}
-		config = append(config, c)
-
+func GetProcessors(t testing.TB, yml []map[string]interface{}) *processors.Processors {
+	list, err := MakeProcessors(t, yml)
+	if err != nil {
+		t.Fatal(err)
 	}
 
-	list, err := processors.New(config)
-	assert.Nil(t, err)
-
 	return list
+}
+
+func MakeProcessors(t testing.TB, yml []map[string]interface{}) (*processors.Processors, error) {
+	t.Helper()
+
+	var config processors.PluginConfig
+	for _, processor := range yml {
+		processorCfg, err := common.NewConfigFrom(processor)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		config = append(config, processorCfg)
+	}
+
+	return processors.New(config)
 }
 
 func TestBadConfig(t *testing.T) {
@@ -72,22 +75,8 @@ func TestBadConfig(t *testing.T) {
 		},
 	}
 
-	config := processors.PluginConfig{}
-
-	for _, action := range yml {
-		c := map[string]*common.Config{}
-
-		for name, actionYml := range action {
-			actionConfig, err := common.NewConfigFrom(actionYml)
-			assert.Nil(t, err)
-
-			c[name] = actionConfig
-		}
-		config = append(config, c)
-	}
-
-	_, err := processors.New(config)
-	assert.NotNil(t, err)
+	_, err := MakeProcessors(t, yml)
+	assert.Error(t, err)
 }
 
 func TestIncludeFields(t *testing.T) {
@@ -136,7 +125,10 @@ func TestIncludeFields(t *testing.T) {
 		},
 	}
 
-	processedEvent := processors.Run(event)
+	processedEvent, err := processors.Run(event)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	expectedEvent := common.MapStr{
 		"proc": common.MapStr{
@@ -202,7 +194,7 @@ func TestIncludeFields1(t *testing.T) {
 		},
 	}
 
-	processedEvent := processors.Run(event)
+	processedEvent, _ := processors.Run(event)
 
 	expectedEvent := common.MapStr{
 		"type": "process",
@@ -255,7 +247,7 @@ func TestDropFields(t *testing.T) {
 		},
 	}
 
-	processedEvent := processors.Run(event)
+	processedEvent, _ := processors.Run(event)
 
 	expectedEvent := common.MapStr{
 		"proc": common.MapStr{
@@ -362,8 +354,8 @@ func TestMultipleIncludeFields(t *testing.T) {
 		"type": "process",
 	}
 
-	actual1 := processors.Run(event1)
-	actual2 := processors.Run(event2)
+	actual1, _ := processors.Run(event1)
+	actual2, _ := processors.Run(event2)
 
 	assert.Equal(t, expected1, actual1.Fields)
 	assert.Equal(t, expected2, actual2.Fields)
@@ -416,7 +408,7 @@ func TestDropEvent(t *testing.T) {
 		},
 	}
 
-	processedEvent := processors.Run(event)
+	processedEvent, _ := processors.Run(event)
 
 	assert.Nil(t, processedEvent)
 }
@@ -460,7 +452,7 @@ func TestEmptyCondition(t *testing.T) {
 		},
 	}
 
-	processedEvent := processors.Run(event)
+	processedEvent, _ := processors.Run(event)
 
 	assert.Nil(t, processedEvent)
 }
@@ -480,23 +472,7 @@ func TestBadCondition(t *testing.T) {
 		},
 	}
 
-	config := processors.PluginConfig{}
-
-	for _, action := range yml {
-		c := map[string]*common.Config{}
-
-		for name, actionYml := range action {
-			actionConfig, err := common.NewConfigFrom(actionYml)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			c[name] = actionConfig
-		}
-		config = append(config, c)
-	}
-
-	_, err := processors.New(config)
+	_, err := MakeProcessors(t, yml)
 	assert.Error(t, err)
 }
 
@@ -515,22 +491,8 @@ func TestMissingFields(t *testing.T) {
 		},
 	}
 
-	config := processors.PluginConfig{}
-
-	for _, action := range yml {
-		c := map[string]*common.Config{}
-
-		for name, actionYml := range action {
-			actionConfig, err := common.NewConfigFrom(actionYml)
-			assert.Nil(t, err)
-
-			c[name] = actionConfig
-		}
-		config = append(config, c)
-	}
-
-	_, err := processors.New(config)
-	assert.NotNil(t, err)
+	_, err := MakeProcessors(t, yml)
+	assert.Error(t, err)
 }
 
 func TestBadConditionConfig(t *testing.T) {
@@ -549,22 +511,8 @@ func TestBadConditionConfig(t *testing.T) {
 		},
 	}
 
-	config := processors.PluginConfig{}
-
-	for _, action := range yml {
-		c := map[string]*common.Config{}
-
-		for name, actionYml := range action {
-			actionConfig, err := common.NewConfigFrom(actionYml)
-			assert.Nil(t, err)
-
-			c[name] = actionConfig
-		}
-		config = append(config, c)
-	}
-
-	_, err := processors.New(config)
-	assert.NotNil(t, err)
+	_, err := MakeProcessors(t, yml)
+	assert.Error(t, err)
 }
 
 func TestDropMissingFields(t *testing.T) {
@@ -606,7 +554,7 @@ func TestDropMissingFields(t *testing.T) {
 		},
 	}
 
-	processedEvent := processors.Run(event)
+	processedEvent, _ := processors.Run(event)
 
 	expectedEvent := common.MapStr{
 		"proc": common.MapStr{

--- a/libbeat/processors/registry.go
+++ b/libbeat/processors/registry.go
@@ -52,7 +52,7 @@ type Constructor func(config *common.Config) (Processor, error)
 var registry = NewNamespace()
 
 func RegisterPlugin(name string, constructor Constructor) {
-	logp.Debug("processors", "Register plugin %s", name)
+	logp.L().Named(logName).Debugf("Register plugin %s", name)
 
 	err := registry.Register(name, constructor)
 	if err != nil {


### PR DESCRIPTION
This allows for a condition to be used with a list of processors and for a list of
processors to be executed if the condition does not match.

This is a contrived example that adds fields and tags to the event if true, otherwise it drops the event.

    processors: [
      {
        "if": {
          "and": [
            {
              "equals.type": "login"
            },
            {
              "range.uid.lt": 500
            }
          ]
        },
        "then": [
          {
            "add_fields": {
              "target": "",
              "fields": {
                "uid_type": "reserved"
              }
            }
          },
          {
            "add_tags": {
              "tags": [
                "reserved_user_login"
              ]
            }
          }
        ],
        "else": {
          "drop_event": null
        }
      }
    ]