### PR TITLE
[Metricbeat] Add Tablespaces dashboard to Oracle module

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -185,6 +185,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add aws overview dashboard. {issue}11007[11007] {pull}12175[12175]
 - Add `decompress_gzip_field` processor. {pull}12733[12733]
 - Add `timestamp` processor for parsing time fields. {pull}12699[12699]
+- Add Oracle Tablespaces Dashboard {pull}12736[12736]
 
 *Auditbeat*
 

--- a/metricbeat/docs/modules_list.asciidoc
+++ b/metricbeat/docs/modules_list.asciidoc
@@ -130,7 +130,7 @@ This file is generated! See scripts/docs_collector.py
 |<<metricbeat-metricset-nats-subscriptions,subscriptions>>   
 |<<metricbeat-module-nginx,Nginx>>     |image:./images/icon-yes.png[Prebuilt dashboards are available]    |  
 .1+| .1+|  |<<metricbeat-metricset-nginx-stubstatus,stubstatus>>   
-|<<metricbeat-module-oracle,Oracle>>  beta[]   |image:./images/icon-no.png[No prebuilt dashboards]    |  
+|<<metricbeat-module-oracle,Oracle>>  beta[]   |image:./images/icon-yes.png[Prebuilt dashboards are available]    |  
 .1+| .1+|  |<<metricbeat-metricset-oracle-tablespace,tablespace>> beta[]  
 |<<metricbeat-module-php_fpm,PHP_FPM>>     |image:./images/icon-no.png[No prebuilt dashboards]    |  
 .2+| .2+|  |<<metricbeat-metricset-php_fpm-pool,pool>>   

--- a/x-pack/metricbeat/module/oracle/_meta/kibana/7/dashboard/Metricbet-Oracle-tablespaces.json
+++ b/x-pack/metricbeat/module/oracle/_meta/kibana/7/dashboard/Metricbet-Oracle-tablespaces.json
@@ -90,7 +90,7 @@
           }
         ],
         "timeRestore": false,
-        "title": "[Metricbeat Oracle] Overview",
+        "title": "[Metricbeat Oracle] Tablespaces",
         "version": 1
       },
       "id": "862e2c20-9bf0-11e9-a61b-f742ed613c57",

