### PR TITLE
New options to configure roles and VPC

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -142,6 +142,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Functionbeat*
 
+- New options to configure roles and VPC. {pull}11779[11779]
+
 *Winlogbeat*
 
 - Add support for reading from .evtx files. {issue}4450[4450]

--- a/x-pack/functionbeat/_meta/beat.reference.yml
+++ b/x-pack/functionbeat/_meta/beat.reference.yml
@@ -34,6 +34,14 @@ functionbeat.provider.aws.functions:
     # There is a hard limit of 3008MiB for each function. Default is 128MiB.
     #memory_size: 128MiB
 
+    # Execution role of the function.
+    #role: arn:aws:iam::123456789012:role/MyFunction
+
+    # Connect to private resources in an Amazon VPC.
+    #virtual_private_cloud:
+    #  security_group_ids: []
+    #  subnet_ids: []
+
     # Dead letter queue configuration, this must be set to an ARN pointing to a SQS queue.
     #dead_letter_config.target_arn:
 
@@ -70,6 +78,14 @@ functionbeat.provider.aws.functions:
     # The maximum memory allocated for this function, the configured size must be a factor of 64.
     # There is a hard limit of 3008MiB for each function. Default is 128MiB.
     #memory_size: 128MiB
+
+    # Execution role of the function.
+    #role: arn:aws:iam::123456789012:role/MyFunction
+
+    # Connect to private resources in an Amazon VPC.
+    #virtual_private_cloud:
+    #  security_group_ids: []
+    #  subnet_ids: []
 
     # Dead letter queue configuration, this must be set to an ARN pointing to a SQS queue.
     #dead_letter_config.target_arn:
@@ -112,6 +128,14 @@ functionbeat.provider.aws.functions:
     # The maximum memory allocated for this function, the configured size must be a factor of 64.
     # There is a hard limit of 3008MiB for each function. Default is 128MiB.
     #memory_size: 128MiB
+
+    # Execution role of the function.
+    #role: arn:aws:iam::123456789012:role/MyFunction
+
+    # Connect to private resources in an Amazon VPC.
+    #virtual_private_cloud:
+    #  security_group_ids: []
+    #  subnet_ids: []
 
     # Dead letter queue configuration, this must be set to an ARN pointing to a SQS queue.
     #dead_letter_config.target_arn:

--- a/x-pack/functionbeat/_meta/beat.yml
+++ b/x-pack/functionbeat/_meta/beat.yml
@@ -38,6 +38,14 @@ functionbeat.provider.aws.functions:
     # Dead letter queue configuration, this must be set to an ARN pointing to a SQS queue.
     #dead_letter_config.target_arn:
 
+    # Execution role of the function.
+    #role: arn:aws:iam::123456789012:role/MyFunction
+
+    # Connect to private resources in an Amazon VPC.
+    #virtual_private_cloud:
+    #  security_group_ids: []
+    #  subnet_ids: []
+
     # Optional fields that you can specify to add additional information to the
     # output. Fields can be scalar values, arrays, dictionaries, or any nested
     # combination of these.
@@ -74,6 +82,14 @@ functionbeat.provider.aws.functions:
 
     # Dead letter queue configuration, this must be set to an ARN pointing to a SQS queue.
     #dead_letter_config.target_arn:
+
+    # Execution role of the function.
+    #role: arn:aws:iam::123456789012:role/MyFunction
+
+    # Connect to private resources in an Amazon VPC.
+    #virtual_private_cloud:
+    #  security_group_ids: []
+    #  subnet_ids: []
 
     # Optional fields that you can specify to add additional information to the
     # output. Fields can be scalar values, arrays, dictionaries, or any nested
@@ -116,6 +132,14 @@ functionbeat.provider.aws.functions:
 
     # Dead letter queue configuration, this must be set to an ARN pointing to a SQS queue.
     #dead_letter_config.target_arn:
+
+    # Execution role of the function.
+    #role: arn:aws:iam::123456789012:role/MyFunction
+
+    # Connect to private resources in an Amazon VPC.
+    #virtual_private_cloud:
+    #  security_group_ids: []
+    #  subnet_ids: []
 
     # Optional fields that you can specify to add additional information to the
     # output. Fields can be scalar values, arrays, dictionaries, or any nested

