### PR TITLE
Strip debug symbols from binaries

### DIFF
--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -49,3 +49,4 @@ The list below covers the major changes between 7.0.0-rc2 and master only.
 - Add support to close beat.Client via beat.CloseRef (a subset of context.Context). {pull}13031[13031]
 - Add checks for types and formats used in fields definitions in `fields.yml` files. {pull}13188[13188]
 - Makefile included in generator copies files from beats repository using `git archive` instead of cp. {pull}13193[13193]
+- Strip debug symbols from binaries to reduce binary sizes. {issue}12768[12768]

--- a/dev-tools/mage/build.go
+++ b/dev-tools/mage/build.go
@@ -48,6 +48,9 @@ func DefaultBuildArgs() BuildArgs {
 	args := BuildArgs{
 		Name: BeatName,
 		CGO:  build.Default.CgoEnabled,
+		LDFlags: []string{
+			"-s", // Strip all debug symbols from binary (does not affect Go stack traces).
+		},
 		Vars: map[string]string{
 			"github.com/elastic/beats/libbeat/version.buildTime": "{{ date }}",
 			"github.com/elastic/beats/libbeat/version.commit":    "{{ commit }}",


### PR DESCRIPTION
The debug symbols are only required for external tools (like debuggers or third party profilers). This does not affect Go stack traces or pprof.

Closes #12768 (<-- see this for more details)