### PR TITLE
Add default region for initial aws api call

### DIFF
--- a/x-pack/metricbeat/module/aws/aws.go
+++ b/x-pack/metricbeat/module/aws/aws.go
@@ -58,6 +58,13 @@ func NewMetricSet(base mb.BaseMetricSet) (*MetricSet, error) {
 		return nil, err
 	}
 
+	var awsCred awscommon.ConfigAWS
+	err = base.Module().UnpackConfig(&awsCred)
+	if err != nil {
+		return nil, err
+	}
+
+	config.AWSConfig = awsCred
 	awsConfig, err := awscommon.GetAWSCredentials(config.AWSConfig)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get aws credentials")
@@ -71,6 +78,8 @@ func NewMetricSet(base mb.BaseMetricSet) (*MetricSet, error) {
 
 	// Construct MetricSet with a full regions list
 	if config.Regions == nil {
+		// set default region to make initial aws api call
+		awsConfig.Region = "us-west-1"
 		svcEC2 := ec2.New(awsConfig)
 		completeRegionsList, err := getRegions(svcEC2)
 		if err != nil {

--- a/x-pack/metricbeat/module/aws/aws.go
+++ b/x-pack/metricbeat/module/aws/aws.go
@@ -20,9 +20,9 @@ import (
 
 // Config defines all required and optional parameters for aws metricsets
 type Config struct {
-	Period    time.Duration `config:"period" validate:"nonzero,required"`
-	Regions   []string      `config:"regions"`
-	AWSConfig awscommon.ConfigAWS
+	Period    time.Duration       `config:"period" validate:"nonzero,required"`
+	Regions   []string            `config:"regions"`
+	AWSConfig awscommon.ConfigAWS `config:",inline"`
 }
 
 // MetricSet is the base metricset for all aws metricsets
@@ -58,13 +58,6 @@ func NewMetricSet(base mb.BaseMetricSet) (*MetricSet, error) {
 		return nil, err
 	}
 
-	var awsCred awscommon.ConfigAWS
-	err = base.Module().UnpackConfig(&awsCred)
-	if err != nil {
-		return nil, err
-	}
-
-	config.AWSConfig = awsCred
 	awsConfig, err := awscommon.GetAWSCredentials(config.AWSConfig)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get aws credentials")


### PR DESCRIPTION
With using `credential_profile_name` to read aws credentials from credential file, `default_region` is removed from the aws module config. This PR is to add a default value for region in aws config to make initial aws api call. This PR also fixed how the config is unpacked.