### PR TITLE
Implement context.Contect in ReporterV2

### DIFF
--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -40,3 +40,4 @@ The list below covers the major changes between 7.0.0-beta1 and master only.
 - Added support for using PYTHON_EXE to control what Python interpreter is used
   by `make` and `mage`. Example: `export PYTHON_EXE=python2.7`. {pull}11212[11212]
 - Prometheus helper for metricbeat contains now `Namespace` field for `prometheus.MetricsMappings` {pull}11424[11424]
+- ReporterV2 implements context.Context

--- a/metricbeat/mb/mb.go
+++ b/metricbeat/mb/mb.go
@@ -22,6 +22,7 @@ to implement Modules and their associated MetricSets.
 package mb
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"time"
@@ -179,6 +180,7 @@ type PushMetricSet interface {
 // ReporterV2 is used by a MetricSet to report Events. The methods return false
 // if and only if publishing failed because the MetricSet is being closed.
 type ReporterV2 interface {
+	context.Context
 	Event(event Event) bool // Event reports a single successful event.
 	Error(err error) bool
 }
@@ -188,10 +190,6 @@ type ReporterV2 interface {
 // stop.
 type PushReporterV2 interface {
 	ReporterV2
-
-	// Done returns a channel that's closed when work done on behalf of this
-	// reporter should be canceled.
-	Done() <-chan struct{}
 }
 
 // ReportingMetricSetV2 is a MetricSet that reports events or errors through the

--- a/metricbeat/module/docker/container/container.go
+++ b/metricbeat/module/docker/container/container.go
@@ -18,8 +18,6 @@
 package container
 
 import (
-	"context"
-
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
 	"github.com/pkg/errors"
@@ -68,7 +66,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // This is based on https://docs.docker.com/engine/reference/api/docker_remote_api_v1.24/#/list-containers.
 func (m *MetricSet) Fetch(r mb.ReporterV2) {
 	// Fetch a list of all containers.
-	containers, err := m.dockerClient.ContainerList(context.Background(), types.ContainerListOptions{})
+	containers, err := m.dockerClient.ContainerList(r, types.ContainerListOptions{})
 	if err != nil {
 		err = errors.Wrap(err, "failed to get docker containers list")
 		logger.Error(err)

--- a/metricbeat/module/docker/event/event.go
+++ b/metricbeat/module/docker/event/event.go
@@ -18,7 +18,6 @@
 package event
 
 import (
-	"context"
 	"fmt"
 	"time"
 
@@ -77,7 +76,6 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 
 // Run listens for docker events and reports them
 func (m *MetricSet) Run(reporter mb.PushReporterV2) {
-	ctx, cancel := context.WithCancel(context.Background())
 	options := types.EventsOptions{
 		Since: fmt.Sprintf("%d", time.Now().Unix()),
 	}
@@ -85,7 +83,7 @@ func (m *MetricSet) Run(reporter mb.PushReporterV2) {
 	defer m.dockerClient.Close()
 
 	for {
-		events, errors := m.dockerClient.Events(ctx, options)
+		events, errors := m.dockerClient.Events(reporter, options)
 
 	WATCH:
 		for {
@@ -102,7 +100,6 @@ func (m *MetricSet) Run(reporter mb.PushReporterV2) {
 
 			case <-reporter.Done():
 				m.logger.Debug("docker", "event watcher stopped")
-				cancel()
 				return
 			}
 		}


### PR DESCRIPTION
Make `ReporterV2` implement `context.Context` based on the `done` channel
metricset wrapper receives. This way all `Fetch()` methods will have a context
that can be used in their clients and requests.

As example two metricsets are migrated to use the new context, one using
`ReporterV2` and another one using `PushReporterV2`.