### PR TITLE
Cherry-pick #11035 to 6.7: Add ip fields to default_field in Elasticsearch template

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -165,6 +165,7 @@ https://github.com/elastic/beats/compare/v6.6.0...6.x[Check the HEAD diff]
 - Add support for index lifecycle management (beta). {pull}7963[7963]
 - Always include Pod UID as part of Pod metadata. {pull]9517[9517]
 - Release Jolokia autodiscover as GA. {pull}9706[9706]
+- Add ip fields to default_field in Elasticsearch template. {pull}11035[11035]
 
 *Auditbeat*
 

--- a/libbeat/template/processor.go
+++ b/libbeat/template/processor.go
@@ -99,11 +99,27 @@ func (p *Processor) Process(fields common.Fields, path string, output common.Map
 			mapping = p.other(&field)
 		}
 
+		switch field.Type {
+		case "", "keyword", "text", "ip":
+			addToDefaultFields(&field)
+		}
+
 		if len(mapping) > 0 {
 			output.Put(common.GenerateKey(field.Name), mapping)
 		}
 	}
 	return nil
+}
+
+func addToDefaultFields(f *common.Field) {
+	fullName := f.Name
+	if f.Path != "" {
+		fullName = f.Path + "." + f.Name
+	}
+
+	if f.Index == nil || (f.Index != nil && *f.Index) {
+		defaultFields = append(defaultFields, fullName)
+	}
 }
 
 func (p *Processor) other(f *common.Field) common.MapStr {
@@ -172,15 +188,6 @@ func (p *Processor) ip(f *common.Field) common.MapStr {
 func (p *Processor) keyword(f *common.Field) common.MapStr {
 	property := getDefaultProperties(f)
 
-	fullName := f.Name
-	if f.Path != "" {
-		fullName = f.Path + "." + f.Name
-	}
-
-	if f.Index == nil || (f.Index != nil && *f.Index) {
-		defaultFields = append(defaultFields, fullName)
-	}
-
 	property["type"] = "keyword"
 
 	switch f.IgnoreAbove {
@@ -207,15 +214,6 @@ func (p *Processor) keyword(f *common.Field) common.MapStr {
 
 func (p *Processor) text(f *common.Field) common.MapStr {
 	properties := getDefaultProperties(f)
-
-	fullName := f.Name
-	if f.Path != "" {
-		fullName = f.Path + "." + f.Name
-	}
-
-	if f.Index == nil || (f.Index != nil && *f.Index) {
-		defaultFields = append(defaultFields, fullName)
-	}
 
 	properties["type"] = "text"
 


### PR DESCRIPTION
Cherry-pick of PR #11035 to 6.7 branch. Original message: 

I recently noticed that pasting an IP into Kibana's KQL bar yielded no results - even though there were plenty of documents with that IP. The reason is that IP fields are currently not included in the `default_field` configuration of the generated template.

I think they should definitely be included, and this adds them.

For Auditbeat, this adds 9 fields. For the others, it looks like 16 for Metricbeat, 15 for Filebeat, 17 for Packetbeat.

/cc @elastic/secops - important for us.