### PR TITLE
[DOCS] Describe how to use Metricbeat to collect monitoring data

### DIFF
--- a/libbeat/docs/monitoring/monitoring-beats.asciidoc
+++ b/libbeat/docs/monitoring/monitoring-beats.asciidoc
@@ -10,10 +10,21 @@ You can use the {stack} {monitor-features} to gain insight into the health of
 
 To monitor {beatname_uc}, make sure monitoring is enabled on your {es} cluster,
 then configure the method used to collect {beatname_uc} metrics. You
+ifndef::serverless[]
 can use one of following methods:
+endif::[]
+ifdef::serverless[]
+can use the following method:
+endif::[]
+
+//REVIEWERS: Not sure what we should say for functionbeat users, but I don't
+//think it makes sense to include the metricbeat monitoring section in the
+//functionbeat docs. 
 
 * <<monitoring-internal-collection,Internal collection>>
+ifndef::serverless[]
 * <<monitoring-metricbeat-collection, {metricbeat}>>
+endif::[]
 
 To learn about monitoring in general, see 
 {stack-ov}/xpack-monitoring.html[Monitoring the {stack}]. 
@@ -22,4 +33,6 @@ To learn about monitoring in general, see
 
 include::monitoring-internal-collection.asciidoc[]
 
+ifndef::serverless[]
 include::monitoring-metricbeat.asciidoc[]
+endif::[]

--- a/libbeat/docs/monitoring/monitoring-beats.asciidoc
+++ b/libbeat/docs/monitoring/monitoring-beats.asciidoc
@@ -23,7 +23,7 @@ endif::[]
 
 * <<monitoring-internal-collection,Internal collection>>
 ifndef::serverless[]
-* <<monitoring-metricbeat-collection, {metricbeat}>>
+* <<monitoring-metricbeat-collection, {metricbeat} collection>>
 endif::[]
 
 To learn about monitoring in general, see 

--- a/libbeat/docs/monitoring/monitoring-beats.asciidoc
+++ b/libbeat/docs/monitoring/monitoring-beats.asciidoc
@@ -1,15 +1,3 @@
-//////////////////////////////////////////////////////////////////////////
-//// This content is shared by all Elastic Beats. Make sure you keep the
-//// descriptions here generic enough to work for all Beats that include
-//// this file. When using cross references, make sure that the cross
-//// references resolve correctly for any files that include this one.
-//// Use the appropriate variables defined in the index.asciidoc file to
-//// resolve Beat names: beatname_uc and beatname_lc.
-//// Use the following include to pull this content into a doc file:
-//// include::../../libbeat/docs/monitoring/configuring.asciidoc[]
-//// Make sure this content appears below a level 2 heading.
-//////////////////////////////////////////////////////////////////////////
-
 [role="xpack"]
 [[monitoring]]
 = Monitoring {beatname_uc}
@@ -17,58 +5,21 @@
 [partintro]
 --
 
-NOTE: The {monitor-features} for {beatname_uc} require {es} {beat_monitoring_version} or later.
+You can use the {stack} {monitor-features} to gain insight into the health of
+{beatname_uc} agents running in your environment. 
 
-The {stack} {monitor-features} enable you to easily monitor {beatname_uc} from {kib}. For more
-information, see
-{stack-ov}/xpack-monitoring.html[Monitoring the {stack}] and
-{kibana-ref}/beats-page.html[Beats Monitoring Metrics].
+To monitor {beatname_uc}, make sure monitoring is enabled on your {es} cluster,
+then configure the method used to collect {beatname_uc} metrics. You
+can use one of following methods:
 
-To configure {beatname_uc} to collect and send monitoring metrics:
+* <<monitoring-internal-collection,Internal collection>>
+* <<monitoring-metricbeat-collection, {metricbeat}>>
 
-. Create a user that has appropriate authority to send system-level monitoring
-data to {es}. For example, you can use the built-in +{beat_monitoring_user}+ user or
-assign the built-in +{beat_monitoring_user}+ role to another user. For more
-information, see
-{stack-ov}/setting-up-authentication.html[Setting Up User Authentication] and
-{stack-ov}/built-in-roles.html[Built-in Roles].
+To learn about monitoring in general, see 
+{stack-ov}/xpack-monitoring.html[Monitoring the {stack}]. 
 
