### PR TITLE
System test for kibana module, xpack code path

### DIFF
--- a/metricbeat/tests/system/test_kibana.py
+++ b/metricbeat/tests/system/test_kibana.py
@@ -47,6 +47,7 @@ class Test(metricbeat.BaseTest):
 
         self.assert_fields_are_documented(evt)
 
+    @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
     def test_xpack(self):
         """
         kibana-xpack module tests

--- a/metricbeat/tests/system/test_kibana.py
+++ b/metricbeat/tests/system/test_kibana.py
@@ -47,6 +47,27 @@ class Test(metricbeat.BaseTest):
 
         self.assert_fields_are_documented(evt)
 
+    def test_xpack(self):
+        """
+        kibana-xpack module tests
+        """
+        self.render_config_template(modules=[{
+            "name": "kibana",
+            "metricsets": [
+                "stats"
+            ],
+            "hosts": self.get_hosts(),
+            "period": "1s",
+            "extras": {
+                "xpack.enabled": "true"
+            }
+        }])
+
+        proc = self.start_beat()
+        self.wait_until(lambda: self.output_lines() > 0)
+        proc.check_kill_and_wait()
+        self.assert_no_logged_warnings()
+
     def get_hosts(self):
         return [self.compose_host("kibana")]
 


### PR DESCRIPTION
Related: #12256.

This PR introduces a system test to exercise the xpack code path (`xpack.enabled: true`) of the Kibana Metricbeat module. 

### Testing this PR

1. Activate the virtual env for system tests.
   ```
   cd metricbeat
   . build/python-env/bin/activate
   ```

1. Build the test binary.
   ```
   make metricbeat.test
   ```

1. Run the integration tests

   ```
   INTEGRATION_TESTS=1  nosetests -v --nocapture tests/system/test_kibana.py
   ```

1. Assert that there are no errors.