### PR TITLE
Don't add the modifier for service name if it is not configured

### DIFF
--- a/metricbeat/mb/module/options.go
+++ b/metricbeat/mb/module/options.go
@@ -64,6 +64,9 @@ func WithMetricSetInfo() Option {
 // given to the `service.name` setting in the module configuration.
 func WithServiceName() Option {
 	return func(w *Wrapper) {
+		if w.Module == nil {
+			return
+		}
 		serviceName := w.Module.Config().ServiceName
 		if serviceName == "" {
 			return

--- a/metricbeat/mb/module/options.go
+++ b/metricbeat/mb/module/options.go
@@ -64,12 +64,12 @@ func WithMetricSetInfo() Option {
 // given to the `service.name` setting in the module configuration.
 func WithServiceName() Option {
 	return func(w *Wrapper) {
+		serviceName := w.Module.Config().ServiceName
+		if serviceName == "" {
+			return
+		}
 		modifier := func(_, _ string, event *mb.Event) {
 			if event == nil {
-				return
-			}
-			serviceName := w.Module.Config().ServiceName
-			if serviceName == "" {
 				return
 			}
 			if event.RootFields == nil {


### PR DESCRIPTION
Check if service.name is configured, and if not, don't add the modifier
so no additional overhead is added for all events if not needed.
