### PR TITLE
[7.3] [logstash/node_stats] Parity with internally-collected fields (#12989)

### DIFF
--- a/metricbeat/module/logstash/node_stats/data_xpack.go
+++ b/metricbeat/module/logstash/node_stats/data_xpack.go
@@ -35,10 +35,17 @@ type jvm struct {
 		HeapUsedInBytes int `json:"heap_used_in_bytes"`
 		HeapUsedPercent int `json:"heap_used_percent"`
 	} `json:"mem"`
+	UptimeInMillis int `json:"uptime_in_millis"`
+}
+
+type events struct {
+	In       int `json:"in"`
+	Filtered int `json:"filtered"`
+	Out      int `json:"out"`
 }
 
 type commonStats struct {
-	Events  map[string]interface{} `json:"events"`
+	Events  events                 `json:"events"`
 	JVM     jvm                    `json:"jvm"`
 	Reloads map[string]interface{} `json:"reloads"`
 	Queue   struct {
@@ -93,13 +100,6 @@ type reloads struct {
 	Failures  int `json:"failures"`
 }
 
-type events struct {
-	DurationInMillis int `json:"duration_in_millis"`
-	In               int `json:"in"`
-	Filtered         int `json:"filtered"`
-	Out              int `json:"out"`
-}
-
 // NodeStats represents the stats of a Logstash node
 type NodeStats struct {
 	nodeInfo
@@ -124,7 +124,7 @@ type PipelineStats struct {
 	ID          string                   `json:"id"`
 	Hash        string                   `json:"hash"`
 	EphemeralID string                   `json:"ephemeral_id"`
-	Events      events                   `json:"events"`
+	Events      map[string]interface{}   `json:"events"`
 	Reloads     reloads                  `json:"reloads"`
 	Queue       map[string]interface{}   `json:"queue"`
 	Vertices    []map[string]interface{} `json:"vertices"`


### PR DESCRIPTION
Backports the following commits to 7.3:
 - [logstash/node_stats] Parity with internally-collected fields  (#12989)