### PR TITLE
Only parse necessary `reloads` sub-fields

### DIFF
--- a/metricbeat/module/logstash/node_stats/data_xpack.go
+++ b/metricbeat/module/logstash/node_stats/data_xpack.go
@@ -66,6 +66,11 @@ type nodeInfo struct {
 	Pipeline    map[string]interface{} `json:"pipeline"`
 }
 
+type reloads struct {
+	Successes int `json:"successes"`
+	Failures  int `json:"failures"`
+}
+
 // NodeStats represents the stats of a Logstash node
 type NodeStats struct {
 	nodeInfo
@@ -90,7 +95,7 @@ type PipelineStats struct {
 	Hash        string                   `json:"hash"`
 	EphemeralID string                   `json:"ephemeral_id"`
 	Events      map[string]interface{}   `json:"events"`
-	Reloads     map[string]interface{}   `json:"reloads"`
+	Reloads     reloads                  `json:"reloads"`
 	Queue       map[string]interface{}   `json:"queue"`
 	Vertices    []map[string]interface{} `json:"vertices"`
 }


### PR DESCRIPTION
In `.monitoring-logstash-*` documents of `type: logstash_stats`, we only index `logstash_stats.pipelines.reloads.failures` and `logstash_stats.pipelines.reloads.successes`:

https://github.com/elastic/elasticsearch/blob/master/x-pack/plugin/core/src/main/resources/monitoring-logstash.json#L333-L342

As such, this PR updates the `logstash/node_stats` code (x-pack code path) to only parse these fields, instead of passing through the entire `logstash_stats.pipelines.reloads` object as-is.

This change will help ensure parity between Metricbeat-collection and internal-collection of `type: logstash_stats` documents.

### Testing this PR

1. Build Metricbeat with this PR.
   ```
   cd $GOPATH/src/github.com/elastic/beats/metricbeat
   mage build
   ```

2. Enable the Logstash module for Stack Monitoring.
   ```
   ./metricbeat modules enable logstash-xpack
   ```

3. Start Logstash.
   ```
   ./bin/logstash -e 'input { stdin {} }'

4. Start Metricbeat.
   ```
   ./metricbeat -e
   ```

5. Verify that the `.monitoring-logstash-*` index contains `type:logstash_stats` documents with the fields as mentioned above.

   ```
   GET .monitoring-logstash-*/_search?q=type:logstash_stats&filter_path=hits.hits._source.logstash_stats.pipelines.reloads&size=1
   ```