### PR TITLE
Cherry-pick #11822 to 7.0, add line about LSM ptrace blocks in the system metricset

### DIFF
--- a/metricbeat/docs/modules/system.asciidoc
+++ b/metricbeat/docs/modules/system.asciidoc
@@ -11,6 +11,8 @@ always applies to the local server, the `hosts` config option is not needed.
 The default metricsets are `cpu`, `load`, `memory`, `network`, `process` and
 `process_summary`.
 
+Note that certain metricsets may access `/proc` to gather process information, and the resulting `ptrace_may_access()` call by the kernel to check for permissions can be blocked by https://gitlab.com/apparmor/apparmor/wikis/TechnicalDoc_Proc_and_ptrace[AppArmor and other LSM software], even though the system module doesn't use `ptrace` directly.
+
 [float]
 === Dashboard
 

--- a/metricbeat/module/system/_meta/docs.asciidoc
+++ b/metricbeat/module/system/_meta/docs.asciidoc
@@ -4,6 +4,8 @@ always applies to the local server, the `hosts` config option is not needed.
 The default metricsets are `cpu`, `load`, `memory`, `network`, `process` and
 `process_summary`.
 
+Note that certain metricsets may access `/proc` to gather process information, and the resulting `ptrace_may_access()` call by the kernel to check for permissions can be blocked by https://gitlab.com/apparmor/apparmor/wikis/TechnicalDoc_Proc_and_ptrace[AppArmor and other LSM software], even though the system module doesn't use `ptrace` directly.
+
 [float]
 === Dashboard
 


### PR DESCRIPTION
Cherry-pick of #11822 at @ruflin 's request.