### PR TITLE
Cherry-pick #12716 to 6.8: Refactoring of entry reading

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -41,6 +41,9 @@ https://github.com/elastic/beats/compare/v6.8.0...6.8.1[Check the HEAD diff]
 
 *Journalbeat*
 
+- Use backoff when no new events are found. {pull}11861[11861]
+- Iterate over journal correctly, so no duplicate entries are sent. {pull}12716[12716]
+
 *Metricbeat*
 
 *Packetbeat*

--- a/journalbeat/reader/journal.go
+++ b/journalbeat/reader/journal.go
@@ -193,20 +193,22 @@ func (r *Reader) Next() (*beat.Event, error) {
 			return nil, err
 		}
 
+		switch {
 		// error while reading next entry
-		if c < 0 {
+		case c < 0:
 			return nil, fmt.Errorf("error while reading next entry %+v", syscall.Errno(-c))
-		}
-
 		// no new entry, so wait
-		if c == 0 {
+		case c == 0:
 			hasNewEntry, err := r.checkForNewEvents()
 			if err != nil {
 				return nil, err
 			}
 			if !hasNewEntry {
-				continue
+				r.backoff.Wait()
 			}
+			continue
+		// new entries are available
+		default:
 		}
 
 		entry, err := r.journal.GetEntry()


### PR DESCRIPTION
Original description:
I have cleaned up the coda around reading entries and fixed an issue when iterating through journals.

Closes #11505
(cherry picked from commit 3c9734ca4fb3cf774fadffefc89bd2180f0f01dd)

Closes #13123 