### PR TITLE
[DOCS] Clarify required privileges for Beats users

### DIFF
--- a/libbeat/docs/security/basic-auth.asciidoc
+++ b/libbeat/docs/security/basic-auth.asciidoc
@@ -19,7 +19,7 @@ under `output.elasticsearch`. For example:
 ----
 output.elasticsearch:
   hosts: ["localhost:9200"]
-  username: "{beat_default_index_prefix}_internal" <1>
+  username: "{beat_default_index_prefix}_writer" <1>
   password: "{pwd}" <2>
 ----
 <1> Let's assume this user has the privileges required to publish events to
@@ -36,7 +36,7 @@ authenticating with {kib}. For example:
 ----
 setup.kibana:
   host: "mykibanahost:5601"
-  username: "{beat_default_index_prefix}_internal" <1>
+  username: "{beat_default_index_prefix}_setup" <1>
   password: "{pwd}" 
 ----
 <1> Let's assume this user has the privileges required to set up dashboards.

--- a/libbeat/docs/security/users.asciidoc
+++ b/libbeat/docs/security/users.asciidoc
@@ -6,7 +6,7 @@ You can use role-based access control to grant users access to secured
 resources. The roles that you set up depend on your organization's security
 requirements and the minimum privileges required to use specific features.
 
-Typically you need the following separate roles:
+Typically you need the create the following separate roles:
 
 * <<privileges-to-setup-beats,setup role>> for setting up index templates and
 other dependencies
@@ -18,102 +18,132 @@ by {beatname_uc}
 create visualizations that access {beatname_uc} data
 
 
-{security} also provides built-in roles that grant a subset of the privileges
+{security} provides built-in roles that grant a subset of the privileges
 needed by {beatname_uc} users. When possible, use the built-in roles to minimize
 the affect of future changes on your security strategy.
 
 
 [[privileges-to-setup-beats]]
-==== Setup role
+==== Grant privileges and roles needed for setup
 
 IMPORTANT: Setting up {beatname_uc} is an admin-level task that requires extra
-privileges. As a best practice, grant this role to administrators only, and use
-a less restrictive role for event publishing.  
+privileges. As a best practice, grant the setup role to administrators only, and
+use a less restrictive role for event publishing.  
 
 Administrators who set up {beatname_uc} typically need to load mappings,
 dashboards, and other objects used to index data into {es} and visualize it in
-{kib}.
+{kib}. 
 
-NOTE: These instructions assume that you are using the default name for
-{beatname_uc} indices. If you are using a custom name, modify the privileges to
-match your index naming pattern.
+To grant users the required privileges:
 
+. Create a *setup role*, called something like +{beat_default_index_prefix}_setup+, that has
+the following privileges:
++
 [options="header"]
 |====
-|Privileges and roles | Why needed?
+|Privileges | Why needed?
 
-|`monitor` privilege
+|`monitor`
 |Send monitoring data to the cluster
 
 ifndef::no_ilm[]
-|`manage_ilm`  privilege
+|`manage_ilm`
 |Set up and manage index lifecycle management (ILM) policy
 endif::no_ilm[]
 
 ifdef::has_ml_jobs[]
-|`manage_ml` privilege
+|`manage_ml`
 |Set up machine learning job configurations
 endif::has_ml_jobs[]
 
-|`manage` privilege on +{beat_default_index_prefix}-*+ indices
+|`manage` on +{beat_default_index_prefix}-*+ indices
 |Set up aliases used by ILM
  
 ifdef::has_ml_jobs[]
-|`read` privilege on +{beat_default_index_prefix}-*+ indices
+|`read` on +{beat_default_index_prefix}-*+ indices
 |Read {beatname_uc} indices in order to set up machine learning jobs
 endif::has_ml_jobs[]
+|====
++
+Omit any privileges that aren't relevant in your environment.
++
+NOTE: These instructions assume that you are using the default name for
+{beatname_uc} indices. If you are using a custom name, modify the privileges to
+match your index naming pattern.
 
