### PR TITLE
[Metricbeat] Fix date format parsing in Zookeeper server Metricset

### DIFF
--- a/metricbeat/module/zookeeper/_meta/Dockerfile
+++ b/metricbeat/module/zookeeper/_meta/Dockerfile
@@ -1,2 +1,2 @@
-FROM jplock/zookeeper:3.4.8
+FROM zookeeper:3.5.5
 HEALTHCHECK --interval=1s --retries=90 CMD nc -z localhost 2181

--- a/metricbeat/module/zookeeper/_meta/Dockerfile
+++ b/metricbeat/module/zookeeper/_meta/Dockerfile
@@ -1,2 +1,2 @@
-FROM zookeeper:3.5.5
+FROM jplock/zookeeper:3.5.5
 HEALTHCHECK --interval=1s --retries=90 CMD nc -z localhost 2181

--- a/metricbeat/module/zookeeper/mntr/_meta/data.json
+++ b/metricbeat/module/zookeeper/mntr/_meta/data.json
@@ -1,9 +1,5 @@
 {
     "@timestamp": "2017-10-12T08:05:34.853Z",
-    "agent": {
-        "hostname": "host.example.com",
-        "name": "host.example.com"
-    },
     "event": {
         "dataset": "zookeeper.mntr",
         "duration": 115000,
@@ -13,13 +9,13 @@
         "name": "mntr"
     },
     "service": {
-        "address": "localhost:2181",
+        "address": "localhost:32770",
         "type": "zookeeper",
-        "version": "3.4.8--1, built on 02/06/2016 03:18 GMT"
+        "version": "3.5.5-390fe37ea45dee01bf87dc1c042b5e3dcce88653, built on 05/03/2019 12:07 GMT"
     },
     "zookeeper": {
         "mntr": {
-            "approximate_data_size": 27,
+            "approximate_data_size": 44,
             "ephemerals_count": 0,
             "latency": {
                 "avg": 0,
@@ -28,15 +24,15 @@
             },
             "max_file_descriptor_count": 1048576,
             "num_alive_connections": 1,
-            "open_file_descriptor_count": 25,
+            "open_file_descriptor_count": 65,
             "outstanding_requests": 0,
             "packets": {
-                "received": 12,
-                "sent": 11
+                "received": 2,
+                "sent": 1
             },
             "server_state": "standalone",
             "watch_count": 0,
-            "znode_count": 4
+            "znode_count": 5
         }
     }
 }

