### PR TITLE
Cherry-pick #10755 to 7.0: Change healthcheck for mysql images

### DIFF
--- a/metricbeat/module/mysql/_meta/Dockerfile
+++ b/metricbeat/module/mysql/_meta/Dockerfile
@@ -3,6 +3,6 @@ FROM $MYSQL_IMAGE
 
 ENV MYSQL_ROOT_PASSWORD test
 
-HEALTHCHECK --interval=1s --retries=90 CMD mysql -u root -p$MYSQL_ROOT_PASSWORD -P 3306 -e "SELECT 1"
+HEALTHCHECK --interval=1s --retries=90 CMD mysql -u root -p$MYSQL_ROOT_PASSWORD -h$HOSTNAME -P 3306 -e "SHOW STATUS" > /dev/null
 
 COPY test.cnf /etc/mysql/conf.d/test.cnf


### PR DESCRIPTION
Cherry-pick of PR #10755 to 7.0 branch. Original message: 

Use host and port to ensure that network connection is used and not
local unix socket.

Use `SHOW STATUS` that is the query used by the metricset.

Tries to fix #10608 