### PR TITLE
[Metricbeat] Migrate heap to reporterV2 interface 

### DIFF
--- a/metricbeat/module/golang/heap/_meta/data.json
+++ b/metricbeat/module/golang/heap/_meta/data.json
@@ -12,40 +12,40 @@
     "golang": {
         "heap": {
             "allocations": {
-                "active": 16670720,
-                "allocated": 14115776,
-                "frees": 2830899,
-                "idle": 6496256,
-                "mallocs": 2921961,
-                "objects": 91062,
-                "total": 458114744
+                "active": 52076544,
+                "allocated": 50143344,
+                "frees": 23897036,
+                "idle": 352256,
+                "mallocs": 24213008,
+                "objects": 315972,
+                "total": 3857953864
             },
             "cmdline": "metricbeat --httpprof :6060 -e",
             "gc": {
-                "cpu_fraction": 0.0000798538053427137,
-                "next_gc_limit": 22896432,
+                "cpu_fraction": 0.00003865910349307519,
+                "next_gc_limit": 52492048,
                 "pause": {
                     "avg": {
-                        "ns": 755847
+                        "ns": 466218
                     },
-                    "count": 77,
+                    "count": 237,
                     "max": {
-                        "ns": 7537934
+                        "ns": 4432500
                     },
                     "sum": {
-                        "ns": 58200246
+                        "ns": 110493700
                     }
                 },
-                "total_count": 77,
+                "total_count": 237,
                 "total_pause": {
-                    "ns": 58200246
+                    "ns": 110493700
                 }
             },
             "system": {
-                "obtained": 23166976,
+                "obtained": 52428800,
                 "released": 0,
-                "stack": 950272,
-                "total": 27908344
+                "stack": 983040,
+                "total": 59263224
             }
         }
     },

--- a/metricbeat/module/golang/heap/data.go
+++ b/metricbeat/module/golang/heap/data.go
@@ -18,10 +18,11 @@
 package heap
 
 import (
+	"runtime"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/module/golang"
-	"runtime"
 )
 
 //Stats contains the memory info that we get from the fetch request

--- a/metricbeat/module/golang/heap/data.go
+++ b/metricbeat/module/golang/heap/data.go
@@ -21,7 +21,6 @@ import (
 	"runtime"
 
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/module/golang"
 )
 
@@ -31,7 +30,7 @@ type Stats struct {
 	Cmdline  []interface{}
 }
 
-func eventMapping(r mb.ReporterV2, stats Stats, m *MetricSet) {
+func eventMapping(stats Stats, m *MetricSet) common.MapStr {
 	var event = common.MapStr{
 		"cmdline": golang.GetCmdStr(stats.Cmdline),
 	}
@@ -106,7 +105,6 @@ func eventMapping(r mb.ReporterV2, stats Stats, m *MetricSet) {
 		},
 	}
 
-	r.Event(mb.Event{
-		MetricSetFields: event,
-	})
+	return event
+
 }

