### PR TITLE
Cherry-pick to 7.0: Change cloud.provider from ec2 to aws and from gce to gcp in add_clou…

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -20,6 +20,9 @@ https://github.com/elastic/beats/compare/v7.0.0...7.0[Check the HEAD diff]
 
 *Metricbeat*
 
+- Add new option `OpMultiplyBuckets` to scale histogram buckets to avoid decimal points in final events {pull}10994[10994]
+- Change cloud.provider from ec2 to aws and from gce to gcp in add_cloud_metadata to align with ECS. {issue}10775[10775] {pull}11687[11687]
+
 *Packetbeat*
 
 *Winlogbeat*

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -20,7 +20,6 @@ https://github.com/elastic/beats/compare/v7.0.0...7.0[Check the HEAD diff]
 
 *Metricbeat*
 
-- Add new option `OpMultiplyBuckets` to scale histogram buckets to avoid decimal points in final events {pull}10994[10994]
 - Change cloud.provider from ec2 to aws and from gce to gcp in add_cloud_metadata to align with ECS. {issue}10775[10775] {pull}11687[11687]
 
 *Packetbeat*

--- a/libbeat/docs/processors-using.asciidoc
+++ b/libbeat/docs/processors-using.asciidoc
@@ -412,7 +412,7 @@ provider and cache the instance metadata.
 
 The following cloud providers are supported:
 
-- Amazon Elastic Compute Cloud (EC2)
+- Amazon Web Services (AWS)
 - Digital Ocean
 - Google Compute Engine (GCE)
 - https://www.qcloud.com/?lang=en[Tencent Cloud] (QCloud)
@@ -444,7 +444,7 @@ default).
 The metadata that is added to events varies by hosting provider. Below are
 examples for each of the supported providers.
 
-_EC2_
+_AWS_
 
 [source,json]
 -------------------------------------------------------------------------------
@@ -453,7 +453,7 @@ _EC2_
     "availability_zone": "us-east-1c",
     "instance_id": "i-4e123456",
     "machine_type": "t2.medium",
-    "provider": "ec2",
+    "provider": "aws",
     "region": "us-east-1"
   }
 }
@@ -472,7 +472,7 @@ _Digital Ocean_
 }
 -------------------------------------------------------------------------------
 
-_GCE_
+_GCP_
 
 [source,json]
 -------------------------------------------------------------------------------
@@ -482,7 +482,7 @@ _GCE_
     "instance_id": "1234556778987654321",
     "machine_type": "f1-micro",
     "project_id": "my-dev",
-    "provider": "gce"
+    "provider": "gcp"
   }
 }
 -------------------------------------------------------------------------------

--- a/libbeat/processors/add_cloud_metadata/provider_aws_ec2.go
+++ b/libbeat/processors/add_cloud_metadata/provider_aws_ec2.go
@@ -40,6 +40,6 @@ func newEc2MetadataFetcher(config *common.Config) (*metadataFetcher, error) {
 		return out
 	}
 
-	fetcher, err := newMetadataFetcher(config, "ec2", nil, metadataHost, ec2Schema, ec2InstanceIdentityURI)
+	fetcher, err := newMetadataFetcher(config, "aws", nil, metadataHost, ec2Schema, ec2InstanceIdentityURI)
 	return fetcher, err
 }

--- a/libbeat/processors/add_cloud_metadata/provider_aws_ec2_test.go
+++ b/libbeat/processors/add_cloud_metadata/provider_aws_ec2_test.go
@@ -84,7 +84,7 @@ func TestRetrieveAWSMetadata(t *testing.T) {
 			common.MapStr{},
 			common.MapStr{
 				"cloud": common.MapStr{
-					"provider": "ec2",
+					"provider": "aws",
 					"instance": common.MapStr{
 						"id": "i-11111111",
 					},
@@ -114,12 +114,12 @@ func TestRetrieveAWSMetadata(t *testing.T) {
 		},
 		{
 			common.MapStr{
-				"provider": "ec2",
+				"provider": "aws",
 			},
 			common.MapStr{
-				"provider": "ec2",
+				"provider": "aws",
 				"cloud": common.MapStr{
-					"provider": "ec2",
+					"provider": "aws",
 					"instance": common.MapStr{
 						"id": "i-11111111",
 					},
@@ -133,15 +133,15 @@ func TestRetrieveAWSMetadata(t *testing.T) {
 		},
 		{
 			common.MapStr{
-				"cloud.provider": "ec2",
+				"cloud.provider": "aws",
 			},
 			// NOTE: In this case, add_cloud_metadata will overwrite cloud fields because
 			// it won't detect cloud.provider as a cloud field. This is not the behavior we
 			// expect and will find a better solution later in issue 11697.
 			common.MapStr{
-				"cloud.provider": "ec2",
+				"cloud.provider": "aws",
 				"cloud": common.MapStr{
-					"provider": "ec2",
+					"provider": "aws",
 					"instance": common.MapStr{
 						"id": "i-11111111",
 					},
@@ -191,7 +191,7 @@ func TestRetrieveAWSMetadataOverwriteTrue(t *testing.T) {
 			common.MapStr{},
 			common.MapStr{
 				"cloud": common.MapStr{
-					"provider": "ec2",
+					"provider": "aws",
 					"instance": common.MapStr{
 						"id": "i-11111111",
 					},
@@ -213,7 +213,7 @@ func TestRetrieveAWSMetadataOverwriteTrue(t *testing.T) {
 			},
 			common.MapStr{
 				"cloud": common.MapStr{
-					"provider": "ec2",
+					"provider": "aws",
 					"instance": common.MapStr{
 						"id": "i-11111111",
 					},
@@ -227,12 +227,12 @@ func TestRetrieveAWSMetadataOverwriteTrue(t *testing.T) {
 		},
 		{
 			common.MapStr{
-				"cloud.provider": "ec2",
+				"cloud.provider": "aws",
 			},
 			common.MapStr{
-				"cloud.provider": "ec2",
+				"cloud.provider": "aws",
 				"cloud": common.MapStr{
-					"provider": "ec2",
+					"provider": "aws",
 					"instance": common.MapStr{
 						"id": "i-11111111",
 					},

--- a/libbeat/processors/add_cloud_metadata/provider_google_gce.go
+++ b/libbeat/processors/add_cloud_metadata/provider_google_gce.go
@@ -70,6 +70,6 @@ func newGceMetadataFetcher(config *common.Config) (*metadataFetcher, error) {
 		return out
 	}
 
-	fetcher, err := newMetadataFetcher(config, "gce", gceHeaders, metadataHost, gceSchema, gceMetadataURI)
+	fetcher, err := newMetadataFetcher(config, "gcp", gceHeaders, metadataHost, gceSchema, gceMetadataURI)
 	return fetcher, err
 }

--- a/libbeat/processors/add_cloud_metadata/provider_google_gce_test.go
+++ b/libbeat/processors/add_cloud_metadata/provider_google_gce_test.go
@@ -152,7 +152,7 @@ func TestRetrieveGCEMetadata(t *testing.T) {
 
 	expected := common.MapStr{
 		"cloud": common.MapStr{
-			"provider": "gce",
+			"provider": "gcp",
 			"instance": common.MapStr{
 				"id":   "3910564293633576924",
 				"name": "test-gce-dev",


### PR DESCRIPTION
…d_metadata (#11687)

* Change cloud.provider from ec2 to aws in add_cloud_metadata
* Change GCE to GCP to match ECS

(cherry picked from commit 69f6aeb6ee6782caa5881d021ebf48bc0ecc0e30)