### PR TITLE
Override vendor in community beats

### DIFF
--- a/generator/beat/{beat}/magefile.go.tmpl
+++ b/generator/beat/{beat}/magefile.go.tmpl
@@ -34,6 +34,7 @@ func init() {
 	devtools.SetBuildVariableSources(devtools.DefaultBeatBuildVariableSources)
 
 	devtools.BeatDescription = "One sentence description of the Beat."
+	devtools.BeatVendor = "{full_name}"
 }
 
 // Build builds the Beat binary.


### PR DESCRIPTION
Vendor is used to decide the license used, and packaging tests fail with
default settings in community beats, because vendor is kept as
"Elastic". Set the full user name as vendor now, so checks applied to
Elastic beats are not applied to community beats.

Thanks @radoondas for reporting it and testing this solution.