--- a/metricbeat/module/golang/heap/data.go
+++ b/metricbeat/module/golang/heap/data.go
@@ -1,0 +1,111 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package heap
+
+import (
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/metricbeat/mb"
+	"github.com/elastic/beats/metricbeat/module/golang"
+	"runtime"
+)
+
+//Stats contains the memory info that we get from the fetch request
+type Stats struct {
+	MemStats runtime.MemStats
+	Cmdline  []interface{}
+}
+
+func eventMapping(r mb.ReporterV2, stats Stats, m *MetricSet) {
+	var event = common.MapStr{
+		"cmdline": golang.GetCmdStr(stats.Cmdline),
+	}
+	//currentNumGC
+	ms := &stats.MemStats
+
+	// add heap summary
+	event["allocations"] = common.MapStr{
+		"mallocs": ms.Mallocs,
+		"frees":   ms.Frees,
+		"objects": ms.HeapObjects,
+
+		// byte counters
+		"total":     ms.TotalAlloc,
+		"allocated": ms.HeapAlloc,
+		"idle":      ms.HeapIdle,
+		"active":    ms.HeapInuse,
+	}
+
+	event["system"] = common.MapStr{
+		"total":    ms.Sys,
+		"obtained": ms.HeapSys,
+		"stack":    ms.StackSys,
+		"released": ms.HeapReleased,
+	}
+
+	// garbage collector summary
+	var duration, maxDuration, avgDuration, count uint64
+	// collect last gc run stats
+	if m.lastNumGC < ms.NumGC {
+		delta := ms.NumGC - m.lastNumGC
+		start := m.lastNumGC
+		if delta > 256 {
+			logger.Debug("golang", "Missing %v gc cycles", delta-256)
+			start = ms.NumGC - 256
+			delta = 256
+		}
+
+		end := start + delta
+		for i := start; i < end; i++ {
+			idx := i % 256
+			d := ms.PauseNs[idx]
+			count++
+			duration += d
+			if d > maxDuration {
+				maxDuration = d
+			}
+		}
+
+		avgDuration = duration / count
+		m.lastNumGC = ms.NumGC
+	}
+
+	event["gc"] = common.MapStr{
+		"next_gc_limit": ms.NextGC,
+		"total_count":   ms.NumGC,
+		"cpu_fraction":  ms.GCCPUFraction,
+		"total_pause": common.MapStr{
+			"ns": ms.PauseTotalNs,
+		},
+		"pause": common.MapStr{
+			"count": count,
+			"sum": common.MapStr{
+				"ns": duration,
+			},
+			"avg": common.MapStr{
+				"ns": avgDuration,
+			},
+			"max": common.MapStr{
+				"ns": maxDuration,
+			},
+		},
+	}
+
+	r.Event(mb.Event{
+		MetricSetFields: event,
+	})
+}

--- a/metricbeat/module/golang/heap/heap.go
+++ b/metricbeat/module/golang/heap/heap.go
@@ -93,5 +93,8 @@ func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
 		return
 	}
 
-	eventMapping(reporter, stats, m)
+	reporter.Event(mb.Event{
+		MetricSetFields: eventMapping(stats, m),
+	})
+
 }

--- a/metricbeat/module/golang/heap/heap.go
+++ b/metricbeat/module/golang/heap/heap.go
@@ -19,15 +19,14 @@ package heap
 
 import (
 	"encoding/json"
-	"runtime"
 
-	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/metricbeat/helper"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/mb/parse"
-	"github.com/elastic/beats/metricbeat/module/golang"
 )
