### PR TITLE
Add `add_observer_metadata processor`

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -144,7 +144,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 - Enable `add_observer_metadata` processor in default config. {pull}11394[11394]
 
-
 *Journalbeat*
 
 *Metricbeat*

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -142,7 +142,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Heartbeat*
 
-- Autodiscover metadata is now included in events by default. So, if you are using the docker provider for instance, you'll see the correct fields under the `docker` key. {pull}10258[10258]
 - Enable `add_observer_metadata` processor in default config. {pull}11394[11394]
 
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -117,6 +117,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - New processor: `truncate_fields`. {pull}11297[11297]
 - Allow a beat to ship monitoring data directly to an Elasticsearch monitoring clsuter. {pull}9260[9260]
 - Updated go-seccomp-bpf library to v1.1.0 which updates syscall lists for Linux v5.0. {pull}NNNN[NNNN]
+- Add `add_observer_metadata` processor. {pull}11394[11394]
 
 *Auditbeat*
 
@@ -140,6 +141,10 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add Filebeat envoyproxy module. {pull}11700[11700]
 
 *Heartbeat*
+
+- Autodiscover metadata is now included in events by default. So, if you are using the docker provider for instance, you'll see the correct fields under the `docker` key. {pull}10258[10258]
+- Enable `add_observer_metadata` processor in default config. {pull}11394[11394]
+
 
 *Journalbeat*
 

--- a/heartbeat/heartbeat.yml
+++ b/heartbeat/heartbeat.yml
@@ -126,6 +126,11 @@ output.elasticsearch:
   # Client Certificate Key
   #ssl.key: "/etc/pki/client/cert.key"
 
+#================================ Processors =====================================
+processors:
+  - add_observer_metadata: ~
+
+
 #================================ Logging =====================================
 
 # Sets log level. The default log level is info.

--- a/heartbeat/heartbeat.yml
+++ b/heartbeat/heartbeat.yml
@@ -128,8 +128,7 @@ output.elasticsearch:
 
 #================================ Processors =====================================
 processors:
-  - add_observer_metadata:
-      netinfo.enabled: true
+  - add_observer_metadata: ~
 
 
 #================================ Logging =====================================

--- a/heartbeat/heartbeat.yml
+++ b/heartbeat/heartbeat.yml
@@ -128,7 +128,8 @@ output.elasticsearch:
 
 #================================ Processors =====================================
 processors:
-  - add_observer_metadata: ~
+  - add_observer_metadata:
+      netinfo.enabled: true
 
 
 #================================ Logging =====================================

--- a/heartbeat/scripts/post_process_config.py
+++ b/heartbeat/scripts/post_process_config.py
@@ -22,6 +22,10 @@ with open(sys.argv[1], 'r') as conf_file:
         if m:
             section_name = m.group(1)
             if section_name == "Processors":
+                output += line # include section name in output
+                output += "processors:\n"
+                output += "  - add_observer_metadata: ~\n"
+                output += "\n\n"
                 inside_processor_section = True
             else:
                 inside_processor_section = False

--- a/heartbeat/scripts/post_process_config.py
+++ b/heartbeat/scripts/post_process_config.py
@@ -22,7 +22,7 @@ with open(sys.argv[1], 'r') as conf_file:
         if m:
             section_name = m.group(1)
             if section_name == "Processors":
-                output += line # include section name in output
+                output += line  # include section name in output
                 output += "processors:\n"
                 output += "  - add_observer_metadata: ~\n"
                 output += "\n\n"

