### PR TITLE
Fix autodiscover for docker in filebeat

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -126,6 +126,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix a issue when remote and local configuration didn't match when fetching configuration from Central Management. {issue}10587[10587]
 - Fix unauthorized error when loading dashboards by adding username and password into kibana config. {issue}10513[10513] {pull}10675[10675]
 - Ensure all beat commands respect configured settings. {pull}10721[10721]
+- Migrate docker autodiscover to ECS. {pull}10836[10836] {issue}10757[10757]
 
 *Auditbeat*
 

--- a/filebeat/tests/system/test_autodiscover.py
+++ b/filebeat/tests/system/test_autodiscover.py
@@ -50,6 +50,6 @@ class TestAutodiscover(filebeat.BaseTest):
 
         # Check metadata is added
         assert output[0]['message'] == 'Busybox output 1'
-        assert output[0]['docker']['container']['image'] == 'busybox'
-        assert output[0]['docker']['container']['labels'] == {}
-        assert 'name' in output[0]['docker']['container']
+        assert output[0]['container']['image']['name'] == 'busybox'
+        assert output[0]['container']['labels'] == {}
+        assert 'name' in output[0]['container']

--- a/heartbeat/tests/system/test_autodiscovery.py
+++ b/heartbeat/tests/system/test_autodiscovery.py
@@ -60,7 +60,7 @@ class TestAutodiscover(BaseTest):
                     # We don't check all the docker fields because this is really the responsibility
                     # of libbeat's autodiscovery code.
                     event = output[0]
-                    if event['monitor']['id'] == 'myid' and event['docker']['container']['id'] is not None:
+                    if event['monitor']['id'] == 'myid' and event['container']['id'] is not None:
                         matched = True
 
         assert matched

--- a/libbeat/autodiscover/providers/docker/docker.go
+++ b/libbeat/autodiscover/providers/docker/docker.go
@@ -162,7 +162,6 @@ func (d *Provider) emitContainer(event bus.Event, flag string) {
 			"docker":    metaOld,
 			"container": metaNew,
 			"meta": common.MapStr{
-				"docker":    metaOld,
 				"container": metaNew,
 			},
 		}
@@ -181,7 +180,6 @@ func (d *Provider) emitContainer(event bus.Event, flag string) {
 			"docker":    metaOld,
 			"container": metaNew,
 			"meta": common.MapStr{
-				"docker":    metaOld,
 				"container": metaNew,
 			},
 		}
