### PR TITLE
Cherry-pick #11676 to 6.7: check for a valid limit before we process a memory event

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -54,6 +54,9 @@ https://github.com/elastic/beats/compare/v6.7.0...6.x[Check the HEAD diff]
 
 *Metricbeat*
 
+- Add _bucket to histogram metrics in Prometheus Collector {pull}11578[11578]
+- Prevent the docker/memory metricset from processing invalid events before container start {pull}11676[11676]
+
 *Packetbeat*
 
 *Winlogbeat*

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -54,7 +54,6 @@ https://github.com/elastic/beats/compare/v6.7.0...6.x[Check the HEAD diff]
 
 *Metricbeat*
 
-- Add _bucket to histogram metrics in Prometheus Collector {pull}11578[11578]
 - Prevent the docker/memory metricset from processing invalid events before container start {pull}11676[11676]
 
 *Packetbeat*

--- a/metricbeat/module/docker/memory/memory.go
+++ b/metricbeat/module/docker/memory/memory.go
@@ -32,6 +32,7 @@ func init() {
 	)
 }
 
+// MetricSet type defines all fields of the MetricSet
 type MetricSet struct {
 	mb.BaseMetricSet
 	memoryService *MemoryService


### PR DESCRIPTION
A backport of #11676. 