### PR TITLE
Cherry-pick #12819 to 7.3: Fix Dockerfile for google-pubsub filebeat input

### DIFF
--- a/x-pack/filebeat/input/googlepubsub/_meta/Dockerfile
+++ b/x-pack/filebeat/input/googlepubsub/_meta/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable
+FROM debian:stretch
 
 RUN \
     apt-get update \


### PR DESCRIPTION
Cherry-pick of PR #12819 to 7.0 branch. Original message:

Seems like beats CI is failing because googlepubsub filebeat input failed to build.
CI failure link: https://travis-ci.org/elastic/beats/jobs/555771486

(cherry picked from commit 95eaf564a2b958d233cc365949d009bfc5b8c8f2)