### PR TITLE
Memlog timestamp

### DIFF
--- a/libbeat/registry/backend/memlog/typeconv.go
+++ b/libbeat/registry/backend/memlog/typeconv.go
@@ -208,6 +208,8 @@ func (u *timeUnfolder) OnInt(ctx gotype.UnfoldCtx, in int64) error {
 }
 
 func (u *timeUnfolder) OnArrayFinished(ctx gotype.UnfoldCtx) error {
+	defer ctx.Done()
+
 	if u.st != timeUnfoldWaitDone {
 		return errors.New("unexpected timestamp array closed")
 	}
@@ -237,6 +239,5 @@ func (u *timeUnfolder) OnArrayFinished(ctx gotype.UnfoldCtx) error {
 		}
 	}
 
-	ctx.Done()
 	return nil
 }

--- a/libbeat/registry/backend/memlog/typeconv.go
+++ b/libbeat/registry/backend/memlog/typeconv.go
@@ -18,6 +18,8 @@
 package memlog
 
 import (
+	"errors"
+	"fmt"
 	"sync"
 	"time"
 
@@ -43,6 +45,23 @@ type valueDecoder struct {
 	value common.MapStr
 }
 
+type timeUnfolder struct {
+	gotype.BaseUnfoldState
+	to   *time.Time
+	a, b uint64
+	st   timeUnfoldState
+}
+
+type timeUnfoldState uint8
+
+const (
+	timeUnfoldInit timeUnfoldState = iota
+	timeUnfoldDone
+	timeUnfoldWaitA
+	timeUnfoldWaitB
+	timeUnfoldWaitDone
+)
+
 var typeConvPool = sync.Pool{
 	New: func() interface{} {
 		t := &typeConv{}
@@ -63,7 +82,9 @@ func (t *typeConv) release() {
 }
 
 func (t *typeConv) init() {
-	unfold, _ := gotype.NewUnfolder(nil)
+	unfold, _ := gotype.NewUnfolder(nil, gotype.Unfolders(
+		unfoldTimestamp,
+	))
 	fold, err := gotype.NewIterator(unfold, gotype.Folders(
 		foldTimestamp,
 	))
@@ -73,47 +94,6 @@ func (t *typeConv) init() {
 
 	t.unfold = unfold
 	t.fold = fold
-}
-
-func foldTimestamp(in *time.Time, v structform.ExtVisitor) error {
-	var (
-		ts  = *in
-		off int16
-		loc = ts.Location()
-	)
-
-	const encodingVersion = 0
-
-	if loc == time.UTC {
-		off = -1
-	} else {
-		_, offset := ts.Zone()
-		offset /= 60 // Note: best effort. If the zone offset has a factional minute, then we will ignore it here
-		if offset < -32768 || offset == -1 || offset > 32767 {
-			offset = 0 // Note: best effort. Ignore offset if it becomes an unexpected value
-		}
-		off = int16(offset)
-	}
-
-	sec := uint64(ts.Unix())
-	extra := (uint64(encodingVersion) << 56) |
-		(uint64(off) << 32) |
-		uint64(ts.Nanosecond())
-
-	if err := v.OnArrayStart(2, structform.Uint64Type); err != nil {
-		return err
-	}
-	if err := v.OnUint64(extra); err != nil {
-		return err
-	}
-	if err := v.OnUint64(sec); err != nil {
-		return err
-	}
-	if err := v.OnArrayFinished(); err != nil {
-		return err
-	}
-
-	return nil
 }
 
 func (t *typeConv) Convert(to, from interface{}) error {
@@ -138,4 +118,125 @@ func (d *valueDecoder) Decode(to interface{}) (err error) {
 		err = d.tx.getTypeConv().Convert(to, d.value)
 	}
 	return
+}
+
+func foldTimestamp(in *time.Time, v structform.ExtVisitor) error {
+	var (
+		ts  = *in
+		off int16
+		loc = ts.Location()
+	)
+
+	const encodingVersion = 0
+
+	if loc == time.UTC {
+		off = -1
+	} else {
+		_, offset := ts.Zone()
+		offset /= 60 // Note: best effort. If the zone offset has a factional minute, then we will ignore it here
+		if offset < -32768 || offset == -1 || offset > 32767 {
+			offset = 0 // Note: best effort. Ignore offset if it becomes an unexpected value
+		}
+		off = int16(offset)
+	}
+
+	sec := uint64(ts.Unix())
+	extra := (uint64(encodingVersion) << 56) |
+		(uint64(uint16(off)) << 32) |
+		uint64(ts.Nanosecond())
+
+	if err := v.OnArrayStart(2, structform.Uint64Type); err != nil {
+		return err
+	}
+	if err := v.OnUint64(extra); err != nil {
+		return err
+	}
+	if err := v.OnUint64(sec); err != nil {
+		return err
+	}
+	if err := v.OnArrayFinished(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func unfoldTimestamp(to *time.Time) gotype.UnfoldState {
+	return &timeUnfolder{to: to}
+}
+
+func (u *timeUnfolder) OnString(ctx gotype.UnfoldCtx, in string) (err error) {
+	if u.st != timeUnfoldInit {
+		return fmt.Errorf("Unexpected string '%v' when trying to unfold a timestamp", in)
+	}
+
+	*u.to, err = time.Parse(time.RFC3339, in)
+	u.st = timeUnfoldDone
+	ctx.Done()
+	return err
+}
+
+func (u *timeUnfolder) OnArrayStart(ctx gotype.UnfoldCtx, len int, _ structform.BaseType) error {
+	if u.st != timeUnfoldInit {
+		return errors.New("unexpected array")
+	}
+
+	if len >= 0 && len != 2 {
+		return fmt.Errorf("%v is no valid encoded timestamp length", len)
+	}
+
+	u.st = timeUnfoldWaitA
+	return nil
+}
+
+func (u *timeUnfolder) OnUint(ctx gotype.UnfoldCtx, in uint64) error {
+	switch u.st {
+	case timeUnfoldWaitA:
+		u.a = in
+		u.st = timeUnfoldWaitB
+	case timeUnfoldWaitB:
+		u.b = in
+		u.st = timeUnfoldWaitDone
+	default:
+		return fmt.Errorf("unexpected number '%v' in timestamp array", in)
+	}
+	return nil
+}
+
+func (u *timeUnfolder) OnInt(ctx gotype.UnfoldCtx, in int64) error {
+	return u.OnUint(ctx, uint64(in))
+}
+
+func (u *timeUnfolder) OnArrayFinished(ctx gotype.UnfoldCtx) error {
+	if u.st != timeUnfoldWaitDone {
+		return errors.New("unexpected timestamp array closed")
+	}
+
+	u.st = timeUnfoldDone
+
+	version := (u.a >> 56) & 0xff
+	if version != 0 {
+		return fmt.Errorf("invalid timestamp [%x, %x]", u.a, u.b)
+	}
+
+	sec := u.b
+	nsec := uint32(u.a)
+	off := int16(u.a >> 32)
+
+	ts := u.to
+	*ts = time.Unix(int64(sec), int64(nsec))
+
+	// adjust location by offset. time.Unix creates a timestamp in the local zone
+	// by default. Only change this if off does not match the local zone it's offset.
+	if off == -1 {
+		*ts = ts.UTC()
+	} else if off != 0 {
+		_, locOff := ts.Zone()
+		if off != int16(locOff/60) {
+			*ts = ts.In(time.FixedZone("", int(off*60)))
+		}
+	}
+
+	ctx.Done()
+	return nil
 }

--- a/libbeat/registry/backend/memlog/typeconv_test.go
+++ b/libbeat/registry/backend/memlog/typeconv_test.go
@@ -84,10 +84,10 @@ func TestTypeConv(t *testing.T) {
 		var v testStruct
 		ts := time.Now()
 		err := tc.Convert(&v, common.MapStr{
-			"timestamp": ts.Format(time.RFC3339),
+			"timestamp": ts.Format(time.RFC3339Nano),
 		})
 		require.NoError(t, err)
-		assert.Equal(t, v.Timestamp.Format(time.RFC3339), ts.Format(time.RFC3339))
+		assert.Equal(t, v.Timestamp.Format(time.RFC3339Nano), ts.Format(time.RFC3339Nano))
 	}))
 }
 

--- a/libbeat/registry/backend/memlog/typeconv_test.go
+++ b/libbeat/registry/backend/memlog/typeconv_test.go
@@ -19,6 +19,7 @@ package memlog
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -45,6 +46,17 @@ func TestTypeConv(t *testing.T) {
 		var m common.MapStr
 		tc.Convert(&m, struct{ A string }{"test"})
 		assert.Equal(t, common.MapStr{"a": "test"}, m)
+	}))
+
+	t.Run("timestamp to MapStr", withTypeConv(func(t *testing.T, tc *typeConv) {
+		var m common.MapStr
+		ts := time.Unix(1234, 5678).UTC()
+
+		off := int16(-1)
+		expected := []uint64{uint64(5678) | uint64(off)<<32, 1234}
+
+		tc.Convert(&m, struct{ Timestamp time.Time }{ts})
+		assert.Equal(t, common.MapStr{"timestamp": expected}, m)
 	}))
 }
 


### PR DESCRIPTION
Requires: #8131 

Add support to encode/decode time.Time values in the registry file.
When encoding we create an array of 2 values holding: `[encoding version | timezone offset | nanoseconds, unix seconds]`. This format is a little more compact in memory, keeps high precision, and easily encodes to JSON on disk.
When decoding into `time.Time` we support decoding using said format or from RFC3339 format.