### PR TITLE
[Metricbeat] Fix Windows flaky test on system/filesystem Metricset

### DIFF
--- a/metricbeat/module/system/filesystem/helper_test.go
+++ b/metricbeat/module/system/filesystem/helper_test.go
@@ -43,6 +43,10 @@ func TestFileSystemList(t *testing.T) {
 	assert.True(t, (len(fss) > 0))
 
 	for _, fs := range fss {
+		if fs.TypeName == "removable" && runtime.GOOS == "windows" {
+			continue
+		}
+
 		if fs.TypeName == "cdrom" {
 			continue
 		}

--- a/metricbeat/module/system/filesystem/helper_test.go
+++ b/metricbeat/module/system/filesystem/helper_test.go
@@ -43,7 +43,7 @@ func TestFileSystemList(t *testing.T) {
 	assert.True(t, (len(fss) > 0))
 
 	for _, fs := range fss {
-		if fs.TypeName == "removable" && runtime.GOOS == "windows" {
+		if (fs.TypeName == "removable" || fs.TypeName == "") && runtime.GOOS == "windows" {
 			continue
 		}
 


### PR DESCRIPTION
Tries to fix this issue https://github.com/elastic/beats/issues/9398

I'm not sure in fact if the cause is that it's looking for a removable device or just an unknown one. The last option is to just skip the test.