### PR TITLE
Fix memory leak in Filebeat pipeline acker

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -87,6 +87,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix `add_docker_metadata` source matching, using `log.file.path` field now. {pull}11577[11577]
 - Add missing Kubernetes metadata fields to Filebeat CoreDNS module, and fix a documentation error. {pull}11591[11591]
 - Reduce memory usage if long lines are truncated to fit `max_bytes` limit. The line buffer is copied into a smaller buffer now. This allows the runtime to release unused memory earlier. {pull}11524[11524]
+- Fix memory leak in Filebeat pipeline acker. {pull}12063[12063]
 
 *Heartbeat*
 

--- a/libbeat/publisher/pipeline/acker.go
+++ b/libbeat/publisher/pipeline/acker.go
@@ -140,7 +140,9 @@ func (a *gapCountACK) ackLoop() {
 			closing = true
 			a.done = nil
 			if a.events.Load() == 0 {
-				// stop worker, if all events accounted for have been ACKed
+				// stop worker, if all events accounted for have been ACKed.
+				// If new events are added after this acker won't handle them, which may
+				// result in duplicates
 				return
 			}
 

--- a/libbeat/publisher/pipeline/acker.go
+++ b/libbeat/publisher/pipeline/acker.go
@@ -133,7 +133,6 @@ func (a *gapCountACK) ackLoop() {
 
 	acks, drop := a.acks, a.drop
 	closing := false
-	empty := false
 
 	for {
 		select {
@@ -149,7 +148,7 @@ func (a *gapCountACK) ackLoop() {
 			return
 
 		case n := <-acks:
-			empty = a.handleACK(n)
+			empty := a.handleACK(n)
 			if empty && closing && a.events.Load() == 0 {
 				// stop worker, if all events accounted for have been ACKed
 				return

--- a/libbeat/publisher/pipeline/acker.go
+++ b/libbeat/publisher/pipeline/acker.go
@@ -152,7 +152,7 @@ func (a *gapCountACK) ackLoop() {
 		case n := <-acks:
 			empty := a.handleACK(n)
 			if empty && closing && a.events.Load() == 0 {
-				// stop worker, if all events accounted for have been ACKed
+				// stop worker, if and only if all events accounted for have been ACKed
 				return
 			}
 


### PR DESCRIPTION
Before this change acker goroutine was kept forever as processed events
count was not correctly updated.

Filebeat sends an empty event to update file states, this event is not
published, but treated as dropped, without updating counters.

This change makes sures that `a.events` counter is updated for dropped
events too, so the acker gets closed (and freed) after all ACKs happen.

Original work by @jsoriano (#11810), and input from @urso, thank you both!