### PR TITLE
[7.0] Backport: Fix typo in Filebeat autodiscover hints doc (#11870)

### DIFF
--- a/filebeat/docs/autodiscover-hints.asciidoc
+++ b/filebeat/docs/autodiscover-hints.asciidoc
@@ -56,7 +56,7 @@ co.elastic.logs/fileset.stderr: error
 [float]
 ===== `co.elastic.logs/raw`
 When an entire input/module configuration needs to be completely set the `raw` hint can be used. You can provide a
-stringified JSON of the input configuration. `raw` overrides every other hint and can be used to create bot a single or
+stringified JSON of the input configuration. `raw` overrides every other hint and can be used to create both a single or
 a list of configurations.
 
 ["source","yaml",subs="attributes"]


### PR DESCRIPTION
Backports #11870 to the 7.0 branch.