### PR TITLE
Missing module.yml.disabled file for palo_alto

### DIFF
--- a/x-pack/filebeat/modules.d/palo_alto.yml.disabled
+++ b/x-pack/filebeat/modules.d/palo_alto.yml.disabled
@@ -1,0 +1,13 @@
+# Module: palo_alto
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-palo_alto.html
+
+- module: palo_alto
+  pan_os:
+    enabled: true
+
+    # Set which input to use between syslog (default) or file.
+    #var.input:
+
+    # Set custom paths for the log files. If left empty,
+    # Filebeat will choose the paths depending on your OS.
+    #var.paths:


### PR DESCRIPTION
This file was missing from the `palo_alto` module.