### PR TITLE
Call make recursively in the generated Metricbeat Makefile

### DIFF
--- a/generator/metricbeat/{beat}/Makefile
+++ b/generator/metricbeat/{beat}/Makefile
@@ -13,7 +13,10 @@ MAGE_IMPORT_PATH=${BEAT_PATH}/vendor/github.com/magefile/mage
 
 # Initial beat setup
 .PHONY: setup
-setup: copy-vendor git-init create-metricset collect git-add
+setup: copy-vendor git-init
+	#call make recursively so we can reload the above include.
+	#Only needed during the first setup phase, before /vendor exists
+	$(MAKE) create-metricset collect git-add
 
 # Copy beats into vendor directory
 .PHONY: copy-vendor


### PR DESCRIPTION
See #8181 for the original bug.

When we first run `make setup` after `generate.py`, there's no vendor directory, so `-include $(ES_BEATS)/metricbeat/Makefile` fails, which means the `create-metricset collect` roles don't exist. We can get around this by calling make recursively after `copy-vendor`, which spawns a new process, which means we reload the `include` which now works.

I'd consider this something of a temporary solution, as ideally we'd turn `generate.py` into a mage role which creates the beat as well as the vendor directory. If we did this, we also wouldn't need to give the custom beat it's own weird, special makefile.
