### PR TITLE
Making parity with internal collector

### DIFF
--- a/metricbeat/module/elasticsearch/node_stats/data_xpack.go
+++ b/metricbeat/module/elasticsearch/node_stats/data_xpack.go
@@ -141,7 +141,7 @@ var (
 			}),
 		}),
 		"thread_pool": c.Dict("thread_pool", s.Schema{
-			"bulk":       c.Dict("bulk", threadPoolStatsSchema),
+			"bulk":       c.Dict("bulk", threadPoolStatsSchema, c.DictOptional),
 			"write":      c.Dict("write", threadPoolStatsSchema),
 			"generic":    c.Dict("generic", threadPoolStatsSchema),
 			"get":        c.Dict("get", threadPoolStatsSchema),

--- a/metricbeat/module/elasticsearch/node_stats/data_xpack.go
+++ b/metricbeat/module/elasticsearch/node_stats/data_xpack.go
@@ -141,7 +141,7 @@ var (
 			}),
 		}),
 		"thread_pool": c.Dict("thread_pool", s.Schema{
-			"analyze":    c.Dict("analyze", threadPoolStatsSchema),
+			"bulk":       c.Dict("bulk", threadPoolStatsSchema),
 			"write":      c.Dict("write", threadPoolStatsSchema),
 			"generic":    c.Dict("generic", threadPoolStatsSchema),
 			"get":        c.Dict("get", threadPoolStatsSchema),


### PR DESCRIPTION
The internal collector for `type:node_stats` documents, collects stats for certain threadpools, as seen here:

https://github.com/elastic/elasticsearch/blob/071b6528740468e980b556c5a88346bb6596cbc6/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/collector/node/NodeStatsMonitoringDoc.java#L145-L165

This PR brings the Metricbeat collection code to parity with the internal collection code for the same threadpool stats.