### PR TITLE
[Metricbeat] Rename Logger method to Log

### DIFF
--- a/metricbeat/mb/mb.go
+++ b/metricbeat/mb/mb.go
@@ -107,7 +107,7 @@ type MetricSet interface {
 	HostData() HostData                  // HostData returns the parsed host data.
 	Registration() MetricSetRegistration // Params used in registration.
 	Metrics() *monitoring.Registry       // MetricSet specific metrics
-	Logger() *logp.Logger                // MetricSet specific logger
+	Log() *logp.Logger                   // MetricSet specific logger
 }
 
 // Closer is an optional interface that a MetricSet can implement in order to
@@ -275,7 +275,7 @@ func (b *BaseMetricSet) Metrics() *monitoring.Registry {
 }
 
 // Logger returns the logger.
-func (b *BaseMetricSet) Logger() *logp.Logger {
+func (b *BaseMetricSet) Log() *logp.Logger {
 	return b.logger
 }
 

--- a/metricbeat/module/elasticsearch/ccr/ccr.go
+++ b/metricbeat/module/elasticsearch/ccr/ccr.go
@@ -60,19 +60,19 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 	isMaster, err := elasticsearch.IsMaster(m.HTTP, m.GetServiceURI())
 	if err != nil {
 		err = errors.Wrap(err, "error determining if connected Elasticsearch node is master")
-		elastic.ReportAndLogError(err, r, m.Log)
+		elastic.ReportAndLogError(err, r, m.Log())
 		return
 	}
 
 	// Not master, no event sent
 	if !isMaster {
-		m.Log.Debug("trying to fetch ccr stats from a non-master node")
+		m.Log().Debug("trying to fetch ccr stats from a non-master node")
 		return
 	}
 
 	info, err := elasticsearch.GetInfo(m.HTTP, m.GetServiceURI())
 	if err != nil {
-		elastic.ReportAndLogError(err, r, m.Log)
+		elastic.ReportAndLogError(err, r, m.Log())
 		return
 	}
 
@@ -81,14 +81,14 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 	ccrUnavailableMessage, err := m.checkCCRAvailability(info.Version.Number)
 	if err != nil {
 		err = errors.Wrap(err, "error determining if CCR is available")
-		elastic.ReportAndLogError(err, r, m.Log)
+		elastic.ReportAndLogError(err, r, m.Log())
 		return
 	}
 
 	if ccrUnavailableMessage != "" {
 		if time.Since(m.lastCCRLicenseMessageTimestamp) > 1*time.Minute {
 			err := fmt.Errorf(ccrUnavailableMessage)
-			elastic.ReportAndLogError(err, r, m.Log)
+			elastic.ReportAndLogError(err, r, m.Log())
 			m.lastCCRLicenseMessageTimestamp = time.Now()
 		}
 		return
@@ -96,7 +96,7 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 
 	content, err := m.HTTP.FetchContent()
 	if err != nil {
-		elastic.ReportAndLogError(err, r, m.Log)
+		elastic.ReportAndLogError(err, r, m.Log())
 		return
 	}
 
@@ -107,7 +107,7 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 	}
 
 	if err != nil {
-		m.Log.Error(err)
+		m.Log().Error(err)
 		return
 	}
 }

--- a/metricbeat/module/elasticsearch/cluster_stats/cluster_stats.go
+++ b/metricbeat/module/elasticsearch/cluster_stats/cluster_stats.go
@@ -55,19 +55,19 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 	isMaster, err := elasticsearch.IsMaster(m.HTTP, m.HostData().SanitizedURI+clusterStatsPath)
 	if err != nil {
 		err := errors.Wrap(err, "error determining if connected Elasticsearch node is master")
-		elastic.ReportAndLogError(err, r, m.Log)
+		elastic.ReportAndLogError(err, r, m.Log())
 		return
 	}
 
 	// Not master, no event sent
 	if !isMaster {
-		m.Log.Debug("trying to fetch cluster stats from a non-master node")
+		m.Log().Debug("trying to fetch cluster stats from a non-master node")
 		return
 	}
 
 	content, err := m.HTTP.FetchContent()
 	if err != nil {
-		elastic.ReportAndLogError(err, r, m.Log)
+		elastic.ReportAndLogError(err, r, m.Log())
 		return
 	}
 
