### PR TITLE
[DOCS] Update how-metricbeat-works.asciidoc

### DIFF
--- a/metricbeat/docs/how-metricbeat-works.asciidoc
+++ b/metricbeat/docs/how-metricbeat-works.asciidoc
@@ -113,7 +113,7 @@ reachable:
 ----
 
 [[key-features]]
-=== Key metricbeat features
+=== Key Metricbeat features
 
 Metricbeat has some key features that are critical to how it works:
 


### PR DESCRIPTION
Tiny, tiny correction to capital "M", as Metricbeat is the name of a product.