### PR TITLE
[Auditbeat] Host: Fix reboot detection logic

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -84,6 +84,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Package dataset: Auto-detect package directories. {pull}12289[12289]
 - Package dataset: Improve dpkg parsing. {pull}12325[12325]
 - System module: Start system module without host ID. {pull}12373[12373]
+- Host dataset: Fix reboot detection logic. {pull}12591[12591]
 
 *Filebeat*
 

--- a/x-pack/auditbeat/module/system/host/host.go
+++ b/x-pack/auditbeat/module/system/host/host.go
@@ -268,7 +268,9 @@ func (ms *MetricSet) reportChanges(report mb.ReporterV2) error {
 	}
 
 	// Report reboots separately
-	if !currentHost.info.BootTime.Equal(ms.lastHost.info.BootTime) {
+	// On Windows, BootTime is not fully accurate and can vary by a few milliseconds.
+	// So we only report a reboot if the new BootTime is at least 1 second after the old.
+	if currentHost.info.BootTime.After(ms.lastHost.info.BootTime.Add(1 * time.Second)) {
 		events = append(events, hostEvent(currentHost, eventTypeEvent, eventActionReboot))
 	}
 


### PR DESCRIPTION
On Windows, `BootTime` is not fully accurate and can vary by a few milliseconds (see `Remarks` for [GetTickCount64](https://docs.microsoft.com/en-us/windows/desktop/api/sysinfoapi/nf-sysinfoapi-gettickcount64)). This causes a lot of false positive `event.action: reboot` events.

This PR changes to only report a reboot if the new `BootTime` is at least 1 second after the old. This should fix Windows and not affect the other platforms, assuming it's impossible to reboot a system twice in 1 second.