### PR TITLE
Reconcile duplicated attributes

### DIFF
--- a/auditbeat/docs/configuring-howto.asciidoc
+++ b/auditbeat/docs/configuring-howto.asciidoc
@@ -14,7 +14,7 @@ There's also a full example configuration file at
 options. For mac and win, look in the archive that you extracted.
 
 The {beatname_uc} configuration file uses http://yaml.org/[YAML] for its syntax.
-See the {libbeat}/config-file-format.html[Config File Format] section of the
+See the {beats-ref}/config-file-format.html[Config File Format] section of the
 _Beats Platform Reference_ for more about the structure of the config file.
 
 The following topics describe how to configure {beatname_uc}:

--- a/auditbeat/docs/getting-started.asciidoc
+++ b/auditbeat/docs/getting-started.asciidoc
@@ -238,7 +238,7 @@ sudo ./{beatname_lc} -e
 <1> To monitor system files, you'll be running {beatname_uc} as root, so you
 need to change ownership of the configuration file, or run {beatname_uc} with
 `--strict.perms=false` specified. See
-{libbeat}/config-file-permissions.html[Config File Ownership and Permissions]
+{beats-ref}/config-file-permissions.html[Config File Ownership and Permissions]
 in the _Beats Platform Reference_.
 
 If you see a warning about too many open files, you need to increase the

--- a/auditbeat/docs/reload-configuration.asciidoc
+++ b/auditbeat/docs/reload-configuration.asciidoc
@@ -44,4 +44,4 @@ definitions. For example:
 
 NOTE: On systems with POSIX file permissions, all Beats configuration files are
 subject to ownership and file permission checks. If you encounter config loading
-errors related to file ownership, see {libbeat}/config-file-permissions.html.
+errors related to file ownership, see {beats-ref}/config-file-permissions.html.

--- a/auditbeat/docs/running-on-kubernetes.asciidoc
+++ b/auditbeat/docs/running-on-kubernetes.asciidoc
@@ -25,7 +25,7 @@ To get the manifests just run:
 
 ["source", "sh", subs="attributes"]
 ------------------------------------------------
-curl -L -O https://raw.githubusercontent.com/elastic/beats/{doc-branch}/deploy/kubernetes/{beatname_lc}-kubernetes.yaml
+curl -L -O https://raw.githubusercontent.com/elastic/beats/{branch}/deploy/kubernetes/{beatname_lc}-kubernetes.yaml
 ------------------------------------------------
 
 [WARNING]

--- a/docs/devguide/create-metricset.asciidoc
+++ b/docs/devguide/create-metricset.asciidoc
@@ -272,7 +272,7 @@ NOTE: Make sure that you run `make collect` after updating the config file
 so that your changes are also applied to the global configuration file and the docs.
 
 For more details about the Metricbeat configuration file, see the topic about
-{metricbeat}/configuration-metricbeat.html[Modules] in the Metricbeat
+{metricbeat-ref}/configuration-metricbeat.html[Modules] in the Metricbeat
 documentation.
 
 

--- a/docs/devguide/creating-beat-from-metricbeat.asciidoc
+++ b/docs/devguide/creating-beat-from-metricbeat.asciidoc
@@ -26,12 +26,12 @@ go get github.com/elastic/beats/metricbeat
 ----
 
 This will clone the beats repository into `GOPATH`. By default `go get`  fetches the master branch. To build your beat
-on a specific version of libbeat, check out the specific branch ({doc-branch} in the example below):
+on a specific version of libbeat, check out the specific branch ({branch} in the example below):
 
 ["source","sh",subs="attributes"]
 ----
 cd ${GOPATH}/src/github.com/elastic/beats
-git checkout {doc-branch}
+git checkout {branch}
 ----
 
 Note: If you have multiple go paths use `${GOPATH%%:*}`instead of `${GOPATH}`.

