### PR TITLE
Remove systemd v233 requirement because it's no longer true

### DIFF
--- a/journalbeat/docs/overview.asciidoc
+++ b/journalbeat/docs/overview.asciidoc
@@ -13,9 +13,3 @@ https://www.elastic.co/products/elasticsearch[Elasticsearch] or
 https://www.elastic.co/products/logstash[Logstash].
 
 include::{libbeat-dir}/docs/shared-libbeat-description.asciidoc[]
-
-[float]
-=== Compatibility
-
-{beatname_uc} requires systemd v233 or later. Versions prior to systemd v233
-have a defect that prevents {beatname_uc} from reading rotated journals.


### PR DESCRIPTION
removes compatibility statement as requested by @kvch 

@kvch Which versions do I need to backport this to?