### PR TITLE
Update shared-template-load.asciidoc

### DIFF
--- a/libbeat/docs/shared-template-load.asciidoc
+++ b/libbeat/docs/shared-template-load.asciidoc
@@ -79,6 +79,8 @@ output.elasticsearch.index: "customname-%{[{beat_version_key}]}-%{+yyyy.MM.dd}"
 setup.template.name: "customname"
 setup.template.pattern: "customname-*"
 -----
+WARNING: If {ref}/ilm.html[Index Lifecycle Management] is enabled (which is the default), `setup.template.name` and `setup.template.pattern` won't be taken into account.
+
 ifndef::no_dashboards[]
 +
 If you're using pre-built Kibana dashboards, also set the


### PR DESCRIPTION
Just added the following warning : 
Warning	If {ref}/ilm.html[Index Lifecycle Management] is enabled (which is the default), setup.template.name and setup.template.pattern won’t be taken into account.

So that users are aware that ILM, that is enabled by default from 7.0 on (https://www.elastic.co/guide/en/beats/functionbeat/current/ilm.html)

Regards,
Christophe.