### PR TITLE
Refactoring: use new Fetch interface that automatically reports and logs errors

### DIFF
--- a/metricbeat/module/elasticsearch/ccr/ccr.go
+++ b/metricbeat/module/elasticsearch/ccr/ccr.go
@@ -56,60 +56,57 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 }
 
 // Fetch gathers stats for each follower shard from the _ccr/stats API
-func (m *MetricSet) Fetch(r mb.ReporterV2) {
+func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 	isMaster, err := elasticsearch.IsMaster(m.HTTP, m.GetServiceURI())
 	if err != nil {
-		err = errors.Wrap(err, "error determining if connected Elasticsearch node is master")
-		elastic.ReportAndLogError(err, r, m.Logger())
-		return
+		return errors.Wrap(err, "error determining if connected Elasticsearch node is master")
 	}
 
 	// Not master, no event sent
 	if !isMaster {
 		m.Logger().Debug("trying to fetch ccr stats from a non-master node")
-		return
+		return nil
 	}
 
 	info, err := elasticsearch.GetInfo(m.HTTP, m.GetServiceURI())
 	if err != nil {
-		elastic.ReportAndLogError(err, r, m.Logger())
-		return
+		return err
 	}
 
 	// CCR is only available in Trial or Platinum license of Elasticsearch. So we check
 	// the license first.
 	ccrUnavailableMessage, err := m.checkCCRAvailability(info.Version.Number)
 	if err != nil {
-		err = errors.Wrap(err, "error determining if CCR is available")
-		elastic.ReportAndLogError(err, r, m.Logger())
-		return
+		return errors.Wrap(err, "error determining if CCR is available")
 	}
 
 	if ccrUnavailableMessage != "" {
 		if time.Since(m.lastCCRLicenseMessageTimestamp) > 1*time.Minute {
-			err := fmt.Errorf(ccrUnavailableMessage)
-			elastic.ReportAndLogError(err, r, m.Logger())
 			m.lastCCRLicenseMessageTimestamp = time.Now()
+			return fmt.Errorf(ccrUnavailableMessage)
 		}
-		return
+		return nil
 	}
 
 	content, err := m.HTTP.FetchContent()
 	if err != nil {
-		elastic.ReportAndLogError(err, r, m.Logger())
-		return
+		return err
 	}
 
 	if m.XPack {
 		err = eventsMappingXPack(r, m, *info, content)
+		if err != nil {
+			// Since this is an x-pack code path, we log the error but don't
+			// return it. Otherwise it would get reported into `metricbeat-*`
+			// indices.
+			m.Logger().Error(err)
+			return nil
+		}
 	} else {
-		err = eventsMapping(r, *info, content)
+		return eventsMapping(r, *info, content)
 	}
 
-	if err != nil {
-		m.Logger().Error(err)
-		return
-	}
+	return nil
 }
 
 func (m *MetricSet) checkCCRAvailability(currentElasticsearchVersion *common.Version) (message string, err error) {

--- a/metricbeat/module/elasticsearch/ccr/data.go
+++ b/metricbeat/module/elasticsearch/ccr/data.go
@@ -63,9 +63,7 @@ func eventsMapping(r mb.ReporterV2, info elasticsearch.Info, content []byte) err
 	var data response
 	err := json.Unmarshal(content, &data)
 	if err != nil {
-		err = errors.Wrap(err, "failure parsing Elasticsearch CCR Stats API response")
-		r.Error(err)
-		return err
+		return errors.Wrap(err, "failure parsing Elasticsearch CCR Stats API response")
 	}
 
 	var errs multierror.Errors
@@ -81,9 +79,7 @@ func eventsMapping(r mb.ReporterV2, info elasticsearch.Info, content []byte) err
 
 			event.MetricSetFields, err = schema.Apply(followerShard)
 			if err != nil {
-				event.Error = errors.Wrap(err, "failure applying shard schema")
-				r.Event(event)
-				errs = append(errs, event.Error)
+				errs = append(errs, errors.Wrap(err, "failure applying shard schema"))
 				continue
 			}
 

--- a/metricbeat/module/elasticsearch/cluster_stats/cluster_stats.go
+++ b/metricbeat/module/elasticsearch/cluster_stats/cluster_stats.go
@@ -20,7 +20,6 @@ package cluster_stats
 import (
 	"github.com/pkg/errors"
 
-	"github.com/elastic/beats/metricbeat/helper/elastic"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/module/elasticsearch"
 )
@@ -51,39 +50,40 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 }
 
 // Fetch methods implements the data gathering and data conversion to the right format
