### PR TITLE
Adapt Kibana interface for external usage

### DIFF
--- a/libbeat/kibana/client.go
+++ b/libbeat/kibana/client.go
@@ -176,6 +176,7 @@ func (conn *Connection) Request(method, extraPath string,
 	return resp.StatusCode, result, retError
 }
 
+// Sends an application/json request to Kibana with appropriate kbn headers
 func (conn *Connection) Send(method, extraPath string,
 	params url.Values, headers http.Header, body io.Reader) (*http.Response, error) {
 
@@ -183,7 +184,7 @@ func (conn *Connection) Send(method, extraPath string,
 
 	req, err := http.NewRequest(method, reqURL, body)
 	if err != nil {
-		return nil, fmt.Errorf("fail to create the HTTP %s request: %v", method, err)
+		return nil, fmt.Errorf("fail to create the HTTP %s request: %+v", method, err)
 	}
 
 	if conn.Username != "" || conn.Password != "" {
@@ -206,6 +207,7 @@ func (conn *Connection) Send(method, extraPath string,
 	return conn.RoundTrip(req)
 }
 
+// Implements RoundTrip interface
 func (conn *Connection) RoundTrip(r *http.Request) (*http.Response, error) {
 	return conn.http.Do(r)
 }

--- a/libbeat/kibana/client.go
+++ b/libbeat/kibana/client.go
@@ -40,7 +40,6 @@ type Connection struct {
 	URL      string
 	Username string
 	Password string
-	Headers  map[string]string
 
 	http    *http.Client
 	version common.Version
@@ -157,31 +156,7 @@ func NewClientWithConfig(config *ClientConfig) (*Client, error) {
 func (conn *Connection) Request(method, extraPath string,
 	params url.Values, headers http.Header, body io.Reader) (int, []byte, error) {
 
-	reqURL := addToURL(conn.URL, extraPath, params)
-
-	req, err := http.NewRequest(method, reqURL, body)
-	if err != nil {
-		return 0, nil, fmt.Errorf("fail to create the HTTP %s request: %v", method, err)
-	}
-
-	if conn.Username != "" || conn.Password != "" {
-		req.SetBasicAuth(conn.Username, conn.Password)
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Add("Accept", "application/json")
-
-	for header, values := range headers {
-		for _, value := range values {
-			req.Header.Add(header, value)
-		}
-	}
-
-	if method != "GET" {
-		req.Header.Set("kbn-version", conn.version.String())
-	}
-
-	resp, err := conn.http.Do(req)
+	resp, err := conn.Send(method, extraPath, params, headers, body)
 	if err != nil {
 		return 0, nil, fmt.Errorf("fail to execute the HTTP %s request: %v", method, err)
 	}
@@ -199,6 +174,40 @@ func (conn *Connection) Request(method, extraPath string,
 
 	retError = extractError(result)
 	return resp.StatusCode, result, retError
+}
+
+func (conn *Connection) Send(method, extraPath string,
+	params url.Values, headers http.Header, body io.Reader) (*http.Response, error) {
+
+	reqURL := addToURL(conn.URL, extraPath, params)
+
+	req, err := http.NewRequest(method, reqURL, body)
+	if err != nil {
+		return nil, fmt.Errorf("fail to create the HTTP %s request: %v", method, err)
+	}
+
+	if conn.Username != "" || conn.Password != "" {
+		req.SetBasicAuth(conn.Username, conn.Password)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Add("Accept", "application/json")
+	req.Header.Set("kbn-xsrf", "1")
+	if method != "GET" {
+		req.Header.Set("kbn-version", conn.version.String())
+	}
+
+	for header, values := range headers {
+		for _, value := range values {
+			req.Header.Add(header, value)
+		}
+	}
+
+	return conn.RoundTrip(req)
+}
+
+func (conn *Connection) RoundTrip(r *http.Request) (*http.Response, error) {
+	return conn.http.Do(r)
 }
 
 func (client *Client) readVersion() error {


### PR DESCRIPTION
- Adds Kibana `kbn-xsrf` header (security).
- Implements `RoundTrip` interface: facilitates testing outside the package, where there is no access to `conn.http`
- Breaks down `SendRequest` in 2 methods, so external callers not interested in the `extractError` functionality can get the bare `*Response` object.