### PR TITLE
[Metricbeat] migrate nginx module to ReporterV2 error

### DIFF
--- a/metricbeat/module/nginx/stubstatus/stubstatus.go
+++ b/metricbeat/module/nginx/stubstatus/stubstatus.go
@@ -19,7 +19,8 @@
 package stubstatus
 
 import (
-	"github.com/elastic/beats/libbeat/logp"
+	"github.com/pkg/errors"
+
 	"github.com/elastic/beats/metricbeat/helper"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/mb/parse"
@@ -41,8 +42,6 @@ var (
 		DefaultPath:   defaultPath,
 	}.Build()
 )
-
-var logger = logp.NewLogger("nginx.stubstatus")
 
 func init() {
 	mb.Registry.MustAddMetricSet("nginx", "stubstatus", New,
@@ -73,15 +72,13 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // Fetch methods implements the data gathering and data conversion to the right
 // format. It publishes the event which is then forwarded to the output. In case
 // of an error set the Error field of mb.Event or simply call report.Error().
-func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
+func (m *MetricSet) Fetch(reporter mb.ReporterV2) error {
 	scanner, err := m.http.FetchScanner()
 	if err != nil {
-		logger.Error(err)
-		reporter.Error(err)
-		return
+		return errors.Wrap(err, "error in http fetch")
 	}
 	event, _ := eventMapping(scanner, m)
 	reporter.Event(mb.Event{MetricSetFields: event})
 
-	return
+	return nil
 }

--- a/metricbeat/module/nginx/stubstatus/stubstatus_integration_test.go
+++ b/metricbeat/module/nginx/stubstatus/stubstatus_integration_test.go
@@ -32,8 +32,8 @@ import (
 func TestFetch(t *testing.T) {
 	compose.EnsureUp(t, "nginx")
 
-	f := mbtest.NewReportingMetricSetV2(t, getConfig())
-	events, errs := mbtest.ReportingFetchV2(f)
+	f := mbtest.NewReportingMetricSetV2Error(t, getConfig())
+	events, errs := mbtest.ReportingFetchV2Error(f)
 	if len(errs) > 0 {
 		t.Fatalf("Expected 0 error, had %d. %v\n", len(errs), errs)
 	}
@@ -49,14 +49,14 @@ func TestFetch(t *testing.T) {
 func TestData(t *testing.T) {
 	compose.EnsureUp(t, "nginx")
 
-	f := mbtest.NewReportingMetricSetV2(t, getConfig())
-	events, errs := mbtest.ReportingFetchV2(f)
+	f := mbtest.NewReportingMetricSetV2Error(t, getConfig())
+	events, errs := mbtest.ReportingFetchV2Error(f)
 	if len(errs) > 0 {
 		t.Fatalf("Expected 0 error, had %d. %v\n", len(errs), errs)
 	}
 	assert.NotEmpty(t, events)
 
-	if err := mbtest.WriteEventsReporterV2(f, t, ""); err != nil {
+	if err := mbtest.WriteEventsReporterV2Error(f, t, ""); err != nil {
 		t.Fatal("write", err)
 	}
 }


### PR DESCRIPTION
See elastic/beats#11374 and elastic/beats#10727