### PR TITLE
Detect if the configured and the migrated registry paths are the same

### DIFF
--- a/journalbeat/checkpoint/checkpoint.go
+++ b/journalbeat/checkpoint/checkpoint.go
@@ -140,6 +140,14 @@ func (c *Checkpoint) findRegistryFile() error {
 		return fmt.Errorf("error accessing previous registry file: %+v", err)
 	}
 
+	// if two files are the same, do not do anything
+	migratedFs, err := os.Stat(migratedPath)
+	if err == nil {
+		if os.SameFile(fs, migratedFs) {
+			return nil
+		}
+	}
+
 	f, err := os.Open(c.file)
 	if err != nil {
 		return err

--- a/journalbeat/tests/system/config/journalbeat.yml.j2
+++ b/journalbeat/tests/system/config/journalbeat.yml.j2
@@ -7,7 +7,7 @@ journalbeat.inputs:
   {% endif %}
   include_matches: [{{ matches }}]
 
-journalbeat.registry: {{ registry_file }}
+journalbeat.registry_file: {{ registry_file }}
 
 ############################# Output ##########################################
 

--- a/journalbeat/tests/system/test_base.py
+++ b/journalbeat/tests/system/test_base.py
@@ -114,8 +114,8 @@ class Test(BaseTest):
         Journalbeat is able to follow reading a from a journal with an existing registry file.
         """
 
-	registry_path = self.beat_path + "/tests/system/input/test.registry"
-	input_path = self.beat_path + "/tests/system/input/test.journal"
+        registry_path = self.beat_path + "/tests/system/input/test.registry"
+        input_path = self.beat_path + "/tests/system/input/test.journal"
         self._prepare_registry_file(registry_path, input_path)
 
         self.render_config_template(
@@ -176,15 +176,16 @@ class Test(BaseTest):
         exit_code = journalbeat_proc.kill_and_wait()
         assert exit_code == 0
 
-        def _prepare_registry_file(self, registry_path, journal_path):
-            lines = []
-            with open(registry_path, "r") as registry_file:
-                lines = registry_file.readlines()
-                lines[2] = "- path: " + journal_path + "\n"
+    def _prepare_registry_file(self, registry_path, journal_path):
+        lines = []
+        with open(registry_path, "r") as registry_file:
+            lines = registry_file.readlines()
+            lines[2] = "- path: " + journal_path + "\n"
 
-            with open(registry_path, "w") as registry_file:
-                for line in lines:
-                    registry_file.write(line)
+        with open(registry_path, "w") as registry_file:
+            for line in lines:
+                registry_file.write(line)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/journalbeat/tests/system/test_base.py
+++ b/journalbeat/tests/system/test_base.py
@@ -176,15 +176,15 @@ class Test(BaseTest):
         exit_code = journalbeat_proc.kill_and_wait()
         assert exit_code == 0
 
-    def _prepare_registry_file(self, registry_path, journal_path):
-        lines = []
-	with open(registry_path, "r") as registry_file:
-            lines = registry_file.readlines()
-            lines[2] = "- path: " + journal_path + "\n"
+        def _prepare_registry_file(self, registry_path, journal_path):
+            lines = []
+            with open(registry_path, "r") as registry_file:
+                lines = registry_file.readlines()
+                lines[2] = "- path: " + journal_path + "\n"
 
-        with open(registry_path, "w") as registry_file:
-            for line in lines:
-                registry_file.write(line)
+            with open(registry_path, "w") as registry_file:
+                for line in lines:
+                    registry_file.write(line)
 
 if __name__ == '__main__':
     unittest.main()

--- a/journalbeat/tests/system/test_base.py
+++ b/journalbeat/tests/system/test_base.py
@@ -4,6 +4,7 @@ import os
 import sys
 import unittest
 import time
+import yaml
 
 
 class Test(BaseTest):
@@ -113,10 +114,14 @@ class Test(BaseTest):
         Journalbeat is able to follow reading a from a journal with an existing registry file.
         """
 
+	registry_path = self.beat_path + "/tests/system/input/test.registry"
+	input_path = self.beat_path + "/tests/system/input/test.journal"
+        self._prepare_registry_file(registry_path, input_path)
+
         self.render_config_template(
-            journal_path=self.beat_path + "/tests/system/input/test.journal",
+            journal_path=input_path,
             seek_method="cursor",
-            registry_file=self.beat_path + "/tests/system/input/test.registry",
+            registry_file=registry_path,
             path=os.path.abspath(self.working_dir) + "/log/*",
         )
         journalbeat_proc = self.start_beat()
@@ -139,7 +144,7 @@ class Test(BaseTest):
         assert exit_code == 0
 
     @unittest.skipUnless(sys.platform.startswith("linux"), "Journald only on Linux")
-    def test_read_events_with_existing_registry(self):
+    def test_read_events_with_include_matches(self):
         """
         Journalbeat is able to pass matchers to the journal reader and read filtered messages.
         """
@@ -171,6 +176,15 @@ class Test(BaseTest):
         exit_code = journalbeat_proc.kill_and_wait()
         assert exit_code == 0
 
+    def _prepare_registry_file(self, registry_path, journal_path):
+        lines = []
+	with open(registry_path, "r") as registry_file:
+            lines = registry_file.readlines()
+            lines[2] = "- path: " + journal_path + "\n"
+
+        with open(registry_path, "w") as registry_file:
+            for line in lines:
+                registry_file.write(line)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The E2E test of starting Journalbeat with an existing registry broke when I have added support and tests for `include_matches`. Thus, when I added the migration of the registry file, the issue was not detected.
Now both the code and the test are fixed.