### PR TITLE
Remove debug code from ec2 metricset code

### DIFF
--- a/x-pack/metricbeat/module/aws/ec2/ec2.go
+++ b/x-pack/metricbeat/module/aws/ec2/ec2.go
@@ -103,10 +103,6 @@ func (m *MetricSet) Fetch(report mb.ReporterV2) {
 		}
 
 		for _, instanceID := range instanceIDs {
-			if instanceID != "i-77f84332" {
-				continue
-			}
-
 			metricDataQueries := constructMetricQueries(listMetricsOutput, instanceID, m.PeriodInSec)
 			if len(metricDataQueries) == 0 {
 				continue

--- a/x-pack/metricbeat/module/aws/ec2/ec2_test.go
+++ b/x-pack/metricbeat/module/aws/ec2/ec2_test.go
@@ -111,7 +111,7 @@ func (m *MockEC2Client) DescribeInstancesRequest(input *ec2.DescribeInstancesInp
 	}
 }
 
-func TestGetinstanceIDs(t *testing.T) {
+func TestGetInstanceIDs(t *testing.T) {
 	mockSvc := &MockEC2Client{}
 	instanceIDs, instancesOutputs, err := getInstancesPerRegion(mockSvc)
 	if err != nil {


### PR DESCRIPTION
Somehow there are some debug code got merged into master. These need to be removed and I will be extra careful next time... 