### PR TITLE
Use NewLazySystemDLL instead of NewLazyDLL

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -85,6 +85,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - ILM: Use GET instead of HEAD when checking for alias to expose detailed error message. {pull}12886[12886]
 - Fix seccomp policy preventing some features to function properly on 32bit Linux systems. {issue}12990[12990] {pull}13008[13008]
 - Fix install-service.ps1's ability to set Windows service's delay start configuration. {pull}13173[13173]
+- Load DLLs only from Windows system directory. {pull}13234[13234]
 
 *Auditbeat*
 

--- a/libbeat/common/file/file_windows.go
+++ b/libbeat/common/file/file_windows.go
@@ -35,7 +35,7 @@ type StateOS struct {
 }
 
 var (
-	modkernel32 = windows.NewLazyDLL("kernel32.dll")
+	modkernel32 = windows.NewLazySystemDLL("kernel32.dll")
 
 	procGetFileInformationByHandleEx = modkernel32.NewProc("GetFileInformationByHandleEx")
 )


### PR DESCRIPTION
The ensures that the code only search for DLLs in the Windows system directory.