### PR TITLE
Cherry-pick #11247 to 7.0: Don't collect empty ip addresses in docker container metricset

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -71,11 +71,8 @@ https://github.com/elastic/beats/compare/v7.0.0-beta1...master[Check the HEAD di
 
 - Fix errors in filebeat Zeek dashboard and README files. Add notice.log support. {pull}10916[10916]
 - Fix a bug when converting NetFlow fields to snake_case. {pull}10950[10950]
-- Add on_failure handler for Zeek ingest pipelines. Fix one field name error for notice and add an additional test
 - Add on_failure handler for Zeek ingest pipelines. Fix one field name error for notice and add an additional test case. {issue}11004[11004] {pull}11105[11105]
 - Fix issue preventing docker container events to be stored if the container has a network interface without ip address. {issue}11225[11225] {pull}11247[11247]
-- Add on_failure handler for Zeek ingest pipelines. Fix one field name error for notice and add an additional test 
-  case. {issue}11004[11004] {pull}11105[11105]
 - Change URLPATH grok pattern to support brackets. {issue}11135[11135] {pull}11252[11252]
 - Add support for iis log with different address format. {issue}11255[11255] {pull}11256[11256]
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -72,6 +72,9 @@ https://github.com/elastic/beats/compare/v7.0.0-beta1...master[Check the HEAD di
 - Fix errors in filebeat Zeek dashboard and README files. Add notice.log support. {pull}10916[10916]
 - Fix a bug when converting NetFlow fields to snake_case. {pull}10950[10950]
 - Add on_failure handler for Zeek ingest pipelines. Fix one field name error for notice and add an additional test
+- Add on_failure handler for Zeek ingest pipelines. Fix one field name error for notice and add an additional test case. {issue}11004[11004] {pull}11105[11105]
+- Fix issue preventing docker container events to be stored if the container has a network interface without ip address. {issue}11225[11225] {pull}11247[11247]
+- Add on_failure handler for Zeek ingest pipelines. Fix one field name error for notice and add an additional test 
   case. {issue}11004[11004] {pull}11105[11105]
 - Change URLPATH grok pattern to support brackets. {issue}11135[11135] {pull}11252[11252]
 - Add support for iis log with different address format. {issue}11255[11255] {pull}11256[11256]

--- a/metricbeat/module/docker/container/data.go
+++ b/metricbeat/module/docker/container/data.go
@@ -71,7 +71,9 @@ func eventMapping(r mb.ReporterV2, cont *types.Container, dedot bool) {
 func extractIPAddresses(networks *types.SummaryNetworkSettings) []string {
 	ipAddresses := make([]string, 0, len(networks.Networks))
 	for _, network := range networks.Networks {
-		ipAddresses = append(ipAddresses, network.IPAddress)
+		if len(network.IPAddress) > 0 {
+			ipAddresses = append(ipAddresses, network.IPAddress)
+		}
 	}
 	return ipAddresses
 }


### PR DESCRIPTION
Cherry-pick of PR #11247 to 7.0 branch. Original message: 

Docker containers can have empty ip addresses if they are running in
host network mode or if they are stopped. Collecting lists with empty
addresses can make type mapping to fail when trying to store them as ip
addresses.

It only affects 7.0 because before these ip addresses were of type
`keyword`.

Fix #11225 