### PR TITLE
[Metricbeat] Fix flaky test in RabbitMQ node Metricset

### DIFF
--- a/metricbeat/module/rabbitmq/node/node_integration_test.go
+++ b/metricbeat/module/rabbitmq/node/node_integration_test.go
@@ -28,8 +28,6 @@ import (
 )
 
 func TestData(t *testing.T) {
-	compose.EnsureUp(t, "rabbitmq")
-
 	ms := mbtest.NewReportingMetricSetV2(t, getConfig())
 	err := mbtest.WriteEventsReporterV2(ms, t, "")
 	if err != nil {


### PR DESCRIPTION
RabbitMQ node was failing sometimes with a timeout. You can see some related issue [here](https://github.com/elastic/beats/issues/10876) where it is consistently failing.

This PR do not allow this flaky to happen it may hide an underlying problem in the Docker initialization of the RabbitMQ container but as far as I have seen, this flaky only fails with `TestData` function and it shouldn't be calling any compose function anyways.

So, the `compose.EnsureUp` call is removed. If the problem persists, at least it will be in `TestFetch` function.