### PR TITLE
[generator] add a choices var to generator.py

### DIFF
--- a/script/generate.py
+++ b/script/generate.py
@@ -110,7 +110,7 @@ def get_parser():
     parser.add_argument("--github_name", help="Github name")
     parser.add_argument("--beat_path", help="Beat path")
     parser.add_argument("--full_name", help="Full name")
-    parser.add_argument("--type", help="Beat type", default="beat")
+    parser.add_argument("--type", help="Beat type", default="beat", choices=["beat", "metricbeat"])
 
     return parser
 


### PR DESCRIPTION
See #12765 for the bug

Adding a `choices` var to the parser argument seemed like the most elegant and most pythonic way to fix this. We might not want to add error handling to `os.walk`, since presumably it ignores all errors for a reason. I also imagine this script won't last too much longer, as we need to migrate all this to mage anyway.