### PR TITLE
Cherry-pick #12769 to 7.x: [Heartbeat] Remove default config dashboard refs

### DIFF
--- a/dev-tools/mage/config.go
+++ b/dev-tools/mage/config.go
@@ -115,6 +115,7 @@ func Config(types ConfigFileType, args ConfigFileParams, targetDir string) error
 		"ExcludeLogstash":      false,
 		"ExcludeRedis":         false,
 		"UseObserverProcessor": false,
+		"ExcludeDashboards":    false,
 	}
 	for k, v := range args.ExtraVars {
 		params[k] = v

--- a/heartbeat/heartbeat.yml
+++ b/heartbeat/heartbeat.yml
@@ -55,18 +55,6 @@ setup.template.settings:
 #  env: staging
 
 
-#============================== Dashboards =====================================
-# These settings control loading the sample dashboards to the Kibana index. Loading
-# the dashboards is disabled by default and can be enabled either by setting the
-# options here or by using the `setup` command.
-#setup.dashboards.enabled: false
-
-# The URL from where to download the dashboards archive. By default this URL
-# has a value which is computed based on the Beat name and version. For released
-# versions, this URL points to the dashboard archive on the artifacts.elastic.co
-# website.
-#setup.dashboards.url:
-
 #============================== Kibana =====================================
 
 # Starting with Beats version 6.0.0, the dashboards are loaded via the Kibana API.

--- a/heartbeat/scripts/mage/config.go
+++ b/heartbeat/scripts/mage/config.go
@@ -39,6 +39,7 @@ func ConfigFileParams() devtools.ConfigFileParams {
 		},
 		ExtraVars: map[string]interface{}{
 			"UseObserverProcessor": true,
+			"ExcludeDashboards":    true,
 		},
 	}
 }

--- a/libbeat/_meta/config.yml.tmpl
+++ b/libbeat/_meta/config.yml.tmpl
@@ -14,7 +14,7 @@
 #fields:
 #  env: staging
 
-
+{{if not .ExcludeDashboards }}
 #============================== Dashboards =====================================
 # These settings control loading the sample dashboards to the Kibana index. Loading
 # the dashboards is disabled by default and can be enabled either by setting the
@@ -26,7 +26,7 @@
 # versions, this URL points to the dashboard archive on the artifacts.elastic.co
 # website.
 #setup.dashboards.url:
-
+{{end}}
 #============================== Kibana =====================================
 
 # Starting with Beats version 6.0.0, the dashboards are loaded via the Kibana API.


### PR DESCRIPTION
Cherry-pick of PR #12769 to 7.x branch. Original message: 

Heartbeat hasn't supported the dashboard commands for a while.
This patch removes the config references.

Fixes https://github.com/elastic/beats/issues/11802