### PR TITLE
Cherry-pick #11121 to 7.0: [Heartbeat] Make dashboard docs point to uptime-contrib.

### DIFF
--- a/heartbeat/docs/getting-started.asciidoc
+++ b/heartbeat/docs/getting-started.asciidoc
@@ -214,7 +214,7 @@ include::{libbeat-dir}/docs/shared-template-load.asciidoc[]
 [[load-kibana-dashboards]]
 === Step 4: Set up the Kibana dashboards
 
-include::{libbeat-dir}/docs/dashboards.asciidoc[]
+Dashboards for heartbeat can be found in the https://github.com/elastic/uptime-contrib[uptime-contrib] github repository.
 
 [[heartbeat-starting]]
 === Step 5: Start Heartbeat


### PR DESCRIPTION
Cherry-pick of PR #11121 to 7.0 branch. Original message: 

These dashboards are now maintained in the new elastic/uptime-contrib repo, so the docs should point there.

See https://github.com/elastic/uptime/issues/12 for context.