-|`kibana_user` role
+. Assign the *setup role*, along with the following built-in roles, to users who
+need to set up {beatname_uc}: 
++
+[options="header"]
+|====
+|Roles | Why needed?
+
+|`kibana_user`
 |Load dependencies, such as example dashboards, if available, into {kib}
 
-|`ingest_admin` role
+|`ingest_admin`
 |Set up index templates and, if available, ingest pipelines
 
 ifdef::apm-server[]
-|`ingest_admin` role
+|`ingest_admin`
 |Set up ingest pipelines
 endif::apm-server[]
 
 ifdef::has_central_config[]
-|`beats_admin` role
+|`beats_admin`
 |Enroll and manage configurations in Beats central management
 endif::has_central_config[]
 |====
++
+Omit any roles that aren't relevant in your environment.
 
 [[privileges-to-publish-monitoring]]
-==== Monitoring role
+==== Grant privileges and roles needed for monitoring
 
 {security} provides the +{beat_default_index_prefix}_system+
 {stack-ov}/built-in-users.html[built-in user] and
 +{beat_default_index_prefix}_system+ {stack-ov}/built-in-roles.html[built-in
 role] for sending monitoring information. You can use the built-in user, or
 create a user who has the privileges needed to send monitoring information.
+
 If you use the +{beat_default_index_prefix}_system+ user, make sure you
 <<beats-system-user,set the password>>.
 
+If you don't use the +{beat_default_index_prefix}_system+ user:
+
+. Create a *monitoring role*, called something like
++{beat_default_index_prefix}_monitoring+, that has the following privileges:
++
 [options="header"]
 |====
-|Privileges and roles | Why needed?
+|Privileges | Why needed?
 
-|`monitor` privilege
+|`monitor`
 |Send monitoring info
 
-|`kibana_user` role
+|`kibana_user`
 |Use {kib}
+|====
 
-|`monitoring_user` role
+. Assign the *monitoring role*, along with the following built-in role, to
+users who need to monitor {beatname_uc}: 
++
+[options="header"]
+|====
+|Role | Why needed?
+|`monitoring_user`
 |Use *Stack Monitoring* in {kib} to monitor {beatname_uc}
 |====
 
 
 [[privileges-to-publish-events]]
-==== Writer role
+==== Grant privileges and roles needed for publishing
 
 Users who publish events to {es} need to create and read from {beatname_uc}
-indices. To minimize the privileges required by the writer role, use the
-<<privileges-to-setup-beats,setup role>> to load dependencies. Then, in the
-configuration file used by the writer role, turn off setup options. For
-example:
+indices. To minimize the privileges required by the writer role, you can use the
+<<privileges-to-setup-beats,setup role>> to pre-load dependencies. Then turn off
+setup options in the  {beatname_uc} config file before running {beatname_uc} to
+publish events. For example:
 
 ifndef::no_ilm[]
 [source,yaml]
@@ -132,73 +162,106 @@ setup.template.enabled: false
 ----
 endif::no_ilm[]
 
-With setup options turned off, the writer role requires:
+To grant the required privileges:
 
+. Create a *writer role*, called something like +{beat_default_index_prefix}_writer+, that has
+the following privileges (this list assumes the setup options shown earlier are
+set to `false`):
++
 [options="header"]
 |====
-|Privileges and roles | Why needed?
+|Privileges | Why needed?
 
 ifndef::apm-server[]
-|`monitor` privilege
+|`monitor`
 |Send monitoring info
 endif::apm-server[]
 
 ifndef::no_ilm[]
-|`read_ilm` privilege
+|`read_ilm`
 |Read the ILM policy when connecting to clusters that support ILM
 endif::no_ilm[]
 
 ifeval::["{beatname_lc}"=="filebeat"]
-|`manage_pipeline` privilege
+|`manage_pipeline`
 |Load ingest pipelines used by modules
 endif::[]
 
 ifndef::no_ilm[]
