### PR TITLE
Only log error (don't also index it) if xpack is enabled.

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -63,6 +63,7 @@ https://github.com/elastic/beats/compare/v7.1.1...7.1[Check the HEAD diff]
 - Ignore prometheus metrics when their values are NaN or Inf. {pull}12084[12084] {issue}10849[10849]
 - Require client_auth by default when ssl is enabled for module http metricset server{pull}12333[12333]
 - Require certificate authorities, certificate file, and key when SSL is enabled for module http metricset server. {pull}12355[12355]
+- In the kibana/stats metricset, only log error (don't also index it) if xpack is enabled. {pull}12353[12353]
 
 *Packetbeat*
 


### PR DESCRIPTION
When `xpack.enabled: true` is set on a stack module, the expectation is that the user won't see any `metricbeat-*` indices. Instead users expect to see `.monitoring-*` indices.

However, metricbeat indexes errors into `metricbeat-*` indices. So in an error situation when `xpack.enabled: true` is set, we don't want to index errors but just log them. That's what this PR fixes for the `kibana/stats` metricset.

Equivalent of #12265 but for 7.1 (see https://github.com/elastic/beats/pull/12265#issuecomment-496907878 for rationale).