### PR TITLE
Cherry-pick #11605 to 6.7: Fix: Correctly initialize the Logger for the TCP input instance.

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -38,9 +38,6 @@ https://github.com/elastic/beats/compare/v6.7.0...6.x[Check the HEAD diff]
 - Fix OS family classification in `add_host_metadata` for Amazon Linux, Raspbian, and RedHat Linux. {issue}9134[9134] {pull}11494[11494]
 - Fix false positives reported in the `host.containerized` field added by `add_host_metadata`. {pull}11494[11494]
 - Fix the add_host_metadata's `host.id` field on older Linux versions. {pull}11494[11494]
-- Fix ILM policy always being overwritten. {pull}11671[11671]
-- Fix template always being overwritten. {pull}11671[11671]
-- Fix matching of string arrays in contains condition. {pull}11691[11691]
 - Fix initialization of the TCP input logger. {pull}11605[11605]
 
 *Auditbeat*

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -38,6 +38,10 @@ https://github.com/elastic/beats/compare/v6.7.0...6.x[Check the HEAD diff]
 - Fix OS family classification in `add_host_metadata` for Amazon Linux, Raspbian, and RedHat Linux. {issue}9134[9134] {pull}11494[11494]
 - Fix false positives reported in the `host.containerized` field added by `add_host_metadata`. {pull}11494[11494]
 - Fix the add_host_metadata's `host.id` field on older Linux versions. {pull}11494[11494]
+- Fix ILM policy always being overwritten. {pull}11671[11671]
+- Fix template always being overwritten. {pull}11671[11671]
+- Fix matching of string arrays in contains condition. {pull}11691[11691]
+- Fix initialization of the TCP input logger. {pull}11605[11605]
 
 *Auditbeat*
 

--- a/filebeat/input/tcp/input.go
+++ b/filebeat/input/tcp/input.go
@@ -84,7 +84,7 @@ func NewInput(
 		started: false,
 		outlet:  out,
 		config:  &config,
-		log:     logp.NewLogger("tcp input").With(config.Config.Host),
+		log:     logp.NewLogger("tcp input").With("address", config.Config.Host),
 	}, nil
 }
 


### PR DESCRIPTION
Cherry-pick of PR #11605 to 6.7 branch. Original message: 

`With()` function was called without the key to identify the value
passed as parameter.