-|`view_index_metadata` privilege on +{beat_default_index_prefix}-*+ indices
+|`view_index_metadata` on +{beat_default_index_prefix}-*+ indices
 |Check for alias when connecting to clusters that support ILM
 endif::no_ilm[]
 
-|`index` privilege on +{beat_default_index_prefix}-*+ indices
+|`index` on +{beat_default_index_prefix}-*+ indices
 |Index events into {es}
 
-|`create_index` privilege on +{beat_default_index_prefix}-*+ indices
+|`create_index` on +{beat_default_index_prefix}-*+ indices
 |Create daily indices when connecting to clusters that do not support ILM
 |====
+ifndef::apm-server[]
++
+Omit any privileges that aren't relevant in your environment.
+endif::apm-server[]
+
+. Assign the *writer role* to users who will index events into {es}. 
 
 [[kibana-user-privileges]]
-==== Reader role
+==== Grant privileges and roles needed to read {beatname_uc} data
 
 {kib} users typically need to view dashboards and visualizations that contain
 {beatname_uc} data. These users might also need to create and edit dashboards
 and visualizations.
 ifdef::has_central_config[]
-If you're using Beats central management, they need to create and manage
-configurations.
+If you're using Beats central management, some of these users might need to
+create and manage configurations.
 endif::has_central_config[]
 
-[options="header"]
-|====
-|Privileges and roles | Why needed?
+To grant users the required privileges:
 
 ifndef::apm-server[]
-|`read` privilege on +{beat_default_index_prefix}-*+ indices
-|Read data indexed by {beatname_uc} 
+. Create a *reader role*, called something like +{beat_default_index_prefix}_reader+, that has
+the following privilege:
++
+[options="header"]
+|====
+|Privilege | Why needed?
 
-|`kibana_user` role
-|Use {kib}. To grant read-only access to dashboards, assign the
-`kibana_dashboard_only_user` role instead.
+|`read` on +{beat_default_index_prefix}-*+ indices
+|Read data indexed by {beatname_uc}
+|====
+
+. Assign the *reader role*, along with the following built-in roles, to
+users who need to read {beatname_uc} data:
++
+[options="header"]
+|====
+|Roles | Why needed?
+
+|`kibana_user` or `kibana_dashboard_only_user`
+|Use {kib}. `kibana_dashboard_only_user` grants read-only access to dashboards.
+
+ifdef::has_central_config[]
+|`beats_admin`
+|Create and manage configurations in Beats central management. Only assign this
+role to users who need to use Beats central management.
+endif::[]
+|====
++
+Omit any roles that aren't relevant in your environment.
 endif::apm-server[]
 
 ifdef::apm-server[]
-|`kibana_user` and `apm_user` roles
-|Use the APM UI
-endif::apm-server[]
-
-ifdef::has_central_config[]
-|`beats_admin` role
-|Create and manage configurations in Beats central management
-endif::[]
+. Assign the following built-in roles to users who need to read {beatname_uc}
+data:
++
+[options="header"]
 |====
+|Roles | Why needed?
+
+|`kibana_user` and `apm_user`
+|Use the APM UI
+|====
+endif::apm-server[]
 
 
 [[learn-more-security]]

--- a/libbeat/docs/security/users.asciidoc
+++ b/libbeat/docs/security/users.asciidoc
@@ -162,14 +162,8 @@ endif::no_ilm[]
 |Index events into {es}
 
 |`create_index` privilege on +{beat_default_index_prefix}-*+ indices
-|Create daily indices when connecting to clusters that do not support ILM {es}
+|Create daily indices when connecting to clusters that do not support ILM
 |====
-
-// TODO: Find out if beats_admin is really required to read configs from central config. If so,
-// need to add:
-//ifdef::has_central_config[]
-//|`beats_admin` role |Read configurations from Beats central management
-//endif::has_central_config[]
 
 [[kibana-user-privileges]]
 ==== Reader role

