### PR TITLE
fix finding docker container IP address for networks from other containers

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -74,6 +74,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
   processor (or by any code utilizing `PutValue()` on a `beat.Event`).
 - Fix leak in script processor when using Javascript functions in a processor chain. {pull}12600[12600]
 - Add additional nil pointer checks to Docker client code to deal with vSphere Integrated Containers {pull}12628[12628]
+- Fix resolving docker container IP address with network from other container. {pull}12726[12726]
 
 *Auditbeat*
 

--- a/libbeat/processors/add_docker_metadata/add_docker_metadata.go
+++ b/libbeat/processors/add_docker_metadata/add_docker_metadata.go
@@ -183,6 +183,10 @@ func (d *addDockerMetadata) Run(event *beat.Event) (*beat.Event, error) {
 			meta.Put("container.labels", labels)
 		}
 
+		if len(container.IPAddresses) > 0 {
+			meta.Put("container.ipaddresses", container.IPAddresses)
+		}
+
 		meta.Put("container.id", container.ID)
 		meta.Put("container.image.name", container.Image)
 		meta.Put("container.name", container.Name)


### PR DESCRIPTION
Fixes code finding container IP in docker, when network is configured from other container. As discussed in other PR https://github.com/elastic/beats/pull/12310#discussion_r289289980

Additionally exposes this IP information in docker metadata from add_docker_metadata processor.