### PR TITLE
[docs] Add APM to simplified security docs

### DIFF
--- a/libbeat/docs/command-reference.asciidoc
+++ b/libbeat/docs/command-reference.asciidoc
@@ -196,9 +196,11 @@ endif::no_dashboards[]
 Exports the index template to stdout. You can specify the `--es.version` and
 `--index` flags to further define what gets exported.
 
+ifndef::apm-server[]
 [[ilm-policy-subcommand]]
 *`ilm-policy`*::
 Exports ILM policy to stdout.
+endif::apm-server[]
 
 *FLAGS*
 

--- a/libbeat/docs/monitoring/monitoring-beats.asciidoc
+++ b/libbeat/docs/monitoring/monitoring-beats.asciidoc
@@ -40,7 +40,7 @@ the same {es} cluster, specify the following minimal configuration:
 --
 ["source","yml",subs="attributes"]
 --------------------
-xpack.monitoring:
+monitoring:
   enabled: true
   elasticsearch:
     username: {beat_monitoring_user}

--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -1568,7 +1568,8 @@ endif::[]
 ++++
 
 ifdef::apm-server[]
-NOTE: This page refers to using a separate instance of APM Server with an existing Elasticsearch Service deployment.
+NOTE: This page refers to using a separate instance of APM Server with an existing
+https://www.elastic.co/cloud/elasticsearch-service[Elasticsearch Service deployment].
 If you want to use APM on Elastic Cloud, see the cloud docs:
 {cloud}/ec-create-deployment.html[Create your deployment] or
 {cloud}/ec-manage-apm-settings.html[Add APM user settings].

--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -1569,7 +1569,9 @@ endif::[]
 
 ifdef::apm-server[]
 NOTE: This page refers to using a separate instance of APM Server with an existing Elasticsearch Service deployment.
-APM Server is not yet supported on Elasticsearch Service.
+If you want to use APM on Elastic Cloud, see the cloud docs:
+{cloud}/ec-create-deployment.html[Create your deployment] or
+{cloud}/ec-manage-apm-settings.html[Add APM user settings].
 endif::apm-server[]
 
 {beatname_uc} comes with two settings that simplify the output configuration

--- a/libbeat/docs/security/basic-auth.asciidoc
+++ b/libbeat/docs/security/basic-auth.asciidoc
@@ -27,6 +27,7 @@ output.elasticsearch:
 <2> The example shows a hard-coded password, but you should store sensitive
 values in the <<keystore,secrets keystore>>.
 --
+ifndef::apm-server[]
 +
 If you've configured the {kib} endpoint, also specify credentials for
 authenticating with {kib}. For example:
@@ -39,6 +40,7 @@ setup.kibana:
   password: "{pwd}" 
 ----
 <1> Let's assume this user has the privileges required to set up dashboards.
+endif::apm-server[]
 
 * To use Public Key Infrastructure (PKI) certificates to authenticate users,
 configure the `certificate` and `key` settings. These settings assume that the

--- a/libbeat/docs/security/users.asciidoc
+++ b/libbeat/docs/security/users.asciidoc
@@ -62,6 +62,12 @@ ifeval::["{beatname_lc}"=="filebeat"]
 |`ingest_admin` role
 endif::[]
 
+ifdef::apm-server[]
+.2+|Set up ingest pipelines
+|`monitor` on cluster
+|`ingest_admin` role
+endif::apm-server[]
+
 .2+|Set up index lifecycle policies
 |`manage_ilm`, `manage_index_templates`, and `monitor` on cluster
 |`manage` on +{beat_default_index_prefix}-*+ indices

--- a/libbeat/docs/security/users.asciidoc
+++ b/libbeat/docs/security/users.asciidoc
@@ -121,24 +121,30 @@ endif::[]
 |`create_index` and `index` on +{beat_default_index_prefix}-*+ indices
 |also requires privileges to <<privileges-to-setup-beats,set up index templates>>
 unless you've disabled automatic template loading
-endif::apm-server[]
-
-ifdef::apm-server[]
-.2+|Send data to a secured cluster without index lifecycle management
-|`manage_index_templates` and `monitor` on cluster
-|`create_index` and `write` on +{beat_default_index_prefix}-*+ indices
-endif::apm-server[]
 
 .2+|Send data to a secured cluster that supports index lifecycle management
 |`manage_index_templates`, `manage_ilm`
-ifndef::apm-server[]
 footnote:[Use `read_ilm` instead of `manage_ilm` if you pre-loaded the lifecycle policy]
-endif::apm-server[]
 , and `monitor` on cluster
 ifeval::["{beatname_lc}"=="filebeat"]
 (and `manage_pipeline` if {beatname_uc} modules are used)
 endif::[]
 | `index` and `manage` on +{beat_default_index_prefix}-*+ indices
+endif::apm-server[]
+
+ifdef::apm-server[]
+.2+|Send data to a secured cluster without index lifecycle management
+|`monitor` on cluster
+|`create_index` and `write` on +{beat_default_index_prefix}-*+ indices
+|also requires privileges to <<privileges-to-setup-beats,set up index templates>>
+unless you've disabled automatic template loading: `setup.template.enabled=false`
+
+.2+|Send data to a secured cluster that supports index lifecycle management
+|`manage_ilm` and `monitor` on cluster
+| `index` and `manage` on +{beat_default_index_prefix}-*+ indices
+|also requires privileges to <<privileges-to-setup-beats,set up index templates>>
+unless you've disabled automatic template loading: `setup.template.enabled=false`
+endif::apm-server[]
 
 ifdef::has_central_config[]
 .2+|Read configurations from Beats central management