-. Add the `monitoring` settings in the {beatname_uc} configuration file. If you
-configured the {es} output and want to send {beatname_uc} monitoring events to
-the same {es} cluster, specify the following minimal configuration:
-+
-["source","yml",subs="attributes"]
---------------------
-monitoring:
-  enabled: true
-  elasticsearch:
-    username: {beat_monitoring_user}
-    password: somepassword
---------------------
-+
-If you configured a different output, such as {ls} or you want to send {beatname_uc}
-monitoring events to a separate {es} cluster (referred to as the _monitoring cluster_),
-you must specify additional configuration options. For example:
-+
-["source","yml",subs="attributes"]
---------------------
-monitoring:
-  enabled: true
-  elasticsearch:
-    hosts: ["https://example.com:9200", "https://example2.com:9200"] <1>
-    username: {beat_monitoring_user}
-    password: somepassword
---------------------
-<1> This setting identifies the hosts and port numbers of {es} nodes
-that are part of the monitoring cluster.
-
-. {kibana-ref}/monitoring-xpack-kibana.html[Configure monitoring in {kib}].
-
-. To verify your monitoring configuration, point your web browser at your {kib}
-host, and select Monitoring from the side navigation. Metrics reported from
-{beatname_uc} should be visible in the Beats section. When {security} is enabled,
-to view the monitoring dashboards you must log in to {kib} as a user who has the
-`kibana_user` and `monitoring_user` roles.
 --
 
-include::shared-monitor-config.asciidoc[]
+include::monitoring-internal-collection.asciidoc[]
+
+include::monitoring-metricbeat.asciidoc[]

--- a/libbeat/docs/monitoring/monitoring-beats.asciidoc
+++ b/libbeat/docs/monitoring/monitoring-beats.asciidoc
@@ -17,10 +17,6 @@ ifdef::serverless[]
 can use the following method:
 endif::[]
 
-//REVIEWERS: Not sure what we should say for functionbeat users, but I don't
-//think it makes sense to include the metricbeat monitoring section in the
-//functionbeat docs. 
-
 * <<monitoring-internal-collection,Internal collection>>
 ifndef::serverless[]
 * <<monitoring-metricbeat-collection, {metricbeat} collection>>

--- a/libbeat/docs/monitoring/monitoring-internal-collection.asciidoc
+++ b/libbeat/docs/monitoring/monitoring-internal-collection.asciidoc
@@ -1,0 +1,68 @@
+//////////////////////////////////////////////////////////////////////////
+//// This content is shared by all Elastic Beats. Make sure you keep the
+//// descriptions here generic enough to work for all Beats that include
+//// this file. When using cross references, make sure that the cross
+//// references resolve correctly for any files that include this one.
+//// Use the appropriate variables defined in the index.asciidoc file to
+//// resolve Beat names: beatname_uc and beatname_lc.
+//// Use the following include to pull this content into a doc file:
+//// include::../../libbeat/docs/monitoring/monitoring-internal-collection.asciidoc[]
+//////////////////////////////////////////////////////////////////////////
+
+[role="xpack"]
+[[monitoring-internal-collection]]
+== Collect {beatname_uc} monitoring data with internal collectors
+++++
+<titleabbrev>Use internal collection</titleabbrev>
+++++
+
+The following method involves sending the metrics to the production cluster, 
+which ultimately routes them to the monitoring cluster. For an alternative 
+method, see <<monitoring-metricbeat-collection>>. 
+
+To learn about monitoring in general, see 
+{stack-ov}/xpack-monitoring.html[Monitoring the {stack}]. 
+
+//TODO: Not sure if these docs need to be updated to be parallel with other
+//stack components since this is the old way of configuring monitoring. 
+
+. Create a user that has appropriate authority to send system-level monitoring
+data to {es}. For example, you can use the built-in +{beat_monitoring_user}+ user or
+assign the built-in +{beat_monitoring_user}+ role to another user. For more
+information, see
+{stack-ov}/setting-up-authentication.html[Setting Up User Authentication] and
+{stack-ov}/built-in-roles.html[Built-in Roles].
+
+. Add the `monitoring` settings in the {beatname_uc} configuration file. If you
+configured the {es} output and want to send {beatname_uc} monitoring events to
+the same {es} cluster, specify the following minimal configuration:
++
+["source","yml",subs="attributes"]
+--------------------
+monitoring:
+  enabled: true
+  elasticsearch:
+    username: {beat_monitoring_user}
+    password: somepassword
+--------------------
++
+If you configured a different output, such as {ls} or you want to send {beatname_uc}
+monitoring events to a separate {es} cluster (referred to as the _monitoring cluster_),
+you must specify additional configuration options. For example:
++
+["source","yml",subs="attributes"]
+--------------------
+monitoring:
+  enabled: true
+  elasticsearch:
+    hosts: ["https://example.com:9200", "https://example2.com:9200"] <1>
+    username: {beat_monitoring_user}
+    password: somepassword
+--------------------
+<1> This setting identifies the hosts and port numbers of {es} nodes
+that are part of the monitoring cluster.
+
+. {kibana-ref}/monitoring-data.html[View the monitoring data in {kib}]. 
+
+
+include::shared-monitor-config.asciidoc[]

--- a/libbeat/docs/monitoring/monitoring-internal-collection.asciidoc
+++ b/libbeat/docs/monitoring/monitoring-internal-collection.asciidoc
@@ -64,6 +64,14 @@ monitoring:
 <1> This setting identifies the hosts and port numbers of {es} nodes
 that are part of the monitoring cluster.
 
