### PR TITLE
Cherry-pick #11018 to 6.7: [Filebeat] [Netflow] fix field name conversion to snake case

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -100,6 +100,7 @@ https://github.com/elastic/beats/compare/v6.6.0...6.x[Check the HEAD diff]
 - Fix bad bytes count in `docker` input when filtering by stream. {pull}10211[10211]
 - Fixed data types for roles and indices fields in `elasticsearch/audit` fileset {pull}10307[10307]
 - Cover empty request data, url and version in Apache2 module{pull}10846[10846]
+- Fix a bug when converting NetFlow fields to snake_case. {pull}10950[10950]
 
 *Heartbeat*
 


### PR DESCRIPTION
Cherry-pick of PR #11018 to 6.7 branch. Original message: 

Initial release field name conversion was buggy:

`postNATSourceIPv4Address` => `post_nast_ource_ipv4_address`

This includes special treatment for badly named field `VRFname`, by convention it should be `VRFName`.