### PR TITLE
Fix metricbeat-kubernetes.yaml link

### DIFF
--- a/deploy/kubernetes/metricbeat/README.md
+++ b/deploy/kubernetes/metricbeat/README.md
@@ -14,7 +14,7 @@ updating YAML manifests under this folder.
 
 We use official [Beats Docker images](https://github.com/elastic/beats-docker),
 as they allow external files configuration, a [ConfigMap](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/)
-is used for kubernetes specific settings. Check [metricbeat-configmap.yaml](metricbeat-configmap.yaml)
+is used for kubernetes specific settings. Check [metricbeat-kubernetes.yaml](metricbeat-configmap.yaml)
 for details.
 
 Also, [metricbeat-daemonset.yaml](metricbeat-daemonset.yaml) uses a set of environment


### PR DESCRIPTION
It look like the metricbeat-configmap.yaml has change name to metricbeat-kubernetes.yaml.
