### PR TITLE
Update vendored gosigar to 0.10.2

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -765,8 +765,8 @@ Elasticsearch, B.V. (https://www.elastic.co/).
 
 --------------------------------------------------------------------
 Dependency: github.com/elastic/gosigar
-Version: v0.10.1
-Revision: fc57ef8c6efc0b4fdc6d7c623173073a6d3d4736
+Version: v0.10.2
+Revision: 1227b9d6877d126ad640087e44439d70dba2df4f
 License type (autodetected): Apache-2.0
 ./vendor/github.com/elastic/gosigar/LICENSE:
 --------------------------------------------------------------------

--- a/vendor/github.com/elastic/gosigar/CHANGELOG.md
+++ b/vendor/github.com/elastic/gosigar/CHANGELOG.md
@@ -2,10 +2,25 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+### Fixed
+
+### Changed
+
+### Deprecated
+
+## [0.10.2]
+
+### Fixed
+- Fix memory leak when getting process arguments. #119
+
 ## [0.10.1]
 
 ### Fixed
-- Replaced the WMI queries with win32 apis due to high CPU usage. #11840
+- Replaced the WMI queries with win32 apis due to high CPU usage. #116
 
 ## [0.10.0]
 

--- a/vendor/github.com/elastic/gosigar/sys/windows/syscall_windows.go
+++ b/vendor/github.com/elastic/gosigar/sys/windows/syscall_windows.go
@@ -526,6 +526,10 @@ func ByteSliceToStringSlice(utf16 []byte) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// Free memory allocated for CommandLineToArgvW arguments.
+	defer syscall.LocalFree((syscall.Handle)(unsafe.Pointer(argsWide)))
+
 	args := make([]string, numArgs)
 	for idx := range args {
 		args[idx] = syscall.UTF16ToString(argsWide[idx][:])

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1246,44 +1246,44 @@
 			"revisionTime": "2018-08-31T13:10:45Z"
 		},
 		{
-			"checksumSHA1": "SyDYkg4fXTa27fsNrjnEQBKoDEQ=",
+			"checksumSHA1": "c1rU7WNZ+1AwZcRPBWhPBHcbZjg=",
 			"path": "github.com/elastic/gosigar",
-			"revision": "fc57ef8c6efc0b4fdc6d7c623173073a6d3d4736",
-			"revisionTime": "2019-04-24T11:51:21Z",
-			"version": "v0.10.1",
-			"versionExact": "v0.10.1"
+			"revision": "1227b9d6877d126ad640087e44439d70dba2df4f",
+			"revisionTime": "2019-05-08T13:07:01Z",
+			"version": "v0.10.2",
+			"versionExact": "v0.10.2"
 		},
 		{
-			"checksumSHA1": "y4HBfgWAm5cwRN3Mn7S3Bn1/pDc=",
+			"checksumSHA1": "TX9y4oPL5YmT4Gb/OU4GIPTdQB4=",
 			"path": "github.com/elastic/gosigar/cgroup",
-			"revision": "fc57ef8c6efc0b4fdc6d7c623173073a6d3d4736",
-			"revisionTime": "2019-04-24T11:51:21Z",
-			"version": "v0.10.1",
-			"versionExact": "v0.10.1"
+			"revision": "1227b9d6877d126ad640087e44439d70dba2df4f",
+			"revisionTime": "2019-05-08T13:07:01Z",
+			"version": "v0.10.2",
+			"versionExact": "v0.10.2"
 		},
 		{
-			"checksumSHA1": "axEkf+eo2z5V+R0nvgr1z+rty4w=",
+			"checksumSHA1": "hPqGM3DENaGfipEODoyZ4mKogTQ=",
 			"path": "github.com/elastic/gosigar/sys",
-			"revision": "fc57ef8c6efc0b4fdc6d7c623173073a6d3d4736",
-			"revisionTime": "2019-04-24T11:51:21Z",
-			"version": "v0.10.1",
-			"versionExact": "v0.10.1"
+			"revision": "1227b9d6877d126ad640087e44439d70dba2df4f",
+			"revisionTime": "2019-05-08T13:07:01Z",
+			"version": "v0.10.2",
+			"versionExact": "v0.10.2"
 		},
 		{
-			"checksumSHA1": "BtggD07yUvVppRyX4HTrRi6sqnQ=",
+			"checksumSHA1": "mLq5lOyD0ZU39ysXuf1ETOLJ+f0=",
 			"path": "github.com/elastic/gosigar/sys/linux",
-			"revision": "fc57ef8c6efc0b4fdc6d7c623173073a6d3d4736",
-			"revisionTime": "2019-04-24T11:51:21Z",
-			"version": "v0.10.1",
-			"versionExact": "v0.10.1"
+			"revision": "1227b9d6877d126ad640087e44439d70dba2df4f",
+			"revisionTime": "2019-05-08T13:07:01Z",
+			"version": "v0.10.2",
+			"versionExact": "v0.10.2"
 		},
 		{
-			"checksumSHA1": "CbP36vKSgkQruWF8PODFN9+SANI=",
+			"checksumSHA1": "R70u1XUHH/t1pquvHEFDeUFtkFk=",
 			"path": "github.com/elastic/gosigar/sys/windows",
-			"revision": "fc57ef8c6efc0b4fdc6d7c623173073a6d3d4736",
-			"revisionTime": "2019-04-24T11:51:21Z",
-			"version": "v0.10.1",
-			"versionExact": "v0.10.1"
+			"revision": "1227b9d6877d126ad640087e44439d70dba2df4f",
+			"revisionTime": "2019-05-08T13:07:01Z",
+			"version": "v0.10.2",
+			"versionExact": "v0.10.2"
 		},
 		{
 			"checksumSHA1": "Klc34HULvwvY4cGA/D8HmqtXLqw=",


### PR DESCRIPTION
#11924 duplicated some code from `go-sysinfo` that is affected by a memory leak (fixed in #12100)

In this case, only master is affected as the PR that introduced the leaky `gosigar` wasn't backported.