### PR TITLE
Allow URL format in Metricbeat Redis module

### DIFF
--- a/metricbeat/mb/parse/url.go
+++ b/metricbeat/mb/parse/url.go
@@ -168,7 +168,7 @@ func SetURLUser(u *url.URL, defaultUser, defaultPass string) {
 		pass = defaultPass
 	}
 
-	if userIsSet && passIsSet {
+	if passIsSet {
 		u.User = url.UserPassword(user, pass)
 	} else if userIsSet {
 		u.User = url.User(user)

--- a/metricbeat/mb/parse/url_test.go
+++ b/metricbeat/mb/parse/url_test.go
@@ -116,6 +116,7 @@ func TestURLHostParserBuilder(t *testing.T) {
 		{map[string]interface{}{}, URLHostParserBuilder{DefaultPath: "/default"}, "http://example.com/default"},
 		{map[string]interface{}{"username": "guest"}, URLHostParserBuilder{}, "http://guest@example.com"},
 		{map[string]interface{}{"username": "guest", "password": "secret"}, URLHostParserBuilder{}, "http://guest:secret@example.com"},
+		{map[string]interface{}{"password": "secret"}, URLHostParserBuilder{}, "http://:secret@example.com"},
 		{map[string]interface{}{"basepath": "/foo"}, URLHostParserBuilder{DefaultPath: "/default"}, "http://example.com/foo/default"},
 		{map[string]interface{}{"basepath": "foo/"}, URLHostParserBuilder{DefaultPath: "/default"}, "http://example.com/foo/default"},
 		{map[string]interface{}{"basepath": "/foo/"}, URLHostParserBuilder{DefaultPath: "/default"}, "http://example.com/foo/default"},

--- a/metricbeat/module/redis/info/info.go
+++ b/metricbeat/module/redis/info/info.go
@@ -29,12 +29,13 @@ import (
 )
 
 var (
-	debugf = logp.MakeDebug("redis-info")
+	debugf     = logp.MakeDebug("redis-info")
+	hostParser = parse.URLHostParserBuilder{DefaultScheme: "redis"}.Build()
 )
 
 func init() {
 	mb.Registry.MustAddMetricSet("redis", "info", New,
-		mb.WithHostParser(parse.PassThruHostParser),
+		mb.WithHostParser(hostParser),
 		mb.DefaultMetricSet(),
 	)
 }

--- a/metricbeat/module/redis/info/info_test.go
+++ b/metricbeat/module/redis/info/info_test.go
@@ -1,0 +1,45 @@
+package info
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/libbeat/common"
+	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
+)
+
+func TestNewMetricSet(t *testing.T) {
+	t.Run("pass in host", func(t *testing.T) {
+		c, err := common.NewConfigFrom(map[string]interface{}{
+			"module":     "redis",
+			"metricsets": []string{"info"},
+			"hosts": []string{
+				"redis://me:secret@localhost:123",
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		ms := mbtest.NewReportingMetricSetV2(t, c)
+		assert.Equal(t, "secret", ms.HostData().Password)
+	})
+
+	t.Run("password in config", func(t *testing.T) {
+		c, err := common.NewConfigFrom(map[string]interface{}{
+			"module":     "redis",
+			"metricsets": []string{"info"},
+			"hosts": []string{
+				"redis://localhost:123",
+			},
+			"password": "secret",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		ms := mbtest.NewReportingMetricSetV2(t, c)
+		assert.Equal(t, "secret", ms.HostData().Password)
+	})
+}

--- a/metricbeat/module/redis/key/key.go
+++ b/metricbeat/module/redis/key/key.go
@@ -27,12 +27,13 @@ import (
 )
 
 var (
-	debugf = logp.MakeDebug("redis-key")
+	debugf     = logp.MakeDebug("redis-key")
+	hostParser = parse.URLHostParserBuilder{DefaultScheme: "redis"}.Build()
 )
 
 func init() {
 	mb.Registry.MustAddMetricSet("redis", "key", New,
-		mb.WithHostParser(parse.PassThruHostParser),
+		mb.WithHostParser(hostParser),
 	)
 }
 

--- a/metricbeat/module/redis/keyspace/keyspace.go
+++ b/metricbeat/module/redis/keyspace/keyspace.go
@@ -27,12 +27,13 @@ import (
 )
 
 var (
-	debugf = logp.MakeDebug("redis-keyspace")
+	debugf     = logp.MakeDebug("redis-keyspace")
+	hostParser = parse.URLHostParserBuilder{DefaultScheme: "redis"}.Build()
 )
 
 func init() {
 	mb.Registry.MustAddMetricSet("redis", "keyspace", New,
-		mb.WithHostParser(parse.PassThruHostParser),
+		mb.WithHostParser(hostParser),
 		mb.DefaultMetricSet(),
 	)
 }

--- a/metricbeat/module/redis/metricset.go
+++ b/metricbeat/module/redis/metricset.go
@@ -39,11 +39,9 @@ func NewMetricSet(base mb.BaseMetricSet) (*MetricSet, error) {
 		IdleTimeout time.Duration `config:"idle_timeout"`
 		Network     string        `config:"network"`
 		MaxConn     int           `config:"maxconn" validate:"min=1"`
-		Password    string        `config:"password"`
 	}{
 		Network:  "tcp",
 		MaxConn:  10,
-		Password: "",
 	}
 	err := base.Module().UnpackConfig(&config)
 	if err != nil {
@@ -52,7 +50,7 @@ func NewMetricSet(base mb.BaseMetricSet) (*MetricSet, error) {
 
 	return &MetricSet{
 		BaseMetricSet: base,
-		pool: CreatePool(base.Host(), config.Password, config.Network,
+		pool: CreatePool(base.Host(), base.HostData().Password, config.Network,
 			config.MaxConn, config.IdleTimeout, base.Module().Config().Timeout),
 	}, nil
 }


### PR DESCRIPTION
Potential fix for elastic/beats#10917 

This change will keep the usual functionality when using this approach:

```yaml
- module: redis
  period: 10s
  # Redis hosts
  hosts: ["127.0.0.1:6379", "127.0.0.2:6379"]
```

Additionally allowing the use of Redis URL syntax:
```yaml
- module: redis
  period: 10s
  # Redis hosts
  hosts: ["127.0.0.1:6379", "redis://:testpassword@127.0.0.2:6379"]
```

The `password` field will be used for all `host:port` values. On URL values, the password set in the scheme will have priority.