### PR TITLE
enable reload auditd rules

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -612,7 +612,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Improve file_integrity monitoring when a file is created/deleted in quick succession. {issue}17347[17347] {pull}22170[22170]
 - system/host: Add new ECS 1.8 field `os.type` in `host.os.type`. {pull}23513[23513]
 - Update Auditbeat auditd module to ECS 1.8 {pull}23594[23594] {issue}23118[23118]
-- Add enrichment of auditd seccomp events with name of the architecture, syscall, and signal. {issue}14055[14055] {pull}19300[19300]
 - Add auditd rule reload for Auditd module. {pull}10835[10835]
 
 *Filebeat*

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -607,6 +607,13 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add file integrity module ECS categorization fields. {pull}18012[18012]
 - Add `file.mime_type`, `file.extension`, and `file.drive_letter` for file integrity module. {pull}18012[18012]
 - Add ECS categorization info for auditd module {pull}18596[18596]
+- Add several improvements for auditd module for improved ECS field mapping {pull}22647[22647]
+- Add ECS 1.7 `configuration` categorization in certain events in auditd module. {pull}23000[23000]
+- Improve file_integrity monitoring when a file is created/deleted in quick succession. {issue}17347[17347] {pull}22170[22170]
+- system/host: Add new ECS 1.8 field `os.type` in `host.os.type`. {pull}23513[23513]
+- Update Auditbeat auditd module to ECS 1.8 {pull}23594[23594] {issue}23118[23118]
+- Add enrichment of auditd seccomp events with name of the architecture, syscall, and signal. {issue}14055[14055] {pull}19300[19300]
+- Add auditd rule reload for Auditd module. {pull}10835[10835]
 
 *Filebeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -607,11 +607,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add file integrity module ECS categorization fields. {pull}18012[18012]
 - Add `file.mime_type`, `file.extension`, and `file.drive_letter` for file integrity module. {pull}18012[18012]
 - Add ECS categorization info for auditd module {pull}18596[18596]
-- Add several improvements for auditd module for improved ECS field mapping {pull}22647[22647]
-- Add ECS 1.7 `configuration` categorization in certain events in auditd module. {pull}23000[23000]
-- Improve file_integrity monitoring when a file is created/deleted in quick succession. {issue}17347[17347] {pull}22170[22170]
-- system/host: Add new ECS 1.8 field `os.type` in `host.os.type`. {pull}23513[23513]
-- Update Auditbeat auditd module to ECS 1.8 {pull}23594[23594] {issue}23118[23118]
 - Add auditd rule reload for Auditd module. {pull}10835[10835]
 
 *Filebeat*

--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -38,6 +38,9 @@ auditbeat.modules:
   rate_limit: 0
   include_raw_message: false
   include_warnings: false
+  reload:
+    enabled: true
+    period: 30s
 
   # Set to true to publish fields with null values in events.
   #keep_null: false

--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -39,7 +39,7 @@ auditbeat.modules:
   include_raw_message: false
   include_warnings: false
   reload:
-    enabled: true
+    enabled: false
     period: 30s
 
   # Set to true to publish fields with null values in events.

--- a/auditbeat/docs/modules/auditd.asciidoc
+++ b/auditbeat/docs/modules/auditd.asciidoc
@@ -210,11 +210,6 @@ that of the `audit_rules` field.
 prevent backpressure from propagating to the kernel and impacting audited
 processes.
 
-*`reload`*:: `enabled` auditbeat check auditd rule files in fixed interval 
-`period`, reload auditd rule on host if any changes to the rule file detected.
-Its similar to the config reload, but instead of .yml files it is for .rules
-files.
-
 +
 --
 The possible values are:
@@ -233,6 +228,11 @@ option accordingly.
 time.
 - `none`: No backpressure mitigation measures are enabled.
 --
+
+*`reload`*:: `enabled` auditbeat check auditd rule files in fixed interval 
+`period`, reload auditd rule on host if any changes to the rule file detected.
+Its similar to the config reload, but instead of .yml files it is for .rules
+files.
 
 include::{docdir}/auditbeat-options.asciidoc[]
 

--- a/auditbeat/docs/modules/auditd.asciidoc
+++ b/auditbeat/docs/modules/auditd.asciidoc
@@ -135,6 +135,9 @@ following example shows all configuration options with their default values.
   include_raw_message: false
   include_warnings: false
   backpressure_strategy: auto
