### PR TITLE
Monitoring parity test: better type comparisons

### DIFF
--- a/libbeat/tests/system/test_monitoring.py
+++ b/libbeat/tests/system/test_monitoring.py
@@ -195,7 +195,8 @@ class Test(BaseTest):
             if isinstance(dict2_val, int):
                 dict2_val = float(dict2_val)
             self.assertEqual(type(dict1_val), type(dict2_val))
-            if type(dict1_val) is dict:
+
+            if isinstance(dict1_val, dict):
                 self.assert_same_structure(dict1_val, dict2_val)
 
     def clean_output_cluster(self):


### PR DESCRIPTION
Motivated by failure in https://travis-ci.org/elastic/beats/jobs/517696747:

```
FAIL: Test that monitoring docs are the same, regardless of how they are shipped.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/go/src/github.com/elastic/beats/libbeat/tests/system/test_monitoring.py", line 151, in test_compare
    self.assert_same_structure(indirect_beats_stats_doc['beats_stats'], direct_beats_stats_doc['beats_stats'])
  File "/go/src/github.com/elastic/beats/libbeat/tests/system/test_monitoring.py", line 193, in assert_same_structure
    self.assert_same_structure(dict1_val, dict2_val)
  File "/go/src/github.com/elastic/beats/libbeat/tests/system/test_monitoring.py", line 193, in assert_same_structure
    self.assert_same_structure(dict1_val, dict2_val)
  File "/go/src/github.com/elastic/beats/libbeat/tests/system/test_monitoring.py", line 193, in assert_same_structure
    self.assert_same_structure(dict1_val, dict2_val)
  File "/go/src/github.com/elastic/beats/libbeat/tests/system/test_monitoring.py", line 191, in assert_same_structure
    self.assertEqual(type(dict1_val), type(dict2_val))
AssertionError: <type 'float'> != <type 'int'>
```

In the case of this failure, the type check is a bit too strict. We really only care that the two values are numbers. This PR makes the necessary changes.

Additionally, it also does a bit of cleanup by using `isinstance` instead of `type` to determine if a value is a dictionary. Apparently this is the more Pythonic way.