### PR TITLE
Add missing docs for filebeat.registry.migrate_file

### DIFF
--- a/filebeat/_meta/common.reference.p2.yml
+++ b/filebeat/_meta/common.reference.p2.yml
@@ -32,6 +32,14 @@
 # batch of events has been published successfully. The default value is 0s.
 #filebeat.registry.flush: 0s
 
+
+# The new registry format uses a directory to store the filebeat state.
+# Filebeat will automatically migrate a 6.x registry file to the new format on startup.
+# The filebeat.registry.migrate_file setting can be used to point filebeat to the
+# location of the old registry file, in case filebeat.registry.path has been
+# changed when upgrading filebeat.
+#filebeat.registry.migrate_file: ${path.data}/registry
+
 # By default Ingest pipelines are not updated if a pipeline with the same ID
 # already exists. If this option is enabled Filebeat overwrites pipelines
 # everytime a new Elasticsearch connection is established.

--- a/filebeat/_meta/common.reference.p2.yml
+++ b/filebeat/_meta/common.reference.p2.yml
@@ -33,11 +33,11 @@
 #filebeat.registry.flush: 0s
 
 
-# The new registry format uses a directory to store the filebeat state.
-# Filebeat will automatically migrate a 6.x registry file to the new format on startup.
-# The filebeat.registry.migrate_file setting can be used to point filebeat to the
-# location of the old registry file, in case filebeat.registry.path has been
-# changed when upgrading filebeat.
+# Starting with Filebeat 7.0, the registry uses a new directory format to store
+# Filebeat state. After you upgrade, Filebeat will automatically migrate a 6.x
+# registry file to use the new directory format. If you changed
+# filebeat.registry.path while upgrading, set filebeat.registry.migrate_file to
+# point to the old registry file.
 #filebeat.registry.migrate_file: ${path.data}/registry
 
 # By default Ingest pipelines are not updated if a pipeline with the same ID

--- a/filebeat/docs/filebeat-general-options.asciidoc
+++ b/filebeat/docs/filebeat-general-options.asciidoc
@@ -88,8 +88,8 @@ filebeat.registry.path: ${path.data}/registry
 filebeat.registry.migrate_file: /path/to/old/registry_file
 -------------------------------------------------------------------------------------
 
-Filebeat will use `filebeat.registry.migrate_file` only if the regisry does not
-exist yet.
+The file will be moved to it's new location only if the new registry using the
+directory format does not exist.
 
 
 [float]

--- a/filebeat/docs/filebeat-general-options.asciidoc
+++ b/filebeat/docs/filebeat-general-options.asciidoc
@@ -76,13 +76,11 @@ helping Filebeat process more events.
 [float]
 ==== `registry.migrate_file`
 
-Prior to Filebeat 7.0 the registry is stored in one file only. On startup
-Filebeat will automatically migrate the old Filebeat 6.x registry file to the 
-new directory based registry.
-
-By default the file location to migrate from is
-assumed to be given by `filebeat.registry.path`, but in case the path has been
-changed when upgrading one can use `filebeat.registry.migrate_file`.
+Prior to Filebeat 7.0 the registry is stored in a singe file. When you upgrade
+to 7.0, Filebeat will automatically migrate the old Filebeat 6.x registry file
+to use the new directory format. Filebeat looks for the file in the location
+specified by `filebeat.registry.path`. If you changed the path while upgrading,
+set `filebeat.registry.migrate_file` to point to the old registry file.
 
 [source,yaml]
 -------------------------------------------------------------------------------------

--- a/filebeat/docs/filebeat-general-options.asciidoc
+++ b/filebeat/docs/filebeat-general-options.asciidoc
@@ -76,7 +76,7 @@ helping Filebeat process more events.
 [float]
 ==== `registry.migrate_file`
 
-Prior to Filebeat 7.0 the registry is stored in a singe file. When you upgrade
+Prior to Filebeat 7.0 the registry is stored in a single file. When you upgrade
 to 7.0, Filebeat will automatically migrate the old Filebeat 6.x registry file
 to use the new directory format. Filebeat looks for the file in the location
 specified by `filebeat.registry.path`. If you changed the path while upgrading,
@@ -88,8 +88,8 @@ filebeat.registry.path: ${path.data}/registry
 filebeat.registry.migrate_file: /path/to/old/registry_file
 -------------------------------------------------------------------------------------
 
-The file will be moved to it's new location only if the new registry using the
-directory format does not exist.
+The registry will be migrated to the new location only if a registry using the
+directory format does not already exist.
 
 
 [float]

