### PR TITLE
[Metricbeat] Remove mb.DefaultMetricSet() from some metricsets in aws

### DIFF
--- a/x-pack/metricbeat/module/aws/rds/rds.go
+++ b/x-pack/metricbeat/module/aws/rds/rds.go
@@ -32,9 +32,7 @@ var (
 // the MetricSet for each host defined in the module's configuration. After the
 // MetricSet has been created then Fetch will begin to be called periodically.
 func init() {
-	mb.Registry.MustAddMetricSet(aws.ModuleName, metricsetName, New,
-		mb.DefaultMetricSet(),
-	)
+	mb.Registry.MustAddMetricSet(aws.ModuleName, metricsetName, New)
 }
 
 // MetricSet holds any configuration or state information. It must implement

--- a/x-pack/metricbeat/module/aws/s3_daily_storage/s3_daily_storage.go
+++ b/x-pack/metricbeat/module/aws/s3_daily_storage/s3_daily_storage.go
@@ -25,9 +25,7 @@ var metricsetName = "s3_daily_storage"
 // the MetricSet for each host defined in the module's configuration. After the
 // MetricSet has been created then Fetch will begin to be called periodically.
 func init() {
-	mb.Registry.MustAddMetricSet(aws.ModuleName, metricsetName, New,
-		mb.DefaultMetricSet(),
-	)
+	mb.Registry.MustAddMetricSet(aws.ModuleName, metricsetName, New)
 }
 
 // MetricSet holds any configuration or state information. It must implement

--- a/x-pack/metricbeat/module/aws/s3_request/s3_request.go
+++ b/x-pack/metricbeat/module/aws/s3_request/s3_request.go
@@ -25,9 +25,7 @@ var metricsetName = "s3_request"
 // the MetricSet for each host defined in the module's configuration. After the
 // MetricSet has been created then Fetch will begin to be called periodically.
 func init() {
-	mb.Registry.MustAddMetricSet(aws.ModuleName, metricsetName, New,
-		mb.DefaultMetricSet(),
-	)
+	mb.Registry.MustAddMetricSet(aws.ModuleName, metricsetName, New)
 }
 
 // MetricSet holds any configuration or state information. It must implement

--- a/x-pack/metricbeat/module/aws/sqs/sqs.go
+++ b/x-pack/metricbeat/module/aws/sqs/sqs.go
@@ -29,9 +29,7 @@ var metricsetName = "sqs"
 // the MetricSet for each host defined in the module's configuration. After the
 // MetricSet has been created then Fetch will begin to be called periodically.
 func init() {
-	mb.Registry.MustAddMetricSet(aws.ModuleName, metricsetName, New,
-		mb.DefaultMetricSet(),
-	)
+	mb.Registry.MustAddMetricSet(aws.ModuleName, metricsetName, New)
 }
 
 // MetricSet holds any configuration or state information. It must implement


### PR DESCRIPTION
@fearful-symmetry pointed out that most of the x-pack aws metricsets are set as default. This PR is to remove some aws metricsets from default.