### PR TITLE
Log rotation - possibility of log rotations of 2,3,4,5,x minutes or h…

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -71,7 +71,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix goroutine leak happening when harvesters are dynamically stopped. {pull}11263[11263]
 - Fix `add_docker_metadata` source matching, using `log.file.path` field now. {pull}11577[11577]
 - Add missing Kubernetes metadata fields to Filebeat CoreDNS module, and fix a documentation error. {pull}11591[11591]
-
+- Libbeat-logp - possibility of log rotations of 2,3,4,5,x minutes or hours {issue}11365[11365], {pull}11608[11608]
 *Heartbeat*
 
 *Journalbeat*

--- a/libbeat/common/file/interval_rotator_test.go
+++ b/libbeat/common/file/interval_rotator_test.go
@@ -209,49 +209,6 @@ func TestYearlyRotator(t *testing.T) {
 	assert.Equal(t, "foo-2019-", a.LogPrefix("foo", time.Now()))
 }
 
-func TestArbitraryIntervalRotator(t *testing.T) {
-	a, err := newIntervalRotator(3 * time.Second)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Monday, 2018-Dec-31
-	clock := &testClock{time.Date(2018, 12, 31, 0, 0, 1, 0, time.Local)}
-	a.clock = clock
-	assert.Equal(t, "foo-2018-12-30-00-00-00-", a.LogPrefix("foo", time.Date(2018, 12, 30, 0, 0, 0, 0, time.Local)))
-	a.Rotate()
-	n := a.NewInterval()
-	assert.False(t, n)
-	assert.Equal(t, "foo-2018-12-31-00-00-00-", a.LogPrefix("foo", time.Now()))
-
-	clock.time = clock.time.Add(time.Second)
-	n = a.NewInterval()
-	assert.False(t, n)
-	assert.Equal(t, "foo-2018-12-31-00-00-00-", a.LogPrefix("foo", time.Now()))
-
-	clock.time = clock.time.Add(time.Second)
-	n = a.NewInterval()
-	assert.True(t, n)
-	a.Rotate()
-	assert.Equal(t, "foo-2018-12-31-00-00-03-", a.LogPrefix("foo", time.Now()))
-
-	clock.time = clock.time.Add(time.Second)
-	n = a.NewInterval()
-	assert.False(t, n)
-	assert.Equal(t, "foo-2018-12-31-00-00-03-", a.LogPrefix("foo", time.Now()))
-
-	clock.time = clock.time.Add(time.Second)
-	n = a.NewInterval()
-	assert.False(t, n)
-	assert.Equal(t, "foo-2018-12-31-00-00-03-", a.LogPrefix("foo", time.Now()))
-
-	clock.time = clock.time.Add(time.Second)
-	n = a.NewInterval()
-	assert.True(t, n)
-	a.Rotate()
-	assert.Equal(t, "foo-2018-12-31-00-00-06-", a.LogPrefix("foo", time.Now()))
-}
-
 func TestIntervalIsTruncatedToSeconds(t *testing.T) {
 	a, err := newIntervalRotator(2345 * time.Millisecond)
 	if err != nil {


### PR DESCRIPTION
@michalpristas I have correted the tests.

There is a difference that before, you had fixed times and for all other time values an arbitrary time function.
No you can use 1,2,3,4,5 sec/min/hour/etc to rotate the time. As a consequence of being allowed to choose time, you do not have arbitrary time anymore. So I removed the arbitrary tests and the code of it.
Please take a look
This patch solves https://github.com/elastic/beats/issues/11365