### PR TITLE
[DOCS] Make each troubleshooting item a separate topic

### DIFF
--- a/auditbeat/docs/faq-ulimit.asciidoc
+++ b/auditbeat/docs/faq-ulimit.asciidoc
@@ -1,6 +1,5 @@
-[float]
 [[ulimit]]
-=== {beatname_uc} fails to watch folders because too many files are open?
+=== {beatname_uc} fails to watch folders because too many files are open
 
 Because of the way file monitoring is implemented on macOS, you may see a
 warning similar to the following:

--- a/auditbeat/docs/faq.asciidoc
+++ b/auditbeat/docs/faq.asciidoc
@@ -1,8 +1,8 @@
 [[faq]]
-== Frequently asked questions
+== Common problems
 
-This section contains frequently asked questions about {beatname_uc}. Also check
-out the
+This section describes common problems you might encounter with
+{beatname_uc}. Also check out the
 https://discuss.elastic.co/c/beats/{beatname_lc}[{beatname_uc} discussion forum].
 
 include::./faq-ulimit.asciidoc[]

--- a/filebeat/docs/faq.asciidoc
+++ b/filebeat/docs/faq.asciidoc
@@ -1,20 +1,19 @@
 [[faq]]
-== Frequently asked questions
+== Common problems
 
-This section contains frequently asked questions about {beatname_uc}. Also check out the
-https://discuss.elastic.co/c/beats/filebeat[{beatname_uc} discussion forum].
+This section describes common problems you might encounter with
+{beatname_uc}. Also check out the
+https://discuss.elastic.co/c/beats/{beatname_lc}[{beatname_uc} discussion forum].
 
-[float]
 [[filebeat-network-volumes]]
-=== Can't read log files from network volumes?
+=== Can't read log files from network volumes
 
 We do not recommend reading log files from network volumes. Whenever possible, install {beatname_uc} on the host machine and
 send the log files directly from there. Reading files from network volumes (especially on Windows) can have unexpected side
 effects. For example, changed file identifiers may result in {beatname_uc} reading a log file from scratch again.
 
-[float]
 [[filebeat-not-collecting-lines]]
-=== {beatname_uc} isn't collecting lines from a file?
+=== {beatname_uc} isn't collecting lines from a file
 
 {beatname_uc} might be incorrectly configured or unable to send events to the output. To resolve the issue:
 
@@ -31,9 +30,8 @@ it's publishing events successfully:
 ./filebeat -c config.yml -e -d "*"
 ----------------------------------------------------------------------
 
-[float]
 [[open-file-handlers]]
-=== Too many open file handlers?
+=== Too many open file handlers
 
 {beatname_uc} keeps the file handler open in case it reaches the end of a file so that it can read new log lines in near real time. If {beatname_uc} is harvesting a large number of files, the number of open files can become an issue. In most environments, the number of files that are actively updated is low. The `close_inactive` configuration option should be set accordingly to close files that are no longer active.
 
@@ -49,18 +47,16 @@ The `close_renamed` and `close_removed` options can be useful on Windows to reso
 
 Make sure that you read the documentation for these configuration options before using any of them.
 
-[float]
 [[reduce-registry-size]]
-=== Registry file is too large?
+=== Registry file is too large
 
 {beatname_uc} keeps the state of each file and persists the state to disk in the registry file. The file state is used to continue file reading at a previous position when {beatname_uc} is restarted. If a large number of new files are produced every day, the registry file might grow to be too large. To reduce the size of the registry file, there are two configuration options available: <<{beatname_lc}-input-log-clean-removed,`clean_removed`>> and <<{beatname_lc}-input-log-clean-inactive,`clean_inactive`>>.
 
 For old files that you no longer touch and are ignored (see <<{beatname_lc}-input-log-ignore-older,`ignore_older`>>), we recommended that you use `clean_inactive`. If old files get removed from disk, then use the `clean_removed` option.
 
 
-[float]
 [[inode-reuse-issue]]