+ifndef::serverless[]
+. <<{beatname_lc}-starting,Start {beatname_uc}>>.
+endif::serverless[]
+
+ifdef::serverless[]
+. <<{beatname_lc}-deploying,Deploy {beatname_uc}>>.
+endif::serverless[]
+
 . {kibana-ref}/monitoring-data.html[View the monitoring data in {kib}]. 
 
 

--- a/libbeat/docs/monitoring/monitoring-internal-collection.asciidoc
+++ b/libbeat/docs/monitoring/monitoring-internal-collection.asciidoc
@@ -13,7 +13,7 @@
 [[monitoring-internal-collection]]
 == Collect {beatname_uc} monitoring data with internal collectors
 ++++
-<titleabbrev>Use internal collection</titleabbrev>
+<titleabbrev>Internal collection</titleabbrev>
 ++++
 
 The following method involves sending the metrics to the production cluster, 

--- a/libbeat/docs/monitoring/monitoring-internal-collection.asciidoc
+++ b/libbeat/docs/monitoring/monitoring-internal-collection.asciidoc
@@ -17,8 +17,10 @@
 ++++
 
 The following method involves sending the metrics to the production cluster, 
-which ultimately routes them to the monitoring cluster. For an alternative 
-method, see <<monitoring-metricbeat-collection>>. 
+which ultimately routes them to the monitoring cluster.
+ifndef::serverless[]
+For an alternative method, see <<monitoring-metricbeat-collection>>.
+endif::[]
 
 To learn about monitoring in general, see 
 {stack-ov}/xpack-monitoring.html[Monitoring the {stack}]. 

--- a/libbeat/docs/monitoring/monitoring-metricbeat.asciidoc
+++ b/libbeat/docs/monitoring/monitoring-metricbeat.asciidoc
@@ -3,7 +3,7 @@
 == Collect {beatname_uc} monitoring data with {metricbeat}
 [subs="attributes"]
 ++++
-<titleabbrev>Use {metricbeat}</titleabbrev>
+<titleabbrev>{metricbeat} collection</titleabbrev>
 ++++
 
 In 7.3 and later, you can use {metricbeat} to collect data about {beatname_uc} 
@@ -11,35 +11,20 @@ and ship it to the monitoring cluster, rather than routing it through the
 production cluster as described in <<monitoring-internal-collection>>.
 
 ifeval::["{beatname_lc}"=="metricbeat"]
-Because you'll be using {metricbeat} itself to monitor {beatname_uc}, you'll
-need to decide whether you want to run more than one instance of {metricbeat} or
-have {beatname_uc} monitor itself. You have a couple options:
-
-* Run two instances of {beatname_uc}: a main instance that collects metrics
-from the system and services running on the server, and a second instance that
+Because you'll be using {metricbeat} to _monitor_ {beatname_uc}, you'll need to
+run two instances of {beatname_uc}: a main instance that collects metrics from
+the system and services running on the server, and a second instance that
 collects metrics from {beatname_uc} only. Using a separate instance as a
 monitoring agent allows you to send monitoring data to a dedicated monitoring
 cluster. If the main agent goes down, the monitoring agent remains active.
-+
+
 If you're running {beatname_uc} as a service, this approach requires extra work
 because you need to run two instances of the same installed  service
-concurrently.
-
-* Configure your existing {beatname_uc} installation to collect monitoring data
-about itself. With this approach, you won't be able to send monitoring data to a
-dedicated monitoring cluster because you must send it to the production cluster
-specified in the {es} output configuration. If the {beatname_uc} instance
-goes down, the flow of monitoring data stops.
-
-//REVIEWERS: The second option (having Metricbeat monitor itself) does not
-//work, but I'm wondering if it's related to an existing bug with the UUID.
-//The .monitoring index does contain data; it just doesn't appear under stack
-//monitoring.
-
-If neither approach appeals to you, use
+concurrently. If you don't want to run two instances concurrently, use
 <<monitoring-internal-collection,internal collection>> instead of using
 {metricbeat}.
 endif::[]
+
 To learn about monitoring in general, see 
 {stack-ov}/xpack-monitoring.html[Monitoring the {stack}].
 
@@ -120,11 +105,9 @@ separate monitoring instance,
 different path. If necessary, set `path.config`, `path.data`, and `path.log`
 to point to the correct directories. See <<directory-layout>> for the default
 locations.
-* If you're using {metricbeat} to monitor itself, stop {metricbeat} and apply
-the following steps to your existing installation.
 endif::[]
 
-. Enable the beat-xpack module in {metricbeat}. +
+. Enable the `beat-xpack` module in {metricbeat}. +
 endif::[]
 +
 --
@@ -143,7 +126,7 @@ For more information, see
 // end::enable-beat-module[]
 --
 
-. Configure the beat-xpack module in {metricbeat}. +
+. Configure the `beat-xpack` module in {metricbeat}. +
 +
 --
 // tag::configure-beat-module[]
@@ -161,6 +144,10 @@ The `modules.d/beat-xpack.yml` file contains the following settings:
   #password: "secret"
   xpack.enabled: true
 ----------------------------------