+
+var logger = logp.NewLogger("golang.heap")
 
 const (
 	defaultScheme = "http"
@@ -77,95 +76,22 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // Fetch methods implements the data gathering and data conversion to the right format
 // It returns the event which is then forward to the output. In case of an error, a
 // descriptive error must be returned.
-func (m *MetricSet) Fetch() (common.MapStr, error) {
+func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
 	data, err := m.http.FetchContent()
 	if err != nil {
-		return nil, err
+		logger.Error(err)
+		reporter.Error(err)
+		return
 	}
 
-	stats := struct {
-		MemStats runtime.MemStats
-		Cmdline  []interface{}
-	}{}
+	var stats Stats
 
 	err = json.Unmarshal(data, &stats)
 	if err != nil {
-		return nil, err
+		logger.Error(err)
+		reporter.Error(err)
+		return
 	}
 
-	var event = common.MapStr{
-		"cmdline": golang.GetCmdStr(stats.Cmdline),
-	}
-
-	ms := &stats.MemStats
-
-	// add heap summary
-	event["allocations"] = common.MapStr{
-		"mallocs": ms.Mallocs,
-		"frees":   ms.Frees,
-		"objects": ms.HeapObjects,
-
-		// byte counters
-		"total":     ms.TotalAlloc,
-		"allocated": ms.HeapAlloc,
-		"idle":      ms.HeapIdle,
-		"active":    ms.HeapInuse,
-	}
-
-	event["system"] = common.MapStr{
-		"total":    ms.Sys,
-		"obtained": ms.HeapSys,
-		"stack":    ms.StackSys,
-		"released": ms.HeapReleased,
-	}
-
-	// garbage collector summary
-	var duration, maxDuration, avgDuration, count uint64
-	// collect last gc run stats
-	if m.lastNumGC < ms.NumGC {
-		delta := ms.NumGC - m.lastNumGC
-		start := m.lastNumGC
-		if delta > 256 {
-			logp.Debug("golang", "Missing %v gc cycles", delta-256)
-			start = ms.NumGC - 256
-			delta = 256
-		}
-
-		end := start + delta
-		for i := start; i < end; i++ {
-			idx := i % 256
-			d := ms.PauseNs[idx]
-			count++
-			duration += d
-			if d > maxDuration {
-				maxDuration = d
-			}
-		}
-
-		avgDuration = duration / count
-		m.lastNumGC = ms.NumGC
-	}
-
-	event["gc"] = common.MapStr{
-		"next_gc_limit": ms.NextGC,
-		"total_count":   ms.NumGC,
-		"cpu_fraction":  ms.GCCPUFraction,
-		"total_pause": common.MapStr{
-			"ns": ms.PauseTotalNs,
-		},
-		"pause": common.MapStr{
-			"count": count,
-			"sum": common.MapStr{
-				"ns": duration,
-			},
-			"avg": common.MapStr{
-				"ns": avgDuration,
-			},
-			"max": common.MapStr{
-				"ns": maxDuration,
-			},
-		},
-	}
-
-	return event, nil
+	eventMapping(reporter, stats, m)
 }

--- a/metricbeat/module/golang/heap/heap_integration_test.go
+++ b/metricbeat/module/golang/heap/heap_integration_test.go
@@ -32,24 +32,27 @@ import (
 func TestData(t *testing.T) {
 	compose.EnsureUp(t, "golang")
 
-	f := mbtest.NewEventFetcher(t, getConfig())
-	err := mbtest.WriteEvent(f, t)
-	if err != nil {
-		t.Fatal("write", err)
+	f := mbtest.NewReportingMetricSetV2(t, getConfig())
+
+	err := mbtest.WriteEventsReporterV2(f, t, "")
+	if !assert.NoError(t, err) {
+		t.FailNow()
 	}
 }
 
 func TestFetch(t *testing.T) {
 	compose.EnsureUp(t, "golang")
 
-	f := mbtest.NewEventFetcher(t, getConfig())
-	event, err := f.Fetch()
-	if !assert.NoError(t, err) {
-		t.FailNow()
+	f := mbtest.NewReportingMetricSetV2(t, getConfig())
+
+	events, errs := mbtest.ReportingFetchV2(f)
+	if len(errs) > 0 {
+		t.Fatalf("Expected 0 error, had %d. %v\n", len(errs), errs)
 	}
 
-	assert.NotNil(t, event)
-	t.Logf("%s/%s event: %+v", f.Module().Name(), f.Name(), event)
+	assert.NotEmpty(t, events)
+
+	t.Logf("%s/%s event: %+v", f.Module().Name(), f.Name(), events[0])
 }
 
 func getConfig() map[string]interface{} {


### PR DESCRIPTION
See  #10774


My first PR here! Feel free to tell me if I did anything egregious. 

It looks like there's no 'standard' way for different metricsets to use their own `eventMapping()` so I just stuck to things I saw others doing. It looks like the golang module was one of the few that didn't have a dedicated `data.go` for processing, so I did that as well.

I'd also like to add a unit test to `eventMapping()` here, since it has a fair bit of logic and that's just something I would normally do, but I think that should be its own PR.