### PR TITLE
Send system_api_version=7 from beats 7.0.0 onwards

### DIFF
--- a/libbeat/monitoring/report/elasticsearch/elasticsearch.go
+++ b/libbeat/monitoring/report/elasticsearch/elasticsearch.go
@@ -68,7 +68,7 @@ var errNoMonitoring = errors.New("xpack monitoring not available")
 // default monitoring api parameters
 var defaultParams = map[string]string{
 	"system_id":          "beats",
-	"system_api_version": "6",
+	"system_api_version": "7",
 }
 
 func init() {


### PR DESCRIPTION
Resolves #11192.

Starting Elasticsearch 7.0.0, the bulk monitoring API is expecting the `system_api_version` parameter to be set to `7` (used to be `6` before). This PR makes that change for all Beats.