### PR TITLE
[DOCS] Adds float attributes in breaking changes

### DIFF
--- a/libbeat/docs/breaking.asciidoc
+++ b/libbeat/docs/breaking.asciidoc
@@ -26,6 +26,7 @@ See the following topics for a description of breaking changes:
 This section discusses the main changes that you should be aware of if you
 upgrade the Beats to version 7.0. {see-relnotes}
 
+[float]
 ==== HTML escaping is disabled by default
 
 Starting with verion 7.0, embedded HTML or special symbols like `<` and `>` are
@@ -34,6 +35,7 @@ To configure the old behavior of escaping HTML, set `escape_html:
 true` in the output configuration.
 
 //tag::notable-breaking-changes[]
+[float]
 ==== Filebeat registry
 
 Starting with version 7.0, Filebeat stores the registry in a sub-directory.
@@ -47,6 +49,7 @@ have been renamed to `filebeat.registry.flush` and
 
 //end::notable-breaking-changes[]
 
+[float]
 ==== ILM support
 
 Support for Index Lifecycle Management is GA with Beats version 7.0. This
@@ -54,13 +57,14 @@ release moved most ILM settings from the `output.elasticsearch.ilm` namespace to
 the `setup.ilm` namespace.
 
 //tag::notable-breaking-changes[]
-
+[float]
 ==== Field name changes
 
 include::./field-name-changes.asciidoc[]
 
 //end::notable-breaking-changes[]
 
+[float]
 ==== Auditbeat type changes
 
 The Auditbeat JSON data types produced by the output have been changed to align
@@ -90,6 +94,7 @@ For more information, see the https://github.com/elastic/migrate-management-beat
 This section discusses the main changes that you should be aware of if you
 upgrade the Beats to version 6.3. {see-relnotes}
 
+[float]
 [[breaking-changes-monitoring]]
 ==== Beats monitoring schema changes
 
@@ -98,6 +103,7 @@ renamed to `beat.cpu.*.time.ms`. As a result of this change, Beats shippers
 released prior to version 6.3 are unable to send monitoring data to clusters
 running on Elasticsearch 6.3 and later. {see-relnotes}
 
+[float]
 [[breaking-changes-mapping-conflict]]
 ==== New `host` namespace may cause mapping conflicts for Logstash
 
@@ -124,6 +130,7 @@ See the info for your particular use case:
 * <<custom-template-non-versioned-indices>>
 * <<beats-template-non-versioned-indices>>
 
+[float]
 [[beats-template-versioned-indices]]
 ===== Use case: You use the Beats index template and versioned indices
 
@@ -150,7 +157,7 @@ information, see:
 * {kibana-ref}/managing-saved-objects.html[Managing Saved Objects]
 * {kibana-ref}/saved-objects-api.html[Kibana Saved Objects API]
 
-
+[float]
 [[custom-template-non-versioned-indices]]
 ===== Use case: You use a custom template and your indices are not versioned
 
@@ -197,6 +204,7 @@ previous Beats versions. This approach resolves the mapping conflict, but you
 should plan to migrate your Logstash configurations to use `host.name` in
 future releases.
 
+[float]
 [[beats-template-non-versioned-indices]]
 ===== Use case: You use the Beats index template and your indices are not versioned
 
@@ -259,7 +267,7 @@ upgrade the Beats from version 5.x to 6.x. {see-relnotes}
 
 // TODO: better link to the consolidated release notes for 6.0.0.
 
-
+[float]
 [[breaking-changes-spooler-removed]]
 ==== Filebeat spooler removed
 
@@ -293,6 +301,7 @@ the new pipeline already works asynchronously by default.
 
 // TODO: for the above new settings, link to their configuration settings.
 
+[float]
 [[breaking-changes-single-output]]
 ==== Only one enabled output
 
@@ -318,6 +327,7 @@ If you used the `file` or `console` outputs for debugging purposes, in addition
 to the main output, we recommend using the `-d "publish"` option which logs the
 published events in the Filebeat logs.
 
+[float]
 [[breaking-changes-ls-index]]
 ==== Logstash index setting now requires version
 
@@ -349,6 +359,7 @@ The index templates that ship with 6.0 are applied to new indices that match the
 pattern `[beat]-[version]-*`. You must update your Logstash config, or the
 templates will not be applied.
 
+[float]
 [[breaking-changes-types]]
 ==== Filebeat prospector type and document type changes
 
@@ -361,6 +372,7 @@ This has led also to the rename of the `input_type` configuration setting to
 `type`. This change is backwards compatible because the old setting still
 works. However, the `input_type` output field was renamed to `prospector.type`.
 
+[float]
 [[breaking-changes-default-config]]
 ==== Filebeat default prospector disabled in the configuration file
 
@@ -375,6 +387,7 @@ with a CLI flag:
 filebeat --modules=system
 ----
 
+[float]
 ==== Other settings changed or moved
 
 The `outputs.elasticsearch.template.*` settings have been moved under
@@ -385,6 +398,7 @@ The `dashboards.*` settings have been moved under `setup.dashboards.*`.
 The Filebeat deprecated options	`force_close_files` and `close_older` are
 removed.
 
+[float]
 [[breaking-changes-import-dashboards]]
 ==== Changes for importing the Kibana dashboards
 
@@ -424,6 +438,7 @@ Kibana URL needs to be set. The option to set the Kibana URL is
 
 The default value for the Kibana host is `localhost:5601`.
 
+[float]
 [[breaking-changes-filters]]
 ==== Metricbeat filters renamed to processors
 
@@ -437,6 +452,7 @@ qualified name (for example, `system.filesystem.mount_point`).
 Starting with version 6.0, the `filters` are renamed to `processors` and they
 can access the fields only by using the fully qualified names.
 
+[float]
 [[breaking-changes-cgo]]
 ==== Binaries are dynamically compiled against libc
 


### PR DESCRIPTION
Related to https://github.com/elastic/stack-docs/pull/256

This PR adds float attributes to the Beats breaking changes, so that they can be re-used by the Installation and Upgrade Guide.  Otherwise, we receive the following messages:

INFO:build_docs:asciidoctor: WARNING: ../../../../beats/libbeat/docs/breaking.asciidoc: line 37: section title out of sequence: expected level 2, got level 3
INFO:build_docs:asciidoctor: WARNING: ../../../../beats/libbeat/docs/breaking.asciidoc: line 49: section title out of sequence: expected level 2, got level 3

Alternatively, we could change the chunking of the Installation and Upgrade Guide, so if this PR is unacceptable, please just let me know.
