### PR TITLE
Keystore dir is in path.data

### DIFF
--- a/libbeat/docs/keystore.asciidoc
+++ b/libbeat/docs/keystore.asciidoc
@@ -64,7 +64,7 @@ To create a secrets keystore, use:
 ----------------------------------------------------------------
 
 
-{beatname_uc} creates the keystore in the directory defined by the `path.config`
+{beatname_uc} creates the keystore in the directory defined by the `path.data`
 configuration setting.
 
 [float]


### PR DESCRIPTION
The documentation https://www.elastic.co/guide/en/beats/metricbeat/7.0/directory-layout.html says that the keystore is located in `path.config` (`/etc/metricbeat` with a `.deb`) but when I install it, it is actually located in `/var/lib/metricbeat` which is `path.data`.

Hope this helps.