### PR TITLE
Adding beat Metricbeat module folder to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -33,6 +33,7 @@
 /metricbeat/module/elasticsearch/ @elastic/stack-monitoring
 /metricbeat/module/kibana/ @elastic/stack-monitoring
 /metricbeat/module/logstash/ @elastic/stack-monitoring
+/metricbeat/module/beat/ @elastic/stack-monitoring
 /x-pack/metricbeat/module/ @elastic/infrastructure
 
 # Heartbeat


### PR DESCRIPTION
This folder was recently added and is owned by the @elastic/stack-monitoring team.