### PR TITLE
TCP input message size problem fix

### DIFF
--- a/filebeat/inputsource/tcp/client.go
+++ b/filebeat/inputsource/tcp/client.go
@@ -73,7 +73,9 @@ func (c *client) handle() error {
 	buf := bufio.NewReader(r)
 	scanner := bufio.NewScanner(buf)
 	scanner.Split(c.splitFunc)
-
+	//16 is ratio of MaxScanTokenSize/startBufSize
+	buffer := make([]byte, c.maxMessageSize/16)
+	scanner.Buffer(buffer, int(c.maxMessageSize))
 	for scanner.Scan() {
 		err := scanner.Err()
 		if err != nil {

--- a/filebeat/inputsource/tcp/server_test.go
+++ b/filebeat/inputsource/tcp/server_test.go
@@ -53,7 +53,7 @@ func TestErrorOnEmptyLineDelimiter(t *testing.T) {
 func TestReceiveEventsAndMetadata(t *testing.T) {
 	expectedMessages := generateMessages(5, 100)
 	largeMessages := generateMessages(10, 4096)
-	extraLargeMessages := generateMessages(10, 700000)
+	extraLargeMessages := generateMessages(2, 65*1024)
 
 	tests := []struct {
 		name             string
@@ -142,11 +142,9 @@ func TestReceiveEventsAndMetadata(t *testing.T) {
 			messageSent:      randomString(600000),
 		},
 		{
-			name:      "MaxBufferSizeSet",
-			splitFunc: SplitFunc([]byte("\n")),
-			cfg: map[string]interface{}{
-				"max_message_size": 700001,
-			},
+			name:             "MaxBufferSizeSet",
+			splitFunc:        SplitFunc([]byte("\n")),
+			cfg:              map[string]interface{}{},
 			expectedMessages: extraLargeMessages,
 			messageSent:      strings.Join(extraLargeMessages, "\n"),
 		},

--- a/filebeat/inputsource/tcp/server_test.go
+++ b/filebeat/inputsource/tcp/server_test.go
@@ -53,7 +53,7 @@ func TestErrorOnEmptyLineDelimiter(t *testing.T) {
 func TestReceiveEventsAndMetadata(t *testing.T) {
 	expectedMessages := generateMessages(5, 100)
 	largeMessages := generateMessages(10, 4096)
-	extraLargeMessages := generateMessages(1, 100000)
+	extraLargeMessages := generateMessages(1, 700000)
 
 	tests := []struct {
 		name             string

--- a/filebeat/inputsource/tcp/server_test.go
+++ b/filebeat/inputsource/tcp/server_test.go
@@ -53,6 +53,7 @@ func TestErrorOnEmptyLineDelimiter(t *testing.T) {
 func TestReceiveEventsAndMetadata(t *testing.T) {
 	expectedMessages := generateMessages(5, 100)
 	largeMessages := generateMessages(10, 4096)
+	extraLargeMessages := generateMessages(1, 100000)
 
 	tests := []struct {
 		name             string
@@ -139,6 +140,15 @@ func TestReceiveEventsAndMetadata(t *testing.T) {
 			},
 			expectedMessages: []string{},
 			messageSent:      randomString(600000),
+		},
+		{
+			name:      "MaxBufferSizeSet",
+			splitFunc: SplitFunc([]byte("\n")),
+			cfg: map[string]interface{}{
+				"max_read_message": 60000,
+			},
+			expectedMessages: extraLargeMessages,
+			messageSent:      strings.Join(extraLargeMessages, "\n"),
 		},
 	}
 

--- a/filebeat/inputsource/tcp/server_test.go
+++ b/filebeat/inputsource/tcp/server_test.go
@@ -54,6 +54,7 @@ func TestReceiveEventsAndMetadata(t *testing.T) {
 	expectedMessages := generateMessages(5, 100)
 	largeMessages := generateMessages(10, 4096)
 	extraLargeMessages := generateMessages(2, 65*1024)
+	randomGeneratedText := randomString(900000)
 
 	tests := []struct {
 		name             string
@@ -126,25 +127,27 @@ func TestReceiveEventsAndMetadata(t *testing.T) {
 			messageSent:      strings.Join(largeMessages, ";"),
 		},
 		{
-			name:             "MaxReadBufferReached",
+			name:             "ReadRandomLargePayload",
 			cfg:              map[string]interface{}{},
 			splitFunc:        SplitFunc([]byte("\n")),
-			expectedMessages: []string{},
-			messageSent:      randomString(900000),
+			expectedMessages: []string{randomGeneratedText},
+			messageSent:      randomGeneratedText,
 		},
 		{
 			name:      "MaxReadBufferReachedUserConfigured",
 			splitFunc: SplitFunc([]byte("\n")),
 			cfg: map[string]interface{}{
-				"max_read_message": 50000,
+				"max_message_size": 50000,
 			},
 			expectedMessages: []string{},
-			messageSent:      randomString(600000),
+			messageSent:      randomGeneratedText,
 		},
 		{
-			name:             "MaxBufferSizeSet",
-			splitFunc:        SplitFunc([]byte("\n")),
-			cfg:              map[string]interface{}{},
+			name:      "MaxBufferSizeSet",
+			splitFunc: SplitFunc([]byte("\n")),
+			cfg: map[string]interface{}{
+				"max_message_size": 66 * 1024,
+			},
 			expectedMessages: extraLargeMessages,
 			messageSent:      strings.Join(extraLargeMessages, "\n"),
 		},

--- a/filebeat/inputsource/tcp/server_test.go
+++ b/filebeat/inputsource/tcp/server_test.go
@@ -53,7 +53,7 @@ func TestErrorOnEmptyLineDelimiter(t *testing.T) {
 func TestReceiveEventsAndMetadata(t *testing.T) {
 	expectedMessages := generateMessages(5, 100)
 	largeMessages := generateMessages(10, 4096)
-	extraLargeMessages := generateMessages(1, 700000)
+	extraLargeMessages := generateMessages(10, 700000)
 
 	tests := []struct {
 		name             string
@@ -145,7 +145,7 @@ func TestReceiveEventsAndMetadata(t *testing.T) {
 			name:      "MaxBufferSizeSet",
 			splitFunc: SplitFunc([]byte("\n")),
 			cfg: map[string]interface{}{
-				"max_read_message": 60000,
+				"max_message_size": 700001,
 			},
 			expectedMessages: extraLargeMessages,
 			messageSent:      strings.Join(extraLargeMessages, "\n"),


### PR DESCRIPTION
Scanner buffer size is set to `maxMessageSize`

Fixes #11966