### PR TITLE
Cherry-pick #12439 to 6.8: Add required ACLs for Kafka metricbeat module

### DIFF
--- a/metricbeat/docs/modules/kafka.asciidoc
+++ b/metricbeat/docs/modules/kafka.asciidoc
@@ -9,6 +9,21 @@ This is the Kafka module.
 
 The default metricsets are `consumergroup` and `partition`.
 
+If authorization is configured in the Kafka cluster, the following ACLs are
+required for the Metricbeat user:
+
+* READ Topic, for the topics to be monitored
+* DESCRIBE Group, for the groups to be monitored
+
+For example, if the `stats` user is being used for Metricbeat, to monitor all
+topics and all consumer groups, ACLS can be granted with the following commands:
+
+[source,shell]
+-----
+kafka-acls --authorizer-properties zookeeper.connect=localhost:2181 --add --allow-principal User:stats --operation Read --topic '*'
+kafka-acls --authorizer-properties zookeeper.connect=localhost:2181 --add --allow-principal User:stats --operation Describe --group '*'
+-----
+
 [float]
 === Compability
 

--- a/metricbeat/module/kafka/_meta/docs.asciidoc
+++ b/metricbeat/module/kafka/_meta/docs.asciidoc
@@ -2,6 +2,21 @@ This is the Kafka module.
 
 The default metricsets are `consumergroup` and `partition`.
 
+If authorization is configured in the Kafka cluster, the following ACLs are
+required for the Metricbeat user:
+
+* READ Topic, for the topics to be monitored
+* DESCRIBE Group, for the groups to be monitored
+
+For example, if the `stats` user is being used for Metricbeat, to monitor all
+topics and all consumer groups, ACLS can be granted with the following commands:
+
+[source,shell]
+-----
+kafka-acls --authorizer-properties zookeeper.connect=localhost:2181 --add --allow-principal User:stats --operation Read --topic '*'
+kafka-acls --authorizer-properties zookeeper.connect=localhost:2181 --add --allow-principal User:stats --operation Describe --group '*'
+-----
+
 [float]
 === Compability
 


### PR DESCRIPTION
Cherry-pick docs of PR #12439 to 6.8 branch.

Add the required ACLs for Kafka metricbeat module to the documentation.