### PR TITLE
Cherry-pick #11639 to 7.0: Add missing `$` in example autodiscover config

### DIFF
--- a/metricbeat/docs/autodiscover-kubernetes-config.asciidoc
+++ b/metricbeat/docs/autodiscover-kubernetes-config.asciidoc
@@ -13,7 +13,7 @@ metricbeat.autodiscover:
           config:
             - module: prometheus
               metricsets: ["collector"]
-              hosts: "${data.host}:{data.port}"
+              hosts: "${data.host}:${data.port}"
 -------------------------------------------------------------------------------------
 
 This configuration launches a `prometheus` module for all containers of pods annotated `prometheus.io.scrape=true`.


### PR DESCRIPTION
Cherry-pick of PR #11639 to 7.0 branch. Original message: 

closes #11622 