### PR TITLE
Un-skip Metricbeat kibana module flaky tests

### DIFF
--- a/metricbeat/module/kibana/_meta/Dockerfile
+++ b/metricbeat/module/kibana/_meta/Dockerfile
@@ -1,2 +1,3 @@
 FROM docker.elastic.co/kibana/kibana:6.6.0
-HEALTHCHECK --interval=1s --retries=300 CMD curl -f http://localhost:5601/api/status | grep '"disconnects"'
+HEALTHCHECK --interval=1s --retries=300 --start-period=60s CMD python -c 'import urllib, json; response = urllib.urlopen("http://myelastic:changeme@localhost:5601/api/status"); data = json.loads(response.read()); exit(1) if data["status"]["overall"]["state"] != "green" else exit(0);'
+

--- a/metricbeat/module/kibana/stats/stats_integration_test.go
+++ b/metricbeat/module/kibana/stats/stats_integration_test.go
@@ -36,7 +36,6 @@ import (
 )
 
 func TestFetch(t *testing.T) {
-	t.Skip("flaky")
 	compose.EnsureUpWithTimeout(t, 600, "elasticsearch", "kibana")
 
 	config := mtest.GetConfig("stats")
@@ -68,7 +67,6 @@ func TestFetch(t *testing.T) {
 }
 
 func TestData(t *testing.T) {
-	t.Skip("flaky")
 	compose.EnsureUp(t, "kibana")
 
 	config := mtest.GetConfig("stats")


### PR DESCRIPTION
Resolves #11261.

This PR:
* un-skips the currently-skipped flaky integration tests for the Metricbeat `kibana` module
* makes the Kibana docker health check more robust, similar to the one in https://github.com/elastic/beats/blob/e2b108436e03bfa0336dd3548f89f9b56bcc5186/x-pack/libbeat/docker-compose.yml#L49-L53