### PR TITLE
Allow path variables in modules.d files

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -119,6 +119,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Apply `max_message_size` to incoming message buffer. {pull}11966[11966]
 - Syslog input will now omit the `process` object from events if it is empty. {pull}12700[12700]
 - Fix multiline pattern in Postgres which was too permissive {issue}12078[12078] {pull}13069[13069]
+- Allow path variables to be used in files loaded from modules.d. {issue}13184[13184]
 
 *Heartbeat*
 

--- a/filebeat/fileset/config.go
+++ b/filebeat/fileset/config.go
@@ -19,9 +19,11 @@ package fileset
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/cfgwarn"
+	"github.com/elastic/beats/libbeat/paths"
 )
 
 // ModuleConfig contains the configuration file options for a module
@@ -53,4 +55,22 @@ func NewFilesetConfig(cfg *common.Config) (*FilesetConfig, error) {
 	}
 
 	return &fcfg, nil
+}
+
+// mergePathDefaults returns a copy of c containing the path variables that must
+// be available for variable expansion in module configuration (e.g. it enables
+// the use of ${path.config} in module config).
+func mergePathDefaults(c *common.Config) (*common.Config, error) {
+	defaults := common.MustNewConfigFrom(map[string]interface{}{
+		"path": map[string]interface{}{
+			"home":   paths.Paths.Home,
+			"config": "${path.home}",
+			"data":   filepath.Join("${path.home}", "data"),
+			"logs":   filepath.Join("${path.home}", "logs"),
+		},
+	})
+	if err := defaults.Merge(c); err != nil {
+		return nil, err
+	}
+	return defaults, nil
 }

--- a/filebeat/fileset/fileset.go
+++ b/filebeat/fileset/fileset.go
@@ -41,7 +41,6 @@ import (
 	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/libbeat/logp"
 	mlimporter "github.com/elastic/beats/libbeat/ml-importer"
-	"github.com/elastic/beats/libbeat/paths"
 )
 
 // Fileset struct is the representation of a fileset.
@@ -353,17 +352,8 @@ func (fs *Fileset) getInputConfig() (*common.Config, error) {
 		return nil, fmt.Errorf("Error reading input config: %v", err)
 	}
 
-	// Additional default settings, that must be available for variable expansion.
-	defaults := common.MustNewConfigFrom(map[string]interface{}{
-		"path": map[string]interface{}{
-			"home":   paths.Paths.Home,
-			"config": "${path.home}",
-			"data":   fmt.Sprint("${path.home}", string(os.PathSeparator), "data"),
-			"logs":   fmt.Sprint("${path.home}", string(os.PathSeparator), "logs"),
-		},
-	})
-
-	if err := cfg.Merge(defaults); err != nil {
+	cfg, err = mergePathDefaults(cfg)
+	if err != nil {
 		return nil, err
 	}
 

--- a/x-pack/filebeat/module/googlecloud/vpcflow/config/input.yml
+++ b/x-pack/filebeat/module/googlecloud/vpcflow/config/input.yml
@@ -1,6 +1,6 @@
 {{ if eq .input "google-pubsub" }}
 
-type: google-pubsub 
+type: google-pubsub
 project_id: {{ .project_id }}
 topic: {{ .topic }}
 subscription.name: {{ .subscription_name }}


### PR DESCRIPTION
This allows path variables (e.g. `${path.config}`) to be used in files loaded from modules.d.

Fixes #13184