### PR TITLE
[metricbeat] Change behavior of Registry.Modules() to make it more consistant. 

### DIFF
--- a/metricbeat/mb/registry.go
+++ b/metricbeat/mb/registry.go
@@ -309,6 +309,15 @@ func (r *Register) Modules() []string {
 		modules = append(modules, module)
 	}
 
+	// List also modules from secondary sources
+	if source := r.secondarySource; source != nil {
+		sourceModules, err := source.Modules()
+		if err != nil {
+			logp.Error(errors.Wrap(err, "failed to get modules from secondary source"))
+		}
+		modules = append(modules, sourceModules...)
+	}
+
 	//grab a more comprehensive list from the metricset keys, then reduce and merge
 	for mod := range r.metricSets {
 		//skip over values we got from the modules map

--- a/metricbeat/mb/registry.go
+++ b/metricbeat/mb/registry.go
@@ -313,7 +313,7 @@ func (r *Register) Modules() []string {
 	if source := r.secondarySource; source != nil {
 		sourceModules, err := source.Modules()
 		if err != nil {
-			logp.Error(errors.Wrap(err, "failed to get modules from secondary source"))
+			logp.L().Errorf("failed to get modules from secondary source: %s", err)
 		}
 		modules = append(modules, sourceModules...)
 	}

--- a/metricbeat/mb/registry.go
+++ b/metricbeat/mb/registry.go
@@ -314,8 +314,16 @@ func (r *Register) Modules() []string {
 		sourceModules, err := source.Modules()
 		if err != nil {
 			logp.L().Errorf("failed to get modules from secondary source: %s", err)
+		} else {
+			for _, module := range sourceModules {
+				if _, ok := dups[module]; ok {
+					continue
+				}
+				dups[module] = true
+				modules = append(modules, module)
+			}
 		}
-		modules = append(modules, sourceModules...)
+
 	}
 
 	// Grab a more comprehensive list from the metricset keys, then reduce and merge

--- a/metricbeat/mb/registry.go
+++ b/metricbeat/mb/registry.go
@@ -300,12 +300,12 @@ func (r *Register) Modules() []string {
 	r.lock.RLock()
 	defer r.lock.RUnlock()
 
-	var dups = map[string]int{}
+	var dups = map[string]bool{}
 
-	//for the sake of compatibility, grab modules the old way as well, right from the modules map
+	// For the sake of compatibility, grab modules the old way as well, right from the modules map
 	modules := make([]string, 0, len(r.modules))
 	for module := range r.modules {
-		dups[module]++
+		dups[module] = true
 		modules = append(modules, module)
 	}
 
@@ -318,9 +318,9 @@ func (r *Register) Modules() []string {
 		modules = append(modules, sourceModules...)
 	}
 
-	//grab a more comprehensive list from the metricset keys, then reduce and merge
+	// Grab a more comprehensive list from the metricset keys, then reduce and merge
 	for mod := range r.metricSets {
-		//skip over values we got from the modules map
+		// Skip over values we got from the modules map
 		if _, ok := dups[mod]; ok {
 			continue
 		}

--- a/metricbeat/mb/registry.go
+++ b/metricbeat/mb/registry.go
@@ -303,10 +303,8 @@ func (r *Register) Modules() []string {
 	var dups = map[string]bool{}
 
 	// For the sake of compatibility, grab modules the old way as well, right from the modules map
-	modules := make([]string, 0, len(r.modules))
 	for module := range r.modules {
 		dups[module] = true
-		modules = append(modules, module)
 	}
 
 	// List also modules from secondary sources
@@ -316,22 +314,18 @@ func (r *Register) Modules() []string {
 			logp.L().Errorf("failed to get modules from secondary source: %s", err)
 		} else {
 			for _, module := range sourceModules {
-				if _, ok := dups[module]; ok {
-					continue
-				}
 				dups[module] = true
-				modules = append(modules, module)
 			}
 		}
-
 	}
 
 	// Grab a more comprehensive list from the metricset keys, then reduce and merge
 	for mod := range r.metricSets {
-		// Skip over values we got from the modules map
-		if _, ok := dups[mod]; ok {
-			continue
-		}
+		dups[mod] = true
+	}
+
+	modules := make([]string, 0, len(r.modules))
+	for mod := range dups {
 		modules = append(modules, mod)
 	}
 

--- a/metricbeat/mb/registry.go
+++ b/metricbeat/mb/registry.go
@@ -300,9 +300,22 @@ func (r *Register) Modules() []string {
 	r.lock.RLock()
 	defer r.lock.RUnlock()
 
+	var dups = map[string]int{}
+
+	//for the sake of compatibility, grab modules the old way as well, right from the modules map
 	modules := make([]string, 0, len(r.modules))
 	for module := range r.modules {
+		dups[module]++
 		modules = append(modules, module)
+	}
+
+	//grab a more comprehensive list from the metricset keys, then reduce and merge
+	for mod := range r.metricSets {
+		//skip over values we got from the modules map
+		if _, ok := dups[mod]; ok {
+			continue
+		}
+		modules = append(modules, mod)
 	}
 
 	return modules

--- a/metricbeat/mb/registry.go
+++ b/metricbeat/mb/registry.go
@@ -324,7 +324,7 @@ func (r *Register) Modules() []string {
 		dups[mod] = true
 	}
 
-	modules := make([]string, 0, len(r.modules))
+	modules := make([]string, 0, len(dups))
 	for mod := range dups {
 		modules = append(modules, mod)
 	}


### PR DESCRIPTION
This came out of both elastic/beats#12648 and a discussion between @andrewkroh and I.

The `mb.Registry.Modules()` function is currently a tad weird. It'll only report modules that have been explicitly registered in `init()`. Not all modules do this. However, by nature of how metricsets are initialized, all _metricsets_ are stored in the registry.

This means that as it stands, you can use the registry to access all metricsets, but not all modules. This changes that, so `Modules()` returns a complete list, using the keys of the `metricSet` dict. The idea of just augmenting the data from `r.modules` and de-duplicating the list was @andrewkroh 's, out of an abundance of caution. 