### PR TITLE
[Metricbeat] Remove make kibana command

### DIFF
--- a/metricbeat/Makefile
+++ b/metricbeat/Makefile
@@ -13,13 +13,6 @@ DOCS_BRANCH=$(shell grep doc-branch ../libbeat/docs/version.asciidoc | cut -c 14
 
 include ${ES_BEATS}/libbeat/scripts/Makefile
 
-# Collects all module dashboards
-.PHONY: kibana
-kibana:
-	@rm -rf _meta/kibana.generated
-	@mkdir -p _meta/kibana.generated
-	@-cp -pr module/*/_meta/kibana/* _meta/kibana.generated
-
 # Collects all module docs
 .PHONY: collect-docs
 collect-docs: python-env
@@ -50,7 +43,7 @@ imports: python-env
 
 # Runs all collection steps and updates afterwards
 .PHONY: collect
-collect: assets collect-docs configs kibana imports
+collect: assets collect-docs configs imports
 
 # Creates a new metricset. Requires the params MODULE and METRICSET
 .PHONY: create-metricset


### PR DESCRIPTION
Recently, I realized that `make kibana` command is still available in the Metricbeat Makefile but that it's invalid after we merged https://github.com/elastic/beats/pull/7224

Remove the command from the Makefile and all its reference as requirement.

I have checked that you can still import dashboards correctly with `make import-dashboards` but definitely it doesn't work with `make kibana`