### PR TITLE
[Metricbeat] Decrease timeout time of compose.EnsureUp functions

### DIFF
--- a/libbeat/tests/compose/compose.go
+++ b/libbeat/tests/compose/compose.go
@@ -28,7 +28,7 @@ import (
 // EnsureUp starts all the requested services (must be defined in docker-compose.yml)
 // with a default timeout of 300 seconds
 func EnsureUp(t *testing.T, services ...string) {
-	EnsureUpWithTimeout(t, 300, services...)
+	EnsureUpWithTimeout(t, 60, services...)
 }
 
 // EnsureUpWithTimeout starts all the requested services (must be defined in docker-compose.yml)

--- a/metricbeat/module/kibana/stats/stats_integration_test.go
+++ b/metricbeat/module/kibana/stats/stats_integration_test.go
@@ -36,7 +36,7 @@ import (
 )
 
 func TestFetch(t *testing.T) {
-	compose.EnsureUpWithTimeout(t, 600, "elasticsearch", "kibana")
+	compose.EnsureUpWithTimeout(t, 570, "elasticsearch", "kibana")
 
 	config := mtest.GetConfig("stats")
 	host := config["hosts"].([]string)[0]

--- a/metricbeat/module/kibana/status/status_integration_test.go
+++ b/metricbeat/module/kibana/status/status_integration_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 func TestFetch(t *testing.T) {
-	compose.EnsureUpWithTimeout(t, 600, "elasticsearch", "kibana")
+	compose.EnsureUpWithTimeout(t, 570, "elasticsearch", "kibana")
 
 	f := mbtest.NewReportingMetricSetV2Error(t, mtest.GetConfig("status"))
 	events, errs := mbtest.ReportingFetchV2Error(f)

--- a/metricbeat/module/logstash/logstash_integration_test.go
+++ b/metricbeat/module/logstash/logstash_integration_test.go
@@ -37,7 +37,7 @@ var metricSets = []string{
 }
 
 func TestFetch(t *testing.T) {
-	compose.EnsureUp(t, "logstash")
+	compose.EnsureUpWithTimeout(t, 300, "logstash")
 
 	for _, metricSet := range metricSets {
 		f := mbtest.NewReportingMetricSetV2Error(t, logstash.GetConfig(metricSet))


### PR DESCRIPTION
Refer [here](https://github.com/elastic/beats/issues/10876) for more info