### PR TITLE
Add regions parameter in aws module config

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -35,7 +35,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add new option `OpMultiplyBuckets` to scale histogram buckets to avoid decimal points in final events {pull}10994[10994]
 - Change cloud.provider from ec2 to aws and from gce to gcp in add_cloud_metadata to align with ECS. {issue}10775[10775] {pull}11687[11687]
 - system/raid metricset now uses /sys/block instead of /proc/mdstat for data. {pull}11613[11613]
-- Replace `default_region` with `regions` in aws module config. {issue}11932[11932] {pull}11956[11956]
 
 *Packetbeat*
 
@@ -178,6 +177,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add AWS cloudwatch metricset. {pull}11798[11798] {issue}11734[11734]
 - Replace `default_region` with `regions` in aws module config. {issue}11932[11932]
 - Replace `default_region` with `regions` in aws module config. {issue}11932[11932] {pull}11956[11956]
+- Add `regions` in aws module config to specify target regions for querying cloudwatch metrics. {issue}11932[11932] {pull}11956[11956]
 
 *Packetbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -175,8 +175,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Added `path_name` and `start_name` to service metricset on windows module {issue}8364[8364] {pull}11877[11877]
 - Add check on object name in the counter path if the instance name is missing {issue}6528[6528] {pull}11878[11878]
 - Add AWS cloudwatch metricset. {pull}11798[11798] {issue}11734[11734]
-- Replace `default_region` with `regions` in aws module config. {issue}11932[11932]
-- Replace `default_region` with `regions` in aws module config. {issue}11932[11932] {pull}11956[11956]
 - Add `regions` in aws module config to specify target regions for querying cloudwatch metrics. {issue}11932[11932] {pull}11956[11956]
 
 *Packetbeat*

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -176,6 +176,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add check on object name in the counter path if the instance name is missing {issue}6528[6528] {pull}11878[11878]
 - Add AWS cloudwatch metricset. {pull}11798[11798] {issue}11734[11734]
 - Replace `default_region` with `regions` in aws module config. {issue}11932[11932]
+- Replace `default_region` with `regions` in aws module config. {issue}11932[11932] {pull}11956[11956]
 
 *Packetbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -175,6 +175,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Added `path_name` and `start_name` to service metricset on windows module {issue}8364[8364] {pull}11877[11877]
 - Add check on object name in the counter path if the instance name is missing {issue}6528[6528] {pull}11878[11878]
 - Add AWS cloudwatch metricset. {pull}11798[11798] {issue}11734[11734]
+- Replace `default_region` with `regions` in aws module config. {issue}11932[11932]
 
 *Packetbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -35,6 +35,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add new option `OpMultiplyBuckets` to scale histogram buckets to avoid decimal points in final events {pull}10994[10994]
 - Change cloud.provider from ec2 to aws and from gce to gcp in add_cloud_metadata to align with ECS. {issue}10775[10775] {pull}11687[11687]
 - system/raid metricset now uses /sys/block instead of /proc/mdstat for data. {pull}11613[11613]
+- Replace `default_region` with `regions` in aws module config. {issue}11932[11932] {pull}11956[11956]
 
 *Packetbeat*
 

--- a/metricbeat/docs/modules/aws.asciidoc
+++ b/metricbeat/docs/modules/aws.asciidoc
@@ -148,8 +148,8 @@ metricbeat.modules:
   secret_access_key: '${AWS_SECRET_ACCESS_KEY:""}'
   session_token: '${AWS_SESSION_TOKEN:""}'
   default_region: '${AWS_REGION:us-west-1}'
-#  regions:
-#    - us-west-1
+  #regions:
+  #  - us-west-1
 - module: aws
   period: 86400s
   metricsets:

--- a/metricbeat/docs/modules/aws.asciidoc
+++ b/metricbeat/docs/modules/aws.asciidoc
@@ -61,7 +61,7 @@ metricbeat.modules:
 - module: aws
   period: 300s
   metricsets:
