### PR TITLE
FIX: Sending duplicate log files from journald sometimes.

### DIFF
--- a/journalbeat/reader/journal.go
+++ b/journalbeat/reader/journal.go
@@ -207,8 +207,9 @@ func (r *Reader) Next() (*beat.Event, error) {
 			}
 			if !hasNewEntry {
 				r.backoff.Wait()
-				continue
 			}
+
+			continue
 		}
 
 		entry, err := r.journal.GetEntry()


### PR DESCRIPTION
When we get a notification from journald about some change, make sure we still
call next(). The return value from next() validates if there is new data.

Previously suprious journald change notifications cause the same log line to
be sent.

This should address this bug:
https://github.com/NicholasPCole/droplet-connectivity-testing/issues/7
https://discuss.elastic.co/t/duplicate-messages-created-by-journalbeat-6-7-1-1/175930