### PR TITLE
Always send _type to Monitoring Bulk API

### DIFF
--- a/libbeat/monitoring/report/elasticsearch/client.go
+++ b/libbeat/monitoring/report/elasticsearch/client.go
@@ -116,9 +116,7 @@ func (c *publishClient) Publish(batch publisher.Batch) error {
 		meta := common.MapStr{
 			"_index":   "",
 			"_routing": nil,
-		}
-		if c.es.GetVersion().Major < 7 {
-			meta["_type"] = t
+			"_type":    t,
 		}
 		bulk := [2]interface{}{
 			common.MapStr{"index": meta},


### PR DESCRIPTION
The Monitoring Bulk API (`POST _xpack/monitoring/_bulk`) does not interpret `_type` in the bulk metadata the same was as the regular Bulk API (`POST _bulk`). In the case of the Monitoring Bulk API, `_type` has a special meaning. It does not correspond to the Elasticsearch document `_type` but rather a `type` field within monitoring documents. The `_type` of those monitoring documents gets automatically set to `_doc` by the Monitoring Bulk API.

Therefore, the Beats monitoring code should always send `_type` to the Monitoring Bulk API.