### PR TITLE
[Auditbeat] Cherry-pick #10694 to 7.x: Package: Disable librpm signal handlers

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -171,6 +171,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 *Auditbeat*
 
 - Enable System module config on Windows. {pull}10237[10237]
+- Package: Disable librpm signal handlers. {pull}10694[10694]
 
 *Filebeat*
 

--- a/x-pack/auditbeat/module/system/package/rpm_linux.go
+++ b/x-pack/auditbeat/module/system/package/rpm_linux.go
@@ -8,10 +8,12 @@ package pkg
 
 import (
 	"fmt"
+	"runtime"
 	"time"
 	"unsafe"
 
 	"github.com/coreos/pkg/dlopen"
+	"github.com/joeshaw/multierror"
 )
 
 /*
@@ -22,6 +24,7 @@ import (
 #include <rpm/header.h>
 #include <rpm/rpmts.h>
 #include <rpm/rpmdb.h>
+#include <rpm/rpmsq.h>
 
 rpmts
 my_rpmtsCreate(void *f) {
@@ -100,7 +103,42 @@ my_rpmtsFree(void *f, rpmts ts) {
   rpmtsFree = (rpmts (*)(rpmts))f;
 
   rpmtsFree(ts);
-}*/
+}
+
+// By default, librpm is going to trap various UNIX signals including SIGINT and SIGTERM
+// which will prevent Beats from shutting down correctly.
+//
+// This disables that behavior. We should be very dilligent in
+// cleaning up in our use of librpm.
+//
+// More recent versions of librpm have a new function rpmsqSetInterruptSafety()
+// to do this, see below.
+//
+// See also:
+// - librpm traps signals and calls exit(1) to terminate the whole process incl. our Go code: https://github.com/rpm-software-management/rpm/blob/rpm-4.11.3-release/lib/rpmdb.c#L640
+// - has caused problems for gdb before, calling rpmsqEnable(_, NULL) is the workaround they also use: https://bugzilla.redhat.com/show_bug.cgi?id=643031
+// - the new rpmsqSetInterruptSafety(), unfortunately only available in librpm>=4.14.0 (CentOS 7 has 4.11.3): https://github.com/rpm-software-management/rpm/commit/56f49d7f5af7c1c8a3eb478431356195adbfdd25
+void
+my_disableLibrpmSignalTraps(void *f) {
+	int (*rpmsqEnable)(int, rpmsqAction_t);
+	rpmsqEnable = (int (*)(int, rpmsqAction_t))f;
+
+	// Disable all traps
+	rpmsqEnable(-SIGHUP, NULL);
+	rpmsqEnable(-SIGINT, NULL);
+	rpmsqEnable(-SIGTERM, NULL);
+	rpmsqEnable(-SIGQUIT, NULL);
+	rpmsqEnable(-SIGPIPE, NULL);
+}
+
+void
+my_rpmsqSetInterruptSafety(void *f, int on) {
+	void (*rpmsqSetInterruptSafety)(int);
+	rpmsqSetInterruptSafety = (void (*)(int))f;
+
+	rpmsqSetInterruptSafety(on);
+}
+*/
 import "C"
 
 // Constants in sync with /usr/include/rpm/rpmtag.h
@@ -117,15 +155,17 @@ const (
 )
 
 type cFunctions struct {
-	rpmtsCreate        unsafe.Pointer
-	rpmReadConfigFiles unsafe.Pointer
-	rpmtsInitIterator  unsafe.Pointer
-	rpmdbNextIterator  unsafe.Pointer
-	headerLink         unsafe.Pointer
-	headerGetEntry     unsafe.Pointer
-	headerFree         unsafe.Pointer
-	rpmdbFreeIterator  unsafe.Pointer
-	rpmtsFree          unsafe.Pointer
+	rpmtsCreate             unsafe.Pointer
+	rpmReadConfigFiles      unsafe.Pointer
+	rpmtsInitIterator       unsafe.Pointer
+	rpmdbNextIterator       unsafe.Pointer
+	headerLink              unsafe.Pointer
+	headerGetEntry          unsafe.Pointer
+	headerFree              unsafe.Pointer
+	rpmdbFreeIterator       unsafe.Pointer
+	rpmtsFree               unsafe.Pointer
+	rpmsqEnable             unsafe.Pointer
+	rpmsqSetInterruptSafety unsafe.Pointer
 }
 
 var cFun *cFunctions
@@ -186,16 +226,41 @@ func dlopenCFunctions() (*cFunctions, error) {
 		return nil, err
 	}
 
+	// Only available in librpm>=4.13.0
+	cFun.rpmsqSetInterruptSafety, err = librpm.GetSymbolPointer("rpmsqSetInterruptSafety")
+	if err != nil {
+		var err2 error
+		// Only available in librpm<4.14.0
+		cFun.rpmsqEnable, err2 = librpm.GetSymbolPointer("rpmsqEnable")
+		if err2 != nil {
+			var errs multierror.Errors
+			errs = append(errs, err, err2)
+			return nil, errs.Err()
+		}
+	}
+
 	return &cFun, nil
 }
 
 func listRPMPackages() ([]*Package, error) {
+	// In newer versions, librpm is using the thread-local variable
+	// `disableInterruptSafety` in rpmio/rpmsq.c to disable signal
+	// traps. To make sure our settings remain in effect throughout
+	// our function calls we have to lock the OS thread here, since
+	// Golang can otherwise use any thread it likes for each C.* call.
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	if cFun == nil {
 		var err error
 		cFun, err = dlopenCFunctions()
 		if err != nil {
 			return nil, err
 		}
+	}
+
+	if cFun.rpmsqSetInterruptSafety != nil {
+		C.my_rpmsqSetInterruptSafety(cFun.rpmsqSetInterruptSafety, 0)
 	}
 
 	rpmts := C.my_rpmtsCreate(cFun.rpmtsCreate)
@@ -211,6 +276,9 @@ func listRPMPackages() ([]*Package, error) {
 	mi := C.my_rpmtsInitIterator(cFun.rpmtsInitIterator, rpmts)
 	if mi == nil {
 		return nil, fmt.Errorf("Failed to get match iterator")
+	}
+	if cFun.rpmsqEnable != nil {
+		C.my_disableLibrpmSignalTraps(cFun.rpmsqEnable)
 	}
 	defer C.my_rpmdbFreeIterator(cFun.rpmdbFreeIterator, mi)
 


### PR DESCRIPTION
Cherry-pick of PR #10694 to 7.x branch. Original message: 

Librpm installs its own signal handlers, preventing Beats from running its own Go handlers and causing an unclean shutdown. This summarily disables librpm's signal handlers. See https://github.com/elastic/beats/issues/10633#issuecomment-461830679 for a detailed description of what is happening.

Resolves https://github.com/elastic/beats/issues/10633.