### PR TITLE
[Metricbeat] Mocked Tests: Do not halt if doc check fails

### DIFF
--- a/metricbeat/mb/testing/data/data_test.go
+++ b/metricbeat/mb/testing/data/data_test.go
@@ -195,7 +195,7 @@ func runTest(t *testing.T, file string, module, metricSetName string, config Con
 	})
 
 	if err := checkDocumented(t, data, config.OmitDocumentedFieldsCheck); err != nil {
-		t.Errorf("'%v' check if fields are documented in `metricbeat/{module}/{metricset}/_meta/fields.yml` " +
+		t.Errorf("'%v' check if fields are documented in `metricbeat/{module}/{metricset}/_meta/fields.yml` "+
 			"file or run 'make update' on Metricbeat folder to update root `metricbeat/fields.yml` in ", err)
 	}
 

--- a/metricbeat/mb/testing/data/data_test.go
+++ b/metricbeat/mb/testing/data/data_test.go
@@ -195,7 +195,8 @@ func runTest(t *testing.T, file string, module, metricSetName string, config Con
 	})
 
 	if err := checkDocumented(t, data, config.OmitDocumentedFieldsCheck); err != nil {
-		t.Errorf("check if fields are documented error: %v in `fields.yml` file", err)
+		t.Errorf("'%v' check if fields are documented in `metricbeat/{module}/{metricset}/_meta/fields.yml` " +
+			"file or run 'make update' on Metricbeat folder to update root `metricbeat/fields.yml` in ", err)
 	}
 
 	// Overwrites the golden files if run with -generate

--- a/metricbeat/mb/testing/data/data_test.go
+++ b/metricbeat/mb/testing/data/data_test.go
@@ -194,7 +194,9 @@ func runTest(t *testing.T, file string, module, metricSetName string, config Con
 		return h1 < h2
 	})
 
-	checkDocumented(t, data, config.OmitDocumentedFieldsCheck)
+	if err := checkDocumented(t, data, config.OmitDocumentedFieldsCheck); err != nil {
+		t.Errorf("check if fields are documented error: %v in `fields.yml` file", err)
+	}
 
 	// Overwrites the golden files if run with -generate
 	if *generateFlag {
@@ -259,15 +261,15 @@ func writeDataJSON(t *testing.T, data common.MapStr, module, metricSet string) {
 }
 
 // checkDocumented checks that all fields which show up in the events are documented
-func checkDocumented(t *testing.T, data []common.MapStr, omitFields []string) {
+func checkDocumented(t *testing.T, data []common.MapStr, omitFields []string) error {
 	fieldsData, err := asset.GetFields("metricbeat")
 	if err != nil {
-		t.Fatal(err)
+		return err
 	}
 
 	fields, err := mapping.LoadFields(fieldsData)
 	if err != nil {
-		t.Fatal(err)
+		return err
 	}
 
 	documentedFields := fields.GetKeys()
@@ -280,9 +282,11 @@ func checkDocumented(t *testing.T, data []common.MapStr, omitFields []string) {
 	for _, d := range data {
 		flat := d.Flatten()
 		if err := documentedFieldCheck(flat, keys, omitFields); err != nil {
-			t.Fatal(err)
+			return err
 		}
 	}
+
+	return nil
 }
 
 func documentedFieldCheck(foundKeys common.MapStr, knownKeys map[string]interface{}, omitFields []string) error {
@@ -300,7 +304,7 @@ func documentedFieldCheck(foundKeys common.MapStr, knownKeys map[string]interfac
 			if _, ok := knownKeys[prefix+".*"]; ok {
 				continue
 			}
-			return errors.Errorf("check if fields are documented error: key missing '%s'", foundKey)
+			return errors.Errorf("field missing '%s'", foundKey)
 		}
 	}
 


### PR DESCRIPTION
With the current behaviour, tests halt if doc checks can't find a field and the `-expected.json` file is not written. With this change, the file is written at least, helping identifying the issue.

@ruflin I was wondering if descriptive errors which leads to the solution to developers and contributors are a _way to go_ as a general rule. In this particular context, I was about to write a very long and descriptive error [here](https://github.com/elastic/beats/compare/master...sayden:feature/mb/do-not-halt-in-doc-check?expand=1#diff-b46c1b2512af7348690dfc422f25bbabR198) because I realized that a field that exists in `{module}/{metricset}/_meta/fields.yml` can still be missing in root `fields.yml` and throw an error... which confused me for a while until I thought to try with a `make update`. WDYT?