### PR TITLE
Include log.source.address for unparseable syslog messages

### DIFF
--- a/filebeat/input/syslog/input.go
+++ b/filebeat/input/syslog/input.go
@@ -141,6 +141,11 @@ func NewInput(
 				},
 				Fields: common.MapStr{
 					"message": string(data),
+					"log": common.MapStr{
+						"source": common.MapStr{
+							"address": metadata.RemoteAddr.String(),
+						},
+					},
 				},
 			})
 		} else {


### PR DESCRIPTION
Fixes #13268