### PR TITLE
Cherry-pick #11086 to 7.0: Regenerate UUID of a Beat when meta.json is empty (#11086)

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -13,6 +13,7 @@ https://github.com/elastic/beats/compare/v7.0.0-beta1...master[Check the HEAD di
 - On Google Cloud Engine (GCE) the add_cloud_metadata will now trim the project
   info from the cloud.machine.type and cloud.availability_zone. {issue}10968[10968]
 - Add `cleanup_timeout` option to docker autodiscover, to wait some time before removing configurations after a container is stopped. {issue]10374[10374] {pull}10905[10905]
+- Empty `meta.json` file will be treated as a missing meta file. {issue}8558[8558]
 - Rename `migration.enabled` config to `migration.6_to_7.enabled`. {pull}11284[11284]
 - Initialize the Paths before the keystore and save the keystore into `data/{beatname}.keystore`. {pull}10706[10706]
 

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"math"
 	"math/big"
 	"math/rand"
@@ -104,7 +105,7 @@ type beatConfig struct {
 	Pipeline   pipeline.Config `config:",inline"`
 	Monitoring *common.Config  `config:"xpack.monitoring"`
 
-	// central managmenet settings
+	// central management settings
 	Management *common.Config `config:"management"`
 
 	// elastic stack 'setup' configurations
@@ -569,7 +570,8 @@ func (b *Beat) configure(settings Settings) error {
 	// log paths values to help with troubleshooting
 	logp.Info(paths.Paths.String())
 
-	err = b.loadMeta()
+	metaPath := paths.Resolve(paths.Data, "meta.json")
+	err = b.loadMeta(metaPath)
 	if err != nil {
 		return err
 	}
@@ -613,12 +615,11 @@ func (b *Beat) configure(settings Settings) error {
 	return err
 }
 
-func (b *Beat) loadMeta() error {
+func (b *Beat) loadMeta(metaPath string) error {
 	type meta struct {
 		UUID uuid.UUID `json:"uuid"`
 	}
 
-	metaPath := paths.Resolve(paths.Data, "meta.json")
 	logp.Debug("beat", "Beat metadata path: %v", metaPath)
 
 	f, err := openRegular(metaPath)
@@ -628,7 +629,7 @@ func (b *Beat) loadMeta() error {
 
 	if err == nil {
 		m := meta{}
-		if err := json.NewDecoder(f).Decode(&m); err != nil {
+		if err := json.NewDecoder(f).Decode(&m); err != nil && err != io.EOF {
 			f.Close()
 			return fmt.Errorf("Beat meta file reading error: %v", err)
 		}
@@ -650,10 +651,19 @@ func (b *Beat) loadMeta() error {
 		return fmt.Errorf("Failed to create Beat meta file: %s", err)
 	}
 
-	err = json.NewEncoder(f).Encode(meta{UUID: b.Info.ID})
-	f.Close()
+	encodeErr := json.NewEncoder(f).Encode(meta{UUID: b.Info.ID})
+	err = f.Sync()
 	if err != nil {
 		return fmt.Errorf("Beat meta file failed to write: %s", err)
+	}
+
+	err = f.Close()
+	if err != nil {
+		return fmt.Errorf("Beat meta file failed to write: %s", err)
+	}
+
+	if encodeErr != nil {
+		return fmt.Errorf("Beat meta file failed to write: %s", encodeErr)
 	}
 
 	// move temporary file into final location
@@ -699,7 +709,7 @@ func (b *Beat) loadDashboards(ctx context.Context, force bool) error {
 	if b.Config.Dashboards.Enabled() {
 
 		// Initialize kibana config. If username and password is set in elasticsearch output config but not in kibana,
-		// initKibanaConfig will attach the ussername and password into kibana config as a part of the initialization.
+		// initKibanaConfig will attach the username and password into kibana config as a part of the initialization.
 		kibanaConfig, err := initKibanaConfig(b.Config)
 		if err != nil {
 			return fmt.Errorf("error initKibanaConfig: %v", err)

--- a/libbeat/cmd/instance/beat_test.go
+++ b/libbeat/cmd/instance/beat_test.go
@@ -20,6 +20,8 @@
 package instance
 
 import (
+	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/elastic/beats/libbeat/cfgfile"
@@ -91,4 +93,25 @@ func TestInitKibanaConfig(t *testing.T) {
 	assert.Equal(t, "elastic-test-password", password)
 	assert.Equal(t, "https", protocol)
 	assert.Equal(t, "127.0.0.1:5601", host)
+}
+
+func TestEmptyMetaJson(t *testing.T) {
+	b, err := NewBeat("filebeat", "testidx", "0.9")
+	if err != nil {
+		panic(err)
+	}
+
+	// prepare empty meta file
+	metaFile, err := ioutil.TempFile("../test", "meta.json")
+	assert.Equal(t, nil, err, "Unable to create temporary meta file")
+
+	metaPath := metaFile.Name()
+	metaFile.Close()
+	defer os.Remove(metaPath)
+
+	// load metadata
+	err = b.loadMeta(metaPath)
+
+	assert.Equal(t, nil, err, "Unable to load meta file properly")
+	assert.NotEqual(t, uuid.Nil, b.Info.ID, "Beats UUID is not set")
 }


### PR DESCRIPTION
Backport of #11086 

Fixes #8558 