### PR TITLE
Add _bucket to histogram metrics in Prometheus Collector

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -114,7 +114,6 @@ https://github.com/elastic/beats/compare/v7.0.0-beta1...v7.0.0-rc1[Check the HEA
 - Add missing aws.ec2.instance.state.name into fields.yml. {issue}11219[11219] {pull}11221[11221]
 - Fix ec2 metricset to collect metrics from Cloudwatch with the same timestamp. {pull}11142[11142]
 - Fix potential memory leak in stopped docker metricsets {pull}11294[11294]
-- Add _bucket to histogram metrics in Prometheus Collector {pull}11578[11578]
 
 *Packetbeat*
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -114,6 +114,7 @@ https://github.com/elastic/beats/compare/v7.0.0-beta1...v7.0.0-rc1[Check the HEA
 - Add missing aws.ec2.instance.state.name into fields.yml. {issue}11219[11219] {pull}11221[11221]
 - Fix ec2 metricset to collect metrics from Cloudwatch with the same timestamp. {pull}11142[11142]
 - Fix potential memory leak in stopped docker metricsets {pull}11294[11294]
+- Add _bucket to histogram metrics in Prometheus Collector {pull}11578[11578]
 
 *Packetbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -62,6 +62,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Metricbeat*
 
+- Add _bucket to histogram metrics in Prometheus Collector {pull}11578[11578]
+
 *Packetbeat*
 
 - Prevent duplicate packet loss error messages in HTTP events. {pull}10709[10709]

--- a/metricbeat/module/prometheus/collector/collector_test.go
+++ b/metricbeat/module/prometheus/collector/collector_test.go
@@ -155,7 +155,7 @@ func TestGetPromEventsFromMetricFamily(t *testing.T) {
 				},
 				{
 					data: common.MapStr{
-						"http_request_duration_microseconds": uint64(10),
+						"http_request_duration_microseconds_bucket": uint64(10),
 					},
 					labels: common.MapStr{"le": "0.99"},
 				},

--- a/metricbeat/module/prometheus/collector/data.go
+++ b/metricbeat/module/prometheus/collector/data.go
@@ -115,7 +115,7 @@ func getPromEventsFromMetricFamily(mf *dto.MetricFamily) []PromEvent {
 
 				events = append(events, PromEvent{
 					data: common.MapStr{
-						name: bucket.GetCumulativeCount(),
+						name + "_bucket": bucket.GetCumulativeCount(),
 					},
 					labels: bucketLabels,
 				})


### PR DESCRIPTION
The names of histograms vary because of the lack of `_bucket` on the name. Can we please add this to make sure that the names are consistent?