### PR TITLE
[Auditbeat] Cherry-pick #12591 to 6.8: Host: Fix reboot detection logic

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -35,6 +35,8 @@ https://github.com/elastic/beats/compare/v6.8.0...6.8.1[Check the HEAD diff]
 
 *Auditbeat*
 
+- Host dataset: Fix reboot detection logic. {pull}12591[12591]
+
 *Filebeat*
 
 - When TLS is configured for the TCP input and a `certificate_authorities` is configured we now default to `required` for the `client_authentication`. {pull}12584[12584]

--- a/x-pack/auditbeat/module/system/host/host.go
+++ b/x-pack/auditbeat/module/system/host/host.go
@@ -264,7 +264,9 @@ func (ms *MetricSet) reportChanges(report mb.ReporterV2) error {
 	}
 
 	// Report reboots separately
-	if !currentHost.info.BootTime.Equal(ms.lastHost.info.BootTime) {
+	// On Windows, BootTime is not fully accurate and can vary by a few milliseconds.
+	// So we only report a reboot if the new BootTime is at least 1 second after the old.
+	if currentHost.info.BootTime.After(ms.lastHost.info.BootTime.Add(1 * time.Second)) {
 		events = append(events, hostEvent(currentHost, eventTypeEvent, eventActionReboot))
 	}
 


### PR DESCRIPTION
Cherry-pick of PR #12591 to 6.8 branch. Original message: 

On Windows, `BootTime` is not fully accurate and can vary by a few milliseconds (see `Remarks` for [GetTickCount64](https://docs.microsoft.com/en-us/windows/desktop/api/sysinfoapi/nf-sysinfoapi-gettickcount64)). This causes a lot of false positive `event.action: reboot` events.

This PR changes to only report a reboot if the new `BootTime` is at least 1 second after the old. This should fix Windows and not affect the other platforms, assuming it's impossible to reboot a system twice in 1 second.