### PR TITLE
[6.8] Remove cluster_name from cluster_state field (#11954)

### DIFF
--- a/metricbeat/module/elasticsearch/cluster_stats/data_xpack.go
+++ b/metricbeat/module/elasticsearch/cluster_stats/data_xpack.go
@@ -181,6 +181,7 @@ func eventMappingXPack(r mb.ReporterV2, m *MetricSet, info elasticsearch.Info, c
 	if err != nil {
 		return errors.Wrap(err, "failed to get cluster state from Elasticsearch")
 	}
+	clusterState.Delete("cluster_name")
 
 	if err = elasticsearch.PassThruField("status", clusterStats, clusterState); err != nil {
 		return errors.Wrap(err, "failed to pass through status field")


### PR DESCRIPTION
Backports the following commits to 6.8:
 - Remove cluster_name from cluster_state field  (#11954)