### PR TITLE
[Auditbeat] Remove unset auid and session fields

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -15,6 +15,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 *Auditbeat*
 
 - Auditd module: Normalized value of `event.category` field from `user-login` to `authentication`. {pull}11432[11432]
+- Auditd module: Unset `auditd.session` and `user.audit.id` fields are removed from audit events. {issue}11431[11431] {pull}11815[11815]
 
 *Filebeat*
 

--- a/auditbeat/module/auditd/audit_linux.go
+++ b/auditbeat/module/auditd/audit_linux.go
@@ -48,6 +48,7 @@ const (
 
 	unicast   = "unicast"
 	multicast = "multicast"
+	uidUnset  = "unset"
 
 	lostEventsUpdateInterval        = time.Second * 15
 	maxDefaultStreamBufferConsumers = 4
@@ -485,9 +486,11 @@ func buildMetricbeatEvent(msgs []*auparse.AuditMessage, config Config) mb.Event 
 			"message_type": strings.ToLower(auditEvent.Type.String()),
 			"sequence":     auditEvent.Sequence,
 			"result":       auditEvent.Result,
-			"session":      auditEvent.Session,
 			"data":         createAuditdData(auditEvent.Data),
 		},
+	}
+	if auditEvent.Session != uidUnset {
+		out.ModuleFields.Put("session", auditEvent.Session)
 	}
 
 	// Add root level fields.
@@ -596,6 +599,9 @@ func addUser(u aucoalesce.User, m common.MapStr) {
 	m.Put("user", user)
 
 	for id, value := range u.IDs {
+		if value == uidUnset {
+			continue
+		}
 		switch id {
 		case "uid":
 			user["id"] = value

--- a/auditbeat/module/auditd/audit_linux_test.go
+++ b/auditbeat/module/auditd/audit_linux_test.go
@@ -146,18 +146,23 @@ func TestLoginType(t *testing.T) {
 			"event.outcome":  "failure",
 			"user.name":      "(invalid user)",
 			"user.id":        nil,
+			"session":        nil,
 		},
 		{
 			"event.category": "authentication",
 			"event.type":     "authentication_success",
 			"event.outcome":  "success",
 			"user.name":      "adrian",
+			"user.audit.id":  nil,
+			"auditd.session": nil,
 		},
 		{
 			"event.category": "user-login",
 			"event.outcome":  "success",
 			"user.name":      "root",
 			"user.id":        "0",
+			"user.audit.id":  "0",
+			"auditd.session": "62",
 		},
 	} {
 		beatEvent := mbtest.StandardizeEvent(ms, events[idx], core.AddDatasetToEvent)
@@ -169,7 +174,8 @@ func TestLoginType(t *testing.T) {
 				assert.NoError(t, err, msg)
 				assert.Equal(t, v, cur, msg)
 			} else {
-				assert.Error(t, err, msg)
+				_, err := beatEvent.GetValue(k)
+				assert.Equal(t, common.ErrKeyNotFound, err, msg)
 			}
 		}
 	}


### PR DESCRIPTION
The auditd module sets `user.audit.id` and `auditd.session` to `unset` when they are not present in the original event.

This changes this behavior and removes the fields from the event. The same logic is applied to any other *ID field that might be marked as unset.

Closes #11431