### PR TITLE
Make helper functions implementation consistent with beat module

### DIFF
--- a/metricbeat/module/logstash/node/node.go
+++ b/metricbeat/module/logstash/node/node.go
@@ -20,7 +20,6 @@ package node
 import (
 	"fmt"
 
-	"github.com/elastic/beats/metricbeat/helper"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/mb/parse"
 	"github.com/elastic/beats/metricbeat/module/logstash"
@@ -50,7 +49,6 @@ var (
 // MetricSet type defines all fields of the MetricSet
 type MetricSet struct {
 	*logstash.MetricSet
-	*helper.HTTP
 }
 
 // New create a new instance of the MetricSet
@@ -60,13 +58,8 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 		return nil, err
 	}
 
-	http, err := helper.NewHTTP(base)
-	if err != nil {
-		return nil, err
-	}
-
 	if ms.XPack {
-		logstashVersion, err := logstash.GetVersion(http, ms.HostData().SanitizedURI+nodePath)
+		logstashVersion, err := logstash.GetVersion(ms)
 		if err != nil {
 			return nil, err
 		}
@@ -84,7 +77,6 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 
 	return &MetricSet{
 		ms,
-		http,
 	}, nil
 }
 
@@ -101,7 +93,7 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 		return eventMapping(r, content)
 	}
 
-	pipelinesContent, err := logstash.GetPipelines(m.HTTP, m.HostData().SanitizedURI+nodePath)
+	pipelinesContent, err := logstash.GetPipelines(m.MetricSet)
 	if err != nil {
 		m.Logger().Error(err)
 		return nil

--- a/metricbeat/module/logstash/node_stats/node_stats.go
+++ b/metricbeat/module/logstash/node_stats/node_stats.go
@@ -20,8 +20,6 @@ package node_stats
 import (
 	"fmt"
 
-	"github.com/elastic/beats/metricbeat/helper"
-
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/mb/parse"
 	"github.com/elastic/beats/metricbeat/module/logstash"
@@ -38,7 +36,7 @@ func init() {
 }
 
 const (
-	nodeStatsPath = "_node/stats"
+	nodeStatsPath = "/_node/stats"
 )
 
 var (
@@ -52,7 +50,6 @@ var (
 // MetricSet type defines all fields of the MetricSet
 type MetricSet struct {
 	*logstash.MetricSet
-	*helper.HTTP
 }
 
 // New create a new instance of the MetricSet
@@ -62,13 +59,8 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 		return nil, err
 	}
 
-	http, err := helper.NewHTTP(base)
-	if err != nil {
-		return nil, err
-	}
-
 	if ms.XPack {
-		logstashVersion, err := logstash.GetVersion(http, ms.HostData().SanitizedURI+nodeStatsPath)
+		logstashVersion, err := logstash.GetVersion(ms)
 		if err != nil {
 			return nil, err
 		}
@@ -83,12 +75,11 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 			return nil, fmt.Errorf(errorMsg, ms.FullyQualifiedName(), logstash.PipelineGraphAPIsAvailableVersion, logstashVersion)
 		}
 
-		http.SetURI(http.GetURI() + "?vertices=true")
+		ms.HTTP.SetURI(ms.HTTP.GetURI() + "?vertices=true")
 	}
 
 	return &MetricSet{
 		ms,
-		http,
 	}, nil
 }
 


### PR DESCRIPTION
Like the `beat` module, the `logstash` module defines a couple of helper functions, viz. `logstash.GetVersion` and `logstash.GetPipelines`. However, prior to this PR, these helper functions accepted a couple of arguments when they could've just accepted one (as is the case with similar functions in the `beat` module).

This PR makes the helper function implementations in the `logstash` module consistent with the helper function implementations in the `beat` module.

This PR should also fix a bug I found while working on https://github.com/elastic/elastic-stack-testing/pull/250 where the Metricbeat logs were showing this error:

```
2019-07-02T14:51:01.384Z        ERROR   [logstash.node_stats]   node_stats/node_stats.go:102    HTTP error 404 in : 404 Not Found
```

### Testing this PR

1. Start up a Logstash node running one or more pipelines.
2. Build Metricbeat with this PR:
   ```
   cd metricbeat
   mage build
   ```

3. Enable the logstash Metricbeat module for Stack Monitoring:

   ```
   metricbeat modules enable logstash-xpack
   ```

5. Start Metricbeat:
   ```
   metricbeat -e
   ```

6. Make sure there are no `ERROR`s in the Metricbeat log.

6. Query the `.monitoring-logstash-7-mb-*` indices to make sure there are documents with `type: logstash_stats` and `type:logstash_state`.
   ```
   POST .monitoring-logstash-7-mb-*/_search
   {
     "collapse": {
       "field": "type"
     }
   }
   ```