### PR TITLE
Allow delete and index actions with a document ID

### DIFF
--- a/libbeat/beat/event.go
+++ b/libbeat/beat/event.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/logp"
 )
 
 // FlagField fields used to keep information or errors when events are parsed.
@@ -52,6 +53,20 @@ func (e *Event) SetID(id string) {
 		e.Meta = common.MapStr{}
 	}
 	e.Meta["_id"] = id
+}
+
+func (e *Event) GetMetaStringValue(key string) (string, error) {
+	var val string
+	if tmp, err := e.GetValue("@metadata." + key); err == nil {
+		if s, ok := tmp.(string); ok {
+			return s, nil
+		} else {
+			logp.Err("Event[%s] '%v' is no string value", key, tmp)
+			return val, nil
+		}
+	} else {
+		return val, err
+	}
 }
 
 func (e *Event) GetValue(key string) (interface{}, error) {

--- a/libbeat/beat/event.go
+++ b/libbeat/beat/event.go
@@ -55,16 +55,16 @@ func (e *Event) SetID(id string) {
 }
 
 func (e *Event) GetMetaStringValue(key string) (string, error) {
-	var val string
-	if tmp, err := e.GetValue("@metadata." + key); err == nil {
-		if s, ok := tmp.(string); ok {
-			return s, nil
-		} else {
-			return val, err
-		}
-	} else {
-		return val, err
+	tmp, err := e.Meta.GetValue(key)
+	if err != nil {
+		return "", err
 	}
+
+	if s, ok := tmp.(string); ok {
+		return s, nil
+	}
+
+	return "", nil
 }
 
 func (e *Event) GetValue(key string) (interface{}, error) {

--- a/libbeat/beat/event.go
+++ b/libbeat/beat/event.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"github.com/elastic/beats/v7/libbeat/common"
-	"github.com/elastic/beats/v7/libbeat/logp"
 )
 
 // FlagField fields used to keep information or errors when events are parsed.
@@ -61,8 +60,7 @@ func (e *Event) GetMetaStringValue(key string) (string, error) {
 		if s, ok := tmp.(string); ok {
 			return s, nil
 		} else {
-			logp.Err("Event[%s] '%v' is no string value", key, tmp)
-			return val, nil
+			return val, err
 		}
 	} else {
 		return val, err

--- a/libbeat/esleg/eslegclient/bulkapi.go
+++ b/libbeat/esleg/eslegclient/bulkapi.go
@@ -42,6 +42,10 @@ type BulkCreateAction struct {
 	Create BulkMeta `json:"create" struct:"create"`
 }
 
+type BulkDeleteAction struct {
+	Delete BulkMeta `json:"delete" struct:"delete"`
+}
+
 type BulkMeta struct {
 	Index    string `json:"_index" struct:"_index"`
 	DocType  string `json:"_type,omitempty" struct:"_type,omitempty"`

--- a/libbeat/esleg/eslegclient/enc.go
+++ b/libbeat/esleg/eslegclient/enc.go
@@ -135,12 +135,9 @@ func (b *jsonEncoder) Add(meta, obj interface{}) error {
 		b.buf.Truncate(pos)
 		return err
 	}
-	// obj will be nil in the case of a delete operation
-	if obj != nil {
-		if err := b.AddRaw(obj); err != nil {
-			b.buf.Truncate(pos)
-			return err
-		}
+	if err := b.AddRaw(obj); err != nil {
+		b.buf.Truncate(pos)
+		return err
 	}
 	return nil
 }

--- a/libbeat/esleg/eslegclient/enc.go
+++ b/libbeat/esleg/eslegclient/enc.go
@@ -135,9 +135,11 @@ func (b *jsonEncoder) Add(meta, obj interface{}) error {
 		b.buf.Truncate(pos)
 		return err
 	}
-	if err := b.AddRaw(obj); err != nil {
-		b.buf.Truncate(pos)
-		return err
+	if obj != nil {
+		if err := b.AddRaw(obj); err != nil {
+			b.buf.Truncate(pos)
+			return err
+		}
 	}
 	return nil
 }

--- a/libbeat/esleg/eslegclient/enc.go
+++ b/libbeat/esleg/eslegclient/enc.go
@@ -135,6 +135,7 @@ func (b *jsonEncoder) Add(meta, obj interface{}) error {
 		b.buf.Truncate(pos)
 		return err
 	}
+	// obj will be nil in the case of a delete operation
 	if obj != nil {
 		if err := b.AddRaw(obj); err != nil {
 			b.buf.Truncate(pos)

--- a/libbeat/outputs/elasticsearch/client.go
+++ b/libbeat/outputs/elasticsearch/client.go
@@ -71,8 +71,8 @@ const (
 )
 
 // opTypeKey defines the metadata key name for event operation type.
-// The key's value can be an empty string, `create`, `index`, or `delete`. If empty, the event will be `create`d if the ID
-// is known, and `index`ed otherwise.
+// The key's value can be an empty string, `create`, `index`, or `delete`. If empty, it will assume
+// either `create` or `index`. See `createEventBulkMeta`. If in doubt, set explicitly.
 const opTypeKey = "op_type"
 
 // NewClient instantiates a new client.

--- a/libbeat/outputs/elasticsearch/client.go
+++ b/libbeat/outputs/elasticsearch/client.go
@@ -73,7 +73,7 @@ const (
 // opTypeKey defines the metadata key name for event operation type.
 // The key's value can be an empty string, `create`, `index`, or `delete`. If empty, the event will be `create`d if the ID
 // is known, and `index`ed otherwise.
-const opTypeKey = "@metadata.op_type"
+const opTypeKey = "op_type"
 
 // NewClient instantiates a new client.
 func NewClient(

--- a/libbeat/outputs/elasticsearch/client.go
+++ b/libbeat/outputs/elasticsearch/client.go
@@ -333,8 +333,7 @@ func createEventBulkMeta(
 		if id != "" {
 			return eslegclient.BulkDeleteAction{Delete: meta}, nil
 		} else {
-			err := fmt.Errorf("op_type delete requires _id")
-			return nil, err
+			return nil, fmt.Errorf("%s %s requires _id", opTypeKey, opTypeDelete)
 		}
 	}
 	if id != "" || version.Major > 7 || (version.Major == 7 && version.Minor >= 5) {

--- a/libbeat/outputs/elasticsearch/client.go
+++ b/libbeat/outputs/elasticsearch/client.go
@@ -316,11 +316,7 @@ func createEventBulkMeta(
 	}
 
 	id, _ := event.GetMetaStringValue("_id")
-	opType, err := event.GetMetaStringValue(opTypeKey)
-	if err != nil {
-		log.Errorf("%s %v is no string value", opTypeKey, opType)
-		return nil, err
-	}
+	opType, _ := event.GetMetaStringValue(opTypeKey)
 
 	meta := eslegclient.BulkMeta{
 		Index:    index,

--- a/libbeat/outputs/elasticsearch/client.go
+++ b/libbeat/outputs/elasticsearch/client.go
@@ -282,7 +282,7 @@ func bulkEncodePublishRequest(
 		}
 		if opType, err := event.GetMetaStringValue(opTypeKey); err == nil && opType == opTypeDelete {
 			// We don't include the event source in a bulk DELETE
-			bulkItems = append(bulkItems, meta, nil)
+			bulkItems = append(bulkItems, meta)
 		} else {
 			bulkItems = append(bulkItems, meta, event)
 		}

--- a/libbeat/outputs/elasticsearch/client.go
+++ b/libbeat/outputs/elasticsearch/client.go
@@ -325,8 +325,13 @@ func createEventBulkMeta(
 		ID:       id,
 	}
 
-	if id != "" && opType == opTypeDelete {
-		return eslegclient.BulkDeleteAction{Delete: meta}, nil
+	if opType == opTypeDelete {
+		if id != "" {
+			return eslegclient.BulkDeleteAction{Delete: meta}, nil
+		} else {
+			err := fmt.Errorf("op_type delete requires _id")
+			return nil, err
+		}
 	}
 	if id != "" || version.Major > 7 || (version.Major == 7 && version.Minor >= 5) {
 		if opType == opTypeIndex {

--- a/libbeat/outputs/elasticsearch/client.go
+++ b/libbeat/outputs/elasticsearch/client.go
@@ -316,7 +316,11 @@ func createEventBulkMeta(
 	}
 
 	id, _ := event.GetMetaStringValue("_id")
-	opType, _ := event.GetMetaStringValue(opTypeKey)
+	opType, err := event.GetMetaStringValue(opTypeKey)
+	if err != nil {
+		log.Errorf("%s %v is no string value", opTypeKey, opType)
+		return nil, err
+	}
 
 	meta := eslegclient.BulkMeta{
 		Index:    index,

--- a/libbeat/outputs/elasticsearch/client.go
+++ b/libbeat/outputs/elasticsearch/client.go
@@ -65,7 +65,15 @@ type bulkResultStats struct {
 
 const (
 	defaultEventType = "doc"
+	opTypeCreate     = "create"
+	opTypeDelete     = "delete"
+	opTypeIndex      = "index"
 )
+
+// opTypeKey defines the metadata key name for event operation type.
+// The key's value can be an empty string, `create`, `index`, or `delete`. If empty, the event will be `create`d if the ID
+// is known, and `index`ed otherwise.
+const opTypeKey = "@metadata.op_type"
 
 // NewClient instantiates a new client.
 func NewClient(
@@ -253,20 +261,6 @@ func (client *Client) publishEvents(
 	return nil, nil
 }
 
-func eventMetaValue(event *beat.Event, key string) string {
-	var val string
-	if m := event.Meta; m != nil {
-		if tmp := m[key]; tmp != nil {
-			if s, ok := tmp.(string); ok {
-				val = s
-			} else {
-				logp.Err("Event[%s] '%v' is no string value", key, val)
-			}
-		}
-	}
-	return val
-}
-
 // bulkEncodePublishRequest encodes all bulk requests and returns slice of events
 // successfully added to the list of bulk items and the list of bulk items.
 func bulkEncodePublishRequest(
@@ -286,8 +280,7 @@ func bulkEncodePublishRequest(
 			log.Errorf("Failed to encode event meta data: %+v", err)
 			continue
 		}
-		opType := eventMetaValue(event, "op_type")
-		if opType == "delete" {
+		if opType, err := event.GetMetaStringValue(opTypeKey); err == nil && opType == opTypeDelete {
 			// We don't include the event source in a bulk DELETE
 			bulkItems = append(bulkItems, meta, nil)
 		} else {
@@ -322,8 +315,8 @@ func createEventBulkMeta(
 		return nil, err
 	}
 
-	id := eventMetaValue(event, "id")
-	opType := eventMetaValue(event, "op_type")
+	id, _ := event.GetMetaStringValue("_id")
+	opType, _ := event.GetMetaStringValue(opTypeKey)
 
 	meta := eslegclient.BulkMeta{
 		Index:    index,
@@ -332,12 +325,14 @@ func createEventBulkMeta(
 		ID:       id,
 	}
 
+	if id != "" && opType == opTypeDelete {
+		return eslegclient.BulkDeleteAction{Delete: meta}, nil
+	}
 	if id != "" || version.Major > 7 || (version.Major == 7 && version.Minor >= 5) {
-		if opType == "" || opType == "create" {
-			return eslegclient.BulkCreateAction{Create: meta}, nil
-		} else if opType == "delete" {
-			return eslegclient.BulkDeleteAction{Delete: meta}, nil
+		if opType == opTypeIndex {
+			return eslegclient.BulkIndexAction{Index: meta}, nil
 		}
+		return eslegclient.BulkCreateAction{Create: meta}, nil
 	}
 	return eslegclient.BulkIndexAction{Index: meta}, nil
 }

--- a/libbeat/outputs/elasticsearch/client_test.go
+++ b/libbeat/outputs/elasticsearch/client_test.go
@@ -374,7 +374,7 @@ func TestBulkEncodeEventsWithOpType(t *testing.T) {
 		case eslegclient.BulkDeleteAction:
 			require.Equal(t, opTypeDelete, caseOpType, caseMessage)
 		default:
-			panic("unknown type")
+			require.FailNow(t, "unknown type")
 		}
 	}
 

--- a/libbeat/outputs/elasticsearch/client_test.go
+++ b/libbeat/outputs/elasticsearch/client_test.go
@@ -355,8 +355,8 @@ func TestBulkEncodeEventsWithOpType(t *testing.T) {
 	}
 
 	encoded, bulkItems := bulkEncodePublishRequest(logp.L(), *common.MustNewVersion(version.GetDefaultVersion()), index, pipeline, events)
-	assert.Equal(t, len(events)-1, len(encoded), "all events should have been encoded")
-	assert.Equal(t, 9, len(bulkItems), "incomplete bulk")
+	require.Equal(t, len(events)-1, len(encoded), "all events should have been encoded")
+	require.Equal(t, 9, len(bulkItems), "incomplete bulk")
 
 	for i := 0; i < len(cases); i++ {
 		bulkEventIndex, _ := cases[i]["bulkIndex"].(int)

--- a/libbeat/outputs/elasticsearch/client_test.go
+++ b/libbeat/outputs/elasticsearch/client_test.go
@@ -368,11 +368,11 @@ func TestBulkEncodeEventsWithOpType(t *testing.T) {
 		switch bulkItems[bulkEventIndex].(type) {
 		case eslegclient.BulkCreateAction:
 			validOpTypes := []string{opTypeCreate, ""}
-			assert.Contains(t, validOpTypes, caseOpType, caseMessage)
+			require.Contains(t, validOpTypes, caseOpType, caseMessage)
 		case eslegclient.BulkIndexAction:
-			assert.Equal(t, opTypeIndex, caseOpType, caseMessage)
+			require.Equal(t, opTypeIndex, caseOpType, caseMessage)
 		case eslegclient.BulkDeleteAction:
-			assert.Equal(t, opTypeDelete, caseOpType, caseMessage)
+			require.Equal(t, opTypeDelete, caseOpType, caseMessage)
 		default:
 			panic("unknown type")
 		}


### PR DESCRIPTION
Our use-case requires our Beat be able to re-index and delete documents. We always know the document ID but libbeat currently only allows us to create a document when the ID is known.

I have implemented the ability to specify whether an event should index or delete documents with a specified ID by setting an `op_type` key in the event metadata. Possible values for the key are `create`, `index` or `delete`. 

The behaviour currently in master hasn't changed, so if no `op_type` is specified, an event will result in a create if the ID is given, or an index otherwise.

I found issue #8534, where the author seems to be asking for update actions when the ID is known, which I could support as part of this PR by allowing an `update` value for the `op_type` key.

I'd love to see this functionality in libbeat and would welcome feedback on this PR. Does anyone have any thoughts about a better way to go about this?