### PR TITLE
Update github.com/elastic/go-sysinfo: Improve container detection

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -155,6 +155,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix a typo in libbeat/outputs/transport/client.go by updating `c.conn.LocalAddr()` to `c.conn.RemoteAddr()`. {pull}11242[11242]
 - Management configuration backup file will now have a timestamps in their name. {pull}11034[11034]
 - Fixed OS family classification in `add_host_metadata` for Amazon Linux, Raspbian, and RedHat Linux. {issue}9134[9134] {pull}11494[11494]
+- Improve container detection in `add_host_metadata`.
 
 *Auditbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -155,7 +155,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix a typo in libbeat/outputs/transport/client.go by updating `c.conn.LocalAddr()` to `c.conn.RemoteAddr()`. {pull}11242[11242]
 - Management configuration backup file will now have a timestamps in their name. {pull}11034[11034]
 - Fixed OS family classification in `add_host_metadata` for Amazon Linux, Raspbian, and RedHat Linux. {issue}9134[9134] {pull}11494[11494]
-- Improve container detection in `add_host_metadata`.
+- Improve container detection in `add_host_metadata`. {pull}11562[11562]
 
 *Auditbeat*
 

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -713,7 +713,7 @@ Apache License 2.0
 
 --------------------------------------------------------------------
 Dependency: github.com/elastic/go-sysinfo
-Revision: ab4f04edfc3d6b3864f5f06a068ddab9ad79774f
+Revision: 77ef9c6e57ee101f346fbe70b5e9026ccf51f2fe
 License type (autodetected): Apache-2.0
 ./vendor/github.com/elastic/go-sysinfo/LICENSE.txt:
 --------------------------------------------------------------------

--- a/vendor/github.com/elastic/go-sysinfo/providers/linux/container.go
+++ b/vendor/github.com/elastic/go-sysinfo/providers/linux/container.go
@@ -46,14 +46,13 @@ func isContainerizedCgroup(data []byte) (bool, error) {
 	s := bufio.NewScanner(bytes.NewReader(data))
 	for n := 0; s.Scan(); n++ {
 		line := s.Bytes()
-		if len(line) == 0 || line[len(line)-1] == '/' {
-			continue
-		}
 
-		if bytes.HasSuffix(line, []byte("init.scope")) {
-			return false, nil
+		// Following a suggestion on Stack Overflow on how to detect
+		// being inside a container: https://stackoverflow.com/a/20012536/235203
+		if bytes.Contains(line, []byte("docker")) || bytes.Contains(line, []byte("lxc")) {
+			return true, nil
 		}
 	}
 
-	return true, s.Err()
+	return false, s.Err()
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1026,44 +1026,44 @@
 		{
 			"checksumSHA1": "QhFIpuHPaV6hKejKcc2wm6y4MSQ=",
 			"path": "github.com/elastic/go-sysinfo",
-			"revision": "ab4f04edfc3d6b3864f5f06a068ddab9ad79774f",
-			"revisionTime": "2019-03-27T18:53:17Z"
+			"revision": "77ef9c6e57ee101f346fbe70b5e9026ccf51f2fe",
+			"revisionTime": "2019-04-01T11:03:12Z"
 		},
 		{
 			"checksumSHA1": "GiZCjX17K265TtamGZZw4R2Jwbk=",
 			"path": "github.com/elastic/go-sysinfo/internal/registry",
-			"revision": "ab4f04edfc3d6b3864f5f06a068ddab9ad79774f",
-			"revisionTime": "2019-03-27T18:53:17Z"
+			"revision": "77ef9c6e57ee101f346fbe70b5e9026ccf51f2fe",
+			"revisionTime": "2019-04-01T11:03:12Z"
 		},
 		{
 			"checksumSHA1": "ovafihHzpBx9Y7+lZh9X5KwNCvE=",
 			"path": "github.com/elastic/go-sysinfo/providers/darwin",
-			"revision": "ab4f04edfc3d6b3864f5f06a068ddab9ad79774f",
-			"revisionTime": "2019-03-27T18:53:17Z"
+			"revision": "77ef9c6e57ee101f346fbe70b5e9026ccf51f2fe",
+			"revisionTime": "2019-04-01T11:03:12Z"
 		},
 		{
-			"checksumSHA1": "OyI+VwDiT4UZjncsDr1GYg1xcdw=",
+			"checksumSHA1": "1PtEeqqL+rCKmZ8vkrgg6FCzGE8=",
 			"path": "github.com/elastic/go-sysinfo/providers/linux",
-			"revision": "ab4f04edfc3d6b3864f5f06a068ddab9ad79774f",
-			"revisionTime": "2019-03-27T18:53:17Z"
+			"revision": "77ef9c6e57ee101f346fbe70b5e9026ccf51f2fe",
+			"revisionTime": "2019-04-01T11:03:12Z"
 		},
 		{
 			"checksumSHA1": "RWLvcP1w9ynKbuCqiW6prwd+EDU=",
 			"path": "github.com/elastic/go-sysinfo/providers/shared",
-			"revision": "ab4f04edfc3d6b3864f5f06a068ddab9ad79774f",
-			"revisionTime": "2019-03-27T18:53:17Z"
+			"revision": "77ef9c6e57ee101f346fbe70b5e9026ccf51f2fe",
+			"revisionTime": "2019-04-01T11:03:12Z"
 		},
 		{
 			"checksumSHA1": "aF05MEkMjbRekzHlwFxmd5WBpeY=",
 			"path": "github.com/elastic/go-sysinfo/providers/windows",
-			"revision": "ab4f04edfc3d6b3864f5f06a068ddab9ad79774f",
-			"revisionTime": "2019-03-27T18:53:17Z"
+			"revision": "77ef9c6e57ee101f346fbe70b5e9026ccf51f2fe",
+			"revisionTime": "2019-04-01T11:03:12Z"
 		},
 		{
 			"checksumSHA1": "MLQioPEjULYbNqqCjfB1/cux08E=",
 			"path": "github.com/elastic/go-sysinfo/types",
-			"revision": "ab4f04edfc3d6b3864f5f06a068ddab9ad79774f",
-			"revisionTime": "2019-03-27T18:53:17Z"
+			"revision": "77ef9c6e57ee101f346fbe70b5e9026ccf51f2fe",
+			"revisionTime": "2019-04-01T11:03:12Z"
 		},
 		{
 			"checksumSHA1": "bNf3GDGhZh86bfCIMM5c5AYfo3g=",


### PR DESCRIPTION
Updates `github.com/elastic/go-sysinfo` to include fix for container detection (https://github.com/elastic/go-sysinfo/pull/43).