### PR TITLE
[Auditbeat][Metricbeat] Cherry-pick #12248 to 7.1: Fix direction of incoming IPv6 sockets

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -38,6 +38,7 @@ https://github.com/elastic/beats/compare/v7.0.0...7.1[Check the HEAD diff]
 - Process dataset: Fixed a memory leak under Windows. {pull}12100[12100]
 - Login dataset: Fix re-read of utmp files. {pull}12028[12028]
 - Package dataset: Fixed a crash inside librpm after Auditbeat has been running for a while. {issue}12147[12147] {pull}12168[12168]
+- Fix direction of incoming IPv6 sockets. {pull}12248[12248]
 
 *Filebeat*
 
@@ -53,6 +54,7 @@ https://github.com/elastic/beats/compare/v7.0.0...7.1[Check the HEAD diff]
 
 - Update documentation with cloudwatch:ListMetrics permission. {pull}11987[11987]
 - Change some field type from scaled_float to long in aws module. {pull}11982[11982]
+- Fix direction of incoming IPv6 sockets. {pull}12248[12248]
 
 *Packetbeat*
 

--- a/metricbeat/helper/socket/listeners.go
+++ b/metricbeat/helper/socket/listeners.go
@@ -19,6 +19,7 @@ package socket
 
 import (
 	"net"
+	"syscall"
 )
 
 // Direction indicates how a socket was initiated.
@@ -113,7 +114,7 @@ func (t *ListenerTable) Put(proto uint8, ip net.IP, port int) {
 // listeners in the table for the protocol and returns Inbound if there is a
 // match. If remotePort is 0 then Listening is returned.
 func (t *ListenerTable) Direction(
-	proto uint8,
+	family uint8, proto uint8,
 	localIP net.IP, localPort int,
 	remoteIP net.IP, remotePort int,
 ) Direction {
@@ -135,14 +136,13 @@ func (t *ListenerTable) Direction(
 
 	// Is there a listener that specific interface? OR
 	// Is there a listener on the "any" address (0.0.0.0 or ::)?
-	isIPv4 := localIP.To4() != nil
 	for _, ip := range interfaces.ips {
 		switch {
 		case ip.Equal(localIP):
 			return Inbound
-		case ip.Equal(net.IPv4zero) && isIPv4:
+		case family == syscall.AF_INET && ip.Equal(net.IPv4zero):
 			return Inbound
-		case ip.Equal(net.IPv6zero) && !isIPv4:
+		case family == syscall.AF_INET6 && ip.Equal(net.IPv6zero):
 			return Inbound
 		}
 	}

--- a/metricbeat/module/system/socket/socket.go
+++ b/metricbeat/module/system/socket/socket.go
@@ -191,7 +191,7 @@ func (m *MetricSet) enrichConnectionData(c *connection) {
 	c.User = m.users.LookupUID(int(c.UID))
 
 	// Determine direction (incoming, outgoing, or listening).
-	c.Direction = m.listeners.Direction(uint8(syscall.IPPROTO_TCP),
+	c.Direction = m.listeners.Direction(uint8(c.Family), uint8(syscall.IPPROTO_TCP),
 		c.LocalIP, c.LocalPort, c.RemoteIP, c.RemotePort)
 
 	// Reverse DNS lookup on the remote IP.

--- a/x-pack/auditbeat/module/system/socket/socket.go
+++ b/x-pack/auditbeat/module/system/socket/socket.go
@@ -379,7 +379,7 @@ func (ms *MetricSet) enrichSocket(socket *Socket) error {
 
 	socket.Username = userAccount.Username
 
-	socket.Direction = ms.listeners.Direction(uint8(syscall.IPPROTO_TCP),
+	socket.Direction = ms.listeners.Direction(uint8(socket.Family), uint8(syscall.IPPROTO_TCP),
 		socket.LocalIP, socket.LocalPort, socket.RemoteIP, socket.RemotePort)
 
 	if ms.ptable != nil {


### PR DESCRIPTION
Cherry-pick of PR #12248 to 7.1 branch. Original message: 

To determine the direction of a socket, we save the list of listening sockets and match non-listening sockets to them. If we find a match, the non-listening socket is `Incoming`, otherwise `Outgoing`.

A problem occurs when matching an IPv6 socket listening on all interfaces (`::`) with an IPv6 socket that has an [IPv4-mapped IPv6 addresses](https://en.wikipedia.org/wiki/IPv6#IPv4-mapped_IPv6_addresses) (e.g. `::ffff:127.0.0.1`). Golang's `To4()` will determine it is an IPv4 address and miss the listening IPv6 socket.

With this PR, we specify the IP family explicitly instead of trying to determine it from the IP address.

Fixes https://github.com/elastic/beats/issues/3306.