### PR TITLE
[DOCS] Updates Elasticsearch and Kibana modules

### DIFF
--- a/metricbeat/docs/modules/elasticsearch.asciidoc
+++ b/metricbeat/docs/modules/elasticsearch.asciidoc
@@ -5,14 +5,15 @@ This file is generated! See scripts/docs_collector.py
 [[metricbeat-module-elasticsearch]]
 == Elasticsearch module
 
-The Elasticsearch module contains a minimal set of metrics to enable monitoring
-of Elasticsearch across multiple versions. The Elasticsearch X-Pack module
-enables you to monitor more Elasticsearch metrics with our {stack-ov}/xpack-monitoring.html[monitoring] feature.
+There are two modules that collect metrics about {es}: 
 
-The default metricsets in the Elasticsearch module are `node` and `node_stats`.
-The default metricsets in the Elasticsearch X-Pack module are `ccr`,
-`cluster_stats`, `index`, `index_recovery`, `index_summary`, `ml_job`,
-`node_stats`, and `shard`.
+* The Elasticsearch module contains a minimal set of metrics to enable
+monitoring of Elasticsearch across multiple versions. The default metricsets in
+this module are `node` and `node_stats`.
+* The Elasticsearch X-Pack module enables you to monitor more Elasticsearch
+metrics with our {stack-ov}/xpack-monitoring.html[monitoring] feature. The
+default metricsets in this module are `ccr`, `cluster_stats`, `index`,
+`index_recovery`, `index_summary`, `ml_job`, `node_stats`, and `shard`.
 
 [float]
 === Compability

--- a/metricbeat/docs/modules/elasticsearch.asciidoc
+++ b/metricbeat/docs/modules/elasticsearch.asciidoc
@@ -5,9 +5,14 @@ This file is generated! See scripts/docs_collector.py
 [[metricbeat-module-elasticsearch]]
 == Elasticsearch module
 
-The Elasticsearch module contains a minimal set of metrics to enable monitoring of Elasticsearch across multiple versions. To monitor more Elasticsearch metrics, use our {stack-ov}/xpack-monitoring.html[monitoring] feature.
+The Elasticsearch module contains a minimal set of metrics to enable monitoring
+of Elasticsearch across multiple versions. The Elasticsearch X-Pack module
+enables you to monitor more Elasticsearch metrics with our {stack-ov}/xpack-monitoring.html[monitoring] feature.
 
-The default metricsets are `node` and `node_stats`.
+The default metricsets in the Elasticsearch module are `node` and `node_stats`.
+The default metricsets in the Elasticsearch X-Pack module are `ccr`,
+`cluster_stats`, `index`, `index_recovery`, `index_summary`, `ml_job`,
+`node_stats`, and `shard`.
 
 [float]
 === Compability

--- a/metricbeat/docs/modules/kibana.asciidoc
+++ b/metricbeat/docs/modules/kibana.asciidoc
@@ -5,12 +5,13 @@ This file is generated! See scripts/docs_collector.py
 [[metricbeat-module-kibana]]
 == Kibana module
 
-The Kibana module tracks only the high-level metrics. The Kibana X-Pack module
-enables you to monitor more Kibana metrics with our
-{stack-ov}/xpack-monitoring.html[monitoring] feature.
+There are two modules that collect metrics about {kib}: 
 
-The default metricset in the Kibana module is `status`.
-The default metricset in the Kibana X-Pack module is `stats`.
+* The Kibana module tracks only the high-level metrics. The default metricset in
+this module is `status`.
+* The Kibana X-Pack module enables you to monitor more Kibana metrics with our
+{stack-ov}/xpack-monitoring.html[monitoring] feature. The default metricset in
+this module is `stats`.
 
 [float]
 === Compatibility

--- a/metricbeat/docs/modules/kibana.asciidoc
+++ b/metricbeat/docs/modules/kibana.asciidoc
@@ -5,9 +5,12 @@ This file is generated! See scripts/docs_collector.py
 [[metricbeat-module-kibana]]
 == Kibana module
 
-The Kibana module only tracks the high-level metrics. To monitor more Kibana metrics, use our {stack-ov}/xpack-monitoring.html[monitoring] feature.
+The Kibana module tracks only the high-level metrics. The Kibana X-Pack module
+enables you to monitor more Kibana metrics with our
+{stack-ov}/xpack-monitoring.html[monitoring] feature.
 
