### PR TITLE
Skip Windows testing if magefile.go does not exist

### DIFF
--- a/dev-tools/jenkins_ci.ps1
+++ b/dev-tools/jenkins_ci.ps1
@@ -34,10 +34,10 @@ $env:RACE_DETECTOR = "true"
 # Install mage from vendor.
 exec { go install github.com/elastic/beats/vendor/github.com/magefile/mage } "mage install FAILURE"
 
-if (Test-Path "$env:beat") {
+if (Test-Path "$env:beat\magefile.go") {
     cd "$env:beat"
 } else {
-    echo "$env:beat does not exist"
+    echo "$env:beat\magefile.go does not exist"
     New-Item -ItemType directory -Path build | Out-Null
     New-Item -Name build\TEST-empty.xml -ItemType File | Out-Null
     exit
@@ -62,5 +62,8 @@ echo "System testing $env:beat"
 $packages = $(go list ./... | select-string -Pattern "/vendor/" -NotMatch | select-string -Pattern "/scripts/cmd/" -NotMatch)
 $packages = ($packages|group|Select -ExpandProperty Name) -join ","
 exec { go test -race -c -cover -covermode=atomic -coverpkg $packages } "go test -race -cover FAILURE"
-Set-Location -Path tests/system
-exec { nosetests --with-timer --with-xunit --xunit-file=../../build/TEST-system.xml } "System test FAILURE"
+
+if (Test-Path "tests\system") {
+    Set-Location -Path tests\system
+    exec { nosetests --with-timer --with-xunit --xunit-file=../../build/TEST-system.xml } "System test FAILURE"
+}


### PR DESCRIPTION
Changes the jenkins_ci.ps1 script to skip testing when magefile.go does not
exist. This will allow us to add projects like x-pack/winlogbeat to the test
matrix because not all branches have an x-pack/winlogbeat/magefile.go
file.


The next step will be to add x-pack/winlogbeat to the test matrix in the JJB config. And cherry-pick this into the other branches that we are actively maintaining and testing on Jenkins.