### PR TITLE
Cherry-pick #11789 to 7.0: set user/group under systemd

### DIFF
--- a/dev-tools/packaging/templates/linux/systemd.unit.tmpl
+++ b/dev-tools/packaging/templates/linux/systemd.unit.tmpl
@@ -5,6 +5,10 @@ Wants=network-online.target
 After=network-online.target
 
 [Service]
+{{ if ne .BeatUser "root" -}}
+User={{ .BeatUser }}
+Group={{ .BeatUser }}
+{{- end }}
 Environment="BEAT_LOG_OPTS=-e"
 Environment="BEAT_CONFIG_OPTS=-c /etc/{{.BeatName}}/{{.BeatName}}.yml"
 Environment="BEAT_PATH_OPTS=-path.home /usr/share/{{.BeatName}} -path.config /etc/{{.BeatName}} -path.data /var/lib/{{.BeatName}} -path.logs /var/log/{{.BeatName}}"


### PR DESCRIPTION
Cherry-pick of PR #11789 to 7.0 branch. Original message: 

if not `root`.  apm-server does not run as root by default as of 7.0.0