### PR TITLE
Cherry-pick #11212 to 7.0: Use PYTHON_EXE env var as the python interpreter 

### DIFF
--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -23,3 +23,12 @@ The list below covers the major changes between 7.0.0-rc1 and master only.
 ==== Bugfixes
 
 ==== Added
+
+- Metricset generator generates beta modules by default now. {pull}10657[10657]
+- The `beat.Event` accessor methods now support `@metadata` keys. {pull}10761[10761]
+- Assertion for documented fields in tests fails if any of the fields in the tested event is documented as an alias. {pull}10921[10921]
+- Support for Logger in the Metricset base instance. {pull}11106[11106]
+- Introduce processing.Support to instance.Setting. This allows Beats to fully modify the event processing. {pull}10801[10801]
+- Filebeat modules can now use ingest pipelines in YAML format. {pull}11209[11209]
+- Added support for using PYTHON_EXE to control what Python interpreter is used
+  by `make` and `mage`. Example: `export PYTHON_EXE=python2.7`. {pull}11212[11212]

--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -24,11 +24,5 @@ The list below covers the major changes between 7.0.0-rc1 and master only.
 
 ==== Added
 
-- Metricset generator generates beta modules by default now. {pull}10657[10657]
-- The `beat.Event` accessor methods now support `@metadata` keys. {pull}10761[10761]
-- Assertion for documented fields in tests fails if any of the fields in the tested event is documented as an alias. {pull}10921[10921]
-- Support for Logger in the Metricset base instance. {pull}11106[11106]
-- Introduce processing.Support to instance.Setting. This allows Beats to fully modify the event processing. {pull}10801[10801]
-- Filebeat modules can now use ingest pipelines in YAML format. {pull}11209[11209]
 - Added support for using PYTHON_EXE to control what Python interpreter is used
   by `make` and `mage`. Example: `export PYTHON_EXE=python2.7`. {pull}11212[11212]

--- a/dev-tools/mage/pytest.go
+++ b/dev-tools/mage/pytest.go
@@ -167,10 +167,17 @@ func PythonVirtualenv() (string, error) {
 		return pythonVirtualenvDir, nil
 	}
 
+	// If set use PYTHON_EXE env var as the python interpreter.
+	var args []string
+	if pythonExe := os.Getenv("PYTHON_EXE"); pythonExe != "" {
+		args = append(args, "-p", pythonExe)
+	}
+	args = append(args, ve)
+
 	// Execute virtualenv.
 	if _, err := os.Stat(ve); err != nil {
 		// Run virtualenv if the dir does not exist.
-		if err := sh.Run("virtualenv", ve); err != nil {
+		if err := sh.Run("virtualenv", args...); err != nil {
 			return "", err
 		}
 	}
@@ -181,7 +188,7 @@ func PythonVirtualenv() (string, error) {
 	}
 
 	pip := virtualenvPath(ve, "pip")
-	args := []string{"install"}
+	args = []string{"install"}
 	if !mg.Verbose() {
 		args = append(args, "--quiet")
 	}

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -250,7 +250,7 @@ load-tests: ## @testing Runs load tests
 # Sets up the virtual python environment
 .PHONY: python-env
 python-env: ${ES_BEATS}/libbeat/tests/system/requirements.txt
-	@test -d ${PYTHON_ENV} || virtualenv ${VIRTUALENV_PARAMS} ${PYTHON_ENV}
+	@test -d ${PYTHON_ENV} || virtualenv $(if ${PYTHON_EXE},-p ${PYTHON_EXE}) ${VIRTUALENV_PARAMS} ${PYTHON_ENV}
 	@. ${PYTHON_ENV}/bin/activate && pip install ${PIP_INSTALL_PARAMS} -q --upgrade pip ; \
 	if [ -a ./tests/system/requirements.txt ] && [ ! ${ES_BEATS}/libbeat/tests/system/requirements.txt -ef ./tests/system/requirements.txt ] ; then \
 		. ${PYTHON_ENV}/bin/activate && pip install ${PIP_INSTALL_PARAMS} -qUr ${ES_BEATS}/libbeat/tests/system/requirements.txt -Ur ./tests/system/requirements.txt ; \


### PR DESCRIPTION
Cherry-pick of PR #11212 to 7.0 branch. Original message: 

Setting the PYTHON_EXE environment variable causes new Python virtual environments
to be created using the specified interpreter.

For example, `PYTHON_EXE=python2.7 make python-env`.