### PR TITLE
7.0: Remove IP fields from default_field in Elasticsearch template

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -63,6 +63,7 @@ https://github.com/elastic/beats/compare/v7.0.0-beta1...master[Check the HEAD di
 - Using an environment variable for the password when enrolling a beat will now raise an error if the variable doesn't exist. {pull}10936[10936]
 - Cancelling enrollment of a beat will not enroll the beat. {issue}10150[10150]
 - Allow to configure Kafka fetching strategy for the topic metadata. {pull}10682[10682]
+- Remove IP fields from default_field in Elasticsearch template.
 
 *Auditbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -63,7 +63,7 @@ https://github.com/elastic/beats/compare/v7.0.0-beta1...master[Check the HEAD di
 - Using an environment variable for the password when enrolling a beat will now raise an error if the variable doesn't exist. {pull}10936[10936]
 - Cancelling enrollment of a beat will not enroll the beat. {issue}10150[10150]
 - Allow to configure Kafka fetching strategy for the topic metadata. {pull}10682[10682]
-- Remove IP fields from default_field in Elasticsearch template.
+- Remove IP fields from default_field in Elasticsearch template. {pull}11400[11400]
 
 *Auditbeat*
 

--- a/libbeat/template/processor.go
+++ b/libbeat/template/processor.go
@@ -101,7 +101,7 @@ func (p *Processor) Process(fields common.Fields, path string, output common.Map
 		}
 
 		switch field.Type {
-		case "", "keyword", "text", "ip":
+		case "", "keyword", "text":
 			addToDefaultFields(&field)
 		}
 


### PR DESCRIPTION
Removes IP fields from the `default_field` array in the generated Elasticsearch template.

Further details in the 6.7 PR: https://github.com/elastic/beats/pull/11399