### PR TITLE
Fix autodiscover for docker in filebeat 

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -205,7 +205,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fixed data types for various hosts fields in `mongodb/replstatus` metricset {pull}10307[10307]
 - Added function to close sql database connection. {pull}10355[10355]
 - Fix issue with `elasticsearch/node_stats` metricset (x-pack) not indexing `source_node` field. {pull}10639[10639]
-- Migrate docker autodiscover to ECS. {issue}10757[10757]
+- Migrate docker autodiscover to ECS. {issue}10757[10757] {pull}10862[10862]
 
 *Packetbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -205,6 +205,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fixed data types for various hosts fields in `mongodb/replstatus` metricset {pull}10307[10307]
 - Added function to close sql database connection. {pull}10355[10355]
 - Fix issue with `elasticsearch/node_stats` metricset (x-pack) not indexing `source_node` field. {pull}10639[10639]
+- Migrate docker autodiscover to ECS. {issue}10757[10757]
 
 *Packetbeat*
 

--- a/filebeat/tests/system/test_autodiscover.py
+++ b/filebeat/tests/system/test_autodiscover.py
@@ -48,7 +48,6 @@ class TestAutodiscover(filebeat.BaseTest):
         output = self.read_output_json()
         proc.check_kill_and_wait()
 
-
         # Check metadata is added
         assert output[0]['message'] == 'Busybox output 1'
         assert output[0]['container']['image'] == 'busybox'

--- a/filebeat/tests/system/test_autodiscover.py
+++ b/filebeat/tests/system/test_autodiscover.py
@@ -48,8 +48,11 @@ class TestAutodiscover(filebeat.BaseTest):
         output = self.read_output_json()
         proc.check_kill_and_wait()
 
+
         # Check metadata is added
         assert output[0]['message'] == 'Busybox output 1'
-        assert output[0]['docker']['container']['image'] == 'busybox'
-        assert output[0]['docker']['container']['labels'] == {}
-        assert 'name' in output[0]['docker']['container']
+        assert output[0]['container']['image'] == 'busybox'
+        assert output[0]['container']['labels'] == {}
+        assert 'name' in output[0]['container']
+
+        self.assert_fields_are_documented(output[0])

--- a/filebeat/tests/system/test_autodiscover.py
+++ b/filebeat/tests/system/test_autodiscover.py
@@ -50,7 +50,7 @@ class TestAutodiscover(filebeat.BaseTest):
 
         # Check metadata is added
         assert output[0]['message'] == 'Busybox output 1'
-        assert output[0]['container']['image'] == 'busybox'
+        assert output[0]['container']['image']['name'] == 'busybox'
         assert output[0]['container']['labels'] == {}
         assert 'name' in output[0]['container']
 

