### PR TITLE
[Auditbeat] User dataset: Numerous fixes to error handling

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -145,6 +145,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Package: Disable librpm signal handlers. {pull}10694[10694]
 - Login: Handle different bad login UTMP types. {pull}10865[10865]
 - System module: Fix and unify bucket closing logic. {pull}10897[10897]
+- User dataset: Numerous fixes to error handling. {pull}10942[10942]
 
 *Filebeat*
 

--- a/x-pack/auditbeat/module/system/user/user.go
+++ b/x-pack/auditbeat/module/system/user/user.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/OneOfOne/xxhash"
 	"github.com/gofrs/uuid"
+	"github.com/joeshaw/multierror"
 	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/auditbeat/datastore"
@@ -288,44 +289,55 @@ func (ms *MetricSet) Fetch(report mb.ReporterV2) {
 
 // reportState reports all existing users on the system.
 func (ms *MetricSet) reportState(report mb.ReporterV2) error {
+	var errs multierror.Errors
 	ms.lastState = time.Now()
 
 	users, err := GetUsers(ms.config.DetectPasswordChanges)
 	if err != nil {
-		return errors.Wrap(err, "failed to get users")
+		errs = append(errs, errors.Wrap(err, "error while getting users"))
 	}
+
 	ms.log.Debugf("Found %v users", len(users))
+	if len(users) > 0 {
+		stateID, err := uuid.NewV4()
+		if err != nil {
+			errs = append(errs, errors.Wrap(err, "error generating state ID"))
+		}
 
-	stateID, err := uuid.NewV4()
-	if err != nil {
-		return errors.Wrap(err, "error generating state ID")
-	}
-	for _, user := range users {
-		event := ms.userEvent(user, eventTypeState, eventActionExistingUser)
-		event.RootFields.Put("event.id", stateID.String())
-		report.Event(event)
+		for _, user := range users {
+			event := ms.userEvent(user, eventTypeState, eventActionExistingUser)
+			event.RootFields.Put("event.id", stateID.String())
+			report.Event(event)
+		}
+
+		if ms.cache != nil {
+			// This will initialize the cache with the current processes
+			ms.cache.DiffAndUpdateCache(convertToCacheable(users))
+		}
+
+		// Save time so we know when to send the state again (config.StatePeriod)
+		timeBytes, err := ms.lastState.MarshalBinary()
+		if err != nil {
+			errs = append(errs, err)
+		} else {
+			err = ms.bucket.Store(bucketKeyStateTimestamp, timeBytes)
+			if err != nil {
+				errs = append(errs, errors.Wrap(err, "error writing state timestamp to disk"))
+			}
+		}
+
+		err = ms.saveUsersToDisk(users)
+		if err != nil {
+			errs = append(errs, err)
+		}
 	}
 
-	if ms.cache != nil {
-		// This will initialize the cache with the current processes
-		ms.cache.DiffAndUpdateCache(convertToCacheable(users))
-	}
-
-	// Save time so we know when to send the state again (config.StatePeriod)
-	timeBytes, err := ms.lastState.MarshalBinary()
-	if err != nil {
-		return err
-	}
-	err = ms.bucket.Store(bucketKeyStateTimestamp, timeBytes)
-	if err != nil {
-		return errors.Wrap(err, "error writing state timestamp to disk")
-	}
-
-	return ms.saveUsersToDisk(users)
+	return errs.Err()
 }
 
 // reportChanges detects and reports any changes to users on this system since the last call.
 func (ms *MetricSet) reportChanges(report mb.ReporterV2) error {
+	var errs multierror.Errors
 	currentTime := time.Now()
 
 	// If this is not the first call to Fetch/reportChanges,
@@ -343,70 +355,75 @@ func (ms *MetricSet) reportChanges(report mb.ReporterV2) error {
 
 	users, err := GetUsers(ms.config.DetectPasswordChanges)
 	if err != nil {
-		return errors.Wrap(err, "failed to get users")
+		errs = append(errs, errors.Wrap(err, "error while getting users"))
 	}
 	ms.log.Debugf("Found %v users", len(users))
 
-	newInCache, missingFromCache := ms.cache.DiffAndUpdateCache(convertToCacheable(users))
+	if len(users) > 0 {
+		newInCache, missingFromCache := ms.cache.DiffAndUpdateCache(convertToCacheable(users))
 
-	if len(newInCache) > 0 && len(missingFromCache) > 0 {
-		// Check for changes to users
-		missingUserMap := make(map[string](*User))
-		for _, missingUser := range missingFromCache {
-			missingUserMap[missingUser.(*User).UID] = missingUser.(*User)
-		}
+		if len(newInCache) > 0 && len(missingFromCache) > 0 {
+			// Check for changes to users
+			missingUserMap := make(map[string](*User))
+			for _, missingUser := range missingFromCache {
+				missingUserMap[missingUser.(*User).UID] = missingUser.(*User)
+			}
 
-		for _, userFromCache := range newInCache {
-			newUser := userFromCache.(*User)
-			oldUser, found := missingUserMap[newUser.UID]
+			for _, userFromCache := range newInCache {
+				newUser := userFromCache.(*User)
+				oldUser, found := missingUserMap[newUser.UID]
 
-			if found {
-				// Report password change separately
-				if ms.config.DetectPasswordChanges && newUser.PasswordType != detectionDisabled &&
-					oldUser.PasswordType != detectionDisabled {
+				if found {
+					// Report password change separately
+					if ms.config.DetectPasswordChanges && newUser.PasswordType != detectionDisabled &&
+						oldUser.PasswordType != detectionDisabled {
 
-					passwordChanged := newUser.PasswordChanged.Before(oldUser.PasswordChanged) ||
-						!bytes.Equal(newUser.PasswordHashHash, oldUser.PasswordHashHash) ||
-						newUser.PasswordType != oldUser.PasswordType
+						passwordChanged := newUser.PasswordChanged.Before(oldUser.PasswordChanged) ||
+							!bytes.Equal(newUser.PasswordHashHash, oldUser.PasswordHashHash) ||
+							newUser.PasswordType != oldUser.PasswordType
 
-					if passwordChanged {
-						report.Event(ms.userEvent(newUser, eventTypeEvent, eventActionPasswordChanged))
+						if passwordChanged {
+							report.Event(ms.userEvent(newUser, eventTypeEvent, eventActionPasswordChanged))
+						}
 					}
-				}
 
-				// Hack to check if only the password changed
-				oldUser.PasswordChanged = newUser.PasswordChanged
-				oldUser.PasswordHashHash = newUser.PasswordHashHash
-				oldUser.PasswordType = newUser.PasswordType
-				if newUser.Hash() != oldUser.Hash() {
-					report.Event(ms.userEvent(newUser, eventTypeEvent, eventActionUserChanged))
-				}
+					// Hack to check if only the password changed
+					oldUser.PasswordChanged = newUser.PasswordChanged
+					oldUser.PasswordHashHash = newUser.PasswordHashHash
+					oldUser.PasswordType = newUser.PasswordType
+					if newUser.Hash() != oldUser.Hash() {
+						report.Event(ms.userEvent(newUser, eventTypeEvent, eventActionUserChanged))
+					}
 
-				delete(missingUserMap, oldUser.UID)
-			} else {
-				report.Event(ms.userEvent(newUser, eventTypeEvent, eventActionUserAdded))
+					delete(missingUserMap, oldUser.UID)
+				} else {
+					report.Event(ms.userEvent(newUser, eventTypeEvent, eventActionUserAdded))
+				}
+			}
+
+			for _, missingUser := range missingUserMap {
+				report.Event(ms.userEvent(missingUser, eventTypeEvent, eventActionUserRemoved))
+			}
+		} else {
+			// No changes to users
+			for _, user := range newInCache {
+				report.Event(ms.userEvent(user.(*User), eventTypeEvent, eventActionUserAdded))
+			}
+
+			for _, user := range missingFromCache {
+				report.Event(ms.userEvent(user.(*User), eventTypeEvent, eventActionUserRemoved))
 			}
 		}
 
-		for _, missingUser := range missingUserMap {
-			report.Event(ms.userEvent(missingUser, eventTypeEvent, eventActionUserRemoved))
-		}
-	} else {
-		// No changes to users
-		for _, user := range newInCache {
-			report.Event(ms.userEvent(user.(*User), eventTypeEvent, eventActionUserAdded))
-		}
-
-		for _, user := range missingFromCache {
-			report.Event(ms.userEvent(user.(*User), eventTypeEvent, eventActionUserRemoved))
+		if len(newInCache) > 0 || len(missingFromCache) > 0 {
+			err = ms.saveUsersToDisk(users)
+			if err != nil {
+				errs = append(errs, err)
+			}
 		}
 	}
 
-	if len(newInCache) > 0 || len(missingFromCache) > 0 {
-		return ms.saveUsersToDisk(users)
-	}
-
-	return nil
+	return errs.Err()
 }
 
 func (ms *MetricSet) userEvent(user *User, eventType string, action eventAction) mb.Event {

--- a/x-pack/auditbeat/module/system/user/user_test.go
+++ b/x-pack/auditbeat/module/system/user/user_test.go
@@ -34,8 +34,11 @@ func TestData(t *testing.T) {
 
 func getConfig() map[string]interface{} {
 	return map[string]interface{}{
-		"module":                       "system",
-		"metricsets":                   []string{"user"},
-		"user.detect_password_changes": true,
+		"module":     "system",
+		"metricsets": []string{"user"},
+
+		// Would require root access to /etc/shadow
+		// which we usually don't have when testing.
+		"user.detect_password_changes": false,
 	}
 }

--- a/x-pack/auditbeat/module/system/user/users_linux.go
+++ b/x-pack/auditbeat/module/system/user/users_linux.go
@@ -21,6 +21,7 @@ import (
 	"os/user"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/joeshaw/multierror"
@@ -72,7 +73,9 @@ func readPasswdFile(readPasswords bool) ([]*User, error) {
 		passwd, err := C.getpwent()
 
 		if passwd == nil {
-			if err != nil {
+			// getpwent() can return ENOENT even when there is no error,
+			// see https://github.com/systemd/systemd/issues/9585.
+			if err != nil && err != syscall.ENOENT {
 				return users, errors.Wrap(err, "error getting user")
 			}
 

--- a/x-pack/auditbeat/module/system/user/users_linux.go
+++ b/x-pack/auditbeat/module/system/user/users_linux.go
@@ -11,8 +11,8 @@ package user
 // #include <pwd.h>
 // #include <shadow.h>
 //
-// void setErrno(int err) {
-//      errno = err;
+// void clearErrno() {
+//      errno = 0;
 // }
 import "C"
 
@@ -75,7 +75,7 @@ func readPasswdFile(readPasswords bool) ([]*User, error) {
 	for {
 		// Setting errno to 0 before calling getpwent().
 		// See return value section of getpwent(3).
-		C.setErrno(0)
+		C.clearErrno()
 
 		passwd, err := C.getpwent()
 
@@ -197,7 +197,7 @@ func readShadowFile() (map[string]shadowFileEntry, error) {
 		// While getspnam(3) does not explicitly call out the need for setting errno to 0
 		// as getpwent(3) does, at least glibc uses the same code for both, and so it
 		// probably makes sense to do the same for both.
-		C.setErrno(0)
+		C.clearErrno()
 
 		spwd, err := C.getspent()
 

--- a/x-pack/auditbeat/tests/system/test_metricsets.py
+++ b/x-pack/auditbeat/tests/system/test_metricsets.py
@@ -91,5 +91,4 @@ class Test(AuditbeatXPackTest):
 
         fields = ["user.entity_id", "system.audit.user.name"]
 
-        # Metricset is beta and that generates a warning, TODO: remove later
-        self.check_metricset("system", "user", COMMON_FIELDS + fields, warnings_allowed=True)
+        self.check_metricset("system", "user", COMMON_FIELDS + fields)


### PR DESCRIPTION
When testing the `user` dataset on Fedora 29, I noticed it's not working. Digging into it, there were a few issues, all of which this PR fixes:

1. When calling C functions via cgo, we should not rely on the error return value to determine if it failed. In most cases, there is no guarantee that `errno` is going to be zero on success (see [here](https://utcc.utoronto.ca/~cks/space/blog/programming/GoCgoErrorReturns) for some detail). Instead, we should check the return value first, and if that indicates that there might have been an error (usually when it's `NULL/nil`) we should check the error return.
2. [getpwent(3)](http://man7.org/linux/man-pages/man3/getpwent.3.html) explicitly states `If one wants to check errno after the call, it should be set to zero before the call.` `errno` cannot be accessed directly in Go code, so we introduce a helper function `setErrno` for that. `getspent(3)` does not have the same warning, but given that at least glibc uses the same code path for both, it's reasonable to assume the same applies. So we set `errno` to `0` before calling both functions.
3. `errno` is thread-local, and the function families `setpwent/endpwent/getpwent` and `setspent/endspent/getspent` are not thread-safe, so we introduce `runtime.LockOSThread()/UnlockOSThread()` to make sure all C functions are run on the same OS thread.
4. Usually, when iterating through users `getpwent()` should return `NULL` and `errno` should be zero when all entries have been returned. However, there is a bug in systemd that causes it to set `errno` to `ENOENT` even when there is no error (https://github.com/systemd/systemd/issues/9585). This bug affects at least Fedora 29. Following this change `ENOENT` is treated as if there is no error. It's not supposed to be a valid error value for `getpwent()` anyway, so should not happen anytime outside this bug.
5. The previous systemd bug caused the `user` dataset to return no users, even though all users had been read successfully. This PR changes to gathering errors in multierrors and returning them alongside whatever data could be read. This is in line with wanting to make the System module more resilient to non-fatal failures during data collection (better to return some things alongside an error than no things at all).
6. The system test will now fail when there are `WARN/ERROR` messages in the log. This change can probably also be made for the other datasets.

Writing up this PR description I'm realizing this combines quite a few issues. I could split it into multiple PRs if anybody wants, though most would have only a few lines of changed code. Because some indentation changed it's best to check Github's `No Whitespace` button.
