### PR TITLE
[Heartbeat] Fix missing url.* fields on TCP NXDOMAIN

### DIFF
--- a/heartbeat/hbtest/hbtestutil.go
+++ b/heartbeat/hbtest/hbtestutil.go
@@ -97,10 +97,17 @@ func TLSChecks(chainIndex, certIndex int, certificate *x509.Certificate) mapval.
 
 // BaseChecks creates a skima.Validator that represents the "monitor" field present
 // in all heartbeat events.
+// If IP is set to "" this will check that the field is not present
 func BaseChecks(ip string, status string, typ string) mapval.Validator {
+	var ipCheck mapval.IsDef
+	if len(ip) > 0 {
+		ipCheck = mapval.IsEqual(ip)
+	} else {
+		ipCheck = mapval.Optional(mapval.IsEqual(ip))
+	}
 	return mapval.MustCompile(mapval.Map{
 		"monitor": mapval.Map{
-			"ip":          ip,
+			"ip":          ipCheck,
 			"duration.us": mapval.IsDuration,
 			"status":      status,
 			"id":          mapval.IsNonEmptyString,

--- a/heartbeat/monitors/active/tcp/tcp.go
+++ b/heartbeat/monitors/active/tcp/tcp.go
@@ -23,11 +23,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/elastic/beats/heartbeat/eventext"
 	"github.com/elastic/beats/heartbeat/monitors"
 	"github.com/elastic/beats/heartbeat/monitors/active/dialchain"
 	"github.com/elastic/beats/heartbeat/monitors/jobs"
-	"github.com/elastic/beats/heartbeat/monitors/wrappers"
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
@@ -91,13 +89,6 @@ func create(
 
 		epJobs, err := dialchain.MakeDialerJobs(db, scheme, eps, config.Mode,
 			func(event *beat.Event, dialer transport.Dialer, addr string) error {
-				u, err := url.Parse(fmt.Sprintf("%s://%s", scheme, addr))
-				if err != nil {
-					return err
-				}
-
-				eventext.MergeEventFields(event, common.MapStr{"url": wrappers.URLFields(u)})
-
 				return pingHost(event, dialer, addr, timeout, validator)
 			})
 		if err != nil {


### PR DESCRIPTION
TCP checks are not adding URL fields on NXDOMAIN endpoints. This fixes that issue.

It does so by ensuring that URL metadata is added before executing the check, and not during, as done previously.

A side effect of this is that we now perform DNS lookups once per `{hostname,port}` instead of once per `{hostname}`. This is worth the increased simplicity however, as the code would be quite convoluted otherwise, which would put us at risk for more bugs.

Related (but different) 6.x issue: https://github.com/elastic/beats/pull/10777