### PR TITLE
Account for no load average reported by ES on Windows

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -145,6 +145,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - When TLS is configured for the http metricset and a `certificate_authorities` is configured we now default to `required` for the `client_authentication`. {pull}12584[12584]
 - Reuse connections in PostgreSQL metricsets. {issue}12504[12504] {pull}12603[12603]
 - PdhExpandWildCardPathW will not expand counter paths in 32 bit windows systems, workaround will use a different function.{issue}12590[12590]{pull}12622[12622]
+- In the elasticsearch/node_stats metricset, if xpack is enabled, make parsing of ES node load average optional as ES on Windows doesn't report load average. {pull}12866[12866]
 
 *Packetbeat*
 

--- a/metricbeat/module/elasticsearch/node_stats/data_xpack.go
+++ b/metricbeat/module/elasticsearch/node_stats/data_xpack.go
@@ -89,7 +89,7 @@ var (
 					"1m":  c.Float("1m", s.Optional),
 					"5m":  c.Float("5m", s.Optional),
 					"15m": c.Float("15m", s.Optional),
-				}),
+				}, c.DictOptional), // No load average reported by ES on Windows
 			}),
 			"cgroup": c.Dict("cgroup", s.Schema{
 				"cpuacct": c.Dict("cpuacct", s.Schema{


### PR DESCRIPTION
Bug reported via https://discuss.elastic.co/t/metricbeat-unable-to-ship-monitoring-information-on-windows-machine/189956.

When the `elasticsearch` module is enabled and configured with `xpack.enabled: true`, the `node_stats` metricset tries to parse CPU load average from the Elasticsearch `GET _nodes/_local/stats` API response. If Elasticsearch is running on Windows, no CPU load average is reported by this API. So Metricbeat currently fails with an error like this:

```
2019-07-11T11:35:51.886+0200    ERROR   [elasticsearch.node_stats] node_stats/node_stats.go:72 1 error: failure to apply node schema: 1 error: key `os.cpu.load_average` not found
```

This PR makes the parsing of CPU load average optional so we don't see this error when ES doesn't report the CPU load average, e.g. when it's running on Windows.