### PR TITLE
Fix changelog for #6579

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -1184,6 +1184,7 @@ https://github.com/elastic/beats/compare/v6.2.3...v6.3.0[View commits]
 *Winlogbeat*
 
 - Fixed a crash under Windows 2003 and XP when an event had less insert strings than required by its format string. {pull}6247[6247]
+- Fix config validation to allow `event_logs.processors`. [pull]6217[6217]
 
 ==== Added
 
@@ -1548,7 +1549,6 @@ https://github.com/elastic/beats/compare/v6.0.1...v6.1.0[View commits]
 
 - Fix the registry file. It was not correctly storing event log names, and
   upon restart it would begin reading at the start of each event log. {issue}5813[5813]
-- Fix config validation to allow `event_logs.processors`. [pull]6217[6217]
 
 ==== Added
 


### PR DESCRIPTION
The changelog entry got merged into the wrong spot during the cherry-pick.
This was originally fixed in v6.2.4.

Relates #6579