### PR TITLE
Docs: Asciidoctor compatibilty step 1

### DIFF
--- a/libbeat/docs/shared-ssl-config.asciidoc
+++ b/libbeat/docs/shared-ssl-config.asciidoc
@@ -6,7 +6,7 @@ You can specify SSL options when you configure:
 * <<configuring-output,outputs>> that support SSL
 ifeval::["{beatname_lc}"!="apm-server"]
 * the <<setup-kibana-endpoint,Kibana endpoint>>
-endif::["{beatname_lc}"!="apm-server"]
+endif::[]
 ifeval::["{beatname_lc}"=="heartbeat"]
 * <<configuration-heartbeat-options,{beatname_uc} monitors>> that support SSL
 endif::[]


### PR DESCRIPTION
Fixes an asciidoctor incompatibility discovered while working on the APM
server.

Mirrors elastic/apm-server#2567