### PR TITLE
[7.3] Collecting missing fields for `type:logstash_state` docs (#13133)

### DIFF
--- a/metricbeat/module/logstash/logstash.go
+++ b/metricbeat/module/logstash/logstash.go
@@ -92,7 +92,10 @@ type graph struct {
 }
 
 type graphContainer struct {
-	Graph *graph `json:"graph,omitempty"`
+	Graph   *graph `json:"graph,omitempty"`
+	Type    string `json:"type"`
+	Version string `json:"version"`
+	Hash    string `json:"hash"`
 }
 
 // PipelineState represents the state (shape) of a Logstash pipeline


### PR DESCRIPTION
Backports the following commits to 7.3:
 - Collecting missing fields for `type:logstash_state` docs  (#13133)