### PR TITLE
[metricbeat] migrate vsphere/virtualmachine to ReporterV2

### DIFF
--- a/metricbeat/module/vsphere/virtualmachine/virtualmachine_test.go
+++ b/metricbeat/module/vsphere/virtualmachine/virtualmachine_test.go
@@ -37,13 +37,14 @@ func TestFetchEventContents(t *testing.T) {
 	ts := model.Service.NewServer()
 	defer ts.Close()
 
-	f := mbtest.NewEventsFetcher(t, getConfig(ts))
-	events, err := f.Fetch()
-	if err != nil {
-		t.Fatal("fetch error", err)
+	f := mbtest.NewReportingMetricSetV2Error(t, getConfig(ts))
+	events, errs := mbtest.ReportingFetchV2Error(f)
+	if len(errs) > 0 {
+		t.Fatalf("Expected 0 error, had %d. %v\n", len(errs), errs)
 	}
 
-	event := events[0]
+	assert.NotEmpty(t, events)
+	event := events[0].MetricSetFields
 
 	t.Logf("%s/%s event: %+v", f.Module().Name(), f.Name(), event.StringToPrint())
 
@@ -81,9 +82,9 @@ func TestData(t *testing.T) {
 	ts := model.Service.NewServer()
 	defer ts.Close()
 
-	f := mbtest.NewEventsFetcher(t, getConfig(ts))
+	f := mbtest.NewReportingMetricSetV2Error(t, getConfig(ts))
 
-	if err := mbtest.WriteEvents(f, t); err != nil {
+	if err := mbtest.WriteEventsReporterV2Error(f, t, ""); err != nil {
 		t.Fatal("write", err)
 	}
 }


### PR DESCRIPTION
See  #10774, We're almost done!

At the request of @ruflin I removed the threading from `Fetch()`. We have a lot of metricsets that fire off events in a loop, and goroutines just seemed to add complexity. 