### PR TITLE
Add GetAWSCredentials function in libbeat common

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -278,6 +278,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add Oracle Module {pull}11890[11890]
 - Add Oracle Tablespaces Dashboard {pull}12736[12736]
 - Collect client provided name for rabbitmq connection. {issue}12851[12851] {pull}12852[12852]
+- Add support to load default aws config file to get credentials. {pull}12727[12727] {issue}12708[12708]
 
 *Packetbeat*
 

--- a/metricbeat/docs/index.asciidoc
+++ b/metricbeat/docs/index.asciidoc
@@ -1,8 +1,11 @@
 = Metricbeat Reference
 
 :libbeat-dir: ../../libbeat
+:libbeat-xpack-dir: ../../../x-pack/libbeat
 
 include::{libbeat-dir}/docs/version.asciidoc[]
+
+include::{libbeat-xpack-dir}/docs/version.asciidoc[]
 
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 

--- a/metricbeat/docs/index.asciidoc
+++ b/metricbeat/docs/index.asciidoc
@@ -1,11 +1,9 @@
 = Metricbeat Reference
 
 :libbeat-dir: ../../libbeat
-:libbeat-xpack-dir: ../../../x-pack/libbeat
+:libbeat-xpack-dir: ../../x-pack/libbeat
 
 include::{libbeat-dir}/docs/version.asciidoc[]
-
-include::{libbeat-xpack-dir}/docs/version.asciidoc[]
 
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 

--- a/metricbeat/docs/index.asciidoc
+++ b/metricbeat/docs/index.asciidoc
@@ -1,7 +1,7 @@
 = Metricbeat Reference
 
 :libbeat-dir: ../../libbeat
-:libbeat-xpack-dir: ../../x-pack/libbeat
+:libbeat-xpack-dir: ../../../x-pack/libbeat
 
 include::{libbeat-dir}/docs/version.asciidoc[]
 

--- a/metricbeat/docs/modules/aws.asciidoc
+++ b/metricbeat/docs/modules/aws.asciidoc
@@ -14,37 +14,14 @@ The default metricsets are `ec2`, `sqs`, `s3_request`, `s3_daily_storage`, `clou
 [float]
 === Module-specific configuration notes
 
-This module uses environment variable `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN` and `AWS_REGION`
-that are referenced in the config file to set values that need to be configurable during deployment. It also
-accept optional configuration `regions` to specify what are the AWS regions to query metrics from. If `regions`
-parameter is not set in the config file, then by default, aws module will query metrics from all available
-AWS regions.
+`aws` module requires AWS credentials configuration in order to make AWS API calls.
+Users can either use `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and/or
+`AWS_SESSION_TOKEN`, or use shared AWS credentials file.
 
-There are two different kinds of AWS credentials can be used here: `access keys` and `temporary security credentials`.
-`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` are the two parts of `access keys`. They are long-term credentials for
-an IAM user or the AWS account root user. Please see
-https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys[AWS Access Keys
- and Secret Access Keys] for more details. `temporary security credentials` has a limited lifetime and consists of an access key ID,
-a secret access key, and a security token which typically returned from `GetSessionToken`. MFA-enabled IAM users would
-need to submit an MFA code while calling `GetSessionToken`. `default_region` identifies the AWS Region whose servers you want to send
-your first API request to by default. This is typically the Region closest to you, but it can be any Region.
-Please see https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html[Temporary Security Credentials] for more details.
-`sts get-session-token` AWS CLI can be used to generate temporary credentials. For example. with MFA-enabled:
-
-----
-aws> sts get-session-token --serial-number arn:aws:iam::1234:mfa/your-email@example.com --token-code 456789 --duration-seconds 129600
-----
-
-Because temporary security credentials are short term, after they expire, the user needs to generate new ones and modify
-the aws.yml config file with the new credentials. Unless https://www.elastic.co/guide/en/beats/metricbeat/current/_live_reloading.html[live reloading]
-feature is enabled for Metricbeat, the user needs to manually restart Metricbeat after updating the config file in order
-to continue collecting Cloudwatch metrics. This will cause data loss if the config file is not updated with new
-credentials before the old ones expire. For Metricbeat, we recommend users to use access keys in config file to enable
-aws module making AWS api calls without have to generate new temporary credentials and update the config frequently.
-
-IAM policy is an entity that defines permissions to an object within your AWS environment. Specific permissions needs
-to be added into the IAM user's policy to authorize Metricbeat to collect AWS monitoring metrics. Please see documentation
-under each metricset for required permissions.
+This module also accepts
+optional configuration `regions` to specify what are the AWS regions to query
+metrics from. If `regions` parameter is not set in the config file, then by
+default, `aws` module will query metrics from all available AWS regions.
 
 The aws module comes with a predefined dashboard. For example:
 

--- a/metricbeat/docs/modules/aws.asciidoc
+++ b/metricbeat/docs/modules/aws.asciidoc
@@ -17,11 +17,12 @@ The default metricsets are `ec2`, `sqs`, `s3_request`, `s3_daily_storage`, `clou
 `aws` module requires AWS credentials configuration in order to make AWS API calls.
 Users can either use `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and/or
 `AWS_SESSION_TOKEN`, or use shared AWS credentials file.
+Please see <<aws-credentials-config>> for more details.
 