-=== Inode reuse causes {beatname_uc} to skip lines?
+=== Inode reuse causes {beatname_uc} to skip lines
 
 On Linux file systems, {beatname_uc} uses the inode and device to identify files. When a file is removed from disk, the inode may be assigned to a new file. In use cases involving file rotation, if an old file is removed and a new one is created immediately afterwards, the new file may have the exact same inode as the file that was removed. In this case, {beatname_uc} assumes that the new file is the same as the old and tries to continue reading at the old position, which is not correct.
 
@@ -68,34 +64,30 @@ By default states are never removed from the registry file. To resolve the inode
 
 You can use <<{beatname_lc}-input-log-clean-removed,`clean_removed`>> for files that are removed from disk. Be aware that `clean_removed` cleans the file state from the registry whenever a file cannot be found during a scan. If the file shows up again later, it will be sent again from scratch.
 
-[float]
 [[windows-file-rotation]]
-=== Open file handlers cause issues with Windows file rotation?
+=== Open file handlers cause issues with Windows file rotation
 
 On Windows, you might have problems renaming or removing files because {beatname_uc} keeps the file handlers open. This can lead to issues with the file rotating system. To avoid this issue, you can use the <<{beatname_lc}-input-log-close-removed,`close_removed`>> and <<{beatname_lc}-input-log-close-renamed,`close_renamed`>> options together.
 
 IMPORTANT: When you configure these options, files may be closed before the harvester has finished reading the files. If the file cannot be picked up again by the input and the harvester hasn't finish reading the file, the missing lines will never be sent to the output.
 
 
-[float]
 [[filebeat-cpu]]
-=== {beatname_uc} is using too much CPU?
+=== {beatname_uc} is using too much CPU
 
 {beatname_uc} might be configured to scan for files too frequently. Check the setting for `scan_frequency` in the `filebeat.yml`
 config file. Setting `scan_frequency` to less than 1s may cause {beatname_uc} to scan the disk in a tight loop.
 
-[float]
 [[dashboard-fields-incorrect-filebeat]]
-=== Dashboard in Kibana is breaking up data fields incorrectly?
+=== Dashboard in {kib} is breaking up data fields incorrectly
 
 The index template might not be loaded correctly. See <<filebeat-template>>.
 
-[float]
 [[fields-not-indexed]]
-=== Fields are not indexed or usable in Kibana visualizations?
+=== Fields are not indexed or usable in {kib} visualizations
 
 If you have recently performed an operation that loads or parses custom, structured logs,
-you might need to refresh the index to make the fields available in Kibana. To refresh
+you might need to refresh the index to make the fields available in {kib}. To refresh
 the index, use the {ref}/indices-refresh.html[refresh API]. For example:
 
 ["source","sh"]
@@ -103,21 +95,19 @@ the index, use the {ref}/indices-refresh.html[refresh API]. For example:
 curl -XPOST 'http://localhost:9200/filebeat-2016.08.09/_refresh'
 ----------------------------------------------------------------------
 
-[float]
 [[newline-character-required-eof]]
-=== {beatname_uc} isn't shipping the last line of a file?
+=== {beatname_uc} isn't shipping the last line of a file
 
 {beatname_uc} uses a newline character to detect the end of an event. If lines are added incrementally to a file that's being
 harvested, a newline character is required after the last line, or {beatname_uc} will not read the last line of
 the file.
 
-[float]
 [[faq-deleted-files-are-not-freed]]
-=== {beatname_uc} keeps open file handlers of deleted files for a long time?
+=== {beatname_uc} keeps open file handlers of deleted files for a long time
 
 In the default behaviour, {beatname_uc} opens the files and keeps them open until it
 reaches the end of them.  In situations when the configured output is blocked
-(e.g. Elasticsearch or Logstash is unavailable) for a long time, this can cause
+(e.g. {es} or {ls} is unavailable) for a long time, this can cause
 {beatname_uc} to keep file handlers to files that were deleted from the file system
 in the mean time. As long as {beatname_uc} keeps the deleted files open, the
 operating system doesn't free up the space on disk, which can lead to increase

--- a/heartbeat/docs/faq.asciidoc
+++ b/heartbeat/docs/faq.asciidoc
@@ -1,9 +1,10 @@
 [[faq]]
-== Frequently asked questions
+== Common problems
 
