### PR TITLE
[7.0] Collect and index CCR auto-follow stats (#11574)

### DIFF
--- a/metricbeat/module/elasticsearch/ccr/data.go
+++ b/metricbeat/module/elasticsearch/ccr/data.go
@@ -51,7 +51,8 @@ var (
 )
 
 type response struct {
-	FollowStats struct {
+	AutoFollowStats map[string]interface{} `json:"auto_follow_stats"`
+	FollowStats     struct {
 		Indices []struct {
 			Shards []map[string]interface{} `json:"shards"`
 		} `json:"indices"`


### PR DESCRIPTION
Backports the following commits to 7.0:
 - Collect and index CCR auto-follow stats (#11574) (#9906)