### PR TITLE
Add decompress_gzip_field processor

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -176,6 +176,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add configurable bulk_flush_frequency in kafka output. {pull}12254[12254]
 - Add `decode_base64_field` processor for decoding base64 field. {pull}11914[11914]
 - Add aws overview dashboard. {issue}11007[11007] {pull}12175[12175]
+- Add `decompress_gzip_field` processor. {pull}12733[12733]
 
 *Auditbeat*
 

--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -330,6 +330,13 @@ auditbeat.modules:
 #    target: ""
 #    overwrite_keys: false
 #
+#processors:
+#- decompress_gzip_field:
+#    from: "field1"
+#    to: "field2"
+#    ignore_missing: false
+#    fail_on_error: true
+#
 # The following example copies the value of message to message_copied
 #
 #processors:

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -1031,6 +1031,13 @@ filebeat.inputs:
 #    target: ""
 #    overwrite_keys: false
 #
+#processors:
+#- decompress_gzip_field:
+#    from: "field1"
+#    to: "field2"
+#    ignore_missing: false
+#    fail_on_error: true
+#
 # The following example copies the value of message to message_copied
 #
 #processors:

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -474,6 +474,13 @@ heartbeat.scheduler:
 #    target: ""
 #    overwrite_keys: false
 #
+#processors:
+#- decompress_gzip_field:
+#    from: "field1"
+#    to: "field2"
+#    ignore_missing: false
+#    fail_on_error: true
+#
 # The following example copies the value of message to message_copied
 #
 #processors:

--- a/journalbeat/journalbeat.reference.yml
+++ b/journalbeat/journalbeat.reference.yml
@@ -270,6 +270,13 @@ setup.template.settings:
 #    target: ""
 #    overwrite_keys: false
 #
+#processors:
+#- decompress_gzip_field:
+#    from: "field1"
+#    to: "field2"
+#    ignore_missing: false
+#    fail_on_error: true
+#
 # The following example copies the value of message to message_copied
 #
 #processors:

--- a/libbeat/_meta/config.reference.yml.tmpl
+++ b/libbeat/_meta/config.reference.yml.tmpl
@@ -218,6 +218,13 @@
 #    target: ""
 #    overwrite_keys: false
 #
+#processors:
+#- decompress_gzip_field:
+#    from: "field1"
+#    to: "field2"
+#    ignore_missing: false
+#    fail_on_error: true
+#
 # The following example copies the value of message to message_copied
 #
 #processors:

--- a/libbeat/docs/processors-using.asciidoc
+++ b/libbeat/docs/processors-using.asciidoc
@@ -215,6 +215,7 @@ ifdef::has_decode_csv_fields_processor[]
 endif::[]
  * <<decode-json-fields,`decode_json_fields`>>
  * <<decode-base64-field,`decode_base64_field`>>
+ * <<decompress-gzip-field,`decompress_gzip_field`>>
  * <<dissect, `dissect`>>
  * <<extract-array,`extract_array`>>
  * <<processor-dns, `dns`>>
@@ -889,6 +890,40 @@ In the example above:
     - field1 is decoded in field2
 
 The `decode_base64_field` processor has the following configuration settings:
+
+`ignore_missing`:: (Optional) If set to true, no error is logged in case a key
+which should be base64 decoded is missing. Default is `false`.
+
+`fail_on_error`:: (Optional) If set to true, in case of an error the base6 4decode
+of fields is stopped and the original event is returned. If set to false, decoding
+continues also if an error happened during decoding. Default is `true`.
+
+See <<conditions>> for a list of supported conditions.
+
+[[decompress-gzip-field]]
+=== Decompress gzip fields
+
+The `decompress_gzip_field` processor specifies a field to gzip decompress.
+The `field` key contains a `from: old-key` and a `to: new-key` pair. `from` is
+the origin and `to` the target name of the field.
+
+To overwrite fields either first rename the target field or use the `drop_fields`
+processor to drop the field and then rename the field.
+
+[source,yaml]
+-------
+processors:
+- decompress_gzip_field:
+    from: "field1"
+    to: "field2"
+    ignore_missing: false
+    fail_on_error: true
+-------
+
+In the example above:
+    - field1 is decoded in field2
+
+The `decompress_gzip_field` processor has the following configuration settings:
 
 `ignore_missing`:: (Optional) If set to true, no error is logged in case a key
 which should be base64 decoded is missing. Default is `false`.

