### PR TITLE
Add ability to override cluster_uuid to be used in monitoring data

### DIFF
--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -1222,6 +1222,13 @@ logging.files:
 # Set to true to enable the monitoring reporter.
 #monitoring.enabled: false
 
+# If output.elasticsearch is enabled, monitoring data for this Auditbeat instance
+# will be associated with the Elasticsearch cluster referenced by output.elasticsearch in
+# the Stack Monitoring UI. However, if a different output is enabled, the monitoring data will
+# show up under a Standalone Cluster in the UI. If you want the monitoring data to be associated
+# with a specific Elasticsearch cluster in the UI, specify that cluster's UUID here.
+#monitoring.override_cluster_uuid:
+
 # Uncomment to send the metrics to Elasticsearch. Most settings from the
 # Elasticsearch output are accepted here as well.
 # Note that the settings should point to your Elasticsearch *monitoring* cluster.

--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -1222,12 +1222,6 @@ logging.files:
 # Set to true to enable the monitoring reporter.
 #monitoring.enabled: false
 
-# If output.elasticsearch is enabled, monitoring data for this Auditbeat instance
-# will be associated with the Elasticsearch cluster referenced by output.elasticsearch in
-# the Stack Monitoring UI. However, if a different output is enabled, the monitoring data will
-# show up under a Standalone Cluster in the UI. If you want the monitoring data to be associated
-# with a specific Elasticsearch cluster in the UI, specify that cluster's UUID here.
-
 # Sets the UUID of the Elasticsearch cluster under which monitoring data for this
 # Auditbeat instance will appear in the Stack Monitoring UI. If output.elasticsearch
 # is enabled, the UUID is derived from the Elasticsearch cluster referenced by output.elasticsearch.

--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -1227,7 +1227,11 @@ logging.files:
 # the Stack Monitoring UI. However, if a different output is enabled, the monitoring data will
 # show up under a Standalone Cluster in the UI. If you want the monitoring data to be associated
 # with a specific Elasticsearch cluster in the UI, specify that cluster's UUID here.
-#monitoring.override_cluster_uuid:
+
+# Sets the UUID of the Elasticsearch cluster under which monitoring data for this
+# Auditbeat instance will appear in the Stack Monitoring UI. If output.elasticsearch
+# is enabled, the UUID is derived from the Elasticsearch cluster referenced by output.elasticsearch.
+#monitoring.cluster_uuid:
 
 # Uncomment to send the metrics to Elasticsearch. Most settings from the
 # Elasticsearch output are accepted here as well.

--- a/auditbeat/auditbeat.yml
+++ b/auditbeat/auditbeat.yml
@@ -168,11 +168,9 @@ processors:
 # Set to true to enable the monitoring reporter.
 #monitoring.enabled: false
 
-# If output.elasticsearch is enabled, monitoring data for this Auditbeat instance
-# will be associated with the Elasticsearch cluster referenced by output.elasticsearch in
-# the Stack Monitoring UI. However, if a different output is enabled, the monitoring data will
-# show up under a Standalone Cluster in the UI. If you want the monitoring data to be associated
-# with a specific Elasticsearch cluster in the UI, specify that cluster's UUID here.
+# Sets the UUID of the Elasticsearch cluster under which monitoring data for this
+# Auditbeat instance will appear in the Stack Monitoring UI. If output.elasticsearch
+# is enabled, the UUID is derived from the Elasticsearch cluster referenced by output.elasticsearch.
 #monitoring.override_cluster_uuid:
 
 # Uncomment to send the metrics to Elasticsearch. Most settings from the

--- a/auditbeat/auditbeat.yml
+++ b/auditbeat/auditbeat.yml
@@ -168,6 +168,13 @@ processors:
 # Set to true to enable the monitoring reporter.
 #monitoring.enabled: false
 
+# If output.elasticsearch is enabled, monitoring data for this Auditbeat instance
+# will be associated with the Elasticsearch cluster referenced by output.elasticsearch in
+# the Stack Monitoring UI. However, if a different output is enabled, the monitoring data will
+# show up under a Standalone Cluster in the UI. If you want the monitoring data to be associated
+# with a specific Elasticsearch cluster in the UI, specify that cluster's UUID here.
+#monitoring.override_cluster_uuid:
+
 # Uncomment to send the metrics to Elasticsearch. Most settings from the
 # Elasticsearch output are accepted here as well.
 # Note that the settings should point to your Elasticsearch *monitoring* cluster.

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -1923,6 +1923,13 @@ logging.files:
 # Set to true to enable the monitoring reporter.
 #monitoring.enabled: false
 
+# If output.elasticsearch is enabled, monitoring data for this Filebeat instance
+# will be associated with the Elasticsearch cluster referenced by output.elasticsearch in
+# the Stack Monitoring UI. However, if a different output is enabled, the monitoring data will
+# show up under a Standalone Cluster in the UI. If you want the monitoring data to be associated
+# with a specific Elasticsearch cluster in the UI, specify that cluster's UUID here.
+#monitoring.override_cluster_uuid:
+
 # Uncomment to send the metrics to Elasticsearch. Most settings from the
 # Elasticsearch output are accepted here as well.
 # Note that the settings should point to your Elasticsearch *monitoring* cluster.

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -1928,7 +1928,11 @@ logging.files:
 # the Stack Monitoring UI. However, if a different output is enabled, the monitoring data will
 # show up under a Standalone Cluster in the UI. If you want the monitoring data to be associated
 # with a specific Elasticsearch cluster in the UI, specify that cluster's UUID here.
-#monitoring.override_cluster_uuid:
+
+# Sets the UUID of the Elasticsearch cluster under which monitoring data for this
+# Filebeat instance will appear in the Stack Monitoring UI. If output.elasticsearch
+# is enabled, the UUID is derived from the Elasticsearch cluster referenced by output.elasticsearch.
+#monitoring.cluster_uuid:
 
 # Uncomment to send the metrics to Elasticsearch. Most settings from the
 # Elasticsearch output are accepted here as well.

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -1923,12 +1923,6 @@ logging.files:
 # Set to true to enable the monitoring reporter.
 #monitoring.enabled: false
 
-# If output.elasticsearch is enabled, monitoring data for this Filebeat instance
-# will be associated with the Elasticsearch cluster referenced by output.elasticsearch in
-# the Stack Monitoring UI. However, if a different output is enabled, the monitoring data will
-# show up under a Standalone Cluster in the UI. If you want the monitoring data to be associated
-# with a specific Elasticsearch cluster in the UI, specify that cluster's UUID here.
-
 # Sets the UUID of the Elasticsearch cluster under which monitoring data for this
 # Filebeat instance will appear in the Stack Monitoring UI. If output.elasticsearch
 # is enabled, the UUID is derived from the Elasticsearch cluster referenced by output.elasticsearch.

--- a/filebeat/filebeat.yml
+++ b/filebeat/filebeat.yml
@@ -196,11 +196,9 @@ processors:
 # Set to true to enable the monitoring reporter.
 #monitoring.enabled: false
 
-# If output.elasticsearch is enabled, monitoring data for this Filebeat instance
-# will be associated with the Elasticsearch cluster referenced by output.elasticsearch in
-# the Stack Monitoring UI. However, if a different output is enabled, the monitoring data will
-# show up under a Standalone Cluster in the UI. If you want the monitoring data to be associated
-# with a specific Elasticsearch cluster in the UI, specify that cluster's UUID here.
+# Sets the UUID of the Elasticsearch cluster under which monitoring data for this
+# Auditbeat instance will appear in the Stack Monitoring UI. If output.elasticsearch
+# is enabled, the UUID is derived from the Elasticsearch cluster referenced by output.elasticsearch.
 #monitoring.override_cluster_uuid:
 
 # Uncomment to send the metrics to Elasticsearch. Most settings from the

--- a/filebeat/filebeat.yml
+++ b/filebeat/filebeat.yml
@@ -196,6 +196,13 @@ processors:
 # Set to true to enable the monitoring reporter.
 #monitoring.enabled: false
 
+# If output.elasticsearch is enabled, monitoring data for this Filebeat instance
+# will be associated with the Elasticsearch cluster referenced by output.elasticsearch in
+# the Stack Monitoring UI. However, if a different output is enabled, the monitoring data will
+# show up under a Standalone Cluster in the UI. If you want the monitoring data to be associated
+# with a specific Elasticsearch cluster in the UI, specify that cluster's UUID here.
+#monitoring.override_cluster_uuid:
+
 # Uncomment to send the metrics to Elasticsearch. Most settings from the
 # Elasticsearch output are accepted here as well.
 # Note that the settings should point to your Elasticsearch *monitoring* cluster.

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -1371,7 +1371,11 @@ logging.files:
 # the Stack Monitoring UI. However, if a different output is enabled, the monitoring data will
 # show up under a Standalone Cluster in the UI. If you want the monitoring data to be associated
 # with a specific Elasticsearch cluster in the UI, specify that cluster's UUID here.
-#monitoring.override_cluster_uuid:
+
+# Sets the UUID of the Elasticsearch cluster under which monitoring data for this
+# Heartbeat instance will appear in the Stack Monitoring UI. If output.elasticsearch
+# is enabled, the UUID is derived from the Elasticsearch cluster referenced by output.elasticsearch.
+#monitoring.cluster_uuid:
 
 # Uncomment to send the metrics to Elasticsearch. Most settings from the
 # Elasticsearch output are accepted here as well.

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -1366,12 +1366,6 @@ logging.files:
 # Set to true to enable the monitoring reporter.
 #monitoring.enabled: false
 
