### PR TITLE
Refactoring: use new method to check metricsets

### DIFF
--- a/metricbeat/tests/system/test_logstash.py
+++ b/metricbeat/tests/system/test_logstash.py
@@ -3,53 +3,22 @@ import metricbeat
 import unittest
 import time
 
-
 class Test(metricbeat.BaseTest):
 
     COMPOSE_SERVICES = ['logstash']
+    FIELDS = ['logstash']
 
     @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
     def test_node(self):
         """
         logstash node metricset test
         """
-        self.render_config_template(modules=[{
-            "name": "logstash",
-            "metricsets": ["node"],
-            "hosts": self.get_hosts(),
-            "period": "1s",
-        }])
-        proc = self.start_beat()
-        self.wait_until(lambda: self.output_lines() > 0, max_timeout=20)
-        proc.check_kill_and_wait()
-        self.assert_no_logged_warnings()
+        self.check_metricset("logstash", "node", self.get_hosts(), self.FIELDS + ["process"])
 
-        output = self.read_output_json()
-        self.assertTrue(len(output) >= 1)
-        evt = output[0]
-        print(evt)
-
-        self.assert_fields_are_documented(evt)
 
     @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
     def test_node_stats(self):
         """
         logstash node_stats metricset test
         """
-        self.render_config_template(modules=[{
-            "name": "logstash",
-            "metricsets": ["node_stats"],
-            "hosts": self.get_hosts(),
-            "period": "1s",
-        }])
-        proc = self.start_beat()
-        self.wait_until(lambda: self.output_lines() > 0, max_timeout=20)
-        proc.check_kill_and_wait()
-        self.assert_no_logged_warnings()
-
-        output = self.read_output_json()
-        self.assertTrue(len(output) >= 1)
-        evt = output[0]
-        print(evt)
-
-        self.assert_fields_are_documented(evt)
+        self.check_metricset("logstash", "node_stats", self.get_hosts(), self.FIELDS)

--- a/metricbeat/tests/system/test_logstash.py
+++ b/metricbeat/tests/system/test_logstash.py
@@ -3,6 +3,7 @@ import metricbeat
 import unittest
 import time
 
+
 class Test(metricbeat.BaseTest):
 
     COMPOSE_SERVICES = ['logstash']
@@ -14,7 +15,6 @@ class Test(metricbeat.BaseTest):
         logstash node metricset test
         """
         self.check_metricset("logstash", "node", self.get_hosts(), self.FIELDS + ["process"])
-
 
     @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
     def test_node_stats(self):


### PR DESCRIPTION
This PR simply refactors the Metricbeat `logstash` module's system tests to use the `check_metricset` method.