### PR TITLE
Backport #11545 to 7.0: Add missing migrated fields for system module.

### DIFF
--- a/dev-tools/ecs-migration.yml
+++ b/dev-tools/ecs-migration.yml
@@ -463,7 +463,26 @@
 - from: system.auth.hostname
   to: host.hostname
   alias: true
-  copy_to: false
+  beat: filebeat
+
+- from: system.auth.message
+  to: message
+  alias: true
+  beat: filebeat
+
+- from: system.auth.program
+  to: process.name
+  alias: true
+  beat: filebeat
+
+- from: system.auth.timestamp
+  to: '@timestamp'
+  alias: true
+  beat: filebeat
+
+- from: system.auth.user
+  to: user.name
+  alias: true
   beat: filebeat
 
 - from: system.auth.pid
@@ -476,12 +495,22 @@
   alias: true
   beat: filebeat
 
+- from: system.auth.groupadd.name
+  to: group.name
+  alias: true
+  beat: filebeat
+
+- from: system.auth.useradd.gid
+  to: group.id
+  alias: true
+  beat: filebeat
+
 - from: system.auth.useradd.uid
   to: user.id
   alias: true
   beat: filebeat
 
-- from: system.auth.useradd.user
+- from: system.auth.useradd.name
   to: user.name
   alias: true
   beat: filebeat

--- a/filebeat/module/system/_meta/kibana/7/dashboard/Filebeat-auth-sudo-commands.json
+++ b/filebeat/module/system/_meta/kibana/7/dashboard/Filebeat-auth-sudo-commands.json
@@ -2,358 +2,358 @@
     "objects": [
         {
             "attributes": {
-                "description": "", 
+                "description": "",
                 "kibanaSavedObjectMeta": {
                     "searchSourceJSON": {
                         "filter": []
                     }
-                }, 
-                "savedSearchId": "b6f321e0-fa25-11e6-bbd3-29c986c96e5a-ecs", 
-                "title": "Sudo commands by user [Filebeat System] ECS", 
-                "uiStateJSON": {}, 
-                "version": 1, 
+                },
+                "savedSearchId": "b6f321e0-fa25-11e6-bbd3-29c986c96e5a-ecs",
+                "title": "Sudo commands by user [Filebeat System] ECS",
+                "uiStateJSON": {},
+                "version": 1,
                 "visState": {
                     "aggs": [
                         {
-                            "enabled": true, 
-                            "id": "1", 
-                            "params": {}, 
-                            "schema": "metric", 
+                            "enabled": true,
+                            "id": "1",
+                            "params": {},
+                            "schema": "metric",
                             "type": "count"
-                        }, 
+                        },
                         {
-                            "enabled": true, 
-                            "id": "2", 
+                            "enabled": true,
+                            "id": "2",
                             "params": {
-                                "customInterval": "2h", 
-                                "extended_bounds": {}, 
-                                "field": "@timestamp", 
-                                "interval": "auto", 
+                                "customInterval": "2h",
+                                "extended_bounds": {},
+                                "field": "@timestamp",
+                                "interval": "auto",
                                 "min_doc_count": 1
-                            }, 
-                            "schema": "segment", 
+                            },
+                            "schema": "segment",
                             "type": "date_histogram"
-                        }, 
+                        },
                         {
-                            "enabled": true, 
-                            "id": "3", 
+                            "enabled": true,
+                            "id": "3",
                             "params": {
-                                "field": "system.auth.user", 
-                                "order": "desc", 
-                                "orderBy": "1", 
+                                "field": "user.name",
+                                "order": "desc",
+                                "orderBy": "1",
                                 "size": 5
-                            }, 
-                            "schema": "group", 
+                            },
+                            "schema": "group",
                             "type": "terms"
                         }
-                    ], 
-                    "listeners": {}, 
+                    ],
+                    "listeners": {},
                     "params": {
-                        "addLegend": true, 
-                        "addTimeMarker": false, 
-                        "addTooltip": true, 
-                        "defaultYExtents": false, 
-                        "legendPosition": "right", 
-                        "mode": "stacked", 
-                        "scale": "linear", 
-                        "setYExtents": false, 
+                        "addLegend": true,
+                        "addTimeMarker": false,
+                        "addTooltip": true,
+                        "defaultYExtents": false,
+                        "legendPosition": "right",
+                        "mode": "stacked",
+                        "scale": "linear",
+                        "setYExtents": false,
                         "times": []
-                    }, 
-                    "title": "Sudo commands by user ECS", 
+                    },
+                    "title": "Sudo commands by user ECS",
                     "type": "histogram"
                 }
-            }, 
-            "id": "5c7af030-fa2a-11e6-bbd3-29c986c96e5a-ecs", 
-            "type": "visualization", 
+            },
+            "id": "5c7af030-fa2a-11e6-bbd3-29c986c96e5a-ecs",
+            "type": "visualization",
             "version": 2
-        }, 
+        },
         {
             "attributes": {
-                "description": "", 
+                "description": "",
                 "kibanaSavedObjectMeta": {
                     "searchSourceJSON": {
-                        "filter": [], 
-                        "highlightAll": true, 
-                        "index": "filebeat-*", 
+                        "filter": [],
+                        "highlightAll": true,
+                        "index": "filebeat-*",
                         "query": {
                             "query_string": {
-                                "analyze_wildcard": true, 
+                                "analyze_wildcard": true,
                                 "query": "_exists_:system.auth.sudo.error"
                             }
                         }
                     }
-                }, 
-                "title": "Sudo errors [Filebeat System] ECS", 
-                "uiStateJSON": {}, 
-                "version": 1, 
+                },
+                "title": "Sudo errors [Filebeat System] ECS",
+                "uiStateJSON": {},
+                "version": 1,
                 "visState": {
                     "aggs": [
                         {
-                            "enabled": true, 
-                            "id": "1", 
-                            "params": {}, 
-                            "schema": "metric", 
+                            "enabled": true,
+                            "id": "1",
+                            "params": {},
+                            "schema": "metric",
                             "type": "count"
-                        }, 
+                        },
                         {
-                            "enabled": true, 
-                            "id": "2", 
+                            "enabled": true,
+                            "id": "2",
                             "params": {
-                                "customInterval": "2h", 
-                                "extended_bounds": {}, 
-                                "field": "@timestamp", 
-                                "interval": "auto", 
+                                "customInterval": "2h",
+                                "extended_bounds": {},
+                                "field": "@timestamp",
+                                "interval": "auto",
                                 "min_doc_count": 1
-                            }, 
-                            "schema": "segment", 
+                            },
+                            "schema": "segment",
                             "type": "date_histogram"
-                        }, 
+                        },
                         {
-                            "enabled": true, 
-                            "id": "3", 
+                            "enabled": true,
+                            "id": "3",
                             "params": {
-                                "field": "system.auth.sudo.error", 
-                                "order": "desc", 
-                                "orderBy": "1", 
+                                "field": "system.auth.sudo.error",
+                                "order": "desc",
+                                "orderBy": "1",
                                 "size": 5
-                            }, 
-                            "schema": "group", 
+                            },
+                            "schema": "group",
                             "type": "terms"
                         }
-                    ], 
-                    "listeners": {}, 
+                    ],
+                    "listeners": {},
                     "params": {
-                        "addLegend": true, 
-                        "addTimeMarker": false, 
-                        "addTooltip": true, 
-                        "defaultYExtents": false, 
-                        "legendPosition": "right", 
-                        "mode": "stacked", 
-                        "scale": "linear", 
-                        "setYExtents": false, 
+                        "addLegend": true,
+                        "addTimeMarker": false,
+                        "addTooltip": true,
+                        "defaultYExtents": false,
+                        "legendPosition": "right",
+                        "mode": "stacked",
+                        "scale": "linear",
+                        "setYExtents": false,
                         "times": []
-                    }, 
-                    "title": "Sudo errors ECS", 
+                    },
+                    "title": "Sudo errors ECS",
                     "type": "histogram"
                 }
-            }, 
-            "id": "51164310-fa2b-11e6-bbd3-29c986c96e5a-ecs", 
-            "type": "visualization", 
+            },
+            "id": "51164310-fa2b-11e6-bbd3-29c986c96e5a-ecs",
+            "type": "visualization",
             "version": 2
-        }, 
+        },
         {
             "attributes": {
-                "description": "", 
+                "description": "",
                 "kibanaSavedObjectMeta": {
                     "searchSourceJSON": {
                         "filter": []
                     }
-                }, 
-                "savedSearchId": "b6f321e0-fa25-11e6-bbd3-29c986c96e5a-ecs", 
-                "title": "Top sudo commands [Filebeat System] ECS", 
+                },
+                "savedSearchId": "b6f321e0-fa25-11e6-bbd3-29c986c96e5a-ecs",
+                "title": "Top sudo commands [Filebeat System] ECS",
                 "uiStateJSON": {
                     "vis": {
                         "params": {
                             "sort": {
-                                "columnIndex": null, 
+                                "columnIndex": null,
                                 "direction": null
                             }
                         }
                     }
-                }, 
-                "version": 1, 
+                },
+                "version": 1,
                 "visState": {
                     "aggs": [
                         {
-                            "enabled": true, 
-                            "id": "1", 
-                            "params": {}, 
-                            "schema": "metric", 
+                            "enabled": true,
+                            "id": "1",
+                            "params": {},
+                            "schema": "metric",
                             "type": "count"
-                        }, 
+                        },
                         {
-                            "enabled": true, 
-                            "id": "2", 
+                            "enabled": true,
+                            "id": "2",
                             "params": {
-                                "field": "system.auth.sudo.command", 
-                                "order": "desc", 
-                                "orderBy": "1", 
+                                "field": "system.auth.sudo.command",
+                                "order": "desc",
+                                "orderBy": "1",
                                 "size": 5
-                            }, 
-                            "schema": "bucket", 
+                            },
+                            "schema": "bucket",
                             "type": "terms"
-                        }, 
+                        },
                         {
-                            "enabled": true, 
-                            "id": "3", 
+                            "enabled": true,
+                            "id": "3",
                             "params": {
-                                "field": "system.auth.user", 
-                                "order": "desc", 
-                                "orderBy": "1", 
+                                "field": "user.name",
+                                "order": "desc",
+                                "orderBy": "1",
                                 "size": 5
-                            }, 
-                            "schema": "bucket", 
+                            },
+                            "schema": "bucket",
                             "type": "terms"
                         }
