### PR TITLE
[Auditbeat] Cherry-pick #12373 to 6.8: Start system module without host ID

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -43,6 +43,7 @@ https://github.com/elastic/beats/compare/v6.7.2...6.8[Check the HEAD diff]
 - Package dataset: Fixed a crash inside librpm after Auditbeat has been running for a while. {issue}12147[12147] {pull}12168[12168]
 - Fix direction of incoming IPv6 sockets. {pull}12248[12248]
 - Package dataset: Auto-detect package directories. {pull}12289[12289]
+- System module: Start system module without host ID. {pull}12373[12373]
 
 *Filebeat*
 

--- a/x-pack/auditbeat/module/system/package/package.go
+++ b/x-pack/auditbeat/module/system/package/package.go
@@ -345,7 +345,9 @@ func (ms *MetricSet) packageEvent(pkg *Package, eventType string, action eventAc
 		MetricSetFields: pkg.toMapStr(),
 	}
 
-	event.MetricSetFields.Put("entity_id", pkg.entityID(ms.HostID()))
+	if ms.HostID() != "" {
+		event.MetricSetFields.Put("entity_id", pkg.entityID(ms.HostID()))
+	}
 
 	if pkg.Error != nil {
 		event.RootFields.Put("error.message", pkg.Error.Error())

--- a/x-pack/auditbeat/module/system/process/process.go
+++ b/x-pack/auditbeat/module/system/process/process.go
@@ -313,7 +313,9 @@ func (ms *MetricSet) processEvent(process *Process, eventType string, action eve
 		event.RootFields.Put("error.message", process.Error.Error())
 	}
 
-	event.RootFields.Put("process.entity_id", process.entityID(ms.HostID()))
+	if ms.HostID() != "" {
+		event.RootFields.Put("process.entity_id", process.entityID(ms.HostID()))
+	}
 
 	return event
 }

--- a/x-pack/auditbeat/module/system/socket/socket.go
+++ b/x-pack/auditbeat/module/system/socket/socket.go
@@ -328,7 +328,9 @@ func (ms *MetricSet) socketEvent(socket *Socket, eventType string, action eventA
 	event.RootFields.Put("event.action", action.String())
 	event.RootFields.Put("message", socketMessage(socket, action))
 
-	event.RootFields.Put("socket.entity_id", socket.entityID(ms.HostID()))
+	if ms.HostID() != "" {
+		event.RootFields.Put("socket.entity_id", socket.entityID(ms.HostID()))
+	}
 
 	return event
 }

--- a/x-pack/auditbeat/module/system/user/user.go
+++ b/x-pack/auditbeat/module/system/user/user.go
@@ -427,21 +427,26 @@ func (ms *MetricSet) reportChanges(report mb.ReporterV2) error {
 }
 
 func (ms *MetricSet) userEvent(user *User, eventType string, action eventAction) mb.Event {
-	return mb.Event{
+	event := mb.Event{
 		RootFields: common.MapStr{
 			"event": common.MapStr{
 				"kind":   eventType,
 				"action": action.String(),
 			},
 			"user": common.MapStr{
-				"entity_id": user.entityID(ms.HostID()),
-				"id":        user.UID,
-				"name":      user.Name,
+				"id":   user.UID,
+				"name": user.Name,
 			},
 			"message": userMessage(user, action),
 		},
 		MetricSetFields: user.toMapStr(),
 	}
+
+	if ms.HostID() != "" {
+		event.RootFields.Put("user.entity_id", user.entityID(ms.HostID()))
+	}
+
+	return event
 }
 
 func userMessage(user *User, action eventAction) string {


### PR DESCRIPTION
Cherry-pick of PR #12373 to 6.8 branch. Original message: 

At the moment, when the System module starts it runs `sysinfo.Host()` to determine the host ID to use when calculating entity IDs. This call will not always succeed on systems that do not implement all the functionality we rely on. For example, we have had reports of Synology NAS systems not having `/etc/machine-id` or `/etc/lsb-release` files (for getting the IDs and OS information, respectively). When this call does not succeed, Auditbeat will fail to start if the System module is enabled (which it is by default).

This PR allows the module to start without the host ID. It will log a warning, and documents will not contain any `entity_id` fields.