### PR TITLE
[Metricbeat] Migrate mysql/galera_status to ReporterV2

### DIFF
--- a/metricbeat/module/mysql/galera_status/status.go
+++ b/metricbeat/module/mysql/galera_status/status.go
@@ -27,16 +27,10 @@ package galera_status
 import (
 	"database/sql"
 
-	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/module/mysql"
 
 	"github.com/pkg/errors"
-)
-
-var (
-	debugf = logp.MakeDebug("mysql-galera-status")
 )
 
 // init registers the MetricSet with the central registry.
@@ -60,18 +54,18 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 
 // Fetch methods implements the data gathering and data conversion to the right format
 // It returns the event which is then forward to the output.
-func (m *MetricSet) Fetch() (common.MapStr, error) {
+func (m *MetricSet) Fetch(reporter mb.ReporterV2) error {
 	if m.db == nil {
 		var err error
 		m.db, err = mysql.NewDB(m.HostData().URI)
 		if err != nil {
-			return nil, errors.Wrap(err, "Galera-status fetch failed")
+			return errors.Wrap(err, "Galera-status fetch failed")
 		}
 	}
 
 	status, err := m.loadStatus(m.db)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	event := eventMapping(status)
@@ -79,7 +73,12 @@ func (m *MetricSet) Fetch() (common.MapStr, error) {
 	if m.Module().Config().Raw {
 		event["raw"] = rawEventMapping(status)
 	}
-	return event, nil
+
+	reporter.Event(mb.Event{
+		MetricSetFields: event,
+	})
+
+	return nil
 }
 
 // loadStatus loads all status entries from the given database into an array.

--- a/metricbeat/module/mysql/galera_status/status.go
+++ b/metricbeat/module/mysql/galera_status/status.go
@@ -27,6 +27,7 @@ package galera_status
 import (
 	"database/sql"
 
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/module/mysql"
 
@@ -49,6 +50,7 @@ type MetricSet struct {
 // New create a new instance of the MetricSet
 // Loads query_mode config setting from the config file
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
+	cfgwarn.Experimental("The galera_status metricset is experimental.")
 	return &MetricSet{BaseMetricSet: base}, nil
 }
 


### PR DESCRIPTION
See #10774 

This metricset is a bit odd. There's no tests at all, and it looks like there's a lot of copy and paste from the mysql/status metricset. In the future, maybe someone cat put in a PR to clean up the code reuse. The lack of tests is a little weirder.  I'm not sure if we need a new docker container added for galera? 