### PR TITLE
Introducing logstash-xpack.yml module configuration variant

### DIFF
--- a/metricbeat/module/logstash/_meta/config-xpack.yml
+++ b/metricbeat/module/logstash/_meta/config-xpack.yml
@@ -1,0 +1,9 @@
+- module: logstash
+  metricsets:
+    - node
+    - node_stats
+  period: 10s
+  hosts: ["localhost:9600"]
+  #username: "user"
+  #password: "secret"
+  xpack.enabled: true

--- a/metricbeat/modules.d/logstash-xpack.yml.disabled
+++ b/metricbeat/modules.d/logstash-xpack.yml.disabled
@@ -1,0 +1,12 @@
+# Module: logstash
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-logstash.html
+
+- module: logstash
+  metricsets:
+    - node
+    - node_stats
+  period: 10s
+  hosts: ["localhost:9600"]
+  #username: "user"
+  #password: "secret"
+  xpack.enabled: true


### PR DESCRIPTION
This PR introduces the `modules.d/logstash-xpack.yml` module configuration variant file. Due to this, users can easily enable the `logstash` Metricbeat module for Stack Monitoring, like so:

```
metricbeat modules enable logstash-xpack
```
