### PR TITLE
Add alias required by windows job on jenkins

### DIFF
--- a/x-pack/metricbeat/magefile.go
+++ b/x-pack/metricbeat/magefile.go
@@ -28,6 +28,12 @@ func init() {
 	devtools.BeatLicense = "Elastic License"
 }
 
+// Aliases provides compatibility with CI while we transition all Beats
+// to having common testing targets.
+var Aliases = map[string]interface{}{
+	"goTestUnit": GoUnitTest, // dev-tools/jenkins_ci.ps1 uses this.
+}
+
 // Build builds the Beat binary.
 func Build() error {
 	return devtools.Build(devtools.DefaultBuildArgs())


### PR DESCRIPTION
X-Pack metricbeat job for Windows requires this target. Using alias as
is done on auditbeat while all beats are migrated to have common testing
targets.

It was removed in https://github.com/elastic/beats/pull/12939/files#diff-395d8b10de696ffe217cdfbdd1d11f49L31