### PR TITLE
Change expired credentials to obviously fake ones

### DIFF
--- a/x-pack/metricbeat/module/aws/mtest/scripts/get_temp_creds.go
+++ b/x-pack/metricbeat/module/aws/mtest/scripts/get_temp_creds.go
@@ -19,8 +19,8 @@ func getCredentialsUsingMFA() {
 	serialNumber := "arn:aws:iam::654321:mfa/test@test.com"
 
 	// access key id and secret access key of your IAM user.
-	accessKeyID := "AKIAIFX3D"
-	secretAccessKey := "jyVKiT"
+	accessKeyID := "FAKE-ACCESS-KEY-ID"
+	secretAccessKey := "FAKE-SECRET-ACCESS-KEY"
 
 	os.Setenv("AWS_ACCESS_KEY_ID", accessKeyID)
 	os.Setenv("AWS_SECRET_ACCESS_KEY", secretAccessKey)

--- a/x-pack/metricbeat/module/aws/mtest/scripts/sqs_send_receive_delete.go
+++ b/x-pack/metricbeat/module/aws/mtest/scripts/sqs_send_receive_delete.go
@@ -91,9 +91,9 @@ func deleteMessage(qURL string, svc sqsiface.SQSAPI, message sqs.Message) error 
 func sqsSendReceiveDelete() {
 	fmt.Println("Please setup AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY and SESSION_TOKEN first. If a temp credentials are needed, please run getTempCreds.go first.")
 	regionsList := []string{"us-west-1", "us-east-1"}
-	accessKeyID := "ASIAZENKQPPN4AXZ3KN2"
-	secretAccessKey := "GcotQB6fb8dPCoCp37BZ4qZWQhwacybhqtbk+xH6"
-	sessionToken := "H6s4gTiZO1kG5150Y9nGkvqkgiyEuT08+CnY0DnmsrPnIpZsqsx9AkltCQF/7iOxF97blS9oCu08hBbmibPU+V/RKLWWr+QF"
+	accessKeyID := "FAKE-ACCESS-KEY-ID"
+	secretAccessKey := "FAKE-SECRET-ACCESS-KEY"
+	sessionToken := "FAKE-SESSION-TOKEN"
 
 	awsConfig := defaults.Config()
 	awsCreds := aws.Credentials{


### PR DESCRIPTION
Thanks for security team to point out: even I'm already using expired/fake credentials in one of my PRs, it's still good to use completely fake one. I'm just making this PR to change credentials to be more obviously fake.