### PR TITLE
[logstash/node_stats] Parity with internally-collected fields

### DIFF
--- a/metricbeat/module/logstash/node_stats/data_xpack.go
+++ b/metricbeat/module/logstash/node_stats/data_xpack.go
@@ -35,6 +35,7 @@ type jvm struct {
 		HeapUsedInBytes int `json:"heap_used_in_bytes"`
 		HeapUsedPercent int `json:"heap_used_percent"`
 	} `json:"mem"`
+	UptimeInMillis int `json:"uptime_in_millis"`
 }
 
 type events struct {

--- a/metricbeat/module/logstash/node_stats/data_xpack.go
+++ b/metricbeat/module/logstash/node_stats/data_xpack.go
@@ -39,10 +39,9 @@ type jvm struct {
 }
 
 type events struct {
-	QueuePushDurationInMillis int `json:"queue_push_duration_in_millis"`
-	In                        int `json:"in"`
-	Filtered                  int `json:"filtered"`
-	Out                       int `json:"out"`
+	In       int `json:"in"`
+	Filtered int `json:"filtered"`
+	Out      int `json:"out"`
 }
 
 type commonStats struct {

--- a/metricbeat/module/logstash/node_stats/data_xpack.go
+++ b/metricbeat/module/logstash/node_stats/data_xpack.go
@@ -39,10 +39,10 @@ type jvm struct {
 }
 
 type events struct {
-	DurationInMillis int `json:"duration_in_millis"`
-	In               int `json:"in"`
-	Filtered         int `json:"filtered"`
-	Out              int `json:"out"`
+	QueuePushDurationInMillis int `json:"queue_push_duration_in_millis"`
+	In                        int `json:"in"`
+	Filtered                  int `json:"filtered"`
+	Out                       int `json:"out"`
 }
 
 type commonStats struct {

--- a/metricbeat/module/logstash/node_stats/data_xpack.go
+++ b/metricbeat/module/logstash/node_stats/data_xpack.go
@@ -37,8 +37,15 @@ type jvm struct {
 	} `json:"mem"`
 }
 
+type events struct {
+	DurationInMillis int `json:"duration_in_millis"`
+	In               int `json:"in"`
+	Filtered         int `json:"filtered"`
+	Out              int `json:"out"`
+}
+
 type commonStats struct {
-	Events  map[string]interface{} `json:"events"`
+	Events  events                 `json:"events"`
 	JVM     jvm                    `json:"jvm"`
 	Reloads map[string]interface{} `json:"reloads"`
 	Queue   struct {
@@ -93,13 +100,6 @@ type reloads struct {
 	Failures  int `json:"failures"`
 }
 
-type events struct {
-	DurationInMillis int `json:"duration_in_millis"`
-	In               int `json:"in"`
-	Filtered         int `json:"filtered"`
-	Out              int `json:"out"`
-}
-
 // NodeStats represents the stats of a Logstash node
 type NodeStats struct {
 	nodeInfo
@@ -124,7 +124,7 @@ type PipelineStats struct {
 	ID          string                   `json:"id"`
 	Hash        string                   `json:"hash"`
 	EphemeralID string                   `json:"ephemeral_id"`
-	Events      events                   `json:"events"`
+	Events      map[string]interface{}   `json:"events"`
 	Reloads     reloads                  `json:"reloads"`
 	Queue       map[string]interface{}   `json:"queue"`
 	Vertices    []map[string]interface{} `json:"vertices"`


### PR DESCRIPTION
This PR fixes the `logstash/node_stats` metricset (x-pack code path) to have parity with internal collection. Specifically, it teaches the metricset to:
1. collect the `logstash_stats.jvm.uptime_in_millis` field,
2. collect the `logstash_stats.pipelines.events.queue_push_duration_in_millis` field, and
3. **not** collect the `logstash_stats.events.queue_push_duration_in_millis` field.

### Testing this PR

1. Build Metricbeat with this PR.
   ```
   cd $GOPATH/src/github.com/elastic/beats/metricbeat
   mage build
   ```

2. Enable the Logstash module for Stack Monitoring.
   ```
   ./metricbeat modules enable logstash-xpack
   ```

3. Start Logstash.
   ```
   ./bin/logstash -e 'input { stdin {} }'

4. Start Metricbeat.
   ```
   ./metricbeat -e
   ```

5. Verify that the `.monitoring-logstash-*` index contains `type:logstash_stats` documents with the fields as mentioned above.

   ```
   GET .monitoring-logstash-*/_search?q=type:logstash_stats&filter_path=hits.hits._source.logstash_stats&size=1
   ```