### PR TITLE
[metricbeat] update error handling in haproxy/info

### DIFF
--- a/metricbeat/module/haproxy/info/data.go
+++ b/metricbeat/module/haproxy/info/data.go
@@ -169,7 +169,10 @@ func eventMapping(info *haproxy.Info, r mb.ReporterV2) (mb.Event, error) {
 		RootFields: common.MapStr{},
 	}
 
-	fields, _ := schema.Apply(source)
+	fields, err := schema.Apply(source)
+	if err != nil {
+		return event, errors.Wrap(err, "error applying schema")
+	}
 	if processID, err := fields.GetValue("pid"); err == nil {
 		event.RootFields.Put("process.pid", processID)
 		fields.Delete("pid")

--- a/metricbeat/module/haproxy/info/data.go
+++ b/metricbeat/module/haproxy/info/data.go
@@ -18,12 +18,13 @@
 package info
 
 import (
+	"github.com/pkg/errors"
+
 	"github.com/elastic/beats/libbeat/common"
 	s "github.com/elastic/beats/libbeat/common/schema"
 	c "github.com/elastic/beats/libbeat/common/schema/mapstrstr"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/module/haproxy"
-	"github.com/pkg/errors"
 
 	"reflect"
 	"strconv"

--- a/metricbeat/module/haproxy/info/info.go
+++ b/metricbeat/module/haproxy/info/info.go
@@ -64,6 +64,10 @@ func (m *MetricSet) Fetch(reporter mb.ReporterV2) error {
 		return errors.Wrap(err, "failed fetching haproxy info")
 	}
 
-	eventMapping(res, reporter)
+	event, err := eventMapping(res, reporter)
+	if err != nil {
+		return errors.Wrap(err, "error in mapping")
+	}
+	reporter.Event(event)
 	return nil
 }


### PR DESCRIPTION
This came out of some digging into this discuss issue: https://discuss.elastic.co/t/haproxy-strconv-parsefloat-parsing-invalid-syntax/181403

It looks like when there's an error in `data.go` , the error is reported to the event, but never returned from `Fetch()` and hence never logged. Ideally, errors should go to both places.

There's still the underlying haproxy bug, which I'm looking into. 