### PR TITLE
Cherry-pick #12439 to 7.2: Add required ACLs for Kafka metricbeat module

### DIFF
--- a/metricbeat/docs/modules/kafka.asciidoc
+++ b/metricbeat/docs/modules/kafka.asciidoc
@@ -9,6 +9,21 @@ This is the Kafka module.
 
 The default metricsets are `consumergroup` and `partition`.
 
+If authorization is configured in the Kafka cluster, the following ACLs are
+required for the Metricbeat user:
+
+* READ Topic, for the topics to be monitored
+* DESCRIBE Group, for the groups to be monitored
+
+For example, if the `stats` user is being used for Metricbeat, to monitor all
+topics and all consumer groups, ACLS can be granted with the following commands:
+
+[source,shell]
+-----
+kafka-acls --authorizer-properties zookeeper.connect=localhost:2181 --add --allow-principal User:stats --operation Read --topic '*'
+kafka-acls --authorizer-properties zookeeper.connect=localhost:2181 --add --allow-principal User:stats --operation Describe --group '*'
+-----
+
 [float]
 === Compability
 

--- a/metricbeat/module/kafka/_meta/Dockerfile
+++ b/metricbeat/module/kafka/_meta/Dockerfile
@@ -14,6 +14,7 @@ RUN mkdir -p ${KAFKA_LOGS_DIR} && mkdir -p ${KAFKA_HOME} && curl -s -o $INSTALL_
     "https://archive.apache.org/dist/kafka/${KAFKA_VERSION}/kafka_2.11-${KAFKA_VERSION}.tgz" && \
     tar xzf ${INSTALL_DIR}/kafka.tgz -C ${KAFKA_HOME} --strip-components 1
 
+ADD kafka_server_jaas.conf /etc/kafka/server_jaas.conf
 ADD run.sh /run.sh
 ADD healthcheck.sh /healthcheck.sh
 

--- a/metricbeat/module/kafka/_meta/docs.asciidoc
+++ b/metricbeat/module/kafka/_meta/docs.asciidoc
@@ -2,6 +2,21 @@ This is the Kafka module.
 
 The default metricsets are `consumergroup` and `partition`.
 
+If authorization is configured in the Kafka cluster, the following ACLs are
+required for the Metricbeat user:
+
+* READ Topic, for the topics to be monitored
+* DESCRIBE Group, for the groups to be monitored
+
+For example, if the `stats` user is being used for Metricbeat, to monitor all
+topics and all consumer groups, ACLS can be granted with the following commands:
+
+[source,shell]
+-----
+kafka-acls --authorizer-properties zookeeper.connect=localhost:2181 --add --allow-principal User:stats --operation Read --topic '*'
+kafka-acls --authorizer-properties zookeeper.connect=localhost:2181 --add --allow-principal User:stats --operation Describe --group '*'
+-----
+
 [float]
 === Compability
 

--- a/metricbeat/module/kafka/_meta/healthcheck.sh
+++ b/metricbeat/module/kafka/_meta/healthcheck.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+[ -f /tmp/.acls_loaded ] || exit 1
+
 TOPIC="foo-`date '+%s-%N'`"
 
 ${KAFKA_HOME}/bin/kafka-topics.sh --zookeeper=127.0.0.1:2181 --create --partitions 1 --topic "${TOPIC}" --replication-factor 1

--- a/metricbeat/module/kafka/_meta/kafka_server_jaas.conf
+++ b/metricbeat/module/kafka/_meta/kafka_server_jaas.conf
@@ -1,0 +1,9 @@
+KafkaServer {
+   org.apache.kafka.common.security.plain.PlainLoginModule required
+   username="admin"
+   password="admin-secret"
+   user_admin="admin-secret"
+   user_producer="producer-secret"
+   user_consumer="consumer-secret"
+   user_stats="test-secret";
+};

--- a/metricbeat/module/kafka/_meta/run.sh
+++ b/metricbeat/module/kafka/_meta/run.sh
@@ -20,17 +20,32 @@ wait_for_port 2181
 
 echo "Starting Kafka broker"
 mkdir -p ${KAFKA_LOGS_DIR}
+export KAFKA_OPTS=-Djava.security.auth.login.config=/etc/kafka/server_jaas.conf
 ${KAFKA_HOME}/bin/kafka-server-start.sh ${KAFKA_HOME}/config/server.properties \
+    --override authorizer.class.name=kafka.security.auth.SimpleAclAuthorizer \
+    --override super.users=User:admin \
+    --override sasl.enabled.mechanisms=PLAIN \
+    --override sasl.mechanism.inter.broker.protocol=PLAIN \
     --override delete.topic.enable=true \
     --override listeners=INSIDE://localhost:9091,OUTSIDE://0.0.0.0:9092 \
     --override advertised.listeners=INSIDE://localhost:9091,OUTSIDE://$KAFKA_ADVERTISED_HOST \
-    --override listener.security.protocol.map=INSIDE:PLAINTEXT,OUTSIDE:PLAINTEXT \
+    --override listener.security.protocol.map=INSIDE:SASL_PLAINTEXT,OUTSIDE:SASL_PLAINTEXT \
     --override inter.broker.listener.name=INSIDE \
     --override logs.dir=${KAFKA_LOGS_DIR} &
 
 wait_for_port 9092
 
 echo "Kafka load status code $?"
