### PR TITLE
[Metricbeat] migrate haproxy module to ReporterV2 error

### DIFF
--- a/metricbeat/module/haproxy/info/info.go
+++ b/metricbeat/module/haproxy/info/info.go
@@ -52,19 +52,18 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 }
 
 // Fetch fetches info stats from the haproxy service.
-func (m *MetricSet) Fetch(r mb.ReporterV2) {
+func (m *MetricSet) Fetch(reporter mb.ReporterV2) error {
 
 	hapc, err := haproxy.NewHaproxyClient(m.HostData().URI)
 	if err != nil {
-		r.Error(errors.Wrap(err, "failed creating haproxy client"))
-		return
+		return errors.Wrap(err, "failed creating haproxy client")
 	}
 
 	res, err := hapc.GetInfo()
 	if err != nil {
-		r.Error(errors.Wrap(err, "failed fetching haproxy info"))
-		return
+		return errors.Wrap(err, "failed fetching haproxy info")
 	}
 
-	eventMapping(res, r)
+	eventMapping(res, reporter)
+	return nil
 }

--- a/metricbeat/module/haproxy/info/info_integration_test.go
+++ b/metricbeat/module/haproxy/info/info_integration_test.go
@@ -32,8 +32,8 @@ import (
 func TestFetch(t *testing.T) {
 	compose.EnsureUp(t, "haproxy")
 
-	f := mbtest.NewReportingMetricSetV2(t, getConfig())
-	events, errs := mbtest.ReportingFetchV2(f)
+	f := mbtest.NewReportingMetricSetV2Error(t, getConfig())
+	events, errs := mbtest.ReportingFetchV2Error(f)
 
 	assert.Empty(t, errs)
 	if !assert.NotEmpty(t, events) {
@@ -49,8 +49,8 @@ func TestData(t *testing.T) {
 	compose.EnsureUp(t, "haproxy")
 
 	config := getConfig()
-	f := mbtest.NewReportingMetricSetV2(t, config)
-	err := mbtest.WriteEventsReporterV2(f, t, ".")
+	f := mbtest.NewReportingMetricSetV2Error(t, config)
+	err := mbtest.WriteEventsReporterV2Error(f, t, ".")
 	if err != nil {
 		t.Fatal("write", err)
 	}

--- a/metricbeat/module/haproxy/stat/stat.go
+++ b/metricbeat/module/haproxy/stat/stat.go
@@ -52,18 +52,17 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 }
 
 // Fetch methods returns a list of stats metrics.
-func (m *MetricSet) Fetch(r mb.ReporterV2) {
+func (m *MetricSet) Fetch(reporter mb.ReporterV2) error {
 	hapc, err := haproxy.NewHaproxyClient(m.HostData().URI)
 	if err != nil {
-		r.Error(errors.Wrap(err, "failed creating haproxy client"))
-		return
+		return errors.Wrap(err, "failed creating haproxy client")
 	}
 
 	res, err := hapc.GetStat()
 	if err != nil {
-		r.Error(errors.Wrap(err, "failed fetching haproxy stat"))
-		return
+		return errors.Wrap(err, "failed fetching haproxy stat")
 	}
 
-	eventMapping(res, r)
+	eventMapping(res, reporter)
+	return nil
 }

--- a/metricbeat/module/haproxy/stat/stat_integration_test.go
+++ b/metricbeat/module/haproxy/stat/stat_integration_test.go
@@ -32,8 +32,8 @@ import (
 func TestFetch(t *testing.T) {
 	compose.EnsureUp(t, "haproxy")
 
-	f := mbtest.NewReportingMetricSetV2(t, getConfig())
-	events, errs := mbtest.ReportingFetchV2(f)
+	f := mbtest.NewReportingMetricSetV2Error(t, getConfig())
+	events, errs := mbtest.ReportingFetchV2Error(f)
 
 	assert.Empty(t, errs)
 	if !assert.NotEmpty(t, events) {
@@ -49,8 +49,8 @@ func TestData(t *testing.T) {
 	compose.EnsureUp(t, "haproxy")
 
 	config := getConfig()
-	f := mbtest.NewReportingMetricSetV2(t, config)
-	err := mbtest.WriteEventsReporterV2(f, t, ".")
+	f := mbtest.NewReportingMetricSetV2Error(t, config)
+	err := mbtest.WriteEventsReporterV2Error(f, t, ".")
 	if err != nil {
 		t.Fatal("write", err)
 	}


### PR DESCRIPTION
See elastic/beats#11374 and elastic/beats#10727