### PR TITLE
[Metricbeat] Add remove fields option to mocked tests config

### DIFF
--- a/metricbeat/mb/testing/data/config.yml
+++ b/metricbeat/mb/testing/data/config.yml
@@ -1,0 +1,7 @@
+type: http
+url: "/server-status?auto="
+suffix: plain
+omit_documented_fields_check:
+  - "apache.status.hostname"
+remove_fields_from_comparison:
+  - "apache.status.hostname"


### PR DESCRIPTION
Split PR from here #11703

Config option remove_fields_from_comparison to remove fields from the JSON generated and expected files to byte-to-byte comparison when asserting tests.