### PR TITLE
Skip flaky test test_clean_inactive on Darwin. See issue #8102

### DIFF
--- a/filebeat/tests/system/test_registrar.py
+++ b/filebeat/tests/system/test_registrar.py
@@ -773,7 +773,7 @@ class Test(BaseTest):
             assert self.get_registry_entry_by_path(os.path.abspath(testfile_path1))["offset"] == 9
             assert self.get_registry_entry_by_path(os.path.abspath(testfile_path2))["offset"] == 8
 
-    @unittest.skipIf(os.name == 'nt', 'flaky test https://github.com/elastic/beats/issues/8102')
+    @unittest.skipIf(os.name == 'nt' or platform.system() == "Darwin", 'flaky test https://github.com/elastic/beats/issues/8102')
     def test_clean_inactive(self):
         """
         Checks that states are properly removed after clean_inactive


### PR DESCRIPTION
The test still fails on macOS (was previously skipped on windows).
This PR skips the test on macOS

See 
https://travis-ci.org/elastic/beats/jobs/562466869

This was reported in issue #8102 previously, but test was only ignored on Windows