### PR TITLE
Don't generate autodiscover config when no port matches host hints

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -104,6 +104,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Change diskio metrics retrieval method (only for Windows) from wmi query to DeviceIOControl function using the IOCTL_DISK_PERFORMANCE control code {pull}11635[11635]
 - Call GetMetricData api per region instead of per instance. {issue}11820[11820] {pull}11882[11882]
 - Update documentation with cloudwatch:ListMetrics permission. {pull}11987[11987]
+- Avoid generating hints-based configuration with empty hosts when no exposed port is suitable for the hosts hint. {issue}8264[8264] {pull}[]
 
 *Packetbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -104,7 +104,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Change diskio metrics retrieval method (only for Windows) from wmi query to DeviceIOControl function using the IOCTL_DISK_PERFORMANCE control code {pull}11635[11635]
 - Call GetMetricData api per region instead of per instance. {issue}11820[11820] {pull}11882[11882]
 - Update documentation with cloudwatch:ListMetrics permission. {pull}11987[11987]
-- Avoid generating hints-based configuration with empty hosts when no exposed port is suitable for the hosts hint. {issue}8264[8264] {pull}[]
+- Avoid generating hints-based configuration with empty hosts when no exposed port is suitable for the hosts hint. {issue}8264[8264] {pull}12086[12086]
 
 *Packetbeat*
 

--- a/metricbeat/autodiscover/builder/hints/metrics_test.go
+++ b/metricbeat/autodiscover/builder/hints/metrics_test.go
@@ -83,6 +83,50 @@ func TestGenerateHints(t *testing.T) {
 			result: common.MapStr{},
 		},
 		{
+			message: "Hints with multiple hosts return only the matching one",
+			event: bus.Event{
+				"host": "1.2.3.4",
+				"port": 9090,
+				"hints": common.MapStr{
+					"metrics": common.MapStr{
+						"module": "mockmoduledefaults",
+						"hosts":  "${data.host}:8888,${data.host}:9090",
+					},
+				},
+			},
+			len: 1,
+			result: common.MapStr{
+				"module":     "mockmoduledefaults",
+				"metricsets": []string{"default"},
+				"timeout":    "3s",
+				"period":     "1m",
+				"enabled":    true,
+				"hosts":      []interface{}{"1.2.3.4:9090"},
+			},
+		},
+		{
+			message: "Hints with multiple hosts return only the one with the template",
+			event: bus.Event{
+				"host": "1.2.3.4",
+				"port": 9090,
+				"hints": common.MapStr{
+					"metrics": common.MapStr{
+						"module": "mockmoduledefaults",
+						"hosts":  "${data.host}:8888,${data.host}:${data.port}",
+					},
+				},
+			},
+			len: 1,
+			result: common.MapStr{
+				"module":     "mockmoduledefaults",
+				"metricsets": []string{"default"},
+				"timeout":    "3s",
+				"period":     "1m",
+				"enabled":    true,
+				"hosts":      []interface{}{"1.2.3.4:9090"},
+			},
+		},
+		{
 			message: "Only module hint should return all metricsets",
 			event: bus.Event{
 				"host": "1.2.3.4",

--- a/metricbeat/autodiscover/builder/hints/metrics_test.go
+++ b/metricbeat/autodiscover/builder/hints/metrics_test.go
@@ -68,6 +68,21 @@ func TestGenerateHints(t *testing.T) {
 			result: common.MapStr{},
 		},
 		{
+			message: "Hints without matching port should return nothing",
+			event: bus.Event{
+				"host": "1.2.3.4",
+				"port": 9090,
+				"hints": common.MapStr{
+					"metrics": common.MapStr{
+						"module": "mockmoduledefaults",
+						"hosts":  "${data.host}:8888",
+					},
+				},
+			},
+			len:    0,
+			result: common.MapStr{},
+		},
+		{
 			message: "Only module hint should return all metricsets",
 			event: bus.Event{
 				"host": "1.2.3.4",
@@ -87,7 +102,7 @@ func TestGenerateHints(t *testing.T) {
 			},
 		},
 		{
-			message: "metricsets hint works",
+			message: "Metricsets hint works",
 			event: bus.Event{
 				"host": "1.2.3.4",
 				"hints": common.MapStr{


### PR DESCRIPTION
On metricbeat, when the host autodiscover hint is used, and it includes
the port, one of the exposed ports has to match with the one in the
hint. If not, no configuration should be generated. If it is generated,
it will have empty hosts, what would lead to unexpected errors as the
ones seen in #8264.

Fixes #8264