### PR TITLE
Update ingest pipelines to use event.timezone

### DIFF
--- a/filebeat/fileset/fileset_test.go
+++ b/filebeat/fileset/fileset_test.go
@@ -269,9 +269,9 @@ func TestGetPipelineConvertTS(t *testing.T) {
 			marshaled, err := json.Marshal(pipeline.contents)
 			require.NoError(t, err)
 			if cfg.Timezone {
-				assert.Contains(t, string(marshaled), "beat.timezone")
+				assert.Contains(t, string(marshaled), "event.timezone")
 			} else {
-				assert.NotContains(t, string(marshaled), "beat.timezone")
+				assert.NotContains(t, string(marshaled), "event.timezone")
 			}
 		})
 	}

--- a/filebeat/module/kafka/log/ingest/pipeline.json
+++ b/filebeat/module/kafka/log/ingest/pipeline.json
@@ -62,7 +62,7 @@
         "field": "kafka.log.timestamp",
         "target_field": "@timestamp",
         "formats": ["yyyy-MM-dd HH:mm:ss,SSS"],
-        {< if .convert_timezone >}"timezone": "{{ beat.timezone }}",{< end >}
+        {< if .convert_timezone >}"timezone": "{{ event.timezone }}",{< end >}
         "ignore_failure": true
       }
     },

--- a/filebeat/module/system/auth/ingest/pipeline.json
+++ b/filebeat/module/system/auth/ingest/pipeline.json
@@ -46,7 +46,7 @@
                     "MMM  d HH:mm:ss",
                     "MMM dd HH:mm:ss"
                 ],
-                {< if .convert_timezone >}"timezone": "{{ beat.timezone }}",{< end >}
+                {< if .convert_timezone >}"timezone": "{{ event.timezone }}",{< end >}
                 "ignore_failure": true
             }
         },

--- a/filebeat/module/system/syslog/ingest/pipeline.json
+++ b/filebeat/module/system/syslog/ingest/pipeline.json
@@ -36,7 +36,7 @@
                     "MMM dd HH:mm:ss",
                     "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZZ"
                 ],
-                {< if .convert_timezone >}"timezone": "{{ beat.timezone }}",{< end >}
+                {< if .convert_timezone >}"timezone": "{{ event.timezone }}",{< end >}
                 "ignore_failure": true
             }
         },

--- a/x-pack/filebeat/module/iptables/log/ingest/pipeline.json
+++ b/x-pack/filebeat/module/iptables/log/ingest/pipeline.json
@@ -64,7 +64,7 @@
                 "date": {
                     "field": "iptables.raw_date",
                     "ignore_failure": true,
-                    {< if .convert_timezone >}"timezone": "{{ beat.timezone }}",{< end >}
+                    {< if .convert_timezone >}"timezone": "{{ event.timezone }}",{< end >}
                     "formats": [
                         "MMM  d HH:mm:ss",
                         "MMM dd HH:mm:ss"


### PR DESCRIPTION
Previously, `beats.timezone` was used, in 7.0+ it's not available anymore. However, some ingest pipelines were still using it.