### PR TITLE
Export function template

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -216,7 +216,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 *Functionbeat*
 
 - New options to configure roles and VPC. {pull}11779[11779]
-- Export function templates. {pull}11923[11923]
+- Export automation templates used to create functions. {pull}11923[11923]
 
 *Winlogbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -216,6 +216,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 *Functionbeat*
 
 - New options to configure roles and VPC. {pull}11779[11779]
+- Export function templates. {pull}11923[11923]
 
 *Winlogbeat*
 

--- a/libbeat/tests/system/beat/beat.py
+++ b/libbeat/tests/system/beat/beat.py
@@ -360,6 +360,18 @@ class TestCase(unittest.TestCase, ComposeMixin):
 
         return data
 
+    def get_log_lines(self, logfile=None):
+        """
+        Returns the log lines as a list of strings
+        """
+        if logfile is None:
+            logfile = self.beat_name + ".log"
+
+        with open(os.path.join(self.working_dir, logfile), 'r') as f:
+            data = f.readlines()
+
+        return data
+
     def wait_log_contains(self, msg, logfile=None,
                           max_timeout=10, poll_interval=0.1,
                           name="log_contains",

--- a/x-pack/functionbeat/cmd/provider_cmd.go
+++ b/x-pack/functionbeat/cmd/provider_cmd.go
@@ -105,7 +105,7 @@ func genPackageCmd() *cobra.Command {
 	return cmd
 }
 
-func genExportTemplateCmd() *cobra.Command {
+func genExportFunctionCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "function",
 		Short: "Export function template",

--- a/x-pack/functionbeat/cmd/provider_cmd.go
+++ b/x-pack/functionbeat/cmd/provider_cmd.go
@@ -5,6 +5,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -18,8 +19,7 @@ import (
 
 var output string
 
-// TODO: Add List() subcommand.
-func handler() (*cliHandler, error) {
+func initProvider() (provider.Provider, error) {
 	b, err := instance.NewInitializedBeat(instance.Settings{Name: Name})
 	if err != nil {
 		return nil, err
@@ -35,7 +35,12 @@ func handler() (*cliHandler, error) {
 		return nil, err
 	}
 
-	provider, err := provider.NewProvider(cfg)
+	return provider.NewProvider(cfg)
+}
+
+// TODO: Add List() subcommand.
+func handler() (*cliHandler, error) {
+	provider, err := initProvider()
 	if err != nil {
 		return nil, err
 	}
@@ -98,4 +103,29 @@ func genPackageCmd() *cobra.Command {
 	}
 	cmd.Flags().StringVarP(&output, "output", "o", "", "full path to the package")
 	return cmd
+}
+
+func genExportTemplateCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "function",
+		Short: "Export function template",
+		Run: cli.RunWith(func(_ *cobra.Command, args []string) error {
+			p, err := initProvider()
+			if err != nil {
+				return err
+			}
+			builder, err := p.TemplateBuilder()
+			if err != nil {
+				return err
+			}
+			for _, name := range args {
+				template, err := builder.RawTemplate(name)
+				if err != nil {
+					return fmt.Errorf("error generating raw template for %s: %+v", name, err)
+				}
+				fmt.Println(template)
+			}
+			return nil
+		}),
+	}
 }

--- a/x-pack/functionbeat/cmd/root.go
+++ b/x-pack/functionbeat/cmd/root.go
@@ -27,4 +27,5 @@ func init() {
 	RootCmd.AddCommand(genUpdateCmd())
 	RootCmd.AddCommand(genRemoveCmd())
 	RootCmd.AddCommand(genPackageCmd())
+	RootCmd.ExportCmd.AddCommand(genExportTemplateCmd())
 }

--- a/x-pack/functionbeat/cmd/root.go
+++ b/x-pack/functionbeat/cmd/root.go
@@ -27,5 +27,11 @@ func init() {
 	RootCmd.AddCommand(genUpdateCmd())
 	RootCmd.AddCommand(genRemoveCmd())
 	RootCmd.AddCommand(genPackageCmd())
+
+	addBeatSpecificSubcommands()
+}
+
+func addBeatSpecificSubcommands() {
+	RootCmd.ExportCmd.Short = "Export current config, index template or function"
 	RootCmd.ExportCmd.AddCommand(genExportTemplateCmd())
 }

--- a/x-pack/functionbeat/cmd/root.go
+++ b/x-pack/functionbeat/cmd/root.go
@@ -33,5 +33,5 @@ func init() {
 
 func addBeatSpecificSubcommands() {
 	RootCmd.ExportCmd.Short = "Export current config, index template or function"
-	RootCmd.ExportCmd.AddCommand(genExportTemplateCmd())
+	RootCmd.ExportCmd.AddCommand(genExportFunctionCmd())
 }

--- a/x-pack/functionbeat/provider/aws/aws.go
+++ b/x-pack/functionbeat/provider/aws/aws.go
@@ -12,7 +12,7 @@ import (
 // Bundle exposes the trigger supported by the AWS provider.
 var Bundle = provider.MustCreate(
 	"aws",
-	provider.NewDefaultProvider("aws", NewCLI),
+	provider.NewDefaultProvider("aws", NewCLI, NewTemplateBuilder),
 	feature.NewDetails("AWS Lambda", "listen to events on AWS lambda", feature.Stable),
 ).MustAddFunction("cloudwatch_logs",
 	NewCloudwatchLogs,

--- a/x-pack/functionbeat/provider/aws/cli_manager.go
+++ b/x-pack/functionbeat/provider/aws/cli_manager.go
@@ -5,9 +5,6 @@
 package aws
 
 import (
-	"crypto/sha256"
-	"encoding/base64"
-	"errors"
 	"fmt"
 	"regexp"
 
@@ -19,7 +16,6 @@ import (
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
-	"github.com/elastic/beats/x-pack/functionbeat/core"
 	"github.com/elastic/beats/x-pack/functionbeat/provider"
 )
 
@@ -49,154 +45,10 @@ type installer interface {
 // It will take care of creating the main lambda function and ask for each function type for the
 // operation that need to be executed to connect the lambda to the triggers.
 type CLIManager struct {
-	provider provider.Provider
-	awsCfg   aws.Config
-	log      *logp.Logger
-	config   *Config
-}
-
-func (c *CLIManager) findFunction(name string) (installer, error) {
-	fn, err := c.provider.FindFunctionByName(name)
-	if err != nil {
-		return nil, err
-	}
-
-	function, ok := fn.(installer)
-	if !ok {
-		return nil, errors.New("incompatible type received, expecting: 'functionManager'")
-	}
-
-	return function, nil
-}
-
-func (c *CLIManager) template(function installer, name, codeLoc string) *cloudformation.Template {
-	lambdaConfig := function.LambdaConfig()
-
-	prefix := func(s string) string {
-		return normalizeResourceName("fnb" + name + s)
-	}
-
-	// AWS variables references:.
-	// AWS::Partition: aws, aws-cn, aws-gov.
-	// AWS::Region: us-east-1, us-east-2, ap-northeast-3,
-	// AWS::AccountId: account id for the current request.
-	// AWS::URLSuffix: amazonaws.com
-	//
-	// Documentation: https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/Welcome.html
-	// Intrinsic function reference: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html
-
-	template := cloudformation.NewTemplate()
-
-	role := lambdaConfig.Role
-	dependsOn := make([]string, 0)
-	if lambdaConfig.Role == "" {
-		c.log.Infof("No role is configured for function %s, creating a custom role.", name)
-
-		roleRes := prefix("") + "IAMRoleLambdaExecution"
-		template.Resources[roleRes] = c.roleTemplate(function, name)
-		role = cloudformation.GetAtt(roleRes, "Arn")
-		dependsOn = []string{roleRes}
-	}
-
-	// Configure the Dead letter, any failed events will be send to the configured amazon resource name.
-	var dlc *cloudformation.AWSLambdaFunction_DeadLetterConfig
-	if lambdaConfig.DeadLetterConfig != nil && len(lambdaConfig.DeadLetterConfig.TargetArn) != 0 {
-		dlc = &cloudformation.AWSLambdaFunction_DeadLetterConfig{
-			TargetArn: lambdaConfig.DeadLetterConfig.TargetArn,
-		}
-	}
-
-	// Configure VPC
-	var vcpConf *cloudformation.AWSLambdaFunction_VpcConfig
-	if lambdaConfig.VPCConfig != nil && len(lambdaConfig.VPCConfig.SecurityGroupIDs) != 0 && len(lambdaConfig.VPCConfig.SubnetIDs) != 0 {
-		vcpConf = &cloudformation.AWSLambdaFunction_VpcConfig{
-			SecurityGroupIds: lambdaConfig.VPCConfig.SecurityGroupIDs,
-			SubnetIds:        lambdaConfig.VPCConfig.SubnetIDs,
-		}
-	}
-
-	// Create the lambda
-	// Doc: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html
-	template.Resources[prefix("")] = &AWSLambdaFunction{
-		AWSLambdaFunction: &cloudformation.AWSLambdaFunction{
-			Code: &cloudformation.AWSLambdaFunction_Code{
-				S3Bucket: c.bucket(),
-				S3Key:    codeLoc,
-			},
-			Description: lambdaConfig.Description,
-			Environment: &cloudformation.AWSLambdaFunction_Environment{
-				// Configure which function need to be run by the lambda function.
-				Variables: map[string]string{
-					"BEAT_STRICT_PERMS": "false", // Disable any check on disk, we are running with really differents permission on lambda.
-					"ENABLED_FUNCTIONS": name,
-				},
-			},
-			DeadLetterConfig:             dlc,
-			VpcConfig:                    vcpConf,
-			FunctionName:                 name,
-			Role:                         role,
-			Runtime:                      runtime,
-			Handler:                      handlerName,
-			MemorySize:                   lambdaConfig.MemorySize.Megabytes(),
-			ReservedConcurrentExecutions: lambdaConfig.Concurrency,
-			Timeout:                      int(lambdaConfig.Timeout.Seconds()),
-		},
-		DependsOn: dependsOn,
-	}
-
-	// Create the log group for the specific function lambda.
-	template.Resources[prefix("LogGroup")] = &cloudformation.AWSLogsLogGroup{
-		LogGroupName: "/aws/lambda/" + name,
-	}
-
-	return template
-}
-
-func (c *CLIManager) roleTemplate(function installer, name string) *cloudformation.AWSIAMRole {
-	// Default policies to writes logs from the Lambda.
-	policies := []cloudformation.AWSIAMRole_Policy{
-		cloudformation.AWSIAMRole_Policy{
-			PolicyName: cloudformation.Join("-", []string{"fnb", "lambda", name}),
-			PolicyDocument: map[string]interface{}{
-				"Statement": []map[string]interface{}{
-					map[string]interface{}{
-						"Action": []string{"logs:CreateLogStream", "logs:PutLogEvents"},
-						"Effect": "Allow",
-						"Resource": []string{
-							cloudformation.Sub("arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/" + name + ":*"),
-						},
-					},
-				},
-			},
-		},
-	}
-
-	// Merge any specific policies from the service.
-	policies = append(policies, function.Policies()...)
-
-	// Create the roles for the lambda.
-	// doc: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html
-	return &cloudformation.AWSIAMRole{
-		AssumeRolePolicyDocument: map[string]interface{}{
-			"Statement": []interface{}{
-				map[string]interface{}{
-					"Action": "sts:AssumeRole",
-					"Effect": "Allow",
-					"Principal": map[string]interface{}{
-						"Service": cloudformation.Join("", []string{
-							"lambda.",
-							cloudformation.Ref("AWS::URLSuffix"),
-						}),
-					},
-				},
-			},
-		},
-		Path:     "/",
-		RoleName: "functionbeat-lambda-" + name,
-		// Allow the lambda to write log to cloudwatch logs.
-		// doc: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html
-		Policies: policies,
-	}
+	templateBuilder *defaultTemplateBuilder
+	awsCfg          aws.Config
+	log             *logp.Logger
+	config          *Config
 }
 
 // stackName cloudformation stack are unique per function.
@@ -205,38 +57,12 @@ func (c *CLIManager) stackName(name string) string {
 }
 
 func (c *CLIManager) deployTemplate(update bool, name string) error {
-	c.log.Debug("Compressing all assets into an artifact")
-	content, err := core.MakeZip()
-	if err != nil {
-		return err
-	}
-	c.log.Debugf("Compression is successful (zip size: %d bytes)", len(content))
-
-	function, err := c.findFunction(name)
+	templateData, err := c.templateBuilder.execute(name)
 	if err != nil {
 		return err
 	}
 
-	fnTemplate := function.Template()
-
-	zipChecksum := checksum(content)
-	codeKey := "functionbeat-deployment/" + name + "/" + zipChecksum + "/functionbeat.zip"
-
-	to := c.template(function, name, codeKey)
-	if err := mergeTemplate(to, fnTemplate); err != nil {
-		return err
-	}
-
-	json, err := to.JSON()
-	if err != nil {
-		return err
-	}
-
-	templateChecksum := checksum(json)
-	templateKey := "functionbeat-deployment/" + name + "/" + templateChecksum + "/cloudformation-template-create.json"
-	templateURL := "https://s3.amazonaws.com/" + c.bucket() + "/" + templateKey
-
-	c.log.Debugf("Using cloudformation template:\n%s", json)
+	c.log.Debugf("Using cloudformation template:\n%s", templateData.json)
 	svcCF := cf.New(c.awsCfg)
 
 	executer := newExecutor(c.log)
@@ -245,34 +71,34 @@ func (c *CLIManager) deployTemplate(update bool, name string) error {
 		c.log,
 		c.awsCfg,
 		c.bucket(),
-		codeKey,
-		content,
+		templateData.codeKey,
+		templateData.zip.content,
 	))
 	executer.Add(newOpUploadToBucket(
 		c.log,
 		c.awsCfg,
 		c.bucket(),
-		templateKey,
-		json,
+		templateData.key,
+		templateData.json,
 	))
 	if update {
 		executer.Add(newOpUpdateCloudFormation(
 			c.log,
 			svcCF,
-			templateURL,
+			templateData.url,
 			c.stackName(name),
 		))
 	} else {
 		executer.Add(newOpCreateCloudFormation(
 			c.log,
 			svcCF,
-			templateURL,
+			templateData.url,
 			c.stackName(name),
 		))
 	}
 
 	executer.Add(newOpWaitCloudFormation(c.log, cf.New(c.awsCfg)))
-	executer.Add(newOpDeleteFileBucket(c.log, c.awsCfg, c.bucket(), codeKey))
+	executer.Add(newOpDeleteFileBucket(c.log, c.awsCfg, c.bucket(), templateData.codeKey))
 
 	ctx := newStackContext()
 	if err := executer.Execute(ctx); err != nil {
@@ -349,59 +175,24 @@ func NewCLI(
 		return nil, err
 	}
 
+	builder, err := provider.TemplateBuilder()
+	if err != nil {
+		return nil, err
+	}
+
+	templateBuilder, ok := builder.(*defaultTemplateBuilder)
+	if !ok {
+		return nil, fmt.Errorf("not defaultTemplateBuilder")
+	}
+
 	return &CLIManager{
-		config:   config,
-		provider: provider,
-		awsCfg:   awsCfg,
-		log:      logp.NewLogger("aws"),
+		config:          config,
+		awsCfg:          awsCfg,
+		log:             logp.NewLogger("aws"),
+		templateBuilder: templateBuilder,
 	}, nil
-}
-
-// mergeTemplate takes two cloudformation and merge them, if a key already exist we return an error.
-func mergeTemplate(to, from *cloudformation.Template) error {
-	merge := func(m1 map[string]interface{}, m2 map[string]interface{}) error {
-		for k, v := range m2 {
-			if _, ok := m1[k]; ok {
-				return fmt.Errorf("key %s already exist in the template map", k)
-			}
-			m1[k] = v
-		}
-		return nil
-	}
-
-	err := merge(to.Parameters, from.Parameters)
-	if err != nil {
-		return err
-	}
-
-	err = merge(to.Mappings, from.Mappings)
-	if err != nil {
-		return err
-	}
-
-	err = merge(to.Conditions, from.Conditions)
-	if err != nil {
-		return err
-	}
-
-	err = merge(to.Resources, from.Resources)
-	if err != nil {
-		return err
-	}
-
-	err = merge(to.Outputs, from.Outputs)
-	if err != nil {
-		return err
-	}
-
-	return nil
 }
 
 func normalizeResourceName(s string) string {
 	return validChars.ReplaceAllString(s, "")
-}
-
-func checksum(data []byte) string {
-	sha := sha256.Sum256(data)
-	return base64.RawURLEncoding.EncodeToString(sha[:])
 }

--- a/x-pack/functionbeat/provider/aws/template_builder.go
+++ b/x-pack/functionbeat/provider/aws/template_builder.go
@@ -101,7 +101,7 @@ func (d *defaultTemplateBuilder) execute(name string) (templateData, error) {
 
 	templateChecksum := checksum(templateJSON)
 	templateKey := keyPrefix + name + "/" + templateChecksum + "/cloudformation-template-create.json"
-	templateURL := "https://s3.amazonaws.com/" + d.bucket + "/" + templateKey
+	templateURL := "https://" + d.bucket + "s3.amazonaws.com/" + templateKey
 
 	return templateData{
 		json:     templateJSON,

--- a/x-pack/functionbeat/provider/aws/template_builder.go
+++ b/x-pack/functionbeat/provider/aws/template_builder.go
@@ -1,0 +1,298 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package aws
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"fmt"
+
+	"github.com/awslabs/goformation/cloudformation"
+
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/x-pack/functionbeat/core"
+	"github.com/elastic/beats/x-pack/functionbeat/provider"
+)
+
+// zipData stores the data on the zip to be deployed
+type zipData struct {
+	content  []byte
+	checksum string
+}
+
+// templateData stores the template and its metadata required to deploy it
+type templateData struct {
+	json     []byte
+	checksum string
+	key      string
+	url      string
+	codeKey  string
+	zip      zipData
+}
+
+type defaultTemplateBuilder struct {
+	provider provider.Provider
+	log      *logp.Logger
+	bucket   string
+}
+
+const (
+	keyPrefix = "functionbeat-deployment/"
+)
+
+func NewTemplateBuilder(log *logp.Logger, cfg *common.Config, p provider.Provider) (provider.TemplateBuilder, error) {
+	config := &Config{}
+	if err := cfg.Unpack(config); err != nil {
+		return nil, err
+	}
+
+	return &defaultTemplateBuilder{
+		provider: p,
+		log:      log,
+		bucket:   string(config.DeployBucket),
+	}, nil
+}
+
+func (d *defaultTemplateBuilder) findFunction(name string) (installer, error) {
+	fn, err := d.provider.FindFunctionByName(name)
+	if err != nil {
+		return nil, err
+	}
+
+	function, ok := fn.(installer)
+	if !ok {
+		return nil, errors.New("incompatible type received, expecting: 'functionManager'")
+	}
+
+	return function, nil
+}
+
+// execute generates a template
+func (d *defaultTemplateBuilder) execute(name string) (templateData, error) {
+	d.log.Debug("Compressing all assets into an artifact")
+	content, err := core.MakeZip()
+	if err != nil {
+		return templateData{}, err
+	}
+	d.log.Debugf("Compression is successful (zip size: %d bytes)", len(content))
+
+	function, err := d.findFunction(name)
+	if err != nil {
+		return templateData{}, err
+	}
+
+	fnTemplate := function.Template()
+
+	zipChecksum := checksum(content)
+	codeKey := keyPrefix + name + "/" + zipChecksum + "/functionbeat.zip"
+	to := d.template(function, name, codeKey)
+	if err := mergeTemplate(to, fnTemplate); err != nil {
+		return templateData{}, err
+	}
+
+	templateJSON, err := to.JSON()
+	if err != nil {
+		return templateData{}, err
+	}
+
+	templateChecksum := checksum(templateJSON)
+	templateKey := keyPrefix + name + "/" + templateChecksum + "/cloudformation-template-create.json"
+	templateURL := "https://s3.amazonaws.com/" + d.bucket + "/" + templateKey
+
+	return templateData{
+		json:     templateJSON,
+		checksum: templateChecksum,
+		key:      templateKey,
+		url:      templateURL,
+		codeKey:  codeKey,
+		zip: zipData{
+			checksum: zipChecksum,
+			content:  content,
+		},
+	}, nil
+}
+
+func (d *defaultTemplateBuilder) template(function installer, name, codeLoc string) *cloudformation.Template {
+	lambdaConfig := function.LambdaConfig()
+
+	prefix := func(s string) string {
+		return normalizeResourceName("fnb" + name + s)
+	}
+
+	// AWS variables references:.
+	// AWS::Partition: aws, aws-cn, aws-gov.
+	// AWS::Region: us-east-1, us-east-2, ap-northeast-3,
+	// AWS::AccountId: account id for the current request.
+	// AWS::URLSuffix: amazonaws.com
+	//
+	// Documentation: https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/Welcome.html
+	// Intrinsic function reference: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html
+
+	template := cloudformation.NewTemplate()
+
+	role := lambdaConfig.Role
+	dependsOn := make([]string, 0)
+	if lambdaConfig.Role == "" {
+		d.log.Infof("No role is configured for function %s, creating a custom role.", name)
+
+		roleRes := prefix("") + "IAMRoleLambdaExecution"
+		template.Resources[roleRes] = d.roleTemplate(function, name)
+		role = cloudformation.GetAtt(roleRes, "Arn")
+		dependsOn = []string{roleRes}
+	}
+
+	// Configure the Dead letter, any failed events will be send to the configured amazon resource name.
+	var dlc *cloudformation.AWSLambdaFunction_DeadLetterConfig
+	if lambdaConfig.DeadLetterConfig != nil && len(lambdaConfig.DeadLetterConfig.TargetArn) != 0 {
+		dlc = &cloudformation.AWSLambdaFunction_DeadLetterConfig{
+			TargetArn: lambdaConfig.DeadLetterConfig.TargetArn,
+		}
+	}
+
+	// Configure VPC
+	var vcpConf *cloudformation.AWSLambdaFunction_VpcConfig
+	if lambdaConfig.VPCConfig != nil && len(lambdaConfig.VPCConfig.SecurityGroupIDs) != 0 && len(lambdaConfig.VPCConfig.SubnetIDs) != 0 {
+		vcpConf = &cloudformation.AWSLambdaFunction_VpcConfig{
+			SecurityGroupIds: lambdaConfig.VPCConfig.SecurityGroupIDs,
+			SubnetIds:        lambdaConfig.VPCConfig.SubnetIDs,
+		}
+	}
+
+	// Create the lambda
+	// Doc: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html
+	template.Resources[prefix("")] = &AWSLambdaFunction{
+		AWSLambdaFunction: &cloudformation.AWSLambdaFunction{
+			Code: &cloudformation.AWSLambdaFunction_Code{
+				S3Bucket: d.bucket,
+				S3Key:    codeLoc,
+			},
+			Description: lambdaConfig.Description,
+			Environment: &cloudformation.AWSLambdaFunction_Environment{
+				// Configure which function need to be run by the lambda function.
+				Variables: map[string]string{
+					"BEAT_STRICT_PERMS": "false", // Disable any check on disk, we are running with really differents permission on lambda.
+					"ENABLED_FUNCTIONS": name,
+				},
+			},
+			DeadLetterConfig:             dlc,
+			VpcConfig:                    vcpConf,
+			FunctionName:                 name,
+			Role:                         role,
+			Runtime:                      runtime,
+			Handler:                      handlerName,
+			MemorySize:                   lambdaConfig.MemorySize.Megabytes(),
+			ReservedConcurrentExecutions: lambdaConfig.Concurrency,
+			Timeout:                      int(lambdaConfig.Timeout.Seconds()),
+		},
+		DependsOn: dependsOn,
+	}
+
+	// Create the log group for the specific function lambda.
+	template.Resources[prefix("LogGroup")] = &cloudformation.AWSLogsLogGroup{
+		LogGroupName: "/aws/lambda/" + name,
+	}
+
+	return template
+}
+
+func (d *defaultTemplateBuilder) roleTemplate(function installer, name string) *cloudformation.AWSIAMRole {
+	// Default policies to writes logs from the Lambda.
+	policies := []cloudformation.AWSIAMRole_Policy{
+		cloudformation.AWSIAMRole_Policy{
+			PolicyName: cloudformation.Join("-", []string{"fnb", "lambda", name}),
+			PolicyDocument: map[string]interface{}{
+				"Statement": []map[string]interface{}{
+					map[string]interface{}{
+						"Action": []string{"logs:CreateLogStream", "logs:PutLogEvents"},
+						"Effect": "Allow",
+						"Resource": []string{
+							cloudformation.Sub("arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/" + name + ":*"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Merge any specific policies from the service.
+	policies = append(policies, function.Policies()...)
+
+	// Create the roles for the lambda.
+	// doc: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html
+	return &cloudformation.AWSIAMRole{
+		AssumeRolePolicyDocument: map[string]interface{}{
+			"Statement": []interface{}{
+				map[string]interface{}{
+					"Action": "sts:AssumeRole",
+					"Effect": "Allow",
+					"Principal": map[string]interface{}{
+						"Service": cloudformation.Join("", []string{
+							"lambda.",
+							cloudformation.Ref("AWS::URLSuffix"),
+						}),
+					},
+				},
+			},
+		},
+		Path:     "/",
+		RoleName: "functionbeat-lambda-" + name,
+		// Allow the lambda to write log to cloudwatch logs.
+		// doc: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html
+		Policies: policies,
+	}
+}
+
+// RawTemplate generates a template and returns it in a string
+func (d *defaultTemplateBuilder) RawTemplate(name string) (string, error) {
+	data, err := d.execute(name)
+	return string(data.json), err
+}
+
+// mergeTemplate takes two cloudformation and merge them, if a key already exist we return an error.
+func mergeTemplate(to, from *cloudformation.Template) error {
+	merge := func(m1 map[string]interface{}, m2 map[string]interface{}) error {
+		for k, v := range m2 {
+			if _, ok := m1[k]; ok {
+				return fmt.Errorf("key %s already exist in the template map", k)
+			}
+			m1[k] = v
+		}
+		return nil
+	}
+
+	err := merge(to.Parameters, from.Parameters)
+	if err != nil {
+		return err
+	}
+
+	err = merge(to.Mappings, from.Mappings)
+	if err != nil {
+		return err
+	}
+
+	err = merge(to.Conditions, from.Conditions)
+	if err != nil {
+		return err
+	}
+
+	err = merge(to.Resources, from.Resources)
+	if err != nil {
+		return err
+	}
+
+	err = merge(to.Outputs, from.Outputs)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func checksum(data []byte) string {
+	sha := sha256.Sum256(data)
+	return base64.RawURLEncoding.EncodeToString(sha[:])
+}

--- a/x-pack/functionbeat/provider/default_provider.go
+++ b/x-pack/functionbeat/provider/default_provider.go
@@ -74,6 +74,7 @@ func (d *DefaultProvider) CLIManager() (CLIManager, error) {
 	return d.managerFactory(nil, d.rawConfig, d)
 }
 
+// TemplateBuilder returns a TemplateBuilder returns a the type responsible to generate templates.
 func (d *DefaultProvider) TemplateBuilder() (TemplateBuilder, error) {
 	return d.templateFactory(d.log, d.rawConfig, d)
 }
@@ -90,8 +91,10 @@ func (*nullCLI) Deploy(_ string) error { return fmt.Errorf("deploy not implement
 func (*nullCLI) Update(_ string) error { return fmt.Errorf("update not implemented") }
 func (*nullCLI) Remove(_ string) error { return fmt.Errorf("remove not implemented") }
 
+// nullTemplateBuilder is used when a provider does not implement a template builder functionality.
 type nullTemplateBuilder struct{}
 
+// NewNullTemplateBuilder returns a NOOP TemplateBuilder.
 func NewNullTemplateBuilder(_ *logp.Logger, _ *common.Config, _ Provider) (TemplateBuilder, error) {
 	return (*nullTemplateBuilder)(nil), nil
 }

--- a/x-pack/functionbeat/provider/default_provider.go
+++ b/x-pack/functionbeat/provider/default_provider.go
@@ -15,16 +15,21 @@ import (
 
 // DefaultProvider implements the minimal required to retrieve and start functions.
 type DefaultProvider struct {
-	rawConfig      *common.Config
-	config         *config.ProviderConfig
-	registry       *Registry
-	name           string
-	log            *logp.Logger
-	managerFactory CLIManagerFactory
+	rawConfig       *common.Config
+	config          *config.ProviderConfig
+	registry        *Registry
+	name            string
+	log             *logp.Logger
+	managerFactory  CLIManagerFactory
+	templateFactory TemplateBuilderFactory
 }
 
 // NewDefaultProvider returns factory methods to handle generic provider.
-func NewDefaultProvider(name string, manager CLIManagerFactory) func(*logp.Logger, *Registry, *common.Config) (Provider, error) {
+func NewDefaultProvider(
+	name string,
+	manager CLIManagerFactory,
+	templater TemplateBuilderFactory,
+) func(*logp.Logger, *Registry, *common.Config) (Provider, error) {
 	return func(log *logp.Logger, registry *Registry, cfg *common.Config) (Provider, error) {
 		c := &config.ProviderConfig{}
 		err := cfg.Unpack(c)
@@ -37,12 +42,13 @@ func NewDefaultProvider(name string, manager CLIManagerFactory) func(*logp.Logge
 		}
 
 		return &DefaultProvider{
-			rawConfig:      cfg,
-			config:         c,
-			registry:       registry,
-			name:           name,
-			log:            log,
-			managerFactory: manager,
+			rawConfig:       cfg,
+			config:          c,
+			registry:        registry,
+			name:            name,
+			log:             log,
+			managerFactory:  manager,
+			templateFactory: templater,
 		}, nil
 	}
 }
@@ -68,6 +74,10 @@ func (d *DefaultProvider) CLIManager() (CLIManager, error) {
 	return d.managerFactory(nil, d.rawConfig, d)
 }
 
+func (d *DefaultProvider) TemplateBuilder() (TemplateBuilder, error) {
+	return d.templateFactory(d.log, d.rawConfig, d)
+}
+
 // nullCLI is used when a provider doesn't implement the CLI to manager functions on the service provider.
 type nullCLI struct{}
 
@@ -79,3 +89,13 @@ func NewNullCli(_ *logp.Logger, _ *common.Config, _ Provider) (CLIManager, error
 func (*nullCLI) Deploy(_ string) error { return fmt.Errorf("deploy not implemented") }
 func (*nullCLI) Update(_ string) error { return fmt.Errorf("update not implemented") }
 func (*nullCLI) Remove(_ string) error { return fmt.Errorf("remove not implemented") }
+
+type nullTemplateBuilder struct{}
+
+func NewNullTemplateBuilder(_ *logp.Logger, _ *common.Config, _ Provider) (TemplateBuilder, error) {
+	return (*nullTemplateBuilder)(nil), nil
+}
+
+func (*nullTemplateBuilder) RawTemplate(_ string) (string, error) {
+	return "", fmt.Errorf("raw temaplate not implemented")
+}

--- a/x-pack/functionbeat/provider/local/local.go
+++ b/x-pack/functionbeat/provider/local/local.go
@@ -22,7 +22,7 @@ const stdinName = "stdin"
 // Bundle exposes the local provider and the STDIN function.
 var Bundle = provider.MustCreate(
 	"local",
-	provider.NewDefaultProvider("local", provider.NewNullCli),
+	provider.NewDefaultProvider("local", provider.NewNullCli, provider.NewNullTemplateBuilder),
 	feature.NewDetails("local events", "allows to trigger events locally.", feature.Experimental),
 ).MustAddFunction(
 	stdinName,

--- a/x-pack/functionbeat/provider/provider.go
+++ b/x-pack/functionbeat/provider/provider.go
@@ -32,6 +32,7 @@ type Provider interface {
 	CreateFunctions(clientFactory, []string) ([]core.Runner, error)
 	FindFunctionByName(string) (Function, error)
 	CLIManager() (CLIManager, error)
+	TemplateBuilder() (TemplateBuilder, error)
 	Name() string
 }
 

--- a/x-pack/functionbeat/provider/registry_test.go
+++ b/x-pack/functionbeat/provider/registry_test.go
@@ -35,6 +35,8 @@ func (m *mockProvider) Name() string { return m.name }
 
 func (m *mockProvider) CLIManager() (CLIManager, error) { return nil, nil }
 
+func (m *mockProvider) TemplateBuilder() (TemplateBuilder, error) { return nil, nil }
+
 func TestRegistry(t *testing.T) {
 	t.Run("provider", testProviderLookup)
 	t.Run("functions", testFunctionLookup)

--- a/x-pack/functionbeat/provider/template.go
+++ b/x-pack/functionbeat/provider/template.go
@@ -1,0 +1,19 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package provider
+
+import (
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
+)
+
+// TemplateBuilderFactory factory method to call to create a new template builder.
+type TemplateBuilderFactory func(*logp.Logger, *common.Config, Provider) (TemplateBuilder, error)
+
+// TemplateBuilder generates templates for a given provider.
+type TemplateBuilder interface {
+	// RawTemplate returns a deployable template string.
+	RawTemplate(string) (string, error)
+}

--- a/x-pack/functionbeat/tests/system/config/functionbeat.yml.j2
+++ b/x-pack/functionbeat/tests/system/config/functionbeat.yml.j2
@@ -1,8 +1,28 @@
 ################### Beat Configuration #########################
+{% if local %}
 functionbeat.provider.local:
     functions:
       - type: stdin
         enabled: true
+{% endif %}
+
+{% if cloudwatch %}
+functionbeat.provider.aws.deploy_bucket: {{ cloudwatch.bucket | default("functionbeat-deploy") }}
+functionbeat.provider.aws.functions:
+  - name: {{ cloudwatch.name }}
+    enabled: true
+    type: cloudwatch_logs
+    description: "lambda function for cloudwatch logs"
+    {% if cloudwatch.role %}role: {{ cloudwatch.role }}{% endif %}
+    {% if cloudwatch.virtual_private_cloud %}
+    virtual_private_cloud:
+      security_group_ids: {{ cloudwatch.virtual_private_cloud.security_group_ids }}
+      subnet_ids: {{ cloudwatch.virtual_private_cloud.subnet_ids }}
+    {% endif %}
+
+    triggers:
+      - log_group_name: {{ cloudwatch.log_group | default("/aws/lambda/functionbeat-cloudwatch") }}
+{% endif %}
 
 ############################# Output ##########################################
 

--- a/x-pack/functionbeat/tests/system/test_base.py
+++ b/x-pack/functionbeat/tests/system/test_base.py
@@ -97,7 +97,9 @@ class Test(BaseTest):
         assert exit_code != 0
 
     def _generate_dummy_binary_for_template_checksum(self):
-        os.mkdir("pkg")
+        if os.path.exists("pkg/functionbeat"):
+            return
+
         with open("pkg/functionbeat", "wb") as f:
             f.write("my dummy functionbeat binary")
 

--- a/x-pack/functionbeat/tests/system/test_base.py
+++ b/x-pack/functionbeat/tests/system/test_base.py
@@ -35,6 +35,8 @@ class Test(BaseTest):
         subnet_ids = ["subnet-ABCDEFGHIJKL"]
         log_group = "/aws/lambda/functionbeat-cloudwatch"
 
+        self._generate_dummy_binary_for_template_checksum()
+
         self.render_config_template(
             path=os.path.abspath(self.working_dir) + "/log/*",
             cloudwatch={
@@ -73,6 +75,8 @@ class Test(BaseTest):
         function_name = "INVALID_$_FUNCTION_$_NAME"
         bucket_name = "my-bucket-name"
 
+        self._generate_dummy_binary_for_template_checksum()
+
         self.render_config_template(
             path=os.path.abspath(self.working_dir) + "/log/*",
             cloudwatch={
@@ -91,6 +95,10 @@ class Test(BaseTest):
 
         exit_code = functionbeat_proc.kill_and_wait()
         assert exit_code != 0
+
+    def _generate_dummy_binary_for_template_checksum(self):
+        with open('pkg/functionbeat', 'wb') as f:
+            f.write("my dummy functionbeat binary")
 
     def _get_generated_function_template(self):
         logs = self.get_log_lines()

--- a/x-pack/functionbeat/tests/system/test_base.py
+++ b/x-pack/functionbeat/tests/system/test_base.py
@@ -100,6 +100,7 @@ class Test(BaseTest):
         if os.path.exists("pkg/functionbeat"):
             return
 
+        os.mkdir("pkg")
         with open("pkg/functionbeat", "wb") as f:
             f.write("my dummy functionbeat binary")
 

--- a/x-pack/functionbeat/tests/system/test_base.py
+++ b/x-pack/functionbeat/tests/system/test_base.py
@@ -97,7 +97,8 @@ class Test(BaseTest):
         assert exit_code != 0
 
     def _generate_dummy_binary_for_template_checksum(self):
-        with open('pkg/functionbeat', 'wb') as f:
+        os.mkdir("pkg")
+        with open("pkg/functionbeat", "wb") as f:
             f.write("my dummy functionbeat binary")
 
     def _get_generated_function_template(self):

--- a/x-pack/functionbeat/tests/system/test_base.py
+++ b/x-pack/functionbeat/tests/system/test_base.py
@@ -1,5 +1,6 @@
 from functionbeat import BaseTest
 
+import json
 import os
 import unittest
 
@@ -12,10 +13,88 @@ class Test(BaseTest):
         Basic test with exiting Functionbeat normally
         """
         self.render_config_template(
-            path=os.path.abspath(self.working_dir) + "/log/*"
+            path=os.path.abspath(self.working_dir) + "/log/*",
+            local=True,
         )
 
         functionbeat_proc = self.start_beat()
         self.wait_until(lambda: self.log_contains("functionbeat is running"))
         exit_code = functionbeat_proc.kill_and_wait()
         assert exit_code == 0
+
+    def test_export_function_template(self):
+        """
+        Test if the template can be exported
+        """
+
+        function_name = "testcloudwatchlogs"
+        bucket_name = "my-bucket-name"
+        fnb_name = "fnb" + function_name
+        role = "arn:aws:iam::123456789012:role/MyFunction"
+        security_group_ids = ["sg-ABCDEFGHIJKL"]
+        subnet_ids = ["subnet-ABCDEFGHIJKL"]
+        log_group = "/aws/lambda/functionbeat-cloudwatch"
+
+        self.render_config_template(
+            path=os.path.abspath(self.working_dir) + "/log/*",
+            cloudwatch={
+                "name": function_name,
+                "bucket": bucket_name,
+                "role": role,
+                "virtual_private_cloud": {
+                    "security_group_ids": security_group_ids,
+                    "subnet_ids": subnet_ids,
+                },
+                "log_group": log_group,
+            },
+        )
+        functionbeat_proc = self.start_beat(
+            logging_args=["-d", "*"],
+            extra_args=["export", "function", function_name]
+        )
+
+        self.wait_until(lambda: self.log_contains("PASS"))
+        exit_code = functionbeat_proc.kill_and_wait()
+        assert exit_code == 0
+
+        function_template = self._get_generated_function_template()
+        function_properties = function_template["Resources"][fnb_name]["Properties"]
+
+        assert function_properties["FunctionName"] == function_name
+        assert function_properties["Code"]["S3Bucket"] == bucket_name
+        assert function_properties["Role"] == role
+        assert function_properties["VpcConfig"]["SecurityGroupIds"] == security_group_ids
+        assert function_properties["VpcConfig"]["SubnetIds"] == subnet_ids
+
+    def test_export_function_template_with_invalid_configuration(self):
+        """
+        Test if invalid configuration is exportable
+        """
+        function_name = "INVALID_$_FUNCTION_$_NAME"
+        bucket_name = "my-bucket-name"
+
+        self.render_config_template(
+            path=os.path.abspath(self.working_dir) + "/log/*",
+            cloudwatch={
+                "name": function_name,
+                "bucket": bucket_name,
+            },
+        )
+        functionbeat_proc = self.start_beat(
+            logging_args=["-d", "*"],
+            extra_args=["export", "function", function_name]
+        )
+
+        self.wait_until(
+            lambda: self.log_contains("error generating raw template for {}: invalid name".format(function_name))
+        )
+
+        exit_code = functionbeat_proc.kill_and_wait()
+        assert exit_code != 0
+
+    def _get_generated_function_template(self):
+        logs = self.get_log_lines()
+        function_template_lines = logs[:-2]
+        raw_function_temaplate = "".join(function_template_lines)
+        function_template = json.loads(raw_function_temaplate)
+        return function_template


### PR DESCRIPTION
A new subcommand is added under `export` named `function`. This command prints the loadable template to stdout for enabled functions.

```
$ ./functionbeat export function cloudwatch
```

I extracted generating templates from `CLIManager`. Now it has a `TemplateBuilder` which constructs the template for the manager. A template builder can be retrieved from a provider, as generating templates is specific to providers. Thus, `CLIManager` does not need to know about the provider anymore.

TODO
- [x] more testing
- [x] changelog entry
- [x] better PR description