### PR TITLE
[7.2] Making field optional as it may not always be present (#12512)

### DIFF
--- a/metricbeat/module/elasticsearch/index/data_xpack.go
+++ b/metricbeat/module/elasticsearch/index/data_xpack.go
@@ -81,7 +81,7 @@ var (
 			"size_in_bytes": c.Int("size_in_bytes"),
 		}),
 		"refresh": c.Dict("refresh", s.Schema{
-			"external_total_time_in_millis": c.Int("external_total_time_in_millis"),
+			"external_total_time_in_millis": c.Int("external_total_time_in_millis", s.Optional),
 			"total_time_in_millis":          c.Int("total_time_in_millis"),
 		}),
 	}


### PR DESCRIPTION
Backports the following commits to 7.2:
 - Making field optional as it may not always be present  (#12512)