--- a/libbeat/docs/security/users.asciidoc
+++ b/libbeat/docs/security/users.asciidoc
@@ -4,32 +4,35 @@
 
 You can use role-based access control to grant users access to secured
 resources. The roles that you set up depend on your organization's security
-requirements and the minimum privileges required to use specific features. 
+requirements and the minimum privileges required to use specific features.
 
-{beatname_uc} users typically perform these main roles: they do the initial
-setup, publish monitoring information, and publish events. If they're using
-{kib}, they view and sometimes create visualizations that access {beatname_uc}
-indices.
+Typically you need the following separate roles:
 
-{security} provides pre-built roles that grant _some_ of the privileges needed
-by {beatname_uc} users. When possible, use the built-in roles to minimize the
-affect of future changes on your security strategy.
+* <<privileges-to-setup-beats,setup role>> for setting up index templates and
+other dependencies
+* <<privileges-to-publish-monitoring,monitoring role>> for sending monitoring
+information
+* <<privileges-to-publish-events,writer role>>  for publishing events collected
+by {beatname_uc}
+* <<kibana-user-privileges,reader role>> for {kib} users who need to view and
+create visualizations that access {beatname_uc} data
 
-For privileges not granted by existing roles, create new roles. At a minimum,
-create a role for setting up {beatname_uc}, a role for publishing events, and a
-role for reading {beatname_uc} indices. Assign these new roles, along with the
-pre-built roles, to grant the full set of privileges required by {beatname_uc}
-users.
 
-The following sections describe the privileges and roles required to perform
-specific job roles. 
+{security} also provides built-in roles that grant a subset of the privileges
+needed by {beatname_uc} users. When possible, use the built-in roles to minimize
+the affect of future changes on your security strategy.
+
 
 [[privileges-to-setup-beats]]
-==== Privileges needed for initial setup
+==== Setup role
 
-Users who set up {beatname_uc} typically need to load mappings, dashboards, and
-other objects used to index data into {es} and visualize it in {kib}. The
-privileges required depend on the setup tasks users need to perform.
+IMPORTANT: Setting up {beatname_uc} is an admin-level task that requires extra
+privileges. As a best practice, grant this role to administrators only, and use
+a less restrictive role for event publishing.  
+
+Administrators who set up {beatname_uc} typically need to load mappings,
+dashboards, and other objects used to index data into {es} and visualize it in
+{kib}.
 
 NOTE: These instructions assume that you are using the default name for
 {beatname_uc} indices. If you are using a custom name, modify the privileges to
@@ -37,49 +40,48 @@ match your index naming pattern.
 
 [options="header"]
 |====
-|Task | Required privileges and roles
+|Privileges and roles | Why needed?
 
-.3+|Set up index templates
-|`manage_index_templates` and `monitor` on cluster
-|`manage_ilm` on cluster (if cluster supports index lifecycle management)
-|`manage` on +{beat_default_index_prefix}-*+ indices (if cluster supports index lifecycle management)
+|`monitor` privilege
+|Send monitoring data to the cluster
 
-ifndef::no_dashboards[]
-|Set up example dashboards
-|`kibana_user` role
-endif::no_dashboards[]
+ifndef::no_ilm[]
+|`manage_ilm`  privilege
+|Set up and manage index lifecycle management (ILM) policy
+endif::no_ilm[]
 
 ifdef::has_ml_jobs[]
-.3+|Set up machine learning job configurations 
-|`manage_ml` and `monitor` on cluster
-|`read` on +{beat_default_index_prefix}-*+ indices
-|`kibana_user` role
+|`manage_ml` privilege
+|Set up machine learning job configurations
 endif::has_ml_jobs[]
 
-ifeval::["{beatname_lc}"=="filebeat"]
-.2+|Set up ingest pipelines
-|`monitor` on cluster
+|`manage` privilege on +{beat_default_index_prefix}-*+ indices
+|Set up aliases used by ILM
+ 
+ifdef::has_ml_jobs[]
+|`read` privilege on +{beat_default_index_prefix}-*+ indices
+|Read {beatname_uc} indices in order to set up machine learning jobs
+endif::has_ml_jobs[]
+
+|`kibana_user` role
+|Load dependencies, such as example dashboards, if available, into {kib}
+
 |`ingest_admin` role
