### PR TITLE
Prevent connection error overflow on windows

### DIFF
--- a/metricbeat/module/postgresql/database/database.go
+++ b/metricbeat/module/postgresql/database/database.go
@@ -57,12 +57,13 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // of an error set the Error field of mb.Event or simply call report.Error().
 func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
 	db, err := sql.Open("postgres", m.HostData().URI)
+	defer db.Close()
 	if err != nil {
 		logger.Error(err)
 		reporter.Error(err)
 		return
 	}
-	defer db.Close()
+	
 
 	results, err := postgresql.QueryStats(db, "SELECT * FROM pg_stat_database")
 	if err != nil {

--- a/metricbeat/module/postgresql/database/database.go
+++ b/metricbeat/module/postgresql/database/database.go
@@ -57,7 +57,9 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // of an error set the Error field of mb.Event or simply call report.Error().
 func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
 	db, err := sql.Open("postgres", m.HostData().URI)
+	if db != nil {
 	defer db.Close()
+	}
 	if err != nil {
 		logger.Error(err)
 		reporter.Error(err)


### PR DESCRIPTION
This small modification assure that Metricbeat closes the connections in case of errors. As reported by #11393. 
The thing is that on windows you have to install openssl to enable postgresql secure connections, the default is to use insecure connection. While pq library uses by default secure connections. 
So the library is throwing an error: pq: SSL is not enabled on the server and not closing connections resulting on an overflow of connections if you set the period below 5 seconds.