### PR TITLE
Use docker compose file version 2.3 as in other files in beats

### DIFF
--- a/metricbeat/docker-compose.yml
+++ b/metricbeat/docker-compose.yml
@@ -1,4 +1,5 @@
-version: '2'
+version: '2.3'
+
 services:
   beat:
     build: ${PWD}/.


### PR DESCRIPTION
2.1 is required to define healthchecks in the docker compose file.
Using 2.3 as is the version used in other beats.