### PR TITLE
Call GetMetricData api per region instead of per instance

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -91,6 +91,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add _bucket to histogram metrics in Prometheus Collector {pull}11578[11578]
 - Prevent the docker/memory metricset from processing invalid events before container start {pull}11676[11676]
 - Change `add_cloud_metadata` processor to not overwrite `cloud` field when it already exist in the event. {pull}11612[11612] {issue}11305[11305]
+- Call GetMetricData api per region instead of per instance. {issue}11820[11820] {pull}11882[11882]
 
 *Packetbeat*
 

--- a/x-pack/metricbeat/module/aws/aws.go
+++ b/x-pack/metricbeat/module/aws/aws.go
@@ -7,6 +7,8 @@ package aws
 import (
 	"strconv"
 
+	"github.com/elastic/beats/libbeat/common"
+
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/defaults"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -148,4 +150,18 @@ func StringInSlice(str string, list []string) bool {
 		}
 	}
 	return false
+}
+
+// InitEvent initialize mb.Event with basic information like service.name, cloud.provider
+func InitEvent(metricsetName string, regionName string) mb.Event {
+	event := mb.Event{}
+	event.Service = metricsetName
+	event.RootFields = common.MapStr{}
+	event.MetricSetFields = common.MapStr{}
+	event.RootFields.Put("service.name", metricsetName)
+	event.RootFields.Put("cloud.provider", "aws")
+	if regionName != "" {
+		event.RootFields.Put("cloud.region", regionName)
+	}
+	return event
 }

