### PR TITLE
Fix docker autodiscovery and docker container fields to follow ECS

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -135,6 +135,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Update rabbitmq.* fields to map to ECS. {pull}10563[10563]
 - Update haproxy.* fields to map to ECS. {pull}10558[10558] {pull}10568[10568]
 - Collect all EC2 meta data from all instances in all states. {pull}10628[10628]
+- Adjust autodiscover and docker container fields to ECS. {pull}10758[10758] {issue}10757[10757]
 
 *Packetbeat*
 

--- a/filebeat/tests/system/test_autodiscover.py
+++ b/filebeat/tests/system/test_autodiscover.py
@@ -48,7 +48,6 @@ class TestAutodiscover(filebeat.BaseTest):
         output = self.read_output_json()
         proc.check_kill_and_wait()
 
-
         # Check metadata is added
         assert output[0]['message'] == 'Busybox output 1'
         assert output[0]['container']['image'] == 'busybox'

--- a/filebeat/tests/system/test_autodiscover.py
+++ b/filebeat/tests/system/test_autodiscover.py
@@ -48,8 +48,11 @@ class TestAutodiscover(filebeat.BaseTest):
         output = self.read_output_json()
         proc.check_kill_and_wait()
 
+
         # Check metadata is added
         assert output[0]['message'] == 'Busybox output 1'
-        assert output[0]['docker']['container']['image'] == 'busybox'
-        assert output[0]['docker']['container']['labels'] == {}
-        assert 'name' in output[0]['docker']['container']
+        assert output[0]['container']['image'] == 'busybox'
+        assert output[0]['container']['labels'] == {}
+        assert 'name' in output[0]['container']
+
+        self.assert_fields_are_documented(output[0])

