### PR TITLE
Add a customized community beat named unitybeat

### DIFF
--- a/libbeat/docs/communitybeats.asciidoc
+++ b/libbeat/docs/communitybeats.asciidoc
@@ -110,3 +110,4 @@ https://github.com/phenomenes/varnishlogbeat[varnishlogbeat]:: Reads log data fr
 https://github.com/phenomenes/varnishstatbeat[varnishstatbeat]:: Reads stats data from a Varnish instance and ships it to Elasticsearch.
 https://gitlab.com/msvechla/vaultbeat[vaultbeat]:: Collects performance metrics and statistics from Hashicorp's Vault.
 https://github.com/eskibars/wmibeat[wmibeat]:: Uses WMI to grab your favorite, configurable Windows metrics.
+https://github.com/kckecheng/unitybeat[unitybeat]:: Collects performance metrics from Dell EMC Unity storage array.


### PR DESCRIPTION
The beat is responsible for collecting performance metrics from Dell EMC Unity SAN storage array. Currently, overall storage processor usage, IOPS and bandwidth are supported.