### PR TITLE
Extend logstash.node metricset for logstash_state stack monitoring data

### DIFF
--- a/metricbeat/module/logstash/logstash.go
+++ b/metricbeat/module/logstash/logstash.go
@@ -45,7 +45,7 @@ type PipelineState struct {
 	Representation map[string]interface{} `json:"representation"`
 	BatchSize      int                    `json:"batch_size"`
 	Workers        int                    `json:"workers"`
-	ClusterID      string                 `json:"cluster_uuid,omitempty"`
+	ClusterIDs     []string               `json:"cluster_uuids,omitempty"` // TODO: see https://github.com/elastic/logstash/issues/10602
 }
 
 // NewMetricSet creates a metricset that can be used to build other metricsets

--- a/metricbeat/module/logstash/logstash.go
+++ b/metricbeat/module/logstash/logstash.go
@@ -19,7 +19,6 @@ package logstash
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/url"
 
 	"github.com/pkg/errors"
@@ -82,8 +81,6 @@ func GetPipelines(http *helper.HTTP, resetURI string) ([]PipelineState, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "could not parse node pipelines response")
 	}
-
-	fmt.Println(pipelinesResponse)
 
 	var pipelines []PipelineState
 	for pipelineID, pipeline := range pipelinesResponse.Pipelines {

--- a/metricbeat/module/logstash/logstash.go
+++ b/metricbeat/module/logstash/logstash.go
@@ -68,7 +68,7 @@ func NewMetricSet(base mb.BaseMetricSet) (*MetricSet, error) {
 
 // GetPipelines returns the list of pipelines running on a Logstash node
 func GetPipelines(http *helper.HTTP, resetURI string) ([]PipelineState, error) {
-	content, err := fetchPath(http, resetURI, "_node/pipelines", "")
+	content, err := fetchPath(http, resetURI, "_node/pipelines", "graph=true")
 	if err != nil {
 		return nil, errors.Wrap(err, "could not fetch node pipelines")
 	}

--- a/metricbeat/module/logstash/logstash.go
+++ b/metricbeat/module/logstash/logstash.go
@@ -18,6 +18,13 @@
 package logstash
 
 import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+
+	"github.com/pkg/errors"
+
+	"github.com/elastic/beats/metricbeat/helper"
 	"github.com/elastic/beats/metricbeat/mb"
 )
 
@@ -27,12 +34,75 @@ const ModuleName = "logstash"
 // MetricSet can be used to build other metricsets within the Logstash module.
 type MetricSet struct {
 	mb.BaseMetricSet
+	XPack bool
+}
+
+// PipelineState represents the state (shape) of a Logstash pipeline
+type PipelineState struct {
+	ID             string                 `json:"id"`
+	Hash           string                 `json:"hash"`
+	EphemeralID    string                 `json:"ephemeral_id"`
+	Graph          map[string]interface{} `json:"graph,omitempty"`
+	Representation map[string]interface{} `json:"representation"`
+	BatchSize      int                    `json:"batch_size"`
+	Workers        int                    `json:"workers"`
+	ClusterID      string                 `json:"cluster_uuid,omitempty"`
 }
 
 // NewMetricSet creates a metricset that can be used to build other metricsets
 // within the Logstash module.
 func NewMetricSet(base mb.BaseMetricSet) (*MetricSet, error) {
+	config := struct {
+		XPack bool `config:"xpack.enabled"`
+	}{
+		XPack: false,
+	}
+	if err := base.Module().UnpackConfig(&config); err != nil {
+		return nil, err
+	}
+
 	return &MetricSet{
 		base,
+		config.XPack,
 	}, nil
+}
+
+// GetPipelines returns the list of pipelines running on a Logstash node
+func GetPipelines(http *helper.HTTP, resetURI string) ([]PipelineState, error) {
+	content, err := fetchPath(http, resetURI, "_node/pipelines", "")
+	if err != nil {
+		return nil, errors.Wrap(err, "could not fetch node pipelines")
+	}
+
+	pipelinesResponse := struct {
+		Pipelines map[string]PipelineState `json:"pipelines"`
+	}{}
+
+	err = json.Unmarshal(content, &pipelinesResponse)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not parse node pipelines response")
+	}
+
+	fmt.Println(pipelinesResponse)
+
+	var pipelines []PipelineState
+	for pipelineID, pipeline := range pipelinesResponse.Pipelines {
+		pipeline.ID = pipelineID
+		pipelines = append(pipelines, pipeline)
+	}
+
+	return pipelines, nil
+}
+
+func fetchPath(http *helper.HTTP, resetURI, path string, query string) ([]byte, error) {
+	defer http.SetURI(resetURI)
+
+	// Parses the uri to replace the path
+	u, _ := url.Parse(resetURI)
+	u.Path = path
+	u.RawQuery = query
+
+	// Http helper includes the HostData with username and password
+	http.SetURI(u.String())
+	return http.FetchContent()
 }

--- a/metricbeat/module/logstash/node/data_xpack.go
+++ b/metricbeat/module/logstash/node/data_xpack.go
@@ -50,6 +50,7 @@ func eventMappingXPack(r mb.ReporterV2, m *MetricSet, pipelines []logstash.Pipel
 			"logstash_state": logstashState,
 		}
 
+		event.ID = pipeline.EphemeralID
 		event.Index = elastic.MakeXPackMonitoringIndexName(elastic.Logstash)
 		r.Event(event)
 	}

