### PR TITLE
Change add_cloud_metadata to not overwrite cloud field

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -79,6 +79,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Prevent the docker/memory metricset from processing invalid events before container start {pull}11676[11676]
 - Stop overwriting cloud.* fields from add_cloud_metadata if they are not empty. {pull}11612[11612] {issue}11305[11305]
 - Change `add_cloud_metadata` processor to not overwrite `cloud` field when it's already exist in the event. {pull}11612[11612] {issue}11305[11305]
+- Change `add_cloud_metadata` processor to not overwrite `cloud` field when it already exist in the event. {pull}11612[11612] {issue}11305[11305]
 
 *Packetbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -77,6 +77,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 - Add _bucket to histogram metrics in Prometheus Collector {pull}11578[11578]
 - Prevent the docker/memory metricset from processing invalid events before container start {pull}11676[11676]
+- Stop overwriting cloud.* fields from add_cloud_metadata if they are not empty. {pull}11612[11612] {issue}11305[11305]
 
 *Packetbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -78,6 +78,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add _bucket to histogram metrics in Prometheus Collector {pull}11578[11578]
 - Prevent the docker/memory metricset from processing invalid events before container start {pull}11676[11676]
 - Stop overwriting cloud.* fields from add_cloud_metadata if they are not empty. {pull}11612[11612] {issue}11305[11305]
+- Change `add_cloud_metadata` processor to not overwrite `cloud` field when it's already exist in the event. {pull}11612[11612] {issue}11305[11305]
 
 *Packetbeat*
 

--- a/libbeat/docs/processors-using.asciidoc
+++ b/libbeat/docs/processors-using.asciidoc
@@ -521,7 +521,8 @@ makes it possible to enable this processor for all your deployments (in the
 cloud or on-premise).
 
 The second optional configuration setting is `overwrite`. When `overwrite` is
-`true` (by default), `add_cloud_metadata` overwrites existing `cloud.*` fields.
+`true`, `add_cloud_metadata` overwrites existing `cloud.*` fields (`false` by
+default).
 
 The metadata that is added to events varies by hosting provider. Below are
 examples for each of the supported providers.

--- a/libbeat/docs/processors-using.asciidoc
+++ b/libbeat/docs/processors-using.asciidoc
@@ -511,14 +511,17 @@ processors:
 - add_cloud_metadata: ~
 -------------------------------------------------------------------------------
 
-The `add_cloud_metadata` processor has one optional configuration setting named
-`timeout` that specifies the maximum amount of time to wait for a successful
+The `add_cloud_metadata` processor has two optional configuration settings. First one is
+`timeout` which specifies the maximum amount of time to wait for a successful
 response when detecting the hosting provider. The default timeout value is
 `3s`.
 
 If a timeout occurs then no instance metadata will be added to the events. This
 makes it possible to enable this processor for all your deployments (in the
 cloud or on-premise).
+
+Second optional configuration setting is `overwrite`. When `overwrite` is `true` (by default),
+`add_cloud_metadata` overwrites existing `cloud.*` fields.
 
 The metadata that is added to events varies by hosting provider. Below are
 examples for each of the supported providers.

--- a/libbeat/docs/processors-using.asciidoc
+++ b/libbeat/docs/processors-using.asciidoc
@@ -511,17 +511,17 @@ processors:
 - add_cloud_metadata: ~
 -------------------------------------------------------------------------------
 
-The `add_cloud_metadata` processor has two optional configuration settings. First one is
-`timeout` which specifies the maximum amount of time to wait for a successful
-response when detecting the hosting provider. The default timeout value is
-`3s`.
+The `add_cloud_metadata` processor has two optional configuration settings.
+The first one is `timeout` which specifies the maximum amount of time to wait
+for a successful response when detecting the hosting provider. The default
+timeout value is `3s`.
 
 If a timeout occurs then no instance metadata will be added to the events. This
 makes it possible to enable this processor for all your deployments (in the
 cloud or on-premise).
 
-Second optional configuration setting is `overwrite`. When `overwrite` is `true` (by default),
-`add_cloud_metadata` overwrites existing `cloud.*` fields.
+The second optional configuration setting is `overwrite`. When `overwrite` is
+`true` (by default), `add_cloud_metadata` overwrites existing `cloud.*` fields.
 
 The metadata that is added to events varies by hosting provider. Below are
 examples for each of the supported providers.

