### PR TITLE
Cherry-pick #12584 to 7.x: When `certificate_authorities` is configured for ServerConfig, we now set client auth to `required`

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -117,8 +117,9 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Skipping unparsable log entries from docker json reader {pull}12268[12268]
 - Parse timezone in PostgreSQL logs as part of the timestamp {pull}12338[12338]
 - Require client_auth by default when ssl is enabled for tcp input {pull}12333[12333]
-- Require certificate authorities, certificate file, and key when SSL is enabled for the TCP input. {pull}12355[12355]
 - Load correct pipelines when system module is configured in modules.d. {pull}12340[12340]
+- Fix timezone offset parsing in system/syslog. {pull}12529[12529]
+- When TLS is configured for the TCP input and a `certificate_authorities` is configured we now default to `required` for the `client_authentication`. {pull}12584[12584]
 
 *Heartbeat*
 
@@ -152,6 +153,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix an issue listing all processes when run under Windows as a non-privileged user. {issue}12301[12301] {pull}12475[12475]
 - Require client_auth by default when ssl is enabled for module http metricset server{pull}12333[12333]
 - The `elasticsearch/index_summary` metricset gracefully handles an empty Elasticsearch cluster when `xpack.enabled: true` is set. {pull}12489[12489] {issue}12487[12487]
+- When TLS is configured for the http metricset and a `certificate_authorities` is configured we now default to `required` for the `client_authentication`. {pull}12584[12584]
 
 *Packetbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -118,7 +118,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Parse timezone in PostgreSQL logs as part of the timestamp {pull}12338[12338]
 - Require client_auth by default when ssl is enabled for tcp input {pull}12333[12333]
 - Load correct pipelines when system module is configured in modules.d. {pull}12340[12340]
-- Fix timezone offset parsing in system/syslog. {pull}12529[12529]
 - When TLS is configured for the TCP input and a `certificate_authorities` is configured we now default to `required` for the `client_authentication`. {pull}12584[12584]
 
 *Heartbeat*

--- a/filebeat/_meta/common.reference.inputs.yml
+++ b/filebeat/_meta/common.reference.inputs.yml
@@ -293,7 +293,8 @@ filebeat.inputs:
   #ssl.curve_types: []
 
   # Configure what types of client authentication are supported. Valid options
-  # are `none`, `optional`, and `required`. Default is required.
+  # are `none`, `optional`, and `required`. When `certificate_authorities` is set it will
+  # default to `required` otherwise it will be set to `none`.
   #ssl.client_authentication: "required"
 
 #------------------------------ Syslog input --------------------------------
@@ -352,7 +353,8 @@ filebeat.inputs:
     #ssl.curve_types: []
 
     # Configure what types of client authentication are supported. Valid options
-    # are `none`, `optional`, and `required`. Default is required.
+    # are `none`, `optional`, and `required`. When `certificate_authorities` is set it will
+    # default to `required` otherwise it will be set to `none`.
     #ssl.client_authentication: "required"
 
 #------------------------------ Docker input --------------------------------

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -670,7 +670,8 @@ filebeat.inputs:
   #ssl.curve_types: []
 
   # Configure what types of client authentication are supported. Valid options
-  # are `none`, `optional`, and `required`. Default is required.
+  # are `none`, `optional`, and `required`. When `certificate_authorities` is set it will
+  # default to `required` otherwise it will be set to `none`.
   #ssl.client_authentication: "required"
 
 #------------------------------ Syslog input --------------------------------
@@ -729,7 +730,8 @@ filebeat.inputs:
     #ssl.curve_types: []
 
     # Configure what types of client authentication are supported. Valid options
-    # are `none`, `optional`, and `required`. Default is required.
+    # are `none`, `optional`, and `required`. When `certificate_authorities` is set it will
+    # default to `required` otherwise it will be set to `none`.
     #ssl.client_authentication: "required"
 
 #------------------------------ Docker input --------------------------------

--- a/libbeat/common/transport/tlscommon/server_config.go
+++ b/libbeat/common/transport/tlscommon/server_config.go
@@ -91,9 +91,14 @@ func LoadTLSServerConfig(config *ServerConfig) (*TLSConfig, error) {
 	}, nil
 }
 
