### PR TITLE
Removing CHANGELOG entries that were erroneously backported

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -221,9 +221,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add AWS cloudwatch metricset. {pull}11798[11798] {issue}11734[11734]
 - Add `regions` in aws module config to specify target regions for querying cloudwatch metrics. {issue}11932[11932] {pull}11956[11956]
 - Keep `etcd` followers members from reporting `leader` metricset events {pull}12004[12004]
-- Add overview dashboard to Consul module {pull}10665[10665]
-- New fields were added in the mysql/status metricset. {pull}12227[12227]
-- Add Vsphere Virtual Machine operating system to `os` field in Vsphere virtualmachine module. {pull}12391[12391]
 - Add validation for elasticsearch and kibana modules' metricsets when xpack.enabled is set to true. {pull}12386[12386]
 
 *Packetbeat*


### PR DESCRIPTION
I accidentally merged some extraneous CHANGELOG entries as part of https://github.com/elastic/beats/pull/12429. Thanks to @cachedout for catching this. This PR fixes the CHANGELOG in the `7.2` branch.