### PR TITLE
Load configuration from modules.d when running setup subcommand

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -111,6 +111,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Skipping unparsable log entries from docker json reader {pull}12268[12268]
 - Require client_auth by default when ssl is enabled for tcp input {pull}12333[12333]
 - Require certificate authorities, certificate file, and key when SSL is enabled for the TCP input. {pull}12355[12355]
+- Load correct pipelines when system module is configured in modules.d. {pull}12340[12340]
 
 *Heartbeat*
 

--- a/filebeat/beater/filebeat.go
+++ b/filebeat/beater/filebeat.go
@@ -160,7 +160,7 @@ func (fb *Filebeat) setupPipelineLoaderCallback(b *beat.Beat) error {
 			return err
 		}
 
-		// When running the subcommand setup, configuration from modules.d directories are
+		// When running the subcommand setup, configuration from modules.d directories
 		// have to be loaded using cfg.Reloader. Otherwise those configurations are skipped.
 		pipelineLoaderFactory := newPipelineLoaderFactory(b.Config.Output.Config())
 		modulesFactory := fileset.NewSetupFactory(b.Info.Version, pipelineLoaderFactory)

--- a/filebeat/beater/filebeat.go
+++ b/filebeat/beater/filebeat.go
@@ -146,20 +146,36 @@ func New(b *beat.Beat, rawConfig *common.Config) (beat.Beater, error) {
 	return fb, nil
 }
 
