### PR TITLE
[Metricbeat] Fix flaky test in Elasticsearch module

### DIFF
--- a/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
+++ b/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
@@ -29,6 +29,8 @@ import (
 	"os"
 	"testing"
 
+	"github.com/pkg/errors"
+
 	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/beats/libbeat/common"
@@ -226,6 +228,9 @@ func createMLJob(host string, version *common.Version) error {
 	}
 
 	body, resp, err := httpPutJSON(host, jobURL, mlJob)
+	if err != nil {
+		return errors.Wrap(err, "error doing PUT request when creating ML job")
+	}
 
 	if resp.StatusCode != 200 {
 		return fmt.Errorf("HTTP error loading ml job %d: %s, %s", resp.StatusCode, resp.Status, string(body))
@@ -237,17 +242,17 @@ func createMLJob(host string, version *common.Version) error {
 func createCCRStats(host string) error {
 	err := setupCCRRemote(host)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "error setup CCR remote settings")
 	}
 
 	err = createCCRLeaderIndex(host)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "error creating CCR leader index")
 	}
 
 	err = createCCRFollowerIndex(host)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "error creating CCR follower index")
 	}
 
 	return nil


### PR DESCRIPTION
Two things in this PR:

- Improve error logging to help in this issue https://github.com/elastic/beats/issues/10866
- Handle an error that causing panics in ES module here https://beats-ci.elastic.co/job/elastic+beats+pull-request+multijob-linux/beat=metricbeat,label=linux-immutable/5262/console
```
12:02:17 command [go test -race -tags integration -cover -coverprofile /tmp/gotestcover-701860008 github.com/elastic/beats/metricbeat/module/elasticsearch]: exit status 1
12:02:17 Building elasticsearch
12:02:17 Step 1/2 : FROM docker.elastic.co/elasticsearch/elasticsearch:6.6.0
12:02:17  ---> 13aa43015aa1
12:02:17 Step 2/2 : HEALTHCHECK --interval=1s --retries=300 CMD curl -f http://localhost:9200/_xpack/license
12:02:17  ---> Using cache
12:02:17  ---> d9b59c3116c3
12:02:17 Successfully built d9b59c3116c3
12:02:17 Successfully tagged metricbeat97f33c937432dee1235f6e4e23541a95e5cab575_elasticsearch:latest
12:02:17 Creating metricbeat97f33c937432dee1235f6e4e23541a95e5cab575_elasticsearch_1 ... 
12:02:17 
12:02:17 Creating metricbeat97f33c937432dee1235f6e4e23541a95e5cab575_elasticsearch_1 ... done
12:02:17 --- FAIL: TestFetch (72.40s)
12:02:17 panic: runtime error: invalid memory address or nil pointer dereference [recovered]
12:02:17 	panic: runtime error: invalid memory address or nil pointer dereference
12:02:17 [signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0xa2f906]
12:02:17 
12:02:17 goroutine 18 [running]:
12:02:17 testing.tRunner.func1(0xc42035a0f0)
12:02:17 	/usr/local/go/src/testing/testing.go:742 +0x567
12:02:17 panic(0xac1300, 0xe882d0)
12:02:17 	/usr/local/go/src/runtime/panic.go:502 +0x24a
12:02:17 github.com/elastic/beats/metricbeat/module/elasticsearch_test.createMLJob(0xc42014a180, 0x12, 0xc42014e700, 0x0, 0x0)
12:02:17 	/go/src/github.com/elastic/beats/metricbeat/module/elasticsearch/elasticsearch_integration_test.go:230 +0x1e6
12:02:17 github.com/elastic/beats/metricbeat/module/elasticsearch_test.TestFetch(0xc42035a0f0)
12:02:17 	/go/src/github.com/elastic/beats/metricbeat/module/elasticsearch/elasticsearch_integration_test.go:77 +0x2c7
12:02:17 testing.tRunner(0xc42035a0f0, 0xb73ff0)
12:02:17 	/usr/local/go/src/testing/testing.go:777 +0x16e
12:02:17 created by testing.(*T).Run
12:02:17 	/usr/local/go/src/testing/testing.go:824 +0x565
12:02:17 FAIL	github.com/elastic/beats/metricbeat/module/elasticsearch	72.544s
```