### PR TITLE
[libbeat] Fix flakey ELB autodiscover test

### DIFF
--- a/x-pack/libbeat/autodiscover/providers/aws/elb/provider.go
+++ b/x-pack/libbeat/autodiscover/providers/aws/elb/provider.go
@@ -6,7 +6,6 @@ package elb
 
 import (
 	"context"
-	"time"
 
 	awscommon "github.com/elastic/beats/x-pack/libbeat/common/aws"
 
@@ -28,8 +27,6 @@ func init() {
 
 // Provider implements autodiscover provider for aws ELBs.
 type Provider struct {
-	fetcher       fetcher
-	period        time.Duration
 	config        *Config
 	bus           bus.Bus
 	builders      autodiscover.Builders
@@ -88,8 +85,6 @@ func internalBuilder(uuid uuid.UUID, bus bus.Bus, config *Config, fetcher fetche
 	}
 
 	p := &Provider{
-		fetcher:   fetcher,
-		period:    config.Period,
 		config:    config,
 		bus:       bus,
 		builders:  builders,
@@ -99,8 +94,8 @@ func internalBuilder(uuid uuid.UUID, bus bus.Bus, config *Config, fetcher fetche
 	}
 
 	p.watcher = newWatcher(
-		p.fetcher,
-		p.period,
+		fetcher,
+		config.Period,
 		p.onWatcherStart,
 		p.onWatcherStop,
 	)

--- a/x-pack/libbeat/autodiscover/providers/aws/elb/provider.go
+++ b/x-pack/libbeat/autodiscover/providers/aws/elb/provider.go
@@ -87,7 +87,7 @@ func internalBuilder(uuid uuid.UUID, bus bus.Bus, config *Config, fetcher fetche
 		return nil, err
 	}
 
-	return &Provider{
+	p := &Provider{
 		fetcher:   fetcher,
 		period:    config.Period,
 		config:    config,
@@ -96,17 +96,20 @@ func internalBuilder(uuid uuid.UUID, bus bus.Bus, config *Config, fetcher fetche
 		appenders: appenders,
 		templates: &mapper,
 		uuid:      uuid,
-	}, nil
-}
+	}
 
-// Start the autodiscover process.
-func (p *Provider) Start() {
 	p.watcher = newWatcher(
 		p.fetcher,
 		p.period,
 		p.onWatcherStart,
 		p.onWatcherStop,
 	)
+
+	return p, nil
+}
+
+// Start the autodiscover process.
+func (p *Provider) Start() {
 	p.watcher.start()
 }
 

--- a/x-pack/libbeat/autodiscover/providers/aws/elb/provider_test.go
+++ b/x-pack/libbeat/autodiscover/providers/aws/elb/provider_test.go
@@ -74,8 +74,6 @@ func Test_internalBuilder(t *testing.T) {
 	provider, err := internalBuilder(uuid, pBus, cfg, fetcher)
 	require.NoError(t, err)
 
-	provider.Start()
-
 	startListener := pBus.Subscribe("start")
 	stopListener := pBus.Subscribe("stop")
 	listenerDone := make(chan struct{})

--- a/x-pack/libbeat/autodiscover/providers/aws/elb/provider_test.go
+++ b/x-pack/libbeat/autodiscover/providers/aws/elb/provider_test.go
@@ -96,9 +96,10 @@ func Test_internalBuilder(t *testing.T) {
 	}()
 
 	// Let run twice to ensure that duplicates don't create two start events
-	// 20ms should be enough to see more than two events since the loop is once per nanosecond
-	time.Sleep(time.Millisecond * 50)
-	events.waitForNumEvents(t, 1, 5*time.Second)
+	// Since we're turning a list of assets into a list of changes the second once() call should be a noop
+	provider.watcher.once()
+	provider.watcher.once()
+	events.waitForNumEvents(t, 1, time.Second)
 
 	assert.Equal(t, 1, events.len())
 
@@ -118,10 +119,10 @@ func Test_internalBuilder(t *testing.T) {
 
 	fetcher.setLbls([]*lbListener{})
 
-	// Let run twice to ensure that duplicates don't create two start events
-	// 20ms should be enough to see more than two events since the loop is once per nanosecond
-	time.Sleep(time.Millisecond * 50)
-	events.waitForNumEvents(t, 2, 5*time.Second)
+	// Let run twice to ensure that duplicates don't cause an issue
+	provider.watcher.once()
+	provider.watcher.once()
+	events.waitForNumEvents(t, 2, time.Second)
 
 	require.Equal(t, 2, events.len())
 
@@ -137,7 +138,9 @@ func Test_internalBuilder(t *testing.T) {
 	preErrorEventCount := events.len()
 	fetcher.setError(errors.New("oops"))
 
-	time.Sleep(time.Millisecond * 50)
+	// Let run twice to ensure that duplicates don't cause an issue
+	provider.watcher.once()
+	provider.watcher.once()
 
 	assert.Equal(t, preErrorEventCount, events.len())
 }


### PR DESCRIPTION
This refactors the test to stop using timeouts mostly in favor of manually triggering refreshes.

We still use a timeout to wait for events, since this is async code that is easier than providing a channel for updates that wouldn't be in the public API, and would need a timeout regardless.