### PR TITLE
Cherry-pick #11294 to 7.0: implement Close() for docker metricsets

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -93,6 +93,7 @@ https://github.com/elastic/beats/compare/v7.0.0-beta1...master[Check the HEAD di
 - Add documentation about jolokia autodiscover fields. {issue}10925[10925] {pull}10979[10979]
 - Add missing aws.ec2.instance.state.name into fields.yml. {issue}11219[11219] {pull}11221[11221]
 - Fix ec2 metricset to collect metrics from Cloudwatch with the same timestamp. {pull}11142[11142]
+- Fix potential memory leak in stopped docker metricsets {pull}11294[11294]
 
 *Packetbeat*
 

--- a/metricbeat/module/docker/container/container.go
+++ b/metricbeat/module/docker/container/container.go
@@ -38,6 +38,7 @@ func init() {
 	)
 }
 
+// MetricSet type defines all fields of the MetricSet
 type MetricSet struct {
 	mb.BaseMetricSet
 	dockerClient *client.Client
@@ -75,4 +76,10 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 		return
 	}
 	eventsMapping(r, containers, m.dedot)
+}
+
+//Close stops the metricset
+func (m *MetricSet) Close() error {
+
+	return m.dockerClient.Close()
 }

--- a/metricbeat/module/docker/cpu/cpu.go
+++ b/metricbeat/module/docker/cpu/cpu.go
@@ -84,3 +84,9 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 	formattedStats := m.cpuService.getCPUStatsList(stats, m.dedot)
 	eventsMapping(r, formattedStats)
 }
+
+//Close stops the metricset
+func (m *MetricSet) Close() error {
+
+	return m.dockerClient.Close()
+}

--- a/metricbeat/module/docker/diskio/diskio.go
+++ b/metricbeat/module/docker/diskio/diskio.go
@@ -75,3 +75,9 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 	formattedStats := m.blkioService.getBlkioStatsList(stats, m.dedot)
 	eventsMapping(r, formattedStats)
 }
+
+//Close stops the metricset
+func (m *MetricSet) Close() error {
+
+	return m.dockerClient.Close()
+}

--- a/metricbeat/module/docker/healthcheck/healthcheck.go
+++ b/metricbeat/module/docker/healthcheck/healthcheck.go
@@ -76,3 +76,9 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 	}
 	eventsMapping(r, containers, m)
 }
+
+//Close stops the metricset
+func (m *MetricSet) Close() error {
+
+	return m.dockerClient.Close()
+}

--- a/metricbeat/module/docker/image/image.go
+++ b/metricbeat/module/docker/image/image.go
@@ -78,3 +78,9 @@ func (m *MetricSet) Fetch() ([]common.MapStr, error) {
 
 	return eventsMapping(images, m.dedot), nil
 }
+
+//Close stops the metricset
+func (m *MetricSet) Close() error {
+
+	return m.dockerClient.Close()
+}

--- a/metricbeat/module/docker/info/info.go
+++ b/metricbeat/module/docker/info/info.go
@@ -67,3 +67,9 @@ func (m *MetricSet) Fetch() (common.MapStr, error) {
 
 	return eventMapping(&info), nil
 }
+
+//Close stops the metricset
+func (m *MetricSet) Close() error {
+
+	return m.dockerClient.Close()
+}

--- a/metricbeat/module/docker/memory/memory.go
+++ b/metricbeat/module/docker/memory/memory.go
@@ -75,3 +75,9 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 	memoryStats := m.memoryService.getMemoryStatsList(stats, m.dedot)
 	eventsMapping(r, memoryStats)
 }
+
+//Close stops the metricset
+func (m *MetricSet) Close() error {
+
+	return m.dockerClient.Close()
+}

--- a/metricbeat/module/docker/network/network.go
+++ b/metricbeat/module/docker/network/network.go
@@ -77,3 +77,9 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 	formattedStats := m.netService.getNetworkStatsPerContainer(stats, m.dedot)
 	eventsMapping(r, formattedStats)
 }
+
+//Close stops the metricset
+func (m *MetricSet) Close() error {
+
+	return m.dockerClient.Close()
+}


### PR DESCRIPTION
backport of #11294 

More info at #11266 

@ruflin asked me to backport this to 7.0, as there's a potential for memory leaks in stopped metricsets.

This is my first cherry-pick, and git was a tad...recalcitrant. The PR looks fine, though?