### PR TITLE
Configurable AWS endpoint

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -238,6 +238,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 - New options to configure roles and VPC. {pull}11779[11779]
 - Export automation templates used to create functions. {pull}11923[11923]
+- Configurable Amazon endpoint. {pull}12369[12369]
 
 *Winlogbeat*
 

--- a/x-pack/functionbeat/_meta/beat.reference.yml
+++ b/x-pack/functionbeat/_meta/beat.reference.yml
@@ -11,6 +11,8 @@
 # Configure functions to run on AWS Lambda, currently we assume that the credentials
 # are present in the environment to correctly create the function when using the CLI.
 #
+# Configure which S3 endpoint should we use.
+functionbeat.provider.aws.endpoint: "s3.amazonaws.com"
 # Configure which S3 bucket we should upload the lambda artifact.
 functionbeat.provider.aws.deploy_bucket: "functionbeat-deploy"
 

--- a/x-pack/functionbeat/_meta/beat.yml
+++ b/x-pack/functionbeat/_meta/beat.yml
@@ -12,6 +12,8 @@
 # Configure functions to run on AWS Lambda, currently we assume that the credentials
 # are present in the environment to correctly create the function when using the CLI.
 #
+# Configure which S3 endpoint should we use.
+functionbeat.provider.aws.endpoint: "s3.amazonaws.com"
 # Configure which S3 bucket we should upload the lambda artifact.
 functionbeat.provider.aws.deploy_bucket: "functionbeat-deploy"
 

--- a/x-pack/functionbeat/docs/config-options.asciidoc
+++ b/x-pack/functionbeat/docs/config-options.asciidoc
@@ -22,6 +22,7 @@ the events to {es}.
 
 ["source","sh",subs="attributes"]
 ----
+{beatname_lc}.provider.aws.endpoint: "s3.amazonaws.com"
 {beatname_lc}.provider.aws.deploy_bucket: "functionbeat-deploy"
 {beatname_lc}.provider.aws.functions:
   - name: cloudwatch
@@ -55,6 +56,12 @@ to deploy.
 
 TIP: If you change the configuration after deploying the function, use
 the <<update-command,`update` command>> to update your deployment.
+
+[float]
+[id="{beatname_lc}-endpoint"]
+==== `provider.aws.endpoint`
+
+AWS endpoint to use in the URL template to load functions.
 
 [float]
 [id="{beatname_lc}-deploy-bucket"]

--- a/x-pack/functionbeat/docs/getting-started.asciidoc
+++ b/x-pack/functionbeat/docs/getting-started.asciidoc
@@ -97,6 +97,7 @@ events from CloudWatch Logs and forwards the events to {es}.
 
 ["source","sh",subs="attributes"]
 -------------------------------------------------------------------------------------
+{beatname_lc}.provider.aws.endpoint: "s3.amazonaws.com"
 {beatname_lc}.provider.aws.deploy_bucket: "functionbeat-deploy"
 {beatname_lc}.provider.aws.functions:
   - name: cloudwatch

--- a/x-pack/functionbeat/functionbeat.reference.yml
+++ b/x-pack/functionbeat/functionbeat.reference.yml
@@ -11,6 +11,8 @@
 # Configure functions to run on AWS Lambda, currently we assume that the credentials
 # are present in the environment to correctly create the function when using the CLI.
 #
+# Configure which S3 endpoint should we use.
+functionbeat.provider.aws.endpoint: "s3.amazonaws.com"
 # Configure which S3 bucket we should upload the lambda artifact.
 functionbeat.provider.aws.deploy_bucket: "functionbeat-deploy"
 

--- a/x-pack/functionbeat/functionbeat.yml
+++ b/x-pack/functionbeat/functionbeat.yml
@@ -12,6 +12,8 @@
 # Configure functions to run on AWS Lambda, currently we assume that the credentials
 # are present in the environment to correctly create the function when using the CLI.
 #
+# Configure which S3 endpoint should we use.
+functionbeat.provider.aws.endpoint: "s3.amazonaws.com"
 # Configure which S3 bucket we should upload the lambda artifact.
 functionbeat.provider.aws.deploy_bucket: "functionbeat-deploy"
 

