### PR TITLE
Cherry-pick #13016 to 7.3: [Heartbeat] Whitelist --index-management flag for heartbeat

### DIFF
--- a/heartbeat/cmd/root.go
+++ b/heartbeat/cmd/root.go
@@ -18,6 +18,7 @@
 package cmd
 
 import (
+	"fmt"
 	// register default heartbeat monitors
 	"github.com/elastic/beats/heartbeat/beater"
 	_ "github.com/elastic/beats/heartbeat/monitors/defaults"
@@ -49,6 +50,9 @@ func init() {
  * ILM Policy
 `
 	setup.ResetFlags()
+	setup.Flags().Bool(cmd.IndexManagementKey, false, "Setup all components related to Elasticsearch index management, including template, ilm policy and rollover alias")
+	setup.Flags().MarkDeprecated(cmd.TemplateKey, fmt.Sprintf("use --%s instead", cmd.IndexManagementKey))
+	setup.Flags().MarkDeprecated(cmd.ILMPolicyKey, fmt.Sprintf("use --%s instead", cmd.IndexManagementKey))
 	setup.Flags().Bool(cmd.TemplateKey, false, "Setup index template")
 	setup.Flags().Bool(cmd.ILMPolicyKey, false, "Setup ILM policy")
 }


### PR DESCRIPTION
Cherry-pick of PR #13016 to 7.3 branch. Original message: 

We received a bug report on [discuss](https://discuss.elastic.co/t/heartbeat-7-2-0-error-unknown-flag-index-management/191670) about this key being missing. It should have been added with https://github.com/elastic/beats/pull/11856 but was missed.

I haven't added tests here because this code is already very declarative. We mostly want to test the presence of this feature, not its implementation. While that has value here, the effort/benefit ratio here feels to me like something we can skip, which is what we did for @ruflin 's original PR.