### PR TITLE
[Generator] Make the metricbeat gen makefile use update instead of collect

### DIFF
--- a/generator/metricbeat/{beat}/Makefile
+++ b/generator/metricbeat/{beat}/Makefile
@@ -17,7 +17,7 @@ CHECK_HEADERS_DISABLED=true
 setup: copy-vendor git-init
 	#call make recursively so we can reload the above include.
 	#Only needed during the first setup phase, before /vendor exists
-	$(MAKE) create-metricset collect git-add
+	$(MAKE) create-metricset update git-add
 
 # Copy beats into vendor directory
 .PHONY: copy-vendor


### PR DESCRIPTION
[The docs seem to suggest](https://www.elastic.co/guide/en/beats/devguide/current/creating-beat-from-metricbeat.html#_step_4_build_amp_run) that `make setup` runs `make update`. However, the makefile only runs `make collect`. Crucially, `collect` leaves out the `{beat}.yml` config file needed in the next step. `update` runs `collect`, so just do that instead.