-endif::[]
+|Set up index templates and, if available, ingest pipelines
 
 ifdef::apm-server[]
-.2+|Set up ingest pipelines
-|`monitor` on cluster
 |`ingest_admin` role
+|Set up ingest pipelines
 endif::apm-server[]
 
-.2+|Set up index lifecycle policies
-|`manage_ilm`, `manage_index_templates`, and `monitor` on cluster
-|`manage` on +{beat_default_index_prefix}-*+ indices
-
 ifdef::has_central_config[]
+|`beats_admin` role
 |Enroll and manage configurations in Beats central management
-|`beats_admin` and `kibana_user` roles
 endif::has_central_config[]
 |====
 
 [[privileges-to-publish-monitoring]]
-==== Privileges needed to publish and view monitoring information
+==== Monitoring role
 
 {security} provides the +{beat_default_index_prefix}_system+
 {stack-ov}/built-in-users.html[built-in user] and
@@ -91,74 +93,86 @@ If you use the +{beat_default_index_prefix}_system+ user, make sure you
 
 [options="header"]
 |====
-|Task | Required privileges and roles
+|Privileges and roles | Why needed?
 
+|`monitor` privilege
 |Send monitoring info
-|`monitor` on cluster
 
+|`kibana_user` role
+|Use {kib}
+
+|`monitoring_user` role
 |Use *Stack Monitoring* in {kib} to monitor {beatname_uc}
-|`monitoring_user` and `kibana_user` roles
 |====
 
 
 [[privileges-to-publish-events]]
-==== Privileges needed to publish events
+==== Writer role
 
 Users who publish events to {es} need to create and read from {beatname_uc}
-indices. The privileges required for this role depend on the tasks users
-need to perform:
+indices. To minimize the privileges required by the writer role, use the
+<<privileges-to-setup-beats,setup role>> to load dependencies. Then, in the
+configuration file used by the writer role, turn off setup options. For
+example:
+
+ifndef::no_ilm[]
+[source,yaml]
+----
+setup.template.enabled: false
+setup.ilm.check_exists: false
+setup.ilm.overwrite: false <1>
+----
+<1> Omit `ilm.check_exists` and `ilm.overwrite` if ILM is disabled.
+endif::no_ilm[]
+
+ifdef::no_ilm[]
+[source,yaml]
+----
+setup.template.enabled: false
+----
+endif::no_ilm[]
+
+With setup options turned off, the writer role requires:
 
 [options="header"]
 |====
-|Task | Required privileges and roles
+|Privileges and roles | Why needed?
 
 ifndef::apm-server[]
-.3+|Send data to a secured cluster without index lifecycle management
-|`monitor` on cluster
-ifeval::["{beatname_lc}"=="filebeat"]
-(and `manage_pipeline` if {beatname_uc} modules are used)
-endif::[]
-|`create_index` and `index` on +{beat_default_index_prefix}-*+ indices
-|also requires privileges to <<privileges-to-setup-beats,set up index templates>>
-unless you've disabled automatic template loading
-
-.2+|Send data to a secured cluster that supports index lifecycle management
-|`manage_index_templates`, `manage_ilm` footnote:[Use `read_ilm` instead of
-`manage_ilm` if you pre-loaded the lifecycle policy], and `monitor`
-on cluster
-ifeval::["{beatname_lc}"=="filebeat"]
-(and `manage_pipeline` if {beatname_uc} modules are used)
-endif::[]
-| `index` and `manage` on +{beat_default_index_prefix}-*+ indices
+|`monitor` privilege
+|Send monitoring info
 endif::apm-server[]
 
