### PR TITLE
Cherry-pick #11502 to 6.7: Fix Kafka download link

### DIFF
--- a/testing/environments/docker/kafka/Dockerfile
+++ b/testing/environments/docker/kafka/Dockerfile
@@ -11,7 +11,7 @@ ENV TERM=linux
 RUN apt-get update && apt-get install -y curl openjdk-8-jre-headless netcat
 
 RUN mkdir -p ${KAFKA_LOGS_DIR} && mkdir -p ${KAFKA_HOME} && curl -s -o $INSTALL_DIR/kafka.tgz \
-    "http://ftp.wayne.edu/apache/kafka/${KAFKA_VERSION}/kafka_2.11-${KAFKA_VERSION}.tgz" && \
+    "http://mirror.easyname.ch/apache/kafka/${KAFKA_VERSION}/kafka_2.11-${KAFKA_VERSION}.tgz" && \
     tar xzf ${INSTALL_DIR}/kafka.tgz -C ${KAFKA_HOME} --strip-components 1
 
 ADD run.sh /run.sh


### PR DESCRIPTION
Cherry-pick of PR #11502 to 6.7 branch. Original message: 

The previous mirror does not seem to be available anymore.