### PR TITLE
[Metricbeat] Migrate the system module to reporterV2 with error return, part two

### DIFF
--- a/metricbeat/module/system/load/load.go
+++ b/metricbeat/module/system/load/load.go
@@ -48,11 +48,10 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 }
 
 // Fetch fetches system load metrics.
-func (m *MetricSet) Fetch(r mb.ReporterV2) {
+func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 	load, err := cpu.Load()
 	if err != nil {
-		r.Error(errors.Wrap(err, "failed to get CPU load values"))
-		return
+		return errors.Wrap(err, "failed to get CPU load values")
 	}
 
 	avgs := load.Averages()
@@ -73,4 +72,6 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 	r.Event(mb.Event{
 		MetricSetFields: event,
 	})
+
+	return nil
 }

--- a/metricbeat/module/system/load/load_test.go
+++ b/metricbeat/module/system/load/load_test.go
@@ -28,8 +28,8 @@ import (
 )
 
 func TestFetch(t *testing.T) {
-	f := mbtest.NewReportingMetricSetV2(t, getConfig())
-	events, errs := mbtest.ReportingFetchV2(f)
+	f := mbtest.NewReportingMetricSetV2Error(t, getConfig())
+	events, errs := mbtest.ReportingFetchV2Error(f)
 
 	assert.Empty(t, errs)
 	if !assert.NotEmpty(t, events) {
@@ -40,8 +40,8 @@ func TestFetch(t *testing.T) {
 }
 
 func TestData(t *testing.T) {
-	f := mbtest.NewReportingMetricSetV2(t, getConfig())
-	err := mbtest.WriteEventsReporterV2(f, t, ".")
+	f := mbtest.NewReportingMetricSetV2Error(t, getConfig())
+	err := mbtest.WriteEventsReporterV2Error(f, t, ".")
 	if err != nil {
 		t.Fatal("write", err)
 	}

--- a/metricbeat/module/system/memory/memory.go
+++ b/metricbeat/module/system/memory/memory.go
@@ -46,18 +46,16 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 }
 
 // Fetch fetches memory metrics from the OS.
-func (m *MetricSet) Fetch(r mb.ReporterV2) {
+func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 	memStat, err := mem.Get()
 	if err != nil {
-		r.Error(errors.Wrap(err, "memory"))
-		return
+		return errors.Wrap(err, "memory")
 	}
 	mem.AddMemPercentage(memStat)
 
 	swapStat, err := mem.GetSwap()
 	if err != nil {
-		r.Error(errors.Wrap(err, "swap"))
-		return
+		return errors.Wrap(err, "swap")
 	}
 	mem.AddSwapPercentage(swapStat)
 
@@ -89,8 +87,7 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 
 	hugePagesStat, err := mem.GetHugeTLBPages()
 	if err != nil {
-		r.Error(errors.Wrap(err, "hugepages"))
-		return
+		return errors.Wrap(err, "hugepages")
 	}
 	if hugePagesStat != nil {
 		mem.AddHugeTLBPagesPercentage(hugePagesStat)
@@ -110,4 +107,6 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 	r.Event(mb.Event{
 		MetricSetFields: memory,
 	})
+
+	return nil
 }

--- a/metricbeat/module/system/memory/memory_test.go
+++ b/metricbeat/module/system/memory/memory_test.go
@@ -28,8 +28,8 @@ import (
 )
 
 func TestFetch(t *testing.T) {
-	f := mbtest.NewReportingMetricSetV2(t, getConfig())
-	events, errs := mbtest.ReportingFetchV2(f)
+	f := mbtest.NewReportingMetricSetV2Error(t, getConfig())
+	events, errs := mbtest.ReportingFetchV2Error(f)
 
 	assert.Empty(t, errs)
 	if !assert.NotEmpty(t, events) {
@@ -40,8 +40,8 @@ func TestFetch(t *testing.T) {
 }
 
 func TestData(t *testing.T) {
-	f := mbtest.NewReportingMetricSetV2(t, getConfig())
-	err := mbtest.WriteEventsReporterV2(f, t, ".")
+	f := mbtest.NewReportingMetricSetV2Error(t, getConfig())
+	err := mbtest.WriteEventsReporterV2Error(f, t, ".")
 	if err != nil {
 		t.Fatal("write", err)
 	}

--- a/metricbeat/module/system/network/network_test.go
+++ b/metricbeat/module/system/network/network_test.go
@@ -28,8 +28,8 @@ import (
 )
 
 func TestFetch(t *testing.T) {
-	f := mbtest.NewReportingMetricSetV2(t, getConfig())
-	events, errs := mbtest.ReportingFetchV2(f)
+	f := mbtest.NewReportingMetricSetV2Error(t, getConfig())
+	events, errs := mbtest.ReportingFetchV2Error(f)
 
 	assert.Empty(t, errs)
 	if !assert.NotEmpty(t, events) {
@@ -40,8 +40,8 @@ func TestFetch(t *testing.T) {
 }
 
 func TestData(t *testing.T) {
-	f := mbtest.NewReportingMetricSetV2(t, getConfig())
-	err := mbtest.WriteEventsReporterV2(f, t, ".")
+	f := mbtest.NewReportingMetricSetV2Error(t, getConfig())
+	err := mbtest.WriteEventsReporterV2Error(f, t, ".")
 	if err != nil {
 		t.Fatal("write", err)
 	}

--- a/metricbeat/module/system/process/config.go
+++ b/metricbeat/module/system/process/config.go
@@ -22,6 +22,7 @@ import (
 	"github.com/elastic/beats/libbeat/metric/system/process"
 )
 
+// Config stores the system/process config options
 type Config struct {
 	Procs           []string                 `config:"processes"`
 	Cgroups         *bool                    `config:"process.cgroups.enabled"`
@@ -33,6 +34,7 @@ type Config struct {
 	CPUTicks        *bool                    `config:"cpu_ticks"` // Deprecated
 }
 
+// Validate checks for depricated config options
 func (c Config) Validate() error {
 	if c.CPUTicks != nil {
 		cfgwarn.Deprecate("6.1", "cpu_ticks is deprecated. Use process.include_cpu_ticks instead")

--- a/metricbeat/module/system/process/process_test.go
+++ b/metricbeat/module/system/process/process_test.go
@@ -29,8 +29,8 @@ import (
 )
 
 func TestFetch(t *testing.T) {
-	f := mbtest.NewReportingMetricSetV2(t, getConfig())
-	events, errs := mbtest.ReportingFetchV2(f)
+	f := mbtest.NewReportingMetricSetV2Error(t, getConfig())
+	events, errs := mbtest.ReportingFetchV2Error(f)
 
 	assert.Empty(t, errs)
 	if !assert.NotEmpty(t, events) {
@@ -41,13 +41,13 @@ func TestFetch(t *testing.T) {
 }
 
 func TestData(t *testing.T) {
-	f := mbtest.NewReportingMetricSetV2(t, getConfig())
+	f := mbtest.NewReportingMetricSetV2Error(t, getConfig())
 
 	// Do a first fetch to have percentages
-	mbtest.ReportingFetchV2(f)
+	mbtest.ReportingFetchV2Error(f)
 	time.Sleep(1 * time.Second)
 
-	err := mbtest.WriteEventsReporterV2(f, t, ".")
+	err := mbtest.WriteEventsReporterV2Error(f, t, ".")
 	if err != nil {
 		t.Fatal("write", err)
 	}


### PR DESCRIPTION
See #11374

The second part of the system module, since it's so huge.