### PR TITLE
fix growing registry file when using kubernetes autodiscover provider

### DIFF
--- a/filebeat/crawler/crawler.go
+++ b/filebeat/crawler/crawler.go
@@ -111,7 +111,7 @@ func (c *Crawler) Start(
 func (c *Crawler) startInput(
 	pipeline beat.Pipeline,
 	config *common.Config,
-	states []file.State,
+	states *file.States,
 ) error {
 	if !config.Enabled() {
 		return nil

--- a/filebeat/input/input.go
+++ b/filebeat/input/input.go
@@ -62,7 +62,7 @@ func New(
 	conf *common.Config,
 	outlet channel.Connector,
 	beatDone chan struct{},
-	states []file.State,
+	states *file.States,
 	dynFields *common.MapStrPointer,
 ) (*Runner, error) {
 	input := &Runner{

--- a/filebeat/input/log/input.go
+++ b/filebeat/input/log/input.go
@@ -108,13 +108,18 @@ func NewInput(
 		meta = nil
 	}
 
+	states := context.States
+	if states == nil {
+		states = file.NewStates()
+	}
+
 	p := &Input{
 		config:      defaultConfig,
 		cfg:         cfg,
 		harvesters:  harvester.NewRegistry(),
 		outlet:      out,
 		stateOutlet: stateOut,
-		states:      file.NewStates(),
+		states:      states,
 		done:        context.Done,
 		meta:        meta,
 	}
@@ -140,7 +145,7 @@ func NewInput(
 		return nil, fmt.Errorf("each input must have at least one path defined")
 	}
 
-	err = p.loadStates(context.States)
+	err = p.loadStates(states.GetStates())
 	if err != nil {
 		return nil, err
 	}

--- a/filebeat/input/registry.go
+++ b/filebeat/input/registry.go
@@ -27,7 +27,7 @@ import (
 )
 
 type Context struct {
-	States        []file.State
+	States        *file.States
 	Done          chan struct{}
 	BeatDone      chan struct{}
 	DynamicFields *common.MapStrPointer

--- a/filebeat/registrar/registrar.go
+++ b/filebeat/registrar/registrar.go
@@ -128,8 +128,8 @@ func (r *Registrar) Init() error {
 }
 
 // GetStates return the registrar states
-func (r *Registrar) GetStates() []file.State {
-	return r.states.GetStates()
+func (r *Registrar) GetStates() *file.States {
+	return r.states
 }
 
 // loadStates fetches the previous reading state from the configure RegistryFile file


### PR DESCRIPTION
When using kubernetes autodiscover provider registry file tends to grow in time leaving a lot of entries with TTL=-2. This entries are never removed from registry. eg.

```
cat data.json | jq -r .[].ttl | sort | uniq -c
    660 -1
   2957 -2
```

I found out, that generating NewStates object when generating new input from autodiscovered config caused this cleaner code https://github.com/elastic/beats/blob/master/filebeat/input/log/input.go#L217 to work on different states object that was used by Input and prevent it from cleaning this removed files.

This fix changes code to operate on original States object both by autodiscover generated inputs and cleaner and makes not exist files getting removed from registry.