### PR TITLE
Connect underlying ES client so ES version is set

### DIFF
--- a/libbeat/monitoring/report/elasticsearch/client.go
+++ b/libbeat/monitoring/report/elasticsearch/client.go
@@ -21,6 +21,8 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/pkg/errors"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/monitoring/report"
@@ -47,6 +49,11 @@ func newPublishClient(
 
 func (c *publishClient) Connect() error {
 	debugf("Monitoring client: connect.")
+
+	err := c.es.Connect()
+	if err != nil {
+		return errors.Wrap(err, "cannot connect underlying Elasticsearch client")
+	}
 
 	params := map[string]string{
 		"filter_path": "features.monitoring.enabled",


### PR DESCRIPTION
Currently, if X-Pack Monitoring is setup for a Beat, the Elasticsearch monitoring code in libbeat tries to make a decision based on the Elasticsearch version over here: https://github.com/elastic/beats/blob/821baec2411eb070cc32bad3b01b87f1178ed220/libbeat/monitoring/report/elasticsearch/client.go#L120

However, it turns out that the Elasticsearch client (`c.es`) never initializes its version properly. As a result, `c.es.GetVersion().Major` will always return `0` (the zero-value for an `int`).

---

The reason for this is that the Monitoring Elasticsearch client's `Connect()` method does not attempt to determine the Elasticsearch cluster's version:

https://github.com/elastic/beats/blob/821baec2411eb070cc32bad3b01b87f1178ed220/libbeat/monitoring/report/elasticsearch/client.go#L48-L81

However, if you look at the Output Elasticsearch client's `Connect()` method, it _does_ attempt to determine the Elasticsearch cluster's version:

https://github.com/elastic/beats/blob/821baec2411eb070cc32bad3b01b87f1178ed220/libbeat/outputs/elasticsearch/client.go#L675-L696

Additionally, it also calls any configured connection callbacks.

---

Since the Monitoring Elasticsearch client is based on the Output Elasticsearch client, this PR makes it so that the first thing the Monitoring Elasticsearch client's `Connect()` method does is call the underlying Output Elasticsearch client's `Connect()` method. That way the base Output Elasticsearch client can perform any generic connection-related duties before the Monitoring Elasticsearch client performs any Monitoring-specific ones.

Resolves #11204 