### PR TITLE
Handle pipelines that don't talk to an ES cluster

### DIFF
--- a/metricbeat/module/logstash/node/data_xpack.go
+++ b/metricbeat/module/logstash/node/data_xpack.go
@@ -80,6 +80,11 @@ func makeClusterToPipelinesMap(pipelines []logstash.PipelineState) map[string][]
 			clusterUUIDs = append(clusterUUIDs, clusterUUID)
 		}
 
+		// If no cluster UUID was found in this pipeline, assign it a blank one
+		if len(clusterUUIDs) == 0 {
+			clusterUUIDs = []string{""}
+		}
+
 		for _, clusterUUID := range clusterUUIDs {
 			clusterPipelines := clusterToPipelinesMap[clusterUUID]
 			if clusterPipelines == nil {

--- a/metricbeat/module/logstash/node_stats/data_xpack.go
+++ b/metricbeat/module/logstash/node_stats/data_xpack.go
@@ -181,6 +181,11 @@ func makeClusterToPipelinesMap(pipelines []PipelineStats) map[string][]PipelineS
 			clusterUUIDs = append(clusterUUIDs, clusterUUID)
 		}
 
+		// If no cluster UUID was found in this pipeline, assign it a blank one
+		if len(clusterUUIDs) == 0 {
+			clusterUUIDs = []string{""}
+		}
+
 		for _, clusterUUID := range clusterUUIDs {
 			clusterPipelines := clusterToPipelinesMap[clusterUUID]
 			if clusterPipelines == nil {


### PR DESCRIPTION
This PR fixes a bug in the `logstash` Metricbeat module when `xpack.enabled: true` is set where Logstash pipelines that didn't connect to any Elasticsearch cluster were not being monitored.

### Testing this PR
1. Start up a Logstash node (built from `master`) running a pipeline that doesn't contain the Elasticsearch output.
   ```
   bin/logstash -e 'input { stdin {} }'
   ```

2. Build Metricbeat with this PR:
   ```
   cd metricbeat
   mage build
   ```

3. Enable the `logstash` Metricbeat module for Stack Monitoring:
   ```
   metricbeat modules enable logstash-xpack
   ```
5. Start Metricbeat:
   ```
   metricbeat -e
   ```
6. Query the `.monitoring-logstash-7-mb-*` indices to make sure there are documents with `type: logstash_state` and `type: logstash_stats`.

   ```
   POST .monitoring-logstash-7-mb-*/_search?q=type:logstash_state
   {
     "collapse": {
       "field": "type"
     }
   }
   ```

   Verify that the documents don't have a `cluster_uuid` field.

7. Now repeat all the steps with a Logstash pipeline that _does_ contain an Elasticsearch output. For step 6, verify that the documents _do_ have a `cluster_uuid` field.