### PR TITLE
Updating monitoring docs with direct monitoring configuration

### DIFF
--- a/libbeat/docs/monitoring/monitoring-beats.asciidoc
+++ b/libbeat/docs/monitoring/monitoring-beats.asciidoc
@@ -17,11 +17,11 @@
 [partintro]
 --
 
-NOTE: {monitoring} for {beatname_uc} requires {es} {beat_monitoring_version} or later.
+NOTE: The {monitor-features} for {beatname_uc} require {es} {beat_monitoring_version} or later.
 
-{monitoring} enables you to easily monitor {beatname_uc} from {kib}. For more
+The {stack} {monitor-features} enable you to easily monitor {beatname_uc} from {kib}. For more
 information, see
-{xpack-ref}/xpack-monitoring.html[Monitoring the Elastic Stack] and
+{stack-ov}/xpack-monitoring.html[Monitoring the {stack}] and
 {kibana-ref}/beats-page.html[Beats Monitoring Metrics].
 
 To configure {beatname_uc} to collect and send monitoring metrics:
@@ -30,8 +30,8 @@ To configure {beatname_uc} to collect and send monitoring metrics:
 data to {es}. For example, you can use the built-in +{beat_monitoring_user}+ user or
 assign the built-in +{beat_monitoring_user}+ role to another user. For more
 information, see
-{xpack-ref}/setting-up-authentication.html[Setting Up User Authentication] and
-{xpack-ref}/built-in-roles.html[Built-in Roles].
+{stack-ov}/setting-up-authentication.html[Setting Up User Authentication] and
+{stack-ov}/built-in-roles.html[Built-in Roles].
 
 . Add the `monitoring` settings in the {beatname_uc} configuration file. If you
 configured the {es} output and want to send {beatname_uc} monitoring events to

--- a/libbeat/docs/monitoring/monitoring-beats.asciidoc
+++ b/libbeat/docs/monitoring/monitoring-beats.asciidoc
@@ -33,32 +33,31 @@ information, see
 {xpack-ref}/setting-up-authentication.html[Setting Up User Authentication] and
 {xpack-ref}/built-in-roles.html[Built-in Roles].
 
-. Add the `xpack.monitoring` settings in the {beatname_uc} configuration file. If you
-configured {es} output, specify the following minimal configuration:
+. Add the `monitoring` settings in the {beatname_uc} configuration file. If you
+configured the {es} output and want to send {beatname_uc} monitoring events to
+the same {es} cluster, specify the following minimal configuration:
 +
 --
 [source, yml]
 --------------------
-xpack.monitoring.enabled: true
+monitoring.enabled: true
 --------------------
 
-If you configured a different output, such as {ls}, you must specify additional
-configuration options. For example:
+If you configured a different output, such as {ls} or you want to send {beatname_uc}
+monitoring events to a separate {es} cluster (referred to as the _monitoring cluster_),
+you must specify additional configuration options. For example:
 
 ["source","yml",subs="attributes"]
 --------------------
-xpack.monitoring:
+monitoring:
   enabled: true
   elasticsearch:
-    hosts: ["https://example.com:9200", "https://example2.com:9200"]
+    hosts: ["https://example.com:9200", "https://example2.com:9200"] <1>
     username: {beat_monitoring_user}
     password: somepassword
 --------------------
-
-NOTE: Currently you must send monitoring data to the same cluster as all other events.
-If you configured {es} output, do not specify additional hosts in the monitoring
-configuration.
-
+<1> This setting identifies the hosts and port numbers of {es} nodes
+that are part of the monitoring cluster.
 --
 
 . {kibana-ref}/monitoring-xpack-kibana.html[Configure monitoring in {kib}].


### PR DESCRIPTION
Beats now have the ability to send their monitoring data directly to the **monitoring** Elasticsearch cluster (#9260). This PR updates the Beats monitoring documentation with this change.

Resolves #11637.