### PR TITLE
Cherry-pick #11494 to 6.7: Update github.com/elastic/go-sysinfo

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -35,6 +35,7 @@ https://github.com/elastic/beats/compare/v6.7.0...6.x[Check the HEAD diff]
 
 - Relax validation of the X-Pack license UID value. {issue}11640[11640]
 - Fix a parsing error with the X-Pack license check on 32-bit system. {issue}11650[11650]
+- Fixed OS family classification in `add_host_metadata` for Amazon Linux, Raspbian, and RedHat Linux. {issue}9134[9134] {pull}11494[11494]
 
 *Auditbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -35,7 +35,9 @@ https://github.com/elastic/beats/compare/v6.7.0...6.x[Check the HEAD diff]
 
 - Relax validation of the X-Pack license UID value. {issue}11640[11640]
 - Fix a parsing error with the X-Pack license check on 32-bit system. {issue}11650[11650]
-- Fixed OS family classification in `add_host_metadata` for Amazon Linux, Raspbian, and RedHat Linux. {issue}9134[9134] {pull}11494[11494]
+- Fix OS family classification in `add_host_metadata` for Amazon Linux, Raspbian, and RedHat Linux. {issue}9134[9134] {pull}11494[11494]
+- Fix false positives reported in the `host.containerized` field by `add_host_metadata`. {pull}11494[11494]
+- Fix the add_host_metadata's `host.id` field on older Linux versions. {pull}11494[11494]
 
 *Auditbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -36,7 +36,7 @@ https://github.com/elastic/beats/compare/v6.7.0...6.x[Check the HEAD diff]
 - Relax validation of the X-Pack license UID value. {issue}11640[11640]
 - Fix a parsing error with the X-Pack license check on 32-bit system. {issue}11650[11650]
 - Fix OS family classification in `add_host_metadata` for Amazon Linux, Raspbian, and RedHat Linux. {issue}9134[9134] {pull}11494[11494]
-- Fix false positives reported in the `host.containerized` field by `add_host_metadata`. {pull}11494[11494]
+- Fix false positives reported in the `host.containerized` field added by `add_host_metadata`. {pull}11494[11494]
 - Fix the add_host_metadata's `host.id` field on older Linux versions. {pull}11494[11494]
 
 *Auditbeat*

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -541,7 +541,7 @@ Apache License 2.0
 
 --------------------------------------------------------------------
 Dependency: github.com/elastic/go-sysinfo
-Revision: 59ef8c0eae46c0929e3b219ac86368d4b5934f91
+Revision: ab4f04edfc3d6b3864f5f06a068ddab9ad79774f
 License type (autodetected): Apache-2.0
 ./vendor/github.com/elastic/go-sysinfo/LICENSE.txt:
 --------------------------------------------------------------------

--- a/vendor/github.com/elastic/go-sysinfo/providers/linux/container.go
+++ b/vendor/github.com/elastic/go-sysinfo/providers/linux/container.go
@@ -21,6 +21,7 @@ import (
 	"bufio"
 	"bytes"
 	"io/ioutil"
+	"os"
 
 	"github.com/pkg/errors"
 )
@@ -31,6 +32,10 @@ const procOneCgroup = "/proc/1/cgroup"
 func IsContainerized() (bool, error) {
 	data, err := ioutil.ReadFile(procOneCgroup)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+
 		return false, errors.Wrap(err, "failed to read process cgroups")
 	}
 

--- a/vendor/github.com/elastic/go-sysinfo/providers/linux/os.go
+++ b/vendor/github.com/elastic/go-sysinfo/providers/linux/os.go
@@ -47,9 +47,10 @@ var (
 	versionRegexp = regexp.MustCompile(versionGrok)
 )
 
