### PR TITLE
[Filebeat] Postgres uses a too permissive multiline pattern

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -114,6 +114,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - When TLS is configured for the TCP input and a `certificate_authorities` is configured we now default to `required` for the `client_authentication`. {pull}12584[12584]
 - Apply `max_message_size` to incoming message buffer. {pull}11966[11966]
 - Syslog input will now omit the `process` object from events if it is empty. {pull}12700[12700]
+- Fix multiline pattern in Postgres which was too permissive {issue}12078[12078] {pull}13069[13069]
 
 *Heartbeat*
 

--- a/filebeat/module/postgresql/log/config/log.yml
+++ b/filebeat/module/postgresql/log/config/log.yml
@@ -5,6 +5,6 @@ paths:
 {{ end }}
 exclude_files: [".gz$"]
 multiline:
-  pattern: '^[-0-9]* '
+  pattern: '^\d{4}-\d{2}-\d{2} '
   negate: true
   match: after

--- a/filebeat/module/postgresql/log/test/postgresql-9.6-debian-with-slowlog.log
+++ b/filebeat/module/postgresql/log/test/postgresql-9.6-debian-with-slowlog.log
@@ -59,3 +59,6 @@
 2017-07-31 13:46:02.670 CEST [5502] postgres@c$lients LOG:  duration: 10.540 ms  statement: insert into cats(name, toy, born) values('kate', 'ball', now());
 2017-07-31 13:46:23.016 CEST [5502] postgres@_clients$db LOG:  duration: 5.156 ms  statement: insert into cats(name, toy, born) values('frida', 'horse', now());
 2017-07-31 13:46:55.637 CEST [5502] postgres@clients_db LOG:  duration: 25.871 ms  statement: create table dogs(name varchar(50) primary key, owner varchar (50) not null, born timestamp not null);
+2019-05-06 19:00:04.511 UTC [913763] elastic@opbeans LOG:  duration: 0.753 ms  statement: SELECT p.id, p.sku, p.name, p.stock, t.name AS type_name FROM products p LEFT JOIN product_types t ON p.type_id=t.id
+    FROM orders JOIN customers ON orders.customer_id=customers.id
+    FROM products JOIN product_types ON type_id=product_types.id

--- a/filebeat/module/postgresql/log/test/postgresql-9.6-debian-with-slowlog.log-expected.json
+++ b/filebeat/module/postgresql/log/test/postgresql-9.6-debian-with-slowlog.log-expected.json
@@ -315,5 +315,26 @@
         "process.pid": 5502,
         "service.type": "postgresql",
         "user.name": "postgres"
+    },
+    {
+        "@timestamp": "2019-05-06T19:00:04.511Z",
+        "event.dataset": "postgresql.log",
+        "event.duration": 753000,
+        "event.module": "postgresql",
+        "event.timezone": "UTC",
+        "fileset.name": "log",
+        "input.type": "log",
+        "log.flags": [
+            "multiline"
+        ],
+        "log.level": "LOG",
+        "log.offset": 4266,
+        "message": "2019-05-06 19:00:04.511 UTC [913763] elastic@opbeans LOG:  duration: 0.753 ms  statement: SELECT p.id, p.sku, p.name, p.stock, t.name AS type_name FROM products p LEFT JOIN product_types t ON p.type_id=t.id\n    FROM orders JOIN customers ON orders.customer_id=customers.id\n    FROM products JOIN product_types ON type_id=product_types.id",
+        "postgresql.log.database": "opbeans",
+        "postgresql.log.query": "SELECT p.id, p.sku, p.name, p.stock, t.name AS type_name FROM products p LEFT JOIN product_types t ON p.type_id=t.id\n    FROM orders JOIN customers ON orders.customer_id=customers.id\n    FROM products JOIN product_types ON type_id=product_types.id",
+        "postgresql.log.timestamp": "2019-05-06 19:00:04.511 UTC",
+        "process.pid": 913763,
+        "service.type": "postgresql",
+        "user.name": "elastic"
     }
 ]


### PR DESCRIPTION
See https://github.com/elastic/beats/issues/12078 for more info.

This PR adds the line mentioned in the issue above and one of the solutions.

After some experimenting, I thought it was better to be more explicit about the pattern and to capture next line only if they are dates, which is our only tested and known behavior. We can open this pattern to something more complex, generic once we found more examples.