### PR TITLE
Change docker container field names to match ECS

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -292,6 +292,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Release AWS module as GA. {pull}10345[10345]
 - Add overview dashboard to Zookeeper Metricbeat module {pull}10379[10379]
 - Add Consul Metricbeat module with Agent Metricset {pull}8631[8631]
+- Adjust docker container fields to ECS.
 
 *Packetbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -292,7 +292,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Release AWS module as GA. {pull}10345[10345]
 - Add overview dashboard to Zookeeper Metricbeat module {pull}10379[10379]
 - Add Consul Metricbeat module with Agent Metricset {pull}8631[8631]
-- Adjust docker container fields to ECS.
+- Adjust docker container fields to ECS. {pull}10826[10826]
 
 *Packetbeat*
 

--- a/metricbeat/module/docker/container/_meta/data.json
+++ b/metricbeat/module/docker/container/_meta/data.json
@@ -1,37 +1,35 @@
 {
     "@timestamp": "2017-10-12T08:05:34.853Z",
-    "beat": {
+    "agent": {
         "hostname": "host.example.com",
         "name": "host.example.com"
     },
+    "container.id": "afb04f8e0c863da14ea842d62a542e290b6d5d8fa4898c5d9e7511f24bd47282",
+    "container.image.name": "docker-filebeat-build:version1",
+    "container.name": "elegant_goldwasser",
     "docker": {
         "container": {
-            "command": "go test -tags=integration github.com/elastic/beats/metricbeat/module/... -data",
-            "created": "2017-12-07T07:20:57.000Z",
-            "id": "d88e67bb6961a5bb70c1c1c48094c6030e43768eed91e827f437111888f9967e",
-            "image": "metricbeatsnapshotnoxpack700alpha1d71419298b58ed8b0a5b60a6d1e4a476ffaf80a8_beat",
+            "command": "/bin/bash",
+            "created": "2019-02-18T18:18:34.000Z",
             "ip_addresses": [
-                "172.18.0.27"
+                "172.20.0.3"
             ],
-            "labels": {
-                "com_docker_compose_container-number": "1",
-                "com_docker_compose_oneoff": "True",
-                "com_docker_compose_project": "metricbeatsnapshotnoxpack700alpha1d71419298b58ed8b0a5b60a6d1e4a476ffaf80a8",
-                "com_docker_compose_service": "beat",
-                "com_docker_compose_version": "1.16.1"
-            },
-            "name": "metricbeatsnapshotnoxpack700alpha1d71419298b58ed8b0a5b60a6d1e4a476ffaf80a8_beat_run_1",
-            "size": {
-                "root_fs": 0,
-                "rw": 0
-            },
-            "status": "Up 6 minutes (healthy)"
+            "size.root_fs": 0,
+            "size.rw": 0,
+            "status": "Up 21 hours"
         }
     },
+    "event": {
+        "dataset": "docker.container",
+        "duration": 115000,
+        "module": "docker"
+    },
     "metricset": {
-        "host": "/var/run/docker.sock",
-        "module": "docker",
-        "name": "container",
-        "rtt": 115
-    }
+        "name": "container"
+    },
+    "service": {
+        "address": "/var/run/docker.sock",
+        "type": "docker"
+    },
+    "service.name": "container"
 }

--- a/metricbeat/module/docker/container/container.go
+++ b/metricbeat/module/docker/container/container.go
@@ -20,10 +20,11 @@ package container
 import (
 	"context"
 
+	"github.com/elastic/beats/libbeat/logp"
+
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
 
-	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/module/docker"
 )
@@ -39,34 +40,42 @@ type MetricSet struct {
 	mb.BaseMetricSet
 	dockerClient *client.Client
 	dedot        bool
+	logger       *logp.Logger
 }
 
 // New creates a new instance of the docker container MetricSet.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
+	logger := logp.NewLogger("docker")
 	config := docker.DefaultConfig()
 	if err := base.Module().UnpackConfig(&config); err != nil {
 		return nil, err
 	}
 
-	client, err := docker.NewDockerClient(base.HostData().URI, config)
+	dockerClient, err := docker.NewDockerClient(base.HostData().URI, config)
 	if err != nil {
 		return nil, err
 	}
 
 	return &MetricSet{
 		BaseMetricSet: base,
-		dockerClient:  client,
+		dockerClient:  dockerClient,
 		dedot:         config.DeDot,
+		logger:        logger,
 	}, nil
 }
 
 // Fetch returns a list of all containers as events.
 // This is based on https://docs.docker.com/engine/reference/api/docker_remote_api_v1.24/#/list-containers.