-This module also accepts
-optional configuration `regions` to specify what are the AWS regions to query
-metrics from. If `regions` parameter is not set in the config file, then by
-default, `aws` module will query metrics from all available AWS regions.
+This module also accepts optional configuration `regions` to specify what are
+the AWS regions to query metrics from. If `regions` parameter is not set in the
+config file, then by default, `aws` module will query metrics from all available
+AWS regions.
 
 The aws module comes with a predefined dashboard. For example:
 

--- a/metricbeat/docs/modules/aws.asciidoc
+++ b/metricbeat/docs/modules/aws.asciidoc
@@ -87,6 +87,9 @@ for a list of AWS services that publish metrics to CloudWatch.
 `period` for `rds` metricset is recommended to be `60s` or multiples of `60s` because Amazon RDS sends metrics and
 dimensions to Amazon CloudWatch every minute.
 
+[id="aws-credentials-config"]
+include::../../../../libbeat/docs/aws-credentials-config.asciidoc[]
+
 
 [float]
 === Example configuration

--- a/metricbeat/docs/modules/aws.asciidoc
+++ b/metricbeat/docs/modules/aws.asciidoc
@@ -88,7 +88,7 @@ for a list of AWS services that publish metrics to CloudWatch.
 dimensions to Amazon CloudWatch every minute.
 
 [id="aws-credentials-config"]
-include::../../../../libbeat/docs/aws-credentials-config.asciidoc[]
+include::{libbeat-xpack-dir}/docs/aws-credentials-config.asciidoc[]
 
 
 [float]

--- a/metricbeat/docs/modules/aws.asciidoc
+++ b/metricbeat/docs/modules/aws.asciidoc
@@ -14,14 +14,14 @@ The default metricsets are `ec2`, `sqs`, `s3_request`, `s3_daily_storage`, `clou
 [float]
 === Module-specific configuration notes
 
-`aws` module requires AWS credentials configuration in order to make AWS API calls.
+The `aws` module requires AWS credentials configuration in order to make AWS API calls.
 Users can either use `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and/or
 `AWS_SESSION_TOKEN`, or use shared AWS credentials file.
 Please see <<aws-credentials-config>> for more details.
 
-This module also accepts optional configuration `regions` to specify what are
-the AWS regions to query metrics from. If `regions` parameter is not set in the
-config file, then by default, `aws` module will query metrics from all available
+This module also accepts optional configuration `regions` to specify which
+AWS regions to query metrics from. If the `regions` parameter is not set in the
+config file, then by default, the `aws` module will query metrics from all available
 AWS regions.
 
 The aws module comes with a predefined dashboard. For example:

