### PR TITLE
[Auditbeat] Fix issues with multiple calls to rpmReadConfigFiles

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -80,7 +80,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Package dataset: Log error when Homebrew is not installed. {pull}11667[11667]
 - Process dataset: Fixed a memory leak under Windows. {pull}12100[12100]
 - Login dataset: Fix re-read of utmp files. {pull}12028[12028]
-- Process dataset: Fixed a crash inside librpm after Auditbeat has been running for a while. {issue}12147[12147] {pull}12168[12168]
+- Package dataset: Fixed a crash inside librpm after Auditbeat has been running for a while. {issue}12147[12147] {pull}12168[12168]
 
 *Filebeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -80,6 +80,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Package dataset: Log error when Homebrew is not installed. {pull}11667[11667]
 - Process dataset: Fixed a memory leak under Windows. {pull}12100[12100]
 - Login dataset: Fix re-read of utmp files. {pull}12028[12028]
+- Process dataset: Fixed a crash inside librpm after Auditbeat has been running for a while. {issue}12147[12147] {pull}12168[12168]
 
 *Filebeat*
 


### PR DESCRIPTION
This patch fixes two issues in Auditbeat's system/package on RPM
distros:

- Multiple calls to rpmReadConfigFiles lead to a crash (segmentation fault). It is necessary to call rpmFreeRpmrc after each call to rpmReadConfigFiles.

  See [this anaconda thread](https://lists.fedorahosted.org/pipermail/anaconda-patches/2015-February/015826.html) for the same issue.

- In addition, it is also necessary to call rpmFreeMacros (when available) to avoid leaking memory after each rpmReadConfigFiles call.

As a side note, I've tried to just unload librpm.so after use, which seems reasonable due to the amount of trouble it's creating and the risk of more memory leaks. Unfortunately, due to optimisations in Linux the library is never freed and leaks persisted.

Fixes #12147