### PR TITLE
Register javascript modules

### DIFF
--- a/libbeat/processors/script/processor.go
+++ b/libbeat/processors/script/processor.go
@@ -25,6 +25,9 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/processors"
 	"github.com/elastic/beats/libbeat/processors/script/javascript"
+
+	// Register javascript modules with the processor.
+	_ "github.com/elastic/beats/libbeat/processors/script/javascript/module"
 )
 
 func init() {


### PR DESCRIPTION
Register modules with the script processor.

This is a follow up to #11260. In that PR we tested the modules by registering them in their unit tests, but I forgot to register them with the Beat.