### PR TITLE
Cherry-pick #12355 to 7.1: Enforce presence of Certificate Authorities, Certificate file and Key when using LoadTLSServerConfig

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -47,6 +47,7 @@ https://github.com/elastic/beats/compare/v7.1.1...7.1[Check the HEAD diff]
 - Fix memory leak in Filebeat pipeline acker. {pull}12063[12063]
 - Fix goroutine leak on non-explicit finalization of log input. {pull}12164[12164]
 - Require client_auth by default when ssl is enabled for tcp input {pull}12333[12333]
+- Require certificate authorities, certificate file, and key when SSL is enabled for the TCP input. {pull}12355[12355]
 
 *Heartbeat*
 
@@ -61,6 +62,7 @@ https://github.com/elastic/beats/compare/v7.1.1...7.1[Check the HEAD diff]
 - Validate that kibana/status metricset cannot be used when xpack is enabled. {pull}12264[12264]
 - Ignore prometheus metrics when their values are NaN or Inf. {pull}12084[12084] {issue}10849[10849]
 - Require client_auth by default when ssl is enabled for module http metricset server{pull}12333[12333]
+- Require certificate authorities, certificate file, and key when SSL is enabled for module http metricset server. {pull}12355[12355]
 
 *Packetbeat*
 

--- a/libbeat/common/transport/tlscommon/server_config.go
+++ b/libbeat/common/transport/tlscommon/server_config.go
@@ -19,6 +19,7 @@ package tlscommon
 
 import (
 	"crypto/tls"
+	"errors"
 
 	"github.com/joeshaw/multierror"
 
@@ -91,6 +92,7 @@ func LoadTLSServerConfig(config *ServerConfig) (*TLSConfig, error) {
 	}, nil
 }
 
+// Unpack unpacks the TLS Server configuration.
 func (c *ServerConfig) Unpack(cfg common.Config) error {
 	clientAuthKey := "client_authentication"
 	if !cfg.HasField(clientAuthKey) {
@@ -101,6 +103,11 @@ func (c *ServerConfig) Unpack(cfg common.Config) error {
 	if err := cfg.Unpack(&sCfg); err != nil {
 		return err
 	}
+
+	if sCfg.VerificationMode != VerifyNone && len(sCfg.CAs) == 0 {
+		return errors.New("certificate_authorities not configured")
+	}
+
 	*c = ServerConfig(sCfg)
 	return nil
 }

--- a/libbeat/common/transport/tlscommon/tls_test.go
+++ b/libbeat/common/transport/tlscommon/tls_test.go
@@ -167,9 +167,15 @@ func TestApplyWithConfig(t *testing.T) {
 }
 
 func TestServerConfigDefaults(t *testing.T) {
+	yamlStr := `
+    certificate: ca_test.pem
+    key: ca_test.key
+    certificate_authorities: [ca_test.pem]
+  `
 	var c ServerConfig
-	config := common.MustNewConfigFrom([]byte(``))
-	err := config.Unpack(&c)
+	config, err := common.NewConfigWithYAML([]byte(yamlStr), "")
+	require.NoError(t, err)
+	err = config.Unpack(&c)
 	require.NoError(t, err)
 	tmp, err := LoadTLSServerConfig(&c)
 	require.NoError(t, err)
@@ -178,8 +184,8 @@ func TestServerConfigDefaults(t *testing.T) {
 
 	assert.NotNil(t, cfg)
 	// values not set by default
-	assert.Len(t, cfg.Certificates, 0)
-	assert.Nil(t, cfg.ClientCAs)
+	assert.Len(t, cfg.Certificates, 1)
+	assert.NotNil(t, cfg.ClientCAs)
 	assert.Len(t, cfg.CipherSuites, 0)
 	assert.Len(t, cfg.CurvePreferences, 0)
 	// values set by default
@@ -187,6 +193,53 @@ func TestServerConfigDefaults(t *testing.T) {
 	assert.Equal(t, int(tls.VersionTLS11), int(cfg.MinVersion))
 	assert.Equal(t, int(tls.VersionTLS12), int(cfg.MaxVersion))
 	assert.Equal(t, tls.RequireAndVerifyClientCert, cfg.ClientAuth)
+}
+
+func TestServerConfigSkipCACertificateAndKeyWhenVerifyNone(t *testing.T) {
+	yamlStr := `
+    verification_mode: none
+  `
+	var c ServerConfig
+	config, err := common.NewConfigWithYAML([]byte(yamlStr), "")
+	require.NoError(t, err)
+	err = config.Unpack(&c)
+	require.NoError(t, err)
+}
+
+func TestServerConfigEnsureCA(t *testing.T) {
+	yamlStr := `
+    certificate: ca_test.pem
+    key: ca_test.key
+  `
+	var c ServerConfig
+	config, err := common.NewConfigWithYAML([]byte(yamlStr), "")
+	require.NoError(t, err)
+	err = config.Unpack(&c)
+	require.Error(t, err)
+}
+
+func TestServerConfigCertificateKey(t *testing.T) {
+	yamlStr := `
+    certificate: ca_test.pem
+    certificate_authorities: [ca_test.pem]
+  `
+	var c ServerConfig
+	config, err := common.NewConfigWithYAML([]byte(yamlStr), "")
+	require.NoError(t, err)
+	err = config.Unpack(&c)
+	require.Error(t, err)
+}
+
+func TestServerConfigCertificate(t *testing.T) {
+	yamlStr := `
+    key: ca_test.key
+    certificate_authorities: [ca_test.pem]
+  `
+	var c ServerConfig
+	config, err := common.NewConfigWithYAML([]byte(yamlStr), "")
+	require.NoError(t, err)
+	err = config.Unpack(&c)
+	require.Error(t, err)
 }
 
 func TestApplyWithServerConfig(t *testing.T) {


### PR DESCRIPTION
Cherry-pick of PR #12355 to 7.1 branch. Original message: 

When TLS is enabled for a Server we enforce CA, Certificate and the private key to make sure that the communication is correctly encrypted.