### PR TITLE
[Auditbeat] Process dataset: Only report processes with executable

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -46,6 +46,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Rename user fields to ECS in auditd module. {pull}10456[10456]
 - Rename `event.type` to `auditd.message_type` in auditd module because event.type is reserved for future use by ECS. {pull}10536[10536]
 - Rename `auditd.messages` to `event.original` and `auditd.warnings` to `error.message`. {pull}10577[10577]
+- Process dataset: Only report processes with executable.
 
 *Filebeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -46,7 +46,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Rename user fields to ECS in auditd module. {pull}10456[10456]
 - Rename `event.type` to `auditd.message_type` in auditd module because event.type is reserved for future use by ECS. {pull}10536[10536]
 - Rename `auditd.messages` to `event.original` and `auditd.warnings` to `error.message`. {pull}10577[10577]
-- Process dataset: Only report processes with executable.
+- Process dataset: Only report processes with executable. {pull}11232[11232]
 
 *Filebeat*
 


### PR DESCRIPTION
The `process` dataset currently reports a lot of kernel processes on Linux, e.g. `kworker/2:0`, `kworker/2:1`, `kworker/3:1`, `cpuhp/1`.

I think we should exclude those. They don't provide a lot of value, the names are not unique, and they will not be able to use potential future features like process executable hashes.