### PR TITLE
[Auditbeat] Package: Enable suse

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -99,6 +99,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 *Auditbeat*
 
 - Auditd module: Add `event.outcome` and `event.type` for ECS. {pull}11432[11432]
+- Package: Enable suse. {pull}11634[11634]
 
 *Filebeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -100,6 +100,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 - Auditd module: Add `event.outcome` and `event.type` for ECS. {pull}11432[11432]
 - Package: Enable suse. {pull}11634[11634]
+- Add support to the system package dataset for the SUSE OS family. {pull}11634[11634]
 
 *Filebeat*
 

--- a/x-pack/auditbeat/module/system/package/package.go
+++ b/x-pack/auditbeat/module/system/package/package.go
@@ -39,6 +39,7 @@ const (
 	namespace     = "system.audit.package"
 
 	redhat = "redhat"
+	suse   = "suse"
 	debian = "debian"
 	darwin = "darwin"
 
@@ -207,7 +208,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	}
 	ms.osFamily = osInfo.Family
 	switch osInfo.Family {
-	case redhat:
+	case redhat, suse:
 		// ok
 	case debian:
 		if _, err := os.Stat(dpkgStatusFile); err != nil {
@@ -471,7 +472,7 @@ func (ms *MetricSet) savePackagesToDisk(packages []*Package) error {
 
 func getPackages(osFamily string) (packages []*Package, err error) {
 	switch osFamily {
-	case redhat:
+	case redhat, suse:
 		packages, err = listRPMPackages()
 		if err != nil {
 			err = errors.Wrap(err, "error getting RPM packages")


### PR DESCRIPTION
Both openSUSE and SLES use RPM under the hood, so we can use the code we already have for CentOS/Fedora.

Depends on https://github.com/elastic/beats/pull/11628.

Fixes https://github.com/elastic/beats-tester/issues/115.