### PR TITLE
[CM] Fix enroll under Windows

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -75,7 +75,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
   processor (or by any code utilizing `PutValue()` on a `beat.Event`).
 - Fix leak in script processor when using Javascript functions in a processor chain. {pull}12600[12600]
 - Add additional nil pointer checks to Docker client code to deal with vSphere Integrated Containers {pull}12628[12628]
-- Fix Central Management enroll under Windows {issue}12797[12797]
+- Fix Central Management enroll under Windows {issue}12797[12797] {pull}12799[12799]
 
 *Auditbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -75,6 +75,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
   processor (or by any code utilizing `PutValue()` on a `beat.Event`).
 - Fix leak in script processor when using Javascript functions in a processor chain. {pull}12600[12600]
 - Add additional nil pointer checks to Docker client code to deal with vSphere Integrated Containers {pull}12628[12628]
+- Fix Central Management enroll under Windows {issue}12797[12797]
 
 *Auditbeat*
 

--- a/x-pack/libbeat/management/enroll.go
+++ b/x-pack/libbeat/management/enroll.go
@@ -55,8 +55,14 @@ func Enroll(
 
 	ts := time.Now()
 
+	// This timestamp format is a variation of RFC3339 replacing colons with
+	// slashes so that it can be used as part of a filename in all OSes.
+	// (Colon is not a valid character for filenames in Windows).
+	// Also removed the TZ-offset as that can cause a plus sign to be output.
+	const fsSafeTimestamp = "2006-01-02T15-04-05"
+
 	// backup current settings:
-	backConfigFile := configFile + "." + ts.Format(time.RFC3339) + ".bak"
+	backConfigFile := configFile + "." + ts.Format(fsSafeTimestamp) + ".bak"
 	fmt.Println("Saving a copy of current settings to " + backConfigFile)
 	err = file.SafeFileRotate(backConfigFile, configFile)
 	if err != nil {


### PR DESCRIPTION
Enrolling of a Beat to Central Management was failing under Windows because the Beat tries to create a configuration backup file that has a colon character in its name, which is not allowed under Windows.

Fixes #12797