### PR TITLE
New processor: truncate_fields

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -269,6 +269,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Gracefully shut down on SIGHUP {pull}10704[10704]
 - New processor: `copy_fields`. {pull}11303[11303]
 - Add `error.message` to events when `fail_on_error` is set in `rename` and `copy_fields` processors. {pull}11303[11303]
+- New processor: `truncate_fields`. {pull}11297[11297]
 
 *Auditbeat*
 

--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -339,6 +339,32 @@ auditbeat.modules:
 #          to: message_copied
 #    fail_on_error: true
 #    ignore_missing: false
+#
+# The following example truncates the value of message to 1024 bytes
+#
+#processors:
+#- truncate_fields:
+#    fields:
+#      - message
+#    max_bytes: 1024
+#    fail_on_error: false
+#    ignore_missing: true
+#
+# The following example preserves the raw message under event.original
+#
+#processors:
+#- copy_fields:
+#    fields:
+#        - from: message
+#          to: event.original
+#    fail_on_error: false
+#    ignore_missing: true
+#- truncate_fields:
+#    fields:
+#      - event.original
+#    max_bytes: 1024
+#    fail_on_error: false
+#    ignore_missing: true
 
 #============================= Elastic Cloud ==================================
 

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -1058,6 +1058,32 @@ filebeat.inputs:
 #          to: message_copied
 #    fail_on_error: true
 #    ignore_missing: false
+#
+# The following example truncates the value of message to 1024 bytes
+#
+#processors:
+#- truncate_fields:
+#    fields:
+#      - message
+#    max_bytes: 1024
+#    fail_on_error: false
+#    ignore_missing: true
+#
+# The following example preserves the raw message under event.original
+#
+#processors:
+#- copy_fields:
+#    fields:
+#        - from: message
+#          to: event.original
+#    fail_on_error: false
+#    ignore_missing: true
+#- truncate_fields:
+#    fields:
+#      - event.original
+#    max_bytes: 1024
+#    fail_on_error: false
+#    ignore_missing: true
 
 #============================= Elastic Cloud ==================================
 

--- a/filebeat/tests/system/test_processors.py
+++ b/filebeat/tests/system/test_processors.py
@@ -212,7 +212,7 @@ class Test(BaseTest):
         self._init_and_read_test_input([
             u"This is my super long line\n",
             u"This is an even longer long line\n",
-            u"A végrehajtás során hiba történt\n", # Error occured during execution (Hungarian)
+            u"A végrehajtás során hiba történt\n",  # Error occured during execution (Hungarian)
             u"This is OK\n",
         ])
 
@@ -239,7 +239,7 @@ class Test(BaseTest):
 
         self._init_and_read_test_input([
             u"This is my super long line\n",
-            u"A végrehajtás során hiba történt\n", # Error occured during execution (Hungarian)
+            u"A végrehajtás során hiba történt\n",  # Error occured during execution (Hungarian)
             u"This is OK\n",
         ])
 

--- a/filebeat/tests/system/test_processors.py
+++ b/filebeat/tests/system/test_processors.py
@@ -1,4 +1,6 @@
+# -*- coding: utf-8 -*-
 from filebeat import BaseTest
