### PR TITLE
Add units section to metrics convention

### DIFF
--- a/docs/devguide/event-conventions.asciidoc
+++ b/docs/devguide/event-conventions.asciidoc
@@ -13,6 +13,7 @@ Use the following naming conventions for field names:
 - Group related fields into subdocuments by using dot (.) notation. Groups typically have common prefixes. For example, if you have fields called `CPULoad` and `CPUSystem` in a service, you would convert
 them into `cpu.load` and `cpu.system` in the event. 
 - Avoid repeating the namespace in field names. If a word or abbreviation appears in the namespace, it's not needed in the field name. For example, instead of `cpu.cpu_load`, use `cpu.load`.
+- Use <<units,units suffix>> when the metric matches one of the known units.
 - Use <<abbreviations,standardised names>> and avoid using abbreviations that aren't commonly known.
 - Organise the documents from general to specific to allow for namespacing. The type, such as `.pct`, should always be last. For example, `system.core.user.pct`.
 - If two fields are the same, but with different units, remove the less granular one. For example, include `timeout.sec`, but don't include `timeout.min`. If a less granular value is required, you can calculate it later.
@@ -36,6 +37,25 @@ workers.idle
 - Do not use dots (.) in individual field names. Dots are reserved for grouping related fields into subdocuments. 
 - Use singular and plural names properly to reflect the field content. For example, use `requests_per_sec` rather than `request_per_sec`. 
 
+[[units]]
+==== Units
+
+These are well-known suffixes to represent units of stored values:
+
+[options="header"]
+|=======================
+|Suffix     |Units
+|count      |number of items
+|pct        |percentage
+|day        |days
+|sec        |seconds
+|ms         |millisecond
+|us         |microseconds
+|ns         |nanoseconds
+|bytes      |bytes
+|mb         |megabytes
+|=======================
+
 
 [[abbreviations]]
 ==== Standardised Names
@@ -46,18 +66,9 @@ Here is a list of standardised names and units that are used across all Beats:
 |=======================
 |Use...     |Instead of... 
 |avg        |average
-|connection |conn 
-|count      | 
-|day        |days, d
+|connection |conn
 |max        |maximum
 |min        |minimum
-|pct        |percentage
 |request    |req
-|sec        |seconds, second, s
-|ms         |millisecond, millis
-|mb         |megabytes
 |msg        |message
-|ns         |nanoseconds
-|norm       |normalized
-|us         |microseconds
 |=======================

--- a/docs/devguide/event-conventions.asciidoc
+++ b/docs/devguide/event-conventions.asciidoc
@@ -46,7 +46,7 @@ possible. For example `system.memory.total.bytes` or `system.diskio.read.count`:
 [options="header"]
 |=======================
 |Suffix     |Units
-|count      |number of items
+|count      |item count
 |pct        |percentage
 |day        |days
 |sec        |seconds

--- a/docs/devguide/event-conventions.asciidoc
+++ b/docs/devguide/event-conventions.asciidoc
@@ -41,7 +41,7 @@ workers.idle
 ==== Units
 
 These are well-known suffixes to represent units of stored values, use them as a dotted suffix when
-possible. For example `system.memory.total.bytes` or `system.diskio.read.count`:
+possible. For example `system.memory.used.bytes` or `system.diskio.read.count`:
 
 [options="header"]
 |=======================

--- a/docs/devguide/event-conventions.asciidoc
+++ b/docs/devguide/event-conventions.asciidoc
@@ -40,7 +40,8 @@ workers.idle
 [[units]]
 ==== Units
 
-These are well-known suffixes to represent units of stored values:
+These are well-known suffixes to represent units of stored values, use them as a dotted suffix when
+possible. For example `system.memory.total.bytes` or `system.diskio.read.count`:
 
 [options="header"]
 |=======================


### PR DESCRIPTION
This change comes to standarize something we have been doing already.
Most units are explicitly added to the metric name, so users know them
when consuming.

I've moved some units from the abbrevations section to avoid duplicating
them, but can copy them back if someone finds this missleading.