### PR TITLE
Cherry-pick #11549 to 7.0: Fix issue 11543 when key 'log' does not exist

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -42,6 +42,8 @@ https://github.com/elastic/beats/compare/v7.0.0-rc1...master[Check the HEAD diff
 *Filebeat*
 
 - Don't apply multiline rules in Logstash json logs. {pull}11346[11346]
+- Fix coredns image in docs.asciidoc for docs build. {pull}11460[11460] {pull}11461[11461]
+- Fix panic in add_kubernetes_metadata processor when key `log` does not exist. {issue}11543[11543] {pull}11549[11549]
 
 *Heartbeat*
 

--- a/filebeat/processor/add_kubernetes_metadata/matchers.go
+++ b/filebeat/processor/add_kubernetes_metadata/matchers.go
@@ -77,7 +77,8 @@ const containerIdLen = 64
 const podUIDPos = 5
 
 func (f *LogPathMatcher) MetadataIndex(event common.MapStr) string {
-	if value, ok := event["log"].(common.MapStr)["file"].(common.MapStr)["path"]; ok {
+	value, err := event.GetValue("log.file.path")
+	if err == nil {
 		source := value.(string)
 		logp.Debug("kubernetes", "Incoming log.file.path value: %s", source)
 


### PR DESCRIPTION
Cherry-pick of PR #11549 to 7.0 branch. Original message: 

Fix issue 11543 when key 'log' does not exist