### PR TITLE
Add link to docs about adding geoip info

### DIFF
--- a/packetbeat/docs/gettingstarted.asciidoc
+++ b/packetbeat/docs/gettingstarted.asciidoc
@@ -325,5 +325,8 @@ include::{libbeat-dir}/docs/opendashboards.asciidoc[]
 The dashboards are provided as examples. We recommend that you
 {kibana-ref}/dashboard.html[customize] them to meet your needs.
 
+TIP: To populate the client locations map in the overview dashboard, follow the
+steps described in <<{beatname_lc}-geoip>>.
+
 [role="screenshot"]
 image:./images/packetbeat-statistics.png[Packetbeat statistics]


### PR DESCRIPTION
Adds link to the getting started guide where we show the client locations map. Should help users who aren't sure how to populate the map in Packetbeat.