--- a/x-pack/functionbeat/functionbeat.reference.yml
+++ b/x-pack/functionbeat/functionbeat.reference.yml
@@ -34,6 +34,14 @@ functionbeat.provider.aws.functions:
     # There is a hard limit of 3008MiB for each function. Default is 128MiB.
     #memory_size: 128MiB
 
+    # Execution role of the function.
+    #role: arn:aws:iam::123456789012:role/MyFunction
+
+    # Connect to private resources in an Amazon VPC.
+    #virtual_private_cloud:
+    #  security_group_ids: []
+    #  subnet_ids: []
+
     # Dead letter queue configuration, this must be set to an ARN pointing to a SQS queue.
     #dead_letter_config.target_arn:
 
@@ -70,6 +78,14 @@ functionbeat.provider.aws.functions:
     # The maximum memory allocated for this function, the configured size must be a factor of 64.
     # There is a hard limit of 3008MiB for each function. Default is 128MiB.
     #memory_size: 128MiB
+
+    # Execution role of the function.
+    #role: arn:aws:iam::123456789012:role/MyFunction
+
+    # Connect to private resources in an Amazon VPC.
+    #virtual_private_cloud:
+    #  security_group_ids: []
+    #  subnet_ids: []
 
     # Dead letter queue configuration, this must be set to an ARN pointing to a SQS queue.
     #dead_letter_config.target_arn:
@@ -112,6 +128,14 @@ functionbeat.provider.aws.functions:
     # The maximum memory allocated for this function, the configured size must be a factor of 64.
     # There is a hard limit of 3008MiB for each function. Default is 128MiB.
     #memory_size: 128MiB
+
+    # Execution role of the function.
+    #role: arn:aws:iam::123456789012:role/MyFunction
+
+    # Connect to private resources in an Amazon VPC.
+    #virtual_private_cloud:
+    #  security_group_ids: []
+    #  subnet_ids: []
 
     # Dead letter queue configuration, this must be set to an ARN pointing to a SQS queue.
     #dead_letter_config.target_arn:

--- a/x-pack/functionbeat/functionbeat.yml
+++ b/x-pack/functionbeat/functionbeat.yml
@@ -38,6 +38,14 @@ functionbeat.provider.aws.functions:
     # Dead letter queue configuration, this must be set to an ARN pointing to a SQS queue.
     #dead_letter_config.target_arn:
 
+    # Execution role of the function.
+    #role: arn:aws:iam::123456789012:role/MyFunction
+
+    # Connect to private resources in an Amazon VPC.
+    #virtual_private_cloud:
+    #  security_group_ids: []
+    #  subnet_ids: []
+
     # Optional fields that you can specify to add additional information to the
     # output. Fields can be scalar values, arrays, dictionaries, or any nested
     # combination of these.
@@ -74,6 +82,14 @@ functionbeat.provider.aws.functions:
 
     # Dead letter queue configuration, this must be set to an ARN pointing to a SQS queue.
     #dead_letter_config.target_arn:
+
+    # Execution role of the function.
+    #role: arn:aws:iam::123456789012:role/MyFunction
+
+    # Connect to private resources in an Amazon VPC.
+    #virtual_private_cloud:
+    #  security_group_ids: []
+    #  subnet_ids: []
 
     # Optional fields that you can specify to add additional information to the
     # output. Fields can be scalar values, arrays, dictionaries, or any nested
@@ -116,6 +132,14 @@ functionbeat.provider.aws.functions:
 
     # Dead letter queue configuration, this must be set to an ARN pointing to a SQS queue.
     #dead_letter_config.target_arn:
+
+    # Execution role of the function.
+    #role: arn:aws:iam::123456789012:role/MyFunction
+
+    # Connect to private resources in an Amazon VPC.
+    #virtual_private_cloud:
+    #  security_group_ids: []
+    #  subnet_ids: []
 
     # Optional fields that you can specify to add additional information to the
     # output. Fields can be scalar values, arrays, dictionaries, or any nested

--- a/x-pack/functionbeat/provider/aws/cli_manager.go
+++ b/x-pack/functionbeat/provider/aws/cli_manager.go
@@ -106,29 +106,37 @@ func (c *CLIManager) template(function installer, name, codeLoc string) *cloudfo
 	// Merge any specific policies from the service.
 	policies = append(policies, function.Policies()...)
 
-	// Create the roles for the lambda.
 	template := cloudformation.NewTemplate()
