### PR TITLE
[metricbeat] migrate rabbitmq to reporterv2 with error return

### DIFF
--- a/metricbeat/module/rabbitmq/connection/connection.go
+++ b/metricbeat/module/rabbitmq/connection/connection.go
@@ -18,6 +18,8 @@
 package connection
 
 import (
+	"github.com/pkg/errors"
+
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/module/rabbitmq"
 )
@@ -44,13 +46,12 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 }
 
 // Fetch makes an HTTP request to fetch connections metrics from the connections endpoint.
-func (m *MetricSet) Fetch(r mb.ReporterV2) {
+func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 	content, err := m.HTTP.FetchContent()
 
 	if err != nil {
-		r.Error(err)
-		return
+		return errors.Wrap(err, "error in fetch")
 	}
 
-	eventsMapping(content, r)
+	return eventsMapping(content, r, m)
 }

--- a/metricbeat/module/rabbitmq/connection/connection_test.go
+++ b/metricbeat/module/rabbitmq/connection/connection_test.go
@@ -33,7 +33,7 @@ func TestFetchEventContents(t *testing.T) {
 
 	reporter := &mbtest.CapturingReporterV2{}
 
-	metricSet := mbtest.NewReportingMetricSetV2(t, getConfig(server.URL))
+	metricSet := mbtest.NewReportingMetricSetV2Error(t, getConfig(server.URL))
 	metricSet.Fetch(reporter)
 
 	e := mbtest.StandardizeEvent(metricSet, reporter.GetEvents()[0])

--- a/metricbeat/module/rabbitmq/connection/data.go
+++ b/metricbeat/module/rabbitmq/connection/data.go
@@ -31,9 +31,9 @@ import (
 var (
 	schema = s.Schema{
 		"name":        c.Str("name"),
-		"vhost":       c.Str("vhost"),
-		"user":        c.Str("user"),
-		"node":        c.Str("node"),
+		"vhost":       c.Str("vhost", s.Required),
+		"user":        c.Str("user", s.Required),
+		"node":        c.Str("node", s.Required),
 		"channels":    c.Int("channels"),
 		"channel_max": c.Int("channel_max"),
 		"frame_max":   c.Int("frame_max"),
@@ -79,7 +79,7 @@ func eventsMapping(content []byte, r mb.ReporterV2, m *MetricSet) error {
 }
 
 func eventMapping(connection map[string]interface{}) (mb.Event, error) {
-	fields, err := schema.Apply(connection)
+	fields, err := schema.Apply(connection, s.FailOnRequired)
 	if err != nil {
 		return mb.Event{}, errors.Wrap(err, "error applying schema")
 	}

--- a/metricbeat/module/rabbitmq/connection/data.go
+++ b/metricbeat/module/rabbitmq/connection/data.go
@@ -106,5 +106,5 @@ func eventMapping(connection map[string]interface{}) (mb.Event, error) {
 		RootFields:      rootFields,
 		ModuleFields:    moduleFields,
 	}
-	return event, err
+	return event, nil
 }

--- a/metricbeat/module/rabbitmq/exchange/exchange.go
+++ b/metricbeat/module/rabbitmq/exchange/exchange.go
@@ -18,6 +18,8 @@
 package exchange
 
 import (
+	"github.com/pkg/errors"
+
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/module/rabbitmq"
 )
@@ -46,13 +48,12 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // Fetch methods implements the data gathering and data conversion to the right
 // format. It publishes the event which is then forwarded to the output. In case
 // of an error set the Error field of mb.Event or simply call report.Error().
-func (m *MetricSet) Fetch(r mb.ReporterV2) {
+func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 	content, err := m.HTTP.FetchContent()
 
 	if err != nil {
-		r.Error(err)
-		return
+		return errors.Wrap(err, "error in fetch")
 	}
 
-	eventsMapping(content, r)
+	return eventsMapping(content, r, m)
 }

--- a/metricbeat/module/rabbitmq/exchange/exchange_test.go
+++ b/metricbeat/module/rabbitmq/exchange/exchange_test.go
@@ -33,7 +33,7 @@ func TestFetchEventContents(t *testing.T) {
 
 	reporter := &mbtest.CapturingReporterV2{}
 
-	metricSet := mbtest.NewReportingMetricSetV2(t, getConfig(server.URL))
+	metricSet := mbtest.NewReportingMetricSetV2Error(t, getConfig(server.URL))
 	metricSet.Fetch(reporter)
 
 	e := mbtest.StandardizeEvent(metricSet, reporter.GetEvents()[0])
@@ -64,8 +64,8 @@ func TestData(t *testing.T) {
 	server := mtest.Server(t, mtest.DefaultServerConfig)
 	defer server.Close()
 
-	ms := mbtest.NewReportingMetricSetV2(t, getConfig(server.URL))
-	err := mbtest.WriteEventsReporterV2Cond(ms, t, "", func(e common.MapStr) bool {
+	ms := mbtest.NewReportingMetricSetV2Error(t, getConfig(server.URL))
+	err := mbtest.WriteEventsReporterV2ErrorCond(ms, t, "", func(e common.MapStr) bool {
 		hasIn, _ := e.HasKey("rabbitmq.exchange.messages.publish_in")
 		hasOut, _ := e.HasKey("rabbitmq.exchange.messages.publish_out")
 		return hasIn && hasOut

--- a/metricbeat/module/rabbitmq/node/data.go
+++ b/metricbeat/module/rabbitmq/node/data.go
@@ -20,6 +20,8 @@ package node
 import (
 	"encoding/json"
 
+	"github.com/pkg/errors"
+
 	s "github.com/elastic/beats/libbeat/common/schema"
 	c "github.com/elastic/beats/libbeat/common/schema/mapstriface"
 	"github.com/elastic/beats/metricbeat/mb"
@@ -145,26 +147,34 @@ var (
 	}
 )
 
-func eventsMapping(r mb.ReporterV2, content []byte) {
+func eventsMapping(r mb.ReporterV2, content []byte, m *ClusterMetricSet) error {
 	var nodes []map[string]interface{}
 	err := json.Unmarshal(content, &nodes)
 	if err != nil {
-		r.Error(err)
-		return
+		return errors.Wrap(err, "error in Unmarshal")
 	}
 
 	for _, node := range nodes {
-		eventMapping(r, node)
+		evt, err := eventMapping(node)
+		if err != nil {
+			m.Logger().Errorf("error in mapping: %s", err)
+			r.Error(err)
+			continue
+		}
+		if !r.Event(evt) {
+			return nil
+		}
 	}
+	return nil
 }
 
-func eventMapping(r mb.ReporterV2, node map[string]interface{}) {
+func eventMapping(node map[string]interface{}) (mb.Event, error) {
 	event, err := schema.Apply(node)
 	if err != nil {
-		r.Error(err)
-		return
+		return mb.Event{}, errors.Wrap(err, "error applying schema")
 	}
-	r.Event(mb.Event{
+	return mb.Event{
 		MetricSetFields: event,
-	})
+	}, nil
+
 }

--- a/metricbeat/module/rabbitmq/node/node.go
+++ b/metricbeat/module/rabbitmq/node/node.go
@@ -89,35 +89,36 @@ func (m *MetricSet) fetchOverview() (*apiOverview, error) {
 }
 
 // Fetch metrics from rabbitmq node
-func (m *MetricSet) Fetch(r mb.ReporterV2) {
+func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 	o, err := m.fetchOverview()
 	if err != nil {
-		r.Error(err)
-		return
+		errors.Wrap(err, "error in fetch")
 	}
 
 	node, err := rabbitmq.NewMetricSet(m.BaseMetricSet, rabbitmq.NodesPath+"/"+o.Node)
 	if err != nil {
-		r.Error(err)
-		return
+		errors.Wrap(err, "error creating new metricset")
 	}
 
 	content, err := node.HTTP.FetchJSON()
 	if err != nil {
-		r.Error(err)
-		return
+		return errors.Wrap(err, "error in fetch")
 	}
 
-	eventMapping(r, content)
+	evt, err := eventMapping(content)
+	if err != nil {
+		return errors.Wrap(err, "error in mapping")
+	}
+	r.Event(evt)
+	return nil
 }
 
 // Fetch metrics from all rabbitmq nodes in the cluster
-func (m *ClusterMetricSet) Fetch(r mb.ReporterV2) {
+func (m *ClusterMetricSet) Fetch(r mb.ReporterV2) error {
 	content, err := m.HTTP.FetchContent()
 	if err != nil {
-		r.Error(err)
-		return
+		return errors.Wrap(err, "error in fetch")
 	}
 
-	eventsMapping(r, content)
+	return eventsMapping(r, content, m)
 }

--- a/metricbeat/module/rabbitmq/node/node.go
+++ b/metricbeat/module/rabbitmq/node/node.go
@@ -92,12 +92,12 @@ func (m *MetricSet) fetchOverview() (*apiOverview, error) {
 func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 	o, err := m.fetchOverview()
 	if err != nil {
-		errors.Wrap(err, "error in fetch")
+		return errors.Wrap(err, "error in fetch")
 	}
 
 	node, err := rabbitmq.NewMetricSet(m.BaseMetricSet, rabbitmq.NodesPath+"/"+o.Node)
 	if err != nil {
-		errors.Wrap(err, "error creating new metricset")
+		return errors.Wrap(err, "error creating new metricset")
 	}
 
 	content, err := node.HTTP.FetchJSON()

--- a/metricbeat/module/rabbitmq/node/node_integration_test.go
+++ b/metricbeat/module/rabbitmq/node/node_integration_test.go
@@ -28,8 +28,8 @@ import (
 )
 
 func TestData(t *testing.T) {
-	ms := mbtest.NewReportingMetricSetV2(t, getConfig())
-	err := mbtest.WriteEventsReporterV2(ms, t, "")
+	ms := mbtest.NewReportingMetricSetV2Error(t, getConfig())
+	err := mbtest.WriteEventsReporterV2Error(ms, t, "")
 	if err != nil {
 		t.Fatal("write", err)
 	}
@@ -41,7 +41,7 @@ func TestFetch(t *testing.T) {
 
 	reporter := &mbtest.CapturingReporterV2{}
 
-	metricSet := mbtest.NewReportingMetricSetV2(t, getConfig())
+	metricSet := mbtest.NewReportingMetricSetV2Error(t, getConfig())
 	metricSet.Fetch(reporter)
 
 	e := mbtest.StandardizeEvent(metricSet, reporter.GetEvents()[0])

--- a/metricbeat/module/rabbitmq/node/node_test.go
+++ b/metricbeat/module/rabbitmq/node/node_test.go
@@ -46,8 +46,8 @@ func testFetch(t *testing.T, collect string) {
 		"node.collect": collect,
 	}
 
-	ms := mbtest.NewReportingMetricSetV2(t, config)
-	events, errors := mbtest.ReportingFetchV2(ms)
+	ms := mbtest.NewReportingMetricSetV2Error(t, config)
+	events, errors := mbtest.ReportingFetchV2Error(ms)
 	if !assert.True(t, len(errors) == 0, "There shouldn't be errors") {
 		t.Log(errors)
 	}
@@ -76,11 +76,11 @@ func testFetch(t *testing.T, collect string) {
 	assert.EqualValues(t, 27352751800, reclaimed["bytes"])
 
 	io := event["io"].(common.MapStr)
-	file_handle := io["file_handle"].(common.MapStr)
-	open_attempt := file_handle["open_attempt"].(common.MapStr)
-	avg := open_attempt["avg"].(common.MapStr)
+	fileHandle := io["file_handle"].(common.MapStr)
+	openAttempt := fileHandle["open_attempt"].(common.MapStr)
+	avg := openAttempt["avg"].(common.MapStr)
 	assert.EqualValues(t, 0, avg["ms"])
-	assert.EqualValues(t, 597670, open_attempt["count"])
+	assert.EqualValues(t, 597670, openAttempt["count"])
 
 	read := io["read"].(common.MapStr)
 	avg = read["avg"].(common.MapStr)
@@ -122,10 +122,10 @@ func testFetch(t *testing.T, collect string) {
 	assert.EqualValues(t, 92, tx["count"])
 
 	msg := event["msg"].(common.MapStr)
-	store_read := msg["store_read"].(common.MapStr)
-	assert.EqualValues(t, 0, store_read["count"])
-	store_write := msg["store_write"].(common.MapStr)
-	assert.EqualValues(t, 0, store_write["count"])
+	storeRead := msg["store_read"].(common.MapStr)
+	assert.EqualValues(t, 0, storeRead["count"])
+	storeWrite := msg["store_write"].(common.MapStr)
+	assert.EqualValues(t, 0, storeWrite["count"])
 
 	assert.EqualValues(t, "rabbit@e2b1ae6390fd", event["name"])
 
@@ -137,8 +137,8 @@ func testFetch(t *testing.T, collect string) {
 
 	queue := event["queue"].(common.MapStr)
 	index := queue["index"].(common.MapStr)
-	journal_write := index["journal_write"].(common.MapStr)
-	assert.EqualValues(t, 448230, journal_write["count"])
+	journalWrite := index["journal_write"].(common.MapStr)
+	assert.EqualValues(t, 448230, journalWrite["count"])
 	read = index["read"].(common.MapStr)
 	assert.EqualValues(t, 0, read["count"])
 	write = index["write"].(common.MapStr)

--- a/metricbeat/module/rabbitmq/queue/data.go
+++ b/metricbeat/module/rabbitmq/queue/data.go
@@ -20,14 +20,13 @@ package queue
 import (
 	"encoding/json"
 
-	"github.com/elastic/beats/metricbeat/mb"
+	"github.com/pkg/errors"
 
-	"github.com/joeshaw/multierror"
+	"github.com/elastic/beats/metricbeat/mb"
 
 	"github.com/elastic/beats/libbeat/common"
 	s "github.com/elastic/beats/libbeat/common/schema"
 	c "github.com/elastic/beats/libbeat/common/schema/mapstriface"
-	"github.com/elastic/beats/libbeat/logp"
 )
 
 var (
@@ -85,32 +84,32 @@ var (
 	}
 )
 
-func eventsMapping(content []byte, r mb.ReporterV2) {
+func eventsMapping(content []byte, r mb.ReporterV2, m *MetricSet) error {
 	var queues []map[string]interface{}
 	err := json.Unmarshal(content, &queues)
 	if err != nil {
-		logp.Err("Error: %+v", err)
-		r.Error(err)
-		return
+		return errors.Wrap(err, "error in mapping")
 	}
 
-	var errors multierror.Errors
 	for _, queue := range queues {
-		err := eventMapping(queue, r)
+		evt, err := eventMapping(queue)
 		if err != nil {
-			errors = append(errors, err)
+			m.Logger().Errorf("error in mapping: %s", err)
+			r.Error(err)
+			continue
+		}
+		if !r.Event(evt) {
+			return nil
 		}
 	}
 
-	if len(errors) > 0 {
-		r.Error(errors.Err())
-	}
+	return nil
 }
 
-func eventMapping(queue map[string]interface{}, r mb.ReporterV2) error {
+func eventMapping(queue map[string]interface{}) (mb.Event, error) {
 	fields, err := schema.Apply(queue)
 	if err != nil {
-		return err
+		return mb.Event{}, errors.Wrap(err, "error applying schema")
 	}
 
 	moduleFields := common.MapStr{}
@@ -128,7 +127,5 @@ func eventMapping(queue map[string]interface{}, r mb.ReporterV2) error {
 		MetricSetFields: fields,
 		ModuleFields:    moduleFields,
 	}
-
-	r.Event(event)
-	return nil
+	return event, nil
 }

--- a/metricbeat/module/rabbitmq/queue/queue.go
+++ b/metricbeat/module/rabbitmq/queue/queue.go
@@ -18,6 +18,8 @@
 package queue
 
 import (
+	"github.com/pkg/errors"
+
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/module/rabbitmq"
 )
@@ -44,13 +46,12 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 }
 
 // Fetch fetches queue data
-func (m *MetricSet) Fetch(r mb.ReporterV2) {
+func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 	content, err := m.HTTP.FetchContent()
 
 	if err != nil {
-		r.Error(err)
-		return
+		return errors.Wrap(err, "error in fetch")
 	}
 
-	eventsMapping(content, r)
+	return eventsMapping(content, r, m)
 }

--- a/metricbeat/module/rabbitmq/queue/queue_test.go
+++ b/metricbeat/module/rabbitmq/queue/queue_test.go
@@ -33,7 +33,7 @@ func TestFetchEventContents(t *testing.T) {
 
 	reporter := &mbtest.CapturingReporterV2{}
 
-	metricSet := mbtest.NewReportingMetricSetV2(t, getConfig(server.URL))
+	metricSet := mbtest.NewReportingMetricSetV2Error(t, getConfig(server.URL))
 	metricSet.Fetch(reporter)
 
 	e := mbtest.StandardizeEvent(metricSet, reporter.GetEvents()[0])
@@ -89,8 +89,8 @@ func TestData(t *testing.T) {
 	server := mtest.Server(t, mtest.DefaultServerConfig)
 	defer server.Close()
 
-	ms := mbtest.NewReportingMetricSetV2(t, getConfig(server.URL))
-	err := mbtest.WriteEventsReporterV2Cond(ms, t, "", func(e common.MapStr) bool {
+	ms := mbtest.NewReportingMetricSetV2Error(t, getConfig(server.URL))
+	err := mbtest.WriteEventsReporterV2ErrorCond(ms, t, "", func(e common.MapStr) bool {
 		hasTotal, _ := e.HasKey("rabbitmq.queue.messages.total")
 		return hasTotal
 	})


### PR DESCRIPTION
See elastic/beats#11374 

This is definitely one of the most complicated migrations yet, and I ended up doing a lot of refactoring to clean up the error handling. I could have done more, but I decided not to go _too_  overboard. 

There's a lot of calling `r.Event` inside a loop, which means we need to revert to our pre-ReporterV2 error handling.