### PR TITLE
Cherry-pick #10875 to 7.0: Force ECS options in filebeat pipelines when filebeat version is over 7.0 and ES version is 6.7.X

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -14,6 +14,8 @@ https://github.com/elastic/beats/compare/v7.0.0-beta1...master[Check the HEAD di
 
 *Filebeat*
 
+- Set `ecs: true` in user_agent processors when loading pipelines with Filebeat 7.0.x into Elasticsearch 6.7.x. {issue}10655[10655] {pull}10875[10875]
+
 *Heartbeat*
 
 *Journalbeat*

--- a/filebeat/fileset/pipelines_test.go
+++ b/filebeat/fileset/pipelines_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/outputs/elasticsearch"
 )
 
@@ -99,6 +100,115 @@ func TestLoadPipelinesWithMultiPipelineFileset(t *testing.T) {
 				assert.IsType(t, MultiplePipelineUnsupportedError{}, err)
 			} else {
 				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestSetEcsProcessors(t *testing.T) {
+	cases := []struct {
+		name          string
+		esVersion     *common.Version
+		content       map[string]interface{}
+		expected      map[string]interface{}
+		isErrExpected bool
+	}{
+		{
+			name:      "ES < 6.7.0",
+			esVersion: common.MustNewVersion("6.6.0"),
+			content: map[string]interface{}{
+				"processors": []interface{}{
+					map[string]interface{}{
+						"user_agent": map[string]interface{}{
+							"field": "foo.http_user_agent",
+						},
+					},
+				}},
+			isErrExpected: true,
+		},
+		{
+			name:      "ES == 6.7.0",
+			esVersion: common.MustNewVersion("6.7.0"),
+			content: map[string]interface{}{
+				"processors": []interface{}{
+					map[string]interface{}{
+						"rename": map[string]interface{}{
+							"field":        "foo.src_ip",
+							"target_field": "source.ip",
+						},
+					},
+					map[string]interface{}{
+						"user_agent": map[string]interface{}{
+							"field": "foo.http_user_agent",
+						},
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"processors": []interface{}{
+					map[string]interface{}{
+						"rename": map[string]interface{}{
+							"field":        "foo.src_ip",
+							"target_field": "source.ip",
+						},
+					},
+					map[string]interface{}{
+						"user_agent": map[string]interface{}{
+							"field": "foo.http_user_agent",
+							"ecs":   true,
+						},
+					},
+				},
+			},
+			isErrExpected: false,
+		},
+		{
+			name:      "ES >= 7.0.0",
+			esVersion: common.MustNewVersion("7.0.0"),
+			content: map[string]interface{}{
+				"processors": []interface{}{
+					map[string]interface{}{
+						"rename": map[string]interface{}{
+							"field":        "foo.src_ip",
+							"target_field": "source.ip",
+						},
+					},
+					map[string]interface{}{
+						"user_agent": map[string]interface{}{
+							"field": "foo.http_user_agent",
+						},
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"processors": []interface{}{
+					map[string]interface{}{
+						"rename": map[string]interface{}{
+							"field":        "foo.src_ip",
+							"target_field": "source.ip",
+						},
+					},
+					map[string]interface{}{
+						"user_agent": map[string]interface{}{
+							"field": "foo.http_user_agent",
+						},
+					},
+				},
+			},
+			isErrExpected: false,
+		},
+	}
+
+	for _, test := range cases {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			err := setECSProcessors(*test.esVersion, "foo-pipeline", test.content)
+			if test.isErrExpected {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, test.expected, test.content)
 			}
 		})
 	}


### PR DESCRIPTION
Cherry-pick of PR #10875 to 7.0 branch. Original message: 

When using the `user_agent` processor to ingest data from Filebeat 7.0
into Elasticsearch 6.X conflicts appear with ECS user_agent fields, this can
be solved by setting `ecs: true` when pipelines are being loaded into 
Elasticsearch 6.7.0.

For minor versions where `ecs`  option is not available, pipelines will fail
to load.

Fix #10655