### PR TITLE
Cherry-pick #11346 to 7.0: Don't use multiline options in Logstash module with json format

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -80,6 +80,7 @@ https://github.com/elastic/beats/compare/v7.0.0-beta1...master[Check the HEAD di
 - Fix issue preventing docker container events to be stored if the container has a network interface without ip address. {issue}11225[11225] {pull}11247[11247]
 - Change URLPATH grok pattern to support brackets. {issue}11135[11135] {pull}11252[11252]
 - Add support for iis log with different address format. {issue}11255[11255] {pull}11256[11256]
+- Don't apply multiline rules in Logstash json logs. {pull}11346[11346]
 
 *Heartbeat*
 

--- a/filebeat/module/logstash/log/config/log.yml
+++ b/filebeat/module/logstash/log/config/log.yml
@@ -4,10 +4,13 @@ paths:
  - {{$path}}
 {{ end }}
 exclude_files: [".gz$"]
+
+{{ if eq .format "plain" }}
 multiline:
   pattern: ^\[[0-9]{4}-[0-9]{2}-[0-9]{2}
   negate: true
   match: after
+{{ end }}
 
 {{ if .convert_timezone }}
 processors:

--- a/filebeat/module/logstash/log/test/logstash-json.log-expected.json
+++ b/filebeat/module/logstash/log/test/logstash-json.log-expected.json
@@ -6,9 +6,6 @@
         "event.module": "logstash",
         "fileset.name": "log",
         "input.type": "log",
-        "log.flags": [
-            "multiline"
-        ],
         "log.level": "INFO",
         "log.offset": 0,
         "logstash.log.log_event.count": 1,
@@ -27,6 +24,37 @@
         "logstash.log.module": "logstash.agent",
         "logstash.log.thread": "Ruby-0-Thread-1: /Users/mat/work/elastic/releases/6.5.1/logstash/lib/bootstrap/environment.rb:6",
         "message": "Pipelines running",
+        "service.type": "logstash"
+    },
+    {
+        "@timestamp": "2019-01-07T21:25:22.538Z",
+        "ecs.version": "1.0.0",
+        "event.dataset": "logstash.log",
+        "event.module": "logstash",
+        "fileset.name": "log",
+        "input.type": "log",
+        "log.level": "INFO",
+        "log.offset": 357,
+        "logstash.log.log_event.pipeline_id": "main",
+        "logstash.log.log_event.thread": "#<Thread:0x7d16ffef run>",
+        "logstash.log.module": "logstash.pipeline",
+        "logstash.log.thread": "[main]>worker7",
+        "message": "Pipeline has terminated",
+        "service.type": "logstash"
+    },
+    {
+        "@timestamp": "2019-01-07T21:25:22.594Z",
+        "ecs.version": "1.0.0",
+        "event.dataset": "logstash.log",
+        "event.module": "logstash",
+        "fileset.name": "log",
+        "input.type": "log",
+        "log.level": "INFO",
+        "log.offset": 566,
+        "logstash.log.log_event.port": 9600,
+        "logstash.log.module": "logstash.agent",
+        "logstash.log.thread": "Api Webserver",
+        "message": "Successfully started Logstash API endpoint",
         "service.type": "logstash"
     }
 ]


### PR DESCRIPTION
Cherry-pick of PR #11346 to 7.0 branch. Original message: 

Multiline options were being applied to json log files with unexpected
results as several lines joined or lines lost.