### PR TITLE
Check if another resource exists when creating an alias

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -199,6 +199,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add aws overview dashboard. {issue}11007[11007] {pull}12175[12175]
 - Add `decompress_gzip_field` processor. {pull}12733[12733]
 - Add `timestamp` processor for parsing time fields. {pull}12699[12699]
+- Add a check so alias creation explicitely fails if there is an index with the same name. {pull}13070[13070]
 
 *Auditbeat*
 

--- a/libbeat/idxmgmt/ilm/client_handler.go
+++ b/libbeat/idxmgmt/ilm/client_handler.go
@@ -179,6 +179,14 @@ func (h *ESClientHandler) CreateAlias(alias Alias) error {
 	// Note: actual aliases are accessible via the index
 	status, res, err := h.client.Request("PUT", "/"+firstIndex, "", nil, body)
 	if status == 400 {
+		hasAlias, err := h.HasAlias(alias.Name)
+		if err != nil {
+			return err
+		}
+		if !hasAlias {
+			return errf(ErrInvalidAlias,
+				"resource '%v' exists, but it is not an alias", alias.Name)
+		}
 		return errOf(ErrAliasAlreadyExists)
 	} else if err != nil {
 		return wrapErrf(err, ErrAliasCreateFailed, "failed to create alias: %s", res)

--- a/libbeat/idxmgmt/ilm/client_handler.go
+++ b/libbeat/idxmgmt/ilm/client_handler.go
@@ -193,13 +193,11 @@ func (h *ESClientHandler) CreateAlias(alias Alias) error {
 	// Note: actual aliases are accessible via the index
 	status, res, err := h.client.Request("PUT", "/"+firstIndex, "", nil, body)
 	if status == 400 {
-		hasAlias, err := h.HasAlias(alias.Name)
+		// HasAlias fails if there is an index with the same name, that is
+		// what we want to check here.
+		_, err := h.HasAlias(alias.Name)
 		if err != nil {
 			return err
-		}
-		if !hasAlias {
-			return errf(ErrInvalidAlias,
-				"resource '%v' exists, but it is not an alias", alias.Name)
 		}
 		return errOf(ErrAliasAlreadyExists)
 	} else if err != nil {

--- a/libbeat/idxmgmt/ilm/client_handler_integration_test.go
+++ b/libbeat/idxmgmt/ilm/client_handler_integration_test.go
@@ -164,7 +164,7 @@ func TestESClientHandler_Alias(t *testing.T) {
 		h := newESClientHandler(t)
 
 		b, err := h.HasAlias(alias.Name)
-		assert.NoError(t, err)
+		assert.Equal(t, ilm.ErrInvalidAlias, ilm.ErrReason(err))
 		assert.False(t, b)
 
 		err = h.CreateAlias(alias)

--- a/libbeat/idxmgmt/ilm/client_handler_integration_test.go
+++ b/libbeat/idxmgmt/ilm/client_handler_integration_test.go
@@ -152,9 +152,33 @@ func TestESClientHandler_Alias(t *testing.T) {
 		assert.NoError(t, err)
 		assert.True(t, b)
 	})
+
+	t.Run("resource exists but is not an alias", func(t *testing.T) {
+		alias := makeAlias("esch-alias-3create")
+
+		es := newRawESClient(t)
+
+		_, _, err := es.Request("PUT", "/"+alias.Name, "", nil, nil)
+		require.NoError(t, err)
+
+		h := newESClientHandler(t)
+
+		b, err := h.HasAlias(alias.Name)
+		assert.NoError(t, err)
+		assert.False(t, b)
+
+		err = h.CreateAlias(alias)
+		require.Error(t, err)
+		assert.Equal(t, ilm.ErrInvalidAlias, ilm.ErrReason(err))
+	})
 }
 
 func newESClientHandler(t *testing.T) ilm.ClientHandler {
+	client := newRawESClient(t)
+	return ilm.NewESClientHandler(client)
+}
+
+func newRawESClient(t *testing.T) ilm.ESClient {
 	client, err := elasticsearch.NewClient(elasticsearch.ClientSettings{
 		URL:              getURL(),
 		Index:            outil.MakeSelector(),
@@ -171,7 +195,7 @@ func newESClientHandler(t *testing.T) ilm.ClientHandler {
 		t.Fatalf("Failed to connect to Test Elasticsearch instance: %v", err)
 	}
 
-	return ilm.NewESClientHandler(client)
+	return client
 }
 
 func makeName(base string) string {

--- a/libbeat/idxmgmt/ilm/error.go
+++ b/libbeat/idxmgmt/ilm/error.go
@@ -38,6 +38,7 @@ var (
 	ErrRequestFailed         = errors.New("request failed")
 	ErrAliasAlreadyExists    = errors.New("alias already exists")
 	ErrAliasCreateFailed     = errors.New("failed to create write alias")
+	ErrInvalidAlias          = errors.New("invalid alias")
 	ErrOpNotAvailable        = errors.New("operation not available")
 )
 


### PR DESCRIPTION
When creating an alias, if an index exists with the same name, alias is
not created assuming that it already exists. This can create some
confusion in some cases, as users can see that setup works, but indexes
and aliases are not correctly configured afterwards, leading to field
mapping issues and other kinds of problems.

This change makes beats explictly check if the resource that already
exists is actually an alias, if not, it returns a different failure that
can be seen by the user when running setup.