-# If output.elasticsearch is enabled, monitoring data for this Heartbeat instance
-# will be associated with the Elasticsearch cluster referenced by output.elasticsearch in
-# the Stack Monitoring UI. However, if a different output is enabled, the monitoring data will
-# show up under a Standalone Cluster in the UI. If you want the monitoring data to be associated
-# with a specific Elasticsearch cluster in the UI, specify that cluster's UUID here.
-
 # Sets the UUID of the Elasticsearch cluster under which monitoring data for this
 # Heartbeat instance will appear in the Stack Monitoring UI. If output.elasticsearch
 # is enabled, the UUID is derived from the Elasticsearch cluster referenced by output.elasticsearch.

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -1366,6 +1366,13 @@ logging.files:
 # Set to true to enable the monitoring reporter.
 #monitoring.enabled: false
 
+# If output.elasticsearch is enabled, monitoring data for this Heartbeat instance
+# will be associated with the Elasticsearch cluster referenced by output.elasticsearch in
+# the Stack Monitoring UI. However, if a different output is enabled, the monitoring data will
+# show up under a Standalone Cluster in the UI. If you want the monitoring data to be associated
+# with a specific Elasticsearch cluster in the UI, specify that cluster's UUID here.
+#monitoring.override_cluster_uuid:
+
 # Uncomment to send the metrics to Elasticsearch. Most settings from the
 # Elasticsearch output are accepted here as well.
 # Note that the settings should point to your Elasticsearch *monitoring* cluster.

--- a/heartbeat/heartbeat.yml
+++ b/heartbeat/heartbeat.yml
@@ -145,6 +145,13 @@ processors:
 # Set to true to enable the monitoring reporter.
 #monitoring.enabled: false
 
+# If output.elasticsearch is enabled, monitoring data for this Heartbeat instance
+# will be associated with the Elasticsearch cluster referenced by output.elasticsearch in
+# the Stack Monitoring UI. However, if a different output is enabled, the monitoring data will
+# show up under a Standalone Cluster in the UI. If you want the monitoring data to be associated
+# with a specific Elasticsearch cluster in the UI, specify that cluster's UUID here.
+#monitoring.override_cluster_uuid:
+
 # Uncomment to send the metrics to Elasticsearch. Most settings from the
 # Elasticsearch output are accepted here as well.
 # Note that the settings should point to your Elasticsearch *monitoring* cluster.

--- a/heartbeat/heartbeat.yml
+++ b/heartbeat/heartbeat.yml
@@ -145,11 +145,9 @@ processors:
 # Set to true to enable the monitoring reporter.
 #monitoring.enabled: false
 
-# If output.elasticsearch is enabled, monitoring data for this Heartbeat instance
-# will be associated with the Elasticsearch cluster referenced by output.elasticsearch in
-# the Stack Monitoring UI. However, if a different output is enabled, the monitoring data will
-# show up under a Standalone Cluster in the UI. If you want the monitoring data to be associated
-# with a specific Elasticsearch cluster in the UI, specify that cluster's UUID here.
+# Sets the UUID of the Elasticsearch cluster under which monitoring data for this
+# Auditbeat instance will appear in the Stack Monitoring UI. If output.elasticsearch
+# is enabled, the UUID is derived from the Elasticsearch cluster referenced by output.elasticsearch.
 #monitoring.override_cluster_uuid:
 
 # Uncomment to send the metrics to Elasticsearch. Most settings from the

--- a/journalbeat/journalbeat.reference.yml
+++ b/journalbeat/journalbeat.reference.yml
@@ -1167,12 +1167,6 @@ logging.files:
 # Set to true to enable the monitoring reporter.
 #monitoring.enabled: false
 
-# If output.elasticsearch is enabled, monitoring data for this Journalbeat instance
-# will be associated with the Elasticsearch cluster referenced by output.elasticsearch in
-# the Stack Monitoring UI. However, if a different output is enabled, the monitoring data will
-# show up under a Standalone Cluster in the UI. If you want the monitoring data to be associated
-# with a specific Elasticsearch cluster in the UI, specify that cluster's UUID here.
-
 # Sets the UUID of the Elasticsearch cluster under which monitoring data for this
 # Journalbeat instance will appear in the Stack Monitoring UI. If output.elasticsearch
 # is enabled, the UUID is derived from the Elasticsearch cluster referenced by output.elasticsearch.

--- a/journalbeat/journalbeat.reference.yml
+++ b/journalbeat/journalbeat.reference.yml
@@ -1172,7 +1172,11 @@ logging.files:
 # the Stack Monitoring UI. However, if a different output is enabled, the monitoring data will
 # show up under a Standalone Cluster in the UI. If you want the monitoring data to be associated
 # with a specific Elasticsearch cluster in the UI, specify that cluster's UUID here.
-#monitoring.override_cluster_uuid:
+
+# Sets the UUID of the Elasticsearch cluster under which monitoring data for this
+# Journalbeat instance will appear in the Stack Monitoring UI. If output.elasticsearch
+# is enabled, the UUID is derived from the Elasticsearch cluster referenced by output.elasticsearch.
+#monitoring.cluster_uuid:
 
 # Uncomment to send the metrics to Elasticsearch. Most settings from the
 # Elasticsearch output are accepted here as well.

--- a/journalbeat/journalbeat.reference.yml
+++ b/journalbeat/journalbeat.reference.yml
@@ -1167,6 +1167,13 @@ logging.files:
 # Set to true to enable the monitoring reporter.
 #monitoring.enabled: false
 
+# If output.elasticsearch is enabled, monitoring data for this Journalbeat instance
+# will be associated with the Elasticsearch cluster referenced by output.elasticsearch in
+# the Stack Monitoring UI. However, if a different output is enabled, the monitoring data will
+# show up under a Standalone Cluster in the UI. If you want the monitoring data to be associated
+# with a specific Elasticsearch cluster in the UI, specify that cluster's UUID here.
+#monitoring.override_cluster_uuid:
+
 # Uncomment to send the metrics to Elasticsearch. Most settings from the
 # Elasticsearch output are accepted here as well.
 # Note that the settings should point to your Elasticsearch *monitoring* cluster.

--- a/journalbeat/journalbeat.yml
+++ b/journalbeat/journalbeat.yml
@@ -165,6 +165,13 @@ processors:
 # Set to true to enable the monitoring reporter.
 #monitoring.enabled: false
 
+# If output.elasticsearch is enabled, monitoring data for this Journalbeat instance
+# will be associated with the Elasticsearch cluster referenced by output.elasticsearch in
+# the Stack Monitoring UI. However, if a different output is enabled, the monitoring data will
+# show up under a Standalone Cluster in the UI. If you want the monitoring data to be associated
+# with a specific Elasticsearch cluster in the UI, specify that cluster's UUID here.
+#monitoring.override_cluster_uuid:
+
 # Uncomment to send the metrics to Elasticsearch. Most settings from the
 # Elasticsearch output are accepted here as well.
 # Note that the settings should point to your Elasticsearch *monitoring* cluster.

--- a/journalbeat/journalbeat.yml
+++ b/journalbeat/journalbeat.yml
@@ -165,11 +165,9 @@ processors:
 # Set to true to enable the monitoring reporter.
 #monitoring.enabled: false
 
-# If output.elasticsearch is enabled, monitoring data for this Journalbeat instance
-# will be associated with the Elasticsearch cluster referenced by output.elasticsearch in
-# the Stack Monitoring UI. However, if a different output is enabled, the monitoring data will
-# show up under a Standalone Cluster in the UI. If you want the monitoring data to be associated
-# with a specific Elasticsearch cluster in the UI, specify that cluster's UUID here.
+# Sets the UUID of the Elasticsearch cluster under which monitoring data for this
+# Auditbeat instance will appear in the Stack Monitoring UI. If output.elasticsearch
+# is enabled, the UUID is derived from the Elasticsearch cluster referenced by output.elasticsearch.
 #monitoring.override_cluster_uuid:
 
 # Uncomment to send the metrics to Elasticsearch. Most settings from the

--- a/libbeat/_meta/config.reference.yml.tmpl
+++ b/libbeat/_meta/config.reference.yml.tmpl
@@ -1115,7 +1115,11 @@ logging.files:
 # the Stack Monitoring UI. However, if a different output is enabled, the monitoring data will
 # show up under a Standalone Cluster in the UI. If you want the monitoring data to be associated
 # with a specific Elasticsearch cluster in the UI, specify that cluster's UUID here.
-#monitoring.override_cluster_uuid:
+
+# Sets the UUID of the Elasticsearch cluster under which monitoring data for this
+# {{.BeatName | title}} instance will appear in the Stack Monitoring UI. If output.elasticsearch
+# is enabled, the UUID is derived from the Elasticsearch cluster referenced by output.elasticsearch.
+#monitoring.cluster_uuid:
 
 # Uncomment to send the metrics to Elasticsearch. Most settings from the
 # Elasticsearch output are accepted here as well.

--- a/libbeat/_meta/config.reference.yml.tmpl
+++ b/libbeat/_meta/config.reference.yml.tmpl
@@ -1110,12 +1110,6 @@ logging.files:
 # Set to true to enable the monitoring reporter.
 #monitoring.enabled: false
 