+ 
+Set the `hosts`, `username`, and `password` settings as required by your
+environment. For other module settings, it's recommended that you accept the
+defaults.
 
 By default, the module collects {beatname_uc} monitoring data from
 `localhost:5066`. If you exposed the metrics on a different host or port when
@@ -196,9 +183,9 @@ file.
 --
 // tag::disable-system-module[]
 By default, the {metricbeat-ref}/metricbeat-module-system.html[system module] is
-enabled. The information it collects, however, is not shown on the *Monitoring*
-page in {kib}. Unless you want to use that information for other purposes, run
-the following command:
+enabled. The information it collects, however, is not shown on the
+*Stack Monitoring* page in {kib}. Unless you want to use that information for
+*other purposes, run the following command:
 
 ["source","sh",subs="attributes,callouts"]
 ----------------------------------------------------------------------
@@ -247,13 +234,11 @@ successfully:
 .. Create a user on the monitoring cluster that has the 
 `remote_monitoring_agent` {stack-ov}/built-in-roles.html[built-in role]. 
 Alternatively, use the `remote_monitoring_user` 
-{stack-ov}/built-in-users.html[built-in user].
-
-//REVIEWERS: the `remote_monitoring_agent` role does not have the privileges
-// required to create metricbeat indices if ILM is enabled. Should we tell users
-// to disable ILM when Metricbeat is used to collect Beats metrics? (edited) 
-// Or do we need to ask to have the ILM-related privileges added to the
-// `remote_monitoring_agent` role?
+{stack-ov}/built-in-users.html[built-in user]. 
++
+TIP: If you're using index lifecycle management, the remote monitoring user
+requires additional privileges to create and read indices. For more
+information, see <<feature-roles>>.
 
 .. Add the `username` and `password` settings to the {es} output information in 
 the {metricbeat} configuration file.

--- a/libbeat/docs/monitoring/monitoring-metricbeat.asciidoc
+++ b/libbeat/docs/monitoring/monitoring-metricbeat.asciidoc
@@ -90,7 +90,9 @@ For more information, see
 <<configuration-monitor,Monitoring configuration options>>.
 --
 
+ifndef::serverless[]
 . <<{beatname_lc}-starting,Start {beatname_uc}>>.
+endif::serverless[]
 
 [float]
 [[configure-metricbeat]]

--- a/libbeat/docs/monitoring/monitoring-metricbeat.asciidoc
+++ b/libbeat/docs/monitoring/monitoring-metricbeat.asciidoc
@@ -184,7 +184,7 @@ file.
 By default, the {metricbeat-ref}/metricbeat-module-system.html[system module] is
 enabled. The information it collects, however, is not shown on the
 *Stack Monitoring* page in {kib}. Unless you want to use that information for
-*other purposes, run the following command:
+other purposes, run the following command:
 
 ["source","sh",subs="attributes,callouts"]
 ----------------------------------------------------------------------

--- a/libbeat/docs/monitoring/monitoring-metricbeat.asciidoc
+++ b/libbeat/docs/monitoring/monitoring-metricbeat.asciidoc
@@ -31,6 +31,11 @@ dedicated monitoring cluster because you must send it to the production cluster
 specified in the {es} output configuration. If the {beatname_uc} instance
 goes down, the flow of monitoring data stops.
 
+//REVIEWERS: The second option (having Metricbeat monitor itself) does not
+//work, but I'm wondering if it's related to an existing bug with the UUID.
+//The .monitoring index does contain data; it just doesn't appear under stack
+//monitoring.
+
 If neither approach appeals to you, use
 <<monitoring-internal-collection,internal collection>> instead of using
 {metricbeat}.
@@ -115,8 +120,8 @@ separate monitoring instance,
 different path. If necessary, set `path.config`, `path.data`, and `path.log`
 to point to the correct directories. See <<directory-layout>> for the default
 locations.
-* If you're using {metricbeat} to monitor itself, apply these steps to your
-existing installation.
+* If you're using {metricbeat} to monitor itself, stop {metricbeat} and apply
+the following steps to your existing installation.
 endif::[]
 
 . Enable the beat-xpack module in {metricbeat}. +

--- a/libbeat/docs/monitoring/monitoring-metricbeat.asciidoc
+++ b/libbeat/docs/monitoring/monitoring-metricbeat.asciidoc
@@ -159,7 +159,6 @@ To monitor multiple {beats} agents, specify a list of hosts, for example:
 hosts: ["http://localhost:5066","http://localhost:5067","http://localhost:5068"]
 ----------------------------------
 
-//REVIEWERS: Didn't test the following. Is this true? 
 If you configured {beatname_uc} to use encrypted communications, you must access
 it via HTTPS. For example, use a `hosts` setting like `https://localhost:5066`.
 // end::configure-beat-module[]

