### PR TITLE
[metricbeat] migrate munin to reporterV2 with error return

### DIFF
--- a/metricbeat/module/munin/node/node_integration_test.go
+++ b/metricbeat/module/munin/node/node_integration_test.go
@@ -32,8 +32,8 @@ import (
 func TestFetch(t *testing.T) {
 	compose.EnsureUp(t, "munin")
 
-	f := mbtest.NewReportingMetricSetV2(t, getConfig())
-	events, errs := mbtest.ReportingFetchV2(f)
+	f := mbtest.NewReportingMetricSetV2Error(t, getConfig())
+	events, errs := mbtest.ReportingFetchV2Error(f)
 
 	assert.Empty(t, errs)
 	if !assert.NotEmpty(t, events) {
@@ -48,8 +48,8 @@ func TestData(t *testing.T) {
 	compose.EnsureUp(t, "munin")
 
 	config := getConfig()
-	f := mbtest.NewReportingMetricSetV2(t, config)
-	err := mbtest.WriteEventsReporterV2(f, t, ".")
+	f := mbtest.NewReportingMetricSetV2Error(t, config)
+	err := mbtest.WriteEventsReporterV2Error(f, t, ".")
 	if err != nil {
 		t.Fatal("write", err)
 	}


### PR DESCRIPTION
see elastic/beats#11374 