### PR TITLE
Don't publish monitoring event if output is ES but no cluster UUID is set

### DIFF
--- a/libbeat/monitoring/report/elasticsearch/elasticsearch.go
+++ b/libbeat/monitoring/report/elasticsearch/elasticsearch.go
@@ -310,13 +310,16 @@ func (r *reporter) snapshotLoop(namespace, prefix string, period time.Duration) 
 			meta.Put("cluster_uuid", clusterUUID)
 		}
 
-		if okToPublish {
-			r.client.Publish(beat.Event{
-				Timestamp: ts,
-				Fields:    fields,
-				Meta:      meta,
-			})
+		if !okToPublish {
+			log.Debug("not publishing monitoring event as cluster_uuid could not be determined yet")
+			return
 		}
+
+		r.client.Publish(beat.Event{
+			Timestamp: ts,
+			Fields:    fields,
+			Meta:      meta,
+		})
 	}
 }
 


### PR DESCRIPTION
This PR is in the same vein as https://github.com/elastic/beats/pull/13020.

If `output.elasticsearch` is being used, we expect monitoring data published by the Beat (when `monitoring.*` settings are used) to include a non-empty `cluster_uuid` field. The value of this field should be the cluster UUID of the Elasticsearch cluster referenced by `output.elasticsearch`.

This PR checks if `output.elasticsearch` is being used. If it is, but we haven't yet determined the cluster UUID of the Elasticsearch cluster referenced by `output.elasticsearch` — because the connection hasn't been established yet for some reason — we don't publish monitoring events for the Beat. Otherwise, monitoring events with an empty `cluster_uuid` field would be published, leading to the Beat showing up under a Standalone Cluster in the Stack Monitoring UI, just until the connection to the `output.elasticsearch` cluster gets established.

### Testing this PR

1. Start an Elasticsearch cluster, say named `esmon`.

2. Configure a Beat such that `output.elasticsearch` is pointing to a non-existent ES cluster (garbage address) and `monitoring.elasticsearch` is pointing to `esmon`.

3. Start up the Beat.

4. Verify that no `.monitoring-beats-*` indices get created in the `esmon` cluster.

5. Now start a second Elasticsearch cluster, say named `esprod`. Note it's cluster UUID by calling the `GET /` API on this cluster.

6. Reconfigure the Beat such that `output.elasticsearch` points to the `esprod` cluster.

7. Restart the Beat.

5. Verify that a `.monitoring-beats-*` index is created in the `esmon` cluster and that documents in it have a `cluster_uuid` field with the value determined in step 5.