### PR TITLE
Un-skip flaky tests

### DIFF
--- a/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
+++ b/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
@@ -63,7 +63,6 @@ var metricSets = []string{
 }
 
 func TestFetch(t *testing.T) {
-	t.Skip("flaky")
 	compose.EnsureUp(t, "elasticsearch")
 
 	host := net.JoinHostPort(getEnvHost(), getEnvPort())
@@ -101,7 +100,6 @@ func TestFetch(t *testing.T) {
 }
 
 func TestData(t *testing.T) {
-	t.Skip("flaky")
 	compose.EnsureUp(t, "elasticsearch")
 
 	host := net.JoinHostPort(getEnvHost(), getEnvPort())

--- a/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
+++ b/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
@@ -261,7 +261,7 @@ func createCCRStats(host string) error {
 		return checkCCRStatsExists(host)
 	}
 
-	exists, err := waitForSuccess(checkCCRStats, 200, 5)
+	exists, err := waitForSuccess(checkCCRStats, 300, 5)
 	if err != nil {
 		return errors.Wrap(err, "error checking if CCR stats exist")
 	}

--- a/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
+++ b/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
@@ -86,8 +86,8 @@ func TestFetch(t *testing.T) {
 	for _, metricSet := range metricSets {
 		checkSkip(t, metricSet, version)
 		t.Run(metricSet, func(t *testing.T) {
-			f := mbtest.NewReportingMetricSetV2(t, getConfig(metricSet))
-			events, errs := mbtest.ReportingFetchV2(f)
+			f := mbtest.NewReportingMetricSetV2Error(t, getConfig(metricSet))
+			events, errs := mbtest.ReportingFetchV2Error(f)
 
 			assert.Empty(t, errs)
 			if !assert.NotEmpty(t, events) {
@@ -112,8 +112,8 @@ func TestData(t *testing.T) {
 	for _, metricSet := range metricSets {
 		checkSkip(t, metricSet, version)
 		t.Run(metricSet, func(t *testing.T) {
-			f := mbtest.NewReportingMetricSetV2(t, getConfig(metricSet))
-			err := mbtest.WriteEventsReporterV2(f, t, metricSet)
+			f := mbtest.NewReportingMetricSetV2Error(t, getConfig(metricSet))
+			err := mbtest.WriteEventsReporterV2Error(f, t, metricSet)
 			if err != nil {
 				t.Fatal("write", err)
 			}


### PR DESCRIPTION
This PR un-skips the flaky integration tests in the Metricbeat elasticsearch module.