### PR TITLE
Collect license expiry date fields as well

### DIFF
--- a/metricbeat/module/elasticsearch/elasticsearch.go
+++ b/metricbeat/module/elasticsearch/elasticsearch.go
@@ -61,17 +61,17 @@ type NodeInfo struct {
 
 // License contains data about the Elasticsearch license
 type License struct {
-	Status             string    `json:"status"`
-	ID                 string    `json:"uid"`
-	Type               string    `json:"type"`
-	ExpiryDate         time.Time `json:"expiry_date"`
-	ExpiryDateInMillis int       `json:"expiry_date_in_millis"`
-	IssueDate          time.Time `json:"issue_date"`
-	IssueDateInMillis  int       `json:"issue_date_in_millis"`
-	MaxNodes           int       `json:"max_nodes"`
-	IssuedTo           string    `json:"issued_to"`
-	Issuer             string    `json:"issuer"`
-	StartDateInMillis  int       `json:"start_date_in_millis"`
+	Status             string     `json:"status"`
+	ID                 string     `json:"uid"`
+	Type               string     `json:"type"`
+	IssueDate          *time.Time `json:"issue_date"`
+	IssueDateInMillis  int        `json:"issue_date_in_millis"`
+	ExpiryDate         *time.Time `json:"expiry_date,omitempty"`
+	ExpiryDateInMillis int        `json:"expiry_date_in_millis,omitempty"`
+	MaxNodes           int        `json:"max_nodes"`
+	IssuedTo           string     `json:"issued_to"`
+	Issuer             string     `json:"issuer"`
+	StartDateInMillis  int        `json:"start_date_in_millis"`
 }
 
 type licenseWrapper struct {

--- a/metricbeat/module/elasticsearch/elasticsearch.go
+++ b/metricbeat/module/elasticsearch/elasticsearch.go
@@ -61,15 +61,17 @@ type NodeInfo struct {
 
 // License contains data about the Elasticsearch license
 type License struct {
-	Status            string    `json:"status"`
-	ID                string    `json:"uid"`
-	Type              string    `json:"type"`
-	IssueDate         time.Time `json:"issue_date"`
-	IssueDateInMillis int       `json:"issue_date_in_millis"`
-	MaxNodes          int       `json:"max_nodes"`
-	IssuedTo          string    `json:"issued_to"`
-	Issuer            string    `json:"issuer"`
-	StartDateInMillis int       `json:"start_date_in_millis"`
+	Status             string    `json:"status"`
+	ID                 string    `json:"uid"`
+	Type               string    `json:"type"`
+	ExpiryDate         time.Time `json:"expiry_date"`
+	ExpiryDateInMillis int       `json:"expiry_date_in_millis"`
+	IssueDate          time.Time `json:"issue_date"`
+	IssueDateInMillis  int       `json:"issue_date_in_millis"`
+	MaxNodes           int       `json:"max_nodes"`
+	IssuedTo           string    `json:"issued_to"`
+	Issuer             string    `json:"issuer"`
+	StartDateInMillis  int       `json:"start_date_in_millis"`
 }
 
 type licenseWrapper struct {


### PR DESCRIPTION
This PR teaches the `elasticsearch.cluster_stats` metricset (x-pack code path) to collect and index the license expiration fields, `expiry_date` and `expiry_date_in_millis` as well.

## Testing this PR

### Basic license

1. Start Elasticsearch with a Basic license.
6. Delete `.monitoring-es-*` indices to start with a clean slate (making it easier to test).
   ```
   DELETE .monitoring-es-*
   ```
2. Turn on Elasticsearch monitoring via the native collection method.
3. Wait ~15 seconds for documents to be indexed into `.monitoring-es-*`.
4. Check the value of the `license` field indexed into a `.monitoring-es-*` document with `type:cluster_stats`. In particular, **note that it is missing** the `expiry_date` and `expiry_date_in_millis` sub-fields.
   ```
   POST .monitoring-es-7-*/_search?filter_path=**.license
   {
     "query": {
       "term": {
         "type": "cluster_stats"
       }
     }
   }
   ```
5. Turn off Elasticsearch native collection.
   ```
   PUT _cluster/settings
   {
     "transient": {
       "xpack.monitoring.elasticsearch.collection.enabled": false
     }
   }
   ```
6. Delete `.monitoring-es-*` indices to start with a clean slate (making it easier to test).
   ```
   DELETE .monitoring-es-*
   ```
7. Build Metricbeat with this PR.
   ```
   cd $GOPATH/src/github.com/elastic/beats/metricbeat
   mage build
   ```
8. Enable Elasticsearch collection via Metricbeat.
   ```
   ./metricbeat modules enable elasticsearch-xpack
   ```
9. Start Metricbeat
   ```
   ./metricbeat
   ```
10. Wait ~15 seconds for documents to be indexed into `.monitoring-es-*`.
11. Check the value of the `license` field indexed into a `.monitoring-es-*` document with `type:cluster_stats`. In particular, **verify that it is missing** the `expiry_date` and `expiry_date_in_millis` sub-fields.
   ```
   POST .monitoring-es-7-*/_search?filter_path=**.license
   {
     "query": {
       "term": {
         "type": "cluster_stats"
       }
     }
   }
   ```

### Trial license

1. Start Elasticsearch with a Trial license. If you started with a Basic license, you can upgrade to Trial via the Kibana License Management UI.
6. Delete `.monitoring-es-*` indices to start with a clean slate (making it easier to test).
   ```
   DELETE .monitoring-es-*
   ```
2. Turn on Elasticsearch monitoring via the native collection method.
3. Wait ~15 seconds for documents to be indexed into `.monitoring-es-*`.
4. Check the value of the `license` field indexed into a `.monitoring-es-*` document with `type:cluster_stats`. In particular, **note that it includes** the `expiry_date` and `expiry_date_in_millis` sub-fields.
   ```
   POST .monitoring-es-7-*/_search?filter_path=**.license
   {
     "query": {
       "term": {
         "type": "cluster_stats"
       }
     }
   }
   ```
5. Turn off Elasticsearch native collection.
   ```
   PUT _cluster/settings
   {
     "transient": {
       "xpack.monitoring.elasticsearch.collection.enabled": false
     }
   }
   ```
6. Delete `.monitoring-es-*` indices to start with a clean slate (making it easier to test).
   ```
   DELETE .monitoring-es-*
   ```
7. Build Metricbeat with this PR.
   ```
   cd $GOPATH/src/github.com/elastic/beats/metricbeat
   mage build
   ```
8. Enable Elasticsearch collection via Metricbeat.
   ```
   ./metricbeat modules enable elasticsearch-xpack
   ```
9. Start Metricbeat
   ```
   ./metricbeat
   ```
10. Wait ~15 seconds for documents to be indexed into `.monitoring-es-*`.
11. Check the value of the `license` field indexed into a `.monitoring-es-*` document with `type:cluster_stats`. In particular, **verify that it includes** the `expiry_date` and `expiry_date_in_millis` sub-fields.
   ```
   POST .monitoring-es-7-*/_search?filter_path=**.license
   {
     "query": {
       "term": {
         "type": "cluster_stats"
       }
     }
   }
   ```



