### PR TITLE
[metricbeat] implement Close() for docker metricsets

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -206,7 +206,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add documentation about jolokia autodiscover fields. {issue}10925[10925] {pull}10979[10979]
 - Add missing aws.ec2.instance.state.name into fields.yml. {issue}11219[11219] {pull}11221[11221]
 - Fix ec2 metricset to collect metrics from Cloudwatch with the same timestamp. {pull}11142[11142]
-- Fix potential memory leak in docker/container metricset {pull}11294[11294]
+- Fix potential memory leak in stopped docker metricsets {pull}11294[11294]
 
 *Packetbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -100,7 +100,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Collect all EC2 meta data from all instances in all states. {pull}10628[10628]
 - Migrate docker module to ECS. {pull}10927[10927]
 - Add new option `OpMultiplyBuckets` to scale histogram buckets to avoid decimal points in final events {pull}10994[10994]
-- Fix potentential memory leak in docker/container metricset {pull}11294[11294]
+
 
 *Packetbeat*
 
@@ -207,6 +207,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add documentation about jolokia autodiscover fields. {issue}10925[10925] {pull}10979[10979]
 - Add missing aws.ec2.instance.state.name into fields.yml. {issue}11219[11219] {pull}11221[11221]
 - Fix ec2 metricset to collect metrics from Cloudwatch with the same timestamp. {pull}11142[11142]
+- Fix potential memory leak in docker/container metricset {pull}11294[11294]
 
 *Packetbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -101,7 +101,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Migrate docker module to ECS. {pull}10927[10927]
 - Add new option `OpMultiplyBuckets` to scale histogram buckets to avoid decimal points in final events {pull}10994[10994]
 
-
 *Packetbeat*
 
 - Adjust Packetbeat `http` fields to ECS Beta 2 {pull}9645[9645]

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -100,6 +100,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Collect all EC2 meta data from all instances in all states. {pull}10628[10628]
 - Migrate docker module to ECS. {pull}10927[10927]
 - Add new option `OpMultiplyBuckets` to scale histogram buckets to avoid decimal points in final events {pull}10994[10994]
+- Fix potentential memory leak in docker/container metricset {pull}11294[11294]
 
 *Packetbeat*
 

--- a/metricbeat/module/docker/container/container.go
+++ b/metricbeat/module/docker/container/container.go
@@ -38,6 +38,7 @@ func init() {
 	)
 }
 
+// MetricSet type defines all fields of the MetricSet
 type MetricSet struct {
 	mb.BaseMetricSet
 	dockerClient *client.Client
@@ -75,4 +76,10 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 		return
 	}
 	eventsMapping(r, containers, m.dedot)
+}
+
+//Close stops the metricset
+func (m *MetricSet) Close() error {
+
+	return m.dockerClient.Close()
 }

--- a/metricbeat/module/docker/cpu/cpu.go
+++ b/metricbeat/module/docker/cpu/cpu.go
@@ -84,3 +84,9 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 	formattedStats := m.cpuService.getCPUStatsList(stats, m.dedot)
 	eventsMapping(r, formattedStats)
 }
+
+//Close stops the metricset
+func (m *MetricSet) Close() error {
+
+	return m.dockerClient.Close()
+}

--- a/metricbeat/module/docker/diskio/diskio.go
+++ b/metricbeat/module/docker/diskio/diskio.go
@@ -75,3 +75,9 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 	formattedStats := m.blkioService.getBlkioStatsList(stats, m.dedot)
 	eventsMapping(r, formattedStats)
 }
+
+//Close stops the metricset
+func (m *MetricSet) Close() error {
+
+	return m.dockerClient.Close()
+}

--- a/metricbeat/module/docker/healthcheck/healthcheck.go
+++ b/metricbeat/module/docker/healthcheck/healthcheck.go
@@ -76,3 +76,9 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 	}
 	eventsMapping(r, containers, m)
 }
+
+//Close stops the metricset
+func (m *MetricSet) Close() error {
+
+	return m.dockerClient.Close()
+}

--- a/metricbeat/module/docker/image/image.go
+++ b/metricbeat/module/docker/image/image.go
@@ -78,3 +78,9 @@ func (m *MetricSet) Fetch() ([]common.MapStr, error) {
 
 	return eventsMapping(images, m.dedot), nil
 }
+
+//Close stops the metricset
+func (m *MetricSet) Close() error {
+
+	return m.dockerClient.Close()
+}

--- a/metricbeat/module/docker/info/info.go
+++ b/metricbeat/module/docker/info/info.go
@@ -67,3 +67,9 @@ func (m *MetricSet) Fetch() (common.MapStr, error) {
 
 	return eventMapping(&info), nil
 }
+
+//Close stops the metricset
+func (m *MetricSet) Close() error {
+
+	return m.dockerClient.Close()
+}

--- a/metricbeat/module/docker/memory/memory.go
+++ b/metricbeat/module/docker/memory/memory.go
@@ -75,3 +75,9 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 	memoryStats := m.memoryService.getMemoryStatsList(stats, m.dedot)
 	eventsMapping(r, memoryStats)
 }
+
+//Close stops the metricset
+func (m *MetricSet) Close() error {
+
+	return m.dockerClient.Close()
+}

--- a/metricbeat/module/docker/network/network.go
+++ b/metricbeat/module/docker/network/network.go
@@ -77,3 +77,9 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 	formattedStats := m.netService.getNetworkStatsPerContainer(stats, m.dedot)
 	eventsMapping(r, formattedStats)
 }
+
+//Close stops the metricset
+func (m *MetricSet) Close() error {
+
+	return m.dockerClient.Close()
+}


### PR DESCRIPTION
More info at #11266 

This is something I noticed while looking over the inconsistencies in how various metricsets do or do not implement a `Close()`.

@ruflin Mentioned that there may be some weird behavior around docker and closing connections. As of now this looks straightforward, but we can check to see if something crops up during CI.