### PR TITLE
CoreDNS tests fix

### DIFF
--- a/metricbeat/module/coredns/_meta/Dockerfile
+++ b/metricbeat/module/coredns/_meta/Dockerfile
@@ -18,7 +18,7 @@ ADD config /etc/coredns
 RUN apk add --update --no-cache bind-tools
 
 # Check if the Coredns container is healthy
-HEALTHCHECK --interval=5s --retries=10 CMD dig @0.0.0.0 my.domain.org +dnssec >/dev/null
+HEALTHCHECK --interval=5s --retries=10 CMD dig @0.0.0.0 my.domain.elastic +dnssec >/dev/null
 
 # Start coredns with custom configuration file
 ENTRYPOINT ["/coredns"]

--- a/metricbeat/module/coredns/_meta/config/Corefile
+++ b/metricbeat/module/coredns/_meta/config/Corefile
@@ -14,7 +14,7 @@
 ###########################################################################
 
 # Zone1
-my.domain.org {
+my.domain.elastic {
     log
     errors
     auto
@@ -25,7 +25,7 @@ my.domain.org {
 
     # If you wish to use a standard Hosts File format, uncomment the following
     # line and customize the specified file
-    hosts /etc/coredns/mydomain.hosts my.domain.org
+    hosts /etc/coredns/mydomain.hosts my.domain.elastic
 }
 
 # Zone2

--- a/metricbeat/module/coredns/_meta/config/mydomain.hosts
+++ b/metricbeat/module/coredns/_meta/config/mydomain.hosts
@@ -1,4 +1,4 @@
-# Hosts file for Domain: my.domain.org
+# Hosts file for Domain: my.domain.elastic
 # Place entries below in standard hosts file format: ipaddress hostname fqdn
 
-192.168.1.1 gateway.my.domain.org
+192.168.1.1 gateway.my.domain.elastic

--- a/metricbeat/module/coredns/_meta/config/mydomain.hosts
+++ b/metricbeat/module/coredns/_meta/config/mydomain.hosts
@@ -1,4 +1,4 @@
 # Hosts file for Domain: my.domain.elastic
 # Place entries below in standard hosts file format: ipaddress hostname fqdn
 
-192.168.1.1 gateway.my.domain.elastic
+127.0.0.1 my.domain.elastic


### PR DESCRIPTION
There seems to be a problem with CoreDNS container domain.
renaming `my.domain.org` to non existent `my.domain.elastic`