### PR TITLE
Add RPM packaging flag to omit build-id links

### DIFF
--- a/dev-tools/mage/pkgtypes.go
+++ b/dev-tools/mage/pkgtypes.go
@@ -651,6 +651,9 @@ func runFPM(spec PackageSpec, packageType PackageType) error {
 		"--name", spec.ServiceName,
 		"--architecture", spec.Arch,
 	)
+	if packageType == RPM {
+		args = append(args, "--rpm-rpmbuild-define", "_build_id_links none")
+	}
 	if spec.Version != "" {
 		args = append(args, "--version", spec.Version)
 	}

--- a/dev-tools/packaging/package_test.go
+++ b/dev-tools/packaging/package_test.go
@@ -123,6 +123,7 @@ func checkRPM(t *testing.T, file string) {
 	checkModulesDPresent(t, "/etc/", p)
 	checkMonitorsDPresent(t, "/etc", p)
 	checkSystemdUnitPermissions(t, p)
+	ensureNoBuildIDLinks(t, p)
 }
 
 func checkDeb(t *testing.T, file string, buf *bytes.Buffer) {
@@ -421,6 +422,18 @@ func checkDockerUser(t *testing.T, p *packageFile, info *dockerInfo, expectRoot 
 	t.Run(fmt.Sprintf("%s user", p.Name), func(t *testing.T) {
 		if expectRoot != (info.Config.User == "root") {
 			t.Errorf("unexpected docker user: %s", info.Config.User)
+		}
+	})
+}
+
+// ensureNoBuildIDLinks checks for regressions related to
+// https://github.com/elastic/beats/issues/12956.
+func ensureNoBuildIDLinks(t *testing.T, p *packageFile) {
+	t.Run(fmt.Sprintf("%s no build_id links", p.Name), func(t *testing.T) {
+		for name := range p.Contents {
+			if strings.Contains(name, "/usr/lib/.build-id") {
+				t.Error("found unexpected /usr/lib/.build-id in package")
+			}
 		}
 	})
 }


### PR DESCRIPTION
This adds a flag to the FPM call that makes RPMs to omit /usr/lib/.build-id links from packages. And it adds a regression test that ensures a failure will occur if the build-id links reappear.

Fixes elastic/beats#12956

Relates elastic/golang-crossbuild#27