### PR TITLE
Add more info to message logged when a duplicated symlink file is found

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -239,6 +239,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Added support for ingesting structured Elasticsearch server logs {pull}10428[10428]
 - Populate more ECS fields in the Suricata module. {pull}10006[10006]
 - Add ISO8601 timestamp support in syslog metricset. {issue}8716[8716] {pull}10736[10736]
+- Add more info to message logged when a duplicated symlink file is found {pull}10845[10845]
 
 *Heartbeat*
 

--- a/filebeat/input/log/input.go
+++ b/filebeat/input/log/input.go
@@ -286,7 +286,7 @@ func (p *Input) getFiles() map[string]os.FileInfo {
 			if p.config.Symlinks {
 				for _, finfo := range paths {
 					if os.SameFile(finfo, fileInfo) {
-						logp.Info("Same file found as symlink and originap. Skipping file: %s", file)
+						logp.Info("Same file found as symlink and original. Skipping file: %s", file)
 						continue OUTER
 					}
 				}

--- a/filebeat/input/log/input.go
+++ b/filebeat/input/log/input.go
@@ -286,7 +286,7 @@ func (p *Input) getFiles() map[string]os.FileInfo {
 			if p.config.Symlinks {
 				for _, finfo := range paths {
 					if os.SameFile(finfo, fileInfo) {
-						logp.Info("Same file found as symlink and original. Skipping file: %s", file)
+						logp.Info("Same file found as symlink and original. Skipping file: %s (as it same as %s)", file, finfo.Name())
 						continue OUTER
 					}
 				}


### PR DESCRIPTION
There was a typo in the message that was logged when `symlinks` are enabled and the same files are found. I also added more context to the message, so it is more informative.
The new message is the following:
```
Same file found as symlink and original. Skipping file: test.log (as it is same as: test-2016.log)
```