### PR TITLE
Add multiplier option to prometheus helper

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -94,6 +94,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Update haproxy.* fields to map to ECS. {pull}10558[10558] {pull}10568[10568]
 - Collect all EC2 meta data from all instances in all states. {pull}10628[10628]
 - Migrate docker module to ECS. {pull}10927[10927]
+- Add new option `OpMultiplyBuckets` to scale histogram buckets to avoid decimal points in final events {pull}10994[10994]
 
 *Packetbeat*
 

--- a/metricbeat/helper/prometheus/prometheus_test.go
+++ b/metricbeat/helper/prometheus/prometheus_test.go
@@ -52,6 +52,14 @@ histogram_metric_bucket{le="1e+09"} 1
 histogram_metric_bucket{le="+Inf"} 1
 histogram_metric_sum 117
 histogram_metric_count 1
+# TYPE histogram_decimal_metric histogram
+histogram_decimal_metric_bucket{le="0.001"} 1
+histogram_decimal_metric_bucket{le="0.01"} 1
+histogram_decimal_metric_bucket{le="0.1"} 2
+histogram_decimal_metric_bucket{le="1"} 3
+histogram_decimal_metric_bucket{le="+Inf"} 5
+histogram_decimal_metric_sum 4.31
+histogram_decimal_metric_count 5
 
 `
 
@@ -324,6 +332,31 @@ func TestPrometheus(t *testing.T) {
 								"100000000":  uint64(1),
 							},
 							"sum": 117.0,
+						},
+					},
+				},
+			},
+		},
+		{
+			msg: "Histogram decimal metric",
+			mapping: &MetricsMapping{
+				Metrics: map[string]MetricMap{
+					"histogram_decimal_metric": Metric("histogram.metric", OpMultiplyBuckets(1000)),
+				},
+			},
+			expected: []common.MapStr{
+				common.MapStr{
+					"histogram": common.MapStr{
+						"metric": common.MapStr{
+							"count": uint64(5),
+							"bucket": common.MapStr{
+								"1":    uint64(1),
+								"10":   uint64(1),
+								"100":  uint64(2),
+								"1000": uint64(3),
+								"+Inf": uint64(5),
+							},
+							"sum": 4.31,
 						},
 					},
 				},


### PR DESCRIPTION
Prometheus histograms can contain buckets with keys in decimal
representation. They create events with dots in the field names, what
can be problematic when stored in Elasticsearch as they will create
sub-objects.

Add a new option to allow to store these keys in different units, so
precission is kept but in a different order of magnitude.