### PR TITLE
Exclude modules with init() in tests from includes lists

### DIFF
--- a/dev-tools/cmd/module_include_list/module_include_list.go
+++ b/dev-tools/cmd/module_include_list/module_include_list.go
@@ -99,19 +99,18 @@ func main() {
 	// Build import paths.
 	var imports []string
 	for _, dir := range dirs {
-		// Skip dirs that have no .go files.
-		goFiles, err := filepath.Glob(filepath.Join(dir, "*.go"))
-		if err != nil {
-			log.Fatal("Failed checking for .go files in package dir: %v", err)
-		}
-		if len(goFiles) == 0 {
-			continue
-		}
-
 		// Skip packages without an init() function because that cannot register
 		// anything as a side-effect of being imported (e.g. filebeat/input/file).
 		var foundInitMethod bool
+		goFiles, err := filepath.Glob(filepath.Join(dir, "*.go"))
+		if err != nil {
+			log.Fatalf("Failed checking for .go files in package dir: %v", err)
+		}
 		for _, f := range goFiles {
+			// Skip test files
+			if strings.HasSuffix(f, "_test.go") {
+				continue
+			}
 			if hasInitMethod(f) {
 				foundInitMethod = true
 				break

--- a/packetbeat/include/list.go
+++ b/packetbeat/include/list.go
@@ -33,7 +33,6 @@ import (
 	_ "github.com/elastic/beats/packetbeat/protos/nfs"
 	_ "github.com/elastic/beats/packetbeat/protos/pgsql"
 	_ "github.com/elastic/beats/packetbeat/protos/redis"
-	_ "github.com/elastic/beats/packetbeat/protos/tcp"
 	_ "github.com/elastic/beats/packetbeat/protos/thrift"
 	_ "github.com/elastic/beats/packetbeat/protos/tls"
 )


### PR DESCRIPTION
Tool that collects modules for the includes lists checks only
include packages that have an init method, but it can also
include packages whose inits methods are defined only in
tests. Exclude these packages from the list.

This is required to do go tests in modules without code as
filebeat modules or metricbeat light modules (#12270).