### PR TITLE
[DOCS] Updated release-state attribute

### DIFF
--- a/libbeat/docs/version.asciidoc
+++ b/libbeat/docs/version.asciidoc
@@ -1,7 +1,7 @@
 :stack-version: 7.1.0
 :doc-branch: 7.1
 :go-version: 1.11.5
-:release-state: unreleased
+:release-state: released
 :python: 2.7.9
 :docker: 1.12
 :docker-compose: 1.11


### PR DESCRIPTION
The 7.1.0 installation instructions aren't showing up yet (e.g. in https://www.elastic.co/guide/en/beats/metricbeat/7.1/metricbeat-installation.html) because the release-state is "unreleased".

Related to https://github.com/elastic/beats/pull/12021/files