### PR TITLE
Only log error (don't also index it) if xpack is enabled.

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -128,6 +128,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix direction of incoming IPv6 sockets. {pull}12248[12248]
 - Validate that kibana/status metricset cannot be used when xpack is enabled. {pull}12264[12264]
 - Ignore prometheus metrics when their values are NaN or Inf. {pull}12084[12084] {issue}10849[10849]
+- In the kibana/stats metricset, only log error (don't also index it) if xpack is enabled. {pull}12265[12265]
 
 *Packetbeat*
 

--- a/metricbeat/module/kibana/stats/stats.go
+++ b/metricbeat/module/kibana/stats/stats.go
@@ -132,6 +132,10 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 
 	err := m.fetchStats(r, now)
 	if err != nil {
+		if m.XPackEnabled {
+			m.Logger().Error(err)
+			return nil
+		}
 		return err
 	}
 


### PR DESCRIPTION
When `xpack.enabled: true` is set on a stack module, the expectation is that the user won't see any `metricbeat-*` indices. Instead users expect to see `.monitoring-*` indices.

However, metricbeat indexes errors into `metricbeat-*` indices. So in an error situation when `xpack.enabled: true` is set, we don't want to index errors but just log them. That's what this PR fixes for the `kibana/stats` metricset.
