### PR TITLE
Add decode base64 field processor

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -190,7 +190,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Processor `add_cloud_metadata` adds fields `cloud.account.id` and `cloud.image.id` for AWS EC2. {pull}12307[12307]
 - Add configurable bulk_flush_frequency in kafka output. {pull}12254[12254]
 - Add `decode_base64_field` processor for decoding base64 field. {pull}11914[11914]
-- Add `decode_base64_fields` processor for decoding base64 fields. {pull}11914[11914]
 
 *Auditbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -190,6 +190,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Processor `add_cloud_metadata` adds fields `cloud.account.id` and `cloud.image.id` for AWS EC2. {pull}12307[12307]
 - Add configurable bulk_flush_frequency in kafka output. {pull}12254[12254]
 - Add `decode_base64_field` processor for decoding base64 field. {pull}11914[11914]
+- Add `decode_base64_fields` processor for decoding base64 fields. {pull}11914[11914]
 
 *Auditbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -189,6 +189,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add `proxy_disable` output flag to explicitly ignore proxy environment variables. {issue}11713[11713] {pull}12243[12243]
 - Processor `add_cloud_metadata` adds fields `cloud.account.id` and `cloud.image.id` for AWS EC2. {pull}12307[12307]
 - Add configurable bulk_flush_frequency in kafka output. {pull}12254[12254]
+- Add `decode_base64_field` processor for decoding base64 field. {pull}11914[11914]
 
 *Auditbeat*
 

--- a/libbeat/docs/processors-using.asciidoc
+++ b/libbeat/docs/processors-using.asciidoc
@@ -214,6 +214,7 @@ ifdef::has_decode_csv_fields_processor[]
  * <<decode-csv-fields,`decode_csv_fields`>>
 endif::[]
  * <<decode-json-fields,`decode_json_fields`>>
+ * <<decode-base64-field,`decode_base64_field`>>
  * <<dissect, `dissect`>>
  * <<extract-array,`extract_array`>>
  * <<processor-dns, `dns`>>
@@ -863,6 +864,28 @@ is treated as if the field was not set at all.
 `overwrite_keys`:: (Optional) A boolean that specifies whether keys that already
 exist in the event are overwritten by keys from the decoded JSON object. The
 default value is false.
+
+[[decode-base64-field]]
+=== Decode Base64 field
+
+The `decode_base64_field` processor decodes field containing Base64 strings.
+
+[source,yaml]
+-----------------------------------------------------
+processors:
+ - decode_base64_field:
+     field: "field1"
+     target: ""
+-----------------------------------------------------
+
+The `decode_base64_field` processor has the following configuration settings:
+
+`field`:: The field containing Base64 strings to decode.
+`target`:: (Optional) The field under which the decoded Base64 will be written. By
+default the decoded Base64 object replaces the string field from which it was
+read.
+`target` with an empty string (`target: ""`). Note that the `null` value (`target:`)
+is treated as if the field was not set at all.
 
 [[community-id]]
 === Community ID Network Flow Hash

--- a/libbeat/docs/processors-using.asciidoc
+++ b/libbeat/docs/processors-using.asciidoc
@@ -214,7 +214,7 @@ ifdef::has_decode_csv_fields_processor[]
  * <<decode-csv-fields,`decode_csv_fields`>>
 endif::[]
  * <<decode-json-fields,`decode_json_fields`>>
- * <<decode-base64-fields,`decode_base64_fields`>>
+ * <<decode-base64-field,`decode_base64_field`>>
  * <<dissect, `dissect`>>
  * <<extract-array,`extract_array`>>
  * <<processor-dns, `dns`>>
@@ -865,38 +865,30 @@ is treated as if the field was not set at all.
 exist in the event are overwritten by keys from the decoded JSON object. The
 default value is false.
 
-[[decode-base64-fields]]
+[[decode-base64-field]]
 === Decode Base64 fields
 
-The `decode_base64_fields` processor specifies a list of fields to base64 decode.
-Under the `fields` key each entry contains a `from: old-key` and a `to: new-key` pair. `from` is
+The `decode_base64_field` processor specifies a field to base64 decode.
+The `field` key contains a `from: old-key` and a `to: new-key` pair. `from` is
 the origin and `to` the target name of the field.
 
