### PR TITLE
Remove ellipse from config example

### DIFF
--- a/winlogbeat/docs/winlogbeat-options.asciidoc
+++ b/winlogbeat/docs/winlogbeat-options.asciidoc
@@ -193,7 +193,6 @@ event IDs.
 --------------------------------------------------------------------------------
 winlogbeat.event_logs:
   - name: Security
-    event_id: ...
     processors:
       - drop_event.when.not.or:
         - equals.event_id: 903


### PR DESCRIPTION
Someone could copy/paste this example without realizing the ellipse must be to be changed to a meaningful event ID filter or be removed.

Discuss: https://discuss.elastic.co/t/event-id-processor-fails-to-start-service/174545/2?u=andrewkroh