### PR TITLE
Cherry-pick #12577 to 7.2: Add warning for logging configuration on systemd

### DIFF
--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -1129,6 +1129,9 @@ setup.kibana:
 # Multiple selectors can be chained.
 #logging.selectors: [ ]
 
+# Send all logging output to stderr. The default is false.
+#logging.to_stderr: false
+
 # Send all logging output to syslog. The default is false.
 #logging.to_syslog: false
 

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -1858,6 +1858,9 @@ setup.kibana:
 # Multiple selectors can be chained.
 #logging.selectors: [ ]
 
+# Send all logging output to stderr. The default is false.
+#logging.to_stderr: false
+
 # Send all logging output to syslog. The default is false.
 #logging.to_syslog: false
 

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -1273,6 +1273,9 @@ setup.kibana:
 # Multiple selectors can be chained.
 #logging.selectors: [ ]
 
+# Send all logging output to stderr. The default is false.
+#logging.to_stderr: false
+
 # Send all logging output to syslog. The default is false.
 #logging.to_syslog: false
 

--- a/journalbeat/journalbeat.reference.yml
+++ b/journalbeat/journalbeat.reference.yml
@@ -1069,6 +1069,9 @@ setup.kibana:
 # Multiple selectors can be chained.
 #logging.selectors: [ ]
 
+# Send all logging output to stderr. The default is false.
+#logging.to_stderr: false
+
 # Send all logging output to syslog. The default is false.
 #logging.to_syslog: false
 

--- a/libbeat/_meta/config.reference.yml
+++ b/libbeat/_meta/config.reference.yml
@@ -1017,6 +1017,9 @@ setup.kibana:
 # Multiple selectors can be chained.
 #logging.selectors: [ ]
 
+# Send all logging output to stderr. The default is false.
+#logging.to_stderr: false
+
 # Send all logging output to syslog. The default is false.
 #logging.to_syslog: false
 

--- a/libbeat/docs/loggingconfig.asciidoc
+++ b/libbeat/docs/loggingconfig.asciidoc
@@ -48,6 +48,13 @@ endif::win_only[]
 TIP: In addition to setting logging options in the config file, you can modify
 the logging output configuration from the command line. See
 <<command-line-options>>.
+
+ifndef::win_only[]
+WARNING: When {beatname_uc} is running on a Linux system with systemd, it uses
+by default the `-e` command line option, that makes it write all the logging output
+to stderr so it can be captured by journald. Other outputs are disabled. See
+<<running-with-systemd>> to know more and learn how to change this.
+endif::win_only[]
 endif::serverless[]
 
 ifdef::serverless[]
@@ -77,6 +84,12 @@ You can specify the following options in the `logging` section of the
 +{beatname_lc}.yml+ config file:
 
 ifndef::serverless[]
+[float]
+==== `logging.to_stderr`
+
+When true, writes all logging output to standard error output. This is
+equivalent to using the `-e` command line option.
+
 [float]
 ==== `logging.to_syslog`
 

--- a/libbeat/docs/shared-systemd.asciidoc
+++ b/libbeat/docs/shared-systemd.asciidoc
@@ -80,8 +80,8 @@ would override `BEAT_LOG_OPTS` to enable debug for Elasticsearch output.
 Environment="BEAT_LOG_OPTS=-e -d elasticsearch"
 ------------------------------------------------
 
-To use settings from the {beatname_uc} file, empty the environment
-variable. For example:
+To change the logging output from the {beatname_uc} configuration file, empty
+the environment variable. For example:
 
 ["source", "systemd", subs="attributes"]
 ------------------------------------------------

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -1746,6 +1746,9 @@ setup.kibana:
 # Multiple selectors can be chained.
 #logging.selectors: [ ]
 
+# Send all logging output to stderr. The default is false.
+#logging.to_stderr: false
+
 # Send all logging output to syslog. The default is false.
 #logging.to_syslog: false
 

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -1497,6 +1497,9 @@ setup.kibana:
 # Multiple selectors can be chained.
 #logging.selectors: [ ]
 
+# Send all logging output to stderr. The default is false.
+#logging.to_stderr: false
+
 # Send all logging output to syslog. The default is false.
 #logging.to_syslog: false
 

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -1050,6 +1050,9 @@ setup.kibana:
 # Multiple selectors can be chained.
 #logging.selectors: [ ]
 
+# Send all logging output to stderr. The default is false.
+#logging.to_stderr: false
+
 # Send all logging output to syslog. The default is false.
 #logging.to_syslog: false
 

--- a/x-pack/auditbeat/auditbeat.reference.yml
+++ b/x-pack/auditbeat/auditbeat.reference.yml
@@ -1180,6 +1180,9 @@ setup.kibana:
 # Multiple selectors can be chained.
 #logging.selectors: [ ]
 
+# Send all logging output to stderr. The default is false.
+#logging.to_stderr: false
+
 # Send all logging output to syslog. The default is false.
 #logging.to_syslog: false
 

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -1999,6 +1999,9 @@ setup.kibana:
 # Multiple selectors can be chained.
 #logging.selectors: [ ]
 
+# Send all logging output to stderr. The default is false.
+#logging.to_stderr: false
+
 # Send all logging output to syslog. The default is false.
 #logging.to_syslog: false
 

--- a/x-pack/functionbeat/functionbeat.reference.yml
+++ b/x-pack/functionbeat/functionbeat.reference.yml
@@ -1186,6 +1186,9 @@ setup.kibana:
 # Multiple selectors can be chained.
 #logging.selectors: [ ]
 
+# Send all logging output to stderr. The default is false.
+#logging.to_stderr: false
+
 # Send all logging output to syslog. The default is false.
 #logging.to_syslog: false
 

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -1810,6 +1810,9 @@ setup.kibana:
 # Multiple selectors can be chained.
 #logging.selectors: [ ]
 
+# Send all logging output to stderr. The default is false.
+#logging.to_stderr: false
+
 # Send all logging output to syslog. The default is false.
 #logging.to_syslog: false
 

--- a/x-pack/winlogbeat/winlogbeat.reference.yml
+++ b/x-pack/winlogbeat/winlogbeat.reference.yml
@@ -1062,6 +1062,9 @@ setup.kibana:
 # Multiple selectors can be chained.
 #logging.selectors: [ ]
 
+# Send all logging output to stderr. The default is false.
+#logging.to_stderr: false
+
 # Send all logging output to syslog. The default is false.
 #logging.to_syslog: false
 


### PR DESCRIPTION
Cherry-pick of PR #12577 to 7.2 branch. Original message: 

Since 7.0 we add the `-e` flag to all beats from the systemd unit file.
This make them to log to stderr on systems with systemd, what is the
recommended behaviour on these systems, so local logs are managed by
journald. This creates some confusion as the added flag makes beats
ignore other output settings added to the configuration files.
Add a new warning in the logging configuration page about this.

Related to #8942 and #12024