### PR TITLE
Fix memory leaks on RunnerFactory and Heartbeat NPEs

### DIFF
--- a/filebeat/autodiscover/autodiscover.go
+++ b/filebeat/autodiscover/autodiscover.go
@@ -51,10 +51,19 @@ func (m *AutodiscoverAdapter) CreateConfig(e bus.Event) ([]*common.Config, error
 
 // CheckConfig tests given config to check if it will work or not, returns errors in case it won't work
 func (m *AutodiscoverAdapter) CheckConfig(c *common.Config) error {
+	var factory cfgfile.RunnerFactory
+
 	if c.HasField("module") {
-		return m.moduleFactory.CheckConfig(c)
+		factory = m.moduleFactory
+	} else {
+		factory = m.inputFactory
 	}
-	return m.inputFactory.CheckConfig(c)
+
+	if checker, ok := factory.(cfgfile.ConfigChecker); ok {
+		return checker.CheckConfig(c)
+	}
+
+	return nil
 }
 
 // Create a module or input from the given config

--- a/filebeat/fileset/factory.go
+++ b/filebeat/fileset/factory.go
@@ -117,12 +117,6 @@ func (f *Factory) Create(p beat.Pipeline, c *common.Config, meta *common.MapStrP
 	}, nil
 }
 
-// CheckConfig checks if a config is valid or not
-func (f *Factory) CheckConfig(config *common.Config) error {
-	// TODO: add code here once we know that spinning up a filebeat input to check for errors doesn't cause memory leaks.
-	return nil
-}
-
 func (p *inputsRunner) Start() {
 	// Load pipelines
 	if p.pipelineLoaderFactory != nil {

--- a/filebeat/input/runnerfactory.go
+++ b/filebeat/input/runnerfactory.go
@@ -56,9 +56,3 @@ func (r *RunnerFactory) Create(
 
 	return p, nil
 }
-
-// CheckConfig checks if a config is valid or not
-func (r *RunnerFactory) CheckConfig(config *common.Config) error {
-	// TODO: add code here once we know that spinning up a filebeat input to check for errors doesn't cause memory leaks.
-	return nil
-}

--- a/heartbeat/monitors/factory.go
+++ b/heartbeat/monitors/factory.go
@@ -44,5 +44,17 @@ func (f *RunnerFactory) Create(p beat.Pipeline, c *common.Config, meta *common.M
 
 // CheckConfig checks to see if the given monitor config is valid.
 func (f *RunnerFactory) CheckConfig(config *common.Config) error {
-	return checkMonitorConfig(config, globalPluginsReg, f.allowWatches)
+	m, err := newMonitor(config, globalPluginsReg, nil, nil, f.allowWatches, nil)
+	// We need to free up any resources like unique ID checks
+	defer func() {
+		if m != nil {
+			m.Stop()
+		}
+	}()
+
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/heartbeat/monitors/monitor.go
+++ b/heartbeat/monitors/monitor.go
@@ -72,12 +72,6 @@ func (m *Monitor) String() string {
 	return fmt.Sprintf("Monitor<pluginName: %s, enabled: %t>", m.name, m.enabled)
 }
 
-func checkMonitorConfig(config *common.Config, registrar *pluginsReg, allowWatches bool) error {
-	m, err := newMonitor(config, registrar, nil, nil, allowWatches, nil)
-	m.Stop() // Stop the monitor to free up the ID from uniqueness checks
-	return err
-}
-
 // ErrWatchesDisabled is returned when the user attempts to declare a watch poll file in a
 var ErrWatchesDisabled = errors.New("watch poll files are only allowed in heartbeat.yml, not dynamic configs")
 
@@ -92,7 +86,25 @@ func (e ErrDuplicateMonitorID) Error() string {
 	return fmt.Sprintf("monitor ID %s is configured for multiple monitors! IDs must be unique values.", e.ID)
 }
 
+// newMonitor Creates a new monitor, without leaking resources in the event of an error.
 func newMonitor(
+	config *common.Config,
+	registrar *pluginsReg,
+	pipelineConnector beat.PipelineConnector,
+	scheduler *scheduler.Scheduler,
+	allowWatches bool,
+	factoryMetadata *common.MapStrPointer,
+) (*Monitor, error) {
+	m, err := newMonitorUnsafe(config, registrar, pipelineConnector, scheduler, allowWatches, factoryMetadata)
+	if m != nil && err != nil {
+		m.Stop()
+	}
+	return m, err
+}
+
+// newMonitorUnsafe is the unsafe way of creating a new monitor because it may return a monitor instance along with an
+// error without freeing monitor resources. m.Stop() must always be called on a non-nil monitor to free resources.
+func newMonitorUnsafe(
 	config *common.Config,
 	registrar *pluginsReg,
 	pipelineConnector beat.PipelineConnector,
@@ -131,13 +143,13 @@ func newMonitor(
 	if m.id != "" {
 		// Ensure we don't have duplicate IDs
 		if _, loaded := uniqueMonitorIDs.LoadOrStore(m.id, m); loaded {
-			return nil, ErrDuplicateMonitorID{m.id}
+			return m, ErrDuplicateMonitorID{m.id}
 		}
 	} else {
 		// If there's no explicit ID generate one
 		hash, err := m.configHash()
 		if err != nil {
-			return nil, err
+			return m, err
 		}
 		m.id = fmt.Sprintf("auto-%s-%#X", m.typ, hash)
 	}
@@ -147,22 +159,22 @@ func newMonitor(
 	m.endpoints = endpoints
 
 	if err != nil {
-		return nil, fmt.Errorf("job err %v", err)
+		return m, fmt.Errorf("job err %v", err)
 	}
 
 	m.configuredJobs, err = m.makeTasks(config, wrappedJobs)
 	if err != nil {
-		return nil, err
+		return m, err
 	}
 
 	err = m.makeWatchTasks(monitorPlugin)
 	if err != nil {
-		return nil, err
+		return m, err
 	}
 
 	if len(m.watchPollTasks) > 0 {
 		if !allowWatches {
-			return nil, ErrWatchesDisabled
+			return m, ErrWatchesDisabled
 		}
 
 		logp.Info(`Obsolete option 'watch.poll_file' declared. This will be removed in a future release. 

--- a/heartbeat/monitors/monitor_test.go
+++ b/heartbeat/monitors/monitor_test.go
@@ -78,6 +78,7 @@ func TestMonitor(t *testing.T) {
 
 func TestDuplicateMonitorIDs(t *testing.T) {
 	serverMonConf := mockPluginConf(t, "custom", "@every 1ms", "http://example.net")
+	badConf := mockBadPluginConf(t, "custom", "@every 1ms")
 	reg := mockPluginsReg()
 	pipelineConnector := &MockPipelineConnector{}
 
@@ -90,12 +91,17 @@ func TestDuplicateMonitorIDs(t *testing.T) {
 		return newMonitor(serverMonConf, reg, pipelineConnector, sched, false, nil)
 	}
 
+	// Ensure that an error is returned on a bad config
+	_, m0Err := newMonitor(badConf, reg, pipelineConnector, sched, false, nil)
+	require.Error(t, m0Err)
+
+	// Would fail if the previous newMonitor didn't free the monitor.id
 	m1, m1Err := makeTestMon()
-	assert.NoError(t, m1Err)
+	require.NoError(t, m1Err)
 	_, m2Err := makeTestMon()
-	assert.Error(t, m2Err)
+	require.Error(t, m2Err)
 
 	m1.Stop()
 	_, m3Err := makeTestMon()
-	assert.NoError(t, m3Err)
+	require.NoError(t, m3Err)
 }

--- a/libbeat/autodiscover/autodiscover.go
+++ b/libbeat/autodiscover/autodiscover.go
@@ -48,7 +48,7 @@ type Adapter interface {
 	CreateConfig(bus.Event) ([]*common.Config, error)
 
 	// RunnerFactory provides runner creation by feeding valid configs
-	cfgfile.RunnerFactory
+	cfgfile.CheckableRunnerFactory
 
 	// EventFilter returns the bus filter to retrieve runner start/stop triggering events
 	EventFilter() []string

--- a/libbeat/autodiscover/factoryadapter.go
+++ b/libbeat/autodiscover/factoryadapter.go
@@ -28,11 +28,11 @@ import (
 
 // FactoryAdapter is an adapter that works with any cfgfile.RunnerFactory.
 type FactoryAdapter struct {
-	factory cfgfile.RunnerFactory
+	factory cfgfile.CheckableRunnerFactory
 }
 
 // NewFactoryAdapter builds and returns an autodiscover adapter that works with any cfgfile.RunnerFactory.
-func NewFactoryAdapter(factory cfgfile.RunnerFactory) *FactoryAdapter {
+func NewFactoryAdapter(factory cfgfile.CheckableRunnerFactory) *FactoryAdapter {
 	return &FactoryAdapter{
 		factory: factory,
 	}

--- a/libbeat/cfgfile/reload.go
+++ b/libbeat/cfgfile/reload.go
@@ -68,7 +68,17 @@ type Reload struct {
 // RunnerFactory is used for creating of new Runners
 type RunnerFactory interface {
 	Create(p beat.Pipeline, config *common.Config, meta *common.MapStrPointer) (Runner, error)
+}
+
+// ConfigChecker is usually combined with a RunnerFactory for implementations that can check a config
+// without a pipeline and metadata.
+type ConfigChecker interface {
 	CheckConfig(config *common.Config) error
+}
+
+type CheckableRunnerFactory interface {
+	RunnerFactory
+	ConfigChecker
 }
 
 // Runner is a simple interface providing a simple way to
@@ -142,7 +152,13 @@ func (rl *Reloader) Check(runnerFactory RunnerFactory) error {
 		if !c.Config.Enabled() {
 			continue
 		}
-		_, err := runnerFactory.Create(rl.pipeline, c.Config, c.Meta)
+
+		if checker, ok := runnerFactory.(ConfigChecker); ok {
+			err = checker.CheckConfig(c.Config)
+		} else {
+			_, err = runnerFactory.Create(rl.pipeline, c.Config, c.Meta)
+		}
+
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Takes over from #11165 . This fixes the reload logic to let heartbeat free resources during config checks by having a custom defined `CheckConfig` method. It also does not require filebeat and metricbeat to implement the same, which would be very complex.