--- a/libbeat/processors/add_cloud_metadata/add_cloud_metadata.go
+++ b/libbeat/processors/add_cloud_metadata/add_cloud_metadata.go
@@ -361,12 +361,12 @@ func (p *addCloudMetadata) Run(event *beat.Event) (*beat.Event, error) {
 	// If cloud key exists in event already, this processor will not overwrite the cloud fields.
 	// For example aws module writes cloud.instance.* to events already, add_cloud_metadata should not overwrite these
 	// fields again.
-	cloudValue, err := event.GetValue("cloud")
-	if cloudValue != nil && err == nil {
-		return event, err
+	cloudValue, _ := event.GetValue("cloud")
+	if cloudValue != nil {
+		return event, nil
 	}
 
-	_, err = event.PutValue("cloud", meta)
+	_, err := event.PutValue("cloud", meta)
 
 	return event, err
 }

--- a/libbeat/processors/add_cloud_metadata/add_cloud_metadata.go
+++ b/libbeat/processors/add_cloud_metadata/add_cloud_metadata.go
@@ -358,9 +358,15 @@ func (p *addCloudMetadata) Run(event *beat.Event) (*beat.Event, error) {
 		return event, nil
 	}
 
-	// This overwrites the meta.cloud if it exists. But the cloud key should be
-	// reserved for this processor so this should happen.
-	_, err := event.PutValue("cloud", meta)
+	// If cloud key exists in event already, this processor will not overwrite the cloud fields.
+	// For example aws module writes cloud.instance.* to events already, add_cloud_metadata should not overwrite these
+	// fields again.
+	cloudValue, err := event.GetValue("cloud")
+	if cloudValue != nil && err == nil {
+		return event, err
+	}
+
+	_, err = event.PutValue("cloud", meta)
 
 	return event, err
 }

--- a/libbeat/processors/add_cloud_metadata/add_cloud_metadata.go
+++ b/libbeat/processors/add_cloud_metadata/add_cloud_metadata.go
@@ -25,7 +25,6 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
-	"strings"
 	"sync"
 	"time"
 
