### PR TITLE
Cherry-pick to 7.2: Uncomment rabbitmq config.yml so it works when rabbitmq enabled (#12349)

### DIFF
--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -430,10 +430,10 @@ filebeat.modules:
     #input:
 
 #------------------------------- RabbitMQ Module -------------------------------
-#- module: rabbitmq
+- module: rabbitmq
   # All logs
-  #log:
-    #enabled: true
+  log:
+    enabled: true
 
     # Set custom paths for the log files. If left empty,
     # Filebeat will choose the paths depending on your OS.

--- a/x-pack/filebeat/module/rabbitmq/_meta/config.yml
+++ b/x-pack/filebeat/module/rabbitmq/_meta/config.yml
@@ -1,7 +1,7 @@
-#- module: rabbitmq
+- module: rabbitmq
   # All logs
-  #log:
-    #enabled: true
+  log:
+    enabled: true
 
     # Set custom paths for the log files. If left empty,
     # Filebeat will choose the paths depending on your OS.

--- a/x-pack/filebeat/modules.d/rabbitmq.yml.disabled
+++ b/x-pack/filebeat/modules.d/rabbitmq.yml.disabled
@@ -1,10 +1,10 @@
 # Module: rabbitmq
 # Docs: https://www.elastic.co/guide/en/beats/filebeat/7.2/filebeat-module-rabbitmq.html
 
-#- module: rabbitmq
+- module: rabbitmq
   # All logs
-  #log:
-    #enabled: true
+  log:
+    enabled: true
 
     # Set custom paths for the log files. If left empty,
     # Filebeat will choose the paths depending on your OS.


### PR DESCRIPTION
Cherry-pick of PR #12349  to 7.2 branch. Original message:

When I was testing rabbitmq module, I ran `./filebeat modules enable rabbitmq` and then started filebeat with `./filebeat -e`. But no filebeat data was collected. I went back to check `rabbitmq.yml` under `modules.d` and realized all the lines in this file were commented out. After removing `#` from rabbitmq.yml file, everything works fine. 

This behavior is not matching other modules in filebeat/metricbeat so I will uncomment several lines in this PR and make sure after running `./filebeat modules enable rabbitmq`, filebeat is ready to collect metrics from rabbitmq logs.

(cherry picked from commit cf0fa6a4dab6742bf902d39d72a117347fef20c2)