### PR TITLE
Use IndexPrefix for kafka and logstash output.

### DIFF
--- a/libbeat/outputs/kafka/kafka.go
+++ b/libbeat/outputs/kafka/kafka.go
@@ -106,7 +106,7 @@ func makeKafka(
 		return outputs.Fail(err)
 	}
 
-	client, err := newKafkaClient(observer, hosts, beat.Beat, config.Key, topic, codec, libCfg)
+	client, err := newKafkaClient(observer, hosts, beat.IndexPrefix, config.Key, topic, codec, libCfg)
 	if err != nil {
 		return outputs.Fail(err)
 	}

--- a/libbeat/outputs/logstash/logstash.go
+++ b/libbeat/outputs/logstash/logstash.go
@@ -44,7 +44,7 @@ func makeLogstash(
 	cfg *common.Config,
 ) (outputs.Group, error) {
 	if !cfg.HasField("index") {
-		cfg.SetString("index", -1, beat.Beat)
+		cfg.SetString("index", -1, beat.IndexPrefix)
 	}
 
 	config := newConfig()


### PR DESCRIPTION
Writing to ES output libbeat falls back to use `beat.Info.IndexPrefix` as default index, if nothing else is configured. Using logstash or kafka, libbeat uses `beat.Info.Beat` as default index.
In case `IndexPrefix` and `Beat` is not the same, the resulting index in ES differs.

This PR intends to fix this inconsistency. 

fixes #10839