### PR TITLE
[Heartbeat] Remove not needed flags from setup command

### DIFF
--- a/heartbeat/cmd/root.go
+++ b/heartbeat/cmd/root.go
@@ -19,14 +19,36 @@ package cmd
 
 import (
 	// register default heartbeat monitors
-	_ "github.com/elastic/beats/heartbeat/monitors/defaults"
-
 	"github.com/elastic/beats/heartbeat/beater"
-	cmd "github.com/elastic/beats/libbeat/cmd"
+	_ "github.com/elastic/beats/heartbeat/monitors/defaults"
+	"github.com/elastic/beats/libbeat/cmd"
+	"github.com/elastic/beats/libbeat/cmd/instance"
 )
 
 // Name of this beat
 var Name = "heartbeat"
 
 // RootCmd to handle beats cli
-var RootCmd = cmd.GenRootCmd(Name, "", beater.New)
+var RootCmd *cmd.BeatsRootCmd
+
+func init() {
+	RootCmd = cmd.GenRootCmdWithSettings(beater.New, instance.Settings{Name: Name})
+
+	// remove dashboard from export commands
+	for _, cmd := range RootCmd.ExportCmd.Commands() {
+		if cmd.Name() == "dashboard" {
+			RootCmd.ExportCmd.RemoveCommand(cmd)
+		}
+	}
+
+	// only add defined flags to setup command
+	setup := RootCmd.SetupCmd
+	setup.Short = "Setup Elasticsearch index template and pipelines"
+	setup.Long = `This command does initial setup of the environment:
+ * Index mapping template in Elasticsearch to ensure fields are mapped.
+ * ILM Policy
+`
+	setup.ResetFlags()
+	setup.Flags().Bool("template", false, "Setup index template")
+	setup.Flags().Bool("ilm-policy", false, "Setup ILM policy")
+}

--- a/heartbeat/cmd/root.go
+++ b/heartbeat/cmd/root.go
@@ -20,6 +20,7 @@ package cmd
 import (
 	// register default heartbeat monitors
 	"github.com/elastic/beats/heartbeat/beater"
+	// Load the monitor types
 	_ "github.com/elastic/beats/heartbeat/monitors/defaults"
 	"github.com/elastic/beats/libbeat/cmd"
 	"github.com/elastic/beats/libbeat/cmd/instance"


### PR DESCRIPTION
Backport of #11856 to 6.8

Fixes https://github.com/elastic/kibana/issues/37216

The setup command until now contained all the possible options from the other Beats. As Heartbeat does not ship anymore with dashboards, the --dashboards command is not needed anymore and is only confusing. I also removed all the other commands except --ilm-policy and --template. I'm not aware that --pipelines or --machine-learning would be used.

Here the comparison between ./heartbeat setup -h from before and after.