### PR TITLE
Only collect fields that are also internally-collected

### DIFF
--- a/metricbeat/module/logstash/node_stats/data_xpack.go
+++ b/metricbeat/module/logstash/node_stats/data_xpack.go
@@ -61,17 +61,22 @@ type os struct {
 	CPU cpu `json:"cpu"`
 }
 
+type pipeline struct {
+	BatchSize int `json:"batch_size"`
+	Workers   int `json:"workers"`
+}
+
 type nodeInfo struct {
-	ID          string                 `json:"id,omitempty"`
-	UUID        string                 `json:"uuid"`
-	EphemeralID string                 `json:"ephemeral_id"`
-	Name        string                 `json:"name"`
-	Host        string                 `json:"host"`
-	Version     string                 `json:"version"`
-	Snapshot    bool                   `json:"snapshot"`
-	Status      string                 `json:"status"`
-	HTTPAddress string                 `json:"http_address"`
-	Pipeline    map[string]interface{} `json:"pipeline"`
+	ID          string   `json:"id,omitempty"`
+	UUID        string   `json:"uuid"`
+	EphemeralID string   `json:"ephemeral_id"`
+	Name        string   `json:"name"`
+	Host        string   `json:"host"`
+	Version     string   `json:"version"`
+	Snapshot    bool     `json:"snapshot"`
+	Status      string   `json:"status"`
+	HTTPAddress string   `json:"http_address"`
+	Pipeline    pipeline `json:"pipeline"`
 }
 
 type reloads struct {

--- a/metricbeat/module/logstash/node_stats/data_xpack.go
+++ b/metricbeat/module/logstash/node_stats/data_xpack.go
@@ -70,6 +70,13 @@ type reloads struct {
 	Failures  int `json:"failures"`
 }
 
+type events struct {
+	DurationInMillis int `json:"duration_in_millis"`
+	In               int `json:"in"`
+	Filtered         int `json:"filtered"`
+	Out              int `json:"out"`
+}
+
 // NodeStats represents the stats of a Logstash node
 type NodeStats struct {
 	nodeInfo
@@ -93,7 +100,7 @@ type PipelineStats struct {
 	ID          string                   `json:"id"`
 	Hash        string                   `json:"hash"`
 	EphemeralID string                   `json:"ephemeral_id"`
-	Events      map[string]interface{}   `json:"events"`
+	Events      events                   `json:"events"`
 	Reloads     reloads                  `json:"reloads"`
 	Queue       map[string]interface{}   `json:"queue"`
 	Vertices    []map[string]interface{} `json:"vertices"`

--- a/metricbeat/module/logstash/node_stats/data_xpack.go
+++ b/metricbeat/module/logstash/node_stats/data_xpack.go
@@ -28,9 +28,18 @@ import (
 	"github.com/elastic/beats/metricbeat/mb"
 )
 
+type jvm struct {
+	GC  map[string]interface{} `json:"gc"`
+	Mem struct {
+		HeapMaxInBytes  int `json:"heap_max_in_bytes"`
+		HeapUsedInBytes int `json:"heap_used_in_bytes"`
+		HeapUsedPercent int `json:"heap_used_percent"`
+	} `json:"mem"`
+}
+
 type commonStats struct {
 	Events  map[string]interface{} `json:"events"`
-	JVM     map[string]interface{} `json:"jvm"`
+	JVM     jvm                    `json:"jvm"`
 	Reloads map[string]interface{} `json:"reloads"`
 	Queue   struct {
 		EventsCount int `json:"events_count"`


### PR DESCRIPTION
[Logstash Monitoring parity tests](https://github.com/elastic/elastic-stack-testing/pull/250) have found that Metricbeat-collected `logstash_stats` documents contain some fields that are not currently present in internally-collected `logstash_stats` documents.

This PR removes the collection of said fields from the Metricbeat `logstash/node_stats` metricset (x-pack code path). Fields removed are:

- [x] `logstash_stats.events.queue_push_duration_in_millis`
- [x] `logstash_stats.jvm.threads`
- [x] `logstash_stats.jvm.mem.heap_committed_in_bytes`
- [x] `logstash_stats.jvm.mem.non_heap_committed_in_bytes`
- [x] `logstash_stats.jvm.mem.pools`
- [x] `logstash_stats.logstash.pipeline.batch_delay`

### Testing this PR

1. Build Metricbeat with this PR.
   ```
   cd $GOPATH/src/github.com/elastic/beats/metricbeat
   mage build
   ```

2. Enable the Logstash module for Stack Monitoring.
   ```
   ./metricbeat modules enable logstash-xpack
   ```

3. Start Logstash.
   ```
   ./bin/logstash -e 'input { stdin {} }'

4. Start Metricbeat.
   ```
   ./metricbeat -e
   ```

5. Verify that the `.monitoring-logstash-*` index contains `type:logstash_stats` documents **without** the fields mentioned above.

   ```
   GET .monitoring-logstash-*/_search?q=type:logstash_stats&filter_path=hits.hits._source.logstash_stats&size=1
   ```