### PR TITLE
Update autodiscovery to also have ECS fields as selectors

### DIFF
--- a/libbeat/autodiscover/providers/docker/docker.go
+++ b/libbeat/autodiscover/providers/docker/docker.go
@@ -135,7 +135,7 @@ func (d *Provider) emitContainer(event bus.Event, flag string) {
 		safemapstr.Put(labelMap, k, v)
 	}
 
-	meta := common.MapStr{
+	metaOld := common.MapStr{
 		"container": common.MapStr{
 			"id":     container.ID,
 			"name":   container.Name,
@@ -143,16 +143,25 @@ func (d *Provider) emitContainer(event bus.Event, flag string) {
 			"labels": labelMap,
 		},
 	}
+	metaNew := common.MapStr{
+		"id":   container.ID,
+		"name": container.Name,
+		"image": common.MapStr{
+			"name": container.Image,
+		},
+		"labels": labelMap,
+	}
 	// Without this check there would be overlapping configurations with and without ports.
 	if len(container.Ports) == 0 {
 		event := bus.Event{
-			"provider": d.uuid,
-			"id":       container.ID,
-			flag:       true,
-			"host":     host,
-			"docker":   meta,
+			"provider":  d.uuid,
+			"id":        container.ID,
+			flag:        true,
+			"host":      host,
+			"docker":    metaOld,
+			"container": metaNew,
 			"meta": common.MapStr{
-				"docker": meta,
+				"docker": metaOld,
 			},
 		}
 
@@ -162,14 +171,15 @@ func (d *Provider) emitContainer(event bus.Event, flag string) {
 	// Emit container container and port information
 	for _, port := range container.Ports {
 		event := bus.Event{
-			"provider": d.uuid,
-			"id":       container.ID,
-			flag:       true,
-			"host":     host,
-			"port":     port.PrivatePort,
-			"docker":   meta,
+			"provider":  d.uuid,
+			"id":        container.ID,
+			flag:        true,
+			"host":      host,
+			"port":      port.PrivatePort,
+			"docker":    metaOld,
+			"container": metaNew,
 			"meta": common.MapStr{
-				"docker": meta,
+				"docker": metaOld,
 			},
 		}
 


### PR DESCRIPTION
This change allows users in 6.7 to start migration their Docker autodisocvery configuration to ECS.

To match docker information for example `"${data.docker.container.id}"` or `"${data.container.id}" can be used.

The fields which are populate in the event are still the same as before, this only changes what can be used for meta information matching.