### PR TITLE
Cherry-pick #13173 to 7.3: Added space after start= needed for start services using sc.exe under Windows

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -63,6 +63,13 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix of docker json parser for missing "log" jsonkey in docker container's log {issue}11464[11464]
 - Fix `@timestamp` being duplicated in events if `@timestamp` is set in a
   processor (or by any code utilizing `PutValue()` on a `beat.Event`).
+- Fix leak in script processor when using Javascript functions in a processor chain. {pull}12600[12600]
+- Add additional nil pointer checks to Docker client code to deal with vSphere Integrated Containers {pull}12628[12628]
+- Fixed `json.add_error_key` property setting for delivering error messages from beat events  {pull}11298[11298]
+- Fix Central Management enroll under Windows {issue}12797[12797] {pull}12799[12799]
+- ILM: Use GET instead of HEAD when checking for alias to expose detailed error message. {pull}12886[12886]
+- Fix seccomp policy preventing some features to function properly on 32bit Linux systems. {issue}12990[12990] {pull}13008[13008]
+- Fix install-service.ps1's ability to set Windows service's delay start configuration. {pull}13173[13173]
 
 *Auditbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -63,12 +63,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix of docker json parser for missing "log" jsonkey in docker container's log {issue}11464[11464]
 - Fix `@timestamp` being duplicated in events if `@timestamp` is set in a
   processor (or by any code utilizing `PutValue()` on a `beat.Event`).
-- Fix leak in script processor when using Javascript functions in a processor chain. {pull}12600[12600]
-- Add additional nil pointer checks to Docker client code to deal with vSphere Integrated Containers {pull}12628[12628]
-- Fixed `json.add_error_key` property setting for delivering error messages from beat events  {pull}11298[11298]
-- Fix Central Management enroll under Windows {issue}12797[12797] {pull}12799[12799]
-- ILM: Use GET instead of HEAD when checking for alias to expose detailed error message. {pull}12886[12886]
-- Fix seccomp policy preventing some features to function properly on 32bit Linux systems. {issue}12990[12990] {pull}13008[13008]
 - Fix install-service.ps1's ability to set Windows service's delay start configuration. {pull}13173[13173]
 
 *Auditbeat*

--- a/dev-tools/packaging/templates/windows/install-service.ps1.tmpl
+++ b/dev-tools/packaging/templates/windows/install-service.ps1.tmpl
@@ -15,6 +15,6 @@ New-Service -name {{.BeatName}} `
 
 # Attempt to set the service to delayed start using sc config.
 Try {
-  Start-Process -FilePath sc.exe -ArgumentList 'config {{.BeatName}} start=delayed-auto'
+  Start-Process -FilePath sc.exe -ArgumentList 'config {{.BeatName}} start= delayed-auto'
 }
 Catch { Write-Host -f red "An error occured setting the service to delayed start." }


### PR DESCRIPTION
Cherry-pick of PR #13173 to 7.3 branch. Original message: 

Documentation: https://docs.microsoft.com/de-de/windows-server/administration/windows-commands/sc-config
- A space is required between an option and its value (for example, type= own. If the space is omitted, the operation will fail.