### PR TITLE
[Filebeat][elasticsearch] fix JSON lines picked up in gc.logs

### DIFF
--- a/filebeat/module/elasticsearch/gc/config/gc.yml
+++ b/filebeat/module/elasticsearch/gc/config/gc.yml
@@ -4,7 +4,7 @@ paths:
  - {{$path}}
 {{ end }}
 exclude_files: [".gz$"]
-exclude_lines: ["^(OpenJDK|Java HotSpot).* Server VM ", "^CommandLine flags: ", "^Memory: "] # exclude JVM8 banner
+exclude_lines: ["^(OpenJDK|Java HotSpot).* Server VM ", "^CommandLine flags: ", "^Memory: ", "^{"] # exclude JVM8 banner and JSON
 multiline:
   pattern: '^\[?[0-9]{4}-[0-9]{2}-[0-9]{2}'
   negate: true


### PR DESCRIPTION
When used with docker autodiscover, the elasticsearch gc module
erroneously picks up JSON formatted line from docker's stdout.

Fix by excluding lines that start with `{`.

Fixes #13164 