@@ -368,14 +367,9 @@ func (p *addCloudMetadata) Run(event *beat.Event) (*beat.Event, error) {
 	// cloud fields. For example aws module writes cloud.instance.* to events already, with overwrite=false,
 	// add_cloud_metadata should not overwrite these fields with new values.
 	if !p.initData.overwrite {
-		for key := range event.Fields {
-			keySplits := strings.Split(key, ".")
-			if keySplits[0] == "cloud" {
-				cloudValue, _ := event.GetValue(key)
-				if cloudValue != nil {
-					return event, nil
-				}
-			}
+		cloudValue, _ := event.GetValue("cloud")
+		if cloudValue != nil {
+			return event, nil
 		}
 	}
 

--- a/libbeat/processors/add_cloud_metadata/provider_aws_ec2_test.go
+++ b/libbeat/processors/add_cloud_metadata/provider_aws_ec2_test.go
@@ -114,18 +114,32 @@ func TestRetrieveAWSMetadata(t *testing.T) {
 		},
 		{
 			common.MapStr{
-				"cloud.provider": "ec2",
+				"provider": "ec2",
 			},
 			common.MapStr{
-				"cloud.provider": "ec2",
+				"provider": "ec2",
+				"cloud": common.MapStr{
+					"provider": "ec2",
+					"instance": common.MapStr{
+						"id": "i-11111111",
+					},
+					"machine": common.MapStr{
+						"type": "t2.medium",
+					},
+					"region":            "us-east-1",
+					"availability_zone": "us-east-1c",
+				},
 			},
 		},
 		{
 			common.MapStr{
-				"provider": "ec2",
+				"cloud.provider": "ec2",
 			},
+			// NOTE: In this case, add_cloud_metadata will overwrite cloud fields because
+			// it won't detect cloud.provider as a cloud field. This is not the behavior we
+			// expect and will find a better solution later in issue 11697.
 			common.MapStr{
-				"provider": "ec2",
+				"cloud.provider": "ec2",
 				"cloud": common.MapStr{
 					"provider": "ec2",
 					"instance": common.MapStr{

--- a/libbeat/processors/add_cloud_metadata/provider_aws_ec2_test.go
+++ b/libbeat/processors/add_cloud_metadata/provider_aws_ec2_test.go
@@ -118,6 +118,14 @@ func TestRetrieveAWSMetadata(t *testing.T) {
 			},
 			common.MapStr{
 				"cloud.provider": "ec2",
+			},
+		},
+		{
+			common.MapStr{
+				"provider": "ec2",
+			},
+			common.MapStr{
+				"provider": "ec2",
 				"cloud": common.MapStr{
 					"provider": "ec2",
 					"instance": common.MapStr{

--- a/libbeat/processors/add_cloud_metadata/provider_aws_ec2_test.go
+++ b/libbeat/processors/add_cloud_metadata/provider_aws_ec2_test.go
@@ -114,13 +114,20 @@ func TestRetrieveAWSMetadata(t *testing.T) {
 		},
 		{
 			common.MapStr{
-				"cloud": common.MapStr{
-					"provider": "ec2",
-				},
+				"cloud.provider": "ec2",
 			},
 			common.MapStr{
+				"cloud.provider": "ec2",
 				"cloud": common.MapStr{
 					"provider": "ec2",
+					"instance": common.MapStr{
+						"id": "i-11111111",
+					},
+					"machine": common.MapStr{
+						"type": "t2.medium",
+					},
+					"region":            "us-east-1",
+					"availability_zone": "us-east-1c",
 				},
 			},
 		},
@@ -198,11 +205,10 @@ func TestRetrieveAWSMetadataOverwriteTrue(t *testing.T) {
 		},
 		{
 			common.MapStr{
-				"cloud": common.MapStr{
-					"provider": "ec2",
-				},
+				"cloud.provider": "ec2",
 			},
 			common.MapStr{
+				"cloud.provider": "ec2",
 				"cloud": common.MapStr{
 					"provider": "ec2",
 					"instance": common.MapStr{

--- a/libbeat/processors/add_cloud_metadata/provider_aws_ec2_test.go
+++ b/libbeat/processors/add_cloud_metadata/provider_aws_ec2_test.go
@@ -75,23 +75,49 @@ func TestRetrieveAWSMetadata(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	actual, err := p.Run(&beat.Event{Fields: common.MapStr{}})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	expected := common.MapStr{
-		"cloud": common.MapStr{
-			"provider": "ec2",
-			"instance": common.MapStr{
-				"id": "i-11111111",
+	cases := []struct {
+		fields          common.MapStr
+		expectedResults common.MapStr
+	}{
+		{
+			common.MapStr{},
+			common.MapStr{
+				"cloud": common.MapStr{
+					"provider": "ec2",
+					"instance": common.MapStr{
+						"id": "i-11111111",
+					},
+					"machine": common.MapStr{
+						"type": "t2.medium",
+					},
+					"region":            "us-east-1",
+					"availability_zone": "us-east-1c",
+				},
 			},
-			"machine": common.MapStr{
-				"type": "t2.medium",
+		},
+		{
+			common.MapStr{
+				"cloud": common.MapStr{
+					"instance": common.MapStr{
+						"id": "i-000",
+					},
+				},
 			},
-			"region":            "us-east-1",
-			"availability_zone": "us-east-1c",
+			common.MapStr{
+				"cloud": common.MapStr{
+					"instance": common.MapStr{
+						"id": "i-000",
+					},
+				},
+			},
 		},
 	}
-	assert.Equal(t, expected, actual.Fields)
+
+	for _, c := range cases {
+		actual, err := p.Run(&beat.Event{Fields: c.fields})
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, c.expectedResults, actual.Fields)
+	}
 }


### PR DESCRIPTION
When aws module is enabled, ec2 metricset will collect data with cloud.* included. If metricbeat is running on GCP or other cloud platforms, with the current add_cloud_metadata processor will overwrite the cloud.* fields from ec2 metricset. 

This PR is to disable the overwrite part for add_cloud_metadata. When cloud.* exists already, add_cloud_metadata will not overwrite cloud fields. 

closes https://github.com/elastic/beats/issues/11305