### PR TITLE
[Auditbeat][Metricbeat] Cherry-pick #12248 to 6.8: Fix direction of incoming IPv6 sockets

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -41,6 +41,7 @@ https://github.com/elastic/beats/compare/v6.7.2...6.8[Check the HEAD diff]
 - Process dataset: Fixed a memory leak under Windows. {pull}12100[12100]
 - Login dataset: Fix re-read of utmp files. {pull}12028[12028]
 - Package dataset: Fixed a crash inside librpm after Auditbeat has been running for a while. {issue}12147[12147] {pull}12168[12168]
+- Fix direction of incoming IPv6 sockets. {pull}12248[12248]
 
 *Filebeat*
 
@@ -55,6 +56,8 @@ https://github.com/elastic/beats/compare/v6.7.2...6.8[Check the HEAD diff]
 *Journalbeat*
 
 *Metricbeat*
+
+- Fix direction of incoming IPv6 sockets. {pull}12248[12248]
 
 *Packetbeat*
 

--- a/metricbeat/helper/socket/listeners_test.go
+++ b/metricbeat/helper/socket/listeners_test.go
@@ -19,6 +19,7 @@ package socket
 
 import (
 	"net"
+	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -33,28 +34,30 @@ func TestListenerTable(t *testing.T) {
 	rAddr := net.ParseIP("198.18.0.1")
 	ephemeralPort := 48199
 	ipv6Addr := net.ParseIP("2001:db8:fe80::217:f2ff:fe07:ed62")
+	ipv4InIpv6 := net.ParseIP("::ffff:127.0.0.1")
 
 	// Any socket with remote port of 0 is listening.
-	assert.Equal(t, Listening, l.Direction(proto, lAddr, httpPort, net.IPv4zero, 0))
+	assert.Equal(t, Listening, l.Direction(syscall.AF_INET, proto, lAddr, httpPort, net.IPv4zero, 0))
 
 	// Listener on 192.0.2.1:80
 	l.Put(proto, lAddr, httpPort)
 
-	assert.Equal(t, Incoming, l.Direction(proto, lAddr, httpPort, rAddr, ephemeralPort))
-	assert.Equal(t, Outgoing, l.Direction(0, lAddr, httpPort, rAddr, ephemeralPort))
-	assert.Equal(t, Outgoing, l.Direction(proto, lAddr, ephemeralPort, rAddr, ephemeralPort))
+	assert.Equal(t, Incoming, l.Direction(syscall.AF_INET, proto, lAddr, httpPort, rAddr, ephemeralPort))
+	assert.Equal(t, Outgoing, l.Direction(syscall.AF_INET, 0, lAddr, httpPort, rAddr, ephemeralPort))
+	assert.Equal(t, Outgoing, l.Direction(syscall.AF_INET, proto, lAddr, ephemeralPort, rAddr, ephemeralPort))
 
 	// Listener on 0.0.0.0:80
 	l.Reset()
 	l.Put(proto, net.IPv4zero, httpPort)
 
-	assert.Equal(t, Incoming, l.Direction(proto, lAddr, httpPort, rAddr, ephemeralPort))
-	assert.Equal(t, Outgoing, l.Direction(proto, ipv6Addr, httpPort, rAddr, ephemeralPort))
+	assert.Equal(t, Incoming, l.Direction(syscall.AF_INET, proto, lAddr, httpPort, rAddr, ephemeralPort))
+	assert.Equal(t, Outgoing, l.Direction(syscall.AF_INET6, proto, ipv6Addr, httpPort, rAddr, ephemeralPort))
 
 	// Listener on :::80
 	l.Reset()
 	l.Put(proto, net.IPv6zero, httpPort)
 
-	assert.Equal(t, Incoming, l.Direction(proto, ipv6Addr, httpPort, rAddr, ephemeralPort))
-	assert.Equal(t, Outgoing, l.Direction(proto, lAddr, httpPort, rAddr, ephemeralPort))
+	assert.Equal(t, Incoming, l.Direction(syscall.AF_INET6, proto, ipv6Addr, httpPort, rAddr, ephemeralPort))
+	assert.Equal(t, Incoming, l.Direction(syscall.AF_INET6, proto, ipv4InIpv6, httpPort, rAddr, ephemeralPort))
+	assert.Equal(t, Outgoing, l.Direction(syscall.AF_INET, proto, lAddr, httpPort, rAddr, ephemeralPort))
 }

--- a/metricbeat/module/system/socket/socket.go
+++ b/metricbeat/module/system/socket/socket.go
@@ -184,7 +184,7 @@ func (m *MetricSet) enrichConnectionData(c *connection) {
 	c.Username = m.users.LookupUID(int(c.UID))
 
 	// Determine direction (incoming, outgoing, or listening).
-	c.Direction = m.listeners.Direction(uint8(syscall.IPPROTO_TCP),
+	c.Direction = m.listeners.Direction(uint8(c.Family), uint8(syscall.IPPROTO_TCP),
 		c.LocalIP, c.LocalPort, c.RemoteIP, c.RemotePort)
 
 	// Reverse DNS lookup on the remote IP.

--- a/x-pack/auditbeat/module/system/socket/socket.go
+++ b/x-pack/auditbeat/module/system/socket/socket.go
@@ -379,7 +379,7 @@ func (ms *MetricSet) enrichSocket(socket *Socket) error {
 
 	socket.Username = userAccount.Username
 
-	socket.Direction = ms.listeners.Direction(uint8(syscall.IPPROTO_TCP),
+	socket.Direction = ms.listeners.Direction(uint8(socket.Family), uint8(syscall.IPPROTO_TCP),
 		socket.LocalIP, socket.LocalPort, socket.RemoteIP, socket.RemotePort)
 
 	if ms.ptable != nil {


### PR DESCRIPTION
Cherry-pick of PR #12248 to 6.8 branch. Original message: 

To determine the direction of a socket, we save the list of listening sockets and match non-listening sockets to them. If we find a match, the non-listening socket is `Incoming`, otherwise `Outgoing`.

A problem occurs when matching an IPv6 socket listening on all interfaces (`::`) with an IPv6 socket that has an [IPv4-mapped IPv6 addresses](https://en.wikipedia.org/wiki/IPv6#IPv4-mapped_IPv6_addresses) (e.g. `::ffff:127.0.0.1`). Golang's `To4()` will determine it is an IPv4 address and miss the listening IPv6 socket.

With this PR, we specify the IP family explicitly instead of trying to determine it from the IP address.

Fixes https://github.com/elastic/beats/issues/3306.