### PR TITLE
[Auditbeat] Socket dataset: Exclude localhost by default

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -17,6 +17,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 - Auditd module: Normalized value of `event.category` field from `user-login` to `authentication`. {pull}11432[11432]
 - Auditd module: Unset `auditd.session` and `user.audit.id` fields are removed from audit events. {issue}11431[11431] {pull}11815[11815]
+- Socket dataset: Exclude localhost by default {pull}11993[11993]
 
 *Filebeat*
 - Modify apache/error dataset to follow ECS. {pull}8963[8963]

--- a/x-pack/auditbeat/auditbeat.reference.yml
+++ b/x-pack/auditbeat/auditbeat.reference.yml
@@ -139,7 +139,7 @@ auditbeat.modules:
   # report local connections.
   # socket.include_localhost: false
 
-# Enabled by default. Auditbeat will read password fields in
+  # Enabled by default. Auditbeat will read password fields in
   # /etc/passwd and /etc/shadow and store a hash locally to
   # detect any changes.
   user.detect_password_changes: true

--- a/x-pack/auditbeat/auditbeat.reference.yml
+++ b/x-pack/auditbeat/auditbeat.reference.yml
@@ -135,7 +135,11 @@ auditbeat.modules:
   # socket.state.period: 12h
   # user.state.period: 12h
 
-  # Enabled by default. Auditbeat will read password fields in
+  # Disabled by default. If enabled, the socket dataset will
+  # report local connections.
+  # socket.include_localhost: false
+
+# Enabled by default. Auditbeat will read password fields in
   # /etc/passwd and /etc/shadow and store a hash locally to
   # detect any changes.
   user.detect_password_changes: true

--- a/x-pack/auditbeat/auditbeat.reference.yml
+++ b/x-pack/auditbeat/auditbeat.reference.yml
@@ -136,7 +136,7 @@ auditbeat.modules:
   # user.state.period: 12h
 
   # Disabled by default. If enabled, the socket dataset will
-  # report local connections.
+  # report sockets to and from localhost.
   # socket.include_localhost: false
 
   # Enabled by default. Auditbeat will read password fields in

--- a/x-pack/auditbeat/docs/modules/system.asciidoc
+++ b/x-pack/auditbeat/docs/modules/system.asciidoc
@@ -66,6 +66,7 @@ sample suggested configuration.
     - user
   period: 10s
   state.period: 12h
+  socket.include_localhost: false
   user.detect_password_changes: true
 ----
 
@@ -74,6 +75,10 @@ datasets - esp. `process` and `socket` - a shorter period is recommended.
 
 *`state.period`*:: The frequency at which the datasets send full state information.
 This option can be overridden per dataset using `{dataset}.state.period`.
+
+*`socket.include_localhost`*:: If the `socket` dataset is configured and this
+option is set to `true`, Auditbeat will include sockets that have localhost
+as either their source and/or destination IP. Defaults to `false`.
 
 *`user.detect_password_changes`*:: If the `user` dataset is configured and
 this option is set to `true`, Auditbeat will read password information in `/etc/passwd`

--- a/x-pack/auditbeat/docs/modules/system.asciidoc
+++ b/x-pack/auditbeat/docs/modules/system.asciidoc
@@ -66,7 +66,9 @@ sample suggested configuration.
     - user
   period: 10s
   state.period: 12h
+
   socket.include_localhost: false
+
   user.detect_password_changes: true
 ----
 
@@ -105,6 +107,7 @@ so a longer polling interval can be used.
     - package
     - user
   period: 1m
+
   user.detect_password_changes: true
 
 - module: system

--- a/x-pack/auditbeat/module/system/_meta/config.yml.tmpl
+++ b/x-pack/auditbeat/module/system/_meta/config.yml.tmpl
@@ -42,7 +42,7 @@
 {{- if .Reference }}
 
   # Disabled by default. If enabled, the socket dataset will
-  # report local connections.
+  # report sockets to and from localhost.
   # socket.include_localhost: false
 {{- end }}
 

