### PR TITLE
Collect field also being collected by internal collector

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -115,6 +115,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add AWS s3_request metricset. {pull}10949[10949] {issue}10055[10055]
 - Add s3_daily_storage metricset. {pull}10940[10940] {issue}10055[10055]
 - Add `coredns` metricbeat module. {pull}10585[10585]
+- The `elasticsearch.index` metricset (with `xpack.enabled: true`) now collects `refresh.external_total_time_in_millis` fields from Elasticsearch. {pull}11616[11616]
 
 *Packetbeat*
 

--- a/metricbeat/module/elasticsearch/index/data_xpack.go
+++ b/metricbeat/module/elasticsearch/index/data_xpack.go
@@ -81,7 +81,8 @@ var (
 			"size_in_bytes": c.Int("size_in_bytes"),
 		}),
 		"refresh": c.Dict("refresh", s.Schema{
-			"total_time_in_millis": c.Int("total_time_in_millis"),
+			"external_total_time_in_millis": c.Int("external_total_time_in_millis"),
+			"total_time_in_millis":          c.Int("total_time_in_millis"),
 		}),
 	}
 


### PR DESCRIPTION
This PR updates the `elasticsearch.index` metricset (x-pack code path) to collect a new field that's now being collected by internal/native `index_stats` collector.