### PR TITLE
`logstash/state` metricset: Update code for parsing cluster_uuids

### DIFF
--- a/metricbeat/module/logstash/logstash.go
+++ b/metricbeat/module/logstash/logstash.go
@@ -38,14 +38,19 @@ type MetricSet struct {
 
 // PipelineState represents the state (shape) of a Logstash pipeline
 type PipelineState struct {
-	ID             string                 `json:"id"`
-	Hash           string                 `json:"hash"`
-	EphemeralID    string                 `json:"ephemeral_id"`
-	Graph          map[string]interface{} `json:"graph,omitempty"`
-	Representation map[string]interface{} `json:"representation"`
-	BatchSize      int                    `json:"batch_size"`
-	Workers        int                    `json:"workers"`
-	ClusterIDs     []string               `json:"cluster_uuids,omitempty"` // TODO: see https://github.com/elastic/logstash/issues/10602
+	ID             string          `json:"id"`
+	Hash           string          `json:"hash"`
+	EphemeralID    string          `json:"ephemeral_id"`
+	Graph          *graphContainer `json:"graph,omitempty"`
+	Representation *graphContainer `json:"representation"`
+	BatchSize      int             `json:"batch_size"`
+	Workers        int             `json:"workers"`
+}
+
+type graphContainer struct {
+	Graph struct {
+		Vertices []map[string]interface{} `json:"vertices"`
+	} `json:"graph"`
 }
 
 // NewMetricSet creates a metricset that can be used to build other metricsets

--- a/metricbeat/module/logstash/node/data_xpack.go
+++ b/metricbeat/module/logstash/node/data_xpack.go
@@ -27,29 +27,19 @@ import (
 )
 
 func eventMappingXPack(r mb.ReporterV2, m *MetricSet, pipelines []logstash.PipelineState) error {
-	for _, pipeline := range pipelines {
-		// Exclude internal pipelines
-		if pipeline.ID[0] == '.' {
-			continue
-		}
+	pipelines = getUserDefinedPipelines(pipelines)
+	clusterToPipelinesMap := makeClusterToPipelinesMap(pipelines)
 
-		// Rename key: graph -> representation
-		pipeline.Representation = pipeline.Graph
-		pipeline.Graph = nil
+	for clusterUUID, clusterPipelines := range clusterToPipelinesMap {
+		for _, pipeline := range clusterPipelines {
+			// Rename key: graph -> representation
+			pipeline.Representation = pipeline.Graph
+			pipeline.Graph = nil
 
-		// Extract cluster_uuids
-		clusterUUIDs := pipeline.ClusterIDs
-		pipeline.ClusterIDs = nil
+			logstashState := map[string]logstash.PipelineState{
+				"pipeline": pipeline,
+			}
 
-		logstashState := map[string]logstash.PipelineState{
-			"pipeline": pipeline,
-		}
-
-		if pipeline.ClusterIDs == nil {
-			pipeline.ClusterIDs = []string{""}
-		}
-
-		for _, clusterUUID := range clusterUUIDs {
 			event := mb.Event{}
 			event.RootFields = common.MapStr{
 				"timestamp":      common.Time(time.Now()),
@@ -69,4 +59,50 @@ func eventMappingXPack(r mb.ReporterV2, m *MetricSet, pipelines []logstash.Pipel
 	}
 
 	return nil
+}
+
+// TODO: Refactor once https://github.com/elastic/beats/pull/11511 is merged
+func makeClusterToPipelinesMap(pipelines []logstash.PipelineState) map[string][]logstash.PipelineState {
+	var clusterToPipelinesMap map[string][]logstash.PipelineState
+	clusterToPipelinesMap = make(map[string][]logstash.PipelineState)
+
+	for _, pipeline := range pipelines {
+		var clusterUUIDs []string
+
+		for _, vertex := range pipeline.Graph.Graph.Vertices {
+			c, ok := vertex["cluster_uuid"]
+			if !ok {
+				continue
+			}
+
+			clusterUUID, ok := c.(string)
+			if !ok {
+				continue
+			}
+
+			clusterUUIDs = append(clusterUUIDs, clusterUUID)
+		}
+
+		for _, clusterUUID := range clusterUUIDs {
+			clusterPipelines := clusterToPipelinesMap[clusterUUID]
+			if clusterPipelines == nil {
+				clusterToPipelinesMap[clusterUUID] = []logstash.PipelineState{}
+			}
+
+			clusterToPipelinesMap[clusterUUID] = append(clusterPipelines, pipeline)
+		}
+	}
+
+	return clusterToPipelinesMap
+}
+
+// TODO: Refactor once https://github.com/elastic/beats/pull/11511 is merged
+func getUserDefinedPipelines(pipelines []logstash.PipelineState) []logstash.PipelineState {
+	userDefinedPipelines := []logstash.PipelineState{}
+	for _, pipeline := range pipelines {
+		if pipeline.ID[0] != '.' {
+			userDefinedPipelines = append(userDefinedPipelines, pipeline)
+		}
+	}
+	return userDefinedPipelines
 }


### PR DESCRIPTION
_Depends on https://github.com/elastic/logstash/issues/10883 being resolved._

Previously, if a Logstash pipeline used an Elasticsearch output, the `GET _node/pipelines?graph=true` API response returned a `pipelines.{id}.cluster_uuids` property. This property contained cluster UUIDs of all Elasticsearch clusters a Logstash pipeline might be connected to via the Elasticsearch output plugin. 

However, we've now decided to get rid of this property. Instead we want to introduce a `pipelines.{id}.graph.graph.vertices[n].cluster_uuid` property (note singular property name) for vertices that represent Elasticsearch output plugins. 

This PR updates the cluster UUIDs parsing logic in the `logstash/state` metricset code (x-pack code path).