-This section contains frequently asked questions about Heartbeat. Also check
-out the
-https://discuss.elastic.co/c/beats/heartbeat[Heartbeat discussion forum].
+This section describes common problems you might encounter with
+{beatname_uc}. Also check out the
+https://discuss.elastic.co/c/beats/{beatname_lc}[{beatname_uc} discussion forum].
 
 include::{libbeat-dir}/docs/faq-limit-bandwidth.asciidoc[]
+
 include::{libbeat-dir}/docs/shared-faq.asciidoc[]

--- a/journalbeat/docs/faq.asciidoc
+++ b/journalbeat/docs/faq.asciidoc
@@ -1,9 +1,9 @@
 [[faq]]
-== Frequently asked questions
+== Common problems
 
-This section contains frequently asked questions about {beatname_uc}. Also check
-out the https://discuss.elastic.co/c/beats/{beatname_lc}[{beatname_uc}
-discussion forum].
+This section describes common problems you might encounter with
+{beatname_uc}. Also check out the
+https://discuss.elastic.co/c/beats/{beatname_lc}[{beatname_uc} discussion forum].
 
 include::{libbeat-dir}/docs/faq-limit-bandwidth.asciidoc[]
 

--- a/libbeat/docs/faq-limit-bandwidth.asciidoc
+++ b/libbeat/docs/faq-limit-bandwidth.asciidoc
@@ -1,6 +1,5 @@
-[float]
 [[bandwidth-throttling]]
-=== Need to limit bandwidth used by {beatname_uc}?
+=== {beatname_uc} uses too much bandwidth
 
 If you need to limit bandwidth usage, we recommend that you configure the network stack on your OS to perform
 bandwidth throttling.

--- a/libbeat/docs/faq-refresh-index.asciidoc
+++ b/libbeat/docs/faq-refresh-index.asciidoc
@@ -1,8 +1,7 @@
-[float]
 [[refresh-index-pattern]]
-=== Fields show up as nested JSON in Kibana?
+=== Fields show up as nested JSON in {kib}
 
-When {beatname_uc} exports a field of type dictionary, and the keys are not known in advance, the Discovery page in Kibana will display the field as a nested JSON object:
+When {beatname_uc} exports a field of type dictionary, and the keys are not known in advance, the Discovery page in {kib} will display the field as a nested JSON object:
 
 [source,shell]
 ----------------------------------------------------------------------
@@ -11,7 +10,8 @@ http.response.headers = {
         "content-type": "application/json"
 }
 ----------------------------------------------------------------------
-To fix this you need to {kibana-ref}/index-patterns.html#reload-fields[reload the index pattern] in Kibana under the Management->Index Patterns, and the index pattern will be
+
+To fix this you need to {kibana-ref}/index-patterns.html#reload-fields[reload the index pattern] in {kib} under the Management->Index Patterns, and the index pattern will be
 updated with a field for each key available in the dictionary:
 
 [source,shell]

--- a/libbeat/docs/shared-faq.asciidoc
+++ b/libbeat/docs/shared-faq.asciidoc
@@ -9,9 +9,8 @@
 //// include::../../libbeat/docs/shared-faq.asciidoc[]
 //////////////////////////////////////////////////////////////////////////
 
-[float]
 [[error-loading-config]]
-=== Error loading config file?
+=== Error loading config file
 
 You may encounter errors loading the config file on POSIX operating systems if:
 
@@ -21,9 +20,8 @@ You may encounter errors loading the config file on POSIX operating systems if:
 See {beats-ref}/config-file-permissions.html[Config File Ownership and Permissions]
 for more about resolving these errors.
 
-[float]
 [[error-found-unexpected-character]]
-=== Found Unexpected or Unknown Characters?
+=== Found unexpected or unknown characters
 
 Either there is a problem with the structure of your config file, or you have
 used a path or expression that the YAML parser cannot resolve because the config
@@ -35,13 +33,12 @@ paths in single quotation marks (see <<wrap-paths-in-quotes>>).
 Also see the general advice under <<yaml-tips>>.
 
 ifndef::only-elasticsearch[]
-[float]
 [[connection-problem]]
-=== Logstash connection doesn't work?
+=== {ls} connection doesn't work
 
