### PR TITLE
Don't try to rename username field if it doesn't exist

### DIFF
--- a/filebeat/module/elasticsearch/audit/ingest/pipeline-json.json
+++ b/filebeat/module/elasticsearch/audit/ingest/pipeline-json.json
@@ -76,6 +76,7 @@
         },
         {
             "rename": {
+                "if": "ctx.elasticsearch.audit?.user?.name != null",
                 "field": "elasticsearch.audit.user.name",
                 "target_field": "elasticsearch.audit.principal"
             }


### PR DESCRIPTION
Fixes #12297.

Currently in the 6.x series, the ingest pipeline created by the `elasticsearch/audit` fileset tries to use the `elasticsearch.audit.user.name` field in a `rename` processor. Depending on the nature of the audit log entry, this field might not exist. So we need to only execute the `rename` processor if the field exists, otherwise Elasticsearch will throw an error. This PR adds this conditional check.

### Testing this PR

1. Install Elasticsearch 6.8.0.
2. Enable the Trial license.
2. Enable Security
3. Enable the audit log.
4. Start Elasticsearch.
4. Pull down this PR.
5. Build Filebeat.
5. Enable the Elasticsearch module.
6. Configure the Elasticsearch module to point to the Elasticsearch audit log (JSON format).
7. Start Filebeat.
8. Try to make an unauthenticated request to Elasticsearch so it fails and gets logged in the audit log.
9. Give Filebeat about 5 seconds to ingest the new audit log entry and try to index it into Elasticsearch.
10. Check the Elasticsearch server log to make sure there are no errors.