### PR TITLE
Cherry-pick #12790 to 7.3: Report host metadata for Kubernetes logs

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -232,8 +232,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add module for ingesting Cisco IOS logs over syslog. {pull}12748[12748]
 - Add module for ingesting Google Cloud VPC flow logs. {pull}12747[12747]
 - Report host metadata for Filebeat logs in Kubernetes. {pull}12790[12790]
-- Add netflow dashboards based on Logstash netflow. {pull}12857[12857]
-- Parse more fields from Elasticsearch slowlogs. {pull}11939[11939]
 
 *Heartbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -231,6 +231,9 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add `google-pubsub` input type for consuming messages from a Google Cloud Pub/Sub topic subscription. {pull}12746[12746]
 - Add module for ingesting Cisco IOS logs over syslog. {pull}12748[12748]
 - Add module for ingesting Google Cloud VPC flow logs. {pull}12747[12747]
+- Report host metadata for Filebeat logs in Kubernetes. {pull}12790[12790]
+- Add netflow dashboards based on Logstash netflow. {pull}12857[12857]
+- Parse more fields from Elasticsearch slowlogs. {pull}11939[11939]
 
 *Heartbeat*
 

--- a/deploy/kubernetes/filebeat-kubernetes.yaml
+++ b/deploy/kubernetes/filebeat-kubernetes.yaml
@@ -33,6 +33,7 @@ data:
 
     processors:
       - add_cloud_metadata:
+      - add_host_metadata:
 
     cloud.id: ${ELASTIC_CLOUD_ID}
     cloud.auth: ${ELASTIC_CLOUD_AUTH}
@@ -57,6 +58,8 @@ spec:
     spec:
       serviceAccountName: filebeat
       terminationGracePeriodSeconds: 30
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: filebeat
         image: docker.elastic.co/beats/filebeat:7.3.0

--- a/deploy/kubernetes/filebeat/filebeat-configmap.yaml
+++ b/deploy/kubernetes/filebeat/filebeat-configmap.yaml
@@ -33,6 +33,7 @@ data:
 
     processors:
       - add_cloud_metadata:
+      - add_host_metadata:
 
     cloud.id: ${ELASTIC_CLOUD_ID}
     cloud.auth: ${ELASTIC_CLOUD_AUTH}

--- a/deploy/kubernetes/filebeat/filebeat-daemonset.yaml
+++ b/deploy/kubernetes/filebeat/filebeat-daemonset.yaml
@@ -13,6 +13,8 @@ spec:
     spec:
       serviceAccountName: filebeat
       terminationGracePeriodSeconds: 30
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: filebeat
         image: docker.elastic.co/beats/filebeat:%VERSION%


### PR DESCRIPTION
Cherry-pick of PR #12790 to 7.3 branch. Original message: 

Filebeat was not reporting host metadata in the default Kubernetes manifest,
this change gives Filebeat access to the hostNetwork to retrieve
localhost metadata. `add_host_metadata` is added to gather it.

After this change `host` metadata should be present in logs, which will make it easier to correlate them with host metrics.