### PR TITLE
Remove _nodes field from under cluster_stats as it's not being used

### DIFF
--- a/metricbeat/module/elasticsearch/cluster_stats/data_xpack.go
+++ b/metricbeat/module/elasticsearch/cluster_stats/data_xpack.go
@@ -161,6 +161,7 @@ func eventMappingXPack(r mb.ReporterV2, m *MetricSet, info elasticsearch.Info, c
 	}
 
 	clusterStats := common.MapStr(data)
+	clusterStats.Delete("_nodes")
 
 	value, err := clusterStats.GetValue("cluster_name")
 	if err != nil {


### PR DESCRIPTION
What it says on the tin.

### Testing this PR
1. Pull down this PR and build Metricbeat.
   ```
   cd metricbeat
   mage build
   ```
2. Enable the `elasticsearch-xpack` Metricbeat module.
   ```
   ./metricbeat modules enable elasticsearch-xpack
   ```
3. Start Metricbeat
   ```
   ./metricbeat -e
   ```

4. Delete older `.monitoring-es-*` documents to start with a clean slate (makes it easier for testing).
   ```
   DELETE .monitoring-es-*
   ```

4. Using Kibana Console check that the Metricbeat-indexed monitoring documents for Elasticsearch don't contain the `cluster_stats._nodes` field.
   ```
   GET .monitoring-es-7-mb-*/_search?q=type:cluster_stats
   ```