-    - "s3_daily_storage"
+    - s3_daily_storage
   access_key_id: '${AWS_ACCESS_KEY_ID}'
   secret_access_key: '${AWS_SECRET_ACCESS_KEY}'
   session_token: '${AWS_SESSION_TOKEN}'
@@ -133,11 +133,20 @@ metricbeat.modules:
   period: 300s
   metricsets:
     - ec2
+  access_key_id: '${AWS_ACCESS_KEY_ID:""}'
+  secret_access_key: '${AWS_SECRET_ACCESS_KEY:""}'
+  session_token: '${AWS_SESSION_TOKEN:""}'
+  default_region: '${AWS_REGION:us-west-1}'
+- module: aws
+  period: 300s
+  metricsets:
     - sqs
   access_key_id: '${AWS_ACCESS_KEY_ID:""}'
   secret_access_key: '${AWS_SECRET_ACCESS_KEY:""}'
   session_token: '${AWS_SESSION_TOKEN:""}'
   default_region: '${AWS_REGION:us-west-1}'
+#  regions:
+#    - us-west-1
 - module: aws
   period: 86400s
   metricsets:

--- a/metricbeat/docs/modules/aws.asciidoc
+++ b/metricbeat/docs/modules/aws.asciidoc
@@ -26,7 +26,8 @@ an IAM user or the AWS account root user. Please see
 https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys[AWS Access Keys
  and Secret Access Keys] for more details. `temporary security credentials` has a limited lifetime and consists of an access key ID,
 a secret access key, and a security token which typically returned from `GetSessionToken`. MFA-enabled IAM users would
-need to submit an MFA code while calling `GetSessionToken`. `default_region` is to set a region for SDK to use for the first AWS API call.
+need to submit an MFA code while calling `GetSessionToken`. `default_region` identifies the AWS Region whose servers you want to send
+your first API request to by default. This is typically the Region closest to you, but it can be any Region.
 Please see https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html[Temporary Security Credentials] for more details.
 `sts get-session-token` AWS CLI can be used to generate temporary credentials. For example. with MFA-enabled:
 

--- a/metricbeat/docs/modules/aws.asciidoc
+++ b/metricbeat/docs/modules/aws.asciidoc
@@ -14,7 +14,7 @@ The default metricsets are `ec2`, `sqs`, `s3_request`, `s3_daily_storage` and `c
 [float]
 === Module-specific configuration notes
 
-This module uses environment variable `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_SESSION_TOKEN`
+This module uses environment variable `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN` and `AWS_REGION`
 that are referenced in the config file to set values that need to be configurable during deployment. It also
 accept optional configuration `regions` to specify what are the AWS regions to query metrics from. If `regions`
 parameter is not set in the config file, then by default, aws module will query metrics from all available
@@ -26,8 +26,8 @@ an IAM user or the AWS account root user. Please see
 https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys[AWS Access Keys
  and Secret Access Keys] for more details. `temporary security credentials` has a limited lifetime and consists of an access key ID,
 a secret access key, and a security token which typically returned from `GetSessionToken`. MFA-enabled IAM users would
-need to submit an MFA code while calling `GetSessionToken`. Please
-see https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html[Temporary Security Credentials] for more details.
+need to submit an MFA code while calling `GetSessionToken`. `default_region` is to set a region for SDK to use for the first AWS API call.
+Please see https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html[Temporary Security Credentials] for more details.
 `sts get-session-token` AWS CLI can be used to generate temporary credentials. For example. with MFA-enabled:
 
 ----
@@ -58,6 +58,7 @@ metricbeat.modules:
   access_key_id: '${AWS_ACCESS_KEY_ID}'
   secret_access_key: '${AWS_SECRET_ACCESS_KEY}'
   session_token: '${AWS_SESSION_TOKEN}'
+  default_region: '${AWS_REGION:us-west-1}'
 - module: aws
   period: 300s
   metricsets:
@@ -65,6 +66,7 @@ metricbeat.modules:
   access_key_id: '${AWS_ACCESS_KEY_ID}'
   secret_access_key: '${AWS_SECRET_ACCESS_KEY}'
   session_token: '${AWS_SESSION_TOKEN}'
+  default_region: '${AWS_REGION:us-west-1}'
   regions:
     - us-west-1
     - us-east-1

--- a/metricbeat/docs/modules/aws.asciidoc
+++ b/metricbeat/docs/modules/aws.asciidoc
@@ -14,8 +14,11 @@ The default metricsets are `ec2`, `sqs`, `s3_request`, `s3_daily_storage` and `c
 [float]
 === Module-specific configuration notes
 
