### PR TITLE
[Metricbeat] migrate the system module to reporterV2 with error return, part three

### DIFF
--- a/metricbeat/module/system/process_summary/process_summary.go
+++ b/metricbeat/module/system/process_summary/process_summary.go
@@ -59,11 +59,10 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // Fetch methods implements the data gathering and data conversion to the right format
 // It returns the event which is then forward to the output. In case of an error, a
 // descriptive error must be returned.
-func (m *MetricSet) Fetch(r mb.ReporterV2) {
+func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 	pids, err := process.Pids()
 	if err != nil {
-		r.Error(errors.Wrap(err, "failed to fetch the list of PIDs"))
-		return
+		return errors.Wrap(err, "failed to fetch the list of PIDs")
 	}
 
 	var summary struct {
@@ -121,4 +120,6 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 		Namespace:       "system.process.summary",
 		MetricSetFields: event,
 	})
+
+	return nil
 }

--- a/metricbeat/module/system/process_summary/process_summary_test.go
+++ b/metricbeat/module/system/process_summary/process_summary_test.go
@@ -30,16 +30,16 @@ import (
 )
 
 func TestData(t *testing.T) {
-	f := mbtest.NewReportingMetricSetV2(t, getConfig())
-	err := mbtest.WriteEventsReporterV2(f, t, ".")
+	f := mbtest.NewReportingMetricSetV2Error(t, getConfig())
+	err := mbtest.WriteEventsReporterV2Error(f, t, ".")
 	if err != nil {
 		t.Fatal("write", err)
 	}
 }
 
 func TestFetch(t *testing.T) {
-	f := mbtest.NewReportingMetricSetV2(t, getConfig())
-	events, errs := mbtest.ReportingFetchV2(f)
+	f := mbtest.NewReportingMetricSetV2Error(t, getConfig())
+	events, errs := mbtest.ReportingFetchV2Error(f)
 
 	require.Empty(t, errs)
 	require.NotEmpty(t, events)

--- a/metricbeat/module/system/raid/raid.go
+++ b/metricbeat/module/system/raid/raid.go
@@ -87,11 +87,10 @@ func blockto1024(b int64) int64 {
 }
 
 // Fetch fetches one event for each device
-func (m *MetricSet) Fetch(r mb.ReporterV2) {
+func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 	devices, err := blockinfo.ListAll(m.sysblock)
 	if err != nil {
-		r.Error(errors.Wrap(err, "failed to parse sysfs"))
-		return
+		return errors.Wrap(err, "failed to parse sysfs")
 	}
 
 	for _, blockDev := range devices {
@@ -125,8 +124,13 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 			event["sync_action"] = blockDev.SyncAction
 		}
 
-		r.Event(mb.Event{
+		isOpen := r.Event(mb.Event{
 			MetricSetFields: event,
 		})
+		if !isOpen {
+			return nil
+		}
 	}
+
+	return nil
 }

--- a/metricbeat/module/system/raid/raid_test.go
+++ b/metricbeat/module/system/raid/raid_test.go
@@ -26,16 +26,16 @@ import (
 )
 
 func TestData(t *testing.T) {
-	f := mbtest.NewReportingMetricSetV2(t, getConfig())
-	err := mbtest.WriteEventsReporterV2(f, t, ".")
+	f := mbtest.NewReportingMetricSetV2Error(t, getConfig())
+	err := mbtest.WriteEventsReporterV2Error(f, t, ".")
 	if err != nil {
 		t.Fatal("write", err)
 	}
 }
 
 func TestFetch(t *testing.T) {
-	f := mbtest.NewReportingMetricSetV2(t, getConfig())
-	events, errs := mbtest.ReportingFetchV2(f)
+	f := mbtest.NewReportingMetricSetV2Error(t, getConfig())
+	events, errs := mbtest.ReportingFetchV2Error(f)
 
 	assert.Empty(t, errs)
 	if !assert.NotEmpty(t, events) {

--- a/metricbeat/module/system/socket/socket.go
+++ b/metricbeat/module/system/socket/socket.go
@@ -110,7 +110,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 }
 
 // Fetch socket metrics from the system
-func (m *MetricSet) Fetch(r mb.ReporterV2) {
+func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 	// Refresh inode to process mapping (must be root).
 	if err := m.ptable.Refresh(); err != nil {
 		debugf("process table refresh had failures: %v", err)
@@ -118,8 +118,7 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 
 	sockets, err := m.netlink.GetSocketList()
 	if err != nil {
-		r.Error(errors.Wrap(err, "failed requesting socket dump"))
-		return
+		return errors.Wrap(err, "failed requesting socket dump")
 	}
 	debugf("netlink returned %d sockets", len(sockets))
 
@@ -133,10 +132,13 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 
 		root, metricSet := c.ToMapStr()
 
-		r.Event(mb.Event{
+		isOpen := r.Event(mb.Event{
 			RootFields:      root,
 			MetricSetFields: metricSet,
 		})
+		if !isOpen {
+			return nil
+		}
 	}
 
 	// Set the "previous" connections set to the "current" connections.
@@ -146,6 +148,8 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 
 	// Reset the listeners for the next iteration.
 	m.listeners.Reset()
+
+	return nil
 }
 
 // filterAndRememberSockets filters sockets to remove sockets that were seen

--- a/metricbeat/module/system/socket/socket_test.go
+++ b/metricbeat/module/system/socket/socket_test.go
@@ -53,7 +53,7 @@ func TestData(t *testing.T) {
 		{sock.OutboundName, "./_meta/data_outbound.json"},
 	}
 
-	f := mbtest.NewReportingMetricSetV2(t, getConfig())
+	f := mbtest.NewReportingMetricSetV2Error(t, getConfig())
 
 	ln, err := net.Listen("tcp", ":0")
 	if err != nil {
@@ -69,7 +69,7 @@ func TestData(t *testing.T) {
 		c.Close()
 
 		t.Run(fmt.Sprintf("direction:%s", df.direction), func(t *testing.T) {
-			err = mbtest.WriteEventsReporterV2Cond(f, t, df.path, directionIs(df.direction))
+			err = mbtest.WriteEventsReporterV2ErrorCond(f, t, df.path, directionIs(df.direction))
 			if err != nil {
 				t.Fatal("write", err)
 			}
@@ -91,8 +91,8 @@ func TestFetch(t *testing.T) {
 		t.Fatal("failed to get port from addr", addr)
 	}
 
-	f := mbtest.NewReportingMetricSetV2(t, getConfig())
-	events, errs := mbtest.ReportingFetchV2(f)
+	f := mbtest.NewReportingMetricSetV2Error(t, getConfig())
+	events, errs := mbtest.ReportingFetchV2Error(f)
 
 	assert.Empty(t, errs)
 	if !assert.NotEmpty(t, events) {

--- a/metricbeat/module/system/uptime/uptime.go
+++ b/metricbeat/module/system/uptime/uptime.go
@@ -46,11 +46,10 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 }
 
 // Fetch fetches the uptime metric from the OS.
-func (m *MetricSet) Fetch(r mb.ReporterV2) {
+func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 	var uptime sigar.Uptime
 	if err := uptime.Get(); err != nil {
-		r.Error(errors.Wrap(err, "failed to get uptime"))
-		return
+		return errors.Wrap(err, "failed to get uptime")
 	}
 
 	r.Event(mb.Event{
@@ -60,4 +59,6 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 			},
 		},
 	})
+
+	return nil
 }

--- a/metricbeat/module/system/uptime/uptime_test.go
+++ b/metricbeat/module/system/uptime/uptime_test.go
@@ -28,16 +28,16 @@ import (
 )
 
 func TestData(t *testing.T) {
-	f := mbtest.NewReportingMetricSetV2(t, getConfig())
-	err := mbtest.WriteEventsReporterV2(f, t, ".")
+	f := mbtest.NewReportingMetricSetV2Error(t, getConfig())
+	err := mbtest.WriteEventsReporterV2Error(f, t, ".")
 	if err != nil {
 		t.Fatal("write", err)
 	}
 }
 
 func TestFetch(t *testing.T) {
-	f := mbtest.NewReportingMetricSetV2(t, getConfig())
-	events, errs := mbtest.ReportingFetchV2(f)
+	f := mbtest.NewReportingMetricSetV2Error(t, getConfig())
+	events, errs := mbtest.ReportingFetchV2Error(f)
 
 	assert.Empty(t, errs)
 	if !assert.NotEmpty(t, events) {


### PR DESCRIPTION
See  elastic/beats#11374

Finally, the last of the system module. So far, not much of note.