### PR TITLE
[Auditbeat] Process dataset: Do not show non-root warning on Windows

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -88,6 +88,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - System module: Start system module without host ID. {pull}12373[12373]
 - Host dataset: Fix reboot detection logic. {pull}12591[12591]
 - Add syscalls used by librpm for the system/package dataset to the default Auditbeat seccomp policy. {issue}12578[12578] {pull}12617[12617]
+- Process dataset: Do not show non-root warning on Windows. {pull}12740[12740]
 
 *Filebeat*
 

--- a/x-pack/auditbeat/module/system/process/process.go
+++ b/x-pack/auditbeat/module/system/process/process.go
@@ -170,7 +170,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 		ms.log.Debug("No state timestamp found")
 	}
 
-	if os.Geteuid() != 0 {
+	if runtime.GOOS != "windows" && os.Geteuid() != 0 {
 		ms.log.Warn("Running as non-root user, will likely not report all processes.")
 	}
 


### PR DESCRIPTION
`os.Geteuid()` always returns `-1` on Windows, so it is not an effective check for administrative privileges then.

This PR just removes the warning on Windows, the message has no impact on the data collection. 