### PR TITLE
[Auditbeat] Package: Nullify Librpm's rpmsqEnable

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -49,6 +49,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 *Auditbeat*
 
 - Package dataset: dlopen versioned librpm shared objects. {pull}11565[11565]
+- Package dataset: Nullify Librpm's rpmsqEnable. {pull}11628[11628]
 
 *Filebeat*
 


### PR DESCRIPTION
We've had a number of problems with Librpm's use of signal traps (https://github.com/elastic/beats/issues/10633). We've tried to fix it by using Librpm functions to disable them (https://github.com/elastic/beats/pull/10694), but there is still the occasional test failure that seems related to it. I've also seen it happen at least once locally.

Now I've started testing the dataset on OpenSUSE and found our fix prevents it from working at all. The Python system test will reliably fail, with the Auditbeat test process shown as terminated by an uncaught `SIGTERM`. If I remove our disabling logic it works, but only on OpenSUSE, and again not on CentOS. I don't know exactly what in Librpm or our use of it is causing the behavior on OpenSUSE, my assumption is that something is going wrong with how we try to unset the signal traps, with the original ones not being restored.

So I'm proposing a more radical solution - overriding the `rpmsqEnable` function in Librpm that sets and unsets signal traps. This is possible since we `dlopen/dlsym` the library into the process, so any functions that are already defined will be used instead of what the library comes with. In a way, this is exactly what the `rpmsqSetInterruptSafety` function does in newer versions of Librpm (see https://github.com/rpm-software-management/rpm/commit/56f49d7f5af7c1c8a3eb478431356195adbfdd25). It is also what gdb did with [this patch](https://git.centos.org/blob/rpms!gdb.git/7b26da83cdbaed9e7fdbb5ebd67de2bbb54f5b7e/SOURCES!gdb-6.6-buildid-locate-rpm-librpm-workaround.patch) following their [bug report](https://bugzilla.redhat.com/show_bug.cgi?id=643031). I should have investigated their fix more closely the last time around.

Hopefully, this will eliminate the residual test failures.

I'll open another PR to enable the OS family `suse` for the package dataset that depends on this.