### PR TITLE
Anchor config file path with path.home var

### DIFF
--- a/x-pack/filebeat/module/cisco/ios/config/input.yml
+++ b/x-pack/filebeat/module/cisco/ios/config/input.yml
@@ -21,4 +21,4 @@ processors:
   - script:
       lang: javascript
       id: cisco_ios
-      file: module/cisco/ios/config/pipeline.js
+      file: ${path.home}/module/cisco/ios/config/pipeline.js


### PR DESCRIPTION
Add ${path.home} to the script file path to anchor it to an absolute location.