### PR TITLE
Fix data race in Winlogbeat eventlog factory

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -166,6 +166,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Winlogbeat*
 
+- Fix data race affecting config validation at startup. {issue}13005[13005]
+
 *Functionbeat*
 
 - Fix function name reference for Kinesis streams in CloudFormation templates {pull}11646[11646]

--- a/libbeat/common/stringset.go
+++ b/libbeat/common/stringset.go
@@ -17,6 +17,8 @@
 
 package common
 
+import "sort"
+
 type StringSet map[string]struct{}
 
 func MakeStringSet(strings ...string) StringSet {
@@ -63,4 +65,14 @@ func (set StringSet) Equals(anotherSet StringSet) bool {
 	}
 
 	return true
+}
+
+// ToSlice returns the items in the set as a sorted slice.
+func (set StringSet) ToSlice() []string {
+	keys := make([]string, 0, len(set))
+	for key := range set {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
 }

--- a/libbeat/common/stringset_test.go
+++ b/libbeat/common/stringset_test.go
@@ -68,3 +68,7 @@ func TestEquals(t *testing.T) {
 		})
 	}
 }
+
+func TestToSlice(t *testing.T) {
+	assert.Equal(t, []string{"a", "b", "c"}, MakeStringSet("c", "b", "a").ToSlice())
+}

--- a/winlogbeat/eventlog/eventlogging.go
+++ b/winlogbeat/eventlog/eventlogging.go
@@ -39,8 +39,8 @@ const (
 	eventLoggingAPIName = "eventlogging"
 )
 
-var eventLoggingConfigKeys = append(commonConfigKeys, "ignore_older",
-	"read_buffer_size", "format_buffer_size")
+var eventLoggingConfigKeys = common.MakeStringSet(append(commonConfigKeys,
+	"ignore_older", "read_buffer_size", "format_buffer_size")...)
 
 type eventLoggingConfig struct {
 	ConfigCommon     `config:",inline"`

--- a/winlogbeat/eventlog/factory.go
+++ b/winlogbeat/eventlog/factory.go
@@ -45,28 +45,19 @@ type validator interface {
 func readConfig(
 	c *common.Config,
 	config interface{},
-	validKeys []string,
+	validKeys common.StringSet,
 ) error {
 	if err := c.Unpack(config); err != nil {
 		return fmt.Errorf("failed unpacking config. %v", err)
-	}
-
-	isValidKey := func(key string) bool {
-		for _, validKey := range validKeys {
-			if key == validKey {
-				return true
-			}
-		}
-		return false
 	}
 
 	var errs multierror.Errors
 	if len(validKeys) > 0 {
 		// Check for invalid keys.
 		for _, k := range c.GetFields() {
-			if !isValidKey(k) {
+			if !validKeys.Has(k) {
 				errs = append(errs, fmt.Errorf("invalid event log key '%s' "+
-					"found. Valid keys are %s", k, strings.Join(validKeys, ", ")))
+					"found. Valid keys are %s", k, strings.Join(validKeys.ToSlice(), ", ")))
 			}
 		}
 	}

--- a/winlogbeat/eventlog/factory.go
+++ b/winlogbeat/eventlog/factory.go
@@ -48,19 +48,24 @@ func readConfig(
 	validKeys []string,
 ) error {
 	if err := c.Unpack(config); err != nil {
-		return fmt.Errorf("Failed unpacking config. %v", err)
+		return fmt.Errorf("failed unpacking config. %v", err)
+	}
+
+	isValidKey := func(key string) bool {
+		for _, validKey := range validKeys {
+			if key == validKey {
+				return true
+			}
+		}
+		return false
 	}
 
 	var errs multierror.Errors
 	if len(validKeys) > 0 {
-		sort.Strings(validKeys)
-
 		// Check for invalid keys.
 		for _, k := range c.GetFields() {
-			k = strings.ToLower(k)
-			i := sort.SearchStrings(validKeys, k)
-			if i >= len(validKeys) || validKeys[i] != k {
-				errs = append(errs, fmt.Errorf("Invalid event log key '%s' "+
+			if !isValidKey(k) {
+				errs = append(errs, fmt.Errorf("invalid event log key '%s' "+
 					"found. Valid keys are %s", k, strings.Join(validKeys, ", ")))
 			}
 		}

--- a/winlogbeat/eventlog/wineventlog.go
+++ b/winlogbeat/eventlog/wineventlog.go
@@ -47,9 +47,9 @@ const (
 	winEventLogAPIName = "wineventlog"
 )
 
-var winEventLogConfigKeys = append(commonConfigKeys, "batch_read_size",
-	"ignore_older", "include_xml", "event_id", "forwarded", "level", "provider",
-	"no_more_events")
+var winEventLogConfigKeys = common.MakeStringSet(append(commonConfigKeys,
+	"batch_read_size", "ignore_older", "include_xml", "event_id", "forwarded",
+	"level", "provider", "no_more_events")...)
 
 type winEventLogConfig struct {
 	ConfigCommon  `config:",inline"`

--- a/winlogbeat/tests/system/test_eventlogging.py
+++ b/winlogbeat/tests/system/test_eventlogging.py
@@ -172,7 +172,7 @@ class Test(WriteReadTest):
             ]
         )
         self.start_beat().check_wait(exit_code=1)
-        assert self.log_contains("4 errors: Invalid event log key")
+        assert self.log_contains("4 errors: invalid event log key")
 
     def test_utf16_characters(self):
         """

--- a/winlogbeat/tests/system/test_wineventlog.py
+++ b/winlogbeat/tests/system/test_wineventlog.py
@@ -325,7 +325,7 @@ class Test(WriteReadTest):
         )
         self.start_beat().check_wait(exit_code=1)
         assert self.log_contains(
-            "1 error: Invalid event log key 'invalid' found.")
+            "1 error: invalid event log key 'invalid' found.")
 
     def test_utf16_characters(self):
         """


### PR DESCRIPTION
The factory was sorting a global slice as part of its config validation. This removes the sorting and replaces it with a simpler (maybe less efficient) implementation.

Fixes #13005