### PR TITLE
[7.0] Backport: Add apache2 renaming to breaking changes doc (#11749)

### DIFF
--- a/libbeat/docs/breaking.asciidoc
+++ b/libbeat/docs/breaking.asciidoc
@@ -54,6 +54,12 @@ the `setup.ilm` namespace.
 
 //tag::notable-breaking-changes[]
 
+[float]
+==== Filebeat apache2 module renamed
+
+The Filebeat `apache2` module is renamed to `apache` in 7.0. 
+
+[float]
 ==== Field name changes
 
 include::./field-name-changes.asciidoc[]


### PR DESCRIPTION
Cherry-picks #11749 into 7.0 branch.