### PR TITLE
Expose error when checking if alias exists

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -79,6 +79,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add additional nil pointer checks to Docker client code to deal with vSphere Integrated Containers {pull}12628[12628]
 - Fixed `json.add_error_key` property setting for delivering error messages from beat events  {pull}11298[11298]
 - Fix Central Management enroll under Windows {issue}12797[12797] {pull}12799[12799]
+- ILM: Use GET instead of HEAD when checking for alias to expose detailed error message. {pull}12886[12886]
 
 *Auditbeat*
 

--- a/libbeat/idxmgmt/ilm/client_handler.go
+++ b/libbeat/idxmgmt/ilm/client_handler.go
@@ -153,7 +153,7 @@ func (h *ESClientHandler) HasILMPolicy(name string) (bool, error) {
 // HasAlias queries Elasticsearch to see if alias exists.
 func (h *ESClientHandler) HasAlias(name string) (bool, error) {
 	path := path.Join(esAliasPath, name)
-	status, b, err := h.client.Request("HEAD", path, "", nil, nil)
+	status, b, err := h.client.Request("GET", path, "", nil, nil)
 	if err != nil && status != 404 {
 		return false, wrapErrf(err, ErrRequestFailed,
 			"failed to check for alias '%v': (status=%v) %s", name, status, b)


### PR DESCRIPTION
We are using a `HEAD /_alias/{alias}` request to check if a particular alias exists during `setup`. If this request fails (e.g. because of missing privileges) we will not get the full error message from Elasticsearch telling us which privilege is missing. Changing to `GET` will get us that while maintaining functionality.

Before (when missing privileges):
```
2019-07-12T10:29:43.672+0100	ERROR	instance/beat.go:877	Exiting: failed to check for alias 'auditbeat-7.2.0': (status=403) : 403 Forbidden: Exiting: failed to check for alias 'auditbeat-7.2.0': (status=403) : 403 Forbidden:
```

After:
```
Exiting: failed to check for alias 'auditbeat-8.0.0': (status=403) {"error":{"root_cause":[{"type":"security_exception","reason":"action [indices:admin/aliases/get] is unauthorized for user [auditbeat]"}],"type":"security_exception","reason":"action [indices:admin/aliases/get] is unauthorized for user [auditbeat]"},"status":403}: 403 Forbidden: {"error":{"root_cause":[{"type":"security_exception","reason":"action [indices:admin/aliases/get] is unauthorized for user [auditbeat]"}],"type":"security_exception","reason":"action [indices:admin/aliases/get] is unauthorized for user [auditbeat]"},"status":403}
```

Also seen in https://github.com/elastic/beats/issues/10241#issuecomment-510701588.