### PR TITLE
[7.0] Backport: Fix typo in autodiscover docs (#11906)

### DIFF
--- a/metricbeat/docs/autodiscover-hints.asciidoc
+++ b/metricbeat/docs/autodiscover-hints.asciidoc
@@ -38,7 +38,7 @@ SSL parameters, as seen in <<configuration-ssl>>.
 [float]
 ===== `co.elastic.logs/raw`
 When an entire module configuration needs to be completely set the `raw` hint can be used. You can provide a
-stringified JSON of the input configuration. `raw` overrides every other hint and can be used to create bot a single or
+stringified JSON of the input configuration. `raw` overrides every other hint and can be used to create both a single or
 a list of configurations.
 
 ["source","yaml",subs="attributes"]


### PR DESCRIPTION
Backports #11906 to the 7.0 branch.