### PR TITLE
[Heartbeat] Better document geo options (docs only)

### DIFF
--- a/heartbeat/docs/configuring-howto.asciidoc
+++ b/heartbeat/docs/configuring-howto.asciidoc
@@ -47,6 +47,8 @@ include::./heartbeat-options.asciidoc[]
 
 include::./heartbeat-general-options.asciidoc[]
 
+include::./heartbeat-observer-options.asciidoc[]
+
 include::{libbeat-dir}/docs/queueconfig.asciidoc[]
 
 include::{libbeat-dir}/docs/outputconfig.asciidoc[]

--- a/heartbeat/docs/heartbeat-observer-options.asciidoc
+++ b/heartbeat/docs/heartbeat-observer-options.asciidoc
@@ -1,0 +1,7 @@
+[[configuration-observer-options]]
+== Specify Observer and Geo Options
+
+It is often useful to view and query various attributes of the instance Heartbeat is running on. This data is attached to events via the <<add-observer-metadata,`add_observer_metadata`>> processor. This processor populates the ECS `observer.*` fields. One field of particular utility is the `observer.geo.name` field, which you can configure via this processor. Use this field to create distinctive geographic regions for your uptime checks. You might label your regions by datacenter name or geographic region, e.g. `virginia-dc-1`, or `us-east-1a`, or `virginia-us`.
+
+Note that Heartbeat should not be used with the similarly named <<add-host-metadata,`add_host_metadata`>> processor. In ECS parlance the host is the thing that is monitored, not the thing doing the monitoring, which is the observer.
+

--- a/heartbeat/docs/heartbeat-observer-options.asciidoc
+++ b/heartbeat/docs/heartbeat-observer-options.asciidoc
@@ -3,5 +3,4 @@
 
 It is often useful to view and query various attributes of the instance Heartbeat is running on. This data is attached to events via the <<add-observer-metadata,`add_observer_metadata`>> processor. This processor populates the ECS `observer.*` fields. One field of particular utility is the `observer.geo.name` field, which you can configure via this processor. Use this field to create distinctive geographic regions for your uptime checks. You might label your regions by datacenter name or geographic region, e.g. `virginia-dc-1`, or `us-east-1a`, or `virginia-us`.
 
-Note that Heartbeat should not be used with the similarly named <<add-host-metadata,`add_host_metadata`>> processor. In ECS parlance the host is the thing that is monitored, not the thing doing the monitoring, which is the observer.
-
+Note that Heartbeat should not be used with the similarly named <<add-host-metadata,`add_host_metadata`>> processor. In ECS parlance the host is the thing that is monitored; the thing doing the monitoring is the observer.


### PR DESCRIPTION
This adds a small docs page pointing people to its use in the main heartbeat docs.

It is a subset of what's in 568d2b459c4593c14898337dce45264192394930, only the docs portion, suitable for backporting to 7.2.

Decided to drop the code changes since it's too close to release for that.