### PR TITLE
Updated link to githubbeat

### DIFF
--- a/libbeat/docs/communitybeats.asciidoc
+++ b/libbeat/docs/communitybeats.asciidoc
@@ -48,7 +48,7 @@ https://github.com/ctindel/fastcombeat[fastcombeat]:: Periodically gather intern
 https://github.com/FStelzer/flowbeat[flowbeat]:: Collects, parses, and indexes http://www.sflow.org/index.php[sflow] samples.
 https://github.com/GeneralElectric/GABeat[gabeat]:: Collects data from Google Analytics Realtime API.
 https://github.com/GoogleCloudPlatform/gcsbeat[gcsbeat]:: Reads data from https://cloud.google.com/storage/[Google Cloud Storage] buckets.
-https://github.com/jlevesy/githubbeat[githubbeat]:: Easily monitors GitHub repository activity.
+https://github.com/josephlewis42/githubbeat[githubbeat]:: Easily monitors GitHub repository activity.
 https://github.com/hpcugent/gpfsbeat[gpfsbeat]:: Collects GPFS metric and quota information.
 https://github.com/ullaakut/hackerbeat[hackerbeat]:: Indexes the top stories of HackerNews into an ElasticSearch instance.
 https://github.com/YaSuenag/hsbeat[hsbeat]:: Reads all performance counters in Java HotSpot VM.


### PR DESCRIPTION
The repository the documentation was previously linking to (https://github.com/jlevesy/githubbeat) is not maintained anymore, the owner suggests using the following fork instead: https://github.com/josephlewis42/githubbeat