### PR TITLE
Rename migration.enabled to migration_67.enabled

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -33,6 +33,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add `cleanup_timeout` option to docker autodiscover, to wait some time before removing configurations after a container is stopped. {issue]10374[10374] {pull}10905[10905]
 - On Google Cloud Engine (GCE) the add_cloud_metadata will now trim the project
   info from the cloud.machine.type and cloud.availability_zone. {issue}10968[10968]
+- Rename `migration.enabled` config to `migration_67.enabled`. {pull}11284[11284]
 
 *Auditbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -33,7 +33,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add `cleanup_timeout` option to docker autodiscover, to wait some time before removing configurations after a container is stopped. {issue]10374[10374] {pull}10905[10905]
 - On Google Cloud Engine (GCE) the add_cloud_metadata will now trim the project
   info from the cloud.machine.type and cloud.availability_zone. {issue}10968[10968]
-- Rename `migration.enabled` config to `migration_67.enabled`. {pull}11284[11284]
+- Rename `migration.enabled` config to `migration.6_to_7.enabled`. {pull}11284[11284]
 
 *Auditbeat*
 

--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -1267,4 +1267,4 @@ logging.files:
 #================================= Migration ==================================
 
 # This allows to enable 6.7 migration aliases
-#migration_67.enabled: false
+#migration.6_to_7.enabled: false

--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -1266,5 +1266,5 @@ logging.files:
 
 #================================= Migration ==================================
 
-# This allows to enable migration aliases
-#migration.enabled: false
+# This allows to enable 6.7 migration aliases
+#migration_67.enabled: false

--- a/auditbeat/auditbeat.yml
+++ b/auditbeat/auditbeat.yml
@@ -178,4 +178,4 @@ processors:
 #================================= Migration ==================================
 
 # This allows to enable 6.7 migration aliases
-#migration_67.enabled: false
+#migration.6_to_7.enabled: false

--- a/auditbeat/auditbeat.yml
+++ b/auditbeat/auditbeat.yml
@@ -177,5 +177,5 @@ processors:
 
 #================================= Migration ==================================
 
-# This allows to enable migration aliases
-#migration.enabled: false
+# This allows to enable 6.7 migration aliases
+#migration_67.enabled: false

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -1977,5 +1977,5 @@ logging.files:
 
 #================================= Migration ==================================
 
-# This allows to enable migration aliases
-#migration.enabled: false
+# This allows to enable 6.7 migration aliases
+#migration_67.enabled: false

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -1978,4 +1978,4 @@ logging.files:
 #================================= Migration ==================================
 
 # This allows to enable 6.7 migration aliases
-#migration_67.enabled: false
+#migration.6_to_7.enabled: false

--- a/filebeat/filebeat.yml
+++ b/filebeat/filebeat.yml
@@ -205,5 +205,5 @@ processors:
 
 #================================= Migration ==================================
 
-# This allows to enable migration aliases
-#migration.enabled: false
+# This allows to enable 6.7 migration aliases
+#migration_67.enabled: false

--- a/filebeat/filebeat.yml
+++ b/filebeat/filebeat.yml
@@ -206,4 +206,4 @@ processors:
 #================================= Migration ==================================
 
 # This allows to enable 6.7 migration aliases
-#migration_67.enabled: false
+#migration.6_to_7.enabled: false

--- a/filebeat/tests/system/test_base.py
+++ b/filebeat/tests/system/test_base.py
@@ -51,7 +51,7 @@ class Test(BaseTest):
             elasticsearch={"host": self.get_elasticsearch_url()},
         )
         exit_code = self.run_beat(extra_args=["setup", "--template",
-                                              "-E", "setup.template.overwrite=true", "-E", "migration.enabled=true"])
+                                              "-E", "setup.template.overwrite=true", "-E", "migration_67.enabled=true"])
 
         assert exit_code == 0
         assert self.log_contains('Loaded index template')