+import io
 import os
 
 """
@@ -192,3 +194,74 @@ class Test(BaseTest):
         )[0]
         assert "extracted.key" not in output
         assert output["message"] == "Hello world"
+
+    def test_truncate_bytes(self):
+        """
+        Check if truncate_fields with max_bytes can truncate long lines and leave short lines as is
+        """
+        self.render_config_template(
+            path=os.path.abspath(self.working_dir) + "/test.log",
+            processors=[{
+                "truncate_fields": {
+                    "max_bytes": 10,
+                    "fields": ["message"],
+                },
+            }]
+        )
+
+        self._init_and_read_test_input([
+            u"This is my super long line\n",
+            u"This is an even longer long line\n",
+            u"A végrehajtás során hiba történt\n", # Error occured during execution (Hungarian)
+            u"This is OK\n",
+        ])
+
+        self._assert_expected_lines([
+            u"This is my",
+            u"This is an",
+            u"A végreha",
+            u"This is OK",
+        ])
+
+    def test_truncate_characters(self):
+        """
+        Check if truncate_fields with max_charaters can truncate long lines and leave short lines as is
+        """
+        self.render_config_template(
+            path=os.path.abspath(self.working_dir) + "/test.log",
+            processors=[{
+                "truncate_fields": {
+                    "max_characters": 10,
+                    "fields": ["message"],
+                },
+            }]
+        )
+
+        self._init_and_read_test_input([
+            u"This is my super long line\n",
+            u"A végrehajtás során hiba történt\n", # Error occured during execution (Hungarian)
+            u"This is OK\n",
+        ])
+
+        self._assert_expected_lines([
+            u"This is my",
+            u"A végrehaj",
+            u"This is OK",
+        ])
+
+    def _init_and_read_test_input(self, input_lines):
+        with io.open(self.working_dir + "/test.log", "w", encoding="utf-8") as f:
+            for line in input_lines:
+                f.write((line))
+
+        filebeat = self.start_beat()
+        self.wait_until(lambda: self.output_has(lines=len(input_lines)))
+        filebeat.check_kill_and_wait()
+
+    def _assert_expected_lines(self, expected_lines):
+        output = self.read_output()
+
+        assert len(output) == len(expected_lines)
+
+        for i in range(len(expected_lines)):
+            assert output[i]["message"] == expected_lines[i]

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -483,6 +483,32 @@ heartbeat.scheduler:
 #          to: message_copied
 #    fail_on_error: true
 #    ignore_missing: false
+#
+# The following example truncates the value of message to 1024 bytes
+#
+#processors:
+#- truncate_fields:
+#    fields:
+#      - message
+#    max_bytes: 1024
+#    fail_on_error: false
+#    ignore_missing: true
+#
+# The following example preserves the raw message under event.original
+#
+#processors:
+#- copy_fields:
+#    fields:
+#        - from: message
+#          to: event.original
+#    fail_on_error: false
+#    ignore_missing: true
+#- truncate_fields:
+#    fields:
+#      - event.original
+#    max_bytes: 1024
+#    fail_on_error: false
+#    ignore_missing: true
 
 #============================= Elastic Cloud ==================================
 

--- a/journalbeat/journalbeat.reference.yml
+++ b/journalbeat/journalbeat.reference.yml
@@ -279,6 +279,32 @@ setup.template.settings:
 #          to: message_copied
 #    fail_on_error: true
 #    ignore_missing: false
+#
+# The following example truncates the value of message to 1024 bytes
+#
+#processors:
+#- truncate_fields:
+#    fields:
+#      - message
+#    max_bytes: 1024
+#    fail_on_error: false
+#    ignore_missing: true
+#
+# The following example preserves the raw message under event.original
+#
+#processors:
+#- copy_fields:
+#    fields:
+#        - from: message
+#          to: event.original
+#    fail_on_error: false
+#    ignore_missing: true
+#- truncate_fields:
+#    fields:
+#      - event.original
+#    max_bytes: 1024
+#    fail_on_error: false
+#    ignore_missing: true
 
 #============================= Elastic Cloud ==================================
 

--- a/libbeat/_meta/config.reference.yml
+++ b/libbeat/_meta/config.reference.yml
@@ -227,6 +227,32 @@
 #          to: message_copied
 #    fail_on_error: true
 #    ignore_missing: false
+#
+# The following example truncates the value of message to 1024 bytes
+#
+#processors:
+#- truncate_fields:
+#    fields:
+#      - message
+#    max_bytes: 1024
+#    fail_on_error: false
+#    ignore_missing: true
+#
+# The following example preserves the raw message under event.original
+#
+#processors:
+#- copy_fields:
+#    fields:
+#        - from: message
+#          to: event.original
+#    fail_on_error: false
+#    ignore_missing: true
+#- truncate_fields:
+#    fields:
+#      - event.original
+#    max_bytes: 1024
+#    fail_on_error: false
+#    ignore_missing: true
 
 #============================= Elastic Cloud ==================================
 

--- a/libbeat/processors/actions/checks.go
+++ b/libbeat/processors/actions/checks.go
@@ -79,3 +79,26 @@ func allowedFields(fields ...string) func(*common.Config) error {
 		return nil
 	}
 }
+
+func mutuallyExclusiveRequiredFields(fields ...string) func(*common.Config) error {
+	return func(cfg *common.Config) error {
+		var foundField string
+		for _, field := range cfg.GetFields() {
+			for _, f := range fields {
+				if field == f {
+					if len(foundField) == 0 {
+						foundField = field
+					} else {
+						return fmt.Errorf("field %s and %s are mutually exclusive", foundField, field)
+					}
+				}
+			}
+		}
+
+		if len(foundField) == 0 {
+			return fmt.Errorf("missing option, select one from %v", fields)
+		}
+		return nil
+	}
+
+}

--- a/libbeat/processors/actions/checks.go
+++ b/libbeat/processors/actions/checks.go
@@ -100,5 +100,4 @@ func mutuallyExclusiveRequiredFields(fields ...string) func(*common.Config) erro
 		}
 		return nil
 	}
-
 }

--- a/libbeat/processors/actions/checks_test.go
+++ b/libbeat/processors/actions/checks_test.go
@@ -1,0 +1,202 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package actions
+
+import (
+	"testing"
+
+	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/processors"
+)
+
+type mockProcessor struct{}
+
+func newMock(c *common.Config) (processors.Processor, error) {
+	return &mockProcessor{}, nil
+}
+
+func (m *mockProcessor) Run(event *beat.Event) (*beat.Event, error) {
+	return event, nil
+}
+
+func (m *mockProcessor) String() string {
+	return "mockProcessor"
+}
+
+func TestRequiredFields(t *testing.T) {
+	tests := map[string]struct {
+		Config   map[string]interface{}
+		Required []string
+		Valid    bool
+	}{
+		"one required field present in the configuration": {
+			Config: map[string]interface{}{
+				"required_field": nil,
+				"not_required":   nil,
+			},
+			Required: []string{
+				"required_field",
+			},
+			Valid: true,
+		},
+		"two required field present in the configuration": {
+			Config: map[string]interface{}{
+				"required_field":         nil,
+				"another_required_field": nil,
+				"not_required":           nil,
+			},
+			Required: []string{
+				"required_field",
+				"another_required_field",
+			},
+			Valid: true,
+		},
+		"one required field present and one missing in the configuration": {
+			Config: map[string]interface{}{
+				"required_field": nil,
+				"not_required":   nil,
+			},
+			Required: []string{
+				"required_field",
+				"one_more_required_field",
+			},
+			Valid: false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			runTest(t, requireFields, test.Config, test.Required, test.Valid)
+		})
+	}
+}
+
+func TestAllowedFields(t *testing.T) {
+	tests := map[string]struct {
+		Config  map[string]interface{}
+		Allowed []string
+		Valid   bool
+	}{
+		"one allowed field present in the configuration": {
+			Config: map[string]interface{}{
+				"allowed_field": nil,
+			},
+			Allowed: []string{
+				"allowed_field",
+			},
+			Valid: true,
+		},
+		"two allowed field present in the configuration": {
+			Config: map[string]interface{}{
+				"allowed_field":         nil,
+				"another_allowed_field": nil,
+			},
+			Allowed: []string{
+				"allowed_field",
+				"another_allowed_field",
+			},
+			Valid: true,
+		},
+		"one allowed field present and one not allowed is present in the configuration": {
+			Config: map[string]interface{}{
+				"allowed_field": nil,
+				"not_allowed":   nil,
+			},
+			Allowed: []string{
+				"allowed_field",
+			},
+			Valid: false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			runTest(t, allowedFields, test.Config, test.Allowed, test.Valid)
+		})
+	}
+}
+
+func TestMutuallyExclusiveRequiredFields(t *testing.T) {
+	tests := map[string]struct {
+		Config            map[string]interface{}
+		MutuallyExclusive []string
+		Valid             bool
+	}{
+		"one mutually exclusive field is present in the configuration": {
+			Config: map[string]interface{}{
+				"first_option": nil,
+			},
+			MutuallyExclusive: []string{
+				"first_option",
+				"second_option",
+			},
+			Valid: true,
+		},
+		"two mutually exclusive field is present in the configuration": {
+			Config: map[string]interface{}{
+				"first_option":  nil,
+				"second_option": nil,
+			},
+			MutuallyExclusive: []string{
+				"first_option",
+				"second_option",
+			},
+			Valid: false,
+		},
+		"no mutually exclusive field is present in the configuration": {
+			Config: map[string]interface{}{
+				"third_option": nil,
+			},
+			MutuallyExclusive: []string{
+				"first_option",
+				"second_option",
+			},
+			Valid: false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			runTest(t, mutuallyExclusiveRequiredFields, test.Config, test.MutuallyExclusive, test.Valid)
+		})
+	}
+}
+
+func runTest(
+	t *testing.T,
+	check func(fields ...string) func(*common.Config) error,
+	config map[string]interface{},
+	fields []string,
+	valid bool,
+) {
+	cfg, err := common.NewConfigFrom(config)
+	if err != nil {
+		t.Fatalf("Unexpected error while creating configuration: %+v\n", err)
+	}
+	factory := configChecked(newMock, check(fields...))
+	_, err = factory(cfg)
+
+	if err != nil && valid {
+		t.Errorf("Unexpected error when validating configuration of processor: %+v\n", err)
+	}
+
+	if err == nil && !valid {
+		t.Errorf("Expected error but nothing was reported\n")
+	}
+}

--- a/libbeat/processors/actions/truncate_fields.go
+++ b/libbeat/processors/actions/truncate_fields.go
@@ -44,7 +44,7 @@ type truncateFields struct {
 	truncate truncater
 }
 
-type truncater func(*truncateFields, []byte) ([]byte, error)
+type truncater func(*truncateFields, []byte) ([]byte, bool, error)
 
 func init() {
 	processors.RegisterPlugin("truncate_fields",
@@ -99,14 +99,14 @@ func (f *truncateFields) truncateSingleField(field string, event *beat.Event) (*
 		if f.config.IgnoreMissing && errors.Cause(err) == common.ErrKeyNotFound {
 			return event, nil
 		}
-		return event, fmt.Errorf("could not fetch value for key: %s, Error: %+v", field, err)
+		return event, errors.Wrapf(err, "could not fetch value for key: %s", field)
 	}
 
 	switch value := v.(type) {
-	case string:
-		return f.addTruncatedString(field, value, event)
 	case []byte:
 		return f.addTruncatedByte(field, value, event)
+	case string:
+		return f.addTruncatedString(field, value, event)
 	default:
 		return event, fmt.Errorf("value cannot be truncated: %+v", value)
 	}
@@ -114,7 +114,7 @@ func (f *truncateFields) truncateSingleField(field string, event *beat.Event) (*
 }
 
 func (f *truncateFields) addTruncatedString(field, value string, event *beat.Event) (*beat.Event, error) {
-	truncated, err := f.truncate(f, []byte(value))
+	truncated, isTruncated, err := f.truncate(f, []byte(value))
 	if err != nil {
 		return event, err
 	}
@@ -122,11 +122,16 @@ func (f *truncateFields) addTruncatedString(field, value string, event *beat.Eve
 	if err != nil {
 		return event, fmt.Errorf("could not add truncated string value for key: %s, Error: %+v", field, err)
 	}
+
+	if isTruncated {
+		common.AddTagsWithKey(event.Fields, "log.flags", []string{"truncated"})
+	}
+
 	return event, nil
 }
 
 func (f *truncateFields) addTruncatedByte(field string, value []byte, event *beat.Event) (*beat.Event, error) {
-	truncated, err := f.truncate(f, value)
+	truncated, isTruncated, err := f.truncate(f, value)
 	if err != nil {
 		return event, err
 	}
@@ -134,45 +139,52 @@ func (f *truncateFields) addTruncatedByte(field string, value []byte, event *bea
 	if err != nil {
 		return event, fmt.Errorf("could not add truncated byte slice value for key: %s, Error: %+v", field, err)
 	}
+
+	if isTruncated {
+		common.AddTagsWithKey(event.Fields, "log.flags", []string{"truncated"})
+	}
+
 	return event, nil
 }
 
-func (f *truncateFields) truncateBytes(value []byte) ([]byte, error) {
+func (f *truncateFields) truncateBytes(value []byte) ([]byte, bool, error) {
 	size := len(value)
-	if size > f.config.MaxBytes {
-		size = f.config.MaxBytes
+	if size <= f.config.MaxBytes {
+		return value, false, nil
 	}
 
+	size = f.config.MaxBytes
 	truncated := make([]byte, size)
 	n := copy(truncated, value[:size])
 	if n != size {
-		return nil, fmt.Errorf("unexpected number of bytes were copied")
+		return nil, false, fmt.Errorf("unexpected number of bytes were copied")
 	}
-	return truncated, nil
+	return truncated, true, nil
 }
 
-func (f *truncateFields) truncateCharacters(value []byte) ([]byte, error) {
+func (f *truncateFields) truncateCharacters(value []byte) ([]byte, bool, error) {
 	count := utf8.RuneCount(value)
-	if count > f.config.MaxChars {
-		count = f.config.MaxChars
+	if count <= f.config.MaxChars {
+		return value, false, nil
 	}
 
+	count = f.config.MaxChars
 	r := bytes.NewReader(value)
 	w := bytes.NewBuffer(nil)
 
 	for i := 0; i < count; i++ {
 		r, _, err := r.ReadRune()
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 
 		_, err = w.WriteRune(r)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 	}
 
-	return w.Bytes(), nil
+	return w.Bytes(), true, nil
 }
 
 func (f *truncateFields) String() string {

--- a/libbeat/processors/actions/truncate_fields.go
+++ b/libbeat/processors/actions/truncate_fields.go
@@ -34,7 +34,7 @@ import (
 type truncateFieldsConfig struct {
 	Fields        []string `config:"fields"`
 	MaxBytes      int      `config:"max_bytes" validate:"min=0"`
-	MaxCount      int      `config:"max_character_count" validate:"min=0"`
+	MaxChars      int      `config:"max_characters" validate:"min=0"`
 	IgnoreMissing bool     `config:"ignore_missing"`
 	FailOnError   bool     `config:"fail_on_error"`
 }
@@ -50,7 +50,7 @@ func init() {
 	processors.RegisterPlugin("truncate_fields",
 		configChecked(newTruncateFields,
 			requireFields("fields"),
-			mutuallyExclusiveRequiredFields("max_bytes", "max_count"),
+			mutuallyExclusiveRequiredFields("max_bytes", "max_characters"),
 		),
 	)
 }
@@ -153,8 +153,8 @@ func (f *truncateFields) truncateBytes(value []byte) ([]byte, error) {
 
 func (f *truncateFields) truncateCharacters(value []byte) ([]byte, error) {
 	count := utf8.RuneCount(value)
-	if count > f.config.MaxCount {
-		count = f.config.MaxCount
+	if count > f.config.MaxChars {
+		count = f.config.MaxChars
 	}
 
 	r := bytes.NewReader(value)

--- a/libbeat/processors/actions/truncate_fields.go
+++ b/libbeat/processors/actions/truncate_fields.go
@@ -1,0 +1,180 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package actions
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/pkg/errors"
+
+	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/processors"
+)
+
+type truncateFieldsConfig struct {
+	Fields        []string `config:"fields"`
+	MaxBytes      int      `config:"max_bytes" validate:"min=0"`
+	MaxCount      int      `config:"max_character_count" validate:"min=0"`
+	IgnoreMissing bool     `config:"ignore_missing"`
+	FailOnError   bool     `config:"fail_on_error"`
+}
+
+type truncateFields struct {
+	config   truncateFieldsConfig
+	truncate truncater
+}
+
+type truncater func(*truncateFields, []byte) ([]byte, error)
+
+func init() {
+	processors.RegisterPlugin("truncate_fields",
+		configChecked(newTruncateFields,
+			requireFields("fields"),
+			mutuallyExclusiveRequiredFields("max_bytes", "max_count"),
+		),
+	)
+}
+
+func newTruncateFields(c *common.Config) (processors.Processor, error) {
+	var config truncateFieldsConfig
+	err := c.Unpack(&config)
+	if err != nil {
+		return nil, fmt.Errorf("fail to unpack the truncate_fields configuration: %s", err)
+	}
+
+	var truncateFunc truncater
+	if config.MaxBytes > 0 {
+		truncateFunc = (*truncateFields).truncateBytes
+	} else {
+		truncateFunc = (*truncateFields).truncateCharacters
+	}
+
+	return &truncateFields{
+		config:   config,
+		truncate: truncateFunc,
+	}, nil
+}
+
+func (f *truncateFields) Run(event *beat.Event) (*beat.Event, error) {
+	var backup common.MapStr
+	if f.config.FailOnError {
+		backup = event.Fields.Clone()
+	}
+
+	for _, field := range f.config.Fields {
+		event, err := f.truncateSingleField(field, event)
+		if err != nil && f.config.FailOnError {
+			logp.Debug("truncate_fields", "Failed to truncate fields: %s", err)
+			event.Fields = backup
+			return event, err
+		}
+	}
+
+	return event, nil
+}
+
+func (f *truncateFields) truncateSingleField(field string, event *beat.Event) (*beat.Event, error) {
+	v, err := event.GetValue(field)
+	if err != nil {
+		if f.config.IgnoreMissing && errors.Cause(err) == common.ErrKeyNotFound {
+			return event, nil
+		}
+		return event, fmt.Errorf("could not fetch value for key: %s, Error: %+v", field, err)
+	}
+
+	switch value := v.(type) {
+	case string:
+		return f.addTruncatedString(field, value, event)
+	case []byte:
+		return f.addTruncatedByte(field, value, event)
+	default:
+		return event, fmt.Errorf("value cannot be truncated: %+v", value)
+	}
+
+}
+
+func (f *truncateFields) addTruncatedString(field, value string, event *beat.Event) (*beat.Event, error) {
+	truncated, err := f.truncate(f, []byte(value))
+	if err != nil {
+		return event, err
+	}
+	_, err = event.PutValue(field, string(truncated))
+	if err != nil {
+		return event, fmt.Errorf("could not add truncated string value for key: %s, Error: %+v", field, err)
+	}
+	return event, nil
+}
+
+func (f *truncateFields) addTruncatedByte(field string, value []byte, event *beat.Event) (*beat.Event, error) {
+	truncated, err := f.truncate(f, value)
+	if err != nil {
+		return event, err
+	}
+	_, err = event.PutValue(field, truncated)
+	if err != nil {
+		return event, fmt.Errorf("could not add truncated byte slice value for key: %s, Error: %+v", field, err)
+	}
+	return event, nil
+}
+
+func (f *truncateFields) truncateBytes(value []byte) ([]byte, error) {
+	size := len(value)
+	if size > f.config.MaxBytes {
+		size = f.config.MaxBytes
+	}
+
+	truncated := make([]byte, size)
+	n := copy(truncated, value[:size])
+	if n != size {
+		return nil, fmt.Errorf("unexpected number of bytes were copied")
+	}
+	return truncated, nil
+}
+
+func (f *truncateFields) truncateCharacters(value []byte) ([]byte, error) {
+	count := utf8.RuneCount(value)
+	if count > f.config.MaxCount {
+		count = f.config.MaxCount
+	}
+
+	r := bytes.NewReader(value)
+	w := bytes.NewBuffer(nil)
+
+	for i := 0; i < count; i++ {
+		r, _, err := r.ReadRune()
+		if err != nil {
+			return nil, err
+		}
+
+		_, err = w.WriteRune(r)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return w.Bytes(), nil
+}
+
+func (f *truncateFields) String() string {
+	return "truncate_fields=" + strings.Join(f.config.Fields, ", ")
+}

--- a/libbeat/processors/actions/truncate_fields.go
+++ b/libbeat/processors/actions/truncate_fields.go
@@ -176,5 +176,11 @@ func (f *truncateFields) truncateCharacters(value []byte) ([]byte, error) {
 }
 
 func (f *truncateFields) String() string {
-	return "truncate_fields=" + strings.Join(f.config.Fields, ", ")
+	var limit string
+	if f.config.MaxBytes > 0 {
+		limit = fmt.Sprintf("max_bytes=%d", f.config.MaxBytes)
+	} else {
+		limit = fmt.Sprintf("max_characters=%d", f.config.MaxChars)
+	}
+	return "truncate_fields=" + strings.Join(f.config.Fields, ", ") + limit
 }

--- a/libbeat/processors/actions/truncate_fields_test.go
+++ b/libbeat/processors/actions/truncate_fields_test.go
@@ -1,0 +1,164 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package actions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/common"
+)
+
+func TestTruncateFields(t *testing.T) {
+
+	var tests = map[string]struct {
+		MaxBytes     int
+		MaxCount     int
+		Input        common.MapStr
+		Output       common.MapStr
+		ShouldError  bool
+		TruncateFunc truncater
+	}{
+		"truncate bytes of too long string line": {
+			MaxBytes: 3,
+			Input: common.MapStr{
+				"message": "too long line",
+			},
+			Output: common.MapStr{
+				"message": "too",
+			},
+			ShouldError:  false,
+			TruncateFunc: (*truncateFields).truncateBytes,
+		},
+		"truncate bytes of too long byte line": {
+			MaxBytes: 3,
+			Input: common.MapStr{
+				"message": []byte("too long line"),
+			},
+			Output: common.MapStr{
+				"message": []byte("too"),
+			},
+			ShouldError:  false,
+			TruncateFunc: (*truncateFields).truncateBytes,
+		},
+		"do not truncate short string line": {
+			MaxBytes: 15,
+			Input: common.MapStr{
+				"message": "shorter line",
+			},
+			Output: common.MapStr{
+				"message": "shorter line",
+			},
+			ShouldError:  false,
+			TruncateFunc: (*truncateFields).truncateBytes,
+		},
+		"do not truncate short byte line": {
+			MaxBytes: 15,
+			Input: common.MapStr{
+				"message": []byte("shorter line"),
+			},
+			Output: common.MapStr{
+				"message": []byte("shorter line"),
+			},
+			ShouldError:  false,
+			TruncateFunc: (*truncateFields).truncateBytes,
+		},
+		"try to truncate integer and get error": {
+			MaxBytes: 5,
+			Input: common.MapStr{
+				"message": 42,
+			},
+			Output: common.MapStr{
+				"message": 42,
+			},
+			ShouldError:  true,
+			TruncateFunc: (*truncateFields).truncateBytes,
+		},
+		"do not truncate characters of short byte line": {
+			MaxCount: 6,
+			Input: common.MapStr{
+				"message": []byte("ez jó"), // this is good (hungarian)
+			},
+			Output: common.MapStr{
+				"message": []byte("ez jó"), // this is good (hungarian)
+			},
+			ShouldError:  false,
+			TruncateFunc: (*truncateFields).truncateCharacters,
+		},
+		"do not truncate bytes of short byte line with multibyte runes": {
+			MaxBytes: 6,
+			Input: common.MapStr{
+				"message": []byte("ez jó"), // this is good (hungarian)
+			},
+			Output: common.MapStr{
+				"message": []byte("ez jó"), // this is good (hungarian)
+			},
+			ShouldError:  false,
+			TruncateFunc: (*truncateFields).truncateBytes,
+		},
+		"truncate characters of too long byte line": {
+			MaxCount: 10,
+			Input: common.MapStr{
+				"message": []byte("ez egy túl hosszú sor"), // this is a too long line (hungarian)
+			},
+			Output: common.MapStr{
+				"message": []byte("ez egy túl"), // this is a too (hungarian)
+			},
+			ShouldError:  false,
+			TruncateFunc: (*truncateFields).truncateCharacters,
+		},
+		"truncate bytes of too long byte line with multibyte runes": {
+			MaxBytes: 10,
+			Input: common.MapStr{
+				"message": []byte("ez egy túl hosszú sor"), // this is a too long line (hungarian)
+			},
+			Output: common.MapStr{
+				"message": []byte("ez egy tú"), // this is a "to" (hungarian)
+			},
+			ShouldError:  false,
+			TruncateFunc: (*truncateFields).truncateBytes,
+		},
+	}
+
+	for _, test := range tests {
+		p := truncateFields{
+			config: truncateFieldsConfig{
+				Fields:      []string{"message"},
+				MaxBytes:    test.MaxBytes,
+				MaxCount:    test.MaxCount,
+				FailOnError: true,
+			},
+			truncate: test.TruncateFunc,
+		}
+
+		event := &beat.Event{
+			Fields: test.Input,
+		}
+
+		newEvent, err := p.Run(event)
+		if test.ShouldError {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
+		}
+
+		assert.Equal(t, test.Output, newEvent.Fields)
+	}
+}

--- a/libbeat/processors/actions/truncate_fields_test.go
+++ b/libbeat/processors/actions/truncate_fields_test.go
@@ -137,28 +137,30 @@ func TestTruncateFields(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
-		p := truncateFields{
-			config: truncateFieldsConfig{
-				Fields:      []string{"message"},
-				MaxBytes:    test.MaxBytes,
-				MaxCount:    test.MaxCount,
-				FailOnError: true,
-			},
-			truncate: test.TruncateFunc,
-		}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			p := truncateFields{
+				config: truncateFieldsConfig{
+					Fields:      []string{"message"},
+					MaxBytes:    test.MaxBytes,
+					MaxCount:    test.MaxCount,
+					FailOnError: true,
+				},
+				truncate: test.TruncateFunc,
+			}
 
-		event := &beat.Event{
-			Fields: test.Input,
-		}
+			event := &beat.Event{
+				Fields: test.Input,
+			}
 
-		newEvent, err := p.Run(event)
-		if test.ShouldError {
-			assert.Error(t, err)
-		} else {
-			assert.NoError(t, err)
-		}
+			newEvent, err := p.Run(event)
+			if test.ShouldError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
 
-		assert.Equal(t, test.Output, newEvent.Fields)
+			assert.Equal(t, test.Output, newEvent.Fields)
+		})
 	}
 }

--- a/libbeat/processors/actions/truncate_fields_test.go
+++ b/libbeat/processors/actions/truncate_fields_test.go
@@ -27,7 +27,6 @@ import (
 )
 
 func TestTruncateFields(t *testing.T) {
-
 	var tests = map[string]struct {
 		MaxBytes     int
 		MaxChars     int

--- a/libbeat/processors/actions/truncate_fields_test.go
+++ b/libbeat/processors/actions/truncate_fields_test.go
@@ -30,7 +30,7 @@ func TestTruncateFields(t *testing.T) {
 
 	var tests = map[string]struct {
 		MaxBytes     int
-		MaxCount     int
+		MaxChars     int
 		Input        common.MapStr
 		Output       common.MapStr
 		ShouldError  bool
@@ -43,6 +43,9 @@ func TestTruncateFields(t *testing.T) {
 			},
 			Output: common.MapStr{
 				"message": "too",
+				"log": common.MapStr{
+					"flags": []string{"truncated"},
+				},
 			},
 			ShouldError:  false,
 			TruncateFunc: (*truncateFields).truncateBytes,
@@ -54,6 +57,9 @@ func TestTruncateFields(t *testing.T) {
 			},
 			Output: common.MapStr{
 				"message": []byte("too"),
+				"log": common.MapStr{
+					"flags": []string{"truncated"},
+				},
 			},
 			ShouldError:  false,
 			TruncateFunc: (*truncateFields).truncateBytes,
@@ -92,7 +98,7 @@ func TestTruncateFields(t *testing.T) {
 			TruncateFunc: (*truncateFields).truncateBytes,
 		},
 		"do not truncate characters of short byte line": {
-			MaxCount: 6,
+			MaxChars: 6,
 			Input: common.MapStr{
 				"message": []byte("ez jó"), // this is good (hungarian)
 			},
@@ -114,12 +120,15 @@ func TestTruncateFields(t *testing.T) {
 			TruncateFunc: (*truncateFields).truncateBytes,
 		},
 		"truncate characters of too long byte line": {
-			MaxCount: 10,
+			MaxChars: 10,
 			Input: common.MapStr{
 				"message": []byte("ez egy túl hosszú sor"), // this is a too long line (hungarian)
 			},
 			Output: common.MapStr{
 				"message": []byte("ez egy túl"), // this is a too (hungarian)
+				"log": common.MapStr{
+					"flags": []string{"truncated"},
+				},
 			},
 			ShouldError:  false,
 			TruncateFunc: (*truncateFields).truncateCharacters,
@@ -131,6 +140,9 @@ func TestTruncateFields(t *testing.T) {
 			},
 			Output: common.MapStr{
 				"message": []byte("ez egy tú"), // this is a "to" (hungarian)
+				"log": common.MapStr{
+					"flags": []string{"truncated"},
+				},
 			},
 			ShouldError:  false,
 			TruncateFunc: (*truncateFields).truncateBytes,
@@ -143,7 +155,7 @@ func TestTruncateFields(t *testing.T) {
 				config: truncateFieldsConfig{
 					Fields:      []string{"message"},
 					MaxBytes:    test.MaxBytes,
-					MaxCount:    test.MaxCount,
+					MaxChars:    test.MaxChars,
 					FailOnError: true,
 				},
 				truncate: test.TruncateFunc,

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -953,6 +953,32 @@ metricbeat.modules:
 #          to: message_copied
 #    fail_on_error: true
 #    ignore_missing: false
+#
+# The following example truncates the value of message to 1024 bytes
+#
+#processors:
+#- truncate_fields:
+#    fields:
+#      - message
+#    max_bytes: 1024
+#    fail_on_error: false
+#    ignore_missing: true
+#
+# The following example preserves the raw message under event.original
+#
+#processors:
+#- copy_fields:
+#    fields:
+#        - from: message
+#          to: event.original
+#    fail_on_error: false
+#    ignore_missing: true
+#- truncate_fields:
+#    fields:
+#      - event.original
+#    max_bytes: 1024
+#    fail_on_error: false
+#    ignore_missing: true
 
 #============================= Elastic Cloud ==================================
 

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -707,6 +707,32 @@ packetbeat.ignore_outgoing: false
 #          to: message_copied
 #    fail_on_error: true
 #    ignore_missing: false
+#
+# The following example truncates the value of message to 1024 bytes
+#
+#processors:
+#- truncate_fields:
+#    fields:
+#      - message
+#    max_bytes: 1024
+#    fail_on_error: false
+#    ignore_missing: true
+#
+# The following example preserves the raw message under event.original
+#
+#processors:
+#- copy_fields:
+#    fields:
+#        - from: message
+#          to: event.original
+#    fail_on_error: false
+#    ignore_missing: true
+#- truncate_fields:
+#    fields:
+#      - event.original
+#    max_bytes: 1024
+#    fail_on_error: false
+#    ignore_missing: true
 
 #============================= Elastic Cloud ==================================
 

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -256,6 +256,32 @@ winlogbeat.event_logs:
 #          to: message_copied
 #    fail_on_error: true
 #    ignore_missing: false
+#
+# The following example truncates the value of message to 1024 bytes
+#
+#processors:
+#- truncate_fields:
+#    fields:
+#      - message
+#    max_bytes: 1024
+#    fail_on_error: false
+#    ignore_missing: true
+#
+# The following example preserves the raw message under event.original
+#
+#processors:
+#- copy_fields:
+#    fields:
+#        - from: message
+#          to: event.original
+#    fail_on_error: false
+#    ignore_missing: true
+#- truncate_fields:
+#    fields:
+#      - event.original
+#    max_bytes: 1024
+#    fail_on_error: false
+#    ignore_missing: true
 
 #============================= Elastic Cloud ==================================
 

--- a/x-pack/auditbeat/auditbeat.reference.yml
+++ b/x-pack/auditbeat/auditbeat.reference.yml
@@ -374,6 +374,32 @@ auditbeat.modules:
 #          to: message_copied
 #    fail_on_error: true
 #    ignore_missing: false
+#
+# The following example truncates the value of message to 1024 bytes
+#
+#processors:
+#- truncate_fields:
+#    fields:
+#      - message
+#    max_bytes: 1024
+#    fail_on_error: false
+#    ignore_missing: true
+#
+# The following example preserves the raw message under event.original
+#
+#processors:
+#- copy_fields:
+#    fields:
+#        - from: message
+#          to: event.original
+#    fail_on_error: false
+#    ignore_missing: true
+#- truncate_fields:
+#    fields:
+#      - event.original
+#    max_bytes: 1024
+#    fail_on_error: false
+#    ignore_missing: true
 
 #============================= Elastic Cloud ==================================
 

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -1164,6 +1164,32 @@ filebeat.inputs:
 #          to: message_copied
 #    fail_on_error: true
 #    ignore_missing: false
+#
+# The following example truncates the value of message to 1024 bytes
+#
+#processors:
+#- truncate_fields:
+#    fields:
+#      - message
+#    max_bytes: 1024
+#    fail_on_error: false
+#    ignore_missing: true
+#
+# The following example preserves the raw message under event.original
+#
+#processors:
+#- copy_fields:
+#    fields:
+#        - from: message
+#          to: event.original
+#    fail_on_error: false
+#    ignore_missing: true
+#- truncate_fields:
+#    fields:
+#      - event.original
+#    max_bytes: 1024
+#    fail_on_error: false
+#    ignore_missing: true
 
 #============================= Elastic Cloud ==================================
 

--- a/x-pack/functionbeat/functionbeat.reference.yml
+++ b/x-pack/functionbeat/functionbeat.reference.yml
@@ -372,6 +372,32 @@ functionbeat.provider.aws.functions:
 #          to: message_copied
 #    fail_on_error: true
 #    ignore_missing: false
+#
+# The following example truncates the value of message to 1024 bytes
+#
+#processors:
+#- truncate_fields:
+#    fields:
+#      - message
+#    max_bytes: 1024
+#    fail_on_error: false
+#    ignore_missing: true
+#
+# The following example preserves the raw message under event.original
+#
+#processors:
+#- copy_fields:
+#    fields:
+#        - from: message
+#          to: event.original
+#    fail_on_error: false
+#    ignore_missing: true
+#- truncate_fields:
+#    fields:
+#      - event.original
+#    max_bytes: 1024
+#    fail_on_error: false
+#    ignore_missing: true
 
 #============================= Elastic Cloud ==================================
 

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -982,6 +982,32 @@ metricbeat.modules:
 #          to: message_copied
 #    fail_on_error: true
 #    ignore_missing: false
+#
+# The following example truncates the value of message to 1024 bytes
+#
+#processors:
+#- truncate_fields:
+#    fields:
+#      - message
+#    max_bytes: 1024
+#    fail_on_error: false
+#    ignore_missing: true
+#
+# The following example preserves the raw message under event.original
+#
+#processors:
+#- copy_fields:
+#    fields:
+#        - from: message
+#          to: event.original
+#    fail_on_error: false
+#    ignore_missing: true
+#- truncate_fields:
+#    fields:
+#      - event.original
+#    max_bytes: 1024
+#    fail_on_error: false
+#    ignore_missing: true
 
 #============================= Elastic Cloud ==================================
 


### PR DESCRIPTION
This PR introduces a new processor `truncate_fields`. To keep raw messages use this processor with `copy_fields`.

### `truncate_fields`

This processor truncates configured fields. Example configuration is below:

```yaml
processors:
- truncate_fields:
    fields:
      - message
    max_bytes: 1024
    fail_on_error: false
    ignore_missing: true
```

### Keep raw events

This preserves the orignal field and truncates it, if it's too long.

```yaml
processors:
- copy_fields:
    fields:
        - from: message
          to: event.original
    fail_on_error: false
    ignore_missing: true
- truncate_fields:
    fields:
      - event.original
    max_bytes: 1024
    fail_on_error: false
    ignore_missing: true
```
Depends on #11303 