### PR TITLE
Add pointer to ILM docs for setting index name

### DIFF
--- a/libbeat/docs/shared-getting-started-intro.asciidoc
+++ b/libbeat/docs/shared-getting-started-intro.asciidoc
@@ -19,4 +19,6 @@ Service for free].
 ==============
 
 After installing the {stack}, read the following topics to learn how to
-install, configure, and run {beatname_uc}:
+install, configure, and run {beatname_uc}. Upgrading to a new version of
+{beatname_uc}? Start by reading the Beats {beats-ref}/upgrading.html[upgrade
+documentation].

--- a/libbeat/docs/shared-ilm.asciidoc
+++ b/libbeat/docs/shared-ilm.asciidoc
@@ -63,6 +63,17 @@ overwrite the template to apply the changes.
 
 The rollover index pattern. The default is `%{now/d}-000001`.
 
+Date math is supported in this setting. For example:
+
+[source,yaml]
+----
+setup.ilm.pattern: "{now/M{YYYY.MM}}-000001"
+----
+
+For more information, see
+{ref}/indices-rollover-index.html#_using_date_math_with_the_rollover_api[Using
+date math with the rollover API].
+
 NOTE: If you modify this setting after loading the index template, you must
 overwrite the template to apply the changes.
 

--- a/libbeat/docs/shared-template-load.asciidoc
+++ b/libbeat/docs/shared-template-load.asciidoc
@@ -64,13 +64,19 @@ If you disable automatic template loading, you need to
 <<load-template-manually,load the template manually>>.
 
 * **Change the index name**
+ifndef::no_ilm[]
 +
-By default, {beatname_uc} writes events to indices named
+TIP: If you're sending events to a cluster that supports index lifecycle
+management, see <<ilm>> to learn how to change the index name.
+endif::no_ilm[]
++
+{beatname_uc} uses time series indices, by default, when index lifecycle
+management is disabled or unsupported. The indices are named
 +{beatname_lc}-{version}-yyyy.MM.dd+, where `yyyy.MM.dd` is the date when the
 events were indexed. To use a different name, you set the
-<<index-option-es,`index`>> option in the Elasticsearch output. The value
-that you specify should include the root name of the index plus version and
-date information. You also need to configure the `setup.template.name` and
+<<index-option-es,`index`>> option in the Elasticsearch output. The value that
+you specify should include the root name of the index plus version and date
+information. You also need to configure the `setup.template.name` and
 `setup.template.pattern` options to match the new name. For example:
 +
 ["source","sh",subs="attributes,callouts"]


### PR DESCRIPTION
Adds a pointer to the docs about configuring ILM (for users who want to rename the index).