### PR TITLE
[7.2] Make `elasticsearch/index_summary` metricset more defensive (#12489)

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -135,6 +135,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix direction of incoming IPv6 sockets. {pull}12248[12248]
 - Ignore prometheus metrics when their values are NaN or Inf. {pull}12084[12084] {issue}10849[10849]
 - Require client_auth by default when ssl is enabled for module http metricset server{pull}12333[12333]
+- The `elasticsearch/index_summary` metricset gracefully handles an empty Elasticsearch cluster when `xpack.enabled: true` is set. {pull}12489[12489] {issue}12487[12487]
 
 *Packetbeat*
 


### PR DESCRIPTION
Backports the following commits to 7.2:
 - Make `elasticsearch/index_summary` metricset more defensive  (#12489)