### PR TITLE
Remove links to ingest plugins that are now modules

### DIFF
--- a/filebeat/docs/modules/cisco.asciidoc
+++ b/filebeat/docs/modules/cisco.asciidoc
@@ -22,9 +22,6 @@ include::../include/what-happens.asciidoc[]
 [float]
 === Compatibility
 
-This module requires the {plugins}/ingest-geoip.html[ingest-geoip]
-Elasticsearch plugin.
-
 include::../include/running-modules.asciidoc[]
 
 [float]

--- a/filebeat/docs/modules/iptables.asciidoc
+++ b/filebeat/docs/modules/iptables.asciidoc
@@ -28,9 +28,6 @@ When you run the module, it performs a few tasks under the hood:
 [float]
 === Compatibility
 
-This module requires the {plugins}/ingest-geoip.html[ingest-geoip]
-Elasticsearch plugins.
-
 include::../include/running-modules.asciidoc[]
 
 [float]

--- a/filebeat/docs/modules/netflow.asciidoc
+++ b/filebeat/docs/modules/netflow.asciidoc
@@ -21,9 +21,6 @@ Elasticsearch Ingest Node.
 [float]
 === Compatibility
 
-This module requires the {plugins}/ingest-geoip.html[ingest-geoip]
-Elasticsearch plugins.
-
 include::../include/running-modules.asciidoc[]
 
 include::../include/configuring-intro.asciidoc[]

--- a/filebeat/docs/modules/suricata.asciidoc
+++ b/filebeat/docs/modules/suricata.asciidoc
@@ -19,10 +19,6 @@ include::../include/what-happens.asciidoc[]
 [float]
 === Compatibility
 
-This module requires the {plugins}/ingest-geoip.html[ingest-geoip]
-and {plugins}/ingest-user-agent.html[ingest-user-agent]
-Elasticsearch plugins.
-
 This module has been developed against Suricata v4.0.4, but is expected to work
 with other versions of Suricata.
 
@@ -56,6 +52,13 @@ include::../include/config-option-intro.asciidoc[]
 ==== `eve` log fileset settings
 
 include::../include/var-paths.asciidoc[]
+
+:has-dashboards!:
+
+:fileset_ex!:
+
+:modulename!:
+
 
 
 [float]

--- a/filebeat/docs/modules/zeek.asciidoc
+++ b/filebeat/docs/modules/zeek.asciidoc
@@ -16,10 +16,6 @@ https://www.zeek.org/manual/release/logs/index.html[Zeek JSON format].
 [float]
 === Compatibility
 
-This module requires the {plugins}/ingest-geoip.html[ingest-geoip]
-and {plugins}/ingest-user-agent.html[ingest-user-agent]
-Elasticsearch plugins.
-
 This module has been developed against Zeek 2.6.1, but is expected to work
 with other versions of Zeek.
 
@@ -33,6 +29,11 @@ This module comes with a sample dashboard. For example:
 
 [role="screenshot"]
 image::./images/kibana-zeek.png[]
+
+:has-dashboards!:
+
+:modulename!:
+
 
 
 [float]

--- a/x-pack/filebeat/module/cisco/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/cisco/_meta/docs.asciidoc
@@ -17,9 +17,6 @@ include::../include/what-happens.asciidoc[]
 [float]
 === Compatibility
 
-This module requires the {plugins}/ingest-geoip.html[ingest-geoip]
-Elasticsearch plugin.
-
 include::../include/running-modules.asciidoc[]
 
 [float]

--- a/x-pack/filebeat/module/iptables/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/iptables/_meta/docs.asciidoc
@@ -23,9 +23,6 @@ When you run the module, it performs a few tasks under the hood:
 [float]
 === Compatibility
 
-This module requires the {plugins}/ingest-geoip.html[ingest-geoip]
-Elasticsearch plugins.
-
 include::../include/running-modules.asciidoc[]
 
 [float]

--- a/x-pack/filebeat/module/netflow/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/netflow/_meta/docs.asciidoc
@@ -16,9 +16,6 @@ Elasticsearch Ingest Node.
 [float]
 === Compatibility
 
-This module requires the {plugins}/ingest-geoip.html[ingest-geoip]
-Elasticsearch plugins.
-
 include::../include/running-modules.asciidoc[]
 
 include::../include/configuring-intro.asciidoc[]

--- a/x-pack/filebeat/module/suricata/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/suricata/_meta/docs.asciidoc
@@ -14,10 +14,6 @@ include::../include/what-happens.asciidoc[]
 [float]
 === Compatibility
 
-This module requires the {plugins}/ingest-geoip.html[ingest-geoip]
-and {plugins}/ingest-user-agent.html[ingest-user-agent]
-Elasticsearch plugins.
-
 This module has been developed against Suricata v4.0.4, but is expected to work
 with other versions of Suricata.
 
@@ -51,3 +47,10 @@ include::../include/config-option-intro.asciidoc[]
 ==== `eve` log fileset settings
 
 include::../include/var-paths.asciidoc[]
+
+:has-dashboards!:
+
+:fileset_ex!:
+
+:modulename!:
+

--- a/x-pack/filebeat/module/zeek/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/zeek/_meta/docs.asciidoc
@@ -11,10 +11,6 @@ https://www.zeek.org/manual/release/logs/index.html[Zeek JSON format].
 [float]
 === Compatibility
 
-This module requires the {plugins}/ingest-geoip.html[ingest-geoip]
-and {plugins}/ingest-user-agent.html[ingest-user-agent]
-Elasticsearch plugins.
-
 This module has been developed against Zeek 2.6.1, but is expected to work
 with other versions of Zeek.
 
@@ -28,3 +24,8 @@ This module comes with a sample dashboard. For example:
 
 [role="screenshot"]
 image::./images/kibana-zeek.png[]
+
+:has-dashboards!:
+
+:modulename!:
+


### PR DESCRIPTION
Removes links to ingest-geoip and ingest-user-agent plugins because they are now modules (no longer a separate install).

Also clears some attribute values (it's a best practice to clear the value to avoid propagating it into a later file). 