### PR TITLE
[CM] Parse enrollment_token response correctly

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -45,6 +45,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Report faulting file when config reload fails. {pull}[11304]11304
 - Fix a typo in libbeat/outputs/transport/client.go by updating `c.conn.LocalAddr()` to `c.conn.RemoteAddr()`. {pull}11242[11242]
 - Management configuration backup file will now have a timestamps in their name. {pull}11034[11034]
+- [CM] Parse enrollment_token response correctly {pull}11648[11648]
 
 *Auditbeat*
 
@@ -58,7 +59,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Improve detection of file deletion on Windows. {pull}10747[10747]
 - Fix goroutine leak happening when harvesters are dynamically stopped. {pull}11263[11263]
 - Fix `add_docker_metadata` source matching, using `log.file.path` field now. {pull}11577[11577]
-- Add missing Kubernetes metadata fields to Filebeat CoreDNS module, and fix a documentation error. {pull}11591[11591] 
+- Add missing Kubernetes metadata fields to Filebeat CoreDNS module, and fix a documentation error. {pull}11591[11591]
 
 *Heartbeat*
 

--- a/x-pack/libbeat/management/api/enrollment_token.go
+++ b/x-pack/libbeat/management/api/enrollment_token.go
@@ -14,16 +14,19 @@ func (c *Client) CreateEnrollmentToken() (string, error) {
 	headers := http.Header{}
 
 	resp := struct {
-		Tokens []string `json:"tokens"`
+		Results []struct {
+			Token string `json:"item"`
+		} `json:"results"`
 	}{}
+
 	_, err := c.request("POST", "/api/beats/enrollment_tokens", nil, headers, &resp)
 	if err != nil {
 		return "", err
 	}
 
-	if len(resp.Tokens) != 1 {
-		return "", fmt.Errorf("Unexpected number of tokens, got %d, only one expected", len(resp.Tokens))
+	if tokensCount := len(resp.Results); tokensCount != 1 {
+		return "", fmt.Errorf("Unexpected number of tokens, got %d, only one expected", tokensCount)
 	}
 
-	return resp.Tokens[0], nil
+	return resp.Results[0].Token, nil
 }

--- a/x-pack/libbeat/management/api/enrollment_token_test.go
+++ b/x-pack/libbeat/management/api/enrollment_token_test.go
@@ -16,7 +16,7 @@ func TestEnrollmentToken(t *testing.T) {
 	server, client := newServerClientPair(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Check correct path is used
 		assert.Equal(t, "/api/beats/enrollment_tokens", r.URL.Path)
-		fmt.Fprintf(w, `{"tokens":["65074ff8639a4661ba7e1bd5ccc209ed"]}`)
+		fmt.Fprintf(w, `{"results": [{"item":"65074ff8639a4661ba7e1bd5ccc209ed"}]}`)
 	}))
 	defer server.Close()
 

--- a/x-pack/libbeat/management/enroll.go
+++ b/x-pack/libbeat/management/enroll.go
@@ -53,10 +53,10 @@ func Enroll(
 
 	configFile := cfgfile.GetDefaultCfgfile()
 
-	ts := time.Now().Unix()
+	ts := time.Now()
 
 	// backup current settings:
-	backConfigFile := configFile + "." + string(ts) + ".bak"
+	backConfigFile := configFile + "." + ts.Format(time.RFC3339) + ".bak"
 	fmt.Println("Saving a copy of current settings to " + backConfigFile)
 	err = file.SafeFileRotate(backConfigFile, configFile)
 	if err != nil {

--- a/x-pack/libbeat/tests/system/test_management.py
+++ b/x-pack/libbeat/tests/system/test_management.py
@@ -15,8 +15,8 @@ from base import BaseTest
 
 
 # Disable because waiting artifacts from https://github.com/elastic/kibana/pull/31660
-# INTEGRATION_TESTS = os.environ.get('INTEGRATION_TESTS', False)
-INTEGRATION_TESTS = False
+INTEGRATION_TESTS = os.environ.get('INTEGRATION_TESTS', False)
+# INTEGRATION_TESTS = False
 TIMEOUT = 2 * 60
 
 


### PR DESCRIPTION
Followup to #11377 

Fixes enrollment token response to be parsed correctly according to a new response format
