### PR TITLE
Cherry-pick #11559 to 7.0: Set migration.6_to_7.enabled: true in short config

### DIFF
--- a/auditbeat/auditbeat.yml
+++ b/auditbeat/auditbeat.yml
@@ -178,4 +178,4 @@ processors:
 #================================= Migration ==================================
 
 # This allows to enable 6.7 migration aliases
-#migration.6_to_7.enabled: false
+#migration.6_to_7.enabled: true

--- a/filebeat/filebeat.yml
+++ b/filebeat/filebeat.yml
@@ -206,4 +206,4 @@ processors:
 #================================= Migration ==================================
 
 # This allows to enable 6.7 migration aliases
-#migration.6_to_7.enabled: false
+#migration.6_to_7.enabled: true

--- a/heartbeat/heartbeat.yml
+++ b/heartbeat/heartbeat.yml
@@ -163,4 +163,4 @@ processors:
 #================================= Migration ==================================
 
 # This allows to enable 6.7 migration aliases
-#migration.6_to_7.enabled: false
+#migration.6_to_7.enabled: true

--- a/journalbeat/journalbeat.yml
+++ b/journalbeat/journalbeat.yml
@@ -175,4 +175,4 @@ processors:
 #================================= Migration ==================================
 
 # This allows to enable 6.7 migration aliases
-#migration.6_to_7.enabled: false
+#migration.6_to_7.enabled: true

--- a/libbeat/_meta/config.yml
+++ b/libbeat/_meta/config.yml
@@ -123,4 +123,4 @@ processors:
 #================================= Migration ==================================
 
 # This allows to enable 6.7 migration aliases
-#migration.6_to_7.enabled: false
+#migration.6_to_7.enabled: true

--- a/metricbeat/metricbeat.yml
+++ b/metricbeat/metricbeat.yml
@@ -150,4 +150,4 @@ processors:
 #================================= Migration ==================================
 
 # This allows to enable 6.7 migration aliases
-#migration.6_to_7.enabled: false
+#migration.6_to_7.enabled: true

--- a/packetbeat/packetbeat.yml
+++ b/packetbeat/packetbeat.yml
@@ -232,4 +232,4 @@ processors:
 #================================= Migration ==================================
 
 # This allows to enable 6.7 migration aliases
-#migration.6_to_7.enabled: false
+#migration.6_to_7.enabled: true

--- a/winlogbeat/winlogbeat.yml
+++ b/winlogbeat/winlogbeat.yml
@@ -154,4 +154,4 @@ processors:
 #================================= Migration ==================================
 
 # This allows to enable 6.7 migration aliases
-#migration.6_to_7.enabled: false
+#migration.6_to_7.enabled: true

--- a/x-pack/auditbeat/auditbeat.yml
+++ b/x-pack/auditbeat/auditbeat.yml
@@ -200,4 +200,4 @@ processors:
 #================================= Migration ==================================
 
 # This allows to enable 6.7 migration aliases
-#migration.6_to_7.enabled: false
+#migration.6_to_7.enabled: true

--- a/x-pack/filebeat/filebeat.yml
+++ b/x-pack/filebeat/filebeat.yml
@@ -206,4 +206,4 @@ processors:
 #================================= Migration ==================================
 
 # This allows to enable 6.7 migration aliases
-#migration.6_to_7.enabled: false
+#migration.6_to_7.enabled: true

--- a/x-pack/functionbeat/functionbeat.yml
+++ b/x-pack/functionbeat/functionbeat.yml
@@ -276,4 +276,4 @@ processors:
 #================================= Migration ==================================
 
 # This allows to enable 6.7 migration aliases
-#migration.6_to_7.enabled: false
+#migration.6_to_7.enabled: true

--- a/x-pack/metricbeat/metricbeat.yml
+++ b/x-pack/metricbeat/metricbeat.yml
@@ -150,4 +150,4 @@ processors:
 #================================= Migration ==================================
 
 # This allows to enable 6.7 migration aliases
-#migration.6_to_7.enabled: false
+#migration.6_to_7.enabled: true


### PR DESCRIPTION
Cherry-pick of PR #11559 to 7.0 branch. Original message: 

To simplify for users to enable the migration aliases, the config option is set to true. Like this when commenting out the config, it is already enabled.

This came out of a discussion where we discovered users assumed it's enabled when commenting out and falsely assumed the migration layer is enabled.