### PR TITLE
Cherry-pick #11315 to 7.0: Update schema version in monitoring index name

### DIFF
--- a/metricbeat/helper/elastic/elastic.go
+++ b/metricbeat/helper/elastic/elastic.go
@@ -77,7 +77,7 @@ func (p Product) String() string {
 // MakeXPackMonitoringIndexName method returns the name of the monitoring index for
 // a given product { elasticsearch, kibana, logstash, beats }
 func MakeXPackMonitoringIndexName(product Product) string {
-	const version = "6"
+	const version = "7"
 
 	return fmt.Sprintf(".monitoring-%v-%v-mb", product.xPackMonitoringIndexString(), version)
 }

--- a/metricbeat/helper/elastic/elastic_test.go
+++ b/metricbeat/helper/elastic/elastic_test.go
@@ -35,22 +35,22 @@ func TestMakeXPackMonitoringIndexName(t *testing.T) {
 		{
 			"Elasticsearch monitoring index",
 			Elasticsearch,
-			".monitoring-es-6-mb",
+			".monitoring-es-7-mb",
 		},
 		{
 			"Kibana monitoring index",
 			Kibana,
-			".monitoring-kibana-6-mb",
+			".monitoring-kibana-7-mb",
 		},
 		{
 			"Logstash monitoring index",
 			Logstash,
-			".monitoring-logstash-6-mb",
+			".monitoring-logstash-7-mb",
 		},
 		{
 			"Beats monitoring index",
 			Beats,
-			".monitoring-beats-6-mb",
+			".monitoring-beats-7-mb",
 		},
 	}
 


### PR DESCRIPTION
Cherry-pick of PR #11315 to 7.0 branch. Original message: 

Starting 7.0, Metricbeat Stack Monitoring modules should index data into `.monitoring-7-*` indices instead of `.monitoring-6-*`. This PR makes this change.

### Testing this PR
1. Setup monitoring for a stack product, e.g. Elasticsearch, with Metricbeat (built from this PR by running `mage build` in the `metricbeat` folder): https://www.elastic.co/guide/en/elasticsearch/reference/current/configuring-metricbeat.html
2. Start Metricbeat.
   ```
   metricbeat -e
   ```
3. Check that only `.monitoring-7-*` indices are being created in Elasticsearch, not `.monitoring-6-*` indices.
   ```
   GET _cat/indices/.monitoring*
   ```
