### PR TITLE
Add Gelfbeat

### DIFF
--- a/libbeat/docs/communitybeats.asciidoc
+++ b/libbeat/docs/communitybeats.asciidoc
@@ -49,6 +49,7 @@ https://github.com/cloudronics/fileoccurancebeat[fileoccurencebeat]:: Checks for
 https://github.com/FStelzer/flowbeat[flowbeat]:: Collects, parses, and indexes http://www.sflow.org/index.php[sflow] samples.
 https://github.com/GeneralElectric/GABeat[gabeat]:: Collects data from Google Analytics Realtime API.
 https://github.com/GoogleCloudPlatform/gcsbeat[gcsbeat]:: Reads data from https://cloud.google.com/storage/[Google Cloud Storage] buckets.
+https://github.com/threatstack/gelfbeat[gelfbeat]:: Collects and parses GELF-encoded UDP messages.
 https://github.com/josephlewis42/githubbeat[githubbeat]:: Easily monitors GitHub repository activity.
 https://github.com/hpcugent/gpfsbeat[gpfsbeat]:: Collects GPFS metric and quota information.
 https://github.com/ullaakut/hackerbeat[hackerbeat]:: Indexes the top stories of HackerNews into an ElasticSearch instance.


### PR DESCRIPTION
Hi! I recently open-sourced Gelfbeat, a libbeats plugin that takes in UDP-encoded GELF messages. Just wanted to add it to the list. Thanks!