### PR TITLE
Update winlog.event_id field name in docs

### DIFF
--- a/winlogbeat/docs/winlogbeat-options.asciidoc
+++ b/winlogbeat/docs/winlogbeat-options.asciidoc
@@ -223,9 +223,9 @@ winlogbeat.event_logs:
   - name: Security
     processors:
       - drop_event.when.not.or:
-        - equals.event_id: 903
-        - equals.event_id: 1024
-        - equals.event_id: 4624
+        - equals.winlog.event_id: 903
+        - equals.winlog.event_id: 1024
+        - equals.winlog.event_id: 4624
 --------------------------------------------------------------------------------
 
 =======================================


### PR DESCRIPTION
For 7.0.0 event_id was renamed to winlog.event_id and the example needed updated.