### PR TITLE
Docker healthcheck metric clarification

### DIFF
--- a/metricbeat/docs/fields.asciidoc
+++ b/metricbeat/docs/fields.asciidoc
@@ -3002,7 +3002,7 @@ Number of reads and writes per second
 == healthcheck fields
 
 Docker container metrics.
-Healthcheck data will only be available from docker containers if the HEALTHCHECK instruction has been used
+Healthcheck data will only be available from docker containers if the `HEALTHCHECK` instruction has been used
 to build the docker images used.
 
 

--- a/metricbeat/docs/fields.asciidoc
+++ b/metricbeat/docs/fields.asciidoc
@@ -3002,7 +3002,7 @@ Number of reads and writes per second
 == healthcheck fields
 
 Docker container metrics.
-Healthcheck data will only be available from docker containers if the `HEALTHCHECK` instruction has been used
+Healthcheck data will only be available from docker containers if the docker `HEALTHCHECK` instruction has been used
 to build the docker images used.
 
 

--- a/metricbeat/docs/fields.asciidoc
+++ b/metricbeat/docs/fields.asciidoc
@@ -3002,6 +3002,8 @@ Number of reads and writes per second
 == healthcheck fields
 
 Docker container metrics.
+Healthcheck data will only be available from docker containers if the HEALTHCHECK instruction has been used
+to build the docker images used.
 
 
 


### PR DESCRIPTION
Docker healthcheck metrics might be confusing if it's not understood that the healthcheck metrics are only available for containers using images that were created with the docker `HEALTHCHECK` instruction:
https://docs.docker.com/engine/reference/builder/#healthcheck

These are not generic docker container healthchecks that metricbeat can monitor for all containers.

