### PR TITLE
[Heartbeat] Fix NPE on monitor configuration errors

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -86,6 +86,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Heartbeat*
 
+- Fix NPE on some monitor configuration errors. {pull}11910[11910]
+
 *Journalbeat*
 
 *Metricbeat*

--- a/heartbeat/monitors/mocks_test.go
+++ b/heartbeat/monitors/mocks_test.go
@@ -163,3 +163,14 @@ func mockPluginConf(t *testing.T, id string, schedule string, url string) *commo
 
 	return conf
 }
+
+func mockInvalidPluginConf(t *testing.T) *common.Config {
+	confMap := map[string]interface{}{
+		"hoeutnheou": "oueanthoue",
+	}
+
+	conf, err := common.NewConfigFrom(confMap)
+	require.NoError(t, err)
+
+	return conf
+}

--- a/heartbeat/monitors/monitor.go
+++ b/heartbeat/monitors/monitor.go
@@ -74,7 +74,9 @@ func (m *Monitor) String() string {
 
 func checkMonitorConfig(config *common.Config, registrar *pluginsReg, allowWatches bool) error {
 	m, err := newMonitor(config, registrar, nil, nil, allowWatches, nil)
-	m.Stop() // Stop the monitor to free up the ID from uniqueness checks
+	if m != nil {
+		m.Stop() // Stop the monitor to free up the ID from uniqueness checks
+	}
 	return err
 }
 

--- a/heartbeat/monitors/monitor_test.go
+++ b/heartbeat/monitors/monitor_test.go
@@ -99,3 +99,20 @@ func TestDuplicateMonitorIDs(t *testing.T) {
 	_, m3Err := makeTestMon()
 	assert.NoError(t, m3Err)
 }
+
+func TestCheckInvalidConfig(t *testing.T) {
+	serverMonConf := mockInvalidPluginConf(t)
+	reg := mockPluginsReg()
+	pipelineConnector := &MockPipelineConnector{}
+
+	sched := scheduler.New(1)
+	err := sched.Start()
+	require.NoError(t, err)
+	defer sched.Stop()
+
+	m, err := newMonitor(serverMonConf, reg, pipelineConnector, sched, false, nil)
+	// This could change if we decide the contract for newMonitor should always return a monitor
+	require.Nil(t, m, "For this test to work we need a nil value for the monitor.")
+
+	require.Error(t, checkMonitorConfig(serverMonConf, reg, false))
+}


### PR DESCRIPTION
These errors cause the `newMonitor` constructor to return a nil object plus error. Without a nil check we get an NPE.

Fixes https://github.com/elastic/beats/issues/11747