### PR TITLE
Update CoreDNS module README file to reflect the changes to autodiscover default input settings (#12382)

### DIFF
--- a/x-pack/filebeat/module/coredns/README.md
+++ b/x-pack/filebeat/module/coredns/README.md
@@ -51,7 +51,7 @@ kubectl apply -f filebeat
     providers:
       - type: kubernetes
         hints.enabled: true
-        default.disable: true
+        hints.default_config.enabled: false
 
   processors:
     - add_kubernetes_metadata:


### PR DESCRIPTION
(cherry picked from commit f40556da35214355398b53d9c8a7d9edd5518dd1)