### PR TITLE
Add dedot option to docker and k8s autodiscover

### DIFF
--- a/libbeat/autodiscover/providers/docker/config.go
+++ b/libbeat/autodiscover/providers/docker/config.go
@@ -32,13 +32,14 @@ type Config struct {
 	Builders     []*common.Config        `config:"builders"`
 	Appenders    []*common.Config        `config:"appenders"`
 	Templates    template.MapperSettings `config:"templates"`
-	Dedot        bool                    `config:"dedot"`
+	Dedot        bool                    `config:"labels.dedot"`
 }
 
 func defaultConfig() *Config {
 	return &Config{
 		Host:   "unix:///var/run/docker.sock",
 		Prefix: "co.elastic",
+		Dedot:  false,
 	}
 }
 

--- a/libbeat/autodiscover/providers/docker/config.go
+++ b/libbeat/autodiscover/providers/docker/config.go
@@ -32,6 +32,7 @@ type Config struct {
 	Builders     []*common.Config        `config:"builders"`
 	Appenders    []*common.Config        `config:"appenders"`
 	Templates    template.MapperSettings `config:"templates"`
+	Dedot        bool                    `config:"dedot"`
 }
 
 func defaultConfig() *Config {

--- a/libbeat/autodiscover/providers/kubernetes/config.go
+++ b/libbeat/autodiscover/providers/kubernetes/config.go
@@ -38,6 +38,7 @@ type Config struct {
 	Builders     []*common.Config        `config:"builders"`
 	Appenders    []*common.Config        `config:"appenders"`
 	Templates    template.MapperSettings `config:"templates"`
+	Dedot        bool                    `config:"annotations.dedot"`
 }
 
 func defaultConfig() *Config {
@@ -46,6 +47,7 @@ func defaultConfig() *Config {
 		SyncPeriod:     1 * time.Second,
 		CleanupTimeout: 60 * time.Second,
 		Prefix:         "co.elastic",
+		Dedot:          false,
 	}
 }
 

--- a/libbeat/autodiscover/providers/kubernetes/kubernetes.go
+++ b/libbeat/autodiscover/providers/kubernetes/kubernetes.go
@@ -192,7 +192,12 @@ func (p *Provider) emitEvents(pod *kubernetes.Pod, flag string, containers []*ku
 		// Pass annotations to all events so that it can be used in templating and by annotation builders.
 		annotations := common.MapStr{}
 		for k, v := range pod.GetMetadata().Annotations {
-			safemapstr.Put(annotations, k, v)
+			if p.config.Dedot {
+				kDedot := common.DeDot(k)
+				annotations.Put(kDedot, v)
+			} else {
+				safemapstr.Put(annotations, k, v)
+			}
 		}
 		kubemeta["annotations"] = annotations
 

--- a/metricbeat/docs/autodiscover-docker-config.asciidoc
+++ b/metricbeat/docs/autodiscover-docker-config.asciidoc
@@ -5,6 +5,7 @@ Metricbeat supports templates for modules:
 metricbeat.autodiscover:
   providers:
     - type: docker
+      labels.dedot: false
       templates:
         - condition:
             contains:
@@ -16,3 +17,4 @@ metricbeat.autodiscover:
 -------------------------------------------------------------------------------------
 
 This configuration launches a `redis` module for all containers running an image with `redis` in the name.
+If labels.dedot set to true, dots in labels will be replaced with `_`.

--- a/metricbeat/docs/autodiscover-kubernetes-config.asciidoc
+++ b/metricbeat/docs/autodiscover-kubernetes-config.asciidoc
@@ -6,6 +6,7 @@ metricbeat.autodiscover:
   providers:
     - type: kubernetes
       include_annotations: ["prometheus.io.scrape"]
+      annotations.dedot: false
       templates:
         - condition:
             contains:
@@ -17,3 +18,4 @@ metricbeat.autodiscover:
 -------------------------------------------------------------------------------------
 
 This configuration launches a `prometheus` module for all containers of pods annotated `prometheus.io.scrape=true`.
+If annotations.dedot set to true, dots in annotations will be replaced with `_`.

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -31,10 +31,13 @@ metricbeat.max_start_delay: 10s
 # Autodiscover allows you to detect changes in the system and spawn new modules
 # as they happen.
 
+# If labels.dedot set to true, dots in labels will be replaced with `_`.
+
 #metricbeat.autodiscover:
   # List of enabled autodiscover providers
 #  providers:
 #    - type: docker
+#      labels.dedot: false
 #      templates:
 #        - condition:
 #            equals.docker.container.image: etcd

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -31,13 +31,10 @@ metricbeat.max_start_delay: 10s
 # Autodiscover allows you to detect changes in the system and spawn new modules
 # as they happen.
 
-# If labels.dedot set to true, dots in labels will be replaced with `_`.
-
 #metricbeat.autodiscover:
   # List of enabled autodiscover providers
 #  providers:
 #    - type: docker
-#      labels.dedot: false
 #      templates:
 #        - condition:
 #            equals.docker.container.image: etcd


### PR DESCRIPTION
Dedot option seems to be missing in docker autodiscover and kubernetes autodiscover. Adding dedot option for both docker and k8s here for https://github.com/elastic/beats/pull/10758 and 