-func (m *MetricSet) Fetch(r mb.ReporterV2) {
+func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 	isMaster, err := elasticsearch.IsMaster(m.HTTP, m.HostData().SanitizedURI+clusterStatsPath)
 	if err != nil {
-		err := errors.Wrap(err, "error determining if connected Elasticsearch node is master")
-		elastic.ReportAndLogError(err, r, m.Logger())
-		return
+		return errors.Wrap(err, "error determining if connected Elasticsearch node is master")
 	}
 
 	// Not master, no event sent
 	if !isMaster {
 		m.Logger().Debug("trying to fetch cluster stats from a non-master node")
-		return
+		return nil
 	}
 
 	content, err := m.HTTP.FetchContent()
 	if err != nil {
-		elastic.ReportAndLogError(err, r, m.Logger())
-		return
+		return err
 	}
 
 	info, err := elasticsearch.GetInfo(m.HTTP, m.HostData().SanitizedURI+clusterStatsPath)
 	if err != nil {
-		r.Error(errors.Wrap(err, "failed to get info from Elasticsearch"))
-		return
+		return err
 	}
 
 	if m.MetricSet.XPack {
 		err = eventMappingXPack(r, m, *info, content)
+		if err != nil {
+			// Since this is an x-pack code path, we log the error but don't
+			// return it. Otherwise it would get reported into `metricbeat-*`
+			// indices.
+			m.Logger().Error(err)
+			return nil
+		}
 	} else {
-		err = eventMapping(r, *info, content)
+		return eventMapping(r, *info, content)
 	}
 
-	if err != nil {
-		m.Logger().Error(err)
-	}
+	return nil
 }

--- a/metricbeat/module/elasticsearch/cluster_stats/data.go
+++ b/metricbeat/module/elasticsearch/cluster_stats/data.go
@@ -64,16 +64,12 @@ func eventMapping(r mb.ReporterV2, info elasticsearch.Info, content []byte) erro
 	var data map[string]interface{}
 	err := json.Unmarshal(content, &data)
 	if err != nil {
-		event.Error = errors.Wrap(err, "failure parsing Elasticsearch Cluster Stats API response")
-		r.Event(event)
-		return event.Error
+		return errors.Wrap(err, "failure parsing Elasticsearch Cluster Stats API response")
 	}
 
 	metricSetFields, err := schema.Apply(data)
 	if err != nil {
-		event.Error = errors.Wrap(err, "failure applying cluster stats schema")
-		r.Event(event)
-		return event.Error
+		return errors.Wrap(err, "failure applying cluster stats schema")
 	}
 
 	event.MetricSetFields = metricSetFields

--- a/metricbeat/module/elasticsearch/index/data.go
+++ b/metricbeat/module/elasticsearch/index/data.go
@@ -60,9 +60,7 @@ func eventsMapping(r mb.ReporterV2, info elasticsearch.Info, content []byte) err
 	var indicesStruct IndicesStruct
 	err := json.Unmarshal(content, &indicesStruct)
 	if err != nil {
-		err = errors.Wrap(err, "failure parsing Elasticsearch Stats API response")
-		r.Error(err)
-		return err
+		return errors.Wrap(err, "failure parsing Elasticsearch Stats API response")
 	}
 
 	var errs multierror.Errors
@@ -78,9 +76,7 @@ func eventsMapping(r mb.ReporterV2, info elasticsearch.Info, content []byte) err
 
 		event.MetricSetFields, err = schema.Apply(index)
 		if err != nil {
-			event.Error = errors.Wrap(err, "failure applying index schema")
-			r.Event(event)
-			errs = append(errs, event.Error)
+			errs = append(errs, errors.Wrap(err, "failure applying index schema"))
 			continue
 		}
 		// Write name here as full name only available as key

