### PR TITLE
Add umask and mremap to Auditbeat seccomp policy

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -86,6 +86,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Package dataset: Improve dpkg parsing. {pull}12325[12325]
 - System module: Start system module without host ID. {pull}12373[12373]
 - Host dataset: Fix reboot detection logic. {pull}12591[12591]
+- Add syscalls used by librpm for the system/package dataset to the default Auditbeat seccomp policy. {issue}12578[12578] {pull}12617[12617]
 
 *Filebeat*
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -223,6 +223,17 @@ Vagrant.configure(2) do |config|
     end
   end
 
+  config.vm.define "centos7", primary: true do |c|
+    c.vm.box = "bento/centos-7"
+    c.vm.network :forwarded_port, guest: 22, host: 2231,  id: "ssh", auto_correct: true
+
+    c.vm.provision "shell", inline: $unixProvision, privileged: false
+    c.vm.provision "shell", inline: linuxGvmProvision, privileged: false
+    c.vm.provision "shell", inline: "yum install -y make gcc python-pip python-virtualenv git"
+
+    c.vm.synced_folder ".", "/vagrant", type: "virtualbox"
+  end
+
 end
 
 # -*- mode: ruby -*-

--- a/x-pack/auditbeat/seccomp_linux.go
+++ b/x-pack/auditbeat/seccomp_linux.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 package main
 
 import (

--- a/x-pack/auditbeat/seccomp_linux.go
+++ b/x-pack/auditbeat/seccomp_linux.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"runtime"
+
+	"github.com/elastic/beats/libbeat/common/seccomp"
+)
+
+func init() {
+	switch runtime.GOARCH {
+	case "amd64", "386":
+		// The system/package dataset uses librpm which has additional syscall
+		// requirements beyond the default policy from libbeat so whitelist
+		// these additional syscalls.
+		if err := seccomp.ModifyDefaultPolicy(seccomp.AddSyscall, "umask", "mremap"); err != nil {
+			panic(err)
+		}
+	}
+}


### PR DESCRIPTION
While running on CentOS 7 with the system/package dataset Auditbeat was violating its seccomp policy. This adds the syscalls that it was using to the default seccomp policy for Auditbeat.

Fixes #12578