### PR TITLE
Normalize GUID case for Windows 2019 tests

### DIFF
--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2012r2-logon.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2012r2-logon.evtx.golden.json
@@ -54,7 +54,7 @@
           "id": 536
         }
       },
-      "provider_guid": "{54849625-5478-4994-A5BA-3E3B0328C30D}",
+      "provider_guid": "{54849625-5478-4994-a5ba-3e3b0328c30d}",
       "provider_name": "Microsoft-Windows-Security-Auditing",
       "record_id": 1535,
       "task": "Logon",
@@ -116,7 +116,7 @@
           "id": 556
         }
       },
-      "provider_guid": "{54849625-5478-4994-A5BA-3E3B0328C30D}",
+      "provider_guid": "{54849625-5478-4994-a5ba-3e3b0328c30d}",
       "provider_name": "Microsoft-Windows-Security-Auditing",
       "record_id": 1538,
       "task": "Logon",
@@ -181,7 +181,7 @@
           "id": 556
         }
       },
-      "provider_guid": "{54849625-5478-4994-A5BA-3E3B0328C30D}",
+      "provider_guid": "{54849625-5478-4994-a5ba-3e3b0328c30d}",
       "provider_name": "Microsoft-Windows-Security-Auditing",
       "record_id": 1542,
       "task": "Logon",
@@ -243,7 +243,7 @@
           "id": 556
         }
       },
-      "provider_guid": "{54849625-5478-4994-A5BA-3E3B0328C30D}",
+      "provider_guid": "{54849625-5478-4994-a5ba-3e3b0328c30d}",
       "provider_name": "Microsoft-Windows-Security-Auditing",
       "record_id": 1545,
       "task": "Logon",
@@ -305,7 +305,7 @@
           "id": 556
         }
       },
-      "provider_guid": "{54849625-5478-4994-A5BA-3E3B0328C30D}",
+      "provider_guid": "{54849625-5478-4994-a5ba-3e3b0328c30d}",
       "provider_name": "Microsoft-Windows-Security-Auditing",
       "record_id": 1547,
       "task": "Logon",
@@ -367,7 +367,7 @@
           "id": 556
         }
       },
-      "provider_guid": "{54849625-5478-4994-A5BA-3E3B0328C30D}",
+      "provider_guid": "{54849625-5478-4994-a5ba-3e3b0328c30d}",
       "provider_name": "Microsoft-Windows-Security-Auditing",
       "record_id": 1550,
       "task": "Logon",
@@ -429,7 +429,7 @@
           "id": 548
         }
       },
-      "provider_guid": "{54849625-5478-4994-A5BA-3E3B0328C30D}",
+      "provider_guid": "{54849625-5478-4994-a5ba-3e3b0328c30d}",
       "provider_name": "Microsoft-Windows-Security-Auditing",
       "record_id": 1553,
       "task": "Logon",
@@ -491,7 +491,7 @@
           "id": 548
         }
       },
-      "provider_guid": "{54849625-5478-4994-A5BA-3E3B0328C30D}",
+      "provider_guid": "{54849625-5478-4994-a5ba-3e3b0328c30d}",
       "provider_name": "Microsoft-Windows-Security-Auditing",
       "record_id": 1556,
       "task": "Logon",
@@ -556,7 +556,7 @@
           "id": 808
         }
       },
-      "provider_guid": "{54849625-5478-4994-A5BA-3E3B0328C30D}",
+      "provider_guid": "{54849625-5478-4994-a5ba-3e3b0328c30d}",
       "provider_name": "Microsoft-Windows-Security-Auditing",
       "record_id": 1561,
       "task": "Logon",
@@ -618,7 +618,7 @@
           "id": 548
         }
       },
-      "provider_guid": "{54849625-5478-4994-A5BA-3E3B0328C30D}",
+      "provider_guid": "{54849625-5478-4994-a5ba-3e3b0328c30d}",
       "provider_name": "Microsoft-Windows-Security-Auditing",
       "record_id": 1563,
       "task": "Logon",
@@ -683,7 +683,7 @@
           "id": 808
         }
       },
