### PR TITLE
Set include_type_name to true when loading template to ES 6.7

### DIFF
--- a/libbeat/template/load.go
+++ b/libbeat/template/load.go
@@ -154,7 +154,8 @@ func (l *Loader) CheckTemplate(templateName string) bool {
 }
 
 func loadJSON(client ESClient, path string, json map[string]interface{}) ([]byte, error) {
-	status, body, err := client.Request("PUT", path, "", nil, json)
+	params := esVersionParams(client.GetVersion())
+	status, body, err := client.Request("PUT", path, "", params, json)
 	if err != nil {
 		return body, fmt.Errorf("couldn't load json. Error: %s", err)
 	}
@@ -163,4 +164,14 @@ func loadJSON(client ESClient, path string, json map[string]interface{}) ([]byte
 	}
 
 	return body, nil
+}
+
+func esVersionParams(ver common.Version) map[string]string {
+	if ver.Major == 6 && ver.Minor == 7 {
+		return map[string]string{
+			"include_type_name": "false",
+		}
+	}
+
+	return nil
 }

--- a/libbeat/template/load.go
+++ b/libbeat/template/load.go
@@ -169,7 +169,7 @@ func loadJSON(client ESClient, path string, json map[string]interface{}) ([]byte
 func esVersionParams(ver common.Version) map[string]string {
 	if ver.Major == 6 && ver.Minor == 7 {
 		return map[string]string{
-			"include_type_name": "false",
+			"include_type_name": "true",
 		}
 	}
 


### PR DESCRIPTION
I haven't seen any deprecation warnings in the logs of ES when testing with ES 6.7.