--- a/x-pack/functionbeat/provider/aws/config.go
+++ b/x-pack/functionbeat/provider/aws/config.go
@@ -17,6 +17,7 @@ import (
 
 // Config expose the configuration option the AWS provider.
 type Config struct {
+	Endpoint     string `config:"endpoint" validate:"nonzero,required"`
 	DeployBucket bucket `config:"deploy_bucket" validate:"nonzero,required"`
 }
 

--- a/x-pack/functionbeat/provider/aws/template_builder.go
+++ b/x-pack/functionbeat/provider/aws/template_builder.go
@@ -37,6 +37,7 @@ type templateData struct {
 type defaultTemplateBuilder struct {
 	provider provider.Provider
 	log      *logp.Logger
+	endpoint string
 	bucket   string
 }
 
@@ -53,6 +54,7 @@ func NewTemplateBuilder(log *logp.Logger, cfg *common.Config, p provider.Provide
 	return &defaultTemplateBuilder{
 		provider: p,
 		log:      log,
+		endpoint: config.Endpoint,
 		bucket:   string(config.DeployBucket),
 	}, nil
 }
@@ -101,7 +103,7 @@ func (d *defaultTemplateBuilder) execute(name string) (templateData, error) {
 
 	templateChecksum := checksum(templateJSON)
 	templateKey := keyPrefix + name + "/" + templateChecksum + "/cloudformation-template-create.json"
-	templateURL := "https://" + d.bucket + "s3.amazonaws.com/" + templateKey
+	templateURL := "https://" + d.bucket + "." + d.endpoint + "/" + templateKey
 
 	return templateData{
 		json:     templateJSON,

--- a/x-pack/functionbeat/tests/system/config/functionbeat.yml.j2
+++ b/x-pack/functionbeat/tests/system/config/functionbeat.yml.j2
@@ -7,6 +7,7 @@ functionbeat.provider.local:
 {% endif %}
 
 {% if cloudwatch %}
+functionbeat.provider.aws.endpoint: {{ cloudwatch.endpoint | default("s3.amazonaws.com") }}
 functionbeat.provider.aws.deploy_bucket: {{ cloudwatch.bucket | default("functionbeat-deploy") }}
 functionbeat.provider.aws.functions:
   - name: {{ cloudwatch.name }}

--- a/x-pack/functionbeat/tests/system/test_base.py
+++ b/x-pack/functionbeat/tests/system/test_base.py
@@ -57,6 +57,7 @@ class Test(BaseTest):
 
         self.wait_until(lambda: self.log_contains("PASS"))
         exit_code = functionbeat_proc.kill_and_wait()
+        print(exit_code)
         assert exit_code == 0
 
         function_template = self._get_generated_function_template()

--- a/x-pack/functionbeat/tests/system/test_base.py
+++ b/x-pack/functionbeat/tests/system/test_base.py
@@ -22,7 +22,7 @@ class Test(BaseTest):
         exit_code = functionbeat_proc.kill_and_wait()
         assert exit_code == 0
 
-    def test_export_function_template(self):
+    def test_export_function(self):
         """
         Test if the template can be exported
         """
@@ -69,7 +69,7 @@ class Test(BaseTest):
         assert function_properties["VpcConfig"]["SecurityGroupIds"] == security_group_ids
         assert function_properties["VpcConfig"]["SubnetIds"] == subnet_ids
 
-    def test_export_function_template_with_invalid_configuration(self):
+    def test_export_function_invalid_conf(self):
         """
         Test if invalid configuration is exportable
         """

--- a/x-pack/functionbeat/tests/system/test_base.py
+++ b/x-pack/functionbeat/tests/system/test_base.py
@@ -56,9 +56,7 @@ class Test(BaseTest):
         )
 
         self.wait_until(lambda: self.log_contains("PASS"))
-        exit_code = functionbeat_proc.kill_and_wait()
-        print(exit_code)
-        assert exit_code == 0
+        functionbeat_proc.check_wait()
 
         function_template = self._get_generated_function_template()
         function_properties = function_template["Resources"][fnb_name]["Properties"]


### PR DESCRIPTION
New option is added to the configuration to support custom AWS endpoints named `endpoint`.

```yaml
# Configure which S3 endpoint should we use.
functionbeat.provider.aws.endpoint: "s3.amazonaws.com"
```
Closes #12368 