### PR TITLE
Ensure kubernetes caches don't expire if they are being read

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -176,6 +176,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Added function to close sql database connection. {pull}10355[10355]
 - Fix issue with `elasticsearch/node_stats` metricset (x-pack) not indexing `source_node` field. {pull}10639[10639]
 - Migrate docker autodiscover to ECS. {issue}10757[10757] {pull}10862[10862]
+- Fix issue in kubernetes module preventing usage percentages to be properly calculated. {pull}10946[10946]
 
 *Packetbeat*
 

--- a/metricbeat/module/kubernetes/util/metrics_cache.go
+++ b/metricbeat/module/kubernetes/util/metrics_cache.go
@@ -111,5 +111,5 @@ func (m *valueMap) Stop() {
 
 // ContainerUID creates an unique ID for from namespace, pod name and container name
 func ContainerUID(namespace, pod, container string) string {
-	return namespace + "-" + pod + "-" + container
+	return namespace + "/" + pod + "/" + container
 }

--- a/metricbeat/module/kubernetes/util/metrics_cache_test.go
+++ b/metricbeat/module/kubernetes/util/metrics_cache_test.go
@@ -72,7 +72,6 @@ func TestTimeout(t *testing.T) {
 	fakeTime.advance(int64(defaultTimeout.Seconds()))
 	afterCh <- fakeTime.get()
 	afterCh <- fakeTime.get()
-	afterCh <- fakeTime.get()
 
 	// Check it expired
 	assert.Equal(t, 0.0, test.Get("foo"))

--- a/metricbeat/module/kubernetes/util/metrics_cache_test.go
+++ b/metricbeat/module/kubernetes/util/metrics_cache_test.go
@@ -47,5 +47,5 @@ func TestGetWithDefault(t *testing.T) {
 }
 
 func TestContainerUID(t *testing.T) {
-	assert.Equal(t, "a-b-c", ContainerUID("a", "b", "c"))
+	assert.Equal(t, "a/b/c", ContainerUID("a", "b", "c"))
 }

--- a/metricbeat/module/kubernetes/util/metrics_cache_test.go
+++ b/metricbeat/module/kubernetes/util/metrics_cache_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 type fakeClock struct {
-	sync.RWMutex
+	sync.Mutex
 	time int64
 }
 


### PR DESCRIPTION
Some metrics in metricbeat kubernetes module are cached during a time,
if they are not updated they are removed. But it is usual to have pods or
containers that are not updated during more time that the expiration cache.
Current implementation was not renovating expiration times for cache
entries so all were eventually removed if updates for them are not received.
Replace it with the cache implementation available in libbeat, but keeping
the existing interface.

Also, use slashes instead of dashes to generate unique container uids.
Dashes can be used by kubernetes names, what could lead to ambiguous
keys for the caches.

Fix #10658