### PR TITLE
Package light modules in licensed metricbeat

### DIFF
--- a/dev-tools/mage/pkg.go
+++ b/dev-tools/mage/pkg.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"log"
 	"runtime"
+	"strconv"
 
 	"github.com/magefile/mage/mg"
 	"github.com/magefile/mage/sh"
@@ -101,6 +102,7 @@ type testPackagesParams struct {
 	HasMonitorsD         bool
 	HasModulesD          bool
 	HasRootUserContainer bool
+	MinModules           *int
 }
 
 // TestPackagesOption defines a option to the TestPackages target.
@@ -110,6 +112,14 @@ type TestPackagesOption func(params *testPackagesParams)
 func WithModules() func(params *testPackagesParams) {
 	return func(params *testPackagesParams) {
 		params.HasModules = true
+	}
+}
+
+// MinModules sets the minimum number of modules to require
+func MinModules(n int) func(params *testPackagesParams) {
+	return func(params *testPackagesParams) {
+		minModules := n
+		params.MinModules = &minModules
 	}
 }
 
@@ -154,6 +164,10 @@ func TestPackages(options ...TestPackagesOption) error {
 
 	if params.HasModules {
 		args = append(args, "--modules")
+	}
+
+	if params.MinModules != nil {
+		args = append(args, "--min-modules", strconv.Itoa(*params.MinModules))
 	}
 
 	if params.HasMonitorsD {

--- a/dev-tools/packaging/package_test.go
+++ b/dev-tools/packaging/package_test.go
@@ -60,6 +60,7 @@ var (
 var (
 	files             = flag.String("files", "../build/distributions/*/*", "filepath glob containing package files")
 	modules           = flag.Bool("modules", false, "check modules folder contents")
+	minModules        = flag.Int("min-modules", 4, "minimum number of modules to expect in modules folder")
 	modulesd          = flag.Bool("modules.d", false, "check modules.d folder contents")
 	monitorsd         = flag.Bool("monitors.d", false, "check monitors.d folder contents")
 	rootOwner         = flag.Bool("root-owner", false, "expect root to own package files")
@@ -339,7 +340,7 @@ func checkMonitorsDPresent(t *testing.T, prefix string, p *packageFile) {
 
 func checkModules(t *testing.T, name, prefix string, r *regexp.Regexp, p *packageFile) {
 	t.Run(fmt.Sprintf("%s %s contents", p.Name, name), func(t *testing.T) {
-		minExpectedModules := 4
+		minExpectedModules := *minModules
 		total := 0
 		for _, entry := range p.Contents {
 			if strings.HasPrefix(entry.File, prefix) && r.MatchString(entry.File) {

--- a/x-pack/metricbeat/magefile.go
+++ b/x-pack/metricbeat/magefile.go
@@ -9,12 +9,18 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/magefile/mage/mg"
 
 	devtools "github.com/elastic/beats/dev-tools/mage"
 	metricbeat "github.com/elastic/beats/metricbeat/scripts/mage"
+)
+
+const (
+	dirModulesGenerated = "build/package/module"
 )
 
 func init() {
@@ -64,6 +70,7 @@ func Package() {
 	devtools.UseElasticBeatXPackPackaging()
 	metricbeat.CustomizePackaging()
 	devtools.PackageKibanaDashboardsFromBuildDir()
+	packageLightModules()
 
 	mg.Deps(Update, metricbeat.PrepareModulePackagingXPack)
 	mg.Deps(CrossBuild, CrossBuildGoDaemon)
@@ -72,7 +79,12 @@ func Package() {
 
 // TestPackages tests the generated packages (i.e. file modes, owners, groups).
 func TestPackages() error {
-	return devtools.TestPackages(devtools.WithModulesD())
+	return devtools.TestPackages(
+		devtools.WithModulesD(),
+		devtools.WithModules(),
+
+		// To be increased or removed when more light modules are added
+		devtools.MinModules(0))
 }
 
 // Fields generates a fields.yml and fields.go for each module.
@@ -163,4 +175,76 @@ func PythonIntegTest(ctx context.Context) error {
 		mg.Deps(devtools.BuildSystemTestBinary)
 		return devtools.PythonNoseTest(devtools.DefaultPythonTestIntegrationArgs())
 	})
+}
+
+// prepareLightModules generates light modules
+func prepareLightModules(path string) error {
+	err := devtools.Clean([]string{dirModulesGenerated})
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dirModulesGenerated, 0755); err != nil {
+		return err
+	}
+
+	filePatterns := []string{
+		"*/module.yml",
+		"*/*/manifest.yml",
+	}
+
+	var files []string
+	for _, pattern := range filePatterns {
+		matches, err := filepath.Glob(filepath.Join(path, pattern))
+		if err != nil {
+			return err
+		}
+		files = append(files, matches...)
+	}
+
+	if len(files) == 0 {
+		return fmt.Errorf("no light modules found")
+	}
+
+	for _, file := range files {
+		rel, _ := filepath.Rel(path, file)
+		dest := filepath.Join(dirModulesGenerated, rel)
+		err := (&devtools.CopyTask{
+			Source:  file,
+			Dest:    dest,
+			Mode:    0644,
+			DirMode: 0755,
+		}).Execute()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// packageLightModules customizes packaging to add light modules
+func packageLightModules() error {
+	prepareLightModules("module")
+
+	var (
+		moduleTarget = "module"
+		module       = devtools.PackageFile{
+			Mode:   0644,
+			Source: dirModulesGenerated,
+		}
+	)
+
+	for _, args := range devtools.Packages {
+		pkgType := args.Types[0]
+		switch pkgType {
+		case devtools.TarGz, devtools.Zip, devtools.Docker:
+			args.Spec.Files[moduleTarget] = module
+		case devtools.Deb, devtools.RPM:
+			args.Spec.Files["/usr/share/{{.BeatName}}/"+moduleTarget] = module
+		case devtools.DMG:
+			args.Spec.Files["/Library/Application Support/{{.BeatVendor}}/{{.BeatName}}/"+moduleTarget] = module
+		default:
+			return fmt.Errorf("unhandled package type: %v", pkgType)
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
Add packaging for light modules to licensed metricbeat.
It is only added to the magefile for this metricbeat but the code
can be easily moved if required in the future for other beats.
A new option is added to package tests to reduce the minimum
number of expected modules, as after this change we will have
zero modules in the `module` directory.

Completes #12270