### PR TITLE
[libbeat] Remove an unused internal field from cfgfile.Reloader

### DIFF
--- a/libbeat/cfgfile/reload.go
+++ b/libbeat/cfgfile/reload.go
@@ -98,12 +98,11 @@ type Runner interface {
 
 // Reloader is used to register and reload modules
 type Reloader struct {
-	pipeline      beat.Pipeline
-	runnerFactory RunnerFactory
-	config        DynamicConfig
-	path          string
-	done          chan struct{}
-	wg            sync.WaitGroup
+	pipeline beat.Pipeline
+	config   DynamicConfig
+	path     string
+	done     chan struct{}
+	wg       sync.WaitGroup
 }
 
 // NewReloader creates new Reloader instance for the given config


### PR DESCRIPTION
A minor cleanup, removing the unused `runnerFactory` field from `cfgfile.Reloader`. It looks like this field was introduced in a [fairly large commit](https://sourcegraph.com/github.com/elastic/beats/-/commit/aed5529a5936b4ab0c87bc4c1bd31c4e38b893fb), probably as refactoring leftovers, so the fact that it was never used was overlooked.