### PR TITLE
Add statistic option to cloudwatch metricset

### DIFF
--- a/metricbeat/docs/modules/aws.asciidoc
+++ b/metricbeat/docs/modules/aws.asciidoc
@@ -205,18 +205,14 @@ metricbeat.modules:
   secret_access_key: '${AWS_SECRET_ACCESS_KEY:""}'
   session_token: '${AWS_SESSION_TOKEN:""}'
   default_region: '${AWS_REGION:us-west-1}'
-  cloudwatch_metrics:
-    - namespace: AWS/EC2
-      metricname: CPUUtilization
+  namespace: AWS/EC2
+  tags.resource_type_filter: ec2:instance
+  metrics:
+    - names: ["CPUUtilization", "DiskReadOps", "DiskWriteOps"]
+      statistics: ["Average", "Maximum"]
       dimensions:
         - name: InstanceId
           value: i-0686946e22cf9494a
-    - namespace: AWS/EBS
-    - namespace: AWS/ELB
-      tags.resource_type_filter: elasticloadbalancing
-  #regions:
-  #  - us-east-1
-  #  - us-east-2
 - module: aws
   period: 60s
   metricsets:

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -194,18 +194,14 @@ metricbeat.modules:
   secret_access_key: '${AWS_SECRET_ACCESS_KEY:""}'
   session_token: '${AWS_SESSION_TOKEN:""}'
   default_region: '${AWS_REGION:us-west-1}'
-  cloudwatch_metrics:
-    - namespace: AWS/EC2
-      metricname: CPUUtilization
+  namespace: AWS/EC2
+  tags.resource_type_filter: ec2:instance
+  metrics:
+    - names: ["CPUUtilization", "DiskReadOps", "DiskWriteOps"]
+      statistics: ["Average", "Maximum"]
       dimensions:
         - name: InstanceId
           value: i-0686946e22cf9494a
-    - namespace: AWS/EBS
-    - namespace: AWS/ELB
-      tags.resource_type_filter: elasticloadbalancing
-  #regions:
-  #  - us-east-1
-  #  - us-east-2
 - module: aws
   period: 60s
   metricsets:

--- a/x-pack/metricbeat/module/aws/_meta/config.yml
+++ b/x-pack/metricbeat/module/aws/_meta/config.yml
@@ -35,18 +35,14 @@
   secret_access_key: '${AWS_SECRET_ACCESS_KEY:""}'
   session_token: '${AWS_SESSION_TOKEN:""}'
   default_region: '${AWS_REGION:us-west-1}'
-  cloudwatch_metrics:
-    - namespace: AWS/EC2
-      metricname: CPUUtilization
+  namespace: AWS/EC2
+  tags.resource_type_filter: ec2:instance
+  metrics:
+    - names: ["CPUUtilization", "DiskReadOps", "DiskWriteOps"]
+      statistics: ["Average", "Maximum"]
       dimensions:
         - name: InstanceId
           value: i-0686946e22cf9494a
-    - namespace: AWS/EBS
-    - namespace: AWS/ELB
-      tags.resource_type_filter: elasticloadbalancing
-  #regions:
-  #  - us-east-1
-  #  - us-east-2
 - module: aws
   period: 60s
   metricsets:

--- a/x-pack/metricbeat/module/aws/utils.go
+++ b/x-pack/metricbeat/module/aws/utils.go
@@ -152,15 +152,15 @@ func FindTimestamp(getMetricDataResults []cloudwatch.MetricDataResult) time.Time
 
 // GetResourcesTags function queries AWS resource groupings tagging API
 // to get a resource tag mapping with specific resource type filters
-func GetResourcesTags(svc resourcegroupstaggingapiiface.ResourceGroupsTaggingAPIAPI, resourceTypeFilters []string) (map[string][]resourcegroupstaggingapi.Tag, error) {
-	if resourceTypeFilters == nil {
+func GetResourcesTags(svc resourcegroupstaggingapiiface.ResourceGroupsTaggingAPIAPI, resourceTypeFilter string) (map[string][]resourcegroupstaggingapi.Tag, error) {
+	if resourceTypeFilter == "" {
 		return map[string][]resourcegroupstaggingapi.Tag{}, nil
 	}
 
 	resourceTagMap := make(map[string][]resourcegroupstaggingapi.Tag)
 	getResourcesInput := &resourcegroupstaggingapi.GetResourcesInput{
 		PaginationToken:     nil,
-		ResourceTypeFilters: resourceTypeFilters,
+		ResourceTypeFilters: []string{resourceTypeFilter},
 	}
 
 	init := true
@@ -174,7 +174,7 @@ func GetResourcesTags(svc resourcegroupstaggingapiiface.ResourceGroupsTaggingAPI
 		}
 
 		getResourcesInput.PaginationToken = output.PaginationToken
-		if resourceTypeFilters == nil || len(output.ResourceTagMappingList) == 0 {
+		if resourceTypeFilter == "" || len(output.ResourceTagMappingList) == 0 {
 			return nil, nil
 		}
 

--- a/x-pack/metricbeat/module/aws/utils_test.go
+++ b/x-pack/metricbeat/module/aws/utils_test.go
@@ -359,7 +359,7 @@ func TestFindIdentifierFromARN(t *testing.T) {
 
 func TestGetResourcesTags(t *testing.T) {
 	mockSvc := &MockResourceGroupsTaggingClient{}
-	resourceTagMap, err := GetResourcesTags(mockSvc, []string{"rds"})
+	resourceTagMap, err := GetResourcesTags(mockSvc, "rds")
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(resourceTagMap))
 

--- a/x-pack/metricbeat/modules.d/aws.yml.disabled
+++ b/x-pack/metricbeat/modules.d/aws.yml.disabled
@@ -38,18 +38,14 @@
   secret_access_key: '${AWS_SECRET_ACCESS_KEY:""}'
   session_token: '${AWS_SESSION_TOKEN:""}'
   default_region: '${AWS_REGION:us-west-1}'
-  cloudwatch_metrics:
-    - namespace: AWS/EC2
-      metricname: CPUUtilization
+  namespace: AWS/EC2
+  tags.resource_type_filter: ec2:instance
+  metrics:
+    - names: ["CPUUtilization", "DiskReadOps", "DiskWriteOps"]
+      statistics: ["Average", "Maximum"]
       dimensions:
         - name: InstanceId
           value: i-0686946e22cf9494a
-    - namespace: AWS/EBS
-    - namespace: AWS/ELB
-      tags.resource_type_filter: elasticloadbalancing
-  #regions:
-  #  - us-east-1
-  #  - us-east-2
 - module: aws
   period: 60s
   metricsets:


### PR DESCRIPTION
```
- module: aws
  period: 300s
  metricsets:
    - cloudwatch
  namespace: AWS/EC2
  tags.resource_type_filter: ec2:instance
  metrics:
    - names: ["CPUUtilization", "DiskReadOps", "DiskWriteOps"]
      statistics: ["Average", "Maximum"]
      dimensions:
        - name: InstanceId
          value: i-0686946e22cf9494a
```