### PR TITLE
Fix append inside a loop in seccomp.ModifyDefaultPolicy

### DIFF
--- a/libbeat/common/seccomp/seccomp.go
+++ b/libbeat/common/seccomp/seccomp.go
@@ -155,15 +155,20 @@ func ModifyDefaultPolicy(changeType PolicyChangeType, syscalls ...string) error 
 	case AddSyscall:
 		list := defaultPolicy.Syscalls[0].Names
 		for _, newSyscall := range syscalls {
+			found := false
 			for _, existingSyscall := range list {
-				if newSyscall == existingSyscall {
+				if found = newSyscall == existingSyscall; found {
 					break
 				}
-
+			}
+			if !found {
 				list = append(list, newSyscall)
 			}
 		}
 		defaultPolicy.Syscalls[0].Names = list
+
+	default:
+		return errors.New("unsupported PolicyChangeType value")
 	}
 
 	return nil


### PR DESCRIPTION
Append to the default policy was adding multiple copies of the same syscall by mistake, causing the list to double in size for each new syscall added.

This isn't a problem as currently ModifyDefaultPolicy is only used to add two new syscalls in all the Beats codebase.