### PR TITLE
Journalbeat does not log to systemd journal

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -114,6 +114,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 *Journalbeat*
 
 - Use backoff when no new events are found. {pull}11861[11861]
+- Do not log to systemd journal. {pull}12712[12712]
 
 *Metricbeat*
 

--- a/dev-tools/packaging/templates/linux/systemd.unit.tmpl
+++ b/dev-tools/packaging/templates/linux/systemd.unit.tmpl
@@ -9,7 +9,9 @@ After=network-online.target
 User={{ .BeatUser }}
 Group={{ .BeatUser }}
 {{- end }}
+{{ if ne .BeatName "journalbeat" -}}
 Environment="BEAT_LOG_OPTS=-e"
+{{- end }}
 Environment="BEAT_CONFIG_OPTS=-c /etc/{{.BeatName}}/{{.BeatName}}.yml"
 Environment="BEAT_PATH_OPTS=-path.home /usr/share/{{.BeatName}} -path.config /etc/{{.BeatName}} -path.data /var/lib/{{.BeatName}} -path.logs /var/log/{{.BeatName}}"
 ExecStart=/usr/share/{{.BeatName}}/bin/{{.BeatName}} $BEAT_LOG_OPTS $BEAT_CONFIG_OPTS $BEAT_PATH_OPTS

--- a/dev-tools/packaging/templates/linux/systemd.unit.tmpl
+++ b/dev-tools/packaging/templates/linux/systemd.unit.tmpl
@@ -9,9 +9,7 @@ After=network-online.target
 User={{ .BeatUser }}
 Group={{ .BeatUser }}
 {{- end }}
-{{ if ne .BeatName "journalbeat" -}}
 Environment="BEAT_LOG_OPTS=-e"
-{{- end }}
 Environment="BEAT_CONFIG_OPTS=-c /etc/{{.BeatName}}/{{.BeatName}}.yml"
 Environment="BEAT_PATH_OPTS=-path.home /usr/share/{{.BeatName}} -path.config /etc/{{.BeatName}} -path.data /var/lib/{{.BeatName}} -path.logs /var/log/{{.BeatName}}"
 ExecStart=/usr/share/{{.BeatName}}/bin/{{.BeatName}} $BEAT_LOG_OPTS $BEAT_CONFIG_OPTS $BEAT_PATH_OPTS

--- a/journalbeat/input/input.go
+++ b/journalbeat/input/input.go
@@ -132,7 +132,7 @@ func (i *Input) Run() {
 			Processor:     i.processors,
 		},
 		ACKCount: func(n int) {
-			i.logger.Infof("journalbeat successfully published %d events", n)
+			i.logger.Debugf("journalbeat successfully published %d events", n)
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
By default all Beats log to systemd journal where systemd is installed. However, as Journalbeat reads from journals, when it publishes messages, it gets logged, and publishes its own logs, and so on... It leads to loops. Alternatively, I could remove the log which reports published messages, but it's too important for debugging.

Closes https://github.com/elastic/beats/issues/11179