### PR TITLE
Cherry-pick #10706 to 6.7: Initialize Paths before loading the keystore

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -10,6 +10,8 @@ https://github.com/elastic/beats/compare/v6.7.0...6.x[Check the HEAD diff]
 
 *Affecting all Beats*
 
+- Initialize the Paths before the keystore and save the keystore into `data/{beatname}.keystore`. {pull}10706[10706]
+
 *Auditbeat*
 
 *Filebeat*


### PR DESCRIPTION
Cherry-pick of PR #10706  to 6.7 branch. Original message: 

The paths were incorrectly initialized meaning that instead of creating
the keystore in the data directory it was created next to the binary.

The problem was the call to `paths.InitPaths()` was done after loading
the keystore, this was causing a chicken and egg situation and
`paths.Resolve(path.Data, "hello")` was returning "hello" instead of
`data/hello`.

To solve that situation we do a partial extract of the configuration,
just enough to initialize the paths and we move on to the keystore and
the complete unpack.