### PR TITLE
[Metricbeat] Fix Socket leak in postgresql module

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -212,6 +212,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add missing aws.ec2.instance.state.name into fields.yml. {issue}11219[11219] {pull}11221[11221]
 - Fix ec2 metricset to collect metrics from Cloudwatch with the same timestamp. {pull}11142[11142]
 - Fix potential memory leak in stopped docker metricsets {pull}11294[11294]
+- Fix a socket leak in the postgresql module. {issue}11393[11393] {pull}11419[11419]
 
 *Packetbeat*
 

--- a/metricbeat/module/postgresql/activity/activity.go
+++ b/metricbeat/module/postgresql/activity/activity.go
@@ -18,8 +18,6 @@
 package activity
 
 import (
-	"database/sql"
-
 	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/libbeat/logp"
@@ -57,15 +55,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // format. It publishes the event which is then forwarded to the output. In case
 // of an error set the Error field of mb.Event or simply call report.Error().
 func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
-	db, err := sql.Open("postgres", m.HostData().URI)
-	if err != nil {
-		logger.Error(err)
-		reporter.Error(err)
-		return
-	}
-	defer db.Close()
-
-	results, err := postgresql.QueryStats(db, "SELECT * FROM pg_stat_activity")
+	results, err := postgresql.QueryStats("postgres", m.HostData().URI, "SELECT * FROM pg_stat_activity")
 	if err != nil {
 		err = errors.Wrap(err, "QueryStats")
 		logger.Error(err)

--- a/metricbeat/module/postgresql/bgwriter/bgwriter.go
+++ b/metricbeat/module/postgresql/bgwriter/bgwriter.go
@@ -18,7 +18,6 @@
 package bgwriter
 
 import (
-	"database/sql"
 	"fmt"
 
 	"github.com/elastic/beats/libbeat/logp"
@@ -57,15 +56,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // format. It publishes the event which is then forwarded to the output. In case
 // of an error set the Error field of mb.Event or simply call report.Error().
 func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
-	db, err := sql.Open("postgres", m.HostData().URI)
-	if err != nil {
-		logger.Error(err)
-		reporter.Error(err)
-		return
-	}
-	defer db.Close()
-
-	results, err := postgresql.QueryStats(db, "SELECT * FROM pg_stat_bgwriter")
+	results, err := postgresql.QueryStats("postgres", m.HostData().URI, "SELECT * FROM pg_stat_bgwriter")
 	if err != nil {
 		err = errors.Wrap(err, "QueryStats")
 		logger.Error(err)

--- a/metricbeat/module/postgresql/database/database.go
+++ b/metricbeat/module/postgresql/database/database.go
@@ -18,8 +18,6 @@
 package database
 
 import (
-	"database/sql"
-
 	"github.com/elastic/beats/libbeat/logp"
 
 	"github.com/pkg/errors"
@@ -56,15 +54,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // format. It publishes the event which is then forwarded to the output. In case
 // of an error set the Error field of mb.Event or simply call report.Error().
 func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
-	db, err := sql.Open("postgres", m.HostData().URI)
-	if err != nil {
-		logger.Error(err)
-		reporter.Error(err)
-		return
-	}
-	defer db.Close()
-
-	results, err := postgresql.QueryStats(db, "SELECT * FROM pg_stat_database")
+	results, err := postgresql.QueryStats("postgres", m.HostData().URI, "SELECT * FROM pg_stat_database")
 	if err != nil {
 		err = errors.Wrap(err, "QueryStats")
 		logger.Error(err)

--- a/metricbeat/module/postgresql/dbcache.go
+++ b/metricbeat/module/postgresql/dbcache.go
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package postgresql
 
 import (

--- a/metricbeat/module/postgresql/dbcache.go
+++ b/metricbeat/module/postgresql/dbcache.go
@@ -6,23 +6,23 @@ import (
 	"sync"
 )
 
-type dbEntry struct {
+type cacheKey struct {
 	driver string
 	uri    string
 }
 
 type dbCacheType struct {
-	dbs  map[dbEntry]*sql.DB
+	dbs  map[cacheKey]*sql.DB
 	lock sync.Mutex
 }
 
 // DBCache keeps a cache of databases for different drivers and URIs.
 var DBCache = dbCacheType{
-	dbs: make(map[dbEntry]*sql.DB, 4),
+	dbs: make(map[cacheKey]*sql.DB, 4),
 }
 
 func (cache *dbCacheType) getDB(driver, uri string) (db *sql.DB, err error) {
-	key := dbEntry{
+	key := cacheKey{
 		driver: driver,
 		uri:    uri,
 	}

--- a/metricbeat/module/postgresql/dbcache.go
+++ b/metricbeat/module/postgresql/dbcache.go
@@ -1,0 +1,51 @@
+package postgresql
+
+import (
+	"context"
+	"database/sql"
+	"sync"
+)
+
+type dbEntry struct {
+	driver string
+	uri    string
+}
+
+type dbCacheType struct {
+	dbs  map[dbEntry]*sql.DB
+	lock sync.Mutex
+}
+
+// DBCache keeps a cache of databases for different drivers and URIs.
+var DBCache = dbCacheType{
+	dbs: make(map[dbEntry]*sql.DB, 4),
+}
+
+func (cache *dbCacheType) getDB(driver, uri string) (db *sql.DB, err error) {
+	key := dbEntry{
+		driver: driver,
+		uri:    uri,
+	}
+	cache.lock.Lock()
+	defer cache.lock.Unlock()
+
+	db, found := cache.dbs[key]
+	if found {
+		return db, nil
+	}
+
+	db, err = sql.Open(driver, uri)
+	if db != nil {
+		cache.dbs[key] = db
+	}
+	return db, err
+}
+
+// GetConnection opens a connection to a DB identified by driver and URI.
+func (cache *dbCacheType) GetConnection(driver, uri string) (conn *sql.Conn, err error) {
+	db, err := cache.getDB(driver, uri)
+	if err != nil {
+		return nil, err
+	}
+	return db.Conn(context.Background())
+}

--- a/metricbeat/module/postgresql/statement/statement.go
+++ b/metricbeat/module/postgresql/statement/statement.go
@@ -18,8 +18,6 @@
 package statement
 
 import (
-	"database/sql"
-
 	"github.com/elastic/beats/libbeat/logp"
 
 	"github.com/pkg/errors"
@@ -68,15 +66,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // format. It publishes the event which is then forwarded to the output. In case
 // of an error set the Error field of mb.Event or simply call report.Error().
 func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
-	db, err := sql.Open("postgres", m.HostData().URI)
-	if err != nil {
-		logger.Error(err)
-		reporter.Error(err)
-		return
-	}
-	defer db.Close()
-
-	results, err := postgresql.QueryStats(db, "SELECT * FROM pg_stat_statements")
+	results, err := postgresql.QueryStats("postgres", m.HostData().URI, "SELECT * FROM pg_stat_statements")
 	if err != nil {
 		err = errors.Wrap(err, "QueryStats")
 		logger.Error(err)


### PR DESCRIPTION
This patch refactors the postgresql module to fix a socket leak caused by creating too many instances of sql.DB.

Fixes #11393