### PR TITLE
Fix a issue when cancelling an enroll.

### DIFF
--- a/x-pack/libbeat/cmd/enroll.go
+++ b/x-pack/libbeat/cmd/enroll.go
@@ -100,7 +100,7 @@ func genEnrollCmd(name, version string) *cobra.Command {
 					}
 				}
 
-				err = management.Enroll(beat, config, enrollmentToken, force)
+				err = management.Enroll(beat, config, enrollmentToken)
 				if err != nil {
 					return errors.Wrap(err, "Error while enrolling")
 				}

--- a/x-pack/libbeat/cmd/enroll.go
+++ b/x-pack/libbeat/cmd/enroll.go
@@ -67,6 +67,16 @@ func genEnrollCmd(name, version string) *cobra.Command {
 					return err
 				}
 
+				confirm, err := confirmConfigOverwrite(force)
+				if err != nil {
+					return err
+				}
+
+				if !confirm {
+					fmt.Println("Enrollment was canceled by the user")
+					return nil
+				}
+
 				var enrollmentToken string
 				if len(args) == 2 {
 					// use given enrollment token
@@ -90,16 +100,12 @@ func genEnrollCmd(name, version string) *cobra.Command {
 					}
 				}
 
-				enrolled, err := management.Enroll(beat, config, enrollmentToken, force)
+				err = management.Enroll(beat, config, enrollmentToken, force)
 				if err != nil {
 					return errors.Wrap(err, "Error while enrolling")
 				}
 
-				if enrolled {
-					fmt.Println("Enrolled and ready to retrieve settings from Kibana")
-				} else {
-					fmt.Println("Enrollment was canceled by the user")
-				}
+				fmt.Println("Enrolled and ready to retrieve settings from Kibana")
 				return nil
 			}),
 	}
@@ -120,4 +126,12 @@ func kibanaConfig(config *common.Config) (*common.Config, error) {
 		return sub, nil
 	}
 	return common.NewConfig(), nil
+}
+
+func confirmConfigOverwrite(force bool) (bool, error) {
+	if force {
+		return true, nil
+	}
+
+	return cli.Confirm("This will replace your current settings. Do you want to continue?", true)
 }

--- a/x-pack/libbeat/management/enroll.go
+++ b/x-pack/libbeat/management/enroll.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/elastic/beats/libbeat/cfgfile"
 	"github.com/elastic/beats/libbeat/cmd/instance"
-	"github.com/elastic/beats/libbeat/common/cli"
 	"github.com/elastic/beats/libbeat/common/file"
 	"github.com/elastic/beats/libbeat/kibana"
 	"github.com/elastic/beats/x-pack/libbeat/management/api"
@@ -22,23 +21,28 @@ const accessTokenKey = "management.accesstoken"
 
 // Enroll this beat to the given kibana
 // This will use Central Management API to enroll and retrieve an access key for config retrieval
-func Enroll(beat *instance.Beat, kibanaConfig *kibana.ClientConfig, enrollmentToken string, force bool) (bool, error) {
+func Enroll(
+	beat *instance.Beat,
+	kibanaConfig *kibana.ClientConfig,
+	enrollmentToken string,
+	force bool,
+) error {
 	// Ignore kibana version to avoid permission errors
 	kibanaConfig.IgnoreVersion = true
 
 	client, err := api.NewClient(kibanaConfig)
 	if err != nil {
-		return false, err
+		return err
 	}
 
 	accessToken, err := client.Enroll(beat.Info.Beat, beat.Info.Name, beat.Info.Version, beat.Info.Hostname, beat.Info.ID, enrollmentToken)
 	if err != nil {
-		return false, err
+		return err
 	}
 
 	// Store access token in keystore
 	if err := storeAccessToken(beat, accessToken); err != nil {
-		return false, err
+		return err
 	}
 
 	// Enrolled, persist state
@@ -47,35 +51,28 @@ func Enroll(beat *instance.Beat, kibanaConfig *kibana.ClientConfig, enrollmentTo
 	config.AccessToken = "${" + accessTokenKey + "}"
 	config.Kibana = kibanaConfig
 
-	confirm, err := confirmConfigOverwrite(force)
+	configFile := cfgfile.GetDefaultCfgfile()
+
+	// backup current settings:
+	backConfigFile := configFile + ".bak"
+	fmt.Println("Saving a copy of current settings to " + backConfigFile)
+	err = file.SafeFileRotate(backConfigFile, configFile)
 	if err != nil {
-		return false, err
+		return errors.Wrap(err, "creating a backup copy of current settings")
 	}
 
-	if confirm {
-		configFile := cfgfile.GetDefaultCfgfile()
+	// create the new ones:
+	f, err := os.OpenFile(configFile, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0600)
+	if err != nil {
+		return errors.Wrap(err, "opening settings file")
+	}
+	defer f.Close()
 
-		// backup current settings:
-		backConfigFile := configFile + ".bak"
-		fmt.Println("Saving a copy of current settings to " + backConfigFile)
-		err := file.SafeFileRotate(backConfigFile, configFile)
-		if err != nil {
-			return false, errors.Wrap(err, "creating a backup copy of current settings")
-		}
-
-		// create the new ones:
-		f, err := os.OpenFile(configFile, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0600)
-		if err != nil {
-			return false, errors.Wrap(err, "opening settings file")
-		}
-		defer f.Close()
-
-		if err := config.OverwriteConfigFile(f, beat.Beat.Info.Beat); err != nil {
-			return false, errors.Wrap(err, "overriding settings file")
-		}
+	if err := config.OverwriteConfigFile(f, beat.Beat.Info.Beat); err != nil {
+		return errors.Wrap(err, "overriding settings file")
 	}
 
-	return true, nil
+	return nil
 }
 
 func storeAccessToken(beat *instance.Beat, accessToken string) error {
@@ -91,12 +88,4 @@ func storeAccessToken(beat *instance.Beat, accessToken string) error {
 	}
 
 	return keystore.Save()
-}
-
-func confirmConfigOverwrite(force bool) (bool, error) {
-	if force {
-		return true, nil
-	}
-
-	return cli.Confirm("This will replace your current settings. Do you want to continue?", true)
 }

--- a/x-pack/libbeat/management/enroll.go
+++ b/x-pack/libbeat/management/enroll.go
@@ -25,7 +25,6 @@ func Enroll(
 	beat *instance.Beat,
 	kibanaConfig *kibana.ClientConfig,
 	enrollmentToken string,
-	force bool,
 ) error {
 	// Ignore kibana version to avoid permission errors
 	kibanaConfig.IgnoreVersion = true


### PR DESCRIPTION
Fix an issue with a partial enroll, when a user refused to overrides a
local configuration actually the enroll command did already used the
token on the ES cluster, this commit move the confirm in the CM instead
of having it in the Enroll's function and is executed by sending the
token or creating any files on disk.

Fixes: #10150