### PR TITLE
[6.6] Backport multiple doc PRs (#10647 #10740 #10741 #10742 #10833 #10859 )

### DIFF
--- a/filebeat/docs/getting-started.asciidoc
+++ b/filebeat/docs/getting-started.asciidoc
@@ -231,10 +231,7 @@ sudo service {beatname_lc} start
 
 *docker:*
 
-["source", "shell", subs="attributes"]
-----------------------------------------------------------------------
-docker run {dockerimage}
-----------------------------------------------------------------------
+See <<running-on-docker>>.
 
 *mac and linux:*
 

--- a/filebeat/docs/modules-getting-started.asciidoc
+++ b/filebeat/docs/modules-getting-started.asciidoc
@@ -116,7 +116,7 @@ load the ingest pipelines manually. To do this, run the `setup` command with
 the `--pipelines` option specified. If you used the
 <<modules-command,`modules`>> command to enable modules in the `modules.d`
 directory, also specify the `--modules` flag. For example, the following command
-loads the ingest pipelines used by all metricsets enabled in the system, nginx,
+loads the ingest pipelines used by all filesets enabled in the system, nginx,
 and mysql modules:
 
 // override modulename attribute so it works with the --modules option
@@ -149,6 +149,10 @@ and mysql modules:
 ----
 PS > .{backslash}{beatname_lc}.exe setup --pipelines --modules {modulename}
 ----
+
+TIP: If you're loading ingest pipelines manually because you want to send events
+to {ls}, also see
+{logstash-ref}/filebeat-modules.html[Working with {beatname_uc} modules].
 
 :has_module_steps!:
 :modulename!:

--- a/journalbeat/docs/overview.asciidoc
+++ b/journalbeat/docs/overview.asciidoc
@@ -13,3 +13,9 @@ https://www.elastic.co/products/elasticsearch[Elasticsearch] or
 https://www.elastic.co/products/logstash[Logstash].
 
 include::{libbeat-dir}/docs/shared-libbeat-description.asciidoc[]
+
+[float]
+=== Compatibility
+
+{beatname_uc} requires systemd v233 or later. Versions prior to systemd v233
+have a defect that prevents {beatname_uc} from reading rotated journals.

--- a/libbeat/docs/loggingconfig.asciidoc
+++ b/libbeat/docs/loggingconfig.asciidoc
@@ -19,6 +19,7 @@ ifndef::serverless[]
 The logging system can write logs to the syslog or rotate log files. If logging
 is not explicitly configured the file output is used.
 
+ifndef::win_only[]
 ["source","yaml",subs="attributes"]
 ----
 logging.level: info
@@ -29,6 +30,20 @@ logging.files:
   keepfiles: 7
   permissions: 0644
 ----
+endif::win_only[]
+
+ifdef::win_only[]
+["source","yaml",subs="attributes"]
+----
+logging.level: info
+logging.to_files: true
+logging.files:
+  path: C:{backslash}ProgramData{backslash}{beatname_lc}{backslash}Logs
+  name: {beatname_lc}
+  keepfiles: 7
+  permissions: 0644
+----
+endif::win_only[]
 
 TIP: In addition to setting logging options in the config file, you can modify
 the logging output configuration from the command line. See

--- a/libbeat/docs/security/basic-auth.asciidoc
+++ b/libbeat/docs/security/basic-auth.asciidoc
@@ -79,12 +79,12 @@ rollover indices:
 --
 ["source","sh",subs="attributes"]
 ---------------------------------------------------------------
-POST _xpack/security/role/{beatname_lc}_ilm
+POST _xpack/security/role/{beat_default_index_prefix}_ilm
 {
   "cluster": ["manage_ilm"],
   "indices": [
     {
-      "names": [ "{beatname_lc}-*","shrink-{beatname_lc}-*"],
+      "names": [ "{beat_default_index_prefix}-*","shrink-{beat_default_index_prefix}-*"],
       "privileges": ["write","create_index","manage","manage_ilm"]
     }
   ]

--- a/libbeat/docs/shared-beats-attributes.asciidoc
+++ b/libbeat/docs/shared-beats-attributes.asciidoc
@@ -14,7 +14,7 @@
 :monitoringdoc: https://www.elastic.co/guide/en/elastic-stack-overview/{doc-branch}
 :dashboards: https://artifacts.elastic.co/downloads/beats/beats-dashboards/beats-dashboards-{stack-version}.zip
 :dockerimage: docker.elastic.co/beats/{beatname_lc}:{version}
-:dockergithub: https://github.com/elastic/beats-docker/tree/{doc-branch}
+:dockerconfig: https://raw.githubusercontent.com/elastic/beats/{doc-branch}/deploy/docker/{beatname_lc}.docker.yml
 :downloads: https://artifacts.elastic.co/downloads/beats
 :ES-version: {stack-version}
 :LS-version: {stack-version}

--- a/libbeat/docs/shared-docker.asciidoc
+++ b/libbeat/docs/shared-docker.asciidoc
@@ -5,8 +5,7 @@ Docker images for {beatname_uc} are available from the Elastic Docker
 registry. The base image is https://hub.docker.com/_/centos/[centos:7].
 
 A list of all published Docker images and tags is available at
-https://www.docker.elastic.co[www.docker.elastic.co]. The source code is in
-{dockergithub}[GitHub].
+https://www.docker.elastic.co[www.docker.elastic.co]. 
 
 These images are free to use under the Elastic license. They contain open source 
 and free commercial features and access to paid commercial features.  

--- a/libbeat/docs/shared-logstash-config.asciidoc
+++ b/libbeat/docs/shared-logstash-config.asciidoc
@@ -22,7 +22,7 @@ the {stack} getting started tutorial. Also see the documentation for the
 If you want to use {ls} to perform additional processing on the data collected by
 {beatname_uc}, you need to configure {beatname_uc} to use {ls}.
 
-To do this, you edit the {beatname_uc} configuration file to disable the Elasticsearch
+To do this, you edit the {beatname_uc} configuration file to disable the {es}
 output by commenting it out and enable the {ls} output by uncommenting the
 logstash section:
 
@@ -36,8 +36,14 @@ output.logstash:
 The `hosts` option specifies the {ls} server and the port (`5044`) where {ls} is configured to listen for incoming
 Beats connections.
 
-For this configuration, you must <<load-template-manually,load the index template into Elasticsearch manually>>
-because the options for auto loading the template are only available for the Elasticsearch output.
+For this configuration, you must <<load-template-manually,load the index template into {es} manually>>
+because the options for auto loading the template are only available for the {es} output.
+
+ifeval::["{beatname_lc}"=="filebeat"]
+Want to use <<filebeat-modules,{beatname_uc} modules>> with {ls}? You need to do
+some extra setup. For more information, see
+{logstash-ref}/filebeat-modules.html[Working with {beatname_uc} modules].
+endif::[]
 
 ifndef::win-only[]
 

--- a/packetbeat/docs/gettingstarted.asciidoc
+++ b/packetbeat/docs/gettingstarted.asciidoc
@@ -273,10 +273,7 @@ sudo service {beatname_lc} start
 
 *docker:*
 
-["source","sh",subs="attributes"]
-----------------------------------------------------------------------
-docker run {dockerimage}
-----------------------------------------------------------------------
+See <<running-on-docker>>.
 
 *mac and linux:*
 

--- a/winlogbeat/docs/getting-started.asciidoc
+++ b/winlogbeat/docs/getting-started.asciidoc
@@ -74,7 +74,7 @@ output.elasticsearch:
 
 logging.to_files: true
 logging.files:
-  path: C:/ProgramData/winlogbeat/Logs
+  path: C:\ProgramData\winlogbeat\Logs
 logging.level: info
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
Cherry-picks the following doc PRs into the 6.6 branch:

https://github.com/elastic/beats/pull/10647
https://github.com/elastic/beats/pull/10740
https://github.com/elastic/beats/pull/10741
https://github.com/elastic/beats/pull/10742
https://github.com/elastic/beats/pull/10833
https://github.com/elastic/beats/pull/10859 

Changes are fairly small, so I'm including in one backport PR for testing/reviewing convenience.