### PR TITLE
Adding JSON paths to FB ES module docs

### DIFF
--- a/filebeat/docs/modules/elasticsearch.asciidoc
+++ b/filebeat/docs/modules/elasticsearch.asciidoc
@@ -76,7 +76,6 @@ Example config:
   audit:
     var.paths:
       - /var/log/elasticsearch/*_access.log  # Plain text logs
-      - /var/log/elasticsearch/*_audit.log   # JSON logs
       - /var/log/elasticsearch/*_audit.json  # JSON logs
 ----
 +

--- a/filebeat/docs/modules/elasticsearch.asciidoc
+++ b/filebeat/docs/modules/elasticsearch.asciidoc
@@ -41,13 +41,13 @@ Example config:
   server:
     enabled: true
     var.paths:
-      - /var/log/elasticsearch/*.log          # Plaintext logs
+      - /var/log/elasticsearch/*.log          # Plain text logs
       - /var/log/elasticsearch/*_server.json  # JSON logs
 ----
 +
-NOTE: If you running against Elasticsearch >= 7.0.0, configure your
+NOTE: If you're running against Elasticsearch >= 7.0.0, configure the
 `var.paths` setting to point to JSON logs. Otherwise, configure it
-to point to plaintext logs.
+to point to plain text logs.
 
 [float]
 ==== `gc` log fileset settings
@@ -75,14 +75,14 @@ Example config:
 ----
   audit:
     var.paths:
-      - /var/log/elasticsearch/*_access.log  # Plaintext logs
+      - /var/log/elasticsearch/*_access.log  # Plain text logs
       - /var/log/elasticsearch/*_audit.log   # JSON logs
       - /var/log/elasticsearch/*_audit.json  # JSON logs
 ----
 +
-NOTE: If you running against Elasticsearch >= 7.0.0, configure your
+NOTE: If you're running against Elasticsearch >= 7.0.0, configure the
 `var.paths` setting to point to JSON logs. Otherwise, configure it
-to point to plaintext logs.
+to point to plain text logs.
 
 [float]
 ==== `slowlog` log fileset settings
@@ -95,15 +95,15 @@ Example config:
 ----
   slowlog:
     var.paths:
-      - /var/log/elasticsearch/*_index_search_slowlog.log     # Plaintext logs
-      - /var/log/elasticsearch/*_index_indexing_slowlog.log   # Plaintext logs
+      - /var/log/elasticsearch/*_index_search_slowlog.log     # Plain text logs
+      - /var/log/elasticsearch/*_index_indexing_slowlog.log   # Plain text logs
       - /var/log/elasticsearch/*_index_search_slowlog.json    # JSON logs
       - /var/log/elasticsearch/*_index_indexing_slowlog.json  # JSON logs
 ----
 +
-NOTE: If you running against Elasticsearch >= 7.0.0, configure your
+NOTE: If you're running against Elasticsearch >= 7.0.0, configure the
 `var.paths` setting to point to JSON logs. Otherwise, configure it
-to point to plaintext logs.
+to point to plain text logs.
 
 [float]
 ==== `deprecation` log fileset settings
@@ -116,13 +116,13 @@ Example config:
 ----
   deprecation:
     var.paths:
-      - /var/log/elasticsearch/*_deprecation.log   # Plaintext logs
+      - /var/log/elasticsearch/*_deprecation.log   # Plain text logs
       - /var/log/elasticsearch/*_deprecation.json  # JSON logs
 ----
 +
-NOTE: If you running against Elasticsearch >= 7.0.0, configure your
+NOTE: If you're running against Elasticsearch >= 7.0.0, configure the
 `var.paths` setting to point to JSON logs. Otherwise, configure it
-to point to plaintext logs.
+to point to plain text logs.
 
 :has-dashboards!:
 

--- a/filebeat/docs/modules/elasticsearch.asciidoc
+++ b/filebeat/docs/modules/elasticsearch.asciidoc
@@ -41,9 +41,13 @@ Example config:
   server:
     enabled: true
     var.paths:
-      - /var/log/elasticsearch/*.log          # Plaintext format path
-      - /var/log/elasticsearch/*_server.json  # JSON format path
+      - /var/log/elasticsearch/*.log          # Plaintext logs
+      - /var/log/elasticsearch/*_server.json  # JSON logs
 ----
++
+NOTE: If you running against Elasticsearch >= 7.0.0, configure your
+`var.paths` setting to point to JSON logs. Otherwise, configure it
+to point to plaintext logs.
 
 [float]
 ==== `gc` log fileset settings
@@ -71,10 +75,14 @@ Example config:
 ----
   audit:
     var.paths:
-      - /var/log/elasticsearch/*_access.log  # Plaintext format path
-      - /var/log/elasticsearch/*_audit.log   # JSON format path
-      - /var/log/elasticsearch/*_audit.json  # JSON format path
+      - /var/log/elasticsearch/*_access.log  # Plaintext logs
+      - /var/log/elasticsearch/*_audit.log   # JSON logs
+      - /var/log/elasticsearch/*_audit.json  # JSON logs
 ----
++
+NOTE: If you running against Elasticsearch >= 7.0.0, configure your
+`var.paths` setting to point to JSON logs. Otherwise, configure it
+to point to plaintext logs.
 
 [float]
 ==== `slowlog` log fileset settings
@@ -87,11 +95,15 @@ Example config:
 ----
   slowlog:
     var.paths:
-      - /var/log/elasticsearch/*_index_search_slowlog.log     # Plaintext format path
-      - /var/log/elasticsearch/*_index_indexing_slowlog.log   # Plaintext format path
-      - /var/log/elasticsearch/*_index_search_slowlog.json    # JSON format path
-      - /var/log/elasticsearch/*_index_indexing_slowlog.json  # JSON format path
+      - /var/log/elasticsearch/*_index_search_slowlog.log     # Plaintext logs
+      - /var/log/elasticsearch/*_index_indexing_slowlog.log   # Plaintext logs
+      - /var/log/elasticsearch/*_index_search_slowlog.json    # JSON logs
+      - /var/log/elasticsearch/*_index_indexing_slowlog.json  # JSON logs
 ----
++
+NOTE: If you running against Elasticsearch >= 7.0.0, configure your
+`var.paths` setting to point to JSON logs. Otherwise, configure it
+to point to plaintext logs.
 
 [float]
 ==== `deprecation` log fileset settings
@@ -104,9 +116,13 @@ Example config:
 ----
   deprecation:
     var.paths:
-      - /var/log/elasticsearch/*_deprecation.log   # Plaintext format path
-      - /var/log/elasticsearch/*_deprecation.json  # JSON format path
+      - /var/log/elasticsearch/*_deprecation.log   # Plaintext logs
+      - /var/log/elasticsearch/*_deprecation.json  # JSON logs
 ----
++
+NOTE: If you running against Elasticsearch >= 7.0.0, configure your
+`var.paths` setting to point to JSON logs. Otherwise, configure it
+to point to plaintext logs.
 
 :has-dashboards!:
 

--- a/filebeat/docs/modules/elasticsearch.asciidoc
+++ b/filebeat/docs/modules/elasticsearch.asciidoc
@@ -41,7 +41,8 @@ Example config:
   server:
     enabled: true
     var.paths:
-      - /var/log/elasticsearch/*.log
+      - /var/log/elasticsearch/*.log          # Plaintext format path
+      - /var/log/elasticsearch/*_server.json  # JSON format path
 ----
 
 [float]
@@ -70,7 +71,9 @@ Example config:
 ----
   audit:
     var.paths:
-      - /var/log/elasticsearch/*_audit.json
+      - /var/log/elasticsearch/*_access.log  # Plaintext format path
+      - /var/log/elasticsearch/*_audit.log   # JSON format path
+      - /var/log/elasticsearch/*_audit.json  # JSON format path
 ----
 
 [float]
@@ -84,8 +87,10 @@ Example config:
 ----
   slowlog:
     var.paths:
-      - /var/log/elasticsearch/*_index_search_slowlog.log
-      - /var/log/elasticsearch/*_index_indexing_slowlog.log
+      - /var/log/elasticsearch/*_index_search_slowlog.log     # Plaintext format path
+      - /var/log/elasticsearch/*_index_indexing_slowlog.log   # Plaintext format path
+      - /var/log/elasticsearch/*_index_search_slowlog.json    # JSON format path
+      - /var/log/elasticsearch/*_index_indexing_slowlog.json  # JSON format path
 ----
 
 [float]
@@ -99,7 +104,8 @@ Example config:
 ----
   deprecation:
     var.paths:
-      - /var/log/elasticsearch/*_deprecation.log
+      - /var/log/elasticsearch/*_deprecation.log   # Plaintext format path
+      - /var/log/elasticsearch/*_deprecation.json  # JSON format path
 ----
 
 :has-dashboards!:

--- a/filebeat/module/elasticsearch/_meta/docs.asciidoc
+++ b/filebeat/module/elasticsearch/_meta/docs.asciidoc
@@ -71,7 +71,6 @@ Example config:
   audit:
     var.paths:
       - /var/log/elasticsearch/*_access.log  # Plain text logs
-      - /var/log/elasticsearch/*_audit.log   # JSON logs
       - /var/log/elasticsearch/*_audit.json  # JSON logs
 ----
 +

--- a/filebeat/module/elasticsearch/_meta/docs.asciidoc
+++ b/filebeat/module/elasticsearch/_meta/docs.asciidoc
@@ -36,7 +36,8 @@ Example config:
   server:
     enabled: true
     var.paths:
-      - /var/log/elasticsearch/*.log
+      - /var/log/elasticsearch/*.log          # Plaintext format path
+      - /var/log/elasticsearch/*_server.json  # JSON format path
 ----
 
 [float]
@@ -65,7 +66,9 @@ Example config:
 ----
   audit:
     var.paths:
-      - /var/log/elasticsearch/*_audit.json
+      - /var/log/elasticsearch/*_access.log  # Plaintext format path
+      - /var/log/elasticsearch/*_audit.log   # JSON format path
+      - /var/log/elasticsearch/*_audit.json  # JSON format path
 ----
 
 [float]
@@ -79,8 +82,10 @@ Example config:
 ----
   slowlog:
     var.paths:
-      - /var/log/elasticsearch/*_index_search_slowlog.log
-      - /var/log/elasticsearch/*_index_indexing_slowlog.log
+      - /var/log/elasticsearch/*_index_search_slowlog.log     # Plaintext format path
+      - /var/log/elasticsearch/*_index_indexing_slowlog.log   # Plaintext format path
+      - /var/log/elasticsearch/*_index_search_slowlog.json    # JSON format path
+      - /var/log/elasticsearch/*_index_indexing_slowlog.json  # JSON format path
 ----
 
 [float]
@@ -94,7 +99,8 @@ Example config:
 ----
   deprecation:
     var.paths:
-      - /var/log/elasticsearch/*_deprecation.log
+      - /var/log/elasticsearch/*_deprecation.log   # Plaintext format path
+      - /var/log/elasticsearch/*_deprecation.json  # JSON format path
 ----
 
 :has-dashboards!:

--- a/filebeat/module/elasticsearch/_meta/docs.asciidoc
+++ b/filebeat/module/elasticsearch/_meta/docs.asciidoc
@@ -36,13 +36,13 @@ Example config:
   server:
     enabled: true
     var.paths:
-      - /var/log/elasticsearch/*.log          # Plaintext logs
+      - /var/log/elasticsearch/*.log          # Plain text logs
       - /var/log/elasticsearch/*_server.json  # JSON logs
 ----
 +
-NOTE: If you running against Elasticsearch >= 7.0.0, configure your
+NOTE: If you're running against Elasticsearch >= 7.0.0, configure the
 `var.paths` setting to point to JSON logs. Otherwise, configure it
-to point to plaintext logs.
+to point to plain text logs.
 
 [float]
 ==== `gc` log fileset settings
@@ -70,14 +70,14 @@ Example config:
 ----
   audit:
     var.paths:
-      - /var/log/elasticsearch/*_access.log  # Plaintext logs
+      - /var/log/elasticsearch/*_access.log  # Plain text logs
       - /var/log/elasticsearch/*_audit.log   # JSON logs
       - /var/log/elasticsearch/*_audit.json  # JSON logs
 ----
 +
-NOTE: If you running against Elasticsearch >= 7.0.0, configure your
+NOTE: If you're running against Elasticsearch >= 7.0.0, configure the
 `var.paths` setting to point to JSON logs. Otherwise, configure it
-to point to plaintext logs.
+to point to plain text logs.
 
 [float]
 ==== `slowlog` log fileset settings
@@ -90,15 +90,15 @@ Example config:
 ----
   slowlog:
     var.paths:
-      - /var/log/elasticsearch/*_index_search_slowlog.log     # Plaintext logs
-      - /var/log/elasticsearch/*_index_indexing_slowlog.log   # Plaintext logs
+      - /var/log/elasticsearch/*_index_search_slowlog.log     # Plain text logs
+      - /var/log/elasticsearch/*_index_indexing_slowlog.log   # Plain text logs
       - /var/log/elasticsearch/*_index_search_slowlog.json    # JSON logs
       - /var/log/elasticsearch/*_index_indexing_slowlog.json  # JSON logs
 ----
 +
-NOTE: If you running against Elasticsearch >= 7.0.0, configure your
+NOTE: If you're running against Elasticsearch >= 7.0.0, configure the
 `var.paths` setting to point to JSON logs. Otherwise, configure it
-to point to plaintext logs.
+to point to plain text logs.
 
 [float]
 ==== `deprecation` log fileset settings
@@ -111,13 +111,13 @@ Example config:
 ----
   deprecation:
     var.paths:
-      - /var/log/elasticsearch/*_deprecation.log   # Plaintext logs
+      - /var/log/elasticsearch/*_deprecation.log   # Plain text logs
       - /var/log/elasticsearch/*_deprecation.json  # JSON logs
 ----
 +
-NOTE: If you running against Elasticsearch >= 7.0.0, configure your
+NOTE: If you're running against Elasticsearch >= 7.0.0, configure the
 `var.paths` setting to point to JSON logs. Otherwise, configure it
-to point to plaintext logs.
+to point to plain text logs.
 
 :has-dashboards!:
 

--- a/filebeat/module/elasticsearch/_meta/docs.asciidoc
+++ b/filebeat/module/elasticsearch/_meta/docs.asciidoc
@@ -36,9 +36,13 @@ Example config:
   server:
     enabled: true
     var.paths:
-      - /var/log/elasticsearch/*.log          # Plaintext format path
-      - /var/log/elasticsearch/*_server.json  # JSON format path
+      - /var/log/elasticsearch/*.log          # Plaintext logs
+      - /var/log/elasticsearch/*_server.json  # JSON logs
 ----
++
+NOTE: If you running against Elasticsearch >= 7.0.0, configure your
+`var.paths` setting to point to JSON logs. Otherwise, configure it
+to point to plaintext logs.
 
 [float]
 ==== `gc` log fileset settings
@@ -66,10 +70,14 @@ Example config:
 ----
   audit:
     var.paths:
-      - /var/log/elasticsearch/*_access.log  # Plaintext format path
-      - /var/log/elasticsearch/*_audit.log   # JSON format path
-      - /var/log/elasticsearch/*_audit.json  # JSON format path
+      - /var/log/elasticsearch/*_access.log  # Plaintext logs
+      - /var/log/elasticsearch/*_audit.log   # JSON logs
+      - /var/log/elasticsearch/*_audit.json  # JSON logs
 ----
++
+NOTE: If you running against Elasticsearch >= 7.0.0, configure your
+`var.paths` setting to point to JSON logs. Otherwise, configure it
+to point to plaintext logs.
 
 [float]
 ==== `slowlog` log fileset settings
@@ -82,11 +90,15 @@ Example config:
 ----
   slowlog:
     var.paths:
-      - /var/log/elasticsearch/*_index_search_slowlog.log     # Plaintext format path
-      - /var/log/elasticsearch/*_index_indexing_slowlog.log   # Plaintext format path
-      - /var/log/elasticsearch/*_index_search_slowlog.json    # JSON format path
-      - /var/log/elasticsearch/*_index_indexing_slowlog.json  # JSON format path
+      - /var/log/elasticsearch/*_index_search_slowlog.log     # Plaintext logs
+      - /var/log/elasticsearch/*_index_indexing_slowlog.log   # Plaintext logs
+      - /var/log/elasticsearch/*_index_search_slowlog.json    # JSON logs
+      - /var/log/elasticsearch/*_index_indexing_slowlog.json  # JSON logs
 ----
++
+NOTE: If you running against Elasticsearch >= 7.0.0, configure your
+`var.paths` setting to point to JSON logs. Otherwise, configure it
+to point to plaintext logs.
 
 [float]
 ==== `deprecation` log fileset settings
@@ -99,9 +111,13 @@ Example config:
 ----
   deprecation:
     var.paths:
-      - /var/log/elasticsearch/*_deprecation.log   # Plaintext format path
-      - /var/log/elasticsearch/*_deprecation.json  # JSON format path
+      - /var/log/elasticsearch/*_deprecation.log   # Plaintext logs
+      - /var/log/elasticsearch/*_deprecation.json  # JSON logs
 ----
++
+NOTE: If you running against Elasticsearch >= 7.0.0, configure your
+`var.paths` setting to point to JSON logs. Otherwise, configure it
+to point to plaintext logs.
 
 :has-dashboards!:
 


### PR DESCRIPTION
Resolves #12000.

Clarifies what log file paths to point to for the Filebeat Elasticsearch module.