### PR TITLE
Cherry-pick #12529 to 7.2: [Filebeat] Fix RFC5424 date format in system/syslog in pipeline

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -107,6 +107,9 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix goroutine leak caused on initialization failures of log input. {pull}12125[12125]
 - Fix goroutine leak on non-explicit finalization of log input. {pull}12164[12164]
 - Require client_auth by default when ssl is enabled for tcp input {pull}12333[12333]
+- Require certificate authorities, certificate file, and key when SSL is enabled for the TCP input. {pull}12355[12355]
+- Load correct pipelines when system module is configured in modules.d. {pull}12340[12340]
+- Fix timezone offset parsing in system/syslog. {pull}12529[12529]
 
 *Heartbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -107,8 +107,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix goroutine leak caused on initialization failures of log input. {pull}12125[12125]
 - Fix goroutine leak on non-explicit finalization of log input. {pull}12164[12164]
 - Require client_auth by default when ssl is enabled for tcp input {pull}12333[12333]
-- Require certificate authorities, certificate file, and key when SSL is enabled for the TCP input. {pull}12355[12355]
-- Load correct pipelines when system module is configured in modules.d. {pull}12340[12340]
 - Fix timezone offset parsing in system/syslog. {pull}12529[12529]
 
 *Heartbeat*

--- a/filebeat/module/system/syslog/ingest/pipeline.json
+++ b/filebeat/module/system/syslog/ingest/pipeline.json
@@ -34,7 +34,10 @@
                 "formats": [
                     "MMM  d HH:mm:ss",
                     "MMM dd HH:mm:ss",
-                    "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZZ"
+                    "yyyy-MM-dd'T'HH:mm:ss.SSSZZ",
+                    "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZZ",
+                    "yyyy-MM-dd'T'HH:mm:ss.SSSXXX",
+                    "yyyy-MM-dd'T'HH:mm:ss.SSSSSSXXX"
                 ],
                 {< if .convert_timezone >}"timezone": "{{ event.timezone }}",{< end >}
                 "ignore_failure": true

--- a/filebeat/module/system/syslog/test/tz-offset.log
+++ b/filebeat/module/system/syslog/test/tz-offset.log
@@ -1,0 +1,2 @@
+1986-04-26T01:23:45.101+0400 rmbkmonitor04 shutdown[2649]: shutting down for system halt
+1986-04-26T01:23:45.388424+04:00 rmbkmonitor04 thermald: constraint_0_power_limit_uw exceeded.

--- a/filebeat/module/system/syslog/test/tz-offset.log-expected.json
+++ b/filebeat/module/system/syslog/test/tz-offset.log-expected.json
@@ -1,9 +1,9 @@
 [
     {
         "@timestamp": "1986-04-25T21:23:45.101Z",
+        "ecs.version": "1.0.0",
         "event.dataset": "system.syslog",
         "event.module": "system",
-        "event.timezone": "+00:00",
         "fileset.name": "syslog",
         "host.hostname": "rmbkmonitor04",
         "input.type": "log",
@@ -16,9 +16,9 @@
     },
     {
         "@timestamp": "1986-04-25T21:23:45.388Z",
+        "ecs.version": "1.0.0",
         "event.dataset": "system.syslog",
         "event.module": "system",
-        "event.timezone": "+00:00",
         "fileset.name": "syslog",
         "host.hostname": "rmbkmonitor04",
         "input.type": "log",

--- a/filebeat/module/system/syslog/test/tz-offset.log-expected.json
+++ b/filebeat/module/system/syslog/test/tz-offset.log-expected.json
@@ -1,0 +1,31 @@
+[
+    {
+        "@timestamp": "1986-04-25T21:23:45.101Z",
+        "event.dataset": "system.syslog",
+        "event.module": "system",
+        "event.timezone": "+00:00",
+        "fileset.name": "syslog",
+        "host.hostname": "rmbkmonitor04",
+        "input.type": "log",
+        "log.file.path": "tz-offset.log",
+        "log.offset": 0,
+        "message": "shutting down for system halt",
+        "process.name": "shutdown",
+        "process.pid": 2649,
+        "service.type": "system"
+    },
+    {
+        "@timestamp": "1986-04-25T21:23:45.388Z",
+        "event.dataset": "system.syslog",
+        "event.module": "system",
+        "event.timezone": "+00:00",
+        "fileset.name": "syslog",
+        "host.hostname": "rmbkmonitor04",
+        "input.type": "log",
+        "log.file.path": "tz-offset.log",
+        "log.offset": 89,
+        "message": "constraint_0_power_limit_uw exceeded.",
+        "process.name": "thermald",
+        "service.type": "system"
+    }
+]


### PR DESCRIPTION
Cherry-pick of PR #12529 to 7.2 branch. Original message: 

The date format used by the system/syslog pipeline has a couple of issues with RFC5424 messages:

- Since Elasticsearch switched from Joda time to Java time, it won't correctly parse timezone offsets that use a colon to separate hours and minutes.

- RFC5424 allows for 1 to 6 digits for the fractional second. This updates the pipeline to also accept 3 decimals (milliseconds).