### PR TITLE
[Generator] pass ES_BEATS to specific makefile

### DIFF
--- a/generator/beat/{beat}/Makefile
+++ b/generator/beat/{beat}/Makefile
@@ -18,7 +18,7 @@ NO_COLLECT=true
 setup: pre-setup git-add
 
 pre-setup: copy-vendor git-init
-	$(MAKE) -f $(LIBBEAT_MAKEFILE) mage
+	$(MAKE) -f $(LIBBEAT_MAKEFILE) mage ES_BEATS=$(ES_BEATS)
 	$(MAKE) -f $(LIBBEAT_MAKEFILE) update BEAT_NAME=$(BEAT_NAME) ES_BEATS=$(ES_BEATS) NO_COLLECT=$(NO_COLLECT)
 
 # Copy beats into vendor directory


### PR DESCRIPTION
Opened a new PR since I somehow broke my branch history.

This is to fix #11137 

After getting some feedback from @graphaelli and others, we're now just passing the `ES_BEATS` variable to the specific make call. I tested this locally with the generator, it seems to work.