### PR TITLE
Remove timezone conditionals from pipeline template

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -186,6 +186,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - New module `palo_alto` for Palo Alto Networks PAN-OS logs. {pull}11999[11999]
 - Add RabbitMQ module. {pull}12032[12032]
 - Add new `container` input. {pull}12162[12162]
+- Add specific date processor to convert timezones so same pipeline can be used when convert_timezone is enabled or disabled. {pull}12253[12253]
 
 *Heartbeat*
 

--- a/filebeat/fileset/fileset_test.go
+++ b/filebeat/fileset/fileset_test.go
@@ -20,7 +20,6 @@
 package fileset
 
 import (
-	"encoding/json"
 	"fmt"
 	"path/filepath"
 	"runtime"
@@ -28,10 +27,8 @@ import (
 	"text/template"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/logp"
 )
 
 func getModuleForTesting(t *testing.T, module, fileset string) *Fileset {

--- a/filebeat/fileset/fileset_test.go
+++ b/filebeat/fileset/fileset_test.go
@@ -232,51 +232,6 @@ func TestGetPipelineNginx(t *testing.T) {
 	assert.Contains(t, pipeline.contents, "processors")
 }
 
-func TestGetPipelineConvertTS(t *testing.T) {
-	logp.TestingSetup(logp.WithSelectors("fileset", "modules"))
-
-	// load system/syslog
-	modulesPath, err := filepath.Abs("../module")
-	assert.NoError(t, err)
-	fs, err := New(modulesPath, "syslog", &ModuleConfig{Module: "system"}, &FilesetConfig{
-		Var: map[string]interface{}{
-			"convert_timezone": true,
-		},
-	})
-	assert.NoError(t, err)
-	assert.NoError(t, fs.Read("6.1.0"))
-
-	cases := map[string]struct {
-		Beat     string
-		Timezone bool
-	}{
-		"6.0.0": {Timezone: false},
-		"6.1.0": {Timezone: true},
-		"6.2.0": {Timezone: true},
-	}
-
-	for esVersion, cfg := range cases {
-		pipelineName := "filebeat-6.1.0-system-syslog-pipeline"
-
-		t.Run(fmt.Sprintf("es=%v", esVersion), func(t *testing.T) {
-			ver := common.MustNewVersion(esVersion)
-			pipelines, err := fs.GetPipelines(*ver)
-			require.NoError(t, err)
-
-			pipeline := pipelines[0]
-			assert.Equal(t, pipelineName, pipeline.id)
-
-			marshaled, err := json.Marshal(pipeline.contents)
-			require.NoError(t, err)
-			if cfg.Timezone {
-				assert.Contains(t, string(marshaled), "event.timezone")
-			} else {
-				assert.NotContains(t, string(marshaled), "event.timezone")
-			}
-		})
-	}
-}
-
 func TestGetTemplateFunctions(t *testing.T) {
 	vars := map[string]interface{}{
 		"builtin": map[string]interface{}{},

--- a/filebeat/module/system/syslog/ingest/pipeline.json
+++ b/filebeat/module/system/syslog/ingest/pipeline.json
@@ -45,7 +45,7 @@
                 "field": "@timestamp",
                 "formats": ["ISO8601"],
                 "timezone": "{{ event.timezone }}",
-                "on_failure": [{"set": {"field": "error.message", "value": "{{ _ingest.on_failure_message }}"}}]
+                "on_failure": [{"append": {"field": "error.message", "value": "{{ _ingest.on_failure_message }}"}}]
             }
         },
         {

--- a/filebeat/module/system/syslog/ingest/pipeline.json
+++ b/filebeat/module/system/syslog/ingest/pipeline.json
@@ -45,7 +45,7 @@
                 "field": "@timestamp",
                 "formats": ["ISO8601"],
                 "timezone": "{{ event.timezone }}",
-                "on_failure": [{"set": {"field": "error", "value": "{{ _ingest.on_failure_message }}"}}]
+                "on_failure": [{"set": {"field": "error.message", "value": "{{ _ingest.on_failure_message }}"}}]
             }
         },
         {

--- a/filebeat/module/system/syslog/ingest/pipeline.json
+++ b/filebeat/module/system/syslog/ingest/pipeline.json
@@ -36,8 +36,16 @@
                     "MMM dd HH:mm:ss",
                     "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZZ"
                 ],
-                {< if .convert_timezone >}"timezone": "{{ event.timezone }}",{< end >}
                 "ignore_failure": true
+            }
+        },
+        {
+            "date": {
+                "if": "ctx.event.timezone != null",
+                "field": "@timestamp",
+                "formats": ["ISO8601"],
+                "timezone": "{{ event.timezone }}",
+                "on_failure": [{"set": {"field": "error", "value": "{{ _ingest.on_failure_message }}"}}]
             }
         },
         {


### PR DESCRIPTION
Some filebeat modules can optionally convert timezones, this option
works by:
* Adding a field with the timezone to the generated events
* Conditionally adding the timezone to the date processor in the ingest
  pipeline when installed

This results in two possible pipelines, that are going to depend on the
configuration used on setup. This is problematic because doesn't allow
multiple beats to have different settings, and is also problematic when
users want to change the setting, as the pipeline needs to be installed
again.

This change removes the condition from the template, and adds an
additional date processor that uses the timezone only if this value is
available. This way the installed pipeline is always the same, can be
used with filebeats with different configurations and doesn't need to be
updated if the setting changes in filebeat.

To be applied in other modules too if approved.