-You may have configured Logstash or {beatname_uc} incorrectly. To resolve the issue:
+You may have configured {ls} or {beatname_uc} incorrectly. To resolve the issue:
 
-* Make sure that Logstash is running and you can connect to it. First, try to ping the Logstash host to verify that you can reach it
+* Make sure that {ls} is running and you can connect to it. First, try to ping the {ls} host to verify that you can reach it
 from the host running {beatname_uc}. Then use either `nc` or `telnet` to make sure that the port is available. For example:
 +
 [source,shell]
@@ -49,49 +46,46 @@ from the host running {beatname_uc}. Then use either `nc` or `telnet` to make su
 ping <hostname or IP>
 telnet <hostname or IP> 5044
 ----------------------------------------------------------------------
-* Verify that the config file for {beatname_uc} specifies the correct port where Logstash is running.
-* Make sure that the Elasticsearch output is commented out in the config file and the Logstash output is uncommented.
+* Verify that the config file for {beatname_uc} specifies the correct port where {ls} is running.
+* Make sure that the {es} output is commented out in the config file and the {ls} output is uncommented.
 * Confirm that the most recent {logstash-ref}/plugins-inputs-beats.html[Beats
-input plugin for Logstash] is installed and configured. Note that Beats will not
+input plugin for {ls}] is installed and configured. Note that Beats will not
 connect to the Lumberjack input plugin. To learn how to install and update
 plugins, see {logstash-ref}/working-with-plugins.html[Working with plugins].
 endif::only-elasticsearch[]
 
 ifndef::only-elasticsearch[]
-[float]
 [[metadata-missing]]
-=== @metadata is missing in Logstash?
+=== @metadata is missing in {ls}
 
-Logstash outputs remove `@metadata` fields automatically. Therefore, if Logstash instances are chained directly or via some message
-queue (for example, Redis or Kafka), the `@metadata` field will not be available in the final Logstash instance.
+{ls} outputs remove `@metadata` fields automatically. Therefore, if {ls} instances are chained directly or via some message
+queue (for example, Redis or Kafka), the `@metadata` field will not be available in the final {ls} instance.
 
-TIP: To preserve `@metadata` fields, use the Logstash mutate filter with the rename setting to rename the fields to
+TIP: To preserve `@metadata` fields, use the {ls} mutate filter with the rename setting to rename the fields to
 non-internal fields.
 endif::only-elasticsearch[]
 
 ifndef::only-elasticsearch[]
-[float]
 [[diff-logstash-beats]]
-=== Difference between Logstash and Beats?
+=== Not sure whether to use {ls} or Beats
 
 Beats are lightweight data shippers that you install as agents on your servers to send specific types of operational
-data to Elasticsearch. Beats have a small footprint and use fewer system resources than Logstash.
+data to {es}. Beats have a small footprint and use fewer system resources than {ls}.
 
-Logstash has a larger footprint, but provides a broad array of input, filter, and output plugins for collecting, enriching,
+{ls} has a larger footprint, but provides a broad array of input, filter, and output plugins for collecting, enriching,
 and transforming data from a variety of sources.
 
-For more information, see the https://www.elastic.co/guide/en/logstash/current/introduction.html[Logstash Introduction] and
+For more information, see the https://www.elastic.co/guide/en/logstash/current/introduction.html[{ls} Introduction] and
 the https://www.elastic.co/guide/en/beats/libbeat/current/beats-reference.html[Beats Overview].
 endif::only-elasticsearch[]
 
 ifndef::only-elasticsearch[]
-[float]
 [[ssl-client-fails]]
-=== SSL client fails to connect to Logstash?
+=== SSL client fails to connect to {ls}
 
-The host running Logstash might be unreachable or the certificate may not be valid. To resolve your issue:
+The host running {ls} might be unreachable or the certificate may not be valid. To resolve your issue:
 
-* Make sure that Logstash is running and you can connect to it. First, try to ping the Logstash host to verify that you can reach it
+* Make sure that {ls} is running and you can connect to it. First, try to ping the {ls} host to verify that you can reach it
 from the host running {beatname_uc}. Then use either `nc` or `telnet` to make sure that the port is available. For example:
 +
 [source,shell]