--- a/libbeat/docs/monitoring/monitoring-metricbeat.asciidoc
+++ b/libbeat/docs/monitoring/monitoring-metricbeat.asciidoc
@@ -1,0 +1,261 @@
+[role="xpack"]
+[[monitoring-metricbeat-collection]]
+== Collect {beatname_uc} monitoring data with {metricbeat}
+[subs="attributes"]
+++++
+<titleabbrev>Use {metricbeat}</titleabbrev>
+++++
+
+In 7.3 and later, you can use {metricbeat} to collect data about {beatname_uc} 
+and ship it to the monitoring cluster, rather than routing it through the 
+production cluster as described in <<monitoring-internal-collection>>.
+
+ifeval::["{beatname_lc}"=="metricbeat"]
+Because you'll be using {metricbeat} itself to monitor {beatname_uc}, you'll
+need to decide whether you want to run more than one instance of {metricbeat} or
+have {beatname_uc} monitor itself. You have a couple options:
+
+* Run two instances of {beatname_uc}: a main instance that collects metrics
+from the system and services running on the server, and a second instance that
+collects metrics from {beatname_uc} only. Using a separate instance as a
+monitoring agent allows you to send monitoring data to a dedicated monitoring
+cluster. If the main agent goes down, the monitoring agent remains active.
++
+If you're running {beatname_uc} as a service, this approach requires extra work
+because you need to run two instances of the same installed  service
+concurrently.
+
+* Configure your existing {beatname_uc} installation to collect monitoring data
+about itself. With this approach, you won't be able to send monitoring data to a
+dedicated monitoring cluster because you must send it to the production cluster
+specified in the {es} output configuration. If the {beatname_uc} instance
+goes down, the flow of monitoring data stops.
+
+If neither approach appeals to you, use
+<<monitoring-internal-collection,internal collection>> instead of using
+{metricbeat}.
+endif::[]
+To learn about monitoring in general, see 
+{stack-ov}/xpack-monitoring.html[Monitoring the {stack}].
+
+//NOTE: The tagged regions are re-used in the Stack Overview.
+
+To collect and ship monitoring data:
+
+. <<configure-shipper,Configure the shipper you want to monitor>>
+
+. <<configure-metricbeat,Install and configure {metricbeat} to collect monitoring data>>
+
+[float]
+[[configure-shipper]]
+=== Configure the shipper you want to monitor
+
+. Enable the HTTP endpoint to allow external collection of monitoring data:
++
+--
+// tag::enable-http-endpoint[]
+Add the following setting in the {beatname_uc} configuration file
+(+{beatname_lc}.yml+):
+
+[source,yaml]
+----------------------------------
+http.enabled: true
+----------------------------------
+
+By default, metrics are exposed on port 5066. If you need to monitor multiple
+{beats} shippers running on the same server, set `http.port` to expose metrics
+for each shipper on a different port number:
+
+[source,yaml]
+----------------------------------
+http.port: 5067
+----------------------------------
+// end::enable-http-endpoint[]
+--
+
+. Disable the default collection of {beatname_uc} monitoring metrics. +
++
+--
+// tag::disable-beat-collection[]
+Add the following setting in the {beatname_uc} configuration file
+(+{beatname_lc}.yml+): 
+
+[source,yaml]
+----------------------------------
+monitoring.enabled: false
+----------------------------------
+// end::disable-beat-collection[]
+
+For more information, see 
+<<configuration-monitor,Monitoring configuration options>>.
+--
+
+. <<{beatname_lc}-starting,Start {beatname_uc}>>.
+
+[float]
+[[configure-metricbeat]]
+=== Install and configure {metricbeat} to collect monitoring data
+
+ifeval::["{beatname_lc}"!="metricbeat"]
+. {metricbeat-ref}/metricbeat-installation.html[Install {metricbeat}] on the
+same server as {beatname_uc}. If you already have {metricbeat} installed on the
+server, skip this step.
+endif::[]
+ifeval::["{beatname_lc}"=="metricbeat"]
+. The next step depends on how you want to run {metricbeat}:
+* If you're running as a service and want to run a separate monitoring instance,
+take the the steps required for your environment to run two instances of
+{metricbeat} as a service. The steps for doing this vary by platform and are
+beyond the scope of this documentation.
+* If you're running the binary directly in the foreground and want to run a
+separate monitoring instance,
+{metricbeat-ref}/metricbeat-installation.html[install {metricbeat}] to a
+different path. If necessary, set `path.config`, `path.data`, and `path.log`
+to point to the correct directories. See <<directory-layout>> for the default
+locations.
+* If you're using {metricbeat} to monitor itself, apply these steps to your
+existing installation.
+endif::[]
+
+. Enable the beat-xpack module in {metricbeat}. +
+endif::[]
++
+--
+// tag::enable-beat-module[]
+For example, to enable the default configuration in the `modules.d` directory, 
+run the following command, using the correct command syntax for your OS:
+
+["source","sh",subs="attributes,callouts"]
+----------------------------------------------------------------------
+metricbeat modules enable beat-xpack
+----------------------------------------------------------------------
+
+For more information, see 
+{metricbeat-ref}/configuration-metricbeat.html[Specify which modules to run] and 
+{metricbeat-ref}/metricbeat-module-beat.html[beat module]. 
+// end::enable-beat-module[]
+--
+
+. Configure the beat-xpack module in {metricbeat}. +
++
+--
+// tag::configure-beat-module[]
+The `modules.d/beat-xpack.yml` file contains the following settings:
+
+[source,yaml]
+----------------------------------
+- module: beat
+  metricsets:
+    - stats
+    - state
+  period: 10s
+  hosts: ["http://localhost:5066"]
+  #username: "user"
+  #password: "secret"
+  xpack.enabled: true
+----------------------------------
+
+By default, the module collects {beatname_uc} monitoring data from
+`localhost:5066`. If you exposed the metrics on a different host or port when
+you enabled the HTTP endpoint, update the `hosts` setting.
+
+To monitor multiple {beats} agents, specify a list of hosts, for example:
+[source,yaml]
+----------------------------------
+hosts: ["http://localhost:5066","http://localhost:5067","http://localhost:5068"]
+----------------------------------
+
+//REVIEWERS: Didn't test the following. Is this true? 
+If you configured {beatname_uc} to use encrypted communications, you must access
+it via HTTPS. For example, use a `hosts` setting like `https://localhost:5066`.
+// end::configure-beat-module[]
+
+// tag::remote-monitoring-user[]
+If the Elastic {security-features} are enabled, you must also provide a user 
+ID and password so that {metricbeat} can collect metrics successfully: 
+
+.. Create a user on the production cluster that has the 
+`remote_monitoring_collector` {stack-ov}/built-in-roles.html[built-in role]. 
+Alternatively, use the `remote_monitoring_user` 
+{stack-ov}/built-in-users.html[built-in user].
+
+.. Add the `username` and `password` settings to the beat module configuration 
+file.
+// end::remote-monitoring-user[]
+--
+
+. Optional: Disable the system module in the {metricbeat}.
++
+--
+// tag::disable-system-module[]
+By default, the {metricbeat-ref}/metricbeat-module-system.html[system module] is
+enabled. The information it collects, however, is not shown on the *Monitoring*
+page in {kib}. Unless you want to use that information for other purposes, run
+the following command:
+
+["source","sh",subs="attributes,callouts"]
+----------------------------------------------------------------------
+metricbeat modules disable system
+----------------------------------------------------------------------
+// end::disable-system-module[] 
+--
+
+. Identify where to send the monitoring data. +
++
+--
+TIP: In production environments, we strongly recommend using a separate cluster 
+(referred to as the _monitoring cluster_) to store the data. Using a separate 
+monitoring cluster prevents production cluster outages from impacting your 
+ability to access your monitoring data. It also prevents monitoring activities 
+from impacting the performance of your production cluster.
+
+For example, specify the {es} output information in the {metricbeat} 
+configuration file (`metricbeat.yml`):
+
+[source,yaml]
+----------------------------------
+output.elasticsearch:
+  # Array of hosts to connect to.
+  hosts: ["http://es-mon-1:9200", "http://es-mon2:9200"] <1>
+  
+  # Optional protocol and basic auth credentials.
+  #protocol: "https"
+  #username: "elastic"
+  #password: "changeme"
+----------------------------------
+<1> In this example, the data is stored on a monitoring cluster with nodes 
+`es-mon-1` and `es-mon-2`.
+
+If you configured the monitoring cluster to use encrypted communications, you
+must access it via HTTPS. For example, use a `hosts` setting like
+`https://es-mon-1:9200`.
+
+IMPORTANT: The {es} {monitor-features} use ingest pipelines, therefore the
+cluster that stores the monitoring data must have at least one ingest node.
+
+If the {es} {security-features} are enabled on the monitoring cluster, you 
+must provide a valid user ID and password so that {metricbeat} can send metrics 
+successfully: 
+
+.. Create a user on the monitoring cluster that has the 
+`remote_monitoring_agent` {stack-ov}/built-in-roles.html[built-in role]. 
+Alternatively, use the `remote_monitoring_user` 
+{stack-ov}/built-in-users.html[built-in user].
+
+//REVIEWERS: the `remote_monitoring_agent` role does not have the privileges
+// required to create metricbeat indices if ILM is enabled. Should we tell users
+// to disable ILM when Metricbeat is used to collect Beats metrics? (edited) 
+// Or do we need to ask to have the ILM-related privileges added to the
+// `remote_monitoring_agent` role?
+
+.. Add the `username` and `password` settings to the {es} output information in 
+the {metricbeat} configuration file.
+
+For more information about these configuration options, see 
+{metricbeat-ref}/elasticsearch-output.html[Configure the {es} output].
+--
+
+. {metricbeat-ref}/metricbeat-starting.html[Start {metricbeat}] to begin
+collecting monitoring data. 
+
+. {kibana-ref}/monitoring-data.html[View the monitoring data in {kib}]. 

