### PR TITLE
[Heartbeat][Docs] Add AWS credentials info to ELB docs for heartbeat

### DIFF
--- a/heartbeat/docs/autodiscover-aws-elb-config.asciidoc
+++ b/heartbeat/docs/autodiscover-aws-elb-config.asciidoc
@@ -7,10 +7,8 @@ heartbeat.autodiscover:
   - type: aws_elb
     period: 1m
     regions: ["us-east-1", "us-east-2"]
-    # If you don't wish to use env vars or shared credentials files explicitly put credentials here.
-    #access_key_id: my-access-key
-    #secret_access_key: my-secret-access-key
-    #session_token: my-session-token
+    access_key_id: my-access-key
+    secret_access_key: my-secret-access-key
     templates:
     - condition:
         equals.port: 8080

--- a/heartbeat/docs/autodiscover-aws-elb-config.asciidoc
+++ b/heartbeat/docs/autodiscover-aws-elb-config.asciidoc
@@ -22,6 +22,3 @@ heartbeat.autodiscover:
 -------------------------------------------------------------------------------------
 
 This configuration launches a `tcp` monitor for all ELBs that have a declared port.
-
-This autodiscover provider takes our standard AWS credentials options.
-

--- a/heartbeat/docs/aws-credentials-examples.asciidoc
+++ b/heartbeat/docs/aws-credentials-examples.asciidoc
@@ -1,0 +1,52 @@
+[source,yaml]
+----
+heartbeat.autodiscover:
+  providers:
+  - type: aws_elb
+    period: 1m
+    regions: ["us-east-1", "us-east-2"]
+    access_key_id: '<access_key_id>'
+    secret_access_key: '<secret_access_key>'
+    session_token: '<session_token>'
+    templates:
+    - type: tcp
+      hosts: ["${data.host}:${data.port}"]
+      schedule: "@every 5s"
+      timeout: 1s
+----
+
+or
+
+[source,yaml]
+----
+heartbeat.autodiscover:
+  providers:
+  - type: aws_elb
+    period: 1m
+    regions: ["us-east-1", "us-east-2"]
+    access_key_id: '${AWS_ACCESS_KEY_ID:""}'
+    secret_access_key: '${AWS_SECRET_ACCESS_KEY:""}'
+    session_token: '${AWS_SESSION_TOKEN:""}'
+    templates:
+    - type: tcp
+      hosts: ["${data.host}:${data.port}"]
+      schedule: "@every 5s"
+      timeout: 1s
+----
+
+* Use shared AWS credentials file
+
+[source,yaml]
+----
+heartbeat.autodiscover:
+  providers:
+  - type: aws_elb
+    period: 1m
+    regions: ["us-east-1", "us-east-2"]
+    credential_profile_name: test-hb
+    templates:
+    - type: tcp
+      hosts: ["${data.host}:${data.port}"]
+      schedule: "@every 5s"
+      timeout: 1s
+----

--- a/libbeat/docs/shared-autodiscover.asciidoc
+++ b/libbeat/docs/shared-autodiscover.asciidoc
@@ -227,7 +227,7 @@ In any case, this feature is controlled with two properties:
 There are multiple ways of setting these properties, and they can vary from
 application to application, please refer to the documentation of your
 application to find the more suitable way to set them in your case.
- 
+
 Jolokia Discovery is based on UDP multicast requests. Agents join the multicast
 group 239.192.48.84, port 24884, and discovery is done by sending queries to
 this group. You have to take into account that UDP traffic between Metricbeat
@@ -294,6 +294,11 @@ These are the available fields during within config templating. The `elb_listene
   * elb_listener.ssl_policy
 
 include::../../{beatname_lc}/docs/autodiscover-aws-elb-config.asciidoc[]
+
+This autodiscover provider takes our standard AWS credentials options, see <<aws-credentials-config>> for more information.
+
+[id="aws-credentials-config"]
+include::{libbeat-xpack-dir}/docs/aws-credentials-config.asciidoc[]
 
 endif::autodiscoverAWSELB[]
 

--- a/libbeat/docs/shared-autodiscover.asciidoc
+++ b/libbeat/docs/shared-autodiscover.asciidoc
@@ -295,7 +295,7 @@ These are the available fields during within config templating. The `elb_listene
 
 include::../../{beatname_lc}/docs/autodiscover-aws-elb-config.asciidoc[]
 
-This autodiscover provider takes our standard AWS credentials options, see <<aws-credentials-config>> below for more information.
+This autodiscover provider takes our standard <<aws-credentials-config,AWS credentials options>>.
 
 [id="aws-credentials-config"]
 include::../../x-pack/libbeat/docs/aws-credentials-config.asciidoc[]

