### PR TITLE
Cherry-pick #10982 to 6.7: Detect if the configured and the migrated registry paths are the same

### DIFF
--- a/journalbeat/checkpoint/checkpoint.go
+++ b/journalbeat/checkpoint/checkpoint.go
@@ -140,6 +140,14 @@ func (c *Checkpoint) findRegistryFile() error {
 		return fmt.Errorf("error accessing previous registry file: %+v", err)
 	}
 
+	// if two files are the same, do not do anything
+	migratedFs, err := os.Stat(migratedPath)
+	if err == nil {
+		if os.SameFile(fs, migratedFs) {
+			return nil
+		}
+	}
+
 	f, err := os.Open(c.file)
 	if err != nil {
 		return err


### PR DESCRIPTION
Cherry-pick of PR #10982 to 6.7 branch. Original message: 

The E2E test of starting Journalbeat with an existing registry broke when I have added support and tests for `include_matches`. Thus, when I added the migration of the registry file, the issue was not detected.
Now both the code and the test are fixed.