### PR TITLE
Change global_fields script so it doesn't produce a needless error message.

### DIFF
--- a/libbeat/scripts/cmd/global_fields/main.go
+++ b/libbeat/scripts/cmd/global_fields/main.go
@@ -97,7 +97,7 @@ func main() {
 	}
 
 	_, err = mapping.LoadFieldsYaml(output)
-	if err != nil {
+	if output != "-" && err != nil {
 		fmt.Fprintf(os.Stderr, "Generated global fields.yml file for %s is invalid: %+v\n", name, err)
 		os.Exit(3)
 	}


### PR DESCRIPTION
As it stands, when this script is run as part of `make update` it exits `3` and produces a kind of confusing error message. This is because the output defaults to `-` and then a later `LoadFieldsYaml` will fail after it tries to load `-` as a file path. This adds a little short circuit so we don't exit. I'm honestly not sure why the final `LoadFieldsYaml` is here, but I figured I should take the least invasive route.