### PR TITLE
[Auditbeat] Cherry-pick #10897 to 6.6: System module: Fix and unify bucket closing logic

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -34,6 +34,8 @@ https://github.com/elastic/beats/compare/v6.6.1...6.6[Check the HEAD diff]
 
 *Auditbeat*
 
+- System module: Fix and unify bucket closing logic. {pull}10897[10897]
+
 *Filebeat*
 
 *Heartbeat*


### PR DESCRIPTION
Cherry-pick of PR #10897 to 6.6 branch. Original message: 

The `host` dataset is erroneously trying to save state in its `Close()` method. It should have saved the state earlier - usually at the end of `Fetch()` - and then should only close the bucket (something it is not doing at all). At the same time, it is not saving state in its `reportState()` method. Combined, this can lead to an error when the dataset is terminated before the first regular `reportChanges()` is run.

This fixes both issues and furthermore unifies the bucket closing logic across all six datasets of the System module.