### PR TITLE
Backport #11936 to 7.0: Revert Filebeat SSH login viz to use system.auth.ssh.event

### DIFF
--- a/filebeat/module/system/_meta/kibana/7/dashboard/Filebeat-ssh-login-attempts.json
+++ b/filebeat/module/system/_meta/kibana/7/dashboard/Filebeat-ssh-login-attempts.json
@@ -11,7 +11,7 @@
                         "query": {
                             "query_string": {
                                 "analyze_wildcard": true,
-                                "query": "event.action:Accepted"
+                                "query": "system.auth.ssh.event:Accepted"
                             }
                         }
                     }
@@ -131,7 +131,7 @@
                             "enabled": true,
                             "id": "3",
                             "params": {
-                                "field": "event.action",
+                                "field": "system.auth.ssh.event",
                                 "order": "desc",
                                 "orderBy": "1",
                                 "size": 5
@@ -171,7 +171,7 @@
                         "query": {
                             "query_string": {
                                 "analyze_wildcard": true,
-                                "query": "event.action:Failed OR event.action:Invalid"
+                                "query": "system.auth.ssh.event:Failed OR system.auth.ssh.event:Invalid"
                             }
                         }
                     }
@@ -227,7 +227,7 @@
                         "query": {
                             "query_string": {
                                 "analyze_wildcard": true,
-                                "query": "event.action:Failed OR event.action:Invalid"
+                                "query": "system.auth.ssh.event:Failed OR system.auth.ssh.event:Invalid"
                             }
                         }
                     }
@@ -302,7 +302,7 @@
         {
             "attributes": {
                 "columns": [
-                    "event.action",
+                    "system.auth.ssh.event",
                     "system.auth.ssh.method",
                     "user.name",
                     "source.ip",
@@ -318,7 +318,7 @@
                         "query": {
                             "query_string": {
                                 "analyze_wildcard": true,
-                                "query": "event.dataset:system.auth AND _exists_:event.action"
+                                "query": "event.dataset:system.auth AND _exists_:system.auth.ssh.event"
                             }
                         }
                     }
@@ -420,7 +420,7 @@
                     {
                         "col": 1,
                         "columns": [
-                            "event.action",
+                            "system.auth.ssh.event",
                             "system.auth.ssh.method",
                             "user.name",
                             "source.ip",


### PR DESCRIPTION
Backport had conflicts: master was on KQL and 7.0 is on Lucene.

Closes #11859