### PR TITLE
Use beat.timezone instead of event.timezone

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -106,6 +106,7 @@ https://github.com/elastic/beats/compare/v6.6.0...6.x[Check the HEAD diff]
 - Fixed data types for roles and indices fields in `elasticsearch/audit` fileset {pull}10307[10307]
 - Cover empty request data, url and version in Apache2 module{pull}10846[10846]
 - Fix a bug when converting NetFlow fields to snake_case. {pull}10950[10950]
+- Fix a bug with the convert_timezone option using the incorrect timezone field. {issue}11055[11055] {pull}11164[11164]
 
 *Heartbeat*
 

--- a/filebeat/module/elasticsearch/audit/ingest/pipeline.json
+++ b/filebeat/module/elasticsearch/audit/ingest/pipeline.json
@@ -37,7 +37,7 @@
                 "formats": [
                     "ISO8601"
                 ],
-                {< if .convert_timezone >}"timezone": "{{ event.timezone }}",{< end >}
+                {< if .convert_timezone >}"timezone": "{{ beat.timezone }}",{< end >}
                 "ignore_failure": true
             }
         },

--- a/filebeat/module/elasticsearch/deprecation/ingest/pipeline.json
+++ b/filebeat/module/elasticsearch/deprecation/ingest/pipeline.json
@@ -33,7 +33,7 @@
                 "formats": [
                     "ISO8601"
                 ],
-                {< if .convert_timezone >}"timezone": "{{ event.timezone }}",{< end >}
+                {< if .convert_timezone >}"timezone": "{{ beat.timezone }}",{< end >}
                 "ignore_failure": true
             }
         },

--- a/filebeat/module/elasticsearch/server/ingest/pipeline.json
+++ b/filebeat/module/elasticsearch/server/ingest/pipeline.json
@@ -63,7 +63,7 @@
                 "formats": [
                     "ISO8601"
                 ],
-                {< if .convert_timezone >}"timezone": "{{ event.timezone }}",{< end >}
+                {< if .convert_timezone >}"timezone": "{{ beat.timezone }}",{< end >}
                 "ignore_failure": true
             }
         },

--- a/filebeat/module/elasticsearch/slowlog/ingest/pipeline.json
+++ b/filebeat/module/elasticsearch/slowlog/ingest/pipeline.json
@@ -26,7 +26,7 @@
               "formats": [
                   "ISO8601"
               ],
-              {< if .convert_timezone >}"timezone": "{{ event.timezone }}",{< end >}
+              {< if .convert_timezone >}"timezone": "{{ beat.timezone }}",{< end >}
               "ignore_failure": true
           }
       },

--- a/filebeat/module/logstash/log/ingest/pipeline-plain.json
+++ b/filebeat/module/logstash/log/ingest/pipeline-plain.json
@@ -40,7 +40,7 @@
                 "formats": [
                   "ISO8601"
               ],
-              {< if .convert_timezone >}"timezone": "{{ event.timezone }}",{< end >}
+              {< if .convert_timezone >}"timezone": "{{ beat.timezone }}",{< end >}
               "ignore_failure": true
             }
         },

--- a/filebeat/module/logstash/slowlog/ingest/pipeline-plain.json
+++ b/filebeat/module/logstash/slowlog/ingest/pipeline-plain.json
@@ -55,7 +55,7 @@
                 "formats": [
                   "ISO8601"
               ],
-              {< if .convert_timezone >}"timezone": "{{ event.timezone }}",{< end >}
+              {< if .convert_timezone >}"timezone": "{{ beat.timezone }}",{< end >}
               "ignore_failure": true
             }
         },

--- a/filebeat/module/nginx/access/ingest/default.json
+++ b/filebeat/module/nginx/access/ingest/default.json
@@ -61,7 +61,7 @@
                 "formats": [
                     "dd/MMM/yyyy:H:m:s Z"
                 ],
-                {< if .convert_timezone >}"timezone": "{{ event.timezone }}",{< end >}
+                {< if .convert_timezone >}"timezone": "{{ beat.timezone }}",{< end >}
                 "ignore_failure": true
             }
         },

--- a/filebeat/module/nginx/error/ingest/pipeline.json
+++ b/filebeat/module/nginx/error/ingest/pipeline.json
@@ -22,7 +22,7 @@
       "field": "nginx.error.time",
       "target_field": "@timestamp",
       "formats": ["yyyy/MM/dd H:m:s"],
-      {< if .convert_timezone >}"timezone": "{{ event.timezone }}",{< end >}
+      {< if .convert_timezone >}"timezone": "{{ beat.timezone }}",{< end >}
       "ignore_failure": true
     }
   }, {


### PR DESCRIPTION
In 6.x the `add_locale` processor will [set the `beat.timezone` field](https://github.com/elastic/beats/blob/6.7/libbeat/processors/add_locale/add_locale.go#L89) (as opposed to `event.timezone`, which is [set starting 7.0](https://github.com/elastic/beats/blob/master/libbeat/processors/add_locale/add_locale.go#L89)). So any 6.x ingest pipelines looking for the timezone field should look for `beat.timezone`, not `event.timezone`.

Fixes #11055.