+// setupPipelineLoaderCallback sets the callback function for loading pipelines during setup.
 func (fb *Filebeat) setupPipelineLoaderCallback(b *beat.Beat) error {
-	if !fb.moduleRegistry.Empty() {
-		overwritePipelines := fb.config.OverwritePipelines
-		if b.InSetupCmd {
-			overwritePipelines = true
+	if b.Config.Output.Name() != "elasticsearch" {
+		logp.Warn(pipelinesWarning)
+		return nil
+	}
+
+	// When running the subcommand setup, configuration from modules.d directories are
+	// have to be loaded using cfg.Reloader. Otherwise those configurations are skipped.
+	var modulesLoader *cfgfile.Reloader
+	var modulesFactory cfgfile.RunnerFactory
+
+	pipelineLoaderFactory := newPipelineLoaderFactory(b.Config.Output.Config())
+	modulesFactory = fileset.NewSetupFactory(b.Info.Version, pipelineLoaderFactory)
+	if fb.config.ConfigModules.Enabled() {
+		modulesLoader = cfgfile.NewReloader(b.Publisher, fb.config.ConfigModules)
+	}
+
+	overwritePipelines := true
+	b.OverwritePipelinesCallback = func(esConfig *common.Config) error {
+		esClient, err := elasticsearch.NewConnectedClient(esConfig)
+		if err != nil {
+			return err
 		}
 
-		b.OverwritePipelinesCallback = func(esConfig *common.Config) error {
-			esClient, err := elasticsearch.NewConnectedClient(esConfig)
-			if err != nil {
-				return err
-			}
-			return fb.moduleRegistry.LoadPipelines(esClient, overwritePipelines)
+		if modulesLoader != nil {
+			modulesLoader.Load(modulesFactory)
 		}
+
+		return fb.moduleRegistry.LoadPipelines(esClient, overwritePipelines)
 	}
 	return nil
 }

--- a/filebeat/fileset/setup.go
+++ b/filebeat/fileset/setup.go
@@ -81,5 +81,5 @@ func (sr *SetupCfgRunner) Stop() {}
 
 // String returns information on the Runner
 func (sr *SetupCfgRunner) String() string {
-	return "Setting up:\n" + sr.moduleRegistry.InfoString()
+	return sr.moduleRegistry.InfoString()
 }

--- a/filebeat/fileset/setup.go
+++ b/filebeat/fileset/setup.go
@@ -1,0 +1,85 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package fileset
+
+import (
+	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/cfgfile"
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
+)
+
+// SetupFactory is for loading module assets when running setup subcommand.
+type SetupFactory struct {
+	beatVersion           string
+	pipelineLoaderFactory PipelineLoaderFactory
+	overwritePipelines    bool
+}
+
+// NewSetupFactory creates a SetupFactory
+func NewSetupFactory(beatVersion string, pipelineLoaderFactory PipelineLoaderFactory) *SetupFactory {
+	return &SetupFactory{
+		beatVersion:           beatVersion,
+		pipelineLoaderFactory: pipelineLoaderFactory,
+		overwritePipelines:    true,
+	}
+}
+
+// Create creates a new SetupCfgRunner to setup module configuration.
+func (sf *SetupFactory) Create(_ beat.Pipeline, c *common.Config, _ *common.MapStrPointer) (cfgfile.Runner, error) {
+	m, err := NewModuleRegistry([]*common.Config{c}, sf.beatVersion, false)
+	if err != nil {
+		return nil, err
+	}
+
+	return &SetupCfgRunner{
+		moduleRegistry:        m,
+		pipelineLoaderFactory: sf.pipelineLoaderFactory,
+		overwritePipelines:    sf.overwritePipelines,
+	}, nil
+}
+
+// SetupCfgRunner is for loading assets of modules.
+type SetupCfgRunner struct {
+	moduleRegistry        *ModuleRegistry
+	pipelineLoaderFactory PipelineLoaderFactory
+	overwritePipelines    bool
+}
+
+// Start loads module pipelines for configured modules.
+func (sr *SetupCfgRunner) Start() {
+	logp.Debug("fileset", "Loading ingest pipelines for modules from modules.d")
+	pipelineLoader, err := sr.pipelineLoaderFactory()
+	if err != nil {
+		logp.Err("Error loading pipeline: %+v", err)
+		return
+	}
+
+	err = sr.moduleRegistry.LoadPipelines(pipelineLoader, sr.overwritePipelines)
+	if err != nil {
+		logp.Err("Error loading pipeline: %s", err)
+	}
+}
+
+// Stopping SetupCfgRunner.
+func (sr *SetupCfgRunner) Stop() {}
+
+// String returns information on the Runner
+func (sr *SetupCfgRunner) String() string {
+	return "Setting up:\n" + sr.moduleRegistry.InfoString()
+}

--- a/filebeat/fileset/setup.go
+++ b/filebeat/fileset/setup.go
@@ -76,7 +76,7 @@ func (sr *SetupCfgRunner) Start() {
 	}
 }
 
-// Stopping SetupCfgRunner.
+// Stopp of SetupCfgRunner.
 func (sr *SetupCfgRunner) Stop() {}
 
 // String returns information on the Runner

--- a/filebeat/tests/system/input/system.yml
+++ b/filebeat/tests/system/input/system.yml
@@ -1,25 +1,7 @@
-# Module: system
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-system.html
-
 - module: system
-  # Syslog
   syslog:
     enabled: true
-
-    # Set custom paths for the log files. If left empty,
-    # Filebeat will choose the paths depending on your OS.
-    #var.paths:
-
-    # Convert the timestamp to UTC. Requires Elasticsearch >= 6.1.
     var.convert_timezone: true
-
-  # Authorization logs
   auth:
     enabled: true
-
-    # Set custom paths for the log files. If left empty,
-    # Filebeat will choose the paths depending on your OS.
-    #var.paths:
-
-    # Convert the timestamp to UTC. Requires Elasticsearch >= 6.1.
     var.convert_timezone: false

--- a/filebeat/tests/system/input/system.yml
+++ b/filebeat/tests/system/input/system.yml
@@ -1,7 +1,0 @@
-- module: system
-  syslog:
-    enabled: true
-    var.convert_timezone: true
-  auth:
-    enabled: true
-    var.convert_timezone: false

--- a/filebeat/tests/system/input/system.yml
+++ b/filebeat/tests/system/input/system.yml
@@ -1,0 +1,25 @@
+# Module: system
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-system.html
+
+- module: system
+  # Syslog
+  syslog:
+    enabled: true
+
+    # Set custom paths for the log files. If left empty,
+    # Filebeat will choose the paths depending on your OS.
+    #var.paths:
+
+    # Convert the timestamp to UTC. Requires Elasticsearch >= 6.1.
+    var.convert_timezone: true
+
+  # Authorization logs
+  auth:
+    enabled: true
+
+    # Set custom paths for the log files. If left empty,
+    # Filebeat will choose the paths depending on your OS.
+    #var.paths:
+
+    # Convert the timestamp to UTC. Requires Elasticsearch >= 6.1.
+    var.convert_timezone: false

--- a/filebeat/tests/system/input/template-test-module/_meta/config.yml
+++ b/filebeat/tests/system/input/template-test-module/_meta/config.yml
@@ -1,0 +1,5 @@
+- module: template-test-module
+  # All logs
+  test:
+    enabled: true
+    var.parse_time: true

--- a/filebeat/tests/system/input/template-test-module/_meta/docs.asciidoc
+++ b/filebeat/tests/system/input/template-test-module/_meta/docs.asciidoc
@@ -1,0 +1,47 @@
+:modulename: template-test-module
+:has-dashboards: true
+
+== template-test-module module
+
+This is the template-test-module module.
+
+include::../include/what-happens.asciidoc[]
+
+[float]
+=== Compatibility
+
+TODO: document with what versions of the software is this tested
+
+
+include::../include/running-modules.asciidoc[]
+
+[float]
+=== Example dashboard
+
+This module comes with a sample dashboard. For example:
+
+TODO: include an image of a sample dashboard. If you do not include a dashboard,
+remove this section and set `:has-dashboards: false` at the top of this file.
+
+include::../include/configuring-intro.asciidoc[]
+
+TODO: provide an example configuration
+
+:fileset_ex: {fileset}
+
+include::../include/config-option-intro.asciidoc[]
+
+TODO: document the variables from each fileset. If you're describing a variable
+that's common to other modules, you can reuse shared descriptions by including
+the relevant file. For example:
+
+[float]
+==== `{fileset}` log fileset settings
+
+include::../include/var-paths.asciidoc[]
+
+:has-dashboards!:
+
+:fileset_ex!:
+
+:modulename!:

--- a/filebeat/tests/system/input/template-test-module/_meta/fields.yml
+++ b/filebeat/tests/system/input/template-test-module/_meta/fields.yml
@@ -1,0 +1,9 @@
+- key: template-test-module
+  title: "template-test-module"
+  description: >
+    template-test-module Module
+  fields:
+    - name: template-test-module
+      type: group
+      description: >
+      fields:

--- a/filebeat/tests/system/input/template-test-module/module.yml
+++ b/filebeat/tests/system/input/template-test-module/module.yml
@@ -1,0 +1,3 @@
+dashboards:
+- id: Filebeat-template-test-module-test-Dashboard
+  file: Filebeat-template-test-module-test.json

--- a/filebeat/tests/system/input/template-test-module/test/config/test.yml
+++ b/filebeat/tests/system/input/template-test-module/test/config/test.yml
@@ -1,0 +1,6 @@
+type: log
+paths:
+{{ range $i, $path := .paths }}
+ - {{$path}}
+{{ end }}
+exclude_files: [".gz$"]

--- a/filebeat/tests/system/input/template-test-module/test/ingest/pipeline.json
+++ b/filebeat/tests/system/input/template-test-module/test/ingest/pipeline.json
@@ -1,0 +1,21 @@
+{
+  "description": "Pipeline for testing template directives in pipelines",
+  "processors": [
+    {
+    {<if .parse_time >}
+      "date": {
+        "field": "field_to_parse",
+        "target_field": "@timestamp",
+        "formats": ["EEE MMM dd H:m:s yyyy", "EEE MMM dd H:m:s.SSSSSS yyyy"],
+        "ignore_failure": true
+      }
+    },
+    {< end >}
+    {
+      "remove": {
+        "field": "field_to_remove",
+        "ignore_failure": true
+      }
+    }
+    ]
+}

--- a/filebeat/tests/system/input/template-test-module/test/manifest.yml
+++ b/filebeat/tests/system/input/template-test-module/test/manifest.yml
@@ -1,0 +1,13 @@
+module_version: 1.0
+
+var:
+  - name: paths
+    default:
+      - /example/test.log*
+    os.darwin:
+      - /usr/local/example/test.log*
+    os.windows:
+      - c:/programdata/example/logs/test.log*
+
+ingest_pipeline: ingest/pipeline.json
+input: config/test.yml

--- a/filebeat/tests/system/test_setup.py
+++ b/filebeat/tests/system/test_setup.py
@@ -17,7 +17,6 @@ class Test(BaseTest):
         print("Using elasticsearch: {}".format(self.elasticsearch_url))
         self.es = Elasticsearch([self.elasticsearch_url])
 
-
     @unittest.skipIf(not INTEGRATION_TESTS,
                      "integration tests are disabled, run with INTEGRATION_TESTS=1 to enable them.")
     @unittest.skipIf(os.getenv("TESTING_ENVIRONMENT") == "2x",
@@ -28,15 +27,15 @@ class Test(BaseTest):
         """
         self.init()
         self.render_config_template(
-            elasticsearch = {
+            elasticsearch={
                 "host": "localhost:9200",
             }
         )
-                
+
         copyfile(self.beat_path + "/tests/system/input/system.yml", self.beat_path + "/modules.d/system.yml")
 
         beat_setup_modules_pipelines = self.start_beat(
-            extra_args = [
+            extra_args=[
                 "setup",
                 "-path.home", self.beat_path,
                 "--pipelines",
@@ -48,12 +47,12 @@ class Test(BaseTest):
         version = self.get_beat_version()
         system_syslog_pipeline_name = "filebeat-" + version + "-system-syslog-pipeline"
         system_syslog_pipeline = self.es.transport.perform_request("GET",
-                "/_ingest/pipeline/" + system_syslog_pipeline_name)
+                                                                   "/_ingest/pipeline/" + system_syslog_pipeline_name)
 
         assert "timezone" in system_syslog_pipeline[system_syslog_pipeline_name]["processors"][3]["date"]
 
         system_auth_pipeline_name = "filebeat-" + version + "-system-auth-pipeline"
         system_auth_pipeline = self.es.transport.perform_request("GET",
-                "/_ingest/pipeline/" + system_auth_pipeline_name)
+                                                                 "/_ingest/pipeline/" + system_auth_pipeline_name)
 
         assert "timezone" not in system_auth_pipeline[system_auth_pipeline_name]["processors"][4]["date"]

--- a/filebeat/tests/system/test_setup.py
+++ b/filebeat/tests/system/test_setup.py
@@ -28,7 +28,7 @@ class Test(BaseTest):
         self.init()
         self.render_config_template(
             elasticsearch={
-                "host": "localhost:9200",
+                "host": self.get_elasticsearch_url(),
             }
         )
 

--- a/filebeat/tests/system/test_setup.py
+++ b/filebeat/tests/system/test_setup.py
@@ -1,0 +1,59 @@
+import unittest
+import os
+import yaml
+from shutil import copyfile
+
+from elasticsearch import Elasticsearch
+
+from filebeat import BaseTest
+
+INTEGRATION_TESTS = os.environ.get('INTEGRATION_TESTS', False)
+
+
+class Test(BaseTest):
+
+    def init(self):
+        self.elasticsearch_url = self.get_elasticsearch_url()
+        print("Using elasticsearch: {}".format(self.elasticsearch_url))
+        self.es = Elasticsearch([self.elasticsearch_url])
+
+
+    @unittest.skipIf(not INTEGRATION_TESTS,
+                     "integration tests are disabled, run with INTEGRATION_TESTS=1 to enable them.")
+    @unittest.skipIf(os.getenv("TESTING_ENVIRONMENT") == "2x",
+                     "integration test not available on 2.x")
+    def test_setup_modules_d_config(self):
+        """
+        Check if template settings are applied to Ingest pipelines when configured from modules.d.
+        """
+        self.init()
+        self.render_config_template(
+            elasticsearch = {
+                "host": "localhost:9200",
+            }
+        )
+                
+        copyfile(self.beat_path + "/tests/system/input/system.yml", self.beat_path + "/modules.d/system.yml")
+
+        beat_setup_modules_pipelines = self.start_beat(
+            extra_args = [
+                "setup",
+                "-path.home", self.beat_path,
+                "--pipelines",
+            ],
+            configure_home=False,
+        )
+        beat_setup_modules_pipelines.check_wait(exit_code=0)
+
+        version = self.get_beat_version()
+        system_syslog_pipeline_name = "filebeat-" + version + "-system-syslog-pipeline"
+        system_syslog_pipeline = self.es.transport.perform_request("GET",
+                "/_ingest/pipeline/" + system_syslog_pipeline_name)
+
+        assert "timezone" in system_syslog_pipeline[system_syslog_pipeline_name]["processors"][3]["date"]
+
+        system_auth_pipeline_name = "filebeat-" + version + "-system-auth-pipeline"
+        system_auth_pipeline = self.es.transport.perform_request("GET",
+                "/_ingest/pipeline/" + system_auth_pipeline_name)
+
+        assert "timezone" not in system_auth_pipeline[system_auth_pipeline_name]["processors"][4]["date"]

--- a/libbeat/cfgfile/reload.go
+++ b/libbeat/cfgfile/reload.go
@@ -234,6 +234,37 @@ func (rl *Reloader) Run(runnerFactory RunnerFactory) {
 	}
 }
 
+// Load loads configuration files once.
+func (rl *Reloader) Load(runnerFactory RunnerFactory) {
+	list := NewRunnerList("load", runnerFactory, rl.pipeline)
+
+	rl.wg.Add(1)
+	defer rl.wg.Done()
+
+	// Stop all running modules when method finishes
+	defer list.Stop()
+
+	gw := NewGlobWatcher(rl.path)
+
+	debugf("Scan for config files")
+	files, _, err := gw.Scan()
+	if err != nil {
+		logp.Err("Error fetching new config files: %v", err)
+	}
+
+	// Load all config objects
+	configs, _ := rl.loadConfigs(files)
+
+	debugf("Number of module configs found: %v", len(configs))
+
+	if err := list.Reload(configs); err != nil {
+		logp.Err("Error loading configuration files: %+v", err)
+		return
+	}
+
+	logp.Info("Loading of config files completed.")
+}
+
 func (rl *Reloader) loadConfigs(files []string) ([]*reload.ConfigWithMeta, error) {
 	// Load all config objects
 	result := []*reload.ConfigWithMeta{}

--- a/libbeat/tests/system/beat/beat.py
+++ b/libbeat/tests/system/beat/beat.py
@@ -181,7 +181,7 @@ class TestCase(unittest.TestCase, ComposeMixin):
                    logging_args=["-e", "-v", "-d", "*"],
                    extra_args=[],
                    env={},
-                   configure_home=True):
+                   home=""):
         """
         Starts beat and returns the process handle. The
         caller is responsible for stopping / waiting for the
@@ -205,12 +205,12 @@ class TestCase(unittest.TestCase, ComposeMixin):
                 os.path.join(self.working_dir, "coverage.cov"),
             ]
 
-        if configure_home:
-            args += [
-                "-path.home", os.path.normpath(self.working_dir),
-            ]
+        path_home = os.path.normpath(self.working_dir)
+        if home:
+            path_home = home
 
         args += [
+            "-path.home", path_home,
             "-c", os.path.join(self.working_dir, config),
         ]
 

--- a/libbeat/tests/system/beat/beat.py
+++ b/libbeat/tests/system/beat/beat.py
@@ -180,7 +180,8 @@ class TestCase(unittest.TestCase, ComposeMixin):
                    output=None,
                    logging_args=["-e", "-v", "-d", "*"],
                    extra_args=[],
-                   env={}):
+                   env={},
+                   configure_home=True):
         """
         Starts beat and returns the process handle. The
         caller is responsible for stopping / waiting for the
@@ -203,8 +204,13 @@ class TestCase(unittest.TestCase, ComposeMixin):
                 "-test.coverprofile",
                 os.path.join(self.working_dir, "coverage.cov"),
             ]
+
+        if configure_home:
+            args += [
+                "-path.home", os.path.normpath(self.working_dir),
+            ]
+
         args += [
-            "-path.home", os.path.normpath(self.working_dir),
             "-c", os.path.join(self.working_dir, config),
         ]
 
@@ -681,3 +687,10 @@ class TestCase(unittest.TestCase, ComposeMixin):
                 raise Exception("Key '{}' found in event is not documented!".format(key))
             if is_documented(key, aliases):
                 raise Exception("Key '{}' found in event is documented as an alias!".format(key))
+
+    def get_beat_version(self):
+        proc = self.start_beat(extra_args=["version"], output="version")
+        proc.wait()
+
+        print(self.get_log(logfile="version")[0])
+        #version = semver.parse(es_info["version"]["number"])

--- a/libbeat/tests/system/beat/beat.py
+++ b/libbeat/tests/system/beat/beat.py
@@ -692,5 +692,4 @@ class TestCase(unittest.TestCase, ComposeMixin):
         proc = self.start_beat(extra_args=["version"], output="version")
         proc.wait()
 
-        print(self.get_log(logfile="version")[0])
-        #version = semver.parse(es_info["version"]["number"])
+        return self.get_log_lines(logfile="version")[0].split()[2]


### PR DESCRIPTION
Previously, when running the subcommand `setup`, configuration from `modules.d` was not loaded. This lead to Filebeat ignoring settings of the module `system` and loading incorrect pipelines.

Now when running setup configuration from the modules folder are read and pipelines are loaded.

### TODO
- [x] more testing to check corner cases
- [x] add automated test
- [x] add changelog entry

Closes #9747