### PR TITLE
[Auditbeat] Export Host fields to gob encoder

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -94,6 +94,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Host dataset: Fix reboot detection logic. {pull}12591[12591]
 - Add syscalls used by librpm for the system/package dataset to the default Auditbeat seccomp policy. {issue}12578[12578] {pull}12617[12617]
 - Process dataset: Do not show non-root warning on Windows. {pull}12740[12740]
+- Host dataset: Export Host fields to gob encoder. {pull}12940[12940]
 
 *Filebeat*
 

--- a/x-pack/auditbeat/module/system/host/host.go
+++ b/x-pack/auditbeat/module/system/host/host.go
@@ -69,12 +69,12 @@ func (action eventAction) String() string {
 
 // Host represents information about a host.
 type Host struct {
-	info types.HostInfo
+	Info types.HostInfo
 	// Uptime() in types.HostInfo recalculates the uptime every time it is called -
 	// so storing it permanently here.
-	uptime time.Duration
-	ips    []net.IP
-	macs   []net.HardwareAddr
+	Uptime time.Duration
+	Ips    []net.IP
+	Macs   []net.HardwareAddr
 }
 
 // changeDetectionHash creates a hash of selected parts of the host information.
@@ -82,18 +82,18 @@ type Host struct {
 func (host *Host) changeDetectionHash() uint64 {
 	h := xxhash.New64()
 
-	if host.info.Containerized != nil {
-		h.WriteString(strconv.FormatBool(*host.info.Containerized))
+	if host.Info.Containerized != nil {
+		h.WriteString(strconv.FormatBool(*host.Info.Containerized))
 	}
 
-	h.WriteString(host.info.Timezone)
-	binary.Write(h, binary.BigEndian, int32(host.info.TimezoneOffsetSec))
-	h.WriteString(host.info.Architecture)
-	h.WriteString(host.info.OS.Platform)
-	h.WriteString(host.info.OS.Name)
-	h.WriteString(host.info.OS.Family)
-	h.WriteString(host.info.OS.Version)
-	h.WriteString(host.info.KernelVersion)
+	h.WriteString(host.Info.Timezone)
+	binary.Write(h, binary.BigEndian, int32(host.Info.TimezoneOffsetSec))
+	h.WriteString(host.Info.Architecture)
+	h.WriteString(host.Info.OS.Platform)
+	h.WriteString(host.Info.OS.Name)
+	h.WriteString(host.Info.OS.Family)
+	h.WriteString(host.Info.OS.Version)
+	h.WriteString(host.Info.KernelVersion)
 
 	return h.Sum64()
 }
@@ -101,40 +101,40 @@ func (host *Host) changeDetectionHash() uint64 {
 func (host *Host) toMapStr() common.MapStr {
 	mapstr := common.MapStr{
 		// https://github.com/elastic/ecs#-host-fields
-		"uptime":              host.uptime,
-		"boottime":            host.info.BootTime,
-		"timezone.name":       host.info.Timezone,
-		"timezone.offset.sec": host.info.TimezoneOffsetSec,
-		"hostname":            host.info.Hostname,
-		"id":                  host.info.UniqueID,
-		"architecture":        host.info.Architecture,
+		"uptime":              host.Uptime,
+		"boottime":            host.Info.BootTime,
+		"timezone.name":       host.Info.Timezone,
+		"timezone.offset.sec": host.Info.TimezoneOffsetSec,
+		"hostname":            host.Info.Hostname,
+		"id":                  host.Info.UniqueID,
+		"architecture":        host.Info.Architecture,
 
 		// https://github.com/elastic/ecs#-operating-system-fields
 		"os": common.MapStr{
-			"platform": host.info.OS.Platform,
-			"name":     host.info.OS.Name,
-			"family":   host.info.OS.Family,
-			"version":  host.info.OS.Version,
-			"kernel":   host.info.KernelVersion,
+			"platform": host.Info.OS.Platform,
+			"name":     host.Info.OS.Name,
+			"family":   host.Info.OS.Family,
+			"version":  host.Info.OS.Version,
+			"kernel":   host.Info.KernelVersion,
 		},
 	}
 
-	if host.info.Containerized != nil {
-		mapstr.Put("containerized", host.info.Containerized)
+	if host.Info.Containerized != nil {
+		mapstr.Put("containerized", host.Info.Containerized)
 	}
 
-	if host.info.OS.Codename != "" {
-		mapstr.Put("os.codename", host.info.OS.Codename)
+	if host.Info.OS.Codename != "" {
+		mapstr.Put("os.codename", host.Info.OS.Codename)
 	}
 
 	var ipStrings []string
-	for _, ip := range host.ips {
+	for _, ip := range host.Ips {
 		ipStrings = append(ipStrings, ip.String())
 	}
 	mapstr.Put("ip", ipStrings)
 
 	var macStrings []string
-	for _, mac := range host.macs {
+	for _, mac := range host.Macs {
 		macStr := mac.String()
 		if macStr != "" {
 			macStrings = append(macStrings, macStr)
@@ -253,29 +253,29 @@ func (ms *MetricSet) reportChanges(report mb.ReporterV2) error {
 	var events []mb.Event
 
 	// Report ID changes as a separate, special event.
-	if ms.lastHost.info.UniqueID != currentHost.info.UniqueID {
+	if ms.lastHost.Info.UniqueID != currentHost.Info.UniqueID {
 		/*
 		 Issue two events - one for the host with the old ID, one for the new
 		 - to link them (since the unique ID is what identifies a host).
 		*/
 		eventOldHost := hostEvent(ms.lastHost, eventTypeEvent, eventActionIDChanged)
-		eventOldHost.MetricSetFields.Put("new_id", currentHost.info.UniqueID)
+		eventOldHost.MetricSetFields.Put("new_id", currentHost.Info.UniqueID)
 		events = append(events, eventOldHost)
 
 		eventNewHost := hostEvent(currentHost, eventTypeEvent, eventActionIDChanged)
-		eventNewHost.MetricSetFields.Put("old_id", ms.lastHost.info.UniqueID)
+		eventNewHost.MetricSetFields.Put("old_id", ms.lastHost.Info.UniqueID)
 		events = append(events, eventNewHost)
 	}
 
 	// Report reboots separately
 	// On Windows, BootTime is not fully accurate and can vary by a few milliseconds.
 	// So we only report a reboot if the new BootTime is at least 1 second after the old.
-	if currentHost.info.BootTime.After(ms.lastHost.info.BootTime.Add(1 * time.Second)) {
+	if currentHost.Info.BootTime.After(ms.lastHost.Info.BootTime.Add(1 * time.Second)) {
 		events = append(events, hostEvent(currentHost, eventTypeEvent, eventActionReboot))
 	}
 
 	// Report hostname changes separately
-	if currentHost.info.Hostname != ms.lastHost.info.Hostname {
+	if currentHost.Info.Hostname != ms.lastHost.Info.Hostname {
 		events = append(events, hostEvent(currentHost, eventTypeEvent, eventActionHostnameChanged))
 	}
 
@@ -307,10 +307,10 @@ func getHost() (*Host, error) {
 	}
 
 	host := &Host{
-		info:   sysinfoHost.Info(),
-		uptime: sysinfoHost.Info().Uptime(),
-		ips:    ips,
-		macs:   macs,
+		Info:   sysinfoHost.Info(),
+		Uptime: sysinfoHost.Info().Uptime(),
+		Ips:    ips,
+		Macs:   macs,
 	}
 
 	return host, nil
@@ -352,18 +352,18 @@ func hostEvent(host *Host, eventType string, action eventAction) mb.Event {
 
 func hostMessage(host *Host, action eventAction) string {
 	var firstIP string
-	if len(host.ips) > 0 {
-		firstIP = host.ips[0].String()
+	if len(host.Ips) > 0 {
+		firstIP = host.Ips[0].String()
 	}
 
 	// Hostname + IP of the first non-loopback interface.
-	hostString := fmt.Sprintf("%v (IP: %v)", host.info.Hostname, firstIP)
+	hostString := fmt.Sprintf("%v (IP: %v)", host.Info.Hostname, firstIP)
 
 	var message string
 	switch action {
 	case eventActionHost:
 		message = fmt.Sprintf("%v host %v is up for %v",
-			host.info.OS.Name, hostString, fmtDuration(host.uptime))
+			host.Info.OS.Name, hostString, fmtDuration(host.Uptime))
 	case eventActionIDChanged:
 		message = fmt.Sprintf("ID of host %v has changed", hostString)
 	case eventActionReboot:


### PR DESCRIPTION
In the `system/host` dataset, the fields of the `Host` struct are not exported, and so cannot be picked up by `gob`. This prevents it being written to disk to detect changes between restarts, and causes error messages like:

`2019-07-17T11:44:37.842+0100	ERROR	[system]	host/host.go:210	error encoding host information: gob: type host.Host has no exported fields`

This PR changes the fields to be exported.

Also mentioned in [this](https://discuss.elastic.co/t/siem-hosts-all-hosts-tables-empty/189832/5?u=cwurm) discuss thread.