### PR TITLE
[Heartbeat] Add certificate tracking fields

### DIFF
--- a/heartbeat/monitors/active/dialchain/_meta/fields.yml
+++ b/heartbeat/monitors/active/dialchain/_meta/fields.yml
@@ -38,6 +38,15 @@
         - name: certificate_not_valid_after
           type: date
           description: Latest time at which the connection's certificates are valid.
+        - name: certificate_root_common_name
+          type: string
+          description: Common Name of certificate root certificate authority.
+        - name: certificate_issuer_common_name
+          type: string
+          description: Common Name of certificate issuer.
+        - name: certificate_common_name
+          type: string
+          description: Common Name of certificate. Useful in identifying wildcards.
         - name: rtt
           type: group
           description: >


### PR DESCRIPTION
We are using heartbeat for monitoring TLS/SSL certificates in our infrastructure.

This request would add the following fields to Heartbeat under the TLS key:

- certificate_root_common_name: Common Name of certificate root certificate authority
- certificate_issuer_common_name: Common Name of certificate issuing certificate authority
- certificate_common_name: Common Name of certificate. Useful in identifying wildcards.

We use this information for a certificate tracking dashboard and thought others may find it useful.

