### PR TITLE
Remove empty compatibility sections

### DIFF
--- a/filebeat/docs/modules/cisco.asciidoc
+++ b/filebeat/docs/modules/cisco.asciidoc
@@ -19,9 +19,6 @@ supported by the {filebeat-ref}/filebeat-module-netflow.html[netflow module] in
 
 include::../include/what-happens.asciidoc[]
 
-[float]
-=== Compatibility
-
 include::../include/running-modules.asciidoc[]
 
 [float]

--- a/filebeat/docs/modules/iptables.asciidoc
+++ b/filebeat/docs/modules/iptables.asciidoc
@@ -25,9 +25,6 @@ When you run the module, it performs a few tasks under the hood:
 
 * Deploys dashboards for visualizing the log data.
 
-[float]
-=== Compatibility
-
 include::../include/running-modules.asciidoc[]
 
 [float]

--- a/filebeat/docs/modules/netflow.asciidoc
+++ b/filebeat/docs/modules/netflow.asciidoc
@@ -18,9 +18,6 @@ This module wraps the <<filebeat-input-netflow,netflow input>> to enrich the
 flow records with geolocation information about the IP endpoints by using
 Elasticsearch Ingest Node.
 
-[float]
-=== Compatibility
-
 include::../include/running-modules.asciidoc[]
 
 include::../include/configuring-intro.asciidoc[]

--- a/x-pack/filebeat/module/cisco/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/cisco/_meta/docs.asciidoc
@@ -14,9 +14,6 @@ supported by the {filebeat-ref}/filebeat-module-netflow.html[netflow module] in
 
 include::../include/what-happens.asciidoc[]
 
-[float]
-=== Compatibility
-
 include::../include/running-modules.asciidoc[]
 
 [float]

--- a/x-pack/filebeat/module/iptables/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/iptables/_meta/docs.asciidoc
@@ -20,9 +20,6 @@ When you run the module, it performs a few tasks under the hood:
 
 * Deploys dashboards for visualizing the log data.
 
-[float]
-=== Compatibility
-
 include::../include/running-modules.asciidoc[]
 
 [float]

--- a/x-pack/filebeat/module/netflow/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/netflow/_meta/docs.asciidoc
@@ -13,9 +13,6 @@ This module wraps the <<filebeat-input-netflow,netflow input>> to enrich the
 flow records with geolocation information about the IP endpoints by using
 Elasticsearch Ingest Node.
 
-[float]
-=== Compatibility
-
 include::../include/running-modules.asciidoc[]
 
 include::../include/configuring-intro.asciidoc[]


### PR DESCRIPTION
Follow up to #11986 where I removed links to the old ingest geoip plugin docs but should have removed the entire section.