### PR TITLE
[Packetbeat] Cherry-pick #11503 to 7.x: nfs: enforce unique ILLEGAL opname when failed to match operation

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -29,6 +29,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 *Packetbeat*
 
 - Add support for mongodb opcode 2013 (OP_MSG). {issue}6191[6191] {pull}8594[8594]
+- NFSv4: Always use opname `ILLEGAL` when failed to match request to a valid nfs operation. {pull}11503[11503]
 
 *Winlogbeat*
 

--- a/packetbeat/protos/nfs/nfs4.go
+++ b/packetbeat/protos/nfs/nfs4.go
@@ -17,8 +17,6 @@
 
 package nfs
 
-import "fmt"
-
 const (
 	opAccess             = 3
 	opClose              = 4
@@ -234,7 +232,7 @@ func (nfs *nfs) findV4MainOpcode(xdr *xdr) string {
 		opname, ok := nfsOpnum4[op]
 
 		if !ok {
-			return fmt.Sprintf("ILLEGAL (%d)", op)
+			return "ILLEGAL"
 		}
 		currentOpname = opname
 


### PR DESCRIPTION
Cherry-pick of PR #11503 to 7.x branch. Original message:

When we fail to map packet to a valid NFS4 operation, then opname
ILLEGAL with opcode it used, like `ILLEGAL (4294967295)`. While
this points to a bug in packet detection, such 'random' illegal
opnames create multiple new operations that confuse kibana.

Do not include opcode into opname ILLEGAL.

Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
(cherry picked from commit f45771555c600234d0429b7b049f8dfe6cc3ef4f)