### PR TITLE
 Fix for not reusable http client leading to connection leaks in Jolokia module

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -96,6 +96,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Update haproxy.* fields to map to ECS. {pull}10558[10558] {pull}10568[10568]
 - Collect all EC2 meta data from all instances in all states. {pull}10628[10628]
 - Migrate docker module to ECS. {pull}10927[10927]
+- Fix for not reusable http client leading to connection leaks in Jolokia module
 
 *Packetbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -96,7 +96,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Update haproxy.* fields to map to ECS. {pull}10558[10558] {pull}10568[10568]
 - Collect all EC2 meta data from all instances in all states. {pull}10628[10628]
 - Migrate docker module to ECS. {pull}10927[10927]
-- Fix for not reusable http client leading to connection leaks in Jolokia module
 
 *Packetbeat*
 
@@ -182,6 +181,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix issue with `elasticsearch/node_stats` metricset (x-pack) not indexing `source_node` field. {pull}10639[10639]
 - Migrate docker autodiscover to ECS. {issue}10757[10757] {pull}10862[10862]
 - Fix issue in kubernetes module preventing usage percentages to be properly calculated. {pull}10946[10946]
+- Fix for not reusable http client leading to connection leaks in Jolokia module {pull}11014[11014]
 
 *Packetbeat*
 

--- a/metricbeat/module/jolokia/jmx/config.go
+++ b/metricbeat/module/jolokia/jmx/config.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
-	"github.com/elastic/beats/metricbeat/helper"
 )
 
 type JMXMapping struct {
@@ -355,20 +354,17 @@ func (pc *JolokiaHTTPGetFetcher) Fetch(m *MetricSet) ([]common.MapStr, error) {
 	}
 
 	for _, r := range httpReqs {
+		m.http.SetMethod(r.HTTPMethod)
+		m.http.SetURI(m.BaseMetricSet.HostData().SanitizedURI + r.URI)
 
-		http, err := helper.NewHTTP(m.BaseMetricSet)
-
-		http.SetMethod(r.HTTPMethod)
-		http.SetURI(m.BaseMetricSet.HostData().SanitizedURI + r.URI)
-
-		resBody, err := http.FetchContent()
+		resBody, err := m.http.FetchContent()
 		if err != nil {
 			return nil, err
 		}
 
 		if logp.IsDebug(metricsetName) {
 			m.log.Debugw("Jolokia response body",
-				"host", m.HostData().Host, "uri", http.GetURI(), "body", string(resBody), "type", "response")
+				"host", m.HostData().Host, "uri", m.http.GetURI(), "body", string(resBody), "type", "response")
 		}
 
 		// Map response to Metricbeat events
@@ -491,19 +487,17 @@ func (pc *JolokiaHTTPPostFetcher) Fetch(m *MetricSet) ([]common.MapStr, error) {
 		}
 	}
 
-	http, err := helper.NewHTTP(m.BaseMetricSet)
+	m.http.SetMethod(httpReqs[0].HTTPMethod)
+	m.http.SetBody(httpReqs[0].Body)
 
-	http.SetMethod(httpReqs[0].HTTPMethod)
-	http.SetBody(httpReqs[0].Body)
-
-	resBody, err := http.FetchContent()
+	resBody, err := m.http.FetchContent()
 	if err != nil {
 		return nil, err
 	}
 
 	if logp.IsDebug(metricsetName) {
 		m.log.Debugw("Jolokia response body",
-			"host", m.HostData().Host, "uri", http.GetURI(), "body", string(resBody), "type", "response")
+			"host", m.HostData().Host, "uri", m.http.GetURI(), "body", string(resBody), "type", "response")
 	}
 
 	// Map response to Metricbeat events


### PR DESCRIPTION
In a host where I have three Wildfly 9 running instances, I installed metricbeat along with Jolokia module in order to keep track of JVM heap usage, etc. 

I'm able to collect regularly all the needed metrics, but after a while that Metricbeat/Jolokia is running, it reaches the limit of maximum file opened in the system, and then it breaks saying: `write error: failed to open new file: open /var/log/metricbeat/metricbeat: too many open files`.

Checking the status of connections by metricbeat PID: `netstat --all --program | grep '<PID>'`, I get tons of entries like the following ones:

```
...
...
tcp        0      0 localhost:57346         localhost:8090          ESTABLISHED 3181/metricbeat     
tcp        0      0 localhost:52678         localhost:8090          ESTABLISHED 3181/metricbeat     
tcp        0      0 localhost:38310         localhost:8090          ESTABLISHED 3181/metricbeat     
tcp        0      0 localhost:43934         localhost:8090          ESTABLISHED 3181/metricbeat     
tcp        0      0 localhost:54988         localhost:8090          ESTABLISHED 3181/metricbeat 
...
...
```

Metricbeat will definitely break after a while, when the number of the above entries is equal to the maximum number of open file descriptors parameter set for the user running the process (`ulimit`).

Thanks also to @jsoriano, we found out that the Jolokia module creates a new client for each request, instead of reusing the already available clients, leading to an unavoidable connections leak.

This PR introduces a fix for it.