### PR TITLE
[7.2] Collect index threadpool stats, if present (#12987)

### DIFF
--- a/metricbeat/module/elasticsearch/node_stats/data_xpack.go
+++ b/metricbeat/module/elasticsearch/node_stats/data_xpack.go
@@ -142,6 +142,7 @@ var (
 		}),
 		"thread_pool": c.Dict("thread_pool", s.Schema{
 			"bulk":       c.Dict("bulk", threadPoolStatsSchema, c.DictOptional),
+			"index":      c.Dict("index", threadPoolStatsSchema, c.DictOptional),
 			"write":      c.Dict("write", threadPoolStatsSchema),
 			"generic":    c.Dict("generic", threadPoolStatsSchema),
 			"get":        c.Dict("get", threadPoolStatsSchema),


### PR DESCRIPTION
Backports the following commits to 7.2:
 - Collect index threadpool stats, if present  (#12987)