+// Unpack unpacks the TLS Server configuration.
 func (c *ServerConfig) Unpack(cfg common.Config) error {
-	clientAuthKey := "client_authentication"
-	if !cfg.HasField(clientAuthKey) {
+	const clientAuthKey = "client_authentication"
+	const ca = "certificate_authorities"
+
+	// When we have explicitely defined the `certificate_authorities` in the configuration we default
+	// to `required` for the `client_authentication`, when CA is not defined we should set to `none`.
+	if cfg.HasField(ca) && !cfg.HasField(clientAuthKey) {
 		cfg.SetString(clientAuthKey, -1, "required")
 	}
 	type serverCfg ServerConfig

--- a/libbeat/common/transport/tlscommon/tls_test.go
+++ b/libbeat/common/transport/tlscommon/tls_test.go
@@ -170,26 +170,54 @@ func TestApplyWithConfig(t *testing.T) {
 }
 
 func TestServerConfigDefaults(t *testing.T) {
-	var c ServerConfig
-	config := common.MustNewConfigFrom([]byte(``))
-	err := config.Unpack(&c)
-	require.NoError(t, err)
-	tmp, err := LoadTLSServerConfig(&c)
-	require.NoError(t, err)
+	t.Run("when CA is not explicitly set", func(t *testing.T) {
+		var c ServerConfig
+		config := common.MustNewConfigFrom([]byte(``))
+		err := config.Unpack(&c)
+		require.NoError(t, err)
+		tmp, err := LoadTLSServerConfig(&c)
+		require.NoError(t, err)
 
-	cfg := tmp.BuildModuleConfig("")
+		cfg := tmp.BuildModuleConfig("")
 
-	assert.NotNil(t, cfg)
-	// values not set by default
-	assert.Len(t, cfg.Certificates, 0)
-	assert.Nil(t, cfg.ClientCAs)
-	assert.Len(t, cfg.CipherSuites, 0)
-	assert.Len(t, cfg.CurvePreferences, 0)
-	// values set by default
-	assert.Equal(t, false, cfg.InsecureSkipVerify)
-	assert.Equal(t, int(tls.VersionTLS11), int(cfg.MinVersion))
-	assert.Equal(t, int(tls.VersionTLS12), int(cfg.MaxVersion))
-	assert.Equal(t, tls.RequireAndVerifyClientCert, cfg.ClientAuth)
+		assert.NotNil(t, cfg)
+		// values not set by default
+		assert.Len(t, cfg.Certificates, 0)
+		assert.Nil(t, cfg.ClientCAs)
+		assert.Len(t, cfg.CipherSuites, 0)
+		assert.Len(t, cfg.CurvePreferences, 0)
+		// values set by default
+		assert.Equal(t, false, cfg.InsecureSkipVerify)
+		assert.Equal(t, int(tls.VersionTLS11), int(cfg.MinVersion))
+		assert.Equal(t, int(tls.VersionTLS12), int(cfg.MaxVersion))
+		assert.Equal(t, tls.NoClientCert, cfg.ClientAuth)
+	})
+	t.Run("when CA is explicitly set", func(t *testing.T) {
+
+		yamlStr := `
+    certificate_authorities: [ca_test.pem]
+`
+		var c ServerConfig
+		config, err := common.NewConfigWithYAML([]byte(yamlStr), "")
+		err = config.Unpack(&c)
+		require.NoError(t, err)
+		tmp, err := LoadTLSServerConfig(&c)
+		require.NoError(t, err)
+
+		cfg := tmp.BuildModuleConfig("")
+
+		assert.NotNil(t, cfg)
+		// values not set by default
+		assert.Len(t, cfg.Certificates, 0)
+		assert.NotNil(t, cfg.ClientCAs)
+		assert.Len(t, cfg.CipherSuites, 0)
+		assert.Len(t, cfg.CurvePreferences, 0)
+		// values set by default
+		assert.Equal(t, false, cfg.InsecureSkipVerify)
+		assert.Equal(t, int(tls.VersionTLS11), int(cfg.MinVersion))
+		assert.Equal(t, int(tls.VersionTLS12), int(cfg.MaxVersion))
+		assert.Equal(t, tls.RequireAndVerifyClientCert, cfg.ClientAuth)
+	})
 }
 
 func TestApplyWithServerConfig(t *testing.T) {

--- a/libbeat/docs/shared-ssl-config.asciidoc
+++ b/libbeat/docs/shared-ssl-config.asciidoc
@@ -225,7 +225,8 @@ ifeval::["{beatname_lc}" == "filebeat"]
 ==== `client_authentication`
 
 This configures what types of client authentication are supported. The valid options
-are `none`, `optional`, and `required`. The default value is required.
+are `none`, `optional`, and `required`. When `certificate_authorities` is set it will
+default to `required` otherwise it will be set to `none`.
 
 NOTE: This option is only valid with the TCP or the Syslog input.
 

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -789,7 +789,8 @@ filebeat.inputs:
   #ssl.curve_types: []
 
   # Configure what types of client authentication are supported. Valid options
-  # are `none`, `optional`, and `required`. Default is required.
+  # are `none`, `optional`, and `required`. When `certificate_authorities` is set it will
+  # default to `required` otherwise it will be set to `none`.
   #ssl.client_authentication: "required"
 
 #------------------------------ Syslog input --------------------------------
@@ -848,7 +849,8 @@ filebeat.inputs:
     #ssl.curve_types: []
 
     # Configure what types of client authentication are supported. Valid options
-    # are `none`, `optional`, and `required`. Default is required.
+    # are `none`, `optional`, and `required`. When `certificate_authorities` is set it will
+    # default to `required` otherwise it will be set to `none`.
     #ssl.client_authentication: "required"
 
 #------------------------------ Docker input --------------------------------


### PR DESCRIPTION
Cherry-pick of PR #12584 to 7.x branch. Original message: 

When a CA is explicitly set in the configuration options we now default
the client authentication to required.