### PR TITLE
Loading external `fields.yml` files

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -240,6 +240,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add `community_id` processor for computing network flow hashes. {pull}10745[10745]
 - Add output test to kafka output {pull}10834[10834]
 - Add ip fields to default_field in Elasticsearch template. {pull}11035[11035]
+- Loading external fields.yml files. {pull}11199[11199]
 
 
 *Auditbeat*

--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -979,6 +979,10 @@ output.elasticsearch:
 #- name: field_name
 #  type: field_type
 
+# List of external fields.yml files to load.
+#setup.template.external_fields:
+#- /path/to/external/fields.yml
+
 # Enable JSON template loading. If this is enabled, the fields.yml is ignored.
 #setup.template.json.enabled: false
 

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -1690,6 +1690,10 @@ output.elasticsearch:
 #- name: field_name
 #  type: field_type
 
+# List of external fields.yml files to load.
+#setup.template.external_fields:
+#- /path/to/external/fields.yml
+
 # Enable JSON template loading. If this is enabled, the fields.yml is ignored.
 #setup.template.json.enabled: false
 

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -1123,6 +1123,10 @@ output.elasticsearch:
 #- name: field_name
 #  type: field_type
 
+# List of external fields.yml files to load.
+#setup.template.external_fields:
+#- /path/to/external/fields.yml
+
 # Enable JSON template loading. If this is enabled, the fields.yml is ignored.
 #setup.template.json.enabled: false
 

--- a/journalbeat/journalbeat.reference.yml
+++ b/journalbeat/journalbeat.reference.yml
@@ -919,6 +919,10 @@ output.elasticsearch:
 #- name: field_name
 #  type: field_type
 
+# List of external fields.yml files to load.
+#setup.template.external_fields:
+#- /path/to/external/fields.yml
+
 # Enable JSON template loading. If this is enabled, the fields.yml is ignored.
 #setup.template.json.enabled: false
 

--- a/libbeat/_meta/config.reference.yml
+++ b/libbeat/_meta/config.reference.yml
@@ -867,6 +867,10 @@ output.elasticsearch:
 #- name: field_name
 #  type: field_type
 
+# List of external fields.yml files to load.
+#setup.template.external_fields:
+#- /path/to/external/fields.yml
+
 # Enable JSON template loading. If this is enabled, the fields.yml is ignored.
 #setup.template.json.enabled: false
 

--- a/libbeat/beat/beat.go
+++ b/libbeat/beat/beat.go
@@ -64,8 +64,6 @@ type Beat struct {
 
 	BeatConfig *common.Config // The beat's own configuration section
 
-	Fields []byte // Data from fields.yml
-
 	ConfigManager management.ConfigManager // config manager
 }
 

