### PR TITLE
Cherry-pick #12950 to 7.1: Reuse connections in redis info metricset

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -66,7 +66,7 @@ https://github.com/elastic/beats/compare/v7.1.1...7.1[Check the HEAD diff]
 - Require certificate authorities, certificate file, and key when SSL is enabled for module http metricset server. {pull}12355[12355]
 - In the kibana/stats metricset, only log error (don't also index it) if xpack is enabled. {pull}12353[12353]
 - When TLS is configured for the http metricset and a `certificate_authorities` is configured we now default to `required` for the `client_authentication`. {pull}12584[12584]
-- Fix connections leak in redis module {pull}12914[12914]
+- Fix connections leak in redis module {pull}12914[12914] {pull}12950[12950]
 
 *Packetbeat*
 

--- a/metricbeat/module/redis/info/info.go
+++ b/metricbeat/module/redis/info/info.go
@@ -58,7 +58,7 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 	conn := m.Connection()
 	defer func() {
 		if err := conn.Close(); err != nil {
-			m.Logger().Debug(errors.Wrapf(err, "failed to release connection"))
+			debugf("failed to release connection: %v", err)
 		}
 	}()
 

--- a/metricbeat/module/redis/key/key.go
+++ b/metricbeat/module/redis/key/key.go
@@ -73,7 +73,11 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // Fetch fetches information from Redis keys
 func (m *MetricSet) Fetch(r mb.ReporterV2) {
 	conn := m.Connection()
-	defer conn.Close()
+	defer func() {
+		if err := conn.Close(); err != nil {
+			m.Logger().Debug(errors.Wrapf(err, "failed to release connection"))
+		}
+	}()
 
 	for _, p := range m.patterns {
 		if err := redis.Select(conn, p.Keyspace); err != nil {

--- a/metricbeat/module/redis/key/key.go
+++ b/metricbeat/module/redis/key/key.go
@@ -75,7 +75,7 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 	conn := m.Connection()
 	defer func() {
 		if err := conn.Close(); err != nil {
-			m.Logger().Debug(errors.Wrapf(err, "failed to release connection"))
+			debugf("failed to release connection: %v", err)
 		}
 	}()
 

--- a/metricbeat/module/redis/keyspace/keyspace.go
+++ b/metricbeat/module/redis/keyspace/keyspace.go
@@ -54,7 +54,11 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // Fetch fetches metrics from Redis by issuing the INFO command.
 func (m *MetricSet) Fetch(r mb.ReporterV2) {
 	conn := m.Connection()
-	defer conn.Close()
+	defer func() {
+		if err := conn.Close(); err != nil {
+			m.Logger().Debug(errors.Wrapf(err, "failed to release connection"))
+		}
+	}()
 
 	// Fetch default INFO.
 	info, err := redis.FetchRedisInfo("keyspace", conn)

--- a/metricbeat/module/redis/keyspace/keyspace.go
+++ b/metricbeat/module/redis/keyspace/keyspace.go
@@ -56,7 +56,7 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 	conn := m.Connection()
 	defer func() {
 		if err := conn.Close(); err != nil {
-			m.Logger().Debug(errors.Wrapf(err, "failed to release connection"))
+			debugf("failed to release connection: %v", err)
 		}
 	}()
 


### PR DESCRIPTION
Cherry-pick of PR #12950 to 7.1 branch. Original message: 

Continues with elastic/beats#12914