### PR TITLE
Read cluster UUID from vertex instead of pipeline

### DIFF
--- a/metricbeat/module/logstash/logstash.go
+++ b/metricbeat/module/logstash/logstash.go
@@ -85,15 +85,19 @@ type graph struct {
 	Edges    []map[string]interface{} `json:"edges"`
 }
 
+type graphContainer struct {
+	Graph *graph `json:"graph,omitempty"`
+}
+
 // PipelineState represents the state (shape) of a Logstash pipeline
 type PipelineState struct {
-	ID             string `json:"id"`
-	Hash           string `json:"hash"`
-	EphemeralID    string `json:"ephemeral_id"`
-	Graph          *graph `json:"graph,omitempty"`
-	Representation *graph `json:"representation"`
-	BatchSize      int    `json:"batch_size"`
-	Workers        int    `json:"workers"`
+	ID             string          `json:"id"`
+	Hash           string          `json:"hash"`
+	EphemeralID    string          `json:"ephemeral_id"`
+	Graph          *graphContainer `json:"graph,omitempty"`
+	Representation *graphContainer `json:"representation"`
+	BatchSize      int             `json:"batch_size"`
+	Workers        int             `json:"workers"`
 }
 
 // NewMetricSet creates a metricset that can be used to build other metricsets

--- a/metricbeat/module/logstash/logstash.go
+++ b/metricbeat/module/logstash/logstash.go
@@ -80,16 +80,21 @@ type MetricSet struct {
 	XPack bool
 }
 
+type graph struct {
+	Vertices []map[string]interface{} `json:"vertices"`
+	Edges    []map[string]interface{} `json:"edges"`
+}
+
 // PipelineState represents the state (shape) of a Logstash pipeline
 type PipelineState struct {
-	ID             string                 `json:"id"`
-	Hash           string                 `json:"hash"`
-	EphemeralID    string                 `json:"ephemeral_id"`
-	Graph          map[string]interface{} `json:"graph,omitempty"`
-	Representation map[string]interface{} `json:"representation"`
-	BatchSize      int                    `json:"batch_size"`
-	Workers        int                    `json:"workers"`
-	ClusterIDs     []string               `json:"cluster_uuids,omitempty"`
+	ID             string   `json:"id"`
+	Hash           string   `json:"hash"`
+	EphemeralID    string   `json:"ephemeral_id"`
+	Graph          *graph   `json:"graph,omitempty"`
+	Representation *graph   `json:"representation"`
+	BatchSize      int      `json:"batch_size"`
+	Workers        int      `json:"workers"`
+	ClusterIDs     []string `json:"cluster_uuids,omitempty"`
 }
 
 // NewMetricSet creates a metricset that can be used to build other metricsets

--- a/metricbeat/module/logstash/logstash.go
+++ b/metricbeat/module/logstash/logstash.go
@@ -87,14 +87,13 @@ type graph struct {
 
 // PipelineState represents the state (shape) of a Logstash pipeline
 type PipelineState struct {
-	ID             string   `json:"id"`
-	Hash           string   `json:"hash"`
-	EphemeralID    string   `json:"ephemeral_id"`
-	Graph          *graph   `json:"graph,omitempty"`
-	Representation *graph   `json:"representation"`
-	BatchSize      int      `json:"batch_size"`
-	Workers        int      `json:"workers"`
-	ClusterIDs     []string `json:"cluster_uuids,omitempty"`
+	ID             string `json:"id"`
+	Hash           string `json:"hash"`
+	EphemeralID    string `json:"ephemeral_id"`
+	Graph          *graph `json:"graph,omitempty"`
+	Representation *graph `json:"representation"`
+	BatchSize      int    `json:"batch_size"`
+	Workers        int    `json:"workers"`
 }
 
 // NewMetricSet creates a metricset that can be used to build other metricsets

--- a/metricbeat/module/logstash/node/data_xpack.go
+++ b/metricbeat/module/logstash/node/data_xpack.go
@@ -66,7 +66,7 @@ func makeClusterToPipelinesMap(pipelines []logstash.PipelineState) map[string][]
 
 	for _, pipeline := range pipelines {
 		var clusterUUIDs []string
-		for _, vertex := range pipeline.Graph.Vertices {
+		for _, vertex := range pipeline.Graph.Graph.Vertices {
 			c, ok := vertex["cluster_uuid"]
 			if !ok {
 				continue


### PR DESCRIPTION
The `GET /_node/pipelines?graph=true` Logstash API used to return a `cluster_uuids` field under the `pipelines.{id}` field.

In https://github.com/elastic/logstash/pull/10884, this field was replaced instead by a `cluster_uuid` field under the `pipelines.{id}.graph.graph.vertices[n].cluster_uuid` field, for vertices that represent an Elasticsearch output plugin.

This PR makes the corresponding adjustments in the Metricbeat `logstash/node` metricset, xpack code path.

### Testing this PR
1. Start up a Logstash node (built from `master`) running one or more pipelines.
2. Build Metricbeat with this PR:
   ```
   cd metricbeat
   mage build
   ```

3. Enable the `logstash` Metricbeat module for Stack Monitoring:
   ```
   metricbeat modules enable logstash-xpack
   ```
5. Start Metricbeat:
   ```
   metricbeat -e
   ```
6. Query the `.monitoring-logstash-7-mb-*` indices to make sure there are as many documents with `type: logstash_state` as there are running Logstash pipelines.
   ```
   GET .monitoring-logstash-7-mb-*/_search?q=type:logstash_state
   ```
7. Repeat the query in 6. above multiple times over the course of a minute or so. Make sure the number of documents stays constant over time. New documents of `type:logstash_state` should only be created if either the shape of one of the Logstash pipelines changes or the pipeline is restarted.
