### PR TITLE
Remove cluster_name from under cluster_stats field

### DIFF
--- a/metricbeat/module/elasticsearch/cluster_stats/data_xpack.go
+++ b/metricbeat/module/elasticsearch/cluster_stats/data_xpack.go
@@ -170,6 +170,7 @@ func eventMappingXPack(r mb.ReporterV2, m *MetricSet, info elasticsearch.Info, c
 	if !ok {
 		return fmt.Errorf("cluster name is not a string")
 	}
+	clusterStats.Delete("cluster_name")
 
 	license, err := elasticsearch.GetLicense(m.HTTP, m.HTTP.GetURI())
 	if err != nil {


### PR DESCRIPTION
We already index the `cluster_name` field as a top-level field in `.monitoring-es-*` docs with `type: cluster_stats`. So we don't need to index it under the `cluster_stats` top-level field as well.

### Testing this PR
1. Pull down this PR and build Metricbeat.
   ```
   cd metricbeat
   mage build
   ```
2. Enable the `elasticsearch` Metricbeat module.
   ```
   ./metricbeat modules enable elasticsearch
   ```
3. Edit `modules.d/elasticsearch.yml` and make sure the `cluster_stats` metricset is enabled. Also set `xpack.enabled: true` for the module.
4. Start Metricbeat
   ```
   ./metricbeat -e
   ```
5. Using Kibana Console check that the Metricbeat-indexed monitoring documents for Elasticsearch don't contain the `cluster_stats.cluster_name` field.
   ```
   GET .monitoring-es-7-mb-*/_search?q=type:cluster_stats
   ```
