### PR TITLE
Multiply also the sum in the prometheus multiplier option

### DIFF
--- a/metricbeat/helper/prometheus/metric.go
+++ b/metricbeat/helper/prometheus/metric.go
@@ -289,6 +289,10 @@ func (o opMultiplyBuckets) Process(field string, value interface{}, labels commo
 	if !ok {
 		return field, value, labels
 	}
+	sum, ok := histogram["sum"].(float64)
+	if !ok {
+		return field, value, labels
+	}
 	multiplied := common.MapStr{}
 	for k, v := range bucket {
 		if f, err := strconv.ParseFloat(k, 64); err == nil {
@@ -299,5 +303,6 @@ func (o opMultiplyBuckets) Process(field string, value interface{}, labels commo
 		}
 	}
 	histogram["bucket"] = multiplied
+	histogram["sum"] = sum * o.multiplier
 	return field, histogram, labels
 }

--- a/metricbeat/helper/prometheus/prometheus_test.go
+++ b/metricbeat/helper/prometheus/prometheus_test.go
@@ -356,7 +356,7 @@ func TestPrometheus(t *testing.T) {
 								"1000": uint64(3),
 								"+Inf": uint64(5),
 							},
-							"sum": 4.31,
+							"sum": 4310.0,
 						},
 					},
 				},


### PR DESCRIPTION
Prometheus multiplier added in elastic/beats#10994 should multiply histogram sum too to be consistent.