--- a/heartbeat/tests/system/test_autodiscovery.py
+++ b/heartbeat/tests/system/test_autodiscovery.py
@@ -25,7 +25,7 @@ class TestAutodiscover(BaseTest):
                 'docker': {
                     'templates': '''
                       - condition:
-                          contains.container.image: redis
+                          contains.docker.container.image: redis
                         config:
                           - type: tcp
                             id: myid

--- a/heartbeat/tests/system/test_autodiscovery.py
+++ b/heartbeat/tests/system/test_autodiscovery.py
@@ -25,7 +25,7 @@ class TestAutodiscover(BaseTest):
                 'docker': {
                     'templates': '''
                       - condition:
-                          contains.docker.container.image: redis
+                          contains.container.image: redis
                         config:
                           - type: tcp
                             id: myid
@@ -60,7 +60,9 @@ class TestAutodiscover(BaseTest):
                     # We don't check all the docker fields because this is really the responsibility
                     # of libbeat's autodiscovery code.
                     event = output[0]
-                    if event['monitor']['id'] == 'myid' and event['docker']['container']['id'] is not None:
+                    if event['monitor']['id'] == 'myid' and event['container']['id'] is not None:
                         matched = True
 
         assert matched
+
+        self.assert_fields_are_documented(output[0])

--- a/libbeat/autodiscover/providers/docker/config.go
+++ b/libbeat/autodiscover/providers/docker/config.go
@@ -32,12 +32,14 @@ type Config struct {
 	Builders     []*common.Config        `config:"builders"`
 	Appenders    []*common.Config        `config:"appenders"`
 	Templates    template.MapperSettings `config:"templates"`
+	Dedot        bool                    `config:"labels.dedot"`
 }
 
 func defaultConfig() *Config {
 	return &Config{
 		Host:   "unix:///var/run/docker.sock",
 		Prefix: "co.elastic",
+		Dedot:  true,
 	}
 }
 

--- a/libbeat/autodiscover/providers/docker/docker.go
+++ b/libbeat/autodiscover/providers/docker/docker.go
@@ -136,23 +136,24 @@ func (d *Provider) emitContainer(event bus.Event, flag string) {
 	}
 
 	meta := common.MapStr{
-		"container": common.MapStr{
-			"id":     container.ID,
-			"name":   container.Name,
-			"image":  container.Image,
-			"labels": labelMap,
+		"id":   container.ID,
+		"name": container.Name,
+		"image": common.MapStr{
+			"name": container.Image,
 		},
+		// TODO: Do we need some dedotting here?
+		"labels": labelMap,
 	}
 	// Without this check there would be overlapping configurations with and without ports.
 	if len(container.Ports) == 0 {
 		event := bus.Event{
-			"provider": d.uuid,
-			"id":       container.ID,
-			flag:       true,
-			"host":     host,
-			"docker":   meta,
+			"provider":  d.uuid,
+			"id":        container.ID,
+			flag:        true,
+			"host":      host,
+			"container": meta,
 			"meta": common.MapStr{
-				"docker": meta,
+				"container": meta,
 			},
 		}
 
@@ -162,14 +163,14 @@ func (d *Provider) emitContainer(event bus.Event, flag string) {
 	// Emit container container and port information
 	for _, port := range container.Ports {
 		event := bus.Event{
-			"provider": d.uuid,
-			"id":       container.ID,
-			flag:       true,
-			"host":     host,
-			"port":     port.PrivatePort,
-			"docker":   meta,
+			"provider":  d.uuid,
+			"id":        container.ID,
+			flag:        true,
+			"host":      host,
+			"port":      port.PrivatePort,
+			"container": meta,
 			"meta": common.MapStr{
-				"docker": meta,
+				"container": meta,
 			},
 		}
 

--- a/libbeat/autodiscover/providers/docker/docker.go
+++ b/libbeat/autodiscover/providers/docker/docker.go
@@ -135,15 +135,24 @@ func (d *Provider) emitContainer(event bus.Event, flag string) {
 		safemapstr.Put(labelMap, k, v)
 	}
 
-	meta := common.MapStr{
+	metaOld := common.MapStr{
+		"container": common.MapStr{
+			"id":     container.ID,
+			"name":   container.Name,
+			"image":  container.Image,
+			"labels": labelMap,
+		},
+	}
+
+	metaNew := common.MapStr{
 		"id":   container.ID,
 		"name": container.Name,
 		"image": common.MapStr{
 			"name": container.Image,
 		},
-		// TODO: Do we need some dedotting here?
 		"labels": labelMap,
 	}
+
 	// Without this check there would be overlapping configurations with and without ports.
 	if len(container.Ports) == 0 {
 		event := bus.Event{
@@ -151,9 +160,10 @@ func (d *Provider) emitContainer(event bus.Event, flag string) {
 			"id":        container.ID,
 			flag:        true,
 			"host":      host,
-			"container": meta,
+			"docker":    metaOld,
+			"container": metaNew,
 			"meta": common.MapStr{
-				"container": meta,
+				"container": metaNew,
 			},
 		}
 
@@ -168,9 +178,10 @@ func (d *Provider) emitContainer(event bus.Event, flag string) {
 			flag:        true,
 			"host":      host,
 			"port":      port.PrivatePort,
-			"container": meta,
+			"docker":    metaOld,
+			"container": metaNew,
 			"meta": common.MapStr{
-				"container": meta,
+				"container": metaNew,
 			},
 		}
 

--- a/libbeat/autodiscover/providers/docker/docker_integration_test.go
+++ b/libbeat/autodiscover/providers/docker/docker_integration_test.go
@@ -103,6 +103,10 @@ func checkEvent(t *testing.T, listener bus.Listener, start bool) {
 			assert.NotNil(t, getValue(e, "container.name"))
 			assert.NotNil(t, getValue(e, "host"))
 			assert.Equal(t, getValue(e, "container"), getValue(e, "meta.container"))
+			assert.Equal(t, getValue(e, "docker.container.id"), getValue(e, "meta.container.id"))
+			assert.Equal(t, getValue(e, "docker.container.name"), getValue(e, "meta.container.name"))
+			assert.Equal(t, getValue(e, "docker.container.labels"), getValue(e, "meta.container.labels"))
+			assert.Equal(t, getValue(e, "docker.container.image"), getValue(e, "meta.container.image.name"))
 			return
 
 		case <-time.After(10 * time.Second):

--- a/libbeat/autodiscover/providers/docker/docker_integration_test.go
+++ b/libbeat/autodiscover/providers/docker/docker_integration_test.go
@@ -93,12 +93,12 @@ func checkEvent(t *testing.T, listener bus.Listener, start bool) {
 				assert.Nil(t, getValue(e, "start"))
 			}
 			assert.Equal(t, getValue(e, "container.image.name"), "busybox")
-			assert.Equal(t, getValue(e, "container.labels"), common.MapStr{
-				"label": common.MapStr{
-					"value": "foo",
-					"child": "bar",
-				},
-			})
+			// labels.dedot=true by default
+			assert.Equal(t, common.MapStr{
+				"label":       "foo",
+				"label_child": "bar",
+			},
+				getValue(e, "container.labels"))
 			assert.NotNil(t, getValue(e, "container.id"))
 			assert.NotNil(t, getValue(e, "container.name"))
 			assert.NotNil(t, getValue(e, "host"))

--- a/libbeat/autodiscover/providers/docker/docker_integration_test.go
+++ b/libbeat/autodiscover/providers/docker/docker_integration_test.go
@@ -82,7 +82,7 @@ func checkEvent(t *testing.T, listener bus.Listener, start bool) {
 		select {
 		case e := <-listener.Events():
 			// Ignore any other container
-			if getValue(e, "container.image") != "busybox" {
+			if getValue(e, "docker.container.image") != "busybox" {
 				continue
 			}
 			if start {

--- a/libbeat/autodiscover/providers/docker/docker_integration_test.go
+++ b/libbeat/autodiscover/providers/docker/docker_integration_test.go
@@ -82,7 +82,7 @@ func checkEvent(t *testing.T, listener bus.Listener, start bool) {
 		select {
 		case e := <-listener.Events():
 			// Ignore any other container
-			if getValue(e, "docker.container.image") != "busybox" {
+			if getValue(e, "container.image") != "busybox" {
 				continue
 			}
 			if start {
@@ -92,17 +92,17 @@ func checkEvent(t *testing.T, listener bus.Listener, start bool) {
 				assert.Equal(t, getValue(e, "stop"), true)
 				assert.Nil(t, getValue(e, "start"))
 			}
-			assert.Equal(t, getValue(e, "docker.container.image"), "busybox")
-			assert.Equal(t, getValue(e, "docker.container.labels"), common.MapStr{
+			assert.Equal(t, getValue(e, "container.image.name"), "busybox")
+			assert.Equal(t, getValue(e, "container.labels"), common.MapStr{
 				"label": common.MapStr{
 					"value": "foo",
 					"child": "bar",
 				},
 			})
-			assert.NotNil(t, getValue(e, "docker.container.id"))
-			assert.NotNil(t, getValue(e, "docker.container.name"))
+			assert.NotNil(t, getValue(e, "container.id"))
+			assert.NotNil(t, getValue(e, "container.name"))
 			assert.NotNil(t, getValue(e, "host"))
-			assert.Equal(t, getValue(e, "docker"), getValue(e, "meta.docker"))
+			assert.Equal(t, getValue(e, "container"), getValue(e, "meta.container"))
 			return
 
 		case <-time.After(10 * time.Second):

--- a/libbeat/autodiscover/providers/docker/docker_test.go
+++ b/libbeat/autodiscover/providers/docker/docker_test.go
@@ -38,6 +38,7 @@ func TestGenerateHints(t *testing.T) {
 		},
 		// Docker meta must be present in the hints
 		{
+			// TODO: why must docker be present in the hints? Did my changes now break something?
 			event: bus.Event{
 				"docker": common.MapStr{
 					"container": common.MapStr{

--- a/libbeat/autodiscover/providers/docker/docker_test.go
+++ b/libbeat/autodiscover/providers/docker/docker_test.go
@@ -38,7 +38,6 @@ func TestGenerateHints(t *testing.T) {
 		},
 		// Docker meta must be present in the hints
 		{
-			// TODO: why must docker be present in the hints? Did my changes now break something?
 			event: bus.Event{
 				"docker": common.MapStr{
 					"container": common.MapStr{

--- a/libbeat/processors/add_docker_metadata/add_docker_metadata.go
+++ b/libbeat/processors/add_docker_metadata/add_docker_metadata.go
@@ -123,11 +123,6 @@ func (d *addDockerMetadata) Run(event *beat.Event) (*beat.Event, error) {
 	var cid string
 	var err error
 
-	// Extract CID
-	if v, err := event.GetValue(dockerContainerIDKey); err == nil {
-		cid, _ = v.(string)
-	}
-
 	// Extract CID from the filepath contained in the "source" field.
 	if d.sourceProcessor != nil {
 		if event.Fields["source"] != nil {

--- a/libbeat/processors/add_docker_metadata/add_docker_metadata.go
+++ b/libbeat/processors/add_docker_metadata/add_docker_metadata.go
@@ -123,6 +123,11 @@ func (d *addDockerMetadata) Run(event *beat.Event) (*beat.Event, error) {
 	var cid string
 	var err error
 
+	// Extract CID
+	if v, err := event.GetValue(dockerContainerIDKey); err == nil {
+		cid, _ = v.(string)
+	}
+
 	// Extract CID from the filepath contained in the "source" field.
 	if d.sourceProcessor != nil {
 		if event.Fields["source"] != nil {

--- a/metricbeat/tests/system/test_autodiscover.py
+++ b/metricbeat/tests/system/test_autodiscover.py
@@ -25,7 +25,7 @@ class TestAutodiscover(metricbeat.BaseTest):
                 'docker': {
                     'templates': '''
                       - condition:
-                          equals.container.image: memcached:latest
+                          equals.docker.container.image: memcached:latest
                         config:
                           - module: memcached
                             metricsets: ["stats"]

--- a/metricbeat/tests/system/test_autodiscover.py
+++ b/metricbeat/tests/system/test_autodiscover.py
@@ -25,7 +25,7 @@ class TestAutodiscover(metricbeat.BaseTest):
                 'docker': {
                     'templates': '''
                       - condition:
-                          equals.docker.container.image: memcached:latest
+                          equals.container.image: memcached:latest
                         config:
                           - module: memcached
                             metricsets: ["stats"]
@@ -51,9 +51,9 @@ class TestAutodiscover(metricbeat.BaseTest):
         proc.check_kill_and_wait()
 
         # Check metadata is added
-        assert output[0]['docker']['container']['image'] == 'memcached:latest'
-        assert output[0]['docker']['container']['labels'] == {}
-        assert 'name' in output[0]['docker']['container']
+        assert output[0]['container']['image'] == 'memcached:latest'
+        assert output[0]['container']['labels'] == {}
+        assert 'name' in output[0]['container']
 
     @unittest.skipIf(not INTEGRATION_TESTS or
                      os.getenv("TESTING_ENVIRONMENT") == "2x",
@@ -93,8 +93,10 @@ class TestAutodiscover(metricbeat.BaseTest):
         proc.check_kill_and_wait()
 
         # Check metadata is added
-        assert output[0]['docker']['container']['image'] == 'memcached:latest'
-        assert 'name' in output[0]['docker']['container']
+        assert output[0]['container']['image'] == 'memcached:latest'
+        assert 'name' in output[0]['container']
+        self.assert_fields_are_documented(output[0])
+
 
     @unittest.skipIf(not INTEGRATION_TESTS or
                      os.getenv("TESTING_ENVIRONMENT") == "2x",
@@ -143,3 +145,4 @@ class TestAutodiscover(metricbeat.BaseTest):
 
         # Check field is added
         assert output[0]['fields']['foo'] == 'bar'
+        self.assert_fields_are_documented(output[0])

--- a/metricbeat/tests/system/test_autodiscover.py
+++ b/metricbeat/tests/system/test_autodiscover.py
@@ -51,7 +51,7 @@ class TestAutodiscover(metricbeat.BaseTest):
         proc.check_kill_and_wait()
 
         # Check metadata is added
-        assert output[0]['container']['image'] == 'memcached:latest'
+        assert output[0]['container']['image']['name'] == 'memcached:latest'
         assert output[0]['container']['labels'] == {}
         assert 'name' in output[0]['container']
 
@@ -93,7 +93,7 @@ class TestAutodiscover(metricbeat.BaseTest):
         proc.check_kill_and_wait()
 
         # Check metadata is added
-        assert output[0]['container']['image'] == 'memcached:latest'
+        assert output[0]['container']['image']['name'] == 'memcached:latest'
         assert 'name' in output[0]['container']
         self.assert_fields_are_documented(output[0])
 

--- a/metricbeat/tests/system/test_autodiscover.py
+++ b/metricbeat/tests/system/test_autodiscover.py
@@ -97,7 +97,6 @@ class TestAutodiscover(metricbeat.BaseTest):
         assert 'name' in output[0]['container']
         self.assert_fields_are_documented(output[0])
 
-
     @unittest.skipIf(not INTEGRATION_TESTS or
                      os.getenv("TESTING_ENVIRONMENT") == "2x",
                      "integration test not available on 2.x")

--- a/metricbeat/tests/system/test_autodiscover_jolokia.py
+++ b/metricbeat/tests/system/test_autodiscover_jolokia.py
@@ -52,3 +52,5 @@ class Test(metricbeat.BaseTest):
         print(evt)
 
         assert evt["jolokia"]["test"]["gc"]["collection_count"] >= 0
+
+        self.assert_fields_are_documented(output[0])


### PR DESCRIPTION
This PR is based on https://github.com/elastic/beats/pull/10758 

Results from autodiscover for docker with filebeat have `docker.container.id` fields instead of the ECS fields `container.id`. 

Turned out the container information in filebeat output came from `docker autodiscover`. Without dedot in autodiscover, labels in output json will not be dedotted. If processor `add_docker_metadata` is enabled, then the labels in json output will be duplicated: one set of labels without dedotting (from autodiscover) and another set of labels after dedotting (from add_docker_metadata).

Please see results in pictures below.
1. With `add_docker_metadata labels.dedot=true` but no dedot for autodiscover (`docker.autodiscover labels.dedot=false`):
<img width="1680" alt="screen shot 2019-02-21 at 2 15 50 pm" src="https://user-images.githubusercontent.com/14081635/53204277-71d54d80-35e8-11e9-874e-ed7794c5ea93.png">
You can see same labels showed up twice, once with dots and the other without.

2. With `docker.autodiscover labels.dedot=true`:
<img width="2098" alt="screen shot 2019-02-21 at 2 08 43 pm" src="https://user-images.githubusercontent.com/14081635/53204369-a77a3680-35e8-11e9-8e7b-6367e57856b6.png">
You can see there is no duplicate labels.