-This module environment variable `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN` and `AWS_REGION`
-references in the config file to set values that need to be configurable during deployment.
+This module uses environment variable `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_SESSION_TOKEN`
+that are referenced in the config file to set values that need to be configurable during deployment. It also
+accept optional configuration `regions` to specify what are the AWS regions to query metrics from. If `regions`
+parameter is not set in the config file, then by default, aws module will query metrics from all available
+AWS regions.
 
 There are two different kinds of AWS credentials can be used here: `access keys` and `temporary security credentials`.
 `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` are the two parts of `access keys`. They are long-term credentials for
@@ -23,7 +26,7 @@ an IAM user or the AWS account root user. Please see
 https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys[AWS Access Keys
  and Secret Access Keys] for more details. `temporary security credentials` has a limited lifetime and consists of an access key ID,
 a secret access key, and a security token which typically returned from `GetSessionToken`. MFA-enabled IAM users would
-need to submit an MFA code while calling `GetSessionToken`. `aws_default_region` is to set the region for SDK to use. Please
+need to submit an MFA code while calling `GetSessionToken`. Please
 see https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html[Temporary Security Credentials] for more details.
 `sts get-session-token` AWS CLI can be used to generate temporary credentials. For example. with MFA-enabled:
 
@@ -55,7 +58,16 @@ metricbeat.modules:
   access_key_id: '${AWS_ACCESS_KEY_ID}'
   secret_access_key: '${AWS_SECRET_ACCESS_KEY}'
   session_token: '${AWS_SESSION_TOKEN}'
-  default_region: '${AWS_REGION:us-west-1}'
+- module: aws
+  period: 300s
+  metricsets:
+    - "s3_daily_storage"
+  access_key_id: '${AWS_ACCESS_KEY_ID}'
+  secret_access_key: '${AWS_SECRET_ACCESS_KEY}'
+  session_token: '${AWS_SESSION_TOKEN}'
+  regions:
+    - us-west-1
+    - us-east-1
 ----
 
 [float]
@@ -135,6 +147,8 @@ metricbeat.modules:
   secret_access_key: '${AWS_SECRET_ACCESS_KEY:""}'
   session_token: '${AWS_SESSION_TOKEN:""}'
   default_region: '${AWS_REGION:us-west-1}'
+  #regions:
+  #  - us-west-1
 - module: aws
   period: 300s
   metricsets:
@@ -150,6 +164,9 @@ metricbeat.modules:
         - name: InstanceId
           value: i-0686946e22cf9494a
     - namespace: AWS/EBS
+  #regions:
+  #  - us-east-1
+  #  - us-east-2
 ----
 
 [float]

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -175,6 +175,8 @@ metricbeat.modules:
   secret_access_key: '${AWS_SECRET_ACCESS_KEY:""}'
   session_token: '${AWS_SESSION_TOKEN:""}'
   default_region: '${AWS_REGION:us-west-1}'
+  #regions:
+  #  - us-west-1
 - module: aws
   period: 300s
   metricsets:
@@ -190,6 +192,9 @@ metricbeat.modules:
         - name: InstanceId
           value: i-0686946e22cf9494a
     - namespace: AWS/EBS
+  #regions:
+  #  - us-east-1
+  #  - us-east-2
 
 #--------------------------------- Ceph Module ---------------------------------
 - module: ceph

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -173,8 +173,8 @@ metricbeat.modules:
   secret_access_key: '${AWS_SECRET_ACCESS_KEY:""}'
   session_token: '${AWS_SESSION_TOKEN:""}'
   default_region: '${AWS_REGION:us-west-1}'
