### PR TITLE
[DOCS] Add 7.1, 7.2, 7.3, and 8.0 breaking changes files

### DIFF
--- a/libbeat/docs/breaking-7.1.asciidoc
+++ b/libbeat/docs/breaking-7.1.asciidoc
@@ -3,3 +3,10 @@
 === Breaking changes in 7.1
 
 {see-relnotes}
+
+//NOTE: The notable-breaking-changes tagged regions are re-used in the
+//Installation and Upgrade Guide
+
+//tag::notable-breaking-changes[]
+
+// end::notable-breaking-changes[]

--- a/libbeat/docs/breaking-7.1.asciidoc
+++ b/libbeat/docs/breaking-7.1.asciidoc
@@ -1,0 +1,5 @@
+[[breaking-changes-7.1]]
+
+=== Breaking changes in 7.1
+
+{see-relnotes}

--- a/libbeat/docs/breaking-7.2.asciidoc
+++ b/libbeat/docs/breaking-7.2.asciidoc
@@ -1,0 +1,17 @@
+[[breaking-changes-7.2]]
+
+=== Breaking changes in 7.2
+
+// NOTE: Comment out this section if there are no breaking changes for 7.2.
+This section discusses the main changes that you should be aware of if you
+upgrade the Beats to version 7.2.
+
+// NOTE: Do not comment out
+{see-relnotes}
+
+//NOTE: The notable-breaking-changes tagged regions are re-used in the
+//Installation and Upgrade Guide
+
+//tag::notable-breaking-changes[]
+
+// end::notable-breaking-changes[]

--- a/libbeat/docs/breaking-7.3.asciidoc
+++ b/libbeat/docs/breaking-7.3.asciidoc
@@ -1,0 +1,17 @@
+[[breaking-changes-7.3]]
+
+=== Breaking changes in 7.3
+
+// NOTE: Comment out this section if there are no breaking changes for 7.3.
+This section discusses the main changes that you should be aware of if you
+upgrade the Beats to version 7.3.
+
+// NOTE: Do not comment out
+{see-relnotes}
+
+//NOTE: The notable-breaking-changes tagged regions are re-used in the
+//Installation and Upgrade Guide
+
+//tag::notable-breaking-changes[]
+
+// end::notable-breaking-changes[]

--- a/libbeat/docs/breaking-8.0.asciidoc
+++ b/libbeat/docs/breaking-8.0.asciidoc
@@ -1,0 +1,15 @@
+[[breaking-changes-8.0]]
+
+=== Breaking changes in 8.0
+
+This section discusses the main changes that you should be aware of if you
+upgrade the Beats to version 8.0.
+
+{see-relnotes}
+
+//NOTE: The notable-breaking-changes tagged regions are re-used in the
+//Installation and Upgrade Guide
+
+//tag::notable-breaking-changes[]
+
+// end::notable-breaking-changes[]

--- a/libbeat/docs/breaking.asciidoc
+++ b/libbeat/docs/breaking.asciidoc
@@ -11,11 +11,15 @@ changes, but there are breaking changes between major versions (e.g. 6.x to
 
 See the following topics for a description of breaking changes:
 
+* <<breaking-changes-7.3>>
+
 * <<breaking-changes-7.2>>
 
 * <<breaking-changes-7.1>>
 
 * <<breaking-changes-7.0>>
+
+include::breaking-7.3.asciidoc[]
 
 include::breaking-7.2.asciidoc[]
 

--- a/libbeat/docs/breaking.asciidoc
+++ b/libbeat/docs/breaking.asciidoc
@@ -11,6 +11,11 @@ changes, but there are breaking changes between major versions (e.g. 6.x to
 
 See the following topics for a description of breaking changes:
 
+* <<breaking-changes-7.1>>
+
 * <<breaking-changes-7.0>>
 
+include::breaking-7.1.asciidoc[]
+
 include::breaking-7.0.asciidoc[]
+

--- a/libbeat/docs/breaking.asciidoc
+++ b/libbeat/docs/breaking.asciidoc
@@ -11,9 +11,13 @@ changes, but there are breaking changes between major versions (e.g. 6.x to
 
 See the following topics for a description of breaking changes:
 
+* <<breaking-changes-7.2>>
+
 * <<breaking-changes-7.1>>
 
 * <<breaking-changes-7.0>>
+
+include::breaking-7.2.asciidoc[]
 
 include::breaking-7.1.asciidoc[]
 


### PR DESCRIPTION
Adds 8.0 and 7.3 breaking changes. The files will not be hooked up to the navigation until we have an 8.x and 7.3 branches. 

Also forward ports changes added in https://github.com/elastic/beats/pull/12326 and https://github.com/elastic/beats/pull/12322.

This PR must be merged at the same time as https://github.com/elastic/stack-docs/pull/350
