### PR TITLE
[7.x] have a conservative default for keystore overwrite (#11335)

### DIFF
--- a/libbeat/cmd/keystore.go
+++ b/libbeat/cmd/keystore.go
@@ -104,7 +104,7 @@ func genAddKeystoreCmd(settings instance.Settings) *cobra.Command {
 func genRemoveKeystoreCmd(settings instance.Settings) *cobra.Command {
 	return &cobra.Command{
 		Use:   "remove",
-		Short: "remove secret",
+		Short: "Remove secret",
 		Run: cli.RunWith(func(cmd *cobra.Command, args []string) error {
 			store, err := getKeystore(settings)
 			if err != nil {
@@ -136,7 +136,7 @@ func createKeystore(settings instance.Settings, force bool) error {
 	}
 
 	if store.IsPersisted() == true && force == false {
-		response := terminal.PromptYesNo("A keystore already exists, Overwrite?", true)
+		response := terminal.PromptYesNo("A keystore already exists, Overwrite?", false)
 		if response == true {
 			err := store.Create(true)
 			if err != nil {

--- a/libbeat/common/config.go
+++ b/libbeat/common/config.go
@@ -432,7 +432,7 @@ func ownerHasExclusiveWritePerms(name string) error {
 	perm := info.Mode().Perm()
 
 	if fileUID != 0 && euid != fileUID {
-		return fmt.Errorf(`config file ("%v") must be owned by the beat user `+
+		return fmt.Errorf(`config file ("%v") must be owned by the user identifier `+
 			`(uid=%v) or root`, name, euid)
 	}
 

--- a/libbeat/keystore/file_keystore.go
+++ b/libbeat/keystore/file_keystore.go
@@ -389,7 +389,7 @@ func (k *FileKeystore) checkPermissions(f string) error {
 	perm := info.Mode().Perm()
 
 	if fileUID != 0 && euid != fileUID {
-		return fmt.Errorf(`config file ("%v") must be owned by the beat user `+
+		return fmt.Errorf(`config file ("%v") must be owned by the user identifier `+
 			`(uid=%v) or root`, f, euid)
 	}
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - have a conservative default for keystore overwrite  (#11335)