### PR TITLE
Add `fs.io_stats` field (only available on Linux)

### DIFF
--- a/metricbeat/module/elasticsearch/node_stats/data_xpack.go
+++ b/metricbeat/module/elasticsearch/node_stats/data_xpack.go
@@ -155,6 +155,15 @@ var (
 				"free_in_bytes":      c.Int("free_in_bytes"),
 				"available_in_bytes": c.Int("available_in_bytes"),
 			}),
+			"io_stats": c.Dict("io_stats", s.Schema{
+				"total": c.Dict("total", s.Schema{
+					"operations":       c.Int("operations"),
+					"read_kilobytes":   c.Int("read_kilobytes"),
+					"read_operations":  c.Int("read_operations"),
+					"write_kilobytes":  c.Int("write_kilobytes"),
+					"write_operations": c.Int("write_operations"),
+				}),
+			}, c.DictOptional),
 		}),
 	}
 

--- a/metricbeat/module/elasticsearch/node_stats/data_xpack.go
+++ b/metricbeat/module/elasticsearch/node_stats/data_xpack.go
@@ -162,7 +162,7 @@ var (
 					"read_operations":  c.Int("read_operations"),
 					"write_kilobytes":  c.Int("write_kilobytes"),
 					"write_operations": c.Int("write_operations"),
-				}),
+				}, c.DictOptional),
 			}, c.DictOptional),
 		}),
 	}


### PR DESCRIPTION
When Elasticsearch is running on Linux, the [Node Stats API](https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-stats.html#fs-info) returns an `nodes.*.fs.io_stats` field.

This PR teaches the `elasticsearch/node_stats` metricset with `xpack.enabled: true` set to collect this optional field and index it into `.monitoring-es-*`. 

### Testing this PR

1. Build Metricbeat with this PR.
   ```
   cd $GOPATH/src/github.com/elastic/beats/metricbeat
   mage build
   ```

2. Enable the Elasticsearch module for Stack Monitoring.
   ```
   ./metricbeat modules enable elasticsearch-xpack
   ```

3. Start Elasticsearch on Linux. Make sure `localhost:9200` on the machine that will run Metricbeat (next step) points to the Elasticsearch cluster running on Linux.

4. Start Metricbeat.
   ```
   ./metricbeat -e
   ```

5. Verify that the `.monitoring-es-*` index contains `type:node_stats` documents with the `node_stats.fs.io_stats` field set.
   ```
   GET .monitoring-es-*/_search?q=type:node_stats&filter_path=hits.hits._source.node_stats.fs&size=1
   ```