### PR TITLE
Set beat ID in registries after loading meta file

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -72,6 +72,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Replace wmi queries with win32 api calls as they were consuming CPU resources {issue}3249[3249] and {issue}11840[11840]
 - Fix queue.spool.write.flush.events config type. {pull}12080[12080]
 - Fixed a memory leak when using the add_process_metadata processor under Windows. {pull}12100[12100]
+- Fixed Beat ID being reported by GET / API. {pull}12180[12180]
 
 *Auditbeat*
 

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -368,6 +368,15 @@ func (b *Beat) launch(settings Settings, bt beat.Creator) error {
 		return err
 	}
 
+	// Reset Beat ID in registry vars, in case it was loaded from meta file
+	infoRegistry := monitoring.GetNamespace("info").GetRegistry()
+	infoUUID := infoRegistry.Get("uuid").(*monitoring.String)
+	infoUUID.Set(b.Info.ID.String())
+
+	serviceRegistry := monitoring.GetNamespace("state").GetRegistry().GetRegistry("service")
+	serviceID := serviceRegistry.Get("id").(*monitoring.String)
+	serviceID.Set(b.Info.ID.String())
+
 	svc.BeforeRun()
 	defer svc.Cleanup()
 

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -168,7 +168,6 @@ func Run(settings Settings, bt beat.Creator) error {
 		monitoring.NewString(registry, "version").Set(b.Info.Version)
 		monitoring.NewString(registry, "beat").Set(b.Info.Beat)
 		monitoring.NewString(registry, "name").Set(b.Info.Name)
-		monitoring.NewString(registry, "uuid").Set(b.Info.ID.String())
 		monitoring.NewString(registry, "hostname").Set(b.Info.Hostname)
 
 		// Add additional info to state registry. This is also reported to monitoring
@@ -176,7 +175,6 @@ func Run(settings Settings, bt beat.Creator) error {
 		serviceRegistry := stateRegistry.NewRegistry("service")
 		monitoring.NewString(serviceRegistry, "version").Set(b.Info.Version)
 		monitoring.NewString(serviceRegistry, "name").Set(b.Info.Beat)
-		monitoring.NewString(serviceRegistry, "id").Set(b.Info.ID.String())
 		beatRegistry := stateRegistry.NewRegistry("beat")
 		monitoring.NewString(beatRegistry, "name").Set(b.Info.Name)
 		monitoring.NewFunc(stateRegistry, "host", host.ReportInfo, monitoring.Report)
@@ -368,14 +366,12 @@ func (b *Beat) launch(settings Settings, bt beat.Creator) error {
 		return err
 	}
 
-	// Reset Beat ID in registry vars, in case it was loaded from meta file
+	// Set Beat ID in registry vars, in case it was loaded from meta file
 	infoRegistry := monitoring.GetNamespace("info").GetRegistry()
-	infoUUID := infoRegistry.Get("uuid").(*monitoring.String)
-	infoUUID.Set(b.Info.ID.String())
+	monitoring.NewString(infoRegistry, "uuid").Set(b.Info.ID.String())
 
 	serviceRegistry := monitoring.GetNamespace("state").GetRegistry().GetRegistry("service")
-	serviceID := serviceRegistry.Get("id").(*monitoring.String)
-	serviceID.Set(b.Info.ID.String())
+	monitoring.NewString(serviceRegistry, "id").Set(b.Info.ID.String())
 
 	svc.BeforeRun()
 	defer svc.Cleanup()


### PR DESCRIPTION
Currently, if you have a Beat that already has a `data/meta.json` file with a UUID in it, that UUID is **not** the one shown when you call http://localhost:5066. This is because the API endpoint uses the UUID from the `info` registry, and this UUID is registered **before** the `data/meta.json` file is loaded up (if one exists).

This PR fixes the issue by setting the UUID in the `info` registry (and another registry that also has it) after the `data/meta.json` file is loaded. That way, the http://localhost:5066 API response will contain the correct UUID.