--- a/metricbeat/module/elasticsearch/index_recovery/data.go
+++ b/metricbeat/module/elasticsearch/index_recovery/data.go
@@ -61,18 +61,14 @@ func eventsMapping(r mb.ReporterV2, info elasticsearch.Info, content []byte) err
 
 	err := json.Unmarshal(content, &data)
 	if err != nil {
-		err = errors.Wrap(err, "failure parsing Elasticsearch Recovery API response")
-		r.Error(err)
-		return err
+		return errors.Wrap(err, "failure parsing Elasticsearch Recovery API response")
 	}
 
 	var errs multierror.Errors
 	for indexName, d := range data {
 		shards, ok := d["shards"]
 		if !ok {
-			err = elastic.MakeErrorForMissingField(indexName+".shards", elastic.Elasticsearch)
-			r.Error(err)
-			errs = append(errs, err)
+			errs = append(errs, elastic.MakeErrorForMissingField(indexName+".shards", elastic.Elasticsearch))
 			continue
 		}
 		for _, data := range shards {
@@ -88,8 +84,8 @@ func eventsMapping(r mb.ReporterV2, info elasticsearch.Info, content []byte) err
 
 			event.MetricSetFields, err = schema.Apply(data)
 			if err != nil {
-				event.Error = errors.Wrap(err, "failure applying shard schema")
-				errs = append(errs, event.Error)
+				errs = append(errs, errors.Wrap(err, "failure applying shard schema"))
+				continue
 			}
 
 			r.Event(event)

--- a/metricbeat/module/elasticsearch/index_recovery/index_recovery.go
+++ b/metricbeat/module/elasticsearch/index_recovery/index_recovery.go
@@ -20,7 +20,6 @@ package index_recovery
 import (
 	"github.com/pkg/errors"
 
-	"github.com/elastic/beats/metricbeat/helper/elastic"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/module/elasticsearch"
 )
@@ -67,40 +66,40 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 }
 
 // Fetch gathers stats for each index from the _stats API
-func (m *MetricSet) Fetch(r mb.ReporterV2) {
+func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 	isMaster, err := elasticsearch.IsMaster(m.HTTP, m.GetServiceURI())
 	if err != nil {
-		err = errors.Wrap(err, "error determining if connected Elasticsearch node is master")
-		elastic.ReportAndLogError(err, r, m.Logger())
-		return
+		return errors.Wrap(err, "error determining if connected Elasticsearch node is master")
 	}
 
 	// Not master, no event sent
 	if !isMaster {
 		m.Logger().Debug("trying to fetch index recovery stats from a non-master node")
-		return
+		return nil
 	}
 
 	info, err := elasticsearch.GetInfo(m.HTTP, m.GetServiceURI())
 	if err != nil {
-		elastic.ReportAndLogError(err, r, m.Logger())
-		return
+		return err
 	}
 
 	content, err := m.HTTP.FetchContent()
 	if err != nil {
-		elastic.ReportAndLogError(err, r, m.Logger())
-		return
+		return err
 	}
 
 	if m.MetricSet.XPack {
 		err = eventsMappingXPack(r, m, *info, content)
+		if err != nil {
+			// Since this is an x-pack code path, we log the error but don't
+			// return it. Otherwise it would get reported into `metricbeat-*`
+			// indices.
+			m.Logger().Error(err)
+			return nil
+		}
 	} else {
-		err = eventsMapping(r, *info, content)
+		return eventsMapping(r, *info, content)
 	}
 
-	if err != nil {
-		m.Logger().Error(err)
-		return
-	}
+	return nil
 }

--- a/metricbeat/module/elasticsearch/index_summary/data.go
+++ b/metricbeat/module/elasticsearch/index_summary/data.go
@@ -83,16 +83,12 @@ func eventMapping(r mb.ReporterV2, info elasticsearch.Info, content []byte) erro
 
 	err := json.Unmarshal(content, &all)
 	if err != nil {
-		event.Error = errors.Wrap(err, "failure parsing Elasticsearch Stats API response")
-		r.Event(event)
-		return event.Error
+		return errors.Wrap(err, "failure parsing Elasticsearch Stats API response")
 	}
 
 	fields, err := schema.Apply(all.Data, s.FailOnRequired)
 	if err != nil {
-		event.Error = errors.Wrap(err, "failure applying stats schema")
-		r.Event(event)
-		return event.Error
+		return errors.Wrap(err, "failure applying stats schema")
 	}
 
 	event.MetricSetFields = fields

--- a/metricbeat/module/elasticsearch/index_summary/index_summary.go
+++ b/metricbeat/module/elasticsearch/index_summary/index_summary.go
@@ -20,7 +20,6 @@ package index_summary
 import (
 	"github.com/pkg/errors"
 
-	"github.com/elastic/beats/metricbeat/helper/elastic"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/mb/parse"
 	"github.com/elastic/beats/metricbeat/module/elasticsearch"
@@ -62,41 +61,40 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 }
 
 // Fetch gathers stats for each index from the _stats API
-func (m *MetricSet) Fetch(r mb.ReporterV2) {
+func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 	isMaster, err := elasticsearch.IsMaster(m.HTTP, m.HostData().SanitizedURI+statsPath)
 	if err != nil {
-		err = errors.Wrap(err, "error determining if connected Elasticsearch node is master")
-		elastic.ReportAndLogError(err, r, m.Logger())
-		return
+		return errors.Wrap(err, "error determining if connected Elasticsearch node is master")
 	}
 
 	// Not master, no event sent
 	if !isMaster {
 		m.Logger().Debug("trying to fetch index summary stats from a non-master node")
-		return
+		return nil
 	}
 
 	content, err := m.HTTP.FetchContent()
 	if err != nil {
-		elastic.ReportAndLogError(err, r, m.Logger())
-		return
+		return err
 	}
 
 	info, err := elasticsearch.GetInfo(m.HTTP, m.HostData().SanitizedURI+statsPath)
 	if err != nil {
-		err = errors.Wrap(err, "failed to get info from Elasticsearch")
-		elastic.ReportAndLogError(err, r, m.Logger())
-		return
+		return errors.Wrap(err, "failed to get info from Elasticsearch")
 	}
 
 	if m.XPack {
 		err = eventMappingXPack(r, m, *info, content)
+		if err != nil {
+			// Since this is an x-pack code path, we log the error but don't
+			// return it. Otherwise it would get reported into `metricbeat-*`
+			// indices.
+			m.Logger().Error(err)
+			return nil
+		}
 	} else {
-		err = eventMapping(r, *info, content)
+		return eventMapping(r, *info, content)
 	}
 
-	if err != nil {
-		m.Logger().Error(err)
-		return
-	}
+	return nil
 }

--- a/metricbeat/module/elasticsearch/ml_job/data.go
+++ b/metricbeat/module/elasticsearch/ml_job/data.go
@@ -50,9 +50,7 @@ func eventsMapping(r mb.ReporterV2, info elasticsearch.Info, content []byte) err
 	jobsData := &jobsStruct{}
 	err := json.Unmarshal(content, jobsData)
 	if err != nil {
-		err = errors.Wrap(err, "failure parsing Elasticsearch ML Job Stats API response")
-		r.Error(err)
-		return err
+		return errors.Wrap(err, "failure parsing Elasticsearch ML Job Stats API response")
 	}
 
 	var errs multierror.Errors
@@ -69,8 +67,8 @@ func eventsMapping(r mb.ReporterV2, info elasticsearch.Info, content []byte) err
 
 		event.MetricSetFields, err = schema.Apply(job)
 		if err != nil {
-			event.Error = errors.Wrap(err, "failure applying ml job schema")
-			errs = append(errs, event.Error)
+			errs = append(errs, errors.Wrap(err, "failure applying ml job schema"))
+			continue
 		}
 
 		r.Event(event)

--- a/metricbeat/module/elasticsearch/ml_job/ml_job.go
+++ b/metricbeat/module/elasticsearch/ml_job/ml_job.go
@@ -20,7 +20,6 @@ package ml_job
 import (
 	"github.com/pkg/errors"
 
-	"github.com/elastic/beats/metricbeat/helper/elastic"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/module/elasticsearch"
 )
@@ -54,25 +53,22 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 }
 
 // Fetch methods implements the data gathering and data conversion to the right format
