### PR TITLE
Document how to run beats on Kubernetes master nodes

### DIFF
--- a/auditbeat/docs/running-on-kubernetes.asciidoc
+++ b/auditbeat/docs/running-on-kubernetes.asciidoc
@@ -55,6 +55,21 @@ may want to change that behavior, so just edit the YAML file and modify them:
 ------------------------------------------------
 
 [float]
+===== Running {beatname_uc} on master nodes
+
+Kubernetes master nodes can use https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/[taints]
+to limit the workloads that can run on them. To run {beatname_uc} on master nodes you may need to
+update the Daemonset spec to include proper tolerations:
+
+[source,yaml]
+------------------------------------------------
+spec:
+ tolerations:
+ - key: node-role.kubernetes.io/master
+   effect: NoSchedule
+------------------------------------------------
+
+[float]
 ==== Deploy
 
 To deploy {beatname_uc} to Kubernetes just run:

--- a/filebeat/docs/running-on-kubernetes.asciidoc
+++ b/filebeat/docs/running-on-kubernetes.asciidoc
@@ -59,6 +59,21 @@ in the manifest file:
 ------------------------------------------------
 
 [float]
+===== Running {beatname_uc} on master nodes
+
+Kubernetes master nodes can use https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/[taints]
+to limit the workloads that can run on them. To run {beatname_uc} on master nodes you may need to
+update the Daemonset spec to include proper tolerations:
+
+[source,yaml]
+------------------------------------------------
+spec:
+ tolerations:
+ - key: node-role.kubernetes.io/master
+   effect: NoSchedule
+------------------------------------------------
+
+[float]
 ===== Red Hat OpenShift configuration
 
 If you are using Red Hat OpenShift, you need to specify additional settings in

--- a/metricbeat/docs/running-on-kubernetes.asciidoc
+++ b/metricbeat/docs/running-on-kubernetes.asciidoc
@@ -65,6 +65,21 @@ in the manifest file:
 ------------------------------------------------
 
 [float]
+===== Running {beatname_uc} on master nodes
+
+Kubernetes master nodes can use https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/[taints]
+to limit the workloads that can run on them. To run {beatname_uc} on master nodes you may need to
+update the Daemonset spec to include proper tolerations:
+
+[source,yaml]
+------------------------------------------------
+spec:
+ tolerations:
+ - key: node-role.kubernetes.io/master
+   effect: NoSchedule
+------------------------------------------------
+
+[float]
 ===== Red Hat OpenShift configuration
 
 If you are using Red Hat OpenShift, you need to specify additional settings in


### PR DESCRIPTION
Some kubernetes deployments limit the workloads that can run on master
nodes. This change documents how to override that behavior by adding
a toleration to DaemonSet specs.