### PR TITLE
[docs] add line to filebeat docs about close_* behavior.

### DIFF
--- a/filebeat/docs/inputs/input-common-file-options.asciidoc
+++ b/filebeat/docs/inputs/input-common-file-options.asciidoc
@@ -77,7 +77,11 @@ certain criteria or time. Closing the harvester means closing the file handler.
 If a file is updated after the harvester is closed, the file will be picked up
 again after `scan_frequency` has elapsed. However, if the file is moved or
 deleted while the harvester is closed, {beatname_uc} will not be able to pick up
-the file again, and any data that the harvester hasn't read will be lost.
+the file again, and any data that the harvester hasn't read will be lost. 
+The `close_*` settings are applied synchronously when {beatname_uc} attempts 
+to read from a file, meaning that if {beatname_uc} is in a blocked state,
+a file that would otherwise be closed remains open until {beatname_uc} 
+once again attempts to read from the file.
 
 
 [float]

--- a/filebeat/docs/inputs/input-common-file-options.asciidoc
+++ b/filebeat/docs/inputs/input-common-file-options.asciidoc
@@ -79,9 +79,9 @@ again after `scan_frequency` has elapsed. However, if the file is moved or
 deleted while the harvester is closed, {beatname_uc} will not be able to pick up
 the file again, and any data that the harvester hasn't read will be lost. 
 The `close_*` settings are applied synchronously when {beatname_uc} attempts 
-to read from a file, meaning that if {beatname_uc} is in a blocked state,
-a file that would otherwise be closed remains open until {beatname_uc} 
-once again attempts to read from the file.
+to read from a file, meaning that if {beatname_uc} is in a blocked state
+due to blocked output, full queue or other issue, a file that would 
+otherwise be closed remains open until {beatname_uc} once again attempts to read from the file.
 
 
 [float]


### PR DESCRIPTION
This doc change attempts to explain the behavior of the `close_*` options. Specifically, that these are applied synchronously and will not be applied if the beat is blocked or otherwise not reading from the file in question.

This came up in a support ticket, and I figured this would be an easy fix to add additional technical detail. 