### PR TITLE
[6.8] Making parity with internal collector (#12830)

### DIFF
--- a/metricbeat/module/elasticsearch/node_stats/data_xpack.go
+++ b/metricbeat/module/elasticsearch/node_stats/data_xpack.go
@@ -141,7 +141,7 @@ var (
 			}),
 		}),
 		"thread_pool": c.Dict("thread_pool", s.Schema{
-			"analyze":    c.Dict("analyze", threadPoolStatsSchema),
+			"bulk":       c.Dict("bulk", threadPoolStatsSchema, c.DictOptional),
 			"write":      c.Dict("write", threadPoolStatsSchema),
 			"generic":    c.Dict("generic", threadPoolStatsSchema),
 			"get":        c.Dict("get", threadPoolStatsSchema),


### PR DESCRIPTION
Backports the following commits to 6.8:
 - Making parity with internal collector  (#12830)