### PR TITLE
 [DOCS] Add homebrew instructions to install docs 

### DIFF
--- a/auditbeat/docs/getting-started.asciidoc
+++ b/auditbeat/docs/getting-started.asciidoc
@@ -75,6 +75,8 @@ tar xzvf {beatname_lc}-{version}-darwin-x86_64.tar.gz
 
 endif::[]
 
+include::{libbeat-dir}/docs/shared-brew-install.asciidoc[]
+
 [[linux]]
 *linux:*
 

--- a/auditbeat/docs/getting-started.asciidoc
+++ b/auditbeat/docs/getting-started.asciidoc
@@ -246,6 +246,8 @@ in the _Beats Platform Reference_.
 If you see a warning about too many open files, you need to increase the
 `ulimit`. See the <<ulimit,FAQ>> for more details.
 
+include::{libbeat-dir}/docs/shared-brew-run.asciidoc[]
+
 *win:*
 
 ["source","sh",subs="attributes"]

--- a/filebeat/docs/getting-started.asciidoc
+++ b/filebeat/docs/getting-started.asciidoc
@@ -75,6 +75,8 @@ tar xzvf filebeat-{version}-darwin-x86_64.tar.gz
 
 endif::[]
 
+include::{libbeat-dir}/docs/shared-brew-install.asciidoc[]
+
 [[linux]]
 *linux:*
 

--- a/heartbeat/docs/getting-started.asciidoc
+++ b/heartbeat/docs/getting-started.asciidoc
@@ -81,6 +81,8 @@ tar xzvf heartbeat-{version}-darwin-x86_64.tar.gz
 
 endif::[]
 
+include::{libbeat-dir}/docs/shared-brew-install.asciidoc[]
+
 [[linux]]
 *linux:*
 

--- a/libbeat/docs/dashboards.asciidoc
+++ b/libbeat/docs/dashboards.asciidoc
@@ -63,6 +63,13 @@ ifdef::mac_os[]
 ----------------------------------------------------------------------
 ./{beatname_lc} setup --dashboards
 ----------------------------------------------------------------------
+
+*brew:*
+
+["source","sh",subs="attributes"]
+----------------------------------------------------------------------
+{beatname_lc} setup --dashboards
+----------------------------------------------------------------------
 endif::mac_os[]
 
 ifdef::linux_os[]
@@ -133,6 +140,18 @@ ifdef::mac_os[]
 ["source","sh",subs="attributes"]
 ----
 ./{beatname_lc} setup -e \
+  -E output.logstash.enabled=false \
+  -E output.elasticsearch.hosts=['localhost:9200'] \
+  -E output.elasticsearch.username={beat_default_index_prefix}_internal \
+  -E output.elasticsearch.password={pwd} \
+  -E setup.kibana.host=localhost:5601 
+----
+
+*brew:*
+
+["source","sh",subs="attributes"]
+----
+{beatname_lc} setup -e \
   -E output.logstash.enabled=false \
   -E output.elasticsearch.hosts=['localhost:9200'] \
   -E output.elasticsearch.username={beat_default_index_prefix}_internal \

--- a/libbeat/docs/shared-brew-install.asciidoc
+++ b/libbeat/docs/shared-brew-install.asciidoc
@@ -12,16 +12,10 @@ ifeval::["{release-state}"!="unreleased"]
 ["source","sh",subs="attributes"]
 -------------------------
 brew tap elastic/tap
-brew install elastic/tap/{beatname_lc}@{brew-version}
+brew install elastic/tap/{beatname_lc}-full
 -------------------------
 
-//REVIEWERS: I've trimmed the instructions here so that they are parallel to
-//the instructions provided for other install methods. Note that I have not been able
-//to test the commands shown here (with version) specified, so please confirm
-// syntax. I'm concerned that providing the command *without* the version might
-// lead users to download the wrong version of the shipper, especially within
-// the Beats guides where we provide exact version downloads.
-
-To install the OSS distribution, specify +elastic/tap/{beatname_lc}-oss@{brew-version}+.
+This installs the most recently released default distribution of. To install the
+OSS distribution, specify +elastic/tap/{beatname_lc}-oss+.
 
 endif::[]

