### PR TITLE
Fix cisco.ios pipeline bug for syslog input

### DIFF
--- a/x-pack/filebeat/module/cisco/ios/config/pipeline.js
+++ b/x-pack/filebeat/module/cisco/ios/config/pipeline.js
@@ -118,13 +118,15 @@ var ciscoIOS = (function() {
     var processMessage = new processor.Chain()
         // Parse the header of the message that is common to all messages.
         .Dissect({
-            "tokenizer": "%{}%%{cisco.ios.facility}-%{event.severity}-%{event.code}: %{_message}",
+            "tokenizer": "%{}%%{cisco.ios.facility}-%{_event_severity}-%{event.code}: %{_message}",
             "field": "message",
             "target_prefix": "",
         })
         .Add(function(evt) {
             evt.Delete("message");
             evt.Rename("_message", "message");
+            evt.Delete("event.severity");
+            evt.Rename("_event_severity", "event.severity");
         })
         .Convert({
             fields: [


### PR DESCRIPTION
This fixes a problem with the pipeline when being used with the syslog input (rather than the files that we test with). The dissect processor tries to set a field that is already added by the syslog input.

    GoError: cannot override existing key with `event.severity`


This hasn't been released yet so I have omitted a changelog entry.