### PR TITLE
Cherry-pick #11891 to 6.7: [Heartbeat] Fix example in docs for autodiscover

### DIFF
--- a/heartbeat/docs/autodiscover-kubernetes-config.asciidoc
+++ b/heartbeat/docs/autodiscover-kubernetes-config.asciidoc
@@ -12,7 +12,7 @@ heartbeat.autodiscover:
               kubernetes.annotations.prometheus.io.scrape: "true"
           config:
             - type: http
-              hosts: ["${data.host}:${data.port}"]
+              urls: ["${data.host}:${data.port}"]
               schedule: "@every 1s"
               timeout: 1s
 -------------------------------------------------------------------------------------


### PR DESCRIPTION
Cherry-pick of PR #11891 to 6.7 branch. Original message: 

The docs used `hosts` instead of the correct `urls` config key.

Fixes elastic/beats#11643