@@ -104,10 +98,9 @@ telnet <hostname or IP> 5044
 +
 TIP: For testing purposes only, you can set `verification_mode: none` to disable hostname checking.
 
-* Use OpenSSL to test connectivity to the Logstash server and diagnose problems. See the https://www.openssl.org/docs/manmaster/apps/s_client.html[OpenSSL documentation] for more info.
-* Make sure that you have enabled SSL (set `ssl => true`) when configuring the https://www.elastic.co/guide/en/logstash/current/plugins-inputs-beats.html[Beats input plugin for Logstash].
+* Use OpenSSL to test connectivity to the {ls} server and diagnose problems. See the https://www.openssl.org/docs/manmaster/apps/s_client.html[OpenSSL documentation] for more info.
+* Make sure that you have enabled SSL (set `ssl => true`) when configuring the https://www.elastic.co/guide/en/logstash/current/plugins-inputs-beats.html[Beats input plugin for {ls}].
 
-[float]
 ==== Common SSL-Related Errors and Resolutions
 
 Here are some common errors and ways to fix them:
@@ -117,7 +110,6 @@ Here are some common errors and ways to fix them:
 * <<getsockopt-connection-refused,getsockopt: connection refused>>
 * <<target-machine-refused-connection,No connection could be made because the target machine actively refused it>>
 
-[float]
 [[cannot-validate-certificate]]
 ===== x509: cannot validate certificate for <IP address> because it doesn't contain any IP SANs
 
@@ -131,19 +123,16 @@ To resolve this problem, try one of these solutions:
 * Re-create the server certificate and add a SubjectAltName (SAN) for the IP address of the server. This make the
 server's certificate valid for both the hostname and the IP address.
 
-[float]
 [[getsockopt-no-route-to-host]]
 ===== getsockopt: no route to host
 
 This is not a SSL problem. It's a networking problem. Make sure the two hosts can communicate.
 
-[float]
 [[getsockopt-connection-refused]]
 ===== getsockopt: connection refused
 
-This is not a SSL problem. Make sure that Logstash is running and that there is no firewall blocking the traffic.
+This is not a SSL problem. Make sure that {ls} is running and that there is no firewall blocking the traffic.
 
-[float]
 [[target-machine-refused-connection]]
 ===== No connection could be made because the target machine actively refused it
 
@@ -151,7 +140,6 @@ A firewall is refusing the connection. Check if a firewall is blocking the traff
 destination host.
 endif::only-elasticsearch[]
 
-[float]
 [[monitoring-shows-fewer-than-expected-beats]]
 === Monitoring UI shows fewer Beats than expected
 

--- a/metricbeat/docs/faq.asciidoc
+++ b/metricbeat/docs/faq.asciidoc
@@ -1,14 +1,14 @@
 [[faq]]
-== Frequently asked questions
+== Common problems
 
-This section contains frequently asked questions about Metricbeat. Also check out the
-https://discuss.elastic.co/c/beats/metricbeat[Metricbeat discussion forum].
+This section describes common problems you might encounter with
+{beatname_uc}. Also check out the
+https://discuss.elastic.co/c/beats/{beatname_lc}[{beatname_uc} discussion forum].
 
-[float]
 [[freebsd-no-such-file]]
-=== Fix for `open /compat/linux/proc: no such file or directory` error on FreeBSD?
+=== "open /compat/linux/proc: no such file or directory" error on FreeBSD
 
-The system metricsets rely a Linux comparability layer to retrieve metrics on
+The system metricsets rely on a Linux compatibility layer to retrieve metrics on
 FreeBSD. You need to mount the Linux procfs filesystem using the following
 commands. You may want to add these filesystems to your `/etc/fstab` so they are
 mounted automatically.

--- a/packetbeat/docs/faq-mysql-ssl.asciidoc
+++ b/packetbeat/docs/faq-mysql-ssl.asciidoc
@@ -1,6 +1,5 @@
-[float]
 [[mysql-no-data]]
-=== {beatname_uc} isn't capturing MySQL performance data?
+=== {beatname_uc} isn't capturing MySQL performance data
 
 You may be listening on the wrong interface or trying to capture data sent over
 an encrypted connection. {beatname_uc} can only monitor MySQL traffic if it is

