### PR TITLE
[Metricbeat] Introduce Logger per metricset

### DIFF
--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -32,3 +32,4 @@ The list below covers the major changes between 7.0.0-beta1 and master only.
 - Move host name addition to a processor. {pull}10728[10728]
 - The `beat.Event` accessor methods now support `@metadata` keys. {pull}10761[10761]
 - Assertion for documented fields in tests fails if any of the fields in the tested event is documented as an alias. {pull}10921[10921]
+- Support for Logger in the Metricset base instance. {pull}[]

--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -32,4 +32,4 @@ The list below covers the major changes between 7.0.0-beta1 and master only.
 - Move host name addition to a processor. {pull}10728[10728]
 - The `beat.Event` accessor methods now support `@metadata` keys. {pull}10761[10761]
 - Assertion for documented fields in tests fails if any of the fields in the tested event is documented as an alias. {pull}10921[10921]
-- Support for Logger in the Metricset base instance. {pull}[]
+- Support for Logger in the Metricset base instance. {pull}11106[11106]

--- a/metricbeat/mb/builders.go
+++ b/metricbeat/mb/builders.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/monitoring"
 )
 
@@ -194,6 +195,7 @@ func newBaseMetricSets(r *Register, m Module) ([]BaseMetricSet, error) {
 				module:  m,
 				host:    host,
 				metrics: metrics,
+				logger:  logp.NewLogger(m.Name() + "." + name),
 			})
 		}
 	}

--- a/metricbeat/mb/mb.go
+++ b/metricbeat/mb/mb.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/monitoring"
 )
 
@@ -106,6 +107,7 @@ type MetricSet interface {
 	HostData() HostData                  // HostData returns the parsed host data.
 	Registration() MetricSetRegistration // Params used in registration.
 	Metrics() *monitoring.Registry       // MetricSet specific metrics
+	Logger() *logp.Logger                // MetricSet specific logger
 }
 
 // Closer is an optional interface that a MetricSet can implement in order to
@@ -241,6 +243,7 @@ type BaseMetricSet struct {
 	hostData     HostData
 	registration MetricSetRegistration
 	metrics      *monitoring.Registry
+	logger       *logp.Logger
 }
 
 func (b *BaseMetricSet) String() string {
@@ -262,6 +265,11 @@ func (b *BaseMetricSet) ID() string {
 // Metrics returns the metrics registry.
 func (b *BaseMetricSet) Metrics() *monitoring.Registry {
 	return b.metrics
+}
+
+// Logger returns the logger.
+func (b *BaseMetricSet) Logger() *logp.Logger {
+	return b.logger
 }
 
 // Name returns the name of the MetricSet. It should not include the name of

--- a/metricbeat/module/system/fsstat/fsstat.go
+++ b/metricbeat/module/system/fsstat/fsstat.go
@@ -23,15 +23,12 @@ import (
 	"strings"
 
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/mb/parse"
 	"github.com/elastic/beats/metricbeat/module/system/filesystem"
 
 	"github.com/pkg/errors"
 )
-
-var debugf = logp.MakeDebug("system-fsstat")
 
 func init() {
 	mb.Registry.MustAddMetricSet("system", "fsstat", New,
@@ -56,7 +53,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 		config.IgnoreTypes = filesystem.DefaultIgnoredTypes()
 	}
 	if len(config.IgnoreTypes) > 0 {
-		logp.Info("Ignoring filesystem types: %s", strings.Join(config.IgnoreTypes, ", "))
+		base.Logger().Info("Ignoring filesystem types: %s", strings.Join(config.IgnoreTypes, ", "))
 	}
 
 	return &MetricSet{
@@ -84,10 +81,10 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 	for _, fs := range fss {
 		stat, err := filesystem.GetFileSystemStat(fs)
 		if err != nil {
-			debugf("error fetching filesystem stats for '%s': %v", fs.DirName, err)
+			m.Logger().Debug("error fetching filesystem stats for '%s': %v", fs.DirName, err)
 			continue
 		}
-		logp.Debug("fsstat", "filesystem: %s total=%d, used=%d, free=%d", stat.Mount, stat.Total, stat.Used, stat.Free)
+		m.Logger().Debug("filesystem: %s total=%d, used=%d, free=%d", stat.Mount, stat.Total, stat.Used, stat.Free)
 
 		totalFiles += stat.Files
 		totalSize += stat.Total


### PR DESCRIPTION
Currently each Metricset initialises its own logger. The selector has to be set manually. This PR moves this code to the initialisation of the Metricset, meaning each metricset has its own logger. This should reduce the code needed in each Metricset and removes errors like putting a wrong or inconsistent selectors.

It's different from before where there was a global logger for all instances of the same metricset and now each metricset instance has it's own logger. This should not make a difference.

As an example implementation the `system.fsstat` metricset was adjusted.