### PR TITLE
Cherry-pick #12164 to 6.7: Fix goroutine leak on non-explicit finalization of log inputs

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -39,6 +39,7 @@ https://github.com/elastic/beats/compare/v6.7.2...6.x[Check the HEAD diff]
 
 - Fix goroutine leak caused on initialization failures of log input. {pull}12125[12125]
 - Fix memory leak in Filebeat pipeline acker. {pull}12063[12063]
+- Fix goroutine leak on non-explicit finalization of log input. {pull}12164[12164]
 
 *Heartbeat*
 


### PR DESCRIPTION
Cherry-pick of PR #12164 to 6.7 branch. Original message: 

If log inputs were finished because their context, or one of their
ouleters have been finished, then they weren't stopping its harvesters,
leaking resources.

Detected on #12106