--- a/libbeat/cmd/instance/imports.go
+++ b/libbeat/cmd/instance/imports.go
@@ -29,6 +29,7 @@ import (
 	_ "github.com/elastic/beats/libbeat/processors/add_host_metadata"
 	_ "github.com/elastic/beats/libbeat/processors/add_kubernetes_metadata"
 	_ "github.com/elastic/beats/libbeat/processors/add_locale"
+	_ "github.com/elastic/beats/libbeat/processors/add_observer_metadata"
 	_ "github.com/elastic/beats/libbeat/processors/add_process_metadata"
 	_ "github.com/elastic/beats/libbeat/processors/communityid"
 	_ "github.com/elastic/beats/libbeat/processors/dissect"

--- a/libbeat/docs/processors-using.asciidoc
+++ b/libbeat/docs/processors-using.asciidoc
@@ -198,6 +198,7 @@ The supported processors are:
  * <<add-docker-metadata,`add_docker_metadata`>>
  * <<add-fields, `add_fields`>>
  * <<add-host-metadata,`add_host_metadata`>>
+ * <<add-observer-metadata,`add_observer_metadata`>>
  * <<add-kubernetes-metadata,`add_kubernetes_metadata`>>
  * <<add-labels, `add_labels`>>
  * <<add-locale,`add_locale`>>
@@ -1173,7 +1174,7 @@ It has the following settings:
 
 
 The `add_host_metadata` processor annotates each event with relevant metadata from the host machine.
-The fields added to the event are looking as following:
+The fields added to the event are look like following:
 
 [source,json]
 -------------------------------------------------------------------------------
@@ -1190,6 +1191,73 @@ The fields added to the event are looking as following:
          "kernel":"16.7.0",
          "name":"Mac OS X"
       },
