### PR TITLE
New processor: copy_fields

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -259,6 +259,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add `script` processor that supports using Javascript to process events. {pull}10850[10850] {pull}11260[11260]
 - Add `script` processor that supports using Javascript to process events. {pull}10850[10850]
 - New processor: `copy_fields`. {pull}11303[11303]
+- Add error.message to events when `fail_on_error` is set in `rename` and `copy_fields` processors. {pull}11303[11303]
 
 *Auditbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -256,10 +256,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add output test to kafka output {pull}10834[10834]
 - Add ip fields to default_field in Elasticsearch template. {pull}11035[11035]
 - Gracefully shut down on SIGHUP {pull}10704[10704]
-- Add `script` processor that supports using Javascript to process events. {pull}10850[10850] {pull}11260[11260]
-- Add `script` processor that supports using Javascript to process events. {pull}10850[10850]
 - New processor: `copy_fields`. {pull}11303[11303]
-- Add error.message to events when `fail_on_error` is set in `rename` and `copy_fields` processors. {pull}11303[11303]
+- Add `error.message` to events when `fail_on_error` is set in `rename` and `copy_fields` processors. {pull}11303[11303]
 
 *Auditbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -257,6 +257,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add ip fields to default_field in Elasticsearch template. {pull}11035[11035]
 - Gracefully shut down on SIGHUP {pull}10704[10704]
 - Add `script` processor that supports using Javascript to process events. {pull}10850[10850] {pull}11260[11260]
+- Add `script` processor that supports using Javascript to process events. {pull}10850[10850]
+- New processor: `copy_fields`. {pull}11297[11297]
 
 *Auditbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -258,7 +258,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Gracefully shut down on SIGHUP {pull}10704[10704]
 - Add `script` processor that supports using Javascript to process events. {pull}10850[10850] {pull}11260[11260]
 - Add `script` processor that supports using Javascript to process events. {pull}10850[10850]
-- New processor: `copy_fields`. {pull}11297[11297]
+- New processor: `copy_fields`. {pull}11303[11303]
 
 *Auditbeat*
 

--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -337,8 +337,8 @@ auditbeat.modules:
 #    fields:
 #        - from: message
 #          to: message_copied
-#    fail_on_error: false
-#    ignore_missing: true
+#    fail_on_error: true
+#    ignore_missing: false
 
 #============================= Elastic Cloud ==================================
 

--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -329,6 +329,16 @@ auditbeat.modules:
 #    max_depth: 1
 #    target: ""
 #    overwrite_keys: false
+#
+# The following example copies the value of message to message_copied
+#
+#processors:
+#- copy_fields:
+#    fields:
+#        - from: message
+#          to: message_copied
+#    fail_on_error: false
+#    ignore_missing: true
 
 #============================= Elastic Cloud ==================================
 

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -1040,6 +1040,16 @@ filebeat.inputs:
 #    max_depth: 1
 #    target: ""
 #    overwrite_keys: false
+#
+# The following example copies the value of message to message_copied
+#
+#processors:
+#- copy_fields:
+#    fields:
+#        - from: message
+#          to: message_copied
+#    fail_on_error: false
+#    ignore_missing: true
 
 #============================= Elastic Cloud ==================================
 

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -1048,8 +1048,8 @@ filebeat.inputs:
 #    fields:
 #        - from: message
 #          to: message_copied
-#    fail_on_error: false
-#    ignore_missing: true
+#    fail_on_error: true
+#    ignore_missing: false
 
 #============================= Elastic Cloud ==================================
 

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -473,6 +473,16 @@ heartbeat.scheduler:
 #    max_depth: 1
 #    target: ""
 #    overwrite_keys: false
+#
+# The following example copies the value of message to message_copied
+#
+#processors:
+#- copy_fields:
+#    fields:
+#        - from: message
+#          to: message_copied
+#    fail_on_error: false
+#    ignore_missing: true
 
 #============================= Elastic Cloud ==================================
 

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -481,8 +481,8 @@ heartbeat.scheduler:
 #    fields:
 #        - from: message
 #          to: message_copied
-#    fail_on_error: false
-#    ignore_missing: true
+#    fail_on_error: true
+#    ignore_missing: false
 
 #============================= Elastic Cloud ==================================
 

