### PR TITLE
Cherry-pick #12950 to 7.2: Reuse connections in redis info metricset

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -40,7 +40,7 @@ https://github.com/elastic/beats/compare/v7.2.0...7.2[Check the HEAD diff]
 
 *Metricbeat*
 
-- Fix connections leak in redis module {pull}12914[12914]
+- Fix connections leak in redis module {pull}12914[12914] {pull}12950[12950]
 
 *Packetbeat*
 

--- a/metricbeat/module/redis/key/key.go
+++ b/metricbeat/module/redis/key/key.go
@@ -70,7 +70,11 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // Fetch fetches information from Redis keys
 func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 	conn := m.Connection()
-	defer conn.Close()
+	defer func() {
+		if err := conn.Close(); err != nil {
+			m.Logger().Debug(errors.Wrapf(err, "failed to release connection"))
+		}
+	}()
 
 	for _, p := range m.patterns {
 		if err := redis.Select(conn, p.Keyspace); err != nil {

--- a/metricbeat/module/redis/keyspace/keyspace.go
+++ b/metricbeat/module/redis/keyspace/keyspace.go
@@ -49,7 +49,11 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // Fetch fetches metrics from Redis by issuing the INFO command.
 func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 	conn := m.Connection()
-	defer conn.Close()
+	defer func() {
+		if err := conn.Close(); err != nil {
+			m.Logger().Debug(errors.Wrapf(err, "failed to release connection"))
+		}
+	}()
 
 	// Fetch default INFO.
 	info, err := redis.FetchRedisInfo("keyspace", conn)


### PR DESCRIPTION
Cherry-pick of PR #12950 to 7.2 branch. Original message: 

Continues with elastic/beats#12914