--- a/heartbeat/tests/system/test_autodiscovery.py
+++ b/heartbeat/tests/system/test_autodiscovery.py
@@ -25,7 +25,7 @@ class TestAutodiscover(BaseTest):
                 'docker': {
                     'templates': '''
                       - condition:
-                          contains.docker.container.image: redis
+                          contains.container.image: redis
                         config:
                           - type: tcp
                             id: myid
@@ -60,7 +60,9 @@ class TestAutodiscover(BaseTest):
                     # We don't check all the docker fields because this is really the responsibility
                     # of libbeat's autodiscovery code.
                     event = output[0]
-                    if event['monitor']['id'] == 'myid' and event['docker']['container']['id'] is not None:
+                    if event['monitor']['id'] == 'myid' and event['container']['id'] is not None:
                         matched = True
 
         assert matched
+
+        self.assert_fields_are_documented(output[0])

--- a/libbeat/autodiscover/providers/docker/docker.go
+++ b/libbeat/autodiscover/providers/docker/docker.go
@@ -141,7 +141,7 @@ func (d *Provider) emitContainer(event bus.Event, flag string) {
 		"image": common.MapStr{
 			"name": container.Image,
 		},
-		// TODO: Do we need some dedotting here?
+		// No need for dedot here. Dedot is done in docker metricbeat.
 		"labels": labelMap,
 	}
 	// Without this check there would be overlapping configurations with and without ports.
@@ -201,7 +201,7 @@ func (d *Provider) generateHints(event bus.Event) bus.Event {
 	e := bus.Event{}
 	var dockerMeta common.MapStr
 
-	if rawDocker, err := common.MapStr(event).GetValue("docker.container"); err == nil {
+	if rawDocker, err := common.MapStr(event).GetValue("container"); err == nil {
 		dockerMeta = rawDocker.(common.MapStr)
 		e["container"] = dockerMeta
 	}

--- a/libbeat/autodiscover/providers/docker/docker.go
+++ b/libbeat/autodiscover/providers/docker/docker.go
@@ -136,23 +136,24 @@ func (d *Provider) emitContainer(event bus.Event, flag string) {
 	}
 
 	meta := common.MapStr{
-		"container": common.MapStr{
-			"id":     container.ID,
-			"name":   container.Name,
-			"image":  container.Image,
-			"labels": labelMap,
+		"id":   container.ID,
+		"name": container.Name,
+		"image": common.MapStr{
+			"name": container.Image,
 		},
+		// TODO: Do we need some dedotting here?
+		"labels": labelMap,
 	}
 	// Without this check there would be overlapping configurations with and without ports.
 	if len(container.Ports) == 0 {
 		event := bus.Event{
-			"provider": d.uuid,
-			"id":       container.ID,
-			flag:       true,
-			"host":     host,
-			"docker":   meta,
+			"provider":  d.uuid,
+			"id":        container.ID,
+			flag:        true,
+			"host":      host,
+			"container": meta,
 			"meta": common.MapStr{
-				"docker": meta,
+				"container": meta,
 			},
 		}
 
@@ -162,14 +163,14 @@ func (d *Provider) emitContainer(event bus.Event, flag string) {
 	// Emit container container and port information
 	for _, port := range container.Ports {
 		event := bus.Event{
-			"provider": d.uuid,
-			"id":       container.ID,
-			flag:       true,
-			"host":     host,
-			"port":     port.PrivatePort,
-			"docker":   meta,
+			"provider":  d.uuid,
+			"id":        container.ID,
+			flag:        true,
+			"host":      host,
+			"port":      port.PrivatePort,
+			"container": meta,
 			"meta": common.MapStr{
-				"docker": meta,
+				"container": meta,
 			},
 		}
 

--- a/libbeat/autodiscover/providers/docker/docker_integration_test.go
+++ b/libbeat/autodiscover/providers/docker/docker_integration_test.go
@@ -82,7 +82,7 @@ func checkEvent(t *testing.T, listener bus.Listener, start bool) {
 		select {
 		case e := <-listener.Events():
 			// Ignore any other container
-			if getValue(e, "docker.container.image") != "busybox" {
+			if getValue(e, "container.image") != "busybox" {
 				continue
 			}
 			if start {
@@ -92,17 +92,17 @@ func checkEvent(t *testing.T, listener bus.Listener, start bool) {
 				assert.Equal(t, getValue(e, "stop"), true)
 				assert.Nil(t, getValue(e, "start"))
 			}
-			assert.Equal(t, getValue(e, "docker.container.image"), "busybox")
-			assert.Equal(t, getValue(e, "docker.container.labels"), common.MapStr{
+			assert.Equal(t, getValue(e, "container.image.name"), "busybox")
+			assert.Equal(t, getValue(e, "container.labels"), common.MapStr{
 				"label": common.MapStr{
 					"value": "foo",
 					"child": "bar",
 				},
 			})
-			assert.NotNil(t, getValue(e, "docker.container.id"))
-			assert.NotNil(t, getValue(e, "docker.container.name"))
+			assert.NotNil(t, getValue(e, "container.id"))
+			assert.NotNil(t, getValue(e, "container.name"))
 			assert.NotNil(t, getValue(e, "host"))
-			assert.Equal(t, getValue(e, "docker"), getValue(e, "meta.docker"))
+			assert.Equal(t, getValue(e, "container"), getValue(e, "meta.container"))
 			return
 
 		case <-time.After(10 * time.Second):

--- a/libbeat/autodiscover/providers/docker/docker_test.go
+++ b/libbeat/autodiscover/providers/docker/docker_test.go
@@ -36,15 +36,12 @@ func TestGenerateHints(t *testing.T) {
 			event:  bus.Event{},
 			result: bus.Event{},
 		},
-		// Docker meta must be present in the hints
+		// Container meta must be present in the hints
 		{
-			// TODO: why must docker be present in the hints? Did my changes now break something?
 			event: bus.Event{
-				"docker": common.MapStr{
-					"container": common.MapStr{
-						"id":   "abc",
-						"name": "foobar",
-					},
+				"container": common.MapStr{
+					"id":   "abc",
+					"name": "foobar",
 				},
 			},
 			result: bus.Event{
@@ -54,20 +51,18 @@ func TestGenerateHints(t *testing.T) {
 				},
 			},
 		},
-		// Docker labels are testing with the following scenarios
+		// Docker container labels are testing with the following scenarios
 		// do.not.include must not be part of the hints
 		// logs/disable should be present in hints.logs.disable=true
 		{
 			event: bus.Event{
-				"docker": common.MapStr{
-					"container": common.MapStr{
-						"id":   "abc",
-						"name": "foobar",
-						"labels": getNestedAnnotations(common.MapStr{
-							"do.not.include":          "true",
-							"co.elastic.logs/disable": "true",
-						}),
-					},
+				"container": common.MapStr{
+					"id":   "abc",
+					"name": "foobar",
+					"labels": getNestedAnnotations(common.MapStr{
+						"do.not.include":          "true",
+						"co.elastic.logs/disable": "true",
+					}),
 				},
 			},
 			result: bus.Event{

--- a/libbeat/autodiscover/providers/docker/docker_test.go
+++ b/libbeat/autodiscover/providers/docker/docker_test.go
@@ -38,6 +38,7 @@ func TestGenerateHints(t *testing.T) {
 		},
 		// Docker meta must be present in the hints
 		{
+			// TODO: why must docker be present in the hints? Did my changes now break something?
 			event: bus.Event{
 				"docker": common.MapStr{
 					"container": common.MapStr{

--- a/metricbeat/metricbeat.yml
+++ b/metricbeat/metricbeat.yml
@@ -60,16 +60,16 @@ setup.template.settings:
 # This requires a Kibana endpoint configuration.
 setup.kibana:
 
-# Kibana Host
-# Scheme and port can be left out and will be set to the default (http and 5601)
-# In case you specify and additional path, the scheme is required: http://localhost:5601/path
-# IPv6 addresses should always be defined as: https://[2001:db8::1]:5601
-#host: "localhost:5601"
+  # Kibana Host
+  # Scheme and port can be left out and will be set to the default (http and 5601)
+  # In case you specify and additional path, the scheme is required: http://localhost:5601/path
+  # IPv6 addresses should always be defined as: https://[2001:db8::1]:5601
+  #host: "localhost:5601"
 
-# Kibana Space ID
-# ID of the Kibana Space into which the dashboards should be loaded. By default,
-# the Default Space will be used.
-#space.id:
+  # Kibana Space ID
+  # ID of the Kibana Space into which the dashboards should be loaded. By default,
+  # the Default Space will be used.
+  #space.id:
 
 #============================= Elastic Cloud ==================================
 
@@ -98,8 +98,8 @@ output.elasticsearch:
   #username: "elastic"
   #password: "changeme"
 
-  #----------------------------- Logstash output --------------------------------
-  #output.logstash:
+#----------------------------- Logstash output --------------------------------
+#output.logstash:
   # The Logstash hosts
   #hosts: ["localhost:5044"]
 

--- a/metricbeat/metricbeat.yml
+++ b/metricbeat/metricbeat.yml
@@ -8,23 +8,51 @@
 # https://www.elastic.co/guide/en/beats/metricbeat/index.html
 
 #==========================  Modules configuration ============================
+metricbeat.modules:
+  - module: docker
+    # metricsets: ["container", "cpu", "diskio", "healthcheck", "info", "memory", "network"]
+    metricsets: ["container"]
+    hosts: ["unix:///var/run/docker.sock"]
+    period: 60s
 
-metricbeat.config.modules:
+metricbeat.autodiscover:
+  providers:
+    - type: docker
+      host: unix:///var/run/docker.sock
+      templates:
+        - condition:
+            contains.docker.container.image: "nginx:"
+          config:
+            - module: nginx
+              metricsets: ["stubstatus"]
+              hosts: ["${data.host}:80"]
+        - condition:
+            contains.docker.container.image: "kibana:"
+          config:
+            - module: kibana
+              hosts: ["${data.host}:5601"]
+        - condition:
+            contains.docker.container.image: "docker.elastic.co/elasticsearch/elasticsearch:"
+          config:
+            - module: elasticsearch
+              hosts: ["${data.host}:9200"]
+
+#metricbeat.config.modules:
   # Glob pattern for configuration loading
-  path: ${path.config}/modules.d/*.yml
+  # path: ${path.config}/modules.d/*.yml
 
   # Set to true to enable config reloading
-  reload.enabled: false
+  # reload.enabled: false
 
   # Period on which files under path should be checked for changes
   #reload.period: 10s
 
 #==================== Elasticsearch template setting ==========================
 
-setup.template.settings:
-  index.number_of_shards: 1
-  index.codec: best_compression
-  #_source.enabled: false
+#setup.template.settings:
+#  index.number_of_shards: 1
+#  index.codec: best_compression
+#  #_source.enabled: false
 
 #================================ General =====================================
 
@@ -64,7 +92,7 @@ setup.kibana:
   # Scheme and port can be left out and will be set to the default (http and 5601)
   # In case you specify and additional path, the scheme is required: http://localhost:5601/path
   # IPv6 addresses should always be defined as: https://[2001:db8::1]:5601
-  #host: "localhost:5601"
+  host: "kibana:5601"
 
   # Kibana Space ID
   # ID of the Kibana Space into which the dashboards should be loaded. By default,
@@ -91,7 +119,7 @@ setup.kibana:
 #-------------------------- Elasticsearch output ------------------------------
 output.elasticsearch:
   # Array of hosts to connect to.
-  hosts: ["localhost:9200"]
+  hosts: ["elasticsearch:9200"]
 
   # Optional protocol and basic auth credentials.
   #protocol: "https"

--- a/metricbeat/metricbeat.yml
+++ b/metricbeat/metricbeat.yml
@@ -8,51 +8,23 @@
 # https://www.elastic.co/guide/en/beats/metricbeat/index.html
 
 #==========================  Modules configuration ============================
-metricbeat.modules:
-  - module: docker
-    # metricsets: ["container", "cpu", "diskio", "healthcheck", "info", "memory", "network"]
-    metricsets: ["container"]
-    hosts: ["unix:///var/run/docker.sock"]
-    period: 60s
 
-metricbeat.autodiscover:
-  providers:
-    - type: docker
-      host: unix:///var/run/docker.sock
-      templates:
-        - condition:
-            contains.docker.container.image: "nginx:"
-          config:
-            - module: nginx
-              metricsets: ["stubstatus"]
-              hosts: ["${data.host}:80"]
-        - condition:
-            contains.docker.container.image: "kibana:"
-          config:
-            - module: kibana
-              hosts: ["${data.host}:5601"]
-        - condition:
-            contains.docker.container.image: "docker.elastic.co/elasticsearch/elasticsearch:"
-          config:
-            - module: elasticsearch
-              hosts: ["${data.host}:9200"]
-
-#metricbeat.config.modules:
+metricbeat.config.modules:
   # Glob pattern for configuration loading
-  # path: ${path.config}/modules.d/*.yml
+  path: ${path.config}/modules.d/*.yml
 
   # Set to true to enable config reloading
-  # reload.enabled: false
+  reload.enabled: false
 
   # Period on which files under path should be checked for changes
   #reload.period: 10s
 
 #==================== Elasticsearch template setting ==========================
 
-#setup.template.settings:
-#  index.number_of_shards: 1
-#  index.codec: best_compression
-#  #_source.enabled: false
+setup.template.settings:
+  index.number_of_shards: 1
+  index.codec: best_compression
+  #_source.enabled: false
 
 #================================ General =====================================
 
@@ -88,16 +60,16 @@ metricbeat.autodiscover:
 # This requires a Kibana endpoint configuration.
 setup.kibana:
 
-  # Kibana Host
-  # Scheme and port can be left out and will be set to the default (http and 5601)
-  # In case you specify and additional path, the scheme is required: http://localhost:5601/path
-  # IPv6 addresses should always be defined as: https://[2001:db8::1]:5601
-  host: "kibana:5601"
+# Kibana Host
+# Scheme and port can be left out and will be set to the default (http and 5601)
+# In case you specify and additional path, the scheme is required: http://localhost:5601/path
+# IPv6 addresses should always be defined as: https://[2001:db8::1]:5601
+#host: "localhost:5601"
 
-  # Kibana Space ID
-  # ID of the Kibana Space into which the dashboards should be loaded. By default,
-  # the Default Space will be used.
-  #space.id:
+# Kibana Space ID
+# ID of the Kibana Space into which the dashboards should be loaded. By default,
+# the Default Space will be used.
+#space.id:
 
 #============================= Elastic Cloud ==================================
 
@@ -119,15 +91,15 @@ setup.kibana:
 #-------------------------- Elasticsearch output ------------------------------
 output.elasticsearch:
   # Array of hosts to connect to.
-  hosts: ["elasticsearch:9200"]
+  hosts: ["localhost:9200"]
 
   # Optional protocol and basic auth credentials.
   #protocol: "https"
   #username: "elastic"
   #password: "changeme"
 
-#----------------------------- Logstash output --------------------------------
-#output.logstash:
+  #----------------------------- Logstash output --------------------------------
+  #output.logstash:
   # The Logstash hosts
   #hosts: ["localhost:5044"]
 

--- a/metricbeat/module/docker/container/_meta/data.json
+++ b/metricbeat/module/docker/container/_meta/data.json
@@ -1,37 +1,47 @@
 {
     "@timestamp": "2017-10-12T08:05:34.853Z",
-    "beat": {
+    "agent": {
         "hostname": "host.example.com",
         "name": "host.example.com"
     },
+    "container.id": "191e533a404a9b36b82a75e2a72f1191bdd5ec33486fd5c132165be61dc3eddd",
+    "container.image.name": "nginx:1.13",
+    "container.labels": {
+        "co_elastic_logs/fileset_stderr": "error",
+        "co_elastic_logs/fileset_stdout": "access",
+        "co_elastic_logs/module": "nginx",
+        "com_docker_compose_config-hash": "f430525112c7ed343346d8ec6975602b03b7fcf9181510002d4ee37d71a7a4e4",
+        "com_docker_compose_container-number": "5",
+        "com_docker_compose_oneoff": "False",
+        "com_docker_compose_project": "docker-autodiscovery",
+        "com_docker_compose_service": "nginx",
+        "com_docker_compose_version": "1.23.2",
+        "maintainer": "NGINX Docker Maintainers \u003cdocker-maint@nginx.com\u003e"
+    },
+    "container.name": "docker-autodiscovery_nginx_5",
     "docker": {
         "container": {
-            "command": "go test -tags=integration github.com/elastic/beats/metricbeat/module/... -data",
-            "created": "2017-12-07T07:20:57.000Z",
-            "id": "d88e67bb6961a5bb70c1c1c48094c6030e43768eed91e827f437111888f9967e",
-            "image": "metricbeatsnapshotnoxpack700alpha1d71419298b58ed8b0a5b60a6d1e4a476ffaf80a8_beat",
+            "command": "nginx -g 'daemon off;'",
+            "created": "2019-02-18T22:10:37.000Z",
             "ip_addresses": [
-                "172.18.0.27"
+                "172.20.0.9"
             ],
-            "labels": {
-                "com_docker_compose_container-number": "1",
-                "com_docker_compose_oneoff": "True",
-                "com_docker_compose_project": "metricbeatsnapshotnoxpack700alpha1d71419298b58ed8b0a5b60a6d1e4a476ffaf80a8",
-                "com_docker_compose_service": "beat",
-                "com_docker_compose_version": "1.16.1"
-            },
-            "name": "metricbeatsnapshotnoxpack700alpha1d71419298b58ed8b0a5b60a6d1e4a476ffaf80a8_beat_run_1",
-            "size": {
-                "root_fs": 0,
-                "rw": 0
-            },
-            "status": "Up 6 minutes (healthy)"
+            "size.root_fs": 0,
+            "size.rw": 0,
+            "status": "Up 5 minutes"
         }
     },
+    "event": {
+        "dataset": "docker.container",
+        "duration": 115000,
+        "module": "docker"
+    },
     "metricset": {
-        "host": "/var/run/docker.sock",
-        "module": "docker",
-        "name": "container",
-        "rtt": 115
-    }
+        "name": "container"
+    },
+    "service": {
+        "address": "/var/run/docker.sock",
+        "type": "docker"
+    },
+    "service.name": "container"
 }

--- a/metricbeat/module/docker/container/container.go
+++ b/metricbeat/module/docker/container/container.go
@@ -23,7 +23,8 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
 
-	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
+
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/module/docker"
 )
@@ -39,34 +40,42 @@ type MetricSet struct {
 	mb.BaseMetricSet
 	dockerClient *client.Client
 	dedot        bool
+	logger       *logp.Logger
 }
 
 // New creates a new instance of the docker container MetricSet.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
+	logger := logp.NewLogger("docker")
 	config := docker.DefaultConfig()
 	if err := base.Module().UnpackConfig(&config); err != nil {
 		return nil, err
 	}
 
-	client, err := docker.NewDockerClient(base.HostData().URI, config)
+	dockerClient, err := docker.NewDockerClient(base.HostData().URI, config)
 	if err != nil {
 		return nil, err
 	}
 
 	return &MetricSet{
 		BaseMetricSet: base,
-		dockerClient:  client,
+		dockerClient:  dockerClient,
 		dedot:         config.DeDot,
+		logger:        logger,
 	}, nil
 }
 
 // Fetch returns a list of all containers as events.
 // This is based on https://docs.docker.com/engine/reference/api/docker_remote_api_v1.24/#/list-containers.
-func (m *MetricSet) Fetch() ([]common.MapStr, error) {
+func (m *MetricSet) Fetch(report mb.ReporterV2) {
 	// Fetch a list of all containers.
 	containers, err := m.dockerClient.ContainerList(context.Background(), types.ContainerListOptions{})
 	if err != nil {
-		return nil, err
+		m.logger.Error(err.Error())
+		report.Error(err)
 	}
-	return eventsMapping(containers, m.dedot), nil
+
+	for _, container := range containers {
+		event := eventMapping(&container, m.dedot)
+		report.Event(event)
+	}
 }

--- a/metricbeat/module/docker/container/container_integration_test.go
+++ b/metricbeat/module/docker/container/container_integration_test.go
@@ -26,8 +26,8 @@ import (
 )
 
 func TestData(t *testing.T) {
-	f := mbtest.NewEventsFetcher(t, getConfig())
-	err := mbtest.WriteEvents(f, t)
+	containerMetricSet := mbtest.NewReportingMetricSetV2(t, getConfig())
+	err := mbtest.WriteEventsReporterV2(containerMetricSet, t, "/")
 	if err != nil {
 		t.Fatal("write", err)
 	}

--- a/metricbeat/module/docker/container/data.go
+++ b/metricbeat/module/docker/container/data.go
@@ -20,41 +20,39 @@ package container
 import (
 	"time"
 
+	"github.com/elastic/beats/metricbeat/mb"
+
 	"github.com/docker/docker/api/types"
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/metricbeat/module/docker"
 )
 
-func eventsMapping(containersList []types.Container, dedot bool) []common.MapStr {
-	myEvents := []common.MapStr{}
-	for _, container := range containersList {
-		myEvents = append(myEvents, eventMapping(&container, dedot))
-	}
-	return myEvents
-}
+func eventMapping(cont *types.Container, dedot bool) (event mb.Event) {
+	mapOfRootFieldsResults := make(map[string]interface{})
+	mapOfRootFieldsResults["service.name"] = "container"
 
-func eventMapping(cont *types.Container, dedot bool) common.MapStr {
-	event := common.MapStr{
-		"created":      common.Time(time.Unix(cont.Created, 0)),
-		"id":           cont.ID,
-		"name":         docker.ExtractContainerName(cont.Names),
-		"command":      cont.Command,
-		"image":        cont.Image,
-		"ip_addresses": extractIPAddresses(cont.NetworkSettings),
-		"size": common.MapStr{
-			"root_fs": cont.SizeRootFs,
-			"rw":      cont.SizeRw,
-		},
-		"status": cont.Status,
-	}
+	// Container fields in ECS
+	mapOfRootFieldsResults["container.id"] = cont.ID
+	mapOfRootFieldsResults["container.image.name"] = cont.Image
+	mapOfRootFieldsResults["container.name"] = docker.ExtractContainerName(cont.Names)
+
+	// Docker container metrics
+	mapOfMetricSetFieldResults := make(map[string]interface{})
+	mapOfMetricSetFieldResults["created"] = common.Time(time.Unix(cont.Created, 0))
+	mapOfMetricSetFieldResults["command"] = cont.Command
+	mapOfMetricSetFieldResults["ip_addresses"] = extractIPAddresses(cont.NetworkSettings)
+	mapOfMetricSetFieldResults["size.root_fs"] = cont.SizeRootFs
+	mapOfMetricSetFieldResults["size.rw"] = cont.SizeRw
+	mapOfMetricSetFieldResults["status"] = cont.Status
 
 	labels := docker.DeDotLabels(cont.Labels, dedot)
-
 	if len(labels) > 0 {
-		event["labels"] = labels
+		mapOfRootFieldsResults["container.labels"] = labels
 	}
 
+	event.RootFields = mapOfRootFieldsResults
+	event.MetricSetFields = mapOfMetricSetFieldResults
 	return event
 }
 

--- a/metricbeat/tests/system/test_autodiscover.py
+++ b/metricbeat/tests/system/test_autodiscover.py
@@ -25,7 +25,7 @@ class TestAutodiscover(metricbeat.BaseTest):
                 'docker': {
                     'templates': '''
                       - condition:
-                          equals.docker.container.image: memcached:latest
+                          equals.container.image: memcached:latest
                         config:
                           - module: memcached
                             metricsets: ["stats"]
@@ -51,9 +51,9 @@ class TestAutodiscover(metricbeat.BaseTest):
         proc.check_kill_and_wait()
 
         # Check metadata is added
-        assert output[0]['docker']['container']['image'] == 'memcached:latest'
-        assert output[0]['docker']['container']['labels'] == {}
-        assert 'name' in output[0]['docker']['container']
+        assert output[0]['container']['image'] == 'memcached:latest'
+        assert output[0]['container']['labels'] == {}
+        assert 'name' in output[0]['container']
 
     @unittest.skipIf(not INTEGRATION_TESTS or
                      os.getenv("TESTING_ENVIRONMENT") == "2x",
@@ -93,8 +93,10 @@ class TestAutodiscover(metricbeat.BaseTest):
         proc.check_kill_and_wait()
 
         # Check metadata is added
-        assert output[0]['docker']['container']['image'] == 'memcached:latest'
-        assert 'name' in output[0]['docker']['container']
+        assert output[0]['container']['image'] == 'memcached:latest'
+        assert 'name' in output[0]['container']
+        self.assert_fields_are_documented(output[0])
+
 
     @unittest.skipIf(not INTEGRATION_TESTS or
                      os.getenv("TESTING_ENVIRONMENT") == "2x",
@@ -143,3 +145,4 @@ class TestAutodiscover(metricbeat.BaseTest):
 
         # Check field is added
         assert output[0]['fields']['foo'] == 'bar'
+        self.assert_fields_are_documented(output[0])

--- a/metricbeat/tests/system/test_autodiscover.py
+++ b/metricbeat/tests/system/test_autodiscover.py
@@ -97,7 +97,6 @@ class TestAutodiscover(metricbeat.BaseTest):
         assert 'name' in output[0]['container']
         self.assert_fields_are_documented(output[0])
 
-
     @unittest.skipIf(not INTEGRATION_TESTS or
                      os.getenv("TESTING_ENVIRONMENT") == "2x",
                      "integration test not available on 2.x")

--- a/metricbeat/tests/system/test_autodiscover_jolokia.py
+++ b/metricbeat/tests/system/test_autodiscover_jolokia.py
@@ -52,3 +52,5 @@ class Test(metricbeat.BaseTest):
         print(evt)
 
         assert evt["jolokia"]["test"]["gc"]["collection_count"] >= 0
+
+        self.assert_fields_are_documented(output[0])


### PR DESCRIPTION
Migrate the docker container fields to ECS container fields:
* docker.container.id -> container.id
* docker.container.image -> container.image.name
* docker.container.name -> container.name
* docker.container.labels -> container.labels

This will fix https://github.com/elastic/beats/issues/10757 and needs to be backported.