### PR TITLE
Remove cluster_name from cluster_state field

### DIFF
--- a/metricbeat/module/elasticsearch/cluster_stats/data_xpack.go
+++ b/metricbeat/module/elasticsearch/cluster_stats/data_xpack.go
@@ -182,6 +182,7 @@ func eventMappingXPack(r mb.ReporterV2, m *MetricSet, info elasticsearch.Info, c
 	if err != nil {
 		return errors.Wrap(err, "failed to get cluster state from Elasticsearch")
 	}
+	clusterState.Delete("cluster_name")
 
 	if err = elasticsearch.PassThruField("status", clusterStats, clusterState); err != nil {
 		return errors.Wrap(err, "failed to pass through status field")


### PR DESCRIPTION
Similar to https://github.com/elastic/beats/pull/11654:

We already index the `cluster_name` field as a top-level field in `.monitoring-es-*` docs with `type: cluster_stats`. So we don't need to index it under the `cluster_state` top-level field as well.

### Testing this PR
1. Pull down this PR and build Metricbeat.
   ```
   cd metricbeat
   mage build
   ```
2. Enable the `elasticsearch-xpack` Metricbeat module.
   ```
   ./metricbeat modules enable elasticsearch-xpack
   ```
3. Start Metricbeat
   ```
   ./metricbeat -e
   ```
4. Using Kibana Console check that the Metricbeat-indexed monitoring documents for Elasticsearch don't contain the `cluster_state.cluster_name` field.
   ```
   GET .monitoring-es-7-mb-*/_search?q=type:cluster_stats
   ```

