### PR TITLE
Fix asciidoc coding error

### DIFF
--- a/auditbeat/docs/fields.asciidoc
+++ b/auditbeat/docs/fields.asciidoc
@@ -2660,6 +2660,8 @@ type: keyword
 An array of strings describing a possible external origin for this file. For example, the URL it was downloaded from. Only supported in macOS, via the kMDItemWhereFroms attribute. Omitted if origin information is not available.
 
 
+--
+
 *`file.origin.raw`*::
 +
 --
@@ -2667,8 +2669,6 @@ type: keyword
 
 This is a non-analyzed field that is useful for aggregations on the origin data.
 
-
---
 
 --
 

--- a/filebeat/docs/fields.asciidoc
+++ b/filebeat/docs/fields.asciidoc
@@ -7453,12 +7453,12 @@ type: keyword
 Information about the running thread where the log originate.
 
 
+--
+
 *`logstash.log.thread.text`*::
 +
 --
 type: text
-
---
 
 --
 
@@ -7515,12 +7515,12 @@ type: keyword
 Information about the running thread where the log originate.
 
 
+--
+
 *`logstash.slowlog.thread.text`*::
 +
 --
 type: text
-
---
 
 --
 
@@ -7532,12 +7532,12 @@ type: keyword
 Raw dump of the original event
 
 
+--
+
 *`logstash.slowlog.event.text`*::
 +
 --
 type: text
-
---
 
 --
 
@@ -7579,12 +7579,12 @@ type: keyword
 String value of the plugin configuration
 
 
+--
+
 *`logstash.slowlog.plugin_params.text`*::
 +
 --
 type: text
-
---
 
 --
 

--- a/libbeat/scripts/generate_fields_docs.py
+++ b/libbeat/scripts/generate_fields_docs.py
@@ -72,13 +72,11 @@ def document_field(output, field, field_path):
         if not field["enabled"]:
             output.write("{}\n\n".format("Object is not enabled."))
 
+    output.write("--\n\n")
+
     if "multi_fields" in field:
-        output.write("--\n\n")
         for subfield in field["multi_fields"]:
             document_field(output, subfield, field_path + "." + subfield["name"])
-    if "multi_fields" not in field:
-        output.write("--\n\n")
-
 
 def fields_to_asciidoc(input, output, beat):
 

--- a/libbeat/scripts/generate_fields_docs.py
+++ b/libbeat/scripts/generate_fields_docs.py
@@ -73,9 +73,11 @@ def document_field(output, field, field_path):
             output.write("{}\n\n".format("Object is not enabled."))
 
     if "multi_fields" in field:
+        output.write("--\n\n")
         for subfield in field["multi_fields"]:
             document_field(output, subfield, field_path + "." + subfield["name"])
-    output.write("--\n\n")
+    if "multi_fields" not in field:
+        output.write("--\n\n")
 
 
 def fields_to_asciidoc(input, output, beat):


### PR DESCRIPTION
Fixes an error in the script that resulted in either missing or extra block delimiters when the source yaml file contained contained multi_fields.

The error did not result in a doc build failure because asciidoc is lenient. Asciidoctor builds were not working.