### PR TITLE
Also collect logstash_stats.events.duration_in_millis

### DIFF
--- a/metricbeat/module/logstash/node_stats/data_xpack.go
+++ b/metricbeat/module/logstash/node_stats/data_xpack.go
@@ -39,9 +39,10 @@ type jvm struct {
 }
 
 type events struct {
-	In       int `json:"in"`
-	Filtered int `json:"filtered"`
-	Out      int `json:"out"`
+	DurationInMillis int `json:"duration_in_millis"`
+	In               int `json:"in"`
+	Filtered         int `json:"filtered"`
+	Out              int `json:"out"`
 }
 
 type commonStats struct {


### PR DESCRIPTION
This PR fixes the `logstash/node_stats` metricset (x-pack code path) to have parity with internal collection. Specifically, it teaches the metricset to collect the `logstash_stats.events.duration_in_millis` field.

### Testing this PR

1. Build Metricbeat with this PR.
   ```
   cd $GOPATH/src/github.com/elastic/beats/metricbeat
   mage build
   ```

2. Enable the Logstash module for Stack Monitoring.
   ```
   ./metricbeat modules enable logstash-xpack
   ```

3. Start Logstash.
   ```
   ./bin/logstash -e 'input { stdin {} }'

4. Start Metricbeat.
   ```
   ./metricbeat -e
   ```

5. Verify that the `.monitoring-logstash-*` index contains `type:logstash_stats` documents with the `logstash_stats.events.duration_in_millis` field.

   ```
   GET .monitoring-logstash-*/_search?q=type:logstash_stats&filter_path=hits.hits._source.logstash_stats&size=1
   ```