-                    ], 
-                    "listeners": {}, 
+                    ],
+                    "listeners": {},
                     "params": {
-                        "perPage": 10, 
-                        "showMeticsAtAllLevels": false, 
-                        "showPartialRows": false, 
-                        "showTotal": false, 
+                        "perPage": 10,
+                        "showMeticsAtAllLevels": false,
+                        "showPartialRows": false,
+                        "showTotal": false,
                         "sort": {
-                            "columnIndex": null, 
+                            "columnIndex": null,
                             "direction": null
-                        }, 
+                        },
                         "totalFunc": "sum"
-                    }, 
-                    "title": "Top sudo commands ECS", 
+                    },
+                    "title": "Top sudo commands ECS",
                     "type": "table"
                 }
-            }, 
-            "id": "dc589770-fa2b-11e6-bbd3-29c986c96e5a-ecs", 
-            "type": "visualization", 
+            },
+            "id": "dc589770-fa2b-11e6-bbd3-29c986c96e5a-ecs",
+            "type": "visualization",
             "version": 2
-        }, 
+        },
         {
             "attributes": {
-                "description": "", 
+                "description": "",
                 "kibanaSavedObjectMeta": {
                     "searchSourceJSON": {}
-                }, 
-                "title": "Dashboards [Filebeat System] ECS", 
-                "uiStateJSON": {}, 
-                "version": 1, 
+                },
+                "title": "Dashboards [Filebeat System] ECS",
+                "uiStateJSON": {},
+                "version": 1,
                 "visState": {
-                    "aggs": [], 
+                    "aggs": [],
                     "params": {
-                        "fontSize": 12, 
+                        "fontSize": 12,
                         "markdown": "[Syslog](#/dashboard/Filebeat-syslog-dashboard-ecs) | [Sudo commands](#/dashboard/277876d0-fa2c-11e6-bbd3-29c986c96e5a-ecs) | [SSH logins](#/dashboard/5517a150-f9ce-11e6-8115-a7c18106d86a-ecs) | [New users and groups](#/dashboard/0d3f2380-fa78-11e6-ae9b-81e5311e8cab-ecs)"
-                    }, 
-                    "title": "Dashboards [Filebeat System] ECS", 
+                    },
+                    "title": "Dashboards [Filebeat System] ECS",
                     "type": "markdown"
                 }
-            }, 
-            "id": "327417e0-8462-11e7-bab8-bd2f0fb42c54-ecs", 
-            "type": "visualization", 
+            },
+            "id": "327417e0-8462-11e7-bab8-bd2f0fb42c54-ecs",
+            "type": "visualization",
             "version": 1
-        }, 
+        },
         {
             "attributes": {
                 "columns": [
-                    "system.auth.user", 
-                    "system.auth.sudo.user", 
-                    "system.auth.sudo.pwd", 
+                    "user.name",
+                    "system.auth.sudo.user",
+                    "system.auth.sudo.pwd",
                     "system.auth.sudo.command"
-                ], 
-                "description": "", 
-                "hits": 0, 
+                ],
+                "description": "",
+                "hits": 0,
                 "kibanaSavedObjectMeta": {
                     "searchSourceJSON": {
-                        "filter": [], 
-                        "highlightAll": true, 
-                        "index": "filebeat-*", 
+                        "filter": [],
+                        "highlightAll": true,
+                        "index": "filebeat-*",
                         "query": {
                             "query_string": {
-                                "analyze_wildcard": true, 
+                                "analyze_wildcard": true,
                                 "query": "_exists_:system.auth.sudo"
                             }
                         }
                     }
-                }, 
+                },
                 "sort": [
-                    "@timestamp", 
+                    "@timestamp",
                     "desc"
-                ], 
-                "title": "Sudo commands [Filebeat System] ECS", 
+                ],
+                "title": "Sudo commands [Filebeat System] ECS",
                 "version": 1
-            }, 
-            "id": "b6f321e0-fa25-11e6-bbd3-29c986c96e5a-ecs", 
-            "type": "search", 
+            },
+            "id": "b6f321e0-fa25-11e6-bbd3-29c986c96e5a-ecs",
+            "type": "search",
             "version": 2
-        }, 
+        },
         {
             "attributes": {
-                "description": "Sudo commands dashboard from the Filebeat System module", 
-                "hits": 0, 
+                "description": "Sudo commands dashboard from the Filebeat System module",
+                "hits": 0,
                 "kibanaSavedObjectMeta": {
                     "searchSourceJSON": {
-                        "filter": [], 
-                        "highlightAll": true, 
+                        "filter": [],
+                        "highlightAll": true,
                         "query": {
-                            "language": "lucene", 
+                            "language": "lucene",
                             "query": {
                                 "query_string": {
-                                    "analyze_wildcard": true, 
+                                    "analyze_wildcard": true,
                                     "query": "*"
                                 }
                             }
-                        }, 
+                        },
                         "version": true
                     }
-                }, 
+                },
                 "optionsJSON": {
                     "darkTheme": false
-                }, 
+                },
                 "panelsJSON": [
                     {
-                        "col": 1, 
-                        "id": "5c7af030-fa2a-11e6-bbd3-29c986c96e5a-ecs", 
-                        "panelIndex": 1, 
-                        "row": 6, 
-                        "size_x": 12, 
-                        "size_y": 4, 
+                        "col": 1,
+                        "id": "5c7af030-fa2a-11e6-bbd3-29c986c96e5a-ecs",
+                        "panelIndex": 1,
+                        "row": 6,
+                        "size_x": 12,
+                        "size_y": 4,
                         "type": "visualization"
-                    }, 
+                    },
                     {
-                        "col": 1, 
-                        "id": "51164310-fa2b-11e6-bbd3-29c986c96e5a-ecs", 
-                        "panelIndex": 2, 
-                        "row": 10, 
-                        "size_x": 12, 
-                        "size_y": 3, 
+                        "col": 1,
+                        "id": "51164310-fa2b-11e6-bbd3-29c986c96e5a-ecs",
+                        "panelIndex": 2,
+                        "row": 10,
+                        "size_x": 12,
+                        "size_y": 3,
                         "type": "visualization"
-                    }, 
+                    },
                     {
-                        "col": 1, 
-                        "id": "dc589770-fa2b-11e6-bbd3-29c986c96e5a-ecs", 
-                        "panelIndex": 3, 
-                        "row": 2, 
-                        "size_x": 12, 
-                        "size_y": 4, 
+                        "col": 1,
+                        "id": "dc589770-fa2b-11e6-bbd3-29c986c96e5a-ecs",
+                        "panelIndex": 3,
+                        "row": 2,
+                        "size_x": 12,
+                        "size_y": 4,
                         "type": "visualization"
-                    }, 
+                    },
                     {
-                        "col": 1, 
-                        "id": "327417e0-8462-11e7-bab8-bd2f0fb42c54-ecs", 
-                        "panelIndex": 4, 
-                        "row": 1, 
-                        "size_x": 12, 
-                        "size_y": 1, 
+                        "col": 1,
+                        "id": "327417e0-8462-11e7-bab8-bd2f0fb42c54-ecs",
+                        "panelIndex": 4,
+                        "row": 1,
+                        "size_x": 12,
+                        "size_y": 1,
                         "type": "visualization"
                     }
-                ], 
-                "timeRestore": false, 
-                "title": "[Filebeat System] Sudo commands ECS", 
+                ],
+                "timeRestore": false,
+                "title": "[Filebeat System] Sudo commands ECS",
                 "uiStateJSON": {
                     "P-3": {
                         "vis": {
                             "params": {
                                 "sort": {
-                                    "columnIndex": null, 
+                                    "columnIndex": null,
                                     "direction": null
                                 }
                             }
                         }
                     }
-                }, 
+                },
                 "version": 1
-            }, 
-            "id": "277876d0-fa2c-11e6-bbd3-29c986c96e5a-ecs", 
-            "type": "dashboard", 
+            },
+            "id": "277876d0-fa2c-11e6-bbd3-29c986c96e5a-ecs",
+            "type": "dashboard",
             "version": 6
         }
-    ], 
+    ],
     "version": "6.0.0-beta1-SNAPSHOT"
 }

