### PR TITLE
[7.0] Remove deprecated Init(), pass instance.Settings around. (#10721)

### DIFF
--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -19,6 +19,10 @@ https://github.com/elastic/beats/compare/v7.0.0-beta1..master[Check the HEAD dif
 The list below covers the major changes between 7.0.0-beta1 and master only.
 
 ==== Breaking changes
+- Outputs receive Index Manager as additional parameter. The index manager can
+  be used to create an index selector. {pull}10347[10347]
+- Remove support for loading dashboards to Elasticsearch 5. {pull}10451[10451]
+- Remove support for deprecated `GenRootCmd` methods. {pull}10721[10721]
 
 ==== Bugfixes
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -28,6 +28,18 @@ https://github.com/elastic/beats/compare/v7.0.0-beta1...master[Check the HEAD di
 
 *Affecting all Beats*
 
+- Enforce validation for the Central Management access token. {issue}9621[9621]
+- Fix config appender registration. {pull}9873[9873]
+- Gracefully handle TLS options when enrolling a Beat. {issue}9129[9129]
+- The backing off now implements jitter to better distribute the load. {issue}10172[10172]
+- Fix TLS certificate DoS vulnerability. {pull}10302[10302]
+- Fix panic and file unlock in spool on atomic operation (arm, x86-32). File lock was not released when panic occurs, leading to the beat deadlocking on startup. {pull}10289[10289]
+- Fix encoding of timestamps when using disk spool. {issue}10099[10099]
+- Fix stopping of modules started by kubernetes autodiscover. {pull}10476[10476]
+- Fix a issue when remote and local configuration didn't match when fetching configuration from Central Management. {issue}10587[10587]
+- Fix unauthorized error when loading dashboards by adding username and password into kibana config. {issue}10513[10513] {pull}10675[10675]
+- Ensure all beat commands respect configured settings. {pull}10721[10721]
+
 *Auditbeat*
 
 *Filebeat*

--- a/auditbeat/cmd/root.go
+++ b/auditbeat/cmd/root.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/elastic/beats/auditbeat/core"
 	"github.com/elastic/beats/libbeat/cmd"
+	"github.com/elastic/beats/libbeat/cmd/instance"
 	"github.com/elastic/beats/metricbeat/beater"
 	"github.com/elastic/beats/metricbeat/mb/module"
 )
@@ -46,6 +47,6 @@ func init() {
 		),
 	)
 	var runFlags = pflag.NewFlagSet(Name, pflag.ExitOnError)
-	RootCmd = cmd.GenRootCmdWithRunFlags(Name, "", create, runFlags)
+	RootCmd = cmd.GenRootCmdWithSettings(create, instance.Settings{RunFlags: runFlags, Name: Name})
 	RootCmd.AddCommand(ShowCmd)
 }

--- a/docs/devguide/newbeat.asciidoc
+++ b/docs/devguide/newbeat.asciidoc
@@ -477,11 +477,12 @@ import (
 
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/cmd"
+	"github.com/elastic/beats/libbeat/cmd/instance"
 
 	"github.com/kimjmin/countbeat/beater"
 )
 
