### PR TITLE
Cherry-pick #10197 to 6.7: Add time encoders to disk spool

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -75,6 +75,7 @@ https://github.com/elastic/beats/compare/v6.6.0...6.x[Check the HEAD diff]
 - Fix stopping of modules started by kubernetes autodiscover. {pull}10476[10476]
 - Fix a issue when remote and local configuration didn't match when fetching configuration from Central Management. {issue}10587[10587]
 - Add ECS-like selectors and dedotting to docker autodiscover. {issue}10757[10757] {pull}10862[10862]
+- Fix encoding of timestamps when using disk spool. {issue}10099[10099]
 
 *Auditbeat*
 

--- a/libbeat/publisher/queue/spool/codec.go
+++ b/libbeat/publisher/queue/spool/codec.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/outputs/codec"
 	"github.com/elastic/beats/libbeat/publisher"
 	"github.com/elastic/go-structform"
 	"github.com/elastic/go-structform/cborl"
@@ -95,7 +96,12 @@ func (e *encoder) reset() {
 		panic("no codec configured")
 	}
 
-	folder, err := gotype.NewIterator(visitor)
+	folder, err := gotype.NewIterator(visitor,
+		gotype.Folders(
+			codec.MakeTimestampEncoder(),
+			codec.MakeBCTimestampEncoder(),
+		),
+	)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Cherry-pick of PR #10197 to 6.7 branch. Original message: 

Register encoders for time.Time and common.Time so that events containing timestamps
can be serialized.

Fixes #10099