### PR TITLE
[Filebeat] Fix Suricata ingest pipeline

### DIFF
--- a/x-pack/filebeat/module/suricata/eve/ingest/pipeline.json
+++ b/x-pack/filebeat/module/suricata/eve/ingest/pipeline.json
@@ -64,7 +64,7 @@
         },
         {
             "script": {
-                "type": "painless",
+                "lang": "painless",
                 "source": "def domain = ctx.destination?.domain; if (domain instanceof Collection) { domain = domain.stream().distinct().collect(Collectors.toList()); if (domain.length == 1) { domain = domain[0]; }ctx.destination.domain = domain; }",
                 "ignore_failure": true
             }


### PR DESCRIPTION
A bad processor definition in the ingest pipeline was causing the tests
to stall.