### PR TITLE
Use different monitoring bulk API paths depending on ES version

### DIFF
--- a/libbeat/monitoring/report/elasticsearch/client.go
+++ b/libbeat/monitoring/report/elasticsearch/client.go
@@ -135,8 +135,7 @@ func (c *publishClient) Publish(batch publisher.Batch) error {
 
 		// Currently one request per event is sent. Reason is that each event can contain different
 		// interval params and X-Pack requires to send the interval param.
-		esVersion := c.es.GetVersion()
-		_, err = c.es.MonitoringBulkWith(esVersion, params, bulk[:])
+		_, err = c.es.SendMonitoringBulk(params, bulk[:])
 
 		if err != nil {
 			failed = append(failed, event)

--- a/libbeat/monitoring/report/elasticsearch/client.go
+++ b/libbeat/monitoring/report/elasticsearch/client.go
@@ -135,7 +135,12 @@ func (c *publishClient) Publish(batch publisher.Batch) error {
 
 		// Currently one request per event is sent. Reason is that each event can contain different
 		// interval params and X-Pack requires to send the interval param.
-		_, err = c.es.BulkWith("_xpack", "monitoring", params, nil, bulk[:])
+		if c.es.GetVersion().Major < 7 {
+			_, err = c.es.BulkWith("_xpack", "monitoring", params, nil, bulk[:])
+		} else {
+			_, err = c.es.MonitoringBulkWith(params, bulk[:])
+		}
+
 		if err != nil {
 			failed = append(failed, event)
 			reason = err

--- a/libbeat/monitoring/report/elasticsearch/client.go
+++ b/libbeat/monitoring/report/elasticsearch/client.go
@@ -135,11 +135,8 @@ func (c *publishClient) Publish(batch publisher.Batch) error {
 
 		// Currently one request per event is sent. Reason is that each event can contain different
 		// interval params and X-Pack requires to send the interval param.
-		if c.es.GetVersion().Major < 7 {
-			_, err = c.es.BulkWith("_xpack", "monitoring", params, nil, bulk[:])
-		} else {
-			_, err = c.es.MonitoringBulkWith(params, bulk[:])
-		}
+		esVersion := c.es.GetVersion()
+		_, err = c.es.MonitoringBulkWith(esVersion, params, bulk[:])
 
 		if err != nil {
 			failed = append(failed, event)

--- a/libbeat/outputs/elasticsearch/bulkapi.go
+++ b/libbeat/outputs/elasticsearch/bulkapi.go
@@ -79,11 +79,10 @@ func (conn *Connection) BulkWith(
 	return readQueryResult(result.raw)
 }
 
-// MonitoringBulkWith creates a HTTP request to the X-Pack Monitoring API containing a bunch of
+// SendMonitoringBulk creates a HTTP request to the X-Pack Monitoring API containing a bunch of
 // operations and sends them to Elasticsearch. The request is retransmitted up to max_retries
 // before returning an error.
-func (conn *Connection) MonitoringBulkWith(
-	esVersion common.Version,
+func (conn *Connection) SendMonitoringBulk(
 	params map[string]string,
 	body []interface{},
 ) (*QueryResult, error) {
@@ -97,7 +96,13 @@ func (conn *Connection) MonitoringBulkWith(
 		return nil, err
 	}
 
-	requ, err := newMonitoringBulkRequest(esVersion, conn.URL, params, enc)
+	if !conn.version.IsValid() {
+		if err := conn.Connect(); err != nil {
+			return nil, err
+		}
+	}
+
+	requ, err := newMonitoringBulkRequest(conn.version, conn.URL, params, enc)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Resolves #9480.

Starting Elasticsearch 7.0.0, Beats should ship their monitoring data to the `_monitoring/bulk` Elasticsearch API endpoint. Prior to 7.0.0, `_xpack/monitoring/_bulk` should be used. This PR implements this version-based conditional logic.

I used Wireshark to look at the ES API endpoints being hit.

Running this PR with ES 8.0.0 or ES 7.0.0, I confirmed that the `POST _monitoring/bulk` endpoint was being hit:

<img width="1436" alt="Screen Shot 2019-03-14 at 10 55 52 AM" src="https://user-images.githubusercontent.com/51061/54380101-ed567780-4647-11e9-8ed1-9b9020bb85d4.png">

And running this PR with ES 6.7.0, I confirmed that the `POST _xpack/monitoring/_bulk` endpoint was being hit:

<img width="1437" alt="Screen Shot 2019-03-14 at 10 56 42 AM" src="https://user-images.githubusercontent.com/51061/54380094-eaf41d80-4647-11e9-8658-d9a6ba14541b.png">
