### PR TITLE
Update filebeat EnvoyProxy module README file to reflect the changes to autodiscover default input settings (#12384)

### DIFF
--- a/x-pack/filebeat/module/envoyproxy/README.md
+++ b/x-pack/filebeat/module/envoyproxy/README.md
@@ -46,7 +46,7 @@ kubectl apply -f filebeat
     providers:
       - type: kubernetes
         hints.enabled: true
-        default.disable: true
+        hints.default_config.enabled: false
 
   processors:
     - add_kubernetes_metadata:


### PR DESCRIPTION
(cherry picked from commit 6e51bcd44e39fb438e930ea0687fe90264ba5e0d)