--- a/libbeat/docs/shared-autodiscover.asciidoc
+++ b/libbeat/docs/shared-autodiscover.asciidoc
@@ -295,10 +295,10 @@ These are the available fields during within config templating. The `elb_listene
 
 include::../../{beatname_lc}/docs/autodiscover-aws-elb-config.asciidoc[]
 
-This autodiscover provider takes our standard AWS credentials options, see <<aws-credentials-config>> for more information.
+This autodiscover provider takes our standard AWS credentials options, see <<aws-credentials-config>> below for more information.
 
 [id="aws-credentials-config"]
-include::{libbeat-xpack-dir}/docs/aws-credentials-config.asciidoc[]
+include::../../x-pack/libbeat/docs/aws-credentials-config.asciidoc[]
 
 endif::autodiscoverAWSELB[]
 

--- a/metricbeat/docs/aws-credentials-examples.asciidoc
+++ b/metricbeat/docs/aws-credentials-examples.asciidoc
@@ -1,3 +1,4 @@
+[source,yaml]
 ----
 metricbeat.modules:
 - module: aws

--- a/metricbeat/docs/aws-credentials-examples.asciidoc
+++ b/metricbeat/docs/aws-credentials-examples.asciidoc
@@ -1,0 +1,36 @@
+----
+metricbeat.modules:
+- module: aws
+  period: 300s
+  metricsets:
+    - ec2
+  access_key_id: '<access_key_id>'
+  secret_access_key: '<secret_access_key>'
+  session_token: '<session_token>'
+----
+
+or
+
+[source,yaml]
+----
+metricbeat.modules:
+- module: aws
+  period: 300s
+  metricsets:
+    - ec2
+  access_key_id: '${AWS_ACCESS_KEY_ID:""}'
+  secret_access_key: '${AWS_SECRET_ACCESS_KEY:""}'
+  session_token: '${AWS_SESSION_TOKEN:""}'
+----
+
+* Use shared AWS credentials file
+
+[source,yaml]
+----
+metricbeat.modules:
+- module: aws
+  period: 300s
+  metricsets:
+    - ec2
+  credential_profile_name: test-mb
+----

--- a/x-pack/libbeat/docs/aws-credentials-config.asciidoc
+++ b/x-pack/libbeat/docs/aws-credentials-config.asciidoc
@@ -1,6 +1,6 @@
 [float]
 === AWS Credentials Configuration
-To configure AWS credentials, there two different ways supported. Look at the examples below, which demonstrate the use of Beats standard AWS authentication parameters using the metricbeat AWS module.
+To configure AWS credentials, there two different ways supported. Look at the examples below, which demonstrate the use of Beats standard AWS authentication.
 
 [float]
 ==== Supported Formats
@@ -10,43 +10,8 @@ Users can either put the credentials into metricbeat module configuration or use
 environment variable `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and/or
 `AWS_SESSION_TOKEN` instead.
 
-[source,yaml]
-----
-metricbeat.modules:
-- module: aws
-  period: 300s
-  metricsets:
-    - ec2
-  access_key_id: '<access_key_id>'
-  secret_access_key: '<secret_access_key>'
-  session_token: '<session_token>'
-----
+include::../../../{beatname_lc}/docs/aws-credentials-examples.asciidoc[]
 
-or
-
-[source,yaml]
-----
-metricbeat.modules:
-- module: aws
-  period: 300s
-  metricsets:
-    - ec2
-  access_key_id: '${AWS_ACCESS_KEY_ID:""}'
-  secret_access_key: '${AWS_SECRET_ACCESS_KEY:""}'
-  session_token: '${AWS_SESSION_TOKEN:""}'
-----
-
-* Use shared AWS credentials file
-
-[source,yaml]
-----
-metricbeat.modules:
-- module: aws
-  period: 300s
-  metricsets:
-    - ec2
-  credential_profile_name: test-mb
-----
 `credential_profile_name` is optional. If there is no `credential_profile_name`
 given, the default profile will be used.
 In Windows, shared credentials file is at `C:\Users\<yourUserName>\.aws\credentials`.

--- a/x-pack/libbeat/docs/aws-credentials-config.asciidoc
+++ b/x-pack/libbeat/docs/aws-credentials-config.asciidoc
@@ -1,6 +1,6 @@
 [float]
 === AWS Credentials Configuration
-To configure AWS credentials, there two different ways supported. Look at the examples below, which demonstrate the use of Beats standard AWS authentication.
+To configure AWS credentials, either put the credentials into the {beatname_uc} configuration, or use a shared credentials file, as shown in the following examples.
 
 [float]
 ==== Supported Formats

--- a/x-pack/libbeat/docs/aws-credentials-config.asciidoc
+++ b/x-pack/libbeat/docs/aws-credentials-config.asciidoc
@@ -1,6 +1,6 @@
 [float]
 === AWS Credentials Configuration
-To configure AWS credentials, there are two different ways supported:
+To configure AWS credentials, there two different ways supported. Look at the examples below, which demonstrate the use of Beats standard AWS authentication parameters using the metricbeat AWS module.
 
 [float]
 ==== Supported Formats


### PR DESCRIPTION
Link to the shared AWS credentials docs. I can't get this to work right however, I'm wondering if @dedemorton or @kaiyan-sheng know the secret to getting the shared docs included here as they are elsewhere? Running `make docs-preview` in `heartbeat` returns the following:

`INFO:build_docs:/out/docs/index.xml:7477: element xref: validity error : IDREF attribute linkend references an unknown ID "aws-credentials-config"`