### PR TITLE
Extend logstash.node_stats metricset for logstash_stats stack monitoring data

### DIFF
--- a/metricbeat/module/logstash/logstash.go
+++ b/metricbeat/module/logstash/logstash.go
@@ -45,7 +45,7 @@ type PipelineState struct {
 	Representation map[string]interface{} `json:"representation"`
 	BatchSize      int                    `json:"batch_size"`
 	Workers        int                    `json:"workers"`
-	ClusterIDs     []string               `json:"cluster_uuids,omitempty"` // TODO: see https://github.com/elastic/logstash/issues/10602
+	ClusterIDs     []string               `json:"cluster_uuids,omitempty"`
 }
 
 // PipelineStats represents the stats of a Logstash pipeline
@@ -57,7 +57,7 @@ type PipelineStats struct {
 	Reloads     map[string]interface{}   `json:"reloads"`
 	Queue       map[string]interface{}   `json:"queue"`
 	Vertices    []map[string]interface{} `json:"vertices"`
-	ClusterIDs  []string                 `json:"cluster_uuids,omitempty"` // TODO: see https://github.com/elastic/logstash/issues/10602
+	ClusterIDs  []string                 `json:"cluster_uuids,omitempty"`
 }
 
 // NewMetricSet creates a metricset that can be used to build other metricsets

--- a/metricbeat/module/logstash/logstash.go
+++ b/metricbeat/module/logstash/logstash.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/metricbeat/helper"
 	"github.com/elastic/beats/metricbeat/mb"
 )
@@ -59,20 +58,6 @@ type PipelineStats struct {
 	Queue       map[string]interface{}   `json:"queue"`
 	Vertices    []map[string]interface{} `json:"vertices"`
 	ClusterIDs  []string                 `json:"cluster_uuids,omitempty"` // TODO: see https://github.com/elastic/logstash/issues/10602
-}
-
-// Info represents the basic info of a Logstash node
-type Info struct {
-	ID          string                 `json:"id,omitempty"`
-	UUID        string                 `json:"uuid"`
-	EphemeralID string                 `json:"ephemeral_id"`
-	Name        string                 `json:"name"`
-	Host        string                 `json:"host"`
-	Version     *common.Version        `json:"version"`
-	Snapshot    bool                   `json:"snapshot"`
-	Status      string                 `json:"status"`
-	HTTPAddress string                 `json:"http_address"`
-	Pipeline    map[string]interface{} `json:"pipeline"` // TODO: https://github.com/elastic/logstash/issues/10121#issuecomment-477960900
 }
 
 // NewMetricSet creates a metricset that can be used to build other metricsets
@@ -141,22 +126,6 @@ func GetPipelinesStats(http *helper.HTTP, resetURI string) ([]PipelineStats, err
 	}
 
 	return pipelines, nil
