### PR TITLE
[Auditbeat] normalized event.type/category/outcome fields for auditd module

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -12,6 +12,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Auditbeat*
 
+- Auditd module: Normalized value of `event.category` field from `user-login` to `authentication`. {pull}11432[11432]
+
 *Filebeat*
 
 *Heartbeat*
@@ -92,6 +94,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Allow a beat to ship monitoring data directly to an Elasticsearch monitoring clsuter. {pull}9260[9260]
 
 *Auditbeat*
+
+- Auditd module: Add `event.outcome` and `event.type` for ECS. {pull}11432[11432]
 
 *Filebeat*
 


### PR DESCRIPTION
The auditd module is updated to set normalized values for event.category
and event.type. It also sets event.outcome from auditd.result.

Currently it supports the following values:

| event.category | event.outcome |        event.type      |
|----------------|---------------|------------------------|
| authentication | success       | authentication_success |
| authentication | failure          | authentication_failure |

Closes #11428