--- a/libbeat/docs/shared-brew-install.asciidoc
+++ b/libbeat/docs/shared-brew-install.asciidoc
@@ -1,0 +1,27 @@
+[[brew]]
+*brew:*
+
+ifeval::["{release-state}"=="unreleased"]
+
+Version {stack-version} of {beatname_uc} has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
+
+["source","sh",subs="attributes"]
+-------------------------
+brew tap elastic/tap
+brew install elastic/tap/{beatname_lc}@{brew-version}
+-------------------------
+
+//REVIEWERS: I've trimmed the instructions here so that they are parallel to
+//the instructions provided for other install methods. Note that I have not been able
+//to test the commands shown here (with version) specified, so please confirm
+// syntax. I'm concerned that providing the command *without* the version might
+// lead users to download the wrong version of the shipper, especially within
+// the Beats guides where we provide exact version downloads.
+
+To install the OSS distribution, specify +elastic/tap/{beatname_lc}-oss@{brew-version}+.
+
+endif::[]

--- a/libbeat/docs/shared-brew-run.asciidoc
+++ b/libbeat/docs/shared-brew-run.asciidoc
@@ -1,0 +1,17 @@
+*brew:*
+
+To have launchd start +elastic/tap/{beatname_lc}+ and then restart it at login,
+run:
+
+["source","sh",subs="attributes"]
+-----
+brew services start elastic/tap/{beatname_lc}
+-----
+
+To run {beatname_uc} in the foreground instead of running it as a background
+service, run:
+
+["source","sh",subs="attributes"]
+-----
+{beatname_lc} -e
+-----

--- a/libbeat/docs/shared-directory-layout.asciidoc
+++ b/libbeat/docs/shared-directory-layout.asciidoc
@@ -90,6 +90,21 @@ the following simple command, all paths are set correctly:
 
 endif::mac_os,win_os[]
 
+//TODO: Verify the following locations.
+
+ifdef::mac_os[]
+===== brew
+[cols="<h,<,<m",options="header",]
+|=======================================================================
+| Type   | Description | Location
+| home   | Home of the {beatname_uc} installation. | /usr/local/var/homebrew/linked/{beatname_lc}
+| bin    | The location for the binary files. | /usr/local/var/homebrew/linked/{beatname_lc}/bin
+| config | The location for configuration files. | /usr/local/etc/{beatname_lc}
+| data   | The location for persistent data files. | /usr/local/var/lib/{beatname_lc}
+| logs   | The location for the logs created by {beatname_uc}. | /usr/local/var/log/{beatname_lc}
+|=======================================================================
+endif::mac_os[]
+
 ifndef::win_only[]
 
 ["source","sh",subs="attributes"]

--- a/libbeat/docs/shared-directory-layout.asciidoc
+++ b/libbeat/docs/shared-directory-layout.asciidoc
@@ -90,21 +90,6 @@ the following simple command, all paths are set correctly:
 
 endif::mac_os,win_os[]
 
-//TODO: Verify the following locations.
-
-ifdef::mac_os[]
-===== brew
-[cols="<h,<,<m",options="header",]
-|=======================================================================
-| Type   | Description | Location
-| home   | Home of the {beatname_uc} installation. | /usr/local/var/homebrew/linked/{beatname_lc}
-| bin    | The location for the binary files. | /usr/local/var/homebrew/linked/{beatname_lc}/bin
-| config | The location for configuration files. | /usr/local/etc/{beatname_lc}
-| data   | The location for persistent data files. | /usr/local/var/lib/{beatname_lc}
-| logs   | The location for the logs created by {beatname_uc}. | /usr/local/var/log/{beatname_lc}
-|=======================================================================
-endif::mac_os[]
-
 ifndef::win_only[]
 
 ["source","sh",subs="attributes"]
@@ -113,6 +98,19 @@ ifndef::win_only[]
 ----------------------------------------------------------------------
 
 endif::win_only[]
