### PR TITLE
Cherry-pick #12082 to 7.x: [Heartbeat] Better document geo options

### DIFF
--- a/heartbeat/docs/configuring-howto.asciidoc
+++ b/heartbeat/docs/configuring-howto.asciidoc
@@ -47,6 +47,8 @@ include::./heartbeat-options.asciidoc[]
 
 include::./heartbeat-general-options.asciidoc[]
 
+include::./heartbeat-observer-options.asciidoc[]
+
 include::{libbeat-dir}/docs/queueconfig.asciidoc[]
 
 include::{libbeat-dir}/docs/outputconfig.asciidoc[]

--- a/heartbeat/docs/heartbeat-observer-options.asciidoc
+++ b/heartbeat/docs/heartbeat-observer-options.asciidoc
@@ -1,0 +1,7 @@
+[[configuration-observer-options]]
+== Specify Observer and Geo Options
+
+It is often useful to view and query various attributes of the instance Heartbeat is running on. This data is attached to events via the <<add-observer-metadata,`add_observer_metadata`>> processor. This processor populates the ECS `observer.*` fields. One field of particular utility is the `observer.geo.name` field, which you can configure via this processor. Use this field to create distinctive geographic regions for your uptime checks. You might label your regions by datacenter name or geographic region, e.g. `virginia-dc-1`, or `us-east-1a`, or `virginia-us`.
+
+Note that Heartbeat should not be used with the similarly named <<add-host-metadata,`add_host_metadata`>> processor. In ECS parlance the host is the thing that is monitored, not the thing doing the monitoring, which is the observer.
+

--- a/heartbeat/heartbeat.yml
+++ b/heartbeat/heartbeat.yml
@@ -128,7 +128,14 @@ output.elasticsearch:
 
 #================================ Processors =====================================
 processors:
-  - add_observer_metadata: ~
+  - add_observer_metadata: 
+  # Optional, but recommended geo settings for the location heartbeat is running in 
+  #geo: 
+    # Token describing this location
+    #name: us-east-1a
+
+    # Lat, Lon "
+    #location: "37.926868, -78.024902"
 
 
 #================================ Logging =====================================

--- a/heartbeat/scripts/post_process_config.py
+++ b/heartbeat/scripts/post_process_config.py
@@ -24,7 +24,14 @@ with open(sys.argv[1], 'r') as conf_file:
             if section_name == "Processors":
                 output += line  # include section name in output
                 output += "processors:\n"
-                output += "  - add_observer_metadata: ~\n"
+                output += "  - add_observer_metadata: \n"
+                output += "  # Optional, but recommended geo settings for the location heartbeat is running in \n"
+                output += "  #geo: \n"
+                output += "    # Token describing this location\n"
+                output += "    #name: us-east-1a\n"
+                output += "\n"
+                output += "    # Lat, Lon \"\n"
+                output += "    #location: \"37.926868, -78.024902\"\n"
                 output += "\n\n"
                 inside_processor_section = True
             else:


### PR DESCRIPTION
Cherry-pick of PR #12082 to 7.x branch. Original message: 

This adds geo options to the `add_observer_metadata` example in the default config.
It also adds a small docs page pointing people to its use in the main heartbeat docs.