--- a/journalbeat/journalbeat.reference.yml
+++ b/journalbeat/journalbeat.reference.yml
@@ -277,8 +277,8 @@ setup.template.settings:
 #    fields:
 #        - from: message
 #          to: message_copied
-#    fail_on_error: false
-#    ignore_missing: true
+#    fail_on_error: true
+#    ignore_missing: false
 
 #============================= Elastic Cloud ==================================
 

--- a/journalbeat/journalbeat.reference.yml
+++ b/journalbeat/journalbeat.reference.yml
@@ -269,6 +269,16 @@ setup.template.settings:
 #    max_depth: 1
 #    target: ""
 #    overwrite_keys: false
+#
+# The following example copies the value of message to message_copied
+#
+#processors:
+#- copy_fields:
+#    fields:
+#        - from: message
+#          to: message_copied
+#    fail_on_error: false
+#    ignore_missing: true
 
 #============================= Elastic Cloud ==================================
 

--- a/libbeat/_meta/config.reference.yml
+++ b/libbeat/_meta/config.reference.yml
@@ -225,8 +225,8 @@
 #    fields:
 #        - from: message
 #          to: message_copied
-#    fail_on_error: false
-#    ignore_missing: true
+#    fail_on_error: true
+#    ignore_missing: false
 
 #============================= Elastic Cloud ==================================
 

--- a/libbeat/_meta/config.reference.yml
+++ b/libbeat/_meta/config.reference.yml
@@ -217,6 +217,16 @@
 #    max_depth: 1
 #    target: ""
 #    overwrite_keys: false
+#
+# The following example copies the value of message to message_copied
+#
+#processors:
+#- copy_fields:
+#    fields:
+#        - from: message
+#          to: message_copied
+#    fail_on_error: false
+#    ignore_missing: true
 
 #============================= Elastic Cloud ==================================
 

--- a/libbeat/processors/actions/copy_fields.go
+++ b/libbeat/processors/actions/copy_fields.go
@@ -102,5 +102,5 @@ func (f *copyFields) copyField(from string, to string, fields common.MapStr) err
 }
 
 func (f *copyFields) String() string {
-	return "copy=" + fmt.Sprintf("%+v", f.config.Fields)
+	return "copy_fields=" + fmt.Sprintf("%+v", f.config.Fields)
 }

--- a/libbeat/processors/actions/copy_fields.go
+++ b/libbeat/processors/actions/copy_fields.go
@@ -73,6 +73,7 @@ func (f *copyFields) Run(event *beat.Event) (*beat.Event, error) {
 		if err != nil && f.config.FailOnError {
 			logp.Debug("copy_fields", "Failed to copy fields: %s", err)
 			event.Fields = backup
+			event.PutValue("error.message", fmt.Sprintf("Failed to copy fields in copy_fields processor: %+v", err))
 			return event, err
 		}
 	}

--- a/libbeat/processors/actions/copy_fields.go
+++ b/libbeat/processors/actions/copy_fields.go
@@ -1,0 +1,106 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package actions
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+
+	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/processors"
+)
+
+type copyFields struct {
+	config copyFieldsConfig
+}
+
+type copyFieldsConfig struct {
+	Fields        []fromTo `config:"fields"`
+	IgnoreMissing bool     `config:"ignore_missing"`
+	FailOnError   bool     `config:"fail_on_error"`
+}
+
+func init() {
+	processors.RegisterPlugin("copy_fields",
+		configChecked(newCopyFields,
+			requireFields("fields"),
+		),
+	)
+}
+
+func newCopyFields(c *common.Config) (processors.Processor, error) {
+	config := copyFieldsConfig{
+		IgnoreMissing: false,
+		FailOnError:   true,
+	}
+	err := c.Unpack(&config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unpack the configuration of copy processor: %s", err)
+	}
+
+	f := &copyFields{
+		config: config,
+	}
+	return f, nil
+}
+
+func (f *copyFields) Run(event *beat.Event) (*beat.Event, error) {
+	var backup common.MapStr
+	if f.config.FailOnError {
+		backup = event.Fields.Clone()
+	}
+
+	for _, field := range f.config.Fields {
+		err := f.copyField(field.From, field.To, event.Fields)
+		if err != nil && f.config.FailOnError {
+			logp.Debug("copy_fields", "Failed to copy fields: %s", err)
+			event.Fields = backup
+			return event, err
+		}
+	}
+
+	return event, nil
+}
+
+func (f *copyFields) copyField(from string, to string, fields common.MapStr) error {
+	exists, _ := fields.HasKey(to)
+	if exists {
+		return fmt.Errorf("target field %s already exists, drop or rename this field first", to)
+	}
+
+	value, err := fields.GetValue(from)
+	if err != nil {
+		if f.config.IgnoreMissing && errors.Cause(err) == common.ErrKeyNotFound {
+			return nil
+		}
+		return fmt.Errorf("could not fetch value for key: %s, Error: %s", from, err)
+	}
+
+	_, err = fields.Put(to, value)
+	if err != nil {
+		return fmt.Errorf("could not copy value to %s: %v, %+v", to, value, err)
+	}
+	return nil
+}
+
+func (f *copyFields) String() string {
+	return "copy=" + fmt.Sprintf("%+v", f.config.Fields)
+}

