### PR TITLE
[Metricbeat] Fix system/uptime metricset under Windows

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -147,6 +147,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - PdhExpandWildCardPathW will not expand counter paths in 32 bit windows systems, workaround will use a different function.{issue}12590[12590]{pull}12622[12622]
 - In the elasticsearch/node_stats metricset, if xpack is enabled, make parsing of ES node load average optional as ES on Windows doesn't report load average. {pull}12866[12866]
 - Ramdisk is not filtered out when collecting disk performance counters in diskio metricset {issue}12814[12814] {pull}12829[12829]
+- Fix wrong uptime reporting by system/uptime metricset under Windows. {pull}12915[12915]
 
 *Packetbeat*
 

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -837,8 +837,8 @@ Elasticsearch, B.V. (https://www.elastic.co/).
 
 --------------------------------------------------------------------
 Dependency: github.com/elastic/gosigar
-Version: v0.10.4
-Revision: f75810decf6f4d88b130bfc4d2ba7ccdcea0c01d
+Version: HEAD
+Revision: f48d9dc84bc636d361c33fab2d7d753b705fd373
 License type (autodetected): Apache-2.0
 ./vendor/github.com/elastic/gosigar/LICENSE:
 --------------------------------------------------------------------

--- a/vendor/github.com/elastic/gosigar/CHANGELOG.md
+++ b/vendor/github.com/elastic/gosigar/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fixed uptime calculation under Windows. #126
+
 ### Changed
 
 ### Deprecated

--- a/vendor/github.com/elastic/gosigar/sigar_windows.go
+++ b/vendor/github.com/elastic/gosigar/sigar_windows.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
-	"sync"
 	"syscall"
 	"time"
 
@@ -24,11 +23,6 @@ var (
 	// 2003 and XP where PROCESS_QUERY_LIMITED_INFORMATION is unknown. For all newer
 	// OS versions it is set to PROCESS_QUERY_LIMITED_INFORMATION.
 	processQueryLimitedInfoAccess = windows.PROCESS_QUERY_LIMITED_INFORMATION
-
-	// bootTime is the time when the OS was last booted. This value may be nil
-	// on operating systems that do not support the WMI query used to obtain it.
-	bootTime     *time.Time
-	bootTimeLock sync.Mutex
 )
 
 func init() {
@@ -63,19 +57,11 @@ func (self *Uptime) Get() error {
 	if !version.IsWindowsVistaOrGreater() {
 		return ErrNotImplemented{runtime.GOOS}
 	}
-
-	bootTimeLock.Lock()
-	defer bootTimeLock.Unlock()
-	if bootTime == nil {
-		uptime, err := windows.GetTickCount64()
-		if err != nil {
-			return errors.Wrap(err, "failed to get boot time using win32 api")
-		}
-		var boot = time.Unix(int64(uptime), 0)
-		bootTime = &boot
+	uptimeMs, err := windows.GetTickCount64()
+	if err != nil {
+		return errors.Wrap(err, "failed to get boot time using GetTickCount64 api")
 	}
-
-	self.Length = time.Since(*bootTime).Seconds()
+	self.Length = float64(time.Duration(uptimeMs)*time.Millisecond) / float64(time.Second)
 	return nil
 }
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1385,44 +1385,44 @@
 			"revisionTime": "2018-08-31T13:10:45Z"
 		},
 		{
-			"checksumSHA1": "0Wy9N78P/Gh12DUbixilznW67ak=",
+			"checksumSHA1": "REELpodvqmrKDkIMKRSrZd9g7sE=",
 			"path": "github.com/elastic/gosigar",
-			"revision": "f75810decf6f4d88b130bfc4d2ba7ccdcea0c01d",
-			"revisionTime": "2019-07-09T16:38:49Z",
-			"version": "v0.10.4",
-			"versionExact": "v0.10.4"
+			"revision": "f48d9dc84bc636d361c33fab2d7d753b705fd373",
+			"revisionTime": "2019-07-15T18:29:51Z",
+			"version": "HEAD",
+			"versionExact": "HEAD"
 		},
 		{
 			"checksumSHA1": "TX9y4oPL5YmT4Gb/OU4GIPTdQB4=",
 			"path": "github.com/elastic/gosigar/cgroup",
-			"revision": "f75810decf6f4d88b130bfc4d2ba7ccdcea0c01d",
-			"revisionTime": "2019-07-09T16:38:49Z",
-			"version": "v0.10.4",
-			"versionExact": "v0.10.4"
+			"revision": "f48d9dc84bc636d361c33fab2d7d753b705fd373",
+			"revisionTime": "2019-07-15T18:29:51Z",
+			"version": "HEAD",
+			"versionExact": "HEAD"
 		},
 		{
 			"checksumSHA1": "hPqGM3DENaGfipEODoyZ4mKogTQ=",
 			"path": "github.com/elastic/gosigar/sys",
-			"revision": "f75810decf6f4d88b130bfc4d2ba7ccdcea0c01d",
-			"revisionTime": "2019-07-09T16:38:49Z",
-			"version": "v0.10.4",
-			"versionExact": "v0.10.4"
+			"revision": "f48d9dc84bc636d361c33fab2d7d753b705fd373",
+			"revisionTime": "2019-07-15T18:29:51Z",
+			"version": "HEAD",
+			"versionExact": "HEAD"
 		},
 		{
 			"checksumSHA1": "mLq5lOyD0ZU39ysXuf1ETOLJ+f0=",
 			"path": "github.com/elastic/gosigar/sys/linux",
-			"revision": "f75810decf6f4d88b130bfc4d2ba7ccdcea0c01d",
-			"revisionTime": "2019-07-09T16:38:49Z",
-			"version": "v0.10.4",
-			"versionExact": "v0.10.4"
+			"revision": "f48d9dc84bc636d361c33fab2d7d753b705fd373",
+			"revisionTime": "2019-07-15T18:29:51Z",
+			"version": "HEAD",
+			"versionExact": "HEAD"
 		},
 		{
 			"checksumSHA1": "ZoHlhk6iiV8eMn0ozjy6mvC5+Dc=",
 			"path": "github.com/elastic/gosigar/sys/windows",
-			"revision": "f75810decf6f4d88b130bfc4d2ba7ccdcea0c01d",
-			"revisionTime": "2019-07-09T16:38:49Z",
-			"version": "v0.10.4",
-			"versionExact": "v0.10.4"
+			"revision": "f48d9dc84bc636d361c33fab2d7d753b705fd373",
+			"revisionTime": "2019-07-15T18:29:51Z",
+			"version": "HEAD",
+			"versionExact": "HEAD"
 		},
 		{
 			"checksumSHA1": "Klc34HULvwvY4cGA/D8HmqtXLqw=",


### PR DESCRIPTION
This updates to latest gosigar which fixes uptime calculation under Windows.