### PR TITLE
Restore `publish` debug flag

### DIFF
--- a/libbeat/publisher/processing/processors.go
+++ b/libbeat/publisher/processing/processors.go
@@ -180,7 +180,7 @@ func debugPrintProcessor(info beat.Info, log *logp.Logger) *processorFn {
 			return event, nil
 		}
 
-		log.Debugf("Publish event: %s", b)
+		logp.Debug("publish", "Publish event: %s", b)
 		return event, nil
 	})
 }


### PR DESCRIPTION
This flag was lost in some refactoring, making output currently
available under `processors` flag