--- a/filebeat/tests/system/test_base.py
+++ b/filebeat/tests/system/test_base.py
@@ -51,7 +51,7 @@ class Test(BaseTest):
             elasticsearch={"host": self.get_elasticsearch_url()},
         )
         exit_code = self.run_beat(extra_args=["setup", "--template",
-                                              "-E", "setup.template.overwrite=true", "-E", "migration_67.enabled=true"])
+                                              "-E", "setup.template.overwrite=true", "-E", "migration.6_to_7.enabled=true"])
 
         assert exit_code == 0
         assert self.log_contains('Loaded index template')

--- a/filebeat/tests/system/test_index_pattern.py
+++ b/filebeat/tests/system/test_index_pattern.py
@@ -25,7 +25,7 @@ class Test(BaseTest):
         self.render_config_template()
         exit_code = self.run_beat(
             logging_args=[],
-            extra_args=["export", "index-pattern", "-E", "migration.enabled:true"])
+            extra_args=["export", "index-pattern", "-E", "migration_67.enabled:true"])
 
         assert exit_code == 0
         assert self.log_contains('"objects": [')

--- a/filebeat/tests/system/test_index_pattern.py
+++ b/filebeat/tests/system/test_index_pattern.py
@@ -25,7 +25,7 @@ class Test(BaseTest):
         self.render_config_template()
         exit_code = self.run_beat(
             logging_args=[],
-            extra_args=["export", "index-pattern", "-E", "migration_67.enabled:true"])
+            extra_args=["export", "index-pattern", "-E", "migration.6_to_7.enabled:true"])
 
         assert exit_code == 0
         assert self.log_contains('"objects": [')

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -1411,4 +1411,4 @@ logging.files:
 #================================= Migration ==================================
 
 # This allows to enable 6.7 migration aliases
-#migration_67.enabled: false
+#migration.6_to_7.enabled: false

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -1410,5 +1410,5 @@ logging.files:
 
 #================================= Migration ==================================
 
-# This allows to enable migration aliases
-#migration.enabled: false
+# This allows to enable 6.7 migration aliases
+#migration_67.enabled: false

--- a/heartbeat/heartbeat.yml
+++ b/heartbeat/heartbeat.yml
@@ -154,5 +154,5 @@ output.elasticsearch:
 
 #================================= Migration ==================================
 
-# This allows to enable migration aliases
-#migration.enabled: false
+# This allows to enable 6.7 migration aliases
+#migration_67.enabled: false

--- a/heartbeat/heartbeat.yml
+++ b/heartbeat/heartbeat.yml
@@ -155,4 +155,4 @@ output.elasticsearch:
 #================================= Migration ==================================
 
 # This allows to enable 6.7 migration aliases
-#migration_67.enabled: false
+#migration.6_to_7.enabled: false

--- a/journalbeat/journalbeat.reference.yml
+++ b/journalbeat/journalbeat.reference.yml
@@ -1206,5 +1206,5 @@ logging.files:
 
 #================================= Migration ==================================
 
-# This allows to enable migration aliases
-#migration.enabled: false
+# This allows to enable 6.7 migration aliases
+#migration_67.enabled: false

--- a/journalbeat/journalbeat.reference.yml
+++ b/journalbeat/journalbeat.reference.yml
@@ -1207,4 +1207,4 @@ logging.files:
 #================================= Migration ==================================
 
 # This allows to enable 6.7 migration aliases
-#migration_67.enabled: false
+#migration.6_to_7.enabled: false

--- a/journalbeat/journalbeat.yml
+++ b/journalbeat/journalbeat.yml
@@ -174,5 +174,5 @@ processors:
 
 #================================= Migration ==================================
 
-# This allows to enable migration aliases
-#migration.enabled: false
+# This allows to enable 6.7 migration aliases
+#migration_67.enabled: false

--- a/journalbeat/journalbeat.yml
+++ b/journalbeat/journalbeat.yml
@@ -175,4 +175,4 @@ processors:
 #================================= Migration ==================================
 
 # This allows to enable 6.7 migration aliases
