### PR TITLE
[Auditbeat] Cherry-pick #11232 to 7.0: Process dataset: Only report processes with executable

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -16,6 +16,8 @@ https://github.com/elastic/beats/compare/v7.0.0-beta1...master[Check the HEAD di
 
 *Auditbeat*
 
+- Process dataset: Only report processes with executable. {pull}11232[11232]
+
 *Filebeat*
 
 - Set `ecs: true` in user_agent processors when loading pipelines with Filebeat 7.0.x into Elasticsearch 6.7.x. {issue}10655[10655] {pull}10875[10875]

--- a/x-pack/auditbeat/module/system/process/process.go
+++ b/x-pack/auditbeat/module/system/process/process.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"os/user"
+	"runtime"
 	"strconv"
 	"time"
 
@@ -420,6 +421,11 @@ func (ms *MetricSet) getProcesses() ([]*Process, error) {
 			if err == nil {
 				process.Group = group
 			}
+		}
+
+		// Exclude Linux kernel processes, they are not very interesting.
+		if runtime.GOOS == "linux" && userInfo.UID == "0" && process.Info.Exe == "" {
+			continue
 		}
 
 		processes = append(processes, process)


### PR DESCRIPTION
Cherry-pick of PR #11232 to 7.0 branch. Original message: 

The `process` dataset currently reports a lot of kernel processes on Linux, e.g. `kworker/2:0`, `kworker/2:1`, `kworker/3:1`, `cpuhp/1`.

I think we should exclude those. They don't provide a lot of value, the names are not unique, and they will not be able to use potential future features like process executable hashes.