### PR TITLE
Revert "Cherry-pick #12355 to 7.0: Enforce presence of Certificate Au…

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -40,7 +40,6 @@ https://github.com/elastic/beats/compare/v7.0.0...7.0[Check the HEAD diff]
 - Fix memory leak in Filebeat pipeline acker. {pull}12063[12063]
 - Fix goroutine leak on non-explicit finalization of log input. {pull}12164[12164]
 - Require client_auth by default when ssl is enabled for tcp input {pull}12333[12333]
-- Require certificate authorities, certificate file, and key when SSL is enabled for the TCP input. {pull}12355[12355]
 
 *Heartbeat*
 
@@ -53,7 +52,6 @@ https://github.com/elastic/beats/compare/v7.0.0...7.0[Check the HEAD diff]
 - Change some field type from scaled_float to long in aws module. {pull}11982[11982]
 - Ignore prometheus metrics when their values are NaN or Inf. {pull}12084[12084] {issue}10849[10849]
 - Require client_auth by default when ssl is enabled for module http metricset server{pull}12333[12333]
-- Require certificate authorities, certificate file, and key when SSL is enabled for module http metricset server. {pull}12355[12355]
 
 *Packetbeat*
 

--- a/libbeat/common/transport/tlscommon/server_config.go
+++ b/libbeat/common/transport/tlscommon/server_config.go
@@ -19,7 +19,6 @@ package tlscommon
 
 import (
 	"crypto/tls"
-	"errors"
 
 	"github.com/joeshaw/multierror"
 
@@ -92,7 +91,6 @@ func LoadTLSServerConfig(config *ServerConfig) (*TLSConfig, error) {
 	}, nil
 }
 
-// Unpack unpacks the TLS Server configuration.
 func (c *ServerConfig) Unpack(cfg common.Config) error {
 	clientAuthKey := "client_authentication"
 	if !cfg.HasField(clientAuthKey) {
@@ -103,11 +101,6 @@ func (c *ServerConfig) Unpack(cfg common.Config) error {
 	if err := cfg.Unpack(&sCfg); err != nil {
 		return err
 	}
-
-	if sCfg.VerificationMode != VerifyNone && len(sCfg.CAs) == 0 {
-		return errors.New("certificate_authorities not configured")
-	}
-
 	*c = ServerConfig(sCfg)
 	return nil
 }

--- a/libbeat/common/transport/tlscommon/tls_test.go
+++ b/libbeat/common/transport/tlscommon/tls_test.go
@@ -167,15 +167,9 @@ func TestApplyWithConfig(t *testing.T) {
 }
 
 func TestServerConfigDefaults(t *testing.T) {
-	yamlStr := `
-    certificate: ca_test.pem
-    key: ca_test.key
-    certificate_authorities: [ca_test.pem]
-  `
 	var c ServerConfig
-	config, err := common.NewConfigWithYAML([]byte(yamlStr), "")
-	require.NoError(t, err)
-	err = config.Unpack(&c)
+	config := common.MustNewConfigFrom([]byte(``))
+	err := config.Unpack(&c)
 	require.NoError(t, err)
 	tmp, err := LoadTLSServerConfig(&c)
 	require.NoError(t, err)
@@ -184,8 +178,8 @@ func TestServerConfigDefaults(t *testing.T) {
 
 	assert.NotNil(t, cfg)
 	// values not set by default
-	assert.Len(t, cfg.Certificates, 1)
-	assert.NotNil(t, cfg.ClientCAs)
+	assert.Len(t, cfg.Certificates, 0)
+	assert.Nil(t, cfg.ClientCAs)
 	assert.Len(t, cfg.CipherSuites, 0)
 	assert.Len(t, cfg.CurvePreferences, 0)
 	// values set by default
@@ -193,53 +187,6 @@ func TestServerConfigDefaults(t *testing.T) {
 	assert.Equal(t, int(tls.VersionTLS11), int(cfg.MinVersion))
 	assert.Equal(t, int(tls.VersionTLS12), int(cfg.MaxVersion))
 	assert.Equal(t, tls.RequireAndVerifyClientCert, cfg.ClientAuth)
-}
-
-func TestServerConfigSkipCACertificateAndKeyWhenVerifyNone(t *testing.T) {
-	yamlStr := `
-    verification_mode: none
-  `
-	var c ServerConfig
-	config, err := common.NewConfigWithYAML([]byte(yamlStr), "")
-	require.NoError(t, err)
-	err = config.Unpack(&c)
-	require.NoError(t, err)
-}
-
-func TestServerConfigEnsureCA(t *testing.T) {
-	yamlStr := `
-    certificate: ca_test.pem
-    key: ca_test.key
-  `
-	var c ServerConfig
-	config, err := common.NewConfigWithYAML([]byte(yamlStr), "")
-	require.NoError(t, err)
-	err = config.Unpack(&c)
-	require.Error(t, err)
-}
-
-func TestServerConfigCertificateKey(t *testing.T) {
-	yamlStr := `
-    certificate: ca_test.pem
-    certificate_authorities: [ca_test.pem]
-  `
-	var c ServerConfig
-	config, err := common.NewConfigWithYAML([]byte(yamlStr), "")
-	require.NoError(t, err)
-	err = config.Unpack(&c)
-	require.Error(t, err)
-}
-
-func TestServerConfigCertificate(t *testing.T) {
-	yamlStr := `
-    key: ca_test.key
-    certificate_authorities: [ca_test.pem]
-  `
-	var c ServerConfig
-	config, err := common.NewConfigWithYAML([]byte(yamlStr), "")
-	require.NoError(t, err)
-	err = config.Unpack(&c)
-	require.Error(t, err)
 }
 
 func TestApplyWithServerConfig(t *testing.T) {


### PR DESCRIPTION
…thorities, Certificate file and Key when using LoadTLSServerConfig (#12363)"

This reverts commit debc457e17a6c1da548ee09f1af0add01458ddbc.