--- a/x-pack/libbeat/common/aws/credentials.go
+++ b/x-pack/libbeat/common/aws/credentials.go
@@ -23,13 +23,14 @@ type ConfigAWS struct {
 // If not, then load from aws config file. If credential_profile_name is not
 // given, then load default profile from the aws config file.
 func GetAWSCredentials(config ConfigAWS) (awssdk.Config, error) {
-	// Check if accessKeyID and secretAccessKey is given from configuration
-	if config.AccessKeyID != "" && config.SecretAccessKey != "" {
+	// Check if accessKeyID or secretAccessKey or sessionToken is given from configuration
+	if config.AccessKeyID != "" || config.SecretAccessKey != "" || config.SessionToken != "" {
 		awsConfig := defaults.Config()
 		awsCredentials := awssdk.Credentials{
 			AccessKeyID:     config.AccessKeyID,
 			SecretAccessKey: config.SecretAccessKey,
 		}
+
 		if config.SessionToken != "" {
 			awsCredentials.SessionToken = config.SessionToken
 		}
@@ -40,7 +41,7 @@ func GetAWSCredentials(config ConfigAWS) (awssdk.Config, error) {
 		return awsConfig, nil
 	}
 
-	// If accessKeyID and secretAccessKey is not given, then load from default config
+	// If accessKeyID, secretAccessKey or sessionToken is not given, then load from default config
 	// Please see https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html
 	// with more details.
 	if config.ProfileName != "" {

--- a/x-pack/libbeat/common/aws/credentials.go
+++ b/x-pack/libbeat/common/aws/credentials.go
@@ -12,10 +12,10 @@ import (
 
 // ConfigAWS is a structure defined for AWS credentials
 type ConfigAWS struct {
-	AccessKeyID               string   `config:"access_key_id"`
-	SecretAccessKey           string   `config:"secret_access_key"`
-	SessionToken              string   `config:"session_token"`
-	ProfileName               string   `config:"credential_profile_name"`
+	AccessKeyID     string `config:"access_key_id"`
+	SecretAccessKey string `config:"secret_access_key"`
+	SessionToken    string `config:"session_token"`
+	ProfileName     string `config:"credential_profile_name"`
 }
 
 // GetAWSCredentials function gets aws credentials from the config.

--- a/x-pack/libbeat/common/aws/credentials.go
+++ b/x-pack/libbeat/common/aws/credentials.go
@@ -1,0 +1,47 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package aws
+
+import (
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/defaults"
+	"github.com/aws/aws-sdk-go-v2/aws/external"
+)
+
+type ConfigAWS struct {
+	AccessKeyID               string   `config:"access_key_id"`
+	SecretAccessKey           string   `config:"secret_access_key"`
+	SessionToken              string   `config:"session_token"`
+	ProfileName               string   `config:"credential_profile_name"`
+}
+
+func GetAWSCredentials(config ConfigAWS) (awssdk.Config, error) {
+	// Check if accessKeyID and secretAccessKey is given from configuration
+	if config.AccessKeyID != "" && config.SecretAccessKey != "" {
+		awsConfig := defaults.Config()
+		awsCredentials := awssdk.Credentials{
+			AccessKeyID:     config.AccessKeyID,
+			SecretAccessKey: config.SecretAccessKey,
+		}
+		if config.SessionToken != "" {
+			awsCredentials.SessionToken = config.SessionToken
+		}
+
+		awsConfig.Credentials = awssdk.StaticCredentialsProvider{
+			Value: awsCredentials,
+		}
+		return awsConfig, nil
+	}
+
+	// If accessKeyID and secretAccessKey is not given, then load from default config
+	// Please see https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html
+	// with more details.
+	if config.ProfileName != "" {
+		return external.LoadDefaultAWSConfig(
+			external.WithSharedConfigProfile(config.ProfileName),
+		)
+	}
+	return external.LoadDefaultAWSConfig()
+}

--- a/x-pack/libbeat/common/aws/credentials.go
+++ b/x-pack/libbeat/common/aws/credentials.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws/external"
 )
 
+// ConfigAWS is a structure defined for AWS credentials
 type ConfigAWS struct {
 	AccessKeyID               string   `config:"access_key_id"`
 	SecretAccessKey           string   `config:"secret_access_key"`
@@ -17,6 +18,10 @@ type ConfigAWS struct {
 	ProfileName               string   `config:"credential_profile_name"`
 }
 
+// GetAWSCredentials function gets aws credentials from the config.
+// If access_key_id and secret_access_key are given, then use them as credentials.
+// If not, then load from aws config file. If credential_profile_name is not
+// given, then load default profile from the aws config file.
 func GetAWSCredentials(config ConfigAWS) (awssdk.Config, error) {
 	// Check if accessKeyID and secretAccessKey is given from configuration
 	if config.AccessKeyID != "" && config.SecretAccessKey != "" {

--- a/x-pack/libbeat/common/aws/credentials_test.go
+++ b/x-pack/libbeat/common/aws/credentials_test.go
@@ -1,0 +1,1 @@
+package aws

--- a/x-pack/libbeat/common/aws/credentials_test.go
+++ b/x-pack/libbeat/common/aws/credentials_test.go
@@ -11,11 +11,11 @@ import (
 
 func TestGetAWSCredentials(t *testing.T) {
 	inputConfig := ConfigAWS{
-		AccessKeyID: "123",
+		AccessKeyID:     "123",
 		SecretAccessKey: "abc",
-		SessionToken: "fake-session-token",
+		SessionToken:    "fake-session-token",
 	}
-	awsConfig, err :=GetAWSCredentials(inputConfig)
+	awsConfig, err := GetAWSCredentials(inputConfig)
 	assert.NoError(t, err)
 
 	retrievedAWSConfig, err := awsConfig.Credentials.Retrieve()

--- a/x-pack/libbeat/common/aws/credentials_test.go
+++ b/x-pack/libbeat/common/aws/credentials_test.go
@@ -1,1 +1,27 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 package aws
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestGetAWSCredentials(t *testing.T) {
+	inputConfig := ConfigAWS{
+		AccessKeyID: "123",
+		SecretAccessKey: "abc",
+		SessionToken: "fake-session-token",
+	}
+	awsConfig, err :=GetAWSCredentials(inputConfig)
+	assert.NoError(t, err)
+
+	retrievedAWSConfig, err := awsConfig.Credentials.Retrieve()
+	assert.NoError(t, err)
+
+	assert.Equal(t, inputConfig.AccessKeyID, retrievedAWSConfig.AccessKeyID)
+	assert.Equal(t, inputConfig.SecretAccessKey, retrievedAWSConfig.SecretAccessKey)
+	assert.Equal(t, inputConfig.SessionToken, retrievedAWSConfig.SessionToken)
+}

--- a/x-pack/libbeat/common/aws/credentials_test.go
+++ b/x-pack/libbeat/common/aws/credentials_test.go
@@ -5,8 +5,9 @@
 package aws
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetAWSCredentials(t *testing.T) {

--- a/x-pack/libbeat/docs/aws-credentials-config.asciidoc
+++ b/x-pack/libbeat/docs/aws-credentials-config.asciidoc
@@ -47,19 +47,21 @@ metricbeat.modules:
     - ec2
   credential_profile_name: test-mb
 ----
+`credential_profile_name` is optional. If there is no `credential_profile_name`
+given, the default profile will be used.
 In Windows, shared credentials file is at `C:\Users\<yourUserName>\.aws\credentials`.
 For Linux, macOS or Unix, the file is located at `~/.aws/credentials`. Please see
 https://docs.aws.amazon.com/ses/latest/DeveloperGuide/create-shared-credentials-file.html[Create Shared Credentials File]
 for more details.
 
 [float]
-==== AWS Credentials Kinds
-There are two different kinds of AWS credentials can be used:
-`access keys` and `temporary security credentials`.
+==== AWS Credentials Types
+There are two different types of AWS credentials can be used:
+access keys and temporary security credentials.
 
 * Access keys
 
-`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` are the two parts of `access keys`.
+`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` are the two parts of access keys.
 They are long-term credentials for an IAM user or the AWS account root user.
 Please see
 https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys[AWS Access Keys
@@ -68,7 +70,7 @@ for more details.
 
 * Temporary security credentials
 
-`temporary security credentials` has a limited lifetime and consists of an
+temporary security credentials has a limited lifetime and consists of an
 access key ID, a secret access key, and a security token which typically returned
 from `GetSessionToken`. MFA-enabled IAM users would need to submit an MFA code
 while calling `GetSessionToken`. `default_region` identifies the AWS Region

--- a/x-pack/libbeat/docs/aws-credentials-config.asciidoc
+++ b/x-pack/libbeat/docs/aws-credentials-config.asciidoc
@@ -1,0 +1,77 @@
+= AWS Credentials Configuration
+To configure AWS credentials, there are two different ways supported:
+
+== Supported Formats
+* Use `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and/or `AWS_SESSION_TOKEN`
+
+[source,yaml]
+----
+metricbeat.modules:
+- module: aws
+  period: 300s
+  metricsets:
+    - ec2
+  access_key_id: '${AWS_ACCESS_KEY_ID:""}'
+  secret_access_key: '${AWS_SECRET_ACCESS_KEY:""}'
+  session_token: '${AWS_SESSION_TOKEN:""}'
+  default_region: '${AWS_REGION:us-west-1}'
+----
+Users can either put the credentials into metricbeat module configuration or use
+environment variable `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`,
+`AWS_SESSION_TOKEN` and/or `AWS_REGION` instead.
+
+* Use shared AWS credentials file
+
+[source,yaml]
+----
+metricbeat.modules:
+- module: aws
+  period: 300s
+  metricsets:
+    - ec2
+  credential_profile_name: test-mb
+----
+In Windows, shared credentials file is at `C:\Users\<yourUserName>\.aws\credentials`.
+For Linux, macOS or Unix, the file is located at `~/.aws/credentials`. Please see
+https://docs.aws.amazon.com/ses/latest/DeveloperGuide/create-shared-credentials-file.html[Create Shared Credentials File]
+for more details.
+
+== AWS Credentials Kinds
+There are two different kinds of AWS credentials can be used:
+`access keys` and `temporary security credentials`.
+
+* Access keys
+
+`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` are the two parts of `access keys`.
+They are long-term credentials for an IAM user or the AWS account root user.
+Please see
+https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys[AWS Access Keys
+ and Secret Access Keys]
+for more details.
+
+* Temporary security credentials
+
+`temporary security credentials` has a limited lifetime and consists of an
+access key ID, a secret access key, and a security token which typically returned
+from `GetSessionToken`. MFA-enabled IAM users would need to submit an MFA code
+while calling `GetSessionToken`. `default_region` identifies the AWS Region
+whose servers you want to send your first API request to by default. This is
+typically the Region closest to you, but it can be any Region. Please see
+https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html[Temporary Security Credentials]
+for more details.
+`sts get-session-token` AWS CLI can be used to generate temporary credentials. For example. with MFA-enabled:
+
+----
+aws> sts get-session-token --serial-number arn:aws:iam::1234:mfa/your-email@example.com --token-code 456789 --duration-seconds 129600
+----
+
+Because temporary security credentials are short term, after they expire, the user needs to generate new ones and modify
+the aws.yml config file with the new credentials. Unless https://www.elastic.co/guide/en/beats/metricbeat/current/_live_reloading.html[live reloading]
+feature is enabled for Metricbeat, the user needs to manually restart Metricbeat after updating the config file in order
+to continue collecting Cloudwatch metrics. This will cause data loss if the config file is not updated with new
+credentials before the old ones expire. For Metricbeat, we recommend users to use access keys in config file to enable
+aws module making AWS api calls without have to generate new temporary credentials and update the config frequently.
+
+IAM policy is an entity that defines permissions to an object within your AWS environment. Specific permissions needs
+to be added into the IAM user's policy to authorize Metricbeat to collect AWS monitoring metrics. Please see documentation
+under each metricset for required permissions.

--- a/x-pack/libbeat/docs/aws-credentials-config.asciidoc
+++ b/x-pack/libbeat/docs/aws-credentials-config.asciidoc
@@ -6,6 +6,24 @@ To configure AWS credentials, there are two different ways supported:
 ==== Supported Formats
 * Use `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and/or `AWS_SESSION_TOKEN`
 
+Users can either put the credentials into metricbeat module configuration or use
+environment variable `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and/or
+`AWS_SESSION_TOKEN` instead.
+
+[source,yaml]
+----
+metricbeat.modules:
+- module: aws
+  period: 300s
+  metricsets:
+    - ec2
+  access_key_id: '<access_key_id>'
+  secret_access_key: '<secret_access_key>'
+  session_token: '<session_token>'
+----
+
+or
+
 [source,yaml]
 ----
 metricbeat.modules:
@@ -16,11 +34,7 @@ metricbeat.modules:
   access_key_id: '${AWS_ACCESS_KEY_ID:""}'
   secret_access_key: '${AWS_SECRET_ACCESS_KEY:""}'
   session_token: '${AWS_SESSION_TOKEN:""}'
-  default_region: '${AWS_REGION:us-west-1}'
 ----
-Users can either put the credentials into metricbeat module configuration or use
-environment variable `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`,
-`AWS_SESSION_TOKEN` and/or `AWS_REGION` instead.
 
 * Use shared AWS credentials file
 

--- a/x-pack/libbeat/docs/aws-credentials-config.asciidoc
+++ b/x-pack/libbeat/docs/aws-credentials-config.asciidoc
@@ -1,7 +1,9 @@
-= AWS Credentials Configuration
+[float]
+=== AWS Credentials Configuration
 To configure AWS credentials, there are two different ways supported:
 
-== Supported Formats
+[float]
+==== Supported Formats
 * Use `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and/or `AWS_SESSION_TOKEN`
 
 [source,yaml]
@@ -36,7 +38,8 @@ For Linux, macOS or Unix, the file is located at `~/.aws/credentials`. Please se
 https://docs.aws.amazon.com/ses/latest/DeveloperGuide/create-shared-credentials-file.html[Create Shared Credentials File]
 for more details.
 
-== AWS Credentials Kinds
+[float]
+==== AWS Credentials Kinds
 There are two different kinds of AWS credentials can be used:
 `access keys` and `temporary security credentials`.
 

--- a/x-pack/metricbeat/module/aws/_meta/config.yml
+++ b/x-pack/metricbeat/module/aws/_meta/config.yml
@@ -2,20 +2,12 @@
   period: 300s
   metricsets:
     - ec2
-  access_key_id: '${AWS_ACCESS_KEY_ID:""}'
-  secret_access_key: '${AWS_SECRET_ACCESS_KEY:""}'
-  session_token: '${AWS_SESSION_TOKEN:""}'
-  default_region: '${AWS_REGION:us-west-1}'
   regions:
     - us-east-1
 - module: aws
   period: 300s
   metricsets:
     - cloudwatch
-  access_key_id: '${AWS_ACCESS_KEY_ID:""}'
-  secret_access_key: '${AWS_SECRET_ACCESS_KEY:""}'
-  session_token: '${AWS_SESSION_TOKEN:""}'
-  default_region: '${AWS_REGION:us-west-1}'
   cloudwatch_metrics:
     - namespace: AWS/EBS
     - namespace: AWS/ELB

--- a/x-pack/metricbeat/module/aws/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/aws/_meta/docs.asciidoc
@@ -7,14 +7,14 @@ The default metricsets are `ec2`, `sqs`, `s3_request`, `s3_daily_storage`, `clou
 [float]
 === Module-specific configuration notes
 
-`aws` module requires AWS credentials configuration in order to make AWS API calls.
+The `aws` module requires AWS credentials configuration in order to make AWS API calls.
 Users can either use `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and/or
 `AWS_SESSION_TOKEN`, or use shared AWS credentials file.
 Please see <<aws-credentials-config>> for more details.
 
-This module also accepts optional configuration `regions` to specify what are
-the AWS regions to query metrics from. If `regions` parameter is not set in the
-config file, then by default, `aws` module will query metrics from all available
+This module also accepts optional configuration `regions` to specify which
+AWS regions to query metrics from. If the `regions` parameter is not set in the
+config file, then by default, the `aws` module will query metrics from all available
 AWS regions.
 
 The aws module comes with a predefined dashboard. For example:

--- a/x-pack/metricbeat/module/aws/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/aws/_meta/docs.asciidoc
@@ -7,37 +7,14 @@ The default metricsets are `ec2`, `sqs`, `s3_request`, `s3_daily_storage`, `clou
 [float]
 === Module-specific configuration notes
 
-This module uses environment variable `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN` and `AWS_REGION`
-that are referenced in the config file to set values that need to be configurable during deployment. It also
-accept optional configuration `regions` to specify what are the AWS regions to query metrics from. If `regions`
-parameter is not set in the config file, then by default, aws module will query metrics from all available
-AWS regions.
+`aws` module requires AWS credentials configuration in order to make AWS API calls.
+Users can either use `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and/or
+`AWS_SESSION_TOKEN`, or use shared AWS credentials file.
 
-There are two different kinds of AWS credentials can be used here: `access keys` and `temporary security credentials`.
-`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` are the two parts of `access keys`. They are long-term credentials for
-an IAM user or the AWS account root user. Please see
-https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys[AWS Access Keys
- and Secret Access Keys] for more details. `temporary security credentials` has a limited lifetime and consists of an access key ID,
-a secret access key, and a security token which typically returned from `GetSessionToken`. MFA-enabled IAM users would
-need to submit an MFA code while calling `GetSessionToken`. `default_region` identifies the AWS Region whose servers you want to send
-your first API request to by default. This is typically the Region closest to you, but it can be any Region.
-Please see https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html[Temporary Security Credentials] for more details.
-`sts get-session-token` AWS CLI can be used to generate temporary credentials. For example. with MFA-enabled:
-
-----
-aws> sts get-session-token --serial-number arn:aws:iam::1234:mfa/your-email@example.com --token-code 456789 --duration-seconds 129600
-----
-
-Because temporary security credentials are short term, after they expire, the user needs to generate new ones and modify
-the aws.yml config file with the new credentials. Unless https://www.elastic.co/guide/en/beats/metricbeat/current/_live_reloading.html[live reloading]
-feature is enabled for Metricbeat, the user needs to manually restart Metricbeat after updating the config file in order
-to continue collecting Cloudwatch metrics. This will cause data loss if the config file is not updated with new
-credentials before the old ones expire. For Metricbeat, we recommend users to use access keys in config file to enable
-aws module making AWS api calls without have to generate new temporary credentials and update the config frequently.
-
-IAM policy is an entity that defines permissions to an object within your AWS environment. Specific permissions needs
-to be added into the IAM user's policy to authorize Metricbeat to collect AWS monitoring metrics. Please see documentation
-under each metricset for required permissions.
+This module also accepts
+optional configuration `regions` to specify what are the AWS regions to query
+metrics from. If `regions` parameter is not set in the config file, then by
+default, `aws` module will query metrics from all available AWS regions.
 
 The aws module comes with a predefined dashboard. For example:
 

--- a/x-pack/metricbeat/module/aws/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/aws/_meta/docs.asciidoc
@@ -10,11 +10,12 @@ The default metricsets are `ec2`, `sqs`, `s3_request`, `s3_daily_storage`, `clou
 `aws` module requires AWS credentials configuration in order to make AWS API calls.
 Users can either use `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and/or
 `AWS_SESSION_TOKEN`, or use shared AWS credentials file.
+Please see <<aws-credentials-config>> for more details.
 
-This module also accepts
-optional configuration `regions` to specify what are the AWS regions to query
-metrics from. If `regions` parameter is not set in the config file, then by
-default, `aws` module will query metrics from all available AWS regions.
+This module also accepts optional configuration `regions` to specify what are
+the AWS regions to query metrics from. If `regions` parameter is not set in the
+config file, then by default, `aws` module will query metrics from all available
+AWS regions.
 
 The aws module comes with a predefined dashboard. For example:
 

--- a/x-pack/metricbeat/module/aws/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/aws/_meta/docs.asciidoc
@@ -81,4 +81,4 @@ for a list of AWS services that publish metrics to CloudWatch.
 dimensions to Amazon CloudWatch every minute.
 
 [id="aws-credentials-config"]
-include::../../../../libbeat/docs/aws-credentials-config.asciidoc[]
+include::{libbeat-xpack-dir}/docs/aws-credentials-config.asciidoc[]

--- a/x-pack/metricbeat/module/aws/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/aws/_meta/docs.asciidoc
@@ -79,3 +79,6 @@ for a list of AWS services that publish metrics to CloudWatch.
 === `rds`
 `period` for `rds` metricset is recommended to be `60s` or multiples of `60s` because Amazon RDS sends metrics and
 dimensions to Amazon CloudWatch every minute.
+
+[id="aws-credentials-config"]
+include::../../../../libbeat/docs/aws-credentials-config.asciidoc[]

--- a/x-pack/metricbeat/module/aws/aws.go
+++ b/x-pack/metricbeat/module/aws/aws.go
@@ -8,25 +8,21 @@ import (
 	"context"
 	"time"
 
-	"github.com/elastic/beats/libbeat/common"
-
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/aws/defaults"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/ec2iface"
 	"github.com/pkg/errors"
 
+	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/metricbeat/mb"
+	awscommon "github.com/elastic/beats/x-pack/libbeat/common/aws"
 )
 
 // Config defines all required and optional parameters for aws metricsets
 type Config struct {
-	Period          time.Duration `config:"period" validate:"nonzero,required"`
-	AccessKeyID     string        `config:"access_key_id" validate:"nonzero,required"`
-	SecretAccessKey string        `config:"secret_access_key" validate:"nonzero,required"`
-	SessionToken    string        `config:"session_token"`
-	DefaultRegion   string        `config:"default_region"`
-	Regions         []string      `config:"regions"`
+	Period    time.Duration `config:"period" validate:"nonzero,required"`
+	Regions   []string      `config:"regions"`
+	AWSConfig awscommon.ConfigAWS
 }
 
 // MetricSet is the base metricset for all aws metricsets
@@ -62,20 +58,10 @@ func NewMetricSet(base mb.BaseMetricSet) (*MetricSet, error) {
 		return nil, err
 	}
 
-	awsConfig := defaults.Config()
-	awsCredentials := awssdk.Credentials{
-		AccessKeyID:     config.AccessKeyID,
-		SecretAccessKey: config.SecretAccessKey,
+	awsConfig, err := awscommon.GetAWSCredentials(config.AWSConfig)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get aws credentials")
 	}
-	if config.SessionToken != "" {
-		awsCredentials.SessionToken = config.SessionToken
-	}
-
-	awsConfig.Credentials = awssdk.StaticCredentialsProvider{
-		Value: awsCredentials,
-	}
-
-	awsConfig.Region = config.DefaultRegion
 
 	metricSet := MetricSet{
 		BaseMetricSet: base,

--- a/x-pack/metricbeat/module/aws/cloudwatch/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/aws/cloudwatch/_meta/docs.asciidoc
@@ -25,16 +25,17 @@ only EC2 instances.
 
 [float]
 === Configuration example
+To be more focused on `cloudwatch` metricset use cases, the examples below do
+not include configurations on AWS credentials.
+Please see <<aws-credentials-config>> for more details on setting AWS credentials
+in configurations in order for this metricset to make proper AWS API calls.
+
 [source,yaml]
 ----
 - module: aws
   period: 300s
   metricsets:
     - cloudwatch
-  access_key_id: '${AWS_ACCESS_KEY_ID:""}'
-  secret_access_key: '${AWS_SECRET_ACCESS_KEY:""}'
-  session_token: '${AWS_SESSION_TOKEN:""}'
-  default_region: '${AWS_REGION:us-west-1}'
   cloudwatch_metrics:
     - namespace: AWS/EBS <1>
     - namespace: AWS/ELB <2>
@@ -71,10 +72,6 @@ from EBS, ELB and EC2 without tag information.
   period: 300s
   metricsets:
     - cloudwatch
-  access_key_id: '${AWS_ACCESS_KEY_ID:""}'
-  secret_access_key: '${AWS_SECRET_ACCESS_KEY:""}'
-  session_token: '${AWS_SESSION_TOKEN:""}'
-  default_region: '${AWS_REGION:us-west-1}'
   cloudwatch_metrics:
     - namespace: AWS/EBS
     - namespace: AWS/ELB
@@ -90,10 +87,6 @@ from EBS, ELB and EC2 with tags from these services.
   period: 300s
   metricsets:
     - cloudwatch
-  access_key_id: '${AWS_ACCESS_KEY_ID:""}'
-  secret_access_key: '${AWS_SECRET_ACCESS_KEY:""}'
-  session_token: '${AWS_SESSION_TOKEN:""}'
-  default_region: '${AWS_REGION:us-west-1}'
   cloudwatch_metrics:
     - namespace: AWS/EBS
       tags.resource_type_filter: ebs
@@ -112,10 +105,6 @@ metric from EC2 instance i-456.
   period: 300s
   metricsets:
     - cloudwatch
-  access_key_id: '${AWS_ACCESS_KEY_ID:""}'
-  secret_access_key: '${AWS_SECRET_ACCESS_KEY:""}'
-  session_token: '${AWS_SESSION_TOKEN:""}'
-  default_region: '${AWS_REGION:us-west-1}'
   cloudwatch_metrics:
     - namespace: AWS/EC2
       metricname: CPUUtilization

--- a/x-pack/metricbeat/module/aws/ec2/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/aws/ec2/_meta/docs.asciidoc
@@ -55,4 +55,7 @@ image::./images/metricbeat-aws-ec2-overview.png[]
   period: 300s
   metricsets:
     - ec2
+  access_key_id: '<access_key_id>'
+  secret_access_key: '<secret_access_key>'
+  session_token: '<session_token>'
 ----

--- a/x-pack/metricbeat/module/aws/ec2/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/aws/ec2/_meta/docs.asciidoc
@@ -55,8 +55,4 @@ image::./images/metricbeat-aws-ec2-overview.png[]
   period: 300s
   metricsets:
     - ec2
-  access_key_id: '${AWS_ACCESS_KEY_ID:""}'
-  secret_access_key: '${AWS_SECRET_ACCESS_KEY:""}'
-  session_token: '${AWS_SESSION_TOKEN:""}'
-  default_region: '${AWS_REGION:us-west-1}'
 ----

--- a/x-pack/metricbeat/module/aws/ec2/ec2_test.go
+++ b/x-pack/metricbeat/module/aws/ec2/ec2_test.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/metricbeat/mb"
-	"github.com/elastic/beats/x-pack/metricbeat/module/aws"
 )
 
 // MockEC2Client struct is used for unit tests.
@@ -126,11 +125,6 @@ func TestGetInstanceIDs(t *testing.T) {
 }
 
 func TestCreateCloudWatchEvents(t *testing.T) {
-	mockModuleConfig := aws.Config{
-		Period:        300 * time.Second,
-		DefaultRegion: regionName,
-	}
-
 	expectedEvent := mb.Event{
 		RootFields: common.MapStr{
 			"service": common.MapStr{"name": "ec2"},
@@ -199,7 +193,7 @@ func TestCreateCloudWatchEvents(t *testing.T) {
 	}
 
 	metricSet := MetricSet{}
-	events, err := metricSet.createCloudWatchEvents(getMetricDataOutput, instancesOutputs, mockModuleConfig.DefaultRegion)
+	events, err := metricSet.createCloudWatchEvents(getMetricDataOutput, instancesOutputs, "us-west-1")
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(events))
 	assert.Equal(t, expectedEvent.RootFields, events[instanceID].RootFields)

--- a/x-pack/metricbeat/module/aws/rds/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/aws/rds/_meta/docs.asciidoc
@@ -24,8 +24,4 @@ The aws rds metricset comes with a predefined dashboard.
   period: 60s
   metricsets:
     - rds
-  access_key_id: '${AWS_ACCESS_KEY_ID:""}'
-  secret_access_key: '${AWS_SECRET_ACCESS_KEY:""}'
-  session_token: '${AWS_SESSION_TOKEN:""}'
-  default_region: '${AWS_REGION:us-west-1}'
 ----

--- a/x-pack/metricbeat/module/aws/rds/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/aws/rds/_meta/docs.asciidoc
@@ -24,4 +24,7 @@ The aws rds metricset comes with a predefined dashboard.
   period: 60s
   metricsets:
     - rds
+  access_key_id: '<access_key_id>'
+  secret_access_key: '<secret_access_key>'
+  session_token: '<session_token>'
 ----

--- a/x-pack/metricbeat/module/aws/s3_daily_storage/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/aws/s3_daily_storage/_meta/docs.asciidoc
@@ -26,4 +26,7 @@ image::./images/metricbeat-aws-s3-overview.png[]
   period: 86400s
   metricsets:
     - s3_daily_storage
+  access_key_id: '<access_key_id>'
+  secret_access_key: '<secret_access_key>'
+  session_token: '<session_token>'
 ----

--- a/x-pack/metricbeat/module/aws/s3_daily_storage/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/aws/s3_daily_storage/_meta/docs.asciidoc
@@ -26,10 +26,4 @@ image::./images/metricbeat-aws-s3-overview.png[]
   period: 86400s
   metricsets:
     - s3_daily_storage
-  access_key_id: '${AWS_ACCESS_KEY_ID:""}'
-  secret_access_key: '${AWS_SECRET_ACCESS_KEY:""}'
-  session_token: '${AWS_SESSION_TOKEN:""}'
-  default_region: '${AWS_REGION:us-west-1}'
-  #regions:
-  #  - us-west-1
 ----

--- a/x-pack/metricbeat/module/aws/s3_request/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/aws/s3_request/_meta/docs.asciidoc
@@ -26,4 +26,7 @@ image::./images/metricbeat-aws-s3-overview.png[]
   period: 86400s
   metricsets:
     - s3_request
+  access_key_id: '<access_key_id>'
+  secret_access_key: '<secret_access_key>'
+  session_token: '<session_token>'
 ----

--- a/x-pack/metricbeat/module/aws/s3_request/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/aws/s3_request/_meta/docs.asciidoc
@@ -26,10 +26,4 @@ image::./images/metricbeat-aws-s3-overview.png[]
   period: 86400s
   metricsets:
     - s3_request
-  access_key_id: '${AWS_ACCESS_KEY_ID:""}'
-  secret_access_key: '${AWS_SECRET_ACCESS_KEY:""}'
-  session_token: '${AWS_SESSION_TOKEN:""}'
-  default_region: '${AWS_REGION:us-west-1}'
-  #regions:
-  #  - us-west-1
 ----

--- a/x-pack/metricbeat/module/aws/sqs/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/aws/sqs/_meta/docs.asciidoc
@@ -27,10 +27,4 @@ image::./images/metricbeat-aws-sqs-overview.png[]
   period: 300s
   metricsets:
     - sqs
-  access_key_id: '${AWS_ACCESS_KEY_ID:""}'
-  secret_access_key: '${AWS_SECRET_ACCESS_KEY:""}'
-  session_token: '${AWS_SESSION_TOKEN:""}'
-  default_region: '${AWS_REGION:us-west-1}'
-  #regions:
-  #  - us-west-1
 ----

--- a/x-pack/metricbeat/module/aws/sqs/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/aws/sqs/_meta/docs.asciidoc
@@ -27,4 +27,7 @@ image::./images/metricbeat-aws-sqs-overview.png[]
   period: 300s
   metricsets:
     - sqs
+  access_key_id: '<access_key_id>'
+  secret_access_key: '<secret_access_key>'
+  session_token: '<session_token>'
 ----

--- a/x-pack/metricbeat/modules.d/aws.yml.disabled
+++ b/x-pack/metricbeat/modules.d/aws.yml.disabled
@@ -5,20 +5,12 @@
   period: 300s
   metricsets:
     - ec2
-  access_key_id: '${AWS_ACCESS_KEY_ID:""}'
-  secret_access_key: '${AWS_SECRET_ACCESS_KEY:""}'
-  session_token: '${AWS_SESSION_TOKEN:""}'
-  default_region: '${AWS_REGION:us-west-1}'
   regions:
     - us-east-1
 - module: aws
   period: 300s
   metricsets:
     - cloudwatch
-  access_key_id: '${AWS_ACCESS_KEY_ID:""}'
-  secret_access_key: '${AWS_SECRET_ACCESS_KEY:""}'
-  session_token: '${AWS_SESSION_TOKEN:""}'
-  default_region: '${AWS_REGION:us-west-1}'
   cloudwatch_metrics:
     - namespace: AWS/EBS
     - namespace: AWS/ELB


### PR DESCRIPTION
This PR creates a function in libbeat common to get aws credentials. If `access_key_id ` and `secret_access_key` are given, then these will be used as aws credentials to make API calls. If they are not given, then this function will load default aws config instead from `~/.aws/credentials` for Linux & Mac or `%USERPROFILE%\.aws\credentials` for Windows. This PR also introduced a new config parameter `credential_profile_name`. It gives `GetAWSCredentials` function the ability to load aws config from a specific profile. Please see https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html for more details.

This function is from https://github.com/elastic/beats/pull/12701 and I realized both metricbeat and filebeat will need this. That's why I'm moving this method to libbeat common. Also functionbeat will be able to use it.

closes: https://github.com/elastic/beats/issues/12708