### PR TITLE
Cherry-pick #12165 to 7.2: Fix of Go panic error due to missing json field log in docker container's log

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -74,6 +74,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Replace wmi queries with win32 api calls as they were consuming CPU resources {issue}3249[3249] and {issue}11840[11840]
 - Fix queue.spool.write.flush.events config type. {pull}12080[12080]
 - Fixed a memory leak when using the add_process_metadata processor under Windows. {pull}12100[12100]
+- Fix of docker json parser for missing "log" jsonkey in docker container's log {issue}11464[11464]
 - Fixed Beat ID being reported by GET / API. {pull}12180[12180]
 
 *Auditbeat*

--- a/libbeat/reader/readjson/docker_json.go
+++ b/libbeat/reader/readjson/docker_json.go
@@ -152,14 +152,13 @@ func (p *DockerJSONReader) parseDockerJSONLog(message *reader.Message, msg *logL
 	if err != nil {
 		return errors.Wrap(err, "parsing docker timestamp")
 	}
+	message.Ts = ts
 
 	message.AddFields(common.MapStr{
 		"stream": msg.Stream,
 	})
 	message.Content = []byte(msg.Log)
-	message.Ts = ts
-	msg.Partial = message.Content[len(message.Content)-1] != byte('\n')
-
+	msg.Partial = (len(message.Content) == 0) || (message.Content[len(message.Content)-1] != byte('\n'))
 	return nil
 }
 

--- a/libbeat/reader/readjson/docker_json_test.go
+++ b/libbeat/reader/readjson/docker_json_test.go
@@ -59,6 +59,17 @@ func TestDockerJSON(t *testing.T) {
 			},
 		},
 		{
+			name:   "0 length message",
+			input:  [][]byte{[]byte(`{"log":"","stream":"stdout","time":"2017-11-09T13:27:36.277747246Z"}`)},
+			stream: "all",
+			expectedMessage: reader.Message{
+				Content: []byte(""),
+				Fields:  common.MapStr{"stream": "stdout"},
+				Ts:      time.Date(2017, 11, 9, 13, 27, 36, 277747246, time.UTC),
+				Bytes:   68,
+			},
+		},
+		{
 			name:          "Wrong CRI",
 			input:         [][]byte{[]byte(`2017-09-12T22:32:21.212861448Z stdout`)},
 			stream:        "all",


### PR DESCRIPTION
Cherry-pick of PR #12165 to 7.2 branch. Original message: 

Due to some CLA issue in PR #11889 I am creating this PR.

I will close old PR accordingly.