--- a/libbeat/processors/actions/copy_fields.go
+++ b/libbeat/processors/actions/copy_fields.go
@@ -71,9 +71,10 @@ func (f *copyFields) Run(event *beat.Event) (*beat.Event, error) {
 	for _, field := range f.config.Fields {
 		err := f.copyField(field.From, field.To, event.Fields)
 		if err != nil && f.config.FailOnError {
-			logp.Debug("copy_fields", "Failed to copy fields: %s", err)
+			errMsg := fmt.Sprintf("Failed to copy fields in copy_fields processor: %s", err)
+			logp.Debug("copy_fields", errMsg)
 			event.Fields = backup
-			event.PutValue("error.message", fmt.Sprintf("Failed to copy fields in copy_fields processor: %+v", err))
+			event.PutValue("error.message", errMsg)
 			return event, err
 		}
 	}

--- a/libbeat/processors/actions/copy_fields.go
+++ b/libbeat/processors/actions/copy_fields.go
@@ -71,10 +71,10 @@ func (f *copyFields) Run(event *beat.Event) (*beat.Event, error) {
 	for _, field := range f.config.Fields {
 		err := f.copyField(field.From, field.To, event.Fields)
 		if err != nil && f.config.FailOnError {
-			errMsg := fmt.Sprintf("Failed to copy fields in copy_fields processor: %s", err)
-			logp.Debug("copy_fields", errMsg)
+			errMsg := fmt.Errorf("Failed to copy fields in copy_fields processor: %s", err)
+			logp.Debug("copy_fields", errMsg.Error())
 			event.Fields = backup
-			event.PutValue("error.message", errMsg)
+			event.PutValue("error.message", errMsg.Error())
 			return event, err
 		}
 	}

--- a/libbeat/processors/actions/copy_fields_test.go
+++ b/libbeat/processors/actions/copy_fields_test.go
@@ -29,10 +29,15 @@ import (
 func TestCopyFields(t *testing.T) {
 
 	var tests = []struct {
+		FromTo   fromTo
 		Input    common.MapStr
 		Expected common.MapStr
 	}{
 		{
+			FromTo: fromTo{
+				From: "message",
+				To:   "message_copied",
+			},
 			Input: common.MapStr{
 				"message": "please copy this line",
 			},
@@ -42,12 +47,48 @@ func TestCopyFields(t *testing.T) {
 			},
 		},
 		{
+			FromTo: fromTo{
+				From: "nested.message",
+				To:   "message_copied",
+			},
 			Input: common.MapStr{
-				"message": 42,
+				"nested": common.MapStr{
+					"message": "please copy this line",
+				},
 			},
 			Expected: common.MapStr{
-				"message":        42,
-				"message_copied": 42,
+				"nested": common.MapStr{
+					"message": "please copy this line",
+				},
+				"message_copied": "please copy this line",
+			},
+		},
+		{
+			FromTo: fromTo{
+				From: "dotted.message",
+				To:   "message_copied",
+			},
+			Input: common.MapStr{
+				"dotted.message": "please copy this line",
+			},
+			Expected: common.MapStr{
+				"dotted.message": "please copy this line",
+				"message_copied": "please copy this line",
+			},
+		},
+		{
+			FromTo: fromTo{
+				From: "message.original",
+				To:   "message.copied",
+			},
+			Input: common.MapStr{
+				"message.original": 42,
+			},
+			Expected: common.MapStr{
+				"message.original": 42,
+				"message": common.MapStr{
+					"copied": 42,
+				},
 			},
 		},
 	}
@@ -56,10 +97,7 @@ func TestCopyFields(t *testing.T) {
 		p := copyFields{
 			copyFieldsConfig{
 				Fields: []fromTo{
-					fromTo{
-						From: "message",
-						To:   "message_copied",
-					},
+					test.FromTo,
 				},
 			},
 		}

--- a/libbeat/processors/actions/copy_fields_test.go
+++ b/libbeat/processors/actions/copy_fields_test.go
@@ -28,12 +28,12 @@ import (
 
 func TestCopyFields(t *testing.T) {
 
-	var tests = []struct {
+	var tests = map[string]struct {
 		FromTo   fromTo
 		Input    common.MapStr
 		Expected common.MapStr
 	}{
-		{
+		"copy string from message to message_copied": {
 			FromTo: fromTo{
 				From: "message",
 				To:   "message_copied",
@@ -46,7 +46,7 @@ func TestCopyFields(t *testing.T) {
 				"message_copied": "please copy this line",
 			},
 		},
-		{
+		"copy string from nested key nested.message to top level field message_copied": {
 			FromTo: fromTo{
 				From: "nested.message",
 				To:   "message_copied",
@@ -63,7 +63,7 @@ func TestCopyFields(t *testing.T) {
 				"message_copied": "please copy this line",
 			},
 		},
-		{
+		"copy string from fieldname with dot to message_copied": {
 			FromTo: fromTo{
 				From: "dotted.message",
 				To:   "message_copied",
@@ -76,7 +76,7 @@ func TestCopyFields(t *testing.T) {
 				"message_copied": "please copy this line",
 			},
 		},
-		{
+		"copy number from fieldname with dot to dotted message.copied": {
 			FromTo: fromTo{
 				From: "message.original",
 				To:   "message.copied",
@@ -93,22 +93,24 @@ func TestCopyFields(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
-		p := copyFields{
-			copyFieldsConfig{
-				Fields: []fromTo{
-					test.FromTo,
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			p := copyFields{
+				copyFieldsConfig{
+					Fields: []fromTo{
+						test.FromTo,
+					},
 				},
-			},
-		}
+			}
 
-		event := &beat.Event{
-			Fields: test.Input,
-		}
+			event := &beat.Event{
+				Fields: test.Input,
+			}
 
-		newEvent, err := p.Run(event)
-		assert.NoError(t, err)
+			newEvent, err := p.Run(event)
+			assert.NoError(t, err)
 
-		assert.Equal(t, test.Expected, newEvent.Fields)
+			assert.Equal(t, test.Expected, newEvent.Fields)
+		})
 	}
 }

--- a/libbeat/processors/actions/copy_fields_test.go
+++ b/libbeat/processors/actions/copy_fields_test.go
@@ -1,0 +1,76 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package actions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/common"
+)
+
+func TestCopyFields(t *testing.T) {
+
+	var tests = []struct {
+		Input    common.MapStr
+		Expected common.MapStr
+	}{
+		{
+			Input: common.MapStr{
+				"message": "please copy this line",
+			},
+			Expected: common.MapStr{
+				"message":        "please copy this line",
+				"message_copied": "please copy this line",
+			},
+		},
+		{
+			Input: common.MapStr{
+				"message": 42,
+			},
+			Expected: common.MapStr{
+				"message":        42,
+				"message_copied": 42,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		p := copyFields{
+			copyFieldsConfig{
+				Fields: []fromTo{
+					fromTo{
+						From: "message",
+						To:   "message_copied",
+					},
+				},
+			},
+		}
+
+		event := &beat.Event{
+			Fields: test.Input,
+		}
+
+		newEvent, err := p.Run(event)
+		assert.NoError(t, err)
+
+		assert.Equal(t, test.Expected, newEvent.Fields)
+	}
+}

--- a/libbeat/processors/actions/copy_fields_test.go
+++ b/libbeat/processors/actions/copy_fields_test.go
@@ -91,7 +91,7 @@ func TestCopyFields(t *testing.T) {
 				},
 			},
 		},
-		"copy number from hierarchical message.original to top level message": {
+		"copy number from hierarchical message.original to top level message which fails": {
 			FromTo: fromTo{
 				From: "message.original",
 				To:   "message",
@@ -105,6 +105,19 @@ func TestCopyFields(t *testing.T) {
 				"message": common.MapStr{
 					"original": 42,
 				},
+			},
+		},
+		"copy number from hierarchical message.original to top level message": {
+			FromTo: fromTo{
+				From: "message.original",
+				To:   "message",
+			},
+			Input: common.MapStr{
+				"message.original": 42,
+			},
+			Expected: common.MapStr{
+				"message.original": 42,
+				"message":          42,
 			},
 		},
 	}

--- a/libbeat/processors/actions/copy_fields_test.go
+++ b/libbeat/processors/actions/copy_fields_test.go
@@ -91,6 +91,22 @@ func TestCopyFields(t *testing.T) {
 				},
 			},
 		},
+		"copy number from hierarchical message.original to top level message": {
+			FromTo: fromTo{
+				From: "message.original",
+				To:   "message",
+			},
+			Input: common.MapStr{
+				"message": common.MapStr{
+					"original": 42,
+				},
+			},
+			Expected: common.MapStr{
+				"message": common.MapStr{
+					"original": 42,
+				},
+			},
+		},
 	}
 
 	for name, test := range tests {

--- a/libbeat/processors/actions/rename.go
+++ b/libbeat/processors/actions/rename.go
@@ -77,6 +77,7 @@ func (f *renameFields) Run(event *beat.Event) (*beat.Event, error) {
 		if err != nil && f.config.FailOnError {
 			logp.Debug("rename", "Failed to rename fields, revert to old event: %s", err)
 			event.Fields = backup
+			event.PutValue("error.message", fmt.Sprintf("Failed to rename fields in processor: %+v", err))
 			return event, err
 		}
 	}

--- a/libbeat/processors/actions/rename.go
+++ b/libbeat/processors/actions/rename.go
@@ -77,7 +77,7 @@ func (f *renameFields) Run(event *beat.Event) (*beat.Event, error) {
 		if err != nil && f.config.FailOnError {
 			logp.Debug("rename", "Failed to rename fields, revert to old event: %s", err)
 			event.Fields = backup
-			event.PutValue("error.message", fmt.Sprintf("Failed to rename fields in processor: %+v", err))
+			event.PutValue("error.message", fmt.Sprintf("Failed to rename fields in processor: %s", err))
 			return event, err
 		}
 	}
@@ -109,7 +109,7 @@ func (f *renameFields) renameField(from string, to string, fields common.MapStr)
 
 	_, err = fields.Put(to, value)
 	if err != nil {
-		return fmt.Errorf("could not put value: %s: %v, %+v", to, value, err)
+		return fmt.Errorf("could not put value: %s: %v, %v", to, value, err)
 	}
 	return nil
 }

--- a/libbeat/processors/actions/rename.go
+++ b/libbeat/processors/actions/rename.go
@@ -75,10 +75,10 @@ func (f *renameFields) Run(event *beat.Event) (*beat.Event, error) {
 	for _, field := range f.config.Fields {
 		err := f.renameField(field.From, field.To, event.Fields)
 		if err != nil && f.config.FailOnError {
-			errMsg := fmt.Sprintf("Failed to rename fields in processor: %s", err)
-			logp.Debug("rename", errMsg)
+			errMsg := fmt.Errorf("Failed to rename fields in processor: %s", err)
+			logp.Debug("rename", errMsg.Error())
 			event.Fields = backup
-			event.PutValue("error.message", errMsg)
+			event.PutValue("error.message", errMsg.Error())
 			return event, err
 		}
 	}

--- a/libbeat/processors/actions/rename.go
+++ b/libbeat/processors/actions/rename.go
@@ -75,9 +75,10 @@ func (f *renameFields) Run(event *beat.Event) (*beat.Event, error) {
 	for _, field := range f.config.Fields {
 		err := f.renameField(field.From, field.To, event.Fields)
 		if err != nil && f.config.FailOnError {
-			logp.Debug("rename", "Failed to rename fields, revert to old event: %s", err)
+			errMsg := fmt.Sprintf("Failed to rename fields in processor: %s", err)
+			logp.Debug("rename", errMsg)
 			event.Fields = backup
-			event.PutValue("error.message", fmt.Sprintf("Failed to rename fields in processor: %s", err))
+			event.PutValue("error.message", errMsg)
 			return event, err
 		}
 	}

--- a/libbeat/processors/actions/rename_test.go
+++ b/libbeat/processors/actions/rename_test.go
@@ -18,6 +18,7 @@
 package actions
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -92,6 +93,9 @@ func TestRenameRun(t *testing.T) {
 			Output: common.MapStr{
 				"a": 2,
 				"b": "q",
+				"error": common.MapStr{
+					"message": "Failed to rename fields in processor: target field b already exists, drop or rename this field first",
+				},
 			},
 			error:         true,
 			FailOnError:   true,
@@ -188,6 +192,9 @@ func TestRenameRun(t *testing.T) {
 			Output: common.MapStr{
 				"a": 9,
 				"c": 10,
+				"error": common.MapStr{
+					"message": "Failed to rename fields in processor: could not put value: a.c: 10, expected map but type is int",
+				},
 			},
 			error:         true,
 			IgnoreMissing: false,
@@ -239,6 +246,7 @@ func TestRenameRun(t *testing.T) {
 			} else {
 				assert.NotNil(t, err)
 			}
+			fmt.Println(newEvent.Fields)
 
 			assert.True(t, reflect.DeepEqual(newEvent.Fields, test.Output))
 		})
@@ -350,6 +358,7 @@ func TestRenameField(t *testing.T) {
 
 			err := f.renameField(test.From, test.To, test.Input)
 			if err != nil {
+				fmt.Println(test.error)
 				assert.Equal(t, test.error, true)
 			}
 

--- a/libbeat/processors/actions/rename_test.go
+++ b/libbeat/processors/actions/rename_test.go
@@ -18,7 +18,6 @@
 package actions
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 
@@ -246,7 +245,6 @@ func TestRenameRun(t *testing.T) {
 			} else {
 				assert.NotNil(t, err)
 			}
-			fmt.Println(newEvent.Fields)
 
 			assert.True(t, reflect.DeepEqual(newEvent.Fields, test.Output))
 		})
@@ -358,7 +356,6 @@ func TestRenameField(t *testing.T) {
 
 			err := f.renameField(test.From, test.To, test.Input)
 			if err != nil {
-				fmt.Println(test.error)
 				assert.Equal(t, test.error, true)
 			}
 

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -943,6 +943,16 @@ metricbeat.modules:
 #    max_depth: 1
 #    target: ""
 #    overwrite_keys: false
+#
+# The following example copies the value of message to message_copied
+#
+#processors:
+#- copy_fields:
+#    fields:
+#        - from: message
+#          to: message_copied
+#    fail_on_error: false
+#    ignore_missing: true
 
 #============================= Elastic Cloud ==================================
 

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -951,8 +951,8 @@ metricbeat.modules:
 #    fields:
 #        - from: message
 #          to: message_copied
-#    fail_on_error: false
-#    ignore_missing: true
+#    fail_on_error: true
+#    ignore_missing: false
 
 #============================= Elastic Cloud ==================================
 

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -697,6 +697,16 @@ packetbeat.ignore_outgoing: false
 #    max_depth: 1
 #    target: ""
 #    overwrite_keys: false
+#
+# The following example copies the value of message to message_copied
+#
+#processors:
+#- copy_fields:
+#    fields:
+#        - from: message
+#          to: message_copied
+#    fail_on_error: false
+#    ignore_missing: true
 
 #============================= Elastic Cloud ==================================
 

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -705,8 +705,8 @@ packetbeat.ignore_outgoing: false
 #    fields:
 #        - from: message
 #          to: message_copied
-#    fail_on_error: false
-#    ignore_missing: true
+#    fail_on_error: true
+#    ignore_missing: false
 
 #============================= Elastic Cloud ==================================
 

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -254,8 +254,8 @@ winlogbeat.event_logs:
 #    fields:
 #        - from: message
 #          to: message_copied
-#    fail_on_error: false
-#    ignore_missing: true
+#    fail_on_error: true
+#    ignore_missing: false
 
 #============================= Elastic Cloud ==================================
 

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -246,6 +246,16 @@ winlogbeat.event_logs:
 #    max_depth: 1
 #    target: ""
 #    overwrite_keys: false
+#
+# The following example copies the value of message to message_copied
+#
+#processors:
+#- copy_fields:
+#    fields:
+#        - from: message
+#          to: message_copied
+#    fail_on_error: false
+#    ignore_missing: true
 
 #============================= Elastic Cloud ==================================
 

--- a/x-pack/auditbeat/auditbeat.reference.yml
+++ b/x-pack/auditbeat/auditbeat.reference.yml
@@ -364,6 +364,16 @@ auditbeat.modules:
 #    max_depth: 1
 #    target: ""
 #    overwrite_keys: false
+#
+# The following example copies the value of message to message_copied
+#
+#processors:
+#- copy_fields:
+#    fields:
+#        - from: message
+#          to: message_copied
+#    fail_on_error: false
+#    ignore_missing: true
 
 #============================= Elastic Cloud ==================================
 

--- a/x-pack/auditbeat/auditbeat.reference.yml
+++ b/x-pack/auditbeat/auditbeat.reference.yml
@@ -372,8 +372,8 @@ auditbeat.modules:
 #    fields:
 #        - from: message
 #          to: message_copied
-#    fail_on_error: false
-#    ignore_missing: true
+#    fail_on_error: true
+#    ignore_missing: false
 
 #============================= Elastic Cloud ==================================
 

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -1119,6 +1119,16 @@ filebeat.inputs:
 #    max_depth: 1
 #    target: ""
 #    overwrite_keys: false
+#
+# The following example copies the value of message to message_copied
+#
+#processors:
+#- copy_fields:
+#    fields:
+#        - from: message
+#          to: message_copied
+#    fail_on_error: false
+#    ignore_missing: true
 
 #============================= Elastic Cloud ==================================
 

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -1127,8 +1127,8 @@ filebeat.inputs:
 #    fields:
 #        - from: message
 #          to: message_copied
-#    fail_on_error: false
-#    ignore_missing: true
+#    fail_on_error: true
+#    ignore_missing: false
 
 #============================= Elastic Cloud ==================================
 

--- a/x-pack/functionbeat/functionbeat.reference.yml
+++ b/x-pack/functionbeat/functionbeat.reference.yml
@@ -362,6 +362,16 @@ functionbeat.provider.aws.functions:
 #    max_depth: 1
 #    target: ""
 #    overwrite_keys: false
+#
+# The following example copies the value of message to message_copied
+#
+#processors:
+#- copy_fields:
+#    fields:
+#        - from: message
+#          to: message_copied
+#    fail_on_error: false
+#    ignore_missing: true
 
 #============================= Elastic Cloud ==================================
 

--- a/x-pack/functionbeat/functionbeat.reference.yml
+++ b/x-pack/functionbeat/functionbeat.reference.yml
@@ -370,8 +370,8 @@ functionbeat.provider.aws.functions:
 #    fields:
 #        - from: message
 #          to: message_copied
-#    fail_on_error: false
-#    ignore_missing: true
+#    fail_on_error: true
+#    ignore_missing: false
 
 #============================= Elastic Cloud ==================================
 

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -972,6 +972,16 @@ metricbeat.modules:
 #    max_depth: 1
 #    target: ""
 #    overwrite_keys: false
+#
+# The following example copies the value of message to message_copied
+#
+#processors:
+#- copy_fields:
+#    fields:
+#        - from: message
+#          to: message_copied
+#    fail_on_error: false
+#    ignore_missing: true
 
 #============================= Elastic Cloud ==================================
 

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -980,8 +980,8 @@ metricbeat.modules:
 #    fields:
 #        - from: message
 #          to: message_copied
-#    fail_on_error: false
-#    ignore_missing: true
+#    fail_on_error: true
+#    ignore_missing: false
 
 #============================= Elastic Cloud ==================================
 


### PR DESCRIPTION
A new processor is introduced as part of support for keeping orignal messages. Options and naming follows the convention of other processors.

### `copy_fields`

This processor copies one field to another. Example configuration is below:

```yaml
processors:
- copy_fields:
    fields:
      - from: message
        to: event.original
    fail_on_error: false
    ignore_missing: true
```

Blocks #11297 