### PR TITLE
Fix alias and template setup order

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -72,6 +72,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Replace wmi queries with win32 api calls as they were consuming CPU resources {issue}3249[3249] and {issue}11840[11840]
 - Fix queue.spool.write.flush.events config type. {pull}12080[12080]
 - Fixed a memory leak when using the add_process_metadata processor under Windows. {pull}12100[12100]
+- Fix initial indices not being correctly managed by ILM. {pull}12149[12149]
 
 *Auditbeat*
 

--- a/libbeat/idxmgmt/idxmgmt_test.go
+++ b/libbeat/idxmgmt/idxmgmt_test.go
@@ -32,6 +32,24 @@ import (
 	"github.com/elastic/beats/libbeat/template"
 )
 
+type mockClientHandler struct {
+	alias, policy string
+	expectsPolicy bool
+
+	tmplCfg   *template.TemplateConfig
+	tmplForce bool
+
+	operations []mockCreateOp
+}
+
+type mockCreateOp uint8
+
+const (
+	mockCreatePolicy mockCreateOp = iota
+	mockCreateTemplate
+	mockCreateAlias
+)
+
 func TestDefaultSupport_Enabled(t *testing.T) {
 	cases := map[string]struct {
 		ilmCalls []onCall
@@ -345,69 +363,76 @@ func TestDefaultSupport_TemplateHandling(t *testing.T) {
 			clientHandler := newMockClientHandler()
 			manager := im.Manager(clientHandler, BeatsAssets([]byte("testbeat fields")))
 			err = manager.Setup(test.loadTemplate, test.loadILM)
+			clientHandler.assertInvariants(t)
 			if test.err {
 				assert.Error(t, err)
 			} else {
 				require.NoError(t, err)
 				if test.tmplCfg == nil {
-					assert.Nil(t, clientHandler.tl.tmplCfg)
+					assert.Nil(t, clientHandler.tmplCfg)
 				} else {
-					assert.Equal(t, test.tmplCfg, clientHandler.tl.tmplCfg)
+					assert.Equal(t, test.tmplCfg, clientHandler.tmplCfg)
 				}
-				assert.Equal(t, test.alias, clientHandler.il.alias)
-				assert.Equal(t, test.policy, clientHandler.il.policy)
+				assert.Equal(t, test.alias, clientHandler.alias)
+				assert.Equal(t, test.policy, clientHandler.policy)
 			}
 		})
 	}
 }
 
+func (op mockCreateOp) String() string {
+	names := []string{"create-policy", "create-template", "create-alias"}
+	if int(op) > len(names) {
+		return "unknown"
+	}
+	return names[op]
+}
+
 func newMockClientHandler() *mockClientHandler {
-	tl := mockTemplateLoader{}
-	il := mockILMClientHandler{}
-	return &mockClientHandler{&il, &tl, &tl, &il}
+	return &mockClientHandler{}
 }
 
-type mockClientHandler struct {
-	ilm.ClientHandler
-	template.Loader
-
-	tl *mockTemplateLoader
-	il *mockILMClientHandler
-}
-
-type mockTemplateLoader struct {
-	tmplCfg *template.TemplateConfig
-	force   bool
-}
-
-func (l *mockTemplateLoader) Load(config template.TemplateConfig, _ beat.Info, fields []byte, migration bool) error {
-	l.force = config.Overwrite
-	l.tmplCfg = &config
+func (h *mockClientHandler) Load(config template.TemplateConfig, _ beat.Info, fields []byte, migration bool) error {
+	h.recordOp(mockCreateTemplate)
+	h.tmplForce = config.Overwrite
+	h.tmplCfg = &config
 	return nil
 }
 
-type mockILMClientHandler struct {
-	alias, policy string
-}
-
-func (ch *mockILMClientHandler) CheckILMEnabled(m ilm.Mode) (bool, error) {
+func (h *mockClientHandler) CheckILMEnabled(m ilm.Mode) (bool, error) {
 	return m == ilm.ModeEnabled || m == ilm.ModeAuto, nil
 }
 
-func (ch *mockILMClientHandler) HasAlias(name string) (bool, error) {
-	return ch.alias == name, nil
+func (h *mockClientHandler) HasAlias(name string) (bool, error) {
+	return h.alias == name, nil
 }
 
-func (ch *mockILMClientHandler) CreateAlias(alias ilm.Alias) error {
-	ch.alias = alias.Name
+func (h *mockClientHandler) CreateAlias(alias ilm.Alias) error {
+	h.recordOp(mockCreateAlias)
+	h.alias = alias.Name
 	return nil
 }
 
-func (ch *mockILMClientHandler) HasILMPolicy(name string) (bool, error) {
-	return ch.policy == name, nil
+func (h *mockClientHandler) HasILMPolicy(name string) (bool, error) {
+	return h.policy == name, nil
 }
 
-func (ch *mockILMClientHandler) CreateILMPolicy(policy ilm.Policy) error {
-	ch.policy = policy.Name
+func (h *mockClientHandler) CreateILMPolicy(policy ilm.Policy) error {
+	h.recordOp(mockCreatePolicy)
+	h.policy = policy.Name
 	return nil
+}
+
+func (h *mockClientHandler) recordOp(op mockCreateOp) {
+	h.operations = append(h.operations, op)
+}
+
+func (h *mockClientHandler) assertInvariants(t *testing.T) {
+	for i, op := range h.operations {
+		for _, older := range h.operations[:i] {
+			if older > op {
+				t.Errorf("Operation: '%v' has been executed before '%v'", older, op)
+			}
+		}
+	}
 }

--- a/libbeat/tests/system/test_ilm.py
+++ b/libbeat/tests/system/test_ilm.py
@@ -21,13 +21,13 @@ class TestRunILM(BaseTest):
         self.es = self.es_client()
         self.idxmgmt = IdxMgmt(self.es, self.index_name)
         self.idxmgmt.delete(index=self.custom_alias)
-        self.idxmgmt.delete(index=self.custom_policy)
         self.idxmgmt.delete(index=self.index_name)
+        self.idxmgmt.delete(index=self.custom_policy)
 
     def tearDown(self):
         self.idxmgmt.delete(index=self.custom_alias)
-        self.idxmgmt.delete(index=self.custom_policy)
         self.idxmgmt.delete(index=self.index_name)
+        self.idxmgmt.delete(index=self.custom_policy)
 
     def render_config(self, **kwargs):
         self.render_config_template(
@@ -169,16 +169,16 @@ class TestCommandSetupILMPolicy(BaseTest):
         self.es = self.es_client()
         self.idxmgmt = IdxMgmt(self.es, self.index_name)
         self.idxmgmt.delete(index=self.custom_alias)
-        self.idxmgmt.delete(index=self.custom_policy)
         self.idxmgmt.delete(index=self.index_name)
+        self.idxmgmt.delete(index=self.custom_policy)
 
         logging.getLogger("urllib3").setLevel(logging.WARNING)
         logging.getLogger("elasticsearch").setLevel(logging.ERROR)
 
     def tearDown(self):
         self.idxmgmt.delete(index=self.custom_alias)
-        self.idxmgmt.delete(index=self.custom_policy)
         self.idxmgmt.delete(index=self.index_name)
+        self.idxmgmt.delete(index=self.custom_policy)
 
     def render_config(self, **kwargs):
         self.render_config_template(


### PR DESCRIPTION
There is the chance an index is not correctly managed by ILM, due to
setup order. This changes fixes the order.