### PR TITLE
Fixing name of ES API in error message

### DIFF
--- a/metricbeat/module/elasticsearch/pending_tasks/data.go
+++ b/metricbeat/module/elasticsearch/pending_tasks/data.go
@@ -47,7 +47,7 @@ func eventsMapping(r mb.ReporterV2, info elasticsearch.Info, content []byte) err
 
 	err := json.Unmarshal(content, &tasksStruct)
 	if err != nil {
-		err = errors.Wrap(err, "failure parsing Elasticsearch ML Job Stats API response")
+		err = errors.Wrap(err, "failure parsing Elasticsearch Pending Tasks API response")
 		r.Error(err)
 		return err
 	}


### PR DESCRIPTION
The `elasticsearch/pending_tasks` metricset was emitting an error message referring to the "ML Job Stats" API, instead of the "Pending Tasks" API. This PR fixes the error message.