--- a/docs/devguide/modules-dev-guide.asciidoc
+++ b/docs/devguide/modules-dev-guide.asciidoc
@@ -304,12 +304,12 @@ variables to dynamically switch between configurations.
 ==== ingest/*.json
 
 The `ingest/` folder contains Elasticsearch
-{elasticsearch}/ingest.html[Ingest Node] pipeline configurations. The Ingest
+{ref}/ingest.html[Ingest Node] pipeline configurations. The Ingest
 Node pipelines are responsible for parsing the log lines and doing other
 manipulations on the data.
 
 The files in this folder are JSON documents representing
-{elasticsearch}/pipeline.html[pipeline definitions]. Just like with the `config/`
+{ref}/pipeline.html[pipeline definitions]. Just like with the `config/`
 folder, you can define multiple pipelines, but a single one is loaded at runtime
 based on the information from `manifest.yml`.
 
@@ -332,9 +332,9 @@ The generator creates a JSON object similar to this one:
 
 From here, you would typically add processors to the `processors` array to do
 the actual parsing. For details on how to use ingest node processors, see the
-{elasticsearch}/ingest-processors.html[ingest node documentation]. In
+{ref}/ingest-processors.html[ingest node documentation]. In
 particular, you will likely find the
-{elasticsearch}/grok-processor.html[Grok processor] to be useful for parsing.
+{ref}/grok-processor.html[Grok processor] to be useful for parsing.
 Here is an example for parsing the Nginx access logs.
 
 [source,json]
@@ -412,7 +412,7 @@ ingest_pipeline:
 ----
 
 While developing the pipeline definition, we recommend making use of the
-{elasticsearch}/simulate-pipeline-api.html[Simulate Pipeline API] for testing
+{ref}/simulate-pipeline-api.html[Simulate Pipeline API] for testing
 and quick iteration.
 
 By default Filebeat does not update Ingest pipelines if already loaded. If you

--- a/docs/devguide/modules-dev-guide.asciidoc
+++ b/docs/devguide/modules-dev-guide.asciidoc
@@ -274,7 +274,7 @@ used to construct the `paths` list for the input `paths` option.
 Any template files that you add to the `config/` folder need to generate a valid
 Filebeat input configuration in YAML format. The options accepted by the
 input configuration are documented in the
-{filebeat}/configuration-filebeat-options.html[Filebeat Inputs] section of
+{filebeat-ref}/configuration-filebeat-options.html[Filebeat Inputs] section of
 the Filebeat documentation.
 
 The template files use the templating language defined by the

--- a/docs/devguide/newbeat.asciidoc
+++ b/docs/devguide/newbeat.asciidoc
@@ -50,12 +50,12 @@ git clone https://github.com/elastic/beats ${GOPATH}/src/github.com/elastic/beat
 ----------------------------------------------------------------------
 
 To build your beat
-on a specific version of libbeat, check out the specific branch ({doc-branch} in the example below):
+on a specific version of libbeat, check out the specific branch ({branch} in the example below):
 
 ["source","sh",subs="attributes"]
 ----
 cd ${GOPATH}/src/github.com/elastic/beats
-git checkout {doc-branch}
+git checkout {branch}
 ----
 
 NOTE: If you have multiple go paths, use `${GOPATH%%:*}` instead of `${GOPATH}`.

--- a/docs/devguide/newbeat.asciidoc
+++ b/docs/devguide/newbeat.asciidoc
@@ -495,4 +495,4 @@ func main() {
 === Sharing Your Beat with the Community
 
 When you're done with your new Beat, how about letting everyone know? Open
-a pull request to add your link to the {libbeat}/community-beats.html[Community Beats] list.
+a pull request to add your link to the {beats-ref}/community-beats.html[Community Beats] list.

--- a/filebeat/docs/configuring-howto.asciidoc
+++ b/filebeat/docs/configuring-howto.asciidoc
@@ -14,7 +14,7 @@ There's also a full example configuration file at
 options. For mac and win, look in the archive that you extracted.
 
 The {beatname_uc} configuration file uses http://yaml.org/[YAML] for its syntax.
-See the {libbeat}/config-file-format.html[Config File Format] section of the
+See the {beats-ref}/config-file-format.html[Config File Format] section of the
 _Beats Platform Reference_ for more about the structure of the config file.
 
 include::../../libbeat/docs/shared-cm-tip.asciidoc[]

--- a/filebeat/docs/faq.asciidoc
+++ b/filebeat/docs/faq.asciidoc
@@ -96,7 +96,7 @@ The index template might not be loaded correctly. See <<filebeat-template>>.
 
 If you have recently performed an operation that loads or parses custom, structured logs,
 you might need to refresh the index to make the fields available in Kibana. To refresh
-the index, use the {elasticsearch}/indices-refresh.html[refresh API]. For example:
+the index, use the {ref}/indices-refresh.html[refresh API]. For example:
 
 ["source","sh"]
 ----------------------------------------------------------------------

--- a/filebeat/docs/getting-started.asciidoc
+++ b/filebeat/docs/getting-started.asciidoc
@@ -246,7 +246,7 @@ sudo ./filebeat -e
 <1> You'll be running Filebeat as root, so you need to change ownership
 of the configuration file, or run Filebeat with `--strict.perms=false`
 specified. See
-{libbeat}/config-file-permissions.html[Config File Ownership and Permissions]
+{beats-ref}/config-file-permissions.html[Config File Ownership and Permissions]
 in the _Beats Platform Reference_.
 
 *win:*

--- a/filebeat/docs/getting-started.asciidoc
+++ b/filebeat/docs/getting-started.asciidoc
@@ -279,7 +279,7 @@ To populate the example dashboards with data, you need to either
 <<configuring-ingest-node,define ingest node pipelines>> or use Logstash to
 parse the data into the fields expected by the dashboards. If you are using
 Logstash, see the
-{logstashdoc}/logstash-config-for-filebeat-modules.html[configuration examples]
+{logstash-ref}/logstash-config-for-filebeat-modules.html[configuration examples]
 in the Logstash documentation for help parsing the log formats supported
 by the dashboards.
 

--- a/filebeat/docs/include/run-command.asciidoc
+++ b/filebeat/docs/include/run-command.asciidoc
@@ -32,7 +32,7 @@ If the module is configured correctly, you'll see
 
 NOTE: Depending on how you've installed {beatname_uc}, you might see errors
 related to file ownership or permissions when you try to run {beatname_uc}
-modules. See {libbeat}/config-file-permissions.html[Config File Ownership and
+modules. See {beats-ref}/config-file-permissions.html[Config File Ownership and
 Permissions] in the _Beats Platform Reference_ for more information.
 
 --

--- a/filebeat/docs/migration.asciidoc
+++ b/filebeat/docs/migration.asciidoc
@@ -12,7 +12,7 @@ to use for tailing log files and forwarding them to Logstash.
 * The registry file, which stores the state of the currently read files, was
   changed.
 * Command line options were removed and moved to the configuration file.
-* Configuration options for outputs are now inherited from libbeat. For details, see the {libbeat}/index.html[Beats Platform Reference].
+* Configuration options for outputs are now inherited from libbeat. For details, see the {beats-ref}/index.html[Beats Platform Reference].
 * The {logstash-ref}/plugins-inputs-beats.html[Beats input plugin for Logstash] is required.
 
 The following topics describe how to migrate from

--- a/filebeat/docs/modules-overview.asciidoc
+++ b/filebeat/docs/modules-overview.asciidoc
@@ -13,7 +13,7 @@ the following:
   The {beatname_uc} configuration is also responsible with stitching together
   multiline events when needed.
 
-* Elasticsearch {elasticsearch}/ingest.html[Ingest Node] pipeline definition,
+* Elasticsearch {ref}/ingest.html[Ingest Node] pipeline definition,
   which is used to parse the log lines.
 
 * Fields definitions, which are used to configure Elasticsearch with the

--- a/filebeat/docs/modules/iptables.asciidoc
+++ b/filebeat/docs/modules/iptables.asciidoc
@@ -28,7 +28,7 @@ When you run the module, it performs a few tasks under the hood:
 [float]
 === Compatibility
 
-This module requires the {elasticsearch-plugins}/ingest-geoip.html[ingest-geoip]
+This module requires the {plugins}/ingest-geoip.html[ingest-geoip]
 Elasticsearch plugins.
 
 include::../include/running-modules.asciidoc[]

--- a/filebeat/docs/modules/logstash.asciidoc
+++ b/filebeat/docs/modules/logstash.asciidoc
@@ -20,7 +20,7 @@ The +{modulename}+ module has two filesets:
 
 
 For the `slowlog` fileset, make sure to configure the
-{logstashdoc}/logging.html#_slowlog[Logstash slowlog option].
+{logstash-ref}/logging.html#_slowlog[Logstash slowlog option].
 
 [float]
 === Compatibility

--- a/filebeat/docs/modules/netflow.asciidoc
+++ b/filebeat/docs/modules/netflow.asciidoc
@@ -21,7 +21,7 @@ Elasticsearch Ingest Node.
 [float]
 === Compatibility
 
-This module requires the {elasticsearch-plugins}/ingest-geoip.html[ingest-geoip]
+This module requires the {plugins}/ingest-geoip.html[ingest-geoip]
 Elasticsearch plugins.
 
 include::../include/running-modules.asciidoc[]

--- a/filebeat/docs/modules/suricata.asciidoc
+++ b/filebeat/docs/modules/suricata.asciidoc
@@ -19,8 +19,8 @@ include::../include/what-happens.asciidoc[]
 [float]
 === Compatibility
 
-This module requires the {elasticsearch-plugins}/ingest-geoip.html[ingest-geoip]
-and {elasticsearch-plugins}/ingest-user-agent.html[ingest-user-agent]
+This module requires the {plugins}/ingest-geoip.html[ingest-geoip]
+and {plugins}/ingest-user-agent.html[ingest-user-agent]
 Elasticsearch plugins.
 
 This module has been developed against Suricata v4.0.4, but is expected to work

--- a/filebeat/docs/modules/zeek.asciidoc
+++ b/filebeat/docs/modules/zeek.asciidoc
@@ -16,8 +16,8 @@ https://www.zeek.org/manual/release/logs/index.html[Zeek JSON format].
 [float]
 === Compatibility
 
-This module requires the {elasticsearch-plugins}/ingest-geoip.html[ingest-geoip]
-and {elasticsearch-plugins}/ingest-user-agent.html[ingest-user-agent]
+This module requires the {plugins}/ingest-geoip.html[ingest-geoip]
+and {plugins}/ingest-user-agent.html[ingest-user-agent]
 Elasticsearch plugins.
 
 This module has been developed against Zeek 2.6.1, but is expected to work

--- a/filebeat/docs/running-on-kubernetes.asciidoc
+++ b/filebeat/docs/running-on-kubernetes.asciidoc
@@ -29,7 +29,7 @@ To download the manifest file, run:
 
 ["source", "sh", subs="attributes"]
 ------------------------------------------------
-curl -L -O https://raw.githubusercontent.com/elastic/beats/{doc-branch}/deploy/kubernetes/filebeat-kubernetes.yaml
+curl -L -O https://raw.githubusercontent.com/elastic/beats/{branch}/deploy/kubernetes/filebeat-kubernetes.yaml
 ------------------------------------------------
 
 [WARNING]

--- a/filebeat/docs/upgrading.asciidoc
+++ b/filebeat/docs/upgrading.asciidoc
@@ -3,5 +3,5 @@
 
 For information about upgrading to a new version, see the following topics in the _Beats Platform Reference_:
 
-* {libbeat}/breaking-changes.html[Breaking Changes]
-* {libbeat}/upgrading.html[Upgrading]
+* {beats-ref}/breaking-changes.html[Breaking Changes]
+* {beats-ref}/upgrading.html[Upgrading]

--- a/filebeat/module/logstash/_meta/docs.asciidoc
+++ b/filebeat/module/logstash/_meta/docs.asciidoc
@@ -15,7 +15,7 @@ The +{modulename}+ module has two filesets:
 
 
 For the `slowlog` fileset, make sure to configure the
-{logstashdoc}/logging.html#_slowlog[Logstash slowlog option].
+{logstash-ref}/logging.html#_slowlog[Logstash slowlog option].
 
 [float]
 === Compatibility

--- a/heartbeat/docs/configuring-howto.asciidoc
+++ b/heartbeat/docs/configuring-howto.asciidoc
@@ -16,7 +16,7 @@ extracted.
 
 The Heartbeat configuration file uses http://yaml.org/[YAML] for its syntax.
 See the
-{libbeat}/config-file-format.html[Config File Format] section of the
+{beats-ref}/config-file-format.html[Config File Format] section of the
 _Beats Platform Reference_ for more about the structure of the config file.
 
 The following topics describe how to configure Heartbeat:

--- a/heartbeat/docs/getting-started.asciidoc
+++ b/heartbeat/docs/getting-started.asciidoc
@@ -243,7 +243,7 @@ sudo ./heartbeat -e
 ----------------------------------------------------------------------
 <1> You'll be running Heartbeat as root, so you need to change ownership of the
 configuration file, or run Heartbeat with `--strict.perms=false` specified. See
-{libbeat}/config-file-permissions.html[Config File Ownership and Permissions]
+{beats-ref}/config-file-permissions.html[Config File Ownership and Permissions]
 in the _Beats Platform Reference_.
 
 *win:*

--- a/heartbeat/docs/overview.asciidoc
+++ b/heartbeat/docs/overview.asciidoc
@@ -7,7 +7,7 @@
 
 Heartbeat is a lightweight daemon that you install on a remote server
 to periodically check the status of your services and determine whether they are
-available. Unlike {metricbeat}/index.html[Metricbeat], which only tells you if
+available. Unlike {metricbeat-ref}/index.html[Metricbeat], which only tells you if
 your servers are up or down, Heartbeat tells you whether your services are
 reachable.
 

--- a/journalbeat/docs/getting-started.asciidoc
+++ b/journalbeat/docs/getting-started.asciidoc
@@ -196,7 +196,7 @@ sudo ./{beatname_lc} -e
 <1> You'll be running {beatname_uc} as root, so you need to change ownership
 of the configuration file, or run {beatname_uc} with `--strict.perms=false`
 specified. See
-{libbeat}/config-file-permissions.html[Config File Ownership and Permissions]
+{beats-ref}/config-file-permissions.html[Config File Ownership and Permissions]
 in the _Beats Platform Reference_.
 
 {beatname_uc} is now ready to send journal events to the defined output.

--- a/libbeat/docs/breaking.asciidoc
+++ b/libbeat/docs/breaking.asciidoc
@@ -16,7 +16,7 @@ See the following topics for a description of breaking changes:
 * <<breaking-changes-6.2>>
 * <<breaking-changes-6.1>>
 * <<breaking-changes-6.0>>
-* {auditbeat}/auditbeat-breaking-changes.html[Breaking changes in Auditbeat 6.2]
+* {auditbeat-ref}/auditbeat-breaking-changes.html[Breaking changes in Auditbeat 6.2]
 
 [[breaking-changes-7.0]]
 

--- a/libbeat/docs/breaking.asciidoc
+++ b/libbeat/docs/breaking.asciidoc
@@ -299,7 +299,7 @@ templates will not be applied.
 
 The `document_type` setting, from the prospector configuration, was removed
 because the `_type` concept is being
-{elasticsearch}/removal-of-types.html[removed from Elasticsearch]. Instead of
+{ref}/removal-of-types.html[removed from Elasticsearch]. Instead of
 the `document_type` setting, you can use a custom field.
 
 This has led also to the rename of the `input_type` configuration setting to

--- a/libbeat/docs/command-reference.asciidoc
+++ b/libbeat/docs/command-reference.asciidoc
@@ -839,7 +839,7 @@ Sets the path for log files. See the <<directory-layout>> section for details.
 *`--strict.perms`*::
 Sets strict permission checking on configuration files. The default is
 `-strict.perms=true`. See
-{libbeat}/config-file-permissions.html[Config file ownership and permissions] in
+{beats-ref}/config-file-permissions.html[Config file ownership and permissions] in
 the _Beats Platform Reference_ for more information.
 
 *`-v, --v`*::

--- a/libbeat/docs/https.asciidoc
+++ b/libbeat/docs/https.asciidoc
@@ -13,7 +13,7 @@
 To secure the communication between {beatname_uc} and Elasticsearch, you can use
 HTTPS and basic authentication. Basic authentication for Elasticsearch is
 available when you enable {security} (see
-{securitydoc}/elasticsearch-security.html[Securing the {stack}] and <<securing-beats>>).
+{stack-ov}/elasticsearch-security.html[Securing the {stack}] and <<securing-beats>>).
 If you aren't using {security}, you can use a web proxy instead.
 
 Here is a sample configuration:

--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -555,7 +555,7 @@ use in Logstash for indexing and filtering:
 }
 ------------------------------------------------------------------------------
 <1> {beatname_uc} uses the `@metadata` field to send metadata to Logstash. See the
-{logstashdoc}/event-dependent-configuration.html#metadata[Logstash documentation]
+{logstash-ref}/event-dependent-configuration.html#metadata[Logstash documentation]
 for more about the `@metadata` field.
 <2> The default is {beatname_lc}. To change this value, set the
 <<logstash-index,`index`>> option in the {beatname_uc} config file.

--- a/libbeat/docs/regexp.asciidoc
+++ b/libbeat/docs/regexp.asciidoc
@@ -28,7 +28,7 @@ to verify that the option you are setting accepts a regular expression.
 
 NOTE: We recommend that you wrap regular expressions in single quotation marks to work around YAML's string escaping rules. For example, `'^\[?[0-9][0-9]:?[0-9][0-9]|^[[:graph:]]+'`.
 
-For more examples of supported regexp patterns, see {filebeat}/multiline-examples.html[Managing Multiline Messages].
+For more examples of supported regexp patterns, see {filebeat-ref}/multiline-examples.html[Managing Multiline Messages].
 Although the examples pertain to Filebeat, the regexp patterns are applicable to other use cases.
 
 The following patterns are supported:

--- a/libbeat/docs/security/linux-seccomp.asciidoc
+++ b/libbeat/docs/security/linux-seccomp.asciidoc
@@ -21,7 +21,7 @@ can be customized through configuration as well.
 A seccomp policy is architecture specific due to the fact that system calls vary
 by architecture. {beatname_uc} includes a whitelist seccomp policy for the
 amd64 and 386 architectures. You can view those policies
-https://github.com/elastic/beats/tree/{doc-branch}/libbeat/common/seccomp[here].
+https://github.com/elastic/beats/tree/{branch}/libbeat/common/seccomp[here].
 
 [float]
 [[seccomp-policy-config]]

--- a/libbeat/docs/security/securing-beats.asciidoc
+++ b/libbeat/docs/security/securing-beats.asciidoc
@@ -7,7 +7,7 @@
 ++++
 
 If you want {beatname_uc} to connect to a cluster that has
-{securitydoc}/elasticsearch-security.html[{security}] enabled, there are extra
+{stack-ov}/elasticsearch-security.html[{security}] enabled, there are extra
 configuration steps:
 
 . <<beats-basic-auth>>.

--- a/libbeat/docs/shared-beats-attributes.asciidoc
+++ b/libbeat/docs/shared-beats-attributes.asciidoc
@@ -1,24 +1,9 @@
-:libbeat: http://www.elastic.co/guide/en/beats/libbeat/{doc-branch}
-:kibana-ref: https://www.elastic.co/guide/en/kibana/{doc-branch}
 :beatsdevguide: http://www.elastic.co/guide/en/beats/devguide/{doc-branch}
-:packetbeat: http://www.elastic.co/guide/en/beats/packetbeat/{doc-branch}
-:metricbeat: http://www.elastic.co/guide/en/beats/metricbeat/{doc-branch}
-:heartbeat: http://www.elastic.co/guide/en/beats/heartbeat/{doc-branch}
-:filebeat: http://www.elastic.co/guide/en/beats/filebeat/{doc-branch}
-:winlogbeat: http://www.elastic.co/guide/en/beats/winlogbeat/{doc-branch}
-:auditbeat: http://www.elastic.co/guide/en/beats/auditbeat/{doc-branch}
-:logstashdoc: https://www.elastic.co/guide/en/logstash/{doc-branch}
-:elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/{doc-branch}
-:elasticsearch-plugins: https://www.elastic.co/guide/en/elasticsearch/plugins/{doc-branch}
-:securitydoc: https://www.elastic.co/guide/en/elastic-stack-overview/{doc-branch}
-:monitoringdoc: https://www.elastic.co/guide/en/elastic-stack-overview/{doc-branch}
 :dashboards: https://artifacts.elastic.co/downloads/beats/beats-dashboards/beats-dashboards-{stack-version}.zip
 :dockerimage: docker.elastic.co/beats/{beatname_lc}:{version}
 :dockerconfig: https://raw.githubusercontent.com/elastic/beats/{doc-branch}/deploy/docker/{beatname_lc}.docker.yml
 :downloads: https://artifacts.elastic.co/downloads/beats
-:ES-version: {stack-version}
-:LS-version: {stack-version}
-:Kibana-version: {stack-version}
+
 :cm-ui: Central Management
 :libbeat-docs: Beats Platform Reference
 :beat_monitoring_user: beats_system

--- a/libbeat/docs/shared-beats-attributes.asciidoc
+++ b/libbeat/docs/shared-beats-attributes.asciidoc
@@ -1,7 +1,7 @@
-:beatsdevguide: http://www.elastic.co/guide/en/beats/devguide/{doc-branch}
+:beatsdevguide: http://www.elastic.co/guide/en/beats/devguide/{branch}
 :dashboards: https://artifacts.elastic.co/downloads/beats/beats-dashboards/beats-dashboards-{stack-version}.zip
 :dockerimage: docker.elastic.co/beats/{beatname_lc}:{version}
-:dockerconfig: https://raw.githubusercontent.com/elastic/beats/{doc-branch}/deploy/docker/{beatname_lc}.docker.yml
+:dockerconfig: https://raw.githubusercontent.com/elastic/beats/{branch}/deploy/docker/{beatname_lc}.docker.yml
 :downloads: https://artifacts.elastic.co/downloads/beats
 
 :cm-ui: Central Management

--- a/libbeat/docs/shared-config-ingest.asciidoc
+++ b/libbeat/docs/shared-config-ingest.asciidoc
@@ -13,7 +13,7 @@
 == Parse data by using ingest node
 
 When you use Elasticsearch for output, you can configure {beatname_uc} to use
-{elasticsearch}/ingest.html[ingest node] to pre-process documents before the
+{ref}/ingest.html[ingest node] to pre-process documents before the
 actual indexing takes place in Elasticsearch. Ingest node is a convenient
 processing option when you want to do some extra processing on your data, but
 you do not require the full power of Logstash. For example, you can create an
@@ -68,4 +68,4 @@ output.elasticsearch:
 When you run {beatname_uc}, the value of `agent.name` is converted to lowercase before indexing.
 
 For more information about defining a pre-processing pipeline, see the
-{elasticsearch}/ingest.html[Ingest Node] documentation.
+{ref}/ingest.html[Ingest Node] documentation.

--- a/libbeat/docs/shared-configuring.asciidoc
+++ b/libbeat/docs/shared-configuring.asciidoc
@@ -9,5 +9,5 @@ that shows all non-deprecated options.
 endif::[]
 
 TIP: See the
-{libbeat}/config-file-format.html[Config File Format] section of the
+{beats-ref}/config-file-format.html[Config File Format] section of the
 _Beats Platform Reference_ for more about the structure of the config file.

--- a/libbeat/docs/shared-faq.asciidoc
+++ b/libbeat/docs/shared-faq.asciidoc
@@ -18,7 +18,7 @@ You may encounter errors loading the config file on POSIX operating systems if:
 * an unauthorized user tries to load the config file, or
 * the config file has the wrong permissions.
 
-See {libbeat}/config-file-permissions.html[Config File Ownership and Permissions]
+See {beats-ref}/config-file-permissions.html[Config File Ownership and Permissions]
 for more about resolving these errors.
 
 [float]

--- a/libbeat/docs/shared-libbeat-description.asciidoc
+++ b/libbeat/docs/shared-libbeat-description.asciidoc
@@ -1,3 +1,3 @@
 {beatname_uc} is an Elastic https://www.elastic.co/products/beats[Beat]. It's
 based on the `libbeat` framework. For more information, see the
-{libbeat}/index.html[{libbeat-docs}]. 
+{beats-ref}/index.html[{libbeat-docs}]. 

--- a/libbeat/docs/shared-note-file-permissions.asciidoc
+++ b/libbeat/docs/shared-note-file-permissions.asciidoc
@@ -1,4 +1,4 @@
 NOTE: On systems with POSIX file permissions, all Beats configuration files are
 subject to ownership and file permission checks. For more information, see
-{libbeat}/config-file-permissions.html[Config File Ownership and Permissions] in
+{beats-ref}/config-file-permissions.html[Config File Ownership and Permissions] in
 the _Beats Platform Reference_.

--- a/libbeat/docs/shared-ssl-logstash-config.asciidoc
+++ b/libbeat/docs/shared-ssl-logstash-config.asciidoc
@@ -20,7 +20,7 @@ To use SSL mutual authentication:
 document. There are many online resources available that describe how to create certificates.
 +
 TIP: If you are using {security}, you can use the
-{elasticsearch}/certutil.html[elasticsearch-certutil tool] to generate certificates.
+{ref}/certutil.html[elasticsearch-certutil tool] to generate certificates.
 
 . Configure {beatname_uc} to use SSL. In the +{beatname_lc}.yml+ config file, specify the following settings under
 `ssl`:
@@ -51,7 +51,7 @@ For more information about these configuration options, see <<configuration-ssl>
 * `ssl_certificate` and `ssl_key`: Specify the certificate and key that Logstash uses to authenticate with the client.
 * `ssl_verify_mode`: Specifies whether the Logstash server verifies the client certificate against the CA. You
 need to specify either `peer` or `force_peer` to make the server ask for the certificate and validate it. If you
-specify `force_peer`, and {beatname_uc} doesn't provide a certificate, the Logstash connection will be closed. If you choose not to use {elasticsearch}/certutil.html[certutil], the certificates that you obtain must allow for both `clientAuth` and `serverAuth` if the extended key usage extension is present.
+specify `force_peer`, and {beatname_uc} doesn't provide a certificate, the Logstash connection will be closed. If you choose not to use {ref}/certutil.html[certutil], the certificates that you obtain must allow for both `clientAuth` and `serverAuth` if the extended key usage extension is present.
 +
 For example:
 +

--- a/libbeat/docs/shared-template-load.asciidoc
+++ b/libbeat/docs/shared-template-load.asciidoc
@@ -16,7 +16,7 @@ the output is not Elasticsearch, you must
 <<load-template-manually,load the template manually>>. 
 endif::only-elasticsearch[]
 
-In Elasticsearch, {elasticsearch}/indices-templates.html[index
+In Elasticsearch, {ref}/indices-templates.html[index
 templates] are used to define settings and mappings that determine how fields
 should be analyzed.
 

--- a/libbeat/docs/step-test-config.asciidoc
+++ b/libbeat/docs/step-test-config.asciidoc
@@ -17,7 +17,7 @@ your config files are in the path expected by {beatname_uc} (see
 <<directory-layout>>), or use the `-c` flag to specify the path to the config
 file. Depending on your OS, you might run into file ownership issues when you
 run this test. See
-{libbeat}/config-file-permissions.html[Config File Ownership and Permissions]
+{beats-ref}/config-file-permissions.html[Config File Ownership and Permissions]
 in the _Beats Platform Reference_ for more information.
 
 endif::[]

--- a/libbeat/docs/template-config.asciidoc
+++ b/libbeat/docs/template-config.asciidoc
@@ -3,7 +3,7 @@
 == Load the Elasticsearch index template
 
 The `setup.template` section of the +{beatname_lc}.yml+ config file specifies
-the {elasticsearch}/indices-templates.html[index template] to use for setting
+the {ref}/indices-templates.html[index template] to use for setting
 mappings in Elasticsearch. If template loading is enabled (the default),
 {beatname_uc} loads the index template automatically after successfully
 connecting to Elasticsearch.
@@ -55,7 +55,7 @@ is false.
 
 *`setup.template.settings`*:: A dictionary of settings to place into the `settings.index` dictionary of the
 Elasticsearch template. For more details about the available Elasticsearch mapping options, please
-see the Elasticsearch {elasticsearch}/mapping.html[mapping reference].
+see the Elasticsearch {ref}/mapping.html[mapping reference].
 +
 Example:
 +
@@ -75,7 +75,7 @@ indices to another cluster, you will need to add additional template settings to
 underlying indices.
 
 *`setup.template.settings._source`*:: A dictionary of settings for the `_source` field. For the available settings,
-please see the Elasticsearch {elasticsearch}/mapping-source-field.html[reference].
+please see the Elasticsearch {ref}/mapping-source-field.html[reference].
 +
 Example:
 +

--- a/metricbeat/docs/configuring-howto.asciidoc
+++ b/metricbeat/docs/configuring-howto.asciidoc
@@ -14,7 +14,7 @@ There's also a full example configuration file at
 options. For mac and win, look in the archive that you extracted.
 
 The {beatname_uc} configuration file uses http://yaml.org/[YAML] for its syntax.
-See the {libbeat}/config-file-format.html[Config File Format] section of the
+See the {beats-ref}/config-file-format.html[Config File Format] section of the
 _Beats Platform Reference_ for more about the structure of the config file.
 
 include::../../libbeat/docs/shared-cm-tip.asciidoc[]

--- a/metricbeat/docs/gettingstarted.asciidoc
+++ b/metricbeat/docs/gettingstarted.asciidoc
@@ -267,7 +267,7 @@ sudo ./{beatname_lc} -e
 <1> You'll be running {beatname_uc} as root, so you need to change ownership of the
 configuration file and any configurations enabled in the `modules.d` directory,
 or run {beatname_uc} with `--strict.perms=false` specified. See
-{libbeat}/config-file-permissions.html[Config File Ownership and Permissions]
+{beats-ref}/config-file-permissions.html[Config File Ownership and Permissions]
 in the _Beats Platform Reference_.
 
 *win:*

--- a/metricbeat/docs/modules/elasticsearch.asciidoc
+++ b/metricbeat/docs/modules/elasticsearch.asciidoc
@@ -5,7 +5,7 @@ This file is generated! See scripts/docs_collector.py
 [[metricbeat-module-elasticsearch]]
 == Elasticsearch module
 
-The Elasticsearch module contains a minimal set of metrics to enable monitoring of Elasticsearch across multiple versions. To monitor more Elasticsearch metrics, use our {monitoringdoc}/xpack-monitoring.html[monitoring] feature.
+The Elasticsearch module contains a minimal set of metrics to enable monitoring of Elasticsearch across multiple versions. To monitor more Elasticsearch metrics, use our {stack-ov}/xpack-monitoring.html[monitoring] feature.
 
 The default metricsets are `node` and `node_stats`.
 

--- a/metricbeat/docs/modules/kibana.asciidoc
+++ b/metricbeat/docs/modules/kibana.asciidoc
@@ -5,7 +5,7 @@ This file is generated! See scripts/docs_collector.py
 [[metricbeat-module-kibana]]
 == Kibana module
 
-The Kibana module only tracks the high-level metrics. To monitor more Kibana metrics, use our {monitoringdoc}/xpack-monitoring.html[monitoring] feature.
+The Kibana module only tracks the high-level metrics. To monitor more Kibana metrics, use our {stack-ov}/xpack-monitoring.html[monitoring] feature.
 
 The default metricset is `status`.
 

--- a/metricbeat/docs/running-on-kubernetes.asciidoc
+++ b/metricbeat/docs/running-on-kubernetes.asciidoc
@@ -35,7 +35,7 @@ To download the manifest file, run:
 
 ["source", "sh", subs="attributes"]
 ------------------------------------------------
-curl -L -O https://raw.githubusercontent.com/elastic/beats/{doc-branch}/deploy/kubernetes/metricbeat-kubernetes.yaml
+curl -L -O https://raw.githubusercontent.com/elastic/beats/{branch}/deploy/kubernetes/metricbeat-kubernetes.yaml
 ------------------------------------------------
 
 [WARNING]

--- a/metricbeat/docs/upgrading.asciidoc
+++ b/metricbeat/docs/upgrading.asciidoc
@@ -3,5 +3,5 @@
 
 For information about upgrading to a new version, see the following topics in the _Beats Platform Reference_:
 
-* {libbeat}/breaking-changes.html[Breaking Changes]
-* {libbeat}/upgrading.html[Upgrading]
+* {beats-ref}/breaking-changes.html[Breaking Changes]
+* {beats-ref}/upgrading.html[Upgrading]

--- a/metricbeat/module/elasticsearch/_meta/docs.asciidoc
+++ b/metricbeat/module/elasticsearch/_meta/docs.asciidoc
@@ -1,4 +1,4 @@
-The Elasticsearch module contains a minimal set of metrics to enable monitoring of Elasticsearch across multiple versions. To monitor more Elasticsearch metrics, use our {monitoringdoc}/xpack-monitoring.html[monitoring] feature.
+The Elasticsearch module contains a minimal set of metrics to enable monitoring of Elasticsearch across multiple versions. To monitor more Elasticsearch metrics, use our {stack-ov}/xpack-monitoring.html[monitoring] feature.
 
 The default metricsets are `node` and `node_stats`.
 

--- a/metricbeat/module/jolokia/jmx/_meta/docs.asciidoc
+++ b/metricbeat/module/jolokia/jmx/_meta/docs.asciidoc
@@ -47,7 +47,7 @@ Elastic "as is".
 
 You can configure nested metric aliases by using dots in the mapping name (for
 example, `gc.cms_collection_time`). For more examples, see
-https://github.com/elastic/beats/blob/{doc-branch}/metricbeat/module/jolokia/jmx/_meta/test/config.yml[/jolokia/jmx/test/config.yml].
+https://github.com/elastic/beats/blob/{branch}/metricbeat/module/jolokia/jmx/_meta/test/config.yml[/jolokia/jmx/test/config.yml].
 
 All metrics from a single mapping will be POSTed to the defined host/port and
 sent to Elastic as a single event. To make it possible to differentiate between

--- a/metricbeat/module/kibana/_meta/docs.asciidoc
+++ b/metricbeat/module/kibana/_meta/docs.asciidoc
@@ -1,4 +1,4 @@
-The Kibana module only tracks the high-level metrics. To monitor more Kibana metrics, use our {monitoringdoc}/xpack-monitoring.html[monitoring] feature.
+The Kibana module only tracks the high-level metrics. To monitor more Kibana metrics, use our {stack-ov}/xpack-monitoring.html[monitoring] feature.
 
 The default metricset is `status`.
 

--- a/packetbeat/docs/configuring-howto.asciidoc
+++ b/packetbeat/docs/configuring-howto.asciidoc
@@ -14,7 +14,7 @@ There's also a full example configuration file at
 options. For mac and win, look in the archive that you extracted.
 
 The {beatname_uc} configuration file uses http://yaml.org/[YAML] for its syntax.
-See the {libbeat}/config-file-format.html[Config File Format] section of the
+See the {beats-ref}/config-file-format.html[Config File Format] section of the
 _Beats Platform Reference_ for more about the structure of the config file.
 
 The following topics describe how to configure Packetbeat:

--- a/packetbeat/docs/gettingstarted.asciidoc
+++ b/packetbeat/docs/gettingstarted.asciidoc
@@ -284,7 +284,7 @@ sudo ./packetbeat -e
 ----------------------------------------------------------------------
 <1> You'll be running Packetbeat as root, so you need to change ownership of the
 configuration file, or run Packetbeat with `--strict.perms=false` specified. See
-{libbeat}/config-file-permissions.html[Config File Ownership and Permissions]in
+{beats-ref}/config-file-permissions.html[Config File Ownership and Permissions]in
 the _Beats Platform Reference_.
 
 *win:*

--- a/packetbeat/docs/overview.asciidoc
+++ b/packetbeat/docs/overview.asciidoc
@@ -7,7 +7,7 @@
 
 Packetbeat is a real-time network packet analyzer that you can use
 with Elasticsearch to provide an _application monitoring and performance
-analytics system_. Packetbeat completes the {libbeat}/index.html[Beats platform]
+analytics system_. Packetbeat completes the {beats-ref}/index.html[Beats platform]
 by providing visibility between the servers of your network.
 
 Packetbeat works by capturing the network traffic between your application servers,

--- a/packetbeat/docs/upgrading.asciidoc
+++ b/packetbeat/docs/upgrading.asciidoc
@@ -3,5 +3,5 @@
 
 For information about upgrading to a new version, see the following topics in the _Beats Platform Reference_:
 
-* {libbeat}/breaking-changes.html[Breaking Changes]
-* {libbeat}/upgrading.html[Upgrading]
+* {beats-ref}/breaking-changes.html[Breaking Changes]
+* {beats-ref}/upgrading.html[Upgrading]

--- a/winlogbeat/docs/configuring-howto.asciidoc
+++ b/winlogbeat/docs/configuring-howto.asciidoc
@@ -12,7 +12,7 @@ To configure {beatname_uc}, you edit the configuration file. You’ll find the c
 +/etc/{beatname_lc}/{beatname_lc}.reference.yml+ that shows all non-deprecated options.
 
 The {beatname_uc} configuration file uses http://yaml.org/[YAML] for its syntax. See the
-{libbeat}/config-file-format.html[Config File Format] section of the
+{beats-ref}/config-file-format.html[Config File Format] section of the
 _Beats Platform Reference_ for more about the structure of the config file.
 
 The following topics describe how to configure Winlogbeat:

--- a/winlogbeat/docs/getting-started.asciidoc
+++ b/winlogbeat/docs/getting-started.asciidoc
@@ -56,7 +56,7 @@ shows all non-deprecated options. For more information about these options, see
 === Step 2: Configure Winlogbeat
 
 To configure Winlogbeat, you edit the `winlogbeat.yml` configuration file. See the
-{libbeat}/config-file-format.html[Config File Format] section of the
+{beats-ref}/config-file-format.html[Config File Format] section of the
 _Beats Platform Reference_ for more about the structure of the config file.
 
 Here is a sample of the `winlogbeat.yml` file:

--- a/winlogbeat/docs/upgrading.asciidoc
+++ b/winlogbeat/docs/upgrading.asciidoc
@@ -3,5 +3,5 @@
 
 For information about upgrading to a new version, see the following topics in the _Beats Platform Reference_:
 
-* {libbeat}/breaking-changes.html[Breaking Changes]
-* {libbeat}/upgrading.html[Upgrading]
+* {beats-ref}/breaking-changes.html[Breaking Changes]
+* {beats-ref}/upgrading.html[Upgrading]

--- a/x-pack/filebeat/module/iptables/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/iptables/_meta/docs.asciidoc
@@ -23,7 +23,7 @@ When you run the module, it performs a few tasks under the hood:
 [float]
 === Compatibility
 
-This module requires the {elasticsearch-plugins}/ingest-geoip.html[ingest-geoip]
+This module requires the {plugins}/ingest-geoip.html[ingest-geoip]
 Elasticsearch plugins.
 
 include::../include/running-modules.asciidoc[]

--- a/x-pack/filebeat/module/netflow/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/netflow/_meta/docs.asciidoc
@@ -16,7 +16,7 @@ Elasticsearch Ingest Node.
 [float]
 === Compatibility
 
-This module requires the {elasticsearch-plugins}/ingest-geoip.html[ingest-geoip]
+This module requires the {plugins}/ingest-geoip.html[ingest-geoip]
 Elasticsearch plugins.
 
 include::../include/running-modules.asciidoc[]

--- a/x-pack/filebeat/module/suricata/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/suricata/_meta/docs.asciidoc
@@ -14,8 +14,8 @@ include::../include/what-happens.asciidoc[]
 [float]
 === Compatibility
 
-This module requires the {elasticsearch-plugins}/ingest-geoip.html[ingest-geoip]
-and {elasticsearch-plugins}/ingest-user-agent.html[ingest-user-agent]
+This module requires the {plugins}/ingest-geoip.html[ingest-geoip]
+and {plugins}/ingest-user-agent.html[ingest-user-agent]
 Elasticsearch plugins.
 
 This module has been developed against Suricata v4.0.4, but is expected to work

--- a/x-pack/filebeat/module/zeek/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/zeek/_meta/docs.asciidoc
@@ -11,8 +11,8 @@ https://www.zeek.org/manual/release/logs/index.html[Zeek JSON format].
 [float]
 === Compatibility
 
-This module requires the {elasticsearch-plugins}/ingest-geoip.html[ingest-geoip]
-and {elasticsearch-plugins}/ingest-user-agent.html[ingest-user-agent]
+This module requires the {plugins}/ingest-geoip.html[ingest-geoip]
+and {plugins}/ingest-user-agent.html[ingest-user-agent]
 Elasticsearch plugins.
 
 This module has been developed against Zeek 2.6.1, but is expected to work

--- a/x-pack/functionbeat/docs/getting-started.asciidoc
+++ b/x-pack/functionbeat/docs/getting-started.asciidoc
@@ -89,7 +89,7 @@ You specify settings in the  +{beatname_lc}.yml+ configuration file. This file
 is located in the archive that you extracted earlier.
 
 TIP: See the
-{libbeat}/config-file-format.html[Config File Format] section of the
+{beats-ref}/config-file-format.html[Config File Format] section of the
 _Beats Platform Reference_ for more about the structure of the config file.
 
 The following example configures a function called `cloudwatch` that collects


### PR DESCRIPTION
Fixes issue #6144 by removing attributes that duplicate attributes defined [here](https://github.com/elastic/docs/blob/master/shared/attributes.asciidoc).

Note that I've changed all paths to use `branch` instead of `doc-branch` to be consistent with the shared attributes file. However, I have not removed `doc-branch` from version.asciidoc because the attribute is used by `make docs`.

I've also removed attributes that are not used anywhere.

@bmorelli25 Please confirm that APM does not use any of the attributes that I've removed.