### PR TITLE
[DOCS] Add pointer to ILM docs from index setting

### DIFF
--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -218,7 +218,7 @@ for more information about the environment variables.
 ===== `index`
 
 ifndef::apm-server[]
-The index name to write events to. The default is
+The index name to write events to when you're using daily indices. The default is
 +"{beatname_lc}-%\{[{beat_version_key}]\}-%\{+yyyy.MM.dd\}"+ (for example,
 +"{beatname_lc}-{version}-{localdate}"+). If you change this setting, you also
 need to configure the `setup.template.name` and `setup.template.pattern` options
@@ -248,6 +248,12 @@ dashboards, you also need to set the `setup.dashboards.index` option (see
 endif::no_dashboards[]
 
 ifndef::apm-server[]
+ifndef::no_ilm[]
+The `index` setting is ignored when index lifecycle management is enabled. If
+you’re sending events to a cluster that supports index lifecycle management, see
+<<ilm>> to learn how to change the index name.
+endif::no_ilm[]
+
 You can set the index dynamically by using a format string to access any event
 field. For example, this configuration uses a custom field, `fields.log_type`,
 to set the index:


### PR DESCRIPTION
Points to ILM docs for users who want to change the default index name.

TBH, I thought I'd already added this pointer, but must have forgotten to push the commit. :-/

What should we say under `indices`? I feel like we've broken that functionality completely for ILM, which seems like a shame. 