-}
-
-// GetInfo returns the basic info for a Logstash node
-func GetInfo(http *helper.HTTP, resetURI string) (*Info, error) {
-	content, err := fetchPath(http, resetURI, "/", "")
-	if err != nil {
-		return nil, errors.Wrap(err, "could not fetch node basic info")
-	}
-
-	info := &Info{}
-	err = json.Unmarshal(content, info)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not parse node basic info response")
-	}
-
-	return info, nil
 }
 
 func fetchPath(http *helper.HTTP, resetURI, path string, query string) ([]byte, error) {

--- a/metricbeat/module/logstash/logstash.go
+++ b/metricbeat/module/logstash/logstash.go
@@ -105,7 +105,7 @@ func GetPipelines(http *helper.HTTP, resetURI string) ([]PipelineState, error) {
 
 // GetPipelinesStats returns the list of pipelines (and their stats) running on a Logstash node
 func GetPipelinesStats(http *helper.HTTP, resetURI string) ([]PipelineStats, error) {
-	content, err := fetchPath(http, resetURI, "_node/stats/pipelines", "")
+	content, err := fetchPath(http, resetURI, "_node/stats", "vertices=true")
 	if err != nil {
 		return nil, errors.Wrap(err, "could not fetch node pipeline stats")
 	}

--- a/metricbeat/module/logstash/node_stats/data_xpack.go
+++ b/metricbeat/module/logstash/node_stats/data_xpack.go
@@ -77,11 +77,11 @@ type NodeStats struct {
 // LogstashStats represents the logstash_stats sub-document indexed into .monitoring-logstash-*
 type LogstashStats struct {
 	commonStats
-	Process   process                `json:"process"`
-	OS        os                     `json:"os"`
-	Pipelines []PipelineStats        `json:"pipelines"`
-	Logstash  map[string]interface{} `json:"logstash"`
-	Timestamp common.Time            `json:"timestamp"`
+	Process   process         `json:"process"`
+	OS        os              `json:"os"`
+	Pipelines []PipelineStats `json:"pipelines"`
+	Logstash  nodeInfo        `json:"logstash"`
+	Timestamp common.Time     `json:"timestamp"`
 }
 
 // PipelineStats represents the stats of a Logstash pipeline
@@ -107,9 +107,6 @@ func eventMappingXPack(r mb.ReporterV2, m *MetricSet, content []byte) error {
 	// Massage Logstash node basic info
 	nodeStats.nodeInfo.UUID = nodeStats.nodeInfo.ID
 	nodeStats.nodeInfo.ID = ""
-	logstash := map[string]interface{}{
-		"logstash": nodeStats.nodeInfo,
-	}
 
 	proc := process{
 		nodeStats.Process.OpenFileDescriptors,
@@ -141,7 +138,7 @@ func eventMappingXPack(r mb.ReporterV2, m *MetricSet, content []byte) error {
 			proc,
 			o,
 			clusterPipelines,
-			logstash,
+			nodeStats.nodeInfo,
 			timestamp,
 		}
 

--- a/metricbeat/module/logstash/node_stats/data_xpack.go
+++ b/metricbeat/module/logstash/node_stats/data_xpack.go
@@ -1,0 +1,141 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package node_stats
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/metricbeat/helper/elastic"
+	"github.com/elastic/beats/metricbeat/mb"
+)
+
+type commonStats struct {
+	Events  map[string]interface{} `json:"events"`
+	JVM     map[string]interface{} `json:"jvm"`
+	OS      map[string]interface{} `json:"os"`
+	Process map[string]interface{} `json:"process"`
+	Reloads map[string]interface{} `json:"reloads"`
+}
+
+// NodeStats represents the stats of a Logstash node
+type NodeStats struct {
+	commonStats
+	Pipelines map[string]PipelineStats `json:"pipelines"`
+}
+
+// LogstashStats represents the logstash_stats sub-document indexed into .monitoring-logstash-*
+type LogstashStats struct {
+	commonStats
+	Pipelines []PipelineStats        `json:"pipelines`
+	Logstash  map[string]interface{} `json:"logstash"`
+	Queue     map[string]interface{} `json:"queue"`
+	Timestamp common.Time            `json:"timestamp"`
+}
+
+// PipelineStats represents the stats of a Logstash pipeline
+type PipelineStats struct {
+	ID          string                   `json:"id"`
+	Hash        string                   `json:"hash"`
+	EphemeralID string                   `json:"ephemeral_id"`
+	Events      map[string]interface{}   `json:"events"`
+	Reloads     map[string]interface{}   `json:"reloads"`
+	Queue       map[string]interface{}   `json:"queue"`
+	Vertices    []map[string]interface{} `json:"vertices"`
+	ClusterIDs  []string                 `json:"cluster_uuids,omitempty"` // TODO: see https://github.com/elastic/logstash/issues/10602
+}
+
+func eventMappingXPack(r mb.ReporterV2, m *MetricSet, content []byte) error {
+	var nodeStats NodeStats
+	err := json.Unmarshal(content, &nodeStats)
+	if err != nil {
+		return errors.Wrap(err, "could not parse node stats response")
+	}
+
+	var pipelines []PipelineStats
+	for pipelineID, pipeline := range nodeStats.Pipelines {
+		pipeline.ID = pipelineID
+		pipelines = append(pipelines, pipeline)
+	}
+
+	pipelines = getUserDefinedPipelines(pipelines)
+	clusterToPipelinesMap := makeClusterToPipelinesMap(pipelines)
+
+	for clusterUUID, clusterPipelines := range clusterToPipelinesMap {
+		timestamp := common.Time(time.Now())
+		logstash := map[string]interface{}{} // TODO
+		queue := map[string]interface{}{}    // TODO
+
+		logstashStats := LogstashStats{nodeStats.commonStats, clusterPipelines, logstash, queue, timestamp}
+
+		// TODO: massage logstashStats.Process
+		// TODO: massage logstashStats.OS
+
+		event := mb.Event{}
+		event.RootFields = common.MapStr{
+			"timestamp":      timestamp,
+			"interval_ms":    m.Module().Config().Period / time.Millisecond,
+			"type":           "logstash_stats",
+			"logstash_stats": logstashStats,
+		}
+
+		if clusterUUID != "" {
+			event.RootFields["cluster_uuid"] = clusterUUID
+		}
+
+		event.Index = elastic.MakeXPackMonitoringIndexName(elastic.Logstash)
+		r.Event(event)
+	}
+
+	return nil
+}
+
+func makeClusterToPipelinesMap(pipelines []PipelineStats) map[string][]PipelineStats {
+	var clusterToPipelinesMap map[string][]PipelineStats
+
+	for _, pipeline := range pipelines {
+		clusterUUIDs := pipeline.ClusterIDs
+		if clusterUUIDs == nil {
+			clusterUUIDs = []string{""}
+		}
+
+		for _, clusterUUID := range clusterUUIDs {
+			clusterPipelines := clusterToPipelinesMap[clusterUUID]
+			if clusterPipelines == nil {
+				clusterPipelines = []PipelineStats{}
+			}
+
+			clusterPipelines = append(clusterPipelines, pipeline)
+		}
+	}
+
+	return clusterToPipelinesMap
+}
+
+func getUserDefinedPipelines(pipelines []PipelineStats) []PipelineStats {
+	userDefinedPipelines := []PipelineStats{}
+	for _, pipeline := range pipelines {
+		if pipeline.ID[0] != '.' {
+			userDefinedPipelines = append(userDefinedPipelines, pipeline)
+		}
+	}
+	return userDefinedPipelines
+}

--- a/metricbeat/module/logstash/node_stats/data_xpack.go
+++ b/metricbeat/module/logstash/node_stats/data_xpack.go
@@ -63,7 +63,7 @@ type nodeInfo struct {
 	Snapshot    bool                   `json:"snapshot"`
 	Status      string                 `json:"status"`
 	HTTPAddress string                 `json:"http_address"`
-	Pipeline    map[string]interface{} `json:"pipeline"` // TODO: https://github.com/elastic/logstash/issues/10121#issuecomment-477960900
+	Pipeline    map[string]interface{} `json:"pipeline"`
 }
 
 // NodeStats represents the stats of a Logstash node

--- a/metricbeat/module/logstash/node_stats/data_xpack.go
+++ b/metricbeat/module/logstash/node_stats/data_xpack.go
@@ -32,12 +32,15 @@ type commonStats struct {
 	Events  map[string]interface{} `json:"events"`
 	JVM     map[string]interface{} `json:"jvm"`
 	Reloads map[string]interface{} `json:"reloads"`
+	Queue   struct {
+		EventsCount int `json:"events_count"`
+	} `json:"queue"`
 }
 
 type cpu struct {
-	Percent     int                    `json:"percent,omitempty"`
-	LoadAverage map[string]interface{} `json:"load_average,omitempty"`
-	NumCPUs     int                    `json:"num_cpus,omitempty"`
+	Percent     int                    `json:"percent"`
+	LoadAverage map[string]interface{} `json:"load_average"`
+	NumCPUs     int                    `json:"num_cpus"`
 }
 
 type process struct {
@@ -78,7 +81,6 @@ type LogstashStats struct {
 	OS        os                     `json:"os"`
 	Pipelines []PipelineStats        `json:"pipelines"`
 	Logstash  map[string]interface{} `json:"logstash"`
-	Queue     map[string]interface{} `json:"queue"`
 	Timestamp common.Time            `json:"timestamp"`
 }
 
@@ -124,8 +126,6 @@ func eventMappingXPack(r mb.ReporterV2, m *MetricSet, content []byte) error {
 		},
 	}
 
-	queue := map[string]interface{}{} // TODO: see https://github.com/elastic/logstash/issues/10610
-
 	var pipelines []PipelineStats
 	for pipelineID, pipeline := range nodeStats.Pipelines {
 		pipeline.ID = pipelineID
@@ -142,7 +142,6 @@ func eventMappingXPack(r mb.ReporterV2, m *MetricSet, content []byte) error {
 			o,
 			clusterPipelines,
 			logstash,
-			queue,
 			timestamp,
 		}
 

--- a/metricbeat/module/logstash/node_stats/data_xpack.go
+++ b/metricbeat/module/logstash/node_stats/data_xpack.go
@@ -111,8 +111,8 @@ func eventMappingXPack(r mb.ReporterV2, m *MetricSet, content []byte) error {
 				NumCPUs:     nodeStats.Process.CPU.NumCPUs,
 			},
 		}
-		logstash := map[string]interface{}{} // TODO
-		queue := map[string]interface{}{}    // TODO
+		logstash := map[string]interface{}{} // TODO; see https://github.com/elastic/logstash/issues/10121
+		queue := map[string]interface{}{}    // TODO: see https://github.com/elastic/logstash/issues/10610
 
 		logstashStats := LogstashStats{
 			nodeStats.commonStats,

--- a/metricbeat/module/logstash/node_stats/data_xpack.go
+++ b/metricbeat/module/logstash/node_stats/data_xpack.go
@@ -59,7 +59,7 @@ type nodeInfo struct {
 	EphemeralID string                 `json:"ephemeral_id"`
 	Name        string                 `json:"name"`
 	Host        string                 `json:"host"`
-	Version     *common.Version        `json:"version"`
+	Version     string                 `json:"version"`
 	Snapshot    bool                   `json:"snapshot"`
 	Status      string                 `json:"status"`
 	HTTPAddress string                 `json:"http_address"`

--- a/metricbeat/module/logstash/node_stats/node_stats.go
+++ b/metricbeat/module/logstash/node_stats/node_stats.go
@@ -35,15 +35,11 @@ func init() {
 	)
 }
 
-const (
-	nodeStatsPath = "/_node/stats"
-)
-
 var (
 	hostParser = parse.URLHostParserBuilder{
 		DefaultScheme: "http",
 		PathConfigKey: "path",
-		DefaultPath:   nodeStatsPath,
+		DefaultPath:   "_node/stats",
 	}.Build()
 )
 

--- a/metricbeat/module/logstash/node_stats/node_stats.go
+++ b/metricbeat/module/logstash/node_stats/node_stats.go
@@ -35,11 +35,13 @@ func init() {
 	)
 }
 
+const nodeStatsPath = "_node/stats"
+
 var (
 	hostParser = parse.URLHostParserBuilder{
 		DefaultScheme: "http",
 		PathConfigKey: "path",
-		DefaultPath:   "_node/stats",
+		DefaultPath:   nodeStatsPath,
 	}.Build()
 )
 
@@ -79,7 +81,12 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 		return eventMapping(r, content)
 	}
 
-	err = eventMappingXPack(r, m, content)
+	info, err := logstash.GetInfo(m.http, m.HostData().SanitizedURI+nodeStatsPath)
+	if err != nil {
+		m.Logger().Error(err)
+	}
+
+	err = eventMappingXPack(r, m, content, info)
 	if err != nil {
 		m.Logger().Error(err)
 	}

--- a/metricbeat/module/logstash/node_stats/node_stats.go
+++ b/metricbeat/module/logstash/node_stats/node_stats.go
@@ -75,5 +75,14 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 		return err
 	}
 
-	return eventMapping(r, content)
+	if !m.MetricSet.XPack {
+		return eventMapping(r, content)
+	}
+
+	err = eventMappingXPack(r, m, content)
+	if err != nil {
+		m.Logger().Error(err)
+	}
+
+	return nil
 }

--- a/metricbeat/module/logstash/node_stats/node_stats.go
+++ b/metricbeat/module/logstash/node_stats/node_stats.go
@@ -35,7 +35,9 @@ func init() {
 	)
 }
 
-const nodeStatsPath = "_node/stats"
+const (
+	nodeStatsPath = "/_node/stats"
+)
 
 var (
 	hostParser = parse.URLHostParserBuilder{
@@ -81,12 +83,7 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 		return eventMapping(r, content)
 	}
 
-	info, err := logstash.GetInfo(m.http, m.HostData().SanitizedURI+nodeStatsPath)
-	if err != nil {
-		m.Logger().Error(err)
-	}
-
-	err = eventMappingXPack(r, m, content, info)
+	err = eventMappingXPack(r, m, content)
 	if err != nil {
 		m.Logger().Error(err)
 	}


### PR DESCRIPTION
This PR extends the `node_stats` metricset in the `logstash` metricbeat module. It teaches it to understand the `xpack.enabled` setting in `modules.d/logstash.yml`. If this setting is set, the metricset indexes `logstash_stats` documents in `.monitoring-logstash-*` indices.

Resolves partially: #7035

### Testing this PR
1. Start up a Logstash node running one or more pipelines.
2. Build Metricbeat with this PR:
   ```
   cd metricbeat
   mage build
   ```

3. Enable the logstash Metricbeat module:

   ```
   metricbeat modules enable logstash
   ```

   _Note:_ `metricbeat modules enable logstash-xpack` _will not work as it has not been implemented yet._

4. Configure the logstash Metricbeat module for X-Pack Monitoring. To do this, edit `modules.d/logstash.yml` and add the following line to it:

   ```
   xpack.enabled: true
   ```

5. Start Metricbeat:
   ```
   metricbeat -e
   ```
6. Query the `.monitoring-logstash-7-mb-*` indices to make sure there are documents with `type: logstash_stats`.
   ```
   GET .monitoring-logstash-7-mb-*/_search?q=type:logstash_stats
   ```
7. Repeat the query in 6. above multiple times over the course of a minute or so. Make sure the number of documents grows over time. New documents of `type:logstash_stats` should be created every 10 seconds (corresponding to the default `period` in `modules.d/logstash.yml`).
   