### PR TITLE
Validate that kibana/status metricset cannot be used with xpack.enabled: true

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -125,6 +125,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Change some field type from scaled_float to long in aws module. {pull}11982[11982]
 - Fixed RabbitMQ `queue` metricset gathering when `consumer_utilisation` is set empty at the metrics source {pull}12089[12089]
 - Fix direction of incoming IPv6 sockets. {pull}12248[12248]
+- Validate that kibana/status metricset cannot be used when xpack is enabled. {pull}12264[12264]
 
 *Packetbeat*
 

--- a/metricbeat/module/kibana/status/status.go
+++ b/metricbeat/module/kibana/status/status.go
@@ -18,6 +18,8 @@
 package status
 
 import (
+	"fmt"
+
 	"github.com/elastic/beats/metricbeat/helper"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/mb/parse"
@@ -52,6 +54,10 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	ms, err := kibana.NewMetricSet(base)
 	if err != nil {
 		return nil, err
+	}
+
+	if ms.XPackEnabled {
+		return nil, fmt.Errorf("The %s metricset cannot be used with xpack.enabled: true", ms.FullyQualifiedName())
 	}
 
 	http, err := helper.NewHTTP(base)


### PR DESCRIPTION
The `kibana/status` metricset doesn't have an x-pack code path (used for stack monitoring). Yet, prior to this PR we would allow users to enable the `kibana/status` metricset AND set `xpack.enabled: true`. This would result in unexpected and invalid behavior.

With this PR if this combination is detected, an error is thrown.