### PR TITLE
Cherry-pick #11530 to 7.0: Updated kafka version to 2.1.1 (#11530)

### DIFF
--- a/metricbeat/docker-compose.yml
+++ b/metricbeat/docker-compose.yml
@@ -114,7 +114,7 @@ services:
     build:
       context: ./module/kafka/_meta
       args:
-        KAFKA_VERSION: 2.1.0
+        KAFKA_VERSION: 2.1.1
 
   kafka_1_1_0:
     build:

--- a/metricbeat/docs/modules/kafka.asciidoc
+++ b/metricbeat/docs/modules/kafka.asciidoc
@@ -12,7 +12,7 @@ The default metricsets are `consumergroup` and `partition`.
 [float]
 === Compability
 
-This module is tested with Kafka 0.10.2.1, 1.1.0 and 2.1.0.
+This module is tested with Kafka 0.10.2.1, 1.1.0 and 2.1.1.
 
 
 [float]

--- a/metricbeat/module/kafka/_meta/Dockerfile
+++ b/metricbeat/module/kafka/_meta/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:stretch
 
-ARG KAFKA_VERSION=2.1.0
+ARG KAFKA_VERSION=2.1.1
 
 ENV KAFKA_HOME /kafka
 # The advertised host is kafka. This means it will not work if container is started locally and connected from localhost to it

--- a/metricbeat/module/kafka/_meta/docs.asciidoc
+++ b/metricbeat/module/kafka/_meta/docs.asciidoc
@@ -5,4 +5,4 @@ The default metricsets are `consumergroup` and `partition`.
 [float]
 === Compability
 
-This module is tested with Kafka 0.10.2.1, 1.1.0 and 2.1.0.
+This module is tested with Kafka 0.10.2.1, 1.1.0 and 2.1.1.

--- a/testing/environments/docker/kafka/Dockerfile
+++ b/testing/environments/docker/kafka/Dockerfile
@@ -4,7 +4,7 @@ ENV KAFKA_HOME /kafka
 # The advertised host is kafka. This means it will not work if container is started locally and connected from localhost to it
 ENV KAFKA_ADVERTISED_HOST kafka
 ENV KAFKA_LOGS_DIR="/kafka-logs"
-ENV KAFKA_VERSION 2.1.0
+ENV KAFKA_VERSION 2.1.1
 ENV _JAVA_OPTIONS "-Djava.net.preferIPv4Stack=true"
 ENV TERM=linux
 


### PR DESCRIPTION
Cherry-pick of PR #11530 to 7.0 branch. Original message:

Updated kafka version to 2.1.1