-Rename fields cannot be used to overwrite fields. To overwrite fields either
-first rename the target field or use the `drop_fields` processor to drop the
-field and then rename the field.
+To overwrite fields either first rename the target field or use the `drop_fields`
+processor to drop the field and then rename the field.
 
 [source,yaml]
 -------
 processors:
-- decode_base64_fields:
-    fields:
-     - from: "field1"
-       to: "field2"
-     - from: "field3"
-       to: "field3"
-     - from: "field4"
-       to: ""
+- decode_base64_field:
+    from: "field1"
+    to: "field2"
     ignore_missing: false
     fail_on_error: true
 -------
 
 In the example above:
     - field1 is decoded in field2
-    - field3 is decoded in field3
-    - field4 is decoded in field4
 
-The `decode_base64_fields` processor has the following configuration settings:
+The `decode_base64_field` processor has the following configuration settings:
 
 `ignore_missing`:: (Optional) If set to true, no error is logged in case a key
 which should be base64 decoded is missing. Default is `false`.

--- a/libbeat/docs/processors-using.asciidoc
+++ b/libbeat/docs/processors-using.asciidoc
@@ -214,7 +214,7 @@ ifdef::has_decode_csv_fields_processor[]
  * <<decode-csv-fields,`decode_csv_fields`>>
 endif::[]
  * <<decode-json-fields,`decode_json_fields`>>
- * <<decode-base64-field,`decode_base64_field`>>
+ * <<decode-base64-fields,`decode_base64_fields`>>
  * <<dissect, `dissect`>>
  * <<extract-array,`extract_array`>>
  * <<processor-dns, `dns`>>
@@ -865,27 +865,50 @@ is treated as if the field was not set at all.
 exist in the event are overwritten by keys from the decoded JSON object. The
 default value is false.
 
-[[decode-base64-field]]
-=== Decode Base64 field
+[[decode-base64-fields]]
+=== Decode Base64 fields
 
-The `decode_base64_field` processor decodes field containing Base64 strings.
+The `decode_base64_fields` processor specifies a list of fields to base64 decode.
+Under the `fields` key each entry contains a `from: old-key` and a `to: new-key` pair. `from` is
+the origin and `to` the target name of the field.
+
+Rename fields cannot be used to overwrite fields. To overwrite fields either
+first rename the target field or use the `drop_fields` processor to drop the
+field and then rename the field.
 
 [source,yaml]
------------------------------------------------------
+-------
 processors:
- - decode_base64_field:
-     field: "field1"
-     target: ""
------------------------------------------------------
+- decode_base64_fields:
+    fields:
+     - from: "field1"
+       to: "field2"
+     - from: "field3"
+       to: "field3"
+     - from: "field4"
+       to: ""
+    ignore_missing: false
+    fail_on_error: true
+-------
 
-The `decode_base64_field` processor has the following configuration settings:
+In the example above:
+    - field1 is decoded in field2
+    - field3 is decoded in field3
+    - field4 is decoded in field4
 
-`field`:: The field containing Base64 strings to decode.
-`target`:: (Optional) The field under which the decoded Base64 will be written. By
-default the decoded Base64 object replaces the string field from which it was
-read.
-`target` with an empty string (`target: ""`). Note that the `null` value (`target:`)
-is treated as if the field was not set at all.
+The `decode_base64_fields` processor has the following configuration settings:
+
+`ignore_missing`:: (Optional) If set to true, no error is logged in case a key
+which should be base64 decoded is missing. Default is `false`.
+
+`fail_on_error`:: (Optional) If set to true, in case of an error the base6 4decode
+of fields is stopped and the original event is returned. If set to false, decoding
+continues also if an error happened during decoding. Default is `true`.
+
+See <<conditions>> for a list of supported conditions.
+
+You can specify multiple `ignore_missing` processors under the `processors`
+section.
 
 [[community-id]]
 === Community ID Network Flow Hash

--- a/libbeat/docs/processors-using.asciidoc
+++ b/libbeat/docs/processors-using.asciidoc
@@ -108,7 +108,7 @@ For example:
 ------
 +
 Similarly, for {beatname_uc} modules, you can define processors under the
-`input` section of the module definition. 
+`input` section of the module definition.
 endif::[]
 ifeval::["{beatname_lc}"=="metricbeat"]
 [source,yaml]
@@ -119,7 +119,7 @@ ifeval::["{beatname_lc}"=="metricbeat"]
   - <processor_name>:
       when:
         <condition>
