### PR TITLE
[dev guide] Add docs on optional schema arguments

### DIFF
--- a/docs/devguide/create-metricset.asciidoc
+++ b/docs/devguide/create-metricset.asciidoc
@@ -245,13 +245,14 @@ func eventMapping(input map[string]interface{}) common.MapStr {
 	return schema.Apply(input) <4>
 }
 ----
-<1> `Required` will explicitly mark a field as non-optional.
-<2> If a field has no Schema Option set, it is equivalent to `Required`.
-<3> `Optional` You can also explicitly mark a field as not required.
-<4> By default, `Apply` will fail and return an error if any field not marked as optional is missing. Using the optional second argument, you can specify how `Apply` handles different fields of the  schema. The possible values are:
-- `AllRequired` is the default behavior. Return an error if any field not marked as optional is missing.
+<1> Marks a field as required.
+<2> If a field has no schema option set, it is equivalent to `Required`.
+<3> Marks the field as optional.
+<4> By default, `Apply` will fail and return an error if any required field is missing. Using the optional second argument, you can specify how `Apply` handles different fields of the  schema. The possible values are:
+- `AllRequired` is the default behavior. Returns an error if any required field is missing, including fields that are required because no schema option is set.
 - `FailOnRequired`  will fail if a field explicitly marked as `required` is missing.
-- `NotFoundKeys(cb func([]string))` will pass a callback function that will be called with the list of missing keys, for more fine-grained error handling.
+- `IgnoreAllErrors` will ignore all parsing errors.
+- `NotFoundKeys(cb func([]string))` takes a callback function that will be called with a list of missing keys, allowing for finer-grained error handling.
 
 In the above example, note that it is possible to create the schema object once
 and apply it to all events. 

--- a/docs/devguide/create-metricset.asciidoc
+++ b/docs/devguide/create-metricset.asciidoc
@@ -276,16 +276,20 @@ var (
 	}
 )
 
-	data, err := schema.apply(input)
+	data, err := schema.Apply(input)
 	if err != nil {
 		return err
 	}
 
 	if m.parseMoreData{
-		additionalSchema.ApplyTo(data, input)
+		_, err := additionalSchema.ApplyTo(data, input)
+		if len(err) > 0 { <1>
+			return err.Err()
+		}
 	}
 
 ----
+<1> `ApplyTo` returns a raw MultiError object, making it suitable for finer-grained error handling.
 
 
 [float]

--- a/docs/devguide/create-metricset.asciidoc
+++ b/docs/devguide/create-metricset.asciidoc
@@ -236,26 +236,57 @@ var (
 		"test_bool":   c.Bool("testBool", s.Optional), <3>
 		"test_float":  c.Float("testFloat"),
 		"test_obj": s.Object{
-			"test_obj_string": c.Str("testObjString"),
+			"test_obj_string": c.Str("testObjString", s.IgnoreAllErrors), <4>
 		},
 	}
 )
 
 func eventMapping(input map[string]interface{}) common.MapStr {
-	return schema.Apply(input) <4>
+	return schema.Apply(input) <5>
 }
 ----
 <1> Marks a field as required.
 <2> If a field has no schema option set, it is equivalent to `Required`.
 <3> Marks the field as optional.
-<4> By default, `Apply` will fail and return an error if any required field is missing. Using the optional second argument, you can specify how `Apply` handles different fields of the  schema. The possible values are:
+<4> Ignore any value conversion error
+<5> By default, `Apply` will fail and return an error if any required field is missing. Using the optional second argument, you can specify how `Apply` handles different fields of the  schema. The possible values are:
 - `AllRequired` is the default behavior. Returns an error if any required field is missing, including fields that are required because no schema option is set.
 - `FailOnRequired`  will fail if a field explicitly marked as `required` is missing.
-- `IgnoreAllErrors` will ignore all parsing errors.
 - `NotFoundKeys(cb func([]string))` takes a callback function that will be called with a list of missing keys, allowing for finer-grained error handling.
 
 In the above example, note that it is possible to create the schema object once