+  reload:
+    period: 30s
+    enabled: true
 ----
 
 This module also supports the
@@ -206,6 +209,12 @@ that of the `audit_rules` field.
 *`backpressure_strategy`*:: Specifies the strategy that {beatname_uc} uses to
 prevent backpressure from propagating to the kernel and impacting audited
 processes.
+
+*`reload`*:: `enabled` auditbeat check auditd rule files in fixed interval 
+`period`, reload auditd rule on host if any changes to the rule file detected.
+Its similar to the config reload, but instead of .yml files it is for .rules
+files.
+
 +
 --
 The possible values are:

--- a/auditbeat/docs/modules/auditd.asciidoc
+++ b/auditbeat/docs/modules/auditd.asciidoc
@@ -137,7 +137,7 @@ following example shows all configuration options with their default values.
   backpressure_strategy: auto
   reload:
     period: 30s
-    enabled: true
+    enabled: false
 ----
 
 This module also supports the

--- a/auditbeat/docs/modules/auditd.asciidoc
+++ b/auditbeat/docs/modules/auditd.asciidoc
@@ -229,10 +229,10 @@ time.
 - `none`: No backpressure mitigation measures are enabled.
 --
 
-*`reload`*:: `enabled` auditbeat check auditd rule files in fixed interval 
-`period`, reload auditd rule on host if any changes to the rule file detected.
-Its similar to the config reload, but instead of .yml files it is for .rules
-files.
+*`reload`*:: `enabled` Causes auditbeat to reload auditd rule files at a fixed 
+interval if any changes to the rule files are detected.
+`period`, Specifies the interval after which auditbeat will check and reload 
+rule files.
 
 include::{docdir}/auditbeat-options.asciidoc[]
 

--- a/auditbeat/module/auditd/_meta/config.yml.tmpl
+++ b/auditbeat/module/auditd/_meta/config.yml.tmpl
@@ -11,6 +11,9 @@
   rate_limit: 0
   include_raw_message: false
   include_warnings: false
+  reload:
+    enabled: false
+    period: 30s
 
   # Set to true to publish fields with null values in events.
   #keep_null: false

--- a/auditbeat/module/auditd/_meta/docs.asciidoc
+++ b/auditbeat/module/auditd/_meta/docs.asciidoc
@@ -128,6 +128,9 @@ following example shows all configuration options with their default values.
   include_raw_message: false
   include_warnings: false
   backpressure_strategy: auto
+  reload:
+    period: 30s
+    enabled: false
 ----
 
 This module also supports the
@@ -217,6 +220,11 @@ option accordingly.
 time.
 - `none`: No backpressure mitigation measures are enabled.
 --
+
+*`reload`*:: `enabled` Causes auditbeat to reload auditd rule files at a fixed 
+interval if any changes to the rule files are detected.
+`period`, Specifies the interval after which auditbeat will check and reload 
+rule files.
 
 include::{docdir}/auditbeat-options.asciidoc[]
 

--- a/auditbeat/module/auditd/audit_linux.go
+++ b/auditbeat/module/auditd/audit_linux.go
@@ -216,7 +216,7 @@ func (ms *MetricSet) Run(reporter mb.PushReporterV2) {
 				case <-reporter.Done():
 					return
 				case msgs := <-out:
-					reporter.Event(buildMetricbeatEvent(msgs, ms.config))
+					reporter.Event(buildMetricbeatEvent(msgs, &ms.config))
 				}
 			}
 		}()
@@ -557,7 +557,7 @@ func filterRecordType(typ auparse.AuditMessageType) bool {
 	return false
 }
 
