### PR TITLE
Cherry-pick #11237 to 7.0: Add missing docs for filebeat.registry.migrate_file

### DIFF
--- a/filebeat/_meta/common.reference.p2.yml
+++ b/filebeat/_meta/common.reference.p2.yml
@@ -32,6 +32,14 @@
 # batch of events has been published successfully. The default value is 0s.
 #filebeat.registry.flush: 0s
 
+
+# Starting with Filebeat 7.0, the registry uses a new directory format to store
+# Filebeat state. After you upgrade, Filebeat will automatically migrate a 6.x
+# registry file to use the new directory format. If you changed
+# filebeat.registry.path while upgrading, set filebeat.registry.migrate_file to
+# point to the old registry file.
+#filebeat.registry.migrate_file: ${path.data}/registry
+
 # By default Ingest pipelines are not updated if a pipeline with the same ID
 # already exists. If this option is enabled Filebeat overwrites pipelines
 # everytime a new Elasticsearch connection is established.

--- a/filebeat/docs/filebeat-general-options.asciidoc
+++ b/filebeat/docs/filebeat-general-options.asciidoc
@@ -73,6 +73,24 @@ NOTE: Filtering out a huge number of logs can cause many registry updates, slowi
 down processing. Setting `registry.flush` to a value >0s reduces write operations,
 helping Filebeat process more events.
 
+[float]
+==== `registry.migrate_file`
+
+Prior to Filebeat 7.0 the registry is stored in a single file. When you upgrade
+to 7.0, Filebeat will automatically migrate the old Filebeat 6.x registry file
+to use the new directory format. Filebeat looks for the file in the location
+specified by `filebeat.registry.path`. If you changed the path while upgrading,
+set `filebeat.registry.migrate_file` to point to the old registry file.
+
+[source,yaml]
+-------------------------------------------------------------------------------------
+filebeat.registry.path: ${path.data}/registry
+filebeat.registry.migrate_file: /path/to/old/registry_file
+-------------------------------------------------------------------------------------
+
+The registry will be migrated to the new location only if a registry using the
+directory format does not already exist.
+
 
 [float]
 ==== `config_dir`

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -790,6 +790,14 @@ filebeat.inputs:
 # batch of events has been published successfully. The default value is 0s.
 #filebeat.registry.flush: 0s
 
+
+# Starting with Filebeat 7.0, the registry uses a new directory format to store
+# Filebeat state. After you upgrade, Filebeat will automatically migrate a 6.x
+# registry file to use the new directory format. If you changed
+# filebeat.registry.path while upgrading, set filebeat.registry.migrate_file to
+# point to the old registry file.
+#filebeat.registry.migrate_file: ${path.data}/registry
+
 # By default Ingest pipelines are not updated if a pipeline with the same ID
 # already exists. If this option is enabled Filebeat overwrites pipelines
 # everytime a new Elasticsearch connection is established.

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -861,6 +861,14 @@ filebeat.inputs:
 # batch of events has been published successfully. The default value is 0s.
 #filebeat.registry.flush: 0s
 
+
+# Starting with Filebeat 7.0, the registry uses a new directory format to store
+# Filebeat state. After you upgrade, Filebeat will automatically migrate a 6.x
+# registry file to use the new directory format. If you changed
+# filebeat.registry.path while upgrading, set filebeat.registry.migrate_file to
+# point to the old registry file.
+#filebeat.registry.migrate_file: ${path.data}/registry
+
 # By default Ingest pipelines are not updated if a pipeline with the same ID
 # already exists. If this option is enabled Filebeat overwrites pipelines
 # everytime a new Elasticsearch connection is established.


### PR DESCRIPTION
Cherry-pick of PR #11237 to 7.0 branch. Original message: 

The `filebeat.registry.migrate_file` has been introduced with 7.0. I just noticed that the doc is still missing.