### PR TITLE
Fix: Correctly initialize the Logger for the TCP input instance.

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -57,7 +57,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix ILM policy always being overwritten. {pull}11671[11671]
 - Fix template always being overwritten. {pull}11671[11671]
 - Fix matching of string arrays in contains condition. {pull}11691[11691]
-- Fix initialization of the TCP input logger. {pull}xxx[xxx]
+- Fix initialization of the TCP input logger. {pull}11605[11605]
 
 *Auditbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -57,6 +57,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix ILM policy always being overwritten. {pull}11671[11671]
 - Fix template always being overwritten. {pull}11671[11671]
 - Fix matching of string arrays in contains condition. {pull}11691[11691]
+- Fix initialization of the TCP input logger. {pull}xxx[xxx]
 
 *Auditbeat*
 

--- a/filebeat/input/tcp/input.go
+++ b/filebeat/input/tcp/input.go
@@ -90,7 +90,7 @@ func NewInput(
 		started: false,
 		outlet:  out,
 		config:  &config,
-		log:     logp.NewLogger("tcp input").With(config.Config.Host),
+		log:     logp.NewLogger("tcp input").With("address", config.Config.Host),
 	}, nil
 }
 


### PR DESCRIPTION
`With()` function was called without the key to identify the value
passed as parameter.