### PR TITLE
Improve docs for Kafka output SSL configuration

### DIFF
--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -686,10 +686,7 @@ The http request timeout in seconds for the Elasticsearch request. The default i
 ===== `ssl`
 
 Configuration options for SSL parameters like the certificate authority to use
-for HTTPS-based connections. The Kafka host keystore should be created with the
-`-keyalg RSA` argument to ensure it uses a cipher supported by
-[Filebeat's Kafka library](https://github.com/Shopify/sarama/wiki/Frequently-Asked-Questions#why-cant-sarama-connect-to-my-kafka-cluster-using-ssl).
-If the `ssl` section is missing, the host CAs are used for HTTPS connections to
+for HTTPS-based connections. If the `ssl` section is missing, the host CAs are used for HTTPS connections to
 Elasticsearch.
 
 See <<configuration-ssl>> for more information.
@@ -1217,8 +1214,11 @@ Note: If set to 0, no ACKs are returned by Kafka. Messages might be lost silentl
 
 ===== `ssl`
 
-Configuration options for SSL parameters like the root CA for Kafka connections. See
-<<configuration-ssl>> for more information.
+Configuration options for SSL parameters like the root CA for Kafka connections.
+ The Kafka host keystore should be created with the
+`-keyalg RSA` argument to ensure it uses a cipher supported by
+https://github.com/Shopify/sarama/wiki/Frequently-Asked-Questions#why-cant-sarama-connect-to-my-kafka-cluster-using-ssl[Filebeat's Kafka library].
+See <<configuration-ssl>> for more information.
 
 //begin inner exclude for redis
 ifndef::no-redis-output[]

--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -686,7 +686,10 @@ The http request timeout in seconds for the Elasticsearch request. The default i
 ===== `ssl`
 
 Configuration options for SSL parameters like the certificate authority to use
-for HTTPS-based connections. If the `ssl` section is missing, the host CAs are used for HTTPS connections to
+for HTTPS-based connections. The Kafka host keystore should be created with the
+`-keyalg RSA` argument to ensure it uses a cipher supported by
+[Filebeat's Kafka library](https://github.com/Shopify/sarama/wiki/Frequently-Asked-Questions#why-cant-sarama-connect-to-my-kafka-cluster-using-ssl).
+If the `ssl` section is missing, the host CAs are used for HTTPS connections to
 Elasticsearch.
 
 See <<configuration-ssl>> for more information.


### PR DESCRIPTION
Add a warning about a common SSL configuration error, thanks to @jsoriano