### PR TITLE
Disable flaky test test_clean_removed_with_clean_inactive (#10606)

### DIFF
--- a/filebeat/tests/system/test_registrar.py
+++ b/filebeat/tests/system/test_registrar.py
@@ -870,6 +870,7 @@ class Test(BaseTest):
         # Make sure the last file in the registry is the correct one and has the correct offset
         assert data[0]["offset"] == self.input_logs.size(file2)
 
+    @unittest.skip('flaky test https://github.com/elastic/beats/issues/10606')
     def test_clean_removed_with_clean_inactive(self):
         """
         Checks that files which were removed, the state is removed


### PR DESCRIPTION
This test is flaky on at least windows and mac, and probably linux as well (in its current form it has multiple race conditions).