### PR TITLE
[7.0] Allow ConcatFields for nodes of type object (#10959)

### DIFF
--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -26,6 +26,7 @@ The list below covers the major changes between 7.0.0-beta1 and master only.
 
 ==== Bugfixes
 - Align default index between elasticsearch and logstash and kafka output. {pull}10841[10841]
+- Fix duplication check for `append_fields` option. {pull}10959[10959]
 
 ==== Added
 

--- a/libbeat/common/field.go
+++ b/libbeat/common/field.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/joeshaw/multierror"
 	"github.com/pkg/errors"
 
 	"github.com/elastic/go-ucfg/yaml"
@@ -303,13 +304,51 @@ func ConcatFields(a, b Fields) (Fields, error) {
 	}
 
 	// check for duplicates
-	for _, k := range b.GetKeys() {
-		if a.HasNode(k) {
-			return nil, fmt.Errorf("concat fails because key '%s' exists is duplicated", k)
-		}
+	if err := a.conflicts(b); err != nil {
+		return nil, err
 	}
 
-	// all fine, let's concat a+b into new array
+	// concat a+b into new array
 	fields := make(Fields, 0, len(a)+len(b))
 	return append(append(fields, a...), b...), nil
+}
+
+func (f Fields) conflicts(fields Fields) error {
+	var errs multierror.Errors
+	for _, key := range fields.GetKeys() {
+		keys := strings.Split(key, ".")
+		if err := f.canConcat(key, keys); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errs.Err()
+}
+
+// canConcat checks if the given string can be concatenated to the existing fields f
+// a key cannot be concatenated if
+// - f has a node with name key
+// - f has a leaf with key's parent name and the leaf's type is not `object`
+func (f Fields) canConcat(k string, keys []string) error {
+	if len(keys) == 0 {
+		return nil
+	}
+	key := keys[0]
+	keys = keys[1:]
+	for _, field := range f {
+		if field.Name != key {
+			continue
+		}
+		// last key to compare
+		if len(keys) == 0 {
+			return errors.Errorf("fields contain key <%s>", k)
+		}
+		// last field to compare, only valid if it is of type object
+		if len(field.Fields) == 0 {
+			if field.Type != "object" {
+				return errors.Errorf("fields contain non object node conflicting with key <%s>", k)
+			}
+		}
+		return field.Fields.canConcat(k, keys)
+	}
+	return nil
 }

--- a/libbeat/common/field_test.go
+++ b/libbeat/common/field_test.go
@@ -18,6 +18,7 @@
 package common
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -26,6 +27,58 @@ import (
 
 	"github.com/elastic/go-ucfg/yaml"
 )
+
+func TestFieldsHasNode(t *testing.T) {
+	tests := map[string]struct {
+		node    string
+		fields  Fields
+		hasNode bool
+	}{
+		"empty fields": {
+			node:    "a.b",
+			fields:  Fields{},
+			hasNode: false,
+		},
+		"no node": {
+			node:    "",
+			fields:  Fields{Field{Name: "a"}},
+			hasNode: false,
+		},
+		"key not in fields, but node in fields": {
+			node: "a.b.c",
+			fields: Fields{
+				Field{Name: "a", Fields: Fields{Field{Name: "b"}}},
+			},
+			hasNode: true,
+		},
+		"last node in fields": {
+			node: "a.b.c",
+			fields: Fields{
+				Field{Name: "a", Fields: Fields{
+					Field{Name: "b", Fields: Fields{
+						Field{Name: "c"},
+					}}}},
+			},
+			hasNode: true,
+		},
+		"node in fields": {
+			node: "a.b",
+			fields: Fields{
+				Field{Name: "a", Fields: Fields{
+					Field{Name: "b", Fields: Fields{
+						Field{Name: "c"},
+					}}}},
+			},
+			hasNode: true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.hasNode, test.fields.HasNode(test.node))
+		})
+	}
+}
 
 func TestFieldsHasKey(t *testing.T) {
 	tests := map[string]struct {
@@ -300,7 +353,7 @@ func TestFieldConcat(t *testing.T) {
 	tests := map[string]struct {
 		a, b Fields
 		want Fields
-		fail bool
+		err  string
 	}{
 		"empty lists": {},
 		"first list only": {
@@ -317,9 +370,9 @@ func TestFieldConcat(t *testing.T) {
 			want: Fields{{Name: "a"}, {Name: "b"}},
 		},
 		"duplicates fail": {
-			a:    Fields{{Name: "a"}},
-			b:    Fields{{Name: "a"}},
-			fail: true,
+			a:   Fields{{Name: "a"}},
+			b:   Fields{{Name: "a"}},
+			err: "1 error: fields contain key <a>",
 		},
 		"nested with common prefix": {
 			a: Fields{{
@@ -335,8 +388,23 @@ func TestFieldConcat(t *testing.T) {
 				{Name: "a", Fields: Fields{{Name: "c"}}},
 			},
 		},
+		"deep nested with common prefix": {
+			a: Fields{{
+				Name:   "a",
+				Fields: Fields{{Name: "b"}},
+			}},
+			b: Fields{{
+				Name: "a",
+				Fields: Fields{{Name: "c", Fields: Fields{
+					{Name: "d"},
+				}}},
+			}},
+			want: Fields{
+				{Name: "a", Fields: Fields{{Name: "b"}}},
+				{Name: "a", Fields: Fields{{Name: "c", Fields: Fields{{Name: "d"}}}}},
+			},
+		},
 		"nested duplicates fail": {
-			fail: true,
 			a: Fields{{
 				Name:   "a",
 				Fields: Fields{{Name: "b"}, {Name: "c"}},
@@ -345,35 +413,125 @@ func TestFieldConcat(t *testing.T) {
 				Name:   "a",
 				Fields: Fields{{Name: "c"}},
 			}},
+			err: "1 error: fields contain key <a.c>",
 		},
 		"a is prefix of b": {
-			fail: true,
-			a:    Fields{{Name: "a"}},
+			a: Fields{{Name: "a"}},
 			b: Fields{{
 				Name:   "a",
 				Fields: Fields{{Name: "b"}},
 			}},
+			err: "1 error: fields contain non object node conflicting with key <a.b>",
+		},
+		"a is object and prefix of b": {
+			a: Fields{{Name: "a", Type: "object"}},
+			b: Fields{{
+				Name:   "a",
+				Fields: Fields{{Name: "b"}},
+			}},
+			want: Fields{
+				{Name: "a", Type: "object"},
+				{Name: "a", Fields: Fields{{Name: "b"}}},
+			},
 		},
 		"b is prefix of a": {
-			fail: true,
 			a: Fields{{
 				Name:   "a",
 				Fields: Fields{{Name: "b"}},
 			}},
-			b: Fields{{Name: "a"}},
+			b:   Fields{{Name: "a"}},
+			err: "1 error: fields contain key <a>",
+		},
+		"multiple errors": {
+			a: Fields{
+				{Name: "a", Fields: Fields{{Name: "b"}}},
+				{Name: "foo", Fields: Fields{{Name: "b"}}},
+				{Name: "bar", Type: "object"},
+			},
+			b: Fields{
+				{Name: "bar", Fields: Fields{{Name: "foo"}}},
+				{Name: "a"},
+				{Name: "foo", Fields: Fields{{Name: "b", Fields: Fields{{Name: "c"}}}}},
+			},
+
+			err: "2 errors: fields contain key <a>; fields contain non object node conflicting with key <foo.b.c>",
 		},
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			fs, err := ConcatFields(test.a, test.b)
-			if test.fail {
-				assert.Error(t, err)
+			if test.err == "" {
+				assert.NoError(t, err)
+				assert.Equal(t, test.want, fs)
 				return
 			}
+			if assert.Error(t, err) {
+				assert.Equal(t, test.err, err.Error())
+			}
+		})
+	}
+}
 
-			assert.NoError(t, err)
-			assert.Equal(t, test.want, fs)
+func TestFieldsCanConcat(t *testing.T) {
+	tests := map[string]struct {
+		key    string
+		fields Fields
+		err    string
+	}{
+		"empty fields": {
+			key:    "a.b",
+			fields: Fields{},
+		},
+		"no key": {
+			key:    "",
+			fields: Fields{Field{Name: "a"}},
+		},
+		"key not in fields, but parent node in fields": {
+			key: "a.b.c",
+			fields: Fields{
+				Field{Name: "a", Fields: Fields{Field{Name: "b"}}},
+			},
+			err: "fields contain non object node conflicting with key <a.b.c>",
+		},
+		"key not in fields, but parent node in fields and of type object": {
+			key: "a.b.c",
+			fields: Fields{
+				Field{Name: "a", Fields: Fields{Field{Name: "b", Type: "object"}}},
+			},
+		},
+		"last node in fields": {
+			key: "a.b.c",
+			fields: Fields{
+				Field{Name: "a", Fields: Fields{
+					Field{Name: "b", Fields: Fields{
+						Field{Name: "c"},
+					}}}},
+			},
+			err: "fields contain key <a.b.c>",
+		},
+		"node in fields": {
+			key: "a.b",
+			fields: Fields{
+				Field{Name: "a", Fields: Fields{
+					Field{Name: "b", Fields: Fields{
+						Field{Name: "c"},
+					}}}},
+			},
+			err: "fields contain key <a.b>",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := test.fields.canConcat(test.key, strings.Split(test.key, "."))
+			if test.err == "" {
+				assert.Nil(t, err)
+				return
+			}
+			if assert.Error(t, err) {
+				assert.Equal(t, test.err, err.Error())
+			}
 		})
 	}
 }


### PR DESCRIPTION
Backports the following commits to 7.0:
 - Allow ConcatFields for nodes of type object  (#10959)