### PR TITLE
[Metricbeat] Fix cloudwatch metricset with given dimensions or metric name in config

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -152,6 +152,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix connections leak in redis module {pull}12914[12914] {pull}12950[12950]
 - Fix wrong uptime reporting by system/uptime metricset under Windows. {pull}12915[12915]
 - Print errors that were being omitted in vSphere metricsets {pull}12816[12816]
+- Fix cloudwatch metricset with given dimensions or metric name in config. {issue}12933[12933]
 
 *Packetbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -152,7 +152,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix connections leak in redis module {pull}12914[12914] {pull}12950[12950]
 - Fix wrong uptime reporting by system/uptime metricset under Windows. {pull}12915[12915]
 - Print errors that were being omitted in vSphere metricsets {pull}12816[12816]
-- Fix cloudwatch metricset with given dimensions or metric name in config. {issue}12933[12933]
 - Fix cloudwatch metricset with given dimensions or metric name in config. {issue}12933[12933] {pull}12935[12935]
 
 *Packetbeat*

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -153,6 +153,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix wrong uptime reporting by system/uptime metricset under Windows. {pull}12915[12915]
 - Print errors that were being omitted in vSphere metricsets {pull}12816[12816]
 - Fix cloudwatch metricset with given dimensions or metric name in config. {issue}12933[12933]
+- Fix cloudwatch metricset with given dimensions or metric name in config. {issue}12933[12933] {pull}12935[12935]
 
 *Packetbeat*
 

--- a/x-pack/metricbeat/module/aws/_meta/config.yml
+++ b/x-pack/metricbeat/module/aws/_meta/config.yml
@@ -8,6 +8,7 @@
   default_region: '${AWS_REGION:us-west-1}'
   regions:
     - us-east-1
+
 - module: aws
   period: 300s
   metricsets:
@@ -17,6 +18,9 @@
   session_token: '${AWS_SESSION_TOKEN:""}'
   default_region: '${AWS_REGION:us-west-1}'
   cloudwatch_metrics:
+    - namespace: AWS/EC2
+      metricname: CPUUtilization
+      tags.resource_type_filter: ec2
     - namespace: AWS/EBS
     - namespace: AWS/ELB
       tags.resource_type_filter: elasticloadbalancing

