### PR TITLE
Revert "Bump docs version for 7.2.1"

### DIFF
--- a/deploy/kubernetes/auditbeat-kubernetes.yaml
+++ b/deploy/kubernetes/auditbeat-kubernetes.yaml
@@ -71,7 +71,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: auditbeat
-        image: docker.elastic.co/beats/auditbeat:7.2.1
+        image: docker.elastic.co/beats/auditbeat:7.2.0
         args: [
           "-c", "/etc/auditbeat.yml"
         ]

--- a/deploy/kubernetes/filebeat-kubernetes.yaml
+++ b/deploy/kubernetes/filebeat-kubernetes.yaml
@@ -59,7 +59,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: filebeat
-        image: docker.elastic.co/beats/filebeat:7.2.1
+        image: docker.elastic.co/beats/filebeat:7.2.0
         args: [
           "-c", "/etc/filebeat.yml",
           "-e",

--- a/deploy/kubernetes/metricbeat-kubernetes.yaml
+++ b/deploy/kubernetes/metricbeat-kubernetes.yaml
@@ -104,7 +104,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: metricbeat
-        image: docker.elastic.co/beats/metricbeat:7.2.1
+        image: docker.elastic.co/beats/metricbeat:7.2.0
         args: [
           "-c", "/etc/metricbeat.yml",
           "-e",
@@ -242,7 +242,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: metricbeat
-        image: docker.elastic.co/beats/metricbeat:7.2.1
+        image: docker.elastic.co/beats/metricbeat:7.2.0
         args: [
           "-c", "/etc/metricbeat.yml",
           "-e",

--- a/libbeat/docs/version.asciidoc
+++ b/libbeat/docs/version.asciidoc
@@ -1,4 +1,4 @@
-:stack-version: 7.2.1
+:stack-version: 7.2.0
 :doc-branch: 7.2
 :go-version: 1.12.4
 :release-state: released


### PR DESCRIPTION
Reverts elastic/beats#12836.

The download instructions in the Beats documentation are currently broken until this gets merged. 