### PR TITLE
Stabilize test_input_pipeline_config

### DIFF
--- a/filebeat/tests/system/test_pipeline.py
+++ b/filebeat/tests/system/test_pipeline.py
@@ -34,7 +34,6 @@ class Test(BaseTest):
 
         self.index_name = "test-filebeat-pipeline"
 
-
     @unittest.skipIf(not INTEGRATION_TESTS,
                      "integration tests are disabled, run with INTEGRATION_TESTS=1 to enable them.")
     @unittest.skipIf(os.getenv("TESTING_ENVIRONMENT") == "2x",

--- a/filebeat/tests/system/test_pipeline.py
+++ b/filebeat/tests/system/test_pipeline.py
@@ -106,4 +106,5 @@ class Test(BaseTest):
             assert o["x-pipeline"] == "test-pipeline"
         finally:
             for pipeline_id, pipeline in list(self.existing_pipelines.items()):
+                print(pipeline_id, pipeline)
                 self.es.transport.perform_request("PUT", "/_ingest/pipeline/"+pipeline_id, body=pipeline)


### PR DESCRIPTION
`test_input_pipeline_config` has been unstable due to too many dynamic scripts executions when uploading the test pipeline. As this pipeline is super primitive, it is highly unlikely that it causes the issue. However, when a new pipeline is uploaded all of those are reloaded on all nodes, so it is possible that an existing pipeline creates the problem. To avoid this, all existing pipelines are deleted while the test is being run. When the test terminates, pipelines are uploaded again not to mess up the existing environment.

This PR only stabilises the test. But the issue still needs an investigation to see which pipeline leads to too many script executions. To make debugging a bit easier, I have added a debug print to see which pipeline fails when the problem resurfaces.

Closes #9587 
Closes #9600
