### PR TITLE
[Filebeat] Introduce UTC as default timezone for modules tests

### DIFF
--- a/filebeat/tests/system/test_modules.py
+++ b/filebeat/tests/system/test_modules.py
@@ -4,7 +4,6 @@ import os
 import unittest
 import glob
 import subprocess
-import time
 
 from elasticsearch import Elasticsearch
 import json

--- a/filebeat/tests/system/test_modules.py
+++ b/filebeat/tests/system/test_modules.py
@@ -142,7 +142,12 @@ class Test(BaseTest):
         output_path = os.path.join(self.working_dir)
         output = open(os.path.join(output_path, "output.log"), "ab")
         output.write(" ".join(cmd) + "\n")
+
+        local_env = os.environ.copy()
+        local_env["TZ"] = 'Etc/UTC'
+
         subprocess.Popen(cmd,
+                         env=local_env,
                          stdin=None,
                          stdout=output,
                          stderr=subprocess.STDOUT,

--- a/filebeat/tests/system/test_modules.py
+++ b/filebeat/tests/system/test_modules.py
@@ -115,9 +115,6 @@ class Test(BaseTest):
             pass
         self.wait_until(lambda: not self.es.indices.exists(self.index_name))
 
-        os.environ['TZ'] = 'Etc/UTC'
-        time.tzset()
-
         cmd = [
             self.filebeat, "-systemTest",
             "-e", "-d", "*", "-once",

--- a/filebeat/tests/system/test_modules.py
+++ b/filebeat/tests/system/test_modules.py
@@ -4,6 +4,7 @@ import os
 import unittest
 import glob
 import subprocess
+import time
 
 from elasticsearch import Elasticsearch
 import json
@@ -113,6 +114,9 @@ class Test(BaseTest):
         except:
             pass
         self.wait_until(lambda: not self.es.indices.exists(self.index_name))
+
+        os.environ['TZ'] = 'Etc/UTC'
+        time.tzset()
 
         cmd = [
             self.filebeat, "-systemTest",


### PR DESCRIPTION
Currently all our modules have convert_timezone disable by default. The reason in 6.x for this was probably that 6.0 did not support convert_timezone and we did not want to introduce a breaking changes. New modules should have convert_timezone enabled by default.

If a module has convert_timezone enabled by default the tests will fail as it takes the timezone of the local computer. To circumvent this, this PR sets the timezone of the tests to UTC so the same time zone is always used.

No generated files were changed in this PR as all modules have convert_timezone off by default. But it will affect https://github.com/elastic/beats/pull/12079 and https://github.com/elastic/beats/pull/12032