### PR TITLE
Add Namespace to prometheus helper mappings

### DIFF
--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -39,3 +39,4 @@ The list below covers the major changes between 7.0.0-beta1 and master only.
 - Filebeat modules can now use ingest pipelines in YAML format. {pull}11209[11209]
 - Added support for using PYTHON_EXE to control what Python interpreter is used
   by `make` and `mage`. Example: `export PYTHON_EXE=python2.7`. {pull}11212[11212]
+- Prometheus helper for metricbeat contains now `Namespace` field for `prometheus.MetricsMappings` {pull}11424[11424]

--- a/metricbeat/helper/prometheus/prometheus.go
+++ b/metricbeat/helper/prometheus/prometheus.go
@@ -93,8 +93,11 @@ func (p *prometheus) GetFamilies() ([]*dto.MetricFamily, error) {
 
 // MetricsMapping defines mapping settings for Prometheus metrics, to be used with `GetProcessedMetrics`
 type MetricsMapping struct {
-	// Metrics translates from from prometheus metric name to Metricbeat fields
+	// Metrics translates from prometheus metric name to Metricbeat fields
 	Metrics map[string]MetricMap
+
+	// Namespace for metrics managed by this mapping
+	Namespace string
 
 	// Labels translate from prometheus label names to Metricbeat fields
 	Labels map[string]LabelMap
@@ -213,7 +216,10 @@ func (p *prometheus) ReportProcessedMetrics(mapping *MetricsMapping, r mb.Report
 		return
 	}
 	for _, event := range events {
-		r.Event(mb.Event{MetricSetFields: event})
+		r.Event(mb.Event{
+			MetricSetFields: event,
+			Namespace:       mapping.Namespace,
+		})
 	}
 }
 


### PR DESCRIPTION
Add Namespace to `prometheus.MetricsMappings`
When a namespace is specified it will propagated to the `mb.Event`object

Fixes elastic/beats#11423 