--- a/filebeat/docs/filebeat-general-options.asciidoc
+++ b/filebeat/docs/filebeat-general-options.asciidoc
@@ -73,6 +73,26 @@ NOTE: Filtering out a huge number of logs can cause many registry updates, slowi
 down processing. Setting `registry.flush` to a value >0s reduces write operations,
 helping Filebeat process more events.
 
+[float]
+==== `registry.migrate_file`
+
+Prior to Filebeat 7.0 the registry is stored in one file only. On startup
+Filebeat will automatically migrate the old Filebeat 6.x registry file to the 
+new directory based registry.
+
+By default the file location to migrate from is
+assumed to be given by `filebeat.registry.path`, but in case the path has been
+changed when upgrading one can use `filebeat.registry.migrate_file`.
+
+[source,yaml]
+-------------------------------------------------------------------------------------
+filebeat.registry.path: ${path.data}/registry
+filebeat.registry.migrate_file: /path/to/old/registry_file
+-------------------------------------------------------------------------------------
+
+Filebeat will use `filebeat.registry.migrate_file` only if the regisry does not
+exist yet.
+
 
 [float]
 ==== `config_dir`

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -801,11 +801,11 @@ filebeat.inputs:
 #filebeat.registry.flush: 0s
 
 
-# The new registry format uses a directory to store the filebeat state.
-# Filebeat will automatically migrate a 6.x registry file to the new format on startup.
-# The filebeat.registry.migrate_file setting can be used to point filebeat to the
-# location of the old registry file, in case filebeat.registry.path has been
-# changed when upgrading filebeat.
+# Starting with Filebeat 7.0, the registry uses a new directory format to store
+# Filebeat state. After you upgrade, Filebeat will automatically migrate a 6.x
+# registry file to use the new directory format. If you changed
+# filebeat.registry.path while upgrading, set filebeat.registry.migrate_file to
+# point to the old registry file.
 #filebeat.registry.migrate_file: ${path.data}/registry
 
 # By default Ingest pipelines are not updated if a pipeline with the same ID

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -800,6 +800,14 @@ filebeat.inputs:
 # batch of events has been published successfully. The default value is 0s.
 #filebeat.registry.flush: 0s
 
+
+# The new registry format uses a directory to store the filebeat state.
+# Filebeat will automatically migrate a 6.x registry file to the new format on startup.
+# The filebeat.registry.migrate_file setting can be used to point filebeat to the
+# location of the old registry file, in case filebeat.registry.path has been
+# changed when upgrading filebeat.
+#filebeat.registry.migrate_file: ${path.data}/registry
+
 # By default Ingest pipelines are not updated if a pipeline with the same ID
 # already exists. If this option is enabled Filebeat overwrites pipelines
 # everytime a new Elasticsearch connection is established.

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -879,6 +879,14 @@ filebeat.inputs:
 # batch of events has been published successfully. The default value is 0s.
 #filebeat.registry.flush: 0s
 
+
+# The new registry format uses a directory to store the filebeat state.
+# Filebeat will automatically migrate a 6.x registry file to the new format on startup.
+# The filebeat.registry.migrate_file setting can be used to point filebeat to the
+# location of the old registry file, in case filebeat.registry.path has been
+# changed when upgrading filebeat.
+#filebeat.registry.migrate_file: ${path.data}/registry
+
 # By default Ingest pipelines are not updated if a pipeline with the same ID
 # already exists. If this option is enabled Filebeat overwrites pipelines
 # everytime a new Elasticsearch connection is established.

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -880,11 +880,11 @@ filebeat.inputs:
 #filebeat.registry.flush: 0s
 
 
-# The new registry format uses a directory to store the filebeat state.
-# Filebeat will automatically migrate a 6.x registry file to the new format on startup.
-# The filebeat.registry.migrate_file setting can be used to point filebeat to the
-# location of the old registry file, in case filebeat.registry.path has been
-# changed when upgrading filebeat.
+# Starting with Filebeat 7.0, the registry uses a new directory format to store
+# Filebeat state. After you upgrade, Filebeat will automatically migrate a 6.x
+# registry file to use the new directory format. If you changed
+# filebeat.registry.path while upgrading, set filebeat.registry.migrate_file to
+# point to the old registry file.
 #filebeat.registry.migrate_file: ${path.data}/registry
 
 # By default Ingest pipelines are not updated if a pipeline with the same ID


### PR DESCRIPTION
The `filebeat.registry.migrate_file` has been introduced with 7.0. I just noticed that the doc is still missing.