### PR TITLE
Cherry-pick #12799 to 7.2: [CM] Fix enroll under Windows

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -30,6 +30,8 @@ https://github.com/elastic/beats/compare/v7.2.0...7.2[Check the HEAD diff]
 
 *Affecting all Beats*
 
+- Fix Central Management enroll under Windows {issue}12797[12797] {pull}12799[12799]
+
 *Auditbeat*
 
 *Filebeat*

--- a/x-pack/libbeat/management/enroll.go
+++ b/x-pack/libbeat/management/enroll.go
@@ -55,8 +55,14 @@ func Enroll(
 
 	ts := time.Now()
 
+	// This timestamp format is a variation of RFC3339 replacing colons with
+	// slashes so that it can be used as part of a filename in all OSes.
+	// (Colon is not a valid character for filenames in Windows).
+	// Also removed the TZ-offset as that can cause a plus sign to be output.
+	const fsSafeTimestamp = "2006-01-02T15-04-05"
+
 	// backup current settings:
-	backConfigFile := configFile + "." + ts.Format(time.RFC3339) + ".bak"
+	backConfigFile := configFile + "." + ts.Format(fsSafeTimestamp) + ".bak"
 	fmt.Println("Saving a copy of current settings to " + backConfigFile)
 	err = file.SafeFileRotate(backConfigFile, configFile)
 	if err != nil {


### PR DESCRIPTION
Cherry-pick of PR #12799 to 7.2 branch. Original message: 

Enrolling of a Beat to Central Management was failing under Windows because the Beat tries to create a configuration backup file that has a colon character in its name, which is not allowed under Windows.

Fixes #12797