### PR TITLE
[Auditbeat] Package dataset: Make librpm code compatible across CentOS 6.x, 7.x, and Fedora 29

### DIFF
--- a/x-pack/auditbeat/module/system/package/rpm_linux.go
+++ b/x-pack/auditbeat/module/system/package/rpm_linux.go
@@ -66,18 +66,22 @@ my_headerLink(void *f, Header h) {
   return headerLink(h);
 }
 
+// Note: Using int32_t instead of rpmTag/rpmTagVal in definitions
+// to make it work on CentOS 6.x, 7.x, and Fedora 29.
 const char *
-my_headerGetString(void *f, Header h, rpmTagVal tag) {
-  const char * (*headerGetString)(Header, rpmTagVal);
-  headerGetString = (const char * (*)(Header, rpmTagVal))f;
+my_headerGetString(void *f, Header h, int32_t tag) {
+  const char * (*headerGetString)(Header, int32_t);
+  headerGetString = (const char * (*)(Header, int32_t))f;
 
   return headerGetString(h, tag);
 }
 
+// Note: Using int32_t instead of rpmTag/rpmTagVal in definitions
+// to make it work on CentOS 6.x, 7.x, and Fedora 29.
 uint64_t
-my_headerGetNumber(void *f, Header h, rpmTagVal tag) {
-  uint64_t (*headerGetNumber)(Header, rpmTagVal);
-  headerGetNumber = (uint64_t (*)(Header, rpmTagVal))f;
+my_headerGetNumber(void *f, Header h, int32_t tag) {
+  uint64_t (*headerGetNumber)(Header, int32_t);
+  headerGetNumber = (uint64_t (*)(Header, int32_t))f;
 
   return headerGetNumber(h, tag);
 }

--- a/x-pack/auditbeat/module/system/package/rpm_linux.go
+++ b/x-pack/auditbeat/module/system/package/rpm_linux.go
@@ -321,7 +321,7 @@ func packageFromHeader(header C.Header, cFun *cFunctions) (*Package, error) {
 	if name != nil {
 		pkg.Name = C.GoString(name)
 	} else {
-		pkg.Error = errors.New("Failed to get package name")
+		return nil, errors.New("Failed to get package name")
 	}
 
 	version := C.my_headerGetString(cFun.headerGetString, header, RPMTAG_VERSION)

--- a/x-pack/auditbeat/module/system/package/rpm_linux.go
+++ b/x-pack/auditbeat/module/system/package/rpm_linux.go
@@ -331,35 +331,13 @@ func packageFromHeader(header C.Header, cFun *cFunctions) (*Package, error) {
 		pkg.Error = errors.New("Failed to get package version")
 	}
 
-	release := C.my_headerGetString(cFun.headerGetString, header, RPMTAG_RELEASE)
-	if release != nil {
-		pkg.Release = C.GoString(release)
-	}
+	pkg.Release = C.GoString(C.my_headerGetString(cFun.headerGetString, header, RPMTAG_RELEASE))
+	pkg.License = C.GoString(C.my_headerGetString(cFun.headerGetString, header, RPMTAG_LICENSE))
+	pkg.Arch = C.GoString(C.my_headerGetString(cFun.headerGetString, header, RPMTAG_ARCH))
+	pkg.URL = C.GoString(C.my_headerGetString(cFun.headerGetString, header, RPMTAG_URL))
+	pkg.Summary = C.GoString(C.my_headerGetString(cFun.headerGetString, header, RPMTAG_SUMMARY))
 
-	license := C.my_headerGetString(cFun.headerGetString, header, RPMTAG_LICENSE)
-	if license != nil {
-		pkg.License = C.GoString(license)
-	}
-
-	arch := C.my_headerGetString(cFun.headerGetString, header, RPMTAG_ARCH)
-	if arch != nil {
-		pkg.Arch = C.GoString(arch)
-	}
-
-	url := C.my_headerGetString(cFun.headerGetString, header, RPMTAG_URL)
-	if url != nil {
-		pkg.URL = C.GoString(url)
-	}
-
-	summary := C.my_headerGetString(cFun.headerGetString, header, RPMTAG_SUMMARY)
-	if summary != nil {
-		pkg.Summary = C.GoString(summary)
-	}
-
-	size := C.my_headerGetNumber(cFun.headerGetNumber, header, RPMTAG_SIZE)
-	if size != 0 {
-		pkg.Size = uint64(size)
-	}
+	pkg.Size = uint64(C.my_headerGetNumber(cFun.headerGetNumber, header, RPMTAG_SIZE))
 
 	installTime := C.my_headerGetNumber(cFun.headerGetNumber, header, RPMTAG_INSTALLTIME)
 	if installTime != 0 {


### PR DESCRIPTION
Librpm version 4.14.2.1 on Fedora 29 no longer contains the `headerGetEntry` method we are currently using. It was deprecated and then removed in version 4.14 (https://github.com/rpm-software-management/rpm/commit/c68fa9ab0bac6e3c3a9b826b5a208447ec16da33).

Also, the much older version 4.8.0 of librpm on CentOS 6.10 (Final) does not yet contain newer data structures for tags like `rpm_tag_t/rpmTag/rpmTagVal`.

This PR makes two changes that should allow this code to work on all three distros (CentOS 6.x, 7.x, Fedora 29 - and hopefully anything in between):

1. Use `headerGetString/headerGetNumber` instead of `headerGetEntry`.
2. Use `int32_t` instead of `rpm_tag_t/rpmTag/rpmTagVal`. Luckily, this seems to work on all three distros. I'd prefer something like a typedef, but unfortunately, C99 does not allow repeating a typedef (C11 does) and so backporting them is not easily possible.

It also makes the code more lenient with errors during data collection: Only when no package name can be found do we return an error.

Together with https://github.com/elastic/beats/pull/10694 this will hopefully allow RPM package collection to work well.