### PR TITLE
[libbeat] Add image.id and account.id to EC2 add_cloud_metadata

### DIFF
--- a/libbeat/processors/add_cloud_metadata/provider_aws_ec2.go
+++ b/libbeat/processors/add_cloud_metadata/provider_aws_ec2.go
@@ -32,6 +32,8 @@ func newEc2MetadataFetcher(config *common.Config) (*metadataFetcher, error) {
 			"machine_type":      c.Str("instanceType"),
 			"region":            c.Str("region"),
 			"availability_zone": c.Str("availabilityZone"),
+			"accountId":         c.Str("accountId"),
+			"ami":               c.Str("imageId"),
 		}.Apply(m)
 		return out
 	}


### PR DESCRIPTION
Some addition data inside the same instance meta-data document is very helpful with node spanning many accounts.