### PR TITLE
Upgrade containers of the stack used for metricbeat tests

### DIFF
--- a/metricbeat/docs/modules/beat.asciidoc
+++ b/metricbeat/docs/modules/beat.asciidoc
@@ -12,7 +12,7 @@ The default metricsets are `state` and `stats`.
 [float]
 === Compability
 
-The beat module is tested with metricbeat 7.2.0.
+The beat module is tested with metricbeat 7.3.0.
 
 
 [float]

--- a/metricbeat/module/beat/_meta/Dockerfile
+++ b/metricbeat/module/beat/_meta/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/beats/metricbeat:7.2.0
+FROM docker.elastic.co/beats/metricbeat:7.3.0
 
 COPY healthcheck.sh /
 HEALTHCHECK --interval=1s --retries=300 CMD sh /healthcheck.sh

--- a/metricbeat/module/beat/_meta/docs.asciidoc
+++ b/metricbeat/module/beat/_meta/docs.asciidoc
@@ -5,4 +5,4 @@ The default metricsets are `state` and `stats`.
 [float]
 === Compability
 
-The beat module is tested with metricbeat 7.2.0.
+The beat module is tested with metricbeat 7.3.0.

--- a/metricbeat/module/elasticsearch/_meta/Dockerfile
+++ b/metricbeat/module/elasticsearch/_meta/Dockerfile
@@ -1,2 +1,2 @@
-FROM docker.elastic.co/elasticsearch/elasticsearch:7.2.0
+FROM docker.elastic.co/elasticsearch/elasticsearch:7.3.0
 HEALTHCHECK --interval=1s --retries=300 CMD curl -f http://localhost:9200/_license

--- a/metricbeat/module/kibana/_meta/Dockerfile
+++ b/metricbeat/module/kibana/_meta/Dockerfile
@@ -1,3 +1,3 @@
-FROM docker.elastic.co/kibana/kibana:7.2.0
+FROM docker.elastic.co/kibana/kibana:7.3.0
 HEALTHCHECK --interval=1s --retries=300 --start-period=60s CMD python -c 'import urllib, json; response = urllib.urlopen("http://myelastic:changeme@localhost:5601/api/status"); data = json.loads(response.read()); exit(1) if data["status"]["overall"]["state"] != "green" else exit(0);'
 

--- a/metricbeat/module/logstash/_meta/Dockerfile
+++ b/metricbeat/module/logstash/_meta/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/logstash/logstash:7.2.0
+FROM docker.elastic.co/logstash/logstash:7.3.0
 
 COPY healthcheck.sh /
 ENV XPACK_MONITORING_ENABLED=FALSE


### PR DESCRIPTION
Upgrade dockers of the stack used for testing in CI so we can
add dashboards created with Kibana 7.3.0.