-#  regions:
-#    - us-west-1
+  #regions:
+  #  - us-west-1
 - module: aws
   period: 86400s
   metricsets:

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -161,11 +161,20 @@ metricbeat.modules:
   period: 300s
   metricsets:
     - ec2
+  access_key_id: '${AWS_ACCESS_KEY_ID:""}'
+  secret_access_key: '${AWS_SECRET_ACCESS_KEY:""}'
+  session_token: '${AWS_SESSION_TOKEN:""}'
+  default_region: '${AWS_REGION:us-west-1}'
+- module: aws
+  period: 300s
+  metricsets:
     - sqs
   access_key_id: '${AWS_ACCESS_KEY_ID:""}'
   secret_access_key: '${AWS_SECRET_ACCESS_KEY:""}'
   session_token: '${AWS_SESSION_TOKEN:""}'
   default_region: '${AWS_REGION:us-west-1}'
+#  regions:
+#    - us-west-1
 - module: aws
   period: 86400s
   metricsets:

--- a/x-pack/metricbeat/module/aws/_meta/config.yml
+++ b/x-pack/metricbeat/module/aws/_meta/config.yml
@@ -16,6 +16,8 @@
   secret_access_key: '${AWS_SECRET_ACCESS_KEY:""}'
   session_token: '${AWS_SESSION_TOKEN:""}'
   default_region: '${AWS_REGION:us-west-1}'
+  #regions:
+  #  - us-west-1
 - module: aws
   period: 300s
   metricsets:
@@ -31,3 +33,6 @@
         - name: InstanceId
           value: i-0686946e22cf9494a
     - namespace: AWS/EBS
+  #regions:
+  #  - us-east-1
+  #  - us-east-2

--- a/x-pack/metricbeat/module/aws/_meta/config.yml
+++ b/x-pack/metricbeat/module/aws/_meta/config.yml
@@ -2,11 +2,20 @@
   period: 300s
   metricsets:
     - ec2
+  access_key_id: '${AWS_ACCESS_KEY_ID:""}'
+  secret_access_key: '${AWS_SECRET_ACCESS_KEY:""}'
+  session_token: '${AWS_SESSION_TOKEN:""}'
+  default_region: '${AWS_REGION:us-west-1}'
+- module: aws
+  period: 300s
+  metricsets:
     - sqs
   access_key_id: '${AWS_ACCESS_KEY_ID:""}'
   secret_access_key: '${AWS_SECRET_ACCESS_KEY:""}'
   session_token: '${AWS_SESSION_TOKEN:""}'
   default_region: '${AWS_REGION:us-west-1}'
+#  regions:
+#    - us-west-1
 - module: aws
   period: 86400s
   metricsets:

--- a/x-pack/metricbeat/module/aws/_meta/config.yml
+++ b/x-pack/metricbeat/module/aws/_meta/config.yml
@@ -14,8 +14,8 @@
   secret_access_key: '${AWS_SECRET_ACCESS_KEY:""}'
   session_token: '${AWS_SESSION_TOKEN:""}'
   default_region: '${AWS_REGION:us-west-1}'
-#  regions:
-#    - us-west-1
+  #regions:
+  #  - us-west-1
 - module: aws
   period: 86400s
   metricsets:

