### PR TITLE
[Metricbeat] Fix error logging in mb/registry

### DIFF
--- a/metricbeat/mb/registry.go
+++ b/metricbeat/mb/registry.go
@@ -280,7 +280,7 @@ func (r *Register) DefaultMetricSets(module string) ([]string, error) {
 		exists = true
 		sourceDefaults, err := source.DefaultMetricSets(module)
 		if err != nil {
-			logp.Error(errors.Wrapf(err, "failed to get default metric sets for module '%s' from secondary source", module))
+			logp.L().Errorf("failed to get default metric sets for module '%s' from secondary source: %s", module, err)
 		} else if len(sourceDefaults) > 0 {
 			defaults = append(defaults, sourceDefaults...)
 		}
@@ -352,7 +352,7 @@ func (r *Register) MetricSets(module string) []string {
 	if source := r.secondarySource; source != nil && source.HasModule(module) {
 		sourceMetricSets, err := source.MetricSets(module)
 		if err != nil {
-			logp.Error(errors.Wrap(err, "failed to get metricsets from secondary source"))
+			logp.L().Errorf("failed to get metricsets from secondary source: %", err)
 		}
 		metricsets = append(metricsets, sourceMetricSets...)
 	}

--- a/metricbeat/mb/registry.go
+++ b/metricbeat/mb/registry.go
@@ -282,7 +282,7 @@ func (r *Register) DefaultMetricSets(module string) ([]string, error) {
 		exists = true
 		sourceDefaults, err := source.DefaultMetricSets(module)
 		if err != nil {
-			r.log.Errorf("failed to get default metric sets for module '%s' from secondary source: %s", module, err)
+			r.log.Errorf("Failed to get default metric sets for module '%s' from secondary source: %s", module, err)
 		} else if len(sourceDefaults) > 0 {
 			defaults = append(defaults, sourceDefaults...)
 		}
@@ -313,7 +313,7 @@ func (r *Register) Modules() []string {
 	if source := r.secondarySource; source != nil {
 		sourceModules, err := source.Modules()
 		if err != nil {
-			r.log.Errorf("failed to get modules from secondary source: %s", err)
+			r.log.Errorf("Failed to get modules from secondary source: %s", err)
 		} else {
 			for _, module := range sourceModules {
 				dups[module] = true
@@ -354,7 +354,7 @@ func (r *Register) MetricSets(module string) []string {
 	if source := r.secondarySource; source != nil && source.HasModule(module) {
 		sourceMetricSets, err := source.MetricSets(module)
 		if err != nil {
-			r.log.Errorf("failed to get metricsets from secondary source: %", err)
+			r.log.Errorf("Failed to get metricsets from secondary source: %s", err)
 		}
 		metricsets = append(metricsets, sourceMetricSets...)
 	}


### PR DESCRIPTION
This came up during a related PR, thanks to @andrewkroh. `logp.Error` isn't actually a logger, but a publicly exposed field type.

Not quite sure if this is the most elegant way to solve this. There's also `logp.Err`, but the godoc says it's deprecated, along with `logp.Info`. `L()` just returns the global logger, which seems like it should be fairly equivalent to creating a new local logger. 