### PR TITLE
Export Kibana Client's Transport and Version

### DIFF
--- a/libbeat/kibana/client.go
+++ b/libbeat/kibana/client.go
@@ -41,8 +41,8 @@ type Connection struct {
 	Username string
 	Password string
 
-	http    *http.Client
-	version common.Version
+	Http    *http.Client
+	Version common.Version
 }
 
 type Client struct {
@@ -134,7 +134,7 @@ func NewClientWithConfig(config *ClientConfig) (*Client, error) {
 			URL:      kibanaURL,
 			Username: username,
 			Password: password,
-			http: &http.Client{
+			Http: &http.Client{
 				Transport: &http.Transport{
 					Dial:    dialer.Dial,
 					DialTLS: tlsDialer.Dial,
@@ -195,7 +195,7 @@ func (conn *Connection) Send(method, extraPath string,
 	req.Header.Add("Accept", "application/json")
 	req.Header.Set("kbn-xsrf", "1")
 	if method != "GET" {
-		req.Header.Set("kbn-version", conn.version.String())
+		req.Header.Set("kbn-version", conn.Version.String())
 	}
 
 	for header, values := range headers {
@@ -209,7 +209,7 @@ func (conn *Connection) Send(method, extraPath string,
 
 // Implements RoundTrip interface
 func (conn *Connection) RoundTrip(r *http.Request) (*http.Response, error) {
-	return conn.http.Do(r)
+	return conn.Http.Do(r)
 }
 
 func (client *Client) readVersion() error {
@@ -253,13 +253,13 @@ func (client *Client) readVersion() error {
 		return fmt.Errorf("fail to parse kibana version (%v): %+v", versionString, err)
 	}
 
-	client.version = *version
+	client.Version = *version
 	return nil
 }
 
 // GetVersion returns the version read from kibana. The version is not set if
 // IgnoreVersion was set when creating the client.
-func (client *Client) GetVersion() common.Version { return client.version }
+func (client *Client) GetVersion() common.Version { return client.Version }
 
 func (client *Client) ImportJSON(url string, params url.Values, jsonBody map[string]interface{}) error {
 

--- a/libbeat/kibana/client.go
+++ b/libbeat/kibana/client.go
@@ -41,7 +41,7 @@ type Connection struct {
 	Username string
 	Password string
 
-	Http    *http.Client
+	HTTP    *http.Client
 	Version common.Version
 }
 
@@ -134,7 +134,7 @@ func NewClientWithConfig(config *ClientConfig) (*Client, error) {
 			URL:      kibanaURL,
 			Username: username,
 			Password: password,
-			Http: &http.Client{
+			HTTP: &http.Client{
 				Transport: &http.Transport{
 					Dial:    dialer.Dial,
 					DialTLS: tlsDialer.Dial,
@@ -209,7 +209,7 @@ func (conn *Connection) Send(method, extraPath string,
 
 // Implements RoundTrip interface
 func (conn *Connection) RoundTrip(r *http.Request) (*http.Response, error) {
-	return conn.Http.Do(r)
+	return conn.HTTP.Do(r)
 }
 
 func (client *Client) readVersion() error {

--- a/libbeat/kibana/client_test.go
+++ b/libbeat/kibana/client_test.go
@@ -35,7 +35,7 @@ func TestErrorJson(t *testing.T) {
 
 	conn := Connection{
 		URL:  kibanaTs.URL,
-		http: http.DefaultClient,
+		Http: http.DefaultClient,
 	}
 	code, _, err := conn.Request(http.MethodPost, "", url.Values{}, nil, nil)
 	assert.Equal(t, http.StatusOK, code)
@@ -50,7 +50,7 @@ func TestErrorBadJson(t *testing.T) {
 
 	conn := Connection{
 		URL:  kibanaTs.URL,
-		http: http.DefaultClient,
+		Http: http.DefaultClient,
 	}
 	code, _, err := conn.Request(http.MethodPost, "", url.Values{}, nil, nil)
 	assert.Equal(t, http.StatusOK, code)
@@ -68,7 +68,7 @@ func TestSuccess(t *testing.T) {
 
 	conn := Connection{
 		URL:  kibanaTs.URL,
-		http: http.DefaultClient,
+		Http: http.DefaultClient,
 	}
 	code, _, err := conn.Request(http.MethodPost, "", url.Values{}, http.Header{"foo": []string{"bar"}}, nil)
 	assert.Equal(t, http.StatusOK, code)

--- a/libbeat/kibana/client_test.go
+++ b/libbeat/kibana/client_test.go
@@ -35,7 +35,7 @@ func TestErrorJson(t *testing.T) {
 
 	conn := Connection{
 		URL:  kibanaTs.URL,
-		Http: http.DefaultClient,
+		HTTP: http.DefaultClient,
 	}
 	code, _, err := conn.Request(http.MethodPost, "", url.Values{}, nil, nil)
 	assert.Equal(t, http.StatusOK, code)
@@ -50,7 +50,7 @@ func TestErrorBadJson(t *testing.T) {
 
 	conn := Connection{
 		URL:  kibanaTs.URL,
-		Http: http.DefaultClient,
+		HTTP: http.DefaultClient,
 	}
 	code, _, err := conn.Request(http.MethodPost, "", url.Values{}, nil, nil)
 	assert.Equal(t, http.StatusOK, code)
@@ -68,7 +68,7 @@ func TestSuccess(t *testing.T) {
 
 	conn := Connection{
 		URL:  kibanaTs.URL,
-		Http: http.DefaultClient,
+		HTTP: http.DefaultClient,
 	}
 	code, _, err := conn.Request(http.MethodPost, "", url.Values{}, http.Header{"foo": []string{"bar"}}, nil)
 	assert.Equal(t, http.StatusOK, code)


### PR DESCRIPTION
Follow up on https://github.com/elastic/beats/pull/12266

I was thinking that implementing the RounTripper interface would be enough, but forgot to export the transport object, which is required to mock a Kibana connection outside its own package.

Also need to export the Version. 

Use case here: https://github.com/elastic/apm-server/pull/2095/commits/e6bbb2059156e14cff512ef71cd50aaa16189001#diff-7abfb8887df4c4f059976f3d276ed9ebR37