-      <parameters> 
+      <parameters>
 ----
 endif::[]
 ifeval::["{beatname_lc}"=="auditbeat"]
@@ -133,7 +133,7 @@ auditbeat.modules:
   - <processor_name>:
       when:
         <condition>
-      <parameters> 
+      <parameters>
 ----
 endif::[]
 ifeval::["{beatname_lc}"=="packetbeat"]
@@ -142,7 +142,7 @@ For example:
 [source,yaml]
 ----
 packetbeat.protocols:
-- type: <protocol_type>  
+- type: <protocol_type>
   processors:
   - <processor_name>:
       when:
@@ -652,7 +652,7 @@ scalar values, arrays, dictionaries, or any nested combination of these.  By
 default the fields that you specify will be grouped under the `fields`
 sub-dictionary in the event. To group the fields under a different
 sub-dictionary, use the `target` setting. To store the fields as
-top-level fields, set `target: ''`. 
+top-level fields, set `target: ''`.
 
 `target`:: (Optional) Sub-dictionary to put all fields into. Defaults to `fields`.
 `fields`:: Fields to be added.
@@ -899,9 +899,6 @@ continues also if an error happened during decoding. Default is `true`.
 
 See <<conditions>> for a list of supported conditions.
 
-You can specify multiple `ignore_missing` processors under the `processors`
-section.
-
 [[community-id]]
 === Community ID Network Flow Hash
 
@@ -1130,7 +1127,7 @@ construct a lookup key with the value of the field `metricset.host`.
 Each Beat can define its own default indexers and matchers which are enabled by
 default. For example, FileBeat enables the `container` indexer, which indexes
 pod metadata based on all container IDs, and a `logs_path` matcher, which takes
-the `log.file.path` field, extracts the container ID, and uses it to retrieve 
+the `log.file.path` field, extracts the container ID, and uses it to retrieve
 metadata.
 
 The configuration below enables the processor when {beatname_lc} is run as a pod in
@@ -1213,7 +1210,7 @@ You can do this by mounting the socket inside the container. For example:
 To avoid privilege issues, you may also need to add `--user=root` to the
 `docker run` flags. Because the user must be part of the docker group in order
 to access `/var/run/docker.sock`, root access is required if {beatname_uc} is
-running as non-root inside the container. 
+running as non-root inside the container.
 =====
 
 [source,yaml]

--- a/libbeat/processors/actions/decode_base64_field.go
+++ b/libbeat/processors/actions/decode_base64_field.go
@@ -1,0 +1,109 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package actions
+
+import (
+	"encoding/base64"
+	"fmt"
+
+	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/processors"
+	"github.com/pkg/errors"
+)
+
+const (
+	processorName = "decode_base64_field"
+)
+
+type decodeBase64Fields struct {
+	log *logp.Logger
+
+	field  string
+	target *string
+}
+
+type base64Config struct {
+	Field  string  `config:"field"`
+	Target *string `config:"target"`
+}
+
+var (
+	defaultBase64Config = base64Config{}
+)
+
+func init() {
+	processors.RegisterPlugin(processorName,
+		configChecked(NewDecodeBase64Field,
+			requireFields("field"),
+			allowedFields("field", "target")))
+}
+
+// NewDecodeBase64Field construct a new decode_base64_field processor.
+func NewDecodeBase64Field(c *common.Config) (processors.Processor, error) {
+	config := defaultBase64Config
+
+	log := logp.NewLogger(processorName)
+
+	err := c.Unpack(&config)
+	if err != nil {
+		return nil, fmt.Errorf("fail to unpack the %s configuration: %s", processorName, err)
+	}
+
+	return &decodeBase64Fields{
+		log:    log,
+		field:  config.Field,
+		target: config.Target,
+	}, nil
+}
+
+func (f *decodeBase64Fields) Run(event *beat.Event) (*beat.Event, error) {
+	data, err := event.GetValue(f.field)
+	if err != nil && errors.Cause(err) != common.ErrKeyNotFound {
+		return event, fmt.Errorf("error trying to GetValue for field : %s in event : %v : %v", f.field, event, err)
+	}
+
+	text, ok := data.(string)
+	if !ok {
+		// ignore non string fields when unmarshaling
+		return event, nil
+	}
+
+	decodeData, err := base64.StdEncoding.DecodeString(text)
+	if err != nil {
+		return event, fmt.Errorf("error trying to unmarshal %s: %v", text, err)
+	}
+
+	target := f.field
+	if f.target != nil {
+		target = *f.target
+	}
+
+	if target != "" {
+		if _, err = event.PutValue(target, string(decodeData)); err != nil {
+			return event, fmt.Errorf("error trying to Put value %v for field : %s: %v", decodeData, f.field, err)
+		}
+	}
+
+	return event, nil
+}
+
+func (f decodeBase64Fields) String() string {
+	return fmt.Sprintf("%s=%s", processorName, f.field)
+}