-var RootCmd = cmd.GenRootCmd("countbeat", "", beater.New)
+var RootCmd = cmd.GenRootCmdWithSettings(beater.New, instance.Settings{Name: "countbeat"})
 
 func main() {
 	if err := RootCmd.Execute(); err != nil {

--- a/filebeat/cmd/root.go
+++ b/filebeat/cmd/root.go
@@ -25,6 +25,7 @@ import (
 	"github.com/elastic/beats/filebeat/beater"
 
 	cmd "github.com/elastic/beats/libbeat/cmd"
+	"github.com/elastic/beats/libbeat/cmd/instance"
 )
 
 // Name of this beat
@@ -37,8 +38,7 @@ func init() {
 	var runFlags = pflag.NewFlagSet(Name, pflag.ExitOnError)
 	runFlags.AddGoFlag(flag.CommandLine.Lookup("once"))
 	runFlags.AddGoFlag(flag.CommandLine.Lookup("modules"))
-
-	RootCmd = cmd.GenRootCmdWithRunFlags(Name, "", beater.New, runFlags)
+	RootCmd = cmd.GenRootCmdWithSettings(beater.New, instance.Settings{RunFlags: runFlags, Name: Name})
 	RootCmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("M"))
 	RootCmd.TestCmd.Flags().AddGoFlag(flag.CommandLine.Lookup("modules"))
 	RootCmd.SetupCmd.Flags().AddGoFlag(flag.CommandLine.Lookup("modules"))

--- a/generator/beat/{beat}/cmd/root.go.tmpl
+++ b/generator/beat/{beat}/cmd/root.go.tmpl
@@ -4,10 +4,11 @@ import (
 	"{beat_path}/beater"
 
 	cmd "github.com/elastic/beats/libbeat/cmd"
+	"github.com/elastic/beats/libbeat/cmd/instance"
 )
 
 // Name of this beat
 var Name = "{beat}"
 
 // RootCmd to handle beats cli
-var RootCmd = cmd.GenRootCmd(Name, "", beater.New)
+var RootCmd = cmd.GenRootCmdWithSettings(beater.New, instance.Settings{Name: Name})

--- a/heartbeat/cmd/root.go
+++ b/heartbeat/cmd/root.go
@@ -20,6 +20,7 @@ package cmd
 import (
 	// register default heartbeat monitors
 	_ "github.com/elastic/beats/heartbeat/monitors/defaults"
+	"github.com/elastic/beats/libbeat/cmd/instance"
 
 	"github.com/elastic/beats/heartbeat/beater"
 	cmd "github.com/elastic/beats/libbeat/cmd"
@@ -29,4 +30,4 @@ import (
 var Name = "heartbeat"
 
 // RootCmd to handle beats cli
-var RootCmd = cmd.GenRootCmd(Name, "", beater.New)
+var RootCmd = cmd.GenRootCmdWithSettings(beater.New, instance.Settings{Name: Name})

--- a/journalbeat/cmd/root.go
+++ b/journalbeat/cmd/root.go
@@ -21,10 +21,11 @@ import (
 	"github.com/elastic/beats/journalbeat/beater"
 
 	cmd "github.com/elastic/beats/libbeat/cmd"
+	"github.com/elastic/beats/libbeat/cmd/instance"
 )
 
 // Name of this beat
 var Name = "journalbeat"
 
 // RootCmd to handle beats cli
-var RootCmd = cmd.GenRootCmd(Name, "", beater.New)
+var RootCmd = cmd.GenRootCmdWithSettings(beater.New, instance.Settings{Name: Name})

--- a/libbeat/cmd/completion.go
+++ b/libbeat/cmd/completion.go
@@ -21,10 +21,12 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/elastic/beats/libbeat/cmd/instance"
+
 	"github.com/spf13/cobra"
 )
 
-func genCompletionCmd(name, version string, rootCmd *BeatsRootCmd) *cobra.Command {
+func genCompletionCmd(_ instance.Settings, rootCmd *BeatsRootCmd) *cobra.Command {
 	completionCmd := cobra.Command{
 		Use:   "completion SHELL",
 		Short: "Output shell completion code for the specified shell (bash and zsh only by the moment)",

--- a/libbeat/cmd/export.go
+++ b/libbeat/cmd/export.go
@@ -24,17 +24,17 @@ import (
 	"github.com/elastic/beats/libbeat/cmd/instance"
 )
 
-func genExportCmd(settings instance.Settings, name, idxPrefix, beatVersion string) *cobra.Command {
+func genExportCmd(settings instance.Settings) *cobra.Command {
 	exportCmd := &cobra.Command{
 		Use:   "export",
 		Short: "Export current config or index template",
 	}
 
-	exportCmd.AddCommand(export.GenExportConfigCmd(settings, name, idxPrefix, beatVersion))
-	exportCmd.AddCommand(export.GenTemplateConfigCmd(settings, name, idxPrefix, beatVersion))
-	exportCmd.AddCommand(export.GenIndexPatternConfigCmd(settings, name, idxPrefix, beatVersion))
-	exportCmd.AddCommand(export.GenDashboardCmd(name, idxPrefix, beatVersion))
-	exportCmd.AddCommand(export.GenGetILMPolicyCmd(settings, name, idxPrefix, beatVersion))
+	exportCmd.AddCommand(export.GenExportConfigCmd(settings))
+	exportCmd.AddCommand(export.GenTemplateConfigCmd(settings))
+	exportCmd.AddCommand(export.GenIndexPatternConfigCmd(settings))
+	exportCmd.AddCommand(export.GenDashboardCmd(settings))
+	exportCmd.AddCommand(export.GenGetILMPolicyCmd(settings))
 
 	return exportCmd
 }

--- a/libbeat/cmd/export/config.go
+++ b/libbeat/cmd/export/config.go
@@ -29,18 +29,18 @@ import (
 )
 
 // GenExportConfigCmd write to stdout the current configuration in the YAML format.
-func GenExportConfigCmd(settings instance.Settings, name, idxPrefix, beatVersion string) *cobra.Command {
+func GenExportConfigCmd(settings instance.Settings) *cobra.Command {
 	return &cobra.Command{
 		Use:   "config",
 		Short: "Export current config to stdout",
 		Run: cli.RunWith(func(cmd *cobra.Command, args []string) error {
-			return exportConfig(settings, name, idxPrefix, beatVersion)
+			return exportConfig(settings)
 		}),
 	}
 }
 
-func exportConfig(settings instance.Settings, name, idxPrefix, beatVersion string) error {
-	b, err := instance.NewBeat(name, idxPrefix, beatVersion)
+func exportConfig(settings instance.Settings) error {
+	b, err := instance.NewBeat(settings.Name, settings.IndexPrefix, settings.Version)
 	if err != nil {
 		return fmt.Errorf("error initializing beat: %s", err)
 	}

--- a/libbeat/cmd/export/dashboard.go
+++ b/libbeat/cmd/export/dashboard.go
@@ -31,7 +31,7 @@ import (
 )
 
 // GenDashboardCmd is the command used to export a dashboard.
-func GenDashboardCmd(name, idxPrefix, beatVersion string) *cobra.Command {
+func GenDashboardCmd(settings instance.Settings) *cobra.Command {
 	genTemplateConfigCmd := &cobra.Command{
 		Use:   "dashboard",
 		Short: "Export defined dashboard to stdout",
@@ -40,12 +40,12 @@ func GenDashboardCmd(name, idxPrefix, beatVersion string) *cobra.Command {
 			yml, _ := cmd.Flags().GetString("yml")
 			decode, _ := cmd.Flags().GetBool("decode")
 
-			b, err := instance.NewBeat(name, idxPrefix, beatVersion)
+			b, err := instance.NewBeat(settings.Name, settings.IndexPrefix, settings.Version)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Error creating beat: %s\n", err)
 				os.Exit(1)
 			}
-			err = b.Init()
+			err = b.InitWithSettings(settings)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Error initializing beat: %s\n", err)
 				os.Exit(1)

--- a/libbeat/cmd/export/ilm_policy.go
+++ b/libbeat/cmd/export/ilm_policy.go
@@ -29,12 +29,12 @@ import (
 )
 
 // GenGetILMPolicyCmd is the command used to export the ilm policy.
-func GenGetILMPolicyCmd(settings instance.Settings, name, idxPrefix, version string) *cobra.Command {
+func GenGetILMPolicyCmd(settings instance.Settings) *cobra.Command {
 	genTemplateConfigCmd := &cobra.Command{
 		Use:   "ilm-policy",
 		Short: "Export ILM policy",
 		Run: func(cmd *cobra.Command, args []string) {
-			b, err := instance.NewBeat(name, idxPrefix, version)
+			b, err := instance.NewBeat(settings.Name, settings.IndexPrefix, settings.Version)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Error initializing beat: %s\n", err)
 				os.Exit(1)

--- a/libbeat/cmd/export/index_pattern.go
+++ b/libbeat/cmd/export/index_pattern.go
@@ -29,14 +29,14 @@ import (
 )
 
 // GenIndexPatternConfigCmd generates an index pattern for Kibana
-func GenIndexPatternConfigCmd(settings instance.Settings, name, idxPrefix, beatVersion string) *cobra.Command {
+func GenIndexPatternConfigCmd(settings instance.Settings) *cobra.Command {
 	genTemplateConfigCmd := &cobra.Command{
 		Use:   "index-pattern",
 		Short: "Export kibana index pattern to stdout",
 		Run: func(cmd *cobra.Command, args []string) {
 			version, _ := cmd.Flags().GetString("es.version")
 
-			b, err := instance.NewBeat(name, idxPrefix, beatVersion)
+			b, err := instance.NewBeat(settings.Name, settings.IndexPrefix, settings.Version)
 			if err != nil {
 				fatalf("Error initializing beat: %+v", err)
 			}
@@ -63,7 +63,7 @@ func GenIndexPatternConfigCmd(settings instance.Settings, name, idxPrefix, beatV
 			if err != nil {
 				fatalf("Error creating version: %+v", err)
 			}
-			indexPattern, err := kibana.NewGenerator(b.Info.IndexPrefix, b.Info.Beat, b.Fields, beatVersion, *v, withMigration)
+			indexPattern, err := kibana.NewGenerator(b.Info.IndexPrefix, b.Info.Beat, b.Fields, settings.Version, *v, withMigration)
 			if err != nil {
 				log.Fatal(err)
 			}
@@ -80,8 +80,7 @@ func GenIndexPatternConfigCmd(settings instance.Settings, name, idxPrefix, beatV
 		},
 	}
 
-	genTemplateConfigCmd.Flags().String("es.version", beatVersion, "Elasticsearch version")
-	genTemplateConfigCmd.Flags().String("index", idxPrefix, "Base index name")
+	genTemplateConfigCmd.Flags().String("es.version", settings.Version, "Elasticsearch version")
 
 	return genTemplateConfigCmd
 }

--- a/libbeat/cmd/export/template.go
+++ b/libbeat/cmd/export/template.go
@@ -31,7 +31,7 @@ import (
 	"github.com/elastic/beats/libbeat/template"
 )
 
-func GenTemplateConfigCmd(settings instance.Settings, name, idxPrefix, beatVersion string) *cobra.Command {
+func GenTemplateConfigCmd(settings instance.Settings) *cobra.Command {
 	genTemplateConfigCmd := &cobra.Command{
 		Use:   "template",
 		Short: "Export index template to stdout",
@@ -40,7 +40,7 @@ func GenTemplateConfigCmd(settings instance.Settings, name, idxPrefix, beatVersi
 			index, _ := cmd.Flags().GetString("index")
 			noILM, _ := cmd.Flags().GetBool("noilm")
 
-			b, err := instance.NewBeat(name, idxPrefix, beatVersion)
+			b, err := instance.NewBeat(settings.Name, settings.IndexPrefix, settings.Version)
 			if err != nil {
 				fatalf("Error initializing beat: %+v", err)
 			}
@@ -106,8 +106,8 @@ func GenTemplateConfigCmd(settings instance.Settings, name, idxPrefix, beatVersi
 		},
 	}
 
-	genTemplateConfigCmd.Flags().String("es.version", beatVersion, "Elasticsearch version")
-	genTemplateConfigCmd.Flags().String("index", idxPrefix, "Base index name")
+	genTemplateConfigCmd.Flags().String("es.version", settings.Version, "Elasticsearch version")
+	genTemplateConfigCmd.Flags().String("index", settings.IndexPrefix, "Base index name")
 	genTemplateConfigCmd.Flags().Bool("noilm", false, "Generate template with ILM disabled")
 
 	return genTemplateConfigCmd

--- a/libbeat/cmd/keystore.go
+++ b/libbeat/cmd/keystore.go
@@ -27,7 +27,6 @@ import (
 	"syscall"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 	tml "golang.org/x/crypto/ssh/terminal"
 
 	"github.com/elastic/beats/libbeat/cmd/instance"
@@ -36,14 +35,14 @@ import (
 	"github.com/elastic/beats/libbeat/keystore"
 )
 
-func getKeystore(name, version string) (keystore.Keystore, error) {
-	b, err := instance.NewBeat(name, "", version)
+func getKeystore(settings instance.Settings) (keystore.Keystore, error) {
+	b, err := instance.NewBeat(settings.Name, settings.IndexPrefix, settings.Version)
 
 	if err != nil {
 		return nil, fmt.Errorf("error initializing beat: %s", err)
 	}
 
-	if err = b.Init(); err != nil {
+	if err = b.InitWithSettings(settings); err != nil {
 		return nil, fmt.Errorf("error initializing beat: %s", err)
 	}
 
@@ -56,44 +55,41 @@ func getKeystore(name, version string) (keystore.Keystore, error) {
 //  - add
 //  - remove
 //  - list
-func genKeystoreCmd(
-	name, idxPrefix, version string,
-	runFlags *pflag.FlagSet,
-) *cobra.Command {
+func genKeystoreCmd(settings instance.Settings) *cobra.Command {
 	keystoreCmd := cobra.Command{
 		Use:   "keystore",
 		Short: "Manage secrets keystore",
 	}
 
-	keystoreCmd.AddCommand(genCreateKeystoreCmd(name, version))
-	keystoreCmd.AddCommand(genAddKeystoreCmd(name, version))
-	keystoreCmd.AddCommand(genRemoveKeystoreCmd(name, version))
-	keystoreCmd.AddCommand(genListKeystoreCmd(name, version))
+	keystoreCmd.AddCommand(genCreateKeystoreCmd(settings))
+	keystoreCmd.AddCommand(genAddKeystoreCmd(settings))
+	keystoreCmd.AddCommand(genRemoveKeystoreCmd(settings))
+	keystoreCmd.AddCommand(genListKeystoreCmd(settings))
 
 	return &keystoreCmd
 }
 
-func genCreateKeystoreCmd(name, version string) *cobra.Command {
+func genCreateKeystoreCmd(settings instance.Settings) *cobra.Command {
 	var flagForce bool
 	command := &cobra.Command{
 		Use:   "create",
 		Short: "Create keystore",
 		Run: cli.RunWith(func(cmd *cobra.Command, args []string) error {
-			return createKeystore(name, version, flagForce)
+			return createKeystore(settings, flagForce)
 		}),
 	}
 	command.Flags().BoolVar(&flagForce, "force", false, "override the existing keystore")
 	return command
 }
 
-func genAddKeystoreCmd(name, version string) *cobra.Command {
+func genAddKeystoreCmd(settings instance.Settings) *cobra.Command {
 	var flagForce bool
 	var flagStdin bool
 	command := &cobra.Command{
 		Use:   "add",
 		Short: "Add secret",
 		Run: cli.RunWith(func(cmd *cobra.Command, args []string) error {
-			store, err := getKeystore(name, version)
+			store, err := getKeystore(settings)
 			if err != nil {
 				return err
 			}
@@ -105,12 +101,12 @@ func genAddKeystoreCmd(name, version string) *cobra.Command {
 	return command
 }
 
-func genRemoveKeystoreCmd(name, version string) *cobra.Command {
+func genRemoveKeystoreCmd(settings instance.Settings) *cobra.Command {
 	return &cobra.Command{
 		Use:   "remove",
 		Short: "remove secret",
 		Run: cli.RunWith(func(cmd *cobra.Command, args []string) error {
-			store, err := getKeystore(name, version)
+			store, err := getKeystore(settings)
 			if err != nil {
 				return err
 			}
@@ -119,12 +115,12 @@ func genRemoveKeystoreCmd(name, version string) *cobra.Command {
 	}
 }
 
-func genListKeystoreCmd(name, version string) *cobra.Command {
+func genListKeystoreCmd(settings instance.Settings) *cobra.Command {
 	return &cobra.Command{
 		Use:   "list",
 		Short: "List keystore",
 		Run: cli.RunWith(func(cmd *cobra.Command, args []string) error {
-			store, err := getKeystore(name, version)
+			store, err := getKeystore(settings)
 			if err != nil {
 				return err
 			}
@@ -133,8 +129,8 @@ func genListKeystoreCmd(name, version string) *cobra.Command {
 	}
 }
 
-func createKeystore(name, version string, force bool) error {
-	store, err := getKeystore(name, version)
+func createKeystore(settings instance.Settings, force bool) error {
+	store, err := getKeystore(settings)
 	if err != nil {
 		return err
 	}
@@ -156,7 +152,7 @@ func createKeystore(name, version string, force bool) error {
 			return fmt.Errorf("Error creating the keystore: %s", err)
 		}
 	}
-	fmt.Printf("Created %s keystore\n", name)
+	fmt.Printf("Created %s keystore\n", settings.Name)
 	return nil
 }
 

--- a/libbeat/cmd/root.go
+++ b/libbeat/cmd/root.go
@@ -24,7 +24,6 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/cfgfile"
@@ -53,38 +52,6 @@ type BeatsRootCmd struct {
 	KeystoreCmd   *cobra.Command
 }
 
-// GenRootCmd returns the root command to use for your beat. It takes the beat name, version,
-// and run command, which will be called if no args are given (for backwards compatibility).
-//
-// Deprecated: Use GenRootCmdWithSettings instead.
-func GenRootCmd(name, version string, beatCreator beat.Creator) *BeatsRootCmd {
-	return GenRootCmdWithRunFlags(name, version, beatCreator, nil)
-}
-
-// GenRootCmdWithRunFlags returns the root command to use for your beat. It takes
-// beat name, version, run command, and runFlags. runFlags parameter must the flagset used by
-// run command.
-//
-// Deprecated: Use GenRootCmdWithSettings instead.
-func GenRootCmdWithRunFlags(name, version string, beatCreator beat.Creator, runFlags *pflag.FlagSet) *BeatsRootCmd {
-	return GenRootCmdWithIndexPrefixWithRunFlags(name, name, version, beatCreator, runFlags)
-}
-
-// GenRootCmdWithIndexPrefixWithRunFlags returns the root command to use for your beat. It takes
-// beat name, index prefix, version, run command, and runFlags. runFlags parameter must the flagset used by
-// run command.
-//
-// Deprecated: Use GenRootCmdWithSettings instead.
-func GenRootCmdWithIndexPrefixWithRunFlags(name, indexPrefix, version string, beatCreator beat.Creator, runFlags *pflag.FlagSet) *BeatsRootCmd {
-	settings := instance.Settings{
-		Name:        name,
-		IndexPrefix: indexPrefix,
-		Version:     version,
-		RunFlags:    runFlags,
-	}
-	return GenRootCmdWithSettings(beatCreator, settings)
-}
-
 // GenRootCmdWithSettings returns the root command to use for your beat. It take the
 // run command, which will be called if no args are given (for backwards compatibility),
 // and beat settings
@@ -93,29 +60,24 @@ func GenRootCmdWithSettings(beatCreator beat.Creator, settings instance.Settings
 		settings.IndexPrefix = settings.Name
 	}
 
-	name := settings.Name
-	version := settings.Version
-	indexPrefix := settings.IndexPrefix
-	runFlags := settings.RunFlags
-
 	rootCmd := &BeatsRootCmd{}
-	rootCmd.Use = name
+	rootCmd.Use = settings.Name
 
 	// Due to a dependence upon the beat name, the default config file path
-	err := cfgfile.ChangeDefaultCfgfileFlag(name)
+	err := cfgfile.ChangeDefaultCfgfileFlag(settings.Name)
 	if err != nil {
 		panic(fmt.Errorf("failed to set default config file path: %v", err))
 	}
 
 	// must be updated prior to CLI flag handling.
 
-	rootCmd.RunCmd = genRunCmd(settings, beatCreator, runFlags)
-	rootCmd.SetupCmd = genSetupCmd(name, indexPrefix, version, beatCreator)
-	rootCmd.VersionCmd = genVersionCmd(name, version)
-	rootCmd.CompletionCmd = genCompletionCmd(name, version, rootCmd)
-	rootCmd.ExportCmd = genExportCmd(settings, name, indexPrefix, version)
-	rootCmd.TestCmd = genTestCmd(name, version, beatCreator)
-	rootCmd.KeystoreCmd = genKeystoreCmd(name, indexPrefix, version, runFlags)
+	rootCmd.RunCmd = genRunCmd(settings, beatCreator)
+	rootCmd.ExportCmd = genExportCmd(settings)
+	rootCmd.TestCmd = genTestCmd(settings, beatCreator)
+	rootCmd.SetupCmd = genSetupCmd(settings, beatCreator)
+	rootCmd.KeystoreCmd = genKeystoreCmd(settings)
+	rootCmd.VersionCmd = genVersionCmd(settings)
+	rootCmd.CompletionCmd = genCompletionCmd(settings, rootCmd)
 
 	// Root command is an alias for run
 	rootCmd.Run = rootCmd.RunCmd.Run

--- a/libbeat/cmd/run.go
+++ b/libbeat/cmd/run.go
@@ -22,13 +22,12 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/cmd/instance"
 )
 
-func genRunCmd(settings instance.Settings, beatCreator beat.Creator, runFlags *pflag.FlagSet) *cobra.Command {
+func genRunCmd(settings instance.Settings, beatCreator beat.Creator) *cobra.Command {
 	name := settings.Name
 	runCmd := cobra.Command{
 		Use:   "run",
@@ -47,8 +46,8 @@ func genRunCmd(settings instance.Settings, beatCreator beat.Creator, runFlags *p
 	runCmd.Flags().AddGoFlag(flag.CommandLine.Lookup("cpuprofile"))
 	runCmd.Flags().AddGoFlag(flag.CommandLine.Lookup("memprofile"))
 
-	if runFlags != nil {
-		runCmd.Flags().AddFlagSet(runFlags)
+	if settings.RunFlags != nil {
+		runCmd.Flags().AddFlagSet(settings.RunFlags)
 	}
 
 	return &runCmd

--- a/libbeat/cmd/setup.go
+++ b/libbeat/cmd/setup.go
@@ -40,7 +40,7 @@ const (
 	ILMPolicyKey = "ilm-policy"
 )
 
-func genSetupCmd(name, idxPrefix, version string, beatCreator beat.Creator) *cobra.Command {
+func genSetupCmd(settings instance.Settings, beatCreator beat.Creator) *cobra.Command {
 	setup := cobra.Command{
 		Use:   "setup",
 		Short: "Setup index template, dashboards and ML jobs",
@@ -53,7 +53,7 @@ func genSetupCmd(name, idxPrefix, version string, beatCreator beat.Creator) *cob
  * ILM policy (for Elasticsearch 6.5 and newer).
 `,
 		Run: func(cmd *cobra.Command, args []string) {
-			beat, err := instance.NewBeat(name, idxPrefix, version)
+			beat, err := instance.NewBeat(settings.Name, settings.IndexPrefix, settings.Version)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Error initializing beat: %s\n", err)
 				os.Exit(1)
@@ -103,7 +103,7 @@ func genSetupCmd(name, idxPrefix, version string, beatCreator beat.Creator) *cob
 				}
 			}
 
-			if err = beat.Setup(beatCreator, s); err != nil {
+			if err = beat.Setup(settings, beatCreator, s); err != nil {
 				os.Exit(1)
 			}
 		},

--- a/libbeat/cmd/test.go
+++ b/libbeat/cmd/test.go
@@ -21,17 +21,18 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/cmd/instance"
 	"github.com/elastic/beats/libbeat/cmd/test"
 )
 
-func genTestCmd(name, beatVersion string, beatCreator beat.Creator) *cobra.Command {
+func genTestCmd(settings instance.Settings, beatCreator beat.Creator) *cobra.Command {
 	exportCmd := &cobra.Command{
 		Use:   "test",
 		Short: "Test config",
 	}
 
-	exportCmd.AddCommand(test.GenTestConfigCmd(name, beatVersion, beatCreator))
-	exportCmd.AddCommand(test.GenTestOutputCmd(name, beatVersion))
+	exportCmd.AddCommand(test.GenTestConfigCmd(settings, beatCreator))
+	exportCmd.AddCommand(test.GenTestOutputCmd(settings))
 
 	return exportCmd
 }

--- a/libbeat/cmd/test/config.go
+++ b/libbeat/cmd/test/config.go
@@ -27,18 +27,18 @@ import (
 	"github.com/elastic/beats/libbeat/cmd/instance"
 )
 
-func GenTestConfigCmd(name, version string, beatCreator beat.Creator) *cobra.Command {
+func GenTestConfigCmd(settings instance.Settings, beatCreator beat.Creator) *cobra.Command {
 	configTestCmd := cobra.Command{
 		Use:   "config",
 		Short: "Test configuration settings",
 		Run: func(cmd *cobra.Command, args []string) {
-			b, err := instance.NewBeat(name, "", version)
+			b, err := instance.NewBeat(settings.Name, settings.IndexPrefix, settings.Version)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Error initializing beat: %s\n", err)
 				os.Exit(1)
 			}
 
-			if err = b.TestConfig(beatCreator); err != nil {
+			if err = b.TestConfig(settings, beatCreator); err != nil {
 				os.Exit(1)
 			}
 		},

--- a/libbeat/cmd/test/output.go
+++ b/libbeat/cmd/test/output.go
@@ -29,18 +29,18 @@ import (
 	"github.com/elastic/beats/libbeat/testing"
 )
 
-func GenTestOutputCmd(name, beatVersion string) *cobra.Command {
+func GenTestOutputCmd(settings instance.Settings) *cobra.Command {
 	return &cobra.Command{
 		Use:   "output",
-		Short: "Test " + name + " can connect to the output by using the current settings",
+		Short: "Test " + settings.Name + " can connect to the output by using the current settings",
 		Run: func(cmd *cobra.Command, args []string) {
-			b, err := instance.NewBeat(name, "", beatVersion)
+			b, err := instance.NewBeat(settings.Name, settings.IndexPrefix, settings.Version)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Error initializing beat: %s\n", err)
 				os.Exit(1)
 			}
 
-			err = b.Init()
+			err = b.InitWithSettings(settings)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Error initializing beat: %s\n", err)
 				os.Exit(1)

--- a/libbeat/cmd/version.go
+++ b/libbeat/cmd/version.go
@@ -28,13 +28,13 @@ import (
 	"github.com/elastic/beats/libbeat/version"
 )
 
-func genVersionCmd(name, beatVersion string) *cobra.Command {
+func genVersionCmd(settings instance.Settings) *cobra.Command {
 	return &cobra.Command{
 		Use:   "version",
 		Short: "Show current version info",
 		Run: cli.RunWith(
 			func(_ *cobra.Command, args []string) error {
-				beat, err := instance.NewBeat(name, "", beatVersion)
+				beat, err := instance.NewBeat(settings.Name, settings.IndexPrefix, settings.Version)
 				if err != nil {
 					return fmt.Errorf("error initializing beat: %s", err)
 				}

--- a/libbeat/libbeat.go
+++ b/libbeat/libbeat.go
@@ -24,7 +24,7 @@ import (
 	"github.com/elastic/beats/libbeat/mock"
 )
 
-var RootCmd = cmd.GenRootCmd(mock.Name, mock.Version, mock.New)
+var RootCmd = cmd.GenRootCmdWithSettings(mock.New, mock.Settings)
 
 func main() {
 	if err := RootCmd.Execute(); err != nil {

--- a/libbeat/mock/mockbeat.go
+++ b/libbeat/mock/mockbeat.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/cmd/instance"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 )
@@ -29,6 +30,8 @@ import (
 
 var Version = "9.9.9"
 var Name = "mockbeat"
+
+var Settings = instance.Settings{Name: Name, Version: Version}
 
 type Mockbeat struct {
 	done chan struct{}

--- a/metricbeat/cmd/root.go
+++ b/metricbeat/cmd/root.go
@@ -23,6 +23,7 @@ import (
 	"github.com/spf13/pflag"
 
 	cmd "github.com/elastic/beats/libbeat/cmd"
+	"github.com/elastic/beats/libbeat/cmd/instance"
 	"github.com/elastic/beats/metricbeat/beater"
 	"github.com/elastic/beats/metricbeat/cmd/test"
 
@@ -40,8 +41,7 @@ var RootCmd *cmd.BeatsRootCmd
 func init() {
 	var runFlags = pflag.NewFlagSet(Name, pflag.ExitOnError)
 	runFlags.AddGoFlag(flag.CommandLine.Lookup("system.hostfs"))
-
-	RootCmd = cmd.GenRootCmdWithRunFlags(Name, "", beater.DefaultCreator(), runFlags)
+	RootCmd = cmd.GenRootCmdWithSettings(beater.DefaultCreator(), instance.Settings{RunFlags: runFlags, Name: Name})
 	RootCmd.AddCommand(cmd.GenModulesCmd(Name, "", buildModulesManager))
 	RootCmd.TestCmd.AddCommand(test.GenTestModulesCmd(Name, ""))
 }

--- a/packetbeat/cmd/root.go
+++ b/packetbeat/cmd/root.go
@@ -26,6 +26,7 @@ import (
 	_ "github.com/elastic/beats/packetbeat/include"
 
 	cmd "github.com/elastic/beats/libbeat/cmd"
+	"github.com/elastic/beats/libbeat/cmd/instance"
 	"github.com/elastic/beats/packetbeat/beater"
 )
 
@@ -43,6 +44,6 @@ func init() {
 	runFlags.AddGoFlag(flag.CommandLine.Lookup("l"))
 	runFlags.AddGoFlag(flag.CommandLine.Lookup("dump"))
 
-	RootCmd = cmd.GenRootCmdWithRunFlags(Name, "", beater.New, runFlags)
+	RootCmd = cmd.GenRootCmdWithSettings(beater.New, instance.Settings{RunFlags: runFlags, Name: Name})
 	RootCmd.AddCommand(genDevicesCommand())
 }

--- a/winlogbeat/cmd/root.go
+++ b/winlogbeat/cmd/root.go
@@ -17,11 +17,14 @@
 
 package cmd
 
-import cmd "github.com/elastic/beats/libbeat/cmd"
+import (
+	cmd "github.com/elastic/beats/libbeat/cmd"
+	"github.com/elastic/beats/libbeat/cmd/instance"
+)
 import "github.com/elastic/beats/winlogbeat/beater"
 
 // Name of this beat
 var Name = "winlogbeat"
 
 // RootCmd to handle beats cli
-var RootCmd = cmd.GenRootCmd(Name, "", beater.New)
+var RootCmd = cmd.GenRootCmdWithSettings(beater.New, instance.Settings{Name: Name})

--- a/x-pack/libbeat/libbeat.go
+++ b/x-pack/libbeat/libbeat.go
@@ -13,7 +13,7 @@ import (
 )
 
 // RootCmd to test libbeat
-var RootCmd = cmd.GenRootCmd(mock.Name, mock.Version, mock.New)
+var RootCmd = cmd.GenRootCmdWithSettings(mock.New, mock.Settings)
 
 func main() {
 	xpackcmd.AddXPack(RootCmd, mock.Name)


### PR DESCRIPTION
Backports the following commits to 7.0:
 - Remove deprecated Init(), pass instance.Settings around.  (#10721)