### PR TITLE
Initialize filtering functionality

### DIFF
--- a/journalbeat/_meta/beat.yml
+++ b/journalbeat/_meta/beat.yml
@@ -30,7 +30,16 @@ journalbeat.inputs:
 
   # Exact matching for field values of events.
   # Matching for nginx entries: "systemd.unit=nginx"
-  #include_matches: []
+  #include_matches.equals: []
+
+  # List of syslog identifiers to filter for
+  #identifiers: ["audit"]
+
+  # List of units to filter for
+  #units: ["docker.service"]
+
+  # If kernel entries are need to be forwarded if units are configured
+  #kernel: false
 
   # Optional fields that you can specify to add additional information to the
   # output. Fields can be scalar values, arrays, dictionaries, or any nested

--- a/journalbeat/input/config.go
+++ b/journalbeat/input/config.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/elastic/beats/journalbeat/config"
+	"github.com/elastic/beats/journalbeat/reader"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/processors"
 )
@@ -38,8 +39,15 @@ type Config struct {
 	Seek config.SeekMode `config:"seek"`
 	// CursorSeekFallback sets where to seek if registry file is not available.
 	CursorSeekFallback config.SeekMode `config:"cursor_seek_fallback"`
+
 	// Matches store the key value pairs to match entries.
-	Matches []string `config:"include_matches"`
+	Matches reader.MatcherConfig `config:"include_matches"`
+	// Units stores the units to monitor
+	Units []string `config:"units"`
+	// Kernel stores whether kernel messages should be monitored
+	Kernel bool `config:"kernel"`
+	// Identifiers stores the syslog identifiers to watch
+	Identifiers []string `config:"identifiers"`
 
 	// Fields and tags to add to events.
 	common.EventMetadata `config:",inline"`

--- a/journalbeat/input/input.go
+++ b/journalbeat/input/input.go
@@ -73,6 +73,9 @@ func New(
 			Seek:               config.Seek,
 			CursorSeekFallback: config.CursorSeekFallback,
 			Matches:            config.Matches,
+			Units:              config.Units,
+			Kernel:             config.Kernel,
+			Identifiers:        config.Identifiers,
 		}
 
 		state := states[reader.LocalSystemJournalID]
@@ -91,6 +94,9 @@ func New(
 			Seek:               config.Seek,
 			CursorSeekFallback: config.CursorSeekFallback,
 			Matches:            config.Matches,
+			Units:              config.Units,
+			Kernel:             config.Kernel,
+			Identifiers:        config.Identifiers,
 		}
 		state := states[p]
 		r, err := reader.New(cfg, done, state, logger)

--- a/journalbeat/journalbeat.reference.yml
+++ b/journalbeat/journalbeat.reference.yml
@@ -30,7 +30,16 @@ journalbeat.inputs:
 
   # Exact matching for field values of events.
   # Matching for nginx entries: "systemd.unit=nginx"
-  #include_matches: []
+  #include_matches.equals: []
+
+  # List of syslog identifiers to filter for
+  #identifiers: ["audit"]
+
+  # List of units to filter for
+  #units: ["docker.service"]
+
+  # If kernel entries are need to be forwarded if units are configured
+  #kernel: false
 
   # Optional fields that you can specify to add additional information to the
   # output. Fields can be scalar values, arrays, dictionaries, or any nested

--- a/journalbeat/journalbeat.yml
+++ b/journalbeat/journalbeat.yml
@@ -30,7 +30,16 @@ journalbeat.inputs:
 
   # Exact matching for field values of events.
   # Matching for nginx entries: "systemd.unit=nginx"
-  #include_matches: []
+  #include_matches.equals: []
+
+  # List of syslog identifiers to filter for
+  #identifiers: ["audit"]
+
+  # List of units to filter for
+  #units: ["docker.service"]
+
+  # If kernel entries are need to be forwarded if units are configured
+  #kernel: false
 
   # Optional fields that you can specify to add additional information to the
   # output. Fields can be scalar values, arrays, dictionaries, or any nested

--- a/journalbeat/reader/config.go
+++ b/journalbeat/reader/config.go
@@ -37,8 +37,15 @@ type Config struct {
 	// Backoff is the current interval to wait before
 	// attemting to read again from the journal.
 	Backoff time.Duration
+
 	// Matches store the key value pairs to match entries.
-	Matches []string
+	Matches MatcherConfig
+	// Units stores the units to monitor
+	Units []string
+	// Kernel stores whether kernel messages should be monitored
+	Kernel bool
+	// Identifiers stores the syslog identifiers to watch
+	Identifiers []string
 }
 
 const (

--- a/journalbeat/reader/matcher.go
+++ b/journalbeat/reader/matcher.go
@@ -1,0 +1,157 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package reader
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/coreos/go-systemd/sdjournal"
+)
+
+type MatcherConfig struct {
+	Equals []string   `config:"equals"`
+	And    [][]string `config:"and"`
+	Or     [][]string `config:"or"`
+
+	isAnd bool
+}
+
+func setupUnitMatchers(j *sdjournal.Journal, units []string, kernel bool) error {
+	for _, unit := range units {
+		cfg := MatcherConfig{
+			Or: [][]string{
+				[]string{
+					sdjournal.SD_JOURNAL_FIELD_SYSTEMD_UNIT + "=" + unit,
+				},
+				[]string{
+					sdjournal.SD_JOURNAL_FIELD_MESSAGE_ID + "=fc2e22bc6ee647b6b90729ab34a250b1",
+					sdjournal.SD_JOURNAL_FIELD_UID + "=1",
+					"COREDUMP_UNIT=" + unit,
+				},
+				[]string{
+					sdjournal.SD_JOURNAL_FIELD_PID + "=1",
+					"UNIT=" + unit,
+				},
+				[]string{
+					sdjournal.SD_JOURNAL_FIELD_UID + "=1",
+					"OBJECT_SYSTEMD_UNIT=" + unit,
+				},
+			},
+		}
+
+		err := setupMatcherConfig(j, cfg)
+		if err != nil {
+			return fmt.Errorf("error while setting up unit matcher for %s: %+v", unit, err)
+		}
+
+	}
+
+	if kernel {
+		cfg := MatcherConfig{
+			Or: [][]string{
+				[]string{
+					"_TRANSPORT=kernel",
+				},
+			},
+		}
+		err := setupMatcherConfig(j, cfg)
+		if err != nil {
+			return fmt.Errorf("error while adding kernel transport to matchers: %+v", err)
+		}
+	}
+
+	return nil
+}
+
+func setupSyslogIdentifierMatchers(j *sdjournal.Journal, identifiers []string) error {
+	identifierFilters := make([]string, 0)
+	for _, identifier := range identifiers {
+		identifierFilters = append(identifierFilters, sdjournal.SD_JOURNAL_FIELD_SYSLOG_IDENTIFIER+"="+identifier)
+	}
+
+	cfg := MatcherConfig{Or: [][]string{identifierFilters}}
+
+	return setupMatcherConfig(j, cfg)
+}
+
+func setupMatcherConfig(j *sdjournal.Journal, c MatcherConfig) error {
+	if c.And != nil {
+		for _, m := range c.And {
+			err := setupMatchers(j, m)
+			if err != nil {
+				return err
+			}
+
+			err = j.AddConjunction()
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	if c.Or != nil {
+		for _, m := range c.Or {
+			err := setupMatchers(j, m)
+			if err != nil {
+				return err
+			}
+
+			err = j.AddDisjunction()
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	if c.Equals != nil {
+		return setupMatchers(j, c.Equals)
+	}
+	return nil
+}
+
+func setupMatchers(j *sdjournal.Journal, matchers []string) error {
+	for _, m := range matchers {
+		match, err := transformMatcherString(m)
+		err = j.AddMatch(match)
+		if err != nil {
+			return fmt.Errorf("error while adding matcher to journal: %+v", err)
+		}
+	}
+	return nil
+}
+
+func transformMatcherString(m string) (string, error) {
+	elems := strings.Split(m, "=")
+	if len(elems) != 2 {
+		return "", fmt.Errorf("invalid match format: %s", m)
+	}
+
+	var p string
+	for journalKey, eventField := range journaldEventFields {
+		if elems[0] == eventField.name {
+			p = journalKey + "=" + elems[1]
+		}
+	}
+
+	// pass custom fields as is
+	if p == "" {
+		p = m
+	}
+	return p, nil
+}

--- a/journalbeat/tests/system/config/journalbeat.yml.j2
+++ b/journalbeat/tests/system/config/journalbeat.yml.j2
@@ -5,7 +5,9 @@ journalbeat.inputs:
   {% if cursor_seek_fallback %}
   cursor_seek_fallback: {{ cursor_seek_fallback }}
   {% endif %}
-  include_matches: [{{ matches }}]
+  include_matches.equals: [{{ matches }}]
+  identifiers: [{{ identifiers }}]
+  units: [{{ units }}]
 
 journalbeat.registry_file: {{ registry_file }}
 


### PR DESCRIPTION
This PR initializes support for the similar filters provided by the community Journalbeat. It does not yet have the complete functionality as wildcards for unit names are missing.
But I am opening this PR to discuss the interface of `include_matches`.

Previously `include_matches` expected a list of filter expressions. Now more advanced filtering is added, but it required a different way of configuration.
Also, the way matches are applied to a systemd journal is a bit counterintuitive. If matcher expressions are applied to the same field, they are connected with OR. In case of differen field names, the expressions are connected with AND. Thus, it does not let you define full locigal expressions as our processor filtering does.

The following configuration matches for entries where `process.name` is either `chromium` or `dockerd`:

```
include_matches.equals:
  - _COMM=chromium
  - _COMM=dockerd
```
If we would like to get entries of `chromium`, `dockerd` and audit messages the following configuration is required.

```
include_matches.or:
  - [
     _COMM=chromium,
     _COMM=dockerd
  ]
  - [
    _TRANSPORT=audit
  ]
```

What I would like to discuss if the configuration above is ok. Another alternative which came to my mind is this:

```
include_matches.or:
  - conditions:
    - _COMM=chromium
    - _COMM=dockers
  - conditions:
    - _TRANSPORT=audit
```

But in my opinion the one I have implemented is simpler. WDYT?

Note that most of the filtering use cases are covered by `unit`, `kernel` and `identifiers`.

TODO
- [ ] add changelog entry

Depends on elastic/beats#10982 