### PR TITLE
Fix matching case insensitive strings

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -89,6 +89,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix some incorrect types and formats in field.yml files. {pull}13188[13188]
 - Load DLLs only from Windows system directory. {pull}13234[13234]
 - Fix mapping for kubernetes.labels and kubernetes.annotations in add_kubernetes_metadata. {issue}12638[12638] {pull}13226[13226]
+- Fix case insensitive regular expressions not working correctly. {pull}13250[13250]
 
 *Auditbeat*
 

--- a/libbeat/common/match/compile.go
+++ b/libbeat/common/match/compile.go
@@ -24,7 +24,7 @@ import (
 
 func compile(r *syntax.Regexp) (stringMatcher, error) {
 	switch {
-	case r.Op == syntax.OpLiteral:
+	case isSubstringLiteral(r):
 		s := string(r.Rune)
 		return &substringMatcher{s, []byte(s)}, nil
 

--- a/libbeat/common/match/matcher_test.go
+++ b/libbeat/common/match/matcher_test.go
@@ -216,6 +216,30 @@ func TestMatchers(t *testing.T) {
 			[]string{"case", "Case", "CaSe", "cAsE"},
 			nil,
 		},
+		{
+			`(?i)case`,
+			typeOf((*regexp.Regexp)(nil)),
+			[]string{"case", "Case", "CaSe", "cAsE"},
+			nil,
+		},
+		{
+			`(?i)[a-z]`,
+			typeOf((*regexp.Regexp)(nil)),
+			[]string{"case", "Case", "CaSe", "cAsE"},
+			nil,
+		},
+		{
+			`(?i)[A-Z]`,
+			typeOf((*regexp.Regexp)(nil)),
+			[]string{"case", "Case", "CaSe", "cAsE"},
+			nil,
+		},
+		{
+			`(c[aA]se)`,
+			typeOf((*regexp.Regexp)(nil)),
+			[]string{"case", "cAse"},
+			[]string{"Case", "CaSe", "cAsE"},
+		},
 	}
 
 	for i, test := range tests {

--- a/libbeat/common/match/matcher_test.go
+++ b/libbeat/common/match/matcher_test.go
@@ -19,6 +19,7 @@ package match
 
 import (
 	"reflect"
+	"regexp"
 	"testing"
 )
 
@@ -208,6 +209,12 @@ func TestMatchers(t *testing.T) {
 				"- 2017-01-02 should not match",
 				"fail",
 			},
+		},
+		{
+			`(?i:case)`,
+			typeOf((*regexp.Regexp)(nil)),
+			[]string{"case", "Case", "CaSe", "cAsE"},
+			nil,
 		},
 	}
 


### PR DESCRIPTION
When definig a regular expressions with `(?i)`, then the  optimizer and
compiler falsly did treat literal strings as case sensitive matches.
With this change we test each string literal for case-sensitivity and
only optimize the match if the `i` flag is not set.