### PR TITLE
Add ability to use existing processors from script processor

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -256,7 +256,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add output test to kafka output {pull}10834[10834]
 - Add ip fields to default_field in Elasticsearch template. {pull}11035[11035]
 - Gracefully shut down on SIGHUP {pull}10704[10704]
-- Add `script` processor that supports using Javascript to process events. {pull}10850[10850]
+- Add `script` processor that supports using Javascript to process events. {pull}10850[10850] {pull}11260[11260]
 
 *Auditbeat*
 

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -505,6 +505,26 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER I
 OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 --------------------------------------------------------------------
+Dependency: github.com/dop251/goja_nodejs
+Revision: adff31b136e6b7e044712aab7236a775e1bd085e
+License type (autodetected): MIT
+./vendor/github.com/dop251/goja_nodejs/LICENSE:
+--------------------------------------------------------------------
+Copyright (c) 2016 Dmitry Panov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+--------------------------------------------------------------------
 Dependency: github.com/dustin/go-humanize
 Revision: 259d2a102b871d17f30e3cd9881a642961a1e486
 License type (autodetected): MIT

--- a/libbeat/processors/actions/decode_json_fields.go
+++ b/libbeat/processors/actions/decode_json_fields.go
@@ -58,12 +58,13 @@ var debug = logp.MakeDebug("filters")
 
 func init() {
 	processors.RegisterPlugin("decode_json_fields",
-		configChecked(newDecodeJSONFields,
+		configChecked(NewDecodeJSONFields,
 			requireFields("fields"),
 			allowedFields("fields", "max_depth", "overwrite_keys", "process_array", "target", "when")))
 }
 
-func newDecodeJSONFields(c *common.Config) (processors.Processor, error) {
+// NewDecodeJSONFields construct a new decode_json_fields processor.
+func NewDecodeJSONFields(c *common.Config) (processors.Processor, error) {
 	config := defaultConfig
 
 	err := c.Unpack(&config)

--- a/libbeat/processors/actions/decode_json_fields_test.go
+++ b/libbeat/processors/actions/decode_json_fields_test.go
@@ -202,7 +202,7 @@ func TestTargetRootOption(t *testing.T) {
 func getActualValue(t *testing.T, config *common.Config, input common.MapStr) common.MapStr {
 	logp.TestingSetup()
 
-	p, err := newDecodeJSONFields(config)
+	p, err := NewDecodeJSONFields(config)
 	if err != nil {
 		logp.Err("Error initializing decode_json_fields")
 		t.Fatal(err)

--- a/libbeat/processors/add_cloud_metadata/add_cloud_metadata.go
+++ b/libbeat/processors/add_cloud_metadata/add_cloud_metadata.go
@@ -49,7 +49,7 @@ var debugf = logp.MakeDebug("filters")
 
 // init registers the add_cloud_metadata processor.
 func init() {
-	processors.RegisterPlugin("add_cloud_metadata", newCloudMetadata)
+	processors.RegisterPlugin("add_cloud_metadata", New)
 }
 
 type schemaConv func(m map[string]interface{}) common.MapStr
@@ -299,7 +299,8 @@ func setupFetchers(c *common.Config) ([]*metadataFetcher, error) {
 	return fetchers, nil
 }
 
-func newCloudMetadata(c *common.Config) (processors.Processor, error) {
+// New constructs a new add_cloud_metadata processor.
+func New(c *common.Config) (processors.Processor, error) {
 	config := struct {
 		Timeout time.Duration `config:"timeout"` // Amount of time to wait for responses from the metadata services.
 	}{

--- a/libbeat/processors/add_cloud_metadata/provider_alibaba_cloud_test.go
+++ b/libbeat/processors/add_cloud_metadata/provider_alibaba_cloud_test.go
@@ -62,7 +62,7 @@ func TestRetrieveAlibabaCloudMetadata(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	p, err := newCloudMetadata(config)
+	p, err := New(config)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libbeat/processors/add_cloud_metadata/provider_aws_ec2_test.go
+++ b/libbeat/processors/add_cloud_metadata/provider_aws_ec2_test.go
@@ -70,7 +70,7 @@ func TestRetrieveAWSMetadata(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	p, err := newCloudMetadata(config)
+	p, err := New(config)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libbeat/processors/add_cloud_metadata/provider_azure_vm_test.go
+++ b/libbeat/processors/add_cloud_metadata/provider_azure_vm_test.go
@@ -67,7 +67,7 @@ func TestRetrieveAzureMetadata(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	p, err := newCloudMetadata(config)
+	p, err := New(config)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libbeat/processors/add_cloud_metadata/provider_digital_ocean_test.go
+++ b/libbeat/processors/add_cloud_metadata/provider_digital_ocean_test.go
@@ -101,7 +101,7 @@ func TestRetrieveDigitalOceanMetadata(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	p, err := newCloudMetadata(config)
+	p, err := New(config)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libbeat/processors/add_cloud_metadata/provider_google_gce_test.go
+++ b/libbeat/processors/add_cloud_metadata/provider_google_gce_test.go
@@ -140,7 +140,7 @@ func TestRetrieveGCEMetadata(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	p, err := newCloudMetadata(config)
+	p, err := New(config)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libbeat/processors/add_cloud_metadata/provider_openstack_nova_test.go
+++ b/libbeat/processors/add_cloud_metadata/provider_openstack_nova_test.go
@@ -66,7 +66,7 @@ func TestRetrieveOpenstackNovaMetadata(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	p, err := newCloudMetadata(config)
+	p, err := New(config)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libbeat/processors/add_cloud_metadata/provider_tencent_cloud_test.go
+++ b/libbeat/processors/add_cloud_metadata/provider_tencent_cloud_test.go
@@ -62,7 +62,7 @@ func TestRetrieveQCloudMetadata(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	p, err := newCloudMetadata(config)
+	p, err := New(config)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libbeat/processors/add_docker_metadata/add_docker_metadata.go
+++ b/libbeat/processors/add_docker_metadata/add_docker_metadata.go
@@ -48,7 +48,7 @@ const (
 var processCgroupPaths = cgroup.ProcessCgroupPaths
 
 func init() {
-	processors.RegisterPlugin(processorName, newDockerMetadataProcessor)
+	processors.RegisterPlugin(processorName, New)
 }
 
 type addDockerMetadata struct {
@@ -63,7 +63,8 @@ type addDockerMetadata struct {
 	dedot     bool          // If set to true, replace dots in labels with `_`.
 }
 
-func newDockerMetadataProcessor(cfg *common.Config) (processors.Processor, error) {
+// New constructs a new add_docker_metadata processor.
+func New(cfg *common.Config) (processors.Processor, error) {
 	return buildDockerMetadataProcessor(cfg, docker.NewWatcher)
 }
 

--- a/libbeat/processors/add_host_metadata/add_host_metadata.go
+++ b/libbeat/processors/add_host_metadata/add_host_metadata.go
@@ -36,7 +36,7 @@ import (
 )
 
 func init() {
-	processors.RegisterPlugin("add_host_metadata", newHostMetadataProcessor)
+	processors.RegisterPlugin("add_host_metadata", New)
 }
 
 type addHostMetadata struct {
@@ -53,7 +53,8 @@ const (
 	processorName = "add_host_metadata"
 )
 
-func newHostMetadataProcessor(cfg *common.Config) (processors.Processor, error) {
+// New constructs a new add_host_metadata processor.
+func New(cfg *common.Config) (processors.Processor, error) {
 	config := defaultConfig()
 	if err := cfg.Unpack(&config); err != nil {
 		return nil, errors.Wrapf(err, "fail to unpack the %v configuration", processorName)

--- a/libbeat/processors/add_host_metadata/add_host_metadata_test.go
+++ b/libbeat/processors/add_host_metadata/add_host_metadata_test.go
@@ -40,7 +40,7 @@ func TestConfigDefault(t *testing.T) {
 	testConfig, err := common.NewConfigFrom(map[string]interface{}{})
 	assert.NoError(t, err)
 
-	p, err := newHostMetadataProcessor(testConfig)
+	p, err := New(testConfig)
 	switch runtime.GOOS {
 	case "windows", "darwin", "linux":
 		assert.NoError(t, err)
@@ -83,7 +83,7 @@ func TestConfigNetInfoEnabled(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	p, err := newHostMetadataProcessor(testConfig)
+	p, err := New(testConfig)
 	switch runtime.GOOS {
 	case "windows", "darwin", "linux":
 		assert.NoError(t, err)
@@ -129,7 +129,7 @@ func TestConfigName(t *testing.T) {
 	testConfig, err := common.NewConfigFrom(config)
 	assert.NoError(t, err)
 
-	p, err := newHostMetadataProcessor(testConfig)
+	p, err := New(testConfig)
 	require.NoError(t, err)
 
 	newEvent, err := p.Run(event)
@@ -163,7 +163,7 @@ func TestConfigGeoEnabled(t *testing.T) {
 	testConfig, err := common.NewConfigFrom(config)
 	assert.NoError(t, err)
 
-	p, err := newHostMetadataProcessor(testConfig)
+	p, err := New(testConfig)
 	require.NoError(t, err)
 
 	newEvent, err := p.Run(event)
@@ -192,7 +192,7 @@ func TestPartialGeo(t *testing.T) {
 	testConfig, err := common.NewConfigFrom(config)
 	assert.NoError(t, err)
 
-	p, err := newHostMetadataProcessor(testConfig)
+	p, err := New(testConfig)
 	require.NoError(t, err)
 
 	newEvent, err := p.Run(event)
@@ -233,7 +233,7 @@ func TestGeoLocationValidation(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			_, err = newHostMetadataProcessor(conf)
+			_, err = New(conf)
 
 			if location.valid {
 				require.NoError(t, err)

--- a/libbeat/processors/add_kubernetes_metadata/kubernetes.go
+++ b/libbeat/processors/add_kubernetes_metadata/kubernetes.go
@@ -41,7 +41,7 @@ type kubernetesAnnotator struct {
 }
 
 func init() {
-	processors.RegisterPlugin("add_kubernetes_metadata", newKubernetesAnnotator)
+	processors.RegisterPlugin("add_kubernetes_metadata", New)
 
 	// Register default indexers
 	Indexing.AddIndexer(PodNameIndexerName, NewPodNameIndexer)
@@ -52,7 +52,8 @@ func init() {
 	Indexing.AddMatcher(FieldFormatMatcherName, NewFieldFormatMatcher)
 }
 
-func newKubernetesAnnotator(cfg *common.Config) (processors.Processor, error) {
+// New constructs a new add_kubernetes_metadata processor.
+func New(cfg *common.Config) (processors.Processor, error) {
 	config := defaultKubernetesAnnotatorConfig()
 
 	err := cfg.Unpack(&config)

--- a/libbeat/processors/add_locale/add_locale.go
+++ b/libbeat/processors/add_locale/add_locale.go
@@ -52,10 +52,11 @@ func (t TimezoneFormat) String() string {
 }
 
 func init() {
-	processors.RegisterPlugin("add_locale", newAddLocale)
+	processors.RegisterPlugin("add_locale", New)
 }
 
-func newAddLocale(c *common.Config) (processors.Processor, error) {
+// New constructs a new add_locale processor.
+func New(c *common.Config) (processors.Processor, error) {
 	config := struct {
 		Format string `config:"format"`
 	}{

--- a/libbeat/processors/add_locale/add_locale_test.go
+++ b/libbeat/processors/add_locale/add_locale_test.go
@@ -87,7 +87,7 @@ func TestTimezoneFormat(t *testing.T) {
 func getActualValue(t *testing.T, config *common.Config, input common.MapStr) common.MapStr {
 	logp.TestingSetup()
 
-	p, err := newAddLocale(config)
+	p, err := New(config)
 	if err != nil {
 		logp.Err("Error initializing add_locale")
 		t.Fatal(err)
@@ -102,7 +102,7 @@ func BenchmarkConstruct(b *testing.B) {
 
 	input := common.MapStr{}
 
-	p, err := newAddLocale(testConfig)
+	p, err := New(testConfig)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/libbeat/processors/add_process_metadata/add_process_metadata.go
+++ b/libbeat/processors/add_process_metadata/add_process_metadata.go
@@ -71,10 +71,11 @@ type processMetadataProvider interface {
 }
 
 func init() {
-	processors.RegisterPlugin(processorName, newProcessMetadataProcessor)
+	processors.RegisterPlugin(processorName, New)
 }
 
-func newProcessMetadataProcessor(cfg *common.Config) (processors.Processor, error) {
+// New constructs a new add_process_metadata processor.
+func New(cfg *common.Config) (processors.Processor, error) {
 	return newProcessMetadataProcessorWithProvider(cfg, &procCache)
 }
 

--- a/libbeat/processors/add_process_metadata/add_process_metadata_test.go
+++ b/libbeat/processors/add_process_metadata/add_process_metadata_test.go
@@ -430,7 +430,7 @@ func TestSelf(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	proc, err := newProcessMetadataProcessor(config)
+	proc, err := New(config)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -463,7 +463,7 @@ func TestBadProcess(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	proc, err := newProcessMetadataProcessor(config)
+	proc, err := New(config)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libbeat/processors/dissect/processor.go
+++ b/libbeat/processors/dissect/processor.go
@@ -34,10 +34,11 @@ type processor struct {
 }
 
 func init() {
-	processors.RegisterPlugin("dissect", newProcessor)
+	processors.RegisterPlugin("dissect", NewProcessor)
 }
 
-func newProcessor(c *common.Config) (processors.Processor, error) {
+// NewProcessor constructs a new dissect processor.
+func NewProcessor(c *common.Config) (processors.Processor, error) {
 	config := defaultConfig
 	err := c.Unpack(&config)
 	if err != nil {

--- a/libbeat/processors/dissect/processor_test.go
+++ b/libbeat/processors/dissect/processor_test.go
@@ -84,7 +84,7 @@ func TestProcessor(t *testing.T) {
 				return
 			}
 
-			processor, err := newProcessor(c)
+			processor, err := NewProcessor(c)
 			if !assert.NoError(t, err) {
 				return
 			}
@@ -113,7 +113,7 @@ func TestFieldDoesntExist(t *testing.T) {
 		return
 	}
 
-	processor, err := newProcessor(c)
+	processor, err := NewProcessor(c)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -163,7 +163,7 @@ func TestFieldAlreadyExist(t *testing.T) {
 				return
 			}
 
-			processor, err := newProcessor(c)
+			processor, err := NewProcessor(c)
 			if !assert.NoError(t, err) {
 				return
 			}
@@ -187,7 +187,7 @@ func TestErrorFlagging(t *testing.T) {
 			return
 		}
 
-		processor, err := newProcessor(c)
+		processor, err := NewProcessor(c)
 		if !assert.NoError(t, err) {
 			return
 		}
@@ -216,7 +216,7 @@ func TestErrorFlagging(t *testing.T) {
 			return
 		}
 
-		processor, err := newProcessor(c)
+		processor, err := NewProcessor(c)
 		if !assert.NoError(t, err) {
 			return
 		}

--- a/libbeat/processors/dns/dns.go
+++ b/libbeat/processors/dns/dns.go
@@ -39,7 +39,7 @@ const logName = "processor.dns"
 var instanceID = atomic.MakeUint32(0)
 
 func init() {
-	processors.RegisterPlugin("dns", newDNSProcessor)
+	processors.RegisterPlugin("dns", New)
 }
 
 type processor struct {
@@ -48,7 +48,8 @@ type processor struct {
 	log      *logp.Logger
 }
 
-func newDNSProcessor(cfg *common.Config) (processors.Processor, error) {
+// New constructs a new DNS processor.
+func New(cfg *common.Config) (processors.Processor, error) {
 	c := defaultConfig
 	if err := cfg.Unpack(&c); err != nil {
 		return nil, errors.Wrap(err, "fail to unpack the dns configuration")

--- a/libbeat/processors/script/javascript/beatevent_v0.go
+++ b/libbeat/processors/script/javascript/beatevent_v0.go
@@ -90,7 +90,9 @@ func (e *beatEventV0) init() {
 func (e *beatEventV0) reset(b *beat.Event) error {
 	e.inner = b
 	e.cancelled = false
-	return e.obj.Set("fields", e.vm.ToValue(e.inner.Fields))
+	e.obj.Set("_private", e)
+	e.obj.Set("fields", e.vm.ToValue(e.inner.Fields))
+	return nil
 }
 
 // Wrapped returns the wrapped beat.Event.

--- a/libbeat/processors/script/javascript/module/console/console.go
+++ b/libbeat/processors/script/javascript/module/console/console.go
@@ -1,0 +1,77 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package console
+
+import (
+	"github.com/dop251/goja"
+	"github.com/dop251/goja_nodejs/require"
+	"go.uber.org/zap"
+
+	"github.com/elastic/beats/libbeat/logp"
+
+	// Require the util module for handling the log format arguments.
+	_ "github.com/dop251/goja_nodejs/util"
+)
+
+// Console is a module that enables logging via the logp package (Beat logger).
+type Console struct {
+	runtime *goja.Runtime
+	util    *goja.Object
+	logger  *logp.Logger
+}
+
+func (c *Console) makeLogFunc(log func(...interface{})) func(call goja.FunctionCall) goja.Value {
+	return func(call goja.FunctionCall) goja.Value {
+		if format, ok := goja.AssertFunction(c.util.Get("format")); ok {
+			ret, err := format(c.util, call.Arguments...)
+			if err != nil {
+				panic(err)
+			}
+
+			log(ret.String())
+		} else {
+			panic(c.runtime.NewTypeError("util.format is not a function"))
+		}
+
+		return nil
+	}
+}
+
+// Require registers the module with the runtime.
+func Require(runtime *goja.Runtime, module *goja.Object) {
+	c := &Console{
+		runtime: runtime,
+		logger:  logp.NewLogger("processor.javascript", zap.AddCallerSkip(1)),
+	}
+
+	c.util = require.Require(runtime, "util").(*goja.Object)
+
+	o := module.Get("exports").(*goja.Object)
+	o.Set("log", c.makeLogFunc(c.logger.Debug))
+	o.Set("error", c.makeLogFunc(c.logger.Error))
+	o.Set("warn", c.makeLogFunc(c.logger.Warn))
+}
+
+// Enable adds console to the given runtime.
+func Enable(runtime *goja.Runtime) {
+	runtime.Set("console", require.Require(runtime, "console"))
+}
+
+func init() {
+	require.RegisterNativeModule("console", Require)
+}

--- a/libbeat/processors/script/javascript/module/console/console.go
+++ b/libbeat/processors/script/javascript/module/console/console.go
@@ -20,8 +20,9 @@ package console
 import (
 	"github.com/dop251/goja"
 	"github.com/dop251/goja_nodejs/require"
-	"github.com/elastic/beats/libbeat/logp"
 	"github.com/pkg/errors"
+
+	"github.com/elastic/beats/libbeat/logp"
 
 	// Require the util module for handling the log format arguments.
 	_ "github.com/dop251/goja_nodejs/util"

--- a/libbeat/processors/script/javascript/module/console/console.go
+++ b/libbeat/processors/script/javascript/module/console/console.go
@@ -45,6 +45,8 @@ func (c *Console) makeLogFunc(level logp.Level) func(call goja.FunctionCall) goj
 			switch level {
 			case logp.DebugLevel:
 				log.Debug(ret.String())
+			case logp.InfoLevel:
+				log.Info(ret.String())
 			case logp.WarnLevel:
 				log.Warn(ret.String())
 			case logp.ErrorLevel:
@@ -69,7 +71,9 @@ func Require(runtime *goja.Runtime, module *goja.Object) {
 	c.util = require.Require(runtime, "util").(*goja.Object)
 
 	o := module.Get("exports").(*goja.Object)
-	o.Set("log", c.makeLogFunc(logp.DebugLevel))
+	o.Set("debug", c.makeLogFunc(logp.DebugLevel))
+	o.Set("info", c.makeLogFunc(logp.InfoLevel))
+	o.Set("log", c.makeLogFunc(logp.InfoLevel))
 	o.Set("warn", c.makeLogFunc(logp.WarnLevel))
 	o.Set("error", c.makeLogFunc(logp.ErrorLevel))
 }

--- a/libbeat/processors/script/javascript/module/console/console_test.go
+++ b/libbeat/processors/script/javascript/module/console/console_test.go
@@ -1,0 +1,58 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package console
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/processors/script/javascript"
+
+	_ "github.com/elastic/beats/libbeat/processors/script/javascript/module/require"
+)
+
+func TestConsole(t *testing.T) {
+	const script = `
+var console = require('console');
+
+function process(evt) {
+	console.log("Info %j", evt.fields);
+	console.warn("Warning [%s]", evt.fields.message);
+	console.error("Error processing event: %j", evt.fields);
+}
+`
+
+	logp.TestingSetup(logp.ToObserverOutput())
+	p, err := javascript.NewFromConfig(javascript.Config{Source: script}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = p.Run(&beat.Event{Fields: common.MapStr{"message": "hello world!"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Len(t, logp.ObserverLogs().FilterMessageSnippet("Info").All(), 1)
+	assert.Len(t, logp.ObserverLogs().FilterMessageSnippet("Warning").All(), 1)
+	assert.Len(t, logp.ObserverLogs().FilterMessageSnippet("Error").All(), 1)
+}

--- a/libbeat/processors/script/javascript/module/console/console_test.go
+++ b/libbeat/processors/script/javascript/module/console/console_test.go
@@ -46,6 +46,10 @@ function process(evt) {
 `
 
 	logp.TestingSetup(logp.ToObserverOutput())
+	observer := logp.ObserverLogs()
+	assert.NotNil(t, observer)
+	startL := logp.L()
+
 	p, err := javascript.NewFromConfig(javascript.Config{Source: script}, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -56,13 +60,14 @@ function process(evt) {
 		t.Fatal(err)
 	}
 
-	ologs := logp.ObserverLogs()
-	assert.NotNil(t, ologs)
+	endL := logp.L()
+	t.Logf("start: %p, end: %p", startL, endL)
+	assert.Equal(t, startL, endL)
 
-	ologs = ologs.FilterMessageSnippet("TestConsole")
-	assert.NotNil(t, ologs)
+	observer = observer.FilterMessageSnippet("TestConsole")
+	assert.NotNil(t, observer)
 
-	logs := ologs.TakeAll()
+	logs := observer.TakeAll()
 	assert.NotNil(t, logs)
 
 	if assert.Len(t, logs, 5) {

--- a/libbeat/processors/script/javascript/module/console/console_test.go
+++ b/libbeat/processors/script/javascript/module/console/console_test.go
@@ -37,7 +37,9 @@ func TestConsole(t *testing.T) {
 var console = require('console');
 
 function process(evt) {
-	console.log("TestConsole Info %j", evt.fields);
+	console.debug("TestConsole Debug");
+	console.log("TestConsole Log/Info");
+	console.info("TestConsole Info %j", evt.fields);
 	console.warn("TestConsole Warning [%s]", evt.fields.message);
 	console.error("TestConsole Error processing event: %j", evt.fields);
 }
@@ -55,14 +57,20 @@ function process(evt) {
 	}
 
 	logs := logp.ObserverLogs().FilterMessageSnippet("TestConsole").TakeAll()
-	if assert.Len(t, logs, 3) {
-		assert.Contains(t, logs[0].Message, "Info")
+	if assert.Len(t, logs, 5) {
+		assert.Contains(t, logs[0].Message, "Debug")
 		assert.Equal(t, logs[0].Level, zap.DebugLevel)
 
-		assert.Contains(t, logs[1].Message, "Warning")
-		assert.Equal(t, logs[1].Level, zap.WarnLevel)
+		assert.Contains(t, logs[1].Message, "Log/Info")
+		assert.Equal(t, logs[1].Level, zap.InfoLevel)
 
-		assert.Contains(t, logs[2].Message, "Error")
-		assert.Equal(t, logs[2].Level, zap.ErrorLevel)
+		assert.Contains(t, logs[2].Message, "Info")
+		assert.Equal(t, logs[2].Level, zap.InfoLevel)
+
+		assert.Contains(t, logs[3].Message, "Warning")
+		assert.Equal(t, logs[3].Level, zap.WarnLevel)
+
+		assert.Contains(t, logs[4].Message, "Error")
+		assert.Equal(t, logs[4].Level, zap.ErrorLevel)
 	}
 }

--- a/libbeat/processors/script/javascript/module/console/console_test.go
+++ b/libbeat/processors/script/javascript/module/console/console_test.go
@@ -45,11 +45,7 @@ function process(evt) {
 }
 `
 
-	logp.TestingSetup(logp.ToObserverOutput())
-	observer := logp.ObserverLogs()
-	assert.NotNil(t, observer)
-	startL := logp.L()
-
+	logp.DevelopmentSetup(logp.ToObserverOutput())
 	p, err := javascript.NewFromConfig(javascript.Config{Source: script}, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -60,16 +56,7 @@ function process(evt) {
 		t.Fatal(err)
 	}
 
-	endL := logp.L()
-	t.Logf("start: %p, end: %p", startL, endL)
-	assert.Equal(t, startL, endL)
-
-	observer = observer.FilterMessageSnippet("TestConsole")
-	assert.NotNil(t, observer)
-
-	logs := observer.TakeAll()
-	assert.NotNil(t, logs)
-
+	logs := logp.ObserverLogs().FilterMessageSnippet("TestConsole").TakeAll()
 	if assert.Len(t, logs, 5) {
 		assert.Contains(t, logs[0].Message, "Debug")
 		assert.Equal(t, logs[0].Level, zap.DebugLevel)

--- a/libbeat/processors/script/javascript/module/console/console_test.go
+++ b/libbeat/processors/script/javascript/module/console/console_test.go
@@ -56,7 +56,15 @@ function process(evt) {
 		t.Fatal(err)
 	}
 
-	logs := logp.ObserverLogs().FilterMessageSnippet("TestConsole").TakeAll()
+	ologs := logp.ObserverLogs()
+	assert.NotNil(t, ologs)
+
+	ologs = ologs.FilterMessageSnippet("TestConsole")
+	assert.NotNil(t, ologs)
+
+	logs := ologs.TakeAll()
+	assert.NotNil(t, logs)
+
 	if assert.Len(t, logs, 5) {
 		assert.Contains(t, logs[0].Message, "Debug")
 		assert.Equal(t, logs[0].Level, zap.DebugLevel)

--- a/libbeat/processors/script/javascript/module/include.go
+++ b/libbeat/processors/script/javascript/module/include.go
@@ -1,0 +1,26 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package module
+
+import (
+	// Register javascript modules.
+	_ "github.com/elastic/beats/libbeat/processors/script/javascript/module/console"
+	_ "github.com/elastic/beats/libbeat/processors/script/javascript/module/path"
+	_ "github.com/elastic/beats/libbeat/processors/script/javascript/module/processor"
+	_ "github.com/elastic/beats/libbeat/processors/script/javascript/module/require"
+)

--- a/libbeat/processors/script/javascript/module/path/path.go
+++ b/libbeat/processors/script/javascript/module/path/path.go
@@ -1,0 +1,74 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package path
+
+import (
+	"path"
+	"path/filepath"
+	"runtime"
+
+	"github.com/dop251/goja"
+	"github.com/dop251/goja_nodejs/require"
+)
+
+// Require registers the path module that provides utilities for working with
+// file and directory paths. It can be accessed using:
+//
+//    // javascript
+//    var path = require('path');
+//
+func Require(vm *goja.Runtime, module *goja.Object) {
+	setPosix := func(o *goja.Object) *goja.Object {
+		o.Set("basename", path.Base)
+		o.Set("dirname", path.Dir)
+		o.Set("extname", path.Ext)
+		o.Set("isAbsolute", path.IsAbs)
+		o.Set("normalize", path.Clean)
+		o.Set("sep", '/')
+		return o
+	}
+
+	setWin32 := func(o *goja.Object) *goja.Object {
+		o.Set("basename", win32.Base)
+		o.Set("dirname", win32.Dir)
+		o.Set("extname", filepath.Ext)
+		o.Set("isAbsolute", win32.IsAbs)
+		o.Set("normalize", win32.Clean)
+		o.Set("sep", win32Separator)
+		return o
+	}
+
+	o := module.Get("exports").(*goja.Object)
+	o.Set("posix", setPosix(vm.NewObject()))
+	o.Set("win32", setWin32(vm.NewObject()))
+
+	if runtime.GOOS == "windows" {
+		setWin32(o)
+	} else {
+		setPosix(o)
+	}
+}
+
+// Enable adds path to the given runtime.
+func Enable(runtime *goja.Runtime) {
+	runtime.Set("path", require.Require(runtime, "path"))
+}
+
+func init() {
+	require.RegisterNativeModule("path", Require)
+}

--- a/libbeat/processors/script/javascript/module/path/path_test.go
+++ b/libbeat/processors/script/javascript/module/path/path_test.go
@@ -1,0 +1,105 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package path_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/processors/script/javascript"
+
+	_ "github.com/elastic/beats/libbeat/processors/script/javascript/module/path"
+	_ "github.com/elastic/beats/libbeat/processors/script/javascript/module/require"
+)
+
+func TestWin32(t *testing.T) {
+	const script = `
+var path = require('path');
+
+function process(evt) {
+    var filename = "C:\\Windows\\system32\\..\\system32\\system32.dll";
+	evt.Put("result", {
+        raw: filename,
+    	basename: path.win32.basename(filename),
+    	dirname:  path.win32.dirname(filename),
+    	extname: path.win32.extname(filename),
+    	isAbsolute: path.win32.isAbsolute(filename),
+    	normalize: path.win32.normalize(filename),
+        sep: path.win32.sep,
+    });
+}
+`
+
+	p, err := javascript.NewFromConfig(javascript.Config{Source: script}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	evt, err := p.Run(&beat.Event{Fields: common.MapStr{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fields := evt.Fields.Flatten()
+	assert.Equal(t, "system32.dll", fields["result.basename"])
+	assert.Equal(t, `C:\Windows\system32`, fields["result.dirname"])
+	assert.Equal(t, ".dll", fields["result.extname"])
+	assert.Equal(t, true, fields["result.isAbsolute"])
+	assert.Equal(t, `C:\Windows\system32\system32.dll`, fields["result.normalize"])
+	assert.EqualValues(t, '\\', fields["result.sep"])
+}
+
+func TestPosix(t *testing.T) {
+	const script = `
+var path = require('path');
+
+function process(evt) {
+    var filename = "/usr/lib/../lib/libcurl.so";
+	evt.Put("result", {
+        raw: filename,
+    	basename: path.posix.basename(filename),
+    	dirname:  path.posix.dirname(filename),
+    	extname: path.posix.extname(filename),
+    	isAbsolute: path.posix.isAbsolute(filename),
+    	normalize: path.posix.normalize(filename),
+        sep: path.posix.sep,
+    });
+}
+`
+
+	p, err := javascript.NewFromConfig(javascript.Config{Source: script}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	evt, err := p.Run(&beat.Event{Fields: common.MapStr{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fields := evt.Fields.Flatten()
+	assert.Equal(t, "libcurl.so", fields["result.basename"])
+	assert.Equal(t, "/usr/lib", fields["result.dirname"])
+	assert.Equal(t, ".so", fields["result.extname"])
+	assert.Equal(t, true, fields["result.isAbsolute"])
+	assert.Equal(t, "/usr/lib/libcurl.so", fields["result.normalize"])
+	assert.EqualValues(t, '/', fields["result.sep"])
+}

--- a/libbeat/processors/script/javascript/module/path/windows.go
+++ b/libbeat/processors/script/javascript/module/path/windows.go
@@ -1,0 +1,245 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package path
+
+import "strings"
+
+const (
+	win32Separator = '\\'
+)
+
+var win32 = windowsFilepath{}
+
+type windowsFilepath struct{}
+
+// IsAbs reports whether the path is absolute.
+func (win windowsFilepath) IsAbs(path string) (b bool) {
+	l := win.volumeNameLen(path)
+	if l == 0 {
+		return false
+	}
+	path = path[l:]
+	if path == "" {
+		return false
+	}
+	return win.isPathSeparator(path[0])
+}
+
+func (win windowsFilepath) Base(path string) string {
+	if path == "" {
+		return "."
+	}
+	// Strip trailing slashes.
+	for len(path) > 0 && win.isPathSeparator(path[len(path)-1]) {
+		path = path[0 : len(path)-1]
+	}
+	// Throw away volume name
+	path = path[len(win.volumeName(path)):]
+	// Find the last element
+	i := len(path) - 1
+	for i >= 0 && !win.isPathSeparator(path[i]) {
+		i--
+	}
+	if i >= 0 {
+		path = path[i+1:]
+	}
+	// If empty now, it had only slashes.
+	if path == "" {
+		return string('\\')
+	}
+	return path
+}
+
+func (win windowsFilepath) Dir(path string) string {
+	vol := win.volumeName(path)
+	i := len(path) - 1
+	for i >= len(vol) && !win.isPathSeparator(path[i]) {
+		i--
+	}
+	dir := win.Clean(path[len(vol) : i+1])
+	if dir == "." && len(vol) > 2 {
+		// must be UNC
+		return vol
+	}
+	return vol + dir
+}
+
+// isWindowsPathSeparator reports whether c is a directory separator character.
+func (windowsFilepath) isPathSeparator(c uint8) bool {
+	// NOTE: Windows accept / as path separator.
+	return c == '\\' || c == '/'
+}
+
+func (win windowsFilepath) volumeName(path string) string {
+	return path[:win.volumeNameLen(path)]
+}
+
+// volumeNameLen returns length of the leading volume name on Windows.
+// It returns 0 elsewhere.
+func (win windowsFilepath) volumeNameLen(path string) int {
+	if len(path) < 2 {
+		return 0
+	}
+	// with drive letter
+	c := path[0]
+	if path[1] == ':' && ('a' <= c && c <= 'z' || 'A' <= c && c <= 'Z') {
+		return 2
+	}
+	// is it UNC? https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247(v=vs.85).aspx
+	if l := len(path); l >= 5 && win.isPathSeparator(path[0]) && win.isPathSeparator(path[1]) &&
+		!win.isPathSeparator(path[2]) && path[2] != '.' {
+		// first, leading `\\` and next shouldn't be `\`. its server name.
+		for n := 3; n < l-1; n++ {
+			// second, next '\' shouldn't be repeated.
+			if win.isPathSeparator(path[n]) {
+				n++
+				// third, following something characters. its share name.
+				if !win.isPathSeparator(path[n]) {
+					if path[n] == '.' {
+						break
+					}
+					for ; n < l; n++ {
+						if win.isPathSeparator(path[n]) {
+							break
+						}
+					}
+					return n
+				}
+				break
+			}
+		}
+	}
+	return 0
+}
+
+func (win windowsFilepath) Clean(path string) string {
+	originalPath := path
+	volLen := win.volumeNameLen(path)
+	path = path[volLen:]
+	if path == "" {
+		if volLen > 1 && originalPath[1] != ':' {
+			// should be UNC
+			return win.FromSlash(originalPath)
+		}
+		return originalPath + "."
+	}
+	rooted := win.isPathSeparator(path[0])
+
+	// Invariants:
+	//	reading from path; r is index of next byte to process.
+	//	writing to buf; w is index of next byte to write.
+	//	dotdot is index in buf where .. must stop, either because
+	//		it is the leading slash or it is a leading ../../.. prefix.
+	n := len(path)
+	out := lazybuf{path: path, volAndPath: originalPath, volLen: volLen}
+	r, dotdot := 0, 0
+	if rooted {
+		out.append(win32Separator)
+		r, dotdot = 1, 1
+	}
+
+	for r < n {
+		switch {
+		case win.isPathSeparator(path[r]):
+			// empty path element
+			r++
+		case path[r] == '.' && (r+1 == n || win.isPathSeparator(path[r+1])):
+			// . element
+			r++
+		case path[r] == '.' && path[r+1] == '.' && (r+2 == n || win.isPathSeparator(path[r+2])):
+			// .. element: remove to last separator
+			r += 2
+			switch {
+			case out.w > dotdot:
+				// can backtrack
+				out.w--
+				for out.w > dotdot && !win.isPathSeparator(out.index(out.w)) {
+					out.w--
+				}
+			case !rooted:
+				// cannot backtrack, but not rooted, so append .. element.
+				if out.w > 0 {
+					out.append(win32Separator)
+				}
+				out.append('.')
+				out.append('.')
+				dotdot = out.w
+			}
+		default:
+			// real path element.
+			// add slash if needed
+			if rooted && out.w != 1 || !rooted && out.w != 0 {
+				out.append(win32Separator)
+			}
+			// copy element
+			for ; r < n && !win.isPathSeparator(path[r]); r++ {
+				out.append(path[r])
+			}
+		}
+	}
+
+	// Turn empty string into "."
+	if out.w == 0 {
+		out.append('.')
+	}
+
+	return win.FromSlash(out.string())
+}
+
+func (windowsFilepath) FromSlash(path string) string {
+	return strings.Replace(path, "/", string(win32Separator), -1)
+}
+
+// A lazybuf is a lazily constructed path buffer.
+// It supports append, reading previously appended bytes,
+// and retrieving the final string. It does not allocate a buffer
+// to hold the output until that output diverges from s.
+type lazybuf struct {
+	path       string
+	buf        []byte
+	w          int
+	volAndPath string
+	volLen     int
+}
+
+func (b *lazybuf) index(i int) byte {
+	if b.buf != nil {
+		return b.buf[i]
+	}
+	return b.path[i]
+}
+
+func (b *lazybuf) append(c byte) {
+	if b.buf == nil {
+		if b.w < len(b.path) && b.path[b.w] == c {
+			b.w++
+			return
+		}
+		b.buf = make([]byte, len(b.path))
+		copy(b.buf, b.path[:b.w])
+	}
+	b.buf[b.w] = c
+	b.w++
+}
+
+func (b *lazybuf) string() string {
+	if b.buf == nil {
+		return b.volAndPath[:b.volLen+b.w]
+	}
+	return b.volAndPath[:b.volLen] + string(b.buf[:b.w])
+}

--- a/libbeat/processors/script/javascript/module/processor/processor.go
+++ b/libbeat/processors/script/javascript/module/processor/processor.go
@@ -1,0 +1,134 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package processor
+
+import (
+	"github.com/dop251/goja"
+	"github.com/dop251/goja_nodejs/require"
+	"github.com/pkg/errors"
+
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/processors"
+	"github.com/elastic/beats/libbeat/processors/actions"
+	"github.com/elastic/beats/libbeat/processors/add_cloud_metadata"
+	"github.com/elastic/beats/libbeat/processors/add_docker_metadata"
+	"github.com/elastic/beats/libbeat/processors/add_host_metadata"
+	"github.com/elastic/beats/libbeat/processors/add_kubernetes_metadata"
+	"github.com/elastic/beats/libbeat/processors/add_locale"
+	"github.com/elastic/beats/libbeat/processors/add_process_metadata"
+	"github.com/elastic/beats/libbeat/processors/communityid"
+	"github.com/elastic/beats/libbeat/processors/dissect"
+	"github.com/elastic/beats/libbeat/processors/dns"
+	"github.com/elastic/beats/libbeat/processors/script/javascript"
+)
+
+// newConstructor returns a JS constructor function. The constructor wraps a
+// beat processor constructor. The javascript constructor must be passed a value
+// that can be treated as the processor's config.
+func newConstructor(
+	s *goja.Runtime,
+	constructor processors.Constructor,
+) func(call goja.ConstructorCall) *goja.Object {
+	return func(call goja.ConstructorCall) *goja.Object {
+		a0 := call.Argument(0)
+		if a0 == nil {
+			panic(s.ToValue("constructor requires a configuration arg"))
+		}
+
+		commonConfig, err := common.NewConfigFrom(a0.Export())
+		if err != nil {
+			panic(s.NewGoError(err))
+		}
+
+		p, err := constructor(commonConfig)
+		if err != nil {
+			panic(s.NewGoError(err))
+		}
+
+		bp := &beatProcessor{s, p}
+		call.This.Set("Run", bp.Run)
+		return nil
+	}
+}
+
+// beatProcessor wraps a beat processor for javascript.
+type beatProcessor struct {
+	runtime *goja.Runtime
+	p       processors.Processor
+}
+
+func (bp *beatProcessor) Run(call goja.FunctionCall) goja.Value {
+	if len(call.Arguments) != 1 {
+		panic(bp.runtime.NewGoError(errors.Errorf("Run requires one argument")))
+	}
+
+	e, ok := call.Argument(0).ToObject(bp.runtime).Get("_private").Export().(javascript.Event)
+	if !ok {
+		panic(bp.runtime.NewGoError(errors.Errorf("arg 0 must be an Event")))
+	}
+
+	if e.IsCancelled() {
+		return goja.Null()
+	}
+
+	beatEvent, err := bp.p.Run(e.Wrapped())
+	if err != nil {
+		panic(bp.runtime.NewGoError(err))
+	}
+
+	if beatEvent == nil {
+		e.Cancel()
+		return goja.Null()
+	}
+
+	return e.JSObject()
+}
+
+// Require registers the processor module that exposes constructors for beat
+// processors from javascript.
+//
+//    // javascript
+//    var processor = require('processor');
+//    var chopLog = new processor.Dissect({tokenizer: "%{key}: %{value}"});
+//
+func Require(runtime *goja.Runtime, module *goja.Object) {
+	o := module.Get("exports").(*goja.Object)
+
+	// Create constructors for most of the Beat processors.
+	// Note that script to avoid nesting. And some of the actions like rename
+	// and add_tags are omitted because those can be done natively in JS.
+	o.Set("AddCloudMetadata", newConstructor(runtime, add_cloud_metadata.New))
+	o.Set("AddDockerMetadata", newConstructor(runtime, add_docker_metadata.New))
+	o.Set("AddHostMetadata", newConstructor(runtime, add_host_metadata.New))
+	o.Set("AddKubernetesMetadata", newConstructor(runtime, add_kubernetes_metadata.New))
+	o.Set("AddLocale", newConstructor(runtime, add_locale.New))
+	o.Set("AddProcessMetadata", newConstructor(runtime, add_process_metadata.New))
+	o.Set("CommunityID", newConstructor(runtime, communityid.New))
+	o.Set("DecodeJSONFields", newConstructor(runtime, actions.NewDecodeJSONFields))
+	o.Set("Dissect", newConstructor(runtime, dissect.NewProcessor))
+	o.Set("DNS", newConstructor(runtime, dns.New))
+}
+
+// Enable adds path to the given runtime.
+func Enable(runtime *goja.Runtime) {
+	runtime.Set("processor", require.Require(runtime, "processor"))
+}
+
+func init() {
+	require.RegisterNativeModule("processor", Require)
+}

--- a/libbeat/processors/script/javascript/module/processor/processor.go
+++ b/libbeat/processors/script/javascript/module/processor/processor.go
@@ -74,12 +74,12 @@ type beatProcessor struct {
 
 func (bp *beatProcessor) Run(call goja.FunctionCall) goja.Value {
 	if len(call.Arguments) != 1 {
-		panic(bp.runtime.NewGoError(errors.Errorf("Run requires one argument")))
+		panic(bp.runtime.NewGoError(errors.New("Run requires one argument")))
 	}
 
 	e, ok := call.Argument(0).ToObject(bp.runtime).Get("_private").Export().(javascript.Event)
 	if !ok {
-		panic(bp.runtime.NewGoError(errors.Errorf("arg 0 must be an Event")))
+		panic(bp.runtime.NewGoError(errors.New("arg 0 must be an Event")))
 	}
 
 	if e.IsCancelled() {

--- a/libbeat/processors/script/javascript/module/processor/processor_test.go
+++ b/libbeat/processors/script/javascript/module/processor/processor_test.go
@@ -1,0 +1,252 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package processor
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/processors/script/javascript"
+
+	_ "github.com/elastic/beats/libbeat/processors/script/javascript/module/require"
+)
+
+func testEvent() *beat.Event {
+	return &beat.Event{
+		Fields: common.MapStr{
+			"source": common.MapStr{
+				"ip": "192.0.2.1",
+			},
+			"destination": common.MapStr{
+				"ip": "192.0.2.1",
+			},
+			"network": common.MapStr{
+				"transport": "igmp",
+			},
+			"message": "key=hello",
+		},
+	}
+}
+
+func TestNewProcessorAddHostMetadata(t *testing.T) {
+	const script = `
+var processor = require('processor');
+
+var addHostMetadata = new processor.AddHostMetadata({"netinfo.enabled": true});
+
+function process(evt) {
+    addHostMetadata.Run(evt);
+}
+`
+
+	logp.TestingSetup()
+	p, err := javascript.NewFromConfig(javascript.Config{Source: script}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	evt, err := p.Run(testEvent())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = evt.GetValue("host.hostname")
+	assert.NoError(t, err)
+}
+
+func TestNewProcessorAddLocale(t *testing.T) {
+	const script = `
+var processor = require('processor');
+
+var addLocale = new processor.AddLocale();
+
+function process(evt) {
+    addLocale.Run(evt);
+}
+`
+
+	logp.TestingSetup()
+	p, err := javascript.NewFromConfig(javascript.Config{Source: script}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	evt, err := p.Run(testEvent())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = evt.GetValue("event.timezone")
+	assert.NoError(t, err)
+}
+
+func TestNewProcessorAddProcessMetadata(t *testing.T) {
+	const script = `
+var processor = require('processor');
+
+var addProcessMetadata = new processor.AddProcessMetadata({
+    match_pids: "process.pid",
+    overwrite_keys: true,
+});
+
+function process(evt) {
+    addProcessMetadata.Run(evt);
+}
+`
+
+	logp.TestingSetup()
+	p, err := javascript.NewFromConfig(javascript.Config{Source: script}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	evt := &beat.Event{Fields: common.MapStr{"process": common.MapStr{"pid": os.Getppid()}}}
+	evt, err = p.Run(evt)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = evt.GetValue("process.name")
+	assert.NoError(t, err)
+	t.Logf("%+v", evt.Fields)
+}
+
+func TestNewProcessorCommunityID(t *testing.T) {
+	const script = `
+var processor = require('processor');
+
+var communityID = new processor.CommunityID();
+
+function process(evt) {
+    communityID.Run(evt);
+}
+`
+
+	logp.TestingSetup()
+	p, err := javascript.NewFromConfig(javascript.Config{Source: script}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	evt, err := p.Run(testEvent())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	id, _ := evt.GetValue("network.community_id")
+	assert.Equal(t, "1:15+Ly6HsDg0sJdTmNktf6rko+os=", id)
+}
+
+func TestNewProcessorDecodeJSONFields(t *testing.T) {
+	const script = `
+var processor = require('processor');
+
+var decodeJSON = new processor.DecodeJSONFields({
+    fields: ["message"],
+    target: "",
+});
+
+function process(evt) {
+	decodeJSON.Run(evt);
+}
+`
+
+	logp.TestingSetup()
+	p, err := javascript.NewFromConfig(javascript.Config{Source: script}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	evt := testEvent()
+	evt.PutValue("message", `{"hello": "world"}`)
+
+	_, err = p.Run(evt)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	v, _ := evt.GetValue("hello")
+	assert.Equal(t, "world", v)
+}
+
+func TestNewProcessorDissect(t *testing.T) {
+	const script = `
+var processor = require('processor');
+
+var chopLog = new processor.Dissect({
+    tokenizer: "key=%{key}",
+    field: "message",
+});
+
+function process(evt) {
+    chopLog.Run(evt);
+}
+`
+
+	logp.TestingSetup()
+	p, err := javascript.NewFromConfig(javascript.Config{Source: script}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	evt, err := p.Run(testEvent())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	key, _ := evt.GetValue("dissect.key")
+	assert.Equal(t, "hello", key)
+}
+
+func TestNewProcessorDNS(t *testing.T) {
+	const script = `
+var processor = require('processor');
+
+var dns = new processor.DNS({
+    type: "reverse",
+    fields: {
+        "source.ip": "source.domain",
+        "destination.ip": "destination.domain"
+    },
+    tag_on_failure: ["_dns_reverse_lookup_failed"],
+});
+
+function process(evt) {
+	dns.Run(evt);
+    if (evt.Get().tags[0] !== "_dns_reverse_lookup_failed") {
+        throw "missing tag"
+    }
+}
+`
+
+	logp.TestingSetup()
+	p, err := javascript.NewFromConfig(javascript.Config{Source: script}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = p.Run(testEvent())
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/libbeat/processors/script/javascript/module/processor/processor_test.go
+++ b/libbeat/processors/script/javascript/module/processor/processor_test.go
@@ -19,6 +19,7 @@ package processor
 
 import (
 	"os"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -219,6 +220,10 @@ function process(evt) {
 }
 
 func TestNewProcessorDNS(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows requires explicit DNS server configuration")
+	}
+
 	const script = `
 var processor = require('processor');
 

--- a/libbeat/processors/script/javascript/module/require/require.go
+++ b/libbeat/processors/script/javascript/module/require/require.go
@@ -1,0 +1,37 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package require
+
+import (
+	"github.com/dop251/goja_nodejs/require"
+	"github.com/pkg/errors"
+
+	"github.com/elastic/beats/libbeat/processors/script/javascript"
+)
+
+func init() {
+	javascript.AddSessionHook("require", func(s javascript.Session) {
+		reg := require.NewRegistryWithLoader(loadSource)
+		reg.Enable(s.Runtime())
+	})
+}
+
+// loadSource disallows loading custom modules from file.
+func loadSource(path string) ([]byte, error) {
+	return nil, errors.Errorf("cannot load %v, only built-in modules are supported", path)
+}

--- a/vendor/github.com/dop251/goja_nodejs/LICENSE
+++ b/vendor/github.com/dop251/goja_nodejs/LICENSE
@@ -1,0 +1,13 @@
+Copyright (c) 2016 Dmitry Panov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/dop251/goja_nodejs/require/module.go
+++ b/vendor/github.com/dop251/goja_nodejs/require/module.go
@@ -1,0 +1,161 @@
+package require
+
+import (
+	js "github.com/dop251/goja"
+
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"sync"
+)
+
+type ModuleLoader func(*js.Runtime, *js.Object)
+type SourceLoader func(path string) ([]byte, error)
+
+var (
+	InvalidModuleError     = errors.New("Invalid module")
+	IllegalModuleNameError = errors.New("Illegal module name")
+)
+
+var native map[string]ModuleLoader
+
+// Registry contains a cache of compiled modules which can be used by multiple Runtimes
+type Registry struct {
+	sync.Mutex
+	compiled map[string]*js.Program
+
+	srcLoader SourceLoader
+}
+
+type RequireModule struct {
+	r       *Registry
+	runtime *js.Runtime
+	modules map[string]*js.Object
+}
+
+func NewRegistryWithLoader(srcLoader SourceLoader) *Registry {
+	return &Registry{
+		srcLoader: srcLoader,
+	}
+}
+
+// Enable adds the require() function to the specified runtime.
+func (r *Registry) Enable(runtime *js.Runtime) *RequireModule {
+	rrt := &RequireModule{
+		r:       r,
+		runtime: runtime,
+		modules: make(map[string]*js.Object),
+	}
+
+	runtime.Set("require", rrt.require)
+	return rrt
+}
+
+func (r *Registry) getCompiledSource(p string) (prg *js.Program, err error) {
+	r.Lock()
+	defer r.Unlock()
+
+	prg = r.compiled[p]
+	if prg == nil {
+		srcLoader := r.srcLoader
+		if srcLoader == nil {
+			srcLoader = ioutil.ReadFile
+		}
+		if s, err1 := srcLoader(p); err1 == nil {
+			source := "(function(module, exports) {" + string(s) + "\n})"
+			prg, err = js.Compile(p, source, false)
+			if err == nil {
+				if r.compiled == nil {
+					r.compiled = make(map[string]*js.Program)
+				}
+				r.compiled[p] = prg
+			}
+		} else {
+			err = err1
+		}
+	}
+	return
+}
+
+func (r *RequireModule) loadModule(path string, jsModule *js.Object) error {
+
+	if ldr, exists := native[path]; exists {
+		ldr(r.runtime, jsModule)
+		return nil
+	}
+
+	prg, err := r.r.getCompiledSource(path)
+
+	if err != nil {
+		return err
+	}
+
+	f, err := r.runtime.RunProgram(prg)
+	if err != nil {
+		return err
+	}
+
+	if call, ok := js.AssertFunction(f); ok {
+		jsExports := jsModule.Get("exports")
+
+		// Run the module source, with "jsModule" as the "module" variable, "jsExports" as "this"(Nodejs capable).
+		_, err = call(jsExports, jsModule, jsExports)
+		if err != nil {
+			return err
+		}
+	} else {
+		return InvalidModuleError
+	}
+
+	return nil
+}
+
+func (r *RequireModule) require(call js.FunctionCall) js.Value {
+	ret, err := r.Require(call.Argument(0).String())
+	if err != nil {
+		panic(r.runtime.NewGoError(err))
+	}
+	return ret
+}
+
+// Require can be used to import modules from Go source (similar to JS require() function).
+func (r *RequireModule) Require(p string) (ret js.Value, err error) {
+	p = filepath.Clean(p)
+	if p == "" {
+		err = IllegalModuleNameError
+		return
+	}
+	module := r.modules[p]
+	if module == nil {
+		module = r.runtime.NewObject()
+		module.Set("exports", r.runtime.NewObject())
+		r.modules[p] = module
+		err = r.loadModule(p, module)
+		if err != nil {
+			delete(r.modules, p)
+			err = fmt.Errorf("Could not load module '%s': %v", p, err)
+			return
+		}
+	}
+	ret = module.Get("exports")
+	return
+}
+
+func Require(runtime *js.Runtime, name string) js.Value {
+	if r, ok := js.AssertFunction(runtime.Get("require")); ok {
+		mod, err := r(js.Undefined(), runtime.ToValue(name))
+		if err != nil {
+			panic(err)
+		}
+		return mod
+	}
+	panic(runtime.NewTypeError("Please enable require for this runtime using new(require.Require).Enable(runtime)"))
+}
+
+func RegisterNativeModule(name string, loader ModuleLoader) {
+	if native == nil {
+		native = make(map[string]ModuleLoader)
+	}
+	native[name] = loader
+}

--- a/vendor/github.com/dop251/goja_nodejs/util/module.go
+++ b/vendor/github.com/dop251/goja_nodejs/util/module.go
@@ -1,0 +1,102 @@
+package util
+
+import (
+	"bytes"
+	"github.com/dop251/goja"
+	"github.com/dop251/goja_nodejs/require"
+)
+
+type Util struct {
+	runtime *goja.Runtime
+}
+
+func (u *Util) format(f rune, val goja.Value, w *bytes.Buffer) bool {
+	switch f {
+	case 's':
+		w.WriteString(val.String())
+	case 'd':
+		w.WriteString(val.ToNumber().String())
+	case 'j':
+		if json, ok := u.runtime.Get("JSON").(*goja.Object); ok {
+			if stringify, ok := goja.AssertFunction(json.Get("stringify")); ok {
+				res, err := stringify(json, val)
+				if err != nil {
+					panic(err)
+				}
+				w.WriteString(res.String())
+			}
+		}
+	case '%':
+		w.WriteByte('%')
+		return false
+	default:
+		w.WriteByte('%')
+		w.WriteRune(f)
+		return false
+	}
+	return true
+}
+
+func (u *Util) Format(b *bytes.Buffer, f string, args ...goja.Value) {
+	pct := false
+	argNum := 0
+	for _, chr := range f {
+		if pct {
+			if argNum < len(args) {
+				if u.format(chr, args[argNum], b) {
+					argNum++
+				}
+			} else {
+				b.WriteByte('%')
+				b.WriteRune(chr)
+			}
+			pct = false
+		} else {
+			if chr == '%' {
+				pct = true
+			} else {
+				b.WriteRune(chr)
+			}
+		}
+	}
+
+	for _, arg := range args[argNum:] {
+		b.WriteByte(' ')
+		b.WriteString(arg.String())
+	}
+}
+
+func (u *Util) js_format(call goja.FunctionCall) goja.Value {
+	var b bytes.Buffer
+	var fmt string
+
+	if arg := call.Argument(0); !goja.IsUndefined(arg) {
+		fmt = arg.String()
+	}
+
+	var args []goja.Value
+	if len(call.Arguments) > 0 {
+		args = call.Arguments[1:]
+	}
+	u.Format(&b, fmt, args...)
+
+	return u.runtime.ToValue(b.String())
+}
+
+func Require(runtime *goja.Runtime, module *goja.Object) {
+	u := &Util{
+		runtime: runtime,
+	}
+	obj := module.Get("exports").(*goja.Object)
+	obj.Set("format", u.js_format)
+}
+
+func New(runtime *goja.Runtime) *Util {
+	return &Util{
+		runtime: runtime,
+	}
+}
+
+func init() {
+	require.RegisterNativeModule("util", Require)
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -819,6 +819,18 @@
 			"revisionTime": "2019-01-28T17:26:24Z"
 		},
 		{
+			"checksumSHA1": "uamJV//FmbK8VqZ8BmZ0Wzi0zM4=",
+			"path": "github.com/dop251/goja_nodejs/require",
+			"revision": "adff31b136e6b7e044712aab7236a775e1bd085e",
+			"revisionTime": "2017-10-11T08:15:05Z"
+		},
+		{
+			"checksumSHA1": "TB6Dp0Oqeu7i+qPLv5DukMEqlvE=",
+			"path": "github.com/dop251/goja_nodejs/util",
+			"revision": "adff31b136e6b7e044712aab7236a775e1bd085e",
+			"revisionTime": "2017-10-11T08:15:05Z"
+		},
+		{
 			"checksumSHA1": "rhLUtXvcmouYuBwOq9X/nYKzvNg=",
 			"path": "github.com/dustin/go-humanize",
 			"revision": "259d2a102b871d17f30e3cd9881a642961a1e486",


### PR DESCRIPTION
This adds a `require` function to the JS runtime that scripts can call to import
"modules". The modules that are added in this PR are

- `processor` - You can construct beat processors in JS (e.g. `new processor.Dissect({...})`).
- `console` - You can write to beat's logger.
- `path` - You can parse win32 and posix paths.

The `processor` module supports constructing:

- `AddCloudMetadata`
- `AddDockerMetadata`
- `AddHostMetadata`
- `AddKubernetesMetadata`
- `AddLocale`
- `AddProcessMetadata`
- `CommunityID`
- `DecodeJSONFields`
- `Dissect`
- `DNS`

#### Basic Example

This is a basic example. It's nothing you couldn't do already with the YAML format, but imagine you need to start adding in some more complex conditions and following some conditional branches.

```javascript
var console = require('console');
var processor = require('processor');

var dissect = new processor.Dissect({
    tokenizer: "pid=%{process.pid}|ppid=%{process.ppid}|",
});
var processMetadata = new processor.AddProcessMetadata({
    match_pids: ["dissect.process.pid"],
});
var parentMetadata = new processor.AddProcessMetadata({
    match_pids: ["dissect.process.ppid"],
    target: "process.parent",
});

function process(event) {
    console.log("fields: %j", event.fields);
    dissect.Run(event);
    processMetadata.Run(event);
    parentMetadata.Run(event);
    event.Delete("dissect");
    event.Rename("message", "log.original");
}
```