### PR TITLE
Dr. Web reports install-service-filebeat.ps1 as malicious

### DIFF
--- a/dev-tools/packaging/templates/windows/install-service.ps1.tmpl
+++ b/dev-tools/packaging/templates/windows/install-service.ps1.tmpl
@@ -17,4 +17,4 @@ New-Service -name {{.BeatName}} `
 Try {
   Start-Process -FilePath sc.exe -ArgumentList 'config {{.BeatName}} start=delayed-auto'
 }
-Catch { Write-Host "An error occured setting the service to delayed start." -ForegroundColor Red }
+Catch { Write-Host -f red "An error occured setting the service to delayed start." }


### PR DESCRIPTION
The Dr. Web component of VirtusTotal reports install-service-filebeat.ps1 as malicious.

Testing reveals that removing -ForegroundColor Red from the catch statement also stops Dr. Web from alerting.