### PR TITLE
Add info about OSS repos

### DIFF
--- a/libbeat/docs/repositories.asciidoc
+++ b/libbeat/docs/repositories.asciidoc
@@ -56,6 +56,7 @@ ifeval::["{release-state}"=="prerelease"]
 --------------------------------------------------
 echo "deb https://artifacts.elastic.co/packages/{major-version}-prerelease/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-{major-version}-prerelease.list
 --------------------------------------------------
++
 endif::[]
 ifeval::["{release-state}"=="released"]
 . Save the repository definition to  +/etc/apt/sources.list.d/elastic-{major-version}.list+:
@@ -64,7 +65,34 @@ ifeval::["{release-state}"=="released"]
 --------------------------------------------------
 echo "deb https://artifacts.elastic.co/packages/{major-version}/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-{major-version}.list
 --------------------------------------------------
++
 endif::[]
+[NOTE]
+==================================================
+
+The package is free to use under the Elastic license. An alternative package
+which contains only features that are available under the Apache 2.0 license is
+also available. To install it, use the following sources list:
+
+ifeval::["{release-state}"=="prerelease"]
+
+["source","sh",subs="attributes,callouts"]
+--------------------------------------------------
+echo "deb https://artifacts.elastic.co/packages/oss-{major-version}-prerelease/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-{major-version}-prerelease.list
+--------------------------------------------------
+
+endif::[]
+
+ifeval::["{release-state}"!="prerelease"]
+
+["source","sh",subs="attributes,callouts"]
+--------------------------------------------------
+echo "deb https://artifacts.elastic.co/packages/oss-{major-version}/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-{major-version}.list
+--------------------------------------------------
+
+endif::[]
+
+==================================================
 +
 [WARNING]
 ==================================================
@@ -146,6 +174,34 @@ autorefresh=1
 type=rpm-md
 --------------------------------------------------
 endif::[]
++
+[NOTE]
+==================================================
+
+The package is free to use under the Elastic license. An alternative package
+which contains only features that are available under the Apache 2.0 license is
+also available. To install it, use the following `baseurl` in your
+`.repo` file:
+
+ifeval::["{release-state}"=="prerelease"]
+
+["source","sh",subs="attributes,callouts"]
+--------------------------------------------------
+baseurl=https://artifacts.elastic.co/packages/oss-{major-version}-prerelease/yum
+--------------------------------------------------
+
+endif::[]
+
+ifeval::["{release-state}"!="prerelease"]
+
+["source","sh",subs="attributes,callouts"]
+--------------------------------------------------
+baseurl=https://artifacts.elastic.co/packages/oss-{major-version}/yum
+--------------------------------------------------
+
+endif::[]
+
+==================================================
 +
 Your repository is ready to use. For example, you can install {beatname_uc} by
 running:

--- a/libbeat/docs/repositories.asciidoc
+++ b/libbeat/docs/repositories.asciidoc
@@ -76,7 +76,7 @@ also available. To install it, use the following sources list:
 
 ifeval::["{release-state}"=="prerelease"]
 
-["source","sh",subs="attributes,callouts"]
+["source","sh",subs="attributes"]
 --------------------------------------------------
 echo "deb https://artifacts.elastic.co/packages/oss-{major-version}-prerelease/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-{major-version}-prerelease.list
 --------------------------------------------------
@@ -85,7 +85,7 @@ endif::[]
 
 ifeval::["{release-state}"!="prerelease"]
 
-["source","sh",subs="attributes,callouts"]
+["source","sh",subs="attributes"]
 --------------------------------------------------
 echo "deb https://artifacts.elastic.co/packages/oss-{major-version}/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-{major-version}.list
 --------------------------------------------------
@@ -185,7 +185,7 @@ also available. To install it, use the following `baseurl` in your
 
 ifeval::["{release-state}"=="prerelease"]
 
-["source","sh",subs="attributes,callouts"]
+["source","sh",subs="attributes"]
 --------------------------------------------------
 baseurl=https://artifacts.elastic.co/packages/oss-{major-version}-prerelease/yum
 --------------------------------------------------
@@ -194,7 +194,7 @@ endif::[]
 
 ifeval::["{release-state}"!="prerelease"]
 
-["source","sh",subs="attributes,callouts"]
+["source","sh",subs="attributes"]
 --------------------------------------------------
 baseurl=https://artifacts.elastic.co/packages/oss-{major-version}/yum
 --------------------------------------------------


### PR DESCRIPTION
@urso I've added info about the OSS distros in the package repos.

I've taken the language from published Elasticsearch docs (didn't edit it, though I was sorely tempted), so it should match what's expected wrt how we talk about OSS packages.

Can you make sure I have the commands right please? 