### PR TITLE
Collect Cloudwatch metrics from the same timestamp

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -197,6 +197,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Change ECS field cloud.provider to aws. {pull}11023[11023]
 - Add documentation about jolokia autodiscover fields. {issue}10925[10925] {pull}10979[10979]
 - Add missing aws.ec2.instance.state.name into fields.yml. {issue}11219[11219] {pull}11221[11221]
+- Fix ec2 metricset to collect metrics from Cloudwatch with the same timestamp. {pull}11142[11142]
 
 *Packetbeat*
 

--- a/metricbeat/docs/modules/aws.asciidoc
+++ b/metricbeat/docs/modules/aws.asciidoc
@@ -31,8 +31,10 @@ see https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html[Te
 aws> sts get-session-token --serial-number arn:aws:iam::1234:mfa/your-email@example.com --token-code 456789 --duration-seconds 129600
 ----
 
-Since temporary security credentials are short term, after they expire, the user needs to generate new ones and modify
-the aws.yml config file with the new credentials. This will cause data loss if the config file is not update with new
+Because temporary security credentials are short term, after they expire, the user needs to generate new ones and modify
+the aws.yml config file with the new credentials. Unless https://www.elastic.co/guide/en/beats/metricbeat/current/_live_reloading.html[live reloading]
+feature is enabled for Metricbeat, the user needs to manually restart Metricbeat after updating the config file in order
+to continue collecting Cloudwatch metrics. This will cause data loss if the config file is not updated with new
 credentials before the old ones expire. For Metricbeat, we recommend users to use access keys in config file to enable
 aws module making AWS api calls without have to generate new temporary credentials and update the config frequently.
 

--- a/x-pack/metricbeat/module/aws/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/aws/_meta/docs.asciidoc
@@ -24,8 +24,10 @@ see https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html[Te
 aws> sts get-session-token --serial-number arn:aws:iam::1234:mfa/your-email@example.com --token-code 456789 --duration-seconds 129600
 ----
 
-Since temporary security credentials are short term, after they expire, the user needs to generate new ones and modify
-the aws.yml config file with the new credentials. This will cause data loss if the config file is not update with new
+Because temporary security credentials are short term, after they expire, the user needs to generate new ones and modify
+the aws.yml config file with the new credentials. Unless https://www.elastic.co/guide/en/beats/metricbeat/current/_live_reloading.html[live reloading]
+feature is enabled for Metricbeat, the user needs to manually restart Metricbeat after updating the config file in order
+to continue collecting Cloudwatch metrics. This will cause data loss if the config file is not updated with new
 credentials before the old ones expire. For Metricbeat, we recommend users to use access keys in config file to enable
 aws module making AWS api calls without have to generate new temporary credentials and update the config frequently.
 

--- a/x-pack/metricbeat/module/aws/ec2/ec2.go
+++ b/x-pack/metricbeat/module/aws/ec2/ec2.go
@@ -177,7 +177,6 @@ func createCloudWatchEvents(getMetricDataResults []cloudwatch.MetricDataResult, 
 			exists, timestampIdx := aws.CheckTimestampInArray(timestamp, output.Timestamps)
 			if exists {
 				labels := strings.Split(*output.Label, " ")
-				// check timestamp to make sure metrics come from the same timestamp
 				if len(output.Values) > timestampIdx {
 					mapOfMetricSetFieldResults[labels[1]] = fmt.Sprint(output.Values[timestampIdx])
 				}

--- a/x-pack/metricbeat/module/aws/ec2/ec2.go
+++ b/x-pack/metricbeat/module/aws/ec2/ec2.go
@@ -166,12 +166,23 @@ func createCloudWatchEvents(getMetricDataResults []cloudwatch.MetricDataResult, 
 
 	// AWS EC2 Metrics
 	mapOfMetricSetFieldResults := make(map[string]interface{})
-	for _, output := range getMetricDataResults {
-		if len(output.Values) == 0 {
-			continue
+
+	// Find a timestamp for all metrics in output
+	timestamp := aws.FindTimestamp(getMetricDataResults)
+	if !timestamp.IsZero() {
+		for _, output := range getMetricDataResults {
+			if len(output.Values) == 0 {
+				continue
+			}
+			exists, timestampIdx := aws.InArray(timestamp, output.Timestamps)
+			if exists {
+				labels := strings.Split(*output.Label, " ")
+				// check timestamp to make sure metrics come from the same timestamp
+				if len(labels) == 2 && len(output.Values) > timestampIdx {
+					mapOfMetricSetFieldResults[labels[1]] = fmt.Sprint(output.Values[timestampIdx])
+				}
+			}
 		}
-		labels := strings.Split(*output.Label, " ")
-		mapOfMetricSetFieldResults[labels[1]] = fmt.Sprint(output.Values[len(output.Values)-1])
 	}
 
 	resultMetricSetFields, err := aws.EventMapping(mapOfMetricSetFieldResults, schemaMetricSetFields)

--- a/x-pack/metricbeat/module/aws/ec2/ec2.go
+++ b/x-pack/metricbeat/module/aws/ec2/ec2.go
@@ -171,7 +171,7 @@ func createCloudWatchEvents(getMetricDataResults []cloudwatch.MetricDataResult, 
 			continue
 		}
 		labels := strings.Split(*output.Label, " ")
-		mapOfMetricSetFieldResults[labels[1]] = fmt.Sprint(output.Values[0])
+		mapOfMetricSetFieldResults[labels[1]] = fmt.Sprint(output.Values[len(output.Values)-1])
 	}
 
 	resultMetricSetFields, err := aws.EventMapping(mapOfMetricSetFieldResults, schemaMetricSetFields)
@@ -181,8 +181,9 @@ func createCloudWatchEvents(getMetricDataResults []cloudwatch.MetricDataResult, 
 	}
 
 	if len(mapOfMetricSetFieldResults) <= 11 {
-		info = "Missing Cloudwatch data for instance " + instanceID + ". This is expected for a new instance during the " +
-			"first data collection. If this shows up multiple times, please recheck the period setting in config."
+		info = "Missing Cloudwatch data for instance " + instanceID + ". This is expected for non-running instances or " +
+			"a new instance during the first data collection. If this shows up multiple times, please recheck the period " +
+			"setting in config."
 	}
 
 	instanceStateName, err := instanceOutput.State.Name.MarshalValue()

--- a/x-pack/metricbeat/module/aws/ec2/ec2.go
+++ b/x-pack/metricbeat/module/aws/ec2/ec2.go
@@ -174,7 +174,7 @@ func createCloudWatchEvents(getMetricDataResults []cloudwatch.MetricDataResult, 
 			if len(output.Values) == 0 {
 				continue
 			}
-			exists, timestampIdx := aws.InArray(timestamp, output.Timestamps)
+			exists, timestampIdx := aws.CheckTimestampInArray(timestamp, output.Timestamps)
 			if exists {
 				labels := strings.Split(*output.Label, " ")
 				// check timestamp to make sure metrics come from the same timestamp

--- a/x-pack/metricbeat/module/aws/ec2/ec2.go
+++ b/x-pack/metricbeat/module/aws/ec2/ec2.go
@@ -178,7 +178,7 @@ func createCloudWatchEvents(getMetricDataResults []cloudwatch.MetricDataResult, 
 			if exists {
 				labels := strings.Split(*output.Label, " ")
 				// check timestamp to make sure metrics come from the same timestamp
-				if len(labels) == 2 && len(output.Values) > timestampIdx {
+				if len(output.Values) > timestampIdx {
 					mapOfMetricSetFieldResults[labels[1]] = fmt.Sprint(output.Values[timestampIdx])
 				}
 			}

--- a/x-pack/metricbeat/module/aws/ec2/ec2_integration_test.go
+++ b/x-pack/metricbeat/module/aws/ec2/ec2_integration_test.go
@@ -39,11 +39,17 @@ func TestFetch(t *testing.T) {
 		mtest.CheckEventField("service.name", "string", event, t)
 		mtest.CheckEventField("cloud.availability_zone", "string", event, t)
 		mtest.CheckEventField("cloud.provider", "string", event, t)
-		mtest.CheckEventField("cloud.image.id", "string", event, t)
 		mtest.CheckEventField("cloud.instance.id", "string", event, t)
 		mtest.CheckEventField("cloud.machine.type", "string", event, t)
 		mtest.CheckEventField("cloud.provider", "string", event, t)
 		mtest.CheckEventField("cloud.region", "string", event, t)
+		mtest.CheckEventField("instance.image.id", "string", event, t)
+		mtest.CheckEventField("instance.state.name", "string", event, t)
+		mtest.CheckEventField("instance.state.code", "int", event, t)
+		mtest.CheckEventField("instance.monitoring.state", "string", event, t)
+		mtest.CheckEventField("instance.core.count", "int", event, t)
+		mtest.CheckEventField("instance.threads_per_core", "int", event, t)
+
 		// MetricSetField
 		mtest.CheckEventField("cpu.total.pct", "float", event, t)
 		mtest.CheckEventField("cpu.credit_usage", "float", event, t)

--- a/x-pack/metricbeat/module/aws/ec2/ec2_test.go
+++ b/x-pack/metricbeat/module/aws/ec2/ec2_test.go
@@ -8,6 +8,7 @@ package ec2
 
 import (
 	"testing"
+	"time"
 
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
@@ -165,27 +166,32 @@ func TestCreateCloudWatchEvents(t *testing.T) {
 	assert.Equal(t, 1, len(instanceIDs))
 	instanceID := instanceIDs[0]
 	assert.Equal(t, instanceID, instanceID)
+	timestamp := time.Now()
 
 	getMetricDataOutput := []cloudwatch.MetricDataResult{
 		{
-			Id:     &id1,
-			Label:  &label1,
-			Values: []float64{0.25},
+			Id:         &id1,
+			Label:      &label1,
+			Values:     []float64{0.25},
+			Timestamps: []time.Time{timestamp},
 		},
 		{
-			Id:     &id2,
-			Label:  &label2,
-			Values: []float64{0.0},
+			Id:         &id2,
+			Label:      &label2,
+			Values:     []float64{0.0},
+			Timestamps: []time.Time{timestamp},
 		},
 		{
-			Id:     &id3,
-			Label:  &label3,
-			Values: []float64{0.0},
+			Id:         &id3,
+			Label:      &label3,
+			Values:     []float64{0.0},
+			Timestamps: []time.Time{timestamp},
 		},
 		{
-			Id:     &id4,
-			Label:  &label4,
-			Values: []float64{0.0},
+			Id:         &id4,
+			Label:      &label4,
+			Values:     []float64{0.0},
+			Timestamps: []time.Time{timestamp},
 		},
 	}
 

--- a/x-pack/metricbeat/module/aws/mtest/integration.go
+++ b/x-pack/metricbeat/module/aws/mtest/integration.go
@@ -76,15 +76,15 @@ func compareType(metricValue interface{}, expectedType string, metricName string
 	switch metricValue.(type) {
 	case float64:
 		if expectedType != "float" {
-			err = errors.New("Failed: Field " + metricName + "is not in type " + expectedType)
+			err = errors.New("Failed: Field " + metricName + " is not in type " + expectedType)
 		}
 	case string:
 		if expectedType != "string" {
-			err = errors.New("Failed: Field " + metricName + "is not in type " + expectedType)
+			err = errors.New("Failed: Field " + metricName + " is not in type " + expectedType)
 		}
 	case int64:
 		if expectedType != "int" {
-			err = errors.New("Failed: Field " + metricName + "is not in type " + expectedType)
+			err = errors.New("Failed: Field " + metricName + " is not in type " + expectedType)
 		}
 	}
 	return

--- a/x-pack/metricbeat/module/aws/s3_request/s3_request.go
+++ b/x-pack/metricbeat/module/aws/s3_request/s3_request.go
@@ -205,14 +205,20 @@ func createS3RequestEvents(outputs []cloudwatch.MetricDataResult, regionName str
 
 	// AWS s3_request metrics
 	mapOfMetricSetFieldResults := make(map[string]interface{})
+
 	// Find a timestamp for all metrics in output
-	if len(outputs) > 0 && len(outputs[0].Timestamps) > 0 {
-		timestamp := outputs[0].Timestamps[0]
+	timestamp := aws.FindTimestamp(outputs)
+	if !timestamp.IsZero() {
 		for _, output := range outputs {
-			labels := strings.Split(*output.Label, " ")
-			// check timestamp to make sure metrics come from the same timestamp
-			if len(labels) == 3 && labels[0] == bucketName && len(output.Values) > 0 && output.Timestamps[0] == timestamp {
-				mapOfMetricSetFieldResults[labels[2]] = fmt.Sprint(output.Values[0])
+			if len(output.Values) == 0 {
+				continue
+			}
+			exists, timestampIdx := aws.CheckTimestampInArray(timestamp, output.Timestamps)
+			if exists {
+				labels := strings.Split(*output.Label, " ")
+				if labels[0] == bucketName && len(output.Values) > timestampIdx {
+					mapOfMetricSetFieldResults[labels[2]] = fmt.Sprint(output.Values[timestampIdx])
+				}
 			}
 		}
 	}

--- a/x-pack/metricbeat/module/aws/utils.go
+++ b/x-pack/metricbeat/module/aws/utils.go
@@ -5,7 +5,6 @@
 package aws
 
 import (
-	"reflect"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
@@ -86,21 +85,15 @@ func EventMapping(input map[string]interface{}, schema s.Schema) (common.MapStr,
 	return schema.Apply(input, s.FailOnRequired)
 }
 
-// InArray checks if input val exists in array and if it exists, return the position.
-func InArray(val interface{}, array interface{}) (exists bool, index int) {
+// CheckTimestampInArray checks if input val exists in array and if it exists, return the position.
+func CheckTimestampInArray(timestamp time.Time, timestampArray []time.Time) (exists bool, index int) {
 	exists = false
 	index = -1
-
-	switch reflect.TypeOf(array).Kind() {
-	case reflect.Slice:
-		s := reflect.ValueOf(array)
-
-		for i := 0; i < s.Len(); i++ {
-			if reflect.DeepEqual(val, s.Index(i).Interface()) == true {
-				index = i
-				exists = true
-				return
-			}
+	for i := 0; i < len(timestampArray); i++ {
+		if timestamp.Equal(timestampArray[i]) {
+			index = i
+			exists = true
+			return
 		}
 	}
 	return

--- a/x-pack/metricbeat/module/aws/utils.go
+++ b/x-pack/metricbeat/module/aws/utils.go
@@ -85,7 +85,7 @@ func EventMapping(input map[string]interface{}, schema s.Schema) (common.MapStr,
 	return schema.Apply(input, s.FailOnRequired)
 }
 
-// CheckTimestampInArray checks if input val exists in array and if it exists, return the position.
+// CheckTimestampInArray checks if input timestamp exists in timestampArray and if it exists, return the position.
 func CheckTimestampInArray(timestamp time.Time, timestampArray []time.Time) (exists bool, index int) {
 	exists = false
 	index = -1

--- a/x-pack/metricbeat/module/aws/utils.go
+++ b/x-pack/metricbeat/module/aws/utils.go
@@ -86,17 +86,13 @@ func EventMapping(input map[string]interface{}, schema s.Schema) (common.MapStr,
 }
 
 // CheckTimestampInArray checks if input timestamp exists in timestampArray and if it exists, return the position.
-func CheckTimestampInArray(timestamp time.Time, timestampArray []time.Time) (exists bool, index int) {
-	exists = false
-	index = -1
+func CheckTimestampInArray(timestamp time.Time, timestampArray []time.Time) (bool, int) {
 	for i := 0; i < len(timestampArray); i++ {
 		if timestamp.Equal(timestampArray[i]) {
-			index = i
-			exists = true
-			return
+			return true, i
 		}
 	}
-	return
+	return false, -1
 }
 
 // FindTimestamp function checks MetricDataResults and find the timestamp to collect metrics from.
@@ -122,7 +118,7 @@ func FindTimestamp(getMetricDataResults []cloudwatch.MetricDataResult) time.Time
 		if output.Timestamps != nil && len(output.Timestamps) == 1 {
 			// Use the first timestamp from Timestamps field to collect the latest data.
 			timestamp = output.Timestamps[0]
-			break
+			return timestamp
 		}
 	}
 
@@ -133,7 +129,7 @@ func FindTimestamp(getMetricDataResults []cloudwatch.MetricDataResult) time.Time
 			if output.Timestamps != nil && len(output.Timestamps) > 1 {
 				// Example Timestamps: [2019-03-11 17:36:00 +0000 UTC,2019-03-11 17:31:00 +0000 UTC]
 				timestamp = output.Timestamps[0]
-				break
+				return timestamp
 			}
 		}
 	}

--- a/x-pack/metricbeat/module/aws/utils_test.go
+++ b/x-pack/metricbeat/module/aws/utils_test.go
@@ -176,14 +176,29 @@ func TestCheckTimestampInArray(t *testing.T) {
 	timestamp2 := timestamp1.Add(5 * time.Minute)
 	timestamp3 := timestamp1.Add(10 * time.Minute)
 
-	timestampArray := []time.Time{timestamp1, timestamp2}
-	exists1, index1 := CheckTimestampInArray(timestamp1, timestampArray)
-	assert.True(t, exists1)
-	assert.Equal(t, 0, index1)
+	cases := []struct {
+		targetTimestamp time.Time
+		expectedExists  bool
+		expectedIndex   int
+	}{
+		{
+			targetTimestamp: timestamp1,
+			expectedExists:  true,
+			expectedIndex:   0,
+		},
+		{
+			targetTimestamp: timestamp3,
+			expectedExists:  false,
+			expectedIndex:   -1,
+		},
+	}
 
-	exists2, index2 := CheckTimestampInArray(timestamp3, timestampArray)
-	assert.False(t, exists2)
-	assert.Equal(t, -1, index2)
+	timestampArray := []time.Time{timestamp1, timestamp2}
+	for _, c := range cases {
+		exists, index := CheckTimestampInArray(c.targetTimestamp, timestampArray)
+		assert.Equal(t, c.expectedExists, exists)
+		assert.Equal(t, c.expectedIndex, index)
+	}
 }
 
 func TestFindTimestamp(t *testing.T) {

--- a/x-pack/metricbeat/module/aws/utils_test.go
+++ b/x-pack/metricbeat/module/aws/utils_test.go
@@ -189,63 +189,74 @@ func TestCheckTimestampInArray(t *testing.T) {
 func TestFindTimestamp(t *testing.T) {
 	timestamp1 := time.Now()
 	timestamp2 := timestamp1.Add(5 * time.Minute)
-	getMetricDataResults1 := []cloudwatch.MetricDataResult{
+	cases := []struct {
+		getMetricDataResults []cloudwatch.MetricDataResult
+		expectedTimestamp    time.Time
+	}{
 		{
-			Id:         &id1,
-			Label:      &label1,
-			StatusCode: cloudwatch.StatusCodeComplete,
-			Timestamps: []time.Time{timestamp1, timestamp2},
-			Values:     []float64{0, 1},
+			getMetricDataResults: []cloudwatch.MetricDataResult{
+				{
+					Id:         &id1,
+					Label:      &label1,
+					StatusCode: cloudwatch.StatusCodeComplete,
+					Timestamps: []time.Time{timestamp1, timestamp2},
+					Values:     []float64{0, 1},
+				},
+				{
+					Id:         &id2,
+					Label:      &label2,
+					StatusCode: cloudwatch.StatusCodeComplete,
+					Timestamps: []time.Time{timestamp1},
+					Values:     []float64{2, 3},
+				},
+			},
+			expectedTimestamp: timestamp1,
 		},
 		{
-			Id:         &id2,
-			Label:      &label2,
-			StatusCode: cloudwatch.StatusCodeComplete,
-			Timestamps: []time.Time{timestamp1},
-			Values:     []float64{2, 3},
+			getMetricDataResults: []cloudwatch.MetricDataResult{
+				{
+					Id:         &id1,
+					Label:      &label1,
+					StatusCode: cloudwatch.StatusCodeComplete,
+					Timestamps: []time.Time{timestamp1, timestamp2},
+					Values:     []float64{0, 1},
+				},
+				{
+					Id:         &id2,
+					Label:      &label2,
+					StatusCode: cloudwatch.StatusCodeComplete,
+				},
+			},
+			expectedTimestamp: timestamp1,
+		},
+		{
+			getMetricDataResults: []cloudwatch.MetricDataResult{
+				{
+					Id:         &id1,
+					Label:      &label1,
+					StatusCode: cloudwatch.StatusCodeComplete,
+					Timestamps: []time.Time{timestamp1, timestamp2},
+					Values:     []float64{0, 1},
+				},
+				{
+					Id:         &id2,
+					Label:      &label2,
+					StatusCode: cloudwatch.StatusCodeComplete,
+				},
+				{
+					Id:         &id3,
+					Label:      &label2,
+					StatusCode: cloudwatch.StatusCodeComplete,
+					Timestamps: []time.Time{timestamp2},
+					Values:     []float64{2, 3},
+				},
+			},
+			expectedTimestamp: timestamp2,
 		},
 	}
-	target1 := FindTimestamp(getMetricDataResults1)
-	assert.Equal(t, timestamp1, target1)
 
-	getMetricDataResults2 := []cloudwatch.MetricDataResult{
-		{
-			Id:         &id1,
-			Label:      &label1,
-			StatusCode: cloudwatch.StatusCodeComplete,
-			Timestamps: []time.Time{timestamp1, timestamp2},
-			Values:     []float64{0, 1},
-		},
-		{
-			Id:         &id2,
-			Label:      &label2,
-			StatusCode: cloudwatch.StatusCodeComplete,
-		},
+	for _, c := range cases {
+		outputTimestamp := FindTimestamp(c.getMetricDataResults)
+		assert.Equal(t, c.expectedTimestamp, outputTimestamp)
 	}
-	target2 := FindTimestamp(getMetricDataResults2)
-	assert.Equal(t, timestamp1, target2)
-
-	getMetricDataResults3 := []cloudwatch.MetricDataResult{
-		{
-			Id:         &id1,
-			Label:      &label1,
-			StatusCode: cloudwatch.StatusCodeComplete,
-			Timestamps: []time.Time{timestamp1, timestamp2},
-			Values:     []float64{0, 1},
-		},
-		{
-			Id:         &id2,
-			Label:      &label2,
-			StatusCode: cloudwatch.StatusCodeComplete,
-		},
-		{
-			Id:         &id3,
-			Label:      &label2,
-			StatusCode: cloudwatch.StatusCodeComplete,
-			Timestamps: []time.Time{timestamp2},
-			Values:     []float64{2, 3},
-		},
-	}
-	target3 := FindTimestamp(getMetricDataResults3)
-	assert.Equal(t, timestamp2, target3)
 }


### PR DESCRIPTION
1. This PR is to address comment: https://github.com/elastic/beats/pull/11023#discussion_r263384590 
2. This PR also added checks for the fields that were missed previously in TestFetch.
3. When testing, I found out 
``` 
getMetricDataResults =  [{
  Id: "ec20",
  Label: "i-0c68eeb552231a8d0 StatusCheckFailed_System",
  StatusCode: Complete,
  Timestamps: [2019-03-08 20:02:00 +0000 UTC,2019-03-08 19:57:00 +0000 UTC],
  Values: [0,0]
} {
  Id: "ec21",
  Label: "i-0c68eeb552231a8d0 CPUUtilization",
  StatusCode: Complete,
  Timestamps: [2019-03-08 19:57:00 +0000 UTC],
  Values: [0.100564971751321]
}]
```

We are collecting data from `2019-03-08 19:57:00 +0000 UTC` for example for `CPUUtilization`, then we need to collect the rest of the metrics from the same timestamp from `Values` array. `FindTimestamp `function finds this timestamp and `CheckTimestampInArray ` function checks if input timestamp exists in array and if it exists, return the position. In this example, `2019-03-08 19:57:00 +0000 UTC` exists in `[2019-03-08 20:02:00 +0000 UTC,2019-03-08 19:57:00 +0000 UTC]` and position is `1`.