### PR TITLE
Add support for http hostname in nginx filebeat module

### DIFF
--- a/filebeat/module/nginx/access/ingest/default.json
+++ b/filebeat/module/nginx/access/ingest/default.json
@@ -5,7 +5,7 @@
             "grok": {
                 "field": "message",
                 "patterns": [
-                    "\"?(?:%{IP_LIST:nginx.access.remote_ip_list}|%{DATA:source.address}) - %{DATA:user.name} \\[%{HTTPDATE:nginx.access.time}\\] \"%{DATA:nginx.access.info}\" %{NUMBER:http.response.status_code:long} %{NUMBER:http.response.body.bytes:long} \"%{DATA:http.request.referrer}\" \"%{DATA:user_agent.original}\""
+                    "\"?(%{HOSTNAME:http.hostname} )?(?:%{IP_LIST:nginx.access.remote_ip_list}|%{DATA:source.address}) - %{DATA:user.name} \\[%{HTTPDATE:nginx.access.time}\\] \"%{DATA:nginx.access.info}\" %{NUMBER:http.response.status_code:long} %{NUMBER:http.response.body.bytes:long} \"%{DATA:http.request.referrer}\" \"%{DATA:user_agent.original}\""
                 ],
                 "pattern_definitions": {
                     "IP_LIST": "%{IP}(\"?,?\\s*%{IP})*"


### PR DESCRIPTION
It is very common to alter the default nginx log format to log http hostname, so that

```
1.2.3.4 - - [12/Aug/2019:12:40:26 +0000] "GET /foo HTTP/1.1" 200 ...
```

becomes

```
example.com 1.2.3.4 - - [12/Aug/2019:12:40:26 +0000] "GET /foo HTTP/1.1" 200 ...
```

We can easily support that if we slightly change grok pattern at [/filebeat/module/nginx/access/ingest/default.json#L8](https://github.com/elastic/beats/blob/master/filebeat/module/nginx/access/ingest/default.json#L8) from

```
"\"?(?:%{IP_LIST:nginx.access.remote_ip_list}|%{DATA:source.address}) ..."
```

to

```
"\"?(%{HOSTNAME:http.hostname} )?(?:%{IP_LIST:nginx.access.remote_ip_list}|%{DATA:source.address}) ..."
```

According to my tests it doesn't break anything but adds support for one common use case