@@ -84,6 +84,6 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 	}
 
 	if err != nil {
-		m.Log.Error(err)
+		m.Log().Error(err)
 	}
 }

--- a/metricbeat/module/elasticsearch/index/index.go
+++ b/metricbeat/module/elasticsearch/index/index.go
@@ -60,26 +60,26 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 	isMaster, err := elasticsearch.IsMaster(m.HTTP, m.HostData().SanitizedURI+statsPath)
 	if err != nil {
 		err = errors.Wrap(err, "error determining if connected Elasticsearch node is master")
-		elastic.ReportAndLogError(err, r, m.Log)
+		elastic.ReportAndLogError(err, r, m.Log())
 		return
 	}
 
 	// Not master, no event sent
 	if !isMaster {
-		m.Log.Debug("trying to fetch index stats from a non-master node")
+		m.Log().Debug("trying to fetch index stats from a non-master node")
 		return
 	}
 
 	content, err := m.HTTP.FetchContent()
 	if err != nil {
-		elastic.ReportAndLogError(err, r, m.Log)
+		elastic.ReportAndLogError(err, r, m.Log())
 		return
 	}
 
 	info, err := elasticsearch.GetInfo(m.HTTP, m.HostData().SanitizedURI)
 	if err != nil {
 		err = errors.Wrap(err, "failed to get info from Elasticsearch")
-		elastic.ReportAndLogError(err, r, m.Log)
+		elastic.ReportAndLogError(err, r, m.Log())
 		return
 	}
 
@@ -90,7 +90,7 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 	}
 
 	if err != nil {
-		m.Log.Error(err)
+		m.Log().Error(err)
 		return
 	}
 }

--- a/metricbeat/module/elasticsearch/index_recovery/index_recovery.go
+++ b/metricbeat/module/elasticsearch/index_recovery/index_recovery.go
@@ -71,25 +71,25 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 	isMaster, err := elasticsearch.IsMaster(m.HTTP, m.GetServiceURI())
 	if err != nil {
 		err = errors.Wrap(err, "error determining if connected Elasticsearch node is master")
-		elastic.ReportAndLogError(err, r, m.Log)
+		elastic.ReportAndLogError(err, r, m.Log())
 		return
 	}
 
 	// Not master, no event sent
 	if !isMaster {
-		m.Log.Debug("trying to fetch index recovery stats from a non-master node")
+		m.Log().Debug("trying to fetch index recovery stats from a non-master node")
 		return
 	}
 
 	info, err := elasticsearch.GetInfo(m.HTTP, m.GetServiceURI())
 	if err != nil {
-		elastic.ReportAndLogError(err, r, m.Log)
+		elastic.ReportAndLogError(err, r, m.Log())
 		return
 	}
 
 	content, err := m.HTTP.FetchContent()
 	if err != nil {
-		elastic.ReportAndLogError(err, r, m.Log)
+		elastic.ReportAndLogError(err, r, m.Log())
 		return
 	}
 
@@ -100,7 +100,7 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 	}
 
 	if err != nil {
-		m.Log.Error(err)
+		m.Log().Error(err)
 		return
 	}
 }

