### PR TITLE
[DOCS] Add 7.1 release highlights

### DIFF
--- a/libbeat/docs/highlights-7.1.0.asciidoc
+++ b/libbeat/docs/highlights-7.1.0.asciidoc
@@ -1,0 +1,22 @@
+[[release-highlights-7.1.0]]
+=== 7.1.0 release highlights
+++++
+<titleabbrev>7.1.0</titleabbrev>
+++++
+
+Each release of {beats} brings new features and product improvements. 
+Here are the highlights of the new features and enhancements in 7.1.0.
+
+Some Elastic Stack security features, such as encrypted communications, 
+file and native authentication, and role-based access control, are now available 
+in more subscription levels. For details, see https://www.elastic.co/subscriptions.
+
+Refer to the {beats} <<breaking-changes-7.1, Breaking Changes>> and <<release-notes, 
+Release Notes>> for a list of bug fixes and other changes.
+
+//NOTE: The notable-highlights tagged regions are re-used in the
+//Installation and Upgrade Guide
+
+// tag::notable-highlights[]
+
+// end::notable-highlights[]

--- a/libbeat/docs/highlights-7.1.0.asciidoc
+++ b/libbeat/docs/highlights-7.1.0.asciidoc
@@ -7,16 +7,16 @@
 Each release of {beats} brings new features and product improvements. 
 Here are the highlights of the new features and enhancements in 7.1.0.
 
-Some Elastic Stack security features, such as encrypted communications, 
-file and native authentication, and role-based access control, are now available 
-in more subscription levels. For details, see https://www.elastic.co/subscriptions.
-
-Refer to the {beats} <<breaking-changes-7.1, Breaking Changes>> and <<release-notes, 
-Release Notes>> for a list of bug fixes and other changes.
-
 //NOTE: The notable-highlights tagged regions are re-used in the
 //Installation and Upgrade Guide
 
 // tag::notable-highlights[]
-
+Some Elastic Stack security features, such as encrypted communications, 
+file and native authentication, and role-based access control, are now available 
+in more subscription levels. For details, see https://www.elastic.co/subscriptions.
 // end::notable-highlights[]
+
+Refer to the {beats} <<breaking-changes-7.1, Breaking Changes>> and <<release-notes, 
+Release Notes>> for a list of bug fixes and other changes.
+
+

--- a/libbeat/docs/highlights.asciidoc
+++ b/libbeat/docs/highlights.asciidoc
@@ -4,6 +4,10 @@
 This section summarizes the most important changes in each release. For the 
 full list, see <<release-notes>> and <<breaking-changes>>. 
 
+* <<release-highlights-7.1.0>>
+
 * <<release-highlights-7.0.0>>
+
+include::highlights-7.1.0.asciidoc[]
 
 include::highlights-7.0.0.asciidoc[]


### PR DESCRIPTION
Adds release highlights for 7.1 release.

Do not merge until after https://github.com/elastic/beats/pull/12328 is merged. The CI will fail until #12328 is merged.