### PR TITLE
Cherry-pick #12458 to 7.2: [Heartbeat] Fix Continuation Dispatch / mode: all pings

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -112,6 +112,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 - Fix NPE on some monitor configuration errors. {pull}11910[11910]
 - Fix NPEs / resource leaks when executing config checks. {pull}11165[11165]
+- Fix duplicated IPs on `mode: all` monitors. {pull}12458[12458]
 
 *Journalbeat*
 


### PR DESCRIPTION
Cherry-pick of PR #12458 to 7.2 branch. Original message: 

Currently mode: all pings are broken. The root cause is that the scheduler dispatch of continuations in the heartbeat task model is broken. Since the only current use of this is `mode:all` pings that is what is affected. The issue was incorrectly aliasing variables when dispatching future work.

This patch also renames some of the related variables to make understanding the code here simpler.

This issue is well described on this wiki page https://github.com/golang/go/wiki/CommonMistakes