### PR TITLE
output.logstash.index doc update

### DIFF
--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -717,7 +717,7 @@ The index root name to write events to. The default is the Beat name. For
 example +"{beatname_lc}"+ generates +"[{beatname_lc}-]{version}-YYYY.MM.DD"+
 indices (for example, +"{beatname_lc}-{version}-2017.04.26"+).
 
-NOTE: This parameter's value will be assigned to the `metadata.beat` field. It can then be reused in Logstash's output section as `%{[@metadata][beat]}`
+NOTE: This parameter's value will be assigned to the `metadata.beat` field. It can then be accessed in Logstash's output section as `%{[@metadata][beat]}`.
 
 ===== `ssl`
 

--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -717,6 +717,8 @@ The index root name to write events to. The default is the Beat name. For
 example +"{beatname_lc}"+ generates +"[{beatname_lc}-]{version}-YYYY.MM.DD"+
 indices (for example, +"{beatname_lc}-{version}-2017.04.26"+).
 
+NOTE: This parameter's value will be assigned to the `metadata.beat` field. It can then be reused in Logstash's output section as `%{[@metadata][beat]}`
+
 ===== `ssl`
 
 Configuration options for SSL parameters like the root CA for Logstash connections. See


### PR DESCRIPTION
Updated the output.logstash.index section to include a note explaing that this parameter's value will be assigned to the metadata.beat field in order to be reused in the Logstash output section.