### PR TITLE
Update syntax for referencing keys

### DIFF
--- a/libbeat/docs/keystore.asciidoc
+++ b/libbeat/docs/keystore.asciidoc
@@ -27,15 +27,15 @@ place of the secret value when you configure sensitive settings.
 The syntax for referencing keys is identical to the syntax for environment
 variables:
 
-`${KEY}`
+`{KEY}`
 
 Where KEY is the name of the key.
 
 For example, imagine that the keystore contains a key called `ES_PWD` with the
 value `yourelasticsearchpassword`:
 
-* In the configuration file, use `output.elasticsearch.password: "${ES_PWD}"`
-* On the command line, use: `-E "output.elasticsearch.password=\${ES_PWD}"`
+* In the configuration file, use `output.elasticsearch.password: "{ES_PWD}"`
+* On the command line, use: `-E "output.elasticsearch.password=\{ES_PWD}"`
 
 When {beatname_uc} unpacks the configuration, it resolves keys before resolving
 environment variables and other variables.


### PR DESCRIPTION
Since 6.7 "${KEY}" is no longer supported