### PR TITLE
Cherry-pick #11463 to 6.5: Remove jessie-updates repo from metricbeat docker images

### DIFF
--- a/metricbeat/module/apache/_meta/Dockerfile
+++ b/metricbeat/module/apache/_meta/Dockerfile
@@ -1,4 +1,5 @@
 FROM httpd:2.4.20
+RUN sed -i "/jessie-updates/d" /etc/apt/sources.list
 RUN apt-get update && apt-get install -y curl
 HEALTHCHECK --interval=1s --retries=90 CMD curl -f http://localhost
 COPY ./httpd.conf /usr/local/apache2/conf/httpd.conf

--- a/metricbeat/module/apache/_meta/Dockerfile.2.4.12
+++ b/metricbeat/module/apache/_meta/Dockerfile.2.4.12
@@ -1,4 +1,5 @@
 FROM httpd:2.4.12
+RUN sed -i "/jessie-updates/d" /etc/apt/sources.list
 RUN apt-get update && apt-get install -y curl
 HEALTHCHECK --interval=1s --retries=90 CMD curl -f http://localhost
 COPY ./httpd.conf /usr/local/apache2/conf/httpd.conf

--- a/metricbeat/module/mongodb/_meta/Dockerfile
+++ b/metricbeat/module/mongodb/_meta/Dockerfile
@@ -1,3 +1,4 @@
 FROM mongo:3.4
+RUN sed -i "/jessie-updates/d" /etc/apt/sources.list
 RUN apt-get update && apt-get install -y netcat
 HEALTHCHECK --interval=1s --retries=90 CMD nc -z localhost 27017

--- a/metricbeat/module/mysql/_meta/Dockerfile
+++ b/metricbeat/module/mysql/_meta/Dockerfile
@@ -1,5 +1,8 @@
-FROM mysql:5.7.12
-RUN apt-get update && apt-get install -y netcat
-HEALTHCHECK --interval=1s --retries=90 CMD nc -z localhost 3306
+ARG MYSQL_IMAGE=mysql:5.7.12
+FROM $MYSQL_IMAGE
 
 ENV MYSQL_ROOT_PASSWORD test
+
+HEALTHCHECK --interval=1s --retries=90 CMD mysql -u root -p$MYSQL_ROOT_PASSWORD -h$HOSTNAME -P 3306 -e "SHOW STATUS" > /dev/null
+
+COPY test.cnf /etc/mysql/conf.d/test.cnf

--- a/metricbeat/module/mysql/_meta/test.cnf
+++ b/metricbeat/module/mysql/_meta/test.cnf
@@ -1,0 +1,2 @@
+[mysqld]
+bind-address = 0.0.0.0

--- a/metricbeat/module/nginx/_meta/Dockerfile
+++ b/metricbeat/module/nginx/_meta/Dockerfile
@@ -1,4 +1,5 @@
 FROM nginx:1.9
+RUN sed -i "/jessie-updates/d" /etc/apt/sources.list
 RUN apt-get update && apt-get install -y curl
 HEALTHCHECK --interval=1s --retries=90 CMD curl -f http://localhost/server-status
 COPY ./nginx.conf /etc/nginx/


### PR DESCRIPTION
Cherry-pick of PR #11463 to 6.5 branch. Original message: 

jessie-updates is not available anymore and it is used by some images,
so CI builds fail with:
```
W: Failed to fetch http://httpredir.debian.org/debian/dists/jessie-updates/main/binary-amd64/Packages  404  Not Found
```
The repo is not really needed for the matter of the tests, so removing it.