### PR TITLE
Cherry-pick #10905 to 6.7: Add cleanup_timeout option to docker autodiscover

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -18,7 +18,6 @@ https://github.com/elastic/beats/compare/v6.6.0...6.x[Check the HEAD diff]
 - Allow Central Management to send events back to kibana. {issue}9382[9382]
 - Fix panic if fields settting is used to configure `hosts.x` fields. {issue}10824[10824] {pull}10935[10935]
 - Introduce query.default_field as part of the template. {pull}11205[11205]
-- Add `cleanup_timeout` option to docker autodiscover, to wait some time before removing configurations after a container is stopped. {issue]10374[10374] {pull}10905[10905]
 
 *Auditbeat*
 
@@ -173,6 +172,7 @@ https://github.com/elastic/beats/compare/v6.6.0...6.x[Check the HEAD diff]
 - Always include Pod UID as part of Pod metadata. {pull]9517[9517]
 - Release Jolokia autodiscover as GA. {pull}9706[9706]
 - Add ip fields to default_field in Elasticsearch template. {pull}11035[11035]
+- Add `cleanup_timeout` option to docker autodiscover, to wait some time before removing configurations after a container is stopped. {issue]10374[10374] {pull}10905[10905]
 
 *Auditbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -18,6 +18,7 @@ https://github.com/elastic/beats/compare/v6.6.0...6.x[Check the HEAD diff]
 - Allow Central Management to send events back to kibana. {issue}9382[9382]
 - Fix panic if fields settting is used to configure `hosts.x` fields. {issue}10824[10824] {pull}10935[10935]
 - Introduce query.default_field as part of the template. {pull}11205[11205]
+- Add `cleanup_timeout` option to docker autodiscover, to wait some time before removing configurations after a container is stopped. {issue]10374[10374] {pull}10905[10905]
 
 *Auditbeat*
 

--- a/filebeat/tests/system/test_autodiscover.py
+++ b/filebeat/tests/system/test_autodiscover.py
@@ -23,6 +23,7 @@ class TestAutodiscover(filebeat.BaseTest):
             inputs=False,
             autodiscover={
                 'docker': {
+                    'cleanup_timeout': '0s',
                     'templates': '''
                       - condition:
                           equals.docker.container.image: busybox

--- a/libbeat/autodiscover/providers/docker/config.go
+++ b/libbeat/autodiscover/providers/docker/config.go
@@ -18,6 +18,8 @@
 package docker
 
 import (
+	"time"
+
 	"github.com/elastic/beats/libbeat/autodiscover/template"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/docker"
@@ -25,14 +27,15 @@ import (
 
 // Config for docker autodiscover provider
 type Config struct {
-	Host         string                  `config:"host"`
-	TLS          *docker.TLSConfig       `config:"ssl"`
-	Prefix       string                  `config:"prefix"`
-	HintsEnabled bool                    `config:"hints.enabled"`
-	Builders     []*common.Config        `config:"builders"`
-	Appenders    []*common.Config        `config:"appenders"`
-	Templates    template.MapperSettings `config:"templates"`
-	Dedot        bool                    `config:"labels.dedot"`
+	Host           string                  `config:"host"`
+	TLS            *docker.TLSConfig       `config:"ssl"`
+	Prefix         string                  `config:"prefix"`
+	HintsEnabled   bool                    `config:"hints.enabled"`
+	Builders       []*common.Config        `config:"builders"`
+	Appenders      []*common.Config        `config:"appenders"`
+	Templates      template.MapperSettings `config:"templates"`
+	Dedot          bool                    `config:"labels.dedot"`
+	CleanupTimeout time.Duration           `config:"cleanup_timeout"`
 }
 
 func defaultConfig() *Config {

--- a/libbeat/autodiscover/providers/docker/docker.go
+++ b/libbeat/autodiscover/providers/docker/docker.go
@@ -19,6 +19,7 @@ package docker
 
 import (
 	"errors"
+	"time"
 
 	"github.com/gofrs/uuid"
 
@@ -115,7 +116,9 @@ func (d *Provider) Start() {
 				d.emitContainer(event, "start")
 
 			case event := <-d.stopListener.Events():
-				d.emitContainer(event, "stop")
+				time.AfterFunc(d.config.CleanupTimeout, func() {
+					d.emitContainer(event, "stop")
+				})
 			}
 		}
 	}()

--- a/libbeat/autodiscover/providers/docker/docker_integration_test.go
+++ b/libbeat/autodiscover/providers/docker/docker_integration_test.go
@@ -43,8 +43,9 @@ func TestDockerStart(t *testing.T) {
 		t.Fatal(err)
 	}
 	bus := bus.New("test")
-	config := common.NewConfig()
-	provider, err := AutodiscoverBuilder(bus, UUID, config)
+	config := defaultConfig()
+	config.CleanupTimeout = 0
+	provider, err := AutodiscoverBuilder(bus, UUID, common.MustNewConfigFrom(config))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/metricbeat/tests/system/test_autodiscover.py
+++ b/metricbeat/tests/system/test_autodiscover.py
@@ -23,6 +23,7 @@ class TestAutodiscover(metricbeat.BaseTest):
         self.render_config_template(
             autodiscover={
                 'docker': {
+                    'cleanup_timeout': '0s',
                     'templates': '''
                       - condition:
                           equals.docker.container.image: memcached:latest
@@ -69,6 +70,7 @@ class TestAutodiscover(metricbeat.BaseTest):
         self.render_config_template(
             autodiscover={
                 'docker': {
+                    'cleanup_timeout': '0s',
                     'hints.enabled': 'true',
                 },
             },
@@ -111,6 +113,7 @@ class TestAutodiscover(metricbeat.BaseTest):
         self.render_config_template(
             autodiscover={
                 'docker': {
+                    'cleanup_timeout': '0s',
                     'hints.enabled': 'true',
                     'appenders': '''
                       - type: config


### PR DESCRIPTION
Cherry-pick of PR #10905 to 6.7 branch. Original message: 

`cleanup_timeout` is used in kubernetes autodiscover to wait some time before the
configurations associated to stopped containers are removed. Add an equivalent
option to docker autodiscover.

Disabled by default in 6.7.

Fix elastic/beats#10374