### PR TITLE
Cherry-pick to 7.0: Add syslog support for ISO8601 format timestamp (#10736)

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -64,27 +64,6 @@ https://github.com/elastic/beats/compare/v7.0.0-beta1...master[Check the HEAD di
 
 *Filebeat*
 
-- Added module for parsing Google Santa logs. {pull}9540[9540]
-- Added netflow input type that supports NetFlow v1, v5, v6, v7, v8, v9 and IPFIX. {issue}9399[9399]
-- Add option to modules.yml file to indicate that a module has been moved {pull}9432[9432].
-- Fix parsing of GC entries in elasticsearch server log. {issue}9513[9513] {pull}9810[9810]
-- Support mysql 5.7.22 slowlog starting with time information. {issue}7892[7892] {pull}9647[9647]
-- Add support for ssl_request_log in apache2 module. {issue}8088[8088] {pull}9833[9833]
-- Add support for iis 7.5 log format. {issue}9753[9753] {pull}9967[9967]
-- Add service.type field to all Modules. By default the field is set with the module name. It can be overwritten with `service.type` config. {pull}10042[10042]
-- Add support for MariaDB in the `slowlog` fileset of `mysql` module. {pull}9731[9731]
-- Apache module's error fileset now performs GeoIP lookup, like the access fileset. {pull}10273[10273]
-- Elasticsearch module's slowlog now populates `event.duration` (ECS). {pull}9293[9293]
-- HAProxy module now populates `event.duration` and `http.response.bytes` (ECS). {pull}10143[10143]
-- Teach elasticsearch/audit fileset to parse out some more fields. {issue}10134[10134] {pull}10137[10137]
-- Add convert_timezone to nginx module. {issue}9839[9839] {pull}10148[10148]
-- Add support for Percona in the `slowlog` fileset of `mysql` module. {issue}6665[6665] {pull}10227[10227]
-- Added support for ingesting structured Elasticsearch audit logs {pull}10352[10352]
-- Added support for ingesting structured Elasticsearch slow logs {pull}10445[10445]
-- Added support for ingesting structured Elasticsearch deprecation logs {pull}10445[10445]
-- New iptables module that receives iptables/ip6tables logs over syslog or file. Supports Ubiquiti Firewall extensions. {issue}8781[8781] {pull}10176[10176]
-- Added support for ingesting structured Elasticsearch server logs {pull}10428[10428]
-- Populate more ECS fields in the Suricata module. {pull}10006[10006]
 - Add ISO8601 timestamp support in syslog metricset. {issue}8716[8716] {pull}10736[10736]
 
 *Heartbeat*

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -64,6 +64,29 @@ https://github.com/elastic/beats/compare/v7.0.0-beta1...master[Check the HEAD di
 
 *Filebeat*
 
+- Added module for parsing Google Santa logs. {pull}9540[9540]
+- Added netflow input type that supports NetFlow v1, v5, v6, v7, v8, v9 and IPFIX. {issue}9399[9399]
+- Add option to modules.yml file to indicate that a module has been moved {pull}9432[9432].
+- Fix parsing of GC entries in elasticsearch server log. {issue}9513[9513] {pull}9810[9810]
+- Support mysql 5.7.22 slowlog starting with time information. {issue}7892[7892] {pull}9647[9647]
+- Add support for ssl_request_log in apache2 module. {issue}8088[8088] {pull}9833[9833]
+- Add support for iis 7.5 log format. {issue}9753[9753] {pull}9967[9967]
+- Add service.type field to all Modules. By default the field is set with the module name. It can be overwritten with `service.type` config. {pull}10042[10042]
+- Add support for MariaDB in the `slowlog` fileset of `mysql` module. {pull}9731[9731]
+- Apache module's error fileset now performs GeoIP lookup, like the access fileset. {pull}10273[10273]
+- Elasticsearch module's slowlog now populates `event.duration` (ECS). {pull}9293[9293]
+- HAProxy module now populates `event.duration` and `http.response.bytes` (ECS). {pull}10143[10143]
+- Teach elasticsearch/audit fileset to parse out some more fields. {issue}10134[10134] {pull}10137[10137]
+- Add convert_timezone to nginx module. {issue}9839[9839] {pull}10148[10148]
+- Add support for Percona in the `slowlog` fileset of `mysql` module. {issue}6665[6665] {pull}10227[10227]
+- Added support for ingesting structured Elasticsearch audit logs {pull}10352[10352]
+- Added support for ingesting structured Elasticsearch slow logs {pull}10445[10445]
+- Added support for ingesting structured Elasticsearch deprecation logs {pull}10445[10445]
+- New iptables module that receives iptables/ip6tables logs over syslog or file. Supports Ubiquiti Firewall extensions. {issue}8781[8781] {pull}10176[10176]
+- Added support for ingesting structured Elasticsearch server logs {pull}10428[10428]
+- Populate more ECS fields in the Suricata module. {pull}10006[10006]
+- Add ISO8601 timestamp support in syslog metricset. {issue}8716[8716] {pull}10736[10736]
+
 *Heartbeat*
 
 *Journalbeat*

--- a/filebeat/module/system/syslog/ingest/pipeline.json
+++ b/filebeat/module/system/syslog/ingest/pipeline.json
@@ -6,7 +6,8 @@
                 "field": "message",
                 "patterns": [
                     "%{SYSLOGTIMESTAMP:system.syslog.timestamp} %{SYSLOGHOST:host.hostname} %{DATA:process.name}(?:\\[%{POSINT:process.pid:long}\\])?: %{GREEDYMULTILINE:system.syslog.message}",
-                    "%{SYSLOGTIMESTAMP:system.syslog.timestamp} %{GREEDYMULTILINE:system.syslog.message}"
+                    "%{SYSLOGTIMESTAMP:system.syslog.timestamp} %{GREEDYMULTILINE:system.syslog.message}",
+                    "%{TIMESTAMP_ISO8601:system.syslog.timestamp} %{SYSLOGHOST:host.hostname} %{DATA:process.name}(?:\\[%{POSINT:process.pid:long}\\])?: %{GREEDYMULTILINE:system.syslog.message}"
                 ],
                 "pattern_definitions" : {
                     "GREEDYMULTILINE" : "(.|\n)*"
@@ -32,7 +33,8 @@
                 "target_field": "@timestamp",
                 "formats": [
                     "MMM  d HH:mm:ss",
-                    "MMM dd HH:mm:ss"
+                    "MMM dd HH:mm:ss",
+                    "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZZ"
                 ],
                 {< if .convert_timezone >}"timezone": "{{ beat.timezone }}",{< end >}
                 "ignore_failure": true

--- a/filebeat/module/system/syslog/test/suse-syslog.log
+++ b/filebeat/module/system/syslog/test/suse-syslog.log
@@ -1,0 +1,2 @@
+2018-08-14T14:30:02.203151+02:00 linux-sqrz systemd[4179]: Stopped target Basic System.
+2018-08-14T14:30:02.203251+02:00 linux-sqrz systemd[4179]: Stopped target Paths.

--- a/filebeat/module/system/syslog/test/suse-syslog.log-expected.json
+++ b/filebeat/module/system/syslog/test/suse-syslog.log-expected.json
@@ -1,0 +1,28 @@
+[
+    {
+        "ecs.version": "1.0.0-beta2",
+        "event.dataset": "system.syslog",
+        "event.module": "system",
+        "fileset.name": "syslog",
+        "host.hostname": "linux-sqrz",
+        "input.type": "log",
+        "log.offset": 0,
+        "message": "Stopped target Basic System.",
+        "process.name": "systemd",
+        "process.pid": 4179,
+        "service.type": "system"
+    },
+    {
+        "ecs.version": "1.0.0-beta2",
+        "event.dataset": "system.syslog",
+        "event.module": "system",
+        "fileset.name": "syslog",
+        "host.hostname": "linux-sqrz",
+        "input.type": "log",
+        "log.offset": 88,
+        "message": "Stopped target Paths.",
+        "process.name": "systemd",
+        "process.pid": 4179,
+        "service.type": "system"
+    }
+]


### PR DESCRIPTION
* Add syslog support for ISO8601 format timestamp

* Add changelog

* Change timestamp pattern

(cherry picked from commit cb241f34a436f79a969d98d14ab50a2c79ca32b7)