--- a/metricbeat/module/logstash/node/data_xpack.go
+++ b/metricbeat/module/logstash/node/data_xpack.go
@@ -37,6 +37,10 @@ func eventMappingXPack(r mb.ReporterV2, m *MetricSet, pipelines []logstash.Pipel
 		pipeline.Representation = pipeline.Graph
 		pipeline.Graph = nil
 
+		// Extract cluster_uuids
+		clusterUUIDs := pipeline.ClusterIDs
+		pipeline.ClusterIDs = nil
+
 		logstashState := map[string]logstash.PipelineState{
 			"pipeline": pipeline,
 		}
@@ -45,7 +49,7 @@ func eventMappingXPack(r mb.ReporterV2, m *MetricSet, pipelines []logstash.Pipel
 			pipeline.ClusterIDs = []string{""}
 		}
 
-		for _, clusterUUID := range pipeline.ClusterIDs {
+		for _, clusterUUID := range clusterUUIDs {
 			event := mb.Event{}
 			event.RootFields = common.MapStr{
 				"timestamp":      common.Time(time.Now()),
@@ -61,7 +65,6 @@ func eventMappingXPack(r mb.ReporterV2, m *MetricSet, pipelines []logstash.Pipel
 			event.ID = pipeline.EphemeralID
 			event.Index = elastic.MakeXPackMonitoringIndexName(elastic.Logstash)
 			r.Event(event)
-
 		}
 	}
 

--- a/metricbeat/module/logstash/node/data_xpack.go
+++ b/metricbeat/module/logstash/node/data_xpack.go
@@ -1,0 +1,52 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package node
+
+import (
+	"time"
+
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/metricbeat/helper/elastic"
+	"github.com/elastic/beats/metricbeat/mb"
+	"github.com/elastic/beats/metricbeat/module/logstash"
+)
+
+func eventMappingXPack(r mb.ReporterV2, m *MetricSet, pipelines []logstash.PipelineState) error {
+	for _, pipeline := range pipelines {
+		pipeline.Representation = pipeline.Graph
+		pipeline.Graph = nil
+
+		logstashState := map[string]logstash.PipelineState{
+			"pipeline": pipeline,
+		}
+
+		event := mb.Event{}
+		event.RootFields = common.MapStr{
+			"cluster_uuid":   pipeline.ClusterID,
+			"timestamp":      common.Time(time.Now()),
+			"interval_ms":    m.Module().Config().Period / time.Millisecond,
+			"type":           "logstash_state",
+			"logstash_state": logstashState,
+		}
+
+		event.Index = elastic.MakeXPackMonitoringIndexName(elastic.Logstash)
+		r.Event(event)
+	}
+
+	return nil
+}

--- a/metricbeat/module/logstash/node/data_xpack.go
+++ b/metricbeat/module/logstash/node/data_xpack.go
@@ -28,6 +28,12 @@ import (
 
 func eventMappingXPack(r mb.ReporterV2, m *MetricSet, pipelines []logstash.PipelineState) error {
 	for _, pipeline := range pipelines {
+		// Exclude internal pipelines
+		if pipeline.ID[0] == '.' {
+			continue
+		}
+
+		// Rename key: graph -> representation
 		pipeline.Representation = pipeline.Graph
 		pipeline.Graph = nil
 


### PR DESCRIPTION
Depends on https://github.com/elastic/logstash/pull/10561. **Do not merge until https://github.com/elastic/logstash/pull/10561 is resolved first.**

This PR extends the `node` metricset in the `logstash` metricbeat module. It teaches it to understand the `xpack.enabled` setting in `modules.d/logstash.yml`. If this setting is set, the metricset indexes `logstash_state` documents in `.monitoring-logstash-*` indices.

Resolves partially: #7035

### Testing this PR
1. Start up a Logstash node (built with https://github.com/elastic/logstash/pull/10561) running one or more pipelines.
2. Build Metricbeat with this PR:
   ```
   cd metricbeat
   mage build
   ```

3. Enable the `logstash` Metricbeat module:
   ```
   metricbeat modules enable logstash
   ```
4. Configure the `logstash` Metricbeat module for X-Pack Monitoring. To do this, edit `modules.d/logstash.yml` and add the following line to it:
   ```
   xpack.enabled: true
   ```
5. Start Metricbeat:
   ```
   metricbeat -e
   ```
6. Query the `.monitoring-logstash-7-mb-*` indices to make sure there are as many documents with `type: logstash_state` as there are running Logstash pipelines.
   ```
   GET .monitoring-logstash-7-mb-*/_search?q=type:logstash_state
   ```
7. Repeat the query in 6. above multiple times over the course of a minute or so. Make sure the number of documents stays constant over time. New documents of `type:logstash_state` should only be created if either the shape of one of the Logstash pipelines changes or the pipeline is restarted.

   
   