### PR TITLE
Adding version check to Logstash metricsets when xpack.enabled: true is set

### DIFF
--- a/metricbeat/module/logstash/node/node.go
+++ b/metricbeat/module/logstash/node/node.go
@@ -66,7 +66,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	}
 
 	if ms.XPack {
-		logstashVersion, err := logstash.GetVersion(http, nodePath)
+		logstashVersion, err := logstash.GetVersion(http, ms.HostData().SanitizedURI+nodePath)
 		if err != nil {
 			return nil, err
 		}

--- a/metricbeat/module/logstash/node_stats/node_stats.go
+++ b/metricbeat/module/logstash/node_stats/node_stats.go
@@ -68,7 +68,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	}
 
 	if ms.XPack {
-		logstashVersion, err := logstash.GetVersion(http, nodeStatsPath)
+		logstashVersion, err := logstash.GetVersion(http, ms.HostData().SanitizedURI+nodeStatsPath)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
When the `logstash` module is used with `xpack.enabled: true` set, Logstash APIs called by the module's metricsets are expected to return Logstash pipeline graphs. Returning pipeline graphs is an enhancement to Logstash APIs that was implemented in 7.3.0 of Logstash. So using the `logstash` module with `xpack.enabled: true` set won't work against Logstash nodes < 7.3.0. 

This PR adds a version check to the Logstash module code and emits an error message in the Metricbeat logs if the version check fails. This is similar to [a version check in the Kibana module](https://github.com/elastic/beats/blob/master/metricbeat/module/kibana/stats/stats.go#L102-L105).

### Testing this PR
1. Start up a Logstash node (running version < 7.3.0) running one or more pipelines.
2. Build Metricbeat with this PR:
   ```
   cd metricbeat
   mage build
   ```

3. Enable the `logstash` Metricbeat module for Stack Monitoring:
   ```
   metricbeat modules enable logstash-xpack
   ```
5. Start Metricbeat:
   ```
   metricbeat -e
   ```
6. Check that an error is shown in the Metricbeat logs about the Logstash module not working with Logstash < 7.3.0 when `xpack.enabled: true` is set.
