### PR TITLE
Cherry-pick #12426 to 7.2: Mark Cisco and PANW modules as beta

### DIFF
--- a/filebeat/docs/modules/cisco.asciidoc
+++ b/filebeat/docs/modules/cisco.asciidoc
@@ -10,6 +10,8 @@ This file is generated! See scripts/docs_collector.py
 
 == Cisco module
 
+beta[]
+
 This is a module for Cisco network device's logs. Currently supports the `asa`
 fileset for Cisco ASA firewall logs received over syslog or read from a file.
 

--- a/filebeat/docs/modules/panw.asciidoc
+++ b/filebeat/docs/modules/panw.asciidoc
@@ -10,6 +10,8 @@ This file is generated! See scripts/docs_collector.py
 
 == Palo Alto Networks module
 
+beta[]
+
 This is a module for Palo Alto Networks PAN-OS firewall monitoring logs received
 over Syslog or read from a file. It currently supports messages of Traffic and
 Threat types.

--- a/x-pack/filebeat/module/cisco/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/cisco/_meta/docs.asciidoc
@@ -5,6 +5,8 @@
 
 == Cisco module
 
+beta[]
+
 This is a module for Cisco network device's logs. Currently supports the `asa`
 fileset for Cisco ASA firewall logs received over syslog or read from a file.
 

--- a/x-pack/filebeat/module/panw/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/panw/_meta/docs.asciidoc
@@ -5,6 +5,8 @@
 
 == Palo Alto Networks module
 
+beta[]
+
 This is a module for Palo Alto Networks PAN-OS firewall monitoring logs received
 over Syslog or read from a file. It currently supports messages of Traffic and
 Threat types.


### PR DESCRIPTION
Cherry-pick of PR #12426 to 7.2 branch. Original message:

Marking those two unreleased modules as Beta so that a breaking
change can be introduced in the future, as there is still some
discussion around field naming.

(cherry picked from commit ed56f992f0c44f54eee655e76b660eb62fdeefdd)