### PR TITLE
[Auditbeat] Cherry-pick #11565 to 7.0: Package: Open versioned librpm shared objects

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -39,6 +39,8 @@ https://github.com/elastic/beats/compare/v7.0.0-rc1...master[Check the HEAD diff
 
 *Auditbeat*
 
+- Package dataset: dlopen versioned librpm shared objects. {pull}11565[11565]
+
 *Filebeat*
 
 - Don't apply multiline rules in Logstash json logs. {pull}11346[11346]

--- a/x-pack/auditbeat/module/system/package/rpm_linux.go
+++ b/x-pack/auditbeat/module/system/package/rpm_linux.go
@@ -178,7 +178,17 @@ var cFun *cFunctions
 
 func dlopenCFunctions() (*cFunctions, error) {
 	var librpmNames = []string{
-		"/usr/lib64/librpm.so",
+		"librpm.so",   // with rpm-devel installed
+		"librpm.so.8", // Fedora 29
+		"librpm.so.3", // CentOS 7
+		"librpm.so.1", // CentOS 6
+
+		// Following for completeness, but not explicitly tested
+		"librpm.so.7",
+		"librpm.so.6",
+		"librpm.so.5",
+		"librpm.so.4",
+		"librpm.so.2",
 	}
 	var cFun cFunctions
 


### PR DESCRIPTION
Cherry-pick of PR #11565 to 7.0 branch. Original message: 

To access Librpm functions in the package dataset, we currently dlopen() `/usr/lib64/librpm.so` which is usually a symlink to the versioned shared object e.g. `/usr/lib64/librpm.so.1`. However, this symlink is only present when the package `rpm-devel` is installed and that's usually not the case by default.

This PR changes to using the versioned shared object names as a fallback when the symlink is not available. Versions 1, 3, and 8 are library versions that are present on systems I've tested on, while other in-between versions are not explicitly tested, but it's reasonable to assume they work. In any case, if any of the functions we are looking for are not available the dataset will still abort.

We will have to add new versions as they become available, e.g. if Fedora 30 ships with `librpm.so.9` the dataset will not work out of the box until we add it to the search path. I've thought about adding it pre-emptively since it's likely that it will just work out of the box (we are not using that many functions, and none of the ones we use should have any side effects), but decided not to since we really don't know what could change. And since the generic `librpm.so` symlink is the first in the search path, it's always possible for the user to create or change this symlink to point to a version of their choice.

I've also changed from an absolute path (`/usr/lib64/librpm.so*`) to a generic one (`librpm.so*`) to be more flexible about the location.

With this change, the package dataset works on CentOS 6, 7, and Fedora 29 without the `rpm-devel` package installed. The package is still required for compilation.