### PR TITLE
Hardcode namespace for prometheus metrics

### DIFF
--- a/metricbeat/module/prometheus/collector/collector.go
+++ b/metricbeat/module/prometheus/collector/collector.go
@@ -97,6 +97,8 @@ func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
 
 	// Converts hash list to slice
 	for _, e := range eventList {
-		reporter.Event(mb.Event{ModuleFields: e})
+		reporter.Event(mb.Event{
+			RootFields: common.MapStr{"prometheus": e},
+		})
 	}
 }


### PR DESCRIPTION
All prometheus metrics should be under `prometheus.metrics`, fix it so
the metricset can be reused on light modules (#12270).