### PR TITLE
Add integration test for s3 input

### DIFF
--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -82,10 +82,10 @@ filebeat.modules:
     enabled: true
 
     # AWS SQS queue url
-    #var.queue_url: sqs_queue_url
+    #var.queue_url: <sqs_queue_url>
 
     # Profile name for aws credential
-    #var.credential_profile_name: fb-aws
+    #var.credential_profile_name: <fb-aws>
 
 #-------------------------------- Cisco Module --------------------------------
 - module: cisco

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -82,10 +82,10 @@ filebeat.modules:
     enabled: true
 
     # AWS SQS queue url
-    #var.queue_url: <sqs_queue_url>
+    #var.queue_url: https://sqs.myregion.amazonaws.com/123456/myqueue
 
     # Profile name for aws credential
-    #var.credential_profile_name: <fb-aws>
+    #var.credential_profile_name: fb-aws
 
 #-------------------------------- Cisco Module --------------------------------
 - module: cisco

--- a/x-pack/filebeat/input/s3/_meta/s3-input.asciidoc
+++ b/x-pack/filebeat/input/s3/_meta/s3-input.asciidoc
@@ -19,3 +19,24 @@ from all log files.
 4. Check SQS if messages are deleted successfully.
 5. Interrupt the s3 input process by killing filebeat during processing new S3 logs,
 check if messages in SQS are in flight instead of deleted.
+
+=== Run s3_test.go
+Instead of manual testing, `s3_test.go` includes some integration tests that can
+be used for validating s3 input. In order to run `s3_test.go`, an AWS environment
+with S3-SQS setup is needed. Please see `S3 and SQS Setup` for more details on
+how to set up the environment. In the test, it does a cleaning first to remove
+all old messages from SQS queue. Then upload a sample log file, which stores in
+`./ftest/sample1.txt`, into S3 bucket. Test function calls `input.Run()`
+function to read the notification message from SQS and find the log file in S3
+target bucket and get the log message. After validating the events, another round
+of cleaning will be done for SQS to remove the message.
+
+Some environment variables are needed for testing:
+
+|===
+| Environment Variable | Sample Value
+| QUEUE_URL | https://sqs.us-west-1.amazonaws.com/1234567/test-s3-notification
+| AWS_PROFILE_NAME | test-mb
+| S3_BUCKET_NAME | test-s3
+| S3_BUCKET_REGION | us-west-1
+|===

--- a/x-pack/filebeat/input/s3/ftest/sample1.txt
+++ b/x-pack/filebeat/input/s3/ftest/sample1.txt
@@ -1,0 +1,2 @@
+logline1
+logline2

--- a/x-pack/filebeat/input/s3/input.go
+++ b/x-pack/filebeat/input/s3/input.go
@@ -185,7 +185,7 @@ func (p *s3Input) Run() {
 	})
 }
 
