### PR TITLE
[Metricbeat] Migrate Kubernetes state_container Metricset to use ReporterV2 interface

### DIFF
--- a/metricbeat/module/kubernetes/state_container/_meta/test/kube-state-metrics.expected
+++ b/metricbeat/module/kubernetes/state_container/_meta/test/kube-state-metrics.expected
@@ -1,208 +1,7 @@
 [
 	{
-		"_module": {
-			"namespace": "kube-system",
-			"node": {
-				"name": "minikube"
-			},
-			"pod": {
-				"name": "kubernetes-dashboard-vw0l6"
-			}
-		},
-		"_namespace": "container",
-		"id": "docker://3aaee8bdd311c015240e99fa2a5a5f2f26b11b51236a683b39d8c1902e423978",
-		"image": "gcr.io/google_containers/kubernetes-dashboard-amd64:v1.5.1",
-		"name": "kubernetes-dashboard",
-		"status": {
-			"phase": "running",
-			"ready": true,
-			"restarts": 2
-		}
-	},
-	{
-		"_module": {
-			"namespace": "jenkins",
-			"node": {
-				"name": "minikube"
-			},
-			"pod": {
-				"name": "wise-lynx-jenkins-1616735317-svn6k"
-			}
-		},
-		"_namespace": "container",
-		"cpu": {
-			"request": {
-				"cores": 0.2
-			}
-		},
-		"id": "docker://e2ee1c2c7b8d4e5fd8c834b83cba8377d6b0e39da18157688ccc1a06b7c53117",
-		"image": "jenkinsci/jenkins:2.46.1",
-		"memory": {
-			"request": {
-				"bytes": 268435456
-			}
-		},
-		"name": "wise-lynx-jenkins",
-		"status": {
-			"phase": "running",
-			"ready": true,
-			"restarts": 1
-		}
-	},
-	{
-		"_module": {
-			"namespace": "default",
-			"node": {
-				"name": "minikube"
-			},
-			"pod": {
-				"name": "jumpy-owl-redis-3481028193-s78x9"
-			}
-		},
-		"_namespace": "container",
-		"cpu": {
-			"request": {
-				"cores": 0.1
-			}
-		},
-		"id": "docker://4fa227874ee68536bf902394fb662f07b99099798ca9cd5c1506b79075acc065",
-		"image": "bitnami/redis:3.2.8-r2",
-		"memory": {
-			"request": {
-				"bytes": 268435456
-			}
-		},
-		"name": "jumpy-owl-redis",
-		"status": {
-			"phase": "waiting",
-			"ready": false,
-			"restarts": 270
-		}
-	},
-	{
-		"_module": {
-			"namespace": "kube-system",
-			"node": {
-				"name": "minikube"
-			},
-			"pod": {
-				"name": "kube-state-metrics-1303537707-7ncd1"
-			}
-		},
-		"_namespace": "container",
-		"cpu": {
-			"limit": {
-				"cores": 0.2
-			},
-			"request": {
-				"cores": 0.1
-			}
-		},
-		"id": "docker://973cbe45982c5126a5caf8c58d964c0ab1d5bb2c165ccc59715fcc1ebd58ab3d",
-		"image": "gcr.io/google_containers/kube-state-metrics:v0.4.1",
-		"memory": {
-			"limit": {
-				"bytes": 52428800
-			},
-			"request": {
-				"bytes": 31457280
-			}
-		},
-		"name": "kube-state-metrics",
-		"status": {
-			"phase": "running",
-			"ready": true,
-			"restarts": 1
-		}
-	},
-	{
-		"_module": {
-			"namespace": "kube-system",
-			"node": {
-				"name": "minikube"
-			},
-			"pod": {
-				"name": "kube-dns-v20-5g5cb"
-			}
-		},
-		"_namespace": "container",
-		"cpu": {
-			"request": {
-				"cores": 0.1
-			}
-		},
-		"id": "docker://fa3d83f648de42492b38fa3e8501d109376f391c50f2bd210c895c8477ae4b62",
-		"image": "gcr.io/google_containers/kubedns-amd64:1.9",
-		"memory": {
-			"limit": {
-				"bytes": 178257920
-			},
-			"request": {
-				"bytes": 73400320
-			}
-		},
-		"name": "kubedns",
-		"status": {
-			"phase": "running",
-			"ready": true,
-			"restarts": 2
-		}
-	},
-	{
-		"_module": {
-			"namespace": "kube-system",
-			"node": {
-				"name": "minikube"
-			},
-			"pod": {
-				"name": "kube-dns-v20-5g5cb"
-			}
-		},
-		"_namespace": "container",
-		"id": "docker://9a4c9462cd078d7be4f0a9b94bcfeb69d5fdd76bff67142df3f58367ac7e8d61",
-		"image": "gcr.io/google_containers/kube-dnsmasq-amd64:1.4",
-		"name": "dnsmasq",
-		"status": {
-			"phase": "running",
-			"ready": true,
-			"restarts": 2
-		}
-	},
-	{
-		"_module": {
-			"namespace": "kube-system",
-			"node": {
-				"name": "minikube"
-			},
-			"pod": {
-				"name": "kube-dns-v20-5g5cb"
-			}
-		},
-		"_namespace": "container",
-		"cpu": {
-			"request": {
-				"cores": 0.01
-			}
-		},
-		"id": "docker://52fa55e051dc5b68e44c027588685b7edd85aaa03b07f7216d399249ff4fc821",
-		"image": "gcr.io/google_containers/exechealthz-amd64:1.2",
-		"memory": {
-			"limit": {
-				"bytes": 52428800
-			},
-			"request": {
-				"bytes": 52428800
-			}
-		},
-		"name": "healthz",
-		"status": {
-			"phase": "running",
-			"ready": true,
-			"restarts": 2
-		}
-	},
-	{
-		"_module": {
+		"RootFields": null,
+		"ModuleFields": {
 			"namespace": "kube-system",
 			"node": {
 				"name": "minikube"
@@ -211,74 +10,28 @@
 				"name": "tiller-deploy-3067024529-9lpmb"
 			}
 		},
-		"_namespace": "container",
-		"id": "docker://469f5d2b7854eb52e5d13dc0cd3e664c1b682b157aabaf596ffe4984f1516902",
-		"image": "gcr.io/kubernetes-helm/tiller:v2.3.1",
-		"name": "tiller",
-		"status": {
-			"phase": "running",
-			"ready": true,
-			"restarts": 1
-		}
+		"MetricSetFields": {
+			"id": "docker://469f5d2b7854eb52e5d13dc0cd3e664c1b682b157aabaf596ffe4984f1516902",
+			"image": "gcr.io/kubernetes-helm/tiller:v2.3.1",
+			"name": "tiller",
+			"status": {
+				"phase": "running",
+				"ready": true,
+				"restarts": 1
+			}
+		},
+		"Index": "",
+		"ID": "",
+		"Namespace": "kubernetes.container",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Service": "",
+		"Took": 0
 	},
 	{
-		"_module": {
-			"namespace": "kube-system",
-			"node": {
-				"name": "minikube"
-			},
-			"pod": {
-				"name": "kube-addon-manager-minikube"
-			}
-		},
-		"_namespace": "container",
-		"cpu": {
-			"request": {
-				"cores": 0.005
-			}
-		},
-		"id": "docker://91fdd43f6b1b4c3dd133cfca53e0b1210bc557c2ae56006026b5ccdb5f52826f",
-		"image": "gcr.io/google-containers/kube-addon-manager:v6.3",
-		"memory": {
-			"request": {
-				"bytes": 52428800
-			}
-		},
-		"name": "kube-addon-manager",
-		"status": {
-			"phase": "running",
-			"ready": true,
-			"restarts": 2
-		}
-	},
-	{
-		"_module": {
-			"namespace": "kube-system",
-			"pod": {
-				"name": "kube-state-metrics-1303537707-mnzbp"
-			}
-		},
-		"_namespace": "container",
-		"cpu": {
-			"limit": {
-				"cores": 0.2
-			},
-			"request": {
-				"cores": 0.1
-			}
-		},
-		"memory": {
-			"limit": {
-				"bytes": 52428800
-			},
-			"request": {
-				"bytes": 31457280
-			}
-		},
-		"name": "kube-state-metrics"
-	},
-	{
-		"_module": {
+		"RootFields": null,
+		"ModuleFields": {
 			"namespace": "test",
 			"node": {
 				"name": "minikube-test"
@@ -287,27 +40,384 @@
 				"name": "kube-dns-v20-5g5cb-test"
 			}
 		},
-		"_namespace": "container",
-		"cpu": {
-			"request": {
-				"cores": 0.2
-			}
-		},
-		"id": "docker://fa3d83f648de42492b38fa3e8501d109376f391c50f2bd210c895c8477ae4b62-test",
-		"image": "gcr.io/google_containers/kubedns-amd64:1.9-test",
-		"memory": {
-			"limit": {
-				"bytes": 278257920
+		"MetricSetFields": {
+			"cpu": {
+				"request": {
+					"cores": 0.2
+				}
 			},
-			"request": {
-				"bytes": 83400320
+			"id": "docker://fa3d83f648de42492b38fa3e8501d109376f391c50f2bd210c895c8477ae4b62-test",
+			"image": "gcr.io/google_containers/kubedns-amd64:1.9-test",
+			"memory": {
+				"limit": {
+					"bytes": 278257920
+				},
+				"request": {
+					"bytes": 83400320
+				}
+			},
+			"name": "kubedns",
+			"status": {
+				"phase": "terminated",
+				"ready": false,
+				"restarts": 3
 			}
 		},
-		"name": "kubedns",
-		"status": {
-			"phase": "terminated",
-			"ready": false,
-			"restarts": 3
-		}
+		"Index": "",
+		"ID": "",
+		"Namespace": "kubernetes.container",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Service": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": {
+			"namespace": "kube-system",
+			"node": {
+				"name": "minikube"
+			},
+			"pod": {
+				"name": "kube-dns-v20-5g5cb"
+			}
+		},
+		"MetricSetFields": {
+			"id": "docker://9a4c9462cd078d7be4f0a9b94bcfeb69d5fdd76bff67142df3f58367ac7e8d61",
+			"image": "gcr.io/google_containers/kube-dnsmasq-amd64:1.4",
+			"name": "dnsmasq",
+			"status": {
+				"phase": "running",
+				"ready": true,
+				"restarts": 2
+			}
+		},
+		"Index": "",
+		"ID": "",
+		"Namespace": "kubernetes.container",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Service": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": {
+			"namespace": "kube-system",
+			"node": {
+				"name": "minikube"
+			},
+			"pod": {
+				"name": "kube-dns-v20-5g5cb"
+			}
+		},
+		"MetricSetFields": {
+			"cpu": {
+				"request": {
+					"cores": 0.01
+				}
+			},
+			"id": "docker://52fa55e051dc5b68e44c027588685b7edd85aaa03b07f7216d399249ff4fc821",
+			"image": "gcr.io/google_containers/exechealthz-amd64:1.2",
+			"memory": {
+				"limit": {
+					"bytes": 52428800
+				},
+				"request": {
+					"bytes": 52428800
+				}
+			},
+			"name": "healthz",
+			"status": {
+				"phase": "running",
+				"ready": true,
+				"restarts": 2
+			}
+		},
+		"Index": "",
+		"ID": "",
+		"Namespace": "kubernetes.container",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Service": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": {
+			"namespace": "kube-system",
+			"node": {
+				"name": "minikube"
+			},
+			"pod": {
+				"name": "kubernetes-dashboard-vw0l6"
+			}
+		},
+		"MetricSetFields": {
+			"id": "docker://3aaee8bdd311c015240e99fa2a5a5f2f26b11b51236a683b39d8c1902e423978",
+			"image": "gcr.io/google_containers/kubernetes-dashboard-amd64:v1.5.1",
+			"name": "kubernetes-dashboard",
+			"status": {
+				"phase": "running",
+				"ready": true,
+				"restarts": 2
+			}
+		},
+		"Index": "",
+		"ID": "",
+		"Namespace": "kubernetes.container",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Service": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": {
+			"namespace": "kube-system",
+			"node": {
+				"name": "minikube"
+			},
+			"pod": {
+				"name": "kube-state-metrics-1303537707-7ncd1"
+			}
+		},
+		"MetricSetFields": {
+			"cpu": {
+				"limit": {
+					"cores": 0.2
+				},
+				"request": {
+					"cores": 0.1
+				}
+			},
+			"id": "docker://973cbe45982c5126a5caf8c58d964c0ab1d5bb2c165ccc59715fcc1ebd58ab3d",
+			"image": "gcr.io/google_containers/kube-state-metrics:v0.4.1",
+			"memory": {
+				"limit": {
+					"bytes": 52428800
+				},
+				"request": {
+					"bytes": 31457280
+				}
+			},
+			"name": "kube-state-metrics",
+			"status": {
+				"phase": "running",
+				"ready": true,
+				"restarts": 1
+			}
+		},
+		"Index": "",
+		"ID": "",
+		"Namespace": "kubernetes.container",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Service": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": {
+			"namespace": "default",
+			"node": {
+				"name": "minikube"
+			},
+			"pod": {
+				"name": "jumpy-owl-redis-3481028193-s78x9"
+			}
+		},
+		"MetricSetFields": {
+			"cpu": {
+				"request": {
+					"cores": 0.1
+				}
+			},
+			"id": "docker://4fa227874ee68536bf902394fb662f07b99099798ca9cd5c1506b79075acc065",
+			"image": "bitnami/redis:3.2.8-r2",
+			"memory": {
+				"request": {
+					"bytes": 268435456
+				}
+			},
+			"name": "jumpy-owl-redis",
+			"status": {
+				"phase": "waiting",
+				"ready": false,
+				"restarts": 270
+			}
+		},
+		"Index": "",
+		"ID": "",
+		"Namespace": "kubernetes.container",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Service": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": {
+			"namespace": "kube-system",
+			"node": {
+				"name": "minikube"
+			},
+			"pod": {
+				"name": "kube-dns-v20-5g5cb"
+			}
+		},
+		"MetricSetFields": {
+			"cpu": {
+				"request": {
+					"cores": 0.1
+				}
+			},
+			"id": "docker://fa3d83f648de42492b38fa3e8501d109376f391c50f2bd210c895c8477ae4b62",
+			"image": "gcr.io/google_containers/kubedns-amd64:1.9",
+			"memory": {
+				"limit": {
+					"bytes": 178257920
+				},
+				"request": {
+					"bytes": 73400320
+				}
+			},
+			"name": "kubedns",
+			"status": {
+				"phase": "running",
+				"ready": true,
+				"restarts": 2
+			}
+		},
+		"Index": "",
+		"ID": "",
+		"Namespace": "kubernetes.container",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Service": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": {
+			"namespace": "kube-system",
+			"node": {
+				"name": "minikube"
+			},
+			"pod": {
+				"name": "kube-addon-manager-minikube"
+			}
+		},
+		"MetricSetFields": {
+			"cpu": {
+				"request": {
+					"cores": 0.005
+				}
+			},
+			"id": "docker://91fdd43f6b1b4c3dd133cfca53e0b1210bc557c2ae56006026b5ccdb5f52826f",
+			"image": "gcr.io/google-containers/kube-addon-manager:v6.3",
+			"memory": {
+				"request": {
+					"bytes": 52428800
+				}
+			},
+			"name": "kube-addon-manager",
+			"status": {
+				"phase": "running",
+				"ready": true,
+				"restarts": 2
+			}
+		},
+		"Index": "",
+		"ID": "",
+		"Namespace": "kubernetes.container",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Service": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": {
+			"namespace": "kube-system",
+			"pod": {
+				"name": "kube-state-metrics-1303537707-mnzbp"
+			}
+		},
+		"MetricSetFields": {
+			"cpu": {
+				"limit": {
+					"cores": 0.2
+				},
+				"request": {
+					"cores": 0.1
+				}
+			},
+			"memory": {
+				"limit": {
+					"bytes": 52428800
+				},
+				"request": {
+					"bytes": 31457280
+				}
+			},
+			"name": "kube-state-metrics"
+		},
+		"Index": "",
+		"ID": "",
+		"Namespace": "kubernetes.container",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Service": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": {
+			"namespace": "jenkins",
+			"node": {
+				"name": "minikube"
+			},
+			"pod": {
+				"name": "wise-lynx-jenkins-1616735317-svn6k"
+			}
+		},
+		"MetricSetFields": {
+			"cpu": {
+				"request": {
+					"cores": 0.2
+				}
+			},
+			"id": "docker://e2ee1c2c7b8d4e5fd8c834b83cba8377d6b0e39da18157688ccc1a06b7c53117",
+			"image": "jenkinsci/jenkins:2.46.1",
+			"memory": {
+				"request": {
+					"bytes": 268435456
+				}
+			},
+			"name": "wise-lynx-jenkins",
+			"status": {
+				"phase": "running",
+				"ready": true,
+				"restarts": 1
+			}
+		},
+		"Index": "",
+		"ID": "",
+		"Namespace": "kubernetes.container",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Service": "",
+		"Took": 0
 	}
 ]

--- a/metricbeat/module/kubernetes/state_container/_meta/test/kube-state-metrics.v1.3.0.expected
+++ b/metricbeat/module/kubernetes/state_container/_meta/test/kube-state-metrics.v1.3.0.expected
@@ -1,257 +1,7 @@
 [
 	{
-		"_module": {
-			"namespace": "kube-system",
-			"node": {
-				"name": "minikube"
-			},
-			"pod": {
-				"name": "kube-dns-6f4fd4bdf-wlmht"
-			}
-		},
-		"_namespace": "container",
-		"cpu": {
-			"request": {
-				"cores": 0.1
-			}
-		},
-		"id": "docker://1958e71d048065d38ce83dafda567c5fa9d0c1278cd7292d55b9f1d80b0a67f9",
-		"image": "gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.7",
-		"memory": {
-			"limit": {
-				"bytes": 178257920
-			},
-			"request": {
-				"bytes": 73400320
-			}
-		},
-		"name": "kubedns",
-		"status": {
-			"phase": "running",
-			"ready": true,
-			"restarts": 0
-		}
-	},
-	{
-		"_module": {
-			"namespace": "kube-system",
-			"node": {
-				"name": "minikube"
-			},
-			"pod": {
-				"name": "kube-controller-manager-minikube"
-			}
-		},
-		"_namespace": "container",
-		"cpu": {
-			"request": {
-				"cores": 0.2
-			}
-		},
-		"id": "docker://4beb9aab887ca162c9cb3534c4826156636241052cd548153eaa2a170b6d102f",
-		"image": "gcr.io/google_containers/kube-controller-manager-amd64:v1.9.7",
-		"name": "kube-controller-manager",
-		"status": {
-			"phase": "running",
-			"ready": true,
-			"restarts": 0
-		}
-	},
-	{
-		"_module": {
-			"namespace": "kube-system",
-			"node": {
-				"name": "minikube"
-			},
-			"pod": {
-				"name": "kube-state-metrics-6479d88c5c-5b6cl"
-			}
-		},
-		"_namespace": "container",
-		"cpu": {
-			"limit": {
-				"cores": 0.1
-			},
-			"request": {
-				"cores": 0.1
-			}
-		},
-		"id": "docker://948c4ebd8ca4fdf352e7fbf7f5c5d381af7e615ced435dc42fde0c1d25851320",
-		"image": "k8s.gcr.io/addon-resizer:1.7",
-		"memory": {
-			"limit": {
-				"bytes": 31457280
-			},
-			"request": {
-				"bytes": 31457280
-			}
-		},
-		"name": "addon-resizer",
-		"status": {
-			"phase": "running",
-			"ready": true,
-			"restarts": 0
-		}
-	},
-	{
-		"_module": {
-			"namespace": "kube-system",
-			"node": {
-				"name": "minikube"
-			},
-			"pod": {
-				"name": "kube-addon-manager-minikube"
-			}
-		},
-		"_namespace": "container",
-		"cpu": {
-			"request": {
-				"cores": 0.005
-			}
-		},
-		"id": "docker://ab382dbe8f8265f88ee9fec7de142f778da4a5fd9fe0334e3bdb6fe851124c08",
-		"image": "k8s.gcr.io/kube-addon-manager:v8.6",
-		"memory": {
-			"request": {
-				"bytes": 52428800
-			}
-		},
-		"name": "kube-addon-manager",
-		"status": {
-			"phase": "running",
-			"ready": true,
-			"restarts": 0
-		}
-	},
-	{
-		"_module": {
-			"namespace": "kube-system",
-			"node": {
-				"name": "minikube"
-			},
-			"pod": {
-				"name": "kube-dns-6f4fd4bdf-wlmht"
-			}
-		},
-		"_namespace": "container",
-		"cpu": {
-			"request": {
-				"cores": 0.15
-			}
-		},
-		"id": "docker://e9560bbace13ca19de4b3771023198e8568f6b5ed6af3a949f10a5b8137b5be9",
-		"image": "gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.7",
-		"memory": {
-			"request": {
-				"bytes": 20971520
-			}
-		},
-		"name": "dnsmasq",
-		"status": {
-			"phase": "running",
-			"ready": true,
-			"restarts": 0
-		}
-	},
-	{
-		"_module": {
-			"namespace": "kube-system",
-			"node": {
-				"name": "minikube"
-			},
-			"pod": {
-				"name": "etcd-minikube"
-			}
-		},
-		"_namespace": "container",
-		"id": "docker://6e96fd8a687409b2314dcc01f209bb0c813c2fb08b8f75ad1695e120d41e1a2a",
-		"image": "gcr.io/google_containers/etcd-amd64:3.1.11",
-		"name": "etcd",
-		"status": {
-			"phase": "running",
-			"ready": true,
-			"restarts": 0
-		}
-	},
-	{
-		"_module": {
-			"namespace": "kube-system",
-			"node": {
-				"name": "minikube"
-			},
-			"pod": {
-				"name": "storage-provisioner"
-			}
-		},
-		"_namespace": "container",
-		"id": "docker://f4cc07b8e7ee5952738c69a0bff0c7b331c10af66faa541197684127d393b760",
-		"image": "gcr.io/k8s-minikube/storage-provisioner:v1.8.1",
-		"name": "storage-provisioner",
-		"status": {
-			"phase": "running",
-			"ready": true,
-			"reason": "ImagePullBackOff",
-			"restarts": 0
-		}
-	},
-	{
-		"_module": {
-			"namespace": "kube-system",
-			"node": {
-				"name": "minikube"
-			},
-			"pod": {
-				"name": "kubernetes-dashboard-77d8b98585-vqtzm"
-			}
-		},
-		"_namespace": "container",
-		"id": "docker://c46bc2164edcb5972be6fc9174155e61179cb04314c4f6da5d25d3a76acadee6",
-		"image": "k8s.gcr.io/kubernetes-dashboard-amd64:v1.8.1",
-		"name": "kubernetes-dashboard",
-		"status": {
-			"phase": "running",
-			"ready": true,
-			"restarts": 0
-		}
-	},
-	{
-		"_module": {
-			"namespace": "kube-system",
-			"node": {
-				"name": "minikube"
-			},
-			"pod": {
-				"name": "kube-state-metrics-6479d88c5c-5b6cl"
-			}
-		},
-		"_namespace": "container",
-		"cpu": {
-			"limit": {
-				"cores": 0.101
-			},
-			"request": {
-				"cores": 0.101
-			}
-		},
-		"id": "docker://88951e0178ea5131fa3e2d7cafacb3a7e63700795dd6fa0d40ed2e4ac1f52f9c",
-		"image": "quay.io/coreos/kube-state-metrics:v1.3.0",
-		"memory": {
-			"limit": {
-				"bytes": 106954752
-			},
-			"request": {
-				"bytes": 106954752
-			}
-		},
-		"name": "kube-state-metrics",
-		"status": {
-			"phase": "running",
-			"ready": true,
-			"restarts": 0
-		}
-	},
-	{
-		"_module": {
+		"RootFields": null,
+		"ModuleFields": {
 			"namespace": "kube-system",
 			"node": {
 				"name": "minikube"
@@ -260,18 +10,98 @@
 				"name": "kube-proxy-znhg6"
 			}
 		},
-		"_namespace": "container",
-		"id": "docker://76c260259ddfd0267b5acb4e514465215ef1ebfa93a4057d592828772e6b39f5",
-		"image": "gcr.io/google_containers/kube-proxy-amd64:v1.9.7",
-		"name": "kube-proxy",
-		"status": {
-			"phase": "running",
-			"ready": true,
-			"restarts": 0
-		}
+		"MetricSetFields": {
+			"id": "docker://76c260259ddfd0267b5acb4e514465215ef1ebfa93a4057d592828772e6b39f5",
+			"image": "gcr.io/google_containers/kube-proxy-amd64:v1.9.7",
+			"name": "kube-proxy",
+			"status": {
+				"phase": "running",
+				"ready": true,
+				"restarts": 0
+			}
+		},
+		"Index": "",
+		"ID": "",
+		"Namespace": "kubernetes.container",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Service": "",
+		"Took": 0
 	},
 	{
-		"_module": {
+		"RootFields": null,
+		"ModuleFields": {
+			"namespace": "kube-system",
+			"node": {
+				"name": "minikube"
+			},
+			"pod": {
+				"name": "kubernetes-dashboard-77d8b98585-vqtzm"
+			}
+		},
+		"MetricSetFields": {
+			"id": "docker://c46bc2164edcb5972be6fc9174155e61179cb04314c4f6da5d25d3a76acadee6",
+			"image": "k8s.gcr.io/kubernetes-dashboard-amd64:v1.8.1",
+			"name": "kubernetes-dashboard",
+			"status": {
+				"phase": "running",
+				"ready": true,
+				"restarts": 0
+			}
+		},
+		"Index": "",
+		"ID": "",
+		"Namespace": "kubernetes.container",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Service": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": {
+			"namespace": "kube-system",
+			"node": {
+				"name": "minikube"
+			},
+			"pod": {
+				"name": "kube-addon-manager-minikube"
+			}
+		},
+		"MetricSetFields": {
+			"cpu": {
+				"request": {
+					"cores": 0.005
+				}
+			},
+			"id": "docker://ab382dbe8f8265f88ee9fec7de142f778da4a5fd9fe0334e3bdb6fe851124c08",
+			"image": "k8s.gcr.io/kube-addon-manager:v8.6",
+			"memory": {
+				"request": {
+					"bytes": 52428800
+				}
+			},
+			"name": "kube-addon-manager",
+			"status": {
+				"phase": "running",
+				"ready": true,
+				"restarts": 0
+			}
+		},
+		"Index": "",
+		"ID": "",
+		"Namespace": "kubernetes.container",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Service": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": {
 			"namespace": "kube-system",
 			"node": {
 				"name": "minikube"
@@ -280,23 +110,186 @@
 				"name": "kube-apiserver-minikube"
 			}
 		},
-		"_namespace": "container",
-		"cpu": {
-			"request": {
-				"cores": 0.25
+		"MetricSetFields": {
+			"cpu": {
+				"request": {
+					"cores": 0.25
+				}
+			},
+			"id": "docker://e9568dfef1dd249cabac4bf09e6bf4a239fe738ae20eba072b6516676fce4bf6",
+			"image": "gcr.io/google_containers/kube-apiserver-amd64:v1.9.7",
+			"name": "kube-apiserver",
+			"status": {
+				"phase": "running",
+				"ready": true,
+				"restarts": 0
 			}
 		},
-		"id": "docker://e9568dfef1dd249cabac4bf09e6bf4a239fe738ae20eba072b6516676fce4bf6",
-		"image": "gcr.io/google_containers/kube-apiserver-amd64:v1.9.7",
-		"name": "kube-apiserver",
-		"status": {
-			"phase": "running",
-			"ready": true,
-			"restarts": 0
-		}
+		"Index": "",
+		"ID": "",
+		"Namespace": "kubernetes.container",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Service": "",
+		"Took": 0
 	},
 	{
-		"_module": {
+		"RootFields": null,
+		"ModuleFields": {
+			"namespace": "kube-system",
+			"node": {
+				"name": "minikube"
+			},
+			"pod": {
+				"name": "kube-state-metrics-6479d88c5c-5b6cl"
+			}
+		},
+		"MetricSetFields": {
+			"cpu": {
+				"limit": {
+					"cores": 0.1
+				},
+				"request": {
+					"cores": 0.1
+				}
+			},
+			"id": "docker://948c4ebd8ca4fdf352e7fbf7f5c5d381af7e615ced435dc42fde0c1d25851320",
+			"image": "k8s.gcr.io/addon-resizer:1.7",
+			"memory": {
+				"limit": {
+					"bytes": 31457280
+				},
+				"request": {
+					"bytes": 31457280
+				}
+			},
+			"name": "addon-resizer",
+			"status": {
+				"phase": "running",
+				"ready": true,
+				"restarts": 0
+			}
+		},
+		"Index": "",
+		"ID": "",
+		"Namespace": "kubernetes.container",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Service": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": {
+			"namespace": "kube-system",
+			"node": {
+				"name": "minikube"
+			},
+			"pod": {
+				"name": "etcd-minikube"
+			}
+		},
+		"MetricSetFields": {
+			"id": "docker://6e96fd8a687409b2314dcc01f209bb0c813c2fb08b8f75ad1695e120d41e1a2a",
+			"image": "gcr.io/google_containers/etcd-amd64:3.1.11",
+			"name": "etcd",
+			"status": {
+				"phase": "running",
+				"ready": true,
+				"restarts": 0
+			}
+		},
+		"Index": "",
+		"ID": "",
+		"Namespace": "kubernetes.container",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Service": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": {
+			"namespace": "kube-system",
+			"node": {
+				"name": "minikube"
+			},
+			"pod": {
+				"name": "kube-state-metrics-6479d88c5c-5b6cl"
+			}
+		},
+		"MetricSetFields": {
+			"cpu": {
+				"limit": {
+					"cores": 0.101
+				},
+				"request": {
+					"cores": 0.101
+				}
+			},
+			"id": "docker://88951e0178ea5131fa3e2d7cafacb3a7e63700795dd6fa0d40ed2e4ac1f52f9c",
+			"image": "quay.io/coreos/kube-state-metrics:v1.3.0",
+			"memory": {
+				"limit": {
+					"bytes": 106954752
+				},
+				"request": {
+					"bytes": 106954752
+				}
+			},
+			"name": "kube-state-metrics",
+			"status": {
+				"phase": "running",
+				"ready": true,
+				"restarts": 0
+			}
+		},
+		"Index": "",
+		"ID": "",
+		"Namespace": "kubernetes.container",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Service": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": {
+			"namespace": "kube-system",
+			"node": {
+				"name": "minikube"
+			},
+			"pod": {
+				"name": "storage-provisioner"
+			}
+		},
+		"MetricSetFields": {
+			"id": "docker://f4cc07b8e7ee5952738c69a0bff0c7b331c10af66faa541197684127d393b760",
+			"image": "gcr.io/k8s-minikube/storage-provisioner:v1.8.1",
+			"name": "storage-provisioner",
+			"status": {
+				"phase": "running",
+				"ready": true,
+				"reason": "ImagePullBackOff",
+				"restarts": 0
+			}
+		},
+		"Index": "",
+		"ID": "",
+		"Namespace": "kubernetes.container",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Service": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": {
 			"namespace": "kube-system",
 			"node": {
 				"name": "minikube"
@@ -305,29 +298,122 @@
 				"name": "kube-dns-6f4fd4bdf-wlmht"
 			}
 		},
-		"_namespace": "container",
-		"cpu": {
-			"request": {
-				"cores": 0.01
+		"MetricSetFields": {
+			"cpu": {
+				"request": {
+					"cores": 0.1
+				}
+			},
+			"id": "docker://1958e71d048065d38ce83dafda567c5fa9d0c1278cd7292d55b9f1d80b0a67f9",
+			"image": "gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.7",
+			"memory": {
+				"limit": {
+					"bytes": 178257920
+				},
+				"request": {
+					"bytes": 73400320
+				}
+			},
+			"name": "kubedns",
+			"status": {
+				"phase": "running",
+				"ready": true,
+				"restarts": 0
 			}
 		},
-		"id": "docker://aad0addd205dc72dc7abc8f9d02a1b429a2f2e1df3acc60431ca6b79746c093b",
-		"image": "gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.7",
-		"memory": {
-			"request": {
-				"bytes": 20971520
-			}
-		},
-		"name": "sidecar",
-		"status": {
-			"phase": "running",
-			"ready": true,
-			"reason": "OOMKilled",
-			"restarts": 0
-		}
+		"Index": "",
+		"ID": "",
+		"Namespace": "kubernetes.container",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Service": "",
+		"Took": 0
 	},
 	{
-		"_module": {
+		"RootFields": null,
+		"ModuleFields": {
+			"namespace": "kube-system",
+			"node": {
+				"name": "minikube"
+			},
+			"pod": {
+				"name": "kube-dns-6f4fd4bdf-wlmht"
+			}
+		},
+		"MetricSetFields": {
+			"cpu": {
+				"request": {
+					"cores": 0.01
+				}
+			},
+			"id": "docker://aad0addd205dc72dc7abc8f9d02a1b429a2f2e1df3acc60431ca6b79746c093b",
+			"image": "gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.7",
+			"memory": {
+				"request": {
+					"bytes": 20971520
+				}
+			},
+			"name": "sidecar",
+			"status": {
+				"phase": "running",
+				"ready": true,
+				"reason": "OOMKilled",
+				"restarts": 0
+			}
+		},
+		"Index": "",
+		"ID": "",
+		"Namespace": "kubernetes.container",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Service": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": {
+			"namespace": "kube-system",
+			"node": {
+				"name": "minikube"
+			},
+			"pod": {
+				"name": "kube-dns-6f4fd4bdf-wlmht"
+			}
+		},
+		"MetricSetFields": {
+			"cpu": {
+				"request": {
+					"cores": 0.15
+				}
+			},
+			"id": "docker://e9560bbace13ca19de4b3771023198e8568f6b5ed6af3a949f10a5b8137b5be9",
+			"image": "gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.7",
+			"memory": {
+				"request": {
+					"bytes": 20971520
+				}
+			},
+			"name": "dnsmasq",
+			"status": {
+				"phase": "running",
+				"ready": true,
+				"restarts": 0
+			}
+		},
+		"Index": "",
+		"ID": "",
+		"Namespace": "kubernetes.container",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Service": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": {
 			"namespace": "kube-system",
 			"node": {
 				"name": "minikube"
@@ -336,19 +422,63 @@
 				"name": "kube-scheduler-minikube"
 			}
 		},
-		"_namespace": "container",
-		"cpu": {
-			"request": {
-				"cores": 0.1
+		"MetricSetFields": {
+			"cpu": {
+				"request": {
+					"cores": 0.1
+				}
+			},
+			"id": "docker://eadcbd54ba914dff6475ae64805887967cfb973aeb9b07364c94372658a71d11",
+			"image": "gcr.io/google_containers/kube-scheduler-amd64:v1.9.7",
+			"name": "kube-scheduler",
+			"status": {
+				"phase": "running",
+				"ready": true,
+				"restarts": 0
 			}
 		},
-		"id": "docker://eadcbd54ba914dff6475ae64805887967cfb973aeb9b07364c94372658a71d11",
-		"image": "gcr.io/google_containers/kube-scheduler-amd64:v1.9.7",
-		"name": "kube-scheduler",
-		"status": {
-			"phase": "running",
-			"ready": true,
-			"restarts": 0
-		}
+		"Index": "",
+		"ID": "",
+		"Namespace": "kubernetes.container",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Service": "",
+		"Took": 0
+	},
+	{
+		"RootFields": null,
+		"ModuleFields": {
+			"namespace": "kube-system",
+			"node": {
+				"name": "minikube"
+			},
+			"pod": {
+				"name": "kube-controller-manager-minikube"
+			}
+		},
+		"MetricSetFields": {
+			"cpu": {
+				"request": {
+					"cores": 0.2
+				}
+			},
+			"id": "docker://4beb9aab887ca162c9cb3534c4826156636241052cd548153eaa2a170b6d102f",
+			"image": "gcr.io/google_containers/kube-controller-manager-amd64:v1.9.7",
+			"name": "kube-controller-manager",
+			"status": {
+				"phase": "running",
+				"ready": true,
+				"restarts": 0
+			}
+		},
+		"Index": "",
+		"ID": "",
+		"Namespace": "kubernetes.container",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Service": "",
+		"Took": 0
 	}
 ]

--- a/metricbeat/module/kubernetes/state_container/_meta/testdata/config.yml
+++ b/metricbeat/module/kubernetes/state_container/_meta/testdata/config.yml
@@ -1,0 +1,3 @@
+type: http
+url: "/metrics"
+suffix: plain

--- a/metricbeat/module/kubernetes/state_container/_meta/testdata/ksm-v1_3_0.plain
+++ b/metricbeat/module/kubernetes/state_container/_meta/testdata/ksm-v1_3_0.plain
@@ -1,0 +1,464 @@
+# HELP go_gc_duration_seconds A summary of the GC invocation durations.
+# TYPE go_gc_duration_seconds summary
+go_gc_duration_seconds{quantile="0"} 5.4333e-05
+go_gc_duration_seconds{quantile="0.25"} 0.000246606
+go_gc_duration_seconds{quantile="0.5"} 0.0006209060000000001
+go_gc_duration_seconds{quantile="0.75"} 0.001966929
+go_gc_duration_seconds{quantile="1"} 0.09220378600000001
+go_gc_duration_seconds_sum 5.104380396
+go_gc_duration_seconds_count 651
+# HELP go_goroutines Number of goroutines that currently exist.
+# TYPE go_goroutines gauge
+go_goroutines 64
+# HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
+# TYPE go_memstats_alloc_bytes gauge
+go_memstats_alloc_bytes 5.142496e+06
+# HELP go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
+# TYPE go_memstats_alloc_bytes_total counter
+go_memstats_alloc_bytes_total 2.375809288e+09
+# HELP go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table.
+# TYPE go_memstats_buck_hash_sys_bytes gauge
+go_memstats_buck_hash_sys_bytes 1.516515e+06
+# HELP go_memstats_frees_total Total number of frees.
+# TYPE go_memstats_frees_total counter
+go_memstats_frees_total 1.7162925e+07
+# HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
+# TYPE go_memstats_gc_sys_bytes gauge
+go_memstats_gc_sys_bytes 1.273856e+06
+# HELP go_memstats_heap_alloc_bytes Number of heap bytes allocated and still in use.
+# TYPE go_memstats_heap_alloc_bytes gauge
+go_memstats_heap_alloc_bytes 5.142496e+06
+# HELP go_memstats_heap_idle_bytes Number of heap bytes waiting to be used.
+# TYPE go_memstats_heap_idle_bytes gauge
+go_memstats_heap_idle_bytes 1.14688e+07
+# HELP go_memstats_heap_inuse_bytes Number of heap bytes that are in use.
+# TYPE go_memstats_heap_inuse_bytes gauge
+go_memstats_heap_inuse_bytes 7.176192e+06
+# HELP go_memstats_heap_objects Number of allocated objects.
+# TYPE go_memstats_heap_objects gauge
+go_memstats_heap_objects 32950
+# HELP go_memstats_heap_released_bytes_total Total number of heap bytes released to OS.
+# TYPE go_memstats_heap_released_bytes_total counter
+go_memstats_heap_released_bytes_total 0
+# HELP go_memstats_heap_sys_bytes Number of heap bytes obtained from system.
+# TYPE go_memstats_heap_sys_bytes gauge
+go_memstats_heap_sys_bytes 1.8644992e+07
+# HELP go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
+# TYPE go_memstats_last_gc_time_seconds gauge
+go_memstats_last_gc_time_seconds 1.4939767617562683e+09
+# HELP go_memstats_lookups_total Total number of pointer lookups.
+# TYPE go_memstats_lookups_total counter
+go_memstats_lookups_total 18621
+# HELP go_memstats_mallocs_total Total number of mallocs.
+# TYPE go_memstats_mallocs_total counter
+go_memstats_mallocs_total 1.7195875e+07
+# HELP go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures.
+# TYPE go_memstats_mcache_inuse_bytes gauge
+go_memstats_mcache_inuse_bytes 2400
+# HELP go_memstats_mcache_sys_bytes Number of bytes used for mcache structures obtained from system.
+# TYPE go_memstats_mcache_sys_bytes gauge
+go_memstats_mcache_sys_bytes 16384
+# HELP go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures.
+# TYPE go_memstats_mspan_inuse_bytes gauge
+go_memstats_mspan_inuse_bytes 98400
+# HELP go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system.
+# TYPE go_memstats_mspan_sys_bytes gauge
+go_memstats_mspan_sys_bytes 114688
+# HELP go_memstats_next_gc_bytes Number of heap bytes when next garbage collection will take place.
+# TYPE go_memstats_next_gc_bytes gauge
+go_memstats_next_gc_bytes 7.698843e+06
+# HELP go_memstats_other_sys_bytes Number of bytes used for other system allocations.
+# TYPE go_memstats_other_sys_bytes gauge
+go_memstats_other_sys_bytes 574741
+# HELP go_memstats_stack_inuse_bytes Number of bytes in use by the stack allocator.
+# TYPE go_memstats_stack_inuse_bytes gauge
+go_memstats_stack_inuse_bytes 4.42368e+06
+# HELP go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator.
+# TYPE go_memstats_stack_sys_bytes gauge
+go_memstats_stack_sys_bytes 4.42368e+06
+# HELP go_memstats_sys_bytes Number of bytes obtained by system. Sum of all system allocations.
+# TYPE go_memstats_sys_bytes gauge
+go_memstats_sys_bytes 2.6564856e+07
+# HELP kube_deployment_metadata_generation Sequence number representing a specific generation of the desired state.
+# TYPE kube_deployment_metadata_generation gauge
+kube_deployment_metadata_generation{deployment="jumpy-owl-redis",namespace="default"} 1
+kube_deployment_metadata_generation{deployment="jumpy-owl-redis",namespace="test"} 2
+kube_deployment_metadata_generation{deployment="kube-state-metrics",namespace="kube-system"} 1
+kube_deployment_metadata_generation{deployment="tiller-deploy",namespace="kube-system"} 1
+kube_deployment_metadata_generation{deployment="wise-lynx-jenkins",namespace="jenkins"} 1
+# HELP kube_deployment_spec_paused Whether the deployment is paused and will not be processed by the deployment controller.
+# TYPE kube_deployment_spec_paused gauge
+kube_deployment_spec_paused{deployment="jumpy-owl-redis",namespace="default"} 0
+kube_deployment_spec_paused{deployment="jumpy-owl-redis",namespace="test"} 1
+kube_deployment_spec_paused{deployment="kube-state-metrics",namespace="kube-system"} 0
+kube_deployment_spec_paused{deployment="tiller-deploy",namespace="kube-system"} 0
+kube_deployment_spec_paused{deployment="wise-lynx-jenkins",namespace="jenkins"} 0
+# HELP kube_deployment_spec_replicas Number of desired pods for a deployment.
+# TYPE kube_deployment_spec_replicas gauge
+kube_deployment_spec_replicas{deployment="jumpy-owl-redis",namespace="default"} 1
+kube_deployment_spec_replicas{deployment="jumpy-owl-redis",namespace="test"} 2
+kube_deployment_spec_replicas{deployment="kube-state-metrics",namespace="kube-system"} 2
+kube_deployment_spec_replicas{deployment="tiller-deploy",namespace="kube-system"} 1
+kube_deployment_spec_replicas{deployment="wise-lynx-jenkins",namespace="jenkins"} 1
+# HELP kube_deployment_spec_strategy_rollingupdate_max_unavailable Maximum number of unavailable replicas during a rolling update of a deployment.
+# TYPE kube_deployment_spec_strategy_rollingupdate_max_unavailable gauge
+kube_deployment_spec_strategy_rollingupdate_max_unavailable{deployment="jumpy-owl-redis",namespace="default"} 1
+kube_deployment_spec_strategy_rollingupdate_max_unavailable{deployment="jumpy-owl-redis",namespace="test"} 3
+kube_deployment_spec_strategy_rollingupdate_max_unavailable{deployment="kube-state-metrics",namespace="kube-system"} 1
+kube_deployment_spec_strategy_rollingupdate_max_unavailable{deployment="tiller-deploy",namespace="kube-system"} 1
+kube_deployment_spec_strategy_rollingupdate_max_unavailable{deployment="wise-lynx-jenkins",namespace="jenkins"} 1
+# HELP kube_deployment_status_observed_generation The generation observed by the deployment controller.
+# TYPE kube_deployment_status_observed_generation gauge
+kube_deployment_status_observed_generation{deployment="jumpy-owl-redis",namespace="default"} 1
+kube_deployment_status_observed_generation{deployment="jumpy-owl-redis",namespace="test"} 4
+kube_deployment_status_observed_generation{deployment="kube-state-metrics",namespace="kube-system"} 1
+kube_deployment_status_observed_generation{deployment="tiller-deploy",namespace="kube-system"} 1
+kube_deployment_status_observed_generation{deployment="wise-lynx-jenkins",namespace="jenkins"} 1
+# HELP kube_deployment_status_replicas The number of replicas per deployment.
+# TYPE kube_deployment_status_replicas gauge
+kube_deployment_status_replicas{deployment="jumpy-owl-redis",namespace="default"} 1
+kube_deployment_status_replicas{deployment="jumpy-owl-redis",namespace="test"} 5
+kube_deployment_status_replicas{deployment="kube-state-metrics",namespace="kube-system"} 2
+kube_deployment_status_replicas{deployment="tiller-deploy",namespace="kube-system"} 1
+kube_deployment_status_replicas{deployment="wise-lynx-jenkins",namespace="jenkins"} 1
+# HELP kube_deployment_status_replicas_available The number of available replicas per deployment.
+# TYPE kube_deployment_status_replicas_available gauge
+kube_deployment_status_replicas_available{deployment="jumpy-owl-redis",namespace="default"} 0
+kube_deployment_status_replicas_available{deployment="jumpy-owl-redis",namespace="test"} 6
+kube_deployment_status_replicas_available{deployment="kube-state-metrics",namespace="kube-system"} 1
+kube_deployment_status_replicas_available{deployment="tiller-deploy",namespace="kube-system"} 1
+kube_deployment_status_replicas_available{deployment="wise-lynx-jenkins",namespace="jenkins"} 1
+# HELP kube_deployment_status_replicas_unavailable The number of unavailable replicas per deployment.
+# TYPE kube_deployment_status_replicas_unavailable gauge
+kube_deployment_status_replicas_unavailable{deployment="jumpy-owl-redis",namespace="default"} 1
+kube_deployment_status_replicas_unavailable{deployment="jumpy-owl-redis",namespace="test"} 7
+kube_deployment_status_replicas_unavailable{deployment="kube-state-metrics",namespace="kube-system"} 1
+kube_deployment_status_replicas_unavailable{deployment="tiller-deploy",namespace="kube-system"} 0
+kube_deployment_status_replicas_unavailable{deployment="wise-lynx-jenkins",namespace="jenkins"} 0
+# HELP kube_deployment_status_replicas_updated The number of updated replicas per deployment.
+# TYPE kube_deployment_status_replicas_updated gauge
+kube_deployment_status_replicas_updated{deployment="jumpy-owl-redis",namespace="default"} 1
+kube_deployment_status_replicas_updated{deployment="jumpy-owl-redis",namespace="test"} 8
+kube_deployment_status_replicas_updated{deployment="kube-state-metrics",namespace="kube-system"} 2
+kube_deployment_status_replicas_updated{deployment="tiller-deploy",namespace="kube-system"} 1
+kube_deployment_status_replicas_updated{deployment="wise-lynx-jenkins",namespace="jenkins"} 1
+# HELP kube_node_info Information about a cluster node.
+# TYPE kube_node_info gauge
+kube_node_info{container_runtime_version="docker://1.11.1",kernel_version="4.7.2",kubelet_version="v1.5.3",kubeproxy_version="v1.5.3",node="minikube",os_image="Buildroot 2016.08"} 1
+kube_node_info{container_runtime_version="docker://1.11.1",kernel_version="4.7.2",kubelet_version="v1.5.3",kubeproxy_version="v1.5.3",node="minikube-test",os_image="Buildroot 2016.08"} 1
+# HELP kube_node_spec_unschedulable Whether a node can schedule new pods.
+# TYPE kube_node_spec_unschedulable gauge
+kube_node_spec_unschedulable{node="minikube"} 0
+kube_node_spec_unschedulable{node="minikube-test"} 1
+# HELP kube_node_status_allocatable_cpu_cores The CPU resources of a node that are available for scheduling.
+# TYPE kube_node_status_allocatable_cpu_cores gauge
+kube_node_status_allocatable_cpu_cores{node="minikube"} 2
+kube_node_status_allocatable_cpu_cores{node="minikube-test"} 3
+# HELP kube_node_status_allocatable_memory_bytes The memory resources of a node that are available for scheduling.
+# TYPE kube_node_status_allocatable_memory_bytes gauge
+kube_node_status_allocatable_memory_bytes{node="minikube"} 2.09778688e+09
+kube_node_status_allocatable_memory_bytes{node="minikube-test"} 3.09778688e+09
+# HELP kube_node_status_allocatable_pods The pod resources of a node that are available for scheduling.
+# TYPE kube_node_status_allocatable_pods gauge
+kube_node_status_allocatable_pods{node="minikube"} 110
+kube_node_status_allocatable_pods{node="minikube-test"} 210
+# HELP kube_node_status_capacity_cpu_cores The total CPU resources of the node.
+# TYPE kube_node_status_capacity_cpu_cores gauge
+kube_node_status_capacity_cpu_cores{node="minikube"} 2
+kube_node_status_capacity_cpu_cores{node="minikube-test"} 4
+# HELP kube_node_status_capacity_memory_bytes The total memory resources of the node.
+# TYPE kube_node_status_capacity_memory_bytes gauge
+kube_node_status_capacity_memory_bytes{node="minikube"} 2.09778688e+09
+kube_node_status_capacity_memory_bytes{node="minikube-test"} 4.09778688e+09
+# HELP kube_node_status_capacity_pods The total pod resources of the node.
+# TYPE kube_node_status_capacity_pods gauge
+kube_node_status_capacity_pods{node="minikube"} 110
+kube_node_status_capacity_pods{node="minikube-test"} 310
+# HELP kube_node_status_out_of_disk Whether the node is out of disk space
+# TYPE kube_node_status_out_of_disk gauge
+kube_node_status_out_of_disk{condition="false",node="minikube"} 1
+kube_node_status_out_of_disk{condition="true",node="minikube"} 0
+kube_node_status_out_of_disk{condition="unknown",node="minikube"} 0
+kube_node_status_out_of_disk{condition="false",node="minikube-test"} 1
+kube_node_status_out_of_disk{condition="true",node="minikube-test"} 0
+kube_node_status_out_of_disk{condition="unknown",node="minikube-test"} 0
+# HELP kube_node_status_ready The ready status of a cluster node.
+# TYPE kube_node_status_ready gauge
+kube_node_status_ready{condition="false",node="minikube"} 0
+kube_node_status_ready{condition="true",node="minikube"} 1
+kube_node_status_ready{condition="unknown",node="minikube"} 0
+kube_node_status_ready{condition="false",node="minikube-test"} 0
+kube_node_status_ready{condition="true",node="minikube-test"} 1
+kube_node_status_ready{condition="unknown",node="minikube-test"} 0
+# HELP kube_pod_container_info Information about a container in a pod.
+# TYPE kube_pod_container_info gauge
+kube_pod_container_info{container="dnsmasq",container_id="docker://9a4c9462cd078d7be4f0a9b94bcfeb69d5fdd76bff67142df3f58367ac7e8d61",image="gcr.io/google_containers/kube-dnsmasq-amd64:1.4",image_id="docker://sha256:3ec65756a89b70b4095e43a340a6e2d5696cac7a93a29619ff5c4b6be9af2773",namespace="kube-system",pod="kube-dns-v20-5g5cb"} 1
+kube_pod_container_info{container="healthz",container_id="docker://52fa55e051dc5b68e44c027588685b7edd85aaa03b07f7216d399249ff4fc821",image="gcr.io/google_containers/exechealthz-amd64:1.2",image_id="docker://sha256:93a43bfb39bfe9795e76ccd75d7a0e6d40e2ae8563456a2a77c1b4cfc3bbd967",namespace="kube-system",pod="kube-dns-v20-5g5cb"} 1
+kube_pod_container_info{container="jumpy-owl-redis",container_id="docker://4fa227874ee68536bf902394fb662f07b99099798ca9cd5c1506b79075acc065",image="bitnami/redis:3.2.8-r2",image_id="docker://sha256:ab2690be624592578e9fb5a64f134fd395d20f401498a686ca75b6f87b55db3f",namespace="default",pod="jumpy-owl-redis-3481028193-s78x9"} 1
+kube_pod_container_info{container="kube-addon-manager",container_id="docker://91fdd43f6b1b4c3dd133cfca53e0b1210bc557c2ae56006026b5ccdb5f52826f",image="gcr.io/google-containers/kube-addon-manager:v6.3",image_id="docker://sha256:79eb64bc98df10a9af7e39f70df817e1862f8a5ec7657714df68439a617ee9ec",namespace="kube-system",pod="kube-addon-manager-minikube"} 1
+kube_pod_container_info{container="kube-state-metrics",container_id="docker://973cbe45982c5126a5caf8c58d964c0ab1d5bb2c165ccc59715fcc1ebd58ab3d",image="gcr.io/google_containers/kube-state-metrics:v0.4.1",image_id="docker://sha256:be329a05c2e77e7d067b4e1dbefa1567a91d0487d3500d608171489369bfd945",namespace="kube-system",pod="kube-state-metrics-1303537707-7ncd1"} 1
+kube_pod_container_info{container="kubedns",container_id="docker://fa3d83f648de42492b38fa3e8501d109376f391c50f2bd210c895c8477ae4b62",image="gcr.io/google_containers/kubedns-amd64:1.9",image_id="docker://sha256:26cf1ed9b14486b93acd70c060a17fea13620393d3aa8e76036b773197c47a05",namespace="kube-system",pod="kube-dns-v20-5g5cb"} 1
+kube_pod_container_info{container="kubedns",container_id="docker://fa3d83f648de42492b38fa3e8501d109376f391c50f2bd210c895c8477ae4b62-test",image="gcr.io/google_containers/kubedns-amd64:1.9-test",image_id="docker://sha256:26cf1ed9b14486b93acd70c060a17fea13620393d3aa8e76036b773197c47a05",namespace="test",pod="kube-dns-v20-5g5cb-test"} 0
+kube_pod_container_info{container="kubernetes-dashboard",container_id="docker://3aaee8bdd311c015240e99fa2a5a5f2f26b11b51236a683b39d8c1902e423978",image="gcr.io/google_containers/kubernetes-dashboard-amd64:v1.5.1",image_id="docker://sha256:1180413103fdfd00a7882d3d8653a220d88c6ea4466fb860e98376c45ee1a1d0",namespace="kube-system",pod="kubernetes-dashboard-vw0l6"} 1
+kube_pod_container_info{container="tiller",container_id="docker://469f5d2b7854eb52e5d13dc0cd3e664c1b682b157aabaf596ffe4984f1516902",image="gcr.io/kubernetes-helm/tiller:v2.3.1",image_id="docker://sha256:38527daf791dbe472c37ecb1e8b13a62e31c00d9ff4c8a1f019d7022a96a43da",namespace="kube-system",pod="tiller-deploy-3067024529-9lpmb"} 1
+kube_pod_container_info{container="wise-lynx-jenkins",container_id="docker://e2ee1c2c7b8d4e5fd8c834b83cba8377d6b0e39da18157688ccc1a06b7c53117",image="jenkinsci/jenkins:2.46.1",image_id="docker://sha256:36023b9defd066ee53c03e33ba3add7225aee8447cb3154133012b1e152153c0",namespace="jenkins",pod="wise-lynx-jenkins-1616735317-svn6k"} 1
+# HELP kube_pod_container_resource_limits_cpu_cores The limit on cpu cores to be used by a container.
+# TYPE kube_pod_container_resource_limits_cpu_cores gauge
+kube_pod_container_resource_limits_cpu_cores{container="kube-state-metrics",namespace="kube-system",node="",pod="kube-state-metrics-1303537707-mnzbp"} 0.2
+kube_pod_container_resource_limits_cpu_cores{container="kube-state-metrics",namespace="kube-system",node="minikube",pod="kube-state-metrics-1303537707-7ncd1"} 0.2
+# HELP kube_pod_container_resource_limits_memory_bytes The limit on memory to be used by a container in bytes.
+# TYPE kube_pod_container_resource_limits_memory_bytes gauge
+kube_pod_container_resource_limits_memory_bytes{container="healthz",namespace="kube-system",node="minikube",pod="kube-dns-v20-5g5cb"} 5.24288e+07
+kube_pod_container_resource_limits_memory_bytes{container="kube-state-metrics",namespace="kube-system",node="",pod="kube-state-metrics-1303537707-mnzbp"} 5.24288e+07
+kube_pod_container_resource_limits_memory_bytes{container="kube-state-metrics",namespace="kube-system",node="minikube",pod="kube-state-metrics-1303537707-7ncd1"} 5.24288e+07
+kube_pod_container_resource_limits_memory_bytes{container="kubedns",namespace="kube-system",node="minikube",pod="kube-dns-v20-5g5cb"} 1.7825792e+08
+kube_pod_container_resource_limits_memory_bytes{container="kubedns",namespace="test",node="minikube-test",pod="kube-dns-v20-5g5cb-test"} 2.7825792e+08
+# HELP kube_pod_container_resource_requests_cpu_cores The number of requested cpu cores by a container.
+# TYPE kube_pod_container_resource_requests_cpu_cores gauge
+kube_pod_container_resource_requests_cpu_cores{container="healthz",namespace="kube-system",node="minikube",pod="kube-dns-v20-5g5cb"} 0.01
+kube_pod_container_resource_requests_cpu_cores{container="jumpy-owl-redis",namespace="default",node="minikube",pod="jumpy-owl-redis-3481028193-s78x9"} 0.1
+kube_pod_container_resource_requests_cpu_cores{container="kube-addon-manager",namespace="kube-system",node="minikube",pod="kube-addon-manager-minikube"} 0.005
+kube_pod_container_resource_requests_cpu_cores{container="kube-state-metrics",namespace="kube-system",node="",pod="kube-state-metrics-1303537707-mnzbp"} 0.1
+kube_pod_container_resource_requests_cpu_cores{container="kube-state-metrics",namespace="kube-system",node="minikube",pod="kube-state-metrics-1303537707-7ncd1"} 0.1
+kube_pod_container_resource_requests_cpu_cores{container="kubedns",namespace="kube-system",node="minikube",pod="kube-dns-v20-5g5cb"} 0.1
+kube_pod_container_resource_requests_cpu_cores{container="kubedns",namespace="test",node="minikube-test",pod="kube-dns-v20-5g5cb-test"} 0.2
+kube_pod_container_resource_requests_cpu_cores{container="wise-lynx-jenkins",namespace="jenkins",node="minikube",pod="wise-lynx-jenkins-1616735317-svn6k"} 0.2
+# HELP kube_pod_container_resource_requests_memory_bytes The number of requested memory bytes  by a container.
+# TYPE kube_pod_container_resource_requests_memory_bytes gauge
+kube_pod_container_resource_requests_memory_bytes{container="healthz",namespace="kube-system",node="minikube",pod="kube-dns-v20-5g5cb"} 5.24288e+07
+kube_pod_container_resource_requests_memory_bytes{container="jumpy-owl-redis",namespace="default",node="minikube",pod="jumpy-owl-redis-3481028193-s78x9"} 2.68435456e+08
+kube_pod_container_resource_requests_memory_bytes{container="kube-addon-manager",namespace="kube-system",node="minikube",pod="kube-addon-manager-minikube"} 5.24288e+07
+kube_pod_container_resource_requests_memory_bytes{container="kube-state-metrics",namespace="kube-system",node="",pod="kube-state-metrics-1303537707-mnzbp"} 3.145728e+07
+kube_pod_container_resource_requests_memory_bytes{container="kube-state-metrics",namespace="kube-system",node="minikube",pod="kube-state-metrics-1303537707-7ncd1"} 3.145728e+07
+kube_pod_container_resource_requests_memory_bytes{container="kubedns",namespace="kube-system",node="minikube",pod="kube-dns-v20-5g5cb"} 7.340032e+07
+kube_pod_container_resource_requests_memory_bytes{container="kubedns",namespace="test",node="minikube-test",pod="kube-dns-v20-5g5cb-test"} 8.340032e+07
+kube_pod_container_resource_requests_memory_bytes{container="wise-lynx-jenkins",namespace="jenkins",node="minikube",pod="wise-lynx-jenkins-1616735317-svn6k"} 2.68435456e+08
+# HELP kube_pod_container_status_ready Describes whether the containers readiness check succeeded.
+# TYPE kube_pod_container_status_ready gauge
+kube_pod_container_status_ready{container="dnsmasq",namespace="kube-system",pod="kube-dns-v20-5g5cb"} 1
+kube_pod_container_status_ready{container="healthz",namespace="kube-system",pod="kube-dns-v20-5g5cb"} 1
+kube_pod_container_status_ready{container="jumpy-owl-redis",namespace="default",pod="jumpy-owl-redis-3481028193-s78x9"} 0
+kube_pod_container_status_ready{container="kube-addon-manager",namespace="kube-system",pod="kube-addon-manager-minikube"} 1
+kube_pod_container_status_ready{container="kube-state-metrics",namespace="kube-system",pod="kube-state-metrics-1303537707-7ncd1"} 1
+kube_pod_container_status_ready{container="kubedns",namespace="kube-system",pod="kube-dns-v20-5g5cb"} 1
+kube_pod_container_status_ready{container="kubedns",namespace="test",pod="kube-dns-v20-5g5cb-test"} 0
+kube_pod_container_status_ready{container="kubernetes-dashboard",namespace="kube-system",pod="kubernetes-dashboard-vw0l6"} 1
+kube_pod_container_status_ready{container="tiller",namespace="kube-system",pod="tiller-deploy-3067024529-9lpmb"} 1
+kube_pod_container_status_ready{container="wise-lynx-jenkins",namespace="jenkins",pod="wise-lynx-jenkins-1616735317-svn6k"} 1
+# HELP kube_pod_container_status_restarts The number of container restarts per container.
+# TYPE kube_pod_container_status_restarts counter
+kube_pod_container_status_restarts{container="dnsmasq",namespace="kube-system",pod="kube-dns-v20-5g5cb"} 2
+kube_pod_container_status_restarts{container="healthz",namespace="kube-system",pod="kube-dns-v20-5g5cb"} 2
+kube_pod_container_status_restarts{container="jumpy-owl-redis",namespace="default",pod="jumpy-owl-redis-3481028193-s78x9"} 270
+kube_pod_container_status_restarts{container="kube-addon-manager",namespace="kube-system",pod="kube-addon-manager-minikube"} 2
+kube_pod_container_status_restarts{container="kube-state-metrics",namespace="kube-system",pod="kube-state-metrics-1303537707-7ncd1"} 1
+kube_pod_container_status_restarts{container="kubedns",namespace="kube-system",pod="kube-dns-v20-5g5cb"} 2
+kube_pod_container_status_restarts{container="kubedns",namespace="test",pod="kube-dns-v20-5g5cb-test"} 3
+kube_pod_container_status_restarts{container="kubernetes-dashboard",namespace="kube-system",pod="kubernetes-dashboard-vw0l6"} 2
+kube_pod_container_status_restarts{container="tiller",namespace="kube-system",pod="tiller-deploy-3067024529-9lpmb"} 1
+kube_pod_container_status_restarts{container="wise-lynx-jenkins",namespace="jenkins",pod="wise-lynx-jenkins-1616735317-svn6k"} 1
+# HELP kube_pod_container_status_running Describes whether the container is currently in running state.
+# TYPE kube_pod_container_status_running gauge
+kube_pod_container_status_running{container="dnsmasq",namespace="kube-system",pod="kube-dns-v20-5g5cb"} 1
+kube_pod_container_status_running{container="healthz",namespace="kube-system",pod="kube-dns-v20-5g5cb"} 1
+kube_pod_container_status_running{container="jumpy-owl-redis",namespace="default",pod="jumpy-owl-redis-3481028193-s78x9"} 0
+kube_pod_container_status_running{container="kube-addon-manager",namespace="kube-system",pod="kube-addon-manager-minikube"} 1
+kube_pod_container_status_running{container="kube-state-metrics",namespace="kube-system",pod="kube-state-metrics-1303537707-7ncd1"} 1
+kube_pod_container_status_running{container="kubedns",namespace="kube-system",pod="kube-dns-v20-5g5cb"} 1
+kube_pod_container_status_running{container="kubedns",namespace="test",pod="kube-dns-v20-5g5cb-test"} 0
+kube_pod_container_status_running{container="kubernetes-dashboard",namespace="kube-system",pod="kubernetes-dashboard-vw0l6"} 1
+kube_pod_container_status_running{container="tiller",namespace="kube-system",pod="tiller-deploy-3067024529-9lpmb"} 1
+kube_pod_container_status_running{container="wise-lynx-jenkins",namespace="jenkins",pod="wise-lynx-jenkins-1616735317-svn6k"} 1
+# HELP kube_pod_container_status_terminated Describes whether the container is currently in terminated state.
+# TYPE kube_pod_container_status_terminated gauge
+kube_pod_container_status_terminated{container="dnsmasq",namespace="kube-system",pod="kube-dns-v20-5g5cb"} 0
+kube_pod_container_status_terminated{container="healthz",namespace="kube-system",pod="kube-dns-v20-5g5cb"} 0
+kube_pod_container_status_terminated{container="jumpy-owl-redis",namespace="default",pod="jumpy-owl-redis-3481028193-s78x9"} 0
+kube_pod_container_status_terminated{container="kube-addon-manager",namespace="kube-system",pod="kube-addon-manager-minikube"} 0
+kube_pod_container_status_terminated{container="kube-state-metrics",namespace="kube-system",pod="kube-state-metrics-1303537707-7ncd1"} 0
+kube_pod_container_status_terminated{container="kubedns",namespace="kube-system",pod="kube-dns-v20-5g5cb"} 0
+kube_pod_container_status_terminated{container="kubedns",namespace="test",pod="kube-dns-v20-5g5cb-test"} 1
+kube_pod_container_status_terminated{container="kubernetes-dashboard",namespace="kube-system",pod="kubernetes-dashboard-vw0l6"} 0
+kube_pod_container_status_terminated{container="tiller",namespace="kube-system",pod="tiller-deploy-3067024529-9lpmb"} 0
+kube_pod_container_status_terminated{container="wise-lynx-jenkins",namespace="jenkins",pod="wise-lynx-jenkins-1616735317-svn6k"} 0
+# HELP kube_pod_container_status_waiting Describes whether the container is currently in waiting state.
+# TYPE kube_pod_container_status_waiting gauge
+kube_pod_container_status_waiting{container="dnsmasq",namespace="kube-system",pod="kube-dns-v20-5g5cb"} 0
+kube_pod_container_status_waiting{container="healthz",namespace="kube-system",pod="kube-dns-v20-5g5cb"} 0
+kube_pod_container_status_waiting{container="jumpy-owl-redis",namespace="default",pod="jumpy-owl-redis-3481028193-s78x9"} 1
+kube_pod_container_status_waiting{container="kube-addon-manager",namespace="kube-system",pod="kube-addon-manager-minikube"} 0
+kube_pod_container_status_waiting{container="kube-state-metrics",namespace="kube-system",pod="kube-state-metrics-1303537707-7ncd1"} 0
+kube_pod_container_status_waiting{container="kubedns",namespace="kube-system",pod="kube-dns-v20-5g5cb"} 0
+kube_pod_container_status_waiting{container="kubedns",namespace="test",pod="kube-dns-v20-5g5cb"} 0
+kube_pod_container_status_waiting{container="kubernetes-dashboard",namespace="kube-system",pod="kubernetes-dashboard-vw0l6"} 0
+kube_pod_container_status_waiting{container="tiller",namespace="kube-system",pod="tiller-deploy-3067024529-9lpmb"} 0
+kube_pod_container_status_waiting{container="wise-lynx-jenkins",namespace="jenkins",pod="wise-lynx-jenkins-1616735317-svn6k"} 0
+# HELP kube_pod_info Information about pod.
+# TYPE kube_pod_info gauge
+kube_pod_info{host_ip="",namespace="kube-system",node="",pod="kube-state-metrics-1303537707-mnzbp",pod_ip=""} 1
+kube_pod_info{host_ip="192.168.99.100",namespace="default",node="minikube",pod="jumpy-owl-redis-3481028193-s78x9",pod_ip="172.17.0.4"} 1
+kube_pod_info{host_ip="192.168.99.200",namespace="test",node="minikube-test",pod="jumpy-owl-redis-3481028193-s78x9",pod_ip="172.17.0.5"} 1
+kube_pod_info{host_ip="192.168.99.100",namespace="jenkins",node="minikube",pod="wise-lynx-jenkins-1616735317-svn6k",pod_ip="172.17.0.7"} 1
+kube_pod_info{host_ip="192.168.99.100",namespace="kube-system",node="minikube",pod="kube-addon-manager-minikube",pod_ip="192.168.99.100"} 1
+kube_pod_info{host_ip="192.168.99.100",namespace="kube-system",node="minikube",pod="kube-dns-v20-5g5cb",pod_ip="172.17.0.6"} 1
+kube_pod_info{host_ip="192.168.99.100",namespace="kube-system",node="minikube",pod="kube-state-metrics-1303537707-7ncd1",pod_ip="172.17.0.3"} 1
+kube_pod_info{host_ip="192.168.99.100",namespace="kube-system",node="minikube",pod="kubernetes-dashboard-vw0l6",pod_ip="172.17.0.5"} 1
+kube_pod_info{host_ip="192.168.99.100",namespace="kube-system",node="minikube",pod="tiller-deploy-3067024529-9lpmb",pod_ip="172.17.0.2"} 1
+# HELP kube_pod_status_phase The pods current phase.
+# TYPE kube_pod_status_phase gauge
+kube_pod_status_phase{namespace="default",phase="Running",pod="jumpy-owl-redis-3481028193-s78x9"} 0
+kube_pod_status_phase{namespace="default",phase="Succeeded",pod="jumpy-owl-redis-3481028193-s78x9"} 1
+kube_pod_status_phase{namespace="default",phase="Unknown",pod="jumpy-owl-redis-3481028193-s78x9"} 0
+kube_pod_status_phase{namespace="test",phase="Running",pod="jumpy-owl-redis-3481028193-s78x9"} 1
+kube_pod_status_phase{namespace="test",phase="Succeeded",pod="jumpy-owl-redis-3481028193-s78x9"} 0
+kube_pod_status_phase{namespace="test",phase="Unknown",pod="jumpy-owl-redis-3481028193-s78x9"} 0
+kube_pod_status_phase{namespace="jenkins",phase="Running",pod="wise-lynx-jenkins-1616735317-svn6k"} 1
+kube_pod_status_phase{namespace="kube-system",phase="Pending",pod="kube-state-metrics-1303537707-mnzbp"} 1
+kube_pod_status_phase{namespace="kube-system",phase="Running",pod="kube-addon-manager-minikube"} 1
+kube_pod_status_phase{namespace="kube-system",phase="Running",pod="kube-dns-v20-5g5cb"} 1
+kube_pod_status_phase{namespace="kube-system",phase="Running",pod="kube-state-metrics-1303537707-7ncd1"} 1
+kube_pod_status_phase{namespace="kube-system",phase="Running",pod="kubernetes-dashboard-vw0l6"} 1
+kube_pod_status_phase{namespace="kube-system",phase="Running",pod="tiller-deploy-3067024529-9lpmb"} 1
+# HELP kube_pod_status_ready Describes whether the pod is ready to serve requests.
+# TYPE kube_pod_status_ready gauge
+kube_pod_status_ready{condition="false",namespace="default",pod="jumpy-owl-redis-3481028193-s78x9"} 1
+kube_pod_status_ready{condition="false",namespace="test",pod="jumpy-owl-redis-3481028193-s78x9"} 0
+kube_pod_status_ready{condition="false",namespace="jenkins",pod="wise-lynx-jenkins-1616735317-svn6k"} 0
+kube_pod_status_ready{condition="false",namespace="kube-system",pod="kube-addon-manager-minikube"} 0
+kube_pod_status_ready{condition="false",namespace="kube-system",pod="kube-dns-v20-5g5cb"} 0
+kube_pod_status_ready{condition="false",namespace="kube-system",pod="kube-state-metrics-1303537707-7ncd1"} 0
+kube_pod_status_ready{condition="false",namespace="kube-system",pod="kubernetes-dashboard-vw0l6"} 0
+kube_pod_status_ready{condition="false",namespace="kube-system",pod="tiller-deploy-3067024529-9lpmb"} 0
+kube_pod_status_ready{condition="true",namespace="default",pod="jumpy-owl-redis-3481028193-s78x9"} 0
+kube_pod_status_ready{condition="true",namespace="test",pod="jumpy-owl-redis-3481028193-s78x9"} 1
+kube_pod_status_ready{condition="true",namespace="jenkins",pod="wise-lynx-jenkins-1616735317-svn6k"} 1
+kube_pod_status_ready{condition="true",namespace="kube-system",pod="kube-addon-manager-minikube"} 1
+kube_pod_status_ready{condition="true",namespace="kube-system",pod="kube-dns-v20-5g5cb"} 1
+kube_pod_status_ready{condition="true",namespace="kube-system",pod="kube-state-metrics-1303537707-7ncd1"} 1
+kube_pod_status_ready{condition="true",namespace="kube-system",pod="kubernetes-dashboard-vw0l6"} 1
+kube_pod_status_ready{condition="true",namespace="kube-system",pod="tiller-deploy-3067024529-9lpmb"} 1
+kube_pod_status_ready{condition="unknown",namespace="default",pod="jumpy-owl-redis-3481028193-s78x9"} 0
+kube_pod_status_ready{condition="unknown",namespace="test",pod="jumpy-owl-redis-3481028193-s78x9"} 0
+kube_pod_status_ready{condition="unknown",namespace="jenkins",pod="wise-lynx-jenkins-1616735317-svn6k"} 0
+kube_pod_status_ready{condition="unknown",namespace="kube-system",pod="kube-addon-manager-minikube"} 0
+kube_pod_status_ready{condition="unknown",namespace="kube-system",pod="kube-dns-v20-5g5cb"} 0
+kube_pod_status_ready{condition="unknown",namespace="kube-system",pod="kube-state-metrics-1303537707-7ncd1"} 0
+kube_pod_status_ready{condition="unknown",namespace="kube-system",pod="kubernetes-dashboard-vw0l6"} 0
+kube_pod_status_ready{condition="unknown",namespace="kube-system",pod="tiller-deploy-3067024529-9lpmb"} 0
+# HELP kube_pod_status_scheduled Describes the status of the scheduling process for the pod.
+# TYPE kube_pod_status_scheduled gauge
+kube_pod_status_scheduled{condition="false",namespace="default",pod="jumpy-owl-redis-3481028193-s78x9"} 0
+kube_pod_status_scheduled{condition="false",namespace="test",pod="jumpy-owl-redis-3481028193-s78x9"} 1
+kube_pod_status_scheduled{condition="false",namespace="jenkins",pod="wise-lynx-jenkins-1616735317-svn6k"} 0
+kube_pod_status_scheduled{condition="false",namespace="kube-system",pod="kube-addon-manager-minikube"} 0
+kube_pod_status_scheduled{condition="false",namespace="kube-system",pod="kube-dns-v20-5g5cb"} 0
+kube_pod_status_scheduled{condition="false",namespace="kube-system",pod="kube-state-metrics-1303537707-7ncd1"} 0
+kube_pod_status_scheduled{condition="false",namespace="kube-system",pod="kube-state-metrics-1303537707-mnzbp"} 1
+kube_pod_status_scheduled{condition="false",namespace="kube-system",pod="kubernetes-dashboard-vw0l6"} 0
+kube_pod_status_scheduled{condition="false",namespace="kube-system",pod="tiller-deploy-3067024529-9lpmb"} 0
+kube_pod_status_scheduled{condition="true",namespace="default",pod="jumpy-owl-redis-3481028193-s78x9"} 1
+kube_pod_status_scheduled{condition="true",namespace="jenkins",pod="wise-lynx-jenkins-1616735317-svn6k"} 1
+kube_pod_status_scheduled{condition="true",namespace="kube-system",pod="kube-addon-manager-minikube"} 1
+kube_pod_status_scheduled{condition="true",namespace="kube-system",pod="kube-dns-v20-5g5cb"} 1
+kube_pod_status_scheduled{condition="true",namespace="kube-system",pod="kube-state-metrics-1303537707-7ncd1"} 1
+kube_pod_status_scheduled{condition="true",namespace="kube-system",pod="kube-state-metrics-1303537707-mnzbp"} 0
+kube_pod_status_scheduled{condition="true",namespace="kube-system",pod="kubernetes-dashboard-vw0l6"} 1
+kube_pod_status_scheduled{condition="true",namespace="kube-system",pod="tiller-deploy-3067024529-9lpmb"} 1
+kube_pod_status_scheduled{condition="unknown",namespace="default",pod="jumpy-owl-redis-3481028193-s78x9"} 0
+kube_pod_status_scheduled{condition="unknown",namespace="jenkins",pod="wise-lynx-jenkins-1616735317-svn6k"} 0
+kube_pod_status_scheduled{condition="unknown",namespace="kube-system",pod="kube-addon-manager-minikube"} 0
+kube_pod_status_scheduled{condition="unknown",namespace="kube-system",pod="kube-dns-v20-5g5cb"} 0
+kube_pod_status_scheduled{condition="unknown",namespace="kube-system",pod="kube-state-metrics-1303537707-7ncd1"} 0
+kube_pod_status_scheduled{condition="unknown",namespace="kube-system",pod="kube-state-metrics-1303537707-mnzbp"} 0
+kube_pod_status_scheduled{condition="unknown",namespace="kube-system",pod="kubernetes-dashboard-vw0l6"} 0
+kube_pod_status_scheduled{condition="unknown",namespace="kube-system",pod="tiller-deploy-3067024529-9lpmb"} 0
+# HELP kube_replicaset_metadata_generation Sequence number representing a specific generation of the desired state.
+# TYPE kube_replicaset_metadata_generation gauge
+kube_replicaset_metadata_generation{namespace="default",replicaset="jumpy-owl-redis-3481028193"} 1
+kube_replicaset_metadata_generation{namespace="jenkins",replicaset="wise-lynx-jenkins-1616735317"} 1
+kube_replicaset_metadata_generation{namespace="kube-system",replicaset="kube-state-metrics-1303537707"} 1
+kube_replicaset_metadata_generation{namespace="test",replicaset="kube-state-metrics-1303537707"} 1
+kube_replicaset_metadata_generation{namespace="kube-system",replicaset="tiller-deploy-3067024529"} 1
+# HELP kube_replicaset_spec_replicas Number of desired pods for a ReplicaSet.
+# TYPE kube_replicaset_spec_replicas gauge
+kube_replicaset_spec_replicas{namespace="default",replicaset="jumpy-owl-redis-3481028193"} 1
+kube_replicaset_spec_replicas{namespace="jenkins",replicaset="wise-lynx-jenkins-1616735317"} 1
+kube_replicaset_spec_replicas{namespace="kube-system",replicaset="kube-state-metrics-1303537707"} 2
+kube_replicaset_spec_replicas{namespace="test",replicaset="kube-state-metrics-1303537707"} 3
+kube_replicaset_spec_replicas{namespace="kube-system",replicaset="tiller-deploy-3067024529"} 1
+# HELP kube_replicaset_status_fully_labeled_replicas The number of fully labeled replicas per ReplicaSet.
+# TYPE kube_replicaset_status_fully_labeled_replicas gauge
+kube_replicaset_status_fully_labeled_replicas{namespace="default",replicaset="jumpy-owl-redis-3481028193"} 1
+kube_replicaset_status_fully_labeled_replicas{namespace="jenkins",replicaset="wise-lynx-jenkins-1616735317"} 1
+kube_replicaset_status_fully_labeled_replicas{namespace="kube-system",replicaset="kube-state-metrics-1303537707"} 2
+kube_replicaset_status_fully_labeled_replicas{namespace="test",replicaset="kube-state-metrics-1303537707"} 4
+kube_replicaset_status_fully_labeled_replicas{namespace="kube-system",replicaset="tiller-deploy-3067024529"} 1
+# HELP kube_replicaset_status_observed_generation The generation observed by the ReplicaSet controller.
+# TYPE kube_replicaset_status_observed_generation gauge
+kube_replicaset_status_observed_generation{namespace="default",replicaset="jumpy-owl-redis-3481028193"} 1
+kube_replicaset_status_observed_generation{namespace="jenkins",replicaset="wise-lynx-jenkins-1616735317"} 1
+kube_replicaset_status_observed_generation{namespace="kube-system",replicaset="kube-state-metrics-1303537707"} 1
+kube_replicaset_status_observed_generation{namespace="test",replicaset="kube-state-metrics-1303537707"} 5
+kube_replicaset_status_observed_generation{namespace="kube-system",replicaset="tiller-deploy-3067024529"} 1
+# HELP kube_replicaset_status_ready_replicas The number of ready replicas per ReplicaSet.
+# TYPE kube_replicaset_status_ready_replicas gauge
+kube_replicaset_status_ready_replicas{namespace="default",replicaset="jumpy-owl-redis-3481028193"} 0
+kube_replicaset_status_ready_replicas{namespace="jenkins",replicaset="wise-lynx-jenkins-1616735317"} 1
+kube_replicaset_status_ready_replicas{namespace="kube-system",replicaset="kube-state-metrics-1303537707"} 1
+kube_replicaset_status_ready_replicas{namespace="test",replicaset="kube-state-metrics-1303537707"} 6
+kube_replicaset_status_ready_replicas{namespace="kube-system",replicaset="tiller-deploy-3067024529"} 1
+# HELP kube_replicaset_status_replicas The number of replicas per ReplicaSet.
+# TYPE kube_replicaset_status_replicas gauge
+kube_replicaset_status_replicas{namespace="default",replicaset="jumpy-owl-redis-3481028193"} 1
+kube_replicaset_status_replicas{namespace="jenkins",replicaset="wise-lynx-jenkins-1616735317"} 1
+kube_replicaset_status_replicas{namespace="kube-system",replicaset="kube-state-metrics-1303537707"} 2
+kube_replicaset_status_replicas{namespace="test",replicaset="kube-state-metrics-1303537707"} 7
+kube_replicaset_status_replicas{namespace="kube-system",replicaset="tiller-deploy-3067024529"} 1
+# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
+# TYPE process_cpu_seconds_total counter
+process_cpu_seconds_total 33.37
+# HELP process_max_fds Maximum number of open file descriptors.
+# TYPE process_max_fds gauge
+process_max_fds 65536
+# HELP process_open_fds Number of open file descriptors.
+# TYPE process_open_fds gauge
+process_open_fds 14
+# HELP process_resident_memory_bytes Resident memory size in bytes.
+# TYPE process_resident_memory_bytes gauge
+process_resident_memory_bytes 4.2102784e+07
+# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
+# TYPE process_start_time_seconds gauge
+process_start_time_seconds 1.4939719827e+09
+# HELP process_virtual_memory_bytes Virtual memory size in bytes.
+# TYPE process_virtual_memory_bytes gauge
+process_virtual_memory_bytes 5.2932608e+07
+# HELP kube_statefulset_created Unix creation timestamp
+# TYPE kube_statefulset_created gauge
+kube_statefulset_created{namespace="default",statefulset="elasticsearch"} 1.511973651e+09
+kube_statefulset_created{namespace="default",statefulset="mysql"} 1.511989697e+09
+kube_statefulset_created{namespace="custom",statefulset="mysql"} 1.511999697e+09
+# HELP kube_statefulset_labels Kubernetes labels converted to Prometheus labels.
+# TYPE kube_statefulset_labels gauge
+kube_statefulset_labels{label_app="oci",label_io_kompose_service="elasticsearch",namespace="default",statefulset="elasticsearch"} 1
+kube_statefulset_labels{label_app="oci",label_custom_pod="true",label_io_kompose_service="s-mysql",namespace="default",statefulset="mysql"} 1
+kube_statefulset_labels{label_app="oci",label_custom_pod="true",label_io_kompose_service="s-mysql",namespace="custom",statefulset="mysql"} 1
+# HELP kube_statefulset_metadata_generation Sequence number representing a specific generation of the desired state for the StatefulSet.
+# TYPE kube_statefulset_metadata_generation gauge
+kube_statefulset_metadata_generation{namespace="default",statefulset="elasticsearch"} 3
+kube_statefulset_metadata_generation{namespace="default",statefulset="mysql"} 4
+kube_statefulset_metadata_generation{namespace="custom",statefulset="mysql"} 5
+# HELP kube_statefulset_replicas Number of desired pods for a StatefulSet.
+# TYPE kube_statefulset_replicas gauge
+kube_statefulset_replicas{namespace="default",statefulset="elasticsearch"} 4
+kube_statefulset_replicas{namespace="default",statefulset="mysql"} 5
+kube_statefulset_replicas{namespace="custom",statefulset="mysql"} 6
+# HELP kube_statefulset_status_observed_generation The generation observed by the StatefulSet controller.
+# TYPE kube_statefulset_status_observed_generation gauge
+kube_statefulset_status_observed_generation{namespace="default",statefulset="elasticsearch"} 1
+kube_statefulset_status_observed_generation{namespace="default",statefulset="mysql"} 2
+kube_statefulset_status_observed_generation{namespace="custom",statefulset="mysql"} 3
+# HELP kube_statefulset_status_replicas The number of replicas per StatefulSet.
+# TYPE kube_statefulset_status_replicas gauge
+kube_statefulset_status_replicas{namespace="default",statefulset="elasticsearch"} 1
+kube_statefulset_status_replicas{namespace="default",statefulset="mysql"} 2
+kube_statefulset_status_replicas{namespace="custom",statefulset="mysql"} 3

--- a/metricbeat/module/kubernetes/state_container/_meta/testdata/ksm-v1_3_0.plain-expected.json
+++ b/metricbeat/module/kubernetes/state_container/_meta/testdata/ksm-v1_3_0.plain-expected.json
@@ -1,0 +1,456 @@
+[
+    {
+        "event": {
+            "dataset": "kubernetes.container",
+            "duration": 115000,
+            "module": "kubernetes"
+        },
+        "kubernetes": {
+            "container": {
+                "cpu": {
+                    "request": {
+                        "cores": 0.01
+                    }
+                },
+                "id": "docker://52fa55e051dc5b68e44c027588685b7edd85aaa03b07f7216d399249ff4fc821",
+                "image": "gcr.io/google_containers/exechealthz-amd64:1.2",
+                "memory": {
+                    "limit": {
+                        "bytes": 52428800
+                    },
+                    "request": {
+                        "bytes": 52428800
+                    }
+                },
+                "name": "healthz",
+                "status": {
+                    "phase": "running",
+                    "ready": true,
+                    "restarts": 2
+                }
+            },
+            "namespace": "kube-system",
+            "node": {
+                "name": "minikube"
+            },
+            "pod": {
+                "name": "kube-dns-v20-5g5cb"
+            }
+        },
+        "metricset": {
+            "name": "state_container"
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "kubernetes"
+        }
+    },
+    {
+        "event": {
+            "dataset": "kubernetes.container",
+            "duration": 115000,
+            "module": "kubernetes"
+        },
+        "kubernetes": {
+            "container": {
+                "id": "docker://3aaee8bdd311c015240e99fa2a5a5f2f26b11b51236a683b39d8c1902e423978",
+                "image": "gcr.io/google_containers/kubernetes-dashboard-amd64:v1.5.1",
+                "name": "kubernetes-dashboard",
+                "status": {
+                    "phase": "running",
+                    "ready": true,
+                    "restarts": 2
+                }
+            },
+            "namespace": "kube-system",
+            "node": {
+                "name": "minikube"
+            },
+            "pod": {
+                "name": "kubernetes-dashboard-vw0l6"
+            }
+        },
+        "metricset": {
+            "name": "state_container"
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "kubernetes"
+        }
+    },
+    {
+        "event": {
+            "dataset": "kubernetes.container",
+            "duration": 115000,
+            "module": "kubernetes"
+        },
+        "kubernetes": {
+            "container": {
+                "cpu": {
+                    "request": {
+                        "cores": 0.1
+                    }
+                },
+                "id": "docker://fa3d83f648de42492b38fa3e8501d109376f391c50f2bd210c895c8477ae4b62",
+                "image": "gcr.io/google_containers/kubedns-amd64:1.9",
+                "memory": {
+                    "limit": {
+                        "bytes": 178257920
+                    },
+                    "request": {
+                        "bytes": 73400320
+                    }
+                },
+                "name": "kubedns",
+                "status": {
+                    "phase": "running",
+                    "ready": true,
+                    "restarts": 2
+                }
+            },
+            "namespace": "kube-system",
+            "node": {
+                "name": "minikube"
+            },
+            "pod": {
+                "name": "kube-dns-v20-5g5cb"
+            }
+        },
+        "metricset": {
+            "name": "state_container"
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "kubernetes"
+        }
+    },
+    {
+        "event": {
+            "dataset": "kubernetes.container",
+            "duration": 115000,
+            "module": "kubernetes"
+        },
+        "kubernetes": {
+            "container": {
+                "cpu": {
+                    "request": {
+                        "cores": 0.2
+                    }
+                },
+                "id": "docker://fa3d83f648de42492b38fa3e8501d109376f391c50f2bd210c895c8477ae4b62-test",
+                "image": "gcr.io/google_containers/kubedns-amd64:1.9-test",
+                "memory": {
+                    "limit": {
+                        "bytes": 278257920
+                    },
+                    "request": {
+                        "bytes": 83400320
+                    }
+                },
+                "name": "kubedns",
+                "status": {
+                    "phase": "terminated",
+                    "ready": false,
+                    "restarts": 3
+                }
+            },
+            "namespace": "test",
+            "node": {
+                "name": "minikube-test"
+            },
+            "pod": {
+                "name": "kube-dns-v20-5g5cb-test"
+            }
+        },
+        "metricset": {
+            "name": "state_container"
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "kubernetes"
+        }
+    },
+    {
+        "event": {
+            "dataset": "kubernetes.container",
+            "duration": 115000,
+            "module": "kubernetes"
+        },
+        "kubernetes": {
+            "container": {
+                "cpu": {
+                    "request": {
+                        "cores": 0.2
+                    }
+                },
+                "id": "docker://e2ee1c2c7b8d4e5fd8c834b83cba8377d6b0e39da18157688ccc1a06b7c53117",
+                "image": "jenkinsci/jenkins:2.46.1",
+                "memory": {
+                    "request": {
+                        "bytes": 268435456
+                    }
+                },
+                "name": "wise-lynx-jenkins",
+                "status": {
+                    "phase": "running",
+                    "ready": true,
+                    "restarts": 1
+                }
+            },
+            "namespace": "jenkins",
+            "node": {
+                "name": "minikube"
+            },
+            "pod": {
+                "name": "wise-lynx-jenkins-1616735317-svn6k"
+            }
+        },
+        "metricset": {
+            "name": "state_container"
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "kubernetes"
+        }
+    },
+    {
+        "event": {
+            "dataset": "kubernetes.container",
+            "duration": 115000,
+            "module": "kubernetes"
+        },
+        "kubernetes": {
+            "container": {
+                "cpu": {
+                    "limit": {
+                        "cores": 0.2
+                    },
+                    "request": {
+                        "cores": 0.1
+                    }
+                },
+                "id": "docker://973cbe45982c5126a5caf8c58d964c0ab1d5bb2c165ccc59715fcc1ebd58ab3d",
+                "image": "gcr.io/google_containers/kube-state-metrics:v0.4.1",
+                "memory": {
+                    "limit": {
+                        "bytes": 52428800
+                    },
+                    "request": {
+                        "bytes": 31457280
+                    }
+                },
+                "name": "kube-state-metrics",
+                "status": {
+                    "phase": "running",
+                    "ready": true,
+                    "restarts": 1
+                }
+            },
+            "namespace": "kube-system",
+            "node": {
+                "name": "minikube"
+            },
+            "pod": {
+                "name": "kube-state-metrics-1303537707-7ncd1"
+            }
+        },
+        "metricset": {
+            "name": "state_container"
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "kubernetes"
+        }
+    },
+    {
+        "event": {
+            "dataset": "kubernetes.container",
+            "duration": 115000,
+            "module": "kubernetes"
+        },
+        "kubernetes": {
+            "container": {
+                "id": "docker://469f5d2b7854eb52e5d13dc0cd3e664c1b682b157aabaf596ffe4984f1516902",
+                "image": "gcr.io/kubernetes-helm/tiller:v2.3.1",
+                "name": "tiller",
+                "status": {
+                    "phase": "running",
+                    "ready": true,
+                    "restarts": 1
+                }
+            },
+            "namespace": "kube-system",
+            "node": {
+                "name": "minikube"
+            },
+            "pod": {
+                "name": "tiller-deploy-3067024529-9lpmb"
+            }
+        },
+        "metricset": {
+            "name": "state_container"
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "kubernetes"
+        }
+    },
+    {
+        "event": {
+            "dataset": "kubernetes.container",
+            "duration": 115000,
+            "module": "kubernetes"
+        },
+        "kubernetes": {
+            "container": {
+                "id": "docker://9a4c9462cd078d7be4f0a9b94bcfeb69d5fdd76bff67142df3f58367ac7e8d61",
+                "image": "gcr.io/google_containers/kube-dnsmasq-amd64:1.4",
+                "name": "dnsmasq",
+                "status": {
+                    "phase": "running",
+                    "ready": true,
+                    "restarts": 2
+                }
+            },
+            "namespace": "kube-system",
+            "node": {
+                "name": "minikube"
+            },
+            "pod": {
+                "name": "kube-dns-v20-5g5cb"
+            }
+        },
+        "metricset": {
+            "name": "state_container"
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "kubernetes"
+        }
+    },
+    {
+        "event": {
+            "dataset": "kubernetes.container",
+            "duration": 115000,
+            "module": "kubernetes"
+        },
+        "kubernetes": {
+            "container": {
+                "cpu": {
+                    "limit": {
+                        "cores": 0.2
+                    },
+                    "request": {
+                        "cores": 0.1
+                    }
+                },
+                "memory": {
+                    "limit": {
+                        "bytes": 52428800
+                    },
+                    "request": {
+                        "bytes": 31457280
+                    }
+                },
+                "name": "kube-state-metrics"
+            },
+            "namespace": "kube-system",
+            "pod": {
+                "name": "kube-state-metrics-1303537707-mnzbp"
+            }
+        },
+        "metricset": {
+            "name": "state_container"
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "kubernetes"
+        }
+    },
+    {
+        "event": {
+            "dataset": "kubernetes.container",
+            "duration": 115000,
+            "module": "kubernetes"
+        },
+        "kubernetes": {
+            "container": {
+                "cpu": {
+                    "request": {
+                        "cores": 0.005
+                    }
+                },
+                "id": "docker://91fdd43f6b1b4c3dd133cfca53e0b1210bc557c2ae56006026b5ccdb5f52826f",
+                "image": "gcr.io/google-containers/kube-addon-manager:v6.3",
+                "memory": {
+                    "request": {
+                        "bytes": 52428800
+                    }
+                },
+                "name": "kube-addon-manager",
+                "status": {
+                    "phase": "running",
+                    "ready": true,
+                    "restarts": 2
+                }
+            },
+            "namespace": "kube-system",
+            "node": {
+                "name": "minikube"
+            },
+            "pod": {
+                "name": "kube-addon-manager-minikube"
+            }
+        },
+        "metricset": {
+            "name": "state_container"
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "kubernetes"
+        }
+    },
+    {
+        "event": {
+            "dataset": "kubernetes.container",
+            "duration": 115000,
+            "module": "kubernetes"
+        },
+        "kubernetes": {
+            "container": {
+                "cpu": {
+                    "request": {
+                        "cores": 0.1
+                    }
+                },
+                "id": "docker://4fa227874ee68536bf902394fb662f07b99099798ca9cd5c1506b79075acc065",
+                "image": "bitnami/redis:3.2.8-r2",
+                "memory": {
+                    "request": {
+                        "bytes": 268435456
+                    }
+                },
+                "name": "jumpy-owl-redis",
+                "status": {
+                    "phase": "waiting",
+                    "ready": false,
+                    "restarts": 270
+                }
+            },
+            "namespace": "default",
+            "node": {
+                "name": "minikube"
+            },
+            "pod": {
+                "name": "jumpy-owl-redis-3481028193-s78x9"
+            }
+        },
+        "metricset": {
+            "name": "state_container"
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "kubernetes"
+        }
+    }
+]

--- a/metricbeat/module/kubernetes/state_container/state_container.go
+++ b/metricbeat/module/kubernetes/state_container/state_container.go
@@ -18,6 +18,8 @@
 package state_container
 
 import (
+	"fmt"
+
 	"github.com/elastic/beats/libbeat/common"
 	p "github.com/elastic/beats/metricbeat/helper/prometheus"
 	"github.com/elastic/beats/metricbeat/mb"
@@ -66,10 +68,6 @@ var (
 			"container_id": p.Label("id"),
 			"image":        p.Label("image"),
 		},
-
-		ExtraFields: map[string]string{
-			mb.NamespaceKey: "container",
-		},
 	}
 )
 
@@ -106,18 +104,22 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	}, nil
 }
 
-// Fetch methods implements the data gathering and data conversion to the right format
-// It returns the event which is then forward to the output. In case of an error, a
-// descriptive error must be returned.
-func (m *MetricSet) Fetch() ([]common.MapStr, error) {
+// Fetch methods implements the data gathering and data conversion to the right
+// format. It publishes the event which is then forwarded to the output. In case
+// of an error set the Error field of mb.Event or simply call report.Error().
+func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
 	m.enricher.Start()
 
 	events, err := m.prometheus.GetProcessedMetrics(mapping)
 	if err != nil {
-		return nil, err
+		m.Logger().Error(err)
+		reporter.Error(err)
+		return
 	}
 
 	m.enricher.Enrich(events)
+
+	fmt.Println("events", len(events))
 
 	// Calculate deprecated nanocores values
 	for _, event := range events {
@@ -132,9 +134,26 @@ func (m *MetricSet) Fetch() ([]common.MapStr, error) {
 				event["cpu.limit.nanocores"] = limitCores * nanocores
 			}
 		}
-	}
 
-	return events, err
+		var moduleFieldsMapStr common.MapStr
+		moduleFields, ok := event[mb.ModuleDataKey]
+		if ok {
+			moduleFieldsMapStr, ok = moduleFields.(common.MapStr)
+			if !ok {
+				m.Logger().Errorf("error trying to convert '%s' from event to common.MapStr", mb.ModuleDataKey)
+			}
+		}
+		delete(event, mb.ModuleDataKey)
+
+		if reported := reporter.Event(mb.Event{
+			MetricSetFields: event,
+			ModuleFields:    moduleFieldsMapStr,
+			Namespace:       "kubernetes.container",
+		}); !reported {
+			m.Logger().Debug("error trying to emit event")
+			return
+		}
+	}
 }
 
 // Close stops this metricset

--- a/metricbeat/module/kubernetes/state_container/state_container.go
+++ b/metricbeat/module/kubernetes/state_container/state_container.go
@@ -18,8 +18,6 @@
 package state_container
 
 import (
-	"fmt"
-
 	"github.com/elastic/beats/libbeat/common"
 	p "github.com/elastic/beats/metricbeat/helper/prometheus"
 	"github.com/elastic/beats/metricbeat/mb"
@@ -118,8 +116,6 @@ func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
 	}
 
 	m.enricher.Enrich(events)
-
-	fmt.Println("events", len(events))
 
 	// Calculate deprecated nanocores values
 	for _, event := range events {

--- a/metricbeat/module/kubernetes/state_container/state_container_test.go
+++ b/metricbeat/module/kubernetes/state_container/state_container_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestEventMapping(t *testing.T) {
-	ptest.TestMetricSetEventsFetcher(t, "kubernetes", "state_container",
+	ptest.TestMetricSet(t, "kubernetes", "state_container",
 		ptest.TestCases{
 			{
 				MetricsFile:  "../_meta/test/kube-state-metrics",


### PR DESCRIPTION
Refer to #10774 for more info

Found a really ugly dependency with Prometheus that needed to upgrade also the Prometheus helper so I have removed the dependency by duplicating code.

We can make a follow up PR to "clean" that. But right now I must keep focused on the migration