### PR TITLE
Expose `monitoring.cluster_uuid` in State API

### DIFF
--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -401,6 +401,14 @@ func (b *Beat) launch(settings Settings, bt beat.Creator) error {
 			return err
 		}
 		defer reporter.Stop()
+
+		// Expose monitoring.cluster_uuid in state API
+		if reporterSettings.ClusterUUID != "" {
+			stateRegistry := monitoring.GetNamespace("state").GetRegistry()
+			monitoringRegistry := stateRegistry.NewRegistry("monitoring")
+			clusterUUIDRegVar := monitoring.NewString(monitoringRegistry, "cluster_uuid")
+			clusterUUIDRegVar.Set(reporterSettings.ClusterUUID)
+		}
 	}
 
 	if b.Config.MetricLogging == nil || b.Config.MetricLogging.Enabled() {

--- a/metricbeat/module/beat/beat.go
+++ b/metricbeat/module/beat/beat.go
@@ -93,6 +93,9 @@ type Info struct {
 
 // State construct contains the relevant data from the Beat's /state endpoint
 type State struct {
+	Monitoring struct {
+		ClusterUUID string `json:"cluster_uuid"`
+	} `json:"monitoring"`
 	Output struct {
 		Name string `json:"name"`
 	} `json:"output"`

--- a/metricbeat/module/beat/stats/data_xpack.go
+++ b/metricbeat/module/beat/stats/data_xpack.go
@@ -83,11 +83,16 @@ func (m *MetricSet) getClusterUUID() (string, error) {
 		return "", errors.Wrap(err, "could not get state information")
 	}
 
+	clusterUUID := state.Monitoring.ClusterUUID
+	if clusterUUID != "" {
+		return clusterUUID, nil
+	}
+
 	if state.Output.Name != "elasticsearch" {
 		return "", nil
 	}
 
-	clusterUUID := state.Outputs.Elasticsearch.ClusterUUID
+	clusterUUID = state.Outputs.Elasticsearch.ClusterUUID
 	if clusterUUID == "" {
 		// Output is ES but cluster UUID could not be determined. No point sending monitoring
 		// data with empty cluster UUID since it will not be associated with the correct ES


### PR DESCRIPTION
Related: #13182.

This PR makes two (related) changes:
- Exposes the `monitoring.cluster_uuid` setting value (if set) in the Beats State HTTP API (`GET /state`).
- Consumes this field from the API response in the `beat` Metricbeat module's `state` and `stats` metricsets.

### Testing this PR
1. Run Elasticsearch. To start with a clean slate, delete `.monitoring-*` indices.
1. Build Filebeat with this PR. Set `monitoring.cluster_uuid` in `filebeat.yml` to `foobar`. Also set `http.enabled` to `true`. Run Filebeat.
2. Call the Filebeat State API: http://localhost:5066/state. Verify that `monitoring.cluster_uuid` is set to `foobar` in the response.
2. Build Metricbeat with this PR. Enable the `beat-xpack` module.  Run Metricbeat.
3. Check that `.monitoring-beats-*` indices are created in Elasticsearch.
4. Check that documents in `.monitoring-beats-*` indices contain the `cluster_uuid` field with value as `foobar`.