### PR TITLE
[7.2] Validate stack modules' metricsets when xpack.enabled = true (#12386)

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -218,6 +218,10 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add AWS cloudwatch metricset. {pull}11798[11798] {issue}11734[11734]
 - Add `regions` in aws module config to specify target regions for querying cloudwatch metrics. {issue}11932[11932] {pull}11956[11956]
 - Keep `etcd` followers members from reporting `leader` metricset events {pull}12004[12004]
+- Add overview dashboard to Consul module {pull}10665[10665]
+- New fields were added in the mysql/status metricset. {pull}12227[12227]
+- Add Vsphere Virtual Machine operating system to `os` field in Vsphere virtualmachine module. {pull}12391[12391]
+- Add validation for elasticsearch and kibana modules' metricsets when xpack.enabled is set to true. {pull}12386[12386]
 
 *Packetbeat*
 

--- a/libbeat/common/stringset.go
+++ b/libbeat/common/stringset.go
@@ -49,3 +49,18 @@ func (set StringSet) Has(s string) (exists bool) {
 	}
 	return
 }
+
+// Equals compares this StringSet with another StringSet.
+func (set StringSet) Equals(anotherSet StringSet) bool {
+	if set.Count() != anotherSet.Count() {
+		return false
+	}
+
+	for k := range set {
+		if !anotherSet.Has(k) {
+			return false
+		}
+	}
+
+	return true
+}

--- a/libbeat/common/stringset_test.go
+++ b/libbeat/common/stringset_test.go
@@ -1,0 +1,70 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEquals(t *testing.T) {
+	tests := []struct {
+		title    string
+		first    []string
+		second   []string
+		expected bool
+	}{
+		{
+			title:    "when we have the same elements, in order",
+			first:    []string{"one", "two"},
+			second:   []string{"one", "two"},
+			expected: true,
+		},
+		{
+			title:    "when we have the same elements, but out of order",
+			first:    []string{"one", "two"},
+			second:   []string{"two", "one"},
+			expected: true,
+		},
+		{
+			title:    "when we have the same elements, with a duplicate",
+			first:    []string{"one", "two"},
+			second:   []string{"one", "two", "one"},
+			expected: true,
+		},
+		{
+			title:    "when we have different number of elements",
+			first:    []string{"one", "two"},
+			second:   []string{"one", "two", "three"},
+			expected: false,
+		},
+		{
+			title:    "when we have different elements",
+			first:    []string{"one", "two"},
+			second:   []string{"one", "three"},
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.title, func(t *testing.T) {
+			assert.Equal(t, test.expected, MakeStringSet(test.first...).Equals(MakeStringSet(test.second...)))
+		})
+	}
+}

--- a/metricbeat/module/elasticsearch/elasticsearch.go
+++ b/metricbeat/module/elasticsearch/elasticsearch.go
@@ -25,12 +25,63 @@ import (
 	"sync"
 	"time"
 
+	"github.com/elastic/beats/metricbeat/mb"
+
 	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/metricbeat/helper"
 	"github.com/elastic/beats/metricbeat/helper/elastic"
 )
+
+func init() {
+	// Register the ModuleFactory function for this module.
+	if err := mb.Registry.AddModule(ModuleName, NewModule); err != nil {
+		panic(err)
+	}
+}
+
+// NewModule creates a new module after performing validation.
+func NewModule(base mb.BaseModule) (mb.Module, error) {
+	if err := validateXPackMetricsets(base); err != nil {
+		return nil, err
+	}
+
+	return &base, nil
+}
+
+// Validate that correct metricsets have been specified if xpack.enabled = true.
+func validateXPackMetricsets(base mb.BaseModule) error {
+	config := struct {
+		Metricsets   []string `config:"metricsets"`
+		XPackEnabled bool     `config:"xpack.enabled"`
+	}{}
+	if err := base.UnpackConfig(&config); err != nil {
+		return err
+	}
+
+	// Nothing to validate if xpack.enabled != true
+	if !config.XPackEnabled {
+		return nil
+	}
+
+	expectedXPackMetricsets := []string{
+		"ccr",
+		"cluster_stats",
+		"index",
+		"index_recovery",
+		"index_summary",
+		"ml_job",
+		"node_stats",
+		"shard",
+	}
+
+	if !common.MakeStringSet(config.Metricsets...).Equals(common.MakeStringSet(expectedXPackMetricsets...)) {
+		return errors.Errorf("The %v module with xpack.enabled: true must have metricsets: %v", ModuleName, expectedXPackMetricsets)
+	}
+
+	return nil
+}
 
 // CCRStatsAPIAvailableVersion is the version of Elasticsearch since when the CCR stats API is available.
 var CCRStatsAPIAvailableVersion = common.MustNewVersion("6.5.0")

--- a/metricbeat/module/kibana/kibana.go
+++ b/metricbeat/module/kibana/kibana.go
@@ -23,12 +23,56 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/pkg/errors"
+
 	"github.com/elastic/beats/libbeat/common"
 
 	"github.com/elastic/beats/metricbeat/helper"
 	"github.com/elastic/beats/metricbeat/helper/elastic"
 	"github.com/elastic/beats/metricbeat/mb"
 )
+
+func init() {
+	// Register the ModuleFactory function for this module.
+	if err := mb.Registry.AddModule(ModuleName, NewModule); err != nil {
+		panic(err)
+	}
+}
+
+// NewModule creates a new module after performing validation.
+func NewModule(base mb.BaseModule) (mb.Module, error) {
+	if err := validateXPackMetricsets(base); err != nil {
+		return nil, err
+	}
+
+	return &base, nil
+}
+
+// Validate that correct metricsets have been specified if xpack.enabled = true.
+func validateXPackMetricsets(base mb.BaseModule) error {
+	config := struct {
+		Metricsets   []string `config:"metricsets"`
+		XPackEnabled bool     `config:"xpack.enabled"`
+	}{}
+	if err := base.UnpackConfig(&config); err != nil {
+		return err
+	}
+
+	// Nothing to validate if xpack.enabled != true
+	if !config.XPackEnabled {
+		return nil
+	}
+
+	expectedXPackMetricsets := []string{
+		"stats",
+	}
+
+	if !common.MakeStringSet(config.Metricsets...).Equals(common.MakeStringSet(expectedXPackMetricsets...)) {
+		return errors.Errorf("The %v module with xpack.enabled: true must have metricsets: %v", ModuleName, expectedXPackMetricsets)
+	}
+
+	return nil
+}
 
 // ModuleName is the name of this module
 const ModuleName = "kibana"


### PR DESCRIPTION
Backports the following commits to 7.2:
 - Validate stack modules' metricsets when xpack.enabled = true  (#12386)