--- a/x-pack/metricbeat/module/aws/ec2/_meta/data.json
+++ b/x-pack/metricbeat/module/aws/ec2/_meta/data.json
@@ -4,11 +4,11 @@
         "ec2": {
             "cpu": {
                 "credit_balance": 144,
-                "credit_usage": 0.008328,
+                "credit_usage": 0.005318,
                 "surplus_credit_balance": 0,
                 "surplus_credits_charged": 0,
                 "total": {
-                    "pct": 0.1000000000000606
+                    "pct": 0.133333333333212
                 }
             },
             "diskio": {
@@ -47,12 +47,12 @@
             },
             "network": {
                 "in": {
-                    "bytes": 615.2,
-                    "packets": 6.2
+                    "bytes": 583,
+                    "packets": 4.8
                 },
                 "out": {
-                    "bytes": 841.4,
-                    "packets": 6.8
+                    "bytes": 746.4,
+                    "packets": 5
                 }
             },
             "status": {

--- a/x-pack/metricbeat/module/aws/ec2/ec2.go
+++ b/x-pack/metricbeat/module/aws/ec2/ec2.go
@@ -18,7 +18,11 @@ import (
 	"github.com/elastic/beats/x-pack/metricbeat/module/aws"
 )
 
-var metricsetName = "ec2"
+var (
+	metricsetName = "ec2"
+	instanceIDIdx = 0
+	metricNameIdx = 1
+)
 
 // init registers the MetricSet with the central registry as soon as the program
 // starts. The New function will be called later to instantiate an instance of
@@ -166,7 +170,7 @@ func (m *MetricSet) createCloudWatchEvents(getMetricDataResults []cloudwatch.Met
 			exists, timestampIdx := aws.CheckTimestampInArray(timestamp, output.Timestamps)
 			if exists {
 				labels := strings.Split(*output.Label, " ")
-				instanceID := labels[0]
+				instanceID := labels[instanceIDIdx]
 				machineType, err := instanceOutput[instanceID].InstanceType.MarshalValue()
 				if err != nil {
 					return events, errors.Wrap(err, "instance.InstanceType.MarshalValue failed")
@@ -176,7 +180,7 @@ func (m *MetricSet) createCloudWatchEvents(getMetricDataResults []cloudwatch.Met
 				events[instanceID].RootFields.Put("cloud.availability_zone", *instanceOutput[instanceID].Placement.AvailabilityZone)
 
 				if len(output.Values) > timestampIdx {
-					metricSetFieldResults[instanceID][labels[1]] = fmt.Sprint(output.Values[timestampIdx])
+					metricSetFieldResults[instanceID][labels[metricNameIdx]] = fmt.Sprint(output.Values[timestampIdx])
 				}
 
 				instanceStateName, err := instanceOutput[instanceID].State.Name.MarshalValue()

--- a/x-pack/metricbeat/module/aws/ec2/ec2.go
+++ b/x-pack/metricbeat/module/aws/ec2/ec2.go
@@ -153,10 +153,11 @@ func constructMetricQueries(listMetricsOutput []cloudwatch.Metric, instanceID st
 }
 
 func createCloudWatchEvents(getMetricDataResults []cloudwatch.MetricDataResult, instanceOutput map[string]ec2.Instance, regionName string) (map[string]mb.Event, string, error) {
+	// Initialize events and metricSetFieldResults per instanceID
 	events := map[string]mb.Event{}
 	metricSetFieldResults := map[string]map[string]interface{}{}
 	info := ""
-	for instanceID, _ := range instanceOutput {
+	for instanceID := range instanceOutput {
 		events[instanceID] = initEC2Event(regionName)
 		metricSetFieldResults[instanceID] = map[string]interface{}{}
 	}
@@ -287,9 +288,10 @@ func initEC2Event(regionName string) mb.Event {
 	event := mb.Event{}
 	event.Service = metricsetName
 	event.RootFields = common.MapStr{}
+	event.MetricSetFields = common.MapStr{}
+
 	event.RootFields.Put("service.name", metricsetName)
 	event.RootFields.Put("cloud.provider", "aws")
 	event.RootFields.Put("cloud.region", regionName)
-	event.MetricSetFields = common.MapStr{}
 	return event
 }

--- a/x-pack/metricbeat/module/aws/ec2/ec2_test.go
+++ b/x-pack/metricbeat/module/aws/ec2/ec2_test.go
@@ -16,10 +16,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2/ec2iface"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/x-pack/metricbeat/module/aws"
-
-	"github.com/elastic/beats/libbeat/common"
 )
 
 // MockEC2Client struct is used for unit tests.
@@ -195,7 +194,8 @@ func TestCreateCloudWatchEvents(t *testing.T) {
 		},
 	}
 
-	events, _, err := createCloudWatchEvents(getMetricDataOutput, instancesOutputs, mockModuleConfig.DefaultRegion)
+	metricSet := MetricSet{}
+	events, err := metricSet.createCloudWatchEvents(getMetricDataOutput, instancesOutputs, mockModuleConfig.DefaultRegion)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(events))
 	assert.Equal(t, expectedEvent.RootFields, events[instanceID].RootFields)

--- a/x-pack/metricbeat/module/aws/ec2/ec2_test.go
+++ b/x-pack/metricbeat/module/aws/ec2/ec2_test.go
@@ -195,11 +195,12 @@ func TestCreateCloudWatchEvents(t *testing.T) {
 		},
 	}
 
-	event, _, err := createCloudWatchEvents(getMetricDataOutput, instanceID, instancesOutputs[instanceID], mockModuleConfig.DefaultRegion)
+	events, _, err := createCloudWatchEvents(getMetricDataOutput, instancesOutputs, mockModuleConfig.DefaultRegion)
 	assert.NoError(t, err)
-	assert.Equal(t, expectedEvent.RootFields, event.RootFields)
-	assert.Equal(t, expectedEvent.MetricSetFields["cpu"], event.MetricSetFields["cpu"])
-	assert.Equal(t, expectedEvent.MetricSetFields["instance"], event.MetricSetFields["instance"])
+	assert.Equal(t, 1, len(events))
+	assert.Equal(t, expectedEvent.RootFields, events[instanceID].RootFields)
+	assert.Equal(t, expectedEvent.MetricSetFields["cpu"], events[instanceID].MetricSetFields["cpu"])
+	assert.Equal(t, expectedEvent.MetricSetFields["instance"], events[instanceID].MetricSetFields["instance"])
 }
 
 func TestConstructMetricQueries(t *testing.T) {


### PR DESCRIPTION
In current ec2 metricset code, we are constructing metricDataQueries per region per instance for GetMetricData cloudwatch api call. Because we have some metadata from DescribeInstances api call for each instance to add into each event. It will be more efficient/cheaper to improve ec2 metricset to construct metricDataQueries per region but not per instance.

closes https://github.com/elastic/beats/issues/11820