### PR TITLE
make IAM Role available in aws module of metricbeat

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -278,6 +278,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add Oracle Tablespaces Dashboard {pull}12736[12736]
 - Collect client provided name for rabbitmq connection. {issue}12851[12851] {pull}12852[12852]
 
+- make IAM Role available in aws module.
 *Packetbeat*
 
 *Functionbeat*

--- a/x-pack/metricbeat/module/aws/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/aws/_meta/docs.asciidoc
@@ -32,8 +32,9 @@ Because temporary security credentials are short term, after they expire, the us
 the aws.yml config file with the new credentials. Unless https://www.elastic.co/guide/en/beats/metricbeat/current/_live_reloading.html[live reloading]
 feature is enabled for Metricbeat, the user needs to manually restart Metricbeat after updating the config file in order
 to continue collecting Cloudwatch metrics. This will cause data loss if the config file is not updated with new
-credentials before the old ones expire. For Metricbeat, we recommend users to use access keys in config file to enable
-aws module making AWS api calls without have to generate new temporary credentials and update the config frequently.
+credentials before the old ones expire. If you do not define the two variables, the IAM Role is used. For Metricbeat,
+we recommend users to use access keys in config file to enable aws module making AWS api calls without have to generate
+new temporary credentials and update the config frequently.
 
 IAM policy is an entity that defines permissions to an object within your AWS environment. Specific permissions needs
 to be added into the IAM user's policy to authorize Metricbeat to collect AWS monitoring metrics. Please see documentation

--- a/x-pack/metricbeat/module/aws/aws.go
+++ b/x-pack/metricbeat/module/aws/aws.go
@@ -12,6 +12,7 @@ import (
 
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/defaults"
+	"github.com/aws/aws-sdk-go-v2/aws/external"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/ec2iface"
 	"github.com/pkg/errors"
@@ -22,8 +23,8 @@ import (
 // Config defines all required and optional parameters for aws metricsets
 type Config struct {
 	Period          time.Duration `config:"period" validate:"nonzero,required"`
-	AccessKeyID     string        `config:"access_key_id" validate:"nonzero,required"`
-	SecretAccessKey string        `config:"secret_access_key" validate:"nonzero,required"`
+	AccessKeyID     string        `config:"access_key_id"`
+	SecretAccessKey string        `config:"secret_access_key"`
 	SessionToken    string        `config:"session_token"`
 	DefaultRegion   string        `config:"default_region"`
 	Regions         []string      `config:"regions"`
@@ -62,17 +63,26 @@ func NewMetricSet(base mb.BaseMetricSet) (*MetricSet, error) {
 		return nil, err
 	}
 
-	awsConfig := defaults.Config()
-	awsCredentials := awssdk.Credentials{
-		AccessKeyID:     config.AccessKeyID,
-		SecretAccessKey: config.SecretAccessKey,
+	cfg := defaults.Config()
+	awsCredentials := awssdk.Credentials{}
+	if config.AccessKeyID != "" && config.SecretAccessKey != "" {
+		awsCredentials = awssdk.Credentials{
+			AccessKeyID:     config.AccessKeyID,
+			SecretAccessKey: config.SecretAccessKey,
+		}
 	}
+
 	if config.SessionToken != "" {
 		awsCredentials.SessionToken = config.SessionToken
 	}
 
-	awsConfig.Credentials = awssdk.StaticCredentialsProvider{
+	cfg.Credentials = awssdk.StaticCredentialsProvider{
 		Value: awsCredentials,
+	}
+
+	awsConfig, err := external.LoadDefaultAWSConfig(cfg)
+	if err != nil {
+		return nil, err
 	}
 
 	awsConfig.Region = config.DefaultRegion


### PR DESCRIPTION
Update to use IAM Role when running metricbeat on EC2 according to IAM's best practices.

https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#use-roles-with-ec2
