### PR TITLE
Update Dockerfiles from the stack to 7.0

### DIFF
--- a/metricbeat/docker-compose.yml
+++ b/metricbeat/docker-compose.yml
@@ -88,7 +88,7 @@ services:
   elasticsearch:
     build: ./module/elasticsearch/_meta
     environment:
-      - "ES_JAVA_OPTS=-Xms105m -Xmx105m"
+      - "ES_JAVA_OPTS=-Xms256m -Xmx256m"
       - "network.host="
       - "transport.host=127.0.0.1"
       - "http.host=0.0.0.0"

--- a/metricbeat/docker-compose.yml
+++ b/metricbeat/docker-compose.yml
@@ -88,7 +88,7 @@ services:
   elasticsearch:
     build: ./module/elasticsearch/_meta
     environment:
-      - "ES_JAVA_OPTS=-Xms90m -Xmx90m"
+      - "ES_JAVA_OPTS=-Xms105m -Xmx105m"
       - "network.host="
       - "transport.host=127.0.0.1"
       - "http.host=0.0.0.0"

--- a/metricbeat/module/elasticsearch/_meta/Dockerfile
+++ b/metricbeat/module/elasticsearch/_meta/Dockerfile
@@ -1,2 +1,2 @@
 FROM docker.elastic.co/elasticsearch/elasticsearch:7.0.0
-HEALTHCHECK --interval=1s --retries=300 CMD curl -f http://localhost:9200/_xpack/license
+HEALTHCHECK --interval=1s --retries=300 CMD curl -f http://localhost:9200/_license

--- a/metricbeat/module/elasticsearch/_meta/Dockerfile
+++ b/metricbeat/module/elasticsearch/_meta/Dockerfile
@@ -1,2 +1,2 @@
-FROM docker.elastic.co/elasticsearch/elasticsearch:6.6.0
+FROM docker.elastic.co/elasticsearch/elasticsearch:7.0.0
 HEALTHCHECK --interval=1s --retries=300 CMD curl -f http://localhost:9200/_xpack/license

--- a/metricbeat/module/kibana/_meta/Dockerfile
+++ b/metricbeat/module/kibana/_meta/Dockerfile
@@ -1,3 +1,3 @@
-FROM docker.elastic.co/kibana/kibana:6.6.0
+FROM docker.elastic.co/kibana/kibana:7.0.0
 HEALTHCHECK --interval=1s --retries=300 --start-period=60s CMD python -c 'import urllib, json; response = urllib.urlopen("http://myelastic:changeme@localhost:5601/api/status"); data = json.loads(response.read()); exit(1) if data["status"]["overall"]["state"] != "green" else exit(0);'
 

--- a/metricbeat/module/logstash/_meta/Dockerfile
+++ b/metricbeat/module/logstash/_meta/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/logstash/logstash:6.6.0
+FROM docker.elastic.co/logstash/logstash:7.0.0
 
 COPY healthcheck.sh /
 ENV XPACK_MONITORING_ENABLED=FALSE


### PR DESCRIPTION
Updating this so we can take advantage of features from 7.0. For
example tests don't pass now if we add a new dashboard exported
from Kibana 7.0.