--- a/libbeat/processors/actions/decode_base64_field.go
+++ b/libbeat/processors/actions/decode_base64_field.go
@@ -112,8 +112,7 @@ func (f *decodeBase64Field) decodeField(from string, to string, fields common.Ma
 
 	text, ok := value.(string)
 	if !ok {
-		// ignore non string fields when unmarshaling
-		return nil
+		return fmt.Errorf("invalid type for `from`, expecting a string received %T", value)
 	}
 
 	decodedData, err := base64.StdEncoding.DecodeString(text)

--- a/libbeat/processors/actions/decode_base64_field.go
+++ b/libbeat/processors/actions/decode_base64_field.go
@@ -31,22 +31,19 @@ import (
 )
 
 const (
-	processorName = "decode_base64_field"
+	processorName = "decode_base64_fields"
 )
 
 type decodeBase64Fields struct {
 	log *logp.Logger
 
 	config base64Config
-	field  string
-	target *string
 }
 
 type base64Config struct {
-	Field         string  `config:"field"`
-	Target        *string `config:"target"`
-	IgnoreMissing bool    `config:"ignore_missing"`
-	FailOnError   bool    `config:"fail_on_error"`
+	Fields        []fromTo `config:"fields"`
+	IgnoreMissing bool     `config:"ignore_missing"`
+	FailOnError   bool     `config:"fail_on_error"`
 }
 
 var (
@@ -59,11 +56,11 @@ var (
 func init() {
 	processors.RegisterPlugin(processorName,
 		checks.ConfigChecked(NewDecodeBase64Field,
-			checks.RequireFields("field"),
-			checks.AllowedFields("field", "target", "when")))
+			checks.RequireFields("fields"),
+			checks.AllowedFields("fields", "when")))
 }
 
-// NewDecodeBase64Field construct a new decode_base64_field processor.
+// NewDecodeBase64Field construct a new decode_base64_fields processor.
 func NewDecodeBase64Field(c *common.Config) (processors.Processor, error) {
 	config := defaultBase64Config
 
@@ -77,8 +74,6 @@ func NewDecodeBase64Field(c *common.Config) (processors.Processor, error) {
 	return &decodeBase64Fields{
 		log:    log,
 		config: config,
-		field:  config.Field,
-		target: config.Target,
 	}, nil
 }
 
@@ -89,40 +84,14 @@ func (f *decodeBase64Fields) Run(event *beat.Event) (*beat.Event, error) {
 		backup = event.Fields.Clone()
 	}
 
-	data, err := event.GetValue(f.field)
-	if err != nil {
-		// Ignore ErrKeyNotFound errors
-		if f.config.IgnoreMissing && errors.Cause(err) == common.ErrKeyNotFound {
-			return event, nil
-		}
-		return event, fmt.Errorf("error trying to GetValue for field : %s in event : %v : %v", f.field, event, err)
-	}
-
-	text, ok := data.(string)
-	if !ok {
-		// ignore non string fields when unmarshaling
-		return event, nil
-	}
-
-	decodeData, err := base64.StdEncoding.DecodeString(text)
-	if err != nil {
-		if f.config.FailOnError {
+	for _, field := range f.config.Fields {
+		err := f.decodeField(field.From, field.To, event.Fields)
+		if err != nil && f.config.FailOnError {
+			errMsg := fmt.Errorf("failed to decode base64 fields in processor: %v", err)
+			f.log.Debug("decode base64", errMsg.Error())
 			event.Fields = backup
-			return event, fmt.Errorf("error trying to unmarshal %s: %v", text, err)
-
-		}
-		return event, nil
-	}
-
-	target := f.field
-	if f.target != nil {
-		target = *f.target
-	}
-
-	if target != "" {
-		if _, err = event.PutValue(target, string(decodeData)); err != nil && f.config.FailOnError {
-			event.Fields = backup
-			return event, fmt.Errorf("error trying to Put value %v for field : %s: %v", decodeData, f.field, err)
+			_, _ = event.PutValue("error.message", errMsg.Error())
+			return event, err
 		}
 	}
 
@@ -130,5 +99,44 @@ func (f *decodeBase64Fields) Run(event *beat.Event) (*beat.Event, error) {
 }
 
 func (f decodeBase64Fields) String() string {
-	return fmt.Sprintf("%s=%s", processorName, f.field)
+	return fmt.Sprintf("%s=%+v", processorName, f.config.Fields)
+}
+
+func (f *decodeBase64Fields) decodeField(from string, to string, fields common.MapStr) error {
+	value, err := fields.GetValue(from)
+	if err != nil {
+		// Ignore ErrKeyNotFound errors
+		if f.config.IgnoreMissing && errors.Cause(err) == common.ErrKeyNotFound {
+			return nil
+		}
+		return fmt.Errorf("could not fetch value for key: %s, Error: %s", from, err)
+	}
+
+	text, ok := value.(string)
+	if !ok {
+		// ignore non string fields when unmarshaling
+		return nil
+	}
+
+	decodedData, err := base64.StdEncoding.DecodeString(text)
+	if err != nil {
+		return fmt.Errorf("error trying to unmarshal %s: %v", text, err)
+	}
+
+	field := to
+	// If to is empty
+	if to == "" || from == to {
+		// Deletion must happen first to support cases where a becomes a.b
+		if err = fields.Delete(from); err != nil {
+			return fmt.Errorf("could not delete key: %s,  %+v", from, err)
+		}
+
+		field = from
+	}
+
+	if _, err = fields.Put(field, string(decodedData)); err != nil {
+		return fmt.Errorf("could not put value: %s: %v, %v", decodedData, field, err)
+	}
+
+	return nil
 }

--- a/libbeat/processors/actions/decode_base64_field.go
+++ b/libbeat/processors/actions/decode_base64_field.go
@@ -27,6 +27,7 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/processors"
+	"github.com/elastic/beats/libbeat/processors/checks"
 )
 
 const (
@@ -51,9 +52,9 @@ var (
 
 func init() {
 	processors.RegisterPlugin(processorName,
-		configChecked(NewDecodeBase64Field,
-			requireFields("field"),
-			allowedFields("field", "target", "when")))
+		checks.ConfigChecked(NewDecodeBase64Field,
+			checks.RequireFields("field"),
+			checks.AllowedFields("field", "target", "when")))
 }
 
 // NewDecodeBase64Field construct a new decode_base64_field processor.

--- a/libbeat/processors/actions/decode_base64_field.go
+++ b/libbeat/processors/actions/decode_base64_field.go
@@ -21,11 +21,12 @@ import (
 	"encoding/base64"
 	"fmt"
 
+	"github.com/pkg/errors"
+
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/processors"
-	"github.com/pkg/errors"
 )
 
 const (

--- a/libbeat/processors/actions/decode_base64_field.go
+++ b/libbeat/processors/actions/decode_base64_field.go
@@ -53,7 +53,7 @@ func init() {
 	processors.RegisterPlugin(processorName,
 		configChecked(NewDecodeBase64Field,
 			requireFields("field"),
-			allowedFields("field", "target")))
+			allowedFields("field", "target", "when")))
 }
 
 // NewDecodeBase64Field construct a new decode_base64_field processor.

--- a/libbeat/processors/actions/decode_base64_field_test.go
+++ b/libbeat/processors/actions/decode_base64_field_test.go
@@ -1,0 +1,134 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package actions
+
+import (
+	"testing"
+
+	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodeBase64(t *testing.T) {
+	testCases := []struct {
+		desc        string
+		config      common.MapStr
+		input       *beat.Event
+		errExpected bool
+		expected    common.MapStr
+	}{
+		{
+			desc: "bad format",
+			config: common.MapStr{
+				"field": "field1",
+			},
+			input: &beat.Event{
+				Fields: common.MapStr{
+					"field1": "bad data",
+				},
+			},
+			errExpected: true,
+			expected: common.MapStr{
+				"field1": "bad data",
+			},
+		},
+		{
+			desc: "correct format",
+			config: common.MapStr{
+				"field": "field1",
+			},
+			input: &beat.Event{
+				Fields: common.MapStr{
+					"field1": "Y29ycmVjdCBkYXRh",
+				},
+			},
+			expected: common.MapStr{
+				"field1": "correct data",
+			},
+		},
+		{
+			desc: "empty data",
+			config: common.MapStr{
+				"field": "field1",
+			},
+			input: &beat.Event{
+				Fields: common.MapStr{
+					"field1": "",
+				},
+			},
+			expected: common.MapStr{
+				"field1": "",
+			},
+		},
+		{
+			desc: "empty target",
+			config: common.MapStr{
+				"field":  "field1",
+				"target": "",
+			},
+			input: &beat.Event{
+				Fields: common.MapStr{
+					"field1": "Y29ycmVjdCBkYXRh",
+				},
+			},
+			expected: common.MapStr{
+				"field1": "Y29ycmVjdCBkYXRh",
+			},
+		},
+		{
+			desc: "correct target",
+			config: common.MapStr{
+				"field":  "field1",
+				"target": "field2",
+			},
+			input: &beat.Event{
+				Fields: common.MapStr{
+					"field1": "Y29ycmVjdCBkYXRh",
+				},
+			},
+			expected: common.MapStr{
+				"field1": "Y29ycmVjdCBkYXRh",
+				"field2": "correct data",
+			},
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			cfg, err := common.NewConfigFrom(test.config)
+			require.NoError(t, err)
+
+			processor, err := NewDecodeBase64Field(cfg)
+			require.NoError(t, err)
+
+			outputEvent, err := processor.Run(test.input)
+
+			if test.errExpected {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, test.expected, outputEvent.Fields)
+		})
+	}
+}

--- a/libbeat/processors/actions/decode_base64_field_test.go
+++ b/libbeat/processors/actions/decode_base64_field_test.go
@@ -20,11 +20,11 @@ package actions
 import (
 	"testing"
 
-	"github.com/elastic/beats/libbeat/beat"
+	"github.com/stretchr/testify/assert"
 
+	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestDecodeBase64Run(t *testing.T) {

--- a/libbeat/processors/actions/decode_base64_field_test.go
+++ b/libbeat/processors/actions/decode_base64_field_test.go
@@ -51,6 +51,22 @@ func TestDecodeBase64(t *testing.T) {
 			},
 		},
 		{
+			desc: "bad format with fail_on_error false",
+			config: common.MapStr{
+				"field":         "field1",
+				"fail_on_error": false,
+			},
+			input: &beat.Event{
+				Fields: common.MapStr{
+					"field1": "bad data",
+				},
+			},
+			errExpected: false,
+			expected: common.MapStr{
+				"field1": "bad data",
+			},
+		},
+		{
 			desc: "correct format",
 			config: common.MapStr{
 				"field": "field1",
@@ -109,12 +125,28 @@ func TestDecodeBase64(t *testing.T) {
 				"field2": "correct data",
 			},
 		},
+		{
+			desc: "ignore missing",
+			config: common.MapStr{
+				"field":          "field3",
+				"target":         "field2",
+				"ignore_missing": true,
+			},
+			input: &beat.Event{
+				Fields: common.MapStr{
+					"field1": "Y29ycmVjdCBkYXRh",
+				},
+			},
+			expected: common.MapStr{
+				"field1": "Y29ycmVjdCBkYXRh",
+			},
+		},
 	}
 
 	for _, test := range testCases {
 		test := test
 		t.Run(test.desc, func(t *testing.T) {
-			t.Parallel()
+			//t.Parallel()
 
 			cfg, err := common.NewConfigFrom(test.config)
 			require.NoError(t, err)

--- a/libbeat/processors/actions/decode_base64_field_test.go
+++ b/libbeat/processors/actions/decode_base64_field_test.go
@@ -38,8 +38,8 @@ func TestDecodeBase64Run(t *testing.T) {
 		{
 			description: "simple field base64 decode",
 			config: base64Config{
-				Fields: []fromTo{
-					{From: "field1", To: "field2"},
+				fromTo: fromTo{
+					From: "field1", To: "field2",
 				},
 				IgnoreMissing: false,
 				FailOnError:   true,
@@ -56,8 +56,8 @@ func TestDecodeBase64Run(t *testing.T) {
 		{
 			description: "simple field base64 decode To empty",
 			config: base64Config{
-				Fields: []fromTo{
-					{From: "field1", To: ""},
+				fromTo: fromTo{
+					From: "field1", To: "",
 				},
 				IgnoreMissing: false,
 				FailOnError:   true,
@@ -73,8 +73,8 @@ func TestDecodeBase64Run(t *testing.T) {
 		{
 			description: "simple field base64 decode from and to equals",
 			config: base64Config{
-				Fields: []fromTo{
-					{From: "field1", To: "field1"},
+				fromTo: fromTo{
+					From: "field1", To: "field1",
 				},
 				IgnoreMissing: false,
 				FailOnError:   true,
@@ -90,8 +90,8 @@ func TestDecodeBase64Run(t *testing.T) {
 		{
 			description: "simple field bad data - fail on error",
 			config: base64Config{
-				Fields: []fromTo{
-					{From: "field1", To: "field1"},
+				fromTo: fromTo{
+					From: "field1", To: "field1",
 				},
 				IgnoreMissing: false,
 				FailOnError:   true,
@@ -110,8 +110,8 @@ func TestDecodeBase64Run(t *testing.T) {
 		{
 			description: "simple field bad data fail on error false",
 			config: base64Config{
-				Fields: []fromTo{
-					{From: "field1", To: "field2"},
+				fromTo: fromTo{
+					From: "field1", To: "field2",
 				},
 				IgnoreMissing: false,
 				FailOnError:   false,
@@ -127,8 +127,8 @@ func TestDecodeBase64Run(t *testing.T) {
 		{
 			description: "missing field",
 			config: base64Config{
-				Fields: []fromTo{
-					{From: "field2", To: "field3"},
+				fromTo: fromTo{
+					From: "field2", To: "field3",
 				},
 				IgnoreMissing: false,
 				FailOnError:   true,
@@ -147,8 +147,8 @@ func TestDecodeBase64Run(t *testing.T) {
 		{
 			description: "missing field ignore",
 			config: base64Config{
-				Fields: []fromTo{
-					{From: "field2", To: "field3"},
+				fromTo: fromTo{
+					From: "field2", To: "field3",
 				},
 				IgnoreMissing: true,
 				FailOnError:   true,
@@ -168,7 +168,7 @@ func TestDecodeBase64Run(t *testing.T) {
 		t.Run(test.description, func(t *testing.T) {
 			t.Parallel()
 
-			f := &decodeBase64Fields{
+			f := &decodeBase64Field{
 				log:    logp.NewLogger(processorName),
 				config: test.config,
 			}

--- a/libbeat/processors/actions/decode_base64_field_test.go
+++ b/libbeat/processors/actions/decode_base64_field_test.go
@@ -20,10 +20,11 @@ package actions
 import (
 	"testing"
 
-	"github.com/elastic/beats/libbeat/beat"
-	"github.com/elastic/beats/libbeat/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/common"
 )
 
 func TestDecodeBase64(t *testing.T) {

--- a/libbeat/processors/script/javascript/module/processor/processor.go
+++ b/libbeat/processors/script/javascript/module/processor/processor.go
@@ -54,6 +54,7 @@ var constructors = map[string]processors.Constructor{
 	"CommunityID":           communityid.New,
 	"Convert":               convert.New,
 	"CopyFields":            actions.NewCopyFields,
+	"DecodeBase64Field":     actions.NewDecodeBase64Field,
 	"DecodeCSVField":        decode_csv_fields.NewDecodeCSVField,
 	"DecodeJSONFields":      actions.NewDecodeJSONFields,
 	"Dissect":               dissect.NewProcessor,


### PR DESCRIPTION
### Description

This PR adds a new processor to be able to decode base64.

The `decode_base64_field` processor decodes field containing Base64 strings.

```yaml
processors:
 - decode_base64_field:
     field: "field1"
     target: ""
```

The `decode_base64_field` processor has the following configuration settings:

- `field`:: The field containing Base64 strings to decode.
- `target`:: (Optional) The field under which the decoded Base64 will be written. By
default the decoded Base64 object replaces the string field from which it was
read.
`target` with an empty string (`target: ""`). Note that the `null` value (`target:`)
is treated as if the field was not set at all.