### PR TITLE
Cherry-pick #12333 to 7.2: Set client.authentication to `required` by default.

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -103,6 +103,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix memory leak in Filebeat pipeline acker. {pull}12063[12063]
 - Fix goroutine leak caused on initialization failures of log input. {pull}12125[12125]
 - Fix goroutine leak on non-explicit finalization of log input. {pull}12164[12164]
+- Skipping unparsable log entries from docker json reader {pull}12268[12268]
+- Require client_auth by default when ssl is enabled for tcp input {pull}12333[12333]
 
 *Heartbeat*
 
@@ -129,6 +131,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fixed RabbitMQ `queue` metricset gathering when `consumer_utilisation` is set empty at the metrics source {pull}12089[12089] 
 - Fix direction of incoming IPv6 sockets. {pull}12248[12248]
 - Ignore prometheus metrics when their values are NaN or Inf. {pull}12084[12084] {issue}10849[10849]
+- In the kibana/stats metricset, only log error (don't also index it) if xpack is enabled. {pull}12265[12265]
+- Require client_auth by default when ssl is enabled for module http metricset server{pull}12333[12333]
 
 *Packetbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -103,7 +103,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix memory leak in Filebeat pipeline acker. {pull}12063[12063]
 - Fix goroutine leak caused on initialization failures of log input. {pull}12125[12125]
 - Fix goroutine leak on non-explicit finalization of log input. {pull}12164[12164]
-- Skipping unparsable log entries from docker json reader {pull}12268[12268]
 - Require client_auth by default when ssl is enabled for tcp input {pull}12333[12333]
 
 *Heartbeat*
@@ -128,10 +127,9 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Avoid generating hints-based configuration with empty hosts when no exposed port is suitable for the hosts hint. {issue}8264[8264] {pull}12086[12086]
 - Fixed a socket leak in the postgresql module under Windows when SSL is disabled on the server. {pull}11393[11393]
 - Change some field type from scaled_float to long in aws module. {pull}11982[11982]
-- Fixed RabbitMQ `queue` metricset gathering when `consumer_utilisation` is set empty at the metrics source {pull}12089[12089] 
+- Fixed RabbitMQ `queue` metricset gathering when `consumer_utilisation` is set empty at the metrics source {pull}12089[12089]
 - Fix direction of incoming IPv6 sockets. {pull}12248[12248]
 - Ignore prometheus metrics when their values are NaN or Inf. {pull}12084[12084] {issue}10849[10849]
-- In the kibana/stats metricset, only log error (don't also index it) if xpack is enabled. {pull}12265[12265]
 - Require client_auth by default when ssl is enabled for module http metricset server{pull}12333[12333]
 
 *Packetbeat*

--- a/filebeat/tests/system/test_tcp_tls.py
+++ b/filebeat/tests/system/test_tcp_tls.py
@@ -127,7 +127,7 @@ class Test(BaseTest):
     @raises(ssl.SSLError)
     def test_tcp_over_tls_mutual_auth_fails(self):
         """
-        Test filebeat TCP with TLS when enforcing client auth with bad client certificates.
+        Test filebeat TCP with TLS with default setting to enforce client auth, with bad client certificates
         """
         input_raw = """
 - type: tcp
@@ -136,7 +136,6 @@ class Test(BaseTest):
   ssl.certificate_authorities: {cacert}
   ssl.certificate: {certificate}
   ssl.key: {key}
-  ssl.client_authentication: required
 """
         config = {
             "host": "127.0.0.1",

--- a/libbeat/common/transport/tlscommon/server_config.go
+++ b/libbeat/common/transport/tlscommon/server_config.go
@@ -21,6 +21,8 @@ import (
 	"crypto/tls"
 
 	"github.com/joeshaw/multierror"
+
+	"github.com/elastic/beats/libbeat/common"
 )
 
 // ServerConfig defines the user configurable tls options for any TCP based service.
@@ -87,6 +89,20 @@ func LoadTLSServerConfig(config *ServerConfig) (*TLSConfig, error) {
 		CurvePreferences: curves,
 		ClientAuth:       tls.ClientAuthType(config.ClientAuth),
 	}, nil
+}
+
+func (c *ServerConfig) Unpack(cfg common.Config) error {
+	clientAuthKey := "client_authentication"
+	if !cfg.HasField(clientAuthKey) {
+		cfg.SetString(clientAuthKey, -1, "required")
+	}
+	type serverCfg ServerConfig
+	var sCfg serverCfg
+	if err := cfg.Unpack(&sCfg); err != nil {
+		return err
+	}
+	*c = ServerConfig(sCfg)
+	return nil
 }
 
 // Validate values the TLSConfig struct making sure certificate sure we have both a certificate and

--- a/libbeat/common/transport/tlscommon/tls_test.go
+++ b/libbeat/common/transport/tlscommon/tls_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/libbeat/common"
 )
@@ -163,6 +164,29 @@ func TestApplyWithConfig(t *testing.T) {
 	assert.Equal(t, int(tls.VersionTLS11), int(cfg.MinVersion))
 	assert.Equal(t, int(tls.VersionTLS12), int(cfg.MaxVersion))
 	assert.Len(t, cfg.CurvePreferences, 1)
+}
+
+func TestServerConfigDefaults(t *testing.T) {
+	var c ServerConfig
+	config := common.MustNewConfigFrom([]byte(``))
+	err := config.Unpack(&c)
+	require.NoError(t, err)
+	tmp, err := LoadTLSServerConfig(&c)
+	require.NoError(t, err)
+
+	cfg := tmp.BuildModuleConfig("")
+
+	assert.NotNil(t, cfg)
+	// values not set by default
+	assert.Len(t, cfg.Certificates, 0)
+	assert.Nil(t, cfg.ClientCAs)
+	assert.Len(t, cfg.CipherSuites, 0)
+	assert.Len(t, cfg.CurvePreferences, 0)
+	// values set by default
+	assert.Equal(t, false, cfg.InsecureSkipVerify)
+	assert.Equal(t, int(tls.VersionTLS11), int(cfg.MinVersion))
+	assert.Equal(t, int(tls.VersionTLS12), int(cfg.MaxVersion))
+	assert.Equal(t, tls.RequireAndVerifyClientCert, cfg.ClientAuth)
 }
 
 func TestApplyWithServerConfig(t *testing.T) {


### PR DESCRIPTION
Cherry-pick of PR #12333 to 7.2 branch. Original message: 

When enabling `ssl` for a server configuration, ensure that client authentication is required by default. 

This fix will require client auth by default for tls communication with experimental filebeat `tcp` input and for metricbeat module `http` metricset `server`.  

We do have integration tests for filebeat where I ensured the default setting is tested. For metricbeat I checked manually as I didn't find any related integration tests. 

@ph please take care of backporting this to whichever versions it should be applied to.