### PR TITLE
Cherry-pick #12885 to 7.3: Add alias required by windows job on jenkins

### DIFF
--- a/x-pack/metricbeat/magefile.go
+++ b/x-pack/metricbeat/magefile.go
@@ -28,6 +28,12 @@ func init() {
 	devtools.BeatLicense = "Elastic License"
 }
 
+// Aliases provides compatibility with CI while we transition all Beats
+// to having common testing targets.
+var Aliases = map[string]interface{}{
+	"goTestUnit": GoUnitTest, // dev-tools/jenkins_ci.ps1 uses this.
+}
+
 // Build builds the Beat binary.
 func Build() error {
 	return devtools.Build(devtools.DefaultBuildArgs())


### PR DESCRIPTION
Cherry-pick of PR #12885 to 7.3 branch. Original message: 

X-Pack metricbeat job for Windows requires this target. Using alias as
is done on auditbeat while all beats are migrated to have common testing
targets.

This may need to be backported.