### PR TITLE
[7.1] Validate that kibana/status metricset cannot be used with xpack.enabled: true (#12264)

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -55,6 +55,7 @@ https://github.com/elastic/beats/compare/v7.0.0...7.1[Check the HEAD diff]
 - Update documentation with cloudwatch:ListMetrics permission. {pull}11987[11987]
 - Change some field type from scaled_float to long in aws module. {pull}11982[11982]
 - Fix direction of incoming IPv6 sockets. {pull}12248[12248]
+- Validate that kibana/status metricset cannot be used when xpack is enabled. {pull}12264[12264]
 
 *Packetbeat*
 

--- a/metricbeat/module/kibana/status/status.go
+++ b/metricbeat/module/kibana/status/status.go
@@ -18,6 +18,8 @@
 package status
 
 import (
+	"fmt"
+
 	"github.com/elastic/beats/metricbeat/helper"
 	"github.com/elastic/beats/metricbeat/helper/elastic"
 	"github.com/elastic/beats/metricbeat/mb"
@@ -53,6 +55,10 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	ms, err := kibana.NewMetricSet(base)
 	if err != nil {
 		return nil, err
+	}
+
+	if ms.XPackEnabled {
+		return nil, fmt.Errorf("The %s metricset cannot be used with xpack.enabled: true", ms.FullyQualifiedName())
 	}
 
 	http, err := helper.NewHTTP(base)


### PR DESCRIPTION
Backports the following commits to 7.1:
 - Validate that kibana/status metricset cannot be used with xpack.enabled: true  (#12264)