### PR TITLE
Skip flaky Kibana Stats integration test

### DIFF
--- a/metricbeat/module/kibana/stats/stats_integration_test.go
+++ b/metricbeat/module/kibana/stats/stats_integration_test.go
@@ -36,6 +36,7 @@ import (
 )
 
 func TestFetch(t *testing.T) {
+	t.Skip("flaky")
 	compose.EnsureUpWithTimeout(t, 600, "elasticsearch", "kibana")
 
 	config := mtest.GetConfig("stats")
@@ -67,6 +68,7 @@ func TestFetch(t *testing.T) {
 }
 
 func TestData(t *testing.T) {
+	t.Skip("flaky")
 	compose.EnsureUp(t, "kibana")
 
 	config := mtest.GetConfig("stats")


### PR DESCRIPTION
We're starting to see errors like this quite frequently (but not all the time) in our CI:

```
Creating metricbeat91226fb6ffe6d06676cfc1383d0a3ffb19f00db7_kibana_1 ... 
    stats_integration_test.go:60: 
        	Error Trace:	stats_integration_test.go:60
        	Error:      	Should be empty, but was [error making http request: Get http://kibana:5601/api/stats?extended=true: net/http: request canceled (Client.Timeout exceeded while awaiting headers)]
        	Test:       	TestFetch
    stats_integration_test.go:61: 
        	Error Trace:	stats_integration_test.go:61
        	Error:      	Should NOT be empty, but was []
        	Test:       	TestFetch
```

So this PR skips this test suite for now, while we try to debug and fix the root cause in https://github.com/elastic/beats/pull/11380.