### PR TITLE
update modules path in reference file

### DIFF
--- a/metricbeat/_meta/common.reference.yml
+++ b/metricbeat/_meta/common.reference.yml
@@ -14,7 +14,7 @@
 metricbeat.config.modules:
 
   # Glob pattern for configuration reloading
-  path: ${path.config}/conf.d/*.yml
+  path: ${path.config}/modules.d/*.yml
 
   # Period on which files under path should be checked for changes
   reload.period: 10s

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -14,7 +14,7 @@
 metricbeat.config.modules:
 
   # Glob pattern for configuration reloading
-  path: ${path.config}/conf.d/*.yml
+  path: ${path.config}/modules.d/*.yml
 
   # Period on which files under path should be checked for changes
   reload.period: 10s


### PR DESCRIPTION
modules reside under the modules.d directory
metricbeat.yml correctly sets path: ${path.config}/modules.d/*.yml
the reference file was using conf.d instead of modules.d, which this PR fixes

Per @ruflin 's recommendations in https://github.com/elastic/beats/pull/11491

(I am not entirely sure I did it correctly this time either)