### PR TITLE
Ignore doc type in ES search API for ES 8

### DIFF
--- a/libbeat/outputs/elasticsearch/api.go
+++ b/libbeat/outputs/elasticsearch/api.go
@@ -23,6 +23,8 @@ import (
 	"strconv"
 
 	"github.com/pkg/errors"
+
+	"github.com/elastic/beats/libbeat/common"
 )
 
 // QueryResult contains the result of a query.
@@ -235,6 +237,9 @@ func (es *Connection) SearchURIWithBody(
 	params map[string]string,
 	body interface{},
 ) (int, *SearchResults, error) {
+	if !es.version.LessThan(&common.Version{Major: 8}) {
+		docType = ""
+	}
 	status, resp, err := es.apiCall("GET", index, docType, "_search", "", params, body)
 	if err != nil {
 		return status, nil, err

--- a/libbeat/outputs/elasticsearch/api_integration_test.go
+++ b/libbeat/outputs/elasticsearch/api_integration_test.go
@@ -61,7 +61,7 @@ func TestIndex(t *testing.T) {
 	}
 	_, result, err := client.SearchURIWithBody(index, "", nil, map[string]interface{}{})
 	if err != nil {
-		t.Errorf("SearchUriWithBody() returns an error: %s", err)
+		t.Fatalf("SearchUriWithBody() returns an error: %s", err)
 	}
 	if result.Hits.Total.Value != 1 {
 		t.Errorf("Wrong number of search results: %d", result.Hits.Total.Value)
@@ -72,7 +72,7 @@ func TestIndex(t *testing.T) {
 	}
 	_, result, err = client.SearchURI(index, "test", params)
 	if err != nil {
-		t.Errorf("SearchUri() returns an error: %s", err)
+		t.Fatalf("SearchUri() returns an error: %s", err)
 	}
 	if result.Hits.Total.Value != 1 {
 		t.Errorf("Wrong number of search results: %d", result.Hits.Total.Value)


### PR DESCRIPTION
ES Search API has removed support for doc types with the
default config, ignore them in the API for the ES output in libbeat.

This is breaking tests, this PR should get tests back to green.