### PR TITLE
Fix custom index name in setup

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -81,6 +81,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix Central Management enroll under Windows {issue}12797[12797] {pull}12799[12799]
 - ILM: Use GET instead of HEAD when checking for alias to expose detailed error message. {pull}12886[12886]
 - Fix seccomp policy preventing some features to function properly on 32bit Linux systems. {issue}12990[12990] {pull}13008[13008]
+- Fix custom index name in setup. {pull}12457[12457]
 
 *Auditbeat*
 

--- a/libbeat/dashboards/modify_json.go
+++ b/libbeat/dashboards/modify_json.go
@@ -46,18 +46,8 @@ func ReplaceIndexInIndexPattern(index string, content common.MapStr) common.MapS
 		return content
 	}
 
-	if objectMaps, ok := content["objects"].([]common.MapStr); ok {
-		// change index pattern name
-		for i, objectMap := range objectMaps {
-
-			objectMap["id"] = index
-			if attributes, ok := objectMap["attributes"].(common.MapStr); ok {
-				attributes["title"] = index
-			}
-			objectMaps[i] = objectMap
-		}
-		content["objects"] = objectMaps
-	} else if objects, ok := content["objects"].([]interface{}); ok {
+	switch objects := content["objects"].(type) {
+	case []interface{}:
 		// change index pattern name
 		for i, object := range objects {
 			objectMap, ok := object.(map[string]interface{})
@@ -72,6 +62,19 @@ func ReplaceIndexInIndexPattern(index string, content common.MapStr) common.MapS
 			objects[i] = objectMap
 		}
 		content["objects"] = objects
+	case []common.MapStr:
+		// change index pattern name
+		for i, objectMap := range objects {
+
+			objectMap["id"] = index
+			if attributes, ok := objectMap["attributes"].(common.MapStr); ok {
+				attributes["title"] = index
+			}
+			objects[i] = objectMap
+		}
+		content["objects"] = objects
+	default:
+		logp.Err("Unexpected object type %T, expected list of objects. Got: %#v", content["objects"], content["objects"])
 	}
 
 	return content

--- a/libbeat/dashboards/modify_json.go
+++ b/libbeat/dashboards/modify_json.go
@@ -46,8 +46,7 @@ func ReplaceIndexInIndexPattern(index string, content common.MapStr) common.MapS
 		return content
 	}
 
-	objectMaps, ok := content["objects"].([]common.MapStr)
-	if ok {
+	if objectMaps, ok := content["objects"].([]common.MapStr); ok {
 		// change index pattern name
 		for i, objectMap := range objectMaps {
 

--- a/libbeat/dashboards/modify_json.go
+++ b/libbeat/dashboards/modify_json.go
@@ -46,21 +46,34 @@ func ReplaceIndexInIndexPattern(index string, content common.MapStr) common.MapS
 		return content
 	}
 
-	objects, ok := content["objects"].([]common.MapStr)
-	if !ok {
-		return content
-	}
+	objectMaps, ok := content["objects"].([]common.MapStr)
+	if ok {
+		// change index pattern name
+		for i, objectMap := range objectMaps {
 
-	// change index pattern name
-	for i, objectMap := range objects {
-
-		objectMap["id"] = index
-		if attributes, ok := objectMap["attributes"].(common.MapStr); ok {
-			attributes["title"] = index
+			objectMap["id"] = index
+			if attributes, ok := objectMap["attributes"].(common.MapStr); ok {
+				attributes["title"] = index
+			}
+			objectMaps[i] = objectMap
 		}
-		objects[i] = objectMap
+		content["objects"] = objectMaps
+	} else if objects, ok := content["objects"].([]interface{}); ok {
+		// change index pattern name
+		for i, object := range objects {
+			objectMap, ok := object.(map[string]interface{})
+			if !ok {
+				continue
+			}
+
+			objectMap["id"] = index
+			if attributes, ok := objectMap["attributes"].(map[string]interface{}); ok {
+				attributes["title"] = index
+			}
+			objects[i] = objectMap
+		}
+		content["objects"] = objects
 	}
-	content["objects"] = objects
 
 	return content
 }

--- a/libbeat/dashboards/modify_json.go
+++ b/libbeat/dashboards/modify_json.go
@@ -46,20 +46,16 @@ func ReplaceIndexInIndexPattern(index string, content common.MapStr) common.MapS
 		return content
 	}
 
-	objects, ok := content["objects"].([]interface{})
+	objects, ok := content["objects"].([]common.MapStr)
 	if !ok {
 		return content
 	}
 
 	// change index pattern name
-	for i, object := range objects {
-		objectMap, ok := object.(map[string]interface{})
-		if !ok {
-			continue
-		}
+	for i, objectMap := range objects {
 
 		objectMap["id"] = index
-		if attributes, ok := objectMap["attributes"].(map[string]interface{}); ok {
+		if attributes, ok := objectMap["attributes"].(common.MapStr); ok {
 			attributes["title"] = index
 		}
 		objects[i] = objectMap


### PR DESCRIPTION
`beatname setup -E setup.dashboards.index="myname-*"` is supposed to create an index pattern in Kibana with a custom index name.

This currently doesn't work ([discuss thread](https://discuss.elastic.co/t/set-index-pattern-name-in-kibana-by-auditbeat-setup/184242)) because of an impossible type assertion in the code (`x.([]interface{})` will never work if x is of type `[]common.MapStr` which it is). 

This fixes the type assertions. I've tested that `setup` can create custom index patterns.