### PR TITLE
Change CRI-O parsing to use RFC3339Nano

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -262,6 +262,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Set `event.category: network_traffic` for Suricata. {pull}10882[10882]
 - Add configuration knob for auto-discover hints to control whether log harvesting is enabled for the pod/container. {issue}10811[10811] {pull}10911[10911]
 - Change Suricata module pipeline to handle `destination.domain` being set if a reverse DNS processor is used. {issue}10510[10510]
+- Change CRI-O parsing to use RFC3339Nano {pull}10951[10951]
 
 *Heartbeat*
 

--- a/libbeat/reader/readjson/docker_json.go
+++ b/libbeat/reader/readjson/docker_json.go
@@ -92,7 +92,7 @@ func (p *DockerJSONReader) parseCRILog(message *reader.Message, msg *logLine) er
 	if len(log) < split {
 		return errors.New("invalid CRI log format")
 	}
-	ts, err := time.Parse(time.RFC3339, string(log[i]))
+	ts, err := time.Parse(time.RFC3339Nano, string(log[i]))
 	if err != nil {
 		return errors.Wrap(err, "parsing CRI timestamp")
 	}


### PR DESCRIPTION
CRI-O uses RFC3339Nano to generate timestamps which was causing the CRI-O based parsing to parse incorrectly. This PR attempts to fix that. 