@@ -215,10 +213,8 @@ func (d *Provider) generateHints(event bus.Event) bus.Event {
 
 	if rawDocker, err := common.MapStr(event).GetValue("docker.container"); err == nil {
 		dockerMeta = rawDocker.(common.MapStr)
-	} else if rawDocker, err := common.MapStr(event).GetValue("container"); err == nil {
-		dockerMeta = rawDocker.(common.MapStr)
+		e["container"] = dockerMeta
 	}
-	e["container"] = dockerMeta
 
 	if host, ok := event["host"]; ok {
 		e["host"] = host

--- a/libbeat/autodiscover/providers/docker/docker_integration_test.go
+++ b/libbeat/autodiscover/providers/docker/docker_integration_test.go
@@ -92,17 +92,21 @@ func checkEvent(t *testing.T, listener bus.Listener, start bool) {
 				assert.Equal(t, getValue(e, "stop"), true)
 				assert.Nil(t, getValue(e, "start"))
 			}
-			assert.Equal(t, getValue(e, "docker.container.image"), "busybox")
-			assert.Equal(t, getValue(e, "docker.container.labels"), common.MapStr{
+			assert.Equal(t, getValue(e, "container.image.name"), "busybox")
+			assert.Equal(t, getValue(e, "container.labels"), common.MapStr{
 				"label": common.MapStr{
 					"value": "foo",
 					"child": "bar",
 				},
 			})
-			assert.NotNil(t, getValue(e, "docker.container.id"))
-			assert.NotNil(t, getValue(e, "docker.container.name"))
+			assert.NotNil(t, getValue(e, "container.id"))
+			assert.NotNil(t, getValue(e, "container.name"))
 			assert.NotNil(t, getValue(e, "host"))
-			assert.Equal(t, getValue(e, "docker"), getValue(e, "meta.docker"))
+			assert.Equal(t, getValue(e, "container"), getValue(e, "meta.container"))
+			assert.Equal(t, getValue(e, "docker.container.id"), getValue(e, "meta.container.id"))
+			assert.Equal(t, getValue(e, "docker.container.name"), getValue(e, "meta.container.name"))
+			assert.Equal(t, getValue(e, "docker.container.labels"), getValue(e, "meta.container.labels"))
+			assert.Equal(t, getValue(e, "docker.container.image"), getValue(e, "meta.container.image.name"))
 			return
 
 		case <-time.After(10 * time.Second):

--- a/libbeat/processors/add_docker_metadata/add_docker_metadata.go
+++ b/libbeat/processors/add_docker_metadata/add_docker_metadata.go
@@ -123,11 +123,6 @@ func (d *addDockerMetadata) Run(event *beat.Event) (*beat.Event, error) {
 	var cid string
 	var err error
 
-	// Extract CID
-	if v, err := event.GetValue(dockerContainerIDKey); err == nil {
-		cid, _ = v.(string)
-	}
-
 	// Extract CID from the filepath contained in the "source" field.
 	if d.sourceProcessor != nil {
 		if event.Fields["source"] != nil {

--- a/libbeat/processors/add_docker_metadata/add_docker_metadata.go
+++ b/libbeat/processors/add_docker_metadata/add_docker_metadata.go
@@ -128,12 +128,17 @@ func (d *addDockerMetadata) Run(event *beat.Event) (*beat.Event, error) {
 		cid, _ = v.(string)
 	}
 
+	// Extract CID from the filepath contained in the "source" field.
 	if d.sourceProcessor != nil {
 		if event.Fields["source"] != nil {
 			event, err = d.sourceProcessor.Run(event)
 			if err != nil {
 				d.log.Debugf("Error while extracting container ID from source path: %v", err)
 				return event, nil
+			}
+
+			if v, err := event.GetValue(dockerContainerIDKey); err == nil {
+				cid, _ = v.(string)
 			}
 		}
 	}

--- a/libbeat/processors/add_docker_metadata/add_docker_metadata.go
+++ b/libbeat/processors/add_docker_metadata/add_docker_metadata.go
@@ -123,17 +123,17 @@ func (d *addDockerMetadata) Run(event *beat.Event) (*beat.Event, error) {
 	var cid string
 	var err error
 
-	// Extract CID from the filepath contained in the "source" field.
+	// Extract CID
+	if v, err := event.GetValue(dockerContainerIDKey); err == nil {
+		cid, _ = v.(string)
+	}
+
 	if d.sourceProcessor != nil {
 		if event.Fields["source"] != nil {
 			event, err = d.sourceProcessor.Run(event)
 			if err != nil {
 				d.log.Debugf("Error while extracting container ID from source path: %v", err)
 				return event, nil
-			}
-
-			if v, err := event.GetValue(dockerContainerIDKey); err == nil {
-				cid, _ = v.(string)
 			}
 		}
 	}

--- a/metricbeat/tests/system/test_autodiscover.py
+++ b/metricbeat/tests/system/test_autodiscover.py
@@ -51,9 +51,9 @@ class TestAutodiscover(metricbeat.BaseTest):
         proc.check_kill_and_wait()
 
         # Check metadata is added
-        assert output[0]['docker']['container']['image'] == 'memcached:latest'
-        assert output[0]['docker']['container']['labels'] == {}
-        assert 'name' in output[0]['docker']['container']
+        assert output[0]['container']['image']['name'] == 'memcached:latest'
+        assert output[0]['container']['labels'] == {}
+        assert 'name' in output[0]['container']
 
     @unittest.skipIf(not INTEGRATION_TESTS or
                      os.getenv("TESTING_ENVIRONMENT") == "2x",
@@ -93,8 +93,8 @@ class TestAutodiscover(metricbeat.BaseTest):
         proc.check_kill_and_wait()
 
         # Check metadata is added
-        assert output[0]['docker']['container']['image'] == 'memcached:latest'
-        assert 'name' in output[0]['docker']['container']
+        assert output[0]['container']['image']['name'] == 'memcached:latest'
+        assert 'name' in output[0]['container']
 
     @unittest.skipIf(not INTEGRATION_TESTS or
                      os.getenv("TESTING_ENVIRONMENT") == "2x",


### PR DESCRIPTION
Results from autodiscover for docker with filebea have `docker.container.id` fields instead of the ECS fields `container.id`. This PR is to figure out why this is happening. 

With this change, now in ES, filebeat output looks like:
<img width="1308" alt="screen shot 2019-02-20 at 8 25 25 am" src="https://user-images.githubusercontent.com/14081635/53102557-28520900-34e9-11e9-9d38-4a96979aa0c8.png">
