### PR TITLE
6.7: Remove IP fields from default_field in Elasticsearch template

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -82,6 +82,7 @@ https://github.com/elastic/beats/compare/v6.6.0...6.x[Check the HEAD diff]
 - Include ip and boolean type when generating index pattern. {pull}10995[10995]
 - Using an environment variable for the password when enrolling a beat will now raise an error if the variable doesn't exist. {pull}10936[10936]
 - Cancelling enrollment of a beat will not enroll the beat. {issue}10150[10150]
+- Remove IP fields from default_field in Elasticsearch template.
 
 *Auditbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -82,7 +82,7 @@ https://github.com/elastic/beats/compare/v6.6.0...6.x[Check the HEAD diff]
 - Include ip and boolean type when generating index pattern. {pull}10995[10995]
 - Using an environment variable for the password when enrolling a beat will now raise an error if the variable doesn't exist. {pull}10936[10936]
 - Cancelling enrollment of a beat will not enroll the beat. {issue}10150[10150]
-- Remove IP fields from default_field in Elasticsearch template.
+- Remove IP fields from default_field in Elasticsearch template. {pull}11399[11399]
 
 *Auditbeat*
 

--- a/libbeat/template/processor.go
+++ b/libbeat/template/processor.go
@@ -100,7 +100,7 @@ func (p *Processor) Process(fields common.Fields, path string, output common.Map
 		}
 
 		switch field.Type {
-		case "", "keyword", "text", "ip":
+		case "", "keyword", "text":
 			addToDefaultFields(&field)
 		}
 


### PR DESCRIPTION
https://github.com/elastic/beats/pull/11035 added IP fields to the `default_field` array in Elasticsearch templates. Unfortunately, this has the side effect of breaking simple queries directly against Elasticsearch:

```
GET packetbeat-*/_search
{ 
  "query": {
    "query_string": {
      "query": "foo"
    }  
  }
}
```

Leads to:
```
{
  "error": {
    "root_cause": [
      {
        "type": "query_shard_exception",
        "reason": "failed to create query: {\n  \"query_string\" : {\n    \"query\" : \"foo\",\n    \"fields\" : [ ],\n    \"type\" : \"best_fields\",\n    \"default_operator\" : \"or\",\n    \"max_determinized_states\" : 10000,\n    \"enable_position_increments\" : true,\n    \"fuzziness\" : \"AUTO\",\n    \"fuzzy_prefix_length\" : 0,\n    \"fuzzy_max_expansions\" : 50,\n    \"phrase_slop\" : 0,\n    \"escape\" : false,\n    \"auto_generate_synonyms_phrase_query\" : true,\n    \"fuzzy_transpositions\" : true,\n    \"boost\" : 1.0\n  }\n}",
        "index_uuid": "50TUmx-qT4et8BprFf8n4w",
        "index": "packetbeat-6.7.0-2019.03.22"
      }
    ],
    "type": "search_phase_execution_exception",
    "reason": "all shards failed",
    "phase": "query",
    "grouped": true,
    "failed_shards": [
      {
        "shard": 0,
        "index": "packetbeat-6.7.0-2019.03.22",
        "node": "P4VMxQ5zTqaTp1KYV4pFOg",
        "reason": {
          "type": "query_shard_exception",
          "reason": "failed to create query: {\n  \"query_string\" : {\n    \"query\" : \"foo\",\n    \"fields\" : [ ],\n    \"type\" : \"best_fields\",\n    \"default_operator\" : \"or\",\n    \"max_determinized_states\" : 10000,\n    \"enable_position_increments\" : true,\n    \"fuzziness\" : \"AUTO\",\n    \"fuzzy_prefix_length\" : 0,\n    \"fuzzy_max_expansions\" : 50,\n    \"phrase_slop\" : 0,\n    \"escape\" : false,\n    \"auto_generate_synonyms_phrase_query\" : true,\n    \"fuzzy_transpositions\" : true,\n    \"boost\" : 1.0\n  }\n}",
          "index_uuid": "50TUmx-qT4et8BprFf8n4w",
          "index": "packetbeat-6.7.0-2019.03.22",
          "caused_by": {
            "type": "illegal_argument_exception",
            "reason": "'foo' is not an IP string literal."
          }
        }
      }
    ]
  },
  "status": 400
}
```

Kibana avoids this by adding `lenient: true`:
> The lenient parameter can be set to true to ignore exceptions caused by data-type mismatches, such as trying to query a numeric field with a text query string. Defaults to false.
https://www.elastic.co/guide/en/elasticsearch/reference/6.7/query-dsl-match-query.html:

So it's never a problem for Kibana, and the workaround for the above query is to just add it:
```
GET _search
{ 
  "query": {
    "query_string": {
      "query": "foo",
      "lenient": true
    }  
  }
}
```

This PR simply removes the IP fields again to restore previous functionality and avoid breaking any existing queries and dashboards.

But we're stuck between a rock and a hard place here: Adding IP fields is clearly valuable to allow users to just paste an IP into the KQL bar (and into a `query_string` query for that matter), but we cannot do it without breaking simple queries  because `lenient` defaults to `false`. :-(

I'll open the same PR for 7.0.
