### PR TITLE
Use time.Duration directly in GetStartTimeEndTime function

### DIFF
--- a/x-pack/metricbeat/module/aws/aws.go
+++ b/x-pack/metricbeat/module/aws/aws.go
@@ -31,10 +31,9 @@ type Config struct {
 // MetricSet is the base metricset for all aws metricsets
 type MetricSet struct {
 	mb.BaseMetricSet
-	RegionsList    []string
-	DurationString string
-	PeriodInSec    int
-	AwsConfig      *awssdk.Config
+	RegionsList []string
+	Period      time.Duration
+	AwsConfig   *awssdk.Config
 }
 
 // ModuleName is the name of this module.
@@ -77,16 +76,10 @@ func NewMetricSet(base mb.BaseMetricSet) (*MetricSet, error) {
 
 	awsConfig.Region = config.DefaultRegion
 
-	durationString, periodSec := convertPeriodToDuration(config.Period)
-	if err != nil {
-		return nil, err
-	}
-
 	metricSet := MetricSet{
-		BaseMetricSet:  base,
-		DurationString: durationString,
-		PeriodInSec:    periodSec,
-		AwsConfig:      &awsConfig,
+		BaseMetricSet: base,
+		Period:        config.Period,
+		AwsConfig:     &awsConfig,
 	}
 
 	// Construct MetricSet with a full regions list
@@ -118,14 +111,6 @@ func getRegions(svc ec2iface.EC2API) (completeRegionsList []string, err error) {
 		completeRegionsList = append(completeRegionsList, *region.RegionName)
 	}
 	return
-}
-
-func convertPeriodToDuration(period time.Duration) (string, int) {
-	// Set starttime double the default frequency earlier than the endtime in order to make sure
-	// GetMetricDataRequest gets the latest data point for each metric.
-	duration := "-" + (period * 2).String()
-	numberPeriod := int(period.Seconds())
-	return duration, numberPeriod
 }
 
 // StringInSlice checks if a string is already exists in list

--- a/x-pack/metricbeat/module/aws/aws_test.go
+++ b/x-pack/metricbeat/module/aws/aws_test.go
@@ -9,7 +9,6 @@ package aws
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -47,39 +46,4 @@ func TestGetRegions(t *testing.T) {
 	}
 	assert.Equal(t, 1, len(regionsList))
 	assert.Equal(t, regionName, regionsList[0])
-}
-
-func TestConvertPeriodToDuration(t *testing.T) {
-	cases := []struct {
-		period               time.Duration
-		expectedDuration     string
-		expectedPeriodNumber int
-	}{
-		{
-			period:               time.Duration(300) * time.Second,
-			expectedDuration:     "-10m0s",
-			expectedPeriodNumber: 300,
-		},
-		{
-			period:               time.Duration(10) * time.Minute,
-			expectedDuration:     "-20m0s",
-			expectedPeriodNumber: 600,
-		},
-		{
-			period:               time.Duration(30) * time.Second,
-			expectedDuration:     "-1m0s",
-			expectedPeriodNumber: 30,
-		},
-		{
-			period:               time.Duration(60) * time.Second,
-			expectedDuration:     "-2m0s",
-			expectedPeriodNumber: 60,
-		},
-	}
-
-	for _, c := range cases {
-		duration, periodSec := convertPeriodToDuration(c.period)
-		assert.Equal(t, c.expectedDuration, duration)
-		assert.Equal(t, c.expectedPeriodNumber, periodSec)
-	}
 }

