### PR TITLE
Fail earlier on compose errors

### DIFF
--- a/libbeat/tests/compose/compose.go
+++ b/libbeat/tests/compose/compose.go
@@ -54,7 +54,7 @@ func EnsureUpWithTimeout(t *testing.T, timeout int, services ...string) {
 	for _, service := range services {
 		err = compose.Start(service)
 		if err != nil {
-			t.Fatal("failed to start service", service, err)
+			t.Fatalf("failed to start service %s: %v", service, err)
 		}
 	}
 


### PR DESCRIPTION
Compose wrapper was retrying on `docker-compose up` till timeout in case
it was caused by resources exhaustion, but most of the times it fails, it
is caused by unrecoverable errors like mistakes in docker-compose.yml or
Dockerfiles. Fail earlier in all cases except in the ones that can be
recovered with the time.

The motivation to handle the case of networks exhaustion is that we are
planning to support multiple docker compose files, and multiple
scenarios or versions at the same time, this can consume all the
available network pools when tests for several modules are run in
parallel.

Related to #7957, #12909.