### PR TITLE
Cherry-pick #12584 to 7.2: When `certificate_authorities` is configured for ServerConfig, we now set client auth to `required`

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -34,11 +34,46 @@ https://github.com/elastic/beats/compare/v7.2.0...7.2[Check the HEAD diff]
 
 *Filebeat*
 
+- Add support for Cisco syslog format used by their switch. {pull}10760[10760]
+- Cover empty request data, url and version in Apache2 module{pull}10730[10730]
+- Fix registry entries not being cleaned due to race conditions. {pull}10747[10747]
+- Improve detection of file deletion on Windows. {pull}10747[10747]
+- Add missing Kubernetes metadata fields to Filebeat CoreDNS module, and fix a documentation error. {pull}11591[11591]
+- Reduce memory usage if long lines are truncated to fit `max_bytes` limit. The line buffer is copied into a smaller buffer now. This allows the runtime to release unused memory earlier. {pull}11524[11524]
+- Fix memory leak in Filebeat pipeline acker. {pull}12063[12063]
+- Fix goroutine leak caused on initialization failures of log input. {pull}12125[12125]
+- Fix goroutine leak on non-explicit finalization of log input. {pull}12164[12164]
+- Skipping unparsable log entries from docker json reader {pull}12268[12268]
+- Parse timezone in PostgreSQL logs as part of the timestamp {pull}12338[12338]
+- Require client_auth by default when ssl is enabled for tcp input {pull}12333[12333]
+- Load correct pipelines when system module is configured in modules.d. {pull}12340[12340]
+- Fix timezone offset parsing in system/syslog. {pull}12529[12529]
+- When TLS is configured for the TCP input and a `certificate_authorities` is configured we now default to `required` for the `client_authentication`. {pull}12584[12584]
+
 *Heartbeat*
 
 *Journalbeat*
 
 *Metricbeat*
