### PR TITLE
Issue warning instead of info when CCR is not available

### DIFF
--- a/metricbeat/module/elasticsearch/ccr/ccr.go
+++ b/metricbeat/module/elasticsearch/ccr/ccr.go
@@ -18,7 +18,6 @@
 package ccr
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/elastic/beats/libbeat/common"
@@ -83,7 +82,7 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 	if ccrUnavailableMessage != "" {
 		if time.Since(m.lastCCRLicenseMessageTimestamp) > 1*time.Minute {
 			m.lastCCRLicenseMessageTimestamp = time.Now()
-			return fmt.Errorf(ccrUnavailableMessage)
+			m.Logger().Warn(ccrUnavailableMessage)
 		}
 		return nil
 	}


### PR DESCRIPTION
Implements the suggestion in https://github.com/elastic/beats/issues/12327#issuecomment-497646355.

### Before this PR

```
2019-05-31T18:16:48.528-0700    INFO    module/wrapper.go:244   Error fetching data for metricset elasticsearch.ccr: the CCR feature is available with a platinum Elasticsearch license. You currently have a basic license. Either upgrade your license or remove the ccr metricset from your Elasticsearch module configuration.
```

### After this PR

```
2019-05-31T18:17:35.011-0700    WARN    [elasticsearch.ccr]     ccr/ccr.go:85   the CCR feature is available with a platinum Elasticsearch license. You currently have a basic license. Either upgrade your license or remove the ccr metricset from your Elasticsearch module configuration.
```

## Testing this PR
1. Start up Elasticsearch without a Trial license (so CCR is not available).
2. Enable the `elasticsearch-xpack` module in Metricbeat (compiled from this PR).
3. Start Metricbeat.
4. Verify that you see a `WARN` level message for CCR, and not an `INFO` level one.