### PR TITLE
Enforce presence of Certificate Authorities, Certificate file and Key when using LoadTLSServerConfig

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -137,7 +137,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Ignore prometheus metrics when their values are NaN or Inf. {pull}12084[12084] {issue}10849[10849]
 - In the kibana/stats metricset, only log error (don't also index it) if xpack is enabled. {pull}12265[12265]
 - Require client_auth by default when ssl is enabled for module http metricset server{pull}12333[12333]
-- Require Certificate authorities, Certificate file and key when SSL is enabled for module http metricset server. {pull}12355[12355]
+- Require certificate authorities, certificate file and key when SSL is enabled for module http metricset server. {pull}12355[12355]
 
 *Packetbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -137,7 +137,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Ignore prometheus metrics when their values are NaN or Inf. {pull}12084[12084] {issue}10849[10849]
 - In the kibana/stats metricset, only log error (don't also index it) if xpack is enabled. {pull}12265[12265]
 - Require client_auth by default when ssl is enabled for module http metricset server{pull}12333[12333]
-- Require certificate authorities, certificate file and key when SSL is enabled for module http metricset server. {pull}12355[12355]
+- Require certificate authorities, certificate file, and key when SSL is enabled for module http metricset server. {pull}12355[12355]
 
 *Packetbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -107,6 +107,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix goroutine leak on non-explicit finalization of log input. {pull}12164[12164]
 - Skipping unparsable log entries from docker json reader {pull}12268[12268]
 - Require client_auth by default when ssl is enabled for tcp input {pull}12333[12333]
+- Require client_auth by default when ssl is enabled for TCP input {pull}12333[12333]
+- Require Certificate authorities, Certificate file and key when SSL is enabled for the TCP input. {pull}xxx[xxx]
 
 *Heartbeat*
 
@@ -136,6 +138,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Ignore prometheus metrics when their values are NaN or Inf. {pull}12084[12084] {issue}10849[10849]
 - In the kibana/stats metricset, only log error (don't also index it) if xpack is enabled. {pull}12265[12265]
 - Require client_auth by default when ssl is enabled for module http metricset server{pull}12333[12333]
+- Require client_auth by default when SSL is enabled for module http metricset server{pull}12333[12333]
+- Require Certificate authorities, Certificate file and key when SSL is enabled for the TCP input. {pull}xxx[xxx]
 
 *Packetbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -107,7 +107,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix goroutine leak on non-explicit finalization of log input. {pull}12164[12164]
 - Skipping unparsable log entries from docker json reader {pull}12268[12268]
 - Require client_auth by default when ssl is enabled for tcp input {pull}12333[12333]
-- Require Certificate authorities, Certificate file and key when SSL is enabled for the TCP input. {pull}12355[12355]
+- Require certificate authorities, certificate file, and key when SSL is enabled for the TCP input. {pull}12355[12355]
 
 *Heartbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -137,7 +137,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Ignore prometheus metrics when their values are NaN or Inf. {pull}12084[12084] {issue}10849[10849]
 - In the kibana/stats metricset, only log error (don't also index it) if xpack is enabled. {pull}12265[12265]
 - Require client_auth by default when ssl is enabled for module http metricset server{pull}12333[12333]
-- Require Certificate authorities, Certificate file and key when SSL is enabled for module http server. {pull}12355[12355]
+- Require Certificate authorities, Certificate file and key when SSL is enabled for module http metricset server. {pull}12355[12355]
 
 *Packetbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -107,8 +107,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix goroutine leak on non-explicit finalization of log input. {pull}12164[12164]
 - Skipping unparsable log entries from docker json reader {pull}12268[12268]
 - Require client_auth by default when ssl is enabled for tcp input {pull}12333[12333]
-- Require client_auth by default when ssl is enabled for TCP input {pull}12333[12333]
-- Require Certificate authorities, Certificate file and key when SSL is enabled for the TCP input. {pull}xxx[xxx]
+- Require Certificate authorities, Certificate file and key when SSL is enabled for the TCP input. {pull}12355[12355]
 
 *Heartbeat*
 
@@ -138,8 +137,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Ignore prometheus metrics when their values are NaN or Inf. {pull}12084[12084] {issue}10849[10849]
 - In the kibana/stats metricset, only log error (don't also index it) if xpack is enabled. {pull}12265[12265]
 - Require client_auth by default when ssl is enabled for module http metricset server{pull}12333[12333]
-- Require client_auth by default when SSL is enabled for module http metricset server{pull}12333[12333]
-- Require Certificate authorities, Certificate file and key when SSL is enabled for the TCP input. {pull}xxx[xxx]
+- Require Certificate authorities, Certificate file and key when SSL is enabled for module http server. {pull}12355[12355]
 
 *Packetbeat*
 

--- a/libbeat/common/transport/tlscommon/server_config.go
+++ b/libbeat/common/transport/tlscommon/server_config.go
@@ -105,7 +105,7 @@ func (c *ServerConfig) Unpack(cfg common.Config) error {
 	}
 
 	if sCfg.VerificationMode != VerifyNone && len(sCfg.CAs) == 0 {
-		return errors.New("certificate authorities not configured")
+		return errors.New("certificate_authorities not configured")
 	}
 
 	*c = ServerConfig(sCfg)

--- a/libbeat/common/transport/tlscommon/server_config.go
+++ b/libbeat/common/transport/tlscommon/server_config.go
@@ -31,8 +31,8 @@ type ServerConfig struct {
 	VerificationMode TLSVerificationMode `config:"verification_mode"` // one of 'none', 'full'
 	Versions         []TLSVersion        `config:"supported_protocols"`
 	CipherSuites     []tlsCipherSuite    `config:"cipher_suites"`
-	CAs              []string            `config:"certificate_authorities"`
-	Certificate      CertificateConfig   `config:",inline"`
+	CAs              []string            `config:"certificate_authorities" validate:"required"`
+	Certificate      CertificateConfig   `config:",inline" validate:"required"`
 	CurveTypes       []tlsCurveType      `config:"curve_types"`
 	ClientAuth       tlsClientAuth       `config:"client_authentication"` //`none`, `optional` or `required`
 }

--- a/libbeat/common/transport/tlscommon/server_config.go
+++ b/libbeat/common/transport/tlscommon/server_config.go
@@ -104,10 +104,8 @@ func (c *ServerConfig) Unpack(cfg common.Config) error {
 		return err
 	}
 
-	if sCfg.VerificationMode != VerifyNone {
-		if len(sCfg.CAs) == 0 {
-			return errors.New("certificate authorities not configured")
-		}
+	if sCfg.VerificationMode != VerifyNone && len(sCfg.CAs) == 0 {
+		return errors.New("certificate authorities not configured")
 	}
 
 	*c = ServerConfig(sCfg)

--- a/libbeat/common/transport/tlscommon/tls_test.go
+++ b/libbeat/common/transport/tlscommon/tls_test.go
@@ -167,9 +167,15 @@ func TestApplyWithConfig(t *testing.T) {
 }
 
 func TestServerConfigDefaults(t *testing.T) {
+	yamlStr := `
+    certificate: ca_test.pem
+    key: ca_test.key
+    certificate_authorities: [ca_test.pem]
+  `
 	var c ServerConfig
-	config := common.MustNewConfigFrom([]byte(``))
-	err := config.Unpack(&c)
+	config, err := common.NewConfigWithYAML([]byte(yamlStr), "")
+	require.NoError(t, err)
+	err = config.Unpack(&c)
 	require.NoError(t, err)
 	tmp, err := LoadTLSServerConfig(&c)
 	require.NoError(t, err)
@@ -178,8 +184,8 @@ func TestServerConfigDefaults(t *testing.T) {
 
 	assert.NotNil(t, cfg)
 	// values not set by default
-	assert.Len(t, cfg.Certificates, 0)
-	assert.Nil(t, cfg.ClientCAs)
+	assert.Len(t, cfg.Certificates, 1)
+	assert.NotNil(t, cfg.ClientCAs)
 	assert.Len(t, cfg.CipherSuites, 0)
 	assert.Len(t, cfg.CurvePreferences, 0)
 	// values set by default
@@ -187,6 +193,30 @@ func TestServerConfigDefaults(t *testing.T) {
 	assert.Equal(t, int(tls.VersionTLS11), int(cfg.MinVersion))
 	assert.Equal(t, int(tls.VersionTLS12), int(cfg.MaxVersion))
 	assert.Equal(t, tls.RequireAndVerifyClientCert, cfg.ClientAuth)
+}
+
+func TestServerConfigEnsureCA(t *testing.T) {
+	yamlStr := `
+    certificate: ca_test.pem
+    key: ca_test.key
+  `
+	var c ServerConfig
+	config, err := common.NewConfigWithYAML([]byte(yamlStr), "")
+	require.NoError(t, err)
+	err = config.Unpack(&c)
+	require.Error(t, err)
+}
+
+func TestServerConfigCertificate(t *testing.T) {
+	yamlStr := `
+    certificate: ca_test.pem
+    certificate_authorities: [ca_test.pem]
+  `
+	var c ServerConfig
+	config, err := common.NewConfigWithYAML([]byte(yamlStr), "")
+	require.NoError(t, err)
+	err = config.Unpack(&c)
+	require.Error(t, err)
 }
 
 func TestApplyWithServerConfig(t *testing.T) {

--- a/libbeat/common/transport/tlscommon/tls_test.go
+++ b/libbeat/common/transport/tlscommon/tls_test.go
@@ -195,6 +195,17 @@ func TestServerConfigDefaults(t *testing.T) {
 	assert.Equal(t, tls.RequireAndVerifyClientCert, cfg.ClientAuth)
 }
 
+func TestServerConfigSkipCACertificateAndKeyWhenVerifyNone(t *testing.T) {
+	yamlStr := `
+    verification_mode: none
+  `
+	var c ServerConfig
+	config, err := common.NewConfigWithYAML([]byte(yamlStr), "")
+	require.NoError(t, err)
+	err = config.Unpack(&c)
+	require.NoError(t, err)
+}
+
 func TestServerConfigEnsureCA(t *testing.T) {
 	yamlStr := `
     certificate: ca_test.pem

--- a/libbeat/common/transport/tlscommon/tls_test.go
+++ b/libbeat/common/transport/tlscommon/tls_test.go
@@ -207,9 +207,21 @@ func TestServerConfigEnsureCA(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestServerConfigCertificate(t *testing.T) {
+func TestServerConfigCertificateKey(t *testing.T) {
 	yamlStr := `
     certificate: ca_test.pem
+    certificate_authorities: [ca_test.pem]
+  `
+	var c ServerConfig
+	config, err := common.NewConfigWithYAML([]byte(yamlStr), "")
+	require.NoError(t, err)
+	err = config.Unpack(&c)
+	require.Error(t, err)
+}
+
+func TestServerConfigCertificate(t *testing.T) {
+	yamlStr := `
+    key: ca_test.key
     certificate_authorities: [ca_test.pem]
   `
 	var c ServerConfig


### PR DESCRIPTION
When TLS is enabled for a Server we enforce CA, Certificate and the private key to make sure that the communication is correctly encrypted.