### PR TITLE
[Filebeat] Skip flaky windows tests

### DIFF
--- a/filebeat/tests/system/test_registrar.py
+++ b/filebeat/tests/system/test_registrar.py
@@ -773,6 +773,7 @@ class Test(BaseTest):
             assert self.get_registry_entry_by_path(os.path.abspath(testfile_path1))["offset"] == 9
             assert self.get_registry_entry_by_path(os.path.abspath(testfile_path2))["offset"] == 8
 
+    @unittest.skipIf(os.name == 'nt', 'flaky test https://github.com/elastic/beats/issues/8102')
     def test_clean_inactive(self):
         """
         Checks that states are properly removed after clean_inactive
@@ -819,6 +820,7 @@ class Test(BaseTest):
         # Make sure the last file in the registry is the correct one and has the correct offset
         assert data[0]["offset"] == self.input_logs.size(file3)
 
+    @unittest.skipIf(os.name == 'nt', 'flaky test https://github.com/elastic/beats/issues/7690')
     def test_clean_removed(self):
         """
         Checks that files which were removed, the state is removed


### PR DESCRIPTION
`test_clean_inactive` (#8102) and `test_clean_removed` (#7690) have been flaky recently again on Windows. Skipping these test for Windows.