### PR TITLE
exclude_usage param is available starting 7.0.1

### DIFF
--- a/metricbeat/module/kibana/kibana.go
+++ b/metricbeat/module/kibana/kibana.go
@@ -38,7 +38,7 @@ var (
 	v6_5_0 = common.MustNewVersion("6.5.0")
 	v6_7_2 = common.MustNewVersion("6.7.2")
 	v7_0_0 = common.MustNewVersion("7.0.0")
-	v7_0_2 = common.MustNewVersion("7.0.2")
+	v7_0_1 = common.MustNewVersion("7.0.1")
 
 	// StatsAPIAvailableVersion is the version of Kibana since when the stats API is available
 	StatsAPIAvailableVersion = v6_4_0
@@ -90,9 +90,9 @@ func IsSettingsAPIAvailable(currentKibanaVersion *common.Version) bool {
 // IsUsageExcludable returns whether the stats API supports the exclude_usage parameter in the
 // given version of Kibana
 func IsUsageExcludable(currentKibanaVersion *common.Version) bool {
-	// (6.7.2 <= currentKibamaVersion < 7.0.0) || (7.0.2 <= currentKibanaVersion)
+	// (6.7.2 <= currentKibamaVersion < 7.0.0) || (7.0.1 <= currentKibanaVersion)
 	return (v6_7_2.LessThanOrEqual(false, currentKibanaVersion) && currentKibanaVersion.LessThan(v7_0_0)) ||
-		v7_0_2.LessThanOrEqual(false, currentKibanaVersion)
+		v7_0_1.LessThanOrEqual(false, currentKibanaVersion)
 }
 
 func fetchPath(http *helper.HTTP, currentPath, newPath string) ([]byte, error) {


### PR DESCRIPTION
Follow up to #11892. Since `exclude_usage` is actually available starting 7.0.1, not 7.0.2, this PR updates the version in the code.