### PR TITLE
[Auditbeat] Cherry-pick #12740 to 6.8: Process dataset: Do not show non-root warning on Windows

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -35,6 +35,8 @@ https://github.com/elastic/beats/compare/v6.8.0...6.8.1[Check the HEAD diff]
 
 *Auditbeat*
 
+- Process dataset: Do not show non-root warning on Windows. {pull}12740[12740]
+
 *Filebeat*
 
 *Heartbeat*

--- a/x-pack/auditbeat/module/system/process/process.go
+++ b/x-pack/auditbeat/module/system/process/process.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"os/user"
+	"runtime"
 	"strconv"
 	"time"
 
@@ -160,7 +161,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 		ms.log.Debug("No state timestamp found")
 	}
 
-	if os.Geteuid() != 0 {
+	if runtime.GOOS != "windows" && os.Geteuid() != 0 {
 		ms.log.Warn("Running as non-root user, will likely not report all processes.")
 	}
 


### PR DESCRIPTION
Cherry-pick of PR #12740 to 6.8 branch. Original message: 

`os.Geteuid()` always returns `-1` on Windows, so it is not an effective check for administrative privileges then.

This PR just removes the warning on Windows, the message has no impact on the data collection. 