### PR TITLE
Add network.iana_number to community_id processor defaults

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -173,6 +173,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Processor `add_cloud_metadata` adds fields `cloud.account.id` and `cloud.image.id` for AWS EC2. {pull}12307[12307]
 - Add configurable bulk_flush_frequency in kafka output. {pull}12254[12254]
 - Add `decode_base64_field` processor for decoding base64 field. {pull}11914[11914]
+- Add support for reading the `network.iana_number` field by default to the community_id processor. {pull}12701[12701]
 - Add aws overview dashboard. {issue}11007[11007] {pull}12175[12175]
 
 *Auditbeat*

--- a/libbeat/docs/processors-using.asciidoc
+++ b/libbeat/docs/processors-using.asciidoc
@@ -934,7 +934,8 @@ processors:
         source_port: my_source_port
         destination_ip: my_dest_ip
         destination_port: my_dest_port
-        transport: proto
+        iana_number: my_iana_number
+        transport: my_transport
         icmp_type: my_icmp_type
         icmp_code: my_icmp_code
       target: network.community_id

--- a/libbeat/processors/communityid/communityid.go
+++ b/libbeat/processors/communityid/communityid.go
@@ -131,10 +131,14 @@ func (p *processor) buildFlow(event *beat.Event) *flowhash.Flow {
 		return nil
 	}
 
-	// protocol
-	v, err = event.GetValue(p.Fields.TransportProtocol)
+	// protocol (try IANA number first)
+	v, err = event.GetValue(p.Fields.IANANumber)
 	if err != nil {
-		return nil
+		// Try transport protocol name next.
+		v, err = event.GetValue(p.Fields.TransportProtocol)
+		if err != nil {
+			return nil
+		}
 	}
 	flow.Protocol, ok = tryToIANATransportProtocol(v)
 	if !ok {
@@ -250,7 +254,11 @@ const (
 	igmpProtocol     uint8 = 2
 	tcpProtocol      uint8 = 6
 	udpProtocol      uint8 = 17
+	greProtocol      uint8 = 47
 	icmpIPv6Protocol uint8 = 58
+	eigrpProtocol    uint8 = 88
+	ospfProtocol     uint8 = 89
+	pimProtocol      uint8 = 103
 	sctpProtocol     uint8 = 132
 )
 
@@ -259,8 +267,12 @@ var transports = map[string]uint8{
 	"igmp":      igmpProtocol,
 	"tcp":       tcpProtocol,
 	"udp":       udpProtocol,
+	"gre":       greProtocol,
 	"ipv6-icmp": icmpIPv6Protocol,
 	"icmpv6":    icmpIPv6Protocol,
+	"eigrp":     eigrpProtocol,
+	"ospf":      ospfProtocol,
+	"pim":       pimProtocol,
 	"sctp":      sctpProtocol,
 }
 

--- a/libbeat/processors/communityid/communityid_test.go
+++ b/libbeat/processors/communityid/communityid_test.go
@@ -46,7 +46,9 @@ func TestRun(t *testing.T) {
 				"ip":   "66.35.250.204",
 				"port": 80,
 			},
-			"network": common.MapStr{"transport": "TCP"},
+			"network": common.MapStr{
+				"transport": "TCP",
+			},
 		}
 	}
 
@@ -125,6 +127,13 @@ func TestRun(t *testing.T) {
 		e.Delete("destination.port")
 		e.Put("network.transport", 2)
 		testProcessor(t, 0, e, "1:D3t8Q1aFA6Ev0A/AO4i9PnU3AeI=")
+	})
+
+	t.Run("iana number", func(t *testing.T) {
+		e := evt()
+		e.Delete("network.transport")
+		e.Put("network.iana_number", tcpProtocol)
+		testProcessor(t, 0, e, "1:LQU9qZlK+B5F3KDmev6m5PMibrg=")
 	})
 }
 

--- a/libbeat/processors/communityid/config.go
+++ b/libbeat/processors/communityid/config.go
@@ -28,6 +28,7 @@ type fieldsConfig struct {
 	SourcePort        string `config:"source_port"`
 	DestinationIP     string `config:"destination_ip"`
 	DestinationPort   string `config:"destination_port"`
+	IANANumber        string `config:"iana_number"` // Transport protocol's IANA number.
 	TransportProtocol string `config:"transport"`
 	ICMPType          string `config:"icmp_type"`
 	ICMPCode          string `config:"icmp_code"`
@@ -40,6 +41,7 @@ func defaultConfig() config {
 			SourcePort:        "source.port",
 			DestinationIP:     "destination.ip",
 			DestinationPort:   "destination.port",
+			IANANumber:        "network.iana_number",
 			TransportProtocol: "network.transport",
 			ICMPType:          "icmp.type",
 			ICMPCode:          "icmp.code",


### PR DESCRIPTION
By default have the community_id processor utilize the value from the `network.iana_number` to get the transport protocol in addition to the value from `network.transport`. The IANA field will take precedence and when not found it will fallback to the transport name field.

This also adds a few more named protocols that the processor will understand: GRE(47), EIGRP(88), OSPF(89), PIM(103)