### PR TITLE
Link to infrastructure monitoring docs from Beats docs

### DIFF
--- a/filebeat/docs/index.asciidoc
+++ b/filebeat/docs/index.asciidoc
@@ -15,6 +15,7 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :beat_default_index_prefix: {beatname_lc}
 :has_ml_jobs: yes
 :has_central_config:
+:has_solutions:
 :deb_os:
 :rpm_os:
 :mac_os:

--- a/libbeat/docs/dashboards.asciidoc
+++ b/libbeat/docs/dashboards.asciidoc
@@ -10,9 +10,7 @@
 //////////////////////////////////////////////////////////////////////////
 
 ifdef::has_solutions[]
-TIP: The example dashboards are a great way to get started visualizing
-{beatname_uc} data in {kib}. For deeper observability into what's happening with
-your infrastructure, though, you'll want to use the
+TIP: For deeper observability into your infrastructure, use the
 {infra-guide}/infrastructure-ui-overview.html[Infrastructure] and
 {infra-guide}/logs-ui-overview.html[Logs] UIs in {kib}. For setup details, see
 the {infra-guide}/index.html[Infrastructure Monitoring Guide].

--- a/libbeat/docs/dashboards.asciidoc
+++ b/libbeat/docs/dashboards.asciidoc
@@ -9,6 +9,15 @@
 //// include::../../libbeat/docs/dashboards.asciidoc[]
 //////////////////////////////////////////////////////////////////////////
 
+ifdef::has_solutions[]
+TIP: The example dashboards are a great way to get started visualizing
+{beatname_uc} data in {kib}. For deeper observability into what's happening with
+your infrastructure, though, you'll want to use the
+{infra-guide}/infrastructure-ui-overview.html[Infrastructure] and
+{infra-guide}/logs-ui-overview.html[Logs] UIs in {kib}. For setup details, see
+the {infra-guide}/index.html[Infrastructure Monitoring Guide].
+endif::has_solutions[]
+
 {beatname_uc} comes packaged with example Kibana dashboards, visualizations,
 and searches for visualizing {beatname_uc} data in Kibana. Before you can use
 the dashboards, you need to create the index pattern, +{beat_default_index_prefix}-*+, and

--- a/libbeat/docs/gettingstarted.asciidoc
+++ b/libbeat/docs/gettingstarted.asciidoc
@@ -26,3 +26,7 @@ After installing the {stack}, see the {beats} getting started guides:
 * {packetbeat-ref}/packetbeat-getting-started.html[Packetbeat]
 * {winlogbeat-ref}/winlogbeat-getting-started.html[Winlogbeat]
 
+If you're planning to use the
+{infra-guide}/infrastructure-ui-overview.html[Infrastructure] and
+{infra-guide}/logs-ui-overview.html[Logs] UIs in {kib}, also see the
+{infra-guide}/index.html[Infrastructure Monitoring Guide].

--- a/libbeat/docs/overview.asciidoc
+++ b/libbeat/docs/overview.asciidoc
@@ -28,6 +28,13 @@ image:./images/beats-platform.png[Beats Platform]
 
 To get started, see <<getting-started>>.
 
+Want to get up and running quickly with infrastructure metrics monitoring and
+centralized log analytics? Try out the
+{infra-guide}/infrastructure-ui-overview.html[Infrastructure] and
+{infra-guide}/logs-ui-overview.html[Logs] UIs
+in {kib}. For setup details, see the {infra-guide}/index.html[Infrastructure
+Monitoring Guide].
+
 [float]
 === Need to capture other kinds of data?
 

--- a/metricbeat/docs/index.asciidoc
+++ b/metricbeat/docs/index.asciidoc
@@ -15,6 +15,7 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :beat_default_index_prefix: {beatname_lc}
 :has_ml_jobs: yes
 :has_central_config:
+:has_solutions:
 :deb_os:
 :rpm_os:
 :mac_os:


### PR DESCRIPTION
Added a link that points to the infrastructure monitoring docs.

Related to https://github.com/elastic/stack-docs/issues/224