### PR TITLE
[6.8] Remove cluster_name from under cluster_stats field (#11654)

### DIFF
--- a/metricbeat/module/elasticsearch/cluster_stats/data_xpack.go
+++ b/metricbeat/module/elasticsearch/cluster_stats/data_xpack.go
@@ -170,6 +170,7 @@ func eventMappingXPack(r mb.ReporterV2, m *MetricSet, info elasticsearch.Info, c
 	if !ok {
 		return fmt.Errorf("cluster name is not a string")
 	}
+	clusterStats.Delete("cluster_name")
 
 	license, err := elasticsearch.GetLicense(m.HTTP, m.HTTP.GetURI())
 	if err != nil {


### PR DESCRIPTION
Backports the following commits to 6.8:
 - Remove cluster_name from under cluster_stats field (#11654) (#9906)