### PR TITLE
[7.3] Only collect fields that are also internally-collected (#12917)

### DIFF
--- a/metricbeat/module/logstash/node_stats/data_xpack.go
+++ b/metricbeat/module/logstash/node_stats/data_xpack.go
@@ -28,9 +28,18 @@ import (
 	"github.com/elastic/beats/metricbeat/mb"
 )
 
+type jvm struct {
+	GC  map[string]interface{} `json:"gc"`
+	Mem struct {
+		HeapMaxInBytes  int `json:"heap_max_in_bytes"`
+		HeapUsedInBytes int `json:"heap_used_in_bytes"`
+		HeapUsedPercent int `json:"heap_used_percent"`
+	} `json:"mem"`
+}
+
 type commonStats struct {
 	Events  map[string]interface{} `json:"events"`
-	JVM     map[string]interface{} `json:"jvm"`
+	JVM     jvm                    `json:"jvm"`
 	Reloads map[string]interface{} `json:"reloads"`
 	Queue   struct {
 		EventsCount int `json:"events_count"`
@@ -52,22 +61,34 @@ type os struct {
 	CPU cpu `json:"cpu"`
 }
 
+type pipeline struct {
+	BatchSize int `json:"batch_size"`
+	Workers   int `json:"workers"`
+}
+
 type nodeInfo struct {
-	ID          string                 `json:"id,omitempty"`
-	UUID        string                 `json:"uuid"`
-	EphemeralID string                 `json:"ephemeral_id"`
-	Name        string                 `json:"name"`
-	Host        string                 `json:"host"`
-	Version     string                 `json:"version"`
-	Snapshot    bool                   `json:"snapshot"`
-	Status      string                 `json:"status"`
-	HTTPAddress string                 `json:"http_address"`
-	Pipeline    map[string]interface{} `json:"pipeline"`
+	ID          string   `json:"id,omitempty"`
+	UUID        string   `json:"uuid"`
+	EphemeralID string   `json:"ephemeral_id"`
+	Name        string   `json:"name"`
+	Host        string   `json:"host"`
+	Version     string   `json:"version"`
+	Snapshot    bool     `json:"snapshot"`
+	Status      string   `json:"status"`
+	HTTPAddress string   `json:"http_address"`
+	Pipeline    pipeline `json:"pipeline"`
 }
 
 type reloads struct {
 	Successes int `json:"successes"`
 	Failures  int `json:"failures"`
+}
+
+type events struct {
+	DurationInMillis int `json:"duration_in_millis"`
+	In               int `json:"in"`
+	Filtered         int `json:"filtered"`
+	Out              int `json:"out"`
 }
 
 // NodeStats represents the stats of a Logstash node
@@ -93,7 +114,7 @@ type PipelineStats struct {
 	ID          string                   `json:"id"`
 	Hash        string                   `json:"hash"`
 	EphemeralID string                   `json:"ephemeral_id"`
-	Events      map[string]interface{}   `json:"events"`
+	Events      events                   `json:"events"`
 	Reloads     reloads                  `json:"reloads"`
 	Queue       map[string]interface{}   `json:"queue"`
 	Vertices    []map[string]interface{} `json:"vertices"`


### PR DESCRIPTION
Backports the following commits to 7.3:
 - Only collect fields that are also internally-collected  (#12917)