### PR TITLE
[Auditbeat] Package: Auto-detect package directories

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -90,6 +90,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix formatting of config files on macOS and Windows. {pull}12148[12148]
 - Fix direction of incoming IPv6 sockets. {pull}12248[12248]
 - Package dataset: Close librpm handle. {pull}12215[12215]
+- Package dataset: Auto-detect package directories. {pull}12289[12289]
 
 *Filebeat*
 

--- a/x-pack/auditbeat/module/system/package/rpm_linux_test.go
+++ b/x-pack/auditbeat/module/system/package/rpm_linux_test.go
@@ -7,19 +7,18 @@
 package pkg
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestRPMPackages(t *testing.T) {
-	os, err := getOS()
-	if err != nil {
+	_, err := os.Stat(rpmPath)
+	if os.IsNotExist(err) {
+		t.Skipf("RPM test only on systems where %v exists", rpmPath)
+	} else if err != nil {
 		t.Fatal(err)
-	}
-
-	if os.Family != "redhat" {
-		t.Skip("RPM test only on Redhat systems")
 	}
 
 	// Control using the exec command
@@ -34,5 +33,4 @@ func TestRPMPackages(t *testing.T) {
 	}
 
 	assert.EqualValues(t, packagesExpected, packages)
-
 }


### PR DESCRIPTION
Users have recently struggled with using Auditbeat on distros the `system/package` dataset does not recognize. When this happens, Auditbeat aborts the start with a not very helpful error message.

* Linux Mint (https://github.com/elastic/beats/issues/12177, https://discuss.elastic.co/t/auditbeat-system-metric-error/180629)
* XenServer (https://github.com/elastic/beats/issues/12198)
* Oracle Linux (https://discuss.elastic.co/t/auditbeat-and-oracle-linux/181572)

This PR fixes this by changing the behavior:

1. Instead of selecting the package manager based on the OS family we check which package directories exist: `/var/lib/dpkg`, `/var/lib/rpm`, or `/usr/local/Cellar`. In the future, we could make these configurable.
2. If we find no directories, we log a warning once and continue checking. We do not abort Auditbeat's launch.

Possible future improvements:

1. Add a `package.type` (naming tbd) to distinguish between rpm, deb, and homebrew packages.
2. Make the package directories configurable by the user. We use the default path for each which will work in most cases, but each package manager allows this to be customized.

This is a bigger change, but I'd want to backport it as a bugfix since the current behavior is causing frustration to users. The system module is still in beta, giving us more freedom in what we backport.