### PR TITLE
Filebeat: apache2(httpd) log path add to module manifest

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -136,6 +136,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Added support for Cisco ASA fields to the netflow input. {pull}11201[11201]
 - Configurable line terminator. {pull}11015[11015]
 - Add Filebeat envoyproxy module. {pull}11700[11700]
+- Add apache2(httpd) log path (`/var/log/httpd`) to make apache2 module work out of the box on Redhat-family OSes. {issue}11887[11887] {pull}11888[11888]
 
 *Heartbeat*
 

--- a/filebeat/module/apache/access/manifest.yml
+++ b/filebeat/module/apache/access/manifest.yml
@@ -5,6 +5,7 @@ var:
     default:
       - /var/log/apache2/access.log*
       - /var/log/apache2/other_vhosts_access.log*
+      - /var/log/httpd/access_log*
     os.darwin:
       - /usr/local/var/log/apache2/access_log*
     os.windows:

--- a/filebeat/module/apache/error/manifest.yml
+++ b/filebeat/module/apache/error/manifest.yml
@@ -4,6 +4,7 @@ var:
   - name: paths
     default:
       - /var/log/apache2/error.log*
+      - /var/log/httpd/error_log*
     os.darwin:
       - /usr/local/var/log/apache2/error_log*
     os.windows:


### PR DESCRIPTION
Fedora, RHEL7 apache package (httpd) create logs to
'/var/log/httpd' instead of '/var/log/apache2' directory,
and the log files are named as '*_log' instead of '.log' format.

To make Filebeat apache2 module work out of the box on these
environments, add '/var/log/httpd/*_log' pattern to the manifest
file will solve this problem.

Fixed: elastic/beats#11887

Signed-off-by: Daniel T. Lee <danieltimlee@gmail.com>