### PR TITLE
Omit empty process field from syslog input

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -106,6 +106,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix timezone offset parsing in system/syslog. {pull}12529[12529]
 - When TLS is configured for the TCP input and a `certificate_authorities` is configured we now default to `required` for the `client_authentication`. {pull}12584[12584]
 - Apply `max_message_size` to incoming message buffer. {pull}11966[11966]
+- Syslog input will now omit the `process` object from events if it is empty. {pull}12700[12700]
 
 *Heartbeat*
 

--- a/filebeat/input/syslog/input.go
+++ b/filebeat/input/syslog/input.go
@@ -249,7 +249,9 @@ func createEvent(ev *event, metadata inputsource.NetworkMetadata, timezone *time
 
 	f["syslog"] = syslog
 	f["event"] = event
-	f["process"] = process
+	if len(process) > 0 {
+		f["process"] = process
+	}
 
 	if ev.Sequence() != -1 {
 		f["event.sequence"] = ev.Sequence()

--- a/filebeat/input/syslog/input_test.go
+++ b/filebeat/input/syslog/input_test.go
@@ -110,11 +110,8 @@ func TestPid(t *testing.T) {
 		m := dummyMetadata()
 		event := createEvent(e, m, time.Local, logp.NewLogger("syslog"))
 
-		v, err := event.GetValue("process")
-		if !assert.NoError(t, err) {
-			return
-		}
-		assert.Equal(t, common.MapStr{}, v)
+		_, err := event.GetValue("process")
+		assert.Equal(t, common.ErrKeyNotFound, err)
 	})
 }
 
@@ -165,12 +162,8 @@ func TestProgram(t *testing.T) {
 		m := dummyMetadata()
 		event := createEvent(e, m, time.Local, logp.NewLogger("syslog"))
 
-		v, err := event.GetValue("process")
-		if !assert.NoError(t, err) {
-			return
-		}
-
-		assert.Equal(t, common.MapStr{}, v)
+		_, err := event.GetValue("process")
+		assert.Equal(t, common.ErrKeyNotFound, err)
 	})
 }
 


### PR DESCRIPTION
If a syslog message contains no process information then the empty `process` object should be omitted from events.