### PR TITLE
docs: remove reference to beats

### DIFF
--- a/libbeat/docs/repositories.asciidoc
+++ b/libbeat/docs/repositories.asciidoc
@@ -27,13 +27,13 @@ to sign all our packages. It is available from https://pgp.mit.edu.
 
 ifeval::["{release-state}"=="unreleased"]
 
-Version {stack-version} of Beats has not yet been released.
+Version {stack-version} of {repo} has not yet been released.
 
 endif::[]
 
 ifeval::["{release-state}"!="unreleased"]
 
-To add the Beats repository for APT:
+To add the {repo} repository for APT:
 
 . Download and install the Public Signing Key:
 +
@@ -102,13 +102,13 @@ endif::[]
 
 ifeval::["{release-state}"=="unreleased"]
 
-Version {stack-version} of Beats has not yet been released.
+Version {stack-version} of {repo} has not yet been released.
 
 endif::[]
 
 ifeval::["{release-state}"!="unreleased"]
 
-To add the Beats repository for YUM:
+To add the {repo} repository for YUM:
 
 . Download and install the public signing key:
 +
@@ -155,7 +155,7 @@ running:
 sudo yum install {beatname_pkg}
 --------------------------------------------------
 
-. To configure the Beat to start automatically during boot, run:
+. To configure {beatname_uc} to start automatically during boot, run:
 +
 ["source","sh",subs="attributes"]
 --------------------------------------------------

--- a/libbeat/docs/shared-beats-attributes.asciidoc
+++ b/libbeat/docs/shared-beats-attributes.asciidoc
@@ -11,3 +11,4 @@
 :beat_monitoring_version: 6.2
 :beat_version_key: agent.version
 :access_role: {beat_default_index_prefix}_reader
+:repo: Beats


### PR DESCRIPTION
For https://github.com/elastic/apm-server/issues/2005.

APM Server is referred to as "Beats" in `repositories.asciidoc`. This PR adds the `:repo:` attribute to distinguish between the Beats and APM Server repositories. 