--- a/x-pack/auditbeat/module/system/_meta/config.yml.tmpl
+++ b/x-pack/auditbeat/module/system/_meta/config.yml.tmpl
@@ -36,11 +36,13 @@
   {{- end }}
 {{ end }}
   {{ if eq .GOOS "linux" -}}
-{{ if .Reference }}
+
+{{ if .Reference -}}
   # Disabled by default. If enabled, the socket dataset will
   # report local connections.
-  socket.include_localhost: false
-{{- end }}
+  # socket.include_localhost: false
+
+{{ end -}}
 
   # Enabled by default. Auditbeat will read password fields in
   # /etc/passwd and /etc/shadow and store a hash locally to

--- a/x-pack/auditbeat/module/system/_meta/config.yml.tmpl
+++ b/x-pack/auditbeat/module/system/_meta/config.yml.tmpl
@@ -23,7 +23,9 @@
   # current state of the system (e.g. all currently
   # running processes, all open sockets).
   state.period: 12h
-{{ if .Reference }}
+
+{{- if .Reference }}
+
   # The state.period can be overridden for any dataset.
   # host.state.period: 12h
   {{ if ne .GOOS "windows" -}}
@@ -33,24 +35,22 @@
   {{ if eq .GOOS "linux" -}}
   # socket.state.period: 12h
   # user.state.period: 12h
-  {{- end }}
-{{ end }}
-  {{ if eq .GOOS "linux" -}}
+  {{- end -}}
+{{- end -}}
+{{- if eq .GOOS "linux" -}}
 
-{{ if .Reference -}}
+{{- if .Reference }}
+
   # Disabled by default. If enabled, the socket dataset will
   # report local connections.
   # socket.include_localhost: false
-
-{{ end -}}
+{{- end }}
 
   # Enabled by default. Auditbeat will read password fields in
   # /etc/passwd and /etc/shadow and store a hash locally to
   # detect any changes.
   user.detect_password_changes: true
-  {{- end }}
 
-  {{ if eq .GOOS "linux" -}}
   # File patterns of the login record files.
 {{- if .Reference }}
   # wtmp: History of successful logins, logouts, and system shutdowns and boots.

--- a/x-pack/auditbeat/module/system/_meta/config.yml.tmpl
+++ b/x-pack/auditbeat/module/system/_meta/config.yml.tmpl
@@ -36,6 +36,12 @@
   {{- end }}
 {{ end }}
   {{ if eq .GOOS "linux" -}}
+{{ if .Reference }}
+  # Disabled by default. If enabled, the socket dataset will
+  # report local connections.
+  socket.include_localhost: false
+{{- end }}
+
   # Enabled by default. Auditbeat will read password fields in
   # /etc/passwd and /etc/shadow and store a hash locally to
   # detect any changes.

--- a/x-pack/auditbeat/module/system/_meta/docs.asciidoc
+++ b/x-pack/auditbeat/module/system/_meta/docs.asciidoc
@@ -61,6 +61,7 @@ sample suggested configuration.
     - user
   period: 10s
   state.period: 12h
+  socket.include_localhost: false
   user.detect_password_changes: true
 ----
 
@@ -69,6 +70,10 @@ datasets - esp. `process` and `socket` - a shorter period is recommended.
 
 *`state.period`*:: The frequency at which the datasets send full state information.
 This option can be overridden per dataset using `{dataset}.state.period`.
+
+*`socket.include_localhost`*:: If the `socket` dataset is configured and this
+option is set to `true`, Auditbeat will include sockets that have localhost
+as either their source and/or destination IP. Defaults to `false`.
 
 *`user.detect_password_changes`*:: If the `user` dataset is configured and
 this option is set to `true`, Auditbeat will read password information in `/etc/passwd`

--- a/x-pack/auditbeat/module/system/_meta/docs.asciidoc
+++ b/x-pack/auditbeat/module/system/_meta/docs.asciidoc
@@ -61,7 +61,9 @@ sample suggested configuration.
     - user
   period: 10s
   state.period: 12h
+
   socket.include_localhost: false
+
   user.detect_password_changes: true
 ----
 
@@ -100,6 +102,7 @@ so a longer polling interval can be used.
     - package
     - user
   period: 1m
+
   user.detect_password_changes: true
 
 - module: system