+
+ifdef::mac_os[]
+===== brew
+[cols="<h,<,<m",options="header",]
+|=======================================================================
+| Type   | Description | Location
+| home   | Home of the {beatname_uc} installation. | /usr/local/var/homebrew/linked/{beatname_lc}-full
+| bin    | The location for the binary files. | /usr/local/var/homebrew/linked/{beatname_lc}-full/bin
+| config | The location for configuration files. | /usr/local/etc/{beatname_lc}
+| data   | The location for persistent data files. | /usr/local/var/lib/{beatname_lc}
+| logs   | The location for the logs created by {beatname_uc}. | /usr/local/var/log/{beatname_lc}
+|=======================================================================
+endif::mac_os[]
 
 ifdef::win_only[]
 

--- a/libbeat/docs/shared-template-load.asciidoc
+++ b/libbeat/docs/shared-template-load.asciidoc
@@ -152,6 +152,13 @@ ifdef::mac_os[]
 ----
 ./{beatname_lc} setup --template{disable_logstash} -E 'output.elasticsearch.hosts=["localhost:9200"]'
 ----
+
+*brew:*
+
+["source","sh",subs="attributes"]
+----
+{beatname_lc} setup --template{disable_logstash} -E 'output.elasticsearch.hosts=["localhost:9200"]'
+----
 endif::mac_os[]
 
 ifdef::linux_os[]
@@ -266,6 +273,13 @@ ifdef::mac_os[]
 ["source","sh",subs="attributes"]
 ----
 ./{beatname_lc} export template > {beatname_lc}.template.json
+----
+
+*brew:*
+
+["source","sh",subs="attributes"]
+----
+{beatname_lc} export template > {beatname_lc}.template.json
 ----
 endif::mac_os[]
 

--- a/libbeat/docs/version.asciidoc
+++ b/libbeat/docs/version.asciidoc
@@ -1,5 +1,4 @@
 :stack-version: 8.0.0
-:brew-version: 8.0
 :doc-branch: master
 :go-version: 1.12.4
 :release-state: unreleased

--- a/libbeat/docs/version.asciidoc
+++ b/libbeat/docs/version.asciidoc
@@ -2,7 +2,7 @@
 :brew-version: 8.0
 :doc-branch: master
 :go-version: 1.12.4
-:release-state: released
+:release-state: unreleased
 :python: 2.7.9
 :docker: 1.12
 :docker-compose: 1.11

--- a/libbeat/docs/version.asciidoc
+++ b/libbeat/docs/version.asciidoc
@@ -1,7 +1,8 @@
 :stack-version: 8.0.0
+:brew-version: 8.0
 :doc-branch: master
 :go-version: 1.12.4
-:release-state: unreleased
+:release-state: released
 :python: 2.7.9
 :docker: 1.12
 :docker-compose: 1.11

--- a/metricbeat/docs/gettingstarted.asciidoc
+++ b/metricbeat/docs/gettingstarted.asciidoc
@@ -84,6 +84,8 @@ tar xzvf {beatname_lc}-{version}-darwin-x86_64.tar.gz
 
 endif::[]
 
+include::{libbeat-dir}/docs/shared-brew-install.asciidoc[]
+
 [[linux]]
 *linux:*
 

--- a/packetbeat/docs/gettingstarted.asciidoc
+++ b/packetbeat/docs/gettingstarted.asciidoc
@@ -83,6 +83,8 @@ tar xzvf packetbeat-{version}-darwin-x86_64.tar.gz
 
 endif::[]
 
+include::{libbeat-dir}/docs/shared-brew-install.asciidoc[]
+
 [[linux]]
 *linux:*
 


### PR DESCRIPTION
Closes #12459 

Open issues/remaining work:

- [ ] Test the documented steps for loading dashboards and other assets. 
- [x] Verify the directory structure.
- [x Reset the `release-state` to `unreleased` before merging final PR (set temporarily to make it easier to review changes).
- [x Figure out why the version setting does not work.
- [x] Figure out why dashboards will not load into Kibana installed through brew and why running in the foreground with `kibana` results in error:   log   [00:41:48.460] [fatal][root] { [Error: ENOENT: no such file or directory, open '/usr/local/var/run/elasticsearch/']
