### PR TITLE
Cherry-pick #11263 to 6.6: Stop waiting for signals on closed outleters

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -37,6 +37,7 @@ https://github.com/elastic/beats/compare/v6.6.2...6.6[Check the HEAD diff]
 *Filebeat*
 
 - Fix a bug with the convert_timezone option using the incorrect timezone field. {issue}11055[11055] {pull}11164[11164]
+- Fix goroutine leak happening when harvesters are dynamically stopped. {pull}11263[11263]
 
 *Heartbeat*
 

--- a/filebeat/channel/interface.go
+++ b/filebeat/channel/interface.go
@@ -32,5 +32,6 @@ type Connector func(*common.Config, *common.MapStrPointer) (Outleter, error)
 // Outleter is the outlet for an input
 type Outleter interface {
 	Close() error
+	Done() <-chan struct{}
 	OnEvent(data *util.Data) bool
 }

--- a/filebeat/input/log/input_other_test.go
+++ b/filebeat/input/log/input_other_test.go
@@ -169,3 +169,4 @@ type TestOutlet struct{}
 
 func (o TestOutlet) OnEvent(event *util.Data) bool { return true }
 func (o TestOutlet) Close() error                  { return nil }
+func (o TestOutlet) Done() <-chan struct{}         { return nil }


### PR DESCRIPTION
Cherry-pick of PR #11263 to 6.6 branch. Original message: 

Outleters start a goroutine to handle the finalization of filebeat. If the
outleter is closed by other means the goroutine will be kept running
even if it has nothing to do, leaking goroutines.

Stop this goroutine if the outleter is closed.