-The default metricset is `status`.
+The default metricset in the Kibana module is `status`.
+The default metricset in the Kibana X-Pack module is `stats`.
 
 [float]
 === Compatibility

--- a/metricbeat/module/elasticsearch/_meta/docs.asciidoc
+++ b/metricbeat/module/elasticsearch/_meta/docs.asciidoc
@@ -1,11 +1,12 @@
-The Elasticsearch module contains a minimal set of metrics to enable monitoring
-of Elasticsearch across multiple versions. The Elasticsearch X-Pack module
-enables you to monitor more Elasticsearch metrics with our {stack-ov}/xpack-monitoring.html[monitoring] feature.
+There are two modules that collect metrics about {es}: 
 
-The default metricsets in the Elasticsearch module are `node` and `node_stats`.
-The default metricsets in the Elasticsearch X-Pack module are `ccr`,
-`cluster_stats`, `index`, `index_recovery`, `index_summary`, `ml_job`,
-`node_stats`, and `shard`.
+* The Elasticsearch module contains a minimal set of metrics to enable
+monitoring of Elasticsearch across multiple versions. The default metricsets in
+this module are `node` and `node_stats`.
+* The Elasticsearch X-Pack module enables you to monitor more Elasticsearch
+metrics with our {stack-ov}/xpack-monitoring.html[monitoring] feature. The
+default metricsets in this module are `ccr`, `cluster_stats`, `index`,
+`index_recovery`, `index_summary`, `ml_job`, `node_stats`, and `shard`.
 
 [float]
 === Compability

--- a/metricbeat/module/elasticsearch/_meta/docs.asciidoc
+++ b/metricbeat/module/elasticsearch/_meta/docs.asciidoc
@@ -1,6 +1,11 @@
-The Elasticsearch module contains a minimal set of metrics to enable monitoring of Elasticsearch across multiple versions. To monitor more Elasticsearch metrics, use our {stack-ov}/xpack-monitoring.html[monitoring] feature.
+The Elasticsearch module contains a minimal set of metrics to enable monitoring
+of Elasticsearch across multiple versions. The Elasticsearch X-Pack module
+enables you to monitor more Elasticsearch metrics with our {stack-ov}/xpack-monitoring.html[monitoring] feature.
 
-The default metricsets are `node` and `node_stats`.
+The default metricsets in the Elasticsearch module are `node` and `node_stats`.
+The default metricsets in the Elasticsearch X-Pack module are `ccr`,
+`cluster_stats`, `index`, `index_recovery`, `index_summary`, `ml_job`,
+`node_stats`, and `shard`.
 
 [float]
 === Compability

--- a/metricbeat/module/kibana/_meta/docs.asciidoc
+++ b/metricbeat/module/kibana/_meta/docs.asciidoc
@@ -1,6 +1,9 @@
-The Kibana module only tracks the high-level metrics. To monitor more Kibana metrics, use our {stack-ov}/xpack-monitoring.html[monitoring] feature.
+The Kibana module tracks only the high-level metrics. The Kibana X-Pack module
+enables you to monitor more Kibana metrics with our
+{stack-ov}/xpack-monitoring.html[monitoring] feature.
 
-The default metricset is `status`.
+The default metricset in the Kibana module is `status`.
+The default metricset in the Kibana X-Pack module is `stats`.
 
 [float]
 === Compatibility

--- a/metricbeat/module/kibana/_meta/docs.asciidoc
+++ b/metricbeat/module/kibana/_meta/docs.asciidoc
@@ -1,9 +1,10 @@
-The Kibana module tracks only the high-level metrics. The Kibana X-Pack module
-enables you to monitor more Kibana metrics with our
-{stack-ov}/xpack-monitoring.html[monitoring] feature.
+There are two modules that collect metrics about {kib}: 
 
-The default metricset in the Kibana module is `status`.
-The default metricset in the Kibana X-Pack module is `stats`.
+* The Kibana module tracks only the high-level metrics. The default metricset in
+this module is `status`.
+* The Kibana X-Pack module enables you to monitor more Kibana metrics with our
+{stack-ov}/xpack-monitoring.html[monitoring] feature. The default metricset in
+this module is `stats`.
 
 [float]
 === Compatibility


### PR DESCRIPTION
This PR updates the descriptions of the Metricbeat [Kibana module](https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-kibana.html) and [Elasticsearch module](https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-elasticsearch.html) to describe the elasticsearch-xpack and kibana-xpack modules.