### PR TITLE
Update the reference document to include a community beat powermaxbeat

### DIFF
--- a/libbeat/docs/communitybeats.asciidoc
+++ b/libbeat/docs/communitybeats.asciidoc
@@ -85,6 +85,7 @@ https://github.com/WuerthIT/perfstatbeat[perfstatbeat]:: Collect performance met
 https://github.com/kozlice/phpfpmbeat[phpfpmbeat]:: Reads status from PHP-FPM.
 https://github.com/joshuar/pingbeat[pingbeat]:: Sends ICMP pings to a list
 of targets and stores the round trip time (RTT) in Elasticsearch.
+https://github.com/kckecheng/powermaxbeat[powermaxbeat]:: Collects performance metrics from Dell EMC PowerMax storage array.
 https://github.com/carlpett/prombeat[prombeat]:: Indexes https://prometheus.io[Prometheus] metrics.
 https://github.com/infonova/prometheusbeat[prometheusbeat]:: Send Prometheus metrics to Elasticsearch via the remote write feature.
 https://github.com/hartfordfive/protologbeat[protologbeat]:: Accepts structured and unstructured logs via UDP or TCP.  Can also be used to receive syslog messages or GELF formatted messages. (To be used as a successor to udplogbeat)


### PR DESCRIPTION
This beat can be used to collect performance metrics from Dell EMC PowerMax SAN storage system.