### PR TITLE
WIP: Refactor output group to interfaces

### DIFF
--- a/libbeat/beat/pipeline.go
+++ b/libbeat/beat/pipeline.go
@@ -21,11 +21,13 @@ import (
 	"time"
 
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/outputs"
 )
 
 type Pipeline interface {
 	PipelineConnector
 	SetACKHandler(PipelineACKHandler) error
+	GetOutputGroup() outputs.Group // FIXME! Causes circular import
 }
 
 // PipelineConnector creates a publishing Client. This is typically backed by a Pipeline.

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -810,14 +810,14 @@ func (b *Beat) makeOutputReloader(outReloader pipeline.OutputReloader) reload.Re
 
 func (b *Beat) makeOutputFactory(
 	cfg common.ConfigNamespace,
-) func(outputs.Observer) (string, outputs.Group, error) {
-	return func(outStats outputs.Observer) (string, outputs.Group, error) {
+) func(outputs.Observer) (string, outputs.IGroup, error) {
+	return func(outStats outputs.Observer) (string, outputs.IGroup, error) {
 		out, err := b.createOutput(outStats, cfg)
 		return cfg.Name(), out, err
 	}
 }
 
-func (b *Beat) createOutput(stats outputs.Observer, cfg common.ConfigNamespace) (outputs.Group, error) {
+func (b *Beat) createOutput(stats outputs.Observer, cfg common.ConfigNamespace) (outputs.IGroup, error) {
 	if !cfg.IsSet() {
 		return outputs.Group{}, nil
 	}

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -394,6 +394,7 @@ func (b *Beat) launch(settings Settings, bt beat.Creator) error {
 		settings := report.Settings{
 			DefaultUsername: settings.Monitoring.DefaultUsername,
 			Format:          reporterSettings.Format,
+			BeatPublisher:   b.Publisher,
 		}
 		reporter, err := report.New(b.Info, settings, monitoringCfg, b.Config.Output)
 		if err != nil {

--- a/libbeat/cmd/test/output.go
+++ b/libbeat/cmd/test/output.go
@@ -47,7 +47,7 @@ func GenTestOutputCmd(settings instance.Settings) *cobra.Command {
 				os.Exit(1)
 			}
 
-			for _, client := range output.Clients {
+			for _, client := range output.GetClients() {
 				tClient, ok := client.(testing.Testable)
 				if !ok {
 					fmt.Printf("%s output doesn't support testing\n", b.Config.Output.Name())

--- a/libbeat/monitoring/report/elasticsearch/elasticsearch.go
+++ b/libbeat/monitoring/report/elasticsearch/elasticsearch.go
@@ -57,7 +57,8 @@ type reporter struct {
 	pipeline *pipeline.Pipeline
 	client   beat.Client
 
-	out []outputs.NetworkClient
+	out           []outputs.NetworkClient
+	beatPublisher beat.Pipeline
 }
 
 const selector = "monitoring"
@@ -209,14 +210,15 @@ func makeReporter(beat beat.Info, settings report.Settings, cfg *common.Config) 
 	}
 
 	r := &reporter{
-		logger:     log,
-		done:       newStopper(),
-		beatMeta:   makeMeta(beat),
-		tags:       config.Tags,
-		checkRetry: checkRetry,
-		pipeline:   pipeline,
-		client:     pipeConn,
-		out:        clients,
+		logger:        log,
+		done:          newStopper(),
+		beatMeta:      makeMeta(beat),
+		tags:          config.Tags,
+		checkRetry:    checkRetry,
+		pipeline:      pipeline,
+		client:        pipeConn,
+		out:           clients,
+		beatPublisher: settings.BeatPublisher,
 	}
 	go r.initLoop(config)
 	return r, nil

--- a/libbeat/monitoring/report/report.go
+++ b/libbeat/monitoring/report/report.go
@@ -50,6 +50,7 @@ type config struct {
 type Settings struct {
 	DefaultUsername string
 	Format          Format
+	BeatPublisher   beat.Pipeline
 }
 
 type Reporter interface {

--- a/libbeat/outputs/console/console.go
+++ b/libbeat/outputs/console/console.go
@@ -57,7 +57,7 @@ func makeConsole(
 	beat beat.Info,
 	observer outputs.Observer,
 	cfg *common.Config,
-) (outputs.Group, error) {
+) (outputs.IGroup, error) {
 	config := defaultConfig
 	err := cfg.Unpack(&config)
 	if err != nil {

--- a/libbeat/outputs/elasticsearch/elasticsearch.go
+++ b/libbeat/outputs/elasticsearch/elasticsearch.go
@@ -59,6 +59,15 @@ type callbacksRegistry struct {
 	mutex     sync.Mutex
 }
 
+type outputGroup struct {
+	outputs.Group
+}
+
+func (o outputGroup) ClusterUUID() (string, error) {
+	// TODO
+	return "", nil
+}
+
 // XXX: it would be fantastic to do this without a package global
 var connectCallbackRegistry = newCallbacksRegistry()
 
@@ -139,7 +148,7 @@ func makeES(
 	beat beat.Info,
 	observer outputs.Observer,
 	cfg *common.Config,
-) (outputs.Group, error) {
+) (outputs.IGroup, error) {
 	if !cfg.HasField("bulk_max_size") {
 		cfg.SetInt("bulk_max_size", -1, defaultBulkSize)
 	}
@@ -213,7 +222,9 @@ func makeES(
 		clients[i] = client
 	}
 
-	return outputs.SuccessNet(config.LoadBalance, config.BulkMaxSize, config.MaxRetries, clients)
+	o, err := outputs.SuccessNet(config.LoadBalance, config.BulkMaxSize, config.MaxRetries, clients)
+	es := outputGroup{o}
+	return es, err
 }
 
 func buildSelectors(

--- a/libbeat/outputs/fileout/file.go
+++ b/libbeat/outputs/fileout/file.go
@@ -48,7 +48,7 @@ func makeFileout(
 	beat beat.Info,
 	observer outputs.Observer,
 	cfg *common.Config,
-) (outputs.Group, error) {
+) (outputs.IGroup, error) {
 	config := defaultConfig
 	if err := cfg.Unpack(&config); err != nil {
 		return outputs.Fail(err)

--- a/libbeat/outputs/kafka/kafka.go
+++ b/libbeat/outputs/kafka/kafka.go
@@ -57,7 +57,7 @@ func makeKafka(
 	beat beat.Info,
 	observer outputs.Observer,
 	cfg *common.Config,
-) (outputs.Group, error) {
+) (outputs.IGroup, error) {
 	debugf("initialize kafka output")
 
 	config, err := readConfig(cfg)

--- a/libbeat/outputs/logstash/logstash.go
+++ b/libbeat/outputs/logstash/logstash.go
@@ -43,7 +43,7 @@ func makeLogstash(
 	beat beat.Info,
 	observer outputs.Observer,
 	cfg *common.Config,
-) (outputs.Group, error) {
+) (outputs.IGroup, error) {
 	config, err := readConfig(cfg, beat)
 	if err != nil {
 		return outputs.Fail(err)

--- a/libbeat/outputs/redis/redis.go
+++ b/libbeat/outputs/redis/redis.go
@@ -53,7 +53,7 @@ func makeRedis(
 	beat beat.Info,
 	observer outputs.Observer,
 	cfg *common.Config,
-) (outputs.Group, error) {
+) (outputs.IGroup, error) {
 
 	if !cfg.HasField("index") {
 		cfg.SetString("index", -1, beat.Beat)

--- a/libbeat/publisher/pipeline/controller.go
+++ b/libbeat/publisher/pipeline/controller.go
@@ -43,6 +43,7 @@ type outputController struct {
 
 // outputGroup configures a group of load balanced outputs with shared work queue.
 type outputGroup struct {
+	outGrp    outputs.Group
 	workQueue workQueue
 	outputs   []outputWorker
 
@@ -98,6 +99,10 @@ func (c *outputController) Close() error {
 	return nil
 }
 
+func (c *outputController) Get() outputs.Group {
+	return c.out.outGrp
+}
+
 func (c *outputController) Set(outGrp outputs.Group) {
 	// create new outputGroup with shared work queue
 	clients := outGrp.Clients
@@ -107,6 +112,7 @@ func (c *outputController) Set(outGrp outputs.Group) {
 		worker[i] = makeClientWorker(c.observer, queue, client)
 	}
 	grp := &outputGroup{
+		outGrp:     outGrp,
 		workQueue:  queue,
 		outputs:    worker,
 		timeToLive: outGrp.Retry + 1,

--- a/libbeat/publisher/pipeline/module.go
+++ b/libbeat/publisher/pipeline/module.go
@@ -48,7 +48,7 @@ type Monitors struct {
 // OutputFactory is used by the publisher pipeline to create an output instance.
 // If the group returned can be empty. The pipeline will accept events, but
 // eventually block.
-type OutputFactory func(outputs.Observer) (string, outputs.Group, error)
+type OutputFactory func(outputs.Observer) (string, outputs.IGroup, error)
 
 func init() {
 	flag.BoolVar(&publishDisabled, "N", false, "Disable actual publishing for testing")
@@ -61,7 +61,7 @@ func Load(
 	monitors Monitors,
 	config Config,
 	processors processing.Supporter,
-	makeOutput func(outputs.Observer) (string, outputs.Group, error),
+	makeOutput func(outputs.Observer) (string, outputs.IGroup, error),
 ) (*Pipeline, error) {
 	log := monitors.Logger
 	if log == nil {
@@ -101,7 +101,7 @@ func Load(
 func loadOutput(
 	monitors Monitors,
 	makeOutput OutputFactory,
-) (outputs.Group, error) {
+) (outputs.IGroup, error) {
 	log := monitors.Logger
 	if log == nil {
 		log = logp.L()

--- a/libbeat/publisher/pipeline/pipeline.go
+++ b/libbeat/publisher/pipeline/pipeline.go
@@ -118,7 +118,7 @@ const (
 type OutputReloader interface {
 	Reload(
 		cfg *reload.ConfigWithMeta,
-		factory func(outputs.Observer, common.ConfigNamespace) (outputs.Group, error),
+		factory func(outputs.Observer, common.ConfigNamespace) (outputs.IGroup, error),
 	) error
 }
 
@@ -145,7 +145,7 @@ func New(
 	beat beat.Info,
 	monitors Monitors,
 	queueFactory queueFactory,
-	out outputs.Group,
+	out outputs.IGroup,
 	settings Settings,
 ) (*Pipeline, error) {
 	var err error
@@ -384,7 +384,7 @@ func (p *Pipeline) ConnectWith(cfg beat.ClientConfig) (beat.Client, error) {
 }
 
 // GetOutputGroup returns the output being used by the pipeline
-func (p *Pipeline) GetOutputGroup() outputs.Group {
+func (p *Pipeline) GetOutputGroup() outputs.IGroup {
 	return p.output.Get()
 }
 

--- a/libbeat/publisher/pipeline/pipeline.go
+++ b/libbeat/publisher/pipeline/pipeline.go
@@ -383,6 +383,11 @@ func (p *Pipeline) ConnectWith(cfg beat.ClientConfig) (beat.Client, error) {
 	return client, nil
 }
 
+// GetOutputGroup returns the output being used by the pipeline
+func (p *Pipeline) GetOutputGroup() outputs.Group {
+	return p.output.Get()
+}
+
 func (p *Pipeline) registerSignalPropagation(c *client) {
 	p.guardStartSigPropagation.Do(func() {
 		p.sigNewClient = make(chan *client, 1)


### PR DESCRIPTION
POC for idea suggested by @urso in https://github.com/elastic/beats/pull/13251#discussion_r314297201.

My thought process behind the changes in this PR is as follows. Please let me know if it's not going in the right direction and I'm happy to try a different approach.
- `outputs.Group` seems to be the closest struct we have in libbeat that represents an output.
- This struct usually gets initialized inside a publisher pipeline. So the publisher pipeline must provide a way to surface it in order to inject the same struct into monitoring reporter settings. These settings are available in each reporter implementation (e.g. the Elasticsearch reporter).
- Inside the monitoring reporter scope, we can grab the aforementioned struct from the reporter settings and use it: we can check if the output represented by the struct is ClusterUUID-aware. If it is, we can then ask it for the ClusterUUID (which may involve forcing a connection; TBD).

Will flesh out more details of PR and clean things up in the code if it seems to be heading in the right direction.