### PR TITLE
Remove CAP_AUDIT_READ from docker-compose.yml

### DIFF
--- a/auditbeat/docker-compose.yml
+++ b/auditbeat/docker-compose.yml
@@ -19,7 +19,6 @@ services:
     pid: host
     cap_add:
       - AUDIT_CONTROL
-      - AUDIT_READ
 
   # This is a proxy used to block beats until all services are healthy.
   # See: https://github.com/docker/compose/issues/4369

--- a/x-pack/auditbeat/docker-compose.yml
+++ b/x-pack/auditbeat/docker-compose.yml
@@ -10,4 +10,3 @@ services:
     pid: host
     cap_add:
       - AUDIT_CONTROL
-      - AUDIT_READ


### PR DESCRIPTION
Some CentOS 7 jenkins workers have started failing because of this capability
which does not exist in their kernel. But because we requet AUDIT_CONTROL it
will be fine to run without AUDIT_READ.

    Cannot create container for service beat: invalid CapAdd: unknown capability: "CAP_AUDIT_READ"

It looks like something changed in the last day w.r.t. to CI.

<img width="1150" alt="Screen Shot 2019-07-25 at 4 15 10 PM" src="https://user-images.githubusercontent.com/4565752/61905717-c2ced200-aef7-11e9-979f-1256c6806e06.png">