--- a/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch_test.go
+++ b/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch_test.go
@@ -276,7 +276,7 @@ func TestReadCloudwatchConfig(t *testing.T) {
 
 func TestCompareAWSDimensions(t *testing.T) {
 	cases := []struct {
-		title                    string
+		title          string
 		dim1           []cloudwatch.Dimension
 		dim2           []cloudwatch.Dimension
 		expectedResult bool

--- a/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch_test.go
+++ b/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch_test.go
@@ -276,11 +276,13 @@ func TestReadCloudwatchConfig(t *testing.T) {
 
 func TestCompareAWSDimensions(t *testing.T) {
 	cases := []struct {
+		title                    string
 		dim1           []cloudwatch.Dimension
 		dim2           []cloudwatch.Dimension
 		expectedResult bool
 	}{
 		{
+			"same dimensions with length 2 but different order",
 			[]cloudwatch.Dimension{
 				{Name: awssdk.String("dept"), Value: awssdk.String("engineering")},
 				{Name: awssdk.String("owner"), Value: awssdk.String("ks")},
@@ -292,6 +294,7 @@ func TestCompareAWSDimensions(t *testing.T) {
 			true,
 		},
 		{
+			"different dimensions with different length",
 			[]cloudwatch.Dimension{
 				{Name: awssdk.String("dept"), Value: awssdk.String("engineering")},
 				{Name: awssdk.String("owner"), Value: awssdk.String("ks")},
@@ -302,6 +305,7 @@ func TestCompareAWSDimensions(t *testing.T) {
 			false,
 		},
 		{
+			"different dimensions with same length",
 			[]cloudwatch.Dimension{
 				{Name: awssdk.String("owner"), Value: awssdk.String("ks")},
 			},
@@ -310,10 +314,20 @@ func TestCompareAWSDimensions(t *testing.T) {
 			},
 			false,
 		},
+		{
+			"compare with an empty dimension",
+			[]cloudwatch.Dimension{
+				{Name: awssdk.String("owner"), Value: awssdk.String("ks")},
+			},
+			[]cloudwatch.Dimension{},
+			false,
+		},
 	}
 
 	for _, c := range cases {
-		output := compareAWSDimensions(c.dim1, c.dim2)
-		assert.Equal(t, c.expectedResult, output)
+		t.Run(c.title, func(t *testing.T) {
+			output := compareAWSDimensions(c.dim1, c.dim2)
+			assert.Equal(t, c.expectedResult, output)
+		})
 	}
 }

--- a/x-pack/metricbeat/module/aws/utils.go
+++ b/x-pack/metricbeat/module/aws/utils.go
@@ -154,7 +154,7 @@ func FindTimestamp(getMetricDataResults []cloudwatch.MetricDataResult) time.Time
 // GetResourcesTags function queries AWS resource groupings tagging API
 // to get a resource tag mapping with specific resource type filters
 func GetResourcesTags(svc resourcegroupstaggingapiiface.ClientAPI, resourceTypeFilters []string) (map[string][]resourcegroupstaggingapi.Tag, error) {
-	if resourceTypeFilters == nil {
+	if resourceTypeFilters == nil || len(resourceTypeFilters) == 0 {
 		return map[string][]resourcegroupstaggingapi.Tag{}, nil
 	}
 
@@ -170,8 +170,7 @@ func GetResourcesTags(svc resourcegroupstaggingapiiface.ClientAPI, resourceTypeF
 		getResourcesRequest := svc.GetResourcesRequest(getResourcesInput)
 		output, err := getResourcesRequest.Send(context.TODO())
 		if err != nil {
-			err = errors.Wrap(err, "error GetResources")
-			return nil, err
+			return nil, errors.Wrap(err, "error GetResources")
 		}
 
 		getResourcesInput.PaginationToken = output.PaginationToken
@@ -182,8 +181,7 @@ func GetResourcesTags(svc resourcegroupstaggingapiiface.ClientAPI, resourceTypeF
 		for _, resourceTag := range output.ResourceTagMappingList {
 			identifier, err := findIdentifierFromARN(*resourceTag.ResourceARN)
 			if err != nil {
-				err = errors.Wrap(err, "error findIdentifierFromARN")
-				return nil, err
+				return nil, errors.Wrap(err, "error findIdentifierFromARN")
 			}
 			resourceTagMap[identifier] = resourceTag.Tags
 		}

--- a/x-pack/metricbeat/modules.d/aws.yml.disabled
+++ b/x-pack/metricbeat/modules.d/aws.yml.disabled
@@ -11,6 +11,7 @@
   default_region: '${AWS_REGION:us-west-1}'
   regions:
     - us-east-1
+
 - module: aws
   period: 300s
   metricsets:
@@ -20,6 +21,9 @@
   session_token: '${AWS_SESSION_TOKEN:""}'
   default_region: '${AWS_REGION:us-west-1}'
   cloudwatch_metrics:
+    - namespace: AWS/EC2
+      metricname: CPUUtilization
+      tags.resource_type_filter: ec2
     - namespace: AWS/EBS
     - namespace: AWS/ELB
       tags.resource_type_filter: elasticloadbalancing


### PR DESCRIPTION
A bug found when testing cloudwatch metricset:
When using configuration with metricname or dimensions configured, for example:
```
- module: aws
  period: 300s
  metricsets:
    - cloudwatch
  cloudwatch_metrics:
    - namespace: AWS/EC2
      metricname: CPUUtilization
      tags.resource_type_filter: ec2
```
`cloudwatch` metricset will collect metrics that's called CPUUtilization and without dimensions. Instead, what we want is to collect metrics that's called CPUUtilization but with all possible dimensions.

## How to test it
* make sure in the aws account that you will use for testing has EC2, EBS and ELB created with tags on some of them
* pull this PR and run `mage update; mage build; ./metricbeat modules enable aws` to build metricbeat and enable aws module
* edit `./modules.d/aws.yml` to only keep the part for `cloudwatch` metricset
* start metricbeat: `AWS_ACCESS_KEY_ID=<access-key-id> AWS_SECRET_ACCESS_KEY=<secret-access-key>  AWS_SESSION_TOKEN=<session-token> AWS_REGION=us-east-1 ./metricbeat -e -c metricbeat.yml -d "publish"`
* check in Kibana to see if metrics are collected from:
all EC2 instances with only `CPUUtilization` metricname
all EBS and ELB metrics
EC2 and ELB with tags
no tags for EBS

closes: https://github.com/elastic/beats/issues/12933