### PR TITLE
Cherry-pick #11357 to 6.7: Fix Winlogbeat escaping CRLF sequences

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -159,6 +159,7 @@ https://github.com/elastic/beats/compare/v6.6.0...6.x[Check the HEAD diff]
 *Winlogbeat*
 
 - Prevent Winlogbeat from dropping events with invalid XML. {pull}11006{11006}
+- Fix Winlogbeat escaping CR, LF and TAB characters. {issue}11328[11328] {pull}11357[11357]
 
 *Functionbeat*
 

--- a/winlogbeat/sys/xmlreader.go
+++ b/winlogbeat/sys/xmlreader.go
@@ -58,7 +58,7 @@ func (r *xmlSafeReader) Read(d []byte) (n int, err error) {
 	}
 	for i := 0; i < len(r.buf); {
 		code, size := utf8.DecodeRune(r.buf[i:])
-		if unicode.IsControl(code) {
+		if !unicode.IsSpace(code) && unicode.IsControl(code) {
 			n = copy(d, r.buf[:i])
 			r.buf = r.buf[n+1:]
 			r.code = []byte(fmt.Sprintf("\\u%04x", code))

--- a/winlogbeat/tests/system/test_eventlogging.py
+++ b/winlogbeat/tests/system/test_eventlogging.py
@@ -232,3 +232,27 @@ class Test(WriteReadTest):
         evts = self.read_events(config)
         self.assertTrue(len(evts), 1)
         self.assertNotIn("message", evts[0])
+
+    def test_multiline_events(self):
+        """
+        eventlogging - Event with newlines and control characters
+        """
+        msg = """
+A trusted logon process has been registered with the Local Security Authority.
+This logon process will be trusted to submit logon requests.
+
+Subject:
+
+Security ID:  SYSTEM
+Account Name:  MS4\x1e$
+Account Domain:  WORKGROUP
+Logon ID:  0x3e7
+Logon Process Name:  IKE"""
+        self.write_event_log(msg)
+        evts = self.read_events()
+        self.assertTrue(len(evts), 1)
+        self.assertEqual(unicode(self.api), evts[0]["winlog.api"], evts[0])
+        self.assertNotIn("event.original", evts[0], msg=evts[0])
+        self.assertIn("message", evts[0], msg=evts[0])
+        self.assertNotIn("\\u000a", evts[0]["message"], msg=evts[0])
+        self.assertEqual(unicode(msg), evts[0]["message"].decode('unicode-escape'), msg=evts[0])

--- a/winlogbeat/tests/system/test_wineventlog.py
+++ b/winlogbeat/tests/system/test_wineventlog.py
@@ -376,3 +376,27 @@ class Test(WriteReadTest):
         evts = self.read_events(config)
         self.assertTrue(len(evts), 1)
         self.assertNotIn("message", evts[0])
+
+    def test_multiline_events(self):
+        """
+        wineventlog - Event with newlines and control characters
+        """
+        msg = """
+A trusted logon process has been registered with the Local Security Authority.
+This logon process will be trusted to submit logon requests.
+
+Subject:
+
+Security ID:  SYSTEM
+Account Name:  MS4\x1e$
+Account Domain:  WORKGROUP
+Logon ID:  0x3e7
+Logon Process Name:  IKE"""
+        self.write_event_log(msg)
+        evts = self.read_events()
+        self.assertTrue(len(evts), 1)
+        self.assertEqual(unicode(self.api), evts[0]["winlog.api"], msg=evts[0])
+        self.assertNotIn("event.original", evts[0], msg=evts[0])
+        self.assertIn("message", evts[0], msg=evts[0])
+        self.assertNotIn("\\u000a", evts[0]["message"], msg=evts[0])
+        self.assertEqual(unicode(msg), evts[0]["message"].decode('unicode-escape'), msg=evts[0])


### PR DESCRIPTION
Cherry-pick of PR #11357 to 6.7 branch. Original message: 

Previous fix (#11006) made Winlogbeat escape CRLF control characters, which are expected in Windows event logs.

Fixes #11328