### PR TITLE
Fix authentication in HTTP helper

### DIFF
--- a/metricbeat/helper/http.go
+++ b/metricbeat/helper/http.go
@@ -81,6 +81,7 @@ func newHTTPFromConfig(config Config, name string, hostData mb.HostData) (*HTTP,
 	}
 
 	return &HTTP{
+		hostData: hostData,
 		client: &http.Client{
 			Transport: &http.Transport{
 				Dial:    dialer.Dial,

--- a/metricbeat/helper/http_test.go
+++ b/metricbeat/helper/http_test.go
@@ -135,6 +135,7 @@ func TestAuthentication(t *testing.T) {
 	require.NoError(t, err)
 
 	response, err := h.FetchResponse()
+	response.Body.Close()
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusUnauthorized, response.StatusCode, "response status code")
 
@@ -149,6 +150,7 @@ func TestAuthentication(t *testing.T) {
 	require.NoError(t, err)
 
 	response, err = h.FetchResponse()
+	response.Body.Close()
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusOK, response.StatusCode, "response status code")
 }

--- a/metricbeat/helper/http_test.go
+++ b/metricbeat/helper/http_test.go
@@ -113,6 +113,46 @@ func TestConnectTimeout(t *testing.T) {
 	checkTimeout(t, h)
 }
 
+func TestAuthentication(t *testing.T) {
+	expectedUser := "elastic"
+	expectedPassword := "super1234"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		user, password, ok := r.BasicAuth()
+		if !ok || user != expectedUser || password != expectedPassword {
+			w.WriteHeader(http.StatusUnauthorized)
+		}
+	}))
+	defer ts.Close()
+
+	cfg := defaultConfig()
+
+	// Unauthorized
+	hostData := mb.HostData{
+		URI:          ts.URL,
+		SanitizedURI: ts.URL,
+	}
+	h, err := newHTTPFromConfig(cfg, "test", hostData)
+	require.NoError(t, err)
+
+	response, err := h.FetchResponse()
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusUnauthorized, response.StatusCode, "response status code")
+
+	// Authorized
+	hostData = mb.HostData{
+		URI:          ts.URL,
+		SanitizedURI: ts.URL,
+		User:         expectedUser,
+		Password:     expectedPassword,
+	}
+	h, err = newHTTPFromConfig(cfg, "test", hostData)
+	require.NoError(t, err)
+
+	response, err = h.FetchResponse()
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, response.StatusCode, "response status code")
+}
+
 func checkTimeout(t *testing.T, h *HTTP) {
 	t.Helper()
 


### PR DESCRIPTION
After the refactor done in #11032, baseData was not being passed to the
HTTP helper, so authentication was not working.

Added a test to avoid regressions here.

Fix #11351