### PR TITLE
Skip flaky docker provider test in libbeat

### DIFF
--- a/libbeat/autodiscover/providers/docker/docker_integration_test.go
+++ b/libbeat/autodiscover/providers/docker/docker_integration_test.go
@@ -33,6 +33,7 @@ import (
 
 // Test docker start emits an autodiscover event
 func TestDockerStart(t *testing.T) {
+	t.Skip("Skipped as flaky: https://github.com/elastic/beats/issues/11627")
 	d, err := dk.NewClient()
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Related: https://github.com/elastic/beats/issues/11627