### PR TITLE
[Metricbeat] fix default config for mysql tests

### DIFF
--- a/metricbeat/module/mysql/testing.go
+++ b/metricbeat/module/mysql/testing.go
@@ -32,11 +32,11 @@ func GetMySQLEnvDSN() string {
 	dsn := os.Getenv("MYSQL_DSN")
 
 	if len(dsn) == 0 {
-		c := &mysql.Config{
-			Net:  "tcp",
-			Addr: "127.0.0.1:3306",
-			User: "root",
-		}
+		c := mysql.NewConfig()
+		c.Net = "tcp"
+		c.Addr = "127.0.0.1:3306"
+		c.User = "root"
+		c.Passwd = "test"
 		dsn = c.FormatDSN()
 	}
 	return dsn


### PR DESCRIPTION
This fixes an issue I discussed in slack with @ruflin . Namely, if you run the mysql integration tests on a host environment via `go test -tags=integration`, it throws an error:

```
=== RUN   TestFetchRaw
[mysql] 2019/03/12 11:50:11 driver.go:123: could not use requested auth plugin 'mysql_native_password': this user requires mysql native password authentication.
```

This is due to how we set the mysql config object when `MYSQL_DSN` isn't set via `docker-compose` 


Most other integration tests hard-code ports/hostnames in cases where a given env var isn't set, so what I've done seems fairly standard, but if anyone objects, please tell me and I can get more clever. Only other thing of note is the use of `mysql.NewConfig()` which seems to be the "preferred" way of creating a new mysql config.