+      "ip": ["192.168.0.1", "10.0.0.1"],
+      "mac": ["00:25:96:12:34:56", "72:00:06:ff:79:f1"],
+      "geo": {
+          "continent_name": "North America",
+          "country_iso_code": "US",
+          "region_name": "New York",
+          "region_iso_code": "NY",
+          "city_name": "New York",
+          "name": "nyc-dc1-rack1",
+          "location": "40.7128, -74.0060"
+        }
+   }
+}
+-------------------------------------------------------------------------------
+
+[[add-observer-metadata]]
+=== Add Observer metadata
+
+beta[]
+
+[source,yaml]
+-------------------------------------------------------------------------------
+processors:
+- add_observer_metadata:
+    netinfo.enabled: false
+    cache.ttl: 5m
+    geo:
+      name: nyc-dc1-rack1
+      location: 40.7128, -74.0060
+      continent_name: North America
+      country_iso_code: US
+      region_name: New York
+      region_iso_code: NY
+      city_name: New York
+-------------------------------------------------------------------------------
+
+It has the following settings:
+
+`netinfo.enabled`:: (Optional) Default false. Include IP addresses and MAC addresses as fields observer.ip and observer.mac
+
+`cache.ttl`:: (Optional) The processor uses an internal cache for the observer metadata. This sets the cache expiration time. The default is 5m, negative values disable caching altogether.
+
+`geo.name`:: User definable token to be used for identifying a discrete location. Frequently a datacenter, rack, or similar.
+
+`geo.location`:: Longitude and latitude in comma separated format.
+
+`geo.continent_name`:: Name of the continent.
+
+`geo.country_name`:: Name of the country.
+
+`geo.region_name`:: Name of the region.
+
+`geo.city_name`:: Name of the city.
+
+`geo.country_iso_code`:: ISO country code.
+
+`geo.region_iso_code`:: ISO region code.
+
+
+The `add_geo_metadata` processor annotates each event with relevant metadata from the observer machine.
+The fields added to the event look like the following:
+
+[source,json]
+-------------------------------------------------------------------------------
+{
+   "host":{
+      
       "ip": ["192.168.0.1", "10.0.0.1"],
       "mac": ["00:25:96:12:34:56", "72:00:06:ff:79:f1"],
       "geo": {

--- a/libbeat/docs/processors-using.asciidoc
+++ b/libbeat/docs/processors-using.asciidoc
@@ -1256,20 +1256,27 @@ The fields added to the event look like the following:
 [source,json]
 -------------------------------------------------------------------------------
 {
-   "host":{
-      
-      "ip": ["192.168.0.1", "10.0.0.1"],
-      "mac": ["00:25:96:12:34:56", "72:00:06:ff:79:f1"],
-      "geo": {
-          "continent_name": "North America",
-          "country_iso_code": "US",
-          "region_name": "New York",
-          "region_iso_code": "NY",
-          "city_name": "New York",
-          "name": "nyc-dc1-rack1",
-          "location": "40.7128, -74.0060"
-        }
-   }
+  "observer" : {
+    "hostname" : "avce",
+    "type" : "heartbeat",
+    "vendor" : "elastic",
+    "ip" : [
+      "192.168.1.251",
+      "fe80::64b2:c3ff:fe5b:b974",
+    ],
+    "mac" : [
+      "dc:c1:02:6f:1b:ed",
+   ],
+    "geo": {
+      "continent_name": "North America",
+      "country_iso_code": "US",
+      "region_name": "New York",
+      "region_iso_code": "NY",
+      "city_name": "New York",
+      "name": "nyc-dc1-rack1",
+      "location": "40.7128, -74.0060"
+    }
+  }
 }
 -------------------------------------------------------------------------------
 

--- a/libbeat/docs/processors-using.asciidoc
+++ b/libbeat/docs/processors-using.asciidoc
@@ -1174,7 +1174,7 @@ It has the following settings:
 
 
 The `add_host_metadata` processor annotates each event with relevant metadata from the host machine.
-The fields added to the event are look like following:
+The fields added to the event look like the following:
 
 [source,json]
 -------------------------------------------------------------------------------
@@ -1266,7 +1266,7 @@ The fields added to the event look like the following:
     ],
     "mac" : [
       "dc:c1:02:6f:1b:ed",
-   ],
+    ],
     "geo": {
       "continent_name": "North America",
       "country_iso_code": "US",

--- a/libbeat/processors/add_host_metadata/add_host_metadata.go
+++ b/libbeat/processors/add_host_metadata/add_host_metadata.go
@@ -23,8 +23,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/elastic/beats/libbeat/processors/util"
-
 	"github.com/joeshaw/multierror"
 	"github.com/pkg/errors"
 
@@ -33,6 +31,7 @@ import (
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/metric/system/host"
 	"github.com/elastic/beats/libbeat/processors"
+	"github.com/elastic/beats/libbeat/processors/util"
 	"github.com/elastic/go-sysinfo"
 )
 

--- a/libbeat/processors/add_host_metadata/add_host_metadata_test.go
+++ b/libbeat/processors/add_host_metadata/add_host_metadata_test.go
@@ -23,9 +23,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"

--- a/libbeat/processors/add_observer_metadata/add_observer_metadata.go
+++ b/libbeat/processors/add_observer_metadata/add_observer_metadata.go
@@ -124,8 +124,6 @@ func (p *observerMetadata) loadData() error {
 	data := common.MapStr{
 		"observer": common.MapStr{
 			"hostname": hostInfo.Hostname,
-			"type":     "heartbeat",
-			"vendor":   "elastic",
 		},
 	}
 	if p.config.NetInfoEnabled {

--- a/libbeat/processors/add_observer_metadata/add_observer_metadata.go
+++ b/libbeat/processors/add_observer_metadata/add_observer_metadata.go
@@ -85,6 +85,9 @@ func (p *observerMetadata) Run(event *beat.Event) (*beat.Event, error) {
 	keyExists, _ := event.Fields.HasKey("observer")
 
 	if p.config.Overwrite || !keyExists {
+		if p.config.Overwrite {
+			event.Fields.Delete("observer")
+		}
 		event.Fields.DeepUpdate(p.data.Get().Clone())
 
 		if len(p.geoData) > 0 {

--- a/libbeat/processors/add_observer_metadata/add_observer_metadata.go
+++ b/libbeat/processors/add_observer_metadata/add_observer_metadata.go
@@ -19,11 +19,9 @@ package add_observer_metadata
 
 import (
 	"fmt"
-	"net"
 	"sync"
 	"time"
 
-	"github.com/joeshaw/multierror"
 	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/libbeat/beat"
@@ -127,7 +125,7 @@ func (p *observerMetadata) loadData() error {
 	}
 	if p.config.NetInfoEnabled {
 		// IP-address and MAC-address
-		var ipList, hwList, err = p.getNetInfo()
+		var ipList, hwList, err = util.GetNetInfo()
 		if err != nil {
 			logp.Info("Error when getting network information %v", err)
 		}
@@ -142,51 +140,6 @@ func (p *observerMetadata) loadData() error {
 
 	p.data.Set(data)
 	return nil
-}
-
-func (p *observerMetadata) getNetInfo() ([]string, []string, error) {
-	var ipList []string
-	var hwList []string
-
-	// Get all interfaces and loop through them
-	ifaces, err := net.Interfaces()
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// Keep track of all errors
-	var errs multierror.Errors
-
-	for _, i := range ifaces {
-		// Skip loopback interfaces
-		if i.Flags&net.FlagLoopback == net.FlagLoopback {
-			continue
-		}
-
-		hw := i.HardwareAddr.String()
-		// Skip empty hardware addresses
-		if hw != "" {
-			hwList = append(hwList, hw)
-		}
-
-		addrs, err := i.Addrs()
-		if err != nil {
-			// If we get an error, keep track of it and continue with the next interface
-			errs = append(errs, err)
-			continue
-		}
-
-		for _, addr := range addrs {
-			switch v := addr.(type) {
-			case *net.IPNet:
-				ipList = append(ipList, v.IP.String())
-			case *net.IPAddr:
-				ipList = append(ipList, v.IP.String())
-			}
-		}
-	}
-
-	return ipList, hwList, errs.Err()
 }
 
 func (p *observerMetadata) String() string {

--- a/libbeat/processors/add_observer_metadata/add_observer_metadata.go
+++ b/libbeat/processors/add_observer_metadata/add_observer_metadata.go
@@ -35,7 +35,7 @@ import (
 )
 
 func init() {
-	processors.RegisterPlugin("add_observer_metadata", newObserverMetadataProcessor)
+	processors.RegisterPlugin("add_observer_metadata", New)
 }
 
 type observerMetadata struct {
@@ -52,7 +52,7 @@ const (
 	processorName = "add_observer_metadata"
 )
 
-func newObserverMetadataProcessor(cfg *common.Config) (processors.Processor, error) {
+func New(cfg *common.Config) (processors.Processor, error) {
 	config := defaultConfig()
 	if err := cfg.Unpack(&config); err != nil {
 		return nil, errors.Wrapf(err, "fail to unpack the %v configuration", processorName)

--- a/libbeat/processors/add_observer_metadata/add_observer_metadata.go
+++ b/libbeat/processors/add_observer_metadata/add_observer_metadata.go
@@ -82,11 +82,16 @@ func (p *observerMetadata) Run(event *beat.Event) (*beat.Event, error) {
 		return nil, err
 	}
 
-	event.Fields.DeepUpdate(p.data.Get().Clone())
+	keyExists, _ := event.Fields.HasKey("observer")
 
-	if len(p.geoData) > 0 {
-		event.Fields.DeepUpdate(p.geoData)
+	if p.config.Overwrite || !keyExists {
+		event.Fields.DeepUpdate(p.data.Get().Clone())
+
+		if len(p.geoData) > 0 {
+			event.Fields.DeepUpdate(p.geoData)
+		}
 	}
+
 	return event, nil
 }
 

--- a/libbeat/processors/add_observer_metadata/add_observer_metadata.go
+++ b/libbeat/processors/add_observer_metadata/add_observer_metadata.go
@@ -52,6 +52,7 @@ const (
 	processorName = "add_observer_metadata"
 )
 
+// New creates a new instance of the add_observer_metadata processor.
 func New(cfg *common.Config) (processors.Processor, error) {
 	config := defaultConfig()
 	if err := cfg.Unpack(&config); err != nil {

--- a/libbeat/processors/add_observer_metadata/add_observer_metadata_test.go
+++ b/libbeat/processors/add_observer_metadata/add_observer_metadata_test.go
@@ -21,9 +21,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
@@ -37,7 +36,7 @@ func TestConfigDefault(t *testing.T) {
 	testConfig, err := common.NewConfigFrom(map[string]interface{}{})
 	assert.NoError(t, err)
 
-	p, err := newObserverMetadataProcessor(testConfig)
+	p, err := New(testConfig)
 
 	newEvent, err := p.Run(event)
 	assert.NoError(t, err)
@@ -69,7 +68,7 @@ func TestConfigNetInfoEnabled(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	p, err := newObserverMetadataProcessor(testConfig)
+	p, err := New(testConfig)
 
 	newEvent, err := p.Run(event)
 	assert.NoError(t, err)
@@ -110,7 +109,7 @@ func TestConfigGeoEnabled(t *testing.T) {
 	testConfig, err := common.NewConfigFrom(config)
 	assert.NoError(t, err)
 
-	p, err := newObserverMetadataProcessor(testConfig)
+	p, err := New(testConfig)
 	require.NoError(t, err)
 
 	newEvent, err := p.Run(event)
@@ -133,7 +132,7 @@ func TestConfigGeoDisabled(t *testing.T) {
 	testConfig, err := common.NewConfigFrom(config)
 	require.NoError(t, err)
 
-	p, err := newObserverMetadataProcessor(testConfig)
+	p, err := New(testConfig)
 	require.NoError(t, err)
 
 	newEvent, err := p.Run(event)

--- a/libbeat/processors/add_observer_metadata/add_observer_metadata_test.go
+++ b/libbeat/processors/add_observer_metadata/add_observer_metadata_test.go
@@ -41,15 +41,7 @@ func TestConfigDefault(t *testing.T) {
 	newEvent, err := p.Run(event)
 	assert.NoError(t, err)
 
-	v, err := newEvent.GetValue("observer.type")
-	assert.NoError(t, err)
-	assert.Equal(t, "heartbeat", v)
-
-	v, err = newEvent.GetValue("observer.vendor")
-	assert.NoError(t, err)
-	assert.Equal(t, "elastic", v)
-
-	v, err = newEvent.GetValue("observer.ip")
+	v, err := newEvent.GetValue("observer.ip")
 	assert.Error(t, err)
 	assert.Nil(t, v)
 
@@ -89,9 +81,9 @@ func TestOverwriteTrue(t *testing.T) {
 	newEvent, err := p.Run(event)
 	require.NoError(t, err)
 
-	v, err := newEvent.GetValue("observer.vendor")
+	v, err := newEvent.GetValue("observer.hostname")
 	require.NoError(t, err)
-	assert.Equal(t, "elastic", v)
+	assert.NotNil(t, v)
 }
 
 func TestConfigNetInfoEnabled(t *testing.T) {
@@ -109,15 +101,7 @@ func TestConfigNetInfoEnabled(t *testing.T) {
 	newEvent, err := p.Run(event)
 	assert.NoError(t, err)
 
-	v, err := newEvent.GetValue("observer.type")
-	assert.NoError(t, err)
-	assert.Equal(t, "heartbeat", v)
-
-	v, err = newEvent.GetValue("observer.vendor")
-	assert.NoError(t, err)
-	assert.Equal(t, "elastic", v)
-
-	v, err = newEvent.GetValue("observer.ip")
+	v, err := newEvent.GetValue("observer.ip")
 	assert.NoError(t, err)
 	assert.NotNil(t, v)
 

--- a/libbeat/processors/add_observer_metadata/add_observer_metadata_test.go
+++ b/libbeat/processors/add_observer_metadata/add_observer_metadata_test.go
@@ -58,6 +58,42 @@ func TestConfigDefault(t *testing.T) {
 	assert.Nil(t, v)
 }
 
+func TestOverwriteFalse(t *testing.T) {
+	event := &beat.Event{
+		Fields:    common.MapStr{"observer": common.MapStr{"foo": "bar"}},
+		Timestamp: time.Now(),
+	}
+	testConfig, err := common.NewConfigFrom(map[string]interface{}{})
+	require.NoError(t, err)
+
+	p, err := New(testConfig)
+
+	newEvent, err := p.Run(event)
+	require.NoError(t, err)
+
+	v, err := newEvent.GetValue("observer")
+	require.NoError(t, err)
+	assert.Equal(t, common.MapStr{"foo": "bar"}, v)
+}
+
+func TestOverwriteTrue(t *testing.T) {
+	event := &beat.Event{
+		Fields:    common.MapStr{"observer": common.MapStr{"foo": "bar"}},
+		Timestamp: time.Now(),
+	}
+	testConfig, err := common.NewConfigFrom(map[string]interface{}{"overwrite": true})
+	require.NoError(t, err)
+
+	p, err := New(testConfig)
+
+	newEvent, err := p.Run(event)
+	require.NoError(t, err)
+
+	v, err := newEvent.GetValue("observer.vendor")
+	require.NoError(t, err)
+	assert.Equal(t, "elastic", v)
+}
+
 func TestConfigNetInfoEnabled(t *testing.T) {
 	event := &beat.Event{
 		Fields:    common.MapStr{},

--- a/libbeat/processors/add_observer_metadata/config.go
+++ b/libbeat/processors/add_observer_metadata/config.go
@@ -25,6 +25,7 @@ import (
 
 // Config for add_host_metadata processor.
 type Config struct {
+	Overwrite      bool            `config:"overwrite"`       // Overwrite if observer fields already exist
 	NetInfoEnabled bool            `config:"netinfo.enabled"` // Add IP and MAC to event
 	CacheTTL       time.Duration   `config:"cache.ttl"`
 	Geo            *util.GeoConfig `config:"geo"`

--- a/libbeat/processors/add_observer_metadata/config.go
+++ b/libbeat/processors/add_observer_metadata/config.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package add_host_metadata
+package add_observer_metadata
 
 import (
 	"time"
@@ -28,7 +28,6 @@ type Config struct {
 	NetInfoEnabled bool            `config:"netinfo.enabled"` // Add IP and MAC to event
 	CacheTTL       time.Duration   `config:"cache.ttl"`
 	Geo            *util.GeoConfig `config:"geo"`
-	Name           string          `config:"name"`
 }
 
 func defaultConfig() Config {

--- a/libbeat/processors/processor.go
+++ b/libbeat/processors/processor.go
@@ -71,7 +71,12 @@ func New(config PluginConfig) (*Processors, error) {
 
 		gen, exists := registry.reg[actionName]
 		if !exists {
-			return nil, errors.Errorf("the processor action %s does not exist", actionName)
+			var validActions []string
+			for k := range registry.reg {
+				validActions = append(validActions, k)
+
+			}
+			return nil, errors.Errorf("the processor action %s does not exist. Valid actions: %v", actionName, strings.Join(validActions, ", "))
 		}
 
 		actionCfg.PrintDebugf("Configure processor action '%v' with:", actionName)

--- a/libbeat/processors/script/javascript/module/processor/processor.go
+++ b/libbeat/processors/script/javascript/module/processor/processor.go
@@ -29,6 +29,7 @@ import (
 	"github.com/elastic/beats/libbeat/processors/add_host_metadata"
 	"github.com/elastic/beats/libbeat/processors/add_kubernetes_metadata"
 	"github.com/elastic/beats/libbeat/processors/add_locale"
+	"github.com/elastic/beats/libbeat/processors/add_observer_metadata"
 	"github.com/elastic/beats/libbeat/processors/add_process_metadata"
 	"github.com/elastic/beats/libbeat/processors/communityid"
 	"github.com/elastic/beats/libbeat/processors/dissect"
@@ -44,6 +45,7 @@ var constructors = map[string]processors.Constructor{
 	"AddFields":             actions.CreateAddFields,
 	"AddHostMetadata":       add_host_metadata.New,
 	"AddKubernetesMetadata": add_kubernetes_metadata.New,
+	"AddObserverMetadata":   add_observer_metadata.New,
 	"AddLocale":             add_locale.New,
 	"AddProcessMetadata":    add_process_metadata.New,
 	"CommunityID":           communityid.New,

--- a/libbeat/processors/util/geo.go
+++ b/libbeat/processors/util/geo.go
@@ -1,0 +1,60 @@
+package util
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+
+	"github.com/elastic/beats/libbeat/common"
+)
+
+// GeoConfig contains geo configuration data.
+type GeoConfig struct {
+	Name           string `config:"name"`
+	Location       string `config:"location"`
+	ContinentName  string `config:"continent_name"`
+	CountryISOCode string `config:"country_iso_code"`
+	RegionName     string `config:"region_name"`
+	RegionISOCode  string `config:"region_iso_code"`
+	CityName       string `config:"city_name"`
+}
+
+func GeoConfigToMap(config GeoConfig) (common.MapStr, error) {
+	if len(config.Location) > 0 {
+		// Regexp matching a number with an optional decimal component
+		// Valid numbers: '123', '123.23', etc.
+		latOrLon := `\-?\d+(\.\d+)?`
+
+		// Regexp matching a pair of lat lon coordinates.
+		// e.g. 40.123, -92.929
+		locRegexp := `^\s*` + // anchor to start of string with optional whitespace
+			latOrLon + // match the latitude
+			`\s*\,\s*` + // match the separator. optional surrounding whitespace
+			latOrLon + // match the longitude
+			`\s*$` //optional whitespace then end anchor
+
+		if m, _ := regexp.MatchString(locRegexp, config.Location); !m {
+			return nil, errors.New(fmt.Sprintf("Invalid lat,lon  string for add_observer_metadata: %s", config.Location))
+		}
+	}
+
+	geoFields := common.MapStr{
+		"name":             config.Name,
+		"location":         config.Location,
+		"continent_name":   config.ContinentName,
+		"country_iso_code": config.CountryISOCode,
+		"region_name":      config.RegionName,
+		"region_iso_code":  config.RegionISOCode,
+		"city_name":        config.CityName,
+	}
+	// Delete any empty values
+	blankStringMatch := regexp.MustCompile(`^\s*$`)
+	for k, v := range geoFields {
+		vStr := v.(string)
+		if blankStringMatch.MatchString(vStr) {
+			delete(geoFields, k)
+		}
+	}
+
+	return geoFields, nil
+}

--- a/libbeat/processors/util/geo.go
+++ b/libbeat/processors/util/geo.go
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package util
 
 import (
@@ -19,6 +36,7 @@ type GeoConfig struct {
 	CityName       string `config:"city_name"`
 }
 
+// GeoConfigToMap converts `geo` sections to a `common.MapStr`.
 func GeoConfigToMap(config GeoConfig) (common.MapStr, error) {
 	if len(config.Location) > 0 {
 		// Regexp matching a number with an optional decimal component

--- a/libbeat/processors/util/geo.go
+++ b/libbeat/processors/util/geo.go
@@ -18,7 +18,6 @@
 package util
 
 import (
-	"errors"
 	"fmt"
 	"regexp"
 
@@ -52,7 +51,7 @@ func GeoConfigToMap(config GeoConfig) (common.MapStr, error) {
 			`\s*$` //optional whitespace then end anchor
 
 		if m, _ := regexp.MatchString(locRegexp, config.Location); !m {
-			return nil, errors.New(fmt.Sprintf("Invalid lat,lon  string for add_observer_metadata: %s", config.Location))
+			return nil, fmt.Errorf("Invalid lat,lon  string for add_observer_metadata: %s", config.Location)
 		}
 	}
 

--- a/libbeat/processors/util/geo_test.go
+++ b/libbeat/processors/util/geo_test.go
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package util
 
 import (

--- a/libbeat/processors/util/geo_test.go
+++ b/libbeat/processors/util/geo_test.go
@@ -1,0 +1,93 @@
+package util
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/libbeat/common"
+)
+
+// parseGeoConfig converts the map into a GeoConfig.
+// Going through go-ucfg we test the config to struct transform / validation.
+func parseConfig(t *testing.T, configMap map[string]interface{}) GeoConfig {
+	config, err := common.NewConfigFrom(configMap)
+	require.NoError(t, err)
+
+	geoConfig := GeoConfig{}
+	err = config.Unpack(&geoConfig)
+	require.NoError(t, err)
+
+	return geoConfig
+}
+
+func TestConfigGeoEnabled(t *testing.T) {
+	config := map[string]interface{}{
+		"name":             "yerevan-am",
+		"location":         "40.177200, 44.503490",
+		"continent_name":   "Asia",
+		"country_iso_code": "AM",
+		"region_name":      "Erevan",
+		"region_iso_code":  "AM-ER",
+		"city_name":        "Yerevan",
+	}
+
+	geoMap, err := GeoConfigToMap(parseConfig(t, config))
+	require.NoError(t, err)
+
+	for configKey, configValue := range config {
+		t.Run(fmt.Sprintf("Check of %s", configKey), func(t *testing.T) {
+			v, ok := geoMap[configKey]
+			assert.True(t, ok, "key has entry")
+			assert.Equal(t, configValue, v)
+		})
+	}
+}
+
+func TestPartialGeo(t *testing.T) {
+	config := map[string]interface{}{
+		"name":      "yerevan-am",
+		"city_name": "  ",
+	}
+
+	geoMap, err := GeoConfigToMap(parseConfig(t, config))
+	require.NoError(t, err)
+
+	assert.Equal(t, "yerevan-am", geoMap["name"])
+
+	missing := []string{"continent_name", "country_name", "country_iso_code", "region_name", "region_iso_code", "city_name"}
+
+	for _, k := range missing {
+		_, exists := geoMap[k]
+		assert.False(t, exists, "key should %s should not exist", k)
+	}
+}
+
+func TestGeoLocationValidation(t *testing.T) {
+	locations := []struct {
+		str   string
+		valid bool
+	}{
+		{"40.177200, 44.503490", true},
+		{"-40.177200, -44.503490", true},
+		{"garbage", false},
+		{"9999999999", false},
+	}
+
+	for _, location := range locations {
+		t.Run(fmt.Sprintf("Location %s validation should be %t", location.str, location.valid), func(t *testing.T) {
+
+			geoConfig := parseConfig(t, common.MapStr{"location": location.str})
+			geoMap, err := GeoConfigToMap(geoConfig)
+
+			if location.valid {
+				require.NoError(t, err)
+				require.Equal(t, location.str, geoMap["location"])
+			} else {
+				require.Error(t, err)
+			}
+		})
+	}
+}

--- a/libbeat/processors/util/netinfo.go
+++ b/libbeat/processors/util/netinfo.go
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package util
 
 import (

--- a/libbeat/processors/util/netinfo.go
+++ b/libbeat/processors/util/netinfo.go
@@ -6,10 +6,8 @@ import (
 	"github.com/joeshaw/multierror"
 )
 
-func GetNetInfo() ([]string, []string, error) {
-	var ipList []string
-	var hwList []string
-
+// GetNetInfo returns lists of IPs and MACs for the machine it is executed on.
+func GetNetInfo() (ipList []string, hwList []string, err error) {
 	// Get all interfaces and loop through them
 	ifaces, err := net.Interfaces()
 	if err != nil {

--- a/libbeat/processors/util/netinfo.go
+++ b/libbeat/processors/util/netinfo.go
@@ -1,0 +1,52 @@
+package util
+
+import (
+	"net"
+
+	"github.com/joeshaw/multierror"
+)
+
+func GetNetInfo() ([]string, []string, error) {
+	var ipList []string
+	var hwList []string
+
+	// Get all interfaces and loop through them
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Keep track of all errors
+	var errs multierror.Errors
+
+	for _, i := range ifaces {
+		// Skip loopback interfaces
+		if i.Flags&net.FlagLoopback == net.FlagLoopback {
+			continue
+		}
+
+		hw := i.HardwareAddr.String()
+		// Skip empty hardware addresses
+		if hw != "" {
+			hwList = append(hwList, hw)
+		}
+
+		addrs, err := i.Addrs()
+		if err != nil {
+			// If we get an error, keep track of it and continue with the next interface
+			errs = append(errs, err)
+			continue
+		}
+
+		for _, addr := range addrs {
+			switch v := addr.(type) {
+			case *net.IPNet:
+				ipList = append(ipList, v.IP.String())
+			case *net.IPAddr:
+				ipList = append(ipList, v.IP.String())
+			}
+		}
+	}
+
+	return ipList, hwList, errs.Err()
+}


### PR DESCRIPTION
Resolves #11379 via addition of new `add_observer_metadata` processor.

In addition to creating the processor this PR extracts out the common operations between `add_observer_metadata` and `add_host_metadata`  for `geo` and `netinfo` fields into a new `processors/util` package.

Please note that the `observer` ECS field does not contain the same values that `host` does. See the [ECS Observer Spec](https://github.com/elastic/ecs#observer) for more info.