-#migration_67.enabled: false
+#migration.6_to_7.enabled: false

--- a/libbeat/_meta/config.reference.yml
+++ b/libbeat/_meta/config.reference.yml
@@ -1154,5 +1154,5 @@ logging.files:
 
 #================================= Migration ==================================
 
-# This allows to enable migration aliases
-#migration.enabled: false
+# This allows to enable 6.7 migration aliases
+#migration_67.enabled: false

--- a/libbeat/_meta/config.reference.yml
+++ b/libbeat/_meta/config.reference.yml
@@ -1155,4 +1155,4 @@ logging.files:
 #================================= Migration ==================================
 
 # This allows to enable 6.7 migration aliases
-#migration_67.enabled: false
+#migration.6_to_7.enabled: false

--- a/libbeat/_meta/config.yml
+++ b/libbeat/_meta/config.yml
@@ -123,4 +123,4 @@ processors:
 #================================= Migration ==================================
 
 # This allows to enable 6.7 migration aliases
-#migration_67.enabled: false
+#migration.6_to_7.enabled: false

--- a/libbeat/_meta/config.yml
+++ b/libbeat/_meta/config.yml
@@ -122,5 +122,5 @@ processors:
 
 #================================= Migration ==================================
 
-# This allows to enable migration aliases
-#migration.enabled: false
+# This allows to enable 6.7 migration aliases
+#migration_67.enabled: false

--- a/libbeat/cmd/export/index_pattern.go
+++ b/libbeat/cmd/export/index_pattern.go
@@ -50,8 +50,8 @@ func GenIndexPatternConfigCmd(settings instance.Settings) *cobra.Command {
 			}
 
 			var withMigration bool
