### PR TITLE
[7.3] Also collect logstash_stats.events.duration_in_millis (#13082)

### DIFF
--- a/metricbeat/module/logstash/node_stats/data_xpack.go
+++ b/metricbeat/module/logstash/node_stats/data_xpack.go
@@ -39,9 +39,10 @@ type jvm struct {
 }
 
 type events struct {
-	In       int `json:"in"`
-	Filtered int `json:"filtered"`
-	Out      int `json:"out"`
+	DurationInMillis int `json:"duration_in_millis"`
+	In               int `json:"in"`
+	Filtered         int `json:"filtered"`
+	Out              int `json:"out"`
 }
 
 type commonStats struct {


### PR DESCRIPTION
Backports the following commits to 7.3:
 - Also collect logstash_stats.events.duration_in_millis  (#13082)