-func (m *MetricSet) Fetch() ([]common.MapStr, error) {
+func (m *MetricSet) Fetch(report mb.ReporterV2) {
 	// Fetch a list of all containers.
 	containers, err := m.dockerClient.ContainerList(context.Background(), types.ContainerListOptions{})
 	if err != nil {
-		return nil, err
+		m.logger.Error(err.Error())
+		report.Error(err)
 	}
-	return eventsMapping(containers, m.dedot), nil
+
+	for _, container := range containers {
+		event := eventMapping(&container, m.dedot)
+		report.Event(event)
+	}
 }

--- a/metricbeat/module/docker/container/container.go
+++ b/metricbeat/module/docker/container/container.go
@@ -19,6 +19,7 @@ package container
 
 import (
 	"context"
+	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/libbeat/logp"
 
@@ -45,7 +46,7 @@ type MetricSet struct {
 
 // New creates a new instance of the docker container MetricSet.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	logger := logp.NewLogger("docker")
+	logger := logp.NewLogger("docker.container")
 	config := docker.DefaultConfig()
 	if err := base.Module().UnpackConfig(&config); err != nil {
 		return nil, err
@@ -70,6 +71,7 @@ func (m *MetricSet) Fetch(report mb.ReporterV2) {
 	// Fetch a list of all containers.
 	containers, err := m.dockerClient.ContainerList(context.Background(), types.ContainerListOptions{})
 	if err != nil {
+		err = errors.Wrap(err, "DockerClient ContainerList failed")
 		m.logger.Error(err.Error())
 		report.Error(err)
 	}

--- a/metricbeat/module/docker/container/container.go
+++ b/metricbeat/module/docker/container/container.go
@@ -19,13 +19,12 @@ package container
 
 import (
 	"context"
-	"github.com/pkg/errors"
-
-	"github.com/elastic/beats/libbeat/logp"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
+	"github.com/pkg/errors"
 
+	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/module/docker"
 )

--- a/metricbeat/module/docker/container/container_integration_test.go
+++ b/metricbeat/module/docker/container/container_integration_test.go
@@ -26,8 +26,8 @@ import (
 )
 
 func TestData(t *testing.T) {
-	f := mbtest.NewEventsFetcher(t, getConfig())
-	err := mbtest.WriteEvents(f, t)
+	containerMetricSet := mbtest.NewReportingMetricSetV2(t, getConfig())
+	err := mbtest.WriteEventsReporterV2(containerMetricSet, t, "/")
 	if err != nil {
 		t.Fatal("write", err)
 	}

--- a/metricbeat/module/docker/container/data.go
+++ b/metricbeat/module/docker/container/data.go
@@ -20,41 +20,39 @@ package container
 import (
 	"time"
 
+	"github.com/elastic/beats/metricbeat/mb"
+
 	"github.com/docker/docker/api/types"
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/metricbeat/module/docker"
 )
 
-func eventsMapping(containersList []types.Container, dedot bool) []common.MapStr {
-	myEvents := []common.MapStr{}
-	for _, container := range containersList {
-		myEvents = append(myEvents, eventMapping(&container, dedot))
-	}
-	return myEvents
-}
+func eventMapping(cont *types.Container, dedot bool) (event mb.Event) {
+	mapOfRootFieldsResults := make(map[string]interface{})
+	mapOfRootFieldsResults["service.name"] = "container"
 
-func eventMapping(cont *types.Container, dedot bool) common.MapStr {
-	event := common.MapStr{
-		"created":      common.Time(time.Unix(cont.Created, 0)),
-		"id":           cont.ID,
-		"name":         docker.ExtractContainerName(cont.Names),
-		"command":      cont.Command,
-		"image":        cont.Image,
-		"ip_addresses": extractIPAddresses(cont.NetworkSettings),
-		"size": common.MapStr{
-			"root_fs": cont.SizeRootFs,
-			"rw":      cont.SizeRw,
-		},
-		"status": cont.Status,
-	}
-
+	// Container fields in ECS
+	mapOfRootFieldsResults["container.id"] = cont.ID
+	mapOfRootFieldsResults["container.image.name"] = cont.Image
+	mapOfRootFieldsResults["container.name"] = docker.ExtractContainerName(cont.Names)
 	labels := docker.DeDotLabels(cont.Labels, dedot)
-
 	if len(labels) > 0 {
-		event["labels"] = labels
+		mapOfRootFieldsResults["container.labels"] = labels
 	}
 
+	event.RootFields = mapOfRootFieldsResults
+
+	// Docker container metrics
+	mapOfMetricSetFieldResults := make(map[string]interface{})
+	mapOfMetricSetFieldResults["created"] = common.Time(time.Unix(cont.Created, 0))
+	mapOfMetricSetFieldResults["command"] = cont.Command
+	mapOfMetricSetFieldResults["ip_addresses"] = extractIPAddresses(cont.NetworkSettings)
+	mapOfMetricSetFieldResults["size.root_fs"] = cont.SizeRootFs
+	mapOfMetricSetFieldResults["size.rw"] = cont.SizeRw
+	mapOfMetricSetFieldResults["status"] = cont.Status
+
+	event.MetricSetFields = mapOfMetricSetFieldResults
 	return event
 }
 


### PR DESCRIPTION
Migrate the docker container fields to ECS container fields:
* docker.container.id -> container.id
* docker.container.image -> container.image.name
* docker.container.name -> container.name
* docker.container.labels -> container.labels

This PR also migrates docker container metricset to use ReporterV2 interface. Please see https://github.com/elastic/beats/issues/10774 for more info.