-and apply it to all events. 
+and apply it to all events. You can also use `ApplyTo` to add additional data to an existing `MapStr` object:
+[source,go]
+----
+
+var (
+	schema = s.Schema{
+		"test_string": c.Str("testString"),
+		"test_int":    c.Int("testInt"),
+		"test_bool":   c.Bool("testBool"),
+		"test_float":  c.Float("testFloat"),
+		"test_obj": s.Object{
+			"test_obj_string": c.Str("testObjString"),
+		},
+	}
+
+	additionalSchema = s.Schema{
+		"second_string": c.Str("secondString"),
+		"second_int": ": c.Int("secondInt")
+	}
+)
+
+	data, err := schema.apply(input)
+	if err {
+		return err
+	}
+
+	if m.parseMoreData{
+		additionalSchema.ApplyTo(data, input)
+	}
+
+----
+
 
 [float]
 ==== Configuration File

--- a/docs/devguide/create-metricset.asciidoc
+++ b/docs/devguide/create-metricset.asciidoc
@@ -220,7 +220,7 @@ common.MapStr{
 }
 ----
 
-You can use the following code to make the transformations:
+You can use the schema package to transform the data, and optionally mark some fields in a schema as required or not. For example:
 
 [source,go]
 ----
@@ -231,9 +231,9 @@ import (
 
 var (
 	schema = s.Schema{
-		"test_string": c.Str("testString"),
-		"test_int":    c.Int("testInt"),
-		"test_bool":   c.Bool("testBool"),
+		"test_string": c.Str("testString", s.Required), <1>
+		"test_int":    c.Int("testInt"), <2>
+		"test_bool":   c.Bool("testBool", s.Optional), <3>
 		"test_float":  c.Float("testFloat"),
 		"test_obj": s.Object{
 			"test_obj_string": c.Str("testObjString"),
@@ -242,12 +242,21 @@ var (
 )
 
 func eventMapping(input map[string]interface{}) common.MapStr {
-	return schema.Apply(input)
+	return schema.Apply(input) <4>
 }
 ----
+<1> `Required` will explicitly mark a field as non-optional.
+<2> If a field has no Schema Option set, it is equivalent to `Required`.
+<3> `Optional` You can also explicitly mark a field as not required.
+<4> By default, `Apply` will fail and return an error if any field not marked as optional is missing. Using the optional second argument, you can specify how `Apply` handles different fields of the  schema. The possible values are:
+- `AllRequired` is the default behavior. Return an error if any field not marked as optional is missing.
+- `FailOnRequired`  will fail if a field explicitly marked as `required` is missing.
+- `NotFoundKeys(cb func([]string))` will pass a callback function that will be called with the list of missing keys, for more fine-grained error handling.
 
 In the above example, note that it is possible to create the schema object once
-and apply it to all events.
+and apply it to all events. 
+
+
 
 [float]
 ==== Configuration File

--- a/docs/devguide/create-metricset.asciidoc
+++ b/docs/devguide/create-metricset.asciidoc
@@ -272,12 +272,12 @@ var (
 
 	additionalSchema = s.Schema{
 		"second_string": c.Str("secondString"),
-		"second_int": ": c.Int("secondInt")
+		"second_int": ": c.Int("secondInt"),
 	}
 )
 
 	data, err := schema.apply(input)
-	if err {
+	if err != nil {
 		return err
 	}
 

--- a/docs/devguide/create-metricset.asciidoc
+++ b/docs/devguide/create-metricset.asciidoc
@@ -256,8 +256,6 @@ func eventMapping(input map[string]interface{}) common.MapStr {
 In the above example, note that it is possible to create the schema object once
 and apply it to all events. 
 
-
-
 [float]
 ==== Configuration File
 The configuration file for a metricset is handled by the module. If there are


### PR DESCRIPTION
This is a response to  #7335, as it adds a great deal of functionality to the `schema` library and none of it seems to be documented. 

This PR expands the `schema.Apply` example to the beats developer guide with documented usage of the various optional arguments now available in `schema.Apply`

There's a few undressed things here:

- should this be a separate example, to emphasize that this functionality is optional?
- I would like to add a code snippet for `NotFoundKeys` but I'm still trying to figure it out.