### PR TITLE
Fix module config defaults in light modules

### DIFF
--- a/metricbeat/mb/lightmetricset.go
+++ b/metricbeat/mb/lightmetricset.go
@@ -97,21 +97,23 @@ func (m *LightMetricSet) Registration(r *Register) (MetricSetRegistration, error
 // baseModule does the configuration overrides in the base module configuration
 // taking into account the light metric set default configurations
 func (m *LightMetricSet) baseModule(from Module) (*BaseModule, error) {
-	baseModule := BaseModule{
-		name: m.Module,
-	}
-	var err error
-	// Set defaults
-	if baseModule.rawConfig, err = common.NewConfigFrom(m.Input.Defaults); err != nil {
+	// Initialize config using input defaults as raw config
+	rawConfig, err := common.NewConfigFrom(m.Input.Defaults)
+	if err != nil {
 		return nil, errors.Wrap(err, "invalid input defaults")
 	}
+
 	// Copy values from user configuration
-	if err = from.UnpackConfig(baseModule.rawConfig); err != nil {
+	if err = from.UnpackConfig(rawConfig); err != nil {
 		return nil, errors.Wrap(err, "failed to copy values from user configuration")
 	}
-	// Update module configuration
-	if err = baseModule.UnpackConfig(&baseModule.config); err != nil {
-		return nil, errors.Wrap(err, "failed to set module configuration")
+
+	// Create the base module
+	baseModule, err := newBaseModuleFromConfig(rawConfig)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create base module")
 	}
+	baseModule.name = m.Module
+
 	return &baseModule, nil
 }

--- a/x-pack/metricbeat/mb/lightmodules_test.go
+++ b/x-pack/metricbeat/mb/lightmodules_test.go
@@ -180,7 +180,6 @@ func TestNewModuleFromConfig(t *testing.T) {
 		"normal module": {
 			config:         common.MapStr{"module": "foo", "metricsets": []string{"bar"}},
 			expectedOption: "default",
-			expectedPeriod: mb.DefaultModuleConfig().Period,
 		},
 		"light module": {
 			config:         common.MapStr{"module": "service", "metricsets": []string{"metricset"}},
@@ -247,9 +246,11 @@ func TestNewModuleFromConfig(t *testing.T) {
 					require.True(t, ok)
 					assert.Equal(t, c.expectedOption, ms.Option)
 					assert.Equal(t, c.expectedQuery, ms.Module().Config().Query)
-					if c.expectedPeriod > 0 {
-						assert.Equal(t, c.expectedPeriod, ms.Module().Config().Period)
+					expectedPeriod := c.expectedPeriod
+					if expectedPeriod == 0 {
+						expectedPeriod = mb.DefaultModuleConfig().Period
 					}
+					assert.Equal(t, expectedPeriod, ms.Module().Config().Period)
 				})
 			}
 		})


### PR DESCRIPTION
Use common base module builder when creating the base module for light
modules, so same defaults are set and same checks are executed. Without
this change there are errors if values that have defaults like `period`
are not set.

Related to #12270