### PR TITLE
Add no_dashboards flag to Heartbeat docs

### DIFF
--- a/heartbeat/docs/configuring-howto.asciidoc
+++ b/heartbeat/docs/configuring-howto.asciidoc
@@ -32,7 +32,6 @@ The following topics describe how to configure Heartbeat:
 * <<{beatname_lc}-geoip>>
 * <<configuration-path>>
 * <<setup-kibana-endpoint>>
-* <<configuration-dashboards>>
 * <<configuration-template>>
 * <<configuration-logging>>
 * <<using-environ-vars>>

--- a/heartbeat/docs/getting-started.asciidoc
+++ b/heartbeat/docs/getting-started.asciidoc
@@ -214,7 +214,7 @@ include::{libbeat-dir}/docs/shared-template-load.asciidoc[]
 [[load-kibana-dashboards]]
 === Step 4: Set up the Kibana dashboards
 
-Dashboards for heartbeat can be found in the https://github.com/elastic/uptime-contrib[uptime-contrib] github repository.
+Dashboards for Heartbeat can be found in the https://github.com/elastic/uptime-contrib[uptime-contrib] github repository.
 
 [[heartbeat-starting]]
 === Step 5: Start Heartbeat
@@ -262,8 +262,9 @@ events to your defined output.
 === Step 6: View the sample Kibana dashboards
 
 To make it easier for you to visualize the status of your services, we have
-created example {beatname_uc} dashboards. You loaded the dashboards earlier when
-you ran the `setup` command.
+created example {beatname_uc} dashboards in the
+https://github.com/elastic/uptime-contrib[uptime-contrib] github repository. If
+you loaded them earlier, open them now.
 
 include::{libbeat-dir}/docs/opendashboards.asciidoc[]
 

--- a/heartbeat/docs/index.asciidoc
+++ b/heartbeat/docs/index.asciidoc
@@ -20,6 +20,7 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :linux_os:
 :docker_platform:
 :win_os:
+:no_dashboards:
 
 include::{libbeat-dir}/docs/shared-beats-attributes.asciidoc[]
 

--- a/libbeat/docs/command-reference.asciidoc
+++ b/libbeat/docs/command-reference.asciidoc
@@ -656,12 +656,23 @@ modules to load pipelines for.
 endif::[]
 
 ifeval::["{beatname_lc}"!="filebeat"]
+
+ifndef::no_dashboards[]
 ["source","sh",subs="attributes"]
 -----
 {beatname_lc} setup --dashboards
 {beatname_lc} setup --machine-learning
 {beatname_lc} setup --template
 -----
+endif::no_dashboards[]
+ifdef::no_dashboards[]
+["source","sh",subs="attributes"]
+-----
+{beatname_lc} setup --machine-learning
+{beatname_lc} setup --template
+-----
+endif::no_dashboards[]
+
 endif::[]
 
 [[test-command]]

--- a/libbeat/docs/shared-docker.asciidoc
+++ b/libbeat/docs/shared-docker.asciidoc
@@ -44,7 +44,11 @@ ifndef::apm-server[]
 ==== Run the {beatname_uc} setup
 
 Running {beatname_uc} with the setup command will create the index pattern and
-load visualizations, dashboards, and machine learning jobs.  Run this command:
+load visualizations
+ifndef::no_dashboards[]
+, dashboards,
+endif::no_dashboards[]
+and machine learning jobs.  Run this command:
 
 ifeval::[("{beatname_lc}"=="filebeat") or ("{beatname_lc}"=="metricbeat") or ("{beatname_lc}"=="heartbeat") or ("{beatname_lc}"=="journalbeat")]
 ["source", "sh", subs="attributes"]


### PR DESCRIPTION
Adds `no_dashboards` flag to suppress shared docs that discuss dashboard loading via setup.

Also fixes a few places where we mention dashboards, but shouldn't.