--- a/packetbeat/docs/faq.asciidoc
+++ b/packetbeat/docs/faq.asciidoc
@@ -1,18 +1,17 @@
 [[faq]]
-== Frequently asked questions
+== Common problems
 
-This section contains frequently asked questions about Packetbeat. Also check out the
-https://discuss.elastic.co/c/beats/packetbeat[Packetbeat discussion forum].
+This section describes common problems you might encounter with
+{beatname_uc}. Also check out the
+https://discuss.elastic.co/c/beats/{beatname_lc}[{beatname_uc} discussion forum].
 
-[float]
 [[dashboard-fields-incorrect]]
-=== Dashboard in Kibana is breaking up data fields incorrectly?
+=== Dashboard in {kib} is breaking up data fields incorrectly
 
 The index template might not be loaded correctly. See <<packetbeat-template>>.
 
-[float]
 [[packetbeat-mirror-ports]]
-=== Packetbeat doesn't see any packets when using mirror ports?
+=== {beatname_uc} doesn't see any packets when using mirror ports
 
 The interface needs to be set to promiscuous mode. Run the following command:
 
@@ -23,9 +22,8 @@ ip link set <device_name> promisc on
 
 For example: `ip link set enp5s0f1 promisc on`
 
-[float]
 [[packetbeat-loopback-interface]]
-=== Packetbeat can't capture traffic from Windows loopback interface?
+=== {beatname_uc} can't capture traffic from Windows loopback interface
 
 The Windows TCP/IP stack does not implement a network loopback interface, making
 it difficult for Windows packet capture drivers to capture traffic from the
@@ -34,12 +32,12 @@ https://nmap.org/npcap/[Npcap] in WinPcap API-compatible mode and select the
 option to support loopback traffic. When you restart Windows, Npcap creates an
 Npcap Loopback Adapter that you can select to capture loopback traffic.
 
-For the list of devices shown here, you would configure Packetbeat
+For the list of devices shown here, you would configure {beatname_uc}
 to use device `4`:
 
-["source","sh"]
+["source","sh",subs="attributes"]
 ----------------------------------------------------------------------
-PS C:\Program Files\Packetbeat .\packetbeat.exe -devices
+PS C:\Program Files\{beatname_uc} .{backslash}{beatname_lc}.exe -devices
 0: \Device\NPF_NdisWanBh (NdisWan Adapter)
 1: \Device\NPF_NdisWanIp (NdisWan Adapter)
 2: \Device\NPF_NdisWanIpv6 (NdisWan Adapter)
@@ -47,11 +45,10 @@ PS C:\Program Files\Packetbeat .\packetbeat.exe -devices
 4: \Device\NPF_{77DFFCAF-1335-4B0D-AFD4-5A4685674FAA} (MS NDIS 6.0 LoopBack Driver)
 ----------------------------------------------------------------------
 
-[float]
 [[packetbeat-missing-transactions]]
-=== Packetbeat is missing long running transactions?
+=== {beatname_uc} is missing long running transactions
 
-Packetbeat has an internal timeout that it uses to time out transactions and TCP connections
+{beatname_uc} has an internal timeout that it uses to time out transactions and TCP connections
 when no packets have been seen for a long time.
 
 To process long running transactions, you can specify a larger value for the <<transaction-timeout-option,`transaction_timeout`>>
@@ -59,6 +56,9 @@ option. However, keep in mind that very large timeout values can increase memory
 response messages are not sent.
 
 include::./faq-mysql-ssl.asciidoc[]
+
 include::{libbeat-dir}/docs/faq-limit-bandwidth.asciidoc[]
+
 include::{libbeat-dir}/docs/shared-faq.asciidoc[]
+
 include::{libbeat-dir}/docs/faq-refresh-index.asciidoc[]

--- a/winlogbeat/docs/faq.asciidoc
+++ b/winlogbeat/docs/faq.asciidoc
@@ -1,32 +1,29 @@
 [[faq]]
-== Frequently asked questions
+== Common problems
 
