### PR TITLE
Clarify docs to indicate that aliases will not fix type mismatches

### DIFF
--- a/libbeat/docs/upgrading.asciidoc
+++ b/libbeat/docs/upgrading.asciidoc
@@ -141,19 +141,29 @@ template to 7.0.
 migration.6_to_7.enabled: true
 ----
 
-The field aliases enable you to use 6.x dashboards and visualizations
-with indices created by {beats} 7.0 or later. However, there are a couple of
-exceptions:
+The field aliases let you use 6.x dashboards and visualizations with indices
+created by {beats} 7.0 or later. The aliases do *not* work with saved searches
+or with API calls that manipulate documents directly. 
 
-* The aliases do *not* work with saved searches or with API calls that
-manipulate documents directly.
-* The aliases do *not* resolve type mismatches caused by field type changes
-in 7.0. Aggregations in 6.x dashboards that rely on those fields will no longer
-work with indices created by {beats} 7.0 or later. 
+Some fields also have type changes in 7.0 that affect the behavior of older
+dashboards and visualizations. To clarify:
+
+* *Some fields have type changes.* Your {kib} visualizations and aggregations 
+will not work on these fields until the conflicts are resolved.
+
+* *Some fields have name changes, but no type changes.* The field aliases
+created by the compatibility layer ensure that visualizations and aggregations
+on the old field names work on old and new data. 7.0 dashboards only
+work on the new field names, and therefore only work with the new data.
+
+* *Some fields have both name and type changes.* Field aliases are created for
+these fields, but your {kib} visualizations and aggregations will not work on
+these fields until the conflicts are resolved. Some of your  {es} API queries
+may continue to work, if the old and new types are compatible.
 
 // TODO: Add a link to the breaking changes after we've added the list of type
-// changes. We should also add more detail to the troubleshooting section to
-// explain how to migrate the
+// changes. 
+// TODO: Add link to docs about resolving conflicts when they are available.
 
 We strongly advise that you adjust your custom {kib} dashboards, machine
 learning jobs, and other content to use the new ECS field names. After removing
@@ -162,7 +172,7 @@ so that field aliases will not be created during your next minor upgrade.
 
 The aliases will be removed in 8.0.
 
-Did you run the Beat or load the index template before reading this section?
+TIP: Did you run the Beat or load the index template before reading this section?
 That's OK. See the clean-up steps described under <<missing-fields>>.
 
 [[upgrade-index-template]]

--- a/libbeat/docs/upgrading.asciidoc
+++ b/libbeat/docs/upgrading.asciidoc
@@ -153,8 +153,8 @@ will not work on these fields until the conflicts are resolved.
 
 * *Some fields have name changes, but no type changes.* The field aliases
 created by the compatibility layer ensure that visualizations and aggregations
-on the old field names work on old and new data. 7.0 dashboards only
-work on the new field names, and therefore only work with the new data.
+on the old field names work on old and new data. 7.0 dashboards work
+only on new field names (and therefore only on new data).
 
 * *Some fields have both name and type changes.* Field aliases are created for
 these fields, but your {kib} visualizations and aggregations will not work on

--- a/libbeat/docs/upgrading.asciidoc
+++ b/libbeat/docs/upgrading.asciidoc
@@ -142,8 +142,18 @@ migration.6_to_7.enabled: true
 ----
 
 The field aliases enable you to use 6.x dashboards and visualizations
-with indices created by {beats} 7.0 or later. The aliases do *not* work
-with saved searches or with API calls that manipulate documents directly.
+with indices created by {beats} 7.0 or later. However, there are a couple of
+exceptions:
+
+* The aliases do *not* work with saved searches or with API calls that
+manipulate documents directly.
+* The aliases do *not* resolve type mismatches caused by field type changes
+in 7.0. Aggregations in 6.x dashboards that rely on those fields will no longer
+work with indices created by {beats} 7.0 or later. 
+
+// TODO: Add a link to the breaking changes after we've added the list of type
+// changes. We should also add more detail to the troubleshooting section to
+// explain how to migrate the
 
 We strongly advise that you adjust your custom {kib} dashboards, machine
 learning jobs, and other content to use the new ECS field names. After removing


### PR DESCRIPTION
Added clarification to upgrade docs to indicate that aliases do not handle type changes between 6.x and 7.0

@webmat FYI. 

We need to get the fields that have type changes documented asap so we can tell users what has changed, especially if that change impacts the 6.x dashboards they are hoping to continue using in 7.0