+// familyMap contains a mapping of family -> []platforms.
 var familyMap = map[string][]string{
-	"redhat": {"redhat", "fedora", "centos", "scientific", "oraclelinux", "amazon"},
-	"debian": {"debian", "ubuntu"},
+	"redhat": {"redhat", "fedora", "centos", "scientific", "oraclelinux", "amzn", "rhel"},
+	"debian": {"debian", "ubuntu", "raspbian"},
 	"suse":   {"suse", "sles", "opensuse"},
 }
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -880,44 +880,44 @@
 		{
 			"checksumSHA1": "QhFIpuHPaV6hKejKcc2wm6y4MSQ=",
 			"path": "github.com/elastic/go-sysinfo",
-			"revision": "59ef8c0eae46c0929e3b219ac86368d4b5934f91",
-			"revisionTime": "2019-01-07T12:18:35Z"
+			"revision": "ab4f04edfc3d6b3864f5f06a068ddab9ad79774f",
+			"revisionTime": "2019-03-27T18:53:17Z"
 		},
 		{
 			"checksumSHA1": "GiZCjX17K265TtamGZZw4R2Jwbk=",
 			"path": "github.com/elastic/go-sysinfo/internal/registry",
-			"revision": "59ef8c0eae46c0929e3b219ac86368d4b5934f91",
-			"revisionTime": "2019-01-07T12:18:35Z"
+			"revision": "ab4f04edfc3d6b3864f5f06a068ddab9ad79774f",
+			"revisionTime": "2019-03-27T18:53:17Z"
 		},
 		{
 			"checksumSHA1": "ovafihHzpBx9Y7+lZh9X5KwNCvE=",
 			"path": "github.com/elastic/go-sysinfo/providers/darwin",
-			"revision": "59ef8c0eae46c0929e3b219ac86368d4b5934f91",
-			"revisionTime": "2019-01-07T12:18:35Z"
+			"revision": "ab4f04edfc3d6b3864f5f06a068ddab9ad79774f",
+			"revisionTime": "2019-03-27T18:53:17Z"
 		},
 		{
-			"checksumSHA1": "AK76ZxnuvK02Dfpmj7b2TD/aiSI=",
+			"checksumSHA1": "OyI+VwDiT4UZjncsDr1GYg1xcdw=",
 			"path": "github.com/elastic/go-sysinfo/providers/linux",
-			"revision": "59ef8c0eae46c0929e3b219ac86368d4b5934f91",
-			"revisionTime": "2019-01-07T12:18:35Z"
+			"revision": "ab4f04edfc3d6b3864f5f06a068ddab9ad79774f",
+			"revisionTime": "2019-03-27T18:53:17Z"
 		},
 		{
 			"checksumSHA1": "RWLvcP1w9ynKbuCqiW6prwd+EDU=",
 			"path": "github.com/elastic/go-sysinfo/providers/shared",
-			"revision": "59ef8c0eae46c0929e3b219ac86368d4b5934f91",
-			"revisionTime": "2019-01-07T12:18:35Z"
+			"revision": "ab4f04edfc3d6b3864f5f06a068ddab9ad79774f",
+			"revisionTime": "2019-03-27T18:53:17Z"
 		},
 		{
 			"checksumSHA1": "aF05MEkMjbRekzHlwFxmd5WBpeY=",
 			"path": "github.com/elastic/go-sysinfo/providers/windows",
-			"revision": "59ef8c0eae46c0929e3b219ac86368d4b5934f91",
-			"revisionTime": "2019-01-07T12:18:35Z"
+			"revision": "ab4f04edfc3d6b3864f5f06a068ddab9ad79774f",
+			"revisionTime": "2019-03-27T18:53:17Z"
 		},
 		{
 			"checksumSHA1": "MLQioPEjULYbNqqCjfB1/cux08E=",
 			"path": "github.com/elastic/go-sysinfo/types",
-			"revision": "59ef8c0eae46c0929e3b219ac86368d4b5934f91",
-			"revisionTime": "2019-01-07T12:18:35Z"
+			"revision": "ab4f04edfc3d6b3864f5f06a068ddab9ad79774f",
+			"revisionTime": "2019-03-27T18:53:17Z"
 		},
 		{
 			"checksumSHA1": "bNf3GDGhZh86bfCIMM5c5AYfo3g=",


### PR DESCRIPTION
Cherry-pick of PR #11494 to 6.7 branch. Original message: 

Fixes #11490 
Fixes #9134