-This section contains frequently asked questions about Winlogbeat. Also check
-out the https://discuss.elastic.co/c/beats/winlogbeat[Winlogbeat discussion
-forum].
+This section describes common problems you might encounter with
+{beatname_uc}. Also check out the
+https://discuss.elastic.co/c/beats/{beatname_lc}[{beatname_uc} discussion forum].
 
-[float]
 [[dashboard-fields-incorrect]]
-=== Dashboard in Kibana is breaking up data fields incorrectly?
+=== Dashboard in {kib} is breaking up data fields incorrectly
 
 The index template might not be loaded correctly. See <<winlogbeat-template>>.
 
-[float]
 [[bogus-computer-name-fields]]
-=== Bogus computer_name fields are reported in some events?
+=== Bogus computer_name fields are reported in some events
 
 Prior to the hostname configuration stage, during OS installation any event log
 records generated may have a randomly assigned hostname.
 
 include::{libbeat-dir}/docs/shared-faq.asciidoc[]
 
-[float]
 [[reading-from-evtx]]
-=== Can Winlogbeat read from .evtx files?
+=== Not sure how to read from .evtx files
 
-Yes, Winlogbeat can ingest archived .evtx files. When you set the `name`
+Yes, {beatname_uc} can ingest archived .evtx files. When you set the `name`
 parameter as the absolute path to an event log file it will read from that file.
-Here's an example. First create a new config file for Winlogbeat.
+Here's an example. First create a new config file for {beatname_uc}.
 
 winlogbeat-evtx.yml
 [source,yaml]
@@ -41,16 +38,16 @@ winlogbeat.registry_file: evtx-registry.yml <4>
 output.elasticsearch.hosts: ['http://localhost:9200']
 ----
 1. `name` will be set to the value of the `EVTX_FILE` environment variable.
-2. `no_more_events` sets the behavior of Winlogbeat when Windows reports that
-   there are no more events to read. We want Winlogbeat to _stop_ rather than
+2. `no_more_events` sets the behavior of {beatname_uc} when Windows reports that
+   there are no more events to read. We want {beatname_uc} to _stop_ rather than
    _wait_ since this is an archived file that will not receive any more events.
-3. `shutdown_timeout` controls the maximum amount of time Winlogbeat will wait
-   to finish publishing the events to Elasticsearch after stopping because it
+3. `shutdown_timeout` controls the maximum amount of time {beatname_uc} will wait
+   to finish publishing the events to {es} after stopping because it
    reached the end of the log.
 4. A separate registry file is used to avoid overwriting the default registry
    file. You can delete this file after you're done ingesting the .evtx data.
 
-Now execute Winlogbeat and wait for it to complete. It will exit when it's done.
+Now execute {beatname_uc} and wait for it to complete. It will exit when it's done.
 
 [source,sh]
 ----

--- a/x-pack/functionbeat/docs/faq.asciidoc
+++ b/x-pack/functionbeat/docs/faq.asciidoc
@@ -1,14 +1,13 @@
 [[faq]]
 [role="xpack"]
-== Frequently asked questions
+== Common problems
 
-This section contains frequently asked questions about {beatname_uc}. Also check
-out the https://discuss.elastic.co/c/beats/{beatname_lc}[{beatname_uc}
-discussion forum].
+This section describes common problems you might encounter with
+{beatname_uc}. Also check out the
+https://discuss.elastic.co/c/beats/{beatname_lc}[{beatname_uc} discussion forum].
 
-[float]
 [[unable-to-deploy]]
-=== Deployment to AWS fails with "failed to create the stack"?
+=== Deployment to AWS fails with "failed to create the stack"
 
 Deployment fails if you attempt to deploy the Lambda function to the wrong
 region.


### PR DESCRIPTION
The FAQ layout no longer works well (not sure it ever did) given the length of some topics that we include for some Beats. I propose that we have a separate HTML page for each troubleshooting item. This will give each topic an SEO boost and make it easier for users to skip over stuff that's not relevant. 

Also did some minor cleanup to use attributes instead of hard-coding product names.

**OPEN ISSUE:** Should I provide a jump list under "Common problems" so users can see all the topics in a section? The jump lists tend to get out-of-date because they are currently maintained manually.