--- a/libbeat/cmd/export/index_pattern.go
+++ b/libbeat/cmd/export/index_pattern.go
@@ -63,7 +63,11 @@ func GenIndexPatternConfigCmd(settings instance.Settings) *cobra.Command {
 			if err != nil {
 				fatalf("Error creating version: %+v", err)
 			}
-			indexPattern, err := kibana.NewGenerator(b.Info.IndexPrefix, b.Info.Beat, b.Fields, settings.Version, *v, withMigration)
+			fields, err := b.Mapping.GetBytes()
+			if err != nil {
+				fatalf("Error reading fields of Beat: %+v", err)
+			}
+			indexPattern, err := kibana.NewGenerator(b.Info.IndexPrefix, b.Info.Beat, fields, settings.Version, *v, withMigration)
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/libbeat/cmd/export/template.go
+++ b/libbeat/cmd/export/template.go
@@ -93,7 +93,11 @@ func GenTemplateConfigCmd(settings instance.Settings) *cobra.Command {
 				fieldsPath := paths.Resolve(paths.Config, tmplCfg.Fields)
 				templateString, err = tmpl.LoadFile(fieldsPath)
 			} else {
-				templateString, err = tmpl.LoadBytes(b.Fields)
+				fields, err := b.Mapping.GetBytes()
+				if err != nil {
+					fatalf("Error getting fields of Beat: %+v", err)
+				}
+				templateString, err = tmpl.LoadBytes(fields)
 			}
 			if err != nil {
 				fatalf("Error generating template: %+v", err)

--- a/libbeat/mapping/support.go
+++ b/libbeat/mapping/support.go
@@ -1,0 +1,146 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package mapping
+
+import (
+	"io/ioutil"
+
+	"github.com/elastic/beats/libbeat/asset"
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
+)
+
+// Supporter returns the configured fields bytes
+type Supporter interface {
+	GetBytes() ([]byte, error)
+}
+
+// fieldsSupport returns the default fields of a Beat
+type fieldsSupport struct {
+	log  *logp.Logger
+	beat string
+}
+
+// customFieldsSupport returns the custom configured fields of a Beat
+type customFieldsSupport struct {
+	log  *logp.Logger
+	beat string
+	path string
+}
+
+// appendFieldsSupport return the default fields of a Beat
+// and the additional fields from append_fields
+type appendFieldsSupport struct {
+	original       Supporter
+	appendedFields []byte
+}
+
+// externalFieldsSupport return the default fields of a Beat
+// and the additional fields from external_fields
+type externalFieldsSupport struct {
+	original Supporter
+	paths    []string
+}
+
+func DefaultSupport(log *logp.Logger, beat string, cfg *common.Config) (Supporter, error) {
+	if log == nil {
+		log = logp.NewLogger("mapping")
+	} else {
+		log = log.Named("mapping")
+	}
+
+	config := struct {
+		Template struct {
+			Fields         string   `config:"fields"`
+			AppendFields   []byte   `config:"append_fields"`
+			ExternalFields []string `config:"external_fields"`
+		} `config:"setup.template"`
+	}{}
+	err := cfg.Unpack(&config)
+	if err != nil {
+		return nil, err
+	}
+
+	// load default fields.ymls of Beat
+	var s Supporter
+	s = &fieldsSupport{
+		log:  log,
+		beat: beat,
+	}
+
+	// custom fields.yml file is configured
+	if config.Template.Fields != "" {
+		s = &customFieldsSupport{
+			log:  log,
+			beat: beat,
+			path: config.Template.Fields,
+		}
+	}
+
+	// append_fields
+	if len(config.Template.AppendFields) > 0 {
+		s = &appendFieldsSupport{
+			original:       s,
+			appendedFields: config.Template.AppendFields,
+		}
+	}
+
+	// external_fields
+	if len(config.Template.ExternalFields) > 0 {
+		s = &externalFieldsSupport{
+			original: s,
+			paths:    config.Template.ExternalFields,
+		}
+	}
+
+	return s, nil
+}
+
+func (f *fieldsSupport) GetBytes() ([]byte, error) {
+	return asset.GetFields(f.beat)
+}
+
+func (c *customFieldsSupport) GetBytes() ([]byte, error) {
+	c.log.Debugf("Reading bytes custom fields.yml from %s", c.path)
+	return ioutil.ReadFile(c.path)
+}
+
+func (a *appendFieldsSupport) GetBytes() ([]byte, error) {
+	fields, err := a.original.GetBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	return append(fields, a.appendedFields...), nil
+}
+
+func (e *externalFieldsSupport) GetBytes() ([]byte, error) {
+	fields, err := e.original.GetBytes()
+	if err != nil {
+		return nil, err
+	}
+	for _, path := range e.paths {
+		f, err := ioutil.ReadFile(path)
+		if err != nil {
+			return nil, err
+		}
+		fields = append(fields, f...)
+	}
+
+	return fields, nil
+}

--- a/libbeat/template/config.go
+++ b/libbeat/template/config.go
@@ -29,9 +29,10 @@ type TemplateConfig struct {
 		Path    string `config:"path"`
 		Name    string `config:"name"`
 	} `config:"json"`
-	AppendFields mapping.Fields   `config:"append_fields"`
-	Overwrite    bool             `config:"overwrite"`
-	Settings     TemplateSettings `config:"settings"`
+	AppendFields   mapping.Fields   `config:"append_fields"`
+	ExternalFields []string         `config:"external_fields"`
+	Overwrite      bool             `config:"overwrite"`
+	Settings       TemplateSettings `config:"settings"`
 }
 
 type TemplateSettings struct {

--- a/libbeat/template/load.go
+++ b/libbeat/template/load.go
@@ -102,18 +102,8 @@ func (l *Loader) Load() error {
 			if err != nil {
 				return fmt.Errorf("could not unmarshal json template: %s", err)
 			}
-			// Load fields from path
-		} else if l.config.Fields != "" {
-			logp.Debug("template", "Load fields.yml from file: %s", l.config.Fields)
-
-			fieldsPath := paths.Resolve(paths.Config, l.config.Fields)
-
-			template, err = tmpl.LoadFile(fieldsPath)
-			if err != nil {
-				return fmt.Errorf("error creating template from file %s: %v", fieldsPath, err)
-			}
 		} else {
-			logp.Debug("template", "Load default fields.yml")
+			logp.Debug("template", "Load fields from configured fields.yml and additions")
 			template, err = tmpl.LoadBytes(l.fields)
 			if err != nil {
 				return fmt.Errorf("error creating template: %v", err)

--- a/libbeat/template/template.go
+++ b/libbeat/template/template.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/libbeat/common/fmtstr"
 	"github.com/elastic/beats/libbeat/mapping"
 	"github.com/elastic/go-ucfg/yaml"
@@ -138,15 +137,6 @@ func (t *Template) load(fields mapping.Fields) (common.MapStr, error) {
 
 	dynamicTemplates = nil
 	defaultFields = nil
-
-	var err error
-	if len(t.config.AppendFields) > 0 {
-		cfgwarn.Experimental("append_fields is used.")
-		fields, err = mapping.ConcatFields(fields, t.config.AppendFields)
-		if err != nil {
-			return nil, err
-		}
-	}
 
 	// Start processing at the root
 	properties := common.MapStr{}

--- a/libbeat/tests/system/config/mockbeat.yml.j2
+++ b/libbeat/tests/system/config/mockbeat.yml.j2
@@ -71,6 +71,8 @@ setup.template:
   settings:
     index.number_of_shards: 1
     index.codec: best_compression
+  append_fields: {{ append_fields_list }}
+  external_fields: {{ external_fields_files }}
   name: {{ es_template_name }}
   pattern: {{ es_template_pattern }}
   overwrite: {{ template_overwrite|default("false") }}

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -1587,6 +1587,10 @@ output.elasticsearch:
 #- name: field_name
 #  type: field_type
 
+# List of external fields.yml files to load.
+#setup.template.external_fields:
+#- /path/to/external/fields.yml
+
 # Enable JSON template loading. If this is enabled, the fields.yml is ignored.
 #setup.template.json.enabled: false
 

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -1347,6 +1347,10 @@ output.elasticsearch:
 #- name: field_name
 #  type: field_type
 
+# List of external fields.yml files to load.
+#setup.template.external_fields:
+#- /path/to/external/fields.yml
+
 # Enable JSON template loading. If this is enabled, the fields.yml is ignored.
 #setup.template.json.enabled: false
 

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -896,6 +896,10 @@ output.elasticsearch:
 #- name: field_name
 #  type: field_type
 
+# List of external fields.yml files to load.
+#setup.template.external_fields:
+#- /path/to/external/fields.yml
+
 # Enable JSON template loading. If this is enabled, the fields.yml is ignored.
 #setup.template.json.enabled: false
 

--- a/x-pack/auditbeat/auditbeat.reference.yml
+++ b/x-pack/auditbeat/auditbeat.reference.yml
@@ -1014,6 +1014,10 @@ output.elasticsearch:
 #- name: field_name
 #  type: field_type
 
+# List of external fields.yml files to load.
+#setup.template.external_fields:
+#- /path/to/external/fields.yml
+
 # Enable JSON template loading. If this is enabled, the fields.yml is ignored.
 #setup.template.json.enabled: false
 

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -1769,6 +1769,10 @@ output.elasticsearch:
 #- name: field_name
 #  type: field_type
 
+# List of external fields.yml files to load.
+#setup.template.external_fields:
+#- /path/to/external/fields.yml
+
 # Enable JSON template loading. If this is enabled, the fields.yml is ignored.
 #setup.template.json.enabled: false
 

--- a/x-pack/functionbeat/functionbeat.reference.yml
+++ b/x-pack/functionbeat/functionbeat.reference.yml
@@ -1012,6 +1012,10 @@ output.elasticsearch:
 #- name: field_name
 #  type: field_type
 
+# List of external fields.yml files to load.
+#setup.template.external_fields:
+#- /path/to/external/fields.yml
+
 # Enable JSON template loading. If this is enabled, the fields.yml is ignored.
 #setup.template.json.enabled: false
 

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -1616,6 +1616,10 @@ output.elasticsearch:
 #- name: field_name
 #  type: field_type
 
+# List of external fields.yml files to load.
+#setup.template.external_fields:
+#- /path/to/external/fields.yml
+
 # Enable JSON template loading. If this is enabled, the fields.yml is ignored.
 #setup.template.json.enabled: false
 


### PR DESCRIPTION
A new option `external_fields` is added to `setup.template` to let users specify their own fields.yml files in addition to the default fields or the one configured in `setup.template.fields`.

```yaml
# List of external fields.yml files to load.
#setup.template.external_fields:
#- /path/to/external/fields.yml
```

Previously, fields collection from fields and configuration was done in multiple places in the codebase. This lead to inconsistencies when loading the template when loading dashboards. This PR moves the process to a single place. It still contains a few hacks, as I do not want to introduce any breaking change in the configuration.

The ideal configuration would be the following:

```yaml
setup.fields.file: /path/to/fields.yml
setup.fields.append:
- name: field_name
  type: field_type
setup.fields.external_fields:
- /path/to/external/fields.yml
```
This could be used when loading the template and dashboards.

I compromised to add the new option to `setup.template`, as fields settings are required by the template. I introduced a new `asset.Supporter` which collect fields from the configuration in `setup.template`. This supporter is able to pass the correct fields list to both template loading and dashboard loading. I moved adding extra fields in `append_fields` from template loading, so these fields are not missing when dashboards are loaded.

Loading JSON templates correctly when loading template and dashboards is not in the scope of this PR.

### New `fields.yml` loading process

Loading of fields is changed to the following process.
1. Collect fields from either the default fields.yml files provided by the Beat or get the fields from `setup.template.fields`
2. User defined fields are gathered from the fields.yml files from `setup.template.external_fields`.
3. More fields are added to these fields which is configured in `setup.template.append_fields`.

### Fixes

From now on it is possible to load custom template into ES when loading dashboards. It means that users can load their own dashboards with user defined fields using a Beat.

### TODO

- [x] add configuration option to reference
- [ ] add E2E test cases

Depends on #11198 