### PR TITLE
[7.3] Only parse necessary `reloads` sub-fields (#12881)

### DIFF
--- a/metricbeat/module/logstash/node_stats/data_xpack.go
+++ b/metricbeat/module/logstash/node_stats/data_xpack.go
@@ -66,6 +66,11 @@ type nodeInfo struct {
 	Pipeline    map[string]interface{} `json:"pipeline"`
 }
 
+type reloads struct {
+	Successes int `json:"successes"`
+	Failures  int `json:"failures"`
+}
+
 // NodeStats represents the stats of a Logstash node
 type NodeStats struct {
 	nodeInfo
@@ -90,7 +95,7 @@ type PipelineStats struct {
 	Hash        string                   `json:"hash"`
 	EphemeralID string                   `json:"ephemeral_id"`
 	Events      map[string]interface{}   `json:"events"`
-	Reloads     map[string]interface{}   `json:"reloads"`
+	Reloads     reloads                  `json:"reloads"`
 	Queue       map[string]interface{}   `json:"queue"`
 	Vertices    []map[string]interface{} `json:"vertices"`
 }


### PR DESCRIPTION
Backports the following commits to 7.3:
 - Only parse necessary `reloads` sub-fields  (#12881)