### PR TITLE
[Metricbeat] migrate the system module to reporterV2 with error return, part one

### DIFF
--- a/metricbeat/module/system/core/core.go
+++ b/metricbeat/module/system/core/core.go
@@ -62,11 +62,11 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 }
 
 // Fetch fetches CPU core metrics from the OS.
-func (m *MetricSet) Fetch(report mb.ReporterV2) {
+func (m *MetricSet) Fetch(report mb.ReporterV2) error {
 	samples, err := m.cores.Sample()
 	if err != nil {
-		report.Error(errors.Wrap(err, "failed to sample CPU core times"))
-		return
+		return errors.Wrap(err, "failed to sample CPU core times")
+
 	}
 
 	for id, sample := range samples {
@@ -98,8 +98,13 @@ func (m *MetricSet) Fetch(report mb.ReporterV2) {
 			}
 		}
 
-		report.Event(mb.Event{
+		isOpen := report.Event(mb.Event{
 			MetricSetFields: event,
 		})
+		if !isOpen {
+			return nil
+		}
 	}
+
+	return nil
 }

--- a/metricbeat/module/system/core/core_test.go
+++ b/metricbeat/module/system/core/core_test.go
@@ -29,8 +29,8 @@ import (
 )
 
 func TestFetch(t *testing.T) {
-	f := mbtest.NewReportingMetricSetV2(t, getConfig())
-	events, errs := mbtest.ReportingFetchV2(f)
+	f := mbtest.NewReportingMetricSetV2Error(t, getConfig())
+	events, errs := mbtest.ReportingFetchV2Error(f)
 
 	assert.Empty(t, errs)
 	if !assert.NotEmpty(t, events) {
@@ -41,12 +41,12 @@ func TestFetch(t *testing.T) {
 }
 
 func TestData(t *testing.T) {
-	f := mbtest.NewReportingMetricSetV2(t, getConfig())
+	f := mbtest.NewReportingMetricSetV2Error(t, getConfig())
 
-	mbtest.ReportingFetchV2(f)
+	mbtest.ReportingFetchV2Error(f)
 	time.Sleep(500 * time.Millisecond)
 
-	err := mbtest.WriteEventsReporterV2(f, t, ".")
+	err := mbtest.WriteEventsReporterV2Error(f, t, ".")
 	if err != nil {
 		t.Fatal("write", err)
 	}

--- a/metricbeat/module/system/cpu/cpu.go
+++ b/metricbeat/module/system/cpu/cpu.go
@@ -63,11 +63,10 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 }
 
 // Fetch fetches CPU metrics from the OS.
-func (m *MetricSet) Fetch(r mb.ReporterV2) {
+func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 	sample, err := m.cpu.Sample()
 	if err != nil {
-		r.Error(errors.Wrap(err, "failed to fetch CPU times"))
-		return
+		return errors.Wrap(err, "failed to fetch CPU times")
 	}
 
 	event := common.MapStr{"cores": cpu.NumCores}
@@ -112,4 +111,6 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 	r.Event(mb.Event{
 		MetricSetFields: event,
 	})
+
+	return nil
 }

--- a/metricbeat/module/system/cpu/cpu_test.go
+++ b/metricbeat/module/system/cpu/cpu_test.go
@@ -29,8 +29,8 @@ import (
 )
 
 func TestFetch(t *testing.T) {
-	f := mbtest.NewReportingMetricSetV2(t, getConfig())
-	events, errs := mbtest.ReportingFetchV2(f)
+	f := mbtest.NewReportingMetricSetV2Error(t, getConfig())
+	events, errs := mbtest.ReportingFetchV2Error(f)
 
 	assert.Empty(t, errs)
 	if !assert.NotEmpty(t, events) {
@@ -41,13 +41,13 @@ func TestFetch(t *testing.T) {
 }
 
 func TestData(t *testing.T) {
-	f := mbtest.NewReportingMetricSetV2(t, getConfig())
+	f := mbtest.NewReportingMetricSetV2Error(t, getConfig())
 
 	// Do a first fetch to have percentages
-	mbtest.ReportingFetchV2(f)
+	mbtest.ReportingFetchV2Error(f)
 	time.Sleep(1 * time.Second)
 
-	err := mbtest.WriteEventsReporterV2(f, t, ".")
+	err := mbtest.WriteEventsReporterV2Error(f, t, ".")
 	if err != nil {
 		t.Fatal("write", err)
 	}

--- a/metricbeat/module/system/diskio/diskio.go
+++ b/metricbeat/module/system/diskio/diskio.go
@@ -58,11 +58,10 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 }
 
 // Fetch fetches disk IO metrics from the OS.
-func (m *MetricSet) Fetch(r mb.ReporterV2) {
+func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 	stats, err := IOCounters(m.includeDevices...)
 	if err != nil {
-		r.Error(errors.Wrap(err, "disk io counters"))
-		return
+		return errors.Wrap(err, "disk io counters")
 	}
 
 	// Sample the current cpu counter
@@ -128,8 +127,13 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 			event["serial_number"] = counters.SerialNumber
 		}
 
-		r.Event(mb.Event{
+		isOpen := r.Event(mb.Event{
 			MetricSetFields: event,
 		})
+		if !isOpen {
+			return nil
+		}
 	}
+
+	return nil
 }

--- a/metricbeat/module/system/diskio/diskio_test.go
+++ b/metricbeat/module/system/diskio/diskio_test.go
@@ -30,8 +30,8 @@ import (
 )
 
 func TestFetch(t *testing.T) {
-	f := mbtest.NewReportingMetricSetV2(t, getConfig())
-	events, errs := mbtest.ReportingFetchV2(f)
+	f := mbtest.NewReportingMetricSetV2Error(t, getConfig())
+	events, errs := mbtest.ReportingFetchV2Error(f)
 
 	assert.Empty(t, errs)
 	if !assert.NotEmpty(t, events) {
@@ -42,11 +42,11 @@ func TestFetch(t *testing.T) {
 }
 
 func TestData(t *testing.T) {
-	f := mbtest.NewReportingMetricSetV2(t, getConfig())
-	err := mbtest.WriteEventsReporterV2(f, t, ".")
+	f := mbtest.NewReportingMetricSetV2Error(t, getConfig())
+	err := mbtest.WriteEventsReporterV2Error(f, t, ".")
 
 	// Do a first fetch to have a sample
-	mbtest.ReportingFetchV2(f)
+	mbtest.ReportingFetchV2Error(f)
 	time.Sleep(1 * time.Second)
 
 	if err != nil {

--- a/metricbeat/module/system/diskio/diskstat_linux_test.go
+++ b/metricbeat/module/system/diskio/diskstat_linux_test.go
@@ -51,8 +51,8 @@ func TestDataNameFilter(t *testing.T) {
 		"diskio.include_devices": []string{"sda", "sda1", "sda2"},
 	}
 
-	f := mbtest.NewReportingMetricSetV2(t, conf)
-	data, errs := mbtest.ReportingFetchV2(f)
+	f := mbtest.NewReportingMetricSetV2Error(t, conf)
+	data, errs := mbtest.ReportingFetchV2Error(f)
 	assert.Empty(t, errs)
 	assert.Equal(t, 3, len(data))
 }
@@ -70,8 +70,8 @@ func TestDataEmptyFilter(t *testing.T) {
 		"metricsets": []string{"diskio"},
 	}
 
-	f := mbtest.NewReportingMetricSetV2(t, conf)
-	data, errs := mbtest.ReportingFetchV2(f)
+	f := mbtest.NewReportingMetricSetV2Error(t, conf)
+	data, errs := mbtest.ReportingFetchV2Error(f)
 	assert.Empty(t, errs)
 	assert.Equal(t, 10, len(data))
 }

--- a/metricbeat/module/system/diskio/diskstat_windows_test.go
+++ b/metricbeat/module/system/diskio/diskstat_windows_test.go
@@ -37,8 +37,8 @@ func TestCDriveFilterOnWindowsTestEnv(t *testing.T) {
 		"diskio.include_devices": []string{"C:"},
 	}
 
-	f := mbtest.NewReportingMetricSetV2(t, conf)
-	data, errs := mbtest.ReportingFetchV2(f)
+	f := mbtest.NewReportingMetricSetV2Error(t, conf)
+	data, errs := mbtest.ReportingFetchV2Error(f)
 	assert.Empty(t, errs)
 	assert.Equal(t, 1, len(data))
 	assert.Equal(t, data[0].MetricSetFields["name"], "C:")
@@ -69,8 +69,8 @@ func TestAllDrivesOnWindowsTestEnv(t *testing.T) {
 		"metricsets": []string{"diskio"},
 	}
 
-	f := mbtest.NewReportingMetricSetV2(t, conf)
-	data, errs := mbtest.ReportingFetchV2(f)
+	f := mbtest.NewReportingMetricSetV2Error(t, conf)
+	data, errs := mbtest.ReportingFetchV2Error(f)
 	assert.Empty(t, errs)
 	assert.True(t, len(data) >= 1)
 	drives, err := getLogicalDriveStrings()

--- a/metricbeat/module/system/filesystem/filesystem.go
+++ b/metricbeat/module/system/filesystem/filesystem.go
@@ -65,11 +65,11 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 
 // Fetch fetches filesystem metrics for all mounted filesystems and returns
 // an event for each mount point.
-func (m *MetricSet) Fetch(r mb.ReporterV2) {
+func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 	fss, err := GetFileSystemList()
 	if err != nil {
-		r.Error(errors.Wrap(err, "filesystem list"))
-		return
+		return errors.Wrap(err, "error getting filesystem list")
+
 	}
 
 	if len(m.config.IgnoreTypes) > 0 {
@@ -88,8 +88,8 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 			MetricSetFields: GetFilesystemEvent(fsStat),
 		}
 		if !r.Event(event) {
-			debugf("Failed to report event, interrupting Fetch")
-			return
+			return nil
 		}
 	}
+	return nil
 }

--- a/metricbeat/module/system/filesystem/filesystem_test.go
+++ b/metricbeat/module/system/filesystem/filesystem_test.go
@@ -28,8 +28,8 @@ import (
 )
 
 func TestFetch(t *testing.T) {
-	f := mbtest.NewReportingMetricSetV2(t, getConfig())
-	events, errs := mbtest.ReportingFetchV2(f)
+	f := mbtest.NewReportingMetricSetV2Error(t, getConfig())
+	events, errs := mbtest.ReportingFetchV2Error(f)
 
 	assert.Empty(t, errs)
 	if !assert.NotEmpty(t, events) {
@@ -40,8 +40,8 @@ func TestFetch(t *testing.T) {
 }
 
 func TestData(t *testing.T) {
-	f := mbtest.NewReportingMetricSetV2(t, getConfig())
-	err := mbtest.WriteEventsReporterV2(f, t, ".")
+	f := mbtest.NewReportingMetricSetV2Error(t, getConfig())
+	err := mbtest.WriteEventsReporterV2Error(f, t, ".")
 	if err != nil {
 		t.Fatal("write", err)
 	}

--- a/metricbeat/module/system/fsstat/fsstat.go
+++ b/metricbeat/module/system/fsstat/fsstat.go
@@ -64,11 +64,10 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 
 // Fetch fetches filesystem metrics for all mounted filesystems and returns
 // a single event containing aggregated data.
-func (m *MetricSet) Fetch(r mb.ReporterV2) {
+func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 	fss, err := filesystem.GetFileSystemList()
 	if err != nil {
-		r.Error(errors.Wrap(err, "filesystem list"))
-		return
+		return errors.Wrap(err, "filesystem list")
 	}
 
 	if len(m.config.IgnoreTypes) > 0 {
@@ -103,4 +102,6 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 			"total_files": totalFiles,
 		},
 	})
+
+	return nil
 }

--- a/metricbeat/module/system/fsstat/fsstat_test.go
+++ b/metricbeat/module/system/fsstat/fsstat_test.go
@@ -29,8 +29,8 @@ import (
 )
 
 func TestFetch(t *testing.T) {
-	f := mbtest.NewReportingMetricSetV2(t, getConfig())
-	events, errs := mbtest.ReportingFetchV2(f)
+	f := mbtest.NewReportingMetricSetV2Error(t, getConfig())
+	events, errs := mbtest.ReportingFetchV2Error(f)
 
 	assert.Empty(t, errs)
 	if !assert.NotEmpty(t, events) {
@@ -41,13 +41,13 @@ func TestFetch(t *testing.T) {
 }
 
 func TestData(t *testing.T) {
-	f := mbtest.NewReportingMetricSetV2(t, getConfig())
+	f := mbtest.NewReportingMetricSetV2Error(t, getConfig())
 
 	// Do a first fetch to have percentages
-	mbtest.ReportingFetchV2(f)
+	mbtest.ReportingFetchV2Error(f)
 	time.Sleep(1 * time.Second)
 
-	err := mbtest.WriteEventsReporterV2(f, t, ".")
+	err := mbtest.WriteEventsReporterV2Error(f, t, ".")
 	if err != nil {
 		t.Fatal("write", err)
 	}


### PR DESCRIPTION
See #11374

I'm doing the system module in chunks, since it's kinda huge. Hopefully it won't be more than 3 parts. A few other non-migration changes here as well, to make the linter happy. 