### PR TITLE
Fixed functionbeat.yml example because it is wrong and misleading

### DIFF
--- a/x-pack/functionbeat/docs/getting-started.asciidoc
+++ b/x-pack/functionbeat/docs/getting-started.asciidoc
@@ -105,9 +105,8 @@ events from CloudWatch Logs and forwards the events to {es}.
     description: "lambda function for cloudwatch logs"
     triggers:
       - log_group_name: /aws/lambda/my-lambda-function
-output.elasticsearch:
-  cloud.id: "MyESDeployment:SomeLongString=="
-  cloud.auth: "elastic:SomeLongString"
+cloud.id: "MyESDeployment:SomeLongString=="
+cloud.auth: "elastic:SomeLongString"
 -------------------------------------------------------------------------------------
 
 To configure {beatname_uc}:


### PR DESCRIPTION
You had cloud.id/cloud.auth under "output.elasticsearch", but that isn't where it belongs, they belong at the root level.  I originally got an error: output.elasticsearch.hosts must be provided.