--- a/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch.go
+++ b/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch.go
@@ -91,10 +91,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // of an error set the Error field of mb.Event or simply call report.Error().
 func (m *MetricSet) Fetch(report mb.ReporterV2) error {
 	// Get startTime and endTime
-	startTime, endTime, err := aws.GetStartTimeEndTime(m.DurationString)
-	if err != nil {
-		return errors.Wrap(err, "error GetStartTimeEndTime")
-	}
+	startTime, endTime := aws.GetStartTimeEndTime(m.Period)
 
 	// Get listMetrics and namespacesTotal from configuration
 	listMetrics, namespacesTotal := readCloudwatchConfig(m.CloudwatchConfigs)
@@ -102,7 +99,7 @@ func (m *MetricSet) Fetch(report mb.ReporterV2) error {
 		awsConfig := m.MetricSet.AwsConfig.Copy()
 		awsConfig.Region = regionName
 		svcCloudwatch := cloudwatch.New(awsConfig)
-		err := createEvents(svcCloudwatch, listMetrics, regionName, m.PeriodInSec, startTime, endTime, report)
+		err := createEvents(svcCloudwatch, listMetrics, regionName, int(m.Period.Seconds()), startTime, endTime, report)
 		if err != nil {
 			return errors.Wrap(err, "createEvents failed")
 		}
@@ -124,7 +121,7 @@ func (m *MetricSet) Fetch(report mb.ReporterV2) error {
 				continue
 			}
 
-			err = createEvents(svcCloudwatch, listMetricsOutput, regionName, m.PeriodInSec, startTime, endTime, report)
+			err = createEvents(svcCloudwatch, listMetricsOutput, regionName, int(m.Period.Seconds()), startTime, endTime, report)
 			if err != nil {
 				return errors.Wrap(err, "createEvents failed for region "+regionName)
 			}

--- a/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch.go
+++ b/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch.go
@@ -99,7 +99,7 @@ func (m *MetricSet) Fetch(report mb.ReporterV2) error {
 		awsConfig := m.MetricSet.AwsConfig.Copy()
 		awsConfig.Region = regionName
 		svcCloudwatch := cloudwatch.New(awsConfig)
-		err := createEvents(svcCloudwatch, listMetrics, regionName, int(m.Period.Seconds()), startTime, endTime, report)
+		err := createEvents(svcCloudwatch, listMetrics, regionName, m.Period, startTime, endTime, report)
 		if err != nil {
 			return errors.Wrap(err, "createEvents failed")
 		}
@@ -121,7 +121,7 @@ func (m *MetricSet) Fetch(report mb.ReporterV2) error {
 				continue
 			}
 
-			err = createEvents(svcCloudwatch, listMetricsOutput, regionName, int(m.Period.Seconds()), startTime, endTime, report)
+			err = createEvents(svcCloudwatch, listMetricsOutput, regionName, m.Period, startTime, endTime, report)
 			if err != nil {
 				return errors.Wrap(err, "createEvents failed for region "+regionName)
 			}
@@ -147,7 +147,7 @@ func readCloudwatchConfig(cloudwatchConfigs []Config) ([]cloudwatch.Metric, []st
 	return listMetrics, namespacesTotal
 }
 
-func constructMetricQueries(listMetricsOutput []cloudwatch.Metric, period int64) []cloudwatch.MetricDataQuery {
+func constructMetricQueries(listMetricsOutput []cloudwatch.Metric, period time.Duration) []cloudwatch.MetricDataQuery {
 	var metricDataQueries []cloudwatch.MetricDataQuery
 	for i, listMetric := range listMetricsOutput {
 		metricDataQuery := createMetricDataQuery(listMetric, i, period)
@@ -178,15 +178,16 @@ func constructLabel(metric cloudwatch.Metric) string {
 	return label
 }
 
-func createMetricDataQuery(metric cloudwatch.Metric, index int, period int64) (metricDataQuery cloudwatch.MetricDataQuery) {
+func createMetricDataQuery(metric cloudwatch.Metric, index int, period time.Duration) (metricDataQuery cloudwatch.MetricDataQuery) {
 	statistic := "Average"
 	id := "cw" + strconv.Itoa(index)
 	label := constructLabel(metric)
+	periodInSec := int64(period.Seconds())
 
 	metricDataQuery = cloudwatch.MetricDataQuery{
 		Id: &id,
 		MetricStat: &cloudwatch.MetricStat{
-			Period: &period,
+			Period: &periodInSec,
 			Stat:   &statistic,
 			Metric: &metric,
 		},
@@ -264,7 +265,7 @@ func convertConfigToListMetrics(cloudwatchConfig Config, namespace string) cloud
 	return listMetricsOutput
 }
 
-func createEvents(svc cloudwatchiface.CloudWatchAPI, listMetricsTotal []cloudwatch.Metric, regionName string, period int, startTime time.Time, endTime time.Time, report mb.ReporterV2) error {
+func createEvents(svc cloudwatchiface.CloudWatchAPI, listMetricsTotal []cloudwatch.Metric, regionName string, period time.Duration, startTime time.Time, endTime time.Time, report mb.ReporterV2) error {
 	identifiers := getIdentifiers(listMetricsTotal)
 	// Initialize events map per region, which stores one event per identifierValue
 	events := map[string]mb.Event{}
@@ -277,7 +278,7 @@ func createEvents(svc cloudwatchiface.CloudWatchAPI, listMetricsTotal []cloudwat
 	var eventsNoIdentifier []mb.Event
 
 	// Construct metricDataQueries
-	metricDataQueries := constructMetricQueries(listMetricsTotal, int64(period))
+	metricDataQueries := constructMetricQueries(listMetricsTotal, period)
 	if len(metricDataQueries) == 0 {
 		return nil
 	}

--- a/x-pack/metricbeat/module/aws/ec2/ec2_test.go
+++ b/x-pack/metricbeat/module/aws/ec2/ec2_test.go
@@ -217,7 +217,7 @@ func TestConstructMetricQueries(t *testing.T) {
 	}
 
 	listMetricsOutput := []cloudwatch.Metric{listMetric}
-	metricDataQuery := constructMetricQueries(listMetricsOutput, instanceID, 300)
+	metricDataQuery := constructMetricQueries(listMetricsOutput, instanceID, 5*time.Minute)
 	assert.Equal(t, 1, len(metricDataQuery))
 	assert.Equal(t, "i-123 CPUUtilization", *metricDataQuery[0].Label)
 	assert.Equal(t, "Average", *metricDataQuery[0].MetricStat.Stat)

--- a/x-pack/metricbeat/module/aws/s3_request/s3_request.go
+++ b/x-pack/metricbeat/module/aws/s3_request/s3_request.go
@@ -54,7 +54,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	}
 
 	// Check if period is set to be multiple of 60s
-	remainder := metricSet.PeriodInSec % 60
+	remainder := int(metricSet.Period.Seconds()) % 60
 	if remainder != 0 {
 		err := errors.New("period needs to be set to 60s (or a multiple of 60s). " +
 			"To avoid data missing or extra costs, please make sure period is set correctly " +
@@ -73,10 +73,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 func (m *MetricSet) Fetch(report mb.ReporterV2) error {
 	namespace := "AWS/S3"
 	// Get startTime and endTime
-	startTime, endTime, err := aws.GetStartTimeEndTime(m.DurationString)
-	if err != nil {
-		return errors.Wrap(err, "Error ParseDuration")
-	}
+	startTime, endTime := aws.GetStartTimeEndTime(m.Period)
 
 	// GetMetricData for AWS S3 from Cloudwatch
 	for _, regionName := range m.MetricSet.RegionsList {
@@ -94,7 +91,7 @@ func (m *MetricSet) Fetch(report mb.ReporterV2) error {
 			continue
 		}
 
-		metricDataQueries := constructMetricQueries(listMetricsOutputs, m.PeriodInSec)
+		metricDataQueries := constructMetricQueries(listMetricsOutputs, int(m.Period.Seconds()))
 		// This happens when S3 cloudwatch request metrics are not enabled.
 		if len(metricDataQueries) == 0 {
 			continue

--- a/x-pack/metricbeat/module/aws/utils.go
+++ b/x-pack/metricbeat/module/aws/utils.go
@@ -16,14 +16,10 @@ import (
 )
 
 // GetStartTimeEndTime function uses durationString to create startTime and endTime for queries.
-func GetStartTimeEndTime(durationString string) (startTime time.Time, endTime time.Time, err error) {
+func GetStartTimeEndTime(duration time.Duration) (startTime time.Time, endTime time.Time) {
 	endTime = time.Now()
-	duration, err := time.ParseDuration(durationString)
-	if err != nil {
-		return
-	}
-	startTime = endTime.Add(duration)
-	return startTime, endTime, nil
+	startTime = endTime.Add(duration * -2)
+	return startTime, endTime
 }
 
 // GetListMetricsOutput function gets listMetrics results from cloudwatch per namespace for each region.

--- a/x-pack/metricbeat/module/aws/utils.go
+++ b/x-pack/metricbeat/module/aws/utils.go
@@ -16,10 +16,11 @@ import (
 )
 
 // GetStartTimeEndTime function uses durationString to create startTime and endTime for queries.
-func GetStartTimeEndTime(duration time.Duration) (startTime time.Time, endTime time.Time) {
-	endTime = time.Now()
-	startTime = endTime.Add(duration * -2)
-	return startTime, endTime
+func GetStartTimeEndTime(period time.Duration) (time.Time, time.Time) {
+	endTime := time.Now()
+	// Set startTime double the period earlier than the endtime in order to
+	// make sure GetMetricDataRequest gets the latest data point for each metric.
+	return endTime.Add(period * -2), endTime
 }
 
 // GetListMetricsOutput function gets listMetrics results from cloudwatch per namespace for each region.

--- a/x-pack/metricbeat/module/aws/utils_test.go
+++ b/x-pack/metricbeat/module/aws/utils_test.go
@@ -112,11 +112,10 @@ func TestGetListMetricsOutput(t *testing.T) {
 }
 
 func TestGetMetricDataPerRegion(t *testing.T) {
-	startTime, endTime, err := GetStartTimeEndTime("-10m")
-	assert.NoError(t, err)
+	startTime, endTime := GetStartTimeEndTime(10 * time.Minute)
 
 	mockSvc := &MockCloudWatchClient{}
-	metricDataQueries := []cloudwatch.MetricDataQuery{}
+	var metricDataQueries []cloudwatch.MetricDataQuery
 	getMetricDataOutput, err := getMetricDataPerRegion(metricDataQueries, nil, mockSvc, startTime, endTime)
 	if err != nil {
 		fmt.Println("failed getMetricDataPerRegion: ", err)
@@ -142,8 +141,7 @@ func TestGetMetricDataPerRegion(t *testing.T) {
 }
 
 func TestGetMetricDataResults(t *testing.T) {
-	startTime, endTime, err := GetStartTimeEndTime("-10m")
-	assert.NoError(t, err)
+	startTime, endTime := GetStartTimeEndTime(10 * time.Minute)
 
 	mockSvc := &MockCloudWatchClient{}
 	metricInfo := cloudwatch.Metric{


### PR DESCRIPTION
In previous PR, I switched period in config from string type to time.Duration type and this made parsing a lot easier. For function `GetStartTimeEndTime`, it can accept time.Duration as input parameter directly to avoid several times of unnecessary parsing. Since this is the only place using `DurationString`, with the change in `GetStartTimeEndTime` function, we can get rid of `convertPeriodToDuration` completely as well. 

This PR is to:
1. Change `GetStartTimeEndTime` input parameter to period in time.Duration format
2. Remove `convertPeriodToDuration` function and the unit test (removing code is always fun 😄)

Thanks to @jsoriano for this suggestion! Link to the comment: https://github.com/elastic/beats/pull/11798#discussion_r278058849