### PR TITLE
[6.8] Remove _nodes field from under cluster_stats as it's not being used (#11955)

### DIFF
--- a/metricbeat/module/elasticsearch/cluster_stats/data_xpack.go
+++ b/metricbeat/module/elasticsearch/cluster_stats/data_xpack.go
@@ -161,6 +161,7 @@ func eventMappingXPack(r mb.ReporterV2, m *MetricSet, info elasticsearch.Info, c
 	}
 
 	clusterStats := common.MapStr(data)
+	clusterStats.Delete("_nodes")
 
 	value, err := clusterStats.GetValue("cluster_name")
 	if err != nil {


### PR DESCRIPTION
Backports the following commits to 6.8:
 - Remove _nodes field from under cluster_stats as it's not being used  (#11955)