### PR TITLE
docs: add ifndef for Kibana ssl

### DIFF
--- a/libbeat/docs/shared-ssl-config.asciidoc
+++ b/libbeat/docs/shared-ssl-config.asciidoc
@@ -28,6 +28,7 @@ ifndef::only-elasticsearch[]
 Also see <<configuring-ssl-logstash>>.
 endif::[]
 
+ifndef::no_kibana[]
 Example Kibana endpoint config with SSL enabled:
 
 [source,yaml]
@@ -38,7 +39,7 @@ setup.kibana.ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 setup.kibana.ssl.certificate: "/etc/pki/client/cert.pem"
 setup.kibana.ssl.key: "/etc/pki/client/cert.key"
 ----
-
+endif::no_kibana[]
 
 ifeval::["{beatname_lc}"=="heartbeat"]
 Example monitor with SSL enabled:


### PR DESCRIPTION
Kibana endpoint config shouldn't be in the APM Server documentation. Adding an `ifndef` for a new `no_kibana` attribute.