### PR TITLE
Don't duplicate @timestamp to beat.Event's Fields

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -80,6 +80,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix of docker json parser for missing "log" jsonkey in docker container's log {issue}11464[11464]
 - Fixed Beat ID being reported by GET / API. {pull}12180[12180]
 - Add host.os.codename to fields.yml. {pull}12261[12261]
+- Fix `@timestamp` being duplicated in events if `@timestamp` is set in a
+  processor (or by any code utilizing `PutValue()` on a `beat.Event`).
 
 *Auditbeat*
 

--- a/libbeat/beat/event.go
+++ b/libbeat/beat/event.go
@@ -76,6 +76,7 @@ func (e *Event) PutValue(key string, v interface{}) (interface{}, error) {
 		default:
 			return nil, errNoTimestamp
 		}
+		return nil, nil
 	} else if subKey, ok := metadataKey(key); ok {
 		if subKey == "" {
 			switch meta := v.(type) {

--- a/libbeat/beat/event_test.go
+++ b/libbeat/beat/event_test.go
@@ -44,8 +44,8 @@ func TestEventPutGetTimestamp(t *testing.T) {
 	assert.Equal(t, ts, v)
 	assert.Equal(t, ts, evt.Timestamp)
 
-	// The @timestamp is also written into Fields.
-	assert.Equal(t, ts, evt.Fields["@timestamp"])
+	// The @timestamp is not written into Fields.
+	assert.Nil(t, evt.Fields["@timestamp"])
 }
 
 func TestEventMetadata(t *testing.T) {

--- a/x-pack/winlogbeat/module/testing_windows.go
+++ b/x-pack/winlogbeat/module/testing_windows.go
@@ -125,9 +125,12 @@ func testPipeline(t testing.TB, evtx string, pipeline string, p *params) {
 				t.Fatalf("%v while processing event:\n%v", err, record.Fields.StringToPrint())
 			}
 
-			// Ensure timezone is UTC. In the normal Beats output this is handled
-			// by the encoder (go-structform).
-			evt.PutValue("@timestamp", evt.Timestamp.UTC())
+			// Copy the timestamp to the beat.Event.Fields because this is what
+			// we write to the golden data for testing purposes. In the normal
+			// Beats output this the handled by the encoder (go-structform).
+			if !evt.Timestamp.IsZero() {
+				evt.Fields["@timestamp"] = evt.Timestamp.UTC()
+			}
 
 			events = append(events, filterEvent(evt.Fields, p.ignoreFields))
 		}


### PR DESCRIPTION
When utilizing `PutValue()` to write `@timestamp` the value was being written to both the internal `Timestamp` field and copied to the `Fields` mapstr. When the event is output this causes duplicate `@timestamp` fields in the JSON.

This fixes that issue and by making `PutValue` only set the internal `Timestamp` field.

This is affecting the Winlogbeat sysmon module because it is copying an event specific timestamp value into the `@timestamp` field. I didn't notice the problem because I was testing with the file output and not Elasticsearch. So this needs to go into the 7.2 branch.