### PR TITLE
Add aws overview dashboard

### DIFF
--- a/x-pack/metricbeat/module/aws/_meta/kibana/7/dashboard/Metricbeat-aws-overview.json
+++ b/x-pack/metricbeat/module/aws/_meta/kibana/7/dashboard/Metricbeat-aws-overview.json
@@ -1,0 +1,381 @@
+{
+  "objects": [
+    {
+      "attributes": {
+        "description": "Metricbeat aws module overview dashboard",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\"query\":{\"language\":\"kuery\",\"query\":\"\"},\"filter\":[]}"
+        },
+        "optionsJSON": "{\"hidePanelTitles\":false,\"useMargins\":true}",
+        "panelsJSON": "[{\"embeddableConfig\":{},\"gridData\":{\"h\":8,\"i\":\"2\",\"w\":24,\"x\":24,\"y\":32},\"panelIndex\":\"2\",\"version\":\"7.0.0\",\"panelRefName\":\"panel_0\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":8,\"i\":\"3\",\"w\":24,\"x\":0,\"y\":16},\"panelIndex\":\"3\",\"version\":\"7.0.0\",\"panelRefName\":\"panel_1\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":8,\"i\":\"4\",\"w\":24,\"x\":0,\"y\":24},\"panelIndex\":\"4\",\"version\":\"7.0.0\",\"panelRefName\":\"panel_2\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":8,\"i\":\"6\",\"w\":24,\"x\":0,\"y\":32},\"panelIndex\":\"6\",\"version\":\"7.0.0\",\"panelRefName\":\"panel_3\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":8,\"i\":\"7\",\"w\":24,\"x\":24,\"y\":24},\"panelIndex\":\"7\",\"version\":\"7.0.0\",\"panelRefName\":\"panel_4\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":8,\"i\":\"8\",\"w\":24,\"x\":24,\"y\":16},\"panelIndex\":\"8\",\"version\":\"7.0.0\",\"panelRefName\":\"panel_5\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":8,\"i\":\"9\",\"w\":24,\"x\":0,\"y\":40},\"panelIndex\":\"9\",\"version\":\"7.0.0\",\"panelRefName\":\"panel_6\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":8,\"i\":\"10\",\"w\":24,\"x\":24,\"y\":40},\"panelIndex\":\"10\",\"version\":\"7.0.0\",\"panelRefName\":\"panel_7\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":9,\"i\":\"11\",\"w\":24,\"x\":24,\"y\":0},\"panelIndex\":\"11\",\"version\":\"7.0.0\",\"panelRefName\":\"panel_8\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":9,\"i\":\"12\",\"w\":9,\"x\":0,\"y\":0},\"panelIndex\":\"12\",\"version\":\"7.0.0\",\"panelRefName\":\"panel_9\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":9,\"i\":\"13\",\"w\":15,\"x\":9,\"y\":0},\"panelIndex\":\"13\",\"version\":\"7.0.0\",\"panelRefName\":\"panel_10\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":7,\"i\":\"14\",\"w\":15,\"x\":18,\"y\":9},\"panelIndex\":\"14\",\"version\":\"7.0.0\",\"panelRefName\":\"panel_11\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":7,\"i\":\"15\",\"w\":9,\"x\":0,\"y\":9},\"panelIndex\":\"15\",\"version\":\"7.0.0\",\"panelRefName\":\"panel_12\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":7,\"i\":\"16\",\"w\":9,\"x\":9,\"y\":9},\"panelIndex\":\"16\",\"version\":\"7.0.0\",\"panelRefName\":\"panel_13\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":7,\"i\":\"17\",\"w\":15,\"x\":33,\"y\":9},\"panelIndex\":\"17\",\"version\":\"7.0.0\",\"panelRefName\":\"panel_14\"}]",
+        "timeRestore": false,
+        "title": "[Metricbeat AWS] Overview",
+        "version": 1
+      },
+      "id": "bd3f2ed0-729c-11e9-9a7b-4d62d5bcf4fc",
+      "migrationVersion": {
+        "dashboard": "7.0.0"
+      },
+      "references": [
+        {
+          "id": "1d386c30-7283-11e9-9a7b-4d62d5bcf4fc",
+          "name": "panel_0",
+          "type": "visualization"
+        },
+        {
+          "id": "92ef5900-728f-11e9-9a7b-4d62d5bcf4fc",
+          "name": "panel_1",
+          "type": "visualization"
+        },
+        {
+          "id": "2178cfd0-7295-11e9-9a7b-4d62d5bcf4fc",
+          "name": "panel_2",
+          "type": "visualization"
+        },
+        {
+          "id": "fc78f050-7282-11e9-9a7b-4d62d5bcf4fc",
+          "name": "panel_3",
+          "type": "visualization"
+        },
+        {
+          "id": "2178cfd0-7295-11e9-9a7b-4d62d5bcf4fc",
+          "name": "panel_4",
+          "type": "visualization"
+        },
+        {
+          "id": "2c864a50-7296-11e9-9a7b-4d62d5bcf4fc",
+          "name": "panel_5",
+          "type": "visualization"
+        },
+        {
+          "id": "2c864a50-7296-11e9-9a7b-4d62d5bcf4fc",
+          "name": "panel_6",
+          "type": "visualization"
+        },
+        {
+          "id": "a7350d40-729b-11e9-9a7b-4d62d5bcf4fc",
+          "name": "panel_7",
+          "type": "visualization"
+        },
+        {
+          "id": "be8828d0-f7f6-11e8-af03-c999c9dea608-ecs",
+          "name": "panel_8",
+          "type": "visualization"
+        },
+        {
+          "id": "05137030-729e-11e9-9a7b-4d62d5bcf4fc",
+          "name": "panel_9",
+          "type": "visualization"
+        },
+        {
+          "id": "09db13f0-2bdd-11e9-9fe1-cde861544141",
+          "name": "panel_10",
+          "type": "visualization"
+        },
+        {
+          "id": "bb82c4d0-6c25-11e9-81bc-7f4cd8b3d892",
+          "name": "panel_11",
+          "type": "visualization"
+        },
+        {
+          "id": "d0a535a0-72a1-11e9-9740-bb8e703feae1",
+          "name": "panel_12",
+          "type": "visualization"
+        },
+        {
+          "id": "0d4174a0-72a3-11e9-9740-bb8e703feae1",
+          "name": "panel_13",
+          "type": "visualization"
+        },
+        {
+          "id": "6f607960-72a3-11e9-9740-bb8e703feae1",
+          "name": "panel_14",
+          "type": "visualization"
+        }
+      ],
+      "type": "dashboard",
+      "updated_at": "2019-05-09T21:47:06.095Z",
+      "version": "WzE5NTAsNl0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\"query\":{\"language\":\"kuery\",\"query\":\"\"},\"filter\":[]}"
+        },
+        "title": "AWS Cloudwatch ELB Latency",
+        "uiStateJSON": "{}",
+        "version": 1,
+        "visState": "{\"title\":\"AWS Cloudwatch ELB Latency\",\"type\":\"metrics\",\"params\":{\"id\":\"61ca57f0-469d-11e7-af02-69e470af7417\",\"type\":\"timeseries\",\"series\":[{\"id\":\"61ca57f1-469d-11e7-af02-69e470af7417\",\"color\":\"#68BC00\",\"split_mode\":\"terms\",\"metrics\":[{\"id\":\"61ca57f2-469d-11e7-af02-69e470af7417\",\"type\":\"avg\",\"field\":\"aws.cloudwatch.metrics.Latency\"}],\"separate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":\"0\",\"stacked\":\"none\",\"terms_field\":\"aws.cloudwatch.dimensions.LoadBalancerName\",\"terms_size\":\"5\",\"terms_order_by\":\"61ca57f2-469d-11e7-af02-69e470af7417\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"\",\"interval\":\"5m\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"axis_scale\":\"normal\",\"show_legend\":1,\"show_grid\":1,\"default_index_pattern\":\"metricbeat-8*\",\"background_color_rules\":[{\"id\":\"c988c710-7282-11e9-a4b1-8f42d835d9b2\"}],\"bar_color_rules\":[{\"id\":\"ca40a560-7282-11e9-a4b1-8f42d835d9b2\"}],\"gauge_color_rules\":[{\"id\":\"cd093b40-7282-11e9-a4b1-8f42d835d9b2\"}],\"gauge_width\":10,\"gauge_inner_width\":10,\"gauge_style\":\"half\"},\"aggs\":[]}"
+      },
+      "id": "1d386c30-7283-11e9-9a7b-4d62d5bcf4fc",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-05-09T17:51:46.803Z",
+      "version": "WzE2NzksNV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\"filter\":[],\"query\":{\"language\":\"kuery\",\"query\":\"\"}}"
+        },
+        "title": "AWS Cloudwatch ECS CPUReservation",
+        "uiStateJSON": "{}",
+        "version": 1,
+        "visState": "{\"aggs\":[],\"params\":{\"annotations\":[],\"axis_formatter\":\"number\",\"axis_position\":\"left\",\"axis_scale\":\"normal\",\"background_color_rules\":[{\"id\":\"23428b30-f7f2-11e8-bff8-21537b07dd44\"}],\"bar_color_rules\":[{\"id\":\"2592bcc0-f7f2-11e8-bff8-21537b07dd44\"}],\"default_index_pattern\":\"metricbeat-8*\",\"id\":\"61ca57f0-469d-11e7-af02-69e470af7417\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"5m\",\"series\":[{\"axis_position\":\"right\",\"chart_type\":\"line\",\"color\":\"rgba(115,216,255,1)\",\"fill\":\"0\",\"filter\":\"\",\"formatter\":\"number\",\"id\":\"61ca57f1-469d-11e7-af02-69e470af7417\",\"label\":\"ECS CPU Reservation\",\"line_width\":1,\"metrics\":[{\"field\":\"aws.cloudwatch.metrics.CPUReservation\",\"id\":\"61ca57f2-469d-11e7-af02-69e470af7417\",\"type\":\"sum\"}],\"point_size\":1,\"separate_axis\":0,\"series_drop_last_bucket\":1,\"split_color_mode\":\"rainbow\",\"split_filters\":[{\"color\":\"rgba(115,216,255,1)\",\"filter\":\"\",\"id\":\"42b6e700-7294-11e9-b1c3-018e9be4a996\",\"label\":\"\"}],\"split_mode\":\"terms\",\"stacked\":\"none\",\"steps\":0,\"terms_field\":\"aws.cloudwatch.dimensions.ClusterName\",\"terms_order_by\":\"61ca57f2-469d-11e7-af02-69e470af7417\",\"terms_size\":\"5\"}],\"show_grid\":1,\"show_legend\":1,\"time_field\":\"@timestamp\",\"type\":\"timeseries\"},\"title\":\"AWS Cloudwatch ECS CPUReservation\",\"type\":\"metrics\"}"
+      },
+      "id": "92ef5900-728f-11e9-9a7b-4d62d5bcf4fc",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-05-09T20:00:19.804Z",
+      "version": "WzE2ODQsNV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\"filter\":[],\"query\":{\"language\":\"kuery\",\"query\":\"\"}}"
+        },
+        "title": "AWS Cloudwatch ECS Memory Utilization",
+        "uiStateJSON": "{}",
+        "version": 1,
+        "visState": "{\"title\":\"AWS Cloudwatch ECS Memory Utilization\",\"type\":\"metrics\",\"params\":{\"annotations\":[],\"axis_formatter\":\"number\",\"axis_position\":\"left\",\"axis_scale\":\"normal\",\"background_color_rules\":[{\"id\":\"23428b30-f7f2-11e8-bff8-21537b07dd44\"}],\"bar_color_rules\":[{\"id\":\"2592bcc0-f7f2-11e8-bff8-21537b07dd44\"}],\"default_index_pattern\":\"metricbeat-8*\",\"id\":\"61ca57f0-469d-11e7-af02-69e470af7417\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"5m\",\"series\":[{\"axis_position\":\"right\",\"chart_type\":\"line\",\"color\":\"rgba(115,216,255,1)\",\"fill\":\"0\",\"filter\":\"\",\"formatter\":\"number\",\"id\":\"61ca57f1-469d-11e7-af02-69e470af7417\",\"label\":\"ECS Memory Utilization\",\"line_width\":1,\"metrics\":[{\"field\":\"aws.cloudwatch.metrics.MemoryUtilization\",\"id\":\"61ca57f2-469d-11e7-af02-69e470af7417\",\"type\":\"sum\"}],\"point_size\":1,\"separate_axis\":0,\"series_drop_last_bucket\":1,\"split_color_mode\":\"rainbow\",\"split_filters\":[{\"color\":\"rgba(115,216,255,1)\",\"filter\":\"\",\"id\":\"42b6e700-7294-11e9-b1c3-018e9be4a996\",\"label\":\"\"}],\"split_mode\":\"terms\",\"stacked\":\"none\",\"steps\":0,\"terms_field\":\"aws.cloudwatch.dimensions.ClusterName\",\"terms_order_by\":\"61ca57f2-469d-11e7-af02-69e470af7417\",\"terms_size\":\"5\"}],\"show_grid\":1,\"show_legend\":1,\"time_field\":\"@timestamp\",\"type\":\"timeseries\"},\"aggs\":[]}"
+      },
+      "id": "2178cfd0-7295-11e9-9a7b-4d62d5bcf4fc",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-05-09T20:07:50.723Z",
+      "version": "WzE2ODYsNV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[]}"
+        },
+        "title": "AWS Cloudwatch ELB Request Count",
+        "uiStateJSON": "{}",
+        "version": 1,
+        "visState": "{\"title\":\"AWS Cloudwatch ELB Request Count\",\"type\":\"metrics\",\"params\":{\"id\":\"61ca57f0-469d-11e7-af02-69e470af7417\",\"type\":\"top_n\",\"series\":[{\"id\":\"61ca57f1-469d-11e7-af02-69e470af7417\",\"color\":\"#68BC00\",\"split_mode\":\"terms\",\"metrics\":[{\"id\":\"61ca57f2-469d-11e7-af02-69e470af7417\",\"type\":\"avg\",\"field\":\"aws.cloudwatch.metrics.RequestCount\"}],\"separate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":\"0\",\"stacked\":\"none\",\"terms_field\":\"aws.cloudwatch.dimensions.LoadBalancerName\",\"terms_size\":\"5\",\"terms_order_by\":\"61ca57f2-469d-11e7-af02-69e470af7417\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"\",\"interval\":\"5m\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"axis_scale\":\"normal\",\"show_legend\":1,\"show_grid\":1,\"default_index_pattern\":\"metricbeat-8*\",\"background_color_rules\":[{\"id\":\"c988c710-7282-11e9-a4b1-8f42d835d9b2\"}],\"bar_color_rules\":[{\"id\":\"ca40a560-7282-11e9-a4b1-8f42d835d9b2\"}],\"gauge_color_rules\":[{\"id\":\"cd093b40-7282-11e9-a4b1-8f42d835d9b2\"}],\"gauge_width\":10,\"gauge_inner_width\":10,\"gauge_style\":\"half\"},\"aggs\":[]}"
+      },
+      "id": "fc78f050-7282-11e9-9a7b-4d62d5bcf4fc",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-05-09T17:50:51.861Z",
+      "version": "WzE2NzgsNV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\"filter\":[],\"query\":{\"language\":\"kuery\",\"query\":\"\"}}"
+        },
+        "title": "AWS Cloudwatch ECS Lambda Invocations",
+        "uiStateJSON": "{}",
+        "version": 1,
+        "visState": "{\"title\":\"AWS Cloudwatch ECS Lambda Invocations\",\"type\":\"metrics\",\"params\":{\"annotations\":[],\"axis_formatter\":\"number\",\"axis_position\":\"left\",\"axis_scale\":\"normal\",\"background_color_rules\":[{\"id\":\"23428b30-f7f2-11e8-bff8-21537b07dd44\"}],\"bar_color_rules\":[{\"id\":\"2592bcc0-f7f2-11e8-bff8-21537b07dd44\"}],\"default_index_pattern\":\"metricbeat-8*\",\"id\":\"61ca57f0-469d-11e7-af02-69e470af7417\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"5m\",\"series\":[{\"axis_position\":\"right\",\"chart_type\":\"line\",\"color\":\"rgba(104,188,0,1)\",\"fill\":\"0\",\"filter\":\"\",\"formatter\":\"number\",\"id\":\"61ca57f1-469d-11e7-af02-69e470af7417\",\"label\":\"ECS Lambda Invocations\",\"line_width\":1,\"metrics\":[{\"field\":\"aws.cloudwatch.metrics.Invocations\",\"id\":\"61ca57f2-469d-11e7-af02-69e470af7417\",\"type\":\"sum\"}],\"point_size\":1,\"separate_axis\":0,\"series_drop_last_bucket\":1,\"split_color_mode\":\"rainbow\",\"split_filters\":[{\"color\":\"rgba(115,216,255,1)\",\"filter\":\"\",\"id\":\"42b6e700-7294-11e9-b1c3-018e9be4a996\",\"label\":\"\"}],\"split_mode\":\"terms\",\"stacked\":\"none\",\"steps\":0,\"terms_field\":\"aws.cloudwatch.dimensions.FunctionName\",\"terms_order_by\":\"61ca57f2-469d-11e7-af02-69e470af7417\",\"terms_size\":\"5\"}],\"show_grid\":1,\"show_legend\":1,\"time_field\":\"@timestamp\",\"type\":\"top_n\",\"gauge_color_rules\":[{\"id\":\"af69cca0-7299-11e9-831b-2d21d499addd\"}],\"gauge_width\":10,\"gauge_inner_width\":10,\"gauge_style\":\"half\"},\"aggs\":[]}"
+      },
+      "id": "2c864a50-7296-11e9-9a7b-4d62d5bcf4fc",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-05-09T20:50:33.884Z",
+      "version": "WzE2OTMsNV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\"filter\":[],\"query\":{\"language\":\"kuery\",\"query\":\"\"}}"
+        },
+        "title": "AWS Cloudwatch ECS Lambda Errors",
+        "uiStateJSON": "{}",
+        "version": 1,
+        "visState": "{\"title\":\"AWS Cloudwatch ECS Lambda Errors\",\"type\":\"metrics\",\"params\":{\"annotations\":[],\"axis_formatter\":\"number\",\"axis_position\":\"left\",\"axis_scale\":\"normal\",\"background_color_rules\":[{\"id\":\"23428b30-f7f2-11e8-bff8-21537b07dd44\"}],\"bar_color_rules\":[{\"id\":\"2592bcc0-f7f2-11e8-bff8-21537b07dd44\"}],\"default_index_pattern\":\"metricbeat-8*\",\"id\":\"61ca57f0-469d-11e7-af02-69e470af7417\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"5m\",\"series\":[{\"axis_position\":\"right\",\"chart_type\":\"line\",\"color\":\"rgba(104,188,0,1)\",\"fill\":\"0\",\"filter\":\"\",\"formatter\":\"number\",\"id\":\"61ca57f1-469d-11e7-af02-69e470af7417\",\"label\":\"ECS Lambda Errors\",\"line_width\":1,\"metrics\":[{\"field\":\"aws.cloudwatch.metrics.Errors\",\"id\":\"61ca57f2-469d-11e7-af02-69e470af7417\",\"type\":\"sum\"}],\"point_size\":1,\"separate_axis\":0,\"series_drop_last_bucket\":1,\"split_color_mode\":\"rainbow\",\"split_filters\":[{\"color\":\"rgba(115,216,255,1)\",\"filter\":\"\",\"id\":\"42b6e700-7294-11e9-b1c3-018e9be4a996\",\"label\":\"\"}],\"split_mode\":\"terms\",\"stacked\":\"none\",\"steps\":0,\"terms_field\":\"aws.cloudwatch.dimensions.FunctionName\",\"terms_order_by\":\"61ca57f2-469d-11e7-af02-69e470af7417\",\"terms_size\":\"5\"}],\"show_grid\":1,\"show_legend\":1,\"time_field\":\"@timestamp\",\"type\":\"top_n\",\"gauge_color_rules\":[{\"id\":\"af69cca0-7299-11e9-831b-2d21d499addd\"}],\"gauge_width\":10,\"gauge_inner_width\":10,\"gauge_style\":\"half\"},\"aggs\":[]}"
+      },
+      "id": "a7350d40-729b-11e9-9a7b-4d62d5bcf4fc",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-05-09T20:50:51.862Z",
+      "version": "WzE2OTQsNV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"kuery\"}}"
+        },
+        "title": "AWS EC2 CPU Utilization ECS",
+        "uiStateJSON": "{}",
+        "version": 1,
+        "visState": "{\"type\":\"metrics\",\"params\":{\"bar_color_rules\":[{\"id\":\"2592bcc0-f7f2-11e8-bff8-21537b07dd44\"}],\"background_color_rules\":[{\"id\":\"23428b30-f7f2-11e8-bff8-21537b07dd44\"}],\"index_pattern\":\"metricbeat-*\",\"time_field\":\"@timestamp\",\"series\":[{\"line_width\":1,\"terms_field\":\"cloud.instance.id\",\"metrics\":[{\"field\":\"aws.ec2.cpu.total.pct\",\"type\":\"avg\",\"id\":\"61ca57f2-469d-11e7-af02-69e470af7417\"}],\"terms_order_by\":\"61ca57f2-469d-11e7-af02-69e470af7417\",\"color\":\"rgba(104,188,0,1)\",\"stacked\":\"none\",\"terms_size\":\"5\",\"label\":\"AWS EC2 CPU Utilization ECS\",\"filter\":\"\",\"steps\":0,\"separate_axis\":0,\"split_mode\":\"terms\",\"chart_type\":\"line\",\"series_drop_last_bucket\":1,\"point_size\":1,\"axis_position\":\"right\",\"formatter\":\"number\",\"id\":\"61ca57f1-469d-11e7-af02-69e470af7417\",\"split_color_mode\":\"rainbow\",\"fill\":\"0\"}],\"axis_formatter\":\"number\",\"interval\":\"5m\",\"axis_position\":\"left\",\"id\":\"61ca57f0-469d-11e7-af02-69e470af7417\",\"show_legend\":1,\"show_grid\":1,\"axis_scale\":\"normal\",\"type\":\"timeseries\",\"annotations\":[]},\"aggs\":[],\"title\":\"AWS EC2 CPU Utilization ECS\"}"
+      },
+      "id": "be8828d0-f7f6-11e8-af03-c999c9dea608-ecs",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-05-09T21:21:48.826Z",
+      "version": "WzE3MjcsNl0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"kuery\"}}"
+        },
+        "title": "AWS Region Filter",
+        "uiStateJSON": "{}",
+        "version": 1,
+        "visState": "{\"title\":\"AWS Region Filter\",\"type\":\"input_control_vis\",\"params\":{\"pinFilters\":false,\"useTimeFilter\":false,\"updateFiltersOnChange\":true,\"controls\":[{\"parent\":\"\",\"id\":\"1549397251041\",\"fieldName\":\"cloud.region\",\"label\":\"region\",\"type\":\"list\",\"options\":{\"type\":\"terms\",\"size\":5,\"multiselect\":true,\"dynamicOptions\":true,\"order\":\"desc\"},\"indexPatternRefName\":\"control_0_index_pattern\"}]},\"aggs\":[]}"
+      },
+      "id": "05137030-729e-11e9-9a7b-4d62d5bcf4fc",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "references": [
+        {
+          "id": "ec1ad9e0-729f-11e9-9740-bb8e703feae1",
+          "name": "control_0_index_pattern",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-05-09T21:18:53.974Z",
+      "version": "WzE3MTAsNl0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.index\"}"
+        },
+        "title": "AWS EC2 Instance State ECS",
+        "uiStateJSON": "{\"vis\": {\"colors\": {\"running\": \"#7EB26D\", \"272\": \"#DEDAF7\", \"stopped\": \"#E24D42\", \"80\": \"#E24D42\", \"16\": \"#629E51\"}, \"legendOpen\": true}}",
+        "version": 1,
+        "visState": "{\"type\":\"pie\",\"params\":{\"isDonut\":false,\"addTooltip\":true,\"labels\":{\"values\":true,\"last_level\":true,\"truncate\":100,\"show\":true},\"legendPosition\":\"right\",\"addLegend\":true,\"type\":\"pie\"},\"aggs\":[{\"params\":{\"customLabel\":\"EC2 Instance State\"},\"type\":\"count\",\"enabled\":true,\"id\":\"1\",\"schema\":\"metric\"},{\"params\":{\"orderBy\":\"1\",\"missingBucket\":false,\"customLabel\":\"\",\"missingBucketLabel\":\"Missing\",\"field\":\"aws.ec2.instance.state.name\",\"otherBucketLabel\":\"Other\",\"otherBucket\":false,\"order\":\"desc\",\"size\":5},\"type\":\"terms\",\"enabled\":true,\"id\":\"2\",\"schema\":\"segment\"}],\"title\":\"AWS EC2 Instance State ECS\"}"
+      },
+      "id": "09db13f0-2bdd-11e9-9fe1-cde861544141",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "references": [
+        {
+          "id": "metricbeat-*",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-05-09T21:21:48.826Z",
+      "version": "WzE3MjksNl0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\"filter\":[],\"query\":{\"language\":\"kuery\",\"query\":\"\"}}"
+        },
+        "title": "AWS SQS Empty Receives",
+        "uiStateJSON": "{}",
+        "version": 1,
+        "visState": "{\"title\":\"AWS SQS Empty Receives\",\"type\":\"metrics\",\"params\":{\"axis_formatter\":\"number\",\"axis_position\":\"left\",\"axis_scale\":\"normal\",\"background_color_rules\":[{\"id\":\"d95adba0-6b8a-11e9-98b0-9b2c3d14a4c1\"}],\"default_index_pattern\":\"metricbeat-8*\",\"id\":\"61ca57f0-469d-11e7-af02-69e470af7417\",\"index_pattern\":\"metricbeat*\",\"interval\":\"5m\",\"series\":[{\"axis_position\":\"right\",\"chart_type\":\"line\",\"color\":\"#68BC00\",\"fill\":\"0\",\"formatter\":\"number\",\"id\":\"61ca57f1-469d-11e7-af02-69e470af7417\",\"line_width\":1,\"metrics\":[{\"field\":\"aws.sqs.empty_receives\",\"id\":\"61ca57f2-469d-11e7-af02-69e470af7417\",\"type\":\"avg\",\"numerator\":\"\",\"percentiles\":[{\"id\":\"74323cf0-6c25-11e9-9cd1-3bdb0c7db024\",\"mode\":\"line\",\"shade\":0.2,\"value\":50}]}],\"point_size\":1,\"separate_axis\":0,\"split_color_mode\":\"rainbow\",\"split_mode\":\"terms\",\"stacked\":\"none\",\"terms_field\":\"aws.sqs.queue.name\",\"terms_order_by\":\"61ca57f2-469d-11e7-af02-69e470af7417\",\"terms_size\":\"5\"}],\"show_grid\":1,\"show_legend\":1,\"time_field\":\"@timestamp\",\"type\":\"top_n\",\"gauge_color_rules\":[{\"id\":\"a778eaa0-6c25-11e9-9cd1-3bdb0c7db024\"}],\"gauge_width\":10,\"gauge_inner_width\":10,\"gauge_style\":\"half\",\"bar_color_rules\":[{\"id\":\"a7e8c370-6c25-11e9-9cd1-3bdb0c7db024\"}]},\"aggs\":[]}"
+      },
+      "id": "bb82c4d0-6c25-11e9-81bc-7f4cd8b3d892",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-05-01T15:28:12.701Z",
+      "version": "WzQ5OSwxXQ=="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[],\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.index\"}"
+        },
+        "title": "AWS S3 Number of S3 Buckets",
+        "uiStateJSON": "{}",
+        "version": 1,
+        "visState": "{\"title\":\"AWS S3 Number of S3 Buckets\",\"type\":\"metric\",\"params\":{\"addTooltip\":true,\"addLegend\":false,\"type\":\"metric\",\"metric\":{\"percentageMode\":false,\"useRanges\":false,\"colorSchema\":\"Green to Red\",\"metricColorMode\":\"None\",\"colorsRange\":[{\"from\":0,\"to\":10000}],\"labels\":{\"show\":true},\"invertColors\":false,\"style\":{\"bgFill\":\"#000\",\"bgColor\":false,\"labelColor\":false,\"subText\":\"\",\"fontSize\":60}}},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"cardinality\",\"schema\":\"metric\",\"params\":{\"field\":\"aws.s3_request.bucket.name\",\"customLabel\":\"Number of S3 Buckets\"}}]}"
+      },
+      "id": "d0a535a0-72a1-11e9-9740-bb8e703feae1",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "references": [
+        {
+          "id": "ec1ad9e0-729f-11e9-9740-bb8e703feae1",
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+          "type": "index-pattern"
+        }
+      ],
+      "type": "visualization",
+      "updated_at": "2019-05-09T21:31:32.730Z",
+      "version": "WzE5NDYsNl0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\"filter\":[],\"query\":{\"language\":\"kuery\",\"query\":\"\"}}"
+        },
+        "title": "AWS S3 Total Error",
+        "uiStateJSON": "{}",
+        "version": 1,
+        "visState": "{\"aggs\":[],\"params\":{\"axis_formatter\":\"number\",\"axis_position\":\"left\",\"axis_scale\":\"normal\",\"background_color_rules\":[{\"id\":\"59207fe0-4762-11e9-bf81-69a4e579cab5\"}],\"bar_color_rules\":[{\"id\":\"5ad9a190-4762-11e9-bf81-69a4e579cab5\"}],\"default_index_pattern\":\"metricbeat-*\",\"id\":\"61ca57f0-469d-11e7-af02-69e470af7417\",\"index_pattern\":\"metricbeat-*\",\"interval\":\"auto\",\"series\":[{\"axis_position\":\"right\",\"chart_type\":\"line\",\"color\":\"#68BC00\",\"fill\":0.5,\"formatter\":\"number\",\"id\":\"61ca57f1-469d-11e7-af02-69e470af7417\",\"label\":\"Total Number of HTTP Errors\",\"line_width\":1,\"metrics\":[{\"field\":\"aws.s3_request.errors.4xx\",\"id\":\"61ca57f2-469d-11e7-af02-69e470af7417\",\"type\":\"sum\"},{\"field\":\"aws.s3_request.errors.5xx\",\"id\":\"edfc15a0-72a2-11e9-a338-6d40b5e3087f\",\"type\":\"sum\"}],\"point_size\":1,\"separate_axis\":0,\"split_mode\":\"everything\",\"stacked\":\"none\"}],\"show_grid\":1,\"show_legend\":1,\"time_field\":\"@timestamp\",\"type\":\"metric\"},\"title\":\"AWS S3 Total Error\",\"type\":\"metrics\"}"
+      },
+      "id": "0d4174a0-72a3-11e9-9740-bb8e703feae1",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-05-09T21:40:23.914Z",
+      "version": "WzE5NDgsNl0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"kuery\"}}"
+        },
+        "title": "AWS SQS Messages Received TopN",
+        "uiStateJSON": "{}",
+        "version": 1,
+        "visState": "{\"title\":\"AWS SQS Messages Received TopN\",\"type\":\"metrics\",\"params\":{\"bar_color_rules\":[{\"id\":\"57cc0200-43b5-11e9-84e9-a97a63579915\"}],\"background_color_rules\":[{\"id\":\"1ccb6710-43b3-11e9-8c70-d17a67455a84\"}],\"index_pattern\":\"metricbeat*\",\"time_field\":\"@timestamp\",\"series\":[{\"line_width\":1,\"terms_field\":\"aws.sqs.queue.name\",\"point_size\":1,\"terms_order_by\":\"61ca57f2-469d-11e7-af02-69e470af7417\",\"color\":\"#68BC00\",\"stacked\":\"none\",\"terms_size\":\"5\",\"metrics\":[{\"field\":\"aws.sqs.messages.received\",\"type\":\"sum\",\"id\":\"61ca57f2-469d-11e7-af02-69e470af7417\"}],\"split_mode\":\"terms\",\"chart_type\":\"line\",\"series_drop_last_bucket\":1,\"separate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"id\":\"61ca57f1-469d-11e7-af02-69e470af7417\",\"split_color_mode\":\"rainbow\",\"fill\":\"0\"}],\"axis_formatter\":\"number\",\"interval\":\"5m\",\"id\":\"61ca57f0-469d-11e7-af02-69e470af7417\",\"show_legend\":1,\"show_grid\":1,\"axis_scale\":\"normal\",\"type\":\"top_n\",\"axis_position\":\"left\",\"default_index_pattern\":\"metricbeat-*\",\"gauge_color_rules\":[{\"id\":\"63f9c5e0-72a3-11e9-bcd6-cf6d59095a42\"}],\"gauge_width\":10,\"gauge_inner_width\":10,\"gauge_style\":\"half\"},\"aggs\":[]}"
+      },
+      "id": "6f607960-72a3-11e9-9740-bb8e703feae1",
+      "migrationVersion": {
+        "visualization": "7.0.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-05-09T21:43:08.533Z",
+      "version": "WzE5NDksNl0="
+    }
+  ],
+  "version": "7.0.0"
+}


### PR DESCRIPTION
With `cloudwatch` metricset merged, we can collect a lot of useful metrics from cloudwatch from different namespaces. Here is an example `aws overview dashboard` which includes metrics from EC2, SQS, S3, ECS, ELB and Lambda:
![localhost_5601_app_kibana (6)](https://user-images.githubusercontent.com/14081635/57500162-89df7380-729f-11e9-9a31-79154fa9895f.png)
![localhost_5601_app_kibana (7)](https://user-images.githubusercontent.com/14081635/57500161-86e48300-729f-11e9-93a6-7409584d7109.png)
