### PR TITLE
Do not collect dashboards from Functionbeat

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -33,8 +33,8 @@ import (
 )
 
 var (
-	// Beats is a list of Beats to collect dashboards from.
-	Beats = []string{
+	// BeatsWithDashboards is a list of Beats to collect dashboards from.
+	BeatsWithDashboards = []string{
 		"heartbeat",
 		"journalbeat",
 		"packetbeat",
@@ -65,7 +65,7 @@ func PackageBeatDashboards() error {
 		OutputFile: "build/distributions/dashboards/{{.Name}}-{{.Version}}{{if .Snapshot}}-SNAPSHOT{{end}}",
 	}
 
-	for _, beatDir := range Beats {
+	for _, beatDir := range BeatsWithDashboards {
 		// The generated dashboard content is moving in the build dir, but
 		// not all projects have been updated so detect which dir to use.
 		dashboardDir := filepath.Join(beatDir, "build/kibana")

--- a/magefile.go
+++ b/magefile.go
@@ -42,7 +42,6 @@ var (
 		"x-pack/auditbeat",
 		"x-pack/filebeat",
 		"x-pack/metricbeat",
-		"x-pack/functionbeat",
 	}
 )
 


### PR DESCRIPTION
As we do not provide dashboards for Functionbeat, there is no need to collect them.
This issue is old but has surfaced as Functionbeat does not use `make` to build targets.