### PR TITLE
[7.x] Backport: Add release highlights

### DIFF
--- a/libbeat/docs/highlights-7.1.0.asciidoc
+++ b/libbeat/docs/highlights-7.1.0.asciidoc
@@ -1,0 +1,20 @@
+[[release-highlights-7.1.0]]
+=== 7.1.0 release highlights
+++++
+<titleabbrev>7.1.0</titleabbrev>
+++++
+
+Each release of {beats} brings new features and product improvements. 
+Here are the highlights of the new features and enhancements in 7.1.0.
+
+Refer to the {beats} <<breaking-changes,Breaking Changes>> and <<release-notes, 
+Release Notes>> for a list of bug fixes and other changes.
+
+coming[7.1.0]
+
+//NOTE: The notable-highlights tagged regions are re-used in the
+//Installation and Upgrade Guide
+
+// tag::notable-highlights[]
+
+// end::notable-highlights[]

--- a/libbeat/docs/highlights.asciidoc
+++ b/libbeat/docs/highlights.asciidoc
@@ -1,0 +1,9 @@
+[[release-highlights]]
+== Release highlights
+
+This section summarizes the most important changes in each release. For the 
+full list, see <<release-notes>> and <<breaking-changes>>. 
+
+* <<release-highlights-7.1.0>>
+
+include::highlights-7.1.0.asciidoc[]

--- a/libbeat/docs/index.asciidoc
+++ b/libbeat/docs/index.asciidoc
@@ -27,6 +27,8 @@ include::./upgrading.asciidoc[]
 
 include::./config-file-format.asciidoc[]
 
+include::./highlights.asciidoc[]
+
 include::./release.asciidoc[]
 
 include::../../libbeat/docs/contributing-to-beats.asciidoc[]


### PR DESCRIPTION
Backports https://github.com/elastic/beats/pull/11621

Related to https://github.com/elastic/stack-docs/pull/276