### PR TITLE
[docs] remove “Beats” from APM Server docs

### DIFF
--- a/libbeat/docs/shared-docker.asciidoc
+++ b/libbeat/docs/shared-docker.asciidoc
@@ -16,7 +16,7 @@ Elastic license levels.
 
 ==== Pulling the image
 
-Obtaining Beats for Docker is as simple as issuing a +docker pull+ command
+Obtaining {beatname_uc} for Docker is as simple as issuing a +docker pull+ command
 against the Elastic Docker registry.
 
 ifeval::["{release-state}"=="unreleased"]


### PR DESCRIPTION
Removing "Beats" from the `running-on-docker` shared file. If you'd like to keep this reference to beats I can change this to an ifndef/ifdef and hard code in APM Server. 

Discovered in https://github.com/elastic/apm-server/pull/2300