### PR TITLE
Cherry-pick to 7.1: Ignore prometheus metrics when their values are NaN or Inf (#12084)

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -56,6 +56,7 @@ https://github.com/elastic/beats/compare/v7.1.1...7.1[Check the HEAD diff]
 - Change some field type from scaled_float to long in aws module. {pull}11982[11982]
 - Fix direction of incoming IPv6 sockets. {pull}12248[12248]
 - Validate that kibana/status metricset cannot be used when xpack is enabled. {pull}12264[12264]
+- Ignore prometheus metrics when their values are NaN or Inf. {pull}12084[12084] {issue}10849[10849]
 
 *Packetbeat*
 

--- a/metricbeat/helper/prometheus/metric.go
+++ b/metricbeat/helper/prometheus/metric.go
@@ -128,28 +128,33 @@ func (m *commonMetric) GetField() string {
 func (m *commonMetric) GetValue(metric *dto.Metric) interface{} {
 	counter := metric.GetCounter()
 	if counter != nil {
-		return int64(counter.GetValue())
+		if !math.IsNaN(counter.GetValue()) && !math.IsInf(counter.GetValue(), 0) {
+			return int64(counter.GetValue())
+		}
 	}
 
 	gauge := metric.GetGauge()
 	if gauge != nil {
-		return gauge.GetValue()
+		if !math.IsNaN(gauge.GetValue()) && !math.IsInf(gauge.GetValue(), 0) {
+			return gauge.GetValue()
+		}
 	}
 
 	summary := metric.GetSummary()
 	if summary != nil {
 		value := common.MapStr{}
-		value["sum"] = summary.GetSampleSum()
-		value["count"] = summary.GetSampleCount()
+		if !math.IsNaN(summary.GetSampleSum()) && !math.IsInf(summary.GetSampleSum(), 0) {
+			value["sum"] = summary.GetSampleSum()
+			value["count"] = summary.GetSampleCount()
+		}
 
 		quantiles := summary.GetQuantile()
 		percentileMap := common.MapStr{}
 		for _, quantile := range quantiles {
-			if !math.IsNaN(quantile.GetValue()) {
-				key := strconv.FormatFloat((100 * quantile.GetQuantile()), 'f', -1, 64)
+			if !math.IsNaN(quantile.GetValue()) && !math.IsInf(quantile.GetValue(), 0) {
+				key := strconv.FormatFloat(100*quantile.GetQuantile(), 'f', -1, 64)
 				percentileMap[key] = quantile.GetValue()
 			}
-
 		}
 
 		if len(percentileMap) != 0 {
@@ -162,14 +167,18 @@ func (m *commonMetric) GetValue(metric *dto.Metric) interface{} {
 	histogram := metric.GetHistogram()
 	if histogram != nil {
 		value := common.MapStr{}
-		value["sum"] = histogram.GetSampleSum()
-		value["count"] = histogram.GetSampleCount()
+		if !math.IsNaN(histogram.GetSampleSum()) && !math.IsInf(histogram.GetSampleSum(), 0) {
+			value["sum"] = histogram.GetSampleSum()
+			value["count"] = histogram.GetSampleCount()
+		}
 
 		buckets := histogram.GetBucket()
 		bucketMap := common.MapStr{}
 		for _, bucket := range buckets {
-			key := strconv.FormatFloat(bucket.GetUpperBound(), 'f', -1, 64)
-			bucketMap[key] = bucket.GetCumulativeCount()
+			if bucket.GetCumulativeCount() != uint64(math.NaN()) && bucket.GetCumulativeCount() != uint64(math.Inf(0)) {
+				key := strconv.FormatFloat(bucket.GetUpperBound(), 'f', -1, 64)
+				bucketMap[key] = bucket.GetCumulativeCount()
+			}
 		}
 
 		if len(bucketMap) != 0 {

--- a/metricbeat/helper/prometheus/prometheus.go
+++ b/metricbeat/helper/prometheus/prometheus.go
@@ -160,7 +160,11 @@ func (p *prometheus) GetProcessedMetrics(mapping *MetricsMapping) ([]common.MapS
 			if field != "" {
 				// Put it in the event if it's a common metric
 				event := getEvent(eventsMap, keyLabels)
-				event.Put(field, value)
+				update := common.MapStr{}
+				update.Put(field, value)
+				// value may be a mapstr (for histograms and summaries), do a deep update to avoid smashing existing fields
+				event.DeepUpdate(update)
+
 				event.DeepUpdate(labels)
 			}
 		}

--- a/metricbeat/module/prometheus/collector/_meta/testdata/metrics-with-naninf.plain
+++ b/metricbeat/module/prometheus/collector/_meta/testdata/metrics-with-naninf.plain
@@ -1,0 +1,32 @@
+# HELP kafka_consumer_records_lag_records The latest lag of the partition
+# TYPE kafka_consumer_records_lag_records gauge
+kafka_consumer_records_lag_records{client_id="consumer1",} NaN
+kafka_consumer_records_lag_records{client_id="consumer2",} +Inf
+kafka_consumer_records_lag_records{client_id="consumer3",} -Inf
+kafka_consumer_records_lag_records{client_id="consumer4",} 5
+# HELP http_failures Total number of http request failures
+# TYPE http_failures counter
+http_failures{method="GET"} 2
+http_failures{method="POST"} NaN
+http_failures{method="DELETE"} +Inf
+# HELP go_gc_duration_seconds A summary of the GC invocation durations.
+# TYPE go_gc_duration_seconds summary
+go_gc_duration_seconds{quantile="0",} NaN
+go_gc_duration_seconds{quantile="0.25",} +Inf
+go_gc_duration_seconds{quantile="0.5",} -Inf
+go_gc_duration_seconds{quantile="0.75"} 9.8154e-05
+go_gc_duration_seconds{quantile="1",} 0.011689149
+go_gc_duration_seconds_sum 3.451780079
+go_gc_duration_seconds_count 13118
+# HELP http_request_duration_seconds request duration histogram
+# TYPE http_request_duration_seconds histogram
+http_request_duration_seconds_bucket{le="0.1"} +Inf
+http_request_duration_seconds_bucket{le="0.2"} -Inf
+http_request_duration_seconds_bucket{le="0.5"} NaN
+http_request_duration_seconds_bucket{le="1"} 1
+http_request_duration_seconds_bucket{le="2"} 2
+http_request_duration_seconds_bucket{le="3"} 3
+http_request_duration_seconds_bucket{le="5"} 3
+http_request_duration_seconds_bucket{le="+Inf"} 3
+http_request_duration_seconds_sum 6
+http_request_duration_seconds_count 3

--- a/metricbeat/module/prometheus/collector/_meta/testdata/metrics-with-naninf.plain-expected.json
+++ b/metricbeat/module/prometheus/collector/_meta/testdata/metrics-with-naninf.plain-expected.json
@@ -1,0 +1,222 @@
+[
+    {
+        "event": {
+            "dataset": "prometheus.collector",
+            "duration": 115000,
+            "module": "prometheus"
+        },
+        "metricset": {
+            "name": "collector"
+        },
+        "prometheus": {
+            "labels": {
+                "client_id": "consumer4"
+            },
+            "metrics": {
+                "kafka_consumer_records_lag_records": 5
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "prometheus"
+        }
+    },
+    {
+        "event": {
+            "dataset": "prometheus.collector",
+            "duration": 115000,
+            "module": "prometheus"
+        },
+        "metricset": {
+            "name": "collector"
+        },
+        "prometheus": {
+            "labels": {
+                "method": "GET"
+            },
+            "metrics": {
+                "http_failures": 2
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "prometheus"
+        }
+    },
+    {
+        "event": {
+            "dataset": "prometheus.collector",
+            "duration": 115000,
+            "module": "prometheus"
+        },
+        "metricset": {
+            "name": "collector"
+        },
+        "prometheus": {
+            "labels": {
+                "le": "5"
+            },
+            "metrics": {
+                "http_request_duration_seconds_bucket": 3
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "prometheus"
+        }
+    },
+    {
+        "event": {
+            "dataset": "prometheus.collector",
+            "duration": 115000,
+            "module": "prometheus"
+        },
+        "metricset": {
+            "name": "collector"
+        },
+        "prometheus": {
+            "labels": {
+                "le": "+Inf"
+            },
+            "metrics": {
+                "http_request_duration_seconds_bucket": 3
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "prometheus"
+        }
+    },
+    {
+        "event": {
+            "dataset": "prometheus.collector",
+            "duration": 115000,
+            "module": "prometheus"
+        },
+        "metricset": {
+            "name": "collector"
+        },
+        "prometheus": {
+            "labels": {
+                "le": "3"
+            },
+            "metrics": {
+                "http_request_duration_seconds_bucket": 3
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "prometheus"
+        }
+    },
+    {
+        "event": {
+            "dataset": "prometheus.collector",
+            "duration": 115000,
+            "module": "prometheus"
+        },
+        "metricset": {
+            "name": "collector"
+        },
+        "prometheus": {
+            "metrics": {
+                "go_gc_duration_seconds_count": 13118,
+                "go_gc_duration_seconds_sum": 3.451780079,
+                "http_request_duration_seconds_count": 3,
+                "http_request_duration_seconds_sum": 6
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "prometheus"
+        }
+    },
+    {
+        "event": {
+            "dataset": "prometheus.collector",
+            "duration": 115000,
+            "module": "prometheus"
+        },
+        "metricset": {
+            "name": "collector"
+        },
+        "prometheus": {
+            "labels": {
+                "le": "2"
+            },
+            "metrics": {
+                "http_request_duration_seconds_bucket": 2
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "prometheus"
+        }
+    },
+    {
+        "event": {
+            "dataset": "prometheus.collector",
+            "duration": 115000,
+            "module": "prometheus"
+        },
+        "metricset": {
+            "name": "collector"
+        },
+        "prometheus": {
+            "labels": {
+                "le": "1"
+            },
+            "metrics": {
+                "http_request_duration_seconds_bucket": 1
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "prometheus"
+        }
+    },
+    {
+        "event": {
+            "dataset": "prometheus.collector",
+            "duration": 115000,
+            "module": "prometheus"
+        },
+        "metricset": {
+            "name": "collector"
+        },
+        "prometheus": {
+            "labels": {
+                "quantile": "1"
+            },
+            "metrics": {
+                "go_gc_duration_seconds": 0.011689149
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "prometheus"
+        }
+    },
+    {
+        "event": {
+            "dataset": "prometheus.collector",
+            "duration": 115000,
+            "module": "prometheus"
+        },
+        "metricset": {
+            "name": "collector"
+        },
+        "prometheus": {
+            "labels": {
+                "quantile": "0.75"
+            },
+            "metrics": {
+                "go_gc_duration_seconds": 0.000098154
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "prometheus"
+        }
+    }
+]

--- a/metricbeat/module/prometheus/collector/data.go
+++ b/metricbeat/module/prometheus/collector/data.go
@@ -55,36 +55,42 @@ func getPromEventsFromMetricFamily(mf *dto.MetricFamily) []PromEvent {
 
 		counter := metric.GetCounter()
 		if counter != nil {
-			events = append(events, PromEvent{
-				data: common.MapStr{
-					name: counter.GetValue(),
-				},
-				labels: labels,
-			})
+			if !math.IsNaN(counter.GetValue()) && !math.IsInf(counter.GetValue(), 0) {
+				events = append(events, PromEvent{
+					data: common.MapStr{
+						name: counter.GetValue(),
+					},
+					labels: labels,
+				})
+			}
 		}
 
 		gauge := metric.GetGauge()
 		if gauge != nil {
-			events = append(events, PromEvent{
-				data: common.MapStr{
-					name: gauge.GetValue(),
-				},
-				labels: labels,
-			})
+			if !math.IsNaN(gauge.GetValue()) && !math.IsInf(gauge.GetValue(), 0) {
+				events = append(events, PromEvent{
+					data: common.MapStr{
+						name: gauge.GetValue(),
+					},
+					labels: labels,
+				})
+			}
 		}
 
 		summary := metric.GetSummary()
 		if summary != nil {
-			events = append(events, PromEvent{
-				data: common.MapStr{
-					name + "_sum":   summary.GetSampleSum(),
-					name + "_count": summary.GetSampleCount(),
-				},
-				labels: labels,
-			})
+			if !math.IsNaN(summary.GetSampleSum()) && !math.IsInf(summary.GetSampleSum(), 0) {
+				events = append(events, PromEvent{
+					data: common.MapStr{
+						name + "_sum":   summary.GetSampleSum(),
+						name + "_count": summary.GetSampleCount(),
+					},
+					labels: labels,
+				})
+			}
 
 			for _, quantile := range summary.GetQuantile() {
-				if math.IsNaN(quantile.GetValue()) {
+				if math.IsNaN(quantile.GetValue()) || math.IsInf(quantile.GetValue(), 0) {
 					continue
 				}
 
@@ -101,15 +107,21 @@ func getPromEventsFromMetricFamily(mf *dto.MetricFamily) []PromEvent {
 
 		histogram := metric.GetHistogram()
 		if histogram != nil {
-			events = append(events, PromEvent{
-				data: common.MapStr{
-					name + "_sum":   histogram.GetSampleSum(),
-					name + "_count": histogram.GetSampleCount(),
-				},
-				labels: labels,
-			})
+			if !math.IsNaN(histogram.GetSampleSum()) && !math.IsInf(histogram.GetSampleSum(), 0) {
+				events = append(events, PromEvent{
+					data: common.MapStr{
+						name + "_sum":   histogram.GetSampleSum(),
+						name + "_count": histogram.GetSampleCount(),
+					},
+					labels: labels,
+				})
+			}
 
 			for _, bucket := range histogram.GetBucket() {
+				if bucket.GetCumulativeCount() == uint64(math.NaN()) || bucket.GetCumulativeCount() == uint64(math.Inf(0)) {
+					continue
+				}
+
 				bucketLabels := labels.Clone()
 				bucketLabels["le"] = strconv.FormatFloat(bucket.GetUpperBound(), 'f', -1, 64)
 


### PR DESCRIPTION
Cherry-pick of PR #12084 to 7.0 branch. Original message:

When prometheus report metrics with value NaN or +Inf or -Inf, metricbeat will fail with error like "Failed to serialize the event: unsupported float value: NaN". This PR is to add the logic to ignore prometheus metrics with NaN/Inf value in `collector` metricset.

This PR also added a `metrics-with-naninf.plain` test data with NaN/Inf as metric value. From the output `metrics-with-naninf.plain-expected.json` you can see, the metrics with NaN/Inf value are not there. 

(cherry picked from commit 9244477294e3494723c0e76cbbe4851d9c451fba)