### PR TITLE
[DOCS] Add conditional coding to remove references to LS

### DIFF
--- a/libbeat/docs/monitoring/monitoring-internal-collection.asciidoc
+++ b/libbeat/docs/monitoring/monitoring-internal-collection.asciidoc
@@ -48,9 +48,13 @@ monitoring:
     password: somepassword
 --------------------
 +
-If you configured a different output, such as {ls} or you want to send {beatname_uc}
-monitoring events to a separate {es} cluster (referred to as the _monitoring cluster_),
-you must specify additional configuration options. For example:
+If you
+ifndef::only-elasticsearch[]
+configured a different output, such as {ls} or you
+endif::only-elasticsearch[]
+want to send {beatname_uc} monitoring events to a separate {es} cluster
+(referred to as the _monitoring cluster_), you must specify additional
+configuration options. For example:
 +
 ["source","yml",subs="attributes"]
 --------------------

--- a/libbeat/docs/shared-config-ingest.asciidoc
+++ b/libbeat/docs/shared-config-ingest.asciidoc
@@ -13,13 +13,15 @@
 == Parse data by using ingest node
 
 When you use Elasticsearch for output, you can configure {beatname_uc} to use
-{ref}/ingest.html[ingest node] to pre-process documents before the
-actual indexing takes place in Elasticsearch. Ingest node is a convenient
-processing option when you want to do some extra processing on your data, but
-you do not require the full power of Logstash. For example, you can create an
-ingest node pipeline in Elasticsearch that consists of one processor that
-removes a field in a document followed by another processor that renames a
-field.
+{ref}/ingest.html[ingest node] to pre-process documents before the actual
+indexing takes place in Elasticsearch.
+ifndef::only-elasticsearch[]
+Ingest node is a convenient processing option when you want to do some extra
+processing on your data, but you do not require the full power of Logstash.
+endif::only-elasticsearch[]
+For example, you can create an ingest node pipeline
+in Elasticsearch that consists of one processor that removes a field in a
+document followed by another processor that renames a field.
 
 After defining the pipeline in Elasticsearch, you simply configure {beatname_uc}
 to use the pipeline. To configure {beatname_uc}, you specify the pipeline ID in

--- a/libbeat/docs/shared-geoip.asciidoc
+++ b/libbeat/docs/shared-geoip.asciidoc
@@ -16,11 +16,13 @@ IP addresses, based on data from the Maxmind GeoLite2 City Database. Because the
 processor uses a geoIP database that's installed on {es}, you don't need
 to install a geoIP database on the machines running {beatname_uc}.
 
+ifndef::only-elasticsearch[]
 NOTE: If your use case involves using {ls}, you can use the
 {logstash-ref}/plugins-filters-geoip.html[GeoIP filter] available in {ls}
 instead of using the `geoip` processor. However, using the `geoip` processor is
 the simplest approach when you don't require the additional processing power of
 {ls}.
+endif::only-elasticsearch[]
 
 [float]
 [id="{beatname_lc}-configuring-geoip"]

--- a/libbeat/docs/shared-getting-started-intro.asciidoc
+++ b/libbeat/docs/shared-getting-started-intro.asciidoc
@@ -4,7 +4,9 @@ related products:
 
 * {es} for storing and indexing the data.
 * {kib} for the UI.
+ifndef::only-elasticsearch[]
 * {ls} (optional) for parsing and enhancing the data.
+endif::only-elasticsearch[]
 
 See {stack-gs}/get-started-elastic-stack.html[Getting started with the {stack}]
 for more information about installing these products.


### PR DESCRIPTION
Conditionally codes sections that mention Logstash so that we can suppress the content for products (like Functionbeat) that only support ES output.

I missed these instances in my first round of fixes several months ago.