### PR TITLE
Add backoff again

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -86,6 +86,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Journalbeat*
 
+- Add backoff again. {pull}11861[11861]
+
 *Metricbeat*
 
 - Add _bucket to histogram metrics in Prometheus Collector {pull}11578[11578]

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -86,7 +86,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Journalbeat*
 
-- Add backoff again. {pull}11861[11861]
+- Use backoff when no new events are found. {pull}11861[11861]
 
 *Metricbeat*
 

--- a/journalbeat/reader/journal.go
+++ b/journalbeat/reader/journal.go
@@ -206,6 +206,7 @@ func (r *Reader) Next() (*beat.Event, error) {
 				return nil, err
 			}
 			if !hasNewEntry {
+				r.backoff.Wait()
 				continue
 			}
 		}
@@ -215,6 +216,7 @@ func (r *Reader) Next() (*beat.Event, error) {
 			return nil, err
 		}
 		event := r.toEvent(entry)
+		r.backoff.Reset()
 
 		return event, nil
 	}


### PR DESCRIPTION
During the refactoring of event reading, backoff was removed accidentaly. Now it's added again.