### PR TITLE
[7.3] Be defensive about determining ES cluster UUID (#13020)

### DIFF
--- a/metricbeat/module/beat/beat.go
+++ b/metricbeat/module/beat/beat.go
@@ -19,6 +19,7 @@ package beat
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/url"
 
 	"github.com/pkg/errors"
@@ -74,6 +75,13 @@ func validateXPackMetricsets(base mb.BaseModule) error {
 // ModuleName is the name of this module.
 const ModuleName = "beat"
 
+var (
+	// ErrClusterUUID is the error to be returned when the monitored beat is using the Elasticsearch output but hasn't
+	// yet connected or is having trouble connecting to that Elasticsearch, so the cluster UUID cannot be
+	// determined
+	ErrClusterUUID = fmt.Errorf("monitored beat is using Elasticsearch output but cluster UUID cannot be determined")
+)
+
 // Info construct contains the relevant data from the Beat's / endpoint
 type Info struct {
 	UUID     string `json:"uuid"`
@@ -85,6 +93,9 @@ type Info struct {
 
 // State construct contains the relevant data from the Beat's /state endpoint
 type State struct {
+	Output struct {
+		Name string `json:"name"`
+	} `json:"output"`
 	Outputs struct {
 		Elasticsearch struct {
 			ClusterUUID string `json:"cluster_uuid"`

--- a/metricbeat/module/beat/stats/data_xpack.go
+++ b/metricbeat/module/beat/stats/data_xpack.go
@@ -83,5 +83,18 @@ func (m *MetricSet) getClusterUUID() (string, error) {
 		return "", errors.Wrap(err, "could not get state information")
 	}
 
-	return state.Outputs.Elasticsearch.ClusterUUID, nil
+	if state.Output.Name != "elasticsearch" {
+		return "", nil
+	}
+
+	clusterUUID := state.Outputs.Elasticsearch.ClusterUUID
+	if clusterUUID == "" {
+		// Output is ES but cluster UUID could not be determined. No point sending monitoring
+		// data with empty cluster UUID since it will not be associated with the correct ES
+		// production cluster. Log error instead.
+		return "", beat.ErrClusterUUID
+	}
+
+	return clusterUUID, nil
+
 }

--- a/metricbeat/tests/system/test_beat.py
+++ b/metricbeat/tests/system/test_beat.py
@@ -7,7 +7,7 @@ from parameterized import parameterized
 
 class Test(metricbeat.BaseTest):
 
-    COMPOSE_SERVICES = ['metricbeat']
+    COMPOSE_SERVICES = ['metricbeat', 'elasticsearch']
     FIELDS = ['beat']
     METRICSETS = ['stats', 'state']
 
@@ -33,6 +33,13 @@ class Test(metricbeat.BaseTest):
                 "xpack.enabled": "true"
             }
         }])
+
+        # Give the monitored Metricbeat instance enough time to collect metrics and index them
+        # into Elasticsearch, so it may establish the connection to Elasticsearch and determine
+        # it's cluster UUID in the process. Otherwise, the monitoring Metricbeat instance will
+        # show errors in its log about not being able to determine the Elasticsearch cluster UUID
+        # to be associated with the monitored Metricbeat instance.
+        time.sleep(30)
 
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0)


### PR DESCRIPTION
Backports the following commits to 7.3:
 - Be defensive about determining ES cluster UUID  (#13020)