-# If output.elasticsearch is enabled, monitoring data for this {{.BeatName | title}} instance
-# will be associated with the Elasticsearch cluster referenced by output.elasticsearch in
-# the Stack Monitoring UI. However, if a different output is enabled, the monitoring data will
-# show up under a Standalone Cluster in the UI. If you want the monitoring data to be associated
-# with a specific Elasticsearch cluster in the UI, specify that cluster's UUID here.
-
 # Sets the UUID of the Elasticsearch cluster under which monitoring data for this
 # {{.BeatName | title}} instance will appear in the Stack Monitoring UI. If output.elasticsearch
 # is enabled, the UUID is derived from the Elasticsearch cluster referenced by output.elasticsearch.

--- a/libbeat/_meta/config.reference.yml.tmpl
+++ b/libbeat/_meta/config.reference.yml.tmpl
@@ -1110,6 +1110,13 @@ logging.files:
 # Set to true to enable the monitoring reporter.
 #monitoring.enabled: false
 
+# If output.elasticsearch is enabled, monitoring data for this {{.BeatName | title}} instance
+# will be associated with the Elasticsearch cluster referenced by output.elasticsearch in
+# the Stack Monitoring UI. However, if a different output is enabled, the monitoring data will
+# show up under a Standalone Cluster in the UI. If you want the monitoring data to be associated
+# with a specific Elasticsearch cluster in the UI, specify that cluster's UUID here.
+#monitoring.override_cluster_uuid:
+
 # Uncomment to send the metrics to Elasticsearch. Most settings from the
 # Elasticsearch output are accepted here as well.
 # Note that the settings should point to your Elasticsearch *monitoring* cluster.

--- a/libbeat/_meta/config.yml.tmpl
+++ b/libbeat/_meta/config.yml.tmpl
@@ -123,11 +123,9 @@ processors:
 # Set to true to enable the monitoring reporter.
 #monitoring.enabled: false
 
-# If output.elasticsearch is enabled, monitoring data for this {{.BeatName | title}} instance
-# will be associated with the Elasticsearch cluster referenced by output.elasticsearch in
-# the Stack Monitoring UI. However, if a different output is enabled, the monitoring data will
-# show up under a Standalone Cluster in the UI. If you want the monitoring data to be associated
-# with a specific Elasticsearch cluster in the UI, specify that cluster's UUID here.
+# Sets the UUID of the Elasticsearch cluster under which monitoring data for this
+# Auditbeat instance will appear in the Stack Monitoring UI. If output.elasticsearch
+# is enabled, the UUID is derived from the Elasticsearch cluster referenced by output.elasticsearch.
 #monitoring.override_cluster_uuid:
 
 # Uncomment to send the metrics to Elasticsearch. Most settings from the

--- a/libbeat/_meta/config.yml.tmpl
+++ b/libbeat/_meta/config.yml.tmpl
@@ -123,6 +123,13 @@ processors:
 # Set to true to enable the monitoring reporter.
 #monitoring.enabled: false
 
