### PR TITLE
Decouple Debug logging from fail_on_error logic

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -166,6 +166,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Affecting all Beats*
 
+- Decouple Debug logging from fail_on_error logic for rename, copy, truncate processors {pull}12451[12451]
 - Add an option to append to existing logs rather than always rotate on start. {pull}11953[11953]
 - Add `network` condition to processors for matching IP addresses against CIDRs. {pull}10743[10743]
 - Add if/then/else support to processors. {pull}10744[10744]

--- a/libbeat/processors/actions/copy_fields.go
+++ b/libbeat/processors/actions/copy_fields.go
@@ -72,12 +72,14 @@ func (f *copyFields) Run(event *beat.Event) (*beat.Event, error) {
 
 	for _, field := range f.config.Fields {
 		err := f.copyField(field.From, field.To, event.Fields)
-		if err != nil && f.config.FailOnError {
+		if err != nil {
 			errMsg := fmt.Errorf("Failed to copy fields in copy_fields processor: %s", err)
 			logp.Debug("copy_fields", errMsg.Error())
-			event.Fields = backup
-			event.PutValue("error.message", errMsg.Error())
-			return event, err
+			if f.config.FailOnError {
+				event.Fields = backup
+				event.PutValue("error.message", errMsg.Error())
+				return event, err
+			}
 		}
 	}
 

--- a/libbeat/processors/actions/rename.go
+++ b/libbeat/processors/actions/rename.go
@@ -76,12 +76,14 @@ func (f *renameFields) Run(event *beat.Event) (*beat.Event, error) {
 
 	for _, field := range f.config.Fields {
 		err := f.renameField(field.From, field.To, event.Fields)
-		if err != nil && f.config.FailOnError {
+		if err != nil {
 			errMsg := fmt.Errorf("Failed to rename fields in processor: %s", err)
 			logp.Debug("rename", errMsg.Error())
-			event.Fields = backup
-			event.PutValue("error.message", errMsg.Error())
-			return event, err
+			if f.config.FailOnError {
+				event.Fields = backup
+				event.PutValue("error.message", errMsg.Error())
+				return event, err
+			}
 		}
 	}
 

--- a/libbeat/processors/actions/truncate_fields.go
+++ b/libbeat/processors/actions/truncate_fields.go
@@ -85,10 +85,12 @@ func (f *truncateFields) Run(event *beat.Event) (*beat.Event, error) {
 
 	for _, field := range f.config.Fields {
 		event, err := f.truncateSingleField(field, event)
-		if err != nil && f.config.FailOnError {
+		if err != nil {
 			logp.Debug("truncate_fields", "Failed to truncate fields: %s", err)
-			event.Fields = backup
-			return event, err
+			if f.config.FailOnError {
+				event.Fields = backup
+				return event, err
+			}
 		}
 	}
 


### PR DESCRIPTION
When using the `rename`, `copy_fields` or `truncate_fields` processors, and specifying multiple fields to be processed

if the processor fails on one of the fields (usually because a field is not present), a Debug log message will only be thrown if `fail_on_error` is `true` .
Logging of the error should be independent of the `fail_on_error` flag.

---------
Ref https://github.com/elastic/beats/pull/12451