### PR TITLE
Fix 404 page not found under generator/metricbeat

### DIFF
--- a/generator/metricbeat/README.md
+++ b/generator/metricbeat/README.md
@@ -1,5 +1,5 @@
 # Creating a Beat based on Metricbeat
 
 The metricset Beat generator enables you to create a Beat that uses Metricbeat as a library and has your
-own metricsets. For more details on how to create your own metricbeat check out the [developer guide](https://www.elastic.co/guide/en/beats/metricbeat/current/creating-beat-from-metricbeat.html).
+own metricsets. For more details on how to create your own metricbeat check out the [developer guide](https://www.elastic.co/guide/en/beats/devguide/current/creating-beat-from-metricbeat.html).
 


### PR DESCRIPTION
Link is broken 
![image](https://user-images.githubusercontent.com/2871786/62247057-ece33100-b3dc-11e9-81a7-a1849195e78c.png)