+# If output.elasticsearch is enabled, monitoring data for this {{.BeatName | title}} instance
+# will be associated with the Elasticsearch cluster referenced by output.elasticsearch in
+# the Stack Monitoring UI. However, if a different output is enabled, the monitoring data will
+# show up under a Standalone Cluster in the UI. If you want the monitoring data to be associated
+# with a specific Elasticsearch cluster in the UI, specify that cluster's UUID here.
+#monitoring.override_cluster_uuid:
+
 # Uncomment to send the metrics to Elasticsearch. Most settings from the
 # Elasticsearch output are accepted here as well.
 # Note that the settings should point to your Elasticsearch *monitoring* cluster.

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -392,8 +392,9 @@ func (b *Beat) launch(settings Settings, bt beat.Creator) error {
 
 	if monitoringCfg.Enabled() {
 		settings := report.Settings{
-			DefaultUsername: settings.Monitoring.DefaultUsername,
-			Format:          reporterSettings.Format,
+			DefaultUsername:     settings.Monitoring.DefaultUsername,
+			Format:              reporterSettings.Format,
+			OverrideClusterUUID: reporterSettings.OverrideClusterUUID,
 		}
 		reporter, err := report.New(b.Info, settings, monitoringCfg, b.Config.Output)
 		if err != nil {

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -392,9 +392,9 @@ func (b *Beat) launch(settings Settings, bt beat.Creator) error {
 
 	if monitoringCfg.Enabled() {
 		settings := report.Settings{
-			DefaultUsername:     settings.Monitoring.DefaultUsername,
-			Format:              reporterSettings.Format,
-			OverrideClusterUUID: reporterSettings.OverrideClusterUUID,
+			DefaultUsername: settings.Monitoring.DefaultUsername,
+			Format:          reporterSettings.Format,
+			ClusterUUID:     reporterSettings.ClusterUUID,
 		}
 		reporter, err := report.New(b.Info, settings, monitoringCfg, b.Config.Output)
 		if err != nil {

--- a/libbeat/monitoring/monitoring.go
+++ b/libbeat/monitoring/monitoring.go
@@ -97,7 +97,16 @@ func SelectConfig(beatCfg BeatConfig) (*common.Config, *report.Settings, error) 
 		return monitoringCfg, &report.Settings{Format: report.FormatXPackMonitoringBulk}, nil
 	case beatCfg.Monitoring.Enabled():
 		monitoringCfg := beatCfg.Monitoring
-		return monitoringCfg, &report.Settings{Format: report.FormatBulk}, nil
+
+		var overrideClusterUUID string
+		if monitoringCfg.HasField("override_cluster_uuid") {
+			var err error
+			overrideClusterUUID, err = monitoringCfg.String("override_cluster_uuid", -1)
+			if err != nil {
+				return nil, nil, err
+			}
+		}
+		return monitoringCfg, &report.Settings{Format: report.FormatBulk, OverrideClusterUUID: overrideClusterUUID}, nil
 	default:
 		return nil, nil, nil
 	}

--- a/libbeat/monitoring/monitoring.go
+++ b/libbeat/monitoring/monitoring.go
@@ -98,15 +98,15 @@ func SelectConfig(beatCfg BeatConfig) (*common.Config, *report.Settings, error) 
 	case beatCfg.Monitoring.Enabled():
 		monitoringCfg := beatCfg.Monitoring
 
-		var overrideClusterUUID string
-		if monitoringCfg.HasField("override_cluster_uuid") {
+		var clusterUUID string
+		if monitoringCfg.HasField("cluster_uuid") {
 			var err error
-			overrideClusterUUID, err = monitoringCfg.String("override_cluster_uuid", -1)
+			clusterUUID, err = monitoringCfg.String("cluster_uuid", -1)
 			if err != nil {
 				return nil, nil, err
 			}
 		}
-		return monitoringCfg, &report.Settings{Format: report.FormatBulk, OverrideClusterUUID: overrideClusterUUID}, nil
+		return monitoringCfg, &report.Settings{Format: report.FormatBulk, ClusterUUID: clusterUUID}, nil
 	default:
 		return nil, nil, nil
 	}

--- a/libbeat/monitoring/monitoring.go
+++ b/libbeat/monitoring/monitoring.go
@@ -97,16 +97,13 @@ func SelectConfig(beatCfg BeatConfig) (*common.Config, *report.Settings, error) 
 		return monitoringCfg, &report.Settings{Format: report.FormatXPackMonitoringBulk}, nil
 	case beatCfg.Monitoring.Enabled():
 		monitoringCfg := beatCfg.Monitoring
-
-		var clusterUUID string
-		if monitoringCfg.HasField("cluster_uuid") {
-			var err error
-			clusterUUID, err = monitoringCfg.String("cluster_uuid", -1)
-			if err != nil {
-				return nil, nil, err
-			}
+		var info struct {
+			ClusterUUID string `config:"cluster_uuid"`
 		}
-		return monitoringCfg, &report.Settings{Format: report.FormatBulk, ClusterUUID: clusterUUID}, nil
+		if err := monitoringCfg.Unpack(&info); err != nil {
+			return nil, nil, err
+		}
+		return monitoringCfg, &report.Settings{Format: report.FormatBulk, ClusterUUID: info.ClusterUUID}, nil
 	default:
 		return nil, nil, nil
 	}

--- a/libbeat/monitoring/report/elasticsearch/config.go
+++ b/libbeat/monitoring/report/elasticsearch/config.go
@@ -28,25 +28,25 @@ import (
 // config is subset of libbeat/outputs/elasticsearch config tailored
 // for reporting metrics only
 type config struct {
-	Hosts               []string
-	Protocol            string
-	Params              map[string]string `config:"parameters"`
-	Headers             map[string]string `config:"headers"`
-	Username            string            `config:"username"`
-	Password            string            `config:"password"`
-	ProxyURL            string            `config:"proxy_url"`
-	CompressionLevel    int               `config:"compression_level" validate:"min=0, max=9"`
-	TLS                 *tlscommon.Config `config:"ssl"`
-	MaxRetries          int               `config:"max_retries"`
-	Timeout             time.Duration     `config:"timeout"`
-	MetricsPeriod       time.Duration     `config:"metrics.period"`
-	StatePeriod         time.Duration     `config:"state.period"`
-	BulkMaxSize         int               `config:"bulk_max_size" validate:"min=0"`
-	BufferSize          int               `config:"buffer_size"`
-	Tags                []string          `config:"tags"`
-	Backoff             backoff           `config:"backoff"`
-	Format              report.Format     `config:"_format"`
-	OverrideClusterUUID string            `config:"override_cluster_uuid"`
+	Hosts            []string
+	Protocol         string
+	Params           map[string]string `config:"parameters"`
+	Headers          map[string]string `config:"headers"`
+	Username         string            `config:"username"`
+	Password         string            `config:"password"`
+	ProxyURL         string            `config:"proxy_url"`
+	CompressionLevel int               `config:"compression_level" validate:"min=0, max=9"`
+	TLS              *tlscommon.Config `config:"ssl"`
+	MaxRetries       int               `config:"max_retries"`
+	Timeout          time.Duration     `config:"timeout"`
+	MetricsPeriod    time.Duration     `config:"metrics.period"`
+	StatePeriod      time.Duration     `config:"state.period"`
+	BulkMaxSize      int               `config:"bulk_max_size" validate:"min=0"`
+	BufferSize       int               `config:"buffer_size"`
+	Tags             []string          `config:"tags"`
+	Backoff          backoff           `config:"backoff"`
+	Format           report.Format     `config:"_format"`
+	ClusterUUID      string            `config:"cluster_uuid"`
 }
 
 type backoff struct {

--- a/libbeat/monitoring/report/elasticsearch/config.go
+++ b/libbeat/monitoring/report/elasticsearch/config.go
@@ -28,24 +28,25 @@ import (
 // config is subset of libbeat/outputs/elasticsearch config tailored
 // for reporting metrics only
 type config struct {
-	Hosts            []string
-	Protocol         string
-	Params           map[string]string `config:"parameters"`
-	Headers          map[string]string `config:"headers"`
-	Username         string            `config:"username"`
-	Password         string            `config:"password"`
-	ProxyURL         string            `config:"proxy_url"`
-	CompressionLevel int               `config:"compression_level" validate:"min=0, max=9"`
-	TLS              *tlscommon.Config `config:"ssl"`
-	MaxRetries       int               `config:"max_retries"`
-	Timeout          time.Duration     `config:"timeout"`
-	MetricsPeriod    time.Duration     `config:"metrics.period"`
-	StatePeriod      time.Duration     `config:"state.period"`
-	BulkMaxSize      int               `config:"bulk_max_size" validate:"min=0"`
-	BufferSize       int               `config:"buffer_size"`
-	Tags             []string          `config:"tags"`
-	Backoff          backoff           `config:"backoff"`
-	Format           report.Format     `config:"_format"`
+	Hosts               []string
+	Protocol            string
+	Params              map[string]string `config:"parameters"`
+	Headers             map[string]string `config:"headers"`
+	Username            string            `config:"username"`
+	Password            string            `config:"password"`
+	ProxyURL            string            `config:"proxy_url"`
+	CompressionLevel    int               `config:"compression_level" validate:"min=0, max=9"`
+	TLS                 *tlscommon.Config `config:"ssl"`
+	MaxRetries          int               `config:"max_retries"`
+	Timeout             time.Duration     `config:"timeout"`
+	MetricsPeriod       time.Duration     `config:"metrics.period"`
+	StatePeriod         time.Duration     `config:"state.period"`
+	BulkMaxSize         int               `config:"bulk_max_size" validate:"min=0"`
+	BufferSize          int               `config:"buffer_size"`
+	Tags                []string          `config:"tags"`
+	Backoff             backoff           `config:"backoff"`
+	Format              report.Format     `config:"_format"`
+	OverrideClusterUUID string            `config:"override_cluster_uuid"`
 }
 
 type backoff struct {

--- a/libbeat/monitoring/report/elasticsearch/elasticsearch.go
+++ b/libbeat/monitoring/report/elasticsearch/elasticsearch.go
@@ -109,8 +109,8 @@ func defaultConfig(settings report.Settings) config {
 		c.Format = settings.Format
 	}
 
-	if settings.OverrideClusterUUID != "" {
-		c.OverrideClusterUUID = settings.OverrideClusterUUID
+	if settings.ClusterUUID != "" {
+		c.ClusterUUID = settings.ClusterUUID
 	}
 
 	return c
@@ -265,12 +265,12 @@ func (r *reporter) initLoop(c config) {
 	log.Info("Successfully connected to X-Pack Monitoring endpoint.")
 
 	// Start collector and send loop if monitoring endpoint has been found.
-	go r.snapshotLoop("state", "state", c.StatePeriod, c.OverrideClusterUUID)
+	go r.snapshotLoop("state", "state", c.StatePeriod, c.ClusterUUID)
 	// For backward compatibility stats is named to metrics.
-	go r.snapshotLoop("stats", "metrics", c.MetricsPeriod, c.OverrideClusterUUID)
+	go r.snapshotLoop("stats", "metrics", c.MetricsPeriod, c.ClusterUUID)
 }
 
-func (r *reporter) snapshotLoop(namespace, prefix string, period time.Duration, overrideClusterUUID string) {
+func (r *reporter) snapshotLoop(namespace, prefix string, period time.Duration, clusterUUID string) {
 	ticker := time.NewTicker(period)
 	defer ticker.Stop()
 
@@ -310,8 +310,8 @@ func (r *reporter) snapshotLoop(namespace, prefix string, period time.Duration, 
 		}
 
 		var clusterUUID string
-		if overrideClusterUUID != "" {
-			clusterUUID = overrideClusterUUID
+		if clusterUUID != "" {
+			clusterUUID = clusterUUID
 		} else {
 			clusterUUID = getClusterUUID()
 		}

--- a/libbeat/monitoring/report/elasticsearch/elasticsearch.go
+++ b/libbeat/monitoring/report/elasticsearch/elasticsearch.go
@@ -98,7 +98,8 @@ func defaultConfig(settings report.Settings) config {
 			Init: 1 * time.Second,
 			Max:  60 * time.Second,
 		},
-		Format: report.FormatXPackMonitoringBulk,
+		Format:      report.FormatXPackMonitoringBulk,
+		ClusterUUID: settings.ClusterUUID,
 	}
 
 	if settings.DefaultUsername != "" {
@@ -107,10 +108,6 @@ func defaultConfig(settings report.Settings) config {
 
 	if settings.Format != report.FormatUnknown {
 		c.Format = settings.Format
-	}
-
-	if settings.ClusterUUID != "" {
-		c.ClusterUUID = settings.ClusterUUID
 	}
 
 	return c

--- a/libbeat/monitoring/report/elasticsearch/elasticsearch.go
+++ b/libbeat/monitoring/report/elasticsearch/elasticsearch.go
@@ -309,10 +309,7 @@ func (r *reporter) snapshotLoop(namespace, prefix string, period time.Duration, 
 			"params": map[string]string{"interval": strconv.Itoa(int(period/time.Second)) + "s"},
 		}
 
-		var clusterUUID string
-		if clusterUUID != "" {
-			clusterUUID = clusterUUID
-		} else {
+		if clusterUUID == "" {
 			clusterUUID = getClusterUUID()
 		}
 		if clusterUUID != "" {

--- a/libbeat/monitoring/report/report.go
+++ b/libbeat/monitoring/report/report.go
@@ -48,9 +48,9 @@ type config struct {
 }
 
 type Settings struct {
-	DefaultUsername     string
-	Format              Format
-	OverrideClusterUUID string
+	DefaultUsername string
+	Format          Format
+	ClusterUUID     string
 }
 
 type Reporter interface {

--- a/libbeat/monitoring/report/report.go
+++ b/libbeat/monitoring/report/report.go
@@ -48,8 +48,9 @@ type config struct {
 }
 
 type Settings struct {
-	DefaultUsername string
-	Format          Format
+	DefaultUsername     string
+	Format              Format
+	OverrideClusterUUID string
 }
 
 type Reporter interface {

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -1881,12 +1881,6 @@ logging.files:
 # Set to true to enable the monitoring reporter.
 #monitoring.enabled: false
 
-# If output.elasticsearch is enabled, monitoring data for this Metricbeat instance
-# will be associated with the Elasticsearch cluster referenced by output.elasticsearch in
-# the Stack Monitoring UI. However, if a different output is enabled, the monitoring data will
-# show up under a Standalone Cluster in the UI. If you want the monitoring data to be associated
-# with a specific Elasticsearch cluster in the UI, specify that cluster's UUID here.
-
 # Sets the UUID of the Elasticsearch cluster under which monitoring data for this
 # Metricbeat instance will appear in the Stack Monitoring UI. If output.elasticsearch
 # is enabled, the UUID is derived from the Elasticsearch cluster referenced by output.elasticsearch.

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -1881,6 +1881,13 @@ logging.files:
 # Set to true to enable the monitoring reporter.
 #monitoring.enabled: false
 
+# If output.elasticsearch is enabled, monitoring data for this Metricbeat instance
+# will be associated with the Elasticsearch cluster referenced by output.elasticsearch in
+# the Stack Monitoring UI. However, if a different output is enabled, the monitoring data will
+# show up under a Standalone Cluster in the UI. If you want the monitoring data to be associated
+# with a specific Elasticsearch cluster in the UI, specify that cluster's UUID here.
+#monitoring.override_cluster_uuid:
+
 # Uncomment to send the metrics to Elasticsearch. Most settings from the
 # Elasticsearch output are accepted here as well.
 # Note that the settings should point to your Elasticsearch *monitoring* cluster.

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -1886,7 +1886,11 @@ logging.files:
 # the Stack Monitoring UI. However, if a different output is enabled, the monitoring data will
 # show up under a Standalone Cluster in the UI. If you want the monitoring data to be associated
 # with a specific Elasticsearch cluster in the UI, specify that cluster's UUID here.
-#monitoring.override_cluster_uuid:
+
+# Sets the UUID of the Elasticsearch cluster under which monitoring data for this
+# Metricbeat instance will appear in the Stack Monitoring UI. If output.elasticsearch
+# is enabled, the UUID is derived from the Elasticsearch cluster referenced by output.elasticsearch.
+#monitoring.cluster_uuid:
 
 # Uncomment to send the metrics to Elasticsearch. Most settings from the
 # Elasticsearch output are accepted here as well.

--- a/metricbeat/metricbeat.yml
+++ b/metricbeat/metricbeat.yml
@@ -140,11 +140,9 @@ processors:
 # Set to true to enable the monitoring reporter.
 #monitoring.enabled: false
 
-# If output.elasticsearch is enabled, monitoring data for this Metricbeat instance
-# will be associated with the Elasticsearch cluster referenced by output.elasticsearch in
-# the Stack Monitoring UI. However, if a different output is enabled, the monitoring data will
-# show up under a Standalone Cluster in the UI. If you want the monitoring data to be associated
-# with a specific Elasticsearch cluster in the UI, specify that cluster's UUID here.
+# Sets the UUID of the Elasticsearch cluster under which monitoring data for this
+# Auditbeat instance will appear in the Stack Monitoring UI. If output.elasticsearch
+# is enabled, the UUID is derived from the Elasticsearch cluster referenced by output.elasticsearch.
 #monitoring.override_cluster_uuid:
 
 # Uncomment to send the metrics to Elasticsearch. Most settings from the

--- a/metricbeat/metricbeat.yml
+++ b/metricbeat/metricbeat.yml
@@ -139,7 +139,6 @@ processors:
 
 # Set to true to enable the monitoring reporter.
 #monitoring.enabled: false
-monitoring.enabled: true
 
 # If output.elasticsearch is enabled, monitoring data for this Metricbeat instance
 # will be associated with the Elasticsearch cluster referenced by output.elasticsearch in
@@ -147,7 +146,6 @@ monitoring.enabled: true
 # show up under a Standalone Cluster in the UI. If you want the monitoring data to be associated
 # with a specific Elasticsearch cluster in the UI, specify that cluster's UUID here.
 #monitoring.override_cluster_uuid:
-monitoring.override_cluster_uuid: foobar
 
 # Uncomment to send the metrics to Elasticsearch. Most settings from the
 # Elasticsearch output are accepted here as well.

--- a/metricbeat/metricbeat.yml
+++ b/metricbeat/metricbeat.yml
@@ -139,6 +139,15 @@ processors:
 
 # Set to true to enable the monitoring reporter.
 #monitoring.enabled: false
+monitoring.enabled: true
+
+# If output.elasticsearch is enabled, monitoring data for this Metricbeat instance
+# will be associated with the Elasticsearch cluster referenced by output.elasticsearch in
+# the Stack Monitoring UI. However, if a different output is enabled, the monitoring data will
+# show up under a Standalone Cluster in the UI. If you want the monitoring data to be associated
+# with a specific Elasticsearch cluster in the UI, specify that cluster's UUID here.
+#monitoring.override_cluster_uuid:
+monitoring.override_cluster_uuid: foobar
 
 # Uncomment to send the metrics to Elasticsearch. Most settings from the
 # Elasticsearch output are accepted here as well.

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -1599,6 +1599,13 @@ logging.files:
 # Set to true to enable the monitoring reporter.
 #monitoring.enabled: false
 
+# If output.elasticsearch is enabled, monitoring data for this Packetbeat instance
+# will be associated with the Elasticsearch cluster referenced by output.elasticsearch in
+# the Stack Monitoring UI. However, if a different output is enabled, the monitoring data will
+# show up under a Standalone Cluster in the UI. If you want the monitoring data to be associated
+# with a specific Elasticsearch cluster in the UI, specify that cluster's UUID here.
+#monitoring.override_cluster_uuid:
+
 # Uncomment to send the metrics to Elasticsearch. Most settings from the
 # Elasticsearch output are accepted here as well.
 # Note that the settings should point to your Elasticsearch *monitoring* cluster.

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -1604,7 +1604,11 @@ logging.files:
 # the Stack Monitoring UI. However, if a different output is enabled, the monitoring data will
 # show up under a Standalone Cluster in the UI. If you want the monitoring data to be associated
 # with a specific Elasticsearch cluster in the UI, specify that cluster's UUID here.
-#monitoring.override_cluster_uuid:
+
+# Sets the UUID of the Elasticsearch cluster under which monitoring data for this
+# Packetbeat instance will appear in the Stack Monitoring UI. If output.elasticsearch
+# is enabled, the UUID is derived from the Elasticsearch cluster referenced by output.elasticsearch.
+#monitoring.cluster_uuid:
 
 # Uncomment to send the metrics to Elasticsearch. Most settings from the
 # Elasticsearch output are accepted here as well.

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -1599,12 +1599,6 @@ logging.files:
 # Set to true to enable the monitoring reporter.
 #monitoring.enabled: false
 
-# If output.elasticsearch is enabled, monitoring data for this Packetbeat instance
-# will be associated with the Elasticsearch cluster referenced by output.elasticsearch in
-# the Stack Monitoring UI. However, if a different output is enabled, the monitoring data will
-# show up under a Standalone Cluster in the UI. If you want the monitoring data to be associated
-# with a specific Elasticsearch cluster in the UI, specify that cluster's UUID here.
-
 # Sets the UUID of the Elasticsearch cluster under which monitoring data for this
 # Packetbeat instance will appear in the Stack Monitoring UI. If output.elasticsearch
 # is enabled, the UUID is derived from the Elasticsearch cluster referenced by output.elasticsearch.

--- a/packetbeat/packetbeat.yml
+++ b/packetbeat/packetbeat.yml
@@ -222,11 +222,9 @@ processors:
 # Set to true to enable the monitoring reporter.
 #monitoring.enabled: false
 
-# If output.elasticsearch is enabled, monitoring data for this Packetbeat instance
-# will be associated with the Elasticsearch cluster referenced by output.elasticsearch in
-# the Stack Monitoring UI. However, if a different output is enabled, the monitoring data will
-# show up under a Standalone Cluster in the UI. If you want the monitoring data to be associated
-# with a specific Elasticsearch cluster in the UI, specify that cluster's UUID here.
+# Sets the UUID of the Elasticsearch cluster under which monitoring data for this
+# Auditbeat instance will appear in the Stack Monitoring UI. If output.elasticsearch
+# is enabled, the UUID is derived from the Elasticsearch cluster referenced by output.elasticsearch.
 #monitoring.override_cluster_uuid:
 
 # Uncomment to send the metrics to Elasticsearch. Most settings from the

--- a/packetbeat/packetbeat.yml
+++ b/packetbeat/packetbeat.yml
@@ -222,6 +222,13 @@ processors:
 # Set to true to enable the monitoring reporter.
 #monitoring.enabled: false
 
+# If output.elasticsearch is enabled, monitoring data for this Packetbeat instance
+# will be associated with the Elasticsearch cluster referenced by output.elasticsearch in
+# the Stack Monitoring UI. However, if a different output is enabled, the monitoring data will
+# show up under a Standalone Cluster in the UI. If you want the monitoring data to be associated
+# with a specific Elasticsearch cluster in the UI, specify that cluster's UUID here.
+#monitoring.override_cluster_uuid:
+
 # Uncomment to send the metrics to Elasticsearch. Most settings from the
 # Elasticsearch output are accepted here as well.
 # Note that the settings should point to your Elasticsearch *monitoring* cluster.

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -1143,6 +1143,13 @@ logging.files:
 # Set to true to enable the monitoring reporter.
 #monitoring.enabled: false
 
+# If output.elasticsearch is enabled, monitoring data for this Winlogbeat instance
+# will be associated with the Elasticsearch cluster referenced by output.elasticsearch in
+# the Stack Monitoring UI. However, if a different output is enabled, the monitoring data will
+# show up under a Standalone Cluster in the UI. If you want the monitoring data to be associated
+# with a specific Elasticsearch cluster in the UI, specify that cluster's UUID here.
+#monitoring.override_cluster_uuid:
+
 # Uncomment to send the metrics to Elasticsearch. Most settings from the
 # Elasticsearch output are accepted here as well.
 # Note that the settings should point to your Elasticsearch *monitoring* cluster.

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -1148,7 +1148,11 @@ logging.files:
 # the Stack Monitoring UI. However, if a different output is enabled, the monitoring data will
 # show up under a Standalone Cluster in the UI. If you want the monitoring data to be associated
 # with a specific Elasticsearch cluster in the UI, specify that cluster's UUID here.
-#monitoring.override_cluster_uuid:
+
+# Sets the UUID of the Elasticsearch cluster under which monitoring data for this
+# Winlogbeat instance will appear in the Stack Monitoring UI. If output.elasticsearch
+# is enabled, the UUID is derived from the Elasticsearch cluster referenced by output.elasticsearch.
+#monitoring.cluster_uuid:
 
 # Uncomment to send the metrics to Elasticsearch. Most settings from the
 # Elasticsearch output are accepted here as well.

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -1143,12 +1143,6 @@ logging.files:
 # Set to true to enable the monitoring reporter.
 #monitoring.enabled: false
 
-# If output.elasticsearch is enabled, monitoring data for this Winlogbeat instance
-# will be associated with the Elasticsearch cluster referenced by output.elasticsearch in
-# the Stack Monitoring UI. However, if a different output is enabled, the monitoring data will
-# show up under a Standalone Cluster in the UI. If you want the monitoring data to be associated
-# with a specific Elasticsearch cluster in the UI, specify that cluster's UUID here.
-
 # Sets the UUID of the Elasticsearch cluster under which monitoring data for this
 # Winlogbeat instance will appear in the Stack Monitoring UI. If output.elasticsearch
 # is enabled, the UUID is derived from the Elasticsearch cluster referenced by output.elasticsearch.

--- a/winlogbeat/winlogbeat.yml
+++ b/winlogbeat/winlogbeat.yml
@@ -147,6 +147,13 @@ processors:
 # Set to true to enable the monitoring reporter.
 #monitoring.enabled: false
 
+# If output.elasticsearch is enabled, monitoring data for this Winlogbeat instance
+# will be associated with the Elasticsearch cluster referenced by output.elasticsearch in
+# the Stack Monitoring UI. However, if a different output is enabled, the monitoring data will
+# show up under a Standalone Cluster in the UI. If you want the monitoring data to be associated
+# with a specific Elasticsearch cluster in the UI, specify that cluster's UUID here.
+#monitoring.override_cluster_uuid:
+
 # Uncomment to send the metrics to Elasticsearch. Most settings from the
 # Elasticsearch output are accepted here as well.
 # Note that the settings should point to your Elasticsearch *monitoring* cluster.

--- a/winlogbeat/winlogbeat.yml
+++ b/winlogbeat/winlogbeat.yml
@@ -147,11 +147,9 @@ processors:
 # Set to true to enable the monitoring reporter.
 #monitoring.enabled: false
 
-# If output.elasticsearch is enabled, monitoring data for this Winlogbeat instance
-# will be associated with the Elasticsearch cluster referenced by output.elasticsearch in
-# the Stack Monitoring UI. However, if a different output is enabled, the monitoring data will
-# show up under a Standalone Cluster in the UI. If you want the monitoring data to be associated
-# with a specific Elasticsearch cluster in the UI, specify that cluster's UUID here.
+# Sets the UUID of the Elasticsearch cluster under which monitoring data for this
+# Auditbeat instance will appear in the Stack Monitoring UI. If output.elasticsearch
+# is enabled, the UUID is derived from the Elasticsearch cluster referenced by output.elasticsearch.
 #monitoring.override_cluster_uuid:
 
 # Uncomment to send the metrics to Elasticsearch. Most settings from the

--- a/x-pack/auditbeat/auditbeat.reference.yml
+++ b/x-pack/auditbeat/auditbeat.reference.yml
@@ -1278,7 +1278,11 @@ logging.files:
 # the Stack Monitoring UI. However, if a different output is enabled, the monitoring data will
 # show up under a Standalone Cluster in the UI. If you want the monitoring data to be associated
 # with a specific Elasticsearch cluster in the UI, specify that cluster's UUID here.
-#monitoring.override_cluster_uuid:
+
+# Sets the UUID of the Elasticsearch cluster under which monitoring data for this
+# Auditbeat instance will appear in the Stack Monitoring UI. If output.elasticsearch
+# is enabled, the UUID is derived from the Elasticsearch cluster referenced by output.elasticsearch.
+#monitoring.cluster_uuid:
 
 # Uncomment to send the metrics to Elasticsearch. Most settings from the
 # Elasticsearch output are accepted here as well.

--- a/x-pack/auditbeat/auditbeat.reference.yml
+++ b/x-pack/auditbeat/auditbeat.reference.yml
@@ -1273,12 +1273,6 @@ logging.files:
 # Set to true to enable the monitoring reporter.
 #monitoring.enabled: false
 
-# If output.elasticsearch is enabled, monitoring data for this Auditbeat instance
-# will be associated with the Elasticsearch cluster referenced by output.elasticsearch in
-# the Stack Monitoring UI. However, if a different output is enabled, the monitoring data will
-# show up under a Standalone Cluster in the UI. If you want the monitoring data to be associated
-# with a specific Elasticsearch cluster in the UI, specify that cluster's UUID here.
-
 # Sets the UUID of the Elasticsearch cluster under which monitoring data for this
 # Auditbeat instance will appear in the Stack Monitoring UI. If output.elasticsearch
 # is enabled, the UUID is derived from the Elasticsearch cluster referenced by output.elasticsearch.

--- a/x-pack/auditbeat/auditbeat.reference.yml
+++ b/x-pack/auditbeat/auditbeat.reference.yml
@@ -1273,6 +1273,13 @@ logging.files:
 # Set to true to enable the monitoring reporter.
 #monitoring.enabled: false
 
+# If output.elasticsearch is enabled, monitoring data for this Auditbeat instance
+# will be associated with the Elasticsearch cluster referenced by output.elasticsearch in
+# the Stack Monitoring UI. However, if a different output is enabled, the monitoring data will
+# show up under a Standalone Cluster in the UI. If you want the monitoring data to be associated
+# with a specific Elasticsearch cluster in the UI, specify that cluster's UUID here.
+#monitoring.override_cluster_uuid:
+
 # Uncomment to send the metrics to Elasticsearch. Most settings from the
 # Elasticsearch output are accepted here as well.
 # Note that the settings should point to your Elasticsearch *monitoring* cluster.

--- a/x-pack/auditbeat/auditbeat.yml
+++ b/x-pack/auditbeat/auditbeat.yml
@@ -190,11 +190,9 @@ processors:
 # Set to true to enable the monitoring reporter.
 #monitoring.enabled: false
 
-# If output.elasticsearch is enabled, monitoring data for this Auditbeat instance
-# will be associated with the Elasticsearch cluster referenced by output.elasticsearch in
-# the Stack Monitoring UI. However, if a different output is enabled, the monitoring data will
-# show up under a Standalone Cluster in the UI. If you want the monitoring data to be associated
-# with a specific Elasticsearch cluster in the UI, specify that cluster's UUID here.
+# Sets the UUID of the Elasticsearch cluster under which monitoring data for this
+# Auditbeat instance will appear in the Stack Monitoring UI. If output.elasticsearch
+# is enabled, the UUID is derived from the Elasticsearch cluster referenced by output.elasticsearch.
 #monitoring.override_cluster_uuid:
 
 # Uncomment to send the metrics to Elasticsearch. Most settings from the

--- a/x-pack/auditbeat/auditbeat.yml
+++ b/x-pack/auditbeat/auditbeat.yml
@@ -190,6 +190,13 @@ processors:
 # Set to true to enable the monitoring reporter.
 #monitoring.enabled: false
 
+# If output.elasticsearch is enabled, monitoring data for this Auditbeat instance
+# will be associated with the Elasticsearch cluster referenced by output.elasticsearch in
+# the Stack Monitoring UI. However, if a different output is enabled, the monitoring data will
+# show up under a Standalone Cluster in the UI. If you want the monitoring data to be associated
+# with a specific Elasticsearch cluster in the UI, specify that cluster's UUID here.
+#monitoring.override_cluster_uuid:
+
 # Uncomment to send the metrics to Elasticsearch. Most settings from the
 # Elasticsearch output are accepted here as well.
 # Note that the settings should point to your Elasticsearch *monitoring* cluster.

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -2209,7 +2209,11 @@ logging.files:
 # the Stack Monitoring UI. However, if a different output is enabled, the monitoring data will
 # show up under a Standalone Cluster in the UI. If you want the monitoring data to be associated
 # with a specific Elasticsearch cluster in the UI, specify that cluster's UUID here.
-#monitoring.override_cluster_uuid:
+
+# Sets the UUID of the Elasticsearch cluster under which monitoring data for this
+# Filebeat instance will appear in the Stack Monitoring UI. If output.elasticsearch
+# is enabled, the UUID is derived from the Elasticsearch cluster referenced by output.elasticsearch.
+#monitoring.cluster_uuid:
 
 # Uncomment to send the metrics to Elasticsearch. Most settings from the
 # Elasticsearch output are accepted here as well.

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -2204,12 +2204,6 @@ logging.files:
 # Set to true to enable the monitoring reporter.
 #monitoring.enabled: false
 
-# If output.elasticsearch is enabled, monitoring data for this Filebeat instance
-# will be associated with the Elasticsearch cluster referenced by output.elasticsearch in
-# the Stack Monitoring UI. However, if a different output is enabled, the monitoring data will
-# show up under a Standalone Cluster in the UI. If you want the monitoring data to be associated
-# with a specific Elasticsearch cluster in the UI, specify that cluster's UUID here.
-
 # Sets the UUID of the Elasticsearch cluster under which monitoring data for this
 # Filebeat instance will appear in the Stack Monitoring UI. If output.elasticsearch
 # is enabled, the UUID is derived from the Elasticsearch cluster referenced by output.elasticsearch.

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -2204,6 +2204,13 @@ logging.files:
 # Set to true to enable the monitoring reporter.
 #monitoring.enabled: false
 
+# If output.elasticsearch is enabled, monitoring data for this Filebeat instance
+# will be associated with the Elasticsearch cluster referenced by output.elasticsearch in
+# the Stack Monitoring UI. However, if a different output is enabled, the monitoring data will
+# show up under a Standalone Cluster in the UI. If you want the monitoring data to be associated
+# with a specific Elasticsearch cluster in the UI, specify that cluster's UUID here.
+#monitoring.override_cluster_uuid:
+
 # Uncomment to send the metrics to Elasticsearch. Most settings from the
 # Elasticsearch output are accepted here as well.
 # Note that the settings should point to your Elasticsearch *monitoring* cluster.

--- a/x-pack/filebeat/filebeat.yml
+++ b/x-pack/filebeat/filebeat.yml
@@ -196,11 +196,9 @@ processors:
 # Set to true to enable the monitoring reporter.
 #monitoring.enabled: false
 
-# If output.elasticsearch is enabled, monitoring data for this Filebeat instance
-# will be associated with the Elasticsearch cluster referenced by output.elasticsearch in
-# the Stack Monitoring UI. However, if a different output is enabled, the monitoring data will
-# show up under a Standalone Cluster in the UI. If you want the monitoring data to be associated
-# with a specific Elasticsearch cluster in the UI, specify that cluster's UUID here.
+# Sets the UUID of the Elasticsearch cluster under which monitoring data for this
+# Auditbeat instance will appear in the Stack Monitoring UI. If output.elasticsearch
+# is enabled, the UUID is derived from the Elasticsearch cluster referenced by output.elasticsearch.
 #monitoring.override_cluster_uuid:
 
 # Uncomment to send the metrics to Elasticsearch. Most settings from the

--- a/x-pack/filebeat/filebeat.yml
+++ b/x-pack/filebeat/filebeat.yml
@@ -196,6 +196,13 @@ processors:
 # Set to true to enable the monitoring reporter.
 #monitoring.enabled: false
 
+# If output.elasticsearch is enabled, monitoring data for this Filebeat instance
+# will be associated with the Elasticsearch cluster referenced by output.elasticsearch in
+# the Stack Monitoring UI. However, if a different output is enabled, the monitoring data will
+# show up under a Standalone Cluster in the UI. If you want the monitoring data to be associated
+# with a specific Elasticsearch cluster in the UI, specify that cluster's UUID here.
+#monitoring.override_cluster_uuid:
+
 # Uncomment to send the metrics to Elasticsearch. Most settings from the
 # Elasticsearch output are accepted here as well.
 # Note that the settings should point to your Elasticsearch *monitoring* cluster.

--- a/x-pack/functionbeat/functionbeat.reference.yml
+++ b/x-pack/functionbeat/functionbeat.reference.yml
@@ -1060,6 +1060,13 @@ logging.files:
 # Set to true to enable the monitoring reporter.
 #monitoring.enabled: false
 
+# If output.elasticsearch is enabled, monitoring data for this Functionbeat instance
+# will be associated with the Elasticsearch cluster referenced by output.elasticsearch in
+# the Stack Monitoring UI. However, if a different output is enabled, the monitoring data will
+# show up under a Standalone Cluster in the UI. If you want the monitoring data to be associated
+# with a specific Elasticsearch cluster in the UI, specify that cluster's UUID here.
+#monitoring.override_cluster_uuid:
+
 # Uncomment to send the metrics to Elasticsearch. Most settings from the
 # Elasticsearch output are accepted here as well.
 # Note that the settings should point to your Elasticsearch *monitoring* cluster.

--- a/x-pack/functionbeat/functionbeat.reference.yml
+++ b/x-pack/functionbeat/functionbeat.reference.yml
@@ -1065,7 +1065,11 @@ logging.files:
 # the Stack Monitoring UI. However, if a different output is enabled, the monitoring data will
 # show up under a Standalone Cluster in the UI. If you want the monitoring data to be associated
 # with a specific Elasticsearch cluster in the UI, specify that cluster's UUID here.
-#monitoring.override_cluster_uuid:
+
+# Sets the UUID of the Elasticsearch cluster under which monitoring data for this
+# Functionbeat instance will appear in the Stack Monitoring UI. If output.elasticsearch
+# is enabled, the UUID is derived from the Elasticsearch cluster referenced by output.elasticsearch.
+#monitoring.cluster_uuid:
 
 # Uncomment to send the metrics to Elasticsearch. Most settings from the
 # Elasticsearch output are accepted here as well.

--- a/x-pack/functionbeat/functionbeat.reference.yml
+++ b/x-pack/functionbeat/functionbeat.reference.yml
@@ -1060,12 +1060,6 @@ logging.files:
 # Set to true to enable the monitoring reporter.
 #monitoring.enabled: false
 
-# If output.elasticsearch is enabled, monitoring data for this Functionbeat instance
-# will be associated with the Elasticsearch cluster referenced by output.elasticsearch in
-# the Stack Monitoring UI. However, if a different output is enabled, the monitoring data will
-# show up under a Standalone Cluster in the UI. If you want the monitoring data to be associated
-# with a specific Elasticsearch cluster in the UI, specify that cluster's UUID here.
-
 # Sets the UUID of the Elasticsearch cluster under which monitoring data for this
 # Functionbeat instance will appear in the Stack Monitoring UI. If output.elasticsearch
 # is enabled, the UUID is derived from the Elasticsearch cluster referenced by output.elasticsearch.

--- a/x-pack/functionbeat/functionbeat.yml
+++ b/x-pack/functionbeat/functionbeat.yml
@@ -364,6 +364,13 @@ processors:
 # Set to true to enable the monitoring reporter.
 #monitoring.enabled: false
 
+# If output.elasticsearch is enabled, monitoring data for this Functionbeat instance
+# will be associated with the Elasticsearch cluster referenced by output.elasticsearch in
+# the Stack Monitoring UI. However, if a different output is enabled, the monitoring data will
+# show up under a Standalone Cluster in the UI. If you want the monitoring data to be associated
+# with a specific Elasticsearch cluster in the UI, specify that cluster's UUID here.
+#monitoring.override_cluster_uuid:
+
 # Uncomment to send the metrics to Elasticsearch. Most settings from the
 # Elasticsearch output are accepted here as well.
 # Note that the settings should point to your Elasticsearch *monitoring* cluster.

--- a/x-pack/functionbeat/functionbeat.yml
+++ b/x-pack/functionbeat/functionbeat.yml
@@ -364,11 +364,9 @@ processors:
 # Set to true to enable the monitoring reporter.
 #monitoring.enabled: false
 
-# If output.elasticsearch is enabled, monitoring data for this Functionbeat instance
-# will be associated with the Elasticsearch cluster referenced by output.elasticsearch in
-# the Stack Monitoring UI. However, if a different output is enabled, the monitoring data will
-# show up under a Standalone Cluster in the UI. If you want the monitoring data to be associated
-# with a specific Elasticsearch cluster in the UI, specify that cluster's UUID here.
+# Sets the UUID of the Elasticsearch cluster under which monitoring data for this
+# Auditbeat instance will appear in the Stack Monitoring UI. If output.elasticsearch
+# is enabled, the UUID is derived from the Elasticsearch cluster referenced by output.elasticsearch.
 #monitoring.override_cluster_uuid:
 
 # Uncomment to send the metrics to Elasticsearch. Most settings from the

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -1978,12 +1978,6 @@ logging.files:
 # Set to true to enable the monitoring reporter.
 #monitoring.enabled: false
 
-# If output.elasticsearch is enabled, monitoring data for this Metricbeat instance
-# will be associated with the Elasticsearch cluster referenced by output.elasticsearch in
-# the Stack Monitoring UI. However, if a different output is enabled, the monitoring data will
-# show up under a Standalone Cluster in the UI. If you want the monitoring data to be associated
-# with a specific Elasticsearch cluster in the UI, specify that cluster's UUID here.
-
 # Sets the UUID of the Elasticsearch cluster under which monitoring data for this
 # Metricbeat instance will appear in the Stack Monitoring UI. If output.elasticsearch
 # is enabled, the UUID is derived from the Elasticsearch cluster referenced by output.elasticsearch.

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -1983,7 +1983,11 @@ logging.files:
 # the Stack Monitoring UI. However, if a different output is enabled, the monitoring data will
 # show up under a Standalone Cluster in the UI. If you want the monitoring data to be associated
 # with a specific Elasticsearch cluster in the UI, specify that cluster's UUID here.
-#monitoring.override_cluster_uuid:
+
+# Sets the UUID of the Elasticsearch cluster under which monitoring data for this
+# Metricbeat instance will appear in the Stack Monitoring UI. If output.elasticsearch
+# is enabled, the UUID is derived from the Elasticsearch cluster referenced by output.elasticsearch.
+#monitoring.cluster_uuid:
 
 # Uncomment to send the metrics to Elasticsearch. Most settings from the
 # Elasticsearch output are accepted here as well.

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -1978,6 +1978,13 @@ logging.files:
 # Set to true to enable the monitoring reporter.
 #monitoring.enabled: false
 
+# If output.elasticsearch is enabled, monitoring data for this Metricbeat instance
+# will be associated with the Elasticsearch cluster referenced by output.elasticsearch in
+# the Stack Monitoring UI. However, if a different output is enabled, the monitoring data will
+# show up under a Standalone Cluster in the UI. If you want the monitoring data to be associated
+# with a specific Elasticsearch cluster in the UI, specify that cluster's UUID here.
+#monitoring.override_cluster_uuid:
+
 # Uncomment to send the metrics to Elasticsearch. Most settings from the
 # Elasticsearch output are accepted here as well.
 # Note that the settings should point to your Elasticsearch *monitoring* cluster.

--- a/x-pack/metricbeat/metricbeat.yml
+++ b/x-pack/metricbeat/metricbeat.yml
@@ -140,11 +140,9 @@ processors:
 # Set to true to enable the monitoring reporter.
 #monitoring.enabled: false
 
-# If output.elasticsearch is enabled, monitoring data for this Metricbeat instance
-# will be associated with the Elasticsearch cluster referenced by output.elasticsearch in
-# the Stack Monitoring UI. However, if a different output is enabled, the monitoring data will
-# show up under a Standalone Cluster in the UI. If you want the monitoring data to be associated
-# with a specific Elasticsearch cluster in the UI, specify that cluster's UUID here.
+# Sets the UUID of the Elasticsearch cluster under which monitoring data for this
+# Auditbeat instance will appear in the Stack Monitoring UI. If output.elasticsearch
+# is enabled, the UUID is derived from the Elasticsearch cluster referenced by output.elasticsearch.
 #monitoring.override_cluster_uuid:
 
 # Uncomment to send the metrics to Elasticsearch. Most settings from the

--- a/x-pack/metricbeat/metricbeat.yml
+++ b/x-pack/metricbeat/metricbeat.yml
@@ -140,6 +140,13 @@ processors:
 # Set to true to enable the monitoring reporter.
 #monitoring.enabled: false
 
+# If output.elasticsearch is enabled, monitoring data for this Metricbeat instance
+# will be associated with the Elasticsearch cluster referenced by output.elasticsearch in
+# the Stack Monitoring UI. However, if a different output is enabled, the monitoring data will
+# show up under a Standalone Cluster in the UI. If you want the monitoring data to be associated
+# with a specific Elasticsearch cluster in the UI, specify that cluster's UUID here.
+#monitoring.override_cluster_uuid:
+
 # Uncomment to send the metrics to Elasticsearch. Most settings from the
 # Elasticsearch output are accepted here as well.
 # Note that the settings should point to your Elasticsearch *monitoring* cluster.

--- a/x-pack/winlogbeat/winlogbeat.reference.yml
+++ b/x-pack/winlogbeat/winlogbeat.reference.yml
@@ -1155,12 +1155,6 @@ logging.files:
 # Set to true to enable the monitoring reporter.
 #monitoring.enabled: false
 
-# If output.elasticsearch is enabled, monitoring data for this Winlogbeat instance
-# will be associated with the Elasticsearch cluster referenced by output.elasticsearch in
-# the Stack Monitoring UI. However, if a different output is enabled, the monitoring data will
-# show up under a Standalone Cluster in the UI. If you want the monitoring data to be associated
-# with a specific Elasticsearch cluster in the UI, specify that cluster's UUID here.
-
 # Sets the UUID of the Elasticsearch cluster under which monitoring data for this
 # Winlogbeat instance will appear in the Stack Monitoring UI. If output.elasticsearch
 # is enabled, the UUID is derived from the Elasticsearch cluster referenced by output.elasticsearch.

--- a/x-pack/winlogbeat/winlogbeat.reference.yml
+++ b/x-pack/winlogbeat/winlogbeat.reference.yml
@@ -1155,6 +1155,13 @@ logging.files:
 # Set to true to enable the monitoring reporter.
 #monitoring.enabled: false
 
+# If output.elasticsearch is enabled, monitoring data for this Winlogbeat instance
+# will be associated with the Elasticsearch cluster referenced by output.elasticsearch in
+# the Stack Monitoring UI. However, if a different output is enabled, the monitoring data will
+# show up under a Standalone Cluster in the UI. If you want the monitoring data to be associated
+# with a specific Elasticsearch cluster in the UI, specify that cluster's UUID here.
+#monitoring.override_cluster_uuid:
+
 # Uncomment to send the metrics to Elasticsearch. Most settings from the
 # Elasticsearch output are accepted here as well.
 # Note that the settings should point to your Elasticsearch *monitoring* cluster.

--- a/x-pack/winlogbeat/winlogbeat.reference.yml
+++ b/x-pack/winlogbeat/winlogbeat.reference.yml
@@ -1160,7 +1160,11 @@ logging.files:
 # the Stack Monitoring UI. However, if a different output is enabled, the monitoring data will
 # show up under a Standalone Cluster in the UI. If you want the monitoring data to be associated
 # with a specific Elasticsearch cluster in the UI, specify that cluster's UUID here.
-#monitoring.override_cluster_uuid:
+
+# Sets the UUID of the Elasticsearch cluster under which monitoring data for this
+# Winlogbeat instance will appear in the Stack Monitoring UI. If output.elasticsearch
+# is enabled, the UUID is derived from the Elasticsearch cluster referenced by output.elasticsearch.
+#monitoring.cluster_uuid:
 
 # Uncomment to send the metrics to Elasticsearch. Most settings from the
 # Elasticsearch output are accepted here as well.

--- a/x-pack/winlogbeat/winlogbeat.yml
+++ b/x-pack/winlogbeat/winlogbeat.yml
@@ -159,6 +159,13 @@ processors:
 # Set to true to enable the monitoring reporter.
 #monitoring.enabled: false
 
+# If output.elasticsearch is enabled, monitoring data for this Winlogbeat instance
+# will be associated with the Elasticsearch cluster referenced by output.elasticsearch in
+# the Stack Monitoring UI. However, if a different output is enabled, the monitoring data will
+# show up under a Standalone Cluster in the UI. If you want the monitoring data to be associated
+# with a specific Elasticsearch cluster in the UI, specify that cluster's UUID here.
+#monitoring.override_cluster_uuid:
+
 # Uncomment to send the metrics to Elasticsearch. Most settings from the
 # Elasticsearch output are accepted here as well.
 # Note that the settings should point to your Elasticsearch *monitoring* cluster.

--- a/x-pack/winlogbeat/winlogbeat.yml
+++ b/x-pack/winlogbeat/winlogbeat.yml
@@ -159,11 +159,9 @@ processors:
 # Set to true to enable the monitoring reporter.
 #monitoring.enabled: false
 
-# If output.elasticsearch is enabled, monitoring data for this Winlogbeat instance
-# will be associated with the Elasticsearch cluster referenced by output.elasticsearch in
-# the Stack Monitoring UI. However, if a different output is enabled, the monitoring data will
-# show up under a Standalone Cluster in the UI. If you want the monitoring data to be associated
-# with a specific Elasticsearch cluster in the UI, specify that cluster's UUID here.
+# Sets the UUID of the Elasticsearch cluster under which monitoring data for this
+# Auditbeat instance will appear in the Stack Monitoring UI. If output.elasticsearch
+# is enabled, the UUID is derived from the Elasticsearch cluster referenced by output.elasticsearch.
 #monitoring.override_cluster_uuid:
 
 # Uncomment to send the metrics to Elasticsearch. Most settings from the


### PR DESCRIPTION
## Background and Problem
Starting 7.2.0, the `xpack.monitoring.*` settings in Beats are deprecated in favor of `monitoring.*` settings. The former were used to define the _production_ cluster to which the Beat should send its monitoring data. The latter are used to define the _monitoring_ cluster to which the Beat should directly send its monitoring data.

When the `monitoring.*` settings are used with an output other than `elasticsearch`, there's no way (currently) to know if the Beat's "regular" (i.e. non-monitoring) data is going to end up in an Elasticsearch cluster. As such, we cannot associate the Beat with an Elasticsearch cluster in the Stack Monitoring UI. Instead we show it under a "Standalone Cluster".

Prior to 7.2.0, if users were using an output other than `elasticsearch`, they would still send monitoring data via the production cluster (by using the `xpack.monitoring.*` settings). As such, the production cluster could enrich the monitoring data such that the Stack Monitoring UI would show the Beat associated with that production Elasticsearch cluster.

Starting 7.2.0 instead, the same Beat has now "moved" to a Standalone Cluster in the UI and [users are not happy about it](https://discuss.elastic.co/t/filebeat-creates-a-standalone-cluster-in-kibana-monitoring/188663), specifically users who know that their Beats are **eventually** sending their regular data into Elasticsearch. Such users would like to see the Beat associated with their production Elasticsearch cluster in the UI.

## Solution

This PR aims to solve the above problem by providing said class of users with a new setting in their Beat's configuration: 

```
monitoring.override_cluster_uuid:
```

By default, this setting is not set, that is, it's value is empty. In this case the value of the `cluster_uuid` field in the Beat's monitoring documents will be determined as follows:

* If the Beat is using the `elasticsearch` output, the `cluster_uuid` will be that of the Elasticsearch cluster referenced by the `elasticsearch` output.
* Else, the `cluster_uuid` will be blank, causing the Beat to show up under Standalone Cluster in the Stack Monitoring UI.

If the `monitoring.override_cluster_uuid` setting is given a value (i.e. the Cluster UUID of an Elasticsearch cluster), this value will be used as the value of the `cluster_uuid` field in the Beat's monitoring documents, **regardless of the output being used by the Beat**.

## Testing this PR

For all test cases below, the same Elasticsearch query is to be run against your Monitoring Elasticsearch cluster. This is the query:

```
POST .monitoring-beats-*/_search
{
  "size": 2, 
  "_source": [
    "type",
    "cluster_uuid"
    ],
  "collapse": {
    "field": "type"
  },
  "sort": [
    {
      "timestamp": {
        "order": "desc"
      }
    }
  ]
}
```

When running this query, note that it may take up to 30 seconds for `type:beats_state` documents to show up.

### When `monitoring.override_cluster_uuid` is set

Verify that the value of the `cluster_uuid` field in `.monitoring-beats-*` documents of `type:beats_stats` as well as `type:beats_state` is the same as that specified for the `monitoring.override_cluster_uuid` setting.

### When `monitoring.override_cluster_uuid` is not set

#### When `output.elasticsearch` is enabled

Verify that the value of the `cluster_uuid` field in `.monitoring-beats-*` documents of `type:beats_stats` as well as `type:beats_state` is the same as the cluster UUID of the Elasticsearch cluster referenced by the `output.elasticsearch` setting. To deteremine this value, call the `GET /` API against the `output.elasticsearch` Elasticsearch cluster.

#### When an output other than `output.elasticsearch` is enabled

Verify that the value of the `cluster_uuid` field in `.monitoring-beats-*` documents of `type:beats_stats` as well as `type:beats_state` is `null`.

For testing, you can enable `output.console`. Make sure to disable `output.elasticsearch` and to point `monitoring.elasticsearch.hosts` to your Monitoring Elasticsearch cluster.
