### PR TITLE
Cherry-pick #10936 to 7.0: When using the --password env:FOO will now return an errors if

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -51,6 +51,7 @@ https://github.com/elastic/beats/compare/v7.0.0-beta1...master[Check the HEAD di
 - Reconnections of Kubernetes watchers are now logged at debug level when they are harmless. {pull}10988[10988]
 - Add missing host.* fields to fields.yml. {pull}11016[11016]
 - Include ip and boolean type when generating index pattern. {pull}10995[10995]
+- Using an environment variable for the password when enrolling a beat will now raise an error if the variable doesn't exist. {pull}10936[10936]
 
 *Auditbeat*
 

--- a/libbeat/common/cli/password.go
+++ b/libbeat/common/cli/password.go
@@ -72,8 +72,13 @@ func stdin(p string) (string, error) {
 
 func env(p string) (string, error) {
 	if len(p) == 0 {
-		return "", errors.New("env variable name is needed when using env: password method")
+		return "", errors.New("environment variable name is needed when using env: password method")
 	}
 
-	return os.Getenv(p), nil
+	v, ok := os.LookupEnv(p)
+	if !ok {
+		return "", fmt.Errorf("environment variable %s does not exist", p)
+	}
+
+	return v, nil
 }

--- a/libbeat/common/cli/password_test.go
+++ b/libbeat/common/cli/password_test.go
@@ -48,6 +48,11 @@ func TestReadPassword(t *testing.T) {
 			input: "",
 			error: true,
 		},
+		{
+			name:  "Test env variable that does not exist",
+			input: "env:DO_NOT_EXIST",
+			error: true,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Cherry-pick of PR #10936 to 7.0 branch. Original message: 

FOO does not exist in the environment.