--- a/libbeat/docs/monitoring/shared-monitor-config.asciidoc
+++ b/libbeat/docs/monitoring/shared-monitor-config.asciidoc
@@ -10,36 +10,33 @@
 //// Make sure this content appears below a level 2 heading.
 //////////////////////////////////////////////////////////////////////////
 
+[role="xpack"]
 [[configuration-monitor]]
-== Monitoring configuration options
-++++
-<titleabbrev>Configuration options</titleabbrev>
-++++
+=== Settings for internal monitoring collection
 
-You can specify the following options in the `xpack.monitoring` section of the
+Use the following settings to configure internal collection when you are not
+using {metricbeat} to collect monitoring data.
+
+You specify these settings in the `monitoring` section of the
 +{beatname_lc}.yml+ config file:
 
-[float]
-=== `enabled`
+==== `enabled`
 
 The `enabled` config is a boolean setting to enable or disable {monitoring}.
 If set to `true`, monitoring is enabled.
 
 The default value is `false`.
 
-[float]
-=== `elasticsearch`
+==== `elasticsearch`
 
 The {es} instances that you want to ship your {beatname_uc} metrics to. This
 configuration option contains the following fields:
 
-[float]
 ==== `bulk_max_size`
 
 The maximum number of metrics to bulk in a single {es} bulk API index request.
 The default is `50`. For more information, see <<elasticsearch-output>>.
 
