### PR TITLE
Cherry-pick #11578 to 7.0: Add _bucket to histogram metrics in Prometheus Collector

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -51,6 +51,8 @@ https://github.com/elastic/beats/compare/v7.0.0-rc1...master[Check the HEAD diff
 
 *Metricbeat*
 
+- Add _bucket to histogram metrics in Prometheus Collector {pull}11578[11578]
+
 *Packetbeat*
 
 *Winlogbeat*

--- a/metricbeat/module/prometheus/collector/collector_test.go
+++ b/metricbeat/module/prometheus/collector/collector_test.go
@@ -155,7 +155,7 @@ func TestGetPromEventsFromMetricFamily(t *testing.T) {
 				},
 				{
 					data: common.MapStr{
-						"http_request_duration_microseconds": uint64(10),
+						"http_request_duration_microseconds_bucket": uint64(10),
 					},
 					labels: common.MapStr{"le": "0.99"},
 				},

--- a/metricbeat/module/prometheus/collector/data.go
+++ b/metricbeat/module/prometheus/collector/data.go
@@ -115,7 +115,7 @@ func getPromEventsFromMetricFamily(mf *dto.MetricFamily) []PromEvent {
 
 				events = append(events, PromEvent{
 					data: common.MapStr{
-						name: bucket.GetCumulativeCount(),
+						name + "_bucket": bucket.GetCumulativeCount(),
 					},
 					labels: bucketLabels,
 				})


### PR DESCRIPTION
Cherry-pick of PR #11578 to 7.0 branch. Original message: 

The names of histograms vary because of the lack of `_bucket` on the name. Can we please add this to make sure that the names are consistent?