+
+# ACLS used to prepare tests
+${KAFKA_HOME}/bin/kafka-acls.sh --authorizer-properties zookeeper.connect=localhost:2181 --add --allow-principal User:producer --operation All --cluster --topic '*' --group '*'
+${KAFKA_HOME}/bin/kafka-acls.sh --authorizer-properties zookeeper.connect=localhost:2181 --add --allow-principal User:consumer --operation All --cluster --topic '*' --group '*'
+
+# Minimal ACLs required by metricbeat. If this needs to be changed, please update docs too
+${KAFKA_HOME}/bin/kafka-acls.sh --authorizer-properties zookeeper.connect=localhost:2181 --add --allow-principal User:stats --operation Describe --group '*'
+${KAFKA_HOME}/bin/kafka-acls.sh --authorizer-properties zookeeper.connect=localhost:2181 --add --allow-principal User:stats --operation Read --topic '*'
+
+touch /tmp/.acls_loaded
 
 # Make sure the container keeps running
 tail -f /dev/null

--- a/metricbeat/module/kafka/partition/partition.go
+++ b/metricbeat/module/kafka/partition/partition.go
@@ -86,6 +86,10 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 	if err != nil {
 		return errors.Wrap(err, "error getting topic metadata")
 	}
+	if len(topics) == 0 {
+		debugf("no topic could be read, check ACLs")
+		return nil
+	}
 
 	evtBroker := common.MapStr{
 		"id":      broker.ID(),

--- a/metricbeat/module/kafka/partition/partition_integration_test.go
+++ b/metricbeat/module/kafka/partition/partition_integration_test.go
@@ -39,6 +39,11 @@ import (
 const (
 	kafkaDefaultHost = "localhost"
 	kafkaDefaultPort = "9092"
+
+	kafkaSASLProducerUsername = "producer"
+	kafkaSASLProducerPassword = "producer-secret"
+	kafkaSASLUsername         = "stats"
+	kafkaSASLPassword         = "test-secret"
 )
 
 func TestData(t *testing.T) {
@@ -71,7 +76,7 @@ func TestTopic(t *testing.T) {
 		t.Fatal("write", err)
 	}
 	if len(dataBefore) == 0 {
-		t.Errorf("No offsets fetched from topic (before): %v", testTopic)
+		t.Fatalf("No offsets fetched from topic (before): %v", testTopic)
 	}
 	t.Logf("before: %v", dataBefore)
 
@@ -87,7 +92,7 @@ func TestTopic(t *testing.T) {
 		t.Fatal("write", err)
 	}
 	if len(dataAfter) == 0 {
-		t.Errorf("No offsets fetched from topic (after): %v", testTopic)
+		t.Fatalf("No offsets fetched from topic (after): %v", testTopic)
 	}
 	t.Logf("after: %v", dataAfter)
 
@@ -128,6 +133,9 @@ func generateKafkaData(t *testing.T, topic string) {
 	config.Producer.Retry.Backoff = 500 * time.Millisecond
 	config.Metadata.Retry.Max = 20
 	config.Metadata.Retry.Backoff = 500 * time.Millisecond
+	config.Net.SASL.Enable = true
+	config.Net.SASL.User = kafkaSASLProducerUsername
+	config.Net.SASL.Password = kafkaSASLProducerPassword
 	client, err := sarama.NewClient([]string{getTestKafkaHost()}, config)
 	if err != nil {
 		t.Errorf("%s", err)
@@ -167,6 +175,8 @@ func getConfig(topic string) map[string]interface{} {
 		"metricsets": []string{"partition"},
 		"hosts":      []string{getTestKafkaHost()},
 		"topics":     topics,
+		"username":   kafkaSASLUsername,
+		"password":   kafkaSASLPassword,
 	}
 }
 

--- a/metricbeat/tests/system/test_kafka.py
+++ b/metricbeat/tests/system/test_kafka.py
@@ -9,6 +9,12 @@ class KafkaTest(metricbeat.BaseTest):
     COMPOSE_SERVICES = ['kafka']
     VERSION = "2.0.0"
 
+    PRODUCER_USERNAME = "producer"
+    PRODUCER_PASSWORD = "producer-secret"
+
+    USERNAME = "stats"
+    PASSWORD = "test-secret"
+
     @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
     def test_partition(self):
         """
@@ -23,6 +29,8 @@ class KafkaTest(metricbeat.BaseTest):
             "hosts": self.get_hosts(),
             "period": "1s",
             "version": self.VERSION,
+            "username": self.USERNAME,
+            "password": self.PASSWORD,
         }])
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0, max_timeout=20)
@@ -38,8 +46,13 @@ class KafkaTest(metricbeat.BaseTest):
     def create_topic(self):
         from kafka import KafkaProducer
 
-        producer = KafkaProducer(bootstrap_servers=self.get_hosts()[0],
-                                 retries=20, retry_backoff_ms=500)
+        producer = KafkaProducer(
+            bootstrap_servers=self.get_hosts()[0],
+            security_protocol="SASL_PLAINTEXT",
+            sasl_mechanism="PLAIN",
+            sasl_plain_username=self.PRODUCER_USERNAME,
+            sasl_plain_password=self.PRODUCER_PASSWORD,
+            retries=20, retry_backoff_ms=500)
         producer.send('foobar', b'some_message_bytes')
 
 


### PR DESCRIPTION
Cherry-pick of PR #12439 to 7.2 branch. Original message: 

Add the required ACLs for Kafka metricbeat module to the documentation
and tests to verify that the module works with the documented ACLs.