### PR TITLE
Cherry-pick #7926 to 6.5: Start autodiscover consumers before producers

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -36,6 +36,7 @@ https://github.com/elastic/beats/compare/v6.5.4...6.5[Check the HEAD diff]
 *Affecting all Beats*
 
 - Enforce validation for the Central Management access token. {issue}9621[9621]
+- Start autodiscover consumers before producers. {pull}7926[7926]
 
 *Auditbeat*
 


### PR DESCRIPTION
Cherry-pick of PR #7926 to 6.5 branch. Original message: 

This PR makes sure that autodiscover consumers are started to listen to the Bus before producers start to produce. This is because, the Bus is a bounded `chan` of size 100. A kubernetes node can have upto 110 pods. In such cases, the producer would be blocked and the consumer would never start.