### PR TITLE
Backport: Fix panic if user sets custom fields starting with host

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -16,6 +16,7 @@ https://github.com/elastic/beats/compare/v6.6.0...6.x[Check the HEAD diff]
 - Port settings have been deprecated in redis/logstash output and will be removed in 7.0. {pull}9915[9915]
 - Update the code of Central Management to align with the new returned format. {pull}10019[10019]
 - Allow Central Management to send events back to kibana. {issue}9382[9382]
+- Fix panic if fields settting is used to configure `hosts.x` fields. {issue}10824[10824] {pull}10935[10935]
 
 *Auditbeat*
 


### PR DESCRIPTION
The root cause has been fixed by #10801 by accident already.  This
selectively backports the checks to 6.7, as #10801 is to much of a
change.

Resolves: #10824 