### PR TITLE
Remove IP fields from default_field in Elasticsearch template

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -147,6 +147,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Cancelling enrollment of a beat will not enroll the beat. {issue}10150[10150]
 - Add missing fields and test cases for libbeat add_kubernetes_metadata processor. {issue}11133[11133], {pull}11134[11134]
 - Report faulting file when config reload fails. {pull}[11304]11304
+- Remove IP fields from default_field in Elasticsearch template.
 
 *Auditbeat*
 

--- a/libbeat/template/processor.go
+++ b/libbeat/template/processor.go
@@ -102,7 +102,7 @@ func (p *Processor) Process(fields mapping.Fields, path string, output common.Ma
 		}
 
 		switch field.Type {
-		case "", "keyword", "text", "ip":
+		case "", "keyword", "text":
 			addToDefaultFields(&field)
 		}
 


### PR DESCRIPTION
Removes IP fields from the `default_field` array in the generated Elasticsearch template.

Further details in the 6.7 PR: https://github.com/elastic/beats/pull/11399