### PR TITLE
[6.8] Validate that kibana/status metricset cannot be used with xpack.enabled: true (#12264)

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -58,6 +58,7 @@ https://github.com/elastic/beats/compare/v6.7.2...6.8[Check the HEAD diff]
 *Metricbeat*
 
 - Fix direction of incoming IPv6 sockets. {pull}12248[12248]
+- Validate that kibana/status metricset cannot be used when xpack is enabled. {pull}12264[12264]
 
 *Packetbeat*
 

--- a/metricbeat/module/kibana/status/status.go
+++ b/metricbeat/module/kibana/status/status.go
@@ -18,6 +18,8 @@
 package status
 
 import (
+	"fmt"
+
 	"github.com/elastic/beats/metricbeat/helper"
 	"github.com/elastic/beats/metricbeat/helper/elastic"
 	"github.com/elastic/beats/metricbeat/mb"
@@ -53,6 +55,10 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	ms, err := kibana.NewMetricSet(base)
 	if err != nil {
 		return nil, err
+	}
+
+	if ms.XPackEnabled {
+		return nil, fmt.Errorf("The %s metricset cannot be used with xpack.enabled: true", ms.FullyQualifiedName())
 	}
 
 	http, err := helper.NewHTTP(base)


### PR DESCRIPTION
Backports the following commits to 6.8:
 - Validate that kibana/status metricset cannot be used with xpack.enabled: true  (#12264)