-			if b.RawConfig.HasField("migration") {
-				sub, err := b.RawConfig.Child("migration", -1)
+			if b.RawConfig.HasField("migration_67") {
+				sub, err := b.RawConfig.Child("migration_67", -1)
 				if err != nil {
 					fatalf("Failed to read migration setting: %+v", err)
 				}

--- a/libbeat/cmd/export/index_pattern.go
+++ b/libbeat/cmd/export/index_pattern.go
@@ -49,21 +49,12 @@ func GenIndexPatternConfigCmd(settings instance.Settings) *cobra.Command {
 				version = b.Info.Version
 			}
 
-			var withMigration bool
-			if b.RawConfig.HasField("migration_67") {
-				sub, err := b.RawConfig.Child("migration_67", -1)
-				if err != nil {
-					fatalf("Failed to read migration setting: %+v", err)
-				}
-				withMigration = sub.Enabled()
-			}
-
 			// Index pattern generation
 			v, err := common.NewVersion(version)
 			if err != nil {
 				fatalf("Error creating version: %+v", err)
 			}
-			indexPattern, err := kibana.NewGenerator(b.Info.IndexPrefix, b.Info.Beat, b.Fields, settings.Version, *v, withMigration)
+			indexPattern, err := kibana.NewGenerator(b.Info.IndexPrefix, b.Info.Beat, b.Fields, settings.Version, *v, b.Config.Migration.Enabled())
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/libbeat/cmd/export/template.go
+++ b/libbeat/cmd/export/template.go
@@ -74,16 +74,7 @@ func GenTemplateConfigCmd(settings instance.Settings) *cobra.Command {
 				tmplCfg = template.DefaultConfig()
 			}
 
-			var withMigration bool
-			if b.RawConfig.HasField("migration_67") {
-				sub, err := b.RawConfig.Child("migration_67", -1)
-				if err != nil {
-					fatalf("Failed to read migration setting: %+v", err)
-				}
-				withMigration = sub.Enabled()
-			}
-
-			tmpl, err := template.New(b.Info.Version, index, *esVersion, tmplCfg, withMigration)
+			tmpl, err := template.New(b.Info.Version, index, *esVersion, tmplCfg, b.Config.Migration.Enabled())
 			if err != nil {
 				fatalf("Error generating template: %+v", err)
 			}

--- a/libbeat/cmd/export/template.go
+++ b/libbeat/cmd/export/template.go
@@ -75,8 +75,8 @@ func GenTemplateConfigCmd(settings instance.Settings) *cobra.Command {
 			}
 
 			var withMigration bool
-			if b.RawConfig.HasField("migration") {
-				sub, err := b.RawConfig.Child("migration", -1)
+			if b.RawConfig.HasField("migration_67") {
+				sub, err := b.RawConfig.Child("migration_67", -1)
 				if err != nil {
 					fatalf("Failed to read migration setting: %+v", err)
 				}

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -695,8 +695,8 @@ func (b *Beat) loadDashboards(ctx context.Context, force bool) error {
 
 	if b.Config.Dashboards.Enabled() {
 		var withMigration bool
-		if b.RawConfig.HasField("migration") {
-			sub, err := b.RawConfig.Child("migration", -1)
+		if b.RawConfig.HasField("migration_67") {
+			sub, err := b.RawConfig.Child("migration_67", -1)
 			if err != nil {
 				return fmt.Errorf("Failed to read migration setting: %+v", err)
 			}

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -110,6 +110,9 @@ type beatConfig struct {
 	// elastic stack 'setup' configurations
 	Dashboards *common.Config `config:"setup.dashboards"`
 	Kibana     *common.Config `config:"setup.kibana"`
+
+	// Migration config to migration from 6 to 7
+	Migration *common.Config `config:"migration.6_to_7"`
 }
 
 var debugf = logp.MakeDebug("beat")
@@ -694,14 +697,6 @@ func (b *Beat) loadDashboards(ctx context.Context, force bool) error {
 	}
 
 	if b.Config.Dashboards.Enabled() {
-		var withMigration bool
-		if b.RawConfig.HasField("migration_67") {
-			sub, err := b.RawConfig.Child("migration_67", -1)
-			if err != nil {
-				return fmt.Errorf("Failed to read migration setting: %+v", err)
-			}
-			withMigration = sub.Enabled()
-		}
 
 		// Initialize kibana config. If username and password is set in elasticsearch output config but not in kibana,
 		// initKibanaConfig will attach the ussername and password into kibana config as a part of the initialization.
@@ -718,7 +713,7 @@ func (b *Beat) loadDashboards(ctx context.Context, force bool) error {
 		// but it's assumed that KB and ES have the same minor version.
 		v := client.GetVersion()
 
-		indexPattern, err := kibana.NewGenerator(b.Info.IndexPrefix, b.Info.Beat, b.Fields, b.Info.Version, v, withMigration)
+		indexPattern, err := kibana.NewGenerator(b.Info.IndexPrefix, b.Info.Beat, b.Fields, b.Info.Version, v, b.Config.Migration.Enabled())
 		if err != nil {
 			return fmt.Errorf("error creating index pattern generator: %v", err)
 		}

--- a/libbeat/idxmgmt/idxmgmt.go
+++ b/libbeat/idxmgmt/idxmgmt.go
@@ -98,7 +98,7 @@ func MakeDefaultSupport(ilmSupport ilm.SupportFactory) SupportFactory {
 			ILM       *common.Config         `config:"setup.ilm"`
 			Template  *common.Config         `config:"setup.template"`
 			Output    common.ConfigNamespace `config:"output"`
-			Migration *common.Config         `config:"migration_67"`
+			Migration *common.Config         `config:"migration.6_to_7"`
 		}{}
 		if configRoot != nil {
 			if err := configRoot.Unpack(&cfg); err != nil {

--- a/libbeat/idxmgmt/idxmgmt.go
+++ b/libbeat/idxmgmt/idxmgmt.go
@@ -98,7 +98,7 @@ func MakeDefaultSupport(ilmSupport ilm.SupportFactory) SupportFactory {
 			ILM       *common.Config         `config:"setup.ilm"`
 			Template  *common.Config         `config:"setup.template"`
 			Output    common.ConfigNamespace `config:"output"`
-			Migration *common.Config         `config:"migration"`
+			Migration *common.Config         `config:"migration_67"`
 		}{}
 		if configRoot != nil {
 			if err := configRoot.Unpack(&cfg); err != nil {

--- a/libbeat/tests/system/test_migration.py
+++ b/libbeat/tests/system/test_migration.py
@@ -47,7 +47,7 @@ class TestCommands(BaseTest):
             extra_args=[
                 "export", "template",
                 "-E", "setup.template.fields=" + self.fields_path,
-                "-E", "migration_67.enabled=false",
+                "-E", "migration.6_to_7.enabled=false",
             ],
             config="libbeat.yml")
 
@@ -64,7 +64,7 @@ class TestCommands(BaseTest):
             extra_args=[
                 "export", "template",
                 "-E", "setup.template.fields=" + self.fields_path,
-                "-E", "migration_67.enabled=true",
+                "-E", "migration.6_to_7.enabled=true",
             ],
             config="libbeat.yml")
 

--- a/libbeat/tests/system/test_migration.py
+++ b/libbeat/tests/system/test_migration.py
@@ -47,7 +47,7 @@ class TestCommands(BaseTest):
             extra_args=[
                 "export", "template",
                 "-E", "setup.template.fields=" + self.fields_path,
-                "-E", "migration.enabled=false",
+                "-E", "migration_67.enabled=false",
             ],
             config="libbeat.yml")
 
@@ -64,7 +64,7 @@ class TestCommands(BaseTest):
             extra_args=[
                 "export", "template",
                 "-E", "setup.template.fields=" + self.fields_path,
-                "-E", "migration.enabled=true",
+                "-E", "migration_67.enabled=true",
             ],
             config="libbeat.yml")
 

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -1874,5 +1874,5 @@ logging.files:
 
 #================================= Migration ==================================
 
-# This allows to enable migration aliases
-#migration.enabled: false
+# This allows to enable 6.7 migration aliases
+#migration_67.enabled: false

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -1875,4 +1875,4 @@ logging.files:
 #================================= Migration ==================================
 
 # This allows to enable 6.7 migration aliases
-#migration_67.enabled: false
+#migration.6_to_7.enabled: false

--- a/metricbeat/metricbeat.yml
+++ b/metricbeat/metricbeat.yml
@@ -150,4 +150,4 @@ processors:
 #================================= Migration ==================================
 
 # This allows to enable 6.7 migration aliases
-#migration_67.enabled: false
+#migration.6_to_7.enabled: false

--- a/metricbeat/metricbeat.yml
+++ b/metricbeat/metricbeat.yml
@@ -149,5 +149,5 @@ processors:
 
 #================================= Migration ==================================
 
-# This allows to enable migration aliases
-#migration.enabled: false
+# This allows to enable 6.7 migration aliases
+#migration_67.enabled: false

--- a/metricbeat/tests/system/test_base.py
+++ b/metricbeat/tests/system/test_base.py
@@ -92,7 +92,7 @@ class Test(BaseTest):
             elasticsearch={"host": self.get_elasticsearch_url()},
         )
         exit_code = self.run_beat(extra_args=["setup", "--template",
-                                              "-E", "setup.template.overwrite=true", "-E", "migration.enabled=true"])
+                                              "-E", "setup.template.overwrite=true", "-E", "migration_67.enabled=true"])
 
         assert exit_code == 0
         assert self.log_contains('Loaded index template')

--- a/metricbeat/tests/system/test_base.py
+++ b/metricbeat/tests/system/test_base.py
@@ -92,7 +92,7 @@ class Test(BaseTest):
             elasticsearch={"host": self.get_elasticsearch_url()},
         )
         exit_code = self.run_beat(extra_args=["setup", "--template",
-                                              "-E", "setup.template.overwrite=true", "-E", "migration_67.enabled=true"])
+                                              "-E", "setup.template.overwrite=true", "-E", "migration.6_to_7.enabled=true"])
 
         assert exit_code == 0
         assert self.log_contains('Loaded index template')

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -1634,5 +1634,5 @@ logging.files:
 
 #================================= Migration ==================================
 
-# This allows to enable migration aliases
-#migration.enabled: false
+# This allows to enable 6.7 migration aliases
+#migration_67.enabled: false

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -1635,4 +1635,4 @@ logging.files:
 #================================= Migration ==================================
 
 # This allows to enable 6.7 migration aliases
-#migration_67.enabled: false
+#migration.6_to_7.enabled: false

--- a/packetbeat/packetbeat.yml
+++ b/packetbeat/packetbeat.yml
@@ -231,5 +231,5 @@ processors:
 
 #================================= Migration ==================================
 
-# This allows to enable migration aliases
-#migration.enabled: false
+# This allows to enable 6.7 migration aliases
+#migration_67.enabled: false

--- a/packetbeat/packetbeat.yml
+++ b/packetbeat/packetbeat.yml
@@ -232,4 +232,4 @@ processors:
 #================================= Migration ==================================
 
 # This allows to enable 6.7 migration aliases
-#migration_67.enabled: false
+#migration.6_to_7.enabled: false

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -1183,5 +1183,5 @@ logging.files:
 
 #================================= Migration ==================================
 
-# This allows to enable migration aliases
-#migration.enabled: false
+# This allows to enable 6.7 migration aliases
+#migration_67.enabled: false

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -1184,4 +1184,4 @@ logging.files:
 #================================= Migration ==================================
 
 # This allows to enable 6.7 migration aliases
-#migration_67.enabled: false
+#migration.6_to_7.enabled: false

--- a/winlogbeat/winlogbeat.yml
+++ b/winlogbeat/winlogbeat.yml
@@ -154,4 +154,4 @@ processors:
 #================================= Migration ==================================
 
 # This allows to enable 6.7 migration aliases
-#migration_67.enabled: false
+#migration.6_to_7.enabled: false

--- a/winlogbeat/winlogbeat.yml
+++ b/winlogbeat/winlogbeat.yml
@@ -153,5 +153,5 @@ processors:
 
 #================================= Migration ==================================
 
-# This allows to enable migration aliases
-#migration.enabled: false
+# This allows to enable 6.7 migration aliases
+#migration_67.enabled: false

--- a/x-pack/auditbeat/auditbeat.reference.yml
+++ b/x-pack/auditbeat/auditbeat.reference.yml
@@ -1302,4 +1302,4 @@ logging.files:
 #================================= Migration ==================================
 
 # This allows to enable 6.7 migration aliases
-#migration_67.enabled: false
+#migration.6_to_7.enabled: false

--- a/x-pack/auditbeat/auditbeat.reference.yml
+++ b/x-pack/auditbeat/auditbeat.reference.yml
@@ -1301,5 +1301,5 @@ logging.files:
 
 #================================= Migration ==================================
 
-# This allows to enable migration aliases
-#migration.enabled: false
+# This allows to enable 6.7 migration aliases
+#migration_67.enabled: false

--- a/x-pack/auditbeat/auditbeat.yml
+++ b/x-pack/auditbeat/auditbeat.yml
@@ -200,4 +200,4 @@ processors:
 #================================= Migration ==================================
 
 # This allows to enable 6.7 migration aliases
-#migration_67.enabled: false
+#migration.6_to_7.enabled: false

--- a/x-pack/auditbeat/auditbeat.yml
+++ b/x-pack/auditbeat/auditbeat.yml
@@ -199,5 +199,5 @@ processors:
 
 #================================= Migration ==================================
 
-# This allows to enable migration aliases
-#migration.enabled: false
+# This allows to enable 6.7 migration aliases
+#migration_67.enabled: false

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -2057,4 +2057,4 @@ logging.files:
 #================================= Migration ==================================
 
 # This allows to enable 6.7 migration aliases
-#migration_67.enabled: false
+#migration.6_to_7.enabled: false

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -2056,5 +2056,5 @@ logging.files:
 
 #================================= Migration ==================================
 
-# This allows to enable migration aliases
-#migration.enabled: false
+# This allows to enable 6.7 migration aliases
+#migration_67.enabled: false

--- a/x-pack/filebeat/filebeat.yml
+++ b/x-pack/filebeat/filebeat.yml
@@ -205,5 +205,5 @@ processors:
 
 #================================= Migration ==================================
 
-# This allows to enable migration aliases
-#migration.enabled: false
+# This allows to enable 6.7 migration aliases
+#migration_67.enabled: false

--- a/x-pack/filebeat/filebeat.yml
+++ b/x-pack/filebeat/filebeat.yml
@@ -206,4 +206,4 @@ processors:
 #================================= Migration ==================================
 
 # This allows to enable 6.7 migration aliases
-#migration_67.enabled: false
+#migration.6_to_7.enabled: false

--- a/x-pack/functionbeat/functionbeat.reference.yml
+++ b/x-pack/functionbeat/functionbeat.reference.yml
@@ -1300,4 +1300,4 @@ logging.files:
 #================================= Migration ==================================
 
 # This allows to enable 6.7 migration aliases
-#migration_67.enabled: false
+#migration.6_to_7.enabled: false

--- a/x-pack/functionbeat/functionbeat.reference.yml
+++ b/x-pack/functionbeat/functionbeat.reference.yml
@@ -1299,5 +1299,5 @@ logging.files:
 
 #================================= Migration ==================================
 
-# This allows to enable migration aliases
-#migration.enabled: false
+# This allows to enable 6.7 migration aliases
+#migration_67.enabled: false

--- a/x-pack/functionbeat/functionbeat.yml
+++ b/x-pack/functionbeat/functionbeat.yml
@@ -275,5 +275,5 @@ processors:
 
 #================================= Migration ==================================
 
-# This allows to enable migration aliases
-#migration.enabled: false
+# This allows to enable 6.7 migration aliases
+#migration_67.enabled: false

--- a/x-pack/functionbeat/functionbeat.yml
+++ b/x-pack/functionbeat/functionbeat.yml
@@ -276,4 +276,4 @@ processors:
 #================================= Migration ==================================
 
 # This allows to enable 6.7 migration aliases
-#migration_67.enabled: false
+#migration.6_to_7.enabled: false

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -1904,4 +1904,4 @@ logging.files:
 #================================= Migration ==================================
 
 # This allows to enable 6.7 migration aliases
-#migration_67.enabled: false
+#migration.6_to_7.enabled: false

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -1903,5 +1903,5 @@ logging.files:
 
 #================================= Migration ==================================
 
-# This allows to enable migration aliases
-#migration.enabled: false
+# This allows to enable 6.7 migration aliases
+#migration_67.enabled: false

--- a/x-pack/metricbeat/metricbeat.yml
+++ b/x-pack/metricbeat/metricbeat.yml
@@ -150,4 +150,4 @@ processors:
 #================================= Migration ==================================
 
 # This allows to enable 6.7 migration aliases
-#migration_67.enabled: false
+#migration.6_to_7.enabled: false

--- a/x-pack/metricbeat/metricbeat.yml
+++ b/x-pack/metricbeat/metricbeat.yml
@@ -149,5 +149,5 @@ processors:
 
 #================================= Migration ==================================
 
-# This allows to enable migration aliases
-#migration.enabled: false
+# This allows to enable 6.7 migration aliases
+#migration_67.enabled: false


### PR DESCRIPTION
This is to make it more clear this is for the migration from 6.7 to 7.0.