### PR TITLE
Enhance Suricata pipeline to handle destination.domain being set

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -252,6 +252,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add Netflow module to enrich flow events with geoip data. {pull}10877[10877]
 - Set `event.category: network_traffic` for Suricata. {pull}10882[10882]
 - Add configuration knob for auto-discover hints to control whether log harvesting is enabled for the pod/container. {issue}10811[10811] {pull}10911[10911]
+- Change Suricata module pipeline to handle `destination.domain` being set if a reverse DNS processor is used. {issue}10510[10510]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/module/suricata/eve/ingest/pipeline.json
+++ b/x-pack/filebeat/module/suricata/eve/ingest/pipeline.json
@@ -64,7 +64,8 @@
         },
         {
             "script": {
-                "source": "def domain = ctx.destination?.domain; if (domain instanceof Collection) { ctx.destination.domain = ctx.destination.domain.stream().distinct().collect(Collectors.toList()); if (domain.length == 1) { ctx.destination.domain = domain[0]; } }",
+                "type": "painless",
+                "source": "def domain = ctx.destination?.domain; if (domain instanceof Collection) { domain = domain.stream().distinct().collect(Collectors.toList()); if (domain.length == 1) { domain = domain[0]; }ctx.destination.domain = domain; }",
                 "ignore_failure": true
             }
         },

--- a/x-pack/filebeat/module/suricata/eve/ingest/pipeline.json
+++ b/x-pack/filebeat/module/suricata/eve/ingest/pipeline.json
@@ -64,7 +64,7 @@
         },
         {
             "script": {
-                "source": "def domain = ctx.destination?.domain; if (domain instanceof Collection) { if (domain.length == 1) { ctx.destination.domain = domain[0]; } else { ctx.destination.domain = ctx.destination.domain.stream().distinct().collect(Collectors.toList()); } }",
+                "source": "def domain = ctx.destination?.domain; if (domain instanceof Collection) { ctx.destination.domain = ctx.destination.domain.stream().distinct().collect(Collectors.toList()); if (domain.length == 1) { ctx.destination.domain = domain[0]; } }",
                 "ignore_failure": true
             }
         },

--- a/x-pack/filebeat/module/suricata/eve/ingest/pipeline.json
+++ b/x-pack/filebeat/module/suricata/eve/ingest/pipeline.json
@@ -50,10 +50,22 @@
             }
         },
         {
-            "rename": {
+            "append": {
+                "if": "ctx.suricata?.eve?.http?.hostname != null",
+                "value": "{{suricata.eve.http.hostname}}",
+                "field": "destination.domain"
+            }
+        },
+        {
+            "remove": {
                 "field": "suricata.eve.http.hostname",
-                "target_field": "destination.domain",
-                "ignore_missing": true
+                "ignore_failure": true
+            }
+        },
+        {
+            "script": {
+                "source": "def domain = ctx.destination?.domain; if (domain instanceof Collection) { if (domain.length == 1) { ctx.destination.domain = domain[0]; } else { ctx.destination.domain = ctx.destination.domain.stream().distinct().collect(Collectors.toList()); } }",
+                "ignore_failure": true
             }
         },
         {


### PR DESCRIPTION
This replaces the usage of a `rename` processor with an `append` + `remove` processor.
Then a script processor is used to deduplicate the domains.

This makes the pipeline compatible with the reverse dns processor being used on the Beat side.

Fixes #10510