### PR TITLE
Remove Windows XP comment from README

### DIFF
--- a/winlogbeat/README.md
+++ b/winlogbeat/README.md
@@ -3,8 +3,7 @@
 *You know, for windows event logs*
 
 Winlogbeat is an open-source log collector that ships Windows Event Logs to
-Elasticsearch or Logstash. It installs as a Windows service on all versions
-since Windows XP.
+Elasticsearch or Logstash. It installs and runs as a Windows service.
 
 ## Contributions
 


### PR DESCRIPTION
Windows XP isn't supported by Go 1.11 and it's not on our support matrix.