### PR TITLE
Bring back -d publish behavior

### DIFF
--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -307,7 +307,7 @@ func (b *Beat) createBeater(bt beat.Creator) (beat.Beater, error) {
 		pipeline.Monitors{
 			Metrics:   reg,
 			Telemetry: monitoring.GetNamespace("state").GetRegistry(),
-			Logger:    logp.L().Named("publisher"),
+			Logger:    logp.L().Named("publish"),
 		},
 		b.Config.Pipeline,
 		b.makeOutputFactory(b.Config.Output),


### PR DESCRIPTION
Traditionally, passing the `-d publish` debug selector to a Beat caused events to be printed to the log.

After recent changes, it is required to also add the `publisher` selector, probably by mistake.