### PR TITLE
Collect Kibana usage stats only once per day

### DIFF
--- a/metricbeat/module/kibana/kibana.go
+++ b/metricbeat/module/kibana/kibana.go
@@ -34,15 +34,17 @@ import (
 const ModuleName = "kibana"
 
 var (
-	// StatsAPIAvailableVersion is the version of Kibana since when the stats API is available
-	StatsAPIAvailableVersion = common.MustNewVersion("6.4.0")
-
-	// SettingsAPIAvailableVersion is the version of Kibana since when the settings API is available
-	SettingsAPIAvailableVersion = common.MustNewVersion("6.5.0")
-
+	v6_4_0 = common.MustNewVersion("6.4.0")
+	v6_5_0 = common.MustNewVersion("6.5.0")
 	v6_7_2 = common.MustNewVersion("6.7.2")
 	v7_0_0 = common.MustNewVersion("7.0.0")
 	v7_0_1 = common.MustNewVersion("7.0.1")
+
+	// StatsAPIAvailableVersion is the version of Kibana since when the stats API is available
+	StatsAPIAvailableVersion = v6_4_0
+
+	// SettingsAPIAvailableVersion is the version of Kibana since when the settings API is available
+	SettingsAPIAvailableVersion = v6_5_0
 )
 
 // ReportErrorForMissingField reports and returns an error message for the given

--- a/metricbeat/module/kibana/kibana.go
+++ b/metricbeat/module/kibana/kibana.go
@@ -85,9 +85,9 @@ func IsSettingsAPIAvailable(currentKibanaVersion *common.Version) bool {
 	return elastic.IsFeatureAvailable(currentKibanaVersion, SettingsAPIAvailableVersion)
 }
 
-// IsExcludeUsageParamAvailable returns whether the stats API supports the exclude_usage parameter in the
+// IsUsageExcludable returns whether the stats API supports the exclude_usage parameter in the
 // given version of Kibana
-func IsExcludeUsageParamAvailable(currentKibanaVersion *common.Version) bool {
+func IsUsageExcludable(currentKibanaVersion *common.Version) bool {
 	return elastic.IsFeatureAvailable(currentKibanaVersion, ExcludeUsageParamAvailableVersion)
 }
 

--- a/metricbeat/module/kibana/kibana.go
+++ b/metricbeat/module/kibana/kibana.go
@@ -38,7 +38,7 @@ var (
 	v6_5_0 = common.MustNewVersion("6.5.0")
 	v6_7_2 = common.MustNewVersion("6.7.2")
 	v7_0_0 = common.MustNewVersion("7.0.0")
-	v7_0_1 = common.MustNewVersion("7.0.1")
+	v7_0_2 = common.MustNewVersion("7.0.2")
 
 	// StatsAPIAvailableVersion is the version of Kibana since when the stats API is available
 	StatsAPIAvailableVersion = v6_4_0
@@ -90,9 +90,9 @@ func IsSettingsAPIAvailable(currentKibanaVersion *common.Version) bool {
 // IsUsageExcludable returns whether the stats API supports the exclude_usage parameter in the
 // given version of Kibana
 func IsUsageExcludable(currentKibanaVersion *common.Version) bool {
-	// (6.7.2 <= currentKibamaVersion < 7.0.0) || (7.0.1 <= currentKibanaVersion)
+	// (6.7.2 <= currentKibamaVersion < 7.0.0) || (7.0.2 <= currentKibanaVersion)
 	return (v6_7_2.LessThanOrEqual(false, currentKibanaVersion) && currentKibanaVersion.LessThan(v7_0_0)) ||
-		v7_0_1.LessThanOrEqual(false, currentKibanaVersion)
+		v7_0_2.LessThanOrEqual(false, currentKibanaVersion)
 }
 
 func fetchPath(http *helper.HTTP, currentPath, newPath string) ([]byte, error) {

--- a/metricbeat/module/kibana/kibana.go
+++ b/metricbeat/module/kibana/kibana.go
@@ -39,6 +39,10 @@ var (
 
 	// SettingsAPIAvailableVersion is the version of Kibana since when the settings API is available
 	SettingsAPIAvailableVersion = common.MustNewVersion("6.5.0")
+
+	// ExcludeUsageParamAvailableVersion is the version of Kibana since when the stats API supports the
+	// exclude_usage parameter
+	ExcludeUsageParamAvailableVersion = common.MustNewVersion("7.1.0")
 )
 
 // ReportErrorForMissingField reports and returns an error message for the given
@@ -79,6 +83,12 @@ func IsStatsAPIAvailable(currentKibanaVersion *common.Version) bool {
 // IsSettingsAPIAvailable returns whether the settings API is available in the given version of Kibana
 func IsSettingsAPIAvailable(currentKibanaVersion *common.Version) bool {
 	return elastic.IsFeatureAvailable(currentKibanaVersion, SettingsAPIAvailableVersion)
+}
+
+// IsExcludeUsageParamAvailable returns whether the stats API supports the exclude_usage parameter in the
+// given version of Kibana
+func IsExcludeUsageParamAvailable(currentKibanaVersion *common.Version) bool {
+	return elastic.IsFeatureAvailable(currentKibanaVersion, ExcludeUsageParamAvailableVersion)
 }
 
 func fetchPath(http *helper.HTTP, currentPath, newPath string) ([]byte, error) {

--- a/metricbeat/module/kibana/kibana.go
+++ b/metricbeat/module/kibana/kibana.go
@@ -42,7 +42,7 @@ var (
 
 	// ExcludeUsageParamAvailableVersion is the version of Kibana since when the stats API supports the
 	// exclude_usage parameter
-	ExcludeUsageParamAvailableVersion = common.MustNewVersion("7.1.0")
+	ExcludeUsageParamAvailableVersion = common.MustNewVersion("6.7.3")
 )
 
 // ReportErrorForMissingField reports and returns an error message for the given

--- a/metricbeat/module/kibana/kibana.go
+++ b/metricbeat/module/kibana/kibana.go
@@ -40,9 +40,9 @@ var (
 	// SettingsAPIAvailableVersion is the version of Kibana since when the settings API is available
 	SettingsAPIAvailableVersion = common.MustNewVersion("6.5.0")
 
-	// ExcludeUsageParamAvailableVersion is the version of Kibana since when the stats API supports the
-	// exclude_usage parameter
-	ExcludeUsageParamAvailableVersion = common.MustNewVersion("6.7.3")
+	v6_7_2 = common.MustNewVersion("6.7.2")
+	v7_0_0 = common.MustNewVersion("7.0.0")
+	v7_0_1 = common.MustNewVersion("7.0.1")
 )
 
 // ReportErrorForMissingField reports and returns an error message for the given
@@ -88,7 +88,9 @@ func IsSettingsAPIAvailable(currentKibanaVersion *common.Version) bool {
 // IsUsageExcludable returns whether the stats API supports the exclude_usage parameter in the
 // given version of Kibana
 func IsUsageExcludable(currentKibanaVersion *common.Version) bool {
-	return elastic.IsFeatureAvailable(currentKibanaVersion, ExcludeUsageParamAvailableVersion)
+	// (6.7.2 <= currentKibamaVersion < 7.0.0) || (7.0.1 <= currentKibanaVersion)
+	return (v6_7_2.LessThanOrEqual(false, currentKibanaVersion) && currentKibanaVersion.LessThan(v7_0_0)) ||
+		v7_0_1.LessThanOrEqual(false, currentKibanaVersion)
 }
 
 func fetchPath(http *helper.HTTP, currentPath, newPath string) ([]byte, error) {


### PR DESCRIPTION
Currently (prior to this PR), we collect Kibana usage data along with all other Kibana stats every 10 seconds (default value, configurable via the `period` module setting).

However, usage data doesn't need to be collected more frequently than once a day. This PR makes it so.

### Testing this PR
1. Start up Elasticsearch.
2. Make sure internal Monitoring collection is stopped in Kibana. To do this add the following to `kibana.yml`:
   ```
   xpack.monitoring.kibana.collection.enabled: false
   ```
3. Start up Kibana.
1. Pull down this PR.
2. Build Metricbeat:
   ```
   cd metricbeat
   mage build
   ```
3. Enable the Kibana X-Pack module:
   ```
   ./metricbeat modules enable kibana-xpack
   ```
5. Start Metricbeat and let it run for ~30 seconds:
   ```
   ./metricbeat -e
   ```
6. Verify that only the oldest of the documents with `type:"kibana_stats"` in `.monitoring-kibana-*` has the `kibana_stats.usage` field:
   ```
   POST .monitoring-kibana-*/_search?filter_path=hits.hits._source.kibana_stats
   {
     "sort": [
       {
         "timestamp": {
           "order": "desc"
         }
       }
     ], 
     "query": {
       "term": {
         "type": "kibana_stats"
       }
     }
   }     
   ```
   