### PR TITLE
Clarify that Netflow is an input in 7.0

### DIFF
--- a/libbeat/docs/highlights-7.0.0.asciidoc
+++ b/libbeat/docs/highlights-7.0.0.asciidoc
@@ -91,9 +91,8 @@ For data relevant to security analytics, {filebeat} adds a
 popular open-source Zeek project, formerly known as Bro, and a
 {filebeat-ref}/filebeat-module-santa.html[Santa] module, which tracks process
 executions on macOS. These modules add to the list of modules added already in
-the 6.x series, including {filebeat-ref}/filebeat-module-suricata.html[Suricata],
-{filebeat-ref}/filebeat-module-iptables.html[IPtables], and
-{filebeat-ref}/filebeat-module-netflow.html[NetFlow].
+the 6.x series, including {filebeat-ref}/filebeat-module-suricata.html[Suricata]
+and {filebeat-ref}/filebeat-module-iptables.html[IPtables].
 
 In addition, the {auditbeat}
 {auditbeat-ref}/auditbeat-module-system.html[system] module keeps improving, and

--- a/libbeat/docs/highlights-7.0.0.asciidoc
+++ b/libbeat/docs/highlights-7.0.0.asciidoc
@@ -90,9 +90,11 @@ For data relevant to security analytics, {filebeat} adds a
 {filebeat-ref}/filebeat-module-zeek.html[Zeek] module that integrates with the
 popular open-source Zeek project, formerly known as Bro, and a
 {filebeat-ref}/filebeat-module-santa.html[Santa] module, which tracks process
-executions on macOS. These modules add to the list of modules added already in
-the 6.x series, including {filebeat-ref}/filebeat-module-suricata.html[Suricata]
-and {filebeat-ref}/filebeat-module-iptables.html[IPtables].
+executions on macOS. These modules add to the list of data sources already
+supported in the 6.x series, including
+{filebeat-ref}/filebeat-module-suricata.html[Suricata],
+{filebeat-ref}/filebeat-module-iptables.html[IPtables], and
+{filebeat-ref}/filebeat-input-netflow.html[NetFlow].
 
 In addition, the {auditbeat}
 {auditbeat-ref}/auditbeat-module-system.html[system] module keeps improving, and


### PR DESCRIPTION
Change misleading text because NetFlow is an input, not a module, in 7.0

The backport for this change is already in https://github.com/elastic/beats/pull/11708