### PR TITLE
Cherry-pick #10754 to 6.7: [Filebeat] Fix Logstash example in docs and correct indentation in Yaml

### DIFF
--- a/filebeat/docs/modules/logstash.asciidoc
+++ b/filebeat/docs/modules/logstash.asciidoc
@@ -53,11 +53,11 @@ file to override the default paths for Logstash logs and set the format to json
   log:
     enabled: true
     var.paths: ["/path/to/log/logstash.log*"]
-    format: json
+    var.format: json
   slowlog:
     enabled: true
     var.paths: ["/path/to/log/logstash-slowlog.log*"]
-    format: json
+    var.format: json
 -----
 
 To specify the same settings at the command line, you use:

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -245,7 +245,7 @@ filebeat.modules:
 
   # Slow logs
   #slowlog:
-   #enabled: true
+    #enabled: true
     # Set custom paths for the log files. If left empty,
     # Filebeat will choose the paths depending on your OS.
     #var.paths:

--- a/filebeat/module/logstash/_meta/config.reference.yml
+++ b/filebeat/module/logstash/_meta/config.reference.yml
@@ -9,7 +9,7 @@
 
   # Slow logs
   #slowlog:
-   #enabled: true
+    #enabled: true
     # Set custom paths for the log files. If left empty,
     # Filebeat will choose the paths depending on your OS.
     #var.paths:

--- a/filebeat/module/logstash/_meta/docs.asciidoc
+++ b/filebeat/module/logstash/_meta/docs.asciidoc
@@ -48,11 +48,11 @@ file to override the default paths for Logstash logs and set the format to json
   log:
     enabled: true
     var.paths: ["/path/to/log/logstash.log*"]
-    format: json
+    var.format: json
   slowlog:
     enabled: true
     var.paths: ["/path/to/log/logstash-slowlog.log*"]
-    format: json
+    var.format: json
 -----
 
 To specify the same settings at the command line, you use:

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -257,7 +257,7 @@ filebeat.modules:
 
   # Slow logs
   #slowlog:
-   #enabled: true
+    #enabled: true
     # Set custom paths for the log files. If left empty,
     # Filebeat will choose the paths depending on your OS.
     #var.paths:


### PR DESCRIPTION
Cherry-pick of PR #10754 to 6.7 branch. Original message: 

* The Logstash example shown on the docs uses a `format: field` that doesn't exists actually, it's `var.format` Look at the end of https://github.com/elastic/beats/blob/master/filebeat/module/logstash/_meta/docs.asciidoc

* Correct indentation: Self explanatory. It was giving a YAML parsing error with the default file stored in `modules.d`