### PR TITLE
Collecting missing fields for `type:logstash_state` docs

### DIFF
--- a/metricbeat/module/logstash/logstash.go
+++ b/metricbeat/module/logstash/logstash.go
@@ -92,7 +92,10 @@ type graph struct {
 }
 
 type graphContainer struct {
-	Graph *graph `json:"graph,omitempty"`
+	Graph   *graph `json:"graph,omitempty"`
+	Type    string `json:"type"`
+	Version string `json:"version"`
+	Hash    string `json:"hash"`
 }
 
 // PipelineState represents the state (shape) of a Logstash pipeline


### PR DESCRIPTION
This PR fixes the `logstash/node` metricset (x-pack code path) to have parity with internal collection. Specifically, it teaches the metricset to collect and index the following fields:
* `logstash_state.pipeline.representation.type`
* `logstash_state.pipeline.representation.version`
* `logstash_state.pipeline.representation.hash`

### Testing this PR

1. Build Metricbeat with this PR.
   ```
   cd $GOPATH/src/github.com/elastic/beats/metricbeat
   mage build
   ```

2. Enable the Logstash module for Stack Monitoring.
   ```
   ./metricbeat modules enable logstash-xpack
   ```

3. Start Logstash.
   ```
   ./bin/logstash -e 'input { stdin {} } output { elasticsearch {} }'

4. Start Metricbeat.
   ```
   ./metricbeat -e
   ```

5. Verify that the `.monitoring-logstash-*` index contains `type:logstash_state` documents with the aforementioned fields as children of the `logstash_state.pipeline.representation` field.

   ```
   GET .monitoring-logstash-*/_search?q=type:logstash_state&filter_path=hits.hits._source.logstash_state.pipeline.representation&size=1
   ```