### PR TITLE
Fix logrus dependency

### DIFF
--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -37,7 +37,7 @@
 		},
 		{
 			"checksumSHA1": "DYv6Q1+VfnUVxMwvk5IshAClLvw=",
-			"path": "github.com/Sirupsen/logrus",
+			"path": "github.com/sirupsen/logrus",
 			"revision": "5e5dc898656f695e2a086b8e12559febbfc01562",
 			"revisionTime": "2017-05-15T10:45:16Z"
 		},


### PR DESCRIPTION
This will fix  the issue https://github.com/elastic/beats/issues/4642

As mentionned, the uppercase letter creates **unexpected module path** error using `go mod` command.

As we can see from logrus repository https://github.com/sirupsen/logrus/issues/570, others libraries have also fixed the issue at their side.