-ifdef::apm-server[]
-.3+|Send data to a secured cluster without index lifecycle management
-|`monitor` on cluster
-|`create_index` and `write` on +{beat_default_index_prefix}-*+ indices
-|also requires privileges to <<privileges-to-setup-beats,set up index templates>>
-unless you've disabled automatic template loading: `setup.template.enabled=false`
+ifndef::no_ilm[]
+|`read_ilm` privilege
+|Read the ILM policy when connecting to clusters that support ILM
+endif::no_ilm[]
 
-.3+|Send data to a secured cluster that supports index lifecycle management
-|`manage_ilm` and `monitor` on cluster
-| `index` and `manage` on +{beat_default_index_prefix}-*+ indices
-|also requires privileges to <<privileges-to-setup-beats,set up index templates>>
-unless you've disabled automatic template loading: `setup.template.enabled=false`
-endif::apm-server[]
+ifeval::["{beatname_lc}"=="filebeat"]
+|`manage_pipeline` privilege
+|Load ingest pipelines used by modules
+endif::[]
 
-ifdef::has_central_config[]
-.2+|Read configurations from Beats central management
-| `monitor` on cluster
-|`beats_admin` role
-endif::has_central_config[]
+ifndef::no_ilm[]
+|`view_index_metadata` privilege on +{beat_default_index_prefix}-*+ indices
+|Check for alias when connecting to clusters that support ILM
+endif::no_ilm[]
+
+|`index` privilege on +{beat_default_index_prefix}-*+ indices
+|Index events into {es}
+
+|`create_index` privilege on +{beat_default_index_prefix}-*+ indices
+|Create daily indices when connecting to clusters that do not support ILM {es}
 |====
 
-// REVIEWERS: Do users need `index` and `manage` on `shrink-beatname-*`, too?
-// Are there other privileges that might be required as indices move through the
-// lifecycle stages?
+// TODO: Find out if beats_admin is really required to read configs from central config. If so,
+// need to add:
+//ifdef::has_central_config[]
+//|`beats_admin` role |Read configurations from Beats central management
+//endif::has_central_config[]
 
 [[kibana-user-privileges]]
-==== Privileges needed by {kib} users
+==== Reader role
 
 {kib} users typically need to view dashboards and visualizations that contain
 {beatname_uc} data. These users might also need to create and edit dashboards
@@ -168,34 +182,30 @@ If you're using Beats central management, they need to create and manage
 configurations.
 endif::has_central_config[]
 
-The privileges required for {kib} users depend on the tasks they need to
-perform: 
-
 [options="header"]
 |====
-|Task | Required privileges and roles
+|Privileges and roles | Why needed?
 
 ifndef::apm-server[]
-.2+|View {beatname_uc} dashboards
-|`read` on +{beat_default_index_prefix}-*+ indices
-|`kibana_dashboard_only_user` role
+|`read` privilege on +{beat_default_index_prefix}-*+ indices
+|Read data indexed by {beatname_uc} 
 
-.2+|View and edit {beatname_uc} dashboards
-|`read` on +{beat_default_index_prefix}-*+ indices
 |`kibana_user` role
+|Use {kib}. To grant read-only access to dashboards, assign the
+`kibana_dashboard_only_user` role instead.
 endif::apm-server[]
 
 ifdef::apm-server[]
-|Use the APM UI
 |`kibana_user` and `apm_user` roles
+|Use the APM UI
 endif::apm-server[]
 
 ifdef::has_central_config[]
-.2+|Create and manage configurations in Beats central management
 |`beats_admin` role
-|`kibana_user` role
+|Create and manage configurations in Beats central management
 endif::[]
 |====
+
 
 [[learn-more-security]]
 ==== Learn more about users and roles


### PR DESCRIPTION
Updates security docs to show more restrictive roles and clarify the division of responsibilities across different roles. Also changed organization because the duplication for each user goal made the content harder to read.

The docs look like this when built:

Updated 7/17: 

![image](https://user-images.githubusercontent.com/14206422/61422680-8846b300-a8c1-11e9-8624-c666f5015950.png)