-func buildMetricbeatEvent(msgs []*auparse.AuditMessage, config Config) mb.Event {
+func buildMetricbeatEvent(msgs []*auparse.AuditMessage, config *Config) mb.Event {
 	auditEvent, err := aucoalesce.CoalesceMessages(msgs)
 	if err != nil {
 		// Add messages on error so that it's possible to debug the problem.

--- a/auditbeat/module/auditd/audit_linux.go
+++ b/auditbeat/module/auditd/audit_linux.go
@@ -235,7 +235,7 @@ type reloader struct {
 	wg     sync.WaitGroup
 }
 
-func newRuleReloader(pathes []string, reload Reload) *reloader {
+func newRuleReloader(pathes []string, reload reload) *reloader {
 
 	newPathes := []string{}
 

--- a/auditbeat/module/auditd/audit_linux.go
+++ b/auditbeat/module/auditd/audit_linux.go
@@ -20,6 +20,7 @@ package auditd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
@@ -29,9 +30,11 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/libbeat/monitoring"
+	"github.com/elastic/beats/v7/libbeat/paths"
 	"github.com/elastic/beats/v7/metricbeat/mb"
 	"github.com/elastic/beats/v7/metricbeat/mb/parse"
 	"github.com/elastic/go-libaudit/v2"

--- a/auditbeat/module/auditd/audit_linux.go
+++ b/auditbeat/module/auditd/audit_linux.go
@@ -228,14 +228,14 @@ func (ms *MetricSet) Run(reporter mb.PushReporterV2) {
 	wg.Wait()
 }
 
-type Reloader struct {
+type reloader struct {
 	reload Reload
 	pathes []string
 	done   chan struct{}
 	wg     sync.WaitGroup
 }
 
-func NewRuleReloader(pathes []string, reload Reload) *Reloader {
+func NewRuleReloader(pathes []string, reload Reload) *reloader {
 
 	newPathes := []string{}
 
@@ -246,7 +246,7 @@ func NewRuleReloader(pathes []string, reload Reload) *Reloader {
 		newPathes = append(newPathes, path)
 	}
 
-	return &Reloader{
+	return &reloader{
 		reload: reload,
 		pathes: newPathes,
 		done:   make(chan struct{}),
@@ -254,7 +254,7 @@ func NewRuleReloader(pathes []string, reload Reload) *Reloader {
 }
 
 // Run runs the reloader
-func (rl *Reloader) Run(ms *MetricSet, reporter mb.PushReporterV2) {
+func (rl *reloader) Run(ms *MetricSet, reporter mb.PushReporterV2) {
 	ms.log.Info("Auditd Rule reloader started")
 
 	rl.wg.Add(1)

--- a/auditbeat/module/auditd/audit_linux.go
+++ b/auditbeat/module/auditd/audit_linux.go
@@ -220,7 +220,7 @@ func (ms *MetricSet) Run(reporter mb.PushReporterV2) {
 	}
 
 	if ms.config.Reload.Enabled {
-		ruleReloader := NewRuleReloader(ms.config.RuleFiles, ms.config.Reload)
+		ruleReloader := newRuleReloader(ms.config.RuleFiles, ms.config.Reload)
 
 		go ruleReloader.Run(ms, reporter)
 	}
@@ -229,13 +229,13 @@ func (ms *MetricSet) Run(reporter mb.PushReporterV2) {
 }
 
 type reloader struct {
-	reload Reload
+	reload reload
 	pathes []string
 	done   chan struct{}
 	wg     sync.WaitGroup
 }
 
-func NewRuleReloader(pathes []string, reload Reload) *reloader {
+func newRuleReloader(pathes []string, reload Reload) *reloader {
 
 	newPathes := []string{}
 

--- a/auditbeat/module/auditd/audit_linux_test.go
+++ b/auditbeat/module/auditd/audit_linux_test.go
@@ -374,7 +374,7 @@ func buildSampleEvent(t testing.TB, lines []string, filename string) {
 		msgs = append(msgs, m)
 	}
 
-	e := buildMetricbeatEvent(msgs, defaultConfig)
+	e := buildMetricbeatEvent(msgs, &defaultConfig)
 	beatEvent := e.BeatEvent(moduleName, metricsetName, core.AddDatasetToEvent)
 	output, err := json.MarshalIndent(&beatEvent.Fields, "", "    ")
 	if err != nil {

--- a/auditbeat/module/auditd/audit_linux_test.go
+++ b/auditbeat/module/auditd/audit_linux_test.go
@@ -324,8 +324,8 @@ func TestRuleReload(t *testing.T) {
 	logp.Info("end beat")
 	assertNoErrors(t, events)
 	assertHasBinCatExecve(t, events)
-
 }
+
 func TestKernelVersion(t *testing.T) {
 	major, minor, full, err := kernelVersion()
 	if err != nil {

--- a/auditbeat/module/auditd/audit_linux_test.go
+++ b/auditbeat/module/auditd/audit_linux_test.go
@@ -285,6 +285,10 @@ func TestRuleReload(t *testing.T) {
 	c := map[string]interface{}{
 		"module":      "auditd",
 		"socket_type": "unicast",
+		"reload": map[string]interface{}{
+			"period":  time.Second * 5,
+			"enabled": true,
+		},
 		"audit_rule_files": []string{
 			"/tmp/test.rules",
 		},
@@ -307,6 +311,9 @@ func TestRuleReload(t *testing.T) {
 			"/tmp/test.rules",
 		).Output()
 	})
+
+	// wait for rule reload
+	time.AfterFunc(time.Second, func() { exec.Command("sleep", "10").Output() })
 
 	time.AfterFunc(time.Second, func() { exec.Command("cat", "/proc/self/status").Output() })
 	events = mbtest.RunPushMetricSetV2(5*time.Second, 0, ms)

--- a/auditbeat/module/auditd/config_linux.go
+++ b/auditbeat/module/auditd/config_linux.go
@@ -54,7 +54,7 @@ type Config struct {
 	SocketType   string   `config:"socket_type"`         // Socket type to use with the kernel (unicast or multicast).
 
 	// reload auditd rule files
-	reload reload `config:"reload"`
+	Reload reload `config:"reload"`
 
 	// Tuning options (advanced, use with care)
 	ReassemblerMaxInFlight uint32        `config:"reassembler.max_in_flight"`
@@ -98,7 +98,7 @@ var defaultConfig = Config{
 	ReassemblerTimeout:     2 * time.Second,
 	StreamBufferQueueSize:  8192,
 	StreamBufferConsumers:  0,
-	reload:                 reload{Enabled: false, Period: 30 * time.Second},
+	Reload:                 reload{Enabled: false, Period: 30 * time.Second},
 }
 
 // Validate validates the rules specified in the config.

--- a/auditbeat/module/auditd/config_linux.go
+++ b/auditbeat/module/auditd/config_linux.go
@@ -31,14 +31,8 @@ import (
 	"github.com/joeshaw/multierror"
 	"github.com/pkg/errors"
 
-	"github.com/elastic/go-libaudit/rule"
-	"github.com/elastic/go-libaudit/rule/flags"
-)
-
-const (
-	moduleName         = "auditd"
-	metricsetName      = "auditd"
-	recursiveGlobDepth = 8
+	"github.com/elastic/go-libaudit/v2/rule"
+	"github.com/elastic/go-libaudit/v2/rule/flags"
 )
 
 // Config defines the kernel metricset's possible configuration options.
@@ -52,9 +46,7 @@ type Config struct {
 	RulesBlob    string   `config:"audit_rules"`         // Audit rules. One rule per line.
 	RuleFiles    []string `config:"audit_rule_files"`    // List of rule files.
 	SocketType   string   `config:"socket_type"`         // Socket type to use with the kernel (unicast or multicast).
-
-	// reload auditd rule files
-	Reload Reload `config:"reload"`
+	Reload       Reload   `config:"reload"`              // reload auditd rule files
 
 	// Tuning options (advanced, use with care)
 	ReassemblerMaxInFlight uint32        `config:"reassembler.max_in_flight"`

--- a/auditbeat/module/auditd/config_linux.go
+++ b/auditbeat/module/auditd/config_linux.go
@@ -92,7 +92,7 @@ var defaultConfig = Config{
 	StreamBufferConsumers:  0,
 	Reload: Reload{
 		Period:  10 * time.Second,
-		Enabled: true,
+		Enabled: false,
 	},
 }
 

--- a/auditbeat/module/auditd/config_linux.go
+++ b/auditbeat/module/auditd/config_linux.go
@@ -98,11 +98,16 @@ var defaultConfig = Config{
 	ReassemblerTimeout:     2 * time.Second,
 	StreamBufferQueueSize:  8192,
 	StreamBufferConsumers:  0,
+	Reload: Reload{
+		Period:  10 * time.Second,
+		Enabled: true,
+	},
 }
 
-// IsEnabled returns true if the enable field is set to true in the config.
+// IsEnabled returns true if the enable field is set to true and the period is
+// not zero in the config.
 func (r *Reload) IsEnabled() bool {
-	return r != nil && (r.Enabled == true || r.Period != 0)
+	return r.Enabled == true && r.Period != 0
 }
 
 // Validate validates the rules specified in the config.


### PR DESCRIPTION
Fulfilled an open issue https://github.com/elastic/beats/issues/8556
Reload `/etc/auditbeat/audit.rules.d/*` files same way as `/etc/auditbeat/modules.d/*yml`

@vjsamuel @andrewkroh Would you help review and merge the PR?