### PR TITLE
docker metadata processor: replace source field with log.field.path

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -57,6 +57,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix registry entries not being cleaned due to race conditions. {pull}10747[10747]
 - Improve detection of file deletion on Windows. {pull}10747[10747]
 - Fix goroutine leak happening when harvesters are dynamically stopped. {pull}11263[11263]
+- Fix `add_docker_metadata` source matching, using `log.file.path` field now. {pull}11577[11577]
 
 *Heartbeat*
 

--- a/libbeat/processors/add_docker_metadata/add_docker_metadata.go
+++ b/libbeat/processors/add_docker_metadata/add_docker_metadata.go
@@ -87,7 +87,7 @@ func buildDockerMetadataProcessor(cfg *common.Config, watcherConstructor docker.
 	var sourceProcessor processors.Processor
 	if config.MatchSource {
 		var procConf, _ = common.NewConfigFrom(map[string]interface{}{
-			"field":     "source",
+			"field":     "log.file.path",
 			"separator": string(os.PathSeparator),
 			"index":     config.SourceIndex,
 			"target":    dockerContainerIDKey,
@@ -123,10 +123,10 @@ func lazyCgroupCacheInit(d *addDockerMetadata) {
 func (d *addDockerMetadata) Run(event *beat.Event) (*beat.Event, error) {
 	var cid string
 	var err error
-
-	// Extract CID from the filepath contained in the "source" field.
+	// Extract CID from the filepath contained in the "log.file.path" field.
 	if d.sourceProcessor != nil {
-		if event.Fields["source"] != nil {
+		lfp, _ := event.Fields.GetValue("log.file.path")
+		if lfp != nil {
 			event, err = d.sourceProcessor.Run(event)
 			if err != nil {
 				d.log.Debugf("Error while extracting container ID from source path: %v", err)

--- a/libbeat/processors/add_docker_metadata/add_docker_metadata_test.go
+++ b/libbeat/processors/add_docker_metadata/add_docker_metadata_test.go
@@ -221,7 +221,11 @@ func TestMatchSource(t *testing.T) {
 		inputSource = "/var/lib/docker/containers/FABADA/foo.log"
 	}
 	input := common.MapStr{
-		"source": inputSource,
+		"log": common.MapStr{
+			"file": common.MapStr{
+				"path": inputSource,
+			},
+		},
 	}
 
 	result, err := p.Run(&beat.Event{Fields: input})
@@ -239,7 +243,11 @@ func TestMatchSource(t *testing.T) {
 			},
 			"name": "name",
 		},
-		"source": inputSource,
+		"log": common.MapStr{
+			"file": common.MapStr{
+				"path": inputSource,
+			},
+		},
 	}, result.Fields)
 }
 


### PR DESCRIPTION
At libbeat's docker metadata processor:

`source` field was dismissed recently at filebeat as per https://github.com/elastic/beats/pull/8902
Container ID is being retrieved from `log.file.path`

Solves #11556