### PR TITLE
Cherry-pick #12870 to 7.3: Fix Oracle docs not showing the metricsets included (#12870)

### DIFF
--- a/metricbeat/docs/modules/oracle.asciidoc
+++ b/metricbeat/docs/modules/oracle.asciidoc
@@ -33,6 +33,7 @@ Then, Metricbeat can be launched normally if the environment variable is set.
 
 The following Metricset is included in the module:
 
+[float]
 === `tablespaces`
 
 Includes information about data files and temp files, grouped by Tablespace with free space available, used space, status of the data files, status of the Tablespace, etc.

--- a/x-pack/metricbeat/module/oracle/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/oracle/_meta/docs.asciidoc
@@ -24,6 +24,7 @@ Then, Metricbeat can be launched normally if the environment variable is set.
 
 The following Metricset is included in the module:
 
+[float]
 === `tablespaces`
 
 Includes information about data files and temp files, grouped by Tablespace with free space available, used space, status of the data files, status of the Tablespace, etc.


### PR DESCRIPTION
Cherry-pick of PR elastic/beats#12870 to 7.3 branch. 

(cherry picked from commit 3a1f494278027d28f70b581b987099943b9e29d3)