### PR TITLE
upgrade docker-compose

### DIFF
--- a/libbeat/tests/system/requirements.txt
+++ b/libbeat/tests/system/requirements.txt
@@ -4,7 +4,7 @@ cached-property==1.4.2
 certifi==2018.1.18
 chardet==3.0.4
 docker==3.7.0
-docker-compose==1.23.2
+docker-compose==1.24.1
 docker-pycreds==0.4.0
 dockerpty==0.4.1
 docopt==0.6.2


### PR DESCRIPTION
Fix `ERROR: docker-compose 1.23.2 has requirement PyYAML<4,>=3.10, but you'll have pyyaml 4.2b1 which is incompatible.` errors during `make update` mentioned in https://github.com/elastic/beats/pull/9902#issuecomment-451798450.