--- a/filebeat/module/system/_meta/kibana/7/dashboard/Filebeat-new-users-and-groups.json
+++ b/filebeat/module/system/_meta/kibana/7/dashboard/Filebeat-new-users-and-groups.json
@@ -2,691 +2,691 @@
     "objects": [
         {
             "attributes": {
-                "description": "", 
+                "description": "",
                 "kibanaSavedObjectMeta": {
                     "searchSourceJSON": {
                         "filter": []
                     }
-                }, 
-                "savedSearchId": "8030c1b0-fa77-11e6-ae9b-81e5311e8cab-ecs", 
-                "title": "New users [Filebeat System] ECS", 
+                },
+                "savedSearchId": "8030c1b0-fa77-11e6-ae9b-81e5311e8cab-ecs",
+                "title": "New users [Filebeat System] ECS",
                 "uiStateJSON": {
                     "vis": {
                         "params": {
                             "sort": {
-                                "columnIndex": null, 
+                                "columnIndex": null,
                                 "direction": null
                             }
                         }
                     }
-                }, 
-                "version": 1, 
+                },
+                "version": 1,
                 "visState": {
                     "aggs": [
                         {
-                            "enabled": true, 
-                            "id": "1", 
-                            "params": {}, 
-                            "schema": "metric", 
+                            "enabled": true,
+                            "id": "1",
+                            "params": {},
+                            "schema": "metric",
                             "type": "count"
-                        }, 
+                        },
                         {
-                            "enabled": true, 
-                            "id": "2", 
+                            "enabled": true,
+                            "id": "2",
                             "params": {
-                                "customLabel": "Host", 
-                                "field": "host.hostname", 
-                                "order": "desc", 
-                                "orderBy": "1", 
+                                "customLabel": "Host",
+                                "field": "host.hostname",
+                                "order": "desc",
+                                "orderBy": "1",
                                 "size": 5
-                            }, 
-                            "schema": "bucket", 
+                            },
+                            "schema": "bucket",
                             "type": "terms"
-                        }, 
+                        },
                         {
-                            "enabled": true, 
-                            "id": "3", 
+                            "enabled": true,
+                            "id": "3",
                             "params": {
-                                "customLabel": "User", 
-                                "field": "system.auth.useradd.name", 
-                                "order": "desc", 
-                                "orderBy": "1", 
+                                "customLabel": "User",
+                                "field": "user.name",
+                                "order": "desc",
+                                "orderBy": "1",
                                 "size": 5
-                            }, 
-                            "schema": "bucket", 
+                            },
+                            "schema": "bucket",
                             "type": "terms"
-                        }, 
+                        },
                         {
-                            "enabled": true, 
-                            "id": "4", 
+                            "enabled": true,
+                            "id": "4",
                             "params": {
-                                "customLabel": "UID", 
-                                "field": "user.id", 
-                                "order": "desc", 
-                                "orderBy": "1", 
+                                "customLabel": "UID",
+                                "field": "user.id",
+                                "order": "desc",
+                                "orderBy": "1",
                                 "size": 5
-                            }, 
-                            "schema": "bucket", 
+                            },
+                            "schema": "bucket",
                             "type": "terms"
-                        }, 
+                        },
                         {
-                            "enabled": true, 
-                            "id": "5", 
+                            "enabled": true,
+                            "id": "5",
                             "params": {
-                                "customLabel": "GID", 
-                                "field": "system.auth.useradd.gid", 
-                                "order": "desc", 
-                                "orderBy": "1", 
+                                "customLabel": "GID",
+                                "field": "group.id",
+                                "order": "desc",
+                                "orderBy": "1",
                                 "size": 5
-                            }, 
-                            "schema": "bucket", 
+                            },
+                            "schema": "bucket",
                             "type": "terms"
-                        }, 
+                        },
                         {
-                            "enabled": true, 
-                            "id": "6", 
+                            "enabled": true,
+                            "id": "6",
                             "params": {
-                                "customLabel": "Home", 
-                                "field": "system.auth.useradd.home", 
-                                "order": "desc", 
-                                "orderBy": "1", 
+                                "customLabel": "Home",
+                                "field": "system.auth.useradd.home",
+                                "order": "desc",
+                                "orderBy": "1",
                                 "size": 5
-                            }, 
-                            "schema": "bucket", 
+                            },
+                            "schema": "bucket",
                             "type": "terms"
-                        }, 
+                        },
                         {
-                            "enabled": true, 
-                            "id": "7", 
+                            "enabled": true,
+                            "id": "7",
                             "params": {
-                                "customLabel": "Shell", 
-                                "field": "system.auth.useradd.shell", 
-                                "order": "desc", 
-                                "orderBy": "1", 
+                                "customLabel": "Shell",
+                                "field": "system.auth.useradd.shell",
+                                "order": "desc",
+                                "orderBy": "1",
                                 "size": 5
-                            }, 
-                            "schema": "bucket", 
+                            },
+                            "schema": "bucket",
                             "type": "terms"
                         }
-                    ], 
-                    "listeners": {}, 
+                    ],
+                    "listeners": {},
                     "params": {
-                        "perPage": 10, 
-                        "showMeticsAtAllLevels": false, 
-                        "showPartialRows": false, 
-                        "showTotal": false, 
+                        "perPage": 10,
+                        "showMeticsAtAllLevels": false,
+                        "showPartialRows": false,
+                        "showTotal": false,
                         "sort": {
-                            "columnIndex": null, 
+                            "columnIndex": null,
                             "direction": null
-                        }, 
+                        },
                         "totalFunc": "sum"
-                    }, 
-                    "title": "New users ECS", 
+                    },
+                    "title": "New users ECS",
                     "type": "table"
                 }
-            }, 
-            "id": "f398d2f0-fa77-11e6-ae9b-81e5311e8cab-ecs", 
-            "type": "visualization", 
+            },
+            "id": "f398d2f0-fa77-11e6-ae9b-81e5311e8cab-ecs",
+            "type": "visualization",
             "version": 2
-        }, 
+        },
         {
             "attributes": {
-                "description": "", 
+                "description": "",
                 "kibanaSavedObjectMeta": {
                     "searchSourceJSON": {
                         "filter": []
                     }
-                }, 
-                "savedSearchId": "8030c1b0-fa77-11e6-ae9b-81e5311e8cab-ecs", 
-                "title": "New users over time [Filebeat System] ECS", 
-                "uiStateJSON": {}, 
-                "version": 1, 
+                },
+                "savedSearchId": "8030c1b0-fa77-11e6-ae9b-81e5311e8cab-ecs",
+                "title": "New users over time [Filebeat System] ECS",
+                "uiStateJSON": {},
+                "version": 1,
                 "visState": {
                     "aggs": [
                         {
-                            "enabled": true, 
-                            "id": "1", 
-                            "params": {}, 
-                            "schema": "metric", 
+                            "enabled": true,
+                            "id": "1",
+                            "params": {},
+                            "schema": "metric",
                             "type": "count"
-                        }, 
+                        },
                         {
-                            "enabled": true, 
-                            "id": "2", 
+                            "enabled": true,
+                            "id": "2",
                             "params": {
-                                "customInterval": "2h", 
-                                "extended_bounds": {}, 
-                                "field": "@timestamp", 
-                                "interval": "auto", 
+                                "customInterval": "2h",
+                                "extended_bounds": {},
+                                "field": "@timestamp",
+                                "interval": "auto",
                                 "min_doc_count": 1
-                            }, 
-                            "schema": "segment", 
+                            },
+                            "schema": "segment",
                             "type": "date_histogram"
-                        }, 
+                        },
                         {
-                            "enabled": true, 
-                            "id": "3", 
+                            "enabled": true,
+                            "id": "3",
                             "params": {
-                                "field": "system.auth.useradd.name", 
-                                "order": "desc", 
-                                "orderBy": "1", 
+                                "field": "user.name",
+                                "order": "desc",
+                                "orderBy": "1",
                                 "size": 5
-                            }, 
-                            "schema": "group", 
+                            },
+                            "schema": "group",
                             "type": "terms"
                         }
-                    ], 
-                    "listeners": {}, 
+                    ],
+                    "listeners": {},
                     "params": {
-                        "addLegend": true, 
-                        "addTimeMarker": false, 
-                        "addTooltip": true, 
-                        "defaultYExtents": false, 
-                        "legendPosition": "bottom", 
-                        "mode": "stacked", 
-                        "scale": "linear", 
-                        "setYExtents": false, 
+                        "addLegend": true,
+                        "addTimeMarker": false,
+                        "addTooltip": true,
+                        "defaultYExtents": false,
+                        "legendPosition": "bottom",
+                        "mode": "stacked",
+                        "scale": "linear",
+                        "setYExtents": false,
                         "times": []
-                    }, 
-                    "title": "New users over time ECS", 
+                    },
+                    "title": "New users over time ECS",
                     "type": "histogram"
                 }
-            }, 
-            "id": "5dd15c00-fa78-11e6-ae9b-81e5311e8cab-ecs", 
-            "type": "visualization", 
+            },
+            "id": "5dd15c00-fa78-11e6-ae9b-81e5311e8cab-ecs",
+            "type": "visualization",
             "version": 2