--- a/libbeat/processors/actions/decompress_gzip_field.go
+++ b/libbeat/processors/actions/decompress_gzip_field.go
@@ -18,6 +18,8 @@
 package actions
 
 import (
+	"bytes"
+	"compress/gzip"
 	"fmt"
 	"io"
 
@@ -28,9 +30,6 @@ import (
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/processors"
 	"github.com/elastic/beats/libbeat/processors/checks"
-
-	"bytes"
-	"compress/gzip"
 )
 
 type decompressGzipField struct {
@@ -113,6 +112,7 @@ func (f *decompressGzipField) decompressGzipField(event *beat.Event) error {
 	var outBuf bytes.Buffer
 	_, err = io.Copy(&outBuf, r)
 	if err != nil {
+		r.Close()
 		return fmt.Errorf("error while decompressing field: %v", err)
 	}
 

--- a/libbeat/processors/actions/decompress_gzip_field.go
+++ b/libbeat/processors/actions/decompress_gzip_field.go
@@ -1,0 +1,133 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package actions
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/pkg/errors"
+
+	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/processors"
+	"github.com/elastic/beats/libbeat/processors/checks"
+
+	"bytes"
+	"compress/gzip"
+)
+
+type decompressGzipField struct {
+	config decompressGzipFieldConfig
+	log    *logp.Logger
+}
+
+type decompressGzipFieldConfig struct {
+	Field         fromTo `config:"field"`
+	IgnoreMissing bool   `config:"ignore_missing"`
+	FailOnError   bool   `config:"fail_on_error"`
+}
+
+func init() {
+	processors.RegisterPlugin("decompress_gzip_field",
+		checks.ConfigChecked(NewDecompressGzipFields,
+			checks.RequireFields("field"),
+			checks.AllowedFields("field", "ignore_missing", "overwrite_keys", "overwrite_keys", "fail_on_error")))
+}
+
+// NewDecompressGzipFields construct a new decompress_gzip_fields processor.
+func NewDecompressGzipFields(c *common.Config) (processors.Processor, error) {
+	config := decompressGzipFieldConfig{
+		IgnoreMissing: false,
+		FailOnError:   true,
+	}
+
+	err := c.Unpack(&config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unpack the decompress_gzip_fields configuration: %+v", err)
+	}
+
+	return &decompressGzipField{config: config, log: logp.NewLogger("decompress_gzip_field")}, nil
+}
+
+// Run applies the decompress_gzip_fields processor to an event.
+func (f *decompressGzipField) Run(event *beat.Event) (*beat.Event, error) {
+	var backup common.MapStr
+	if f.config.FailOnError {
+		backup = event.Fields.Clone()
+	}
+
+	err := f.decompressGzipField(event)
+	if err != nil {
+		errMsg := fmt.Errorf("Failed to decompress field in decompress_gzip_field processor: %v", err)
+		f.log.Debug(errMsg.Error())
+		if f.config.FailOnError {
+			event.Fields = backup
+			event.PutValue("error.message", errMsg.Error())
+			return event, err
+		}
+	}
+	return event, nil
+}
+
+func (f *decompressGzipField) decompressGzipField(event *beat.Event) error {
+	data, err := event.GetValue(f.config.Field.From)
+	if err != nil {
+		if f.config.IgnoreMissing && errors.Cause(err) == common.ErrKeyNotFound {
+			return nil
+		}
+		return fmt.Errorf("could not fetch value for key: %s, Error: %v", f.config.Field.From, err)
+	}
+
+	var inBuf *bytes.Buffer
+	switch txt := data.(type) {
+	case []byte:
+		inBuf = bytes.NewBuffer(txt)
+	case string:
+		inBuf = bytes.NewBufferString(txt)
+	default:
+		return fmt.Errorf("cannot decompress type %+v", txt)
+	}
+
+	r, err := gzip.NewReader(inBuf)
+	if err != nil {
+		return errors.Wrapf(err, "error decompressing field %s", f.config.Field.From)
+	}
+
+	var outBuf bytes.Buffer
+	_, err = io.Copy(&outBuf, r)
+	if err != nil {
+		return fmt.Errorf("error while decompressing field: %v", err)
+	}
+
+	err = r.Close()
+	if err != nil {
+		return fmt.Errorf("error closing gzip reader: %v", err)
+	}
+
+	if _, err = event.PutValue(f.config.Field.To, outBuf.String()); err != nil {
+		return fmt.Errorf("could not put decompressed data: %v", err)
+	}
+	return nil
+}
+
+// String returns a string representation of this processor.
+func (f decompressGzipField) String() string {
+	return fmt.Sprintf("decompress_gzip_fields=%+v", f.config.Field)
+}

--- a/libbeat/processors/actions/decompress_gzip_field_test.go
+++ b/libbeat/processors/actions/decompress_gzip_field_test.go
@@ -1,0 +1,191 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package actions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
+)
+
+func TestDecompressGzip(t *testing.T) {
+	var testCases = []struct {
+		description string
+		config      decompressGzipFieldConfig
+		input       common.MapStr
+		output      common.MapStr
+		error       bool
+	}{
+		{
+			description: "bytes field gzip decompress",
+			config: decompressGzipFieldConfig{
+				Field: fromTo{
+					From: "field1", To: "field2",
+				},
+				IgnoreMissing: false,
+				FailOnError:   true,
+			},
+			input: common.MapStr{
+				"field1": []byte{31, 139, 8, 0, 0, 0, 0, 0, 0, 255, 74, 73, 77, 206, 207, 45, 40, 74, 45, 46, 78, 77, 81, 72, 73, 44, 73, 4, 4, 0, 0, 255, 255, 108, 158, 105, 19, 17, 0, 0, 0},
+			},
+			output: common.MapStr{
+				"field1": []byte{31, 139, 8, 0, 0, 0, 0, 0, 0, 255, 74, 73, 77, 206, 207, 45, 40, 74, 45, 46, 78, 77, 81, 72, 73, 44, 73, 4, 4, 0, 0, 255, 255, 108, 158, 105, 19, 17, 0, 0, 0},
+				"field2": "decompressed data",
+			},
+			error: false,
+		},
+		{
+			description: "string field gzip decompress",
+			config: decompressGzipFieldConfig{
+				Field: fromTo{
+					From: "field1", To: "field2",
+				},
+				IgnoreMissing: false,
+				FailOnError:   true,
+			},
+			input: common.MapStr{
+				"field1": string([]byte{31, 139, 8, 0, 0, 0, 0, 0, 0, 255, 74, 73, 77, 206, 207, 45, 40, 74, 45, 46, 78, 77, 81, 72, 73, 44, 73, 4, 4, 0, 0, 255, 255, 108, 158, 105, 19, 17, 0, 0, 0}),
+			},
+			output: common.MapStr{
+				"field1": string([]byte{31, 139, 8, 0, 0, 0, 0, 0, 0, 255, 74, 73, 77, 206, 207, 45, 40, 74, 45, 46, 78, 77, 81, 72, 73, 44, 73, 4, 4, 0, 0, 255, 255, 108, 158, 105, 19, 17, 0, 0, 0}),
+				"field2": "decompressed data",
+			},
+			error: false,
+		},
+		{
+			description: "simple field gzip decompress in place",
+			config: decompressGzipFieldConfig{
+				Field: fromTo{
+					From: "field1", To: "field1",
+				},
+				IgnoreMissing: false,
+				FailOnError:   true,
+			},
+			input: common.MapStr{
+				"field1": []byte{31, 139, 8, 0, 0, 0, 0, 0, 0, 255, 74, 73, 77, 206, 207, 45, 40, 74, 45, 46, 78, 77, 81, 72, 73, 44, 73, 4, 4, 0, 0, 255, 255, 108, 158, 105, 19, 17, 0, 0, 0},
+			},
+			output: common.MapStr{
+				"field1": "decompressed data",
+			},
+			error: false,
+		},
+		{
+			description: "invalid data - fail on error",
+			config: decompressGzipFieldConfig{
+				Field: fromTo{
+					From: "field1", To: "field1",
+				},
+				IgnoreMissing: false,
+				FailOnError:   true,
+			},
+			input: common.MapStr{
+				"field1": "invalid gzipped data",
+			},
+			output: common.MapStr{
+				"field1": "invalid gzipped data",
+				"error": common.MapStr{
+					"message": "Failed to decompress field in decompress_gzip_field processor: error decompressing field field1: gzip: invalid header",
+				},
+			},
+			error: true,
+		},
+		{
+			description: "invalid data - do not fail",
+			config: decompressGzipFieldConfig{
+				Field: fromTo{
+					From: "field1", To: "field2",
+				},
+				IgnoreMissing: false,
+				FailOnError:   false,
+			},
+			input: common.MapStr{
+				"field1": "invalid gzipped data",
+			},
+			output: common.MapStr{
+				"field1": "invalid gzipped data",
+			},
+			error: false,
+		},
+		{
+			description: "missing field - do not ignore it",
+			config: decompressGzipFieldConfig{
+				Field: fromTo{
+					From: "field2", To: "field3",
+				},
+				IgnoreMissing: false,
+				FailOnError:   true,
+			},
+			input: common.MapStr{
+				"field1": "my value",
+			},
+			output: common.MapStr{
+				"field1": "my value",
+				"error": common.MapStr{
+					"message": "Failed to decompress field in decompress_gzip_field processor: could not fetch value for key: field2, Error: key not found",
+				},
+			},
+			error: true,
+		},
+		{
+			description: "missing field ignore",
+			config: decompressGzipFieldConfig{
+				Field: fromTo{
+					From: "field2", To: "field3",
+				},
+				IgnoreMissing: true,
+				FailOnError:   true,
+			},
+			input: common.MapStr{
+				"field1": "my value",
+			},
+			output: common.MapStr{
+				"field1": "my value",
+			},
+			error: false,
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.description, func(t *testing.T) {
+			t.Parallel()
+
+			f := &decompressGzipField{
+				log:    logp.NewLogger("decompress_gzip_field"),
+				config: test.config,
+			}
+
+			event := &beat.Event{
+				Fields: test.input,
+			}
+
+			newEvent, err := f.Run(event)
+			if !test.error {
+				assert.Nil(t, err)
+			} else {
+				assert.NotNil(t, err)
+			}
+
+			assert.Equal(t, test.output, newEvent.Fields)
+		})
+	}
+}

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -988,6 +988,13 @@ metricbeat.modules:
 #    target: ""
 #    overwrite_keys: false
 #
+#processors:
+#- decompress_gzip_field:
+#    from: "field1"
+#    to: "field2"
+#    ignore_missing: false
+#    fail_on_error: true
+#
 # The following example copies the value of message to message_copied
 #
 #processors:

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -698,6 +698,13 @@ packetbeat.ignore_outgoing: false
 #    target: ""
 #    overwrite_keys: false
 #
+#processors:
+#- decompress_gzip_field:
+#    from: "field1"
+#    to: "field2"
+#    ignore_missing: false
+#    fail_on_error: true
+#
 # The following example copies the value of message to message_copied
 #
 #processors:

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -251,6 +251,13 @@ winlogbeat.event_logs:
 #    target: ""
 #    overwrite_keys: false
 #
+#processors:
+#- decompress_gzip_field:
+#    from: "field1"
+#    to: "field2"
+#    ignore_missing: false
+#    fail_on_error: true
+#
 # The following example copies the value of message to message_copied
 #
 #processors:

--- a/x-pack/auditbeat/auditbeat.reference.yml
+++ b/x-pack/auditbeat/auditbeat.reference.yml
@@ -381,6 +381,13 @@ auditbeat.modules:
 #    target: ""
 #    overwrite_keys: false
 #
+#processors:
+#- decompress_gzip_field:
+#    from: "field1"
+#    to: "field2"
+#    ignore_missing: false
+#    fail_on_error: true
+#
 # The following example copies the value of message to message_copied
 #
 #processors:

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -1179,6 +1179,13 @@ filebeat.inputs:
 #    target: ""
 #    overwrite_keys: false
 #
+#processors:
+#- decompress_gzip_field:
+#    from: "field1"
+#    to: "field2"
+#    ignore_missing: false
+#    fail_on_error: true
+#
 # The following example copies the value of message to message_copied
 #
 #processors:

--- a/x-pack/functionbeat/_meta/beat.reference.yml
+++ b/x-pack/functionbeat/_meta/beat.reference.yml
@@ -150,6 +150,15 @@ functionbeat.provider.aws.functions:
 
     # Define custom processors for this function.
     #processors:
+    #  This example extracts the raw data from events.
+    #  - decode_base64_field:
+    #      field:
+    #        from: message
+    #        to: message
+    #  - decompress_gzip_field:
+    #      field:
+    #        from: message
+    #        to: message
     #  - decode_json_fields:
     #      fields: ["message"]
     #      process_array: false

--- a/x-pack/functionbeat/_meta/beat.yml
+++ b/x-pack/functionbeat/_meta/beat.yml
@@ -151,6 +151,15 @@ functionbeat.provider.aws.functions:
 
     # Define custom processors for this function.
     #processors:
+    #  This example extracts the raw data from events.
+    #  - decode_base64_field:
+    #      field:
+    #        from: message
+    #        to: message
+    #  - decompress_gzip_field:
+    #      field:
+    #        from: message
+    #        to: message
     #  - decode_json_fields:
     #      fields: ["message"]
     #      process_array: false

--- a/x-pack/functionbeat/functionbeat.reference.yml
+++ b/x-pack/functionbeat/functionbeat.reference.yml
@@ -150,6 +150,15 @@ functionbeat.provider.aws.functions:
 
     # Define custom processors for this function.
     #processors:
+    #  This example extracts the raw data from events.
+    #  - decode_base64_field:
+    #      field:
+    #        from: message
+    #        to: message
+    #  - decompress_gzip_field:
+    #      field:
+    #        from: message
+    #        to: message
     #  - decode_json_fields:
     #      fields: ["message"]
     #      process_array: false
@@ -388,6 +397,13 @@ functionbeat.provider.aws.functions:
 #    max_depth: 1
 #    target: ""
 #    overwrite_keys: false
+#
+#processors:
+#- decompress_gzip_field:
+#    from: "field1"
+#    to: "field2"
+#    ignore_missing: false
+#    fail_on_error: true
 #
 # The following example copies the value of message to message_copied
 #

--- a/x-pack/functionbeat/functionbeat.yml
+++ b/x-pack/functionbeat/functionbeat.yml
@@ -151,6 +151,15 @@ functionbeat.provider.aws.functions:
 
     # Define custom processors for this function.
     #processors:
+    #  This example extracts the raw data from events.
+    #  - decode_base64_field:
+    #      field:
+    #        from: message
+    #        to: message
+    #  - decompress_gzip_field:
+    #      field:
+    #        from: message
+    #        to: message
     #  - decode_json_fields:
     #      fields: ["message"]
     #      process_array: false

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -1072,6 +1072,13 @@ metricbeat.modules:
 #    target: ""
 #    overwrite_keys: false
 #
+#processors:
+#- decompress_gzip_field:
+#    from: "field1"
+#    to: "field2"
+#    ignore_missing: false
+#    fail_on_error: true
+#
 # The following example copies the value of message to message_copied
 #
 #processors:

--- a/x-pack/winlogbeat/winlogbeat.reference.yml
+++ b/x-pack/winlogbeat/winlogbeat.reference.yml
@@ -263,6 +263,13 @@ winlogbeat.event_logs:
 #    target: ""
 #    overwrite_keys: false
 #
+#processors:
+#- decompress_gzip_field:
+#    from: "field1"
+#    to: "field2"
+#    ignore_missing: false
+#    fail_on_error: true
+#
 # The following example copies the value of message to message_copied
 #
 #processors:


### PR DESCRIPTION
This PR adds a new processor named `decompress_gzip_field`. As the name implies, it decompresses gzipped fields.

Example configuration:
```yaml
processors:
- decompress_gzip_field:
    from: "source"
    to: "destination"
    ignore_missing: false
    fail_on_error: true
```

I also added reference configuration to Kinesis functions, so users can quickly enable decoding data from streams.