-      "provider_guid": "{54849625-5478-4994-A5BA-3E3B0328C30D}",
+      "provider_guid": "{54849625-5478-4994-a5ba-3e3b0328c30d}",
       "provider_name": "Microsoft-Windows-Security-Auditing",
       "record_id": 1567,
       "task": "Logon",
@@ -745,7 +745,7 @@
           "id": 556
         }
       },
-      "provider_guid": "{54849625-5478-4994-A5BA-3E3B0328C30D}",
+      "provider_guid": "{54849625-5478-4994-a5ba-3e3b0328c30d}",
       "provider_name": "Microsoft-Windows-Security-Auditing",
       "record_id": 1570,
       "task": "Logon",
@@ -807,7 +807,7 @@
           "id": 1132
         }
       },
-      "provider_guid": "{54849625-5478-4994-A5BA-3E3B0328C30D}",
+      "provider_guid": "{54849625-5478-4994-a5ba-3e3b0328c30d}",
       "provider_name": "Microsoft-Windows-Security-Auditing",
       "record_id": 1574,
       "task": "Logon",
@@ -869,7 +869,7 @@
           "id": 1132
         }
       },
-      "provider_guid": "{54849625-5478-4994-A5BA-3E3B0328C30D}",
+      "provider_guid": "{54849625-5478-4994-a5ba-3e3b0328c30d}",
       "provider_name": "Microsoft-Windows-Security-Auditing",
       "record_id": 1576,
       "task": "Logon",
@@ -931,7 +931,7 @@
           "id": 504
         }
       },
-      "provider_guid": "{54849625-5478-4994-A5BA-3E3B0328C30D}",
+      "provider_guid": "{54849625-5478-4994-a5ba-3e3b0328c30d}",
       "provider_name": "Microsoft-Windows-Security-Auditing",
       "record_id": 1578,
       "task": "Logon",
@@ -993,7 +993,7 @@
           "id": 1132
         }
       },
-      "provider_guid": "{54849625-5478-4994-A5BA-3E3B0328C30D}",
+      "provider_guid": "{54849625-5478-4994-a5ba-3e3b0328c30d}",
       "provider_name": "Microsoft-Windows-Security-Auditing",
       "record_id": 1581,
       "task": "Logon",
@@ -1055,7 +1055,7 @@
           "id": 344
         }
       },
-      "provider_guid": "{54849625-5478-4994-A5BA-3E3B0328C30D}",
+      "provider_guid": "{54849625-5478-4994-a5ba-3e3b0328c30d}",
       "provider_name": "Microsoft-Windows-Security-Auditing",
       "record_id": 1583,
       "task": "Logon",
@@ -1120,7 +1120,7 @@
           "id": 2756
         }
       },
-      "provider_guid": "{54849625-5478-4994-A5BA-3E3B0328C30D}",
+      "provider_guid": "{54849625-5478-4994-a5ba-3e3b0328c30d}",
       "provider_name": "Microsoft-Windows-Security-Auditing",
       "record_id": 1585,
       "task": "Logon"

