### PR TITLE
[libbeat] Add unit tests for libbeat's client proxy settings

### DIFF
--- a/libbeat/outputs/elasticsearch/client_proxy_test.go
+++ b/libbeat/outputs/elasticsearch/client_proxy_test.go
@@ -218,6 +218,11 @@ func (tl *testListeners) close() {
 
 func (tl *testListeners) checkFinalState(
 	t *testing.T, expectedServerCount int, expectedProxyCount int) {
+	// The lock here should be superfluous, since we only call checkFinalState
+	// after the clients have terminated, but golang still detects it as a data
+	// race, so we lock here anyway.
+	tl.mutex.Lock()
+	defer tl.mutex.Unlock()
 	assert.Equal(t, expectedServerCount, tl.serverRequestCount)
 	assert.Equal(t, expectedProxyCount, tl.proxyRequestCount)
 	if len(tl.errors) > 0 {

--- a/libbeat/outputs/elasticsearch/client_proxy_test.go
+++ b/libbeat/outputs/elasticsearch/client_proxy_test.go
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 // This file contains tests to confirm that elasticsearch.Client uses proxy
 // settings following the intended precedence.
 
@@ -15,8 +32,9 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/elastic/beats/libbeat/outputs/outil"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/libbeat/outputs/outil"
 )
 
 // TestClientPing is a placeholder test that does nothing on a standard run,
@@ -165,7 +183,9 @@ type testListeners struct {
 	server *httptest.Server
 	proxy  *httptest.Server
 
-	// T
+	// This mutex must be held in order to modify the structure.
+	// Using a mutex for servers that are expected to receive ~1 request in
+	// their lifetime might be pedantic, but I really dislike race conditions.
 	mutex sync.Mutex
 
 	serverRequestCount int // Requests directly to the server
@@ -174,7 +194,10 @@ type testListeners struct {
 	errors []string
 }
 
+// start creates and starts the server and proxy listeners.
 func (tl *testListeners) start(t *testing.T) {
+	tl.mutex.Lock()
+	defer tl.mutex.Unlock()
 	tl.server = httptest.NewServer(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			tl.mutex.Lock()

--- a/libbeat/outputs/elasticsearch/client_proxy_test.go
+++ b/libbeat/outputs/elasticsearch/client_proxy_test.go
@@ -194,7 +194,7 @@ func (s serverState) proxyRequestCount() int {
 	return s._proxyRequestCount.Load()
 }
 
-// startServers starts endpoints representing a backend sefrver and a proxy,
+// startServers starts endpoints representing a backend server and a proxy,
 // and returns the corresponding serverState and a teardown function that
 // should be called to shut them down at the end of the test.
 func startServers(t *testing.T) (*serverState, func()) {


### PR DESCRIPTION
These tests set up server listeners and create libbeat clients with varying proxy settings, and verify that the clients ping the correct target URL.

This is a preparation for #11713, since most of the logic (and work) is in testing the proxy settings; the much simpler PR adding the proxy-disable flag will be a followup to this one, to keep the functional changes isolated in case of rollbacks etc.