### PR TITLE
Update CoreDNS module README file to reflect the changes to autodiscover default input settings

### DIFF
--- a/x-pack/filebeat/module/coredns/README.md
+++ b/x-pack/filebeat/module/coredns/README.md
@@ -51,7 +51,7 @@ kubectl apply -f filebeat
     providers:
       - type: kubernetes
         hints.enabled: true
-        default.disable: true
+        hints.default_config.enabled: false
 
   processors:
     - add_kubernetes_metadata:


### PR DESCRIPTION
Fix issue #[12380](https://github.com/elastic/beats/issues/12380)