-        }, 
+        },
         {
             "attributes": {
-                "description": "", 
+                "description": "",
                 "kibanaSavedObjectMeta": {
                     "searchSourceJSON": {
                         "filter": []
                     }
-                }, 
-                "savedSearchId": "8030c1b0-fa77-11e6-ae9b-81e5311e8cab-ecs", 
-                "title": "New users by shell [Filebeat System] ECS", 
+                },
+                "savedSearchId": "8030c1b0-fa77-11e6-ae9b-81e5311e8cab-ecs",
+                "title": "New users by shell [Filebeat System] ECS",
                 "uiStateJSON": {
                     "vis": {
                         "colors": {
-                            "/bin/bash": "#E24D42", 
-                            "/bin/false": "#508642", 
+                            "/bin/bash": "#E24D42",
+                            "/bin/false": "#508642",
                             "/sbin/nologin": "#7EB26D"
-                        }, 
+                        },
                         "legendOpen": true
                     }
-                }, 
-                "version": 1, 
+                },
+                "version": 1,
                 "visState": {
                     "aggs": [
                         {
-                            "enabled": true, 
-                            "id": "1", 
-                            "params": {}, 
-                            "schema": "metric", 
+                            "enabled": true,
+                            "id": "1",
+                            "params": {},
+                            "schema": "metric",
                             "type": "count"
-                        }, 
+                        },
                         {
-                            "enabled": true, 
-                            "id": "2", 
+                            "enabled": true,
+                            "id": "2",
                             "params": {
-                                "field": "system.auth.useradd.shell", 
-                                "order": "desc", 
-                                "orderBy": "1", 
+                                "field": "system.auth.useradd.shell",
+                                "order": "desc",
+                                "orderBy": "1",
                                 "size": 5
-                            }, 
-                            "schema": "segment", 
+                            },
+                            "schema": "segment",
                             "type": "terms"
-                        }, 
+                        },
                         {
-                            "enabled": true, 
-                            "id": "3", 
+                            "enabled": true,
+                            "id": "3",
                             "params": {
-                                "field": "system.auth.useradd.name", 
-                                "order": "desc", 
-                                "orderBy": "1", 
+                                "field": "user.name",
+                                "order": "desc",
+                                "orderBy": "1",
                                 "size": 5
-                            }, 
-                            "schema": "segment", 
+                            },
+                            "schema": "segment",
                             "type": "terms"
                         }
-                    ], 
-                    "listeners": {}, 
+                    ],
+                    "listeners": {},
                     "params": {
-                        "addLegend": true, 
-                        "addTooltip": true, 
-                        "isDonut": false, 
+                        "addLegend": true,
+                        "addTooltip": true,
+                        "isDonut": false,
                         "legendPosition": "right"
-                    }, 
-                    "title": "New users by shell ECS", 
+                    },
+                    "title": "New users by shell ECS",
                     "type": "pie"
                 }
-            }, 
-            "id": "e121b140-fa78-11e6-a1df-a78bd7504d38-ecs", 
-            "type": "visualization", 
+            },
+            "id": "e121b140-fa78-11e6-a1df-a78bd7504d38-ecs",
+            "type": "visualization",
             "version": 2
-        }, 
+        },
         {
             "attributes": {
-                "description": "", 
+                "description": "",
                 "kibanaSavedObjectMeta": {
                     "searchSourceJSON": {
                         "filter": []
                     }
-                }, 
-                "savedSearchId": "8030c1b0-fa77-11e6-ae9b-81e5311e8cab-ecs", 
-                "title": "New users by home directory [Filebeat System] ECS", 
+                },
+                "savedSearchId": "8030c1b0-fa77-11e6-ae9b-81e5311e8cab-ecs",
+                "title": "New users by home directory [Filebeat System] ECS",
                 "uiStateJSON": {
                     "vis": {
                         "colors": {
-                            "/bin/bash": "#E24D42", 
-                            "/bin/false": "#508642", 
-                            "/nonexistent": "#629E51", 
+                            "/bin/bash": "#E24D42",
+                            "/bin/false": "#508642",
+                            "/nonexistent": "#629E51",
                             "/sbin/nologin": "#7EB26D"
-                        }, 
+                        },
                         "legendOpen": true
                     }
-                }, 
-                "version": 1, 
+                },
+                "version": 1,
                 "visState": {
                     "aggs": [
                         {
-                            "enabled": true, 
-                            "id": "1", 
-                            "params": {}, 
-                            "schema": "metric", 
+                            "enabled": true,
+                            "id": "1",
+                            "params": {},
+                            "schema": "metric",
                             "type": "count"
-                        }, 
+                        },
                         {
-                            "enabled": true, 
-                            "id": "2", 
+                            "enabled": true,
+                            "id": "2",
                             "params": {
-                                "field": "system.auth.useradd.home", 
-                                "order": "desc", 
-                                "orderBy": "1", 
+                                "field": "system.auth.useradd.home",
+                                "order": "desc",
+                                "orderBy": "1",
                                 "size": 5
-                            }, 
-                            "schema": "segment", 
+                            },
+                            "schema": "segment",
                             "type": "terms"
-                        }, 
+                        },
                         {
-                            "enabled": true, 
-                            "id": "3", 
+                            "enabled": true,
+                            "id": "3",
                             "params": {
-                                "field": "system.auth.useradd.name", 
-                                "order": "desc", 
-                                "orderBy": "1", 
+                                "field": "user.name",
+                                "order": "desc",
+                                "orderBy": "1",
                                 "size": 5
-                            }, 
-                            "schema": "segment", 
+                            },
+                            "schema": "segment",
                             "type": "terms"
                         }
-                    ], 
-                    "listeners": {}, 
+                    ],
+                    "listeners": {},
                     "params": {
-                        "addLegend": true, 
-                        "addTooltip": true, 
-                        "isDonut": false, 
+                        "addLegend": true,
+                        "addTooltip": true,
+                        "isDonut": false,
                         "legendPosition": "right"
-                    }, 
-                    "title": "New users by home directory ECS", 
+                    },
+                    "title": "New users by home directory ECS",
                     "type": "pie"
                 }
-            }, 
-            "id": "d56ee420-fa79-11e6-a1df-a78bd7504d38-ecs", 
-            "type": "visualization", 
+            },
+            "id": "d56ee420-fa79-11e6-a1df-a78bd7504d38-ecs",
+            "type": "visualization",
             "version": 2
-        }, 
+        },
         {
             "attributes": {
-                "description": "", 
+                "description": "",
                 "kibanaSavedObjectMeta": {
                     "searchSourceJSON": {
                         "filter": []
                     }
-                }, 
-                "savedSearchId": "eb0039f0-fa7f-11e6-a1df-a78bd7504d38-ecs", 
-                "title": "New groups [Filebeat System] ECS", 
+                },
+                "savedSearchId": "eb0039f0-fa7f-11e6-a1df-a78bd7504d38-ecs",
+                "title": "New groups [Filebeat System] ECS",
                 "uiStateJSON": {
                     "vis": {
                         "params": {
                             "sort": {
-                                "columnIndex": null, 
+                                "columnIndex": null,
                                 "direction": null
                             }
                         }
                     }
-                }, 
-                "version": 1, 
+                },
+                "version": 1,
                 "visState": {
                     "aggs": [
                         {
-                            "enabled": true, 
-                            "id": "1", 
-                            "params": {}, 
-                            "schema": "metric", 
+                            "enabled": true,
+                            "id": "1",
+                            "params": {},
+                            "schema": "metric",
                             "type": "count"
-                        }, 
+                        },
                         {
-                            "enabled": true, 
-                            "id": "2", 
+                            "enabled": true,
+                            "id": "2",
                             "params": {
-                                "field": "system.auth.groupadd.name", 
-                                "order": "desc", 
-                                "orderBy": "1", 
+                                "field": "group.name",
+                                "order": "desc",
+                                "orderBy": "1",
                                 "size": 5
-                            }, 
-                            "schema": "bucket", 
+                            },
+                            "schema": "bucket",
                             "type": "terms"
-                        }, 
+                        },
                         {
-                            "enabled": true, 
-                            "id": "3", 
+                            "enabled": true,
+                            "id": "3",
                             "params": {
-                                "field": "group.id", 
-                                "order": "desc", 
-                                "orderBy": "1", 
+                                "field": "group.id",
+                                "order": "desc",
+                                "orderBy": "1",
                                 "size": 5
-                            }, 
-                            "schema": "bucket", 
+                            },
+                            "schema": "bucket",
                             "type": "terms"
                         }
-                    ], 
-                    "listeners": {}, 
+                    ],
+                    "listeners": {},
                     "params": {
-                        "perPage": 10, 
-                        "showMeticsAtAllLevels": false, 
-                        "showPartialRows": false, 
-                        "showTotal": false, 
+                        "perPage": 10,
+                        "showMeticsAtAllLevels": false,
+                        "showPartialRows": false,
+                        "showTotal": false,
                         "sort": {
-                            "columnIndex": null, 
+                            "columnIndex": null,
                             "direction": null
-                        }, 
+                        },
                         "totalFunc": "sum"
-                    }, 
-                    "title": "New groups ECS", 
+                    },
+                    "title": "New groups ECS",
                     "type": "table"
                 }
-            }, 
-            "id": "12667040-fa80-11e6-a1df-a78bd7504d38-ecs", 
-            "type": "visualization", 
+            },
+            "id": "12667040-fa80-11e6-a1df-a78bd7504d38-ecs",
+            "type": "visualization",
             "version": 2
