### PR TITLE
[DOCS] Create documentation for fields.yml (#6049)

### DIFF
--- a/docs/devguide/fields-yml.asciidoc
+++ b/docs/devguide/fields-yml.asciidoc
@@ -1,0 +1,116 @@
+[[event-fields-yml]]
+=== Defining field mappings
+
+Fields used by your Beat, along with their mapping details, must be defined in `_meta/fields.yml`. After editing this file, you must re-run `make update`.
+
+The fields are defined in the `fields` array:
+[source,yaml]
+----------------------------------------------------------------------
+- key: mybeat
+  title: mybeat
+  description: These are the fields used by mybeat.
+  fields:
+    - name: surname <1>
+      type: keyword <2>
+      required: true <3>
+      description: > <4>
+        The surname.
+    - name: forenames
+      type: keyword
+      required: true
+      description: >
+        The forenames.
+    - name: full_name
+      type: text
+      required: false
+      description: >
+        The surname and forenames combined into one field for easy searchability.
+----------------------------------------------------------------------
+
+<1> `name`: The field name
+<2> `type`: The field type. The value for the `type` key can be any of the datatypes https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-types.html[available in Elasticsearch]. If no value is specified, the field will default to being a `keyword`.
+<3> `required`: Whether or not a field value is required
+<4> `description`: Some information about the field contents
+
+==== Mapping parameters
+Other mapping parameters can be specified for each field. More detail on each of these parameters can be found in the Elasticsearch documentation for https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-params.html[Mapping Parameters].
+[horizontal]
+`format`:: Specify a custom date format used by the field.
+`multi_fields`:: For `text` or `keyword` fields, `multi_fields` can be used to define multi-field mappings.
+`enabled`:: Whether or not the field is enabled.
+`analyzer`:: Which analyzer to use when indexing.
+`search_analyzer`:: Which analyzer to use when searching.
+`norms`:: Applies to `text` and `keyword` fields. Default is `false`.
+`dynamic`:: Dynamic field control. Can be one of `true` (default), `false` or `strict`.
+`index`:: Whether or not the field should be indexed.
+`doc_values`:: Whether or not the field should have doc values generated. See docs.
+`copy_to`:: Which field to copy the field value into.
+`ignore_above`:: When this property value is missing or is `0`, it receives the `libbeat` default value of `1024`. If the value is `-1`, the Elasticsearch default value will be applied. Any other specified value will be applied as-is.
+
+If we wanted to be able to search over both name fields in one go, we could copy the `surname` and `forenames` fields into the `full_name` field at index time using the `copy_to` mapping parameter:
+[source,yaml]
+----------------------------------------------------------------------
+- key: mybeat
+  title: mybeat
+  description: These are the fields used by mybeat.
+  fields:
+    - name: surname
+      type: keyword
+      required: true
+      copy_to: full_name <1>
+      description: >
+        The surname.
+    - name: forenames
+      type: keyword
+      required: true
+      copy_to: full_name <2>
+      description: >
+        The forenames.
+    - name: full_name
+      type: text
+      required: false
+      description: >
+        The surname and forenames combined into one field for easy searchability.
+----------------------------------------------------------------------
+<1> Copy the value of `forenames` into `full_name`
+<2> Copy the value of `forenames` into `full_name`
+
+There are also some Kibana-specific properties, not detailed here. These are: `analyzed`, `count`, `searchable`, `aggregatable`, `script`. Kibana parameters can also be described using the `pattern`, `input_format`, `output_format`, `output_precision`, `label_template`, `url_template` and `open_link_in_current_tab` parameters.
+
+==== Defining text multi-fields
+There are various options that can be applied when using text fields. A simple text field using the default analyzer can be defined without any other options, as in the example above.
+
+When using `text` mappings, if you need to keep the original keyword value, for instance to use in aggregations or ordering, you can apply a multi-field mapping. We can use this in our mapping for the `surname` and `forenames` fields like this:
+[source,yaml]
+----------------------------------------------------------------------
+- key: mybeat
+  title: mybeat
+  description: These are the fields used by mybeat.
+  fields:
+    - name: surname
+      type: keyword
+      required: true
+      copy_to: full_name
+      description: >
+        The surname.
+      multi_fields: <1>
+        - name: keyword <2>
+          type: keyword <3>
+    - name: forenames
+      type: keyword
+      required: true
+      copy_to: full_name
+      multi_fields:
+        - name: raw
+          type: keyword
+      description: >
+        The forenames.
+    - name: full_name
+      type: text
+      required: false
+      description: >
+        The surname and forenames combined into one field for easy searchability.
+----------------------------------------------------------------------
+<1> `multi_fields`: Define the `multi_fields` mapping parameter
+<2> `name`: This is a conventional name for a multi-field. It can be anything you like (`raw` is another common option) but the convention is to use `keyword`.
+<3> `type`: Specify the `keyword` type so we can use the field in aggregations or to order documents.

--- a/docs/devguide/fields-yml.asciidoc
+++ b/docs/devguide/fields-yml.asciidoc
@@ -72,7 +72,7 @@ If we wanted to be able to search over both name fields in one go, we could copy
       description: >
         The surname and forenames combined into one field for easy searchability.
 ----------------------------------------------------------------------
-<1> Copy the value of `forenames` into `full_name`
+<1> Copy the value of `surname` into `full_name`
 <2> Copy the value of `forenames` into `full_name`
 
 There are also some Kibana-specific properties, not detailed here. These are: `analyzed`, `count`, `searchable`, `aggregatable`, `script`. Kibana parameters can also be described using the `pattern`, `input_format`, `output_format`, `output_precision`, `label_template`, `url_template` and `open_link_in_current_tab` parameters.

--- a/docs/devguide/fields-yml.asciidoc
+++ b/docs/devguide/fields-yml.asciidoc
@@ -3,28 +3,29 @@
 
 Fields used by your Beat, along with their mapping details, must be defined in `_meta/fields.yml`. After editing this file, you must re-run `make update`.
 
-The fields are defined in the `fields` array:
+Define the field mappings in the `fields` array:
+
 [source,yaml]
 ----------------------------------------------------------------------
 - key: mybeat
   title: mybeat
   description: These are the fields used by mybeat.
   fields:
-    - name: surname <1>
+    - name: last_name <1>
       type: keyword <2>
       required: true <3>
       description: > <4>
-        The surname.
-    - name: forenames
+        The last name.
+    - name: first_name
       type: keyword
       required: true
       description: >
-        The forenames.
-    - name: full_name
+        The first name.
+    - name: comment
       type: text
       required: false
       description: >
-        The surname and forenames combined into one field for easy searchability.
+        Comment made by the user.
 ----------------------------------------------------------------------
 
 <1> `name`: The field name
@@ -33,7 +34,8 @@ The fields are defined in the `fields` array:
 <4> `description`: Some information about the field contents
 
 ==== Mapping parameters
-Other mapping parameters can be specified for each field. More detail on each of these parameters can be found in the Elasticsearch documentation for https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-params.html[Mapping Parameters].
+Other mapping parameters can be specified for each field. Consult the https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-params.html[Elasticsearch reference] for more details on each of these parameters.
+
 [horizontal]
 `format`:: Specify a custom date format used by the field.
 `multi_fields`:: For `text` or `keyword` fields, `multi_fields` can be used to define multi-field mappings.
@@ -47,70 +49,56 @@ Other mapping parameters can be specified for each field. More detail on each of
 `copy_to`:: Which field to copy the field value into.
 `ignore_above`:: When this property value is missing or is `0`, it receives the `libbeat` default value of `1024`. If the value is `-1`, the Elasticsearch default value will be applied. Any other specified value will be applied as-is.
 
-If we wanted to be able to search over both name fields in one go, we could copy the `surname` and `forenames` fields into the `full_name` field at index time using the `copy_to` mapping parameter:
+For example, we could use the `copy_to` mapping parameter to copy the `last_name` and `first_name` fields into the `full_name` field at index time:
+
 [source,yaml]
 ----------------------------------------------------------------------
 - key: mybeat
   title: mybeat
   description: These are the fields used by mybeat.
   fields:
-    - name: surname
-      type: keyword
+    - name: last_name
+      type: text
       required: true
       copy_to: full_name <1>
       description: >
-        The surname.
-    - name: forenames
-      type: keyword
+        The last name.
+    - name: first_name
+      type: text
       required: true
       copy_to: full_name <2>
       description: >
-        The forenames.
+        The first name.
     - name: full_name
       type: text
       required: false
       description: >
-        The surname and forenames combined into one field for easy searchability.
+        The last_name and first_name combined into one field for easy searchability.
 ----------------------------------------------------------------------
-<1> Copy the value of `surname` into `full_name`
-<2> Copy the value of `forenames` into `full_name`
+<1> Copy the value of `last_name` into `full_name`
+<2> Copy the value of `first_name` into `full_name`
 
-There are also some Kibana-specific properties, not detailed here. These are: `analyzed`, `count`, `searchable`, `aggregatable`, `script`. Kibana parameters can also be described using the `pattern`, `input_format`, `output_format`, `output_precision`, `label_template`, `url_template` and `open_link_in_current_tab` parameters.
+There are also some Kibana-specific properties, not detailed here. These are: `analyzed`, `count`, `searchable`, `aggregatable`, `script`. Kibana parameters can also be described using the `pattern`, `input_format`, `output_format`, `output_precision`, `label_template`, `url_template` and `open_link_in_current_tab`.
 
 ==== Defining text multi-fields
 There are various options that can be applied when using text fields. A simple text field using the default analyzer can be defined without any other options, as in the example above.
 
-When using `text` mappings, if you need to keep the original keyword value, for instance to use in aggregations or ordering, you can apply a multi-field mapping. We can use this in our mapping for the `surname` and `forenames` fields like this:
+To keep the original keyword value when using `text` mappings, for instance to use in aggregations or ordering, a multi-field mapping can be used:
+
 [source,yaml]
 ----------------------------------------------------------------------
 - key: mybeat
   title: mybeat
   description: These are the fields used by mybeat.
   fields:
-    - name: surname
-      type: keyword
-      required: true
-      copy_to: full_name
-      description: >
-        The surname.
+    - name: city
+      type: text
       multi_fields: <1>
         - name: keyword <2>
           type: keyword <3>
-    - name: forenames
-      type: keyword
-      required: true
-      copy_to: full_name
-      multi_fields:
-        - name: raw
-          type: keyword
-      description: >
-        The forenames.
-    - name: full_name
-      type: text
-      required: false
-      description: >
-        The surname and forenames combined into one field for easy searchability.
 ----------------------------------------------------------------------
 <1> `multi_fields`: Define the `multi_fields` mapping parameter
-<2> `name`: This is a conventional name for a multi-field. It can be anything you like (`raw` is another common option) but the convention is to use `keyword`.
+<2> `name`: This is a conventional name for a multi-field. It can be anything (`raw` is another common option) but the convention is to use `keyword`.
 <3> `type`: Specify the `keyword` type so we can use the field in aggregations or to order documents.
+
+Consult the https://www.elastic.co/guide/en/elasticsearch/reference/current/multi-fields.html[reference] for more information on multi-fields.

--- a/docs/devguide/index.asciidoc
+++ b/docs/devguide/index.asciidoc
@@ -23,6 +23,8 @@ include::{libbeat-dir}/docs/communitybeats.asciidoc[]
 
 include::./newbeat.asciidoc[]
 
+include::./fields-yml.asciidoc[]
+
 include::./event-conventions.asciidoc[]
 
 include::./newdashboards.asciidoc[]

--- a/docs/devguide/newbeat.asciidoc
+++ b/docs/devguide/newbeat.asciidoc
@@ -431,6 +431,8 @@ When you add fields to the event object, you also need to add them to the `_meta
 
 Remember to run `make update` to apply your updates.
 
+For more information on defining field mappings in `_meta/fields.yml`, see <<event-fields-yml>>.
+
 For more detail about naming the fields in an event, see <<event-conventions>>.
 
 [[stop-method]]


### PR DESCRIPTION
Add a new documentation page for `_meta/fields.yml`. This mentions what I'd consider most of the commonly used options, with a few examples.