--- a/x-pack/metricbeat/module/aws/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/aws/_meta/docs.asciidoc
@@ -7,8 +7,11 @@ The default metricsets are `ec2`, `sqs`, `s3_request`, `s3_daily_storage` and `c
 [float]
 === Module-specific configuration notes
 
-This module environment variable `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN` and `AWS_REGION`
-references in the config file to set values that need to be configurable during deployment.
+This module uses environment variable `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_SESSION_TOKEN`
+that are referenced in the config file to set values that need to be configurable during deployment. It also
+accept optional configuration `regions` to specify what are the AWS regions to query metrics from. If `regions`
+parameter is not set in the config file, then by default, aws module will query metrics from all available
+AWS regions.
 
 There are two different kinds of AWS credentials can be used here: `access keys` and `temporary security credentials`.
 `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` are the two parts of `access keys`. They are long-term credentials for
@@ -16,7 +19,7 @@ an IAM user or the AWS account root user. Please see
 https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys[AWS Access Keys
  and Secret Access Keys] for more details. `temporary security credentials` has a limited lifetime and consists of an access key ID,
 a secret access key, and a security token which typically returned from `GetSessionToken`. MFA-enabled IAM users would
-need to submit an MFA code while calling `GetSessionToken`. `aws_default_region` is to set the region for SDK to use. Please
+need to submit an MFA code while calling `GetSessionToken`. Please
 see https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html[Temporary Security Credentials] for more details.
 `sts get-session-token` AWS CLI can be used to generate temporary credentials. For example. with MFA-enabled:
 
@@ -48,7 +51,16 @@ metricbeat.modules:
   access_key_id: '${AWS_ACCESS_KEY_ID}'
   secret_access_key: '${AWS_SECRET_ACCESS_KEY}'
   session_token: '${AWS_SESSION_TOKEN}'
-  default_region: '${AWS_REGION:us-west-1}'
+- module: aws
+  period: 300s
+  metricsets:
+    - "s3_daily_storage"
+  access_key_id: '${AWS_ACCESS_KEY_ID}'
+  secret_access_key: '${AWS_SECRET_ACCESS_KEY}'
+  session_token: '${AWS_SESSION_TOKEN}'
+  regions:
+    - us-west-1
+    - us-east-1
 ----
 
 [float]

--- a/x-pack/metricbeat/module/aws/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/aws/_meta/docs.asciidoc
@@ -19,7 +19,8 @@ an IAM user or the AWS account root user. Please see
 https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys[AWS Access Keys
  and Secret Access Keys] for more details. `temporary security credentials` has a limited lifetime and consists of an access key ID,
 a secret access key, and a security token which typically returned from `GetSessionToken`. MFA-enabled IAM users would
-need to submit an MFA code while calling `GetSessionToken`. `default_region` is to set a region for SDK to use for the first AWS API call.
+need to submit an MFA code while calling `GetSessionToken`. `default_region` identifies the AWS Region whose servers you want to send
+your first API request to by default. This is typically the Region closest to you, but it can be any Region.
 Please see https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html[Temporary Security Credentials] for more details.
 `sts get-session-token` AWS CLI can be used to generate temporary credentials. For example. with MFA-enabled:
 

--- a/x-pack/metricbeat/module/aws/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/aws/_meta/docs.asciidoc
@@ -54,7 +54,7 @@ metricbeat.modules:
 - module: aws
   period: 300s
   metricsets:
-    - "s3_daily_storage"
+    - s3_daily_storage
   access_key_id: '${AWS_ACCESS_KEY_ID}'
   secret_access_key: '${AWS_SECRET_ACCESS_KEY}'
   session_token: '${AWS_SESSION_TOKEN}'

--- a/x-pack/metricbeat/module/aws/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/aws/_meta/docs.asciidoc
@@ -7,7 +7,7 @@ The default metricsets are `ec2`, `sqs`, `s3_request`, `s3_daily_storage` and `c
 [float]
 === Module-specific configuration notes
 
-This module uses environment variable `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_SESSION_TOKEN`
+This module uses environment variable `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN` and `AWS_REGION`
 that are referenced in the config file to set values that need to be configurable during deployment. It also
 accept optional configuration `regions` to specify what are the AWS regions to query metrics from. If `regions`
 parameter is not set in the config file, then by default, aws module will query metrics from all available
@@ -19,8 +19,8 @@ an IAM user or the AWS account root user. Please see
 https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys[AWS Access Keys
  and Secret Access Keys] for more details. `temporary security credentials` has a limited lifetime and consists of an access key ID,
 a secret access key, and a security token which typically returned from `GetSessionToken`. MFA-enabled IAM users would
