### PR TITLE
Remove `cluster_uuid` from vertices

### DIFF
--- a/metricbeat/module/logstash/node/data_xpack.go
+++ b/metricbeat/module/logstash/node/data_xpack.go
@@ -31,6 +31,8 @@ func eventMappingXPack(r mb.ReporterV2, m *MetricSet, pipelines []logstash.Pipel
 	clusterToPipelinesMap := makeClusterToPipelinesMap(pipelines)
 	for clusterUUID, pipelines := range clusterToPipelinesMap {
 		for _, pipeline := range pipelines {
+			removeClusterUUIDsFromPipeline(pipeline)
+
 			// Rename key: graph -> representation
 			pipeline.Representation = pipeline.Graph
 			pipeline.Graph = nil
@@ -106,4 +108,15 @@ func getUserDefinedPipelines(pipelines []logstash.PipelineState) []logstash.Pipe
 		}
 	}
 	return userDefinedPipelines
+}
+
+func removeClusterUUIDsFromPipeline(pipeline logstash.PipelineState) {
+	for _, vertex := range pipeline.Graph.Graph.Vertices {
+		_, exists := vertex["cluster_uuid"]
+		if !exists {
+			continue
+		}
+
+		delete(vertex, "cluster_uuid")
+	}
 }


### PR DESCRIPTION
This PR fixes the `logstash/node` metricset (x-pack code path) to have parity with internal collection. Specifically, it teaches the metricset to remove any `cluster_uuid` fields found in pipeline graph vertex objects.

### Testing this PR

1. Build Metricbeat with this PR.
   ```
   cd $GOPATH/src/github.com/elastic/beats/metricbeat
   mage build
   ```

2. Enable the Logstash module for Stack Monitoring.
   ```
   ./metricbeat modules enable logstash-xpack
   ```

3. Start Logstash.
   ```
   ./bin/logstash -e 'input { stdin {} } output { elasticsearch {} }'
   ```

4. Start Metricbeat.
   ```
   ./metricbeat -e
   ```

5. Verify that the `.monitoring-logstash-*` index contains `type:logstash_state` documents with the `logstash_state.pipeline.representation.graph.vertices` array of objects, none of which contain the `cluster_uuid` field in them.

   ```
   GET .monitoring-logstash-*/_search?q=type:logstash_state&filter_path=hits.hits._source.logstash_state.pipeline.representation.graph.vertices&size=1
   ```