### PR TITLE
Add community_id network flow hash processor

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -205,6 +205,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Calls to Elasticsearch X-Pack APIs made by Beats won't cause deprecation logs in Elasticsearch logs. {9656}9656[9656]
 - Add `network` condition to processors for matching IP addresses against CIDRs. {pull}10743[10743]
 - Add if/then/else support to processors. {pull}10744[10744]
+- Add `community_id` processor for computing network flow hashes. {pull}10745[10745]
+
 
 *Auditbeat*
 

--- a/libbeat/cmd/instance/imports.go
+++ b/libbeat/cmd/instance/imports.go
@@ -30,6 +30,7 @@ import (
 	_ "github.com/elastic/beats/libbeat/processors/add_kubernetes_metadata"
 	_ "github.com/elastic/beats/libbeat/processors/add_locale"
 	_ "github.com/elastic/beats/libbeat/processors/add_process_metadata"
+	_ "github.com/elastic/beats/libbeat/processors/communityid"
 	_ "github.com/elastic/beats/libbeat/processors/dissect"
 	_ "github.com/elastic/beats/libbeat/processors/dns"
 	_ "github.com/elastic/beats/libbeat/publisher/includes" // Register publisher pipeline modules

--- a/libbeat/docs/processors-using.asciidoc
+++ b/libbeat/docs/processors-using.asciidoc
@@ -744,6 +744,9 @@ processors:
 If the necessary fields are not present in the event then the processor will
 silently continue without adding the target field.
 
+The processor also accepts an optional `seed` parameter that must be a 16-bit
+unsigned integer. This value gets incorporated into all generated hashes.
+
 [[drop-event]]
 === Drop events
 

--- a/libbeat/docs/processors-using.asciidoc
+++ b/libbeat/docs/processors-using.asciidoc
@@ -196,6 +196,7 @@ The supported processors are:
 
  * <<add-cloud-metadata,`add_cloud_metadata`>>
  * <<add-locale,`add_locale`>>
+ * <<community-id,`community_id`>>
  * <<decode-json-fields,`decode_json_fields`>>
  * <<drop-event,`drop_event`>>
  * <<drop-fields,`drop_fields`>>
@@ -698,6 +699,50 @@ is treated as if the field was not set at all.
 `overwrite_keys`:: (Optional) A boolean that specifies whether keys that already
 exist in the event are overwritten by keys from the decoded JSON object. The
 default value is false.
+
+[[community-id]]
+=== Community ID Network Flow Hash
+
+The `community_id` processor computes a network flow hash according to the
+https://github.com/corelight/community-id-spec[Community ID Flow Hash
+specification].
+
+The flow hash is useful for correlating all network events related to a
+single flow. For example you can filter on a community ID value and you might
+get back the Netflow records from multiple collectors and layer 7 protocol
+records from Packetbeat.
+
+By default the processor is configured to read the flow parameters from the
+appropriate Elastic Common Schema (ECS) fields. If you are processing ECS data
+then no parameters are required.
+
+[source,yaml]
+----
+processors:
+  - community_id:
+----
+
+If the data does not conform to ECS then you can customize the field names
+that the processor reads from. You can also change the `target` field which
+is where the computed hash is written to.
+
+[source,yaml]
+----
+processors:
+  - community_id:
+      fields:
+        source_ip: my_source_ip
+        source_port: my_source_port
+        destination_ip: my_dest_ip
+        destination_port: my_dest_port
+        transport: proto
+        icmp_type: my_icmp_type
+        icmp_code: my_icmp_code
+      target: network.community_id
+----
+
+If the necessary fields are not present in the event then the processor will
+silently continue without adding the target field.
 
 [[drop-event]]
 === Drop events

