### PR TITLE
Enable default fields for Elasticsearch 6.x

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -17,6 +17,7 @@ https://github.com/elastic/beats/compare/v6.6.0...6.x[Check the HEAD diff]
 - Update the code of Central Management to align with the new returned format. {pull}10019[10019]
 - Allow Central Management to send events back to kibana. {issue}9382[9382]
 - Fix panic if fields settting is used to configure `hosts.x` fields. {issue}10824[10824] {pull}10935[10935]
+- Introduce query.default_field as part of the template. {pull}11205[11205]
 
 *Auditbeat*
 

--- a/libbeat/template/template.go
+++ b/libbeat/template/template.go
@@ -277,7 +277,7 @@ func buildIdxSettings(ver common.Version, userSettings common.MapStr) common.Map
 		indexSettings.Put("number_of_routing_shards", defaultNumberOfRoutingShards)
 	}
 
-	if ver.Major >= 7 {
+	if ver.Major >= 6 {
 		// copy defaultFields, as defaultFields is shared global slice.
 		fields := make([]string, len(defaultFields))
 		copy(fields, defaultFields)

--- a/libbeat/template/template.go
+++ b/libbeat/template/template.go
@@ -277,7 +277,8 @@ func buildIdxSettings(ver common.Version, userSettings common.MapStr) common.Map
 		indexSettings.Put("number_of_routing_shards", defaultNumberOfRoutingShards)
 	}
 
-	if ver.Major >= 6 {
+	// 6.0 is excluded because it did not support an array for query.default_field
+	if ver.Major >= 6 && !(ver.Major == 6 && ver.Minor == 0) {
 		// copy defaultFields, as defaultFields is shared global slice.
 		fields := make([]string, len(defaultFields))
 		copy(fields, defaultFields)


### PR DESCRIPTION
Previously default_fields were only enabled for Elasticsearch 7.x. For the migration it is required that also indices from Elasticsearch 6.x have the default_field option set. This enables it for 6.x.

Closes https://github.com/elastic/beats/issues/11187