### PR TITLE
Add links to Logstash docs about working with Filebeat modules

### DIFF
--- a/filebeat/docs/modules-getting-started.asciidoc
+++ b/filebeat/docs/modules-getting-started.asciidoc
@@ -100,7 +100,7 @@ load the ingest pipelines manually. To do this, run the `setup` command with
 the `--pipelines` option specified. If you used the
 <<modules-command,`modules`>> command to enable modules in the `modules.d`
 directory, also specify the `--modules` flag. For example, the following command
-loads the ingest pipelines used by all metricsets enabled in the system, nginx,
+loads the ingest pipelines used by all filesets enabled in the system, nginx,
 and mysql modules:
 
 // override modulename attribute so it works with the --modules option
@@ -133,6 +133,10 @@ and mysql modules:
 ----
 PS > .{backslash}{beatname_lc}.exe setup --pipelines --modules {modulename}
 ----
+
+TIP: If you're loading ingest pipelines manually because you want to send events
+to {ls}, also see
+{logstash-ref}/filebeat-modules.html[Working with {beatname_uc} modules].
 
 :has_module_steps!:
 :modulename!:

--- a/libbeat/docs/shared-logstash-config.asciidoc
+++ b/libbeat/docs/shared-logstash-config.asciidoc
@@ -22,7 +22,7 @@ the {stack} getting started tutorial. Also see the documentation for the
 If you want to use {ls} to perform additional processing on the data collected by
 {beatname_uc}, you need to configure {beatname_uc} to use {ls}.
 
-To do this, you edit the {beatname_uc} configuration file to disable the Elasticsearch
+To do this, you edit the {beatname_uc} configuration file to disable the {es}
 output by commenting it out and enable the {ls} output by uncommenting the
 logstash section:
 
@@ -36,8 +36,14 @@ output.logstash:
 The `hosts` option specifies the {ls} server and the port (`5044`) where {ls} is configured to listen for incoming
 Beats connections.
 
-For this configuration, you must <<load-template-manually,load the index template into Elasticsearch manually>>
-because the options for auto loading the template are only available for the Elasticsearch output.
+For this configuration, you must <<load-template-manually,load the index template into {es} manually>>
+because the options for auto loading the template are only available for the {es} output.
+
+ifeval::["{beatname_lc}"=="filebeat"]
+Want to use <<filebeat-modules,{beatname_uc} modules>> with {ls}? You need to do
+some extra setup. For more information, see
+{logstash-ref}/filebeat-modules.html[Working with {beatname_uc} modules].
+endif::[]
 
 ifndef::win-only[]
 ifndef::apm-server[]


### PR DESCRIPTION
Adds links that point to the new content added in https://github.com/elastic/logstash/pull/10438).