--- a/libbeat/processors/communityid/communityid.go
+++ b/libbeat/processors/communityid/communityid.go
@@ -1,0 +1,265 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package communityid
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
+
+	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/flowhash"
+	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/processors"
+)
+
+const logName = "processor.community_id"
+
+func init() {
+	processors.RegisterPlugin("community_id", New)
+}
+
+type processor struct {
+	config
+	log    *logp.Logger
+	hasher flowhash.Hasher
+}
+
+// New constructs a new processor that computes community ID flowhash. The
+// values that are incorporated into the hash vary by protocol.
+//
+// TCP / UDP / SCTP:
+//   IP src / IP dst / IP proto / source port / dest port
+//
+// ICMPv4 / ICMPv6:
+//   IP src / IP dst / IP proto / ICMP type + "counter-type" or code
+//
+// Other IP-borne protocols:
+//   IP src / IP dst / IP proto
+func New(cfg *common.Config) (processors.Processor, error) {
+	c := defaultConfig()
+	if err := cfg.Unpack(&c); err != nil {
+		return nil, errors.Wrap(err, "fail to unpack the community_id configuration")
+	}
+
+	return newFromConfig(c)
+}
+
+func newFromConfig(c config) (*processor, error) {
+	return &processor{
+		config: c,
+		log:    logp.NewLogger(logName),
+		hasher: flowhash.CommunityID,
+	}, nil
+}
+
+func (p *processor) String() string {
+	return fmt.Sprintf("community_id=[target=%s, fields=["+
+		"source_ip=%v, source_port=%v, "+
+		"destination_ip=%v, destination_port=%v, "+
+		"transport_protocol=%v, "+
+		"icmp_type=%v, icmp_code=%v]",
+		p.Target, p.Fields.SourceIP, p.Fields.SourcePort,
+		p.Fields.DestinationIP, p.Fields.DestinationPort,
+		p.Fields.TransportProtocol, p.Fields.ICMPType, p.Fields.ICMPCode)
+}
+
+func (p *processor) Run(event *beat.Event) (*beat.Event, error) {
+	// If already set then bail out.
+	_, err := event.GetValue(p.Target)
+	if err == nil {
+		return event, nil
+	}
+
+	flow := p.buildFlow(event)
+	if flow == nil {
+		return event, nil
+	}
+
+	id := p.hasher.Hash(*flow)
+	_, err = event.PutValue(p.Target, id)
+	return event, err
+}
+
+func (p *processor) buildFlow(event *beat.Event) *flowhash.Flow {
+	var flow flowhash.Flow
+
+	// source ip
+	v, err := event.GetValue(p.Fields.SourceIP)
+	if err != nil {
+		return nil
+	}
+	var ok bool
+	flow.SourceIP, ok = tryToIP(v)
+	if !ok {
+		return nil
+	}
+
+	// destination ip
+	v, err = event.GetValue(p.Fields.DestinationIP)
+	if err != nil {
+		return nil
+	}
+	flow.DestinationIP, ok = tryToIP(v)
+	if !ok {
+		return nil
+	}
+
+	// protocol
+	v, err = event.GetValue(p.Fields.TransportProtocol)
+	if err != nil {
+		return nil
+	}
+	flow.Protocol, ok = tryToIANATransportProtocol(v)
+	if !ok {
+		return nil
+	}
+
+	switch flow.Protocol {
+	case tcpProtocol, udpProtocol, sctpProtocol:
+		// source port
+		v, err = event.GetValue(p.Fields.SourcePort)
+		if err != nil {
+			return nil
+		}
+		flow.SourcePort, ok = tryToUint16(v)
+		if !ok || flow.SourcePort == 0 {
+			return nil
+		}
+
+		// destination port
+		v, err = event.GetValue(p.Fields.DestinationPort)
+		if err != nil {
+			return nil
+		}
+		flow.DestinationPort, ok = tryToUint16(v)
+		if !ok || flow.DestinationPort == 0 {
+			return nil
+		}
+	case icmpProtocol, icmpIPv6Protocol:
+		v, err = event.GetValue(p.Fields.ICMPType)
+		if err != nil {
+			return nil
+		}
+		flow.ICMP.Type, ok = tryToUint8(v)
+		if !ok {
+			return nil
+		}
+
+		v, err = event.GetValue(p.Fields.ICMPCode)
+		if err != nil {
+			return nil
+		}
+		flow.ICMP.Code, ok = tryToUint8(v)
+		if !ok {
+			return nil
+		}
+	}
+
+	return &flow
+}
+
+func tryToIP(from interface{}) (net.IP, bool) {
+	switch v := from.(type) {
+	case net.IP:
+		return v, true
+	case string:
+		ip := net.ParseIP(v)
+		return ip, ip != nil
+	default:
+		return nil, false
+	}
+}
+
+// tryToUint16 tries to coerce the given interface to an uint16. On success it
+// returns the int value and true.
+func tryToUint16(from interface{}) (uint16, bool) {
+	switch v := from.(type) {
+	case int:
+		return uint16(v), true
+	case int8:
+		return uint16(v), true
+	case int16:
+		return uint16(v), true
+	case int32:
+		return uint16(v), true
+	case int64:
+		return uint16(v), true
+	case uint:
+		return uint16(v), true
+	case uint8:
+		return uint16(v), true
+	case uint16:
+		return v, true
+	case uint32:
+		return uint16(v), true
+	case uint64:
+		return uint16(v), true
+	case string:
+		num, err := strconv.ParseUint(v, 0, 16)
+		if err != nil {
+			return 0, false
+		}
+		return uint16(num), true
+	default:
+		return 0, false
+	}
+}
+
+func tryToUint8(from interface{}) (uint8, bool) {
+	to, ok := tryToUint16(from)
+	return uint8(to), ok
+}
+
+const (
+	icmpProtocol     uint8 = 1
+	igmpProtocol     uint8 = 2
+	tcpProtocol      uint8 = 6
+	udpProtocol      uint8 = 17
+	icmpIPv6Protocol uint8 = 58
+	sctpProtocol     uint8 = 132
+)
+
+var transports = map[string]uint8{
+	"icmp":      icmpProtocol,
+	"igmp":      igmpProtocol,
+	"tcp":       tcpProtocol,
+	"udp":       udpProtocol,
+	"icmp-ipv6": icmpIPv6Protocol,
+	"sctp":      sctpProtocol,
+}
+
+func tryToIANATransportProtocol(from interface{}) (uint8, bool) {
+	switch v := from.(type) {
+	case string:
+		transport, found := transports[v]
+		if !found {
+			transport, found = transports[strings.ToLower(v)]
+		}
+		if found {
+			return transport, found
+		}
+	}
+
+	// Allow raw protocol numbers.
+	return tryToUint8(from)
+}

