### PR TITLE
Cherry-pick #11067 to 7.x: Fix a issue when cancelling an enroll.

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -169,6 +169,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix a issue when remote and local configuration didn't match when fetching configuration from Central Management. {issue}10587[10587]
 - Add missing host.* fields to fields.yml. {pull}11016[11016]
 - Include ip and boolean type when generating index pattern. {pull}10995[10995]
+- Cancelling enrollment of a beat will not enroll the beat. {issue}10150[10150]
 
 *Auditbeat*
 


### PR DESCRIPTION
Cherry-pick of PR #11067 to 7.x branch. Original message: 

Fix an issue with a partial enroll, when a user refused to overrides a
local configuration actually the enroll command did already used the
token on the ES cluster, this commit move the confirm in the CM instead
of having it in the Enroll's function and is executed by sending the
token or creating any files on disk.

Fixes: #10150