### PR TITLE
[Auditbeat] Fix hostname references in System module dashboards

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -81,6 +81,7 @@ https://github.com/elastic/beats/compare/v6.6.0...6.x[Check the HEAD diff]
 - Enable System module config on Windows. {pull}10237[10237]
 - Package: Disable librpm signal handlers. {pull}10694[10694]
 - Login: Handle different bad login UTMP types. {pull}10865[10865]
+- Fix hostname references in System module dashbords.
 
 *Filebeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -81,7 +81,7 @@ https://github.com/elastic/beats/compare/v6.6.0...6.x[Check the HEAD diff]
 - Enable System module config on Windows. {pull}10237[10237]
 - Package: Disable librpm signal handlers. {pull}10694[10694]
 - Login: Handle different bad login UTMP types. {pull}10865[10865]
-- Fix hostname references in System module dashbords.
+- Fix hostname references in System module dashbords. {pull}11064[11064]
 
 *Filebeat*
 

--- a/x-pack/auditbeat/module/system/_meta/kibana/6/dashboard/auditbeat-system-login-dashboard.json
+++ b/x-pack/auditbeat/module/system/_meta/kibana/6/dashboard/auditbeat-system-login-dashboard.json
@@ -586,7 +586,7 @@
     {
       "attributes": {
         "columns": [
-          "host.hostname",
+          "host.name",
           "user.name",
           "event.outcome",
           "message"

--- a/x-pack/auditbeat/module/system/_meta/kibana/6/dashboard/auditbeat-system-overview-dashboard.json
+++ b/x-pack/auditbeat/module/system/_meta/kibana/6/dashboard/auditbeat-system-overview-dashboard.json
@@ -1803,7 +1803,7 @@
     {
       "attributes": {
         "columns": [
-          "host.hostname",
+          "host.name",
           "event.dataset",
           "event.action",
           "message"

--- a/x-pack/auditbeat/module/system/_meta/kibana/6/dashboard/auditbeat-system-package-dashboard.json
+++ b/x-pack/auditbeat/module/system/_meta/kibana/6/dashboard/auditbeat-system-package-dashboard.json
@@ -618,7 +618,7 @@
     {
       "attributes": {
         "columns": [
-          "host.hostname",
+          "host.name",
           "event.action",
           "message"
         ],

--- a/x-pack/auditbeat/module/system/_meta/kibana/6/dashboard/auditbeat-system-process-dashboard.json
+++ b/x-pack/auditbeat/module/system/_meta/kibana/6/dashboard/auditbeat-system-process-dashboard.json
@@ -332,7 +332,7 @@
     {
       "attributes": {
         "columns": [
-          "host.hostname",
+          "host.name",
           "user.name",
           "event.action",
           "process.pid",

--- a/x-pack/auditbeat/module/system/_meta/kibana/6/dashboard/auditbeat-system-socket-dashboard.json
+++ b/x-pack/auditbeat/module/system/_meta/kibana/6/dashboard/auditbeat-system-socket-dashboard.json
@@ -454,7 +454,7 @@
     {
       "attributes": {
         "columns": [
-          "host.hostname",
+          "host.name",
           "network.direction",
           "process.name",
           "message"

--- a/x-pack/auditbeat/module/system/_meta/kibana/6/dashboard/auditbeat-system-user-dashboard.json
+++ b/x-pack/auditbeat/module/system/_meta/kibana/6/dashboard/auditbeat-system-user-dashboard.json
@@ -568,7 +568,7 @@
     {
       "attributes": {
         "columns": [
-          "host.hostname",
+          "host.name",
           "system.audit.user.name",
           "system.audit.user.password.type",
           "message"


### PR DESCRIPTION
In 6.7, the `add_host_metadata` processor still uses `host.name`. In 7.0 this changes to `host.hostname`. And unfortunately, while a field alias is defined Kibana [does not honor those](https://github.com/elastic/kibana/issues/21705) in the saved searches we are using in the System module dashboards. So this changes to using `host.name` for 6.7.