### PR TITLE
Do not skip test_file_disappear_appear on Windows anymore

### DIFF
--- a/filebeat/tests/system/test_crawler.py
+++ b/filebeat/tests/system/test_crawler.py
@@ -264,7 +264,6 @@ class Test(BaseTest):
 
         assert len(output) == 5 + 6
 
-    @unittest.skipIf(os.name == 'nt', 'flaky test https://github.com/elastic/beats/issues/9213')
     def test_file_disappear_appear(self):
         """
         Checks that filebeat keeps running in case a log files is deleted


### PR DESCRIPTION
Fixes around detecting the deletion of a file on Windows are possibly fixed this issue: https://github.com/elastic/beats/pull/10747

I am triggering a few Jenkins builds to see if the theory holds up.

Closes https://github.com/elastic/beats/issues/9213