### PR TITLE
Fix return placement in cli_test

### DIFF
--- a/libbeat/common/cli/cli_test.go
+++ b/libbeat/common/cli/cli_test.go
@@ -48,8 +48,8 @@ func TestExitWithError(t *testing.T) {
 			RunWith(func(cmd *cobra.Command, args []string) error {
 				return fmt.Errorf("Something bad")
 			})(cmd, args)
-			return
 		}()
+		return
 	}
 
 	stderr, err := runCli("TestExitWithError")


### PR DESCRIPTION
`cli_test.go:TestExitWithError` puts its `return` in the wrong place (inside the nested anonymous function call, rather than immediately after it as the other tests do). This makes no difference if `TestExitWithError` works as it's supposed to, because the expected behavior is to immediately terminate the program. But if a bug prevented that, instead of just failing the test it would pass through to the next block and create a chain of child processes all attempting to do the same client test.

(The main reason this is a concern is because I'm writing a new test based on the same pattern, and copy-pasting that code would have given the wrong behavior 😜)