### PR TITLE
[docs] Add section to devguide on build targets

### DIFF
--- a/docs/devguide/contributing.asciidoc
+++ b/docs/devguide/contributing.asciidoc
@@ -107,7 +107,26 @@ These commands have the following dependencies:
 
 Virtualenv can be installed with the command `easy_install virtualenv` or `pip
 install virtualenv`. More details can be found
-https://virtualenv.pypa.io/en/latest/installation.html[here]. Both of these commands should be run before submitting a PR.
+https://virtualenv.pypa.io/en/latest/installation.html[here]. Both of these commands should be run before submitting a PR. You can view all the available make targets with `make help`.
+
+
+[float]
+[[build-target-env-vars]]
+=== Selecting Build Targets
+
+Beats is built using the `make release` target. By default, make will select from a limited number of default build targets:
+
+- darwin/amd64
+- linux/386 
+- linux/amd64
+- windows/386 
+- windows/amd64
+
+You can change build targets using the `PLATFORMS` environment variable. Targets set with the `PLATFORMS` variable can either be a GOOS value, or a GOOS/arch pair. For example, `linux` and `linux/amd64` are both valid targets. You can select multiple targets, and the `PLATFORMS` list is space delimited, for example `darwin windows` will build on all supported darwin and windows architectures. In addition, you can add or remove from the list of build targets by prepending `+` or `-` ot a given target, as such: `+bsd` or `-darwin`.
+
+You can find the complete list of supported build targets with `go tool dist list`.
+
+
 
 [float]
 [[running-testsuite]]


### PR DESCRIPTION
I've complained about this at least 4 times, so I figured I should go ahead and fix it. None of the various environment variables that `mage` looks for are really documented anywhere. The most important of these is `PLATFORMS` which can be used to select the build targets, so I decided to add a section explaining how to use it.

I also added a blurb about `make help` since there's a ton of obscure make targets as well.