### PR TITLE
Continuation of: Adriansr fix mb windows procs #12301 (#12475)

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -134,6 +134,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fixed RabbitMQ `queue` metricset gathering when `consumer_utilisation` is set empty at the metrics source {pull}12089[12089]
 - Fix direction of incoming IPv6 sockets. {pull}12248[12248]
 - Ignore prometheus metrics when their values are NaN or Inf. {pull}12084[12084] {issue}10849[10849]
+- In the kibana/stats metricset, only log error (don't also index it) if xpack is enabled. {pull}12265[12265]
+- Fix an issue listing all processes when run under Windows as a non-privileged user. {issue}12301[12301] {pull}12475[12475]
 - Require client_auth by default when ssl is enabled for module http metricset server{pull}12333[12333]
 
 *Packetbeat*

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -765,8 +765,8 @@ Elasticsearch, B.V. (https://www.elastic.co/).
 
 --------------------------------------------------------------------
 Dependency: github.com/elastic/gosigar
-Version: v0.10.2
-Revision: 1227b9d6877d126ad640087e44439d70dba2df4f
+Version: v0.10.3
+Revision: 99ed9cf55303a9d3936cb656b9a86a4a6e67b30a
 License type (autodetected): Apache-2.0
 ./vendor/github.com/elastic/gosigar/LICENSE:
 --------------------------------------------------------------------

--- a/libbeat/metric/system/process/process.go
+++ b/libbeat/metric/system/process/process.go
@@ -483,7 +483,7 @@ func (procStats *Stats) getSingleProcess(pid int, newProcs ProcsMap) *Process {
 
 	err = process.getDetails(procStats.isWhitelistedEnvVar)
 	if err != nil {
-		logp.Err("Error getting process details. pid=%d: %v", process.Pid, err)
+		logp.Debug("processes", "Error getting details for process %s with pid=%d: %v", process.Name, process.Pid, err)
 		return nil
 	}
 

--- a/vendor/github.com/elastic/gosigar/CHANGELOG.md
+++ b/vendor/github.com/elastic/gosigar/CHANGELOG.md
@@ -12,6 +12,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Deprecated
 
+## [0.10.3]
+
+### Fixed
+- ProcState.Get() doesn't fail under Windows when it cannot obtain process ownership information. #121
+
 ## [0.10.2]
 
 ### Fixed

--- a/vendor/github.com/elastic/gosigar/sigar_windows.go
+++ b/vendor/github.com/elastic/gosigar/sigar_windows.go
@@ -194,10 +194,11 @@ func (self *ProcState) Get(pid int) error {
 		errs = append(errs, errors.Wrap(err, "getParentPid failed"))
 	}
 
-	self.Username, err = getProcCredName(pid)
-	if err != nil {
-		errs = append(errs, errors.Wrap(err, "getProcCredName failed"))
-	}
+	// getProcCredName will often fail when run as a non-admin user. This is
+	// caused by strict ACL of the process token belonging to other users.
+	// Instead of failing completely, ignore this error and still return most
+	// data with an empty Username.
+	self.Username, _ = getProcCredName(pid)
 
 	if len(errs) > 0 {
 		errStrs := make([]string, 0, len(errs))
@@ -274,17 +275,13 @@ func getProcCredName(pid int) (string, error) {
 	if err != nil {
 		return "", errors.Wrapf(err, "OpenProcessToken failed for pid=%v", pid)
 	}
+	// Close token to prevent handle leaks.
+	defer token.Close()
 
 	// Find the token user.
 	tokenUser, err := token.GetTokenUser()
 	if err != nil {
 		return "", errors.Wrapf(err, "GetTokenInformation failed for pid=%v", pid)
-	}
-
-	// Close token to prevent handle leaks.
-	err = token.Close()
-	if err != nil {
-		return "", errors.Wrapf(err, "failed while closing process token handle for pid=%v", pid)
 	}
 
 	// Look up domain account by SID.

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1246,44 +1246,44 @@
 			"revisionTime": "2018-08-31T13:10:45Z"
 		},
 		{
-			"checksumSHA1": "c1rU7WNZ+1AwZcRPBWhPBHcbZjg=",
+			"checksumSHA1": "tuhGcluN3UtoiFBovqsep6aPx3s=",
 			"path": "github.com/elastic/gosigar",
-			"revision": "1227b9d6877d126ad640087e44439d70dba2df4f",
-			"revisionTime": "2019-05-08T13:07:01Z",
-			"version": "v0.10.2",
-			"versionExact": "v0.10.2"
+			"revision": "99ed9cf55303a9d3936cb656b9a86a4a6e67b30a",
+			"revisionTime": "2019-05-27T11:32:19Z",
+			"version": "v0.10.3",
+			"versionExact": "v0.10.3"
 		},
 		{
 			"checksumSHA1": "TX9y4oPL5YmT4Gb/OU4GIPTdQB4=",
 			"path": "github.com/elastic/gosigar/cgroup",
-			"revision": "1227b9d6877d126ad640087e44439d70dba2df4f",
-			"revisionTime": "2019-05-08T13:07:01Z",
-			"version": "v0.10.2",
-			"versionExact": "v0.10.2"
+			"revision": "99ed9cf55303a9d3936cb656b9a86a4a6e67b30a",
+			"revisionTime": "2019-05-27T11:32:19Z",
+			"version": "v0.10.3",
+			"versionExact": "v0.10.3"
 		},
 		{
 			"checksumSHA1": "hPqGM3DENaGfipEODoyZ4mKogTQ=",
 			"path": "github.com/elastic/gosigar/sys",
-			"revision": "1227b9d6877d126ad640087e44439d70dba2df4f",
-			"revisionTime": "2019-05-08T13:07:01Z",
-			"version": "v0.10.2",
-			"versionExact": "v0.10.2"
+			"revision": "99ed9cf55303a9d3936cb656b9a86a4a6e67b30a",
+			"revisionTime": "2019-05-27T11:32:19Z",
+			"version": "v0.10.3",
+			"versionExact": "v0.10.3"
 		},
 		{
 			"checksumSHA1": "mLq5lOyD0ZU39ysXuf1ETOLJ+f0=",
 			"path": "github.com/elastic/gosigar/sys/linux",
-			"revision": "1227b9d6877d126ad640087e44439d70dba2df4f",
-			"revisionTime": "2019-05-08T13:07:01Z",
-			"version": "v0.10.2",
-			"versionExact": "v0.10.2"
+			"revision": "99ed9cf55303a9d3936cb656b9a86a4a6e67b30a",
+			"revisionTime": "2019-05-27T11:32:19Z",
+			"version": "v0.10.3",
+			"versionExact": "v0.10.3"
 		},
 		{
 			"checksumSHA1": "R70u1XUHH/t1pquvHEFDeUFtkFk=",
 			"path": "github.com/elastic/gosigar/sys/windows",
-			"revision": "1227b9d6877d126ad640087e44439d70dba2df4f",
-			"revisionTime": "2019-05-08T13:07:01Z",
-			"version": "v0.10.2",
-			"versionExact": "v0.10.2"
+			"revision": "99ed9cf55303a9d3936cb656b9a86a4a6e67b30a",
+			"revisionTime": "2019-05-27T11:32:19Z",
+			"version": "v0.10.3",
+			"versionExact": "v0.10.3"
 		},
 		{
 			"checksumSHA1": "Klc34HULvwvY4cGA/D8HmqtXLqw=",


### PR DESCRIPTION
Backport to 7.2 https://github.com/elastic/beats/pull/12475#issuecomment-501257765

* [Metricbeat] Fix system/process* metricsets under Windows

This updates vendored elastic/gosigar to v0.10.3, which addresses an
issue when listing processes under a non-privileged Windows user.

For the system/process metricset, only processes belonging to the user
under which Metricbeat is running were reported.

For the system/process_summary metricset, process belonging to other
users were reported as unknown state.

This fix will make Metricbeat able to report all processes, but
information about which users owns those processes will be missing.

Fixes elastic/beats#12301

* Added test func in order to provide more information on the failing match

* Fix build error

* Removed test func, correcting access rights in sigar_windows file (gosigar pr will follow), test only

* Revert test changes, return debug message for process.getDetails

* Replaced the PR number in the changelog

* Adding selector to log debug message

* Wrong type for pid in debug message

(cherry picked from commit 08b5c387ad6ed1020e01aea4c9ef3687b2b5f3fe)