-	// doc: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html
-	template.Resources[prefix("")+"IAMRoleLambdaExecution"] = &cloudformation.AWSIAMRole{
-		AssumeRolePolicyDocument: map[string]interface{}{
-			"Statement": []interface{}{
-				map[string]interface{}{
-					"Action": "sts:AssumeRole",
-					"Effect": "Allow",
-					"Principal": map[string]interface{}{
-						"Service": cloudformation.Join("", []string{
-							"lambda.",
-							cloudformation.Ref("AWS::URLSuffix"),
-						}),
+
+	role := lambdaConfig.Role
+	dependsOn := make([]string, 0)
+	if lambdaConfig.Role == "" {
+		// Create the roles for the lambda.
+		// doc: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html
+		template.Resources[prefix("")+"IAMRoleLambdaExecution"] = &cloudformation.AWSIAMRole{
+			AssumeRolePolicyDocument: map[string]interface{}{
+				"Statement": []interface{}{
+					map[string]interface{}{
+						"Action": "sts:AssumeRole",
+						"Effect": "Allow",
+						"Principal": map[string]interface{}{
+							"Service": cloudformation.Join("", []string{
+								"lambda.",
+								cloudformation.Ref("AWS::URLSuffix"),
+							}),
+						},
 					},
 				},
 			},
-		},
-		Path:     "/",
-		RoleName: "functionbeat-lambda-" + name,
-		// Allow the lambda to write log to cloudwatch logs.
-		// doc: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html
-		Policies: policies,
+			Path:     "/",
+			RoleName: "functionbeat-lambda-" + name,
+			// Allow the lambda to write log to cloudwatch logs.
+			// doc: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html
+			Policies: policies,
+		}
+
+		role = cloudformation.GetAtt(prefix("")+"IAMRoleLambdaExecution", "Arn")
+		dependsOn = []string{prefix("") + "IAMRoleLambdaExecution"}
 	}
 
 	// Configure the Dead letter, any failed events will be send to the configured amazon resource name.
@@ -136,6 +144,15 @@ func (c *CLIManager) template(function installer, name, codeLoc string) *cloudfo
 	if lambdaConfig.DeadLetterConfig != nil && len(lambdaConfig.DeadLetterConfig.TargetArn) != 0 {
 		dlc = &cloudformation.AWSLambdaFunction_DeadLetterConfig{
 			TargetArn: lambdaConfig.DeadLetterConfig.TargetArn,
+		}
+	}
+
+	// Configure VPC
+	var vcpConf *cloudformation.AWSLambdaFunction_VpcConfig
+	if lambdaConfig.VPCConfig != nil && len(lambdaConfig.VPCConfig.SecurityGroupIDs) != 0 && len(lambdaConfig.VPCConfig.SubnetIDs) != 0 {
+		vcpConf = &cloudformation.AWSLambdaFunction_VpcConfig{
+			SecurityGroupIds: lambdaConfig.VPCConfig.SecurityGroupIDs,
+			SubnetIds:        lambdaConfig.VPCConfig.SubnetIDs,
 		}
 	}
 
@@ -156,15 +173,16 @@ func (c *CLIManager) template(function installer, name, codeLoc string) *cloudfo
 				},
 			},
 			DeadLetterConfig:             dlc,
+			VpcConfig:                    vcpConf,
 			FunctionName:                 name,
-			Role:                         cloudformation.GetAtt(prefix("")+"IAMRoleLambdaExecution", "Arn"),
+			Role:                         role,
 			Runtime:                      runtime,
 			Handler:                      handlerName,
 			MemorySize:                   lambdaConfig.MemorySize.Megabytes(),
 			ReservedConcurrentExecutions: lambdaConfig.Concurrency,
 			Timeout:                      int(lambdaConfig.Timeout.Seconds()),
 		},
-		DependsOn: []string{prefix("") + "IAMRoleLambdaExecution"},
+		DependsOn: dependsOn,
 	}
 
 	// Create the log group for the specific function lambda.

