### PR TITLE
Cherry-pick #11796 to 7.0: Don't report errors in x-pack code path

### DIFF
--- a/metricbeat/module/elasticsearch/ccr/data_xpack.go
+++ b/metricbeat/module/elasticsearch/ccr/data_xpack.go
@@ -34,9 +34,7 @@ func eventsMappingXPack(r mb.ReporterV2, m *MetricSet, info elasticsearch.Info, 
 	var data response
 	err := json.Unmarshal(content, &data)
 	if err != nil {
-		err = errors.Wrap(err, "failure parsing Elasticsearch CCR Stats API response")
-		r.Error(err)
-		return err
+		return errors.Wrap(err, "failure parsing Elasticsearch CCR Stats API response")
 	}
 
 	var errors multierror.Errors

--- a/metricbeat/module/kibana/stats/data_xpack.go
+++ b/metricbeat/module/kibana/stats/data_xpack.go
@@ -116,7 +116,7 @@ type dataParser func(mb.ReporterV2, common.MapStr, time.Time) (string, string, c
 func statsDataParser(r mb.ReporterV2, data common.MapStr, now time.Time) (string, string, common.MapStr, error) {
 	clusterUUID, ok := data["clusterUuid"].(string)
 	if !ok {
-		return "", "", nil, elastic.ReportErrorForMissingField("clusterUuid", elastic.Kibana, r)
+		return "", "", nil, elastic.MakeErrorForMissingField("clusterUuid", elastic.Kibana)
 	}
 
 	kibanaStatsFields, err := schemaXPackMonitoringStats.Apply(data)
@@ -126,15 +126,15 @@ func statsDataParser(r mb.ReporterV2, data common.MapStr, now time.Time) (string
 
 	process, ok := data["process"].(map[string]interface{})
 	if !ok {
-		return "", "", nil, elastic.ReportErrorForMissingField("process", elastic.Kibana, r)
+		return "", "", nil, elastic.MakeErrorForMissingField("process", elastic.Kibana)
 	}
 	memory, ok := process["memory"].(map[string]interface{})
 	if !ok {
-		return "", "", nil, elastic.ReportErrorForMissingField("process.memory", elastic.Kibana, r)
+		return "", "", nil, elastic.MakeErrorForMissingField("process.memory", elastic.Kibana)
 	}
 	rss, ok := memory["resident_set_size_bytes"].(float64)
 	if !ok {
-		return "", "", nil, elastic.ReportErrorForMissingField("process.memory.resident_set_size_bytes", elastic.Kibana, r)
+		return "", "", nil, elastic.MakeErrorForMissingField("process.memory.resident_set_size_bytes", elastic.Kibana)
 	}
 	kibanaStatsFields.Put("process.memory.resident_set_size_in_bytes", int64(rss))
 
@@ -143,7 +143,7 @@ func statsDataParser(r mb.ReporterV2, data common.MapStr, now time.Time) (string
 	// Make usage field passthrough as-is
 	usage, ok := data["usage"].(map[string]interface{})
 	if !ok {
-		return "", "", nil, elastic.ReportErrorForMissingField("usage", elastic.Kibana, r)
+		return "", "", nil, elastic.MakeErrorForMissingField("usage", elastic.Kibana)
 	}
 	kibanaStatsFields.Put("usage", usage)
 
@@ -153,12 +153,12 @@ func statsDataParser(r mb.ReporterV2, data common.MapStr, now time.Time) (string
 func settingsDataParser(r mb.ReporterV2, data common.MapStr, now time.Time) (string, string, common.MapStr, error) {
 	clusterUUID, ok := data["cluster_uuid"].(string)
 	if !ok {
-		return "", "", nil, elastic.ReportErrorForMissingField("cluster_uuid", elastic.Kibana, r)
+		return "", "", nil, elastic.MakeErrorForMissingField("cluster_uuid", elastic.Kibana)
 	}
 
 	kibanaSettingsFields, ok := data["settings"]
 	if !ok {
-		return "", "", nil, elastic.ReportErrorForMissingField("settings", elastic.Kibana, r)
+		return "", "", nil, elastic.MakeErrorForMissingField("settings", elastic.Kibana)
 	}
 
 	return "kibana_settings", clusterUUID, kibanaSettingsFields.(map[string]interface{}), nil


### PR DESCRIPTION
Cherry-pick of PR #11796 to 7.0 branch. Original message: 

The X-Pack code path shouldn't report errors as they will get indexed into `metricbeat-*` indices, not `.monitoring-*` indices (which don't have a field for errors anyway).