### PR TITLE
[docs] Add x-pack role to x-pack module docs

### DIFF
--- a/metricbeat/docs/modules/aws.asciidoc
+++ b/metricbeat/docs/modules/aws.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-module-aws]]
+[role="xpack"]
 == aws module
 
 This module periodically fetches monitoring metrics from AWS Cloudwatch using

--- a/metricbeat/docs/modules/cockroachdb.asciidoc
+++ b/metricbeat/docs/modules/cockroachdb.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-module-cockroachdb]]
+[role="xpack"]
 == CockroachDB module
 
 beta[]

--- a/metricbeat/docs/modules/coredns.asciidoc
+++ b/metricbeat/docs/modules/coredns.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-module-coredns]]
+[role="xpack"]
 == coredns module
 
 beta[]

--- a/metricbeat/docs/modules/mssql.asciidoc
+++ b/metricbeat/docs/modules/mssql.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-module-mssql]]
+[role="xpack"]
 == MSSQL module
 
 beta[]

--- a/metricbeat/docs/modules/oracle.asciidoc
+++ b/metricbeat/docs/modules/oracle.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-module-oracle]]
+[role="xpack"]
 == Oracle module
 
 beta[]

--- a/metricbeat/docs/modules/statsd.asciidoc
+++ b/metricbeat/docs/modules/statsd.asciidoc
@@ -3,6 +3,7 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[metricbeat-module-statsd]]
+[role="xpack"]
 == Statsd module
 
 beta[]

--- a/metricbeat/scripts/mage/docs_collector.go
+++ b/metricbeat/scripts/mage/docs_collector.go
@@ -45,6 +45,7 @@ type moduleData struct {
 	Settings   []string `yaml:"settings"`
 	CfgFile    string
 	Asciidoc   string
+	IsXpack    bool
 	Metricsets []metricsetData
 }
 
@@ -84,6 +85,14 @@ var funcMap = template.FuncMap{
 		return mage.BeatName
 	},
 	"title": strings.Title,
+}
+
+// checkXpack checks to see if the module belongs to x-pack
+func checkXpack(path string) bool {
+	if strings.Contains(path, "x-pack") {
+		return true
+	}
+	return false
 }
 
 // setupDirectory clears and re-creates the docs/modules directory.
@@ -328,6 +337,7 @@ func gatherData(modules []string) ([]moduleData, error) {
 			return moduleList, err
 		}
 
+		fieldsm.IsXpack = checkXpack(module)
 		fieldsm.Path = module
 		fieldsm.CfgFile = cfgPath
 		fieldsm.Metricsets = metricsets

--- a/metricbeat/scripts/mage/docs_collector.go
+++ b/metricbeat/scripts/mage/docs_collector.go
@@ -87,12 +87,10 @@ var funcMap = template.FuncMap{
 	"title": strings.Title,
 }
 
-// checkXpack checks to see if the module belongs to x-pack
+// checkXpack checks to see if the module belongs to x-pack.
 func checkXpack(path string) bool {
-	if strings.Contains(path, "x-pack") {
-		return true
-	}
-	return false
+	return strings.Contains(path, "x-pack")
+
 }
 
 // setupDirectory clears and re-creates the docs/modules directory.

--- a/metricbeat/scripts/mage/template/moduleDoc.tmpl
+++ b/metricbeat/scripts/mage/template/moduleDoc.tmpl
@@ -3,6 +3,8 @@ This file is generated! See scripts/mage/docs_collector.go
 ////
 
 [[{{getBeatName}}-module-{{.Base}}]]
+{{- if .IsXpack}}
+[role="xpack"]{{end}}
 == {{.Title}} module
 
 {{if not (eq .Release "ga") -}}


### PR DESCRIPTION
See elastic/beats#13112

This should be fairly straight-forward. I'm wondering if there's a better way to discern x-pack modules, but there doesn't seem to be any kind of 'tag' for x-pack in _meta anywhere, so I just keep using the file path.   