### PR TITLE
Fix JSON log file paths for elasticsearch/audit fileset

### DIFF
--- a/filebeat/docs/modules/elasticsearch.asciidoc
+++ b/filebeat/docs/modules/elasticsearch.asciidoc
@@ -70,7 +70,6 @@ Example config:
 ----
   audit:
     var.paths:
-      - /var/log/elasticsearch/*_access.log
       - /var/log/elasticsearch/*_audit.json
 ----
 

--- a/filebeat/docs/modules/elasticsearch.asciidoc
+++ b/filebeat/docs/modules/elasticsearch.asciidoc
@@ -71,6 +71,7 @@ Example config:
   audit:
     var.paths:
       - /var/log/elasticsearch/*_access.log
+      - /var/log/elasticsearch/*_audit.json
 ----
 
 [float]

--- a/filebeat/module/elasticsearch/_meta/docs.asciidoc
+++ b/filebeat/module/elasticsearch/_meta/docs.asciidoc
@@ -66,7 +66,7 @@ Example config:
   audit:
     var.paths:
       - /var/log/elasticsearch/*_access.log
-      - /var/log/elasticsearch/*_audit.log
+      - /var/log/elasticsearch/*_audit.json
 ----
 
 [float]

--- a/filebeat/module/elasticsearch/_meta/docs.asciidoc
+++ b/filebeat/module/elasticsearch/_meta/docs.asciidoc
@@ -66,6 +66,7 @@ Example config:
   audit:
     var.paths:
       - /var/log/elasticsearch/*_access.log
+      - /var/log/elasticsearch/*_audit.log
 ----
 
 [float]

--- a/filebeat/module/elasticsearch/_meta/docs.asciidoc
+++ b/filebeat/module/elasticsearch/_meta/docs.asciidoc
@@ -65,7 +65,6 @@ Example config:
 ----
   audit:
     var.paths:
-      - /var/log/elasticsearch/*_access.log
       - /var/log/elasticsearch/*_audit.json
 ----
 

--- a/filebeat/module/elasticsearch/audit/manifest.yml
+++ b/filebeat/module/elasticsearch/audit/manifest.yml
@@ -4,12 +4,15 @@ var:
   - name: paths
     default:
       - /var/log/elasticsearch/*_access.log
+      - /var/log/elasticsearch/*_audit.log
       - /var/log/elasticsearch/*_audit.json
     os.darwin:
       - /usr/local/var/lib/elasticsearch/*_access.log
+      - /usr/local/var/lib/elasticsearch/*_audit.log
       - /usr/local/var/lib/elasticsearch/*_audit.json
     os.windows:
       - c:/ProgramData/Elastic/Elasticsearch/logs/*_access.log
+      - c:/ProgramData/Elastic/Elasticsearch/logs/*_audit.log
       - c:/ProgramData/Elastic/Elasticsearch/logs/*_audit.json
   - name: convert_timezone
     default: false

--- a/filebeat/module/elasticsearch/audit/manifest.yml
+++ b/filebeat/module/elasticsearch/audit/manifest.yml
@@ -4,13 +4,13 @@ var:
   - name: paths
     default:
       - /var/log/elasticsearch/*_access.log
-      - /var/log/elasticsearch/*_audit.log
+      - /var/log/elasticsearch/*_audit.json
     os.darwin:
       - /usr/local/var/lib/elasticsearch/*_access.log
-      - /usr/local/var/lib/elasticsearch/*_audit.log
+      - /usr/local/var/lib/elasticsearch/*_audit.json
     os.windows:
       - c:/ProgramData/Elastic/Elasticsearch/logs/*_access.log
-      - c:/ProgramData/Elastic/Elasticsearch/logs/*_audit.log
+      - c:/ProgramData/Elastic/Elasticsearch/logs/*_audit.json
   - name: convert_timezone
     default: false
     # if ES < 6.1.0, this flag switches to false automatically when evaluating the


### PR DESCRIPTION
The `elasticsearch/audit` fileset can consume either plaintext (`*_access.log`) or JSON (`*_audit.json`) formatted Elasticsearch audit logs.

This PR makes the following two changes:

- It updates the default JSON audit log file paths to include `*_audit.json` as well. Starting with 7.0, Elasticsearch writes JSON audit logs to `*_audit.json`. Prior to 7.0, Elasticsearch wrote JSON audit logs to `*_audit.log` files.
- It replaces the old plaintext audit log file path with the new JSON audit log file path to the docs.