--- a/x-pack/auditbeat/module/system/socket/_meta/docs.asciidoc
+++ b/x-pack/auditbeat/module/system/socket/_meta/docs.asciidoc
@@ -12,11 +12,11 @@ It is implemented for Linux only.
 On Linux, the dataset uses the
 http://man7.org/linux/man-pages/man7/sock_diag.7.html[sock_diag netlink subsystem]
 to periodically receive a list of all sockets from the kernel. The polling frequency
-can be set using the `period` configuration parameter. A low value (e.g. `1s`) is
+can be set using the `period` configuration option. A low value (e.g. `1s`) is
 recommended to capture short-lived sockets.
 
 By default, sockets from or to `localhost` will be excluded. This can be controlled using
-the `socket.include_localhost` configuration parameter.
+the `socket.include_localhost` configuration option.
 
 [float]
 ==== Example dashboard

--- a/x-pack/auditbeat/module/system/socket/_meta/docs.asciidoc
+++ b/x-pack/auditbeat/module/system/socket/_meta/docs.asciidoc
@@ -4,7 +4,20 @@ beta[]
 
 This is the `socket` dataset of the system module.
 
+[float]
+=== Implementation
+
 It is implemented for Linux only.
+
+On Linux, the dataset uses the
+http://man7.org/linux/man-pages/man7/sock_diag.7.html[sock_diag netlink subsystem]
+to periodically receive a list of all sockets from the kernel. The polling frequency
+can be set using the `period` configuration parameter. A low value (e.g. `1s`) is
+recommended to capture short-lived sockets.
+
+By default, sockets from or to `localhost` will be excluded. This can be controlled using
+the `socket.include_localhost` configuration parameter.
+
 
 [float]
 ==== Example dashboard

--- a/x-pack/auditbeat/module/system/socket/_meta/docs.asciidoc
+++ b/x-pack/auditbeat/module/system/socket/_meta/docs.asciidoc
@@ -18,7 +18,6 @@ recommended to capture short-lived sockets.
 By default, sockets from or to `localhost` will be excluded. This can be controlled using
 the `socket.include_localhost` configuration parameter.
 
-
 [float]
 ==== Example dashboard
 