--- a/metricbeat/module/elasticsearch/index_summary/index_summary.go
+++ b/metricbeat/module/elasticsearch/index_summary/index_summary.go
@@ -66,26 +66,26 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 	isMaster, err := elasticsearch.IsMaster(m.HTTP, m.HostData().SanitizedURI+statsPath)
 	if err != nil {
 		err = errors.Wrap(err, "error determining if connected Elasticsearch node is master")
-		elastic.ReportAndLogError(err, r, m.Log)
+		elastic.ReportAndLogError(err, r, m.Log())
 		return
 	}
 
 	// Not master, no event sent
 	if !isMaster {
-		m.Log.Debug("trying to fetch index summary stats from a non-master node")
+		m.Log().Debug("trying to fetch index summary stats from a non-master node")
 		return
 	}
 
 	content, err := m.HTTP.FetchContent()
 	if err != nil {
-		elastic.ReportAndLogError(err, r, m.Log)
+		elastic.ReportAndLogError(err, r, m.Log())
 		return
 	}
 
 	info, err := elasticsearch.GetInfo(m.HTTP, m.HostData().SanitizedURI+statsPath)
 	if err != nil {
 		err = errors.Wrap(err, "failed to get info from Elasticsearch")
-		elastic.ReportAndLogError(err, r, m.Log)
+		elastic.ReportAndLogError(err, r, m.Log())
 		return
 	}
 
@@ -96,7 +96,7 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 	}
 
 	if err != nil {
-		m.Log.Error(err)
+		m.Log().Error(err)
 		return
 	}
 }

--- a/metricbeat/module/elasticsearch/metricset.go
+++ b/metricbeat/module/elasticsearch/metricset.go
@@ -18,7 +18,6 @@
 package elasticsearch
 
 import (
-	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/metricbeat/helper"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/mb/parse"
@@ -44,7 +43,6 @@ type MetricSet struct {
 	servicePath string
 	*helper.HTTP
 	XPack bool
-	Log   *logp.Logger
 }
 
 // NewMetricSet creates an metric set that can be used to build other metric
@@ -69,7 +67,6 @@ func NewMetricSet(base mb.BaseMetricSet, servicePath string) (*MetricSet, error)
 		servicePath,
 		http,
 		config.XPack,
-		logp.NewLogger(ModuleName),
 	}
 
 	ms.SetServiceURI(servicePath)

--- a/metricbeat/module/elasticsearch/ml_job/ml_job.go
+++ b/metricbeat/module/elasticsearch/ml_job/ml_job.go
@@ -59,19 +59,19 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 	isMaster, err := elasticsearch.IsMaster(m.HTTP, m.GetServiceURI())
 	if err != nil {
 		err = errors.Wrap(err, "error determining if connected Elasticsearch node is master")
-		elastic.ReportAndLogError(err, r, m.Log)
+		elastic.ReportAndLogError(err, r, m.Log())
 		return
 	}
 
 	// Not master, no event sent
 	if !isMaster {
-		m.Log.Debug("trying to fetch machine learning job stats from a non-master node")
+		m.Log().Debug("trying to fetch machine learning job stats from a non-master node")
 		return
 	}
 
 	info, err := elasticsearch.GetInfo(m.HTTP, m.GetServiceURI())
 	if err != nil {
-		elastic.ReportAndLogError(err, r, m.Log)
+		elastic.ReportAndLogError(err, r, m.Log())
 		return
 	}
 
@@ -83,7 +83,7 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 
 	content, err := m.HTTP.FetchContent()
 	if err != nil {
-		elastic.ReportAndLogError(err, r, m.Log)
+		elastic.ReportAndLogError(err, r, m.Log())
 		return
 	}
 
@@ -94,7 +94,7 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 	}
 
 	if err != nil {
-		m.Log.Error(err)
+		m.Log().Error(err)
 		return
 	}
 }

--- a/metricbeat/module/elasticsearch/node/node.go
+++ b/metricbeat/module/elasticsearch/node/node.go
@@ -67,20 +67,20 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 func (m *MetricSet) Fetch(r mb.ReporterV2) {
 	content, err := m.HTTP.FetchContent()
 	if err != nil {
-		elastic.ReportAndLogError(err, r, m.Log)
+		elastic.ReportAndLogError(err, r, m.Log())
 		return
 	}
 
 	info, err := elasticsearch.GetInfo(m.HTTP, m.HostData().SanitizedURI+nodeStatsPath)
 	if err != nil {
 		err = errors.Wrap(err, "failed to get info from Elasticsearch")
-		elastic.ReportAndLogError(err, r, m.Log)
+		elastic.ReportAndLogError(err, r, m.Log())
 		return
 	}
 
 	err = eventsMapping(r, *info, content)
 	if err != nil {
-		elastic.ReportAndLogError(err, r, m.Log)
+		elastic.ReportAndLogError(err, r, m.Log())
 		return
 	}
 }

