### PR TITLE
Cherry-pick #12125 to 7.0: Fix goroutine leak on initialization failures of log input

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -36,6 +36,8 @@ https://github.com/elastic/beats/compare/v7.0.0...7.0[Check the HEAD diff]
 
 *Filebeat*
 
+- Fix goroutine leak caused on initialization failures of log input. {pull}12125[12125]
+
 *Heartbeat*
 
 *Journalbeat*

--- a/filebeat/input/log/input.go
+++ b/filebeat/input/log/input.go
@@ -76,6 +76,12 @@ func NewInput(
 	outlet channel.Connector,
 	context input.Context,
 ) (input.Input, error) {
+	cleanupNeeded := true
+	cleanupIfNeeded := func(f func() error) {
+		if cleanupNeeded {
+			f()
+		}
+	}
 
 	// Note: underlying output.
 	//  The input and harvester do have different requirements
@@ -87,11 +93,13 @@ func NewInput(
 	if err != nil {
 		return nil, err
 	}
+	defer cleanupIfNeeded(out.Close)
 
 	// stateOut will only be unblocked if the beat is shut down.
 	// otherwise it can block on a full publisher pipeline, so state updates
 	// can be forwarded correctly to the registrar.
 	stateOut := channel.CloseOnSignal(channel.SubOutlet(out), context.BeatDone)
+	defer cleanupIfNeeded(stateOut.Close)
 
 	meta := context.Meta
 	if len(meta) == 0 {
@@ -137,6 +145,7 @@ func NewInput(
 
 	logp.Info("Configured paths: %v", p.config.Paths)
 
+	cleanupNeeded = false
 	return p, nil
 }
 


### PR DESCRIPTION
Cherry-pick of PR #12125 to 7.0 branch. Original message: 

Detected on #12106, possibly related to  #9302.

These outlets should be probably created on `Run()`, but it
cannot return an error. I'd fix it like this by now,
and would do further refactors on future PRs.