### PR TITLE
[Auditbeat] Package: Improve dpkg parsing

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -91,6 +91,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix direction of incoming IPv6 sockets. {pull}12248[12248]
 - Package dataset: Close librpm handle. {pull}12215[12215]
 - Package dataset: Auto-detect package directories. {pull}12289[12289]
+- Package dataset: Improve dpkg parsing. {pull}12325[12325]
 
 *Filebeat*
 

--- a/x-pack/auditbeat/module/system/package/package.go
+++ b/x-pack/auditbeat/module/system/package/package.go
@@ -508,7 +508,7 @@ func listDebPackages() ([]*Package, error) {
 
 	var packages []*Package
 	var skipPackage bool
-	pkg := &Package{}
+	var pkg *Package
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
 		line := scanner.Text()
@@ -518,7 +518,7 @@ func listDebPackages() ([]*Package, error) {
 				packages = append(packages, pkg)
 			}
 			skipPackage = false
-			pkg = &Package{}
+			pkg = nil
 			continue
 		} else if skipPackage {
 			// Skipping this package - read on.
@@ -534,6 +534,11 @@ func listDebPackages() ([]*Package, error) {
 			return nil, fmt.Errorf("the following line was unexpected (no ':' found): '%s'", line)
 		}
 		value := strings.TrimSpace(words[1])
+
+		if pkg == nil {
+			pkg = &Package{}
+		}
+
 		switch strings.ToLower(words[0]) {
 		case "package":
 			pkg.Name = value
@@ -553,12 +558,21 @@ func listDebPackages() ([]*Package, error) {
 			if err != nil {
 				return nil, errors.Wrapf(err, "error converting %s to int", value)
 			}
+		case "homepage":
+			pkg.URL = value
 		default:
 			continue
 		}
 	}
+
 	if err = scanner.Err(); err != nil {
 		return nil, errors.Wrapf(err, "error scanning file %v", dpkgStatusFile)
 	}
+
+	// Append last package if file ends without newline
+	if pkg != nil && !skipPackage {
+		packages = append(packages, pkg)
+	}
+
 	return packages, nil
 }

--- a/x-pack/auditbeat/module/system/package/package_test.go
+++ b/x-pack/auditbeat/module/system/package/package_test.go
@@ -7,10 +7,14 @@
 package pkg
 
 import (
+	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/beats/auditbeat/core"
 	abtest "github.com/elastic/beats/auditbeat/testing"
+	"github.com/elastic/beats/libbeat/logp"
 	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
 )
 
@@ -18,6 +22,8 @@ func TestData(t *testing.T) {
 	defer abtest.SetupDataDir(t)()
 
 	f := mbtest.NewReportingMetricSetV2(t, getConfig())
+	defer f.(*MetricSet).bucket.DeleteBucket()
+
 	events, errs := mbtest.ReportingFetchV2(f)
 	if len(errs) > 0 {
 		t.Fatalf("received error: %+v", errs[0])
@@ -29,6 +35,47 @@ func TestData(t *testing.T) {
 
 	fullEvent := mbtest.StandardizeEvent(f, events[len(events)-1], core.AddDatasetToEvent)
 	mbtest.WriteEventToDataJSON(t, fullEvent, "")
+}
+
+func TestDpkg(t *testing.T) {
+	logp.TestingSetup()
+
+	defer abtest.SetupDataDir(t)()
+
+	// Disable all except dpkg
+	rpmPathOld := rpmPath
+	dpkgPathOld := dpkgPath
+	brewPathOld := homebrewCellarPath
+	defer func() {
+		rpmPath = rpmPathOld
+		dpkgPath = dpkgPathOld
+		homebrewCellarPath = brewPathOld
+	}()
+	rpmPath = "/does/not/exist"
+	homebrewCellarPath = "/does/not/exist"
+
+	var err error
+	dpkgPath, err = filepath.Abs("testdata/dpkg/")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	f := mbtest.NewReportingMetricSetV2(t, getConfig())
+	defer f.(*MetricSet).bucket.DeleteBucket()
+
+	events, errs := mbtest.ReportingFetchV2(f)
+	if len(errs) > 0 {
+		t.Fatalf("received error: %+v", errs[0])
+	}
+
+	if assert.Len(t, events, 1) {
+		event := mbtest.StandardizeEvent(f, events[0], core.AddDatasetToEvent)
+		checkFieldValue(t, event, "system.audit.package.name", "test")
+		checkFieldValue(t, event, "system.audit.package.summary", "Test Package")
+		checkFieldValue(t, event, "system.audit.package.url", "https://www.elastic.co/")
+		checkFieldValue(t, event, "system.audit.package.version", "8.2.0-1ubuntu2~18.04")
+		checkFieldValue(t, event, "system.audit.package.entity_id", "+LbVb+f5cZZcYzCp")
+	}
 }
 
 func getConfig() map[string]interface{} {

--- a/x-pack/auditbeat/module/system/package/package_test.go
+++ b/x-pack/auditbeat/module/system/package/package_test.go
@@ -74,7 +74,6 @@ func TestDpkg(t *testing.T) {
 		checkFieldValue(t, event, "system.audit.package.summary", "Test Package")
 		checkFieldValue(t, event, "system.audit.package.url", "https://www.elastic.co/")
 		checkFieldValue(t, event, "system.audit.package.version", "8.2.0-1ubuntu2~18.04")
-		checkFieldValue(t, event, "system.audit.package.entity_id", "+LbVb+f5cZZcYzCp")
 	}
 }
 

--- a/x-pack/auditbeat/module/system/package/testdata/dpkg/status
+++ b/x-pack/auditbeat/module/system/package/testdata/dpkg/status
@@ -1,0 +1,15 @@
+Package: test
+Status: install ok installed
+Priority: optional
+Section: libs
+Installed-Size: 269
+Maintainer: <>
+Architecture: amd64
+Multi-Arch: same
+Source: test-0
+Version: 8.2.0-1ubuntu2~18.04
+Depends: <>
+Description: Test Package
+ This is a test package.
+Homepage: https://www.elastic.co/
+Original-Maintainer: <>


### PR DESCRIPTION
Improves parsing of the dpkg status file in two ways:

1. Adds `system.audit.package.url` from the `Homepage` field.
2. Fixes a bug where when the status file does not end in a newline the last package will not be reported. I'm not sure if this bug can be encountered in the wild (dpkg seems to add a newline to the status file), but I encountered it with the test file so I'd rather make it work.

Also adds a test dpkg status file and a unit test reading it.