--- a/x-pack/functionbeat/provider/aws/cli_manager.go
+++ b/x-pack/functionbeat/provider/aws/cli_manager.go
@@ -160,7 +160,7 @@ func (c *CLIManager) roleTemplate(function installer, name string) *cloudformati
 			PolicyDocument: map[string]interface{}{
 				"Statement": []map[string]interface{}{
 					map[string]interface{}{
-						"Action": []string{"logs:CreateLogStream", "Logs:PutLogEvents"},
+						"Action": []string{"logs:CreateLogStream", "logs:PutLogEvents"},
 						"Effect": "Allow",
 						"Resource": []string{
 							cloudformation.Sub("arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/" + name + ":*"),

--- a/x-pack/functionbeat/provider/aws/cloudwatch_logs_test.go
+++ b/x-pack/functionbeat/provider/aws/cloudwatch_logs_test.go
@@ -49,7 +49,7 @@ func TestCloudwatchLogs(t *testing.T) {
 	cfg := common.MustNewConfigFrom(map[string]interface{}{
 		"name":        "foobar",
 		"description": "my long description",
-		"role":        "arn:aws:iam::00000000:role/functionbeat",
+		"role":        "arn:aws:iam::000000000000:role/functionbeat",
 		"triggers": []map[string]interface{}{
 			map[string]interface{}{
 				"log_group_name": "foo",

--- a/x-pack/functionbeat/provider/aws/config.go
+++ b/x-pack/functionbeat/provider/aws/config.go
@@ -6,6 +6,7 @@ package aws
 
 import (
 	"fmt"
+	"regexp"
 	"time"
 	"unicode"
 
@@ -23,11 +24,16 @@ type Config struct {
 const maxMegabytes = 3008
 
 // DefaultLambdaConfig confguration for AWS lambda function.
-var DefaultLambdaConfig = &lambdaConfig{
-	MemorySize:  128 * 1024 * 1024,
-	Timeout:     time.Second * 3,
-	Concurrency: 5,
-}
+var (
+	DefaultLambdaConfig = &lambdaConfig{
+		MemorySize:  128 * 1024 * 1024,
+		Timeout:     time.Second * 3,
+		Concurrency: 5,
+	}
+
+	arnRolePattern = "arn:(aws[a-zA-Z-]*)?:iam::\\d{12}:role/?[a-zA-Z_0-9+=,.@\\-_/]+"
+	roleRE         = regexp.MustCompile(arnRolePattern)
+)
 
 type lambdaConfig struct {
 	Concurrency      int               `config:"concurrency" validate:"min=0,max=1000"`
@@ -35,6 +41,8 @@ type lambdaConfig struct {
 	Description      string            `config:"description"`
 	MemorySize       MemSizeFactor64   `config:"memory_size"`
 	Timeout          time.Duration     `config:"timeout" validate:"nonzero,positive"`
+	Role             string            `config:"role"`
+	VPCConfig        *vpcConfig        `config:"virtual_private_cloud"`
 }
 
 func (c *lambdaConfig) Validate() error {
@@ -46,11 +54,20 @@ func (c *lambdaConfig) Validate() error {
 		return fmt.Errorf("'memory_size' must be lower than %d", maxMegabytes)
 	}
 
+	if c.Role != "" && !roleRE.MatchString(c.Role) {
+		return fmt.Errorf("invalid role: '%s', name must match pattern %s", c.Role, arnRolePattern)
+	}
+
 	return nil
 }
 
 type deadLetterConfig struct {
 	TargetArn string `config:"target_arn"`
+}
+
+type vpcConfig struct {
+	SecurityGroupIDs []string `config:"security_group_ids" validate:"required"`
+	SubnetIDs        []string `config:"subnet_ids" validate:"required"`
 }
 
 // MemSizeFactor64 implements a human understandable format for bytes but also make sure that all

--- a/x-pack/functionbeat/provider/aws/config.go
+++ b/x-pack/functionbeat/provider/aws/config.go
@@ -31,6 +31,7 @@ var (
 		Concurrency: 5,
 	}
 
+	// Source: https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-Role
 	arnRolePattern = "arn:(aws[a-zA-Z-]*)?:iam::\\d{12}:role/?[a-zA-Z_0-9+=,.@\\-_/]+"
 	roleRE         = regexp.MustCompile(arnRolePattern)
 )


### PR DESCRIPTION
From now on it is possible to configure permissions in `functionbeat.yml` for the deployed lambda function. Two new options are added: `role` and `virtual_private_cloud`.

```yaml
# Execution role of the function.
role: arn:aws:iam::123456789012:role/MyFunction
```
```yaml
# Connect to private resources in an Amazon VPC.
virtual_private_cloud:
  security_group_ids:
    - mySecurityGroup
    - anotherSecurityGroup
  subnet_ids:
    - myUniqueID
```

Note: I don't really like the name `virtual_private_cloud` as it's too long. But naming the option `vpc` seems wrong. Do you have any other suggestions?

Closes #9425 