-        }, 
+        },
         {
             "attributes": {
-                "description": "", 
+                "description": "",
                 "kibanaSavedObjectMeta": {
                     "searchSourceJSON": {
                         "filter": []
                     }
-                }, 
-                "savedSearchId": "eb0039f0-fa7f-11e6-a1df-a78bd7504d38-ecs", 
-                "title": "New groups over time [Filebeat System] ECS", 
-                "uiStateJSON": {}, 
-                "version": 1, 
+                },
+                "savedSearchId": "eb0039f0-fa7f-11e6-a1df-a78bd7504d38-ecs",
+                "title": "New groups over time [Filebeat System] ECS",
+                "uiStateJSON": {},
+                "version": 1,
                 "visState": {
                     "aggs": [
                         {
-                            "enabled": true, 
-                            "id": "1", 
-                            "params": {}, 
-                            "schema": "metric", 
+                            "enabled": true,
+                            "id": "1",
+                            "params": {},
+                            "schema": "metric",
                             "type": "count"
-                        }, 
+                        },
                         {
-                            "enabled": true, 
-                            "id": "2", 
+                            "enabled": true,
+                            "id": "2",
                             "params": {
-                                "customInterval": "2h", 
-                                "extended_bounds": {}, 
-                                "field": "@timestamp", 
-                                "interval": "auto", 
+                                "customInterval": "2h",
+                                "extended_bounds": {},
+                                "field": "@timestamp",
+                                "interval": "auto",
                                 "min_doc_count": 1
-                            }, 
-                            "schema": "segment", 
+                            },
+                            "schema": "segment",
                             "type": "date_histogram"
-                        }, 
+                        },
                         {
-                            "enabled": true, 
-                            "id": "3", 
+                            "enabled": true,
+                            "id": "3",
                             "params": {
-                                "field": "system.auth.groupadd.name", 
-                                "order": "desc", 
-                                "orderBy": "1", 
+                                "field": "group.name",
+                                "order": "desc",
+                                "orderBy": "1",
                                 "size": 5
-                            }, 
-                            "schema": "group", 
+                            },
+                            "schema": "group",
                             "type": "terms"
                         }
-                    ], 
-                    "listeners": {}, 
+                    ],
+                    "listeners": {},
                     "params": {
-                        "addLegend": true, 
-                        "addTimeMarker": false, 
-                        "addTooltip": true, 
-                        "defaultYExtents": false, 
-                        "legendPosition": "bottom", 
-                        "mode": "stacked", 
-                        "scale": "linear", 
-                        "setYExtents": false, 
+                        "addLegend": true,
+                        "addTimeMarker": false,
+                        "addTooltip": true,
+                        "defaultYExtents": false,
+                        "legendPosition": "bottom",
+                        "mode": "stacked",
+                        "scale": "linear",
+                        "setYExtents": false,
                         "times": []
-                    }, 
-                    "title": "New groups over time ECS", 
+                    },
+                    "title": "New groups over time ECS",
                     "type": "histogram"
                 }
-            }, 
-            "id": "346bb290-fa80-11e6-a1df-a78bd7504d38-ecs", 
-            "type": "visualization", 
+            },
+            "id": "346bb290-fa80-11e6-a1df-a78bd7504d38-ecs",
+            "type": "visualization",
             "version": 2
-        }, 
+        },
         {
             "attributes": {
-                "description": "", 
+                "description": "",
                 "kibanaSavedObjectMeta": {
                     "searchSourceJSON": {}
-                }, 
-                "title": "Dashboards [Filebeat System] ECS", 
-                "uiStateJSON": {}, 
-                "version": 1, 
+                },
+                "title": "Dashboards [Filebeat System] ECS",
+                "uiStateJSON": {},
+                "version": 1,
                 "visState": {
-                    "aggs": [], 
+                    "aggs": [],
                     "params": {
-                        "fontSize": 12, 
+                        "fontSize": 12,
                         "markdown": "[Syslog](#/dashboard/Filebeat-syslog-dashboard-ecs) | [Sudo commands](#/dashboard/277876d0-fa2c-11e6-bbd3-29c986c96e5a-ecs) | [SSH logins](#/dashboard/5517a150-f9ce-11e6-8115-a7c18106d86a-ecs) | [New users and groups](#/dashboard/0d3f2380-fa78-11e6-ae9b-81e5311e8cab-ecs)"
-                    }, 
-                    "title": "Dashboards [Filebeat System] ECS", 
+                    },
+                    "title": "Dashboards [Filebeat System] ECS",
                     "type": "markdown"
                 }
-            }, 
-            "id": "327417e0-8462-11e7-bab8-bd2f0fb42c54-ecs", 
-            "type": "visualization", 
+            },
+            "id": "327417e0-8462-11e7-bab8-bd2f0fb42c54-ecs",
+            "type": "visualization",
             "version": 1
-        }, 
+        },
         {
             "attributes": {
                 "columns": [
-                    "system.auth.useradd.name", 
-                    "user.id", 
-                    "system.auth.useradd.gid", 
-                    "system.auth.useradd.home", 
+                    "user.name",
+                    "user.id",
+                    "group.id",
+                    "system.auth.useradd.home",
                     "system.auth.useradd.shell"
-                ], 
-                "description": "", 
-                "hits": 0, 
+                ],
+                "description": "",
+                "hits": 0,
                 "kibanaSavedObjectMeta": {
                     "searchSourceJSON": {
-                        "filter": [], 
-                        "highlightAll": true, 
-                        "index": "filebeat-*", 
+                        "filter": [],
+                        "highlightAll": true,
+                        "index": "filebeat-*",
                         "query": {
                             "query_string": {
-                                "analyze_wildcard": true, 
+                                "analyze_wildcard": true,
                                 "query": "_exists_:system.auth.useradd"
                             }
                         }
                     }
-                }, 
+                },
                 "sort": [
-                    "@timestamp", 
+                    "@timestamp",
                     "desc"
-                ], 
-                "title": "useradd logs [Filebeat System] ECS", 
+                ],
+                "title": "useradd logs [Filebeat System] ECS",
                 "version": 1
-            }, 
-            "id": "8030c1b0-fa77-11e6-ae9b-81e5311e8cab-ecs", 
-            "type": "search", 
+            },
+            "id": "8030c1b0-fa77-11e6-ae9b-81e5311e8cab-ecs",
+            "type": "search",
             "version": 2
-        }, 
+        },
         {
             "attributes": {
                 "columns": [
-                    "system.auth.groupadd.name", 
+                    "group.name",
                     "group.id"
-                ], 
-                "description": "", 
-                "hits": 0, 
+                ],
+                "description": "",
+                "hits": 0,
                 "kibanaSavedObjectMeta": {
                     "searchSourceJSON": {
-                        "filter": [], 
-                        "highlightAll": true, 
-                        "index": "filebeat-*", 
+                        "filter": [],
+                        "highlightAll": true,
+                        "index": "filebeat-*",
                         "query": {
                             "query_string": {
-                                "analyze_wildcard": true, 
+                                "analyze_wildcard": true,
                                 "query": "_exists_:system.auth.groupadd"
                             }
                         }
                     }
-                }, 
+                },
                 "sort": [
-                    "@timestamp", 
+                    "@timestamp",
                     "desc"
-                ], 
-                "title": "groupadd logs [Filebeat System] ECS", 
+                ],
+                "title": "groupadd logs [Filebeat System] ECS",
                 "version": 1
-            }, 
-            "id": "eb0039f0-fa7f-11e6-a1df-a78bd7504d38-ecs", 
-            "type": "search", 
+            },
+            "id": "eb0039f0-fa7f-11e6-a1df-a78bd7504d38-ecs",
+            "type": "search",
             "version": 2
-        }, 
+        },
         {
             "attributes": {
-                "description": "New users and groups dashboard for the System module in Filebeat", 
-                "hits": 0, 
+                "description": "New users and groups dashboard for the System module in Filebeat",
+                "hits": 0,
                 "kibanaSavedObjectMeta": {
                     "searchSourceJSON": {
-                        "filter": [], 
-                        "highlightAll": true, 
+                        "filter": [],
+                        "highlightAll": true,
                         "query": {
-                            "language": "lucene", 
+                            "language": "lucene",
                             "query": {
                                 "query_string": {
-                                    "analyze_wildcard": true, 
+                                    "analyze_wildcard": true,
                                     "query": "*"
                                 }
                             }
-                        }, 
+                        },
                         "version": true
                     }
-                }, 
+                },
                 "optionsJSON": {
                     "darkTheme": false
-                }, 
+                },
                 "panelsJSON": [
                     {
-                        "col": 1, 
-                        "id": "f398d2f0-fa77-11e6-ae9b-81e5311e8cab-ecs", 
-                        "panelIndex": 1, 
-                        "row": 2, 
-                        "size_x": 6, 
-                        "size_y": 3, 
+                        "col": 1,
+                        "id": "f398d2f0-fa77-11e6-ae9b-81e5311e8cab-ecs",
+                        "panelIndex": 1,
+                        "row": 2,
+                        "size_x": 6,
+                        "size_y": 3,
                         "type": "visualization"
-                    }, 
+                    },
                     {
-                        "col": 7, 
-                        "id": "5dd15c00-fa78-11e6-ae9b-81e5311e8cab-ecs", 
-                        "panelIndex": 2, 
-                        "row": 2, 
-                        "size_x": 6, 
-                        "size_y": 3, 
+                        "col": 7,
+                        "id": "5dd15c00-fa78-11e6-ae9b-81e5311e8cab-ecs",
+                        "panelIndex": 2,
+                        "row": 2,
+                        "size_x": 6,
+                        "size_y": 3,
                         "type": "visualization"
-                    }, 
+                    },
                     {
-                        "col": 1, 
-                        "id": "e121b140-fa78-11e6-a1df-a78bd7504d38-ecs", 
-                        "panelIndex": 3, 
-                        "row": 5, 
-                        "size_x": 6, 
-                        "size_y": 3, 
+                        "col": 1,
+                        "id": "e121b140-fa78-11e6-a1df-a78bd7504d38-ecs",
+                        "panelIndex": 3,
+                        "row": 5,
+                        "size_x": 6,
+                        "size_y": 3,
                         "type": "visualization"
-                    }, 
+                    },
                     {
-                        "col": 7, 
-                        "id": "d56ee420-fa79-11e6-a1df-a78bd7504d38-ecs", 
-                        "panelIndex": 4, 
-                        "row": 5, 
-                        "size_x": 6, 
-                        "size_y": 3, 
+                        "col": 7,
+                        "id": "d56ee420-fa79-11e6-a1df-a78bd7504d38-ecs",
+                        "panelIndex": 4,
+                        "row": 5,
+                        "size_x": 6,
+                        "size_y": 3,
                         "type": "visualization"
-                    }, 
+                    },
                     {
-                        "col": 1, 
-                        "id": "12667040-fa80-11e6-a1df-a78bd7504d38-ecs", 
-                        "panelIndex": 5, 
-                        "row": 8, 
-                        "size_x": 6, 
-                        "size_y": 3, 
+                        "col": 1,
+                        "id": "12667040-fa80-11e6-a1df-a78bd7504d38-ecs",
+                        "panelIndex": 5,
+                        "row": 8,
+                        "size_x": 6,
+                        "size_y": 3,
                         "type": "visualization"
-                    }, 
+                    },
                     {
-                        "col": 7, 
-                        "id": "346bb290-fa80-11e6-a1df-a78bd7504d38-ecs", 
-                        "panelIndex": 6, 
-                        "row": 8, 
-                        "size_x": 6, 
-                        "size_y": 3, 
+                        "col": 7,
+                        "id": "346bb290-fa80-11e6-a1df-a78bd7504d38-ecs",
+                        "panelIndex": 6,
+                        "row": 8,
+                        "size_x": 6,
+                        "size_y": 3,
                         "type": "visualization"
-                    }, 
+                    },
                     {
-                        "col": 1, 
-                        "id": "327417e0-8462-11e7-bab8-bd2f0fb42c54-ecs", 
-                        "panelIndex": 7, 
-                        "row": 1, 
-                        "size_x": 12, 
-                        "size_y": 1, 
+                        "col": 1,
+                        "id": "327417e0-8462-11e7-bab8-bd2f0fb42c54-ecs",
+                        "panelIndex": 7,
+                        "row": 1,
+                        "size_x": 12,
+                        "size_y": 1,
                         "type": "visualization"
                     }