--- a/libbeat/docs/security/users.asciidoc
+++ b/libbeat/docs/security/users.asciidoc
@@ -133,13 +133,13 @@ endif::[]
 endif::apm-server[]
 
 ifdef::apm-server[]
-.2+|Send data to a secured cluster without index lifecycle management
+.3+|Send data to a secured cluster without index lifecycle management
 |`monitor` on cluster
 |`create_index` and `write` on +{beat_default_index_prefix}-*+ indices
 |also requires privileges to <<privileges-to-setup-beats,set up index templates>>
 unless you've disabled automatic template loading: `setup.template.enabled=false`
 
-.2+|Send data to a secured cluster that supports index lifecycle management
+.3+|Send data to a secured cluster that supports index lifecycle management
 |`manage_ilm` and `monitor` on cluster
 | `index` and `manage` on +{beat_default_index_prefix}-*+ indices
 |also requires privileges to <<privileges-to-setup-beats,set up index templates>>

--- a/libbeat/docs/security/users.asciidoc
+++ b/libbeat/docs/security/users.asciidoc
@@ -175,7 +175,7 @@ perform:
 |====
 |Task | Required privileges and roles
 
-ifndef::no_dashboards[]
+ifndef::apm-server[]
 .2+|View {beatname_uc} dashboards
 |`read` on +{beat_default_index_prefix}-*+ indices
 |`kibana_dashboard_only_user` role
@@ -183,7 +183,7 @@ ifndef::no_dashboards[]
 .2+|View and edit {beatname_uc} dashboards
 |`read` on +{beat_default_index_prefix}-*+ indices
 |`kibana_user` role
-endif::no_dashboards[]
+endif::apm-server[]
 
 ifdef::apm-server[]
 |Use the APM UI

--- a/libbeat/docs/security/users.asciidoc
+++ b/libbeat/docs/security/users.asciidoc
@@ -106,6 +106,7 @@ need to perform:
 |====
 |Task | Required privileges and roles
 
+ifndef::apm-server[]
 .3+|Send data to a secured cluster without index lifecycle management
 |`monitor` on cluster
 ifeval::["{beatname_lc}"=="filebeat"]
@@ -114,11 +115,20 @@ endif::[]
 |`create_index` and `index` on +{beat_default_index_prefix}-*+ indices
 |also requires privileges to <<privileges-to-setup-beats,set up index templates>>
 unless you've disabled automatic template loading
+endif::apm-server[]
+
+ifdef::apm-server[]
+.2+|Send data to a secured cluster without index lifecycle management
+|`manage_index_templates` and `monitor` on cluster
+|`create_index` and `write` on +{beat_default_index_prefix}-*+ indices
+endif::apm-server[]
 
 .2+|Send data to a secured cluster that supports index lifecycle management
-|`manage_index_templates`,`manage_ilm` footnote:[Use `read_ilm` instead of
-`manage_ilm` if you pre-loaded the lifecycle policy], and `monitor`
-on cluster
+|`manage_index_templates`, `manage_ilm`
+ifndef::apm-server[]
+footnote:[Use `read_ilm` instead of `manage_ilm` if you pre-loaded the lifecycle policy]
+endif::apm-server[]
+, and `monitor` on cluster
 ifeval::["{beatname_lc}"=="filebeat"]
 (and `manage_pipeline` if {beatname_uc} modules are used)
 endif::[]
@@ -153,6 +163,7 @@ perform:
 |====
 |Task | Required privileges and roles
 
+ifndef::no_dashboards[]
 .2+|View {beatname_uc} dashboards
 |`read` on +{beat_default_index_prefix}-*+ indices
 |`kibana_dashboard_only_user` role
@@ -160,6 +171,12 @@ perform:
 .2+|View and edit {beatname_uc} dashboards
 |`read` on +{beat_default_index_prefix}-*+ indices
 |`kibana_user` role
+endif::no_dashboards[]
+
+ifdef::apm-server[]
+|Use the APM UI
+|`kibana_user` and `apm_user` roles
+endif::apm-server[]
 
 ifdef::has_central_config[]
 .2+|Create and manage configurations in Beats central management

--- a/libbeat/docs/security/users.asciidoc
+++ b/libbeat/docs/security/users.asciidoc
@@ -123,9 +123,9 @@ endif::[]
 unless you've disabled automatic template loading
 
 .2+|Send data to a secured cluster that supports index lifecycle management
-|`manage_index_templates`, `manage_ilm`
-footnote:[Use `read_ilm` instead of `manage_ilm` if you pre-loaded the lifecycle policy]
-, and `monitor` on cluster
+|`manage_index_templates`, `manage_ilm` footnote:[Use `read_ilm` instead of
+`manage_ilm` if you pre-loaded the lifecycle policy], and `monitor`
+on cluster
 ifeval::["{beatname_lc}"=="filebeat"]
 (and `manage_pipeline` if {beatname_uc} modules are used)
 endif::[]


### PR DESCRIPTION
* Persists the APM xpack security changes in https://github.com/elastic/apm-server/pull/2228. Waiting for approval on the APM side before marking this as ready for review.
* Follow up to DeDe's work on https://github.com/elastic/beats/pull/11329.