### PR TITLE
[Auditbeat] Fix formatting of config files on macOS and Windows

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -81,6 +81,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Process dataset: Fixed a memory leak under Windows. {pull}12100[12100]
 - Login dataset: Fix re-read of utmp files. {pull}12028[12028]
 - Package dataset: Fixed a crash inside librpm after Auditbeat has been running for a while. {issue}12147[12147] {pull}12168[12168]
+- Fix formatting of config files on macOS and Windows. {pull}12148[12148]
 
 *Filebeat*
 

--- a/auditbeat/docs/modules/auditd.asciidoc
+++ b/auditbeat/docs/modules/auditd.asciidoc
@@ -298,5 +298,6 @@ auditbeat.modules:
     #-a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -k access
     #-a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -k access
 
+
 ----
 

--- a/auditbeat/module/auditd/_meta/config.yml.tmpl
+++ b/auditbeat/module/auditd/_meta/config.yml.tmpl
@@ -41,4 +41,5 @@
     ## Unauthorized access attempts.
     #-a always,exit -F arch=b{{call .ArchBits .GOARCH}} -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -k access
     #-a always,exit -F arch=b{{call .ArchBits .GOARCH}} -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -k access
+
 {{ end }}

--- a/auditbeat/module/file_integrity/_meta/config.yml.tmpl
+++ b/auditbeat/module/file_integrity/_meta/config.yml.tmpl
@@ -11,23 +11,22 @@
   - /sbin
   - /usr/sbin
   - /usr/local/sbin
-  {{- else if eq .GOOS "windows" }}
+{{ else if eq .GOOS "windows" }}
   paths:
   - C:/windows
   - C:/windows/system32
   - C:/Program Files
   - C:/Program Files (x86)
-  {{- else }}
+{{ else }}
   paths:
   - /bin
   - /usr/bin
   - /sbin
   - /usr/sbin
   - /etc
-  {{- end }}
+{{ end -}}
 
 {{- if .Reference }}
-
   # List of regular expressions to filter out notifications for unwanted files.
   # Wrap in single quotes to workaround YAML escaping rules. By default no files
   # are ignored.

--- a/auditbeat/module/file_integrity/_meta/config.yml.tmpl
+++ b/auditbeat/module/file_integrity/_meta/config.yml.tmpl
@@ -1,9 +1,9 @@
-{{ if .Reference -}}
+{{- if .Reference -}}
 # The file integrity module sends events when files are changed (created,
 # updated, deleted). The events contain file metadata and hashes.
 {{ end -}}
 - module: file_integrity
-  {{ if eq .GOOS "darwin" -}}
+  {{- if eq .GOOS "darwin" }}
   paths:
   - /bin
   - /usr/bin
@@ -11,13 +11,13 @@
   - /sbin
   - /usr/sbin
   - /usr/local/sbin
-  {{ else if eq .GOOS "windows" -}}
+  {{- else if eq .GOOS "windows" }}
   paths:
   - C:/windows
   - C:/windows/system32
   - C:/Program Files
   - C:/Program Files (x86)
-  {{ else -}}
+  {{- else }}
   paths:
   - /bin
   - /usr/bin
@@ -25,19 +25,21 @@
   - /usr/sbin
   - /etc
   {{- end }}
-{{ if .Reference }}
+
+{{- if .Reference }}
+
   # List of regular expressions to filter out notifications for unwanted files.
   # Wrap in single quotes to workaround YAML escaping rules. By default no files
   # are ignored.
-  {{ if eq .GOOS "darwin" -}}
+  {{- if eq .GOOS "darwin" }}
   exclude_files:
   - '\.DS_Store$'
   - '\.swp$'
-  {{ else if eq .GOOS "windows" -}}
+  {{- else if eq .GOOS "windows" }}
   exclude_files:
   - '(?i)\.lnk$'
   - '(?i)\.swp$'
-  {{ else -}}
+  {{- else }}
   exclude_files:
   - '(?i)\.sw[nop]$'
   - '~$'
@@ -46,10 +48,10 @@
 
   # List of regular expressions used to explicitly include files. When configured,
   # Auditbeat will ignore files unless they match a pattern.
-  {{ if eq .GOOS "windows" -}}
+  {{- if eq .GOOS "windows" }}
   #include_files:
   #- '\\\.ssh($|\\)'
-  {{ else -}}
+  {{- else }}
   #include_files:
   #- '/\.ssh($|/)'
   {{- end }}

--- a/x-pack/auditbeat/module/system/_meta/config.yml.tmpl
+++ b/x-pack/auditbeat/module/system/_meta/config.yml.tmpl
@@ -7,14 +7,14 @@
 - module: system
   datasets:
     - host    # General host information, e.g. uptime, IPs
-    {{ if eq .GOOS "linux" -}}
+    {{- if eq .GOOS "linux" }}
     - login   # User logins, logouts, and system boots.
-    {{- end }}
-    {{ if ne .GOOS "windows" -}}
+    {{- end -}}
+    {{- if ne .GOOS "windows" }}
     - package # Installed, updated, and removed packages
     {{- end }}
     - process # Started and stopped processes
-    {{ if eq .GOOS "linux" -}}
+    {{- if eq .GOOS "linux" }}
     - socket  # Opened and closed sockets
     - user    # User information
     {{- end }}
@@ -28,11 +28,11 @@
 
   # The state.period can be overridden for any dataset.
   # host.state.period: 12h
