### PR TITLE
Improve package tests for docker

### DIFF
--- a/auditbeat/magefile.go
+++ b/auditbeat/magefile.go
@@ -90,7 +90,7 @@ func Package() {
 
 // TestPackages tests the generated packages (i.e. file modes, owners, groups).
 func TestPackages() error {
-	return devtools.TestPackages()
+	return devtools.TestPackages(devtools.WithRootUserContainer())
 }
 
 // Update is an alias for running fields, dashboards, config, includes.

--- a/dev-tools/mage/pkg.go
+++ b/dev-tools/mage/pkg.go
@@ -97,9 +97,10 @@ func (b packageBuilder) Build() error {
 }
 
 type testPackagesParams struct {
-	HasModules   bool
-	HasMonitorsD bool
-	HasModulesD  bool
+	HasModules           bool
+	HasMonitorsD         bool
+	HasModulesD          bool
+	HasRootUserContainer bool
 }
 
 // TestPackagesOption defines a option to the TestPackages target.
@@ -123,6 +124,13 @@ func WithMonitorsD() func(params *testPackagesParams) {
 func WithModulesD() func(params *testPackagesParams) {
 	return func(params *testPackagesParams) {
 		params.HasModulesD = true
+	}
+}
+
+// WithRootUserContainer allows root when checking user in container
+func WithRootUserContainer() func(params *testPackagesParams) {
+	return func(params *testPackagesParams) {
+		params.HasRootUserContainer = true
 	}
 }
 
@@ -156,9 +164,14 @@ func TestPackages(options ...TestPackagesOption) error {
 		args = append(args, "--modules.d")
 	}
 
+	if params.HasRootUserContainer {
+		args = append(args, "--root-user-container")
+	}
+
 	if BeatUser == "root" {
 		args = append(args, "-root-owner")
 	}
+
 	args = append(args, "-files", MustExpand("{{.PWD}}/build/distributions/*"))
 
 	if out, err := goTest(args...); err != nil {

--- a/packetbeat/magefile.go
+++ b/packetbeat/magefile.go
@@ -136,7 +136,7 @@ func Package() {
 
 // TestPackages tests the generated packages (i.e. file modes, owners, groups).
 func TestPackages() error {
-	return devtools.TestPackages()
+	return devtools.TestPackages(devtools.WithRootUserContainer())
 }
 
 // Update updates the generated files.

--- a/x-pack/auditbeat/magefile.go
+++ b/x-pack/auditbeat/magefile.go
@@ -84,7 +84,7 @@ func Package() {
 
 // TestPackages tests the generated packages (i.e. file modes, owners, groups).
 func TestPackages() error {
-	return devtools.TestPackages()
+	return devtools.TestPackages(devtools.WithRootUserContainer())
 }
 
 // Update is an alias for running fields, dashboards, config.


### PR DESCRIPTION
Docker user was being check with the owner of the files, that is not
always the same, what is making build fail for some beats.
Add an explicit flag to check that root is expected when checking for
the docker user.

Add checks for files permissions too.

Continues with #10998