### PR TITLE
Add max_connections to TCP input

### DIFF
--- a/filebeat/_meta/common.reference.inputs.yml
+++ b/filebeat/_meta/common.reference.inputs.yml
@@ -231,8 +231,8 @@ filebeat.inputs:
   # Network type to be used for redis connection. Default: tcp
   #network: tcp
 
-  # Max number of concurrent connections. By default it is not limited.
-  #maxconn: 0
+  # Max number of concurrent connections. Default: 10
+  #maxconn: 10
 
   # Redis AUTH password. Empty by default.
   #password: foobared
@@ -263,8 +263,8 @@ filebeat.inputs:
   # Maximum size in bytes of the message received over TCP
   #max_message_size: 20MiB
 
-  # Maximum number of connections
-  #max_connections: 10
+  # Max number of concurrent connections, or 0 for no limit. Default: 0
+  #max_connections: 0
 
   # The number of seconds of inactivity before a remote connection is closed.
   #timeout: 300s

--- a/filebeat/_meta/common.reference.inputs.yml
+++ b/filebeat/_meta/common.reference.inputs.yml
@@ -231,8 +231,8 @@ filebeat.inputs:
   # Network type to be used for redis connection. Default: tcp
   #network: tcp
 
-  # Max number of concurrent connections. Default: 10
-  #maxconn: 10
+  # Max number of concurrent connections. By default it is not limited.
+  #maxconn: 0
 
   # Redis AUTH password. Empty by default.
   #password: foobared

--- a/filebeat/_meta/common.reference.inputs.yml
+++ b/filebeat/_meta/common.reference.inputs.yml
@@ -263,6 +263,9 @@ filebeat.inputs:
   # Maximum size in bytes of the message received over TCP
   #max_message_size: 20MiB
 
+  # Maximum number of connections
+  #max_connections: 10
+
   # The number of seconds of inactivity before a remote connection is closed.
   #timeout: 300s
 

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -640,6 +640,9 @@ filebeat.inputs:
   # Maximum size in bytes of the message received over TCP
   #max_message_size: 20MiB
 
+  # Maximum number of connections
+  #max_connections: 10
+
   # The number of seconds of inactivity before a remote connection is closed.
   #timeout: 300s
 

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -608,8 +608,8 @@ filebeat.inputs:
   # Network type to be used for redis connection. Default: tcp
   #network: tcp
 
-  # Max number of concurrent connections. Default: 10
-  #maxconn: 10
+  # Max number of concurrent connections. By default it is not limited.
+  #maxconn: 0
 
   # Redis AUTH password. Empty by default.
   #password: foobared

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -608,8 +608,8 @@ filebeat.inputs:
   # Network type to be used for redis connection. Default: tcp
   #network: tcp
 
-  # Max number of concurrent connections. By default it is not limited.
-  #maxconn: 0
+  # Max number of concurrent connections. Default: 10
+  #maxconn: 10
 
   # Redis AUTH password. Empty by default.
   #password: foobared
@@ -640,8 +640,8 @@ filebeat.inputs:
   # Maximum size in bytes of the message received over TCP
   #max_message_size: 20MiB
 
-  # Maximum number of connections
-  #max_connections: 10
+  # Max number of concurrent connections, or 0 for no limit. Default: 0
+  #max_connections: 0
 
   # The number of seconds of inactivity before a remote connection is closed.
   #timeout: 300s

--- a/filebeat/input/tcp/config.go
+++ b/filebeat/input/tcp/config.go
@@ -40,7 +40,7 @@ var defaultConfig = config{
 	Config: tcp.Config{
 		Timeout:        time.Minute * 5,
 		MaxMessageSize: 20 * humanize.MiByte,
-		MaxConnections: 10,
+		MaxConnections: 0,
 	},
 	LineDelimiter: "\n",
 }

--- a/filebeat/input/tcp/config.go
+++ b/filebeat/input/tcp/config.go
@@ -40,6 +40,7 @@ var defaultConfig = config{
 	Config: tcp.Config{
 		Timeout:        time.Minute * 5,
 		MaxMessageSize: 20 * humanize.MiByte,
+		MaxConnections: 10,
 	},
 	LineDelimiter: "\n",
 }

--- a/filebeat/input/tcp/config.go
+++ b/filebeat/input/tcp/config.go
@@ -40,7 +40,6 @@ var defaultConfig = config{
 	Config: tcp.Config{
 		Timeout:        time.Minute * 5,
 		MaxMessageSize: 20 * humanize.MiByte,
-		MaxConnections: 0,
 	},
 	LineDelimiter: "\n",
 }

--- a/filebeat/inputsource/tcp/config.go
+++ b/filebeat/inputsource/tcp/config.go
@@ -35,7 +35,7 @@ type Config struct {
 	Host           string                  `config:"host"`
 	Timeout        time.Duration           `config:"timeout" validate:"nonzero,positive"`
 	MaxMessageSize cfgtype.ByteSize        `config:"max_message_size" validate:"nonzero,positive"`
-	MaxConnections int                     `config:"max_connections" validate:"nonzero,positive"`
+	MaxConnections int                     `config:"max_connections"`
 	TLS            *tlscommon.ServerConfig `config:"ssl"`
 }
 

