### PR TITLE
Update packetbeat-options.asciidoc

### DIFF
--- a/packetbeat/docs/packetbeat-options.asciidoc
+++ b/packetbeat/docs/packetbeat-options.asciidoc
@@ -135,7 +135,7 @@ packetbeat.interfaces.snaplen: 1514
 [float]
 ==== `type`
 
-Packetbeat supports three sniffer types:
+Packetbeat supports two sniffer types:
 
  * `pcap`, which uses the libpcap library and works on most platforms, but
    it's not the fastest option.


### PR DESCRIPTION
I can't find the third type. So I think it should be "two types".