### PR TITLE
Remove beta label from add_host_metadata

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -206,6 +206,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add `timestamp` processor for parsing time fields. {pull}12699[12699]
 - Add a check so alias creation explicitely fails if there is an index with the same name. {pull}13070[13070]
 - Update kubernetes watcher to use official client-go libraries. {pull}13051[13051]
+- add_host_metadata is no GA. {pull}13148[13148]
 
 *Auditbeat*
 

--- a/libbeat/docs/processors-using.asciidoc
+++ b/libbeat/docs/processors-using.asciidoc
@@ -1354,8 +1354,6 @@ forget metadata for a container, 60s by default.
 [[add-host-metadata]]
 === Add Host metadata
 
-beta[]
-
 [source,yaml]
 -------------------------------------------------------------------------------
 processors:


### PR DESCRIPTION
Move add_host_metadata to GA. This processor is enabled by default for quite some time.