### PR TITLE
Only parse/index necessary `os.cpu` and `process.cpu` fields

### DIFF
--- a/metricbeat/module/logstash/node_stats/data_xpack.go
+++ b/metricbeat/module/logstash/node_stats/data_xpack.go
@@ -40,7 +40,6 @@ type commonStats struct {
 type cpu struct {
 	Percent     int                    `json:"percent"`
 	LoadAverage map[string]interface{} `json:"load_average"`
-	NumCPUs     int                    `json:"num_cpus"`
 }
 
 type process struct {
@@ -119,7 +118,6 @@ func eventMappingXPack(r mb.ReporterV2, m *MetricSet, content []byte) error {
 	o := os{
 		cpu{
 			LoadAverage: nodeStats.Process.CPU.LoadAverage,
-			NumCPUs:     nodeStats.Process.CPU.NumCPUs,
 		},
 	}
 

--- a/metricbeat/module/logstash/node_stats/data_xpack.go
+++ b/metricbeat/module/logstash/node_stats/data_xpack.go
@@ -38,8 +38,8 @@ type commonStats struct {
 }
 
 type cpu struct {
-	Percent     int                    `json:"percent"`
-	LoadAverage map[string]interface{} `json:"load_average"`
+	Percent     int                    `json:"percent,omitempty"`
+	LoadAverage map[string]interface{} `json:"load_average,omitempty"`
 }
 
 type process struct {


### PR DESCRIPTION
### `os.cpu`

In `.monitoring-logstash-*` documents of `type: logstash_stats`, we only index `logstash_stats.os.cpu.load_average` field:

https://github.com/elastic/elasticsearch/blob/master/x-pack/plugin/core/src/main/resources/monitoring-logstash.json#L161-L177

As such, this PR updates the `logstash/node_stats` code (x-pack code path) to only index this field, instead of also indexing the `logstash_stats.os.cpu.num_cpus` and `logstash_stats.os.cpu.percent` fields.

### `process.cpu`

In `.monitoring-logstash-*` documents of `type: logstash_stats`, we only index `logstash_stats.process.cpu.percent` field:

https://github.com/elastic/elasticsearch/blob/master/x-pack/plugin/core/src/main/resources/monitoring-logstash.json#L216-L222

As such, this PR updates the `logstash/node_stats` code (x-pack code path) to only parse and index this field, instead of also indexing a `logstash_stats.process.cpu.load_average` field.

These changes will help ensure parity between Metricbeat-collection and internal-collection of `type: logstash_stats` documents.

### Testing this PR

1. Build Metricbeat with this PR.
   ```
   cd $GOPATH/src/github.com/elastic/beats/metricbeat
   mage build
   ```

2. Enable the Logstash module for Stack Monitoring.
   ```
   ./metricbeat modules enable logstash-xpack
   ```

3. Start Logstash.
   ```
   ./bin/logstash -e 'input { stdin {} }'

4. Start Metricbeat.
   ```
   ./metricbeat -e
   ```

5. Verify that the `.monitoring-logstash-*` index contains `type:logstash_stats` documents with the fields as mentioned above.

   ```
   GET .monitoring-logstash-*/_search?q=type:logstash_stats&filter_path=hits.hits._source.logstash_stats.os.cpu,hits.hits._source.logstash_stats.process.cpu&size=1
   ```