### PR TITLE
Fix base64 decode processor

### DIFF
--- a/libbeat/docs/processors-using.asciidoc
+++ b/libbeat/docs/processors-using.asciidoc
@@ -890,8 +890,9 @@ processor to drop the field and then rename the field.
 -------
 processors:
 - decode_base64_field:
-    from: "field1"
-    to: "field2"
+    field:
+      from: "field1"
+      to: "field2"
     ignore_missing: false
     fail_on_error: true
 -------
@@ -924,8 +925,9 @@ processor to drop the field and then rename the field.
 -------
 processors:
 - decompress_gzip_field:
-    from: "field1"
-    to: "field2"
+    field:
+      from: "field1"
+      to: "field2"
     ignore_missing: false
     fail_on_error: true
 -------

--- a/libbeat/processors/actions/decode_base64_field.go
+++ b/libbeat/processors/actions/decode_base64_field.go
@@ -41,9 +41,9 @@ type decodeBase64Field struct {
 }
 
 type base64Config struct {
-	fromTo        `config:"field"`
-	IgnoreMissing bool `config:"ignore_missing"`
-	FailOnError   bool `config:"fail_on_error"`
+	Field         fromTo `config:"field"`
+	IgnoreMissing bool   `config:"ignore_missing"`
+	FailOnError   bool   `config:"fail_on_error"`
 }
 
 var (
@@ -84,7 +84,7 @@ func (f *decodeBase64Field) Run(event *beat.Event) (*beat.Event, error) {
 		backup = event.Fields.Clone()
 	}
 
-	err := f.decodeField(f.config.From, f.config.To, event.Fields)
+	err := f.decodeField(f.config.Field.From, f.config.Field.To, event.Fields)
 	if err != nil && f.config.FailOnError {
 		errMsg := fmt.Errorf("failed to decode base64 fields in processor: %v", err)
 		f.log.Debug("decode base64", errMsg.Error())
@@ -97,7 +97,7 @@ func (f *decodeBase64Field) Run(event *beat.Event) (*beat.Event, error) {
 }
 
 func (f decodeBase64Field) String() string {
-	return fmt.Sprintf("%s=%+v", processorName, f.config.fromTo)
+	return fmt.Sprintf("%s=%+v", processorName, f.config.Field)
 }
 
 func (f *decodeBase64Field) decodeField(from string, to string, fields common.MapStr) error {

--- a/libbeat/processors/actions/decode_base64_field_test.go
+++ b/libbeat/processors/actions/decode_base64_field_test.go
@@ -38,7 +38,7 @@ func TestDecodeBase64Run(t *testing.T) {
 		{
 			description: "simple field base64 decode",
 			config: base64Config{
-				fromTo: fromTo{
+				Field: fromTo{
 					From: "field1", To: "field2",
 				},
 				IgnoreMissing: false,
@@ -56,7 +56,7 @@ func TestDecodeBase64Run(t *testing.T) {
 		{
 			description: "simple field base64 decode To empty",
 			config: base64Config{
-				fromTo: fromTo{
+				Field: fromTo{
 					From: "field1", To: "",
 				},
 				IgnoreMissing: false,
@@ -73,7 +73,7 @@ func TestDecodeBase64Run(t *testing.T) {
 		{
 			description: "simple field base64 decode from and to equals",
 			config: base64Config{
-				fromTo: fromTo{
+				Field: fromTo{
 					From: "field1", To: "field1",
 				},
 				IgnoreMissing: false,
@@ -90,7 +90,7 @@ func TestDecodeBase64Run(t *testing.T) {
 		{
 			description: "simple field bad data - fail on error",
 			config: base64Config{
-				fromTo: fromTo{
+				Field: fromTo{
 					From: "field1", To: "field1",
 				},
 				IgnoreMissing: false,
@@ -110,7 +110,7 @@ func TestDecodeBase64Run(t *testing.T) {
 		{
 			description: "simple field bad data fail on error false",
 			config: base64Config{
-				fromTo: fromTo{
+				Field: fromTo{
 					From: "field1", To: "field2",
 				},
 				IgnoreMissing: false,
@@ -127,7 +127,7 @@ func TestDecodeBase64Run(t *testing.T) {
 		{
 			description: "missing field",
 			config: base64Config{
-				fromTo: fromTo{
+				Field: fromTo{
 					From: "field2", To: "field3",
 				},
 				IgnoreMissing: false,
@@ -147,7 +147,7 @@ func TestDecodeBase64Run(t *testing.T) {
 		{
 			description: "missing field ignore",
 			config: base64Config{
-				fromTo: fromTo{
+				Field: fromTo{
 					From: "field2", To: "field3",
 				},
 				IgnoreMissing: true,


### PR DESCRIPTION
Previously, `base64_decode_field` was broken in libbeat. The user was not able to configure the processor correctly, so the configuration would be parsed.