### PR TITLE
[DOCS] Replace deprecated --template option with --index-management

### DIFF
--- a/docs/devguide/newdashboards.asciidoc
+++ b/docs/devguide/newdashboards.asciidoc
@@ -49,10 +49,12 @@ To import the dashboards, run the `setup` command.
 The `setup` phase loads:
 
 - Index mapping template in Elasticsearch
-- Kibana dashboards
-- Machine Learning jobs (if available)
+- Kibana dashboards (where available)
+- Machine Learning (ML) jobs (where available)
+- Ingest pipelines (where available)
+- ILM policy (for Elasticsearch 6.5 and newer)
 
-For more details about the `setup` command, run the following:
+For more details about the `setup` command, run:
 
 [source,shell]
 ----
@@ -63,16 +65,18 @@ This command does initial setup of the environment:
  * Index mapping template in Elasticsearch to ensure fields are mapped.
  * Kibana dashboards (where available).
  * ML jobs (where available).
+ * Ingest pipelines (where available).
+ * ILM policy (for Elasticsearch 6.5 and newer).
 
 Usage:
-  filebeat setup [flags]
+  metricbeat setup [flags]
 
 Flags:
-      --dashboards         Setup dashboards only
+      --dashboards         Setup dashboards
   -h, --help               help for setup
-      --machine-learning   Setup machine learning job configurations only
-      --modules string     List of enabled modules (comma separated)
-      --index-management           Setup index template only
+      --index-management   Setup all components related to Elasticsearch index management, including template, ilm policy and rollover alias
+      --machine-learning   Setup machine learning job configurations
+      --pipelines          Setup Ingest pipelines
 ----
 
 The flags are useful when you don't want to load everything. For example, to

--- a/docs/devguide/newdashboards.asciidoc
+++ b/docs/devguide/newdashboards.asciidoc
@@ -72,7 +72,7 @@ Flags:
   -h, --help               help for setup
       --machine-learning   Setup machine learning job configurations only
       --modules string     List of enabled modules (comma separated)
-      --template           Setup index template only
+      --index-management           Setup index template only
 ----
 
 The flags are useful when you don't want to load everything. For example, to

--- a/docs/devguide/newdashboards.asciidoc
+++ b/docs/devguide/newdashboards.asciidoc
@@ -54,6 +54,8 @@ The `setup` phase loads several dependencies, such as:
 - Ingest pipelines
 - ILM policy
 
+The dependencies vary depending on the Beat you're setting up.
+
 For more details about the `setup` command, run:
 
 [source,shell]

--- a/docs/devguide/newdashboards.asciidoc
+++ b/docs/devguide/newdashboards.asciidoc
@@ -56,7 +56,7 @@ The `setup` phase loads several dependencies, such as:
 
 The dependencies vary depending on the Beat you're setting up.
 
-For more details about the `setup` command, run:
+For more details about the `setup` command, see the command-line help. For example:
 
 [source,shell]
 ----

--- a/docs/devguide/newdashboards.asciidoc
+++ b/docs/devguide/newdashboards.asciidoc
@@ -46,12 +46,12 @@ To import the dashboards, run the `setup` command.
 ./metricbeat setup
 -------------------------
 
-The `setup` phase loads:
+The `setup` phase loads several dependencies, such as: 
 
 - Index mapping template in Elasticsearch
-- Kibana dashboards (where available)
-- Machine Learning (ML) jobs (where available)
-- Ingest pipelines (where available)
+- Kibana dashboards
+- Machine Learning (ML) jobs
+- Ingest pipelines
 - ILM policy (for Elasticsearch 6.5 and newer)
 
 For more details about the `setup` command, run:

--- a/docs/devguide/newdashboards.asciidoc
+++ b/docs/devguide/newdashboards.asciidoc
@@ -52,7 +52,7 @@ The `setup` phase loads several dependencies, such as:
 - Kibana dashboards
 - Machine Learning (ML) jobs
 - Ingest pipelines
-- ILM policy (for Elasticsearch 6.5 and newer)
+- ILM policy
 
 For more details about the `setup` command, run:
 

--- a/libbeat/docs/shared-template-load.asciidoc
+++ b/libbeat/docs/shared-template-load.asciidoc
@@ -141,7 +141,7 @@ ifdef::deb_os,rpm_os[]
 *deb and rpm:*
 ["source","sh",subs="attributes"]
 ----
-{beatname_lc} setup --template{disable_logstash} -E 'output.elasticsearch.hosts=["localhost:9200"]'
+{beatname_lc} setup --index-management{disable_logstash} -E 'output.elasticsearch.hosts=["localhost:9200"]'
 ----
 endif::deb_os,rpm_os[]
 
@@ -150,14 +150,14 @@ ifdef::mac_os[]
 
 ["source","sh",subs="attributes"]
 ----
-./{beatname_lc} setup --template{disable_logstash} -E 'output.elasticsearch.hosts=["localhost:9200"]'
+./{beatname_lc} setup --index-management{disable_logstash} -E 'output.elasticsearch.hosts=["localhost:9200"]'
 ----
 
 *brew:*
 
 ["source","sh",subs="attributes"]
 ----
-{beatname_lc} setup --template{disable_logstash} -E 'output.elasticsearch.hosts=["localhost:9200"]'
+{beatname_lc} setup --index-management{disable_logstash} -E 'output.elasticsearch.hosts=["localhost:9200"]'
 ----
 endif::mac_os[]
 
@@ -166,7 +166,7 @@ ifdef::linux_os[]
 
 ["source","sh",subs="attributes"]
 ----
-./{beatname_lc} setup --template{disable_logstash} -E 'output.elasticsearch.hosts=["localhost:9200"]'
+./{beatname_lc} setup --index-management{disable_logstash} -E 'output.elasticsearch.hosts=["localhost:9200"]'
 ----
 endif::linux_os[]
 
@@ -176,7 +176,7 @@ ifdef::docker_platform[]
 
 ["source","sh",subs="attributes"]
 ----------------------------------------------------------------------
-docker run {dockerimage} setup --template{disable_logstash} -E 'output.elasticsearch.hosts=["localhost:9200"]'
+docker run {dockerimage} setup --index-management{disable_logstash} -E 'output.elasticsearch.hosts=["localhost:9200"]'
 ----------------------------------------------------------------------
 endif::docker_platform[]
 
@@ -193,7 +193,7 @@ and run:
 
 ["source","sh",subs="attributes"]
 ----------------------------------------------------------------------
-PS > .{backslash}{beatname_lc}.exe setup --template{disable_logstash} -E 'output.elasticsearch.hosts=["localhost:9200"]'
+PS > .{backslash}{beatname_lc}.exe setup --index-management{disable_logstash} -E 'output.elasticsearch.hosts=["localhost:9200"]'
 ----------------------------------------------------------------------
 endif::win_os[]
 


### PR DESCRIPTION
Replaces remaining instances of the deprecated option (--template).