### PR TITLE
Fix flakiness in goroutines checker tests

### DIFF
--- a/libbeat/tests/resources/goroutines_test.go
+++ b/libbeat/tests/resources/goroutines_test.go
@@ -40,14 +40,23 @@ func TestGoroutinesChecker(t *testing.T) {
 		},
 		{
 			title: "fast goroutine",
-			test:  func() { go func() {}() },
+			test: func() {
+				started := make(chan struct{})
+				go func() {
+					started <- struct{}{}
+				}()
+				<-started
+			},
 		},
 		{
 			title: "blocked goroutine",
 			test: func() {
+				started := make(chan struct{})
 				go func() {
+					started <- struct{}{}
 					<-block
 				}()
+				<-started
 			},
 			timeout: 500 * time.Millisecond,
 			fail:    true,


### PR DESCRIPTION
In goroutines checker tests, ensure that goroutines of testing scenarios
have been started before checking for the result of the test. In some
cases it could happen that the checker is run before the goroutines are
started, failing with false negatives.