### PR TITLE
[Libbeat] Fix array matching in contains condition

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -51,6 +51,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix a parsing error with the X-Pack license check on 32-bit system. {issue}11650[11650]
 - Fix ILM policy always being overwritten. {pull}11671[11671]
 - Fix template always being overwritten. {pull}11671[11671]
+- Fix matching of string arrays in contains condition. {pull}11691[11691]
 
 *Auditbeat*
 

--- a/libbeat/common/match/matcher.go
+++ b/libbeat/common/match/matcher.go
@@ -119,19 +119,19 @@ func (m *Matcher) Unpack(s string) error {
 	return nil
 }
 
-func (m *Matcher) MatchAnyString(strs []string) bool {
+func (m *Matcher) MatchAnyString(strs []interface{}) bool {
 	return matchAnyStrings(m.stringMatcher, strs)
 }
 
-func (m *Matcher) MatchAllStrings(strs []string) bool {
+func (m *Matcher) MatchAllStrings(strs []interface{}) bool {
 	return matchAllStrings(m.stringMatcher, strs)
 }
 
-func (m *ExactMatcher) MatchAnyString(strs []string) bool {
+func (m *ExactMatcher) MatchAnyString(strs []interface{}) bool {
 	return matchAnyStrings(m.stringMatcher, strs)
 }
 
-func (m *ExactMatcher) MatchAllStrings(strs []string) bool {
+func (m *ExactMatcher) MatchAllStrings(strs []interface{}) bool {
 	return matchAllStrings(m.stringMatcher, strs)
 }
 
@@ -145,18 +145,18 @@ func (m *ExactMatcher) Unpack(s string) error {
 	return nil
 }
 
-func matchAnyStrings(m stringMatcher, strs []string) bool {
+func matchAnyStrings(m stringMatcher, strs []interface{}) bool {
 	for _, s := range strs {
-		if m.MatchString(s) {
+		if str, ok := s.(string); ok && m.MatchString(str) {
 			return true
 		}
 	}
 	return false
 }
 
-func matchAllStrings(m stringMatcher, strs []string) bool {
+func matchAllStrings(m stringMatcher, strs []interface{}) bool {
 	for _, s := range strs {
-		if !m.MatchString(s) {
+		if str, ok := s.(string); ok && !m.MatchString(str) {
 			return false
 		}
 	}

--- a/libbeat/common/match/matcher.go
+++ b/libbeat/common/match/matcher.go
@@ -120,22 +120,22 @@ func (m *Matcher) Unpack(s string) error {
 }
 
 // MatchAnyString succeeds if any string in the given array contains a match.
-func (m *Matcher) MatchAnyString(strs []interface{}) bool {
+func (m *Matcher) MatchAnyString(strs interface{}) bool {
 	return matchAnyStrings(m.stringMatcher, strs)
 }
 
 // MatchAllStrings succeeds if all strings in the given array contain a match.
-func (m *Matcher) MatchAllStrings(strs []interface{}) bool {
+func (m *Matcher) MatchAllStrings(strs interface{}) bool {
 	return matchAllStrings(m.stringMatcher, strs)
 }
 
 // MatchAnyString succeeds if any string in the given array is an exact match.
-func (m *ExactMatcher) MatchAnyString(strs []interface{}) bool {
+func (m *ExactMatcher) MatchAnyString(strs interface{}) bool {
 	return matchAnyStrings(m.stringMatcher, strs)
 }
 
 // MatchAllStrings succeeds if all strings in the given array are an exact match.
-func (m *ExactMatcher) MatchAllStrings(strs []interface{}) bool {
+func (m *ExactMatcher) MatchAllStrings(strs interface{}) bool {
 	return matchAllStrings(m.stringMatcher, strs)
 }
 
@@ -149,19 +149,37 @@ func (m *ExactMatcher) Unpack(s string) error {
 	return nil
 }
 
-func matchAnyStrings(m stringMatcher, strs []interface{}) bool {
-	for _, s := range strs {
-		if str, ok := s.(string); ok && m.MatchString(str) {
-			return true
+func matchAnyStrings(m stringMatcher, strs interface{}) bool {
+	switch v := strs.(type) {
+	case []interface{}:
+		for _, s := range v {
+			if str, ok := s.(string); ok && m.MatchString(str) {
+				return true
+			}
+		}
+	case []string:
+		for _, s := range v {
+			if m.MatchString(s) {
+				return true
+			}
 		}
 	}
 	return false
 }
 
-func matchAllStrings(m stringMatcher, strs []interface{}) bool {
-	for _, s := range strs {
-		if str, ok := s.(string); ok && !m.MatchString(str) {
-			return false
+func matchAllStrings(m stringMatcher, strs interface{}) bool {
+	switch v := strs.(type) {
+	case []interface{}:
+		for _, s := range v {
+			if str, ok := s.(string); ok && !m.MatchString(str) {
+				return false
+			}
+		}
+	case []string:
+		for _, s := range v {
+			if !m.MatchString(s) {
+				return false
+			}
 		}
 	}
 	return true

--- a/libbeat/common/match/matcher.go
+++ b/libbeat/common/match/matcher.go
@@ -119,18 +119,22 @@ func (m *Matcher) Unpack(s string) error {
 	return nil
 }
 
+// MatchAnyString succeeds if any string in the given array contains a match.
 func (m *Matcher) MatchAnyString(strs []interface{}) bool {
 	return matchAnyStrings(m.stringMatcher, strs)
 }
 
+// MatchAllStrings succeeds if all strings in the given array contain a match.
 func (m *Matcher) MatchAllStrings(strs []interface{}) bool {
 	return matchAllStrings(m.stringMatcher, strs)
 }
 
+// MatchAnyString succeeds if any string in the given array is an exact match.
 func (m *ExactMatcher) MatchAnyString(strs []interface{}) bool {
 	return matchAnyStrings(m.stringMatcher, strs)
 }
 
+// MatchAllStrings succeeds if all strings in the given array are an exact match.
 func (m *ExactMatcher) MatchAllStrings(strs []interface{}) bool {
 	return matchAllStrings(m.stringMatcher, strs)
 }

--- a/libbeat/conditions/conditions_test.go
+++ b/libbeat/conditions/conditions_test.go
@@ -70,6 +70,7 @@ var secdTestEvent = &beat.Event{
 			"username": "monica",
 			"keywords": []interface{}{"foo", "bar"},
 		},
+		"tags":  []string{"auditbeat", "prod", "security"},
 		"type":  "process",
 		"final": false,
 	},

--- a/libbeat/conditions/conditions_test.go
+++ b/libbeat/conditions/conditions_test.go
@@ -68,7 +68,7 @@ var secdTestEvent = &beat.Event{
 			"ppid":     1,
 			"state":    "running",
 			"username": "monica",
-			"keywords": []string{"foo", "bar"},
+			"keywords": []interface{}{"foo", "bar"},
 		},
 		"type":  "process",
 		"final": false,

--- a/libbeat/conditions/matcher.go
+++ b/libbeat/conditions/matcher.go
@@ -86,7 +86,7 @@ func (c Matcher) Check(event ValuesMap) bool {
 				return false
 			}
 
-		case []string:
+		case []interface{}:
 			if !matcher.MatchAnyString(v) {
 				return false
 			}

--- a/libbeat/conditions/matcher.go
+++ b/libbeat/conditions/matcher.go
@@ -86,11 +86,10 @@ func (c Matcher) Check(event ValuesMap) bool {
 				return false
 			}
 
-		case []interface{}:
+		case []interface{}, []string:
 			if !matcher.MatchAnyString(v) {
 				return false
 			}
-
 		default:
 			str, err := ExtractString(value)
 			if err != nil {

--- a/libbeat/conditions/matcher_test.go
+++ b/libbeat/conditions/matcher_test.go
@@ -64,6 +64,14 @@ func TestContainsSingleFieldPositiveMatch(t *testing.T) {
 	})
 }
 
+func TestContainsArrayOfStringPositiveMatch(t *testing.T) {
+	testConfig(t, true, secdTestEvent, &Config{
+		Contains: &Fields{fields: map[string]interface{}{
+			"tags": "prod",
+		}},
+	})
+}
+
 func TestRegexpCondition(t *testing.T) {
 	logp.TestingSetup()
 


### PR DESCRIPTION
Matching arrays of strings inside a `contains` condition doesn't work properly with the output of JSON decoding as it is expecting fields of type `[]string` when they are in this case `[]interface{}`.

It outputs the following error:
`2019-04-08T12:10:31.866+0200	WARN	[conditions]	conditions/matcher.go:97	unexpected type []interface {} in contains condition as it accepts only strings.`

Fixes: #3138