### PR TITLE
[Metricbeat] Add nil pointer checks for docker NetworkSettings

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -73,7 +73,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix `@timestamp` being duplicated in events if `@timestamp` is set in a
   processor (or by any code utilizing `PutValue()` on a `beat.Event`).
 - Fix leak in script processor when using Javascript functions in a processor chain. {pull}12600[12600]
-- Add additional nil pointer checks to deal with vSphere Integrated Containers {pull}12628[12628]
+- Add additional nil pointer checks to Docker client code to deal with vSphere Integrated Containers {pull}12628[12628]
 
 *Auditbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -73,6 +73,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix `@timestamp` being duplicated in events if `@timestamp` is set in a
   processor (or by any code utilizing `PutValue()` on a `beat.Event`).
 - Fix leak in script processor when using Javascript functions in a processor chain. {pull}12600[12600]
+- Add additional nil pointer checks to deal with vSphere Integrated Containers {pull}12628[12628]
 
 *Auditbeat*
 

--- a/libbeat/common/docker/watcher.go
+++ b/libbeat/common/docker/watcher.go
@@ -334,9 +334,12 @@ func (w *watcher) listContainers(options types.ContainerListOptions) ([]*Contain
 	var result []*Container
 	for _, c := range containers {
 		var ipaddresses []string
-		for _, net := range c.NetworkSettings.Networks {
-			if net.IPAddress != "" {
-				ipaddresses = append(ipaddresses, net.IPAddress)
+		if c.NetworkSettings != nil {
+			// Handle alternate platforms like VMWare's VIC that might not have this data.
+			for _, net := range c.NetworkSettings.Networks {
+				if net.IPAddress != "" {
+					ipaddresses = append(ipaddresses, net.IPAddress)
+				}
 			}
 		}
 

--- a/metricbeat/module/docker/container/data.go
+++ b/metricbeat/module/docker/container/data.go
@@ -69,6 +69,10 @@ func eventMapping(r mb.ReporterV2, cont *types.Container, dedot bool) {
 }
 
 func extractIPAddresses(networks *types.SummaryNetworkSettings) []string {
+	// Handle alternate platforms like VMWare's VIC that might not have this data.
+	if networks == nil {
+		return []string{}
+	}
 	ipAddresses := make([]string, 0, len(networks.Networks))
 	for _, network := range networks.Networks {
 		if len(network.IPAddress) > 0 {


### PR DESCRIPTION
This was @exekias  and I's idea, as a quick hotfix to deal with #12524.
See also vmware/vic#8564  
We decided at this point we don't need full support for VIC, but It can't hurt to add more nil pointer checks.

I'm still trying to figure out to what degree this would impact other parts of the docker module. I don't have a lot of experience setting up vSphere, which isn't helping. 