### PR TITLE
Try to avoid flakiness on http helper timeout tests

### DIFF
--- a/metricbeat/helper/http_test.go
+++ b/metricbeat/helper/http_test.go
@@ -77,10 +77,11 @@ func TestGetAuthHeaderFromTokenNoFile(t *testing.T) {
 }
 
 func TestTimeout(t *testing.T) {
-	c := make(chan struct{})
-	defer close(c)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		<-c
+		select {
+		case <-time.After(5 * time.Nanosecond):
+		case <-r.Context().Done():
+		}
 	}))
 	defer ts.Close()
 
@@ -118,8 +119,11 @@ func checkTimeout(t *testing.T, h *HTTP) {
 
 	done := make(chan struct{})
 	go func() {
-		_, err := h.FetchResponse()
+		response, err := h.FetchResponse()
 		assert.Error(t, err)
+		if response != nil {
+			response.Body.Close()
+		}
 		done <- struct{}{}
 	}()
 


### PR DESCRIPTION
Block the response only during a time or till the context is done.
Close body if a request object is returned.

Fix #11336