### PR TITLE
Collect `os.cgroup` field, if present

### DIFF
--- a/metricbeat/module/logstash/node_stats/data_xpack.go
+++ b/metricbeat/module/logstash/node_stats/data_xpack.go
@@ -57,8 +57,17 @@ type process struct {
 	CPU                 cpu `json:"cpu"`
 }
 
+type cgroup struct {
+	CPUAcct map[string]interface{} `json:"cpuacct"`
+	CPU     struct {
+		Stat         map[string]interface{} `json:"stat"`
+		ControlGroup string                 `json:"control_group"`
+	} `json:"cpu"`
+}
+
 type os struct {
-	CPU cpu `json:"cpu"`
+	CPU    cpu    `json:"cpu"`
+	CGroup cgroup `json:"cgroup,omitempty"`
 }
 
 type pipeline struct {
@@ -96,6 +105,7 @@ type NodeStats struct {
 	nodeInfo
 	commonStats
 	Process   process                  `json:"process"`
+	OS        os                       `json:"os"`
 	Pipelines map[string]PipelineStats `json:"pipelines"`
 }
 
@@ -145,6 +155,7 @@ func eventMappingXPack(r mb.ReporterV2, m *MetricSet, content []byte) error {
 		cpu{
 			LoadAverage: nodeStats.Process.CPU.LoadAverage,
 		},
+		nodeStats.OS.CGroup,
 	}
 
 	var pipelines []PipelineStats


### PR DESCRIPTION
Currently, if Logstash is running in a containerized environment*, the `GET _node/stats` API will return an `os.cgroups` field. This field needs to be collected and indexed by the `logstash/node_stats` metricset (xpack code path) in order to achieve parity with what's being indexed via Logstash's internal monitoring collection.

This PR fixes the disparity by teaching the `logstash/node_stats` metricset (xpack code path) to collect the `os.cgroup` field and index it into the `logstash_stats.os.cgroup` field in documents of `type: logstash_stats` in `.monitoring-logstash-*` indices.

*More accurately it's if Logstash is running in an environment where the [kernel has cgroups enabled](https://github.com/elastic/logstash/issues/10963#issuecomment-511833151).

### Testing this PR

1. Build Metricbeat with this PR, for Linux.
   ```
   cd $GOPATH/src/github.com/elastic/beats/metricbeat
   GOOS=linux mage build
   ```

2. Enable the Logstash module for Stack Monitoring.
   ```
   ./metricbeat modules enable logstash-xpack
   ```

3. Start Logstash on Linux, ensuring that the kernel has cgroups enabled.
   ```
   ./bin/logstash -e 'input { stdin {} }'
   ```

4. Start Metricbeat on the same machine as Logstash.
   ```
   ./metricbeat -e
   ```

5. Verify that the `.monitoring-logstash-*` index contains `type:logstash_stats` documents with the `logstash_stats.os.cgroup` field present in them.

   ```
   GET .monitoring-logstash-*/_search?q=type:logstash_stats&filter_path=hits.hits._source.logstash_stats.os.cgroup&size=1
   ```