-                ], 
-                "timeRestore": false, 
-                "title": "[Filebeat System] New users and groups ECS", 
+                ],
+                "timeRestore": false,
+                "title": "[Filebeat System] New users and groups ECS",
                 "uiStateJSON": {
                     "P-1": {
                         "vis": {
                             "params": {
                                 "sort": {
-                                    "columnIndex": null, 
+                                    "columnIndex": null,
                                     "direction": null
                                 }
                             }
                         }
-                    }, 
+                    },
                     "P-5": {
                         "vis": {
                             "params": {
                                 "sort": {
-                                    "columnIndex": null, 
+                                    "columnIndex": null,
                                     "direction": null
                                 }
                             }
                         }
                     }
-                }, 
+                },
                 "version": 1
-            }, 
-            "id": "0d3f2380-fa78-11e6-ae9b-81e5311e8cab-ecs", 
-            "type": "dashboard", 
+            },
+            "id": "0d3f2380-fa78-11e6-ae9b-81e5311e8cab-ecs",
+            "type": "dashboard",
             "version": 6
         }
-    ], 
+    ],
     "version": "6.0.0-beta1-SNAPSHOT"
 }

--- a/filebeat/module/system/_meta/kibana/7/dashboard/Filebeat-ssh-login-attempts.json
+++ b/filebeat/module/system/_meta/kibana/7/dashboard/Filebeat-ssh-login-attempts.json
@@ -2,489 +2,489 @@
     "objects": [
         {
             "attributes": {
-                "description": "", 
+                "description": "",
                 "kibanaSavedObjectMeta": {
                     "searchSourceJSON": {
-                        "filter": [], 
-                        "highlightAll": true, 
-                        "index": "filebeat-*", 
+                        "filter": [],
+                        "highlightAll": true,
+                        "index": "filebeat-*",
                         "query": {
                             "query_string": {
-                                "analyze_wildcard": true, 
+                                "analyze_wildcard": true,
                                 "query": "event.action:Accepted"
                             }
                         }
                     }
-                }, 
-                "title": "Successful SSH logins [Filebeat System] ECS", 
+                },
+                "title": "Successful SSH logins [Filebeat System] ECS",
                 "uiStateJSON": {
                     "vis": {
                         "colors": {
-                            "Accepted": "#3F6833", 
-                            "Failed": "#F9934E", 
-                            "Invalid": "#447EBC", 
-                            "password": "#BF1B00", 
+                            "Accepted": "#3F6833",
+                            "Failed": "#F9934E",
+                            "Invalid": "#447EBC",
+                            "password": "#BF1B00",
                             "publickey": "#629E51"
                         }
                     }
-                }, 
-                "version": 1, 
+                },
+                "version": 1,
                 "visState": {
                     "aggs": [
                         {
-                            "enabled": true, 
-                            "id": "1", 
-                            "params": {}, 
-                            "schema": "metric", 
+                            "enabled": true,
+                            "id": "1",
+                            "params": {},
+                            "schema": "metric",
                             "type": "count"
-                        }, 
+                        },
                         {
-                            "enabled": true, 
-                            "id": "2", 
+                            "enabled": true,
+                            "id": "2",
                             "params": {
-                                "customInterval": "2h", 
-                                "extended_bounds": {}, 
-                                "field": "@timestamp", 
-                                "interval": "auto", 
+                                "customInterval": "2h",
+                                "extended_bounds": {},
+                                "field": "@timestamp",
+                                "interval": "auto",
                                 "min_doc_count": 1
-                            }, 
-                            "schema": "segment", 
+                            },
+                            "schema": "segment",
                             "type": "date_histogram"
-                        }, 
+                        },
                         {
-                            "enabled": true, 
-                            "id": "3", 
+                            "enabled": true,
+                            "id": "3",
                             "params": {
-                                "field": "system.auth.ssh.method", 
-                                "order": "desc", 
-                                "orderBy": "1", 
+                                "field": "system.auth.ssh.method",
+                                "order": "desc",
+                                "orderBy": "1",
                                 "size": 5
-                            }, 
-                            "schema": "group", 
+                            },
+                            "schema": "group",
                             "type": "terms"
                         }
-                    ], 
-                    "listeners": {}, 
+                    ],
+                    "listeners": {},
                     "params": {
-                        "addLegend": true, 
-                        "addTimeMarker": false, 
-                        "addTooltip": true, 
-                        "defaultYExtents": false, 
-                        "legendPosition": "right", 
-                        "mode": "stacked", 
-                        "scale": "linear", 
-                        "setYExtents": false, 
+                        "addLegend": true,
+                        "addTimeMarker": false,
+                        "addTooltip": true,
+                        "defaultYExtents": false,
+                        "legendPosition": "right",
+                        "mode": "stacked",
+                        "scale": "linear",
+                        "setYExtents": false,
                         "times": []
-                    }, 
-                    "title": "Successful SSH logins ECS", 
+                    },
+                    "title": "Successful SSH logins ECS",
                     "type": "histogram"
                 }
-            }, 
-            "id": "d16bb400-f9cc-11e6-8115-a7c18106d86a-ecs", 
-            "type": "visualization", 
+            },
+            "id": "d16bb400-f9cc-11e6-8115-a7c18106d86a-ecs",
+            "type": "visualization",
             "version": 2
-        }, 
+        },
         {
             "attributes": {
-                "description": "", 
+                "description": "",
                 "kibanaSavedObjectMeta": {
                     "searchSourceJSON": {
-                        "filter": [], 
-                        "highlightAll": true, 
+                        "filter": [],
+                        "highlightAll": true,
                         "index": "filebeat-*"
                     }
-                }, 
-                "title": "SSH login attempts [Filebeat System] ECS", 
+                },
+                "title": "SSH login attempts [Filebeat System] ECS",
                 "uiStateJSON": {
                     "vis": {
                         "colors": {
-                            "Accepted": "#3F6833", 
-                            "Failed": "#F9934E", 
+                            "Accepted": "#3F6833",
+                            "Failed": "#F9934E",
                             "Invalid": "#447EBC"
                         }
                     }
-                }, 
-                "version": 1, 
+                },
+                "version": 1,
                 "visState": {
                     "aggs": [
                         {
-                            "enabled": true, 
-                            "id": "1", 
-                            "params": {}, 
-                            "schema": "metric", 
+                            "enabled": true,
+                            "id": "1",
+                            "params": {},
+                            "schema": "metric",
                             "type": "count"
-                        }, 
+                        },
                         {
-                            "enabled": true, 
-                            "id": "2", 
+                            "enabled": true,
+                            "id": "2",
                             "params": {
-                                "customInterval": "2h", 
-                                "extended_bounds": {}, 
-                                "field": "@timestamp", 
-                                "interval": "auto", 
+                                "customInterval": "2h",
+                                "extended_bounds": {},
+                                "field": "@timestamp",
+                                "interval": "auto",
                                 "min_doc_count": 1
-                            }, 
-                            "schema": "segment", 
+                            },
+                            "schema": "segment",
                             "type": "date_histogram"
-                        }, 
+                        },
                         {
-                            "enabled": true, 
-                            "id": "3", 
+                            "enabled": true,
+                            "id": "3",
                             "params": {
-                                "field": "event.action", 
-                                "order": "desc", 
-                                "orderBy": "1", 
+                                "field": "event.action",
+                                "order": "desc",
+                                "orderBy": "1",
                                 "size": 5
-                            }, 
-                            "schema": "group", 
+                            },
+                            "schema": "group",
                             "type": "terms"
                         }