-need to submit an MFA code while calling `GetSessionToken`. Please
-see https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html[Temporary Security Credentials] for more details.
+need to submit an MFA code while calling `GetSessionToken`. `default_region` is to set a region for SDK to use for the first AWS API call.
+Please see https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html[Temporary Security Credentials] for more details.
 `sts get-session-token` AWS CLI can be used to generate temporary credentials. For example. with MFA-enabled:
 
 ----
@@ -51,6 +51,7 @@ metricbeat.modules:
   access_key_id: '${AWS_ACCESS_KEY_ID}'
   secret_access_key: '${AWS_SECRET_ACCESS_KEY}'
   session_token: '${AWS_SESSION_TOKEN}'
+  default_region: '${AWS_REGION:us-west-1}'
 - module: aws
   period: 300s
   metricsets:
@@ -58,6 +59,7 @@ metricbeat.modules:
   access_key_id: '${AWS_ACCESS_KEY_ID}'
   secret_access_key: '${AWS_SECRET_ACCESS_KEY}'
   session_token: '${AWS_SESSION_TOKEN}'
+  default_region: '${AWS_REGION:us-west-1}'
   regions:
     - us-west-1
     - us-east-1

--- a/x-pack/metricbeat/module/aws/aws.go
+++ b/x-pack/metricbeat/module/aws/aws.go
@@ -75,7 +75,7 @@ func NewMetricSet(base mb.BaseMetricSet) (*MetricSet, error) {
 		Value: awsCredentials,
 	}
 