--- a/libbeat/processors/communityid/communityid_test.go
+++ b/libbeat/processors/communityid/communityid_test.go
@@ -1,0 +1,142 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package communityid
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/common"
+)
+
+func TestNewDefaults(t *testing.T) {
+	_, err := New(common.NewConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRun(t *testing.T) {
+	// From flowhash package testdata.
+	// 1:LQU9qZlK+B5F3KDmev6m5PMibrg= | 128.232.110.120 66.35.250.204 6 34855 80
+	evt := func() common.MapStr {
+		return common.MapStr{
+			"source": common.MapStr{
+				"ip":   "128.232.110.120",
+				"port": 34855,
+			},
+			"destination": common.MapStr{
+				"ip":   "66.35.250.204",
+				"port": 80,
+			},
+			"network": common.MapStr{"transport": "TCP"},
+		}
+	}
+
+	t.Run("valid", func(t *testing.T) {
+		testProcessor(t, evt(), "1:LQU9qZlK+B5F3KDmev6m5PMibrg=")
+	})
+
+	t.Run("invalid source IP", func(t *testing.T) {
+		e := evt()
+		e.Put("source.ip", 2162716280)
+		testProcessor(t, e, nil)
+	})
+
+	t.Run("invalid source port", func(t *testing.T) {
+		e := evt()
+		e.Put("source.port", 0)
+		testProcessor(t, e, nil)
+	})
+
+	t.Run("invalid destination IP", func(t *testing.T) {
+		e := evt()
+		e.Put("destination.ip", "308.111.1.2.3")
+		testProcessor(t, e, nil)
+	})
+
+	t.Run("invalid destination port", func(t *testing.T) {
+		e := evt()
+		e.Put("source.port", nil)
+		testProcessor(t, e, nil)
+	})
+
+	t.Run("unknown protocol", func(t *testing.T) {
+		e := evt()
+		e.Put("network.transport", "xyz")
+		testProcessor(t, e, nil)
+	})
+
+	t.Run("icmp", func(t *testing.T) {
+		e := evt()
+		e.Put("network.transport", "icmp")
+		e.Put("icmp.type", 3)
+		e.Put("icmp.code", 3)
+		testProcessor(t, e, "1:KF3iG9XD24nhlSy4r1TcYIr5mfE=")
+	})
+
+	t.Run("icmp without typecode", func(t *testing.T) {
+		e := evt()
+		e.Put("network.transport", "icmp")
+		testProcessor(t, e, nil)
+	})
+
+	t.Run("igmp", func(t *testing.T) {
+		e := evt()
+		e.Delete("source.port")
+		e.Delete("destination.port")
+		e.Put("network.transport", "igmp")
+		testProcessor(t, e, "1:D3t8Q1aFA6Ev0A/AO4i9PnU3AeI=")
+	})
+
+	t.Run("protocol number as string", func(t *testing.T) {
+		e := evt()
+		e.Delete("source.port")
+		e.Delete("destination.port")
+		e.Put("network.transport", "2")
+		testProcessor(t, e, "1:D3t8Q1aFA6Ev0A/AO4i9PnU3AeI=")
+	})
+
+	t.Run("protocol number", func(t *testing.T) {
+		e := evt()
+		e.Delete("source.port")
+		e.Delete("destination.port")
+		e.Put("network.transport", 2)
+		testProcessor(t, e, "1:D3t8Q1aFA6Ev0A/AO4i9PnU3AeI=")
+	})
+}
+
+func testProcessor(t testing.TB, fields common.MapStr, expectedHash interface{}) {
+	t.Helper()
+
+	c := defaultConfig()
+	p, err := newFromConfig(c)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := p.Run(&beat.Event{Fields: fields})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	id, _ := out.GetValue(c.Target)
+	assert.EqualValues(t, expectedHash, id)
+}

--- a/libbeat/processors/communityid/config.go
+++ b/libbeat/processors/communityid/config.go
@@ -1,0 +1,48 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package communityid
+
+type config struct {
+	Fields fieldsConfig `config:"fields"`
+	Target string       `config:"target"`
+}
+
+type fieldsConfig struct {
+	SourceIP          string `config:"source_ip"`
+	SourcePort        string `config:"source_port"`
+	DestinationIP     string `config:"destination_ip"`
+	DestinationPort   string `config:"destination_port"`
+	TransportProtocol string `config:"transport"`
+	ICMPType          string `config:"icmp_type"`
+	ICMPCode          string `config:"icmp_code"`
+}
+
+func defaultConfig() config {
+	return config{
+		Fields: fieldsConfig{
+			SourceIP:          "source.ip",
+			SourcePort:        "source.port",
+			DestinationIP:     "destination.ip",
+			DestinationPort:   "destination.port",
+			TransportProtocol: "network.transport",
+			ICMPType:          "icmp.type",
+			ICMPCode:          "icmp.code",
+		},
+		Target: "network.community_id",
+	}
+}

--- a/libbeat/processors/communityid/config.go
+++ b/libbeat/processors/communityid/config.go
@@ -20,6 +20,7 @@ package communityid
 type config struct {
 	Fields fieldsConfig `config:"fields"`
 	Target string       `config:"target"`
+	Seed   uint16       `config:"seed"`
 }
 
 type fieldsConfig struct {


### PR DESCRIPTION
This adds a processor for computing flow hashes based on the community_id specification.
https://github.com/corelight/community-id-spec

Examples

    # IPTables Log Example
    processors:
      - dissect:
          tokenizer: "%{}SRC=%{source.ip} DST=%{destination.ip} %{}PROTO=%{network.transport} SPT=%{source.port} DPT=%{destination.port} "
          field: "message"
          target_prefix: ""
      - dissect:
          when.equals.network.transport: icmp
          tokenizer: "%{}TYPE=%{icmp.type} CODE=%{icmp.code} "
          field: "message"
          target_prefix: ""
      - community_id:
.

    # Suricata EVE JSON Log Example
    processors:
      - community_id:
          fields:
            source_ip: json.src_ip
            source_port: json.src_port
            destination_ip: json.dest_ip
            destination_port: json.dest_port
            transport: json.proto