### PR TITLE
Cherry-pick #12885 to 7.1: Add alias required by windows job on jenkins

### DIFF
--- a/x-pack/metricbeat/magefile.go
+++ b/x-pack/metricbeat/magefile.go
@@ -26,6 +26,12 @@ func init() {
 	mage.BeatLicense = "Elastic License"
 }
 
+// Aliases provides compatibility with CI while we transition all Beats
+// to having common testing targets.
+var Aliases = map[string]interface{}{
+	"goTestUnit": GoUnitTest, // dev-tools/jenkins_ci.ps1 uses this.
+}
+
 // Build builds the Beat binary.
 func Build() error {
 	return mage.Build(mage.DefaultBuildArgs())


### PR DESCRIPTION
Cherry-pick of PR #12885 to 7.1 branch. Original message: 

X-Pack metricbeat job for Windows requires this target. Using alias as
is done on auditbeat while all beats are migrated to have common testing
targets.

This may need to be backported.