### PR TITLE
Cherry-pick #12864 to 7.2: Use `container` input in doc examples

### DIFF
--- a/filebeat/_meta/common.reference.inputs.yml
+++ b/filebeat/_meta/common.reference.inputs.yml
@@ -357,17 +357,14 @@ filebeat.inputs:
     # default to `required` otherwise it will be set to `none`.
     #ssl.client_authentication: "required"
 
-#------------------------------ Docker input --------------------------------
-# Experimental: Docker input reads and parses `json-file` logs from Docker
-#- type: docker
+#------------------------------ Container input --------------------------------
+#- type: container
   #enabled: false
 
-  # Combine partial lines flagged by `json-file` format
-  #combine_partials: true
+  # Paths for container logs that should be crawled and fetched.
+  #paths:
+  #  -/var/lib/docker/containers/*/*.log
 
-  # Use this to read from all containers, replace * with a container id to read from one:
-  #containers:
-  #  stream: all # can be all, stdout or stderr
-  #  ids:
-  #    - '*'
+  # Configure stream to filter to a specific stream: stdout, stderr or all (default)
+  #stream: all
 

--- a/filebeat/_meta/common.reference.p2.yml
+++ b/filebeat/_meta/common.reference.p2.yml
@@ -11,7 +11,7 @@
 #        - condition:
 #            equals.docker.container.image: busybox
 #          config:
-#            - type: log
+#            - type: container
 #              paths:
 #                - /var/lib/docker/containers/${data.docker.container.id}/*.log
 

--- a/filebeat/docs/autodiscover-docker-config.asciidoc
+++ b/filebeat/docs/autodiscover-docker-config.asciidoc
@@ -5,15 +5,14 @@ Filebeat supports templates for inputs and modules.
 filebeat.autodiscover:
   providers:
     - type: docker
-      labels.dedot: true
       templates:
         - condition:
             contains:
               docker.container.image: redis
           config:
-            - type: docker
-              containers.ids:
-                - "${data.docker.container.id}"
+            - type: container
+              paths:
+                - /var/lib/docker/containers/${data.docker.container.id}/*.log
               exclude_lines: ["^\\s+[\\-`('.|_]"]  # drop asciiart lines
 -------------------------------------------------------------------------------------
 
@@ -27,7 +26,6 @@ If you are using modules, you can override the default input and use the docker 
 filebeat.autodiscover:
   providers:
     - type: docker
-      labels.dedot: true
       templates:
         - condition:
             contains:
@@ -36,7 +34,7 @@ filebeat.autodiscover:
             - module: redis
               log:
                 input:
-                  type: docker
-                  containers.ids:
-                    - "${data.docker.container.id}"
+                  type: container
+                  paths:
+                    - /var/lib/docker/containers/${data.docker.container.id}/*.log
 -------------------------------------------------------------------------------------

--- a/filebeat/docs/autodiscover-hints.asciidoc
+++ b/filebeat/docs/autodiscover-hints.asciidoc
@@ -107,7 +107,7 @@ filebeat.autodiscover:
       hints.default_config:
         type: container
         paths:
-          /var/log/container/*-${container.id}.log  # CRI path
+          - /var/log/container/*-${container.id}.log  # CRI path
 -------------------------------------------------------------------------------------
 
 You can also disable default settings entirely, so only Pods annotated like `co.elastic.logs/enabled: true`
@@ -176,7 +176,7 @@ filebeat.autodiscover:
       hints.default_config:
         type: container
         paths:
-          /var/log/container/*-${container.id}.log  # CRI path
+          - /var/log/container/*-${container.id}.log  # CRI path
 -------------------------------------------------------------------------------------
 
 You can also disable default settings entirely, so only containers labeled with `co.elastic.logs/enabled: true`

--- a/filebeat/docs/autodiscover-kubernetes-config.asciidoc
+++ b/filebeat/docs/autodiscover-kubernetes-config.asciidoc
@@ -10,9 +10,9 @@ filebeat.autodiscover:
             equals:
               kubernetes.namespace: kube-system
           config:
-            - type: docker
-              containers.ids:
-                - "${data.kubernetes.container.id}"
+            - type: container
+              paths:
+                - /var/log/container/*-${data.kubernetes.container.id}.log
               exclude_lines: ["^\\s+[\\-`('.|_]"]  # drop asciiart lines
 -------------------------------------------------------------------------------------
 
@@ -34,7 +34,7 @@ filebeat.autodiscover:
             - module: redis
               log:
                 input:
-                  type: docker
-                  containers.ids:
-                    - "${data.kubernetes.container.id}"
+                  type: container
+                  paths:
+                    - /var/log/container/*-${data.kubernetes.container.id}.log
 -------------------------------------------------------------------------------------

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -762,19 +762,16 @@ filebeat.inputs:
     # default to `required` otherwise it will be set to `none`.
     #ssl.client_authentication: "required"
 
-#------------------------------ Docker input --------------------------------
-# Experimental: Docker input reads and parses `json-file` logs from Docker
-#- type: docker
+#------------------------------ Container input --------------------------------
+#- type: container
   #enabled: false
 
-  # Combine partial lines flagged by `json-file` format
-  #combine_partials: true
+  # Paths for container logs that should be crawled and fetched.
+  #paths:
+  #  -/var/lib/docker/containers/*/*.log
 
-  # Use this to read from all containers, replace * with a container id to read from one:
-  #containers:
-  #  stream: all # can be all, stdout or stderr
-  #  ids:
-  #    - '*'
+  # Configure stream to filter to a specific stream: stdout, stderr or all (default)
+  #stream: all
 
 #========================== Filebeat autodiscover ==============================
 
@@ -789,7 +786,7 @@ filebeat.inputs:
 #        - condition:
 #            equals.docker.container.image: busybox
 #          config:
-#            - type: log
+#            - type: container
 #              paths:
 #                - /var/lib/docker/containers/${data.docker.container.id}/*.log
 

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -874,19 +874,16 @@ filebeat.inputs:
     # default to `required` otherwise it will be set to `none`.
     #ssl.client_authentication: "required"
 
-#------------------------------ Docker input --------------------------------
-# Experimental: Docker input reads and parses `json-file` logs from Docker
-#- type: docker
+#------------------------------ Container input --------------------------------
+#- type: container
   #enabled: false
 
-  # Combine partial lines flagged by `json-file` format
-  #combine_partials: true
+  # Paths for container logs that should be crawled and fetched.
+  #paths:
+  #  -/var/lib/docker/containers/*/*.log
 
-  # Use this to read from all containers, replace * with a container id to read from one:
-  #containers:
-  #  stream: all # can be all, stdout or stderr
-  #  ids:
-  #    - '*'
+  # Configure stream to filter to a specific stream: stdout, stderr or all (default)
+  #stream: all
 
 #------------------------------ NetFlow input --------------------------------
 # Experimental: Config options for the Netflow/IPFIX collector over UDP input
@@ -930,7 +927,7 @@ filebeat.inputs:
 #        - condition:
 #            equals.docker.container.image: busybox
 #          config:
-#            - type: log
+#            - type: container
 #              paths:
 #                - /var/lib/docker/containers/${data.docker.container.id}/*.log
 


### PR DESCRIPTION
Cherry-pick of PR #12864 to 7.2 branch. Original message: 

Documentation examples are still using the deprecated `docker` input,
this change updates them to make use of the new `container` input, with
the same behavior expected.

Closes #12795 