### PR TITLE
Cherry-pick #11073 to 7.x: [Uptime] Fix docs for HTTP status checks

### DIFF
--- a/heartbeat/docs/heartbeat-options.asciidoc
+++ b/heartbeat/docs/heartbeat-options.asciidoc
@@ -455,8 +455,7 @@ Under `check.request`, specify these options:
 
 Under `check.response`, specify these options:
 
-*`status`*:: The expected status code. If this setting is not configured or
-it's set to 0, any status code other than 404 is accepted.
+*`status`*:: The expected status code. 4xx and 5xx codes are considered `down` by default. Other codes are considered `up`.
 *`headers`*:: The required response headers.
 *`body`*:: A list of regular expressions to match the the body output. Only a single expression needs to match.
 *`json`*:: A list of <<conditions,condition>> expressions executed against the body when parsed as JSON.


### PR DESCRIPTION
Cherry-pick of PR #11073 to 7.x branch. Original message: 

The old docs weren't updated when 0dbb695 was merged.

This corrects them, indicating how we handle 4xx and 5xx HTTP codes

Resolves https://github.com/elastic/beats/issues/10971