### PR TITLE
LimitReader copies bytes instead of slicing so the underlying big array can be freed

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -73,6 +73,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix goroutine leak happening when harvesters are dynamically stopped. {pull}11263[11263]
 - Fix `add_docker_metadata` source matching, using `log.file.path` field now. {pull}11577[11577]
 - Add missing Kubernetes metadata fields to Filebeat CoreDNS module, and fix a documentation error. {pull}11591[11591]
+- LimitReader copies bytes instead of slicing so the underlying big array can be freed. {pull}11524[11524]
 
 *Heartbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -73,7 +73,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix goroutine leak happening when harvesters are dynamically stopped. {pull}11263[11263]
 - Fix `add_docker_metadata` source matching, using `log.file.path` field now. {pull}11577[11577]
 - Add missing Kubernetes metadata fields to Filebeat CoreDNS module, and fix a documentation error. {pull}11591[11591]
-- LimitReader copies bytes instead of slicing so the underlying big array can be freed. {pull}11524[11524]
+- Reduce memory usage if long lines are truncated to fit `max_bytes` limit. The line buffer is copied into a smaller buffer now. This allows the runtime to release unused memory earlier. {pull}11524[11524]
 
 *Heartbeat*
 

--- a/libbeat/reader/readfile/limit.go
+++ b/libbeat/reader/readfile/limit.go
@@ -39,10 +39,12 @@ func NewLimitReader(r reader.Reader, maxBytes int) *LimitReader {
 func (r *LimitReader) Next() (reader.Message, error) {
 	message, err := r.reader.Next()
 	if len(message.Content) > r.maxBytes {
-		n = copy(message.Content, message.Content[:r.maxBytes])
+		tmp := make([]byte, r.maxBytes)
+		n = copy(tmp, message.Content)
 		if n != r.MaxBytes {
 			return event, fmt.Errorf("unexpected number of bytes were copied, %d instead of limit %d", n, r.MaxBytes)
 		}
+		message.Content = tmp
 		message.AddFlagsWithKey("log.flags", "truncated")
 	}
 	return message, err

--- a/libbeat/reader/readfile/limit.go
+++ b/libbeat/reader/readfile/limit.go
@@ -18,6 +18,8 @@
 package readfile
 
 import (
+	"fmt"
+
 	"github.com/elastic/beats/libbeat/reader"
 )
 
@@ -37,7 +39,10 @@ func NewLimitReader(r reader.Reader, maxBytes int) *LimitReader {
 func (r *LimitReader) Next() (reader.Message, error) {
 	message, err := r.reader.Next()
 	if len(message.Content) > r.maxBytes {
-		message.Content = message.Content[:r.maxBytes]
+		n = copy(message.Content, message.Content[:r.maxBytes])
+		if n != r.MaxBytes {
+			return event, fmt.Errorf("unexpected number of bytes were copied, %d instead of limit %d", n, r.MaxBytes)
+		}
 		message.AddFlagsWithKey("log.flags", "truncated")
 	}
 	return message, err

--- a/libbeat/reader/readfile/limit.go
+++ b/libbeat/reader/readfile/limit.go
@@ -40,9 +40,9 @@ func (r *LimitReader) Next() (reader.Message, error) {
 	message, err := r.reader.Next()
 	if len(message.Content) > r.maxBytes {
 		tmp := make([]byte, r.maxBytes)
-		n = copy(tmp, message.Content)
-		if n != r.MaxBytes {
-			return event, fmt.Errorf("unexpected number of bytes were copied, %d instead of limit %d", n, r.MaxBytes)
+		n := copy(tmp, message.Content)
+		if n != r.maxBytes {
+			return message, fmt.Errorf("unexpected number of bytes were copied, %d instead of limit %d", n, r.maxBytes)
 		}
 		message.Content = tmp
 		message.AddFlagsWithKey("log.flags", "truncated")


### PR DESCRIPTION
In `LimitReader` when truncating the line if the configured limit was reached, the message was sliced. Slicing does not touch the underlying array. To make sure the long line can be truncated and freed, the reader copies the contents to a new array. Thus, freeing the data.