### PR TITLE
Collect index threadpool stats, if present

### DIFF
--- a/metricbeat/module/elasticsearch/node_stats/data_xpack.go
+++ b/metricbeat/module/elasticsearch/node_stats/data_xpack.go
@@ -142,6 +142,7 @@ var (
 		}),
 		"thread_pool": c.Dict("thread_pool", s.Schema{
 			"bulk":       c.Dict("bulk", threadPoolStatsSchema, c.DictOptional),
+			"index":      c.Dict("index", threadPoolStatsSchema, c.DictOptional),
 			"write":      c.Dict("write", threadPoolStatsSchema),
 			"generic":    c.Dict("generic", threadPoolStatsSchema),
 			"get":        c.Dict("get", threadPoolStatsSchema),


### PR DESCRIPTION
The `index` threadpool was present in Elastiscearch [until 6.8.0](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/modules-threadpool.html). From [7.0.0 onwards](https://www.elastic.co/guide/en/elasticsearch/reference/7.0/modules-threadpool.html) this threadpool was subsumed under the `write` threadpool.

This PR teaches the `elasticsearch/node_stats` metricset (x-pack code path) to collect the `index` threadpool stats, if they are present (e.g. when the user is using Metricbeat to monitor Elasticsearch 6.8.x or lower).