### PR TITLE
[DOCS] Updates 7.2 version attributes

### DIFF
--- a/libbeat/docs/version.asciidoc
+++ b/libbeat/docs/version.asciidoc
@@ -1,9 +1,9 @@
 :stack-version: 7.2.0
-:doc-branch: 7.x
+:doc-branch: 7.2
 :go-version: 1.12.4
 :release-state: unreleased
 :python: 2.7.9
 :docker: 1.12
 :docker-compose: 1.11
-:branch: 7.x
+:branch: 7.2
 :major-version: 7.x


### PR DESCRIPTION
This PR updates the branch information from `7.x` to `7.2`.