### PR TITLE
[6.8] Un-skip flaky tests (#12388)

### DIFF
--- a/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
+++ b/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
@@ -131,9 +131,9 @@ func getEnvPort() string {
 // GetConfig returns config for elasticsearch module
 func getConfig(metricset string) map[string]interface{} {
 	return map[string]interface{}{
-		"module":                     elasticsearch.ModuleName,
-		"metricsets":                 []string{metricset},
-		"hosts":                      []string{getEnvHost() + ":" + getEnvPort()},
+		"module":     elasticsearch.ModuleName,
+		"metricsets": []string{metricset},
+		"hosts":      []string{getEnvHost() + ":" + getEnvPort()},
 		"index_recovery.active_only": false,
 	}
 }


### PR DESCRIPTION
Backports the following commits to 6.8:
 - Un-skip flaky tests  (#12388)