+
+- Change diskio metrics retrieval method (only for Windows) from wmi query to DeviceIOControl function using the IOCTL_DISK_PERFORMANCE control code {pull}11635[11635]
+- Call GetMetricData api per region instead of per instance. {issue}11820[11820] {pull}11882[11882]
+- Update documentation with cloudwatch:ListMetrics permission. {pull}11987[11987]
+- Check permissions in system socket metricset based on capabilities. {pull}12039[12039]
+- Get process information from sockets owned by current user when system socket metricset is run without privileges. {pull}12039[12039]
+- Avoid generating hints-based configuration with empty hosts when no exposed port is suitable for the hosts hint. {issue}8264[8264] {pull}12086[12086]
+- Fixed a socket leak in the postgresql module under Windows when SSL is disabled on the server. {pull}11393[11393]
+- Change some field type from scaled_float to long in aws module. {pull}11982[11982]
+- Fixed RabbitMQ `queue` metricset gathering when `consumer_utilisation` is set empty at the metrics source {pull}12089[12089]
+- Fix direction of incoming IPv6 sockets. {pull}12248[12248]
+- Refactored Windows perfmon metricset: replaced method to retrieve counter paths with PdhExpandWildCardPathW, separated code by responsibility, removed unused functions {pull}12212[12212]
+- Validate that kibana/status metricset cannot be used when xpack is enabled. {pull}12264[12264]
+- Ignore prometheus metrics when their values are NaN or Inf. {pull}12084[12084] {issue}10849[10849]
+- In the kibana/stats metricset, only log error (don't also index it) if xpack is enabled. {pull}12265[12265]
+- Fix an issue listing all processes when run under Windows as a non-privileged user. {issue}12301[12301] {pull}12475[12475]
+- Require client_auth by default when ssl is enabled for module http metricset server{pull}12333[12333]
+- The `elasticsearch/index_summary` metricset gracefully handles an empty Elasticsearch cluster when `xpack.enabled: true` is set. {pull}12489[12489] {issue}12487[12487]
+- When TLS is configured for the http metricset and a `certificate_authorities` is configured we now default to `required` for the `client_authentication`. {pull}12584[12584]
 
 *Packetbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -34,20 +34,6 @@ https://github.com/elastic/beats/compare/v7.2.0...7.2[Check the HEAD diff]
 
 *Filebeat*
 
-- Add support for Cisco syslog format used by their switch. {pull}10760[10760]
-- Cover empty request data, url and version in Apache2 module{pull}10730[10730]
-- Fix registry entries not being cleaned due to race conditions. {pull}10747[10747]
-- Improve detection of file deletion on Windows. {pull}10747[10747]
-- Add missing Kubernetes metadata fields to Filebeat CoreDNS module, and fix a documentation error. {pull}11591[11591]
-- Reduce memory usage if long lines are truncated to fit `max_bytes` limit. The line buffer is copied into a smaller buffer now. This allows the runtime to release unused memory earlier. {pull}11524[11524]
-- Fix memory leak in Filebeat pipeline acker. {pull}12063[12063]
-- Fix goroutine leak caused on initialization failures of log input. {pull}12125[12125]
-- Fix goroutine leak on non-explicit finalization of log input. {pull}12164[12164]
-- Skipping unparsable log entries from docker json reader {pull}12268[12268]
-- Parse timezone in PostgreSQL logs as part of the timestamp {pull}12338[12338]
-- Require client_auth by default when ssl is enabled for tcp input {pull}12333[12333]
-- Load correct pipelines when system module is configured in modules.d. {pull}12340[12340]
-- Fix timezone offset parsing in system/syslog. {pull}12529[12529]
 - When TLS is configured for the TCP input and a `certificate_authorities` is configured we now default to `required` for the `client_authentication`. {pull}12584[12584]
 
 *Heartbeat*
@@ -56,23 +42,6 @@ https://github.com/elastic/beats/compare/v7.2.0...7.2[Check the HEAD diff]
 
 *Metricbeat*
 
-- Change diskio metrics retrieval method (only for Windows) from wmi query to DeviceIOControl function using the IOCTL_DISK_PERFORMANCE control code {pull}11635[11635]
-- Call GetMetricData api per region instead of per instance. {issue}11820[11820] {pull}11882[11882]
-- Update documentation with cloudwatch:ListMetrics permission. {pull}11987[11987]
-- Check permissions in system socket metricset based on capabilities. {pull}12039[12039]
-- Get process information from sockets owned by current user when system socket metricset is run without privileges. {pull}12039[12039]
-- Avoid generating hints-based configuration with empty hosts when no exposed port is suitable for the hosts hint. {issue}8264[8264] {pull}12086[12086]
-- Fixed a socket leak in the postgresql module under Windows when SSL is disabled on the server. {pull}11393[11393]
-- Change some field type from scaled_float to long in aws module. {pull}11982[11982]
-- Fixed RabbitMQ `queue` metricset gathering when `consumer_utilisation` is set empty at the metrics source {pull}12089[12089]
-- Fix direction of incoming IPv6 sockets. {pull}12248[12248]
-- Refactored Windows perfmon metricset: replaced method to retrieve counter paths with PdhExpandWildCardPathW, separated code by responsibility, removed unused functions {pull}12212[12212]
-- Validate that kibana/status metricset cannot be used when xpack is enabled. {pull}12264[12264]
-- Ignore prometheus metrics when their values are NaN or Inf. {pull}12084[12084] {issue}10849[10849]
-- In the kibana/stats metricset, only log error (don't also index it) if xpack is enabled. {pull}12265[12265]
-- Fix an issue listing all processes when run under Windows as a non-privileged user. {issue}12301[12301] {pull}12475[12475]
-- Require client_auth by default when ssl is enabled for module http metricset server{pull}12333[12333]
-- The `elasticsearch/index_summary` metricset gracefully handles an empty Elasticsearch cluster when `xpack.enabled: true` is set. {pull}12489[12489] {issue}12487[12487]
 - When TLS is configured for the http metricset and a `certificate_authorities` is configured we now default to `required` for the `client_authentication`. {pull}12584[12584]
 
 *Packetbeat*

--- a/filebeat/_meta/common.reference.inputs.yml
+++ b/filebeat/_meta/common.reference.inputs.yml
@@ -293,7 +293,8 @@ filebeat.inputs:
   #ssl.curve_types: []
 
   # Configure what types of client authentication are supported. Valid options
-  # are `none`, `optional`, and `required`. Default is required.
+  # are `none`, `optional`, and `required`. When `certificate_authorities` is set it will
+  # default to `required` otherwise it will be set to `none`.
   #ssl.client_authentication: "required"
 
 #------------------------------ Syslog input --------------------------------
@@ -352,7 +353,8 @@ filebeat.inputs:
     #ssl.curve_types: []
 
     # Configure what types of client authentication are supported. Valid options
-    # are `none`, `optional`, and `required`. Default is required.
+    # are `none`, `optional`, and `required`. When `certificate_authorities` is set it will
+    # default to `required` otherwise it will be set to `none`.
     #ssl.client_authentication: "required"
 
 #------------------------------ Docker input --------------------------------

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -698,7 +698,8 @@ filebeat.inputs:
   #ssl.curve_types: []
 
   # Configure what types of client authentication are supported. Valid options
-  # are `none`, `optional`, and `required`. Default is required.
+  # are `none`, `optional`, and `required`. When `certificate_authorities` is set it will
+  # default to `required` otherwise it will be set to `none`.
   #ssl.client_authentication: "required"
 
 #------------------------------ Syslog input --------------------------------
@@ -757,7 +758,8 @@ filebeat.inputs:
     #ssl.curve_types: []
 
     # Configure what types of client authentication are supported. Valid options
-    # are `none`, `optional`, and `required`. Default is required.
+    # are `none`, `optional`, and `required`. When `certificate_authorities` is set it will
+    # default to `required` otherwise it will be set to `none`.
     #ssl.client_authentication: "required"
 
 #------------------------------ Docker input --------------------------------

--- a/libbeat/common/transport/tlscommon/server_config.go
+++ b/libbeat/common/transport/tlscommon/server_config.go
@@ -91,9 +91,14 @@ func LoadTLSServerConfig(config *ServerConfig) (*TLSConfig, error) {
 	}, nil
 }
 
+// Unpack unpacks the TLS Server configuration.
 func (c *ServerConfig) Unpack(cfg common.Config) error {
-	clientAuthKey := "client_authentication"
-	if !cfg.HasField(clientAuthKey) {
+	const clientAuthKey = "client_authentication"
+	const ca = "certificate_authorities"
+
+	// When we have explicitely defined the `certificate_authorities` in the configuration we default
+	// to `required` for the `client_authentication`, when CA is not defined we should set to `none`.
+	if cfg.HasField(ca) && !cfg.HasField(clientAuthKey) {
 		cfg.SetString(clientAuthKey, -1, "required")
 	}
 	type serverCfg ServerConfig

--- a/libbeat/common/transport/tlscommon/tls_test.go
+++ b/libbeat/common/transport/tlscommon/tls_test.go
@@ -167,26 +167,54 @@ func TestApplyWithConfig(t *testing.T) {
 }
 
 func TestServerConfigDefaults(t *testing.T) {
-	var c ServerConfig
-	config := common.MustNewConfigFrom([]byte(``))
-	err := config.Unpack(&c)
-	require.NoError(t, err)
-	tmp, err := LoadTLSServerConfig(&c)
-	require.NoError(t, err)
+	t.Run("when CA is not explicitly set", func(t *testing.T) {
+		var c ServerConfig
+		config := common.MustNewConfigFrom([]byte(``))
+		err := config.Unpack(&c)
+		require.NoError(t, err)
+		tmp, err := LoadTLSServerConfig(&c)
+		require.NoError(t, err)
 
-	cfg := tmp.BuildModuleConfig("")
+		cfg := tmp.BuildModuleConfig("")
 
-	assert.NotNil(t, cfg)
-	// values not set by default
-	assert.Len(t, cfg.Certificates, 0)
-	assert.Nil(t, cfg.ClientCAs)
-	assert.Len(t, cfg.CipherSuites, 0)
-	assert.Len(t, cfg.CurvePreferences, 0)
-	// values set by default
-	assert.Equal(t, false, cfg.InsecureSkipVerify)
-	assert.Equal(t, int(tls.VersionTLS11), int(cfg.MinVersion))
-	assert.Equal(t, int(tls.VersionTLS12), int(cfg.MaxVersion))
-	assert.Equal(t, tls.RequireAndVerifyClientCert, cfg.ClientAuth)
+		assert.NotNil(t, cfg)
+		// values not set by default
+		assert.Len(t, cfg.Certificates, 0)
+		assert.Nil(t, cfg.ClientCAs)
+		assert.Len(t, cfg.CipherSuites, 0)
+		assert.Len(t, cfg.CurvePreferences, 0)
+		// values set by default
+		assert.Equal(t, false, cfg.InsecureSkipVerify)
+		assert.Equal(t, int(tls.VersionTLS11), int(cfg.MinVersion))
+		assert.Equal(t, int(tls.VersionTLS12), int(cfg.MaxVersion))
+		assert.Equal(t, tls.NoClientCert, cfg.ClientAuth)
+	})
+	t.Run("when CA is explicitly set", func(t *testing.T) {
+
+		yamlStr := `
+    certificate_authorities: [ca_test.pem]
+`
+		var c ServerConfig
+		config, err := common.NewConfigWithYAML([]byte(yamlStr), "")
+		err = config.Unpack(&c)
+		require.NoError(t, err)
+		tmp, err := LoadTLSServerConfig(&c)
+		require.NoError(t, err)
+
+		cfg := tmp.BuildModuleConfig("")
+
+		assert.NotNil(t, cfg)
+		// values not set by default
+		assert.Len(t, cfg.Certificates, 0)
+		assert.NotNil(t, cfg.ClientCAs)
+		assert.Len(t, cfg.CipherSuites, 0)
+		assert.Len(t, cfg.CurvePreferences, 0)
+		// values set by default
+		assert.Equal(t, false, cfg.InsecureSkipVerify)
+		assert.Equal(t, int(tls.VersionTLS11), int(cfg.MinVersion))
+		assert.Equal(t, int(tls.VersionTLS12), int(cfg.MaxVersion))
+		assert.Equal(t, tls.RequireAndVerifyClientCert, cfg.ClientAuth)
+	})
 }
 
 func TestApplyWithServerConfig(t *testing.T) {

--- a/libbeat/docs/shared-ssl-config.asciidoc
+++ b/libbeat/docs/shared-ssl-config.asciidoc
@@ -225,7 +225,8 @@ ifeval::["{beatname_lc}" == "filebeat"]
 ==== `client_authentication`
 
 This configures what types of client authentication are supported. The valid options
-are `none`, `optional`, and `required`. The default value is required.
+are `none`, `optional`, and `required`. When `certificate_authorities` is set it will
+default to `required` otherwise it will be set to `none`.
 
 NOTE: This option is only valid with the TCP or the Syslog input.
 

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -810,7 +810,8 @@ filebeat.inputs:
   #ssl.curve_types: []
 
   # Configure what types of client authentication are supported. Valid options
-  # are `none`, `optional`, and `required`. Default is required.
+  # are `none`, `optional`, and `required`. When `certificate_authorities` is set it will
+  # default to `required` otherwise it will be set to `none`.
   #ssl.client_authentication: "required"
 
 #------------------------------ Syslog input --------------------------------
@@ -869,7 +870,8 @@ filebeat.inputs:
     #ssl.curve_types: []
 
     # Configure what types of client authentication are supported. Valid options
-    # are `none`, `optional`, and `required`. Default is required.
+    # are `none`, `optional`, and `required`. When `certificate_authorities` is set it will
+    # default to `required` otherwise it will be set to `none`.
     #ssl.client_authentication: "required"
 
 #------------------------------ Docker input --------------------------------


### PR DESCRIPTION
Cherry-pick of PR #12584 to 7.2 branch. Original message: 

When a CA is explicitly set in the configuration options we now default
the client authentication to required.