### PR TITLE
Cherry-pick #11164 to 6.6: Use beat.timezone instead of event.timezone

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -36,7 +36,6 @@ https://github.com/elastic/beats/compare/v6.6.2...6.6[Check the HEAD diff]
 
 *Filebeat*
 
-- Fix a bug when converting NetFlow fields to snake_case. {pull}10950[10950]
 - Fix a bug with the convert_timezone option using the incorrect timezone field. {issue}11055[11055] {pull}11164[11164]
 
 *Heartbeat*

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -36,6 +36,9 @@ https://github.com/elastic/beats/compare/v6.6.2...6.6[Check the HEAD diff]
 
 *Filebeat*
 
+- Fix a bug when converting NetFlow fields to snake_case. {pull}10950[10950]
+- Fix a bug with the convert_timezone option using the incorrect timezone field. {issue}11055[11055] {pull}11164[11164]
+
 *Heartbeat*
 
 *Journalbeat*

--- a/filebeat/module/elasticsearch/audit/ingest/pipeline.json
+++ b/filebeat/module/elasticsearch/audit/ingest/pipeline.json
@@ -64,7 +64,7 @@
                 "formats": [
                     "ISO8601"
                 ],
-                {< if .convert_timezone >}"timezone": "{{ event.timezone }}",{< end >}
+                {< if .convert_timezone >}"timezone": "{{ beat.timezone }}",{< end >}
                 "ignore_failure": true
             }
         },

--- a/filebeat/module/elasticsearch/deprecation/ingest/pipeline.json
+++ b/filebeat/module/elasticsearch/deprecation/ingest/pipeline.json
@@ -33,7 +33,7 @@
                 "formats": [
                     "ISO8601"
                 ],
-                {< if .convert_timezone >}"timezone": "{{ event.timezone }}",{< end >}
+                {< if .convert_timezone >}"timezone": "{{ beat.timezone }}",{< end >}
                 "ignore_failure": true
             }
         },

--- a/filebeat/module/elasticsearch/server/ingest/pipeline.json
+++ b/filebeat/module/elasticsearch/server/ingest/pipeline.json
@@ -34,7 +34,7 @@
                 "formats": [
                     "ISO8601"
                 ],
-                {< if .convert_timezone >}"timezone": "{{ event.timezone }}",{< end >}
+                {< if .convert_timezone >}"timezone": "{{ beat.timezone }}",{< end >}
                 "ignore_failure": true
             }
         },

--- a/filebeat/module/elasticsearch/slowlog/ingest/pipeline.json
+++ b/filebeat/module/elasticsearch/slowlog/ingest/pipeline.json
@@ -26,7 +26,7 @@
               "formats": [
                   "ISO8601"
               ],
-              {< if .convert_timezone >}"timezone": "{{ event.timezone }}",{< end >}
+              {< if .convert_timezone >}"timezone": "{{ beat.timezone }}",{< end >}
               "ignore_failure": true
           }
       },

--- a/filebeat/module/logstash/log/ingest/pipeline-plain.json
+++ b/filebeat/module/logstash/log/ingest/pipeline-plain.json
@@ -40,7 +40,7 @@
                 "formats": [
                   "ISO8601"
               ],
-              {< if .convert_timezone >}"timezone": "{{ event.timezone }}",{< end >}
+              {< if .convert_timezone >}"timezone": "{{ beat.timezone }}",{< end >}
               "ignore_failure": true
             }
         },

--- a/filebeat/module/logstash/slowlog/ingest/pipeline-plain.json
+++ b/filebeat/module/logstash/slowlog/ingest/pipeline-plain.json
@@ -55,7 +55,7 @@
                 "formats": [
                   "ISO8601"
               ],
-              {< if .convert_timezone >}"timezone": "{{ event.timezone }}",{< end >}
+              {< if .convert_timezone >}"timezone": "{{ beat.timezone }}",{< end >}
               "ignore_failure": true
             }
         },


### PR DESCRIPTION
Cherry-pick of PR #11164 to 6.6 branch. Original message: 

In 6.x the `add_locale` processor will [set the `beat.timezone` field](https://github.com/elastic/beats/blob/6.7/libbeat/processors/add_locale/add_locale.go#L89) (as opposed to `event.timezone`, which is [set starting 7.0](https://github.com/elastic/beats/blob/master/libbeat/processors/add_locale/add_locale.go#L89)). So any 6.x ingest pipelines looking for the timezone field should look for `beat.timezone`, not `event.timezone`.

Fixes #11055.