### PR TITLE
[Auditbeat] Cherry-pick #10897 to 6.7: System module: Fix and unify bucket closing logic

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -82,6 +82,7 @@ https://github.com/elastic/beats/compare/v6.6.0...6.x[Check the HEAD diff]
 - Package: Disable librpm signal handlers. {pull}10694[10694]
 - Login: Handle different bad login UTMP types. {pull}10865[10865]
 - Fix hostname references in System module dashbords. {pull}11064[11064]
+- System module: Fix and unify bucket closing logic. {pull}10897[10897]
 
 *Filebeat*
 

--- a/x-pack/auditbeat/module/system/login/utmp.go
+++ b/x-pack/auditbeat/module/system/login/utmp.go
@@ -84,8 +84,10 @@ func NewUtmpFileReader(log *logp.Logger, bucket datastore.Bucket, config config)
 
 // Close performs any cleanup tasks when the UTMP reader is done.
 func (r *UtmpFileReader) Close() error {
-	err := r.bucket.Close()
-	return errors.Wrap(err, "error closing bucket")
+	if r.bucket != nil {
+		return r.bucket.Close()
+	}
+	return nil
 }
 
 // ReadNew returns any new UTMP entries in any files matching the configured pattern.


### PR DESCRIPTION
Cherry-pick of PR #10897 to 6.7 branch. Original message: 

The `host` dataset is erroneously trying to save state in its `Close()` method. It should have saved the state earlier - usually at the end of `Fetch()` - and then should only close the bucket (something it is not doing at all). At the same time, it is not saving state in its `reportState()` method. Combined, this can lead to an error when the dataset is terminated before the first regular `reportChanges()` is run.

This fixes both issues and furthermore unifies the bucket closing logic across all six datasets of the System module.