### PR TITLE
[Metricbeat] migrate envoyproxy module to ReporterV2 error

### DIFF
--- a/metricbeat/module/envoyproxy/server/server.go
+++ b/metricbeat/module/envoyproxy/server/server.go
@@ -18,7 +18,8 @@
 package server
 
 import (
-	"github.com/elastic/beats/libbeat/logp"
+	"github.com/pkg/errors"
+
 	"github.com/elastic/beats/metricbeat/helper"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/mb/parse"
@@ -35,8 +36,6 @@ var (
 		DefaultPath:   defaultPath,
 	}.Build()
 )
-
-var logger = logp.NewLogger("envoyproxy.server")
 
 func init() {
 	mb.Registry.MustAddMetricSet("envoyproxy", "server", New,
@@ -69,16 +68,14 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // Fetch methods implements the data gathering and data conversion to the right
 // format. It publishes the event which is then forwarded to the output. In case
 // of an error set the Error field of mb.Event or simply call report.Error().
-func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
+func (m *MetricSet) Fetch(reporter mb.ReporterV2) error {
 	content, err := m.http.FetchContent()
 	if err != nil {
-		logger.Error(err)
-		reporter.Error(err)
-		return
+		return errors.Wrap(err, "error in http fetch")
 	}
 
 	event, _ := eventMapping(content)
 	reporter.Event(mb.Event{MetricSetFields: event})
 
-	return
+	return nil
 }

--- a/metricbeat/module/envoyproxy/server/server_integration_test.go
+++ b/metricbeat/module/envoyproxy/server/server_integration_test.go
@@ -32,8 +32,8 @@ import (
 func TestFetch(t *testing.T) {
 	compose.EnsureUp(t, "envoyproxy")
 
-	f := mbtest.NewReportingMetricSetV2(t, getConfig())
-	events, errs := mbtest.ReportingFetchV2(f)
+	f := mbtest.NewReportingMetricSetV2Error(t, getConfig())
+	events, errs := mbtest.ReportingFetchV2Error(f)
 	if len(errs) > 0 {
 		t.Fatalf("Expected 0 error, had %d. %v\n", len(errs), errs)
 	}
@@ -45,14 +45,14 @@ func TestFetch(t *testing.T) {
 func TestData(t *testing.T) {
 	compose.EnsureUp(t, "envoyproxy")
 
-	f := mbtest.NewReportingMetricSetV2(t, getConfig())
-	events, errs := mbtest.ReportingFetchV2(f)
+	f := mbtest.NewReportingMetricSetV2Error(t, getConfig())
+	events, errs := mbtest.ReportingFetchV2Error(f)
 	if len(errs) > 0 {
 		t.Fatalf("Expected 0 error, had %d. %v\n", len(errs), errs)
 	}
 	assert.NotEmpty(t, events)
 
-	if err := mbtest.WriteEventsReporterV2(f, t, ""); err != nil {
+	if err := mbtest.WriteEventsReporterV2Error(f, t, ""); err != nil {
 		t.Fatal("write", err)
 	}
 }

--- a/metricbeat/module/envoyproxy/server/server_test.go
+++ b/metricbeat/module/envoyproxy/server/server_test.go
@@ -93,8 +93,8 @@ func TestFetchEventContent(t *testing.T) {
 		"hosts":      []string{server.URL},
 	}
 
-	f := mbtest.NewReportingMetricSetV2(t, config)
-	events, errs := mbtest.ReportingFetchV2(f)
+	f := mbtest.NewReportingMetricSetV2Error(t, config)
+	events, errs := mbtest.ReportingFetchV2Error(f)
 	if len(errs) > 0 {
 		t.Fatalf("Expected 0 error, had %d. %v\n", len(errs), errs)
 	}
@@ -131,10 +131,10 @@ func TestFetchTimeout(t *testing.T) {
 		"timeout":    "50ms",
 	}
 
-	f := mbtest.NewReportingMetricSetV2(t, config)
+	f := mbtest.NewReportingMetricSetV2Error(t, config)
 
 	start := time.Now()
-	events, errs := mbtest.ReportingFetchV2(f)
+	events, errs := mbtest.ReportingFetchV2Error(f)
 	if len(errs) == 0 {
 		t.Fatalf("Expected an error, had %d. %v\n", len(errs), errs)
 	}


### PR DESCRIPTION
See elastic/beats#11374 and elastic/beats#10727