### PR TITLE
Cherry-pick #12913 to 7.3: Fix keyspace configuration in redis key metricset

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -145,6 +145,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Reuse connections in PostgreSQL metricsets. {issue}12504[12504] {pull}12603[12603]
 - PdhExpandWildCardPathW will not expand counter paths in 32 bit windows systems, workaround will use a different function.{issue}12590[12590]{pull}12622[12622]
 - In the elasticsearch/node_stats metricset, if xpack is enabled, make parsing of ES node load average optional as ES on Windows doesn't report load average. {pull}12866[12866]
+- Fix incoherent behaviour in redis key metricset when keyspace is specified both in host URL and key pattern {pull}12913[12913]
 - Fix connections leak in redis module {pull}12914[12914] {pull}12950[12950]
 - Fix wrong uptime reporting by system/uptime metricset under Windows. {pull}12915[12915]
 

--- a/metricbeat/module/redis/key/key.go
+++ b/metricbeat/module/redis/key/key.go
@@ -43,7 +43,7 @@ type MetricSet struct {
 
 // KeyPattern contains the information required to query keys
 type KeyPattern struct {
-	Keyspace uint   `config:"keyspace"`
+	Keyspace *uint  `config:"keyspace"`
 	Pattern  string `config:"pattern" validate:"required"`
 	Limit    uint   `config:"limit"`
 }
@@ -79,8 +79,14 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 	}()
 
 	for _, p := range m.patterns {
-		if err := redis.Select(conn, p.Keyspace); err != nil {
-			msg := errors.Wrapf(err, "Failed to select keyspace %d", p.Keyspace)
+		var keyspace uint
+		if p.Keyspace == nil {
+			keyspace = m.OriginalDBNumber()
+		} else {
+			keyspace = *p.Keyspace
+		}
+		if err := redis.Select(conn, keyspace); err != nil {
+			msg := errors.Wrapf(err, "Failed to select keyspace %d", keyspace)
 			m.Logger().Error(msg)
 			r.Error(err)
 			continue
@@ -88,7 +94,7 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 
 		keys, err := redis.FetchKeys(conn, p.Pattern, p.Limit)
 		if err != nil {
-			msg := errors.Wrapf(err, "Failed to list keys in keyspace %d with pattern '%s'", p.Keyspace, p.Pattern)
+			msg := errors.Wrapf(err, "Failed to list keys in keyspace %d with pattern '%s'", keyspace, p.Pattern)
 			m.Logger().Error(msg)
 			r.Error(err)
 			continue
@@ -101,14 +107,15 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 		for _, key := range keys {
 			keyInfo, err := redis.FetchKeyInfo(conn, key)
 			if err != nil {
-				msg := fmt.Errorf("Failed to fetch key info for key %s in keyspace %d", key, p.Keyspace)
+				msg := fmt.Errorf("Failed to fetch key info for key %s in keyspace %d", key, keyspace)
 				m.Logger().Error(msg)
 				r.Error(err)
 				continue
 			}
-			event := eventMapping(p.Keyspace, keyInfo)
+			event := eventMapping(keyspace, keyInfo)
 			if !r.Event(event) {
-				return errors.New("metricset has closed")
+				m.Logger().Debug("Failed to report event, interrupting fetch")
+				return nil
 			}
 		}
 	}

--- a/metricbeat/module/redis/key/key_integration_test.go
+++ b/metricbeat/module/redis/key/key_integration_test.go
@@ -20,11 +20,13 @@
 package key
 
 import (
+	"fmt"
 	"testing"
 
 	rd "github.com/garyburd/redigo/redis"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/tests/compose"
 	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
 	"github.com/elastic/beats/metricbeat/module/redis"
@@ -35,10 +37,10 @@ var host = redis.GetRedisEnvHost() + ":" + redis.GetRedisEnvPort()
 func TestFetch(t *testing.T) {
 	compose.EnsureUp(t, "redis")
 
-	addEntry(t)
+	addEntry(t, "foo", 1)
 
-	ms := mbtest.NewReportingMetricSetV2Error(t, getConfig())
-	events, err := mbtest.ReportingFetchV2Error(ms)
+	ms := mbtest.NewFetcher(t, getConfig())
+	events, err := ms.FetchEvents()
 	if err != nil {
 		t.Fatal("fetch", err)
 	}
@@ -50,24 +52,75 @@ func TestFetch(t *testing.T) {
 func TestData(t *testing.T) {
 	compose.EnsureUp(t, "redis")
 
-	addEntry(t)
+	addEntry(t, "foo", 1)
 
-	ms := mbtest.NewReportingMetricSetV2Error(t, getConfig())
-	err := mbtest.WriteEventsReporterV2Error(ms, t, "")
-	if err != nil {
-		t.Fatal("write", err)
+	ms := mbtest.NewFetcher(t, getConfig())
+	ms.WriteEvents(t, "")
+}
+
+func TestFetchMultipleKeyspaces(t *testing.T) {
+	compose.EnsureUp(t, "redis")
+
+	expectedKeyspaces := map[string]uint{
+		"foo": 0,
+		"bar": 1,
+		"baz": 2,
+	}
+	expectedEvents := len(expectedKeyspaces)
+
+	for name, keyspace := range expectedKeyspaces {
+		addEntry(t, name, keyspace)
+	}
+
+	config := getConfig()
+	config["key.patterns"] = []map[string]interface{}{
+		{
+			"pattern":  "foo",
+			"keyspace": 0,
+		},
+		{
+			"pattern": "bar",
+			// keyspace set to 1 in the host url
+		},
+		{
+			"pattern":  "baz",
+			"keyspace": 2,
+		},
+	}
+
+	ms := mbtest.NewFetcher(t, config)
+	events, err := ms.FetchEvents()
+
+	assert.Len(t, err, 0)
+	assert.Len(t, events, expectedEvents)
+
+	for _, event := range events {
+		name := event.MetricSetFields["name"].(string)
+		expectedKeyspace, found := expectedKeyspaces[name]
+		if !assert.True(t, found, name+" not expected") {
+			continue
+		}
+		id := event.MetricSetFields["id"].(string)
+		assert.Equal(t, fmt.Sprintf("%d:%s", expectedKeyspace, name), id)
+		keyspace := event.ModuleFields["keyspace"].(common.MapStr)
+		keyspaceID := keyspace["id"].(string)
+		assert.Equal(t, fmt.Sprintf("db%d", expectedKeyspace), keyspaceID)
 	}
 }
 
 // addEntry adds an entry to redis
-func addEntry(t *testing.T) {
+func addEntry(t *testing.T, key string, keyspace uint) {
 	// Insert at least one event to make sure db exists
 	c, err := rd.Dial("tcp", host)
 	if err != nil {
 		t.Fatal("connect", err)
 	}
+	_, err = c.Do("SELECT", keyspace)
+	if err != nil {
+		t.Fatal("select", err)
+	}
 	defer c.Close()
-	_, err = c.Do("SET", "foo", "bar", "EX", "360")
+	_, err = c.Do("SET", key, "bar", "EX", "360")
 	if err != nil {
 		t.Fatal("SET", err)
 	}
@@ -77,7 +130,7 @@ func getConfig() map[string]interface{} {
 	return map[string]interface{}{
 		"module":     "redis",
 		"metricsets": []string{"key"},
-		"hosts":      []string{host},
+		"hosts":      []string{host + "/1"},
 		"key.patterns": []map[string]interface{}{
 			{
 				"pattern": "foo",

--- a/metricbeat/module/redis/key/key_integration_test.go
+++ b/metricbeat/module/redis/key/key_integration_test.go
@@ -39,8 +39,8 @@ func TestFetch(t *testing.T) {
 
 	addEntry(t, "foo", 1)
 
-	ms := mbtest.NewFetcher(t, getConfig())
-	events, err := ms.FetchEvents()
+	ms := mbtest.NewReportingMetricSetV2Error(t, getConfig())
+	events, err := mbtest.ReportingFetchV2Error(ms)
 	if err != nil {
 		t.Fatal("fetch", err)
 	}
@@ -54,8 +54,11 @@ func TestData(t *testing.T) {
 
 	addEntry(t, "foo", 1)
 
-	ms := mbtest.NewFetcher(t, getConfig())
-	ms.WriteEvents(t, "")
+	ms := mbtest.NewReportingMetricSetV2Error(t, getConfig())
+	err := mbtest.WriteEventsReporterV2Error(ms, t, "")
+	if err != nil {
+		t.Fatal("write", err)
+	}
 }
 
 func TestFetchMultipleKeyspaces(t *testing.T) {
@@ -88,8 +91,8 @@ func TestFetchMultipleKeyspaces(t *testing.T) {
 		},
 	}
 
-	ms := mbtest.NewFetcher(t, config)
-	events, err := ms.FetchEvents()
+	ms := mbtest.NewReportingMetricSetV2Error(t, config)
+	events, err := mbtest.ReportingFetchV2Error(ms)
 
 	assert.Len(t, err, 0)
 	assert.Len(t, events, expectedEvents)

--- a/metricbeat/module/redis/metricset.go
+++ b/metricbeat/module/redis/metricset.go
@@ -32,7 +32,7 @@ import (
 // MetricSet for fetching Redis server information and statistics.
 type MetricSet struct {
 	mb.BaseMetricSet
-	pool *rd.Pool
+	pool *Pool
 }
 
 // NewMetricSet creates the base for Redis metricsets
@@ -72,6 +72,12 @@ func (m *MetricSet) Connection() rd.Conn {
 // Close redis connections
 func (m *MetricSet) Close() error {
 	return m.pool.Close()
+}
+
+// OriginalDBNumber returns the originally configured database number, this can be used by
+// metricsets that change keyspace to go back to the originally configured one
+func (m *MetricSet) OriginalDBNumber() uint {
+	return uint(m.pool.DBNumber())
 }
 
 func getPasswordDBNumber(hostData mb.HostData) (string, int, error) {


### PR DESCRIPTION
Cherry-pick of PR #12913 to 7.3 branch. Original message: 

Fix incoherent behaviour when keyspace is specified in the redis host
URL and not in some of the key patterns. If it was not specified it used
the default 0 instead of using the one in the redis host.

Redis doesn't have a direct way to request the keyspace being currently
used by a client, documentation mentions that is responsibility of the
client to keep track of the keyspace used if it changes it using `Select`.
This solution stores the db number originally configured and uses it
in the `key` metricset if no other keyspace is configured.

Fixes elastic/beats#12874