### PR TITLE
[Auditbeat] Cherry-pick #10872 to 6.7: Login: Recover from panics, safeguard array access

### DIFF
--- a/x-pack/auditbeat/module/system/login/utmp.go
+++ b/x-pack/auditbeat/module/system/login/utmp.go
@@ -94,6 +94,7 @@ func (r *UtmpFileReader) ReadNew() (<-chan LoginRecord, <-chan error) {
 	errorC := make(chan error)
 
 	go func() {
+		defer logp.Recover("A panic occurred while collecting login information")
 		defer close(loginRecordC)
 		defer close(errorC)
 

--- a/x-pack/auditbeat/module/system/login/utmp_c.go
+++ b/x-pack/auditbeat/module/system/login/utmp_c.go
@@ -104,6 +104,9 @@ func newUtmp(utmp *utmpC) *Utmp {
 // byteToString converts a NULL terminated char array to a Go string.
 func byteToString(b []byte) string {
 	n := bytes.IndexByte(b, 0)
+	if n == -1 {
+		n = len(b)
+	}
 	return string(b[:n])
 }
 


### PR DESCRIPTION
Cherry-pick of PR #10872 to 6.7 branch. Original message: 

Fixes two concerns in the login dataset:

1. Since it's using an internal goroutine it should recover from any panics.
2. Puts in a safeguard for any byte arrays coming from C.