### PR TITLE
Cherry-pick #10564 to 7.0: Remove experimental flags and mark most of the AWS provider trigger stable.

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -33,6 +33,12 @@ https://github.com/elastic/beats/compare/v7.0.0-beta1...master[Check the HEAD di
 
 *Functionbeat*
 
+- Mark Functionbeat  as GA. {pull}10564[10564]
+
+- Correctly normalize Cloudformation resource name. {issue}10087[10087]
+- Functionbeat can now deploy a function for Kinesis. {10116}10116[10116]
+- Allow functionbeat to use the keystore. {issue}9009[9009]
+
 ==== Bugfixes
 
 *Affecting all Beats*


### PR DESCRIPTION
Cherry-pick of PR #10564 to 7.0 branch. Original message: 

Kinesis marked as stable
SQS marked as stable
cloudwatch marked as stable