### PR TITLE
update modules path in the reference file

### DIFF
--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -14,7 +14,7 @@
 metricbeat.config.modules:
 
   # Glob pattern for configuration reloading
-  path: ${path.config}/conf.d/*.yml
+  path: ${path.config}/modules.d/*.yml
 
   # Period on which files under path should be checked for changes
   reload.period: 10s


### PR DESCRIPTION
modules reside under the modules.d directory
metricbeat.yml correctly sets path: ${path.config}/modules.d/*.yml
the reference file uses conf.d instead of modules.d