### PR TITLE
Cherry-pick #11676 to 7.0: check for a valid limit before we process a memory event

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -82,6 +82,9 @@ https://github.com/elastic/beats/compare/v7.0.0...7.0[Check the HEAD diff]
 
 *Metricbeat*
 
+- Add _bucket to histogram metrics in Prometheus Collector {pull}11578[11578]
+- Prevent the docker/memory metricset from processing invalid events before container start {pull}11676[11676]
+
 *Packetbeat*
 
 *Winlogbeat*

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -82,7 +82,6 @@ https://github.com/elastic/beats/compare/v7.0.0...7.0[Check the HEAD diff]
 
 *Metricbeat*
 
-- Add _bucket to histogram metrics in Prometheus Collector {pull}11578[11578]
 - Prevent the docker/memory metricset from processing invalid events before container start {pull}11676[11676]
 
 *Packetbeat*

--- a/metricbeat/module/docker/memory/memory.go
+++ b/metricbeat/module/docker/memory/memory.go
@@ -35,6 +35,7 @@ func init() {
 	)
 }
 
+// MetricSet type defines all fields of the MetricSet
 type MetricSet struct {
 	mb.BaseMetricSet
 	memoryService *MemoryService


### PR DESCRIPTION
A backport of #11676. @ruflin Asked me to backport this, with the idea that the 7.0 branch will become 7.0.1, and it should not be merged until 7.0 is released. 