### PR TITLE
[Auditbeat] Fix broken visualisations in file_integrity module

### DIFF
--- a/auditbeat/module/file_integrity/_meta/kibana/7/dashboard/auditbeat-file-integrity.json
+++ b/auditbeat/module/file_integrity/_meta/kibana/7/dashboard/auditbeat-file-integrity.json
@@ -376,7 +376,7 @@
                             "id": "3", 
                             "params": {
                                 "customLabel": "Path", 
-                                "field": "file.path.raw", 
+                                "field": "file.path", 
                                 "order": "desc", 
                                 "orderBy": "1", 
                                 "size": 10
@@ -541,7 +541,7 @@
                             "id": "2", 
                             "params": {
                                 "customLabel": "File", 
-                                "field": "file.path.raw", 
+                                "field": "file.path", 
                                 "order": "desc", 
                                 "orderBy": "1", 
                                 "size": 1
@@ -816,7 +816,7 @@
                             "id": "2", 
                             "params": {
                                 "customLabel": "Path", 
-                                "field": "file.path.raw", 
+                                "field": "file.path", 
                                 "order": "desc", 
                                 "orderBy": "1", 
                                 "size": 10
@@ -872,7 +872,7 @@
                             "id": "2", 
                             "params": {
                                 "customLabel": "Path", 
-                                "field": "file.path.raw", 
+                                "field": "file.path", 
                                 "order": "desc", 
                                 "orderBy": "1", 
                                 "size": 10


### PR DESCRIPTION
The mapping no longer contains the `file.path.raw` field. Changing to
`file.path`  makes the affected visualisation work again.

Fixes #13162 