### PR TITLE
Cherry-pick #12393 to 7.2: Fix authentication_failure event.type for security module

### DIFF
--- a/x-pack/winlogbeat/module/security/config/winlogbeat-security.js
+++ b/x-pack/winlogbeat/module/security/config/winlogbeat-security.js
@@ -18,7 +18,7 @@ var security = (function () {
     var addAuthFailed = new processor.AddFields({
         fields: {
             "event.category": "authentication",
-            "event.type": "authentication_failed",
+            "event.type": "authentication_failure",
         },
         target: "",
     });

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2012r2-logon.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2012r2-logon.evtx.golden.json
@@ -1069,7 +1069,7 @@
       "category": "authentication",
       "code": 4625,
       "kind": "event",
-      "type": "authentication_failed"
+      "type": "authentication_failure"
     },
     "log": {
       "level": "information"


### PR DESCRIPTION
Cherry-pick of PR #12393 to 7.2 branch. Original message: 

Change authentication_failed to authentication_failure in the event.type field added by the Security module.

Relates #11651