-                    ], 
-                    "listeners": {}, 
+                    ],
+                    "listeners": {},
                     "params": {
-                        "addLegend": true, 
-                        "addTimeMarker": false, 
-                        "addTooltip": true, 
-                        "defaultYExtents": false, 
-                        "legendPosition": "right", 
-                        "mode": "stacked", 
-                        "scale": "linear", 
-                        "setYExtents": false, 
+                        "addLegend": true,
+                        "addTimeMarker": false,
+                        "addTooltip": true,
+                        "defaultYExtents": false,
+                        "legendPosition": "right",
+                        "mode": "stacked",
+                        "scale": "linear",
+                        "setYExtents": false,
                         "times": []
-                    }, 
-                    "title": "SSH login attempts ECS", 
+                    },
+                    "title": "SSH login attempts ECS",
                     "type": "histogram"
                 }
-            }, 
-            "id": "78b74f30-f9cd-11e6-8115-a7c18106d86a-ecs", 
-            "type": "visualization", 
+            },
+            "id": "78b74f30-f9cd-11e6-8115-a7c18106d86a-ecs",
+            "type": "visualization",
             "version": 2
-        }, 
+        },
         {
             "attributes": {
-                "description": "", 
+                "description": "",
                 "kibanaSavedObjectMeta": {
                     "searchSourceJSON": {
-                        "filter": [], 
-                        "highlightAll": true, 
-                        "index": "filebeat-*", 
+                        "filter": [],
+                        "highlightAll": true,
+                        "index": "filebeat-*",
                         "query": {
                             "query_string": {
-                                "analyze_wildcard": true, 
+                                "analyze_wildcard": true,
                                 "query": "event.action:Failed OR event.action:Invalid"
                             }
                         }
                     }
-                }, 
-                "title": "SSH users of failed login attempts [Filebeat System] ECS", 
-                "uiStateJSON": {}, 
-                "version": 1, 
+                },
+                "title": "SSH users of failed login attempts [Filebeat System] ECS",
+                "uiStateJSON": {},
+                "version": 1,
                 "visState": {
                     "aggs": [
                         {
-                            "enabled": true, 
-                            "id": "1", 
-                            "params": {}, 
-                            "schema": "metric", 
+                            "enabled": true,
+                            "id": "1",
+                            "params": {},
+                            "schema": "metric",
                             "type": "count"
-                        }, 
+                        },
                         {
-                            "enabled": true, 
-                            "id": "2", 
+                            "enabled": true,
+                            "id": "2",
                             "params": {
-                                "field": "system.auth.user", 
-                                "order": "desc", 
-                                "orderBy": "1", 
+                                "field": "user.name",
+                                "order": "desc",
+                                "orderBy": "1",
                                 "size": 50
-                            }, 
-                            "schema": "segment", 
+                            },
+                            "schema": "segment",
                             "type": "terms"
                         }
-                    ], 
-                    "listeners": {}, 
+                    ],
+                    "listeners": {},
                     "params": {
-                        "maxFontSize": 72, 
-                        "minFontSize": 18, 
-                        "orientation": "single", 
+                        "maxFontSize": 72,
+                        "minFontSize": 18,
+                        "orientation": "single",
                         "scale": "linear"
-                    }, 
-                    "title": "SSH users of failed login attempts ECS", 
+                    },
+                    "title": "SSH users of failed login attempts ECS",
                     "type": "tagcloud"
                 }
-            }, 
-            "id": "341ffe70-f9ce-11e6-8115-a7c18106d86a-ecs", 
-            "type": "visualization", 
+            },
+            "id": "341ffe70-f9ce-11e6-8115-a7c18106d86a-ecs",
+            "type": "visualization",
             "version": 2
-        }, 
+        },
         {
             "attributes": {
-                "description": "", 
+                "description": "",
                 "kibanaSavedObjectMeta": {
                     "searchSourceJSON": {
-                        "filter": [], 
-                        "highlightAll": true, 
-                        "index": "filebeat-*", 
+                        "filter": [],
+                        "highlightAll": true,
+                        "index": "filebeat-*",
                         "query": {
                             "query_string": {
-                                "analyze_wildcard": true, 
+                                "analyze_wildcard": true,
                                 "query": "event.action:Failed OR event.action:Invalid"
                             }
                         }
                     }
-                }, 
-                "title": "SSH failed login attempts source locations [Filebeat System] ECS", 
+                },
+                "title": "SSH failed login attempts source locations [Filebeat System] ECS",
                 "uiStateJSON": {
                     "mapCenter": [
-                        17.602139123350838, 
+                        17.602139123350838,
                         69.697265625
-                    ], 
+                    ],
                     "mapZoom": 2
-                }, 
-                "version": 1, 
+                },
+                "version": 1,
                 "visState": {
                     "aggs": [
                         {
-                            "enabled": true, 
-                            "id": "1", 
-                            "params": {}, 
-                            "schema": "metric", 
+                            "enabled": true,
+                            "id": "1",
+                            "params": {},
+                            "schema": "metric",
                             "type": "count"
-                        }, 
+                        },
                         {
-                            "enabled": true, 
-                            "id": "2", 
+                            "enabled": true,
+                            "id": "2",
                             "params": {
-                                "autoPrecision": true, 
-                                "field": "source.geo.location", 
+                                "autoPrecision": true,
+                                "field": "source.geo.location",
                                 "precision": 2
-                            }, 
-                            "schema": "segment", 
+                            },
+                            "schema": "segment",
                             "type": "geohash_grid"
                         }
-                    ], 
-                    "listeners": {}, 
+                    ],
+                    "listeners": {},
                     "params": {
-                        "addTooltip": true, 
-                        "heatBlur": 15, 
-                        "heatMaxZoom": 16, 
-                        "heatMinOpacity": 0.1, 
-                        "heatNormalizeData": true, 
-                        "heatRadius": 25, 
-                        "isDesaturated": true, 
-                        "legendPosition": "bottomright", 
+                        "addTooltip": true,
+                        "heatBlur": 15,
+                        "heatMaxZoom": 16,
+                        "heatMinOpacity": 0.1,
+                        "heatNormalizeData": true,
+                        "heatRadius": 25,
+                        "isDesaturated": true,
+                        "legendPosition": "bottomright",
                         "mapCenter": [
-                            15, 
+                            15,
                             5
-                        ], 
-                        "mapType": "Shaded Circle Markers", 
-                        "mapZoom": 2, 
+                        ],
+                        "mapType": "Shaded Circle Markers",
+                        "mapZoom": 2,
                         "wms": {
-                            "enabled": false, 
+                            "enabled": false,
                             "options": {
-                                "attribution": "Maps provided by USGS", 
-                                "format": "image/png", 
-                                "layers": "0", 
-                                "styles": "", 
-                                "transparent": true, 
+                                "attribution": "Maps provided by USGS",
+                                "format": "image/png",
+                                "layers": "0",
+                                "styles": "",
+                                "transparent": true,
                                 "version": "1.3.0"
-                            }, 
+                            },
                             "url": "https://basemap.nationalmap.gov/arcgis/services/USGSTopo/MapServer/WMSServer"
                         }
-                    }, 
-                    "title": "SSH failed login attempts source locations ECS", 
+                    },
+                    "title": "SSH failed login attempts source locations ECS",
                     "type": "tile_map"
                 }
-            }, 
-            "id": "3cec3eb0-f9d3-11e6-8a3e-2b904044ea1d-ecs", 
-            "type": "visualization", 
+            },
+            "id": "3cec3eb0-f9d3-11e6-8a3e-2b904044ea1d-ecs",
+            "type": "visualization",
             "version": 2
-        }, 
+        },
         {
             "attributes": {
                 "columns": [
-                    "event.action", 
-                    "system.auth.ssh.method", 
-                    "system.auth.user", 
-                    "source.ip", 
+                    "event.action",
+                    "system.auth.ssh.method",
+                    "user.name",
+                    "source.ip",
                     "source.geo.country_iso_code"
-                ], 
-                "description": "", 
-                "hits": 0, 
+                ],
+                "description": "",
+                "hits": 0,
                 "kibanaSavedObjectMeta": {
                     "searchSourceJSON": {
-                        "filter": [], 
-                        "highlightAll": true, 
-                        "index": "filebeat-*", 
+                        "filter": [],
+                        "highlightAll": true,
+                        "index": "filebeat-*",
                         "query": {
                             "query_string": {
-                                "analyze_wildcard": true, 
+                                "analyze_wildcard": true,
                                 "query": "event.dataset:system.auth AND _exists_:event.action"
                             }
                         }
                     }
-                }, 
+                },
                 "sort": [
-                    "@timestamp", 
+                    "@timestamp",
                     "desc"
-                ], 
-                "title": "SSH login attempts [Filebeat System] ECS", 
+                ],
+                "title": "SSH login attempts [Filebeat System] ECS",
                 "version": 1
-            }, 
-            "id": "62439dc0-f9c9-11e6-a747-6121780e0414-ecs", 
-            "type": "search", 
+            },
+            "id": "62439dc0-f9c9-11e6-a747-6121780e0414-ecs",
+            "type": "search",
             "version": 2
