### PR TITLE
fix TCP input message size problem, issue#11966

### DIFF
--- a/filebeat/inputsource/tcp/client.go
+++ b/filebeat/inputsource/tcp/client.go
@@ -72,6 +72,7 @@ func (c *client) handle() error {
 	r := NewResetableLimitedReader(NewDeadlineReader(c.conn, c.timeout), c.maxMessageSize)
 	buf := bufio.NewReader(r)
 	scanner := bufio.NewScanner(buf)
+	scanner.Buffer(make([]byte, c.maxMessageSize), int(c.maxMessageSize))
 	scanner.Split(c.splitFunc)
 
 	for scanner.Scan() {

--- a/filebeat/inputsource/tcp/server_test.go
+++ b/filebeat/inputsource/tcp/server_test.go
@@ -53,6 +53,7 @@ func TestErrorOnEmptyLineDelimiter(t *testing.T) {
 func TestReceiveEventsAndMetadata(t *testing.T) {
 	expectedMessages := generateMessages(5, 100)
 	largeMessages := generateMessages(10, 4096)
+	overlengthMessages := generateMessages(5, 64*1024+1)
 
 	tests := []struct {
 		name             string
@@ -139,6 +140,13 @@ func TestReceiveEventsAndMetadata(t *testing.T) {
 			},
 			expectedMessages: []string{},
 			messageSent:      randomString(600000),
+		},
+		{
+			name:             "NewLineWithOverlengthMessages",
+			cfg:              map[string]interface{}{},
+			splitFunc:        SplitFunc([]byte("\n")),
+			expectedMessages: overlengthMessages,
+			messageSent:      strings.Join(overlengthMessages, "\n"),
 		},
 	}
 


### PR DESCRIPTION
When Filebeat uses TCP input, we can set the option `max_message_size` as maximum size in bytes of the message received over TCP. But, there is another option that limits the message size when Filebeat calls 

> scanner.Scan()

 to collect data: `MaxScanTokenSize,` the meaning of this option is the maximum size used to buffer a message. Filebeat does not override `MaxScanTokenSize` with `max_message_size`, which causes an error when the value of `max_message_size` we set is greater than `MaxScanTokenSize` and the length of our message is greater than `MaxScanTokenSize` and less than `max_message_size.` (position: filebeat/inputsource/tcp) . beats version: 6.5.4, but 7.0 also has this problem.