-[float]
 ==== `backoff.init`
 
 The number of seconds to wait before trying to reconnect to Elasticsearch after
@@ -48,13 +45,11 @@ reconnect. If the attempt fails, the backoff timer is increased exponentially up
 to `backoff.max`. After a successful connection, the backoff timer is reset. The
 default is 1s.
 
-[float]
-===== `backoff.max`
+==== `backoff.max`
 
 The maximum number of seconds to wait before attempting to connect to
 Elasticsearch after a network error. The default is 60s.
 
-[float]
 ==== `compression_level`
 
 The gzip compression level. Setting this value to `0` disables compression. The
@@ -62,70 +57,59 @@ compression level must be in the range of `1` (best speed) to `9` (best
 compression). The default value is `0`. Increasing the compression level
 reduces the network usage but increases the CPU usage.
 
-[float]
 ==== `headers`
 
 Custom HTTP headers to add to each request. For more information, see
 <<elasticsearch-output>>.
 
-[float]
 ==== `hosts`
 
 The list of {es} nodes to connect to. Monitoring metrics are distributed to
 these nodes in round robin order. For more information, see
 <<elasticsearch-output>>.
 
-[float]
 ==== `max_retries`
 
 The number of times to retry sending the monitoring metrics after a failure.
 After the specified number of retries, the metrics are typically dropped. The
 default value is `3`. For more information, see <<elasticsearch-output>>.
 
-[float]
 ==== `parameters`
 
 Dictionary of HTTP parameters to pass within the url with index operations.
 
-[float]
 ==== `password`
 
 The password that {beatname_uc} uses to authenticate with the {es} instances for
 shipping monitoring data.
 
-[float]
 ==== `metrics.period`
 
 The time interval (in seconds) when metrics are sent to the {es} cluster. A new
 snapshot of {beatname_uc} metrics is generated and scheduled for publishing each
 period. The default value is 10 * time.Second.
 
-[float]
 ==== `state.period`
 
 The time interval (in seconds) when state information are sent to the {es} cluster. A new
 snapshot of {beatname_uc} state is generated and scheduled for publishing each
 period. The default value is 60 * time.Second.
 
-[float]
 ==== `protocol`
 
 The name of the protocol to use when connecting to the {es} cluster. The options
 are: `http` or `https`. The default is `http`. If you specify a URL for `hosts`,
 however, the value of protocol is overridden by the scheme you specify in the URL.
 
-[float]
 ==== `proxy_url`
 
 The URL of the proxy to use when connecting to the {es} cluster. For more
 information, see <<elasticsearch-output>>.
 
-[float]
 ==== `timeout`
 
 The HTTP request timeout in seconds for the {es} request. The default is `90`.
 
-[float]
 ==== `ssl`
 
 Configuration options for Transport Layer Security (TLS) or Secure Sockets Layer
@@ -133,7 +117,6 @@ Configuration options for Transport Layer Security (TLS) or Secure Sockets Layer
 connections. If the `ssl` section is missing, the host CAs are used for
 HTTPS connections to {es}. For more information, see <<configuration-ssl>>.
 
-[float]
 ==== `username`
 
 The user ID that {beatname_uc} uses to authenticate with the {es} instances for

--- a/libbeat/docs/security/users.asciidoc
+++ b/libbeat/docs/security/users.asciidoc
@@ -169,6 +169,7 @@ information.
 |`remote_monitoring_agent`
 |Send monitoring data to the monitoring cluster
 |====
+
 . Assign the following role to users who will view the monitoring data in
 {kib}:
 

