### PR TITLE
Fix a race condition in the TCP input

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -27,6 +27,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 - Add read_buffer configuration option. {pull}11739[11739]
 - `convert_timezone` option is removed and locale is always added to the event so timezone is used when parsing the timestamp, this behaviour can be overriden with processors. {pull}12410[12410]
+- Fix a race condition in the TCP input when close the client socket. {pull}x[x]
 
 *Heartbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -27,7 +27,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 - Add read_buffer configuration option. {pull}11739[11739]
 - `convert_timezone` option is removed and locale is always added to the event so timezone is used when parsing the timestamp, this behaviour can be overriden with processors. {pull}12410[12410]
-- Fix a race condition in the TCP input when close the client socket. {pull}x[x]
+- Fix a race condition in the TCP input when close the client socket. {pull}13038[13038]
 
 *Heartbeat*
 

--- a/filebeat/inputsource/tcp/client.go
+++ b/filebeat/inputsource/tcp/client.go
@@ -41,8 +41,8 @@ type splitHandler struct {
 	timeout        time.Duration
 }
 
-// ClientFactory returns a ConnectionHandler func
-type ClientFactory func(config Config) ConnectionHandler
+// HandlerFactory returns a ConnectionHandler func
+type HandlerFactory func(config Config) ConnectionHandler
 
 // ConnectionHandler interface provides mechanisms for handling of incoming TCP connections
 type ConnectionHandler interface {
@@ -50,7 +50,7 @@ type ConnectionHandler interface {
 }
 
 // SplitHandlerFactory allows creation of a ConnectionHandler that can do splitting of messages received on a TCP connection.
-func SplitHandlerFactory(callback inputsource.NetworkFunc, splitFunc bufio.SplitFunc) ClientFactory {
+func SplitHandlerFactory(callback inputsource.NetworkFunc, splitFunc bufio.SplitFunc) HandlerFactory {
 	return func(config Config) ConnectionHandler {
 		return newSplitHandler(
 			callback,

--- a/filebeat/inputsource/tcp/closeref.go
+++ b/filebeat/inputsource/tcp/closeref.go
@@ -1,0 +1,113 @@
+package tcp
+
+import (
+	"sync"
+
+	"github.com/pkg/errors"
+)
+
+// CloserFunc is the function called by the Closer on `Close()`.
+type CloserFunc func()
+
+// ErrClosed is returned when the Closer is closed.
+var ErrClosed = errors.New("closer is closed")
+
+// CloseRef implements a subset of the context.Context interface and it's use to synchronize
+// the shutdown of multiple go-routines.
+type CloseRef interface {
+	Done() <-chan struct{}
+	Err() error
+}
+
+// Closer implements a shutdown strategy when dealing with multiples go-routines, it creates a tree
+// of Closer, when you call `Close()` on a parent the `Close()` method will be called on the current
+// closer and any of the childs it may have and will remove the current node from the parent.
+//
+// NOTE: The `Close()` is reentrant but will propage the close only once.
+type Closer struct {
+	mu       sync.Mutex
+	done     chan struct{}
+	err      error
+	parent   *Closer
+	children map[*Closer]struct{}
+	callback CloserFunc
+}
+
+// Close closes the closes and propagates the close to any child, on close the close callback will
+// be called, this can be used for custom cleanup like closing a TCP socket.
+func (c *Closer) Close() {
+	c.mu.Lock()
+	if c.err != nil {
+		c.mu.Unlock()
+		return
+	}
+
+	if c.callback != nil {
+		c.callback()
+	}
+
+	close(c.done)
+
+	// propagate close to children.
+	if c.children != nil {
+		for child := range c.children {
+			child.Close()
+		}
+		c.children = nil
+	}
+
+	c.err = ErrClosed
+	c.mu.Unlock()
+
+	if c.parent != nil {
+		c.removeChild(c)
+	}
+}
+
+// Done returns the synchronization channel, the channel will be closed if `Close()` was called on
+// the current node or any parent it may have.
+func (c *Closer) Done() <-chan struct{} {
+	return c.done
+}
+
+// Err returns an error if the Closer was already closed.
+func (c *Closer) Err() error {
+	c.mu.Lock()
+	err := c.err
+	c.mu.Unlock()
+	return err
+}
+
+func (c *Closer) removeChild(child *Closer) {
+	c.mu.Lock()
+	delete(c.children, child)
+	c.mu.Unlock()
+}
+
+func (c *Closer) addChild(child *Closer) {
+	c.mu.Lock()
+	if c.children == nil {
+		c.children = make(map[*Closer]struct{})
+	}
+	c.children[child] = struct{}{}
+	c.mu.Unlock()
+}
+
+// WithCloser wraps a new closer into a child of an existing closer.
+func WithCloser(parent *Closer, fn CloserFunc) *Closer {
+	child := &Closer{
+		done:     make(chan struct{}),
+		parent:   parent,
+		callback: fn,
+	}
+	parent.addChild(child)
+	return child
+}
+
+// NewCloser creates a new Closer.
+func NewCloser(fn CloserFunc) *Closer {
+	return &Closer{
+		done:     make(chan struct{}),
+		callback: fn,
+	}
+}

--- a/filebeat/inputsource/tcp/closeref.go
+++ b/filebeat/inputsource/tcp/closeref.go
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package tcp
 
 import (

--- a/filebeat/inputsource/tcp/handler.go
+++ b/filebeat/inputsource/tcp/handler.go
@@ -46,7 +46,7 @@ type HandlerFactory func(config Config) ConnectionHandler
 
 // ConnectionHandler interface provides mechanisms for handling of incoming TCP connections
 type ConnectionHandler interface {
-	Handle(closeRef, net.Conn) error
+	Handle(CloseRef, net.Conn) error
 }
 
 // SplitHandlerFactory allows creation of a ConnectionHandler that can do splitting of messages received on a TCP connection.
@@ -79,7 +79,7 @@ func newSplitHandler(
 }
 
 // Handle takes a connection as input and processes data received on it.
-func (c *splitHandler) Handle(closer closeRef, conn net.Conn) error {
+func (c *splitHandler) Handle(closer CloseRef, conn net.Conn) error {
 	c.metadata = inputsource.NetworkMetadata{
 		RemoteAddr: conn.RemoteAddr(),
 		TLS:        extractSSLInformation(conn),

--- a/filebeat/inputsource/tcp/server.go
+++ b/filebeat/inputsource/tcp/server.go
@@ -105,7 +105,7 @@ func (s *Server) run() {
 			}
 		}
 
-		client := s.factory(*s.config)
+		client := s.factory(*s.config, conn)
 
 		s.wg.Add(1)
 		go func() {
@@ -117,7 +117,7 @@ func (s *Server) run() {
 			defer s.unregisterClient(client)
 			s.log.Debugw("New client", "remote_address", conn.RemoteAddr(), "total", s.clientsCount())
 
-			err := client.Handle(conn)
+			err := client.Handle()
 			if err != nil {
 				s.log.Debugw("client error", "error", err)
 			}

--- a/filebeat/inputsource/tcp/server_test.go
+++ b/filebeat/inputsource/tcp/server_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/dustin/go-humanize"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/filebeat/inputsource"
 	"github.com/elastic/beats/libbeat/common"
@@ -180,7 +181,7 @@ func TestReceiveEventsAndMetadata(t *testing.T) {
 			defer server.Stop()
 
 			conn, err := net.Dial("tcp", server.Listener.Addr().String())
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			fmt.Fprint(conn, test.messageSent)
 			conn.Close()
 


### PR DESCRIPTION
Pass the `net.Conn` object when creating the client instead of passing it to the
`Handle()` method that keep a reference to it. By doing this we do not
have to worry about read or write race over the internal field. The
client still need a reference to the connection when the out of bound
call to `Close()` is executed to make sure we are getting out of a
`Read()` call early.

Tested with :

```
while true; do go test -v -race; done
```

Found in #13021