### PR TITLE
[metricbeat] add make fmt to contributing guide

### DIFF
--- a/docs/devguide/contributing.asciidoc
+++ b/docs/devguide/contributing.asciidoc
@@ -83,21 +83,28 @@ recommend that you install it.
 === Update scripts
 
 The Beats use a variety of scripts based on Python to generate configuration files
-and documentation. The command used for this is:
+and documentation. The primary command used for this is:
 
 [source,shell]
 --------------------------------------------------------------------------------
 make update
 --------------------------------------------------------------------------------
 
-This command has the following dependencies:
+Another command properly formats go source files and adds a copyright header:
+
+[source,shell]
+--------------------------------------------------------------------------------
+make fmt
+--------------------------------------------------------------------------------
+
+These commands have the following dependencies:
 
 * Python >= {python}
 * https://virtualenv.pypa.io/en/latest/[virtualenv] for Python
 
 Virtualenv can be installed with the command `easy_install virtualenv` or `pip
 install virtualenv`. More details can be found
-https://virtualenv.pypa.io/en/latest/installation.html[here].
+https://virtualenv.pypa.io/en/latest/installation.html[here]. Both of these commands should be run before submitting a PR.
 
 [float]
 [[running-testsuite]]


### PR DESCRIPTION
See #11102

The CI pipeline will fail fairly early on if a `make fmt` check fails. However, this command doesn't seem to be anywhere in the documentation, and I've even seen a discuss question about the resulting CI error message. We should add at least one mention of this to the docs.