### PR TITLE
Cherry-pick #11288 to 6.7: [Filebeat] Fix of syslog parsing for Priority value <0> ( #11010 )

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -113,6 +113,7 @@ https://github.com/elastic/beats/compare/v6.6.0...6.x[Check the HEAD diff]
 - Fix a bug with the convert_timezone option using the incorrect timezone field. {issue}11055[11055] {pull}11164[11164]
 - Change URLPATH grok pattern to support brackets. {issue}11135[11135] {pull}11252[11252]
 - Add support for iis log with different address format. {issue}11255[11255] {pull}11256[11256]
+- Add fix to parse syslog message with priority value 0. {issue}11010[11010]
 
 *Heartbeat*
 

--- a/filebeat/input/syslog/event.go
+++ b/filebeat/input/syslog/event.go
@@ -216,7 +216,7 @@ func (s *event) Priority() int {
 
 // HasPriority returns if the priority was in original event.
 func (s *event) HasPriority() bool {
-	return s.priority > 0
+	return s.priority >= 0
 }
 
 // Severity returns the severity, will return -1 if priority is not set.


### PR DESCRIPTION
Cherry-pick of PR #11288 to 6.7 branch. Original message: 

Fix of #11010 
Old pull request #11011 will be closed for the same issue because of base branch mismatch.