### PR TITLE
[Heartbeat] Remove not needed flags from setup command

### DIFF
--- a/heartbeat/cmd/root.go
+++ b/heartbeat/cmd/root.go
@@ -19,15 +19,36 @@ package cmd
 
 import (
 	// register default heartbeat monitors
-	_ "github.com/elastic/beats/heartbeat/monitors/defaults"
-	"github.com/elastic/beats/libbeat/cmd/instance"
-
 	"github.com/elastic/beats/heartbeat/beater"
+	_ "github.com/elastic/beats/heartbeat/monitors/defaults"
 	cmd "github.com/elastic/beats/libbeat/cmd"
+	"github.com/elastic/beats/libbeat/cmd/instance"
 )
 
 // Name of this beat
 var Name = "heartbeat"
 
 // RootCmd to handle beats cli
-var RootCmd = cmd.GenRootCmdWithSettings(beater.New, instance.Settings{Name: Name})
+var RootCmd *cmd.BeatsRootCmd
+
+func init() {
+	RootCmd = cmd.GenRootCmdWithSettings(beater.New, instance.Settings{Name: Name})
+
+	// remove dashboard from export commands
+	for _, cmd := range RootCmd.ExportCmd.Commands() {
+		if cmd.Name() == "dashboard" {
+			RootCmd.ExportCmd.RemoveCommand(cmd)
+		}
+	}
+
+	// only add defined flags to setup command
+	setup := RootCmd.SetupCmd
+	setup.Short = "Setup Elasticsearch index template and pipelines"
+	setup.Long = `This command does initial setup of the environment:
+ * Index mapping template in Elasticsearch to ensure fields are mapped.
+ * ILM Policy
+`
+	setup.ResetFlags()
+	setup.Flags().Bool(cmd.TemplateKey, false, "Setup index template")
+	setup.Flags().Bool(cmd.ILMPolicyKey, false, "Setup ILM policy")
+}


### PR DESCRIPTION
The setup command until now contained all the possible options from the other Beats. As Heartbeat does not ship anymore with dashboards, the --dashboards command is not needed anymore and is only confusing. I also removed all the other commands except `--ilm-policy` and `--template`. I'm not aware that `--pipelines` or `--machine-learning` would be used.

Here the comparison between `./heartbeat setup -h` from before and after.

Before:

```
This command does initial setup of the environment:

 * Index mapping template in Elasticsearch to ensure fields are mapped.
 * Kibana dashboards (where available).
 * ML jobs (where available).
 * Ingest pipelines (where available).
 * ILM policy (for Elasticsearch 6.5 and newer).

Usage:
  heartbeat setup [flags]

Flags:
      --dashboards         Setup dashboards
  -h, --help               help for setup
      --ilm-policy         Setup ILM policy
      --machine-learning   Setup machine learning job configurations
      --pipelines          Setup Ingest pipelines
      --template           Setup index template
```

After:

```
This command does initial setup of the environment:
 * Index mapping template in Elasticsearch to ensure fields are mapped.
 * ILM Policy

Usage:
  heartbeat setup [flags]

Flags:
  -h, --help         help for setup
      --ilm-policy   Setup ILM policy
      --template     Setup index template
```

In this PR I did not include a check for the config option `setup.dashboards` to make sure they are not there like apm-server does (https://github.com/elastic/apm-server/blob/2baefab778fdfe70c47bc2fb488677b2e43e4635/beater/beater.go#L60) as I don't think it's necessary.