-func (p *s3Input) run(svcSQS *sqs.Client, svcS3 *s3.Client, visibilityTimeout int64) {
+func (p *s3Input) run(svcSQS sqsiface.ClientAPI, svcS3 s3iface.ClientAPI, visibilityTimeout int64) {
 	defer p.logger.Infof("s3 input worker for '%v' has stopped.", p.config.QueueURL)
 	defer p.workerWg.Done()
 	p.logger.Infof("s3 input worker has started. with queueURL: %v", p.config.QueueURL)
@@ -236,7 +236,7 @@ func (p *s3Input) Wait() {
 	p.workerWg.Wait()
 }
 
-func (p *s3Input) processor(queueURL string, messages []sqs.Message, visibilityTimeout int64, svcS3 *s3.Client, svcSQS *sqs.Client) {
+func (p *s3Input) processor(queueURL string, messages []sqs.Message, visibilityTimeout int64, svcS3 s3iface.ClientAPI, svcSQS sqsiface.ClientAPI) {
 	var wg sync.WaitGroup
 	numMessages := len(messages)
 	wg.Add(numMessages)
@@ -250,7 +250,7 @@ func (p *s3Input) processor(queueURL string, messages []sqs.Message, visibilityT
 	wg.Wait()
 }
 
-func (p *s3Input) processMessage(svcS3 *s3.Client, message sqs.Message, wg *sync.WaitGroup, errC chan error) {
+func (p *s3Input) processMessage(svcS3 s3iface.ClientAPI, message sqs.Message, wg *sync.WaitGroup, errC chan error) {
 	defer wg.Done()
 
 	s3Infos, err := handleSQSMessage(message)

--- a/x-pack/filebeat/input/s3/input_test.go
+++ b/x-pack/filebeat/input/s3/input_test.go
@@ -27,8 +27,8 @@ type MockS3Client struct {
 }
 
 var (
-	s3LogString1 = "36c1f test-s3-ks [20/Jun/2019] 1.2.3.4 arn:aws:iam::1234:user/kaiyan.sheng@elastic.co 5141F REST.HEAD.OBJECT Screen1.png \n"
-	s3LogString2 = "28kdg test-s3-ks [20/Jun/2019] 1.2.3.4 arn:aws:iam::1234:user/kaiyan.sheng@elastic.co 5A070 REST.HEAD.OBJECT Screen2.png \n"
+	s3LogString1 = "36c1f test-s3-ks [20/Jun/2019] 1.2.3.4 arn:aws:iam::1234:user/test@elastic.co 5141F REST.HEAD.OBJECT Screen1.png \n"
+	s3LogString2 = "28kdg test-s3-ks [20/Jun/2019] 1.2.3.4 arn:aws:iam::1234:user/test@elastic.co 5A070 REST.HEAD.OBJECT Screen2.png \n"
 	mockSvc      = &MockS3Client{}
 	info         = s3Info{
 		name:   "test-s3-ks",

--- a/x-pack/filebeat/input/s3/input_test.go
+++ b/x-pack/filebeat/input/s3/input_test.go
@@ -26,10 +26,16 @@ type MockS3Client struct {
 	s3iface.ClientAPI
 }
 
+// MockS3ClientErr struct is used for unit tests.
+type MockS3ClientErr struct {
+	s3iface.ClientAPI
+}
+
 var (
 	s3LogString1 = "36c1f test-s3-ks [20/Jun/2019] 1.2.3.4 arn:aws:iam::1234:user/test@elastic.co 5141F REST.HEAD.OBJECT Screen1.png \n"
 	s3LogString2 = "28kdg test-s3-ks [20/Jun/2019] 1.2.3.4 arn:aws:iam::1234:user/test@elastic.co 5A070 REST.HEAD.OBJECT Screen2.png \n"
 	mockSvc      = &MockS3Client{}
+	mockSvcErr   = &MockS3ClientErr{}
 	info         = s3Info{
 		name:   "test-s3-ks",
 		key:    "log2019-06-21-16-16-54",
@@ -45,6 +51,16 @@ func (m *MockS3Client) GetObjectRequest(input *s3.GetObjectInput) s3.GetObjectRe
 			Data: &s3.GetObjectOutput{
 				Body: logBody,
 			},
+			HTTPRequest: httpReq,
+		},
+	}
+}
+
+func (m *MockS3ClientErr) GetObjectRequest(input *s3.GetObjectInput) s3.GetObjectRequest {
+	httpReq, _ := http.NewRequest("", "", nil)
+	return s3.GetObjectRequest{
+		Request: &awssdk.Request{
+			Data:        &s3.GetObjectOutput{},
 			HTTPRequest: httpReq,
 		},
 	}
@@ -123,6 +139,12 @@ func TestNewS3BucketReader(t *testing.T) {
 			assert.Equal(t, "", log)
 		}
 	}
+}
+
+func TestNewS3BucketReaderErr(t *testing.T) {
+	reader, err := newS3BucketReader(mockSvcErr, info, &channelContext{})
+	assert.Error(t, err, "s3 get object response body is empty")
+	assert.Nil(t, reader)
 }
 
 func TestCreateEvent(t *testing.T) {

--- a/x-pack/filebeat/input/s3/s3_integration_test.go
+++ b/x-pack/filebeat/input/s3/s3_integration_test.go
@@ -329,6 +329,11 @@ type MockSQSClient struct {
 	sqsiface.ClientAPI
 }
 
+// MockS3ClientErr struct is used for unit tests.
+type MockS3ClientErr struct {
+	s3iface.ClientAPI
+}
+
 var (
 	sqsMessageTest = "{\"Records\":[{\"eventSource\":\"aws:s3\",\"awsRegion\":\"ap-southeast-1\"," +
 		"\"eventTime\":\"2019-06-21T16:16:54.629Z\",\"eventName\":\"ObjectCreated:Put\"," +
@@ -360,7 +365,53 @@ func (m *MockSQSClient) DeleteMessageRequest(input *sqs.DeleteMessageInput) sqs.
 	}
 }
 
-func TestS3InputWithMock(t *testing.T) {
+func (m *MockS3ClientErr) GetObjectRequest(input *s3.GetObjectInput) s3.GetObjectRequest {
+	httpReq, _ := http.NewRequest("", "", nil)
+	return s3.GetObjectRequest{
+		Request: &awssdk.Request{
+			Data:        &s3.GetObjectOutput{},
+			HTTPRequest: httpReq,
+		},
+	}
+}
+
+func (m *MockSQSClient) ChangeMessageVisibilityRequest(input *sqs.ChangeMessageVisibilityInput) sqs.ChangeMessageVisibilityRequest {
+	httpReq, _ := http.NewRequest("", "", nil)
+	return sqs.ChangeMessageVisibilityRequest{
+		Request: &awssdk.Request{
+			Data:        &sqs.ChangeMessageVisibilityOutput{},
+			HTTPRequest: httpReq,
+		},
+	}
+}
+
+func TestMockS3InputWithError(t *testing.T) {
+	defer resources.NewGoroutinesChecker().Check(t)
+	cfg := common.MustNewConfigFrom(map[string]interface{}{
+		"queue_url": "https://sqs.ap-southeast-1.amazonaws.com/123456/test",
+	})
+
+	runTest(t, cfg, func(input *s3Input, out *stubOutleter, t *testing.T) {
+		svcS3 := &MockS3ClientErr{}
+		svcSQS := &MockSQSClient{}
+
+		wg := sync.WaitGroup{}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			input.run(svcSQS, svcS3, 300)
+		}()
+
+		time.AfterFunc(1*time.Second, func() { out.Close() })
+		events, ok := out.waitForEvents(0)
+		if !ok {
+			t.Fatalf("Expected 0 events, but got %d.", len(events))
+		}
+		input.Stop()
+	})
+}
+
+func TestMockS3Input(t *testing.T) {
 	defer resources.NewGoroutinesChecker().Check(t)
 	cfg := common.MustNewConfigFrom(map[string]interface{}{
 		"queue_url": "https://sqs.ap-southeast-1.amazonaws.com/123456/test",
@@ -382,7 +433,7 @@ func TestS3InputWithMock(t *testing.T) {
 		if !ok {
 			t.Fatalf("Expected 2 events, but got %d.", len(events))
 		}
-		input.Stop()
+		input.Wait()
 
 		// check events
 		for i, event := range events {

--- a/x-pack/filebeat/input/s3/s3_integration_test.go
+++ b/x-pack/filebeat/input/s3/s3_integration_test.go
@@ -139,7 +139,7 @@ func (input *s3Input) deleteAllMessages(t *testing.T, awsConfig awssdk.Config, q
 	return nil
 }
 
-func inputConfig() *common.Config {
+func defaultTestConfig() *common.Config {
 	return common.MustNewConfigFrom(map[string]interface{}{
 		"queue_url": os.Getenv("QUEUE_URL"),
 	})
@@ -223,10 +223,9 @@ func (o *stubOutleter) OnEvent(event beat.Event) bool {
 }
 
 func TestS3Input(t *testing.T) {
-	cfg := inputConfig()
+	inputConfig := defaultTestConfig()
 
-	runTest(t, cfg, func(t *testing.T, input *s3Input, out *stubOutleter) {
-		defer out.Close()
+	runTest(t, inputConfig, func(t *testing.T, input *s3Input, out *stubOutleter) {
 		config, info := getConfigForTest()
 		if info != "" {
 			t.Skipf("failed to get config for test: %v", info)
@@ -355,7 +354,6 @@ func TestMockS3Input(t *testing.T) {
 	})
 
 	runTest(t, cfg, func(t *testing.T, input *s3Input, out *stubOutleter) {
-		defer out.Close()
 		svcS3 := &MockS3Client{}
 		svcSQS := &MockSQSClient{}
 

--- a/x-pack/filebeat/input/s3/s3_integration_test.go
+++ b/x-pack/filebeat/input/s3/s3_integration_test.go
@@ -226,6 +226,7 @@ func TestS3Input(t *testing.T) {
 	cfg := inputConfig()
 
 	runTest(t, cfg, func(t *testing.T, input *s3Input, out *stubOutleter) {
+		defer out.Close()
 		config, info := getConfigForTest()
 		if info != "" {
 			t.Skipf("failed to get config for test: %v", info)
@@ -267,7 +268,6 @@ func TestS3Input(t *testing.T) {
 			input.run(svcSQS, svcS3, 300)
 		}()
 
-		time.AfterFunc(10*time.Second, func() { out.Close() })
 		events, ok := out.waitForEvents(2)
 		if !ok {
 			t.Fatalf("Expected 2 events, but got %d.", len(events))
@@ -355,6 +355,7 @@ func TestMockS3Input(t *testing.T) {
 	})
 
 	runTest(t, cfg, func(t *testing.T, input *s3Input, out *stubOutleter) {
+		defer out.Close()
 		svcS3 := &MockS3Client{}
 		svcSQS := &MockSQSClient{}
 
@@ -365,7 +366,6 @@ func TestMockS3Input(t *testing.T) {
 			input.run(svcSQS, svcS3, 300)
 		}()
 
-		time.AfterFunc(10*time.Second, func() { out.Close() })
 		events, ok := out.waitForEvents(2)
 		if !ok {
 			t.Fatalf("Expected 2 events, but got %d.", len(events))

--- a/x-pack/filebeat/input/s3/s3_test.go
+++ b/x-pack/filebeat/input/s3/s3_test.go
@@ -111,7 +111,7 @@ func uploadSampleLogFile(t *testing.T, awsConfig awssdk.Config, bucketName strin
 	}
 }
 
-func collectOldMessages(t *testing.T, awsConfig awssdk.Config, queueURL string, visibilityTimeout int64, svcSQS *sqs.Client) []string {
+func collectOldMessages(t *testing.T, queueURL string, visibilityTimeout int64, svcSQS *sqs.Client) []string {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -143,7 +143,7 @@ func (input *s3Input) deleteAllMessages(t *testing.T, awsConfig awssdk.Config, q
 	init := true
 	for init || len(messageReceiptHandles) > 0 {
 		init = false
-		messageReceiptHandles = collectOldMessages(t, awsConfig, queueURL, visibilityTimeout, svcSQS)
+		messageReceiptHandles = collectOldMessages(t, queueURL, visibilityTimeout, svcSQS)
 		for _, receiptHandle := range messageReceiptHandles {
 			err := input.deleteMessage(queueURL, receiptHandle, svcSQS)
 			if err != nil {
@@ -178,7 +178,7 @@ func runTest(t *testing.T, cfg *common.Config, run func(input *s3Input, out *stu
 
 	in, err := NewInput(cfg, connector, inputCtx)
 	if err != nil {
-		t.Fatal(err)
+		t.Skipf("Skipping: %v", err)
 	}
 	s3Input := in.(*s3Input)
 	defer s3Input.Stop()

--- a/x-pack/filebeat/input/s3/s3_test.go
+++ b/x-pack/filebeat/input/s3/s3_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/elastic/beats/filebeat/input"
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/tests/resources"
 	awscommon "github.com/elastic/beats/x-pack/libbeat/common/aws"
 )
 
@@ -285,7 +286,7 @@ func TestS3Input(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			input.Run()
+			input.run(svcSQS, svcS3, 300)
 		}()
 
 		time.AfterFunc(10*time.Second, func() { out.Close() })
@@ -360,6 +361,7 @@ func (m *MockSQSClient) DeleteMessageRequest(input *sqs.DeleteMessageInput) sqs.
 }
 
 func TestS3InputWithMock(t *testing.T) {
+	defer resources.NewGoroutinesChecker().Check(t)
 	cfg := common.MustNewConfigFrom(map[string]interface{}{
 		"queue_url": "https://sqs.ap-southeast-1.amazonaws.com/123456/test",
 	})

--- a/x-pack/filebeat/input/s3/s3_test.go
+++ b/x-pack/filebeat/input/s3/s3_test.go
@@ -35,8 +35,8 @@ const (
 func getConfigForTest() (config, string) {
 	awsConfig := awscommon.ConfigAWS{}
 	info := ""
-	queueUrl := os.Getenv("QUEUE_URL")
-	if queueUrl == "" {
+	queueURL := os.Getenv("QUEUE_URL")
+	if queueURL == "" {
 		info = "Skipping: $QUEUE_URL is not set in environment."
 	}
 
@@ -44,7 +44,7 @@ func getConfigForTest() (config, string) {
 	if profileName != "" {
 		awsConfig.ProfileName = profileName
 		config := config{
-			QueueURL:          queueUrl,
+			QueueURL:          queueURL,
 			AwsConfig:         awsConfig,
 			VisibilityTimeout: visibilityTimeout,
 		}
@@ -74,7 +74,7 @@ func getConfigForTest() (config, string) {
 		}
 	}
 	config := config{
-		QueueURL:          queueUrl,
+		QueueURL:          queueURL,
 		AwsConfig:         awsConfig,
 		VisibilityTimeout: visibilityTimeout,
 	}

--- a/x-pack/filebeat/module/aws/_meta/config.yml
+++ b/x-pack/filebeat/module/aws/_meta/config.yml
@@ -3,7 +3,7 @@
     enabled: true
 
     # AWS SQS queue url
-    #var.queue_url: sqs_queue_url
+    #var.queue_url: <sqs_queue_url>
 
     # Profile name for aws credential
-    #var.credential_profile_name: fb-aws
+    #var.credential_profile_name: <fb-aws>

--- a/x-pack/filebeat/module/aws/_meta/config.yml
+++ b/x-pack/filebeat/module/aws/_meta/config.yml
@@ -3,7 +3,7 @@
     enabled: true
 
     # AWS SQS queue url
-    #var.queue_url: <sqs_queue_url>
+    #var.queue_url: https://sqs.myregion.amazonaws.com/123456/myqueue
 
     # Profile name for aws credential
-    #var.credential_profile_name: <fb-aws>
+    #var.credential_profile_name: fb-aws

--- a/x-pack/filebeat/modules.d/aws.yml.disabled
+++ b/x-pack/filebeat/modules.d/aws.yml.disabled
@@ -6,7 +6,7 @@
     enabled: true
 
     # AWS SQS queue url
-    #var.queue_url: <sqs_queue_url>
+    #var.queue_url: https://sqs.myregion.amazonaws.com/123456/myqueue
 
     # Profile name for aws credential
-    #var.credential_profile_name: <fb-aws>
+    #var.credential_profile_name: fb-aws

--- a/x-pack/filebeat/modules.d/aws.yml.disabled
+++ b/x-pack/filebeat/modules.d/aws.yml.disabled
@@ -6,7 +6,7 @@
     enabled: true
 
     # AWS SQS queue url
-    #var.queue_url: sqs_queue_url
+    #var.queue_url: <sqs_queue_url>
 
     # Profile name for aws credential
-    #var.credential_profile_name: fb-aws
+    #var.credential_profile_name: <fb-aws>


### PR DESCRIPTION
This PR is to add integration test for s3 input, which is a part of https://github.com/elastic/beats/issues/13128. 

It includes cleaning SQS queue, upload a sample log file into S3 bucket, run `s3Input.Run()` function, check events collected by s3 input, cleanup SQS queue. 