--- a/metricbeat/module/zookeeper/server/_meta/data.json
+++ b/metricbeat/module/zookeeper/server/_meta/data.json
@@ -1,9 +1,5 @@
 {
     "@timestamp": "2017-10-12T08:05:34.853Z",
-    "agent": {
-        "hostname": "host.example.com",
-        "name": "host.example.com"
-    },
     "event": {
         "dataset": "zookeeper.server",
         "duration": 115000,
@@ -15,7 +11,7 @@
     "service": {
         "address": "localhost:2181",
         "type": "zookeeper",
-        "version": "3.4.13-2d71af4dbe22557fda74f9a9b4309b15a7487f03"
+        "version": "3.5.5-390fe37ea45dee01bf87dc1c042b5e3dcce88653"
     },
     "zookeeper": {
         "server": {
@@ -28,11 +24,11 @@
                 "min": 0
             },
             "mode": "standalone",
-            "node_count": 4,
+            "node_count": 5,
             "outstanding": 0,
-            "received": 38,
-            "sent": 37,
-            "version_date": "06/29/2018 04:05 GMT",
+            "received": 11,
+            "sent": 10,
+            "version_date": "2019-05-03T12:07:00Z",
             "zxid": "0x0"
         }
     }

--- a/metricbeat/module/zookeeper/server/data.go
+++ b/metricbeat/module/zookeeper/server/data.go
@@ -20,12 +20,13 @@ package server
 import (
 	"bufio"
 	"encoding/binary"
-	"github.com/pkg/errors"
 	"io"
 	"regexp"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"

--- a/metricbeat/module/zookeeper/server/data.go
+++ b/metricbeat/module/zookeeper/server/data.go
@@ -59,8 +59,9 @@ func parseSrvr(i io.Reader, logger *logp.Logger) (common.MapStr, string, error) 
 	date, err := time.Parse("01/02/2006 03:04 GMT", dateString)
 	if err != nil {
 		logger.Debugf("error trying to parse date '%s'", dateString)
+	} else {
+		output.Put("version_date", date.Format(time.RFC3339))
 	}
-	output.Put("version_date", date.Format(time.RFC3339))
 
 	for scanner.Scan() {
 		line := scanner.Text()

--- a/metricbeat/module/zookeeper/server/data.go
+++ b/metricbeat/module/zookeeper/server/data.go
@@ -20,12 +20,12 @@ package server
 import (
 	"bufio"
 	"encoding/binary"
+	"github.com/pkg/errors"
 	"io"
 	"regexp"
 	"strconv"
 	"strings"
-
-	"github.com/pkg/errors"
+	"time"
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
@@ -53,7 +53,13 @@ func parseSrvr(i io.Reader, logger *logp.Logger) (common.MapStr, string, error) 
 	output := common.MapStr{}
 
 	version := versionCapturer.FindStringSubmatch(scanner.Text())[1]
-	output.Put("version_date", dateCapturer.FindStringSubmatch(scanner.Text())[1])
+	dateString := dateCapturer.FindStringSubmatch(scanner.Text())[1]
+
+	date, err := time.Parse("01/02/2006 03:04 GMT", dateString)
+	if err != nil {
+		logger.Debugf("error trying to parse date '%s'", dateString)
+	}
+	output.Put("version_date", date.Format(time.RFC3339))
 
 	for scanner.Scan() {
 		line := scanner.Text()

--- a/metricbeat/module/zookeeper/server/server_integration_test.go
+++ b/metricbeat/module/zookeeper/server/server_integration_test.go
@@ -48,7 +48,7 @@ func TestFetch(t *testing.T) {
 		metricsetFields := event.MetricSetFields
 
 		// Check values
-		assert.Equal(t, "02/06/2016 03:18 GMT", metricsetFields["version_date"])
+		assert.Equal(t, "2019-05-03T12:07:00Z", metricsetFields["version_date"])
 
 		received := metricsetFields["received"].(int64)
 		assert.True(t, received >= 0)

--- a/metricbeat/module/zookeeper/server/server_test.go
+++ b/metricbeat/module/zookeeper/server/server_test.go
@@ -19,15 +19,14 @@ package server
 
 import (
 	"bytes"
-	"testing"
-
 	"github.com/stretchr/testify/assert"
+	"testing"
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 )
 
-var srvrTestInput = `Zookeeper version: 3.4.13-2d71af4dbe22557fda74f9a9b4309b15a7487f03, built on 06/29/2018 04:05 GMT
+var srvrTestInput = `Zookeeper version: 3.5.5-390fe37ea45dee01bf87dc1c042b5e3dcce88653, built on 05/03/2019 12:07 GMT
 Latency min/avg/max: 1/2/3
 Received: 46
 Sent: 45
@@ -46,8 +45,8 @@ func TestParser(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assert.Equal(t, "06/29/2018 04:05 GMT", mapStr["version_date"])
-	assert.Equal(t, "3.4.13-2d71af4dbe22557fda74f9a9b4309b15a7487f03", versionID)
+	assert.Equal(t, "2019-05-03T12:07:00Z", mapStr["version_date"])
+	assert.Equal(t, "3.5.5-390fe37ea45dee01bf87dc1c042b5e3dcce88653", versionID)
 
 	latency := mapStr["latency"].(common.MapStr)
 	assert.Equal(t, int64(1), latency["min"])

--- a/metricbeat/module/zookeeper/server/server_test.go
+++ b/metricbeat/module/zookeeper/server/server_test.go
@@ -19,8 +19,9 @@ package server
 
 import (
 	"bytes"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"


### PR DESCRIPTION
Fixes https://github.com/elastic/beats/issues/13161 by parsing the date in Go and writing it into the event into RFC3339 format. This way Elasticsearch can recognize it so it can be ingested and formatted in Kibana later.