### PR TITLE
Making field optional as it may not always be present

### DIFF
--- a/metricbeat/module/elasticsearch/index/data_xpack.go
+++ b/metricbeat/module/elasticsearch/index/data_xpack.go
@@ -81,7 +81,7 @@ var (
 			"size_in_bytes": c.Int("size_in_bytes"),
 		}),
 		"refresh": c.Dict("refresh", s.Schema{
-			"external_total_time_in_millis": c.Int("external_total_time_in_millis"),
+			"external_total_time_in_millis": c.Int("external_total_time_in_millis", s.Optional),
 			"total_time_in_millis":          c.Int("total_time_in_millis"),
 		}),
 	}


### PR DESCRIPTION
Resolves #12511.

This field was introduced in Elasticsearch 7.2.0: https://github.com/elastic/elasticsearch/pull/38643. So it won't exist if Metricbeat is monitoring an older version of Elasticsearch. So we mark it as optional in the schema.