### PR TITLE
Remove broken link to docker source code

### DIFF
--- a/libbeat/docs/shared-beats-attributes.asciidoc
+++ b/libbeat/docs/shared-beats-attributes.asciidoc
@@ -14,7 +14,6 @@
 :monitoringdoc: https://www.elastic.co/guide/en/elastic-stack-overview/{doc-branch}
 :dashboards: https://artifacts.elastic.co/downloads/beats/beats-dashboards/beats-dashboards-{stack-version}.zip
 :dockerimage: docker.elastic.co/beats/{beatname_lc}:{version}
-:dockergithub: https://github.com/elastic/beats-docker/tree/{doc-branch}
 :dockerconfig: https://raw.githubusercontent.com/elastic/beats/{doc-branch}/deploy/docker/{beatname_lc}.docker.yml
 :downloads: https://artifacts.elastic.co/downloads/beats
 :ES-version: {stack-version}

--- a/libbeat/docs/shared-docker.asciidoc
+++ b/libbeat/docs/shared-docker.asciidoc
@@ -5,8 +5,7 @@ Docker images for {beatname_uc} are available from the Elastic Docker
 registry. The base image is https://hub.docker.com/_/centos/[centos:7].
 
 A list of all published Docker images and tags is available at
-https://www.docker.elastic.co[www.docker.elastic.co]. The source code is in
-{dockergithub}[GitHub].
+https://www.docker.elastic.co[www.docker.elastic.co]. 
 
 These images are free to use under the Elastic license. They contain open source 
 and free commercial features and access to paid commercial features.  


### PR DESCRIPTION
Closes issue #10821 

@jsoriano I don't see why users need to know where the source lives (especially now that it's in the main beats repo), so I removed the sentence. Let me know if you would prefer that I update the link instead. Also let me know how far I should backport this change. Usually we only do the current and future branches.