--- a/x-pack/auditbeat/module/system/socket/config.go
+++ b/x-pack/auditbeat/module/system/socket/config.go
@@ -12,6 +12,7 @@ import (
 type Config struct {
 	StatePeriod       time.Duration `config:"state.period"`
 	SocketStatePeriod time.Duration `config:"socket.state.period"`
+	IncludeLocalhost  bool          `config:"socket.include_localhost"`
 }
 
 // Validate validates the host metricset config.
@@ -27,5 +28,6 @@ func (c *Config) effectiveStatePeriod() time.Duration {
 }
 
 var defaultConfig = Config{
-	StatePeriod: 1 * time.Hour,
+	StatePeriod:      1 * time.Hour,
+	IncludeLocalhost: false,
 }

--- a/x-pack/auditbeat/module/system/socket/socket.go
+++ b/x-pack/auditbeat/module/system/socket/socket.go
@@ -220,8 +220,8 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // Fetch collects the user information. It is invoked periodically.
 func (ms *MetricSet) Fetch(report mb.ReporterV2) {
 	needsStateUpdate := time.Since(ms.lastState) > ms.config.effectiveStatePeriod()
-	if needsStateUpdate || ms.cache.IsEmpty() {
-		ms.log.Debugf("State update needed (needsStateUpdate=%v, cache.IsEmpty()=%v)", needsStateUpdate, ms.cache.IsEmpty())
+	if needsStateUpdate {
+		ms.log.Debug("Sending state")
 		err := ms.reportState(report)
 		if err != nil {
 			ms.log.Error(err)

--- a/x-pack/auditbeat/module/system/socket/socket.go
+++ b/x-pack/auditbeat/module/system/socket/socket.go
@@ -391,7 +391,15 @@ func (ms *MetricSet) getSockets() ([]*Socket, error) {
 
 	sockets := make([]*Socket, 0, len(diags))
 	for _, diag := range diags {
-		sockets = append(sockets, newSocket(diag))
+		socket := newSocket(diag)
+
+		if !ms.config.IncludeLocalhost &&
+			(socket.LocalIP.IsLoopback() || socket.RemoteIP.IsLoopback()) {
+
+			continue
+		}
+
+		sockets = append(sockets, socket)
 	}
 
 	return sockets, nil

--- a/x-pack/auditbeat/module/system/socket/socket_test.go
+++ b/x-pack/auditbeat/module/system/socket/socket_test.go
@@ -65,8 +65,9 @@ func testSocket() *Socket {
 }
 
 func TestOutbound(t *testing.T) {
-	// Consume first set of events - list of all currently open sockets
 	ms := mbtest.NewReportingMetricSetV2(t, getConfig())
+
+	// Consume first set of events - list of all currently open sockets
 	events, errs := mbtest.ReportingFetchV2(ms)
 	if errs != nil {
 		t.Fatal("fetch", errs)
@@ -110,8 +111,9 @@ func TestOutbound(t *testing.T) {
 }
 
 func TestListening(t *testing.T) {
-	// Consume first set of events - list of all currently open sockets
 	ms := mbtest.NewReportingMetricSetV2(t, getConfig())
+
+	// Consume first set of events - list of all currently open sockets
 	events, errs := mbtest.ReportingFetchV2(ms)
 	if errs != nil {
 		t.Fatal("fetch", errs)

--- a/x-pack/auditbeat/module/system/socket/socket_test.go
+++ b/x-pack/auditbeat/module/system/socket/socket_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/elastic/beats/auditbeat/core"
 	abtest "github.com/elastic/beats/auditbeat/testing"
+	"github.com/elastic/beats/libbeat/common"
 	sock "github.com/elastic/beats/metricbeat/helper/socket"
 	"github.com/elastic/beats/metricbeat/mb"
 	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
@@ -63,17 +64,58 @@ func testSocket() *Socket {
 	}
 }
 
-func TestFetch(t *testing.T) {
-	defer abtest.SetupDataDir(t)()
-
-	// Consume first event: list of all currently open sockets
+func TestOutbound(t *testing.T) {
+	// Consume first set of events - list of all currently open sockets
 	ms := mbtest.NewReportingMetricSetV2(t, getConfig())
 	events, errs := mbtest.ReportingFetchV2(ms)
 	if errs != nil {
 		t.Fatal("fetch", errs)
 	}
-	_, err := events[0].RootFields.HasKey("destination.port")
-	assert.NoError(t, err)
+
+	conn, err := net.Dial("tcp", "google.com:80")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	localPort := getPort(t, conn.LocalAddr())
+
+	// Consume second set of events - should contain socket we just opened
+	events, errs = mbtest.ReportingFetchV2(ms)
+	if errs != nil {
+		t.Fatal("fetch", errs)
+	}
+
+	var event *mb.Event
+	for _, evt := range events {
+		sourcePort, err := evt.RootFields.GetValue("source.port")
+		if assert.NoError(t, err) {
+			if sourcePort == localPort {
+				event = &evt
+				break
+			}
+		}
+	}
+
+	if event == nil {
+		t.Fatal("socket not found")
+	}
+
+	checkFieldValue(t, event.RootFields, "event.action", eventActionSocketOpened.String())
+	checkFieldValue(t, event.RootFields, "process.pid", os.Getpid())
+	checkFieldValue(t, event.RootFields, "process.name", "socket.test")
+	checkFieldValue(t, event.RootFields, "user.id", os.Geteuid())
+	checkFieldValue(t, event.RootFields, "network.direction", sock.Outbound.String())
+	checkFieldValue(t, event.RootFields, "destination.port", 80)
+}
+
+func TestListening(t *testing.T) {
+	// Consume first set of events - list of all currently open sockets
+	ms := mbtest.NewReportingMetricSetV2(t, getConfig())
+	events, errs := mbtest.ReportingFetchV2(ms)
+	if errs != nil {
+		t.Fatal("fetch", errs)
+	}
 
 	ln, err := net.Listen("tcp", ":0")
 	if err != nil {
@@ -81,74 +123,154 @@ func TestFetch(t *testing.T) {
 	}
 	defer ln.Close()
 
-	addr := ln.Addr().String()
-	i := strings.LastIndex(addr, ":")
-	listenerPort, err := strconv.Atoi(addr[i+1:])
-	if err != nil {
-		t.Fatal("failed to get port from addr", addr)
-	}
+	listenerPort := getPort(t, ln.Addr())
 
-	// Consume second event: Socket we just opened
+	// Consume second set of events - should contain socket we just opened
 	events, errs = mbtest.ReportingFetchV2(ms)
 	if errs != nil {
 		t.Fatal("fetch", errs)
 	}
 
-	var found bool
+	var event *mb.Event
 	for _, evt := range events {
-		port, ok := getRequiredValue("destination.port", evt, t).(int)
-		if !ok {
-			t.Fatal("destination.port is not an int")
+		destinationPort, err := evt.RootFields.GetValue("destination.port")
+		if assert.NoError(t, err) {
+			if destinationPort == listenerPort {
+				event = &evt
+				break
+			}
 		}
-		if port != listenerPort {
-			continue
-		}
-
-		pid, ok := getRequiredValue("process.pid", evt, t).(int)
-		if !ok {
-			t.Fatal("process.pid is not an int")
-		}
-		assert.Equal(t, os.Getpid(), pid)
-
-		processName, ok := getRequiredValue("process.name", evt, t).(string)
-		if !ok {
-			t.Fatal("process.name is not a string")
-		}
-		assert.Equal(t, "socket.test", processName)
-
-		uid, ok := getRequiredValue("user.id", evt, t).(uint32)
-		if !ok {
-			t.Fatal("user.uid is not a uint32")
-		}
-		assert.EqualValues(t, os.Geteuid(), uid)
-
-		dir, ok := getRequiredValue("network.direction", evt, t).(string)
-		if !ok {
-			t.Fatal("network.direction is not a string")
-		}
-		assert.Equal(t, "listening", dir)
-
-		found = true
-		break
 	}
 
-	assert.True(t, found, "listener not found")
+	if event == nil {
+		t.Fatal("socket not found")
+	}
+
+	checkFieldValue(t, event.RootFields, "event.action", eventActionSocketOpened.String())
+	checkFieldValue(t, event.RootFields, "process.pid", os.Getpid())
+	checkFieldValue(t, event.RootFields, "process.name", "socket.test")
+	checkFieldValue(t, event.RootFields, "user.id", os.Geteuid())
+	checkFieldValue(t, event.RootFields, "network.direction", sock.Listening.String())
 }
 
-func getRequiredValue(key string, mbEvent mb.Event, t testing.TB) interface{} {
-	v, err := mbEvent.RootFields.GetValue(key)
+func TestLocalhost(t *testing.T) {
+	config := getConfig()
+	config["socket.include_localhost"] = true
+
+	ms := mbtest.NewReportingMetricSetV2(t, config)
+
+	// Consume first set of events - list of all currently open sockets
+	events, errs := mbtest.ReportingFetchV2(ms)
+	if errs != nil {
+		t.Fatal("fetch", errs)
+	}
+
+	ln, err := net.Listen("tcp4", "127.0.0.1:")
 	if err != nil {
-		t.Fatalf("err=%v, key=%v, event=%v", key, err, mbEvent)
+		t.Fatal(err)
 	}
-	if v == nil {
-		t.Fatalf("key %v not found in %v", key, mbEvent)
+	defer ln.Close()
+
+	listenerPort := getPort(t, ln.Addr())
+
+	events, errs = mbtest.ReportingFetchV2(ms)
+	if len(errs) > 0 {
+		t.Fatalf("received error: %+v", errs[0])
 	}
-	return v
+	if len(events) == 0 {
+		t.Fatal("no events were generated")
+	}
+
+	var event *mb.Event
+	for _, evt := range events {
+		destinationPort, err := evt.RootFields.GetValue("destination.port")
+		if assert.NoError(t, err) {
+			if destinationPort == listenerPort {
+				event = &evt
+				break
+			}
+		}
+	}
+
+	if event == nil {
+		t.Fatal("socket not found")
+	}
+
+	checkFieldValue(t, event.RootFields, "event.action", eventActionSocketOpened.String())
+	checkFieldValue(t, event.RootFields, "process.pid", os.Getpid())
+	checkFieldValue(t, event.RootFields, "process.name", "socket.test")
+	checkFieldValue(t, event.RootFields, "user.id", os.Geteuid())
+	checkFieldValue(t, event.RootFields, "network.direction", sock.Listening.String())
+	checkFieldValue(t, event.RootFields, "destination.ip", "127.0.0.1")
+}
+
+func TestLocalhostExcluded(t *testing.T) {
+	config := getConfig()
+	config["socket.include_localhost"] = false
+
+	ms := mbtest.NewReportingMetricSetV2(t, config)
+
+	ln, err := net.Listen("tcp4", "127.0.0.1:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	listenerPort := getPort(t, ln.Addr())
+
+	events, errs := mbtest.ReportingFetchV2(ms)
+	if len(errs) > 0 {
+		t.Fatalf("received error: %+v", errs[0])
+	}
+	if len(events) == 0 {
+		t.Fatal("no events were generated")
+	}
+
+	var event *mb.Event
+	for _, evt := range events {
+		destinationPort, err := evt.RootFields.GetValue("destination.port")
+		if assert.NoError(t, err) {
+			if destinationPort == listenerPort {
+				event = &evt
+				break
+			}
+		}
+	}
+
+	if event != nil {
+		t.Fatalf("unexpected socket found: %v", event)
+	}
+}
+
+func checkFieldValue(t *testing.T, mapstr common.MapStr, fieldName string, fieldValue interface{}) {
+	value, err := mapstr.GetValue(fieldName)
+	if assert.NoError(t, err) {
+		switch v := value.(type) {
+		case uint32:
+			assert.Equal(t, fieldValue, int(v))
+		case net.IP:
+			assert.Equal(t, fieldValue, v.String())
+		default:
+			assert.Equal(t, fieldValue, v)
+		}
+	}
 }
 
 func getConfig() map[string]interface{} {
 	return map[string]interface{}{
-		"module":     "system",
-		"metricsets": []string{"socket"},
+		"module":   "system",
+		"datasets": []string{"socket"},
 	}
+}
+
+func getPort(t *testing.T, addr net.Addr) int {
+	s := addr.String()
+	i := strings.LastIndex(s, ":")
+
+	port, err := strconv.Atoi(s[i+1:])
+	if err != nil {
+		t.Fatal("failed to get port from addr", addr)
+	}
+
+	return port
 }

--- a/x-pack/auditbeat/tests/system/test_metricsets.py
+++ b/x-pack/auditbeat/tests/system/test_metricsets.py
@@ -81,7 +81,8 @@ class Test(AuditbeatXPackTest):
         # errors_allowed=True - The socket metricset fills the `error` field if the process enrichment fails
         # (e.g. process has exited). This should not fail the test.
         # warnings_allowed=True - Metricset is beta and that generates a warning, TODO: remove later
-        self.check_metricset("system", "socket", COMMON_FIELDS + fields, errors_allowed=True, warnings_allowed=True)
+        self.check_metricset("system", "socket", COMMON_FIELDS + fields, extras={"socket.include_localhost": "true"},
+                             errors_allowed=True, warnings_allowed=True)
 
     @unittest.skipUnless(sys.platform == "linux2", "Only implemented for Linux")
     def test_metricset_user(self):


### PR DESCRIPTION
Adds a new configuration option `socket.include_localhost` to control if sockets from or to localhost/loopback should be included. It defaults to `false` to reduce the large amount of data the dataset produces.

I also took the opportunity to clean up, organize, and expand the unit tests - the tests are now `TestData`, `TestOutbound` (connects to `google.com:80`), `TestListening`, `TestLocalhost`, and `TestLocalhostExcluded`.

I also added a section `Implementation` to the docs with a blurb about how the socket dataset works on Linux.

This is a breaking change since it changes what the socket dataset reports by default. It's worth doing in a minor release IMO since the dataset is quite noisy and the value of local connections is questionable. The current functionality can be restored by setting `socket.include_localhost: true`.