### PR TITLE
[metricbeat] change hostname/port of example for scraping an exporter

### DIFF
--- a/metricbeat/module/prometheus/collector/_meta/docs.asciidoc
+++ b/metricbeat/module/prometheus/collector/_meta/docs.asciidoc
@@ -11,7 +11,7 @@ to retrieve the metrics from (`/metrics` by default) can be configured with `met
 -------------------------------------------------------------------------------------
 - module: prometheus
   period: 10s
-  hosts: ["localhost:9090"]
+  hosts: ["node:9100"]
   metrics_path: /metrics
 
   #username: "user"


### PR DESCRIPTION
This is a fix for  #11282

`9090` is the port used by the prom server, so the doc example for scraping from individual hosts should probably use something else. 