-	awsConfig.Region = "us-east-1"
+	awsConfig.Region = config.DefaultRegion
 
 	durationString, periodSec := convertPeriodToDuration(config.Period)
 	if err != nil {

--- a/x-pack/metricbeat/module/aws/ec2/ec2.go
+++ b/x-pack/metricbeat/module/aws/ec2/ec2.go
@@ -263,7 +263,7 @@ func getInstancesPerRegion(svc ec2iface.EC2API) (instanceIDs []string, instances
 func createMetricDataQuery(metric cloudwatch.Metric, instanceID string, index int, periodInSec int) (metricDataQuery cloudwatch.MetricDataQuery) {
 	statistic := "Average"
 	period := int64(periodInSec)
-	id := "ec2" + strconv.Itoa(index)
+	id := metricsetName + strconv.Itoa(index)
 	metricDims := metric.Dimensions
 
 	for _, dim := range metricDims {

--- a/x-pack/metricbeat/module/aws/mtest/integration.go
+++ b/x-pack/metricbeat/module/aws/mtest/integration.go
@@ -20,6 +20,11 @@ func GetConfigForTest(metricSetName string, period string) (map[string]interface
 	secretAccessKey, okSecretAccessKey := os.LookupEnv("AWS_SECRET_ACCESS_KEY")
 	sessionToken, okSessionToken := os.LookupEnv("AWS_SESSION_TOKEN")
 
+	defaultRegion, _ := os.LookupEnv("AWS_REGION")
+	if defaultRegion == "" {
+		defaultRegion = "us-west-1"
+	}
+
 	info := ""
 	config := map[string]interface{}{}
 	if !okAccessKeyID || accessKeyID == "" {
@@ -33,6 +38,7 @@ func GetConfigForTest(metricSetName string, period string) (map[string]interface
 			"metricsets":        []string{metricSetName},
 			"access_key_id":     accessKeyID,
 			"secret_access_key": secretAccessKey,
+			"default_region":    defaultRegion,
 		}
 
 		if okSessionToken && sessionToken != "" {

--- a/x-pack/metricbeat/module/aws/mtest/integration.go
+++ b/x-pack/metricbeat/module/aws/mtest/integration.go
@@ -19,10 +19,6 @@ func GetConfigForTest(metricSetName string, period string) (map[string]interface
 	accessKeyID, okAccessKeyID := os.LookupEnv("AWS_ACCESS_KEY_ID")
 	secretAccessKey, okSecretAccessKey := os.LookupEnv("AWS_SECRET_ACCESS_KEY")
 	sessionToken, okSessionToken := os.LookupEnv("AWS_SESSION_TOKEN")
-	defaultRegion, _ := os.LookupEnv("AWS_REGION")
-	if defaultRegion == "" {
-		defaultRegion = "us-west-1"
-	}
 
 	info := ""
 	config := map[string]interface{}{}
@@ -37,7 +33,6 @@ func GetConfigForTest(metricSetName string, period string) (map[string]interface
 			"metricsets":        []string{metricSetName},
 			"access_key_id":     accessKeyID,
 			"secret_access_key": secretAccessKey,
-			"default_region":    defaultRegion,
 		}
 
 		if okSessionToken && sessionToken != "" {

--- a/x-pack/metricbeat/module/aws/mtest/integration.go
+++ b/x-pack/metricbeat/module/aws/mtest/integration.go
@@ -19,7 +19,6 @@ func GetConfigForTest(metricSetName string, period string) (map[string]interface
 	accessKeyID, okAccessKeyID := os.LookupEnv("AWS_ACCESS_KEY_ID")
 	secretAccessKey, okSecretAccessKey := os.LookupEnv("AWS_SECRET_ACCESS_KEY")
 	sessionToken, okSessionToken := os.LookupEnv("AWS_SESSION_TOKEN")
-
 	defaultRegion, _ := os.LookupEnv("AWS_REGION")
 	if defaultRegion == "" {
 		defaultRegion = "us-west-1"

--- a/x-pack/metricbeat/modules.d/aws.yml.disabled
+++ b/x-pack/metricbeat/modules.d/aws.yml.disabled
@@ -16,6 +16,8 @@
   secret_access_key: '${AWS_SECRET_ACCESS_KEY:""}'
   session_token: '${AWS_SESSION_TOKEN:""}'
   default_region: '${AWS_REGION:us-west-1}'
+  #regions:
+  #  - us-west-1
 - module: aws
   period: 300s
   metricsets:
@@ -31,3 +33,6 @@
         - name: InstanceId
           value: i-0686946e22cf9494a
     - namespace: AWS/EBS
+  #regions:
+  #  - us-east-1
+  #  - us-east-2

--- a/x-pack/metricbeat/modules.d/aws.yml.disabled
+++ b/x-pack/metricbeat/modules.d/aws.yml.disabled
@@ -2,11 +2,20 @@
   period: 300s
   metricsets:
     - ec2
+  access_key_id: '${AWS_ACCESS_KEY_ID:""}'
+  secret_access_key: '${AWS_SECRET_ACCESS_KEY:""}'
+  session_token: '${AWS_SESSION_TOKEN:""}'
+  default_region: '${AWS_REGION:us-west-1}'
+- module: aws
+  period: 300s
+  metricsets:
     - sqs
   access_key_id: '${AWS_ACCESS_KEY_ID:""}'
   secret_access_key: '${AWS_SECRET_ACCESS_KEY:""}'
   session_token: '${AWS_SESSION_TOKEN:""}'
   default_region: '${AWS_REGION:us-west-1}'
+#  regions:
+#    - us-west-1
 - module: aws
   period: 86400s
   metricsets:

--- a/x-pack/metricbeat/modules.d/aws.yml.disabled
+++ b/x-pack/metricbeat/modules.d/aws.yml.disabled
@@ -14,8 +14,8 @@
   secret_access_key: '${AWS_SECRET_ACCESS_KEY:""}'
   session_token: '${AWS_SESSION_TOKEN:""}'
   default_region: '${AWS_REGION:us-west-1}'
-#  regions:
-#    - us-west-1
+  #regions:
+  #  - us-west-1
 - module: aws
   period: 86400s
   metricsets:


### PR DESCRIPTION
This PR is to add `regions` in config for aws module. With `regions`, we give users the ability to specify what are the regions they want to collect cloudwatch metrics from for different AWS services. `regions` is optional, when there is no `regions` in the config, the code will get a full list of AWS regions and loop through all of them. 

Please see https://github.com/elastic/beats/issues/11932 for more details.