--- a/libbeat/docs/security/users.asciidoc
+++ b/libbeat/docs/security/users.asciidoc
@@ -141,6 +141,7 @@ users who need to monitor {beatname_uc}:
 |Use *Stack Monitoring* in {kib} to monitor {beatname_uc}
 |====
 
+ifndef::serverless[]
 ===== {metricbeat} collection
 
 For <<monitoring-metricbeat-collection,{metricbeat} collection>>, {security}
@@ -179,6 +180,7 @@ information.
 |`monitoring_user`
 |Use *Stack Monitoring* in {kib} to monitor {beatname_uc}
 |====
+endif::serverless[]
 
 [[privileges-to-publish-events]]
 ==== Grant privileges and roles needed for publishing

--- a/libbeat/docs/security/users.asciidoc
+++ b/libbeat/docs/security/users.asciidoc
@@ -100,7 +100,13 @@ Omit any roles that aren't relevant in your environment.
 [[privileges-to-publish-monitoring]]
 ==== Grant privileges and roles needed for monitoring
 
-{security} provides the +{beat_default_index_prefix}_system+
+{security} provides built-in users and roles for monitoring. The privileges and
+roles needed depend on the method used to collect monitoring data.
+
+===== Internal collection
+
+For <<monitoring-internal-collection,internal collection>>, {security}
+provides the +{beat_default_index_prefix}_system+
 {stack-ov}/built-in-users.html[built-in user] and
 +{beat_default_index_prefix}_system+ {stack-ov}/built-in-roles.html[built-in
 role] for sending monitoring information. You can use the built-in user, or
@@ -135,6 +141,43 @@ users who need to monitor {beatname_uc}:
 |Use *Stack Monitoring* in {kib} to monitor {beatname_uc}
 |====
 
+===== {metricbeat} collection
+
+For <<monitoring-metricbeat-collection,{metricbeat} collection>>, {security}
+provides the `remote_monitoring_user` {stack-ov}/built-in-users.html[built-in
+user], and the `remote_monitoring_collector` and `remote_monitoring_agent`
+{stack-ov}/built-in-roles.html[built-in roles] for collecting and sending
+monitoring information. You can use the built-in user, or
+create a user who has the privileges needed to collect and send monitoring
+information.
+
+If you use the `remote_monitoring_user` user, make sure you
+<<beats-system-user,set the password>>.
+
+If you don't use the `remote_monitoring_user` user:
+
+. Create a user on the production cluster who will collect and send monitoring
+information.
+
+. Assign the following roles to the user: 
++
+[options="header"]
+|====
+|Role | Why needed?
+|`remote_monitoring_collector`
+|Collect monitoring metrics from {beatname_uc}
+|`remote_monitoring_agent`
+|Send monitoring data to the monitoring cluster
+|====
+. Assign the following role to users who will view the monitoring data in
+{kib}:
+
+[options="header"]
+|====
+|Role | Why needed?
+|`monitoring_user`
+|Use *Stack Monitoring* in {kib} to monitor {beatname_uc}
+|====
 
 [[privileges-to-publish-events]]
 ==== Grant privileges and roles needed for publishing


### PR DESCRIPTION
This PR adds instructions for using Metricbeat to collect monitoring data. It provides content that's parallel to what we provide in other books.

However, I do not think the current user experience is very good. Having the docs live in different books makes the content very fragmented. Also it was sometimes hard for me to tell which content applied to the old way vs the new way of collecting metrics.

I hope after we get the initial content in place, we can go back and improve the user experience.

It's not just a problem with the docs. There are a lot of places where users can make mistakes that prevent things from working. Adding security to the mix makes it even more complicated...especially when features like ILM aren't even taken into consideration with the default users/roles.

Issues to resolve before merging:

- [x] The `remote_monitoring_agent` role does not have the privileges required to create metricbeat indices if ILM is enabled. Should we tell users to disable ILM, or should we indicate that additional privileges are required when connecting to a cluster that supports ILM (default for beats is auto, which means that Beats use lifecycle management if the cluster supports it)?

Resolution: I've added a tip with a pointer to the section that describes how to secure Beats.

- [x] What do we want to say to Functionbeat users about beats monitoring? Do we want to continue to document internal collection? Of course, using Metricbeat for collection doesn't make sense.  Will users want to use Functionbeat itself to read logs from the CloudWatch log group to which Functionbeat writes logs?

Resolution: already done.

- [x] Determine whether Metricbeat can monitor itself. Right now, this does not seem to work. Even though the monitoring data gets indexed into the .monitoring index in Kibana, it does not appear in the Stack monitoring view. This might be related to an issue with setting the UUID for the ES cluster (https://github.com/elastic/beats/pull/13020). Need to confirm that using Metricbeat to monitor itself is a valid use case. 

Resolution: removed the section.

To do after merging:
- [ ] Make parallel changes to introductory topics in the ES, LS, and Kib docs (to make the distinction between internal collection and metricbeat clearer).