### PR TITLE
Cherry-pick #12399 to 7.2: Fix references to `beat.timezone` in docs

### DIFF
--- a/filebeat/docs/include/var-convert-timezone.asciidoc
+++ b/filebeat/docs/include/var-convert-timezone.asciidoc
@@ -2,9 +2,9 @@
 
 If this option is enabled, Filebeat reads the local timezone and uses it at log
 parsing time to convert the timestamp to UTC. The local timezone is also added
-in each event in a dedicated field (`beat.timezone`). The conversion is only
+in each event in a dedicated field (`event.timezone`). The conversion is only
 possible in Elasticsearch >= 6.1. If the Elasticsearch version is less than 6.1,
-the `beat.timezone` field is added, but the conversion to UTC is not made.  The
+the `event.timezone` field is added, but the conversion to UTC is not made.  The
 default is
 ifdef::default_convert_timezone[`true`]
 ifndef::default_convert_timezone[`false`]

--- a/libbeat/docs/processors-using.asciidoc
+++ b/libbeat/docs/processors-using.asciidoc
@@ -732,7 +732,7 @@ The `add_locale` processor enriches each event with the machine's time zone
 offset from UTC or with the name of the time zone. It supports one configuration
 option named `format` that controls whether an offset or time zone abbreviation
 is added to the event. The default format is `offset`. The processor adds the
-a `beat.timezone` value to each event.
+a `event.timezone` value to each event.
 
 The configuration below enables the processor with the default settings.
 


### PR DESCRIPTION
Cherry-pick of PR #12399 to 7.2 branch. Original message: 

`beat.timezone` was moved to `event.timezone` as part of the ECS
migration done for 7.0. Update some pending references in documentation.