### PR TITLE
 Fix of docker json parser for missing "log" jsonkey in docker container's log

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -65,6 +65,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix formatting for `event.duration`, "human readable" was not working well for this. {pull}11675[11675]
 - Fix initialization of the TCP input logger. {pull}11605[11605]
 - Fix flaky service_integration_windows_test test by introducing a confidence factor and enriching the error message with more service details. {issue}8880[8880] and {issue}7977[7977]
+- Fix of docker json parser for missing "log" jsonkey in docker container's log {issue}11464[11464]
 
 *Auditbeat*
 

--- a/libbeat/reader/readjson/docker_json.go
+++ b/libbeat/reader/readjson/docker_json.go
@@ -144,13 +144,13 @@ func (p *DockerJSONReader) parseDockerJSONLog(message *reader.Message, msg *logL
 	if err != nil {
 		return errors.Wrap(err, "parsing docker timestamp")
 	}
+	message.Ts = ts
 
 	message.AddFields(common.MapStr{
 		"stream": msg.Stream,
 	})
 	message.Content = []byte(msg.Log)
-	message.Ts = ts
-	msg.Partial = message.Content[len(message.Content)-1] != byte('\n')
+	msg.Partial = (len(message.Content) == 0) || (message.Content[len(message.Content)-1] != byte('\n'))
 
 	return nil
 }


### PR DESCRIPTION
fixes elastic/beats#11464 