### PR TITLE
Cherry-pick #11243 to 7.0: Skip password test in metricbeat redis module

### DIFF
--- a/metricbeat/module/redis/info/info_integration_test.go
+++ b/metricbeat/module/redis/info/info_integration_test.go
@@ -40,6 +40,9 @@ func TestFetch(t *testing.T) {
 	if err != nil {
 		t.Fatal("fetch", err)
 	}
+	if len(events) == 0 {
+		t.Fatal("no events")
+	}
 	event := events[0].MetricSetFields
 
 	t.Logf("%s/%s event: %+v", ms.Module().Name(), ms.Name(), event)

--- a/metricbeat/module/redis/metricset_integration_test.go
+++ b/metricbeat/module/redis/metricset_integration_test.go
@@ -37,6 +37,8 @@ const (
 )
 
 func TestPasswords(t *testing.T) {
+	t.Skip("Changing password affects other tests, see https://github.com/elastic/beats/issues/10955")
+
 	compose.EnsureUp(t, "redis")
 
 	registry := mb.NewRegister()


### PR DESCRIPTION
Cherry-pick of PR #11243 to 7.0 branch. Original message: 

At the moment, docker containers are shared between tests. Password test
changes the password as part of its checks, what can affect the
connection of other tests using the same instance, skip this test by
now to avoid flakiness in the rest of tests.

elastic/beats#7957 will run each package on a different docker compose scenario, what
will help to control this kind of interactions.

Fix #11354