-  {{ if ne .GOOS "windows" -}}
+  {{- if ne .GOOS "windows" }}
   # package.state.period: 12h
   {{- end }}
   # process.state.period: 12h
-  {{ if eq .GOOS "linux" -}}
+  {{- if eq .GOOS "linux" }}
   # socket.state.period: 12h
   # user.state.period: 12h
   {{- end }}


### PR DESCRIPTION
I've noticed that the formatting of `auditbeat.yml` and `auditbeat.reference.yml` is not consistent across platforms. The checked in version is for Linux and is fine, but macOS and Windows have a number of additional empty lines breaking up configuration blocks or extending whitespace unnecessarily. This PR should make everything look nice on all platforms.

Change diffs (e.g. using `GOOS=darwin mage config`):

### Linux
N/A (no changes)

### macOS - auditbeat.yml
```
--- auditbeat.yml	2019-05-09 14:30:03.000000000 -0700
+++ auditbeat.darwin.yml	2019-05-09 14:18:27.000000000 -0700
@@ -10,7 +10,6 @@
 #==========================  Modules configuration =============================
 auditbeat.modules:

-
 - module: file_integrity
   paths:
   - /bin
@@ -19,15 +18,12 @@
   - /sbin
   - /usr/sbin
   - /usr/local/sbin
-

 - module: system
   datasets:
     - host    # General host information, e.g. uptime, IPs
-
     - package # Installed, updated, and removed packages
     - process # Started and stopped processes
-

   # How often datasets send state updates with the
   # current state of the system (e.g. all currently
```

### macOS - auditbeat.reference.yml
```
--- auditbeat.reference.yml	2019-05-09 14:30:03.000000000 -0700
+++ auditbeat.reference.darwin.yml	2019-05-09 14:18:43.000000000 -0700
@@ -29,7 +29,6 @@
 #==========================  Modules configuration =============================
 auditbeat.modules:

-
 # The file integrity module sends events when files are changed (created,
 # updated, deleted). The events contain file metadata and hashes.
 - module: file_integrity
@@ -40,7 +39,6 @@
   - /sbin
   - /usr/sbin
   - /usr/local/sbin
-

   # List of regular expressions to filter out notifications for unwanted files.
   # Wrap in single quotes to workaround YAML escaping rules. By default no files
@@ -48,7 +46,6 @@
   exclude_files:
   - '\.DS_Store$'
   - '\.swp$'
-

   # List of regular expressions used to explicitly include files. When configured,
   # Auditbeat will ignore files unless they match a pattern.
@@ -83,10 +80,8 @@
 - module: system
   datasets:
     - host    # General host information, e.g. uptime, IPs
-
     - package # Installed, updated, and removed packages
     - process # Started and stopped processes
-

   # How often datasets send state updates with the
   # current state of the system (e.g. all currently
@@ -97,7 +92,6 @@
   # host.state.period: 12h
   # package.state.period: 12h
   # process.state.period: 12h
-

   # Average file read rate for hashing of the process executable. Default is "50 MiB".
   process.hash.scan_rate_per_sec: 50 MiB
```

### Windows - auditbeat.yml
```
--- auditbeat.yml	2019-05-09 14:33:26.000000000 -0700
+++ auditbeat.windows.yml	2019-05-09 14:19:31.000000000 -0700
@@ -10,22 +10,17 @@
 #==========================  Modules configuration =============================
 auditbeat.modules:

-
 - module: file_integrity
   paths:
   - C:/windows
   - C:/windows/system32
   - C:/Program Files
   - C:/Program Files (x86)
-

 - module: system
   datasets:
     - host    # General host information, e.g. uptime, IPs
-
-
     - process # Started and stopped processes
-

   # How often datasets send state updates with the
   # current state of the system (e.g. all currently
```

### Windows - auditbeat.reference.yml
```
--- auditbeat.reference.yml	2019-05-09 14:33:26.000000000 -0700
+++ auditbeat.reference.windows.yml	2019-05-09 14:19:53.000000000 -0700
@@ -29,7 +29,6 @@
 #==========================  Modules configuration =============================
 auditbeat.modules:

-
 # The file integrity module sends events when files are changed (created,
 # updated, deleted). The events contain file metadata and hashes.
 - module: file_integrity
@@ -38,7 +37,6 @@
   - C:/windows/system32
   - C:/Program Files
   - C:/Program Files (x86)
-

   # List of regular expressions to filter out notifications for unwanted files.
   # Wrap in single quotes to workaround YAML escaping rules. By default no files
@@ -46,13 +44,11 @@
   exclude_files:
   - '(?i)\.lnk$'
   - '(?i)\.swp$'
-

   # List of regular expressions used to explicitly include files. When configured,
   # Auditbeat will ignore files unless they match a pattern.
   #include_files:
   #- '\\\.ssh($|\\)'
-

   # Scan over the configured file paths at startup and send events for new or
   # modified files since the last time Auditbeat was running.
@@ -82,10 +78,7 @@
 - module: system
   datasets:
     - host    # General host information, e.g. uptime, IPs
-
-
     - process # Started and stopped processes
-

   # How often datasets send state updates with the
   # current state of the system (e.g. all currently
@@ -94,9 +87,7 @@

   # The state.period can be overridden for any dataset.
   # host.state.period: 12h
-
   # process.state.period: 12h
-

   # Average file read rate for hashing of the process executable. Default is "50 MiB".
   process.hash.scan_rate_per_sec: 50 MiB
```