### PR TITLE
[functionbeat] Fix function name reference for Kinesis streams in CF templates

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -101,6 +101,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Functionbeat*
 
+- Fix function name reference for Kinesis streams in CloudFormation templates {pull}11646[11646]
+
 ==== Added
 
 *Affecting all Beats*

--- a/x-pack/functionbeat/provider/aws/kinesis.go
+++ b/x-pack/functionbeat/provider/aws/kinesis.go
@@ -158,15 +158,15 @@ func (k *Kinesis) LambdaConfig() *lambdaConfig {
 func (k *Kinesis) Template() *cloudformation.Template {
 	template := cloudformation.NewTemplate()
 	prefix := func(suffix string) string {
-		return normalizeResourceName("fnb" + k.config.Name + k.Name() + suffix)
+		return normalizeResourceName("fnb" + k.config.Name + suffix)
 	}
 
 	for _, trigger := range k.config.Triggers {
-		resourceName := prefix(trigger.EventSourceArn)
+		resourceName := prefix(k.Name() + trigger.EventSourceArn)
 		template.Resources[resourceName] = &cloudformation.AWSLambdaEventSourceMapping{
 			BatchSize:        trigger.BatchSize,
 			EventSourceArn:   trigger.EventSourceArn,
-			FunctionName:     cloudformation.GetAtt(normalizeResourceName("fnb"+k.config.Name), "Arn"),
+			FunctionName:     cloudformation.GetAtt(prefix(""), "Arn"),
 			StartingPosition: trigger.StartingPosition.String(),
 		}
 	}

--- a/x-pack/functionbeat/provider/aws/kinesis.go
+++ b/x-pack/functionbeat/provider/aws/kinesis.go
@@ -166,7 +166,7 @@ func (k *Kinesis) Template() *cloudformation.Template {
 		template.Resources[resourceName] = &cloudformation.AWSLambdaEventSourceMapping{
 			BatchSize:        trigger.BatchSize,
 			EventSourceArn:   trigger.EventSourceArn,
-			FunctionName:     cloudformation.GetAtt("fnb"+k.config.Name, "Arn"),
+			FunctionName:     cloudformation.GetAtt(normalizeResourceName("fnb"+k.config.Name), "Arn"),
 			StartingPosition: trigger.StartingPosition.String(),
 		}
 	}


### PR DESCRIPTION
This PR solves the issue when function names containing non-alphanumerical characters cause the CloudFormation template to be invalid when using Kinesis as a trigger.

A normalized name of the function is added to the  `Resources` section of the template as a key, so the value of `FunctionName` referencing the function should be normalized as well.