### PR TITLE
[Metricbeat] migrate golang module to ReporterV2 error

### DIFF
--- a/metricbeat/module/golang/expvar/expvar.go
+++ b/metricbeat/module/golang/expvar/expvar.go
@@ -18,15 +18,13 @@
 package expvar
 
 import (
-	"github.com/elastic/beats/libbeat/logp"
+	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/metricbeat/helper"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/mb/parse"
 	"github.com/elastic/beats/metricbeat/module/golang"
 )
-
-var logger = logp.NewLogger("golang.expvar")
 
 const (
 	defaultScheme = "http"
@@ -85,13 +83,10 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // Fetch methods implements the data gathering and data conversion to the right format
 // It returns the event which is then forward to the output. In case of an error, a
 // descriptive error must be returned.
-func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
+func (m *MetricSet) Fetch(reporter mb.ReporterV2) error {
 	json, err := m.http.FetchJSON()
-
 	if err != nil {
-		logger.Error(err)
-		reporter.Error(err)
-		return
+		return errors.Wrap(err, "Error in http fetch")
 	}
 
 	//flatten cmdline
@@ -101,4 +96,6 @@ func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
 		MetricSetFields: json,
 		Namespace:       m.Module().Name() + "." + m.namespace,
 	})
+
+	return nil
 }

--- a/metricbeat/module/golang/expvar/expvar.go
+++ b/metricbeat/module/golang/expvar/expvar.go
@@ -86,7 +86,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 func (m *MetricSet) Fetch(reporter mb.ReporterV2) error {
 	json, err := m.http.FetchJSON()
 	if err != nil {
-		return errors.Wrap(err, "Error in http fetch")
+		return errors.Wrap(err, "error in http fetch")
 	}
 
 	//flatten cmdline

--- a/metricbeat/module/golang/expvar/expvar_integration_test.go
+++ b/metricbeat/module/golang/expvar/expvar_integration_test.go
@@ -32,9 +32,9 @@ import (
 func TestData(t *testing.T) {
 	compose.EnsureUp(t, "golang")
 
-	f := mbtest.NewReportingMetricSetV2(t, getConfig())
+	f := mbtest.NewReportingMetricSetV2Error(t, getConfig())
 
-	err := mbtest.WriteEventsReporterV2(f, t, "")
+	err := mbtest.WriteEventsReporterV2Error(f, t, "")
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}
@@ -43,9 +43,9 @@ func TestData(t *testing.T) {
 func TestFetch(t *testing.T) {
 	compose.EnsureUp(t, "golang")
 
-	f := mbtest.NewReportingMetricSetV2(t, getConfig())
+	f := mbtest.NewReportingMetricSetV2Error(t, getConfig())
 
-	events, errs := mbtest.ReportingFetchV2(f)
+	events, errs := mbtest.ReportingFetchV2Error(f)
 	if len(errs) > 0 {
 		t.Fatalf("Expected 0 error, had %d. %v\n", len(errs), errs)
 	}

--- a/metricbeat/module/golang/heap/heap.go
+++ b/metricbeat/module/golang/heap/heap.go
@@ -20,11 +20,12 @@ package heap
 import (
 	"encoding/json"
 
+	"github.com/pkg/errors"
+
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/metricbeat/helper"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/mb/parse"
-	"github.com/pkg/errors"
 )
 
 var logger = logp.NewLogger("golang.heap")

--- a/metricbeat/module/golang/heap/heap.go
+++ b/metricbeat/module/golang/heap/heap.go
@@ -24,6 +24,7 @@ import (
 	"github.com/elastic/beats/metricbeat/helper"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/mb/parse"
+	"github.com/pkg/errors"
 )
 
 var logger = logp.NewLogger("golang.heap")
@@ -76,25 +77,22 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // Fetch methods implements the data gathering and data conversion to the right format
 // It returns the event which is then forward to the output. In case of an error, a
 // descriptive error must be returned.
-func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
+func (m *MetricSet) Fetch(reporter mb.ReporterV2) error {
 	data, err := m.http.FetchContent()
 	if err != nil {
-		logger.Error(err)
-		reporter.Error(err)
-		return
+		return errors.Wrap(err, "Error in http fetch")
 	}
 
 	var stats Stats
 
 	err = json.Unmarshal(data, &stats)
 	if err != nil {
-		logger.Error(err)
-		reporter.Error(err)
-		return
+		return errors.Wrap(err, "Error unmarshalling json")
 	}
 
 	reporter.Event(mb.Event{
 		MetricSetFields: eventMapping(stats, m),
 	})
 
+	return nil
 }

--- a/metricbeat/module/golang/heap/heap.go
+++ b/metricbeat/module/golang/heap/heap.go
@@ -81,14 +81,14 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 func (m *MetricSet) Fetch(reporter mb.ReporterV2) error {
 	data, err := m.http.FetchContent()
 	if err != nil {
-		return errors.Wrap(err, "Error in http fetch")
+		return errors.Wrap(err, "error in http fetch")
 	}
 
 	var stats Stats
 
 	err = json.Unmarshal(data, &stats)
 	if err != nil {
-		return errors.Wrap(err, "Error unmarshalling json")
+		return errors.Wrap(err, "error unmarshalling json")
 	}
 
 	reporter.Event(mb.Event{

--- a/metricbeat/module/golang/heap/heap_integration_test.go
+++ b/metricbeat/module/golang/heap/heap_integration_test.go
@@ -32,9 +32,9 @@ import (
 func TestData(t *testing.T) {
 	compose.EnsureUp(t, "golang")
 
-	f := mbtest.NewReportingMetricSetV2(t, getConfig())
+	f := mbtest.NewReportingMetricSetV2Error(t, getConfig())
 
-	err := mbtest.WriteEventsReporterV2(f, t, "")
+	err := mbtest.WriteEventsReporterV2Error(f, t, "")
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}
@@ -43,9 +43,9 @@ func TestData(t *testing.T) {
 func TestFetch(t *testing.T) {
 	compose.EnsureUp(t, "golang")
 
-	f := mbtest.NewReportingMetricSetV2(t, getConfig())
+	f := mbtest.NewReportingMetricSetV2Error(t, getConfig())
 
-	events, errs := mbtest.ReportingFetchV2(f)
+	events, errs := mbtest.ReportingFetchV2Error(f)
 	if len(errs) > 0 {
 		t.Fatalf("Expected 0 error, had %d. %v\n", len(errs), errs)
 	}


### PR DESCRIPTION
See  #11374 and #10727 

This was @ruflin and my idea, now that we have a "cleaner" error interface that could potentially remove some boilerplate from `Fetch()`.

We also decided to do this on a module-by-module basis where possible, to avoid spamming with excessive PRs, as each change is rather small. However I'm not set on this, and we could do it metricset-by-metricset if people prefer. 