### PR TITLE
[DOCS] Adds tagged regions in Beats breaking changes

### DIFF
--- a/libbeat/docs/breaking.asciidoc
+++ b/libbeat/docs/breaking.asciidoc
@@ -30,10 +30,12 @@ upgrade the Beats to version 7.0. {see-relnotes}
 
 //tag::notable-breaking-changes[]
 
-// end::notable-breaking-changes[]
+[float]
 ==== Field name changes
 
 include::./field-name-changes.asciidoc[]
+
+// end::notable-breaking-changes[]
 
 [[breaking-changes-6.3]]
 === Breaking changes in 6.3

--- a/libbeat/docs/breaking.asciidoc
+++ b/libbeat/docs/breaking.asciidoc
@@ -25,6 +25,12 @@ See the following topics for a description of breaking changes:
 This section discusses the main changes that you should be aware of if you
 upgrade the Beats to version 7.0. {see-relnotes}
 
+//NOTE: The notable-breaking-changes tagged regions are re-used in the
+//Installation and Upgrade Guide
+
+//tag::notable-breaking-changes[]
+
+// end::notable-breaking-changes[]
 ==== Field name changes
 
 include::./field-name-changes.asciidoc[]


### PR DESCRIPTION
This PR adds a tagged region ("notable-breaking-changes") in https://www.elastic.co/guide/en/beats/libbeat/7.0/breaking-changes-7.0.html so that it can be re-used in https://www.elastic.co/guide/en/elastic-stack/7.0/elastic-stack-breaking-changes.html

For now I  tagged the entire "Field name changes" as notable, but that can be altered as necessary. If there are no notable changes, please just leave a blank line in the tagged region.