--- a/x-pack/metricbeat/module/oracle/_meta/kibana/7/dashboard/Metricbet-Oracle-tablespaces.json
+++ b/x-pack/metricbeat/module/oracle/_meta/kibana/7/dashboard/Metricbet-Oracle-tablespaces.json
@@ -1,0 +1,536 @@
+{
+  "objects": [
+    {
+      "attributes": {
+        "description": "",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "optionsJSON": {
+          "hidePanelTitles": false,
+          "useMargins": true
+        },
+        "panelsJSON": [
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "1",
+              "w": 19,
+              "x": 0,
+              "y": 0
+            },
+            "panelIndex": "1",
+            "panelRefName": "panel_0",
+            "title": "Avg data file size by filename",
+            "version": "8.0.0-SNAPSHOT"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "2",
+              "w": 24,
+              "x": 0,
+              "y": 15
+            },
+            "panelIndex": "2",
+            "panelRefName": "panel_1",
+            "title": "Tablespace Total Size",
+            "version": "8.0.0-SNAPSHOT"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "3",
+              "w": 19,
+              "x": 19,
+              "y": 0
+            },
+            "panelIndex": "3",
+            "panelRefName": "panel_2",
+            "title": "Maximum data file size",
+            "version": "8.0.0-SNAPSHOT"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "4",
+              "w": 10,
+              "x": 38,
+              "y": 0
+            },
+            "panelIndex": "4",
+            "panelRefName": "panel_3",
+            "title": "Ratio of used space in Tablespaces",
+            "version": "8.0.0-SNAPSHOT"
+          },
+          {
+            "embeddableConfig": {},
+            "gridData": {
+              "h": 15,
+              "i": "5",
+              "w": 24,
+              "x": 24,
+              "y": 15
+            },
+            "panelIndex": "5",
+            "panelRefName": "panel_4",
+            "title": "Ratio of used space in data files",
+            "version": "8.0.0-SNAPSHOT"
+          }
+        ],
+        "timeRestore": false,
+        "title": "[Metricbeat Oracle] Overview",
+        "version": 1
+      },
+      "id": "862e2c20-9bf0-11e9-a61b-f742ed613c57",
+      "migrationVersion": {
+        "dashboard": "7.0.0"
+      },
+      "references": [
+        {
+          "id": "c92efe60-9bef-11e9-a61b-f742ed613c57",
+          "name": "panel_0",
+          "type": "visualization"
+        },
+        {
+          "id": "05acae50-9bf0-11e9-a61b-f742ed613c57",
+          "name": "panel_1",
+          "type": "visualization"
+        },
+        {
+          "id": "4c051a90-9bf0-11e9-a61b-f742ed613c57",
+          "name": "panel_2",
+          "type": "visualization"
+        },
+        {
+          "id": "981779d0-9bfc-11e9-a61b-f742ed613c57",
+          "name": "panel_3",
+          "type": "visualization"
+        },
+        {
+          "id": "072de430-9bfd-11e9-a61b-f742ed613c57",
+          "name": "panel_4",
+          "type": "visualization"
+        }
+      ],
+      "type": "dashboard",
+      "updated_at": "2019-07-01T13:32:15.355Z",
+      "version": "Wzk0MywxNF0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Avg data file size by filename [Metricbeat Oracle]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "auto",
+            "legend_position": "bottom",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "bytes",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Data file size by filename",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "agg_with": "noop",
+                    "field": "oracle.tablespace.data_file.size.bytes",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "order": "desc",
+                    "size": 1,
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "stacked",
+                "terms_field": "oracle.tablespace.data_file.name",
+                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Avg data file size by filename [Metricbeat Oracle]",
+          "type": "metrics"
+        }
+      },
+      "id": "c92efe60-9bef-11e9-a61b-f742ed613c57",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-01T12:24:40.028Z",
+      "version": "WzkzOCwxNF0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Tablespace Total Size [Metricbeat Oracle]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(115,216,255,1)",
+                "fill": 0.5,
+                "formatter": "bytes",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Tablespace total size",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "oracle.tablespace.space.total.bytes",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "stacked",
+                "terms_field": "oracle.tablespace.name",
+                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Tablespace Total Size [Metricbeat Oracle]",
+          "type": "metrics"
+        }
+      },
+      "id": "05acae50-9bf0-11e9-a61b-f742ed613c57",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-01T11:09:27.312Z",
+      "version": "WzkzNCwxNF0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Maximum data file size [Metricbeat Oracle]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "auto",
+            "legend_position": "bottom",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(254,146,0,1)",
+                "fill": 0.5,
+                "formatter": "bytes",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Maximum data file size",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "oracle.tablespace.data_file.size.max.bytes",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "stacked",
+                "terms_field": "oracle.tablespace.data_file.name",
+                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Maximum data file size [Metricbeat Oracle]",
+          "type": "metrics"
+        }
+      },
+      "id": "4c051a90-9bf0-11e9-a61b-f742ed613c57",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-01T11:09:16.058Z",
+      "version": "WzkzMywxNF0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Ratio of used space in Tablespaces [Metricbeat Oracle]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "bar_color_rules": [
+              {
+                "id": "70de46f0-9bfc-11e9-baad-815beb8da1b5"
+              }
+            ],
+            "default_index_pattern": "metricbeat-*",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "percent",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "oracle.tablespace.space.used.bytes",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  },
+                  {
+                    "field": "oracle.tablespace.space.total.bytes",
+                    "id": "37c93d70-9bfc-11e9-baad-815beb8da1b5",
+                    "type": "avg"
+                  },
+                  {
+                    "denominator": "2",
+                    "field": "oracle.tablespace.space.total.bytes",
+                    "id": "0d474830-9bfc-11e9-baad-815beb8da1b5",
+                    "numerator": "1",
+                    "script": "params.used / params.total",
+                    "type": "math",
+                    "variables": [
+                      {
+                        "field": "61ca57f2-469d-11e7-af02-69e470af7417",
+                        "id": "34e8d9d0-9bfc-11e9-baad-815beb8da1b5",
+                        "name": "used"
+                      },
+                      {
+                        "field": "37c93d70-9bfc-11e9-baad-815beb8da1b5",
+                        "id": "467fdf40-9bfc-11e9-baad-815beb8da1b5",
+                        "name": "total"
+                      }
+                    ]
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": "oracle.tablespace.name",
+                "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "top_n"
+          },
+          "title": "Ratio of used space in Tablespaces [Metricbeat Oracle]",
+          "type": "metrics"
+        }
+      },
+      "id": "981779d0-9bfc-11e9-a61b-f742ed613c57",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-01T12:34:39.724Z",
+      "version": "WzkzOSwxNF0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Ratio of used space in data files [Metricbeat Oracle]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "bar_color_rules": [
+              {
+                "id": "da9fa430-9bfc-11e9-baad-815beb8da1b5"
+              }
+            ],
+            "default_index_pattern": "metricbeat-*",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "",
+            "interval": "auto",
+            "legend_position": "bottom",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(204,204,204,1)",
+                "fill": 0.5,
+                "formatter": "percent",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Ratio of used space in data files",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "oracle.tablespace.data_file.size.max.bytes",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "avg"
+                  },
+                  {
+                    "field": "oracle.tablespace.data_file.size.bytes",
+                    "id": "c0f200a0-9bfc-11e9-baad-815beb8da1b5",
+                    "type": "avg"
+                  },
+                  {
+                    "id": "c8289f00-9bfc-11e9-baad-815beb8da1b5",
+                    "script": "params.used / params.max",
+                    "type": "math",
+                    "variables": [
+                      {
+                        "field": "61ca57f2-469d-11e7-af02-69e470af7417",
+                        "id": "c9a63e50-9bfc-11e9-baad-815beb8da1b5",
+                        "name": "max"
+                      },
+                      {
+                        "field": "c0f200a0-9bfc-11e9-baad-815beb8da1b5",
+                        "id": "cddc46e0-9bfc-11e9-baad-815beb8da1b5",
+                        "name": "used"
+                      }
+                    ]
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "stacked",
+                "terms_field": "oracle.tablespace.data_file.name",
+                "terms_order_by": "c0f200a0-9bfc-11e9-baad-815beb8da1b5"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "top_n"
+          },
+          "title": "Ratio of used space in data files [Metricbeat Oracle]",
+          "type": "metrics"
+        }
+      },
+      "id": "072de430-9bfd-11e9-a61b-f742ed613c57",
+      "migrationVersion": {
+        "visualization": "7.2.0"
+      },
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2019-07-01T12:37:59.842Z",
+      "version": "Wzk0MSwxNF0="
+    }
+  ],
+  "version": "8.0.0-SNAPSHOT"
+}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4249331/60441173-bcaa4600-9c16-11e9-96d5-f7edb121fc24.png)

It only contains data from the currently merged Metricset `tablespace`. It shows:

* Green: Average data file size by filename
* Orange: Maximum data file size by filename
* Blue: Tablespace total Size.
* Horizontal green: Ratio of used space in Tablespaces (used/total)
* Grey: Ratio of used space in data files (used/total)