### PR TITLE
Fix typo in pr-review internal cross reference syntax

### DIFF
--- a/docs/devguide/contributing.asciidoc
+++ b/docs/devguide/contributing.asciidoc
@@ -24,9 +24,10 @@ order to assure our users of the origin and continuing existence of the code.
 You only need to sign the CLA once.
 
 . Send a pull request! Push your changes to your fork of the repository and
-https://help.github.com/articles/using-pull-requests[submit a pull request] using our
-<pr-review,pull request guidelines>. In the pull request, describe what your changes do and mention
-any bugs/issues related to the pull request. Please also add a changelog entry to
+https://help.github.com/articles/using-pull-requests[submit a pull request]
+using our <<pr-review,pull request guidelines>>. In the pull request, describe
+what your changes do and mention any bugs/issues related to the pull request.
+Please also add a changelog entry to
 https://github.com/elastic/beats/blob/master/CHANGELOG.next.asciidoc[CHANGELOG.next.asciidoc].
 
 [float]


### PR DESCRIPTION
The _pull request guidelines_ link is incorrectly being rendered as raw `<pr-review,pull request guidelines>` on the production [Contributing to Beats](https://www.elastic.co/guide/en/beats/devguide/current/beats-contributing.html) doc. 