### PR TITLE
Cherry-pick #12099 to 6.7: Skip Windows testing if magefile.go does not exist

### DIFF
--- a/dev-tools/jenkins_ci.ps1
+++ b/dev-tools/jenkins_ci.ps1
@@ -38,10 +38,10 @@ echo "Fetching testing dependencies"
 # TODO (elastic/beats#5050): Use a vendored copy of this.
 exec { go get github.com/docker/libcompose }
 
-if (Test-Path "$env:beat") {
+if (Test-Path "$env:beat\magefile.go") {
     cd "$env:beat"
 } else {
-    echo "$env:beat does not exist"
+    echo "$env:beat\magefile.go does not exist"
     New-Item -ItemType directory -Path build | Out-Null
     New-Item -Name build\TEST-empty.xml -ItemType File | Out-Null
     exit
@@ -66,5 +66,8 @@ echo "System testing $env:beat"
 $packages = $(go list ./... | select-string -Pattern "/vendor/" -NotMatch | select-string -Pattern "/scripts/cmd/" -NotMatch)
 $packages = ($packages|group|Select -ExpandProperty Name) -join ","
 exec { go test -race -c -cover -covermode=atomic -coverpkg $packages } "go test -race -cover FAILURE"
-Set-Location -Path tests/system
-exec { nosetests --with-timer --with-xunit --xunit-file=../../build/TEST-system.xml } "System test FAILURE"
+
+if (Test-Path "tests\system") {
+    Set-Location -Path tests\system
+    exec { nosetests --with-timer --with-xunit --xunit-file=../../build/TEST-system.xml } "System test FAILURE"
+}


### PR DESCRIPTION
Cherry-pick of PR #12099 to 6.7 branch. Original message: 

Changes the jenkins_ci.ps1 script to skip testing when magefile.go does not
exist. This will allow us to add projects like x-pack/winlogbeat to the test
matrix because not all branches have an x-pack/winlogbeat/magefile.go
file.


The next step will be to add x-pack/winlogbeat to the test matrix in the JJB config. And cherry-pick this into the other branches that we are actively maintaining and testing on Jenkins.