--- a/x-pack/winlogbeat/module/sysmon/test/testdata/sysmon-9.01.evtx.golden.json
+++ b/x-pack/winlogbeat/module/sysmon/test/testdata/sysmon-9.01.evtx.golden.json
@@ -22,7 +22,7 @@
           "id": 4724
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 1,
       "user": {
@@ -56,7 +56,7 @@
           "id": 4516
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 2,
       "user": {
@@ -84,14 +84,14 @@
       "args": [
         "C:\\Windows\\Sysmon.exe"
       ],
-      "entity_id": "{42F11C3B-CE01-5C8F-0000-0010C73E2A00}",
+      "entity_id": "{42f11c3b-ce01-5c8f-0000-0010c73e2a00}",
       "executable": "C:\\Windows\\Sysmon.exe",
       "name": "Sysmon.exe",
       "parent": {
         "args": [
           "C:\\Windows\\system32\\services.exe"
         ],
-        "entity_id": "{42F11C3B-6E1A-5C8C-0000-0010F14D0000}",
+        "entity_id": "{42f11c3b-6e1a-5c8c-0000-0010f14d0000}",
         "executable": "C:\\Windows\\System32\\services.exe",
         "name": "services.exe",
         "pid": 488
@@ -112,7 +112,7 @@
         "Description": "System activity monitor",
         "FileVersion": "9.01",
         "IntegrityLevel": "System",
-        "LogonGuid": "{42F11C3B-6E1A-5C8C-0000-0020E7030000}",
+        "LogonGuid": "{42f11c3b-6e1a-5c8c-0000-0020e7030000}",
         "LogonId": "0x3e7",
         "Product": "Sysinternals Sysmon",
         "TerminalSessionId": "0"
@@ -124,7 +124,7 @@
           "id": 4516
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 3,
       "user": {
@@ -153,7 +153,7 @@
         "C:\\Windows\\system32\\wbem\\unsecapp.exe",
         "-Embedding"
       ],
-      "entity_id": "{42F11C3B-CE01-5C8F-0000-00102C412A00}",
+      "entity_id": "{42f11c3b-ce01-5c8f-0000-00102c412a00}",
       "executable": "C:\\Windows\\System32\\wbem\\unsecapp.exe",
       "name": "unsecapp.exe",
       "parent": {
@@ -162,7 +162,7 @@
           "-k",
           "DcomLaunch"
         ],
-        "entity_id": "{42F11C3B-6E1B-5C8C-0000-00102F610000}",
+        "entity_id": "{42f11c3b-6e1b-5c8c-0000-00102f610000}",
         "executable": "C:\\Windows\\System32\\svchost.exe",
         "name": "svchost.exe",
         "pid": 560
@@ -183,7 +183,7 @@
         "Description": "Sink to receive asynchronous callbacks for WMI client application",
         "FileVersion": "6.3.9600.16384 (winblue_rtm.130821-1623)",
         "IntegrityLevel": "System",
-        "LogonGuid": "{42F11C3B-6E1A-5C8C-0000-0020E7030000}",
+        "LogonGuid": "{42f11c3b-6e1a-5c8c-0000-0020e7030000}",
         "LogonId": "0x3e7",
         "Product": "Microsoft® Windows® Operating System",
         "TerminalSessionId": "0"
@@ -195,7 +195,7 @@
           "id": 4516
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 4,
       "user": {
@@ -217,7 +217,7 @@
       "level": "information"
     },
     "process": {
-      "entity_id": "{42F11C3B-CDF4-5C8F-0000-0010E61E2A00}",
+      "entity_id": "{42f11c3b-cdf4-5c8f-0000-0010e61e2a00}",
       "executable": "C:\\Users\\vagrant\\AppData\\Local\\Temp\\Sysmon.exe",
       "name": "Sysmon.exe",
       "pid": 4616
@@ -233,7 +233,7 @@
           "id": 4516
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 5,
       "user": {
@@ -255,7 +255,7 @@
       "level": "information"
     },
     "process": {
-      "entity_id": "{42F11C3B-CDF4-5C8F-0000-0010071E2A00}",
+      "entity_id": "{42f11c3b-cdf4-5c8f-0000-0010071e2a00}",
       "executable": "C:\\Users\\vagrant\\Downloads\\Sysmon.exe",
       "name": "Sysmon.exe",
       "pid": 4648
@@ -271,7 +271,7 @@
           "id": 4516
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 6,
       "user": {
@@ -300,7 +300,7 @@
         "C:\\Windows\\system32\\wbem\\wmiprvse.exe",
         "-Embedding"
       ],
-      "entity_id": "{42F11C3B-CE03-5C8F-0000-0010E9462A00}",
+      "entity_id": "{42f11c3b-ce03-5c8f-0000-0010e9462a00}",
       "executable": "C:\\Windows\\System32\\wbem\\WmiPrvSE.exe",
       "name": "WmiPrvSE.exe",
       "parent": {
@@ -309,7 +309,7 @@
           "-k",
           "DcomLaunch"
         ],
-        "entity_id": "{42F11C3B-6E1B-5C8C-0000-00102F610000}",
+        "entity_id": "{42f11c3b-6e1b-5c8c-0000-00102f610000}",
         "executable": "C:\\Windows\\System32\\svchost.exe",
         "name": "svchost.exe",
         "pid": 560
@@ -330,7 +330,7 @@
         "Description": "WMI Provider Host",
         "FileVersion": "6.3.9600.16384 (winblue_rtm.130821-1623)",
         "IntegrityLevel": "System",
-        "LogonGuid": "{42F11C3B-6E1A-5C8C-0000-0020E7030000}",
+        "LogonGuid": "{42f11c3b-6e1a-5c8c-0000-0020e7030000}",
         "LogonId": "0x3e7",
         "Product": "Microsoft® Windows® Operating System",
         "TerminalSessionId": "0"
@@ -342,7 +342,7 @@
           "id": 4516
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 7,
       "user": {
@@ -374,7 +374,7 @@
       "type": "ipv6"
     },
     "process": {
-      "entity_id": "{42F11C3B-0BAD-5C8C-0000-0010DFBC0000}",
+      "entity_id": "{42f11c3b-0bad-5c8c-0000-0010dfbc0000}",
       "executable": "C:\\Windows\\System32\\svchost.exe",
       "name": "svchost.exe",
       "pid": 924
@@ -398,7 +398,7 @@
           "id": 4492
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 8,
       "user": {
@@ -430,7 +430,7 @@
       "type": "ipv4"
     },
     "process": {
-      "entity_id": "{42F11C3B-0BAD-5C8C-0000-0010DFBC0000}",
+      "entity_id": "{42f11c3b-0bad-5c8c-0000-0010dfbc0000}",
       "executable": "C:\\Windows\\System32\\svchost.exe",
       "name": "svchost.exe",
       "pid": 924
@@ -455,7 +455,7 @@
           "id": 4492
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 9,
       "user": {
@@ -487,7 +487,7 @@
       "type": "ipv4"
     },
     "process": {
-      "entity_id": "{42F11C3B-CCAA-5C8F-0000-0010B4E22700}",
+      "entity_id": "{42f11c3b-ccaa-5c8f-0000-0010b4e22700}",
       "executable": "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe",
       "name": "chrome.exe",
       "pid": 1600
@@ -512,7 +512,7 @@
           "id": 4492
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 10,
       "user": {
@@ -544,7 +544,7 @@
       "type": "ipv4"
     },
     "process": {
-      "entity_id": "{42F11C3B-CCAA-5C8F-0000-0010B4E22700}",
+      "entity_id": "{42f11c3b-ccaa-5c8f-0000-0010b4e22700}",
       "executable": "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe",
       "name": "chrome.exe",
       "pid": 1600
@@ -569,7 +569,7 @@
           "id": 4492
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 11,
       "user": {
@@ -601,7 +601,7 @@
       "type": "ipv4"
     },
     "process": {
-      "entity_id": "{42F11C3B-6E19-5C8C-0000-0010EB030000}",
+      "entity_id": "{42f11c3b-6e19-5c8c-0000-0010eb030000}",
       "executable": "System",
       "name": "System",
       "pid": 4
@@ -629,7 +629,7 @@
           "id": 4492
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 12,
       "user": {
@@ -662,7 +662,7 @@
       "type": "ipv4"
     },
     "process": {
-      "entity_id": "{42F11C3B-6E19-5C8C-0000-0010EB030000}",
+      "entity_id": "{42f11c3b-6e19-5c8c-0000-0010eb030000}",
       "executable": "System",
       "name": "System",
       "pid": 4
@@ -689,7 +689,7 @@
           "id": 4492
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 13,
       "user": {
@@ -721,7 +721,7 @@
       "type": "ipv6"
     },
     "process": {
-      "entity_id": "{42F11C3B-0BAD-5C8C-0000-0010DFBC0000}",
+      "entity_id": "{42f11c3b-0bad-5c8c-0000-0010dfbc0000}",
       "executable": "C:\\Windows\\System32\\svchost.exe",
       "name": "svchost.exe",
       "pid": 924
@@ -746,7 +746,7 @@
           "id": 4492
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 14,
       "user": {
@@ -778,7 +778,7 @@
       "type": "ipv6"
     },
     "process": {
-      "entity_id": "{42F11C3B-0BAD-5C8C-0000-0010DFBC0000}",
+      "entity_id": "{42f11c3b-0bad-5c8c-0000-0010dfbc0000}",
       "executable": "C:\\Windows\\System32\\svchost.exe",
       "name": "svchost.exe",
       "pid": 924
@@ -802,7 +802,7 @@
           "id": 4492
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 15,
       "user": {
@@ -834,7 +834,7 @@
       "type": "ipv4"
     },
     "process": {
-      "entity_id": "{42F11C3B-6E19-5C8C-0000-0010EB030000}",
+      "entity_id": "{42f11c3b-6e19-5c8c-0000-0010eb030000}",
       "executable": "System",
       "name": "System",
       "pid": 4
@@ -861,7 +861,7 @@
           "id": 4492
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 16,
       "user": {
@@ -893,7 +893,7 @@
       "type": "ipv4"
     },
     "process": {
-      "entity_id": "{42F11C3B-6E19-5C8C-0000-0010EB030000}",
+      "entity_id": "{42f11c3b-6e19-5c8c-0000-0010eb030000}",
       "executable": "System",
       "name": "System",
       "pid": 4
@@ -920,7 +920,7 @@
           "id": 4492
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 17,
       "user": {
@@ -952,7 +952,7 @@
       "type": "ipv6"
     },
     "process": {
-      "entity_id": "{42F11C3B-0BAD-5C8C-0000-0010DFBC0000}",
+      "entity_id": "{42f11c3b-0bad-5c8c-0000-0010dfbc0000}",
       "executable": "C:\\Windows\\System32\\svchost.exe",
       "name": "svchost.exe",
       "pid": 924
@@ -976,7 +976,7 @@
           "id": 4492
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 18,
       "user": {
@@ -1008,7 +1008,7 @@
       "type": "ipv6"
     },
     "process": {
-      "entity_id": "{42F11C3B-0BAD-5C8C-0000-0010DFBC0000}",
+      "entity_id": "{42f11c3b-0bad-5c8c-0000-0010dfbc0000}",
       "executable": "C:\\Windows\\System32\\svchost.exe",
       "name": "svchost.exe",
       "pid": 924
@@ -1032,7 +1032,7 @@
           "id": 4492
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 19,
       "user": {
@@ -1064,7 +1064,7 @@
       "type": "ipv4"
     },
     "process": {
-      "entity_id": "{42F11C3B-6E19-5C8C-0000-0010EB030000}",
+      "entity_id": "{42f11c3b-6e19-5c8c-0000-0010eb030000}",
       "executable": "System",
       "name": "System",
       "pid": 4
@@ -1092,7 +1092,7 @@
           "id": 4492
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 20,
       "user": {
@@ -1124,7 +1124,7 @@
       "type": "ipv4"
     },
     "process": {
-      "entity_id": "{42F11C3B-6E19-5C8C-0000-0010EB030000}",
+      "entity_id": "{42f11c3b-6e19-5c8c-0000-0010eb030000}",
       "executable": "System",
       "name": "System",
       "pid": 4
@@ -1152,7 +1152,7 @@
           "id": 4492
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 21,
       "user": {
@@ -1184,7 +1184,7 @@
       "type": "ipv4"
     },
     "process": {
-      "entity_id": "{42F11C3B-6E19-5C8C-0000-0010EB030000}",
+      "entity_id": "{42f11c3b-6e19-5c8c-0000-0010eb030000}",
       "executable": "System",
       "name": "System",
       "pid": 4
@@ -1212,7 +1212,7 @@
           "id": 4492
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 22,
       "user": {
@@ -1244,7 +1244,7 @@
       "type": "ipv4"
     },
     "process": {
-      "entity_id": "{42F11C3B-6E19-5C8C-0000-0010EB030000}",
+      "entity_id": "{42f11c3b-6e19-5c8c-0000-0010eb030000}",
       "executable": "System",
       "name": "System",
       "pid": 4
@@ -1272,7 +1272,7 @@
           "id": 4492
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 23,
       "user": {
@@ -1294,7 +1294,7 @@
       "level": "information"
     },
     "process": {
-      "entity_id": "{42F11C3B-CCC6-5C8F-0000-001005082900}",
+      "entity_id": "{42f11c3b-ccc6-5c8f-0000-001005082900}",
       "executable": "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe",
       "name": "chrome.exe",
       "pid": 4832
@@ -1310,7 +1310,7 @@
           "id": 4516
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 24,
       "user": {
@@ -1332,7 +1332,7 @@
       "level": "information"
     },
     "process": {
-      "entity_id": "{42F11C3B-CCCC-5C8F-0000-0010E8272900}",
+      "entity_id": "{42f11c3b-cccc-5c8f-0000-0010e8272900}",
       "executable": "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe",
       "name": "chrome.exe",
       "pid": 3208
@@ -1348,7 +1348,7 @@
           "id": 4516
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 25,
       "user": {
@@ -1373,7 +1373,7 @@
       "level": "information"
     },
     "process": {
-      "entity_id": "{42F11C3B-CCAA-5C8F-0000-0010B4E22700}",
+      "entity_id": "{42f11c3b-ccaa-5c8f-0000-0010b4e22700}",
       "executable": "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe",
       "name": "chrome.exe",
       "pid": 1600
@@ -1393,7 +1393,7 @@
           "id": 4516
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 26,
       "user": {
@@ -1418,7 +1418,7 @@
       "level": "information"
     },
     "process": {
-      "entity_id": "{42F11C3B-CCAA-5C8F-0000-0010B4E22700}",
+      "entity_id": "{42f11c3b-ccaa-5c8f-0000-0010b4e22700}",
       "executable": "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe",
       "name": "chrome.exe",
       "pid": 1600
@@ -1438,7 +1438,7 @@
           "id": 4516
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 27,
       "user": {
@@ -1463,7 +1463,7 @@
       "level": "information"
     },
     "process": {
-      "entity_id": "{42F11C3B-CCAA-5C8F-0000-0010B4E22700}",
+      "entity_id": "{42f11c3b-ccaa-5c8f-0000-0010b4e22700}",
       "executable": "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe",
       "name": "chrome.exe",
       "pid": 1600
@@ -1483,7 +1483,7 @@
           "id": 4516
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 28,
       "user": {
@@ -1508,7 +1508,7 @@
       "level": "information"
     },
     "process": {
-      "entity_id": "{42F11C3B-CCAA-5C8F-0000-0010B4E22700}",
+      "entity_id": "{42f11c3b-ccaa-5c8f-0000-0010b4e22700}",
       "executable": "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe",
       "name": "chrome.exe",
       "pid": 1600
@@ -1528,7 +1528,7 @@
           "id": 4516
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 29,
       "user": {
@@ -1550,7 +1550,7 @@
       "level": "information"
     },
     "process": {
-      "entity_id": "{42F11C3B-CCAB-5C8F-0000-001064EB2700}",
+      "entity_id": "{42f11c3b-ccab-5c8f-0000-001064eb2700}",
       "executable": "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe",
       "name": "chrome.exe",
       "pid": 2680
@@ -1566,7 +1566,7 @@
           "id": 4516
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 30,
       "user": {
@@ -1591,7 +1591,7 @@
       "level": "information"
     },
     "process": {
-      "entity_id": "{42F11C3B-CCAA-5C8F-0000-0010B4E22700}",
+      "entity_id": "{42f11c3b-ccaa-5c8f-0000-0010b4e22700}",
       "executable": "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe",
       "name": "chrome.exe",
       "pid": 1600
@@ -1611,7 +1611,7 @@
           "id": 4516
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 31,
       "user": {
@@ -1636,7 +1636,7 @@
       "level": "information"
     },
     "process": {
-      "entity_id": "{42F11C3B-CCAA-5C8F-0000-0010B4E22700}",
+      "entity_id": "{42f11c3b-ccaa-5c8f-0000-0010b4e22700}",
       "executable": "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe",
       "name": "chrome.exe",
       "pid": 1600
@@ -1656,7 +1656,7 @@
           "id": 4516
         }
       },
-      "provider_guid": "{5770385F-C22A-43E0-BF4C-06F5698FFBD9}",
+      "provider_guid": "{5770385f-c22a-43e0-bf4c-06f5698ffbd9}",
       "provider_name": "Microsoft-Windows-Sysmon",
       "record_id": 32,
       "user": {


### PR DESCRIPTION
This cherry-picks part of #13047 which fixes testing on Windows 2019.
GUIDs are formatted differently in Windows 2019 than they were in
past Windows versions so the golden tests were failing.