-        }, 
+        },
         {
             "attributes": {
-                "description": "", 
+                "description": "",
                 "kibanaSavedObjectMeta": {
                     "searchSourceJSON": {}
-                }, 
-                "title": "Dashboards [Filebeat System] ECS", 
-                "uiStateJSON": {}, 
-                "version": 1, 
+                },
+                "title": "Dashboards [Filebeat System] ECS",
+                "uiStateJSON": {},
+                "version": 1,
                 "visState": {
-                    "aggs": [], 
+                    "aggs": [],
                     "params": {
-                        "fontSize": 12, 
+                        "fontSize": 12,
                         "markdown": "[Syslog](#/dashboard/Filebeat-syslog-dashboard-ecs) | [Sudo commands](#/dashboard/277876d0-fa2c-11e6-bbd3-29c986c96e5a-ecs) | [SSH logins](#/dashboard/5517a150-f9ce-11e6-8115-a7c18106d86a-ecs) | [New users and groups](#/dashboard/0d3f2380-fa78-11e6-ae9b-81e5311e8cab-ecs)"
-                    }, 
-                    "title": "Dashboards [Filebeat System] ECS", 
+                    },
+                    "title": "Dashboards [Filebeat System] ECS",
                     "type": "markdown"
                 }
-            }, 
-            "id": "327417e0-8462-11e7-bab8-bd2f0fb42c54-ecs", 
-            "type": "visualization", 
+            },
+            "id": "327417e0-8462-11e7-bab8-bd2f0fb42c54-ecs",
+            "type": "visualization",
             "version": 1
-        }, 
+        },
         {
             "attributes": {
-                "description": "SSH dashboard for the System module in Filebeat", 
-                "hits": 0, 
+                "description": "SSH dashboard for the System module in Filebeat",
+                "hits": 0,
                 "kibanaSavedObjectMeta": {
                     "searchSourceJSON": {
-                        "filter": [], 
-                        "highlightAll": true, 
+                        "filter": [],
+                        "highlightAll": true,
                         "query": {
-                            "language": "lucene", 
+                            "language": "lucene",
                             "query": {
                                 "query_string": {
-                                    "analyze_wildcard": true, 
+                                    "analyze_wildcard": true,
                                     "query": "*"
                                 }
                             }
-                        }, 
+                        },
                         "version": true
                     }
-                }, 
+                },
                 "optionsJSON": {
                     "darkTheme": false
-                }, 
+                },
                 "panelsJSON": [
                     {
-                        "col": 1, 
-                        "id": "d16bb400-f9cc-11e6-8115-a7c18106d86a-ecs", 
-                        "panelIndex": 1, 
-                        "row": 5, 
-                        "size_x": 12, 
-                        "size_y": 3, 
+                        "col": 1,
+                        "id": "d16bb400-f9cc-11e6-8115-a7c18106d86a-ecs",
+                        "panelIndex": 1,
+                        "row": 5,
+                        "size_x": 12,
+                        "size_y": 3,
                         "type": "visualization"
-                    }, 
+                    },
                     {
-                        "col": 1, 
-                        "id": "78b74f30-f9cd-11e6-8115-a7c18106d86a-ecs", 
-                        "panelIndex": 2, 
-                        "row": 2, 
-                        "size_x": 12, 
-                        "size_y": 3, 
+                        "col": 1,
+                        "id": "78b74f30-f9cd-11e6-8115-a7c18106d86a-ecs",
+                        "panelIndex": 2,
+                        "row": 2,
+                        "size_x": 12,
+                        "size_y": 3,
                         "type": "visualization"
-                    }, 
+                    },
                     {
-                        "col": 1, 
-                        "id": "341ffe70-f9ce-11e6-8115-a7c18106d86a-ecs", 
-                        "panelIndex": 3, 
-                        "row": 8, 
-                        "size_x": 6, 
-                        "size_y": 4, 
+                        "col": 1,
+                        "id": "341ffe70-f9ce-11e6-8115-a7c18106d86a-ecs",
+                        "panelIndex": 3,
+                        "row": 8,
+                        "size_x": 6,
+                        "size_y": 4,
                         "type": "visualization"
-                    }, 
+                    },
                     {
-                        "col": 7, 
-                        "id": "3cec3eb0-f9d3-11e6-8a3e-2b904044ea1d-ecs", 
-                        "panelIndex": 4, 
-                        "row": 8, 
-                        "size_x": 6, 
-                        "size_y": 4, 
+                        "col": 7,
+                        "id": "3cec3eb0-f9d3-11e6-8a3e-2b904044ea1d-ecs",
+                        "panelIndex": 4,
+                        "row": 8,
+                        "size_x": 6,
+                        "size_y": 4,
                         "type": "visualization"
-                    }, 
+                    },
                     {
-                        "col": 1, 
+                        "col": 1,
                         "columns": [
-                            "event.action", 
-                            "system.auth.ssh.method", 
-                            "system.auth.user", 
-                            "source.ip", 
+                            "event.action",
+                            "system.auth.ssh.method",
+                            "user.name",
+                            "source.ip",
                             "source.geo.country_iso_code"
-                        ], 
-                        "id": "62439dc0-f9c9-11e6-a747-6121780e0414-ecs", 
-                        "panelIndex": 5, 
-                        "row": 12, 
-                        "size_x": 12, 
-                        "size_y": 3, 
+                        ],
+                        "id": "62439dc0-f9c9-11e6-a747-6121780e0414-ecs",
+                        "panelIndex": 5,
+                        "row": 12,
+                        "size_x": 12,
+                        "size_y": 3,
                         "sort": [
-                            "@timestamp", 
+                            "@timestamp",
                             "desc"
-                        ], 
+                        ],
                         "type": "search"
-                    }, 
+                    },
                     {
-                        "col": 1, 
-                        "id": "327417e0-8462-11e7-bab8-bd2f0fb42c54-ecs", 
-                        "panelIndex": 6, 
-                        "row": 1, 
-                        "size_x": 12, 
-                        "size_y": 1, 
+                        "col": 1,
+                        "id": "327417e0-8462-11e7-bab8-bd2f0fb42c54-ecs",
+                        "panelIndex": 6,
+                        "row": 1,
+                        "size_x": 12,
+                        "size_y": 1,
                         "type": "visualization"
                     }
-                ], 
-                "timeRestore": false, 
-                "title": "[Filebeat System] SSH login attempts ECS", 
+                ],
+                "timeRestore": false,
+                "title": "[Filebeat System] SSH login attempts ECS",
                 "uiStateJSON": {
                     "P-4": {
                         "mapBounds": {
                             "bottom_right": {
-                                "lat": 10.31491928581316, 
+                                "lat": 10.31491928581316,
                                 "lon": 74.53125
-                            }, 
+                            },
                             "top_left": {
-                                "lat": 60.50052541051131, 
+                                "lat": 60.50052541051131,
                                 "lon": -27.94921875
                             }
-                        }, 
+                        },
                         "mapCenter": [
-                            39.774769485295465, 
+                            39.774769485295465,
                             23.203125
-                        ], 
+                        ],
                         "mapCollar": {
                             "bottom_right": {
-                                "lat": -14.777884999999998, 
+                                "lat": -14.777884999999998,
                                 "lon": 125.771485
-                            }, 
+                            },
                             "top_left": {
-                                "lat": 85.593335, 
+                                "lat": 85.593335,
                                 "lon": -79.189455
-                            }, 
+                            },
                             "zoom": 3
-                        }, 
+                        },
                         "mapZoom": 3
                     }
-                }, 
+                },
                 "version": 1
-            }, 
-            "id": "5517a150-f9ce-11e6-8115-a7c18106d86a-ecs", 
-            "type": "dashboard", 
+            },
+            "id": "5517a150-f9ce-11e6-8115-a7c18106d86a-ecs",
+            "type": "dashboard",
             "version": 7
         }
-    ], 
+    ],
     "version": "6.0.0-beta1-SNAPSHOT"
 }

--- a/libbeat/docs/field-name-changes.asciidoc
+++ b/libbeat/docs/field-name-changes.asciidoc
@@ -292,7 +292,9 @@
 |`suricata.eve.src_port`            |`source.port`
 |`suricata.eve.timestamp`            |`@timestamp`
 |`system.auth.groupadd.gid`            |`group.id`
+|`system.auth.groupadd.name`            |`group.name`
 |`system.auth.hostname`            |`host.hostname`
+|`system.auth.message`            |`message`
 |`system.auth.pid`            |`process.pid`
 |`system.auth.program`            |`process.name`
 |`system.auth.ssh.geoip.city_name`            |`source.geo.city_name`
@@ -303,8 +305,11 @@
 |`system.auth.ssh.geoip.region_name`            |`source.geo.region_name`
 |`system.auth.ssh.ip`            |`source.ip`
 |`system.auth.ssh.port`            |`source.port`
+|`system.auth.timestamp`            |`@timestamp`
+|`system.auth.user`            |`user.name`
+|`system.auth.useradd.gid`            |`group.id`
+|`system.auth.useradd.name`            |`user.name`
 |`system.auth.useradd.uid`            |`user.id`
-|`system.auth.useradd.user`            |`user.name`
 |`system.syslog.hostname`            |`host.hostname`
 |`system.syslog.message`            |`message`
 |`system.syslog.pid`            |`process.pid`


### PR DESCRIPTION
Backport of PR #11545 to 7.0 branch.

Had conflicts in dashboards, where master is now on `language:kuery`
and 7.0 is on `language:lucene`. I've ensured 7.0 stayed on `language:lucene`.

Original message:

* This adds all missing migrated fields for the system module to ecs-migration.yml
* The breaking changes doc has been updated accordingly with script/renamed_fields.py
* The corresponding dashboards for the system module have been updated manually (sorry for all the whitespace diff)