### PR TITLE
Make `elasticsearch/index_summary` metricset more defensive

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -148,6 +148,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Ignore prometheus metrics when their values are NaN or Inf. {pull}12084[12084] {issue}10849[10849]
 - In the kibana/stats metricset, only log error (don't also index it) if xpack is enabled. {pull}12265[12265]
 - Require client_auth by default when ssl is enabled for module http metricset server{pull}12333[12333]
+- The `elasticsearch/index_summary` metricset gracefully handles an empty Elasticsearch cluster when `xpack.enabled: true` is set. {pull}12489[12489] {issue}12487[12487]
 
 *Packetbeat*
 

--- a/metricbeat/module/elasticsearch/index_summary/data_xpack.go
+++ b/metricbeat/module/elasticsearch/index_summary/data_xpack.go
@@ -19,6 +19,7 @@ package index_summary
 
 import (
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/pkg/errors"
@@ -65,6 +66,17 @@ func eventMappingXPack(r mb.ReporterV2, m *MetricSet, info elasticsearch.Info, c
 	err := json.Unmarshal(content, &all)
 	if err != nil {
 		return errors.Wrap(err, "failure parsing Elasticsearch Stats API response")
+	}
+
+	p := all.Data["primaries"]
+	primaries, ok := p.(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("primaries is not a map")
+	}
+
+	if len(primaries) == 0 {
+		// There is no data in the cluster, hence no metrics to parse or report
+		return nil
 	}
 
 	fields, err := xpackSchema.Apply(all.Data)

--- a/metricbeat/module/elasticsearch/index_summary/data_xpack.go
+++ b/metricbeat/module/elasticsearch/index_summary/data_xpack.go
@@ -32,42 +32,27 @@ import (
 )
 
 var (
-	schemaXPack = s.Schema{
-		"primaries": c.Dict("primaries", s.Schema{
-			"docs": c.Dict("docs", s.Schema{
-				"count": c.Int("count"),
-			}),
-			"store": c.Dict("store", s.Schema{
-				"size_in_bytes": c.Int("size_in_bytes"),
-			}),
-			"indexing": c.Dict("indexing", s.Schema{
-				"index_total":             c.Int("index_total"),
-				"index_time_in_millis":    c.Int("index_time_in_millis"),
-				"is_throttled":            c.Bool("is_throttled"),
-				"throttle_time_in_millis": c.Int("throttle_time_in_millis"),
-			}),
-			"search": c.Dict("search", s.Schema{
-				"query_total":          c.Int("query_total"),
-				"query_time_in_millis": c.Int("query_time_in_millis"),
-			}),
+	xpackSchema = s.Schema{
+		"primaries": c.Dict("primaries", indexStatsSchema),
+		"total":     c.Dict("total", indexStatsSchema),
+	}
+
+	indexStatsSchema = s.Schema{
+		"docs": c.Dict("docs", s.Schema{
+			"count": c.Int("count"),
 		}),
-		"total": c.Dict("total", s.Schema{
-			"docs": c.Dict("docs", s.Schema{
-				"count": c.Int("count"),
-			}),
-			"store": c.Dict("store", s.Schema{
-				"size_in_bytes": c.Int("size_in_bytes"),
-			}),
-			"indexing": c.Dict("indexing", s.Schema{
-				"index_total":             c.Int("index_total"),
-				"index_time_in_millis":    c.Int("index_time_in_millis"),
-				"is_throttled":            c.Bool("is_throttled"),
-				"throttle_time_in_millis": c.Int("throttle_time_in_millis"),
-			}),
-			"search": c.Dict("search", s.Schema{
-				"query_total":          c.Int("query_total"),
-				"query_time_in_millis": c.Int("query_time_in_millis"),
-			}),
+		"store": c.Dict("store", s.Schema{
+			"size_in_bytes": c.Int("size_in_bytes"),
+		}),
+		"indexing": c.Dict("indexing", s.Schema{
+			"index_total":             c.Int("index_total"),
+			"index_time_in_millis":    c.Int("index_time_in_millis"),
+			"is_throttled":            c.Bool("is_throttled"),
+			"throttle_time_in_millis": c.Int("throttle_time_in_millis"),
+		}),
+		"search": c.Dict("search", s.Schema{
+			"query_total":          c.Int("query_total"),
+			"query_time_in_millis": c.Int("query_time_in_millis"),
 		}),
 	}
 )
@@ -82,7 +67,7 @@ func eventMappingXPack(r mb.ReporterV2, m *MetricSet, info elasticsearch.Info, c
 		return errors.Wrap(err, "failure parsing Elasticsearch Stats API response")
 	}
 
-	fields, err := schemaXPack.Apply(all.Data)
+	fields, err := xpackSchema.Apply(all.Data)
 	if err != nil {
 		return errors.Wrap(err, "failure applying stats schema")
 	}


### PR DESCRIPTION
Resolves #12487.

When there is absolutely no data in an Elasticsearch cluster, the `elasticsearch/index_summary` metricset, with `xpack.enabled: true` set, emits the following error in the Metricbeat log:

```
2019-06-10T03:00:47.439-0700    ERROR   [elasticsearch.index_summary]   index_summary/index_summary.go:92       failure applying stats schema: 8 errors: key `total.docs` not found; key `total.store` not found; key `total.indexing` not found; key `total.search` not found; key `primaries.docs` not found; key `primaries.store` not found; key `primaries.indexing` not found; key `primaries.search` not found
```

Having absolutely no data in the cluster is a "cold start" edge case that must be handled gracefully. This PR makes it so.

Concretely, this PR:
* Adds a guard clause to check if the `GET _stats` API response being used by the `elasticsearch/index_summary` metricset contains any stats for primary shards. If it doesn't, it doesn't try to parse the API response any further.
* Does a minor bit of refactoring, reusing the same schema structure in two places to avoid duplication of code.

### Testing this PR

1. Make sure Elasticsearch API is accessible on `http://localhost:9200`.
2. Enable the `elasticsearch-xpack` Metricbeat module.
   ```
   ./metricbeat modules enable elasticsearch-xpack
   ```

2. Make sure there is no data in Elasticsearch. If there is, make sure nothing is indexing to it, and then run:
   ```
   curl -X DELETE 'http://localhost:9200/*'
   ```

3. Run Metricbeat.
   ```
   ./metricbeat -e
   ```

4. Assert that no errors are thrown in the Metricbeat log.
5. Assert that a `.monitoring-es-*mb*` index gets created in Elasticsearch.
   ```
   curl -s http://localhost:9200/_cat/indices/.monitoring*
   ```