### PR TITLE
[libbeat]image.id and account.id for add_cloud_metadata EC2

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -164,6 +164,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - New `extract_array` processor. {pull}11761[11761]
 - Add number of goroutines to reported metrics. {pull}12135[12135]
 - Add `proxy_disable` output flag to explicitly ignore proxy environment variables. {issue}11713[11713] {pull}12243[12243]
+- Processor `add_cloud_metadata` adds fields `cloud.account.id` and `cloud.image.id` for AWS EC2. {pull}12307[12307]
 
 *Auditbeat*
 

--- a/libbeat/docs/processors-using.asciidoc
+++ b/libbeat/docs/processors-using.asciidoc
@@ -543,9 +543,11 @@ _AWS_
 -------------------------------------------------------------------------------
 {
   "cloud": {
+    "account.id": "123456789012",
     "availability_zone": "us-east-1c",
-    "instance_id": "i-4e123456",
-    "machine_type": "t2.medium",
+    "instance.id": "i-4e123456",
+    "machine.type": "t2.medium",
+    "image.id": "ami-abcd1234",
     "provider": "aws",
     "region": "us-east-1"
   }
@@ -558,7 +560,7 @@ _Digital Ocean_
 -------------------------------------------------------------------------------
 {
   "cloud": {
-    "instance_id": "1234567",
+    "instance.id": "1234567",
     "provider": "digitalocean",
     "region": "nyc2"
   }
@@ -572,9 +574,9 @@ _GCP_
 {
   "cloud": {
     "availability_zone": "us-east1-b",
-    "instance_id": "1234556778987654321",
-    "machine_type": "f1-micro",
-    "project_id": "my-dev",
+    "instance.id": "1234556778987654321",
+    "machine.type": "f1-micro",
+    "project.id": "my-dev",
     "provider": "gcp"
   }
 }
@@ -587,7 +589,7 @@ _Tencent Cloud_
 {
   "cloud": {
     "availability_zone": "gz-azone2",
-    "instance_id": "ins-qcloudv5",
+    "instance.id": "ins-qcloudv5",
     "provider": "qcloud",
     "region": "china-south-gz"
   }
@@ -604,7 +606,7 @@ ECS instance.
 {
   "cloud": {
     "availability_zone": "cn-shenzhen",
-    "instance_id": "i-wz9g2hqiikg0aliyun2b",
+    "instance.id": "i-wz9g2hqiikg0aliyun2b",
     "provider": "ecs",
     "region": "cn-shenzhen-a"
   }
@@ -618,9 +620,9 @@ _Azure Virtual Machine_
 {
   "cloud": {
     "provider": "az",
-    "instance_id": "04ab04c3-63de-4709-a9f9-9ab8c0411d5e",
-    "instance_name": "test-az-vm",
-    "machine_type": "Standard_D3_v2",
+    "instance.id": "04ab04c3-63de-4709-a9f9-9ab8c0411d5e",
+    "instance.name": "test-az-vm",
+    "machine.type": "Standard_D3_v2",
     "region": "eastus2"
   }
 }
@@ -632,11 +634,11 @@ _Openstack Nova_
 -------------------------------------------------------------------------------
 {
   "cloud": {
-    "provider": "openstack",
-    "instance_name": "test-998d932195.mycloud.tld",
+    "instance.name": "test-998d932195.mycloud.tld",
+    "instance.id": "i-00011a84",
     "availability_zone": "xxxx-az-c",
-    "instance_id": "i-00011a84",
-    "machine_type": "m2.large"
+    "provider": "openstack",
+    "machine.type": "m2.large"
   }
 }
 -------------------------------------------------------------------------------

--- a/libbeat/processors/add_cloud_metadata/provider_aws_ec2.go
+++ b/libbeat/processors/add_cloud_metadata/provider_aws_ec2.go
@@ -23,19 +23,18 @@ import (
 	c "github.com/elastic/beats/libbeat/common/schema/mapstriface"
 )
 
+const ec2InstanceIdentityURI = "/2014-02-25/dynamic/instance-identity/document"
+
 // AWS EC2 Metadata Service
 func newEc2MetadataFetcher(config *common.Config) (*metadataFetcher, error) {
-	ec2InstanceIdentityURI := "/2014-02-25/dynamic/instance-identity/document"
 	ec2Schema := func(m map[string]interface{}) common.MapStr {
 		out, _ := s.Schema{
-			"instance": s.Object{
-				"id": c.Str("instanceId"),
-			},
-			"machine": s.Object{
-				"type": c.Str("instanceType"),
-			},
+			"instance":          s.Object{"id": c.Str("instanceId")},
+			"machine":           s.Object{"type": c.Str("instanceType")},
 			"region":            c.Str("region"),
 			"availability_zone": c.Str("availabilityZone"),
+			"account":           s.Object{"id": c.Str("accountId")},
+			"image":             s.Object{"id": c.Str("imageId")},
 		}.Apply(m)
 		return out
 	}

--- a/libbeat/processors/add_cloud_metadata/provider_aws_ec2_test.go
+++ b/libbeat/processors/add_cloud_metadata/provider_aws_ec2_test.go
@@ -24,10 +24,11 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
-	"github.com/stretchr/testify/assert"
 )
 
 func createEC2MockAPI(responseMap map[string]string) *httptest.Server {

--- a/libbeat/processors/add_cloud_metadata/provider_aws_ec2_test.go
+++ b/libbeat/processors/add_cloud_metadata/provider_aws_ec2_test.go
@@ -18,239 +18,230 @@
 package add_cloud_metadata
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
+	"github.com/stretchr/testify/assert"
 )
 
-const ec2InstanceIdentityDocument = `{
-  "devpayProductCodes" : null,
-  "privateIp" : "10.0.0.1",
-  "availabilityZone" : "us-east-1c",
-  "accountId" : "111111111111111",
-  "version" : "2010-08-31",
-  "instanceId" : "i-11111111",
-  "billingProducts" : null,
-  "instanceType" : "t2.medium",
-  "imageId" : "ami-6869aa05",
-  "pendingTime" : "2016-09-20T15:43:02Z",
-  "architecture" : "x86_64",
-  "kernelId" : null,
-  "ramdiskId" : null,
-  "region" : "us-east-1"
-}`
-
-func initEC2TestServer() *httptest.Server {
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.RequestURI == "/2014-02-25/dynamic/instance-identity/document" {
-			w.Write([]byte(ec2InstanceIdentityDocument))
+func createEC2MockAPI(responseMap map[string]string) *httptest.Server {
+	h := func(w http.ResponseWriter, r *http.Request) {
+		if res, ok := responseMap[r.RequestURI]; ok {
+			w.Write([]byte(res))
 			return
 		}
-
 		http.Error(w, "not found", http.StatusNotFound)
-	}))
+	}
+	return httptest.NewServer(http.HandlerFunc(h))
 }
 
-func TestRetrieveAWSMetadata(t *testing.T) {
+func TestMain(m *testing.M) {
 	logp.TestingSetup()
+	code := m.Run()
+	os.Exit(code)
 
-	server := initEC2TestServer()
-	defer server.Close()
+}
 
-	config, err := common.NewConfigFrom(map[string]interface{}{
-		"host":      server.Listener.Addr().String(),
-		"overwrite": false,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
+func TestRetrieveAWSMetadataEC2(t *testing.T) {
 
-	p, err := New(config)
-	if err != nil {
-		t.Fatal(err)
-	}
+	const (
+		// not the best way to use a response template
+		// but this should serve until we need to test
+		// documents containing very different values
+		accountIDDoc1        = "111111111111111"
+		regionDoc1           = "us-east-1"
+		availabilityZoneDoc1 = "us-east-1c"
+		instanceIDDoc1       = "i-11111111"
+		imageIDDoc1          = "ami-abcd1234"
+		instanceTypeDoc1     = "t2.medium"
 
-	cases := []struct {
-		fields          common.MapStr
-		expectedResults common.MapStr
+		instanceIDDoc2 = "i-22222222"
+
+		templateDoc = `{
+	  "accountId" : "%s",
+	  "region" : "%s",
+	  "availabilityZone" : "%s",
+	  "instanceId" : "%s",
+	  "imageId" : "%s",
+	  "instanceType" : "%s",
+	  "devpayProductCodes" : null,
+	  "privateIp" : "10.0.0.1",	  
+	  "version" : "2010-08-31",
+	  "billingProducts" : null,
+	  "pendingTime" : "2016-09-20T15:43:02Z",
+	  "architecture" : "x86_64",
+	  "kernelId" : null,
+	  "ramdiskId" : null
+	}`
+	)
+
+	sampleEC2Doc1 := fmt.Sprintf(
+		templateDoc,
+		accountIDDoc1,
+		regionDoc1,
+		availabilityZoneDoc1,
+		instanceIDDoc1,
+		imageIDDoc1,
+		instanceTypeDoc1,
+	)
+
+	var testCases = []struct {
+		testName           string
+		ec2ResponseMap     map[string]string
+		processorOverwrite bool
+		previousEvent      common.MapStr
+
+		expectedEvent common.MapStr
 	}{
 		{
-			common.MapStr{},
-			common.MapStr{
+			testName:           "all fields from processor",
+			ec2ResponseMap:     map[string]string{ec2InstanceIdentityURI: sampleEC2Doc1},
+			processorOverwrite: false,
+			previousEvent:      common.MapStr{},
+			expectedEvent: common.MapStr{
 				"cloud": common.MapStr{
-					"provider": "aws",
-					"instance": common.MapStr{
-						"id": "i-11111111",
-					},
-					"machine": common.MapStr{
-						"type": "t2.medium",
-					},
-					"region":            "us-east-1",
-					"availability_zone": "us-east-1c",
+					"provider":          "aws",
+					"account":           common.MapStr{"id": accountIDDoc1},
+					"instance":          common.MapStr{"id": instanceIDDoc1},
+					"machine":           common.MapStr{"type": instanceTypeDoc1},
+					"image":             common.MapStr{"id": imageIDDoc1},
+					"region":            regionDoc1,
+					"availability_zone": availabilityZoneDoc1,
 				},
 			},
 		},
+
 		{
-			common.MapStr{
+			testName:           "instanceId pre-informed, no overwrite",
+			ec2ResponseMap:     map[string]string{ec2InstanceIdentityURI: sampleEC2Doc1},
+			processorOverwrite: false,
+			previousEvent: common.MapStr{
 				"cloud": common.MapStr{
-					"instance": common.MapStr{
-						"id": "i-000",
-					},
+					"instance": common.MapStr{"id": instanceIDDoc2},
 				},
 			},
-			common.MapStr{
+			expectedEvent: common.MapStr{
 				"cloud": common.MapStr{
-					"instance": common.MapStr{
-						"id": "i-000",
-					},
-				},
-			},
-		},
-		{
-			common.MapStr{
-				"provider": "aws",
-			},
-			common.MapStr{
-				"provider": "aws",
-				"cloud": common.MapStr{
-					"provider": "aws",
-					"instance": common.MapStr{
-						"id": "i-11111111",
-					},
-					"machine": common.MapStr{
-						"type": "t2.medium",
-					},
-					"region":            "us-east-1",
-					"availability_zone": "us-east-1c",
+					"instance": common.MapStr{"id": instanceIDDoc2},
 				},
 			},
 		},
+
 		{
-			common.MapStr{
-				"cloud.provider": "aws",
-			},
 			// NOTE: In this case, add_cloud_metadata will overwrite cloud fields because
 			// it won't detect cloud.provider as a cloud field. This is not the behavior we
 			// expect and will find a better solution later in issue 11697.
-			common.MapStr{
-				"cloud.provider": "aws",
-				"cloud": common.MapStr{
-					"provider": "aws",
-					"instance": common.MapStr{
-						"id": "i-11111111",
-					},
-					"machine": common.MapStr{
-						"type": "t2.medium",
-					},
-					"region":            "us-east-1",
-					"availability_zone": "us-east-1c",
-				},
-			},
-		},
-	}
-
-	for _, c := range cases {
-		actual, err := p.Run(&beat.Event{Fields: c.fields})
-		if err != nil {
-			t.Fatal(err)
-		}
-		assert.Equal(t, c.expectedResults, actual.Fields)
-	}
-}
-
-func TestRetrieveAWSMetadataOverwriteTrue(t *testing.T) {
-	logp.TestingSetup()
-
-	server := initEC2TestServer()
-	defer server.Close()
-
-	config, err := common.NewConfigFrom(map[string]interface{}{
-		"host":      server.Listener.Addr().String(),
-		"overwrite": true,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	p, err := New(config)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	cases := []struct {
-		fields          common.MapStr
-		expectedResults common.MapStr
-	}{
-		{
-			common.MapStr{},
-			common.MapStr{
-				"cloud": common.MapStr{
-					"provider": "aws",
-					"instance": common.MapStr{
-						"id": "i-11111111",
-					},
-					"machine": common.MapStr{
-						"type": "t2.medium",
-					},
-					"region":            "us-east-1",
-					"availability_zone": "us-east-1c",
-				},
-			},
-		},
-		{
-			common.MapStr{
-				"cloud": common.MapStr{
-					"instance": common.MapStr{
-						"id": "i-000",
-					},
-				},
-			},
-			common.MapStr{
-				"cloud": common.MapStr{
-					"provider": "aws",
-					"instance": common.MapStr{
-						"id": "i-11111111",
-					},
-					"machine": common.MapStr{
-						"type": "t2.medium",
-					},
-					"region":            "us-east-1",
-					"availability_zone": "us-east-1c",
-				},
-			},
-		},
-		{
-			common.MapStr{
+			testName:           "only cloud.provider pre-informed, no overwrite",
+			ec2ResponseMap:     map[string]string{ec2InstanceIdentityURI: sampleEC2Doc1},
+			processorOverwrite: false,
+			previousEvent: common.MapStr{
 				"cloud.provider": "aws",
 			},
-			common.MapStr{
+			expectedEvent: common.MapStr{
 				"cloud.provider": "aws",
 				"cloud": common.MapStr{
-					"provider": "aws",
-					"instance": common.MapStr{
-						"id": "i-11111111",
-					},
-					"machine": common.MapStr{
-						"type": "t2.medium",
-					},
-					"region":            "us-east-1",
-					"availability_zone": "us-east-1c",
+					"provider":          "aws",
+					"account":           common.MapStr{"id": accountIDDoc1},
+					"instance":          common.MapStr{"id": instanceIDDoc1},
+					"machine":           common.MapStr{"type": instanceTypeDoc1},
+					"image":             common.MapStr{"id": imageIDDoc1},
+					"region":            regionDoc1,
+					"availability_zone": availabilityZoneDoc1,
+				},
+			},
+		},
+
+		{
+			testName:           "all fields from processor, overwrite",
+			ec2ResponseMap:     map[string]string{ec2InstanceIdentityURI: sampleEC2Doc1},
+			processorOverwrite: true,
+			previousEvent:      common.MapStr{},
+			expectedEvent: common.MapStr{
+				"cloud": common.MapStr{
+					"provider":          "aws",
+					"account":           common.MapStr{"id": accountIDDoc1},
+					"instance":          common.MapStr{"id": instanceIDDoc1},
+					"machine":           common.MapStr{"type": instanceTypeDoc1},
+					"image":             common.MapStr{"id": imageIDDoc1},
+					"region":            regionDoc1,
+					"availability_zone": availabilityZoneDoc1,
+				},
+			},
+		},
+
+		{
+			testName:           "instanceId pre-informed, overwrite",
+			ec2ResponseMap:     map[string]string{ec2InstanceIdentityURI: sampleEC2Doc1},
+			processorOverwrite: true,
+			previousEvent: common.MapStr{
+				"cloud": common.MapStr{
+					"instance": common.MapStr{"id": instanceIDDoc2},
+				},
+			},
+			expectedEvent: common.MapStr{
+				"cloud": common.MapStr{
+					"provider":          "aws",
+					"account":           common.MapStr{"id": accountIDDoc1},
+					"instance":          common.MapStr{"id": instanceIDDoc1},
+					"machine":           common.MapStr{"type": instanceTypeDoc1},
+					"image":             common.MapStr{"id": imageIDDoc1},
+					"region":            regionDoc1,
+					"availability_zone": availabilityZoneDoc1,
+				},
+			},
+		},
+
+		{
+			testName:           "only cloud.provider pre-informed, overwrite",
+			ec2ResponseMap:     map[string]string{ec2InstanceIdentityURI: sampleEC2Doc1},
+			processorOverwrite: false,
+			previousEvent: common.MapStr{
+				"cloud.provider": "aws",
+			},
+			expectedEvent: common.MapStr{
+				"cloud.provider": "aws",
+				"cloud": common.MapStr{
+					"provider":          "aws",
+					"account":           common.MapStr{"id": accountIDDoc1},
+					"instance":          common.MapStr{"id": instanceIDDoc1},
+					"machine":           common.MapStr{"type": instanceTypeDoc1},
+					"image":             common.MapStr{"id": imageIDDoc1},
+					"region":            regionDoc1,
+					"availability_zone": availabilityZoneDoc1,
 				},
 			},
 		},
 	}
 
-	for _, c := range cases {
-		actual, err := p.Run(&beat.Event{Fields: c.fields})
-		if err != nil {
-			t.Fatal(err)
-		}
-		assert.Equal(t, c.expectedResults, actual.Fields)
+	for _, tc := range testCases {
+		t.Run(tc.testName, func(t *testing.T) {
+			server := createEC2MockAPI(tc.ec2ResponseMap)
+			defer server.Close()
+
+			config, err := common.NewConfigFrom(map[string]interface{}{
+				"host":      server.Listener.Addr().String(),
+				"overwrite": tc.processorOverwrite,
+			})
+			if err != nil {
+				t.Fatalf("error creating config from map: %s", err.Error())
+			}
+
+			cmp, err := New(config)
+			if err != nil {
+				t.Fatalf("error creating new metadata processor: %s", err.Error())
+			}
+
+			actual, err := cmp.Run(&beat.Event{Fields: tc.previousEvent})
+			if err != nil {
+				t.Fatalf("error running processor: %s", err.Error())
+			}
+			assert.Equal(t, tc.expectedEvent, actual.Fields)
+		})
 	}
 }


### PR DESCRIPTION
Continuing @jbagel2 effort on https://github.com/elastic/beats/pull/10914

Adding to libbeat `add_cloud_metadata` processor's EC2 implementation:
- `image.id`
- `account.id`

Note: `image.id` is not part of ECS, but sounds like a feasible name whether it is included or not in a future ECS reference.

Tests have been unified into a single test cased test, and `account.id` and `image.id` has been added to checks.
