### PR TITLE
Cherry-pick #12914 to 7.1: Release connections in metricbeat redis module

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -66,6 +66,7 @@ https://github.com/elastic/beats/compare/v7.1.1...7.1[Check the HEAD diff]
 - Require certificate authorities, certificate file, and key when SSL is enabled for module http metricset server. {pull}12355[12355]
 - In the kibana/stats metricset, only log error (don't also index it) if xpack is enabled. {pull}12353[12353]
 - When TLS is configured for the http metricset and a `certificate_authorities` is configured we now default to `required` for the `client_authentication`. {pull}12584[12584]
+- Fix connections leak in redis module {pull}12914[12914]
 
 *Packetbeat*
 

--- a/metricbeat/module/redis/info/info.go
+++ b/metricbeat/module/redis/info/info.go
@@ -55,8 +55,11 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 
 // Fetch fetches metrics from Redis by issuing the INFO command.
 func (m *MetricSet) Fetch(r mb.ReporterV2) {
+	conn := m.Connection()
+	defer conn.Close()
+
 	// Fetch default INFO.
-	info, err := redis.FetchRedisInfo("default", m.Connection())
+	info, err := redis.FetchRedisInfo("default", conn)
 	if err != nil {
 		logp.Err("Failed to fetch redis info: %s", err)
 		return

--- a/metricbeat/module/redis/key/key.go
+++ b/metricbeat/module/redis/key/key.go
@@ -73,6 +73,8 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // Fetch fetches information from Redis keys
 func (m *MetricSet) Fetch(r mb.ReporterV2) {
 	conn := m.Connection()
+	defer conn.Close()
+
 	for _, p := range m.patterns {
 		if err := redis.Select(conn, p.Keyspace); err != nil {
 			logp.Err("Failed to select keyspace %d: %s", p.Keyspace, err)

--- a/metricbeat/module/redis/keyspace/keyspace.go
+++ b/metricbeat/module/redis/keyspace/keyspace.go
@@ -53,8 +53,11 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 
 // Fetch fetches metrics from Redis by issuing the INFO command.
 func (m *MetricSet) Fetch(r mb.ReporterV2) {
+	conn := m.Connection()
+	defer conn.Close()
+
 	// Fetch default INFO.
-	info, err := redis.FetchRedisInfo("keyspace", m.Connection())
+	info, err := redis.FetchRedisInfo("keyspace", conn)
 	if err != nil {
 		logp.Err("Failed to fetch redis info for keyspaces: %s", err)
 		return


### PR DESCRIPTION
Cherry-pick of PR #12914 to 7.1 branch. Original message: 

Release pooled connections in metricbeat redis module when they are not
needed anymore so they can be reused.