### PR TITLE
Add ip fields to default_field in Elasticsearch template

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -218,6 +218,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add if/then/else support to processors. {pull}10744[10744]
 - Add `community_id` processor for computing network flow hashes. {pull}10745[10745]
 - Add output test to kafka output {pull}10834[10834]
+- Add ip fields to default_field in Elasticsearch template. {pull}11035[11035]
 
 
 *Auditbeat*

--- a/libbeat/template/processor.go
+++ b/libbeat/template/processor.go
@@ -100,11 +100,27 @@ func (p *Processor) Process(fields common.Fields, path string, output common.Map
 			mapping = p.other(&field)
 		}
 
+		switch field.Type {
+		case "", "keyword", "text":
+			addToDefaultFields(&field)
+		}
+
 		if len(mapping) > 0 {
 			output.Put(common.GenerateKey(field.Name), mapping)
 		}
 	}
 	return nil
+}
+
+func addToDefaultFields(f *common.Field) {
+	fullName := f.Name
+	if f.Path != "" {
+		fullName = f.Path + "." + f.Name
+	}
+
+	if f.Index == nil || (f.Index != nil && *f.Index) {
+		defaultFields = append(defaultFields, fullName)
+	}
 }
 
 func (p *Processor) other(f *common.Field) common.MapStr {
@@ -173,15 +189,6 @@ func (p *Processor) ip(f *common.Field) common.MapStr {
 func (p *Processor) keyword(f *common.Field) common.MapStr {
 	property := getDefaultProperties(f)
 
-	fullName := f.Name
-	if f.Path != "" {
-		fullName = f.Path + "." + f.Name
-	}
-
-	if f.Index == nil || (f.Index != nil && *f.Index) {
-		defaultFields = append(defaultFields, fullName)
-	}
-
 	property["type"] = "keyword"
 
 	switch f.IgnoreAbove {
@@ -208,15 +215,6 @@ func (p *Processor) keyword(f *common.Field) common.MapStr {
 
 func (p *Processor) text(f *common.Field) common.MapStr {
 	properties := getDefaultProperties(f)
-
-	fullName := f.Name
-	if f.Path != "" {
-		fullName = f.Path + "." + f.Name
-	}
-
-	if f.Index == nil || (f.Index != nil && *f.Index) {
-		defaultFields = append(defaultFields, fullName)
-	}
 
 	properties["type"] = "text"
 

--- a/libbeat/template/processor.go
+++ b/libbeat/template/processor.go
@@ -101,7 +101,7 @@ func (p *Processor) Process(fields common.Fields, path string, output common.Map
 		}
 
 		switch field.Type {
-		case "", "keyword", "text":
+		case "", "keyword", "text", "ip":
 			addToDefaultFields(&field)
 		}
 


### PR DESCRIPTION
I recently noticed that pasting an IP into Kibana's KQL bar yielded no results - even though there were plenty of documents with that IP. The reason is that IP fields are currently not included in the `default_field` configuration of the generated template.

I think they should definitely be included, and this adds them.

For Auditbeat, this adds 9 fields. For the others, it looks like 16 for Metricbeat, 15 for Filebeat, 17 for Packetbeat.

/cc @elastic/secops - important for us.