-func (m *MetricSet) Fetch(r mb.ReporterV2) {
+func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 
 	isMaster, err := elasticsearch.IsMaster(m.HTTP, m.GetServiceURI())
 	if err != nil {
-		err = errors.Wrap(err, "error determining if connected Elasticsearch node is master")
-		elastic.ReportAndLogError(err, r, m.Logger())
-		return
+		return errors.Wrap(err, "error determining if connected Elasticsearch node is master")
 	}
 
 	// Not master, no event sent
 	if !isMaster {
 		m.Logger().Debug("trying to fetch machine learning job stats from a non-master node")
-		return
+		return nil
 	}
 
 	info, err := elasticsearch.GetInfo(m.HTTP, m.GetServiceURI())
 	if err != nil {
-		elastic.ReportAndLogError(err, r, m.Logger())
-		return
+		return err
 	}
 
 	if info.Version.Number.Major < 7 {
@@ -83,18 +79,21 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 
 	content, err := m.HTTP.FetchContent()
 	if err != nil {
-		elastic.ReportAndLogError(err, r, m.Logger())
-		return
+		return err
 	}
 
 	if m.XPack {
 		err = eventsMappingXPack(r, m, *info, content)
+		if err != nil {
+			// Since this is an x-pack code path, we log the error but don't
+			// return it. Otherwise it would get reported into `metricbeat-*`
+			// indices.
+			m.Logger().Error(err)
+			return nil
+		}
 	} else {
-		err = eventsMapping(r, *info, content)
+		return eventsMapping(r, *info, content)
 	}
 
-	if err != nil {
-		m.Logger().Error(err)
-		return
-	}
+	return nil
 }

--- a/metricbeat/module/elasticsearch/node/data.go
+++ b/metricbeat/module/elasticsearch/node/data.go
@@ -69,9 +69,7 @@ func eventsMapping(r mb.ReporterV2, info elasticsearch.Info, content []byte) err
 
 	err := json.Unmarshal(content, &nodesStruct)
 	if err != nil {
-		err = errors.Wrap(err, "failure parsing Elasticsearch Node Stats API response")
-		r.Error(err)
-		return err
+		return errors.Wrap(err, "failure parsing Elasticsearch Node Stats API response")
 	}
 
 	var errs multierror.Errors
@@ -87,9 +85,7 @@ func eventsMapping(r mb.ReporterV2, info elasticsearch.Info, content []byte) err
 
 		event.MetricSetFields, err = schema.Apply(node)
 		if err != nil {
-			event.Error = errors.Wrap(err, "failure applying node schema")
-			r.Event(event)
-			errs = append(errs, event.Error)
+			errs = append(errs, errors.Wrap(err, "failure applying node schema"))
 			continue
 		}
 

--- a/metricbeat/module/elasticsearch/node/node.go
+++ b/metricbeat/module/elasticsearch/node/node.go
@@ -20,7 +20,6 @@ package node
 import (
 	"github.com/pkg/errors"
 
-	"github.com/elastic/beats/metricbeat/helper/elastic"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/mb/parse"
 	"github.com/elastic/beats/metricbeat/module/elasticsearch"
@@ -64,23 +63,16 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // Fetch methods implements the data gathering and data conversion to the right format
 // It returns the event which is then forward to the output. In case of an error, a
 // descriptive error must be returned.
-func (m *MetricSet) Fetch(r mb.ReporterV2) {
+func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 	content, err := m.HTTP.FetchContent()
 	if err != nil {
-		elastic.ReportAndLogError(err, r, m.Logger())
-		return
+		return err
 	}
 
 	info, err := elasticsearch.GetInfo(m.HTTP, m.HostData().SanitizedURI+nodeStatsPath)
 	if err != nil {
-		err = errors.Wrap(err, "failed to get info from Elasticsearch")
-		elastic.ReportAndLogError(err, r, m.Logger())
-		return
+		return errors.Wrap(err, "failed to get info from Elasticsearch")
 	}
 
-	err = eventsMapping(r, *info, content)
-	if err != nil {
-		elastic.ReportAndLogError(err, r, m.Logger())
-		return
-	}
+	return eventsMapping(r, *info, content)
 }

--- a/metricbeat/module/elasticsearch/node/node_test.go
+++ b/metricbeat/module/elasticsearch/node/node_test.go
@@ -71,7 +71,7 @@ func TestFetch(t *testing.T) {
 			}
 			reporter := &mbtest.CapturingReporterV2{}
 
-			metricSet := mbtest.NewReportingMetricSetV2(t, config)
+			metricSet := mbtest.NewReportingMetricSetV2Error(t, config)
 			metricSet.Fetch(reporter)
 
 			e := mbtest.StandardizeEvent(metricSet, reporter.GetEvents()[0])

--- a/metricbeat/module/elasticsearch/node_stats/data.go
+++ b/metricbeat/module/elasticsearch/node_stats/data.go
@@ -115,9 +115,7 @@ func eventsMapping(r mb.ReporterV2, info elasticsearch.Info, content []byte) err
 	nodeData := &nodesStruct{}
 	err := json.Unmarshal(content, nodeData)
 	if err != nil {
-		err = errors.Wrap(err, "failure parsing Elasticsearch Node Stats API response")
-		r.Error(err)
-		return err
+		return errors.Wrap(err, "failure parsing Elasticsearch Node Stats API response")
 	}
 
 	var errs multierror.Errors
@@ -139,25 +137,19 @@ func eventsMapping(r mb.ReporterV2, info elasticsearch.Info, content []byte) err
 
 		event.MetricSetFields, err = schema.Apply(node)
 		if err != nil {
-			event.Error = errors.Wrap(err, "failure to apply node schema")
-			r.Event(event)
-			errs = append(errs, event.Error)
+			errs = append(errs, errors.Wrap(err, "failure to apply node schema"))
 			continue
 		}
 
 		name, err := event.MetricSetFields.GetValue("name")
 		if err != nil {
-			event.Error = elastic.MakeErrorForMissingField("name", elastic.Elasticsearch)
-			r.Event(event)
-			errs = append(errs, event.Error)
+			errs = append(errs, elastic.MakeErrorForMissingField("name", elastic.Elasticsearch))
 			continue
 		}
 
 		nameStr, ok := name.(string)
 		if !ok {
-			event.Error = fmt.Errorf("name is not a string")
-			r.Event(event)
-			errs = append(errs, event.Error)
+			errs = append(errs, fmt.Errorf("name is not a string"))
 			continue
 		}
 		event.ModuleFields.Put("node.name", nameStr)

--- a/metricbeat/module/elasticsearch/pending_tasks/data.go
+++ b/metricbeat/module/elasticsearch/pending_tasks/data.go
@@ -47,13 +47,11 @@ func eventsMapping(r mb.ReporterV2, info elasticsearch.Info, content []byte) err
 
 	err := json.Unmarshal(content, &tasksStruct)
 	if err != nil {
-		err = errors.Wrap(err, "failure parsing Elasticsearch Pending Tasks API response")
-		r.Error(err)
-		return err
+		return errors.Wrap(err, "failure parsing Elasticsearch Pending Tasks API response")
 	}
 
 	if tasksStruct.Tasks == nil {
-		return elastic.ReportErrorForMissingField("tasks", elastic.Elasticsearch, r)
+		return elastic.MakeErrorForMissingField("tasks", elastic.Elasticsearch)
 	}
 
 	var errs multierror.Errors
@@ -69,8 +67,8 @@ func eventsMapping(r mb.ReporterV2, info elasticsearch.Info, content []byte) err
 
 		event.MetricSetFields, err = schema.Apply(task)
 		if err != nil {
-			event.Error = errors.Wrap(err, "failure applying task schema")
-			errs = append(errs, event.Error)
+			errs = append(errs, errors.Wrap(err, "failure applying task schema"))
+			continue
 		}
 
 		r.Event(event)

--- a/metricbeat/module/elasticsearch/pending_tasks/pending_tasks.go
+++ b/metricbeat/module/elasticsearch/pending_tasks/pending_tasks.go
@@ -20,7 +20,6 @@ package pending_tasks
 import (
 	"github.com/pkg/errors"
 
-	"github.com/elastic/beats/metricbeat/helper/elastic"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/module/elasticsearch"
 )
@@ -59,35 +58,27 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 }
 
 // Fetch methods implements the data gathering and data conversion to the right format
-func (m *MetricSet) Fetch(r mb.ReporterV2) {
+func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 	isMaster, err := elasticsearch.IsMaster(m.HTTP, m.GetServiceURI())
 	if err != nil {
-		err := errors.Wrap(err, "error determining if connected Elasticsearch node is master")
-		elastic.ReportAndLogError(err, r, m.Logger())
-		return
+		return errors.Wrap(err, "error determining if connected Elasticsearch node is master")
 	}
 
 	// Not master, no event sent
 	if !isMaster {
 		m.Logger().Debug("trying to fetch pending tasks from a non-master node")
-		return
+		return nil
 	}
 
 	info, err := elasticsearch.GetInfo(m.HTTP, m.GetServiceURI())
 	if err != nil {
-		elastic.ReportAndLogError(err, r, m.Logger())
-		return
+		return err
 	}
 
 	content, err := m.HTTP.FetchContent()
 	if err != nil {
-		elastic.ReportAndLogError(err, r, m.Logger())
-		return
+		return err
 	}
 
-	err = eventsMapping(r, *info, content)
-	if err != nil {
-		m.Logger().Error(err)
-		return
-	}
+	return eventsMapping(r, *info, content)
 }

--- a/metricbeat/module/elasticsearch/shard/data.go
+++ b/metricbeat/module/elasticsearch/shard/data.go
@@ -58,9 +58,7 @@ func eventsMapping(r mb.ReporterV2, content []byte) error {
 	stateData := &stateStruct{}
 	err := json.Unmarshal(content, stateData)
 	if err != nil {
-		err = errors.Wrap(err, "failure parsing Elasticsearch Cluster State API response")
-		r.Error(err)
-		return err
+		return errors.Wrap(err, "failure parsing Elasticsearch Cluster State API response")
 	}
 
 	var errs multierror.Errors
@@ -79,27 +77,21 @@ func eventsMapping(r mb.ReporterV2, content []byte) error {
 
 				fields, err := schema.Apply(shard)
 				if err != nil {
-					event.Error = errors.Wrap(err, "failure applying shard schema")
-					r.Event(event)
-					errs = append(errs, event.Error)
+					errs = append(errs, errors.Wrap(err, "failure applying shard schema"))
 					continue
 				}
 
 				// Handle node field: could be string or null
 				err = elasticsearch.PassThruField("node", shard, fields)
 				if err != nil {
-					event.Error = errors.Wrap(err, "failure passing through node field")
-					r.Event(event)
-					errs = append(errs, event.Error)
+					errs = append(errs, errors.Wrap(err, "failure passing through node field"))
 					continue
 				}
 
 				// Handle relocating_node field: could be string or null
 				err = elasticsearch.PassThruField("relocating_node", shard, fields)
 				if err != nil {
-					event.Error = errors.Wrap(err, "failure passing through relocating_node field")
-					r.Event(event)
-					errs = append(errs, event.Error)
+					errs = append(errs, errors.Wrap(err, "failure passing through relocating_node field"))
 					continue
 				}
 


### PR DESCRIPTION
Refactors code in the `elasticsearch` Metricbeat module to use the new `Fetch` interface introduced in https://github.com/elastic/beats/pull/10727.

Note that x-pack code paths in this module were not refactored to use the new interface as we don't want errors from those code paths to be reported into `metricbeat-*` indices, only logged to Metricbeat logs.

Related: #11763 and #11767.