### PR TITLE
When using the --password env:FOO will now return an errors if

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -30,7 +30,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - ILM will be available by default if Elasticsearch > 7.0 is used. {pull}10347[10347]
 - Allow Central Management to send events back to kibana. {issue}9382[9382]
 - Initialize the Paths before the keystore and save the keystore into `data/{beatname}.keystore`. {pull}10706[10706]
-- Using an environment variable for the password when enrolling a beat will now raise an error if the variable doesn't exist. {pull}10936[10936]
 
 *Auditbeat*
 
@@ -127,6 +126,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix a issue when remote and local configuration didn't match when fetching configuration from Central Management. {issue}10587[10587]
 - Fix unauthorized error when loading dashboards by adding username and password into kibana config. {issue}10513[10513] {pull}10675[10675]
 - Ensure all beat commands respect configured settings. {pull}10721[10721]
+- Using an environment variable for the password when enrolling a beat will now raise an error if the variable doesn't exist. {pull}10936[10936]
 
 *Auditbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -30,6 +30,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - ILM will be available by default if Elasticsearch > 7.0 is used. {pull}10347[10347]
 - Allow Central Management to send events back to kibana. {issue}9382[9382]
 - Initialize the Paths before the keystore and save the keystore into `data/{beatname}.keystore`. {pull}10706[10706]
+- Using an environment variable for the password when enrolling a beat will now raise an error if the variable doesn't exist. {pull}10936[10936]
 
 *Auditbeat*
 

--- a/libbeat/common/cli/password.go
+++ b/libbeat/common/cli/password.go
@@ -72,7 +72,7 @@ func stdin(p string) (string, error) {
 
 func env(p string) (string, error) {
 	if len(p) == 0 {
-		return "", errors.New("env variable name is needed when using env: password method")
+		return "", errors.New("environment variable name is needed when using env: password method")
 	}
 
 	v, ok := os.LookupEnv(p)

--- a/libbeat/common/cli/password.go
+++ b/libbeat/common/cli/password.go
@@ -2,7 +2,7 @@
 // license agreements. See the NOTICE file distributed with
 // this work for additional information regarding copyright
 // ownership. Elasticsearch B.V. licenses this file to you under
-// Apache License, Version 2.0 (the "License"); you may
+// the Apache License, Version 2.0 (the "License"); you may
 // not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //

--- a/libbeat/common/cli/password.go
+++ b/libbeat/common/cli/password.go
@@ -75,5 +75,10 @@ func env(p string) (string, error) {
 		return "", errors.New("env variable name is needed when using env: password method")
 	}
 
-	return os.Getenv(p), nil
+	v, ok := os.LookupEnv(p)
+	if !ok {
+		return "", fmt.Errorf("the environment variable %s does not exist", p)
+	}
+
+	return v, nil
 }

--- a/libbeat/common/cli/password.go
+++ b/libbeat/common/cli/password.go
@@ -2,7 +2,7 @@
 // license agreements. See the NOTICE file distributed with
 // this work for additional information regarding copyright
 // ownership. Elasticsearch B.V. licenses this file to you under
-// the Apache License, Version 2.0 (the "License"); you may
+// Apache License, Version 2.0 (the "License"); you may
 // not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
@@ -77,7 +77,7 @@ func env(p string) (string, error) {
 
 	v, ok := os.LookupEnv(p)
 	if !ok {
-		return "", fmt.Errorf("the environment variable %s does not exist", p)
+		return "", fmt.Errorf("environment variable %s does not exist", p)
 	}
 
 	return v, nil

--- a/libbeat/common/cli/password_test.go
+++ b/libbeat/common/cli/password_test.go
@@ -48,6 +48,11 @@ func TestReadPassword(t *testing.T) {
 			input: "",
 			error: true,
 		},
+		{
+			name:  "Test env variable that does not exist",
+			input: "env:DO_NOT_EXIST",
+			error: true,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
FOO does not exist in the environment.