--- a/filebeat/inputsource/tcp/config.go
+++ b/filebeat/inputsource/tcp/config.go
@@ -35,6 +35,7 @@ type Config struct {
 	Host           string                  `config:"host"`
 	Timeout        time.Duration           `config:"timeout" validate:"nonzero,positive"`
 	MaxMessageSize cfgtype.ByteSize        `config:"max_message_size" validate:"nonzero,positive"`
+	MaxConnections int                     `config:"max_connections" validate:"nonzero,positive"`
 	TLS            *tlscommon.ServerConfig `config:"ssl"`
 }
 

--- a/filebeat/inputsource/tcp/server.go
+++ b/filebeat/inputsource/tcp/server.go
@@ -193,7 +193,10 @@ func (s *Server) createServer() (net.Listener, error) {
 		}
 	}
 
-	return netutil.LimitListener(l, s.config.MaxConnections), nil
+	if s.config.MaxConnections > 0 {
+		return netutil.LimitListener(l, s.config.MaxConnections), nil
+	}
+	return l, nil
 }
 
 func (s *Server) clientsCount() int {

--- a/vendor/golang.org/x/net/netutil/listen.go
+++ b/vendor/golang.org/x/net/netutil/listen.go
@@ -1,0 +1,74 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package netutil provides network utility functions, complementing the more
+// common ones in the net package.
+package netutil // import "golang.org/x/net/netutil"
+
+import (
+	"net"
+	"sync"
+)
+
+// LimitListener returns a Listener that accepts at most n simultaneous
+// connections from the provided Listener.
+func LimitListener(l net.Listener, n int) net.Listener {
+	return &limitListener{
+		Listener: l,
+		sem:      make(chan struct{}, n),
+		done:     make(chan struct{}),
+	}
+}
+
+type limitListener struct {
+	net.Listener
+	sem       chan struct{}
+	closeOnce sync.Once     // ensures the done chan is only closed once
+	done      chan struct{} // no values sent; closed when Close is called
+}
+
+// acquire acquires the limiting semaphore. Returns true if successfully
+// accquired, false if the listener is closed and the semaphore is not
+// acquired.
+func (l *limitListener) acquire() bool {
+	select {
+	case <-l.done:
+		return false
+	case l.sem <- struct{}{}:
+		return true
+	}
+}
+func (l *limitListener) release() { <-l.sem }
+
+func (l *limitListener) Accept() (net.Conn, error) {
+	acquired := l.acquire()
+	// If the semaphore isn't acquired because the listener was closed, expect
+	// that this call to accept won't block, but immediately return an error.
+	c, err := l.Listener.Accept()
+	if err != nil {
+		if acquired {
+			l.release()
+		}
+		return nil, err
+	}
+	return &limitListenerConn{Conn: c, release: l.release}, nil
+}
+
+func (l *limitListener) Close() error {
+	err := l.Listener.Close()
+	l.closeOnce.Do(func() { close(l.done) })
+	return err
+}
+
+type limitListenerConn struct {
+	net.Conn
+	releaseOnce sync.Once
+	release     func()
+}
+
+func (l *limitListenerConn) Close() error {
+	err := l.Conn.Close()
+	l.releaseOnce.Do(l.release)
+	return err
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -2346,6 +2346,12 @@
 			"versionExact": "release-branch.go1.9"
 		},
 		{
+			"checksumSHA1": "CkkyCjLPBm0OGzfMuTfaDsd45X4=",
+			"path": "golang.org/x/net/netutil",
+			"revision": "3b0461eec859c4b73bb64fdc8285971fd33e3938",
+			"revisionTime": "2019-06-20T19:42:36Z"
+		},
+		{
 			"checksumSHA1": "QEm/dePZ0lOnyOs+m22KjXfJ/IU=",
 			"path": "golang.org/x/net/proxy",
 			"revision": "44b7c21cbf19450f38b337eb6b6fe4f6496fb5b3",

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -759,6 +759,9 @@ filebeat.inputs:
   # Maximum size in bytes of the message received over TCP
   #max_message_size: 20MiB
 
+  # Maximum number of connections
+  #max_connections: 10
+
   # The number of seconds of inactivity before a remote connection is closed.
   #timeout: 300s
 

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -727,8 +727,8 @@ filebeat.inputs:
   # Network type to be used for redis connection. Default: tcp
   #network: tcp
 
-  # Max number of concurrent connections. Default: 10
-  #maxconn: 10
+  # Max number of concurrent connections. By default it is not limited.
+  #maxconn: 0
 
   # Redis AUTH password. Empty by default.
   #password: foobared

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -727,8 +727,8 @@ filebeat.inputs:
   # Network type to be used for redis connection. Default: tcp
   #network: tcp
 
-  # Max number of concurrent connections. By default it is not limited.
-  #maxconn: 0
+  # Max number of concurrent connections. Default: 10
+  #maxconn: 10
 
   # Redis AUTH password. Empty by default.
   #password: foobared
@@ -759,8 +759,8 @@ filebeat.inputs:
   # Maximum size in bytes of the message received over TCP
   #max_message_size: 20MiB
 
-  # Maximum number of connections
-  #max_connections: 10
+  # Max number of concurrent connections, or 0 for no limit. Default: 0
+  #max_connections: 0
 
   # The number of seconds of inactivity before a remote connection is closed.
   #timeout: 300s


### PR DESCRIPTION
New configuration option is added to the TCP input of Filebeat to limit the number of incoming connections. By default it is set to 0 which means, it's unlimited.

```
# Max number of concurrent connections, or 0 for no limit. Default: 0
#max_connections: 0
```

Vendored
* `golang.org/x/net/netutil`