### PR TITLE
[DOCS] Show Npcap in packetbeat installation steps

### DIFF
--- a/packetbeat/docs/faq.asciidoc
+++ b/packetbeat/docs/faq.asciidoc
@@ -27,23 +27,19 @@ For example: `ip link set enp5s0f1 promisc on`
 [[packetbeat-loopback-interface]]
 === Packetbeat can't capture traffic from Windows loopback interface?
 
-Packetbeat is unable to capture traffic from the loopback device (127.0.0.1 traffic)
-because the Windows TCP/IP stack does not implement a network loopback interface,
-making it difficult for Windows packet capture drivers like WinPcap to sniff traffic.
-
-As a workaround, you can try installing
-https://github.com/nmap/npcap/releases[Npcap], an update of WinPcap. Make sure
-you install Npcap in WinPcap API-compatible mode (`/winpcap_mode=yes`), or
-{beatname_uc} will be unable to find the required DLLs. After installing Npcap,
-restart Windows. Npcap creates an Npcap Loopback Adapter that you can select if
-you want to capture loopback traffic.
+The Windows TCP/IP stack does not implement a network loopback interface, making
+it difficult for Windows packet capture drivers to capture traffic from the
+loopback device (127.0.0.1 traffic). To resolve this issue, install
+https://nmap.org/npcap/[Npcap] in WinPcap API-compatible mode and select the
+option to support loopback traffic. When you restart Windows, Npcap creates an
+Npcap Loopback Adapter that you can select to capture loopback traffic.
 
 For the list of devices shown here, you would configure Packetbeat
 to use device `4`:
 
 ["source","sh"]
 ----------------------------------------------------------------------
-PS C:\Users\vagrant\Desktop\packetbeat-1.2.0-windows> .\packetbeat.exe -devices
+PS C:\Program Files\Packetbeat .\packetbeat.exe -devices
 0: \Device\NPF_NdisWanBh (NdisWan Adapter)
 1: \Device\NPF_NdisWanIp (NdisWan Adapter)
 2: \Device\NPF_NdisWanIpv6 (NdisWan Adapter)

--- a/packetbeat/docs/gettingstarted.asciidoc
+++ b/packetbeat/docs/gettingstarted.asciidoc
@@ -113,9 +113,8 @@ endif::[]
 
 ifeval::["{release-state}"!="unreleased"]
 
-. Download and install WinPcap from this
-http://www.winpcap.org/install/default.htm[page]. WinPcap is a library that uses
-a driver to enable packet capturing.
+. Download https://nmap.org/npcap/[Npcap] and install it in WinPcap
+API-compatible mode. Npcap is a packet sniffing library for Windows.
 
 . Download the Packetbeat Windows zip file from the
 https://www.elastic.co/downloads/beats/packetbeat[downloads page].

--- a/packetbeat/docs/gettingstarted.asciidoc
+++ b/packetbeat/docs/gettingstarted.asciidoc
@@ -114,7 +114,9 @@ endif::[]
 ifeval::["{release-state}"!="unreleased"]
 
 . Download https://nmap.org/npcap/[Npcap] and install it in WinPcap
-API-compatible mode. Npcap is a packet sniffing library for Windows.
+API-compatible mode. Npcap is a packet sniffing library for Windows. If you plan
+to capture traffic from the loopback device (127.0.0.1 traffic), also select the
+option to support loopback traffic. 
 
 . Download the Packetbeat Windows zip file from the
 https://www.elastic.co/downloads/beats/packetbeat[downloads page].


### PR DESCRIPTION
Winpcap is no longer maintained and is susceptible to DLL hacking. I've updated the docs to recommend Npcap, but I need dev to confirm that this is now our recommendation.

@adriansr Sounds like you installed this. Can you please confirm that this is the recommendation? 