### PR TITLE
[7.0] Backport: Fix missing period in setup.dashboards.always_kibana. (#11495)

### DIFF
--- a/libbeat/docs/dashboardsconfig.asciidoc
+++ b/libbeat/docs/dashboardsconfig.asciidoc
@@ -102,7 +102,7 @@ NOTE: This setting only works for Kibana 6.0 and newer.
 [float]
 ==== `setup.dashboards.always_kibana`
 
-Force loading of dashboards using the Kibana API without querying Elasticsearch for the version
+Force loading of dashboards using the Kibana API without querying Elasticsearch for the version.
 The default is `false`.
 
 [float]


### PR DESCRIPTION
Cherry-picks #11495 into 7.0 branch.