### PR TITLE
[Auditbeat] Configure container logs to be sent to stdout

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -19,7 +19,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Auditd module: Normalized value of `event.category` field from `user-login` to `authentication`. {pull}11432[11432]
 - Auditd module: Unset `auditd.session` and `user.audit.id` fields are removed from audit events. {issue}11431[11431] {pull}11815[11815]
 - Socket dataset: Exclude localhost by default {pull}11993[11993]
-- Configure container logs to be sent to stdout {pull}12751[12751]
 
 *Filebeat*
 
@@ -89,6 +88,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - System module: Start system module without host ID. {pull}12373[12373]
 - Host dataset: Fix reboot detection logic. {pull}12591[12591]
 - Add syscalls used by librpm for the system/package dataset to the default Auditbeat seccomp policy. {issue}12578[12578] {pull}12617[12617]
+- Configure container logs to be sent to stdout {pull}12751[12751]
 
 *Filebeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -19,6 +19,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Auditd module: Normalized value of `event.category` field from `user-login` to `authentication`. {pull}11432[11432]
 - Auditd module: Unset `auditd.session` and `user.audit.id` fields are removed from audit events. {issue}11431[11431] {pull}11815[11815]
 - Socket dataset: Exclude localhost by default {pull}11993[11993]
+- Configure container logs to be sent to stdout {pull}12751[12751]
 
 *Filebeat*
 

--- a/deploy/kubernetes/auditbeat-kubernetes.yaml
+++ b/deploy/kubernetes/auditbeat-kubernetes.yaml
@@ -73,7 +73,7 @@ spec:
       - name: auditbeat
         image: docker.elastic.co/beats/auditbeat:8.0.0
         args: [
-          "-c", "/etc/auditbeat.yml"
+          "-c", "/etc/auditbeat.yml", "-e"
         ]
         env:
         - name: ELASTICSEARCH_HOST

--- a/deploy/kubernetes/auditbeat/auditbeat-daemonset.yaml
+++ b/deploy/kubernetes/auditbeat/auditbeat-daemonset.yaml
@@ -20,7 +20,7 @@ spec:
       - name: auditbeat
         image: docker.elastic.co/beats/auditbeat:%VERSION%
         args: [
-          "-c", "/etc/auditbeat.yml"
+          "-c", "/etc/auditbeat.yml", "-e"
         ]
         env:
         - name: ELASTICSEARCH_HOST


### PR DESCRIPTION
Auditbeat logs are currently using the default settings, writing to /usr/share/auditbeat/logs/auditbeat.
This corrects that, and configures logs to be written to stdout (so that they are readable using `kubectl logs <image>`)