### PR TITLE
[6.8] Make `elasticsearch/index_summary` metricset more defensive (#12489)

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -66,6 +66,7 @@ https://github.com/elastic/beats/compare/v6.7.2...6.8[Check the HEAD diff]
 - Require client_auth by default when ssl is enabled for module http metricset server{pull}12333[12333]
 - Require certificate authorities, certificate file, and key when SSL is enabled for module http metricset server. {pull}12355[12355]
 - In the kibana/stats metricset, only log error (don't also index it) if xpack is enabled. {pull}12353[12353]
+- The `elasticsearch/index_summary` metricset gracefully handles an empty Elasticsearch cluster when `xpack.enabled: true` is set. {pull}12489[12489] {issue}12487[12487]
 
 *Packetbeat*
 


### PR DESCRIPTION
Backports the following commits to 6.8:
 - Make `elasticsearch/index_summary` metricset more defensive  (#12489)