--- a/metricbeat/module/elasticsearch/node_stats/node_stats.go
+++ b/metricbeat/module/elasticsearch/node_stats/node_stats.go
@@ -56,26 +56,26 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 func (m *MetricSet) Fetch(r mb.ReporterV2) {
 	content, err := m.HTTP.FetchContent()
 	if err != nil {
-		elastic.ReportAndLogError(err, r, m.Log)
+		elastic.ReportAndLogError(err, r, m.Log())
 		return
 	}
 
 	info, err := elasticsearch.GetInfo(m.HTTP, m.GetServiceURI())
 	if err != nil {
-		elastic.ReportAndLogError(err, r, m.Log)
+		elastic.ReportAndLogError(err, r, m.Log())
 		return
 	}
 
 	if m.XPack {
 		err = eventsMappingXPack(r, m, *info, content)
 		if err != nil {
-			m.Log.Error(err)
+			m.Log().Error(err)
 			return
 		}
 	} else {
 		err = eventsMapping(r, *info, content)
 		if err != nil {
-			elastic.ReportAndLogError(err, r, m.Log)
+			elastic.ReportAndLogError(err, r, m.Log())
 			return
 		}
 	}

--- a/metricbeat/module/elasticsearch/pending_tasks/pending_tasks.go
+++ b/metricbeat/module/elasticsearch/pending_tasks/pending_tasks.go
@@ -63,31 +63,31 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 	isMaster, err := elasticsearch.IsMaster(m.HTTP, m.GetServiceURI())
 	if err != nil {
 		err := errors.Wrap(err, "error determining if connected Elasticsearch node is master")
-		elastic.ReportAndLogError(err, r, m.Log)
+		elastic.ReportAndLogError(err, r, m.Log())
 		return
 	}
 
 	// Not master, no event sent
 	if !isMaster {
-		m.Log.Debug("trying to fetch pending tasks from a non-master node")
+		m.Log().Debug("trying to fetch pending tasks from a non-master node")
 		return
 	}
 
 	info, err := elasticsearch.GetInfo(m.HTTP, m.GetServiceURI())
 	if err != nil {
-		elastic.ReportAndLogError(err, r, m.Log)
+		elastic.ReportAndLogError(err, r, m.Log())
 		return
 	}
 
 	content, err := m.HTTP.FetchContent()
 	if err != nil {
-		elastic.ReportAndLogError(err, r, m.Log)
+		elastic.ReportAndLogError(err, r, m.Log())
 		return
 	}
 
 	err = eventsMapping(r, *info, content)
 	if err != nil {
-		m.Log.Error(err)
+		m.Log().Error(err)
 		return
 	}
 }

--- a/metricbeat/module/elasticsearch/shard/shard.go
+++ b/metricbeat/module/elasticsearch/shard/shard.go
@@ -57,19 +57,19 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 	isMaster, err := elasticsearch.IsMaster(m.HTTP, m.HostData().SanitizedURI+statePath)
 	if err != nil {
 		err := errors.Wrap(err, "error determining if connected Elasticsearch node is master")
-		elastic.ReportAndLogError(err, r, m.Log)
+		elastic.ReportAndLogError(err, r, m.Log())
 		return
 	}
 
 	// Not master, no event sent
 	if !isMaster {
-		m.Log.Debug("trying to fetch shard stats from a non-master node")
+		m.Log().Debug("trying to fetch shard stats from a non-master node")
 		return
 	}
 
 	content, err := m.HTTP.FetchContent()
 	if err != nil {
-		elastic.ReportAndLogError(err, r, m.Log)
+		elastic.ReportAndLogError(err, r, m.Log())
 		return
 	}
 
@@ -80,7 +80,7 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 	}
 
 	if err != nil {
-		m.Log.Error(err)
+		m.Log().Error(err)
 		return
 	}
 }

--- a/metricbeat/module/kibana/metricset.go
+++ b/metricbeat/module/kibana/metricset.go
@@ -18,7 +18,6 @@
 package kibana
 
 import (
-	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/metricbeat/mb"
 )
 
@@ -26,7 +25,6 @@ import (
 type MetricSet struct {
 	mb.BaseMetricSet
 	XPackEnabled bool
-	Log          *logp.Logger
 }
 
 // NewMetricSet creates a metricset that can be used to build other metricsets
@@ -40,6 +38,5 @@ func NewMetricSet(base mb.BaseMetricSet) (*MetricSet, error) {
 	return &MetricSet{
 		base,
 		config.XPackEnabled,
-		logp.NewLogger(ModuleName),
 	}, nil
 }

--- a/metricbeat/module/kibana/stats/stats.go
+++ b/metricbeat/module/kibana/stats/stats.go
@@ -134,7 +134,7 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 func (m *MetricSet) fetchStats(r mb.ReporterV2, now time.Time) {
 	content, err := m.statsHTTP.FetchContent()
 	if err != nil {
-		elastic.ReportAndLogError(err, r, m.Log)
+		elastic.ReportAndLogError(err, r, m.Log())
 		return
 	}
 
@@ -142,13 +142,13 @@ func (m *MetricSet) fetchStats(r mb.ReporterV2, now time.Time) {
 		intervalMs := m.calculateIntervalMs()
 		err = eventMappingStatsXPack(r, intervalMs, now, content)
 		if err != nil {
-			m.Log.Error(err)
+			m.Log().Error(err)
 			return
 		}
 	} else {
 		err = eventMapping(r, content)
 		if err != nil {
-			elastic.ReportAndLogError(err, r, m.Log)
+			elastic.ReportAndLogError(err, r, m.Log())
 			return
 		}
 	}
@@ -157,14 +157,14 @@ func (m *MetricSet) fetchStats(r mb.ReporterV2, now time.Time) {
 func (m *MetricSet) fetchSettings(r mb.ReporterV2, now time.Time) {
 	content, err := m.settingsHTTP.FetchContent()
 	if err != nil {
-		m.Log.Error(err)
+		m.Log().Error(err)
 		return
 	}
 
 	intervalMs := m.calculateIntervalMs()
 	err = eventMappingSettingsXPack(r, intervalMs, now, content)
 	if err != nil {
-		m.Log.Error(err)
+		m.Log().Error(err)
 		return
 	}
 }

--- a/metricbeat/module/kibana/status/status.go
+++ b/metricbeat/module/kibana/status/status.go
@@ -72,14 +72,14 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 func (m *MetricSet) Fetch(r mb.ReporterV2) {
 	content, err := m.http.FetchContent()
 	if err != nil {
-		elastic.ReportAndLogError(err, r, m.Log)
+		elastic.ReportAndLogError(err, r, m.Log())
 		return
 	}
 
 	err = eventMapping(r, content)
 
 	if err != nil {
-		m.Log.Error(err)
+		m.Log().Error(err)
 		return
 	}
 }

--- a/metricbeat/module/logstash/logstash.go
+++ b/metricbeat/module/logstash/logstash.go
@@ -18,7 +18,6 @@
 package logstash
 
 import (
-	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/metricbeat/mb"
 )
 
@@ -28,7 +27,6 @@ const ModuleName = "logstash"
 // MetricSet can be used to build other metricsets within the Logstash module.
 type MetricSet struct {
 	mb.BaseMetricSet
-	Log *logp.Logger
 }
 
 // NewMetricSet creates a metricset that can be used to build other metricsets
@@ -36,6 +34,5 @@ type MetricSet struct {
 func NewMetricSet(base mb.BaseMetricSet) (*MetricSet, error) {
 	return &MetricSet{
 		base,
-		logp.NewLogger(ModuleName),
 	}, nil
 }

--- a/metricbeat/module/logstash/node/node.go
+++ b/metricbeat/module/logstash/node/node.go
@@ -72,13 +72,13 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 func (m *MetricSet) Fetch(r mb.ReporterV2) {
 	content, err := m.http.FetchContent()
 	if err != nil {
-		elastic.ReportAndLogError(err, r, m.Log)
+		elastic.ReportAndLogError(err, r, m.Log())
 		return
 	}
 
 	err = eventMapping(r, content)
 	if err != nil {
-		m.Log.Error(err)
+		m.Log().Error(err)
 		return
 	}
 }

--- a/metricbeat/module/logstash/node_stats/node_stats.go
+++ b/metricbeat/module/logstash/node_stats/node_stats.go
@@ -73,13 +73,13 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 func (m *MetricSet) Fetch(r mb.ReporterV2) {
 	content, err := m.http.FetchContent()
 	if err != nil {
-		elastic.ReportAndLogError(err, r, m.Log)
+		elastic.ReportAndLogError(err, r, m.Log())
 		return
 	}
 
 	err = eventMapping(r, content)
 	if err != nil {
-		m.Log.Error(err)
+		m.Log().Error(err)
 		return
 	}
 }

--- a/metricbeat/module/nats/connections/connections.go
+++ b/metricbeat/module/nats/connections/connections.go
@@ -18,7 +18,6 @@
 package connections
 
 import (
-	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/metricbeat/helper"
 	"github.com/elastic/beats/metricbeat/helper/elastic"
 	"github.com/elastic/beats/metricbeat/mb"
@@ -56,7 +55,6 @@ func init() {
 type MetricSet struct {
 	mb.BaseMetricSet
 	http *helper.HTTP
-	Log  *logp.Logger
 }
 
 // New creates a new instance of the MetricSet. New is responsible for unpacking
@@ -74,7 +72,6 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	return &MetricSet{
 		base,
 		http,
-		logp.NewLogger("nats"),
 	}, nil
 }
 
@@ -84,12 +81,12 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 func (m *MetricSet) Fetch(r mb.ReporterV2) {
 	content, err := m.http.FetchContent()
 	if err != nil {
-		elastic.ReportAndLogError(err, r, m.Log)
+		elastic.ReportAndLogError(err, r, m.Log())
 		return
 	}
 	err = eventMapping(r, content)
 	if err != nil {
-		elastic.ReportAndLogError(err, r, m.Log)
+		elastic.ReportAndLogError(err, r, m.Log())
 		return
 	}
 }

--- a/metricbeat/module/nats/routes/routes.go
+++ b/metricbeat/module/nats/routes/routes.go
@@ -18,7 +18,6 @@
 package routes
 
 import (
-	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/metricbeat/helper"
 	"github.com/elastic/beats/metricbeat/helper/elastic"
 	"github.com/elastic/beats/metricbeat/mb"
@@ -56,7 +55,6 @@ func init() {
 type MetricSet struct {
 	mb.BaseMetricSet
 	http *helper.HTTP
-	Log  *logp.Logger
 }
 
 // New creates a new instance of the MetricSet. New is responsible for unpacking
@@ -74,7 +72,6 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	return &MetricSet{
 		base,
 		http,
-		logp.NewLogger("nats"),
 	}, nil
 }
 
@@ -84,12 +81,12 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 func (m *MetricSet) Fetch(r mb.ReporterV2) {
 	content, err := m.http.FetchContent()
 	if err != nil {
-		elastic.ReportAndLogError(err, r, m.Log)
+		elastic.ReportAndLogError(err, r, m.Log())
 		return
 	}
 	err = eventMapping(r, content)
 	if err != nil {
-		elastic.ReportAndLogError(err, r, m.Log)
+		elastic.ReportAndLogError(err, r, m.Log())
 		return
 	}
 }

--- a/metricbeat/module/nats/stats/stats.go
+++ b/metricbeat/module/nats/stats/stats.go
@@ -18,7 +18,6 @@
 package stats
 
 import (
-	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/metricbeat/helper"
 	"github.com/elastic/beats/metricbeat/helper/elastic"
 	"github.com/elastic/beats/metricbeat/mb"
@@ -56,7 +55,6 @@ func init() {
 type MetricSet struct {
 	mb.BaseMetricSet
 	http *helper.HTTP
-	Log  *logp.Logger
 }
 
 // New creates a new instance of the MetricSet. New is responsible for unpacking
@@ -74,7 +72,6 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	return &MetricSet{
 		base,
 		http,
-		logp.NewLogger("nats"),
 	}, nil
 }
 
@@ -84,12 +81,12 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 func (m *MetricSet) Fetch(r mb.ReporterV2) {
 	content, err := m.http.FetchContent()
 	if err != nil {
-		elastic.ReportAndLogError(err, r, m.Log)
+		elastic.ReportAndLogError(err, r, m.Log())
 		return
 	}
 	err = eventMapping(r, content)
 	if err != nil {
-		elastic.ReportAndLogError(err, r, m.Log)
+		elastic.ReportAndLogError(err, r, m.Log())
 		return
 	}
 }

--- a/metricbeat/module/nats/subscriptions/subscriptions.go
+++ b/metricbeat/module/nats/subscriptions/subscriptions.go
@@ -18,7 +18,6 @@
 package subscriptions
 
 import (
-	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/metricbeat/helper"
 	"github.com/elastic/beats/metricbeat/helper/elastic"
 	"github.com/elastic/beats/metricbeat/mb"
@@ -56,7 +55,6 @@ func init() {
 type MetricSet struct {
 	mb.BaseMetricSet
 	http *helper.HTTP
-	Log  *logp.Logger
 }
 
 // New creates a new instance of the MetricSet. New is responsible for unpacking
@@ -74,7 +72,6 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	return &MetricSet{
 		base,
 		http,
-		logp.NewLogger("nats"),
 	}, nil
 }
 
@@ -84,12 +81,12 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 func (m *MetricSet) Fetch(r mb.ReporterV2) {
 	content, err := m.http.FetchContent()
 	if err != nil {
-		elastic.ReportAndLogError(err, r, m.Log)
+		elastic.ReportAndLogError(err, r, m.Log())
 		return
 	}
 	err = eventMapping(r, content)
 	if err != nil {
-		elastic.ReportAndLogError(err, r, m.Log)
+		elastic.ReportAndLogError(err, r, m.Log())
 		return
 	}
 }

--- a/metricbeat/module/system/fsstat/fsstat.go
+++ b/metricbeat/module/system/fsstat/fsstat.go
@@ -53,7 +53,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 		config.IgnoreTypes = filesystem.DefaultIgnoredTypes()
 	}
 	if len(config.IgnoreTypes) > 0 {
-		base.Logger().Info("Ignoring filesystem types: %s", strings.Join(config.IgnoreTypes, ", "))
+		base.Log().Info("Ignoring filesystem types: %s", strings.Join(config.IgnoreTypes, ", "))
 	}
 
 	return &MetricSet{
@@ -81,10 +81,10 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 	for _, fs := range fss {
 		stat, err := filesystem.GetFileSystemStat(fs)
 		if err != nil {
-			m.Logger().Debug("error fetching filesystem stats for '%s': %v", fs.DirName, err)
+			m.Log().Debug("error fetching filesystem stats for '%s': %v", fs.DirName, err)
 			continue
 		}
-		m.Logger().Debug("filesystem: %s total=%d, used=%d, free=%d", stat.Mount, stat.Total, stat.Used, stat.Free)
+		m.Log().Debug("filesystem: %s total=%d, used=%d, free=%d", stat.Mount, stat.Total, stat.Used, stat.Free)
 
 		totalFiles += stat.Files
 		totalSize += stat.Total


### PR DESCRIPTION
Based on the comment https://github.com/elastic/beats/pull/11106#discussion_r263123125 the Logger method is renamed to Log. It turned out this was already almost a convention which we used across the metricsets. This meant the Log variable and Log() method conflicted and required an update in the metricsets that had a Log variable.

No functionality was changed in this PR.