### PR TITLE
[6.7] Ensure index pattern version is a string (#10689) 

### DIFF
--- a/libbeat/kibana/index_pattern_generator.go
+++ b/libbeat/kibana/index_pattern_generator.go
@@ -97,7 +97,7 @@ func (i *IndexPatternGenerator) generateMinVersion6(attrs common.MapStr) common.
 			common.MapStr{
 				"type":       "index-pattern",
 				"id":         i.indexName,
-				"version":    1,
+				"version":    "1",
 				"attributes": attrs,
 			},
 		},

--- a/libbeat/kibana/testdata/beat-6.json
+++ b/libbeat/kibana/testdata/beat-6.json
@@ -10,7 +10,7 @@
       },
       "id": "beat-*",
       "type": "index-pattern",
-      "version": 1
+      "version": "1"
     }
   ],
   "version": "7.0.0-alpha1"

--- a/libbeat/kibana/testdata/extensive/metricbeat-6.json
+++ b/libbeat/kibana/testdata/extensive/metricbeat-6.json
@@ -8,7 +8,7 @@
         "timeFieldName": "@timestamp", 
         "title": "metricbeat-*"
       }, 
-      "version": 1, 
+      "version": "1",
       "type": "index-pattern", 
       "id": "metricbeat-*"
     }


### PR DESCRIPTION
Backports the following commits to 6.7:

* Ensure index pattern version is a string  (#10689)