### PR TITLE
ILM: Encode / as %2F when creating first index

### DIFF
--- a/libbeat/idxmgmt/ilm/eshandler.go
+++ b/libbeat/idxmgmt/ilm/eshandler.go
@@ -138,6 +138,11 @@ func (h *esClientHandler) CreateAlias(alias Alias) error {
 	firstIndex := fmt.Sprintf("<%s-%s>", alias.Name, alias.Pattern)
 	firstIndex = url.PathEscape(firstIndex)
 
+	// url.PathEscape does not encode / to %2F, which is correct per RFC3986. However,
+	// Elasticsearch requires this encoding to be done when using date math in Index
+	// APIs: https://www.elastic.co/guide/en/elasticsearch/reference/master/date-math-index-names.html
+	firstIndex = strings.ReplaceAll(firstIndex, "/", "%2F")
+
 	body := common.MapStr{
 		"aliases": common.MapStr{
 			alias.Name: common.MapStr{


### PR DESCRIPTION
@tsullivan reported the following error whikle running Metricbeat with ILM enabled:

```
metricbeat_1           | 2019-03-19T17:46:36.832Z       ERROR   pipeline/output.go:100  Failed to connect to backoff(elasticsearch(http://elasticsearch-proxy:9200)): Connection marked as failed because the onConnect callback failed: failed to create alias: {"error":"Incorrect HTTP method for uri [/<metricbeat-8.0.0-{now/d}-000001>] and method [PUT], allowed: [POST]","status":405}: 405 Method Not Allowed: {"error":"Incorrect HTTP method for uri [/<metricbeat-8.0.0-{now/d}-000001>] and method [PUT], allowed: [POST]","status":405}
```

I did some investigating and I believe this PR should fix this error.