### PR TITLE
[7.0] Fix JSON log file paths for elasticsearch/audit fileset (#11907)

### DIFF
--- a/filebeat/docs/modules/elasticsearch.asciidoc
+++ b/filebeat/docs/modules/elasticsearch.asciidoc
@@ -70,7 +70,7 @@ Example config:
 ----
   audit:
     var.paths:
-      - /var/log/elasticsearch/*_access.log
+      - /var/log/elasticsearch/*_audit.json
 ----
 
 [float]

--- a/filebeat/module/elasticsearch/_meta/docs.asciidoc
+++ b/filebeat/module/elasticsearch/_meta/docs.asciidoc
@@ -65,7 +65,7 @@ Example config:
 ----
   audit:
     var.paths:
-      - /var/log/elasticsearch/*_access.log
+      - /var/log/elasticsearch/*_audit.json
 ----
 
 [float]

--- a/filebeat/module/elasticsearch/audit/manifest.yml
+++ b/filebeat/module/elasticsearch/audit/manifest.yml
@@ -5,12 +5,15 @@ var:
     default:
       - /var/log/elasticsearch/*_access.log
       - /var/log/elasticsearch/*_audit.log
+      - /var/log/elasticsearch/*_audit.json
     os.darwin:
       - /usr/local/var/lib/elasticsearch/*_access.log
       - /usr/local/var/lib/elasticsearch/*_audit.log
+      - /usr/local/var/lib/elasticsearch/*_audit.json
     os.windows:
       - c:/ProgramData/Elastic/Elasticsearch/logs/*_access.log
       - c:/ProgramData/Elastic/Elasticsearch/logs/*_audit.log
+      - c:/ProgramData/Elastic/Elasticsearch/logs/*_audit.json
   - name: convert_timezone
     default: false
     # if ES < 6.1.0, this flag switches to false automatically when evaluating the


### PR DESCRIPTION
Backports the following commits to 7.0:
 - Fix JSON log file paths for elasticsearch/audit fileset  (#11907)