### PR TITLE
[Functionbeat] fix cloudwatch logs timestamp to use logRecord timestamp…

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -181,6 +181,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 *Functionbeat*
 
 - Fix function name reference for Kinesis streams in CloudFormation templates {pull}11646[11646]
+- Fix Cloudwatch logs timestamp to use timestamp of the log record instead of when the record was processed {pull}13291[13291]
 
 ==== Added
 

--- a/x-pack/functionbeat/provider/aws/aws/transformer/transformer.go
+++ b/x-pack/functionbeat/provider/aws/aws/transformer/transformer.go
@@ -24,7 +24,7 @@ func CloudwatchLogs(request events.CloudwatchLogsData) []beat.Event {
 
 	for idx, logEvent := range request.LogEvents {
 		events[idx] = beat.Event{
-			Timestamp: time.Unix(0, logEvent.Timestamp * 1000000),
+			Timestamp: time.Unix(0, logEvent.Timestamp*1000000),
 			Fields: common.MapStr{
 				"message":              logEvent.Message,
 				"id":                   logEvent.ID,

--- a/x-pack/functionbeat/provider/aws/aws/transformer/transformer.go
+++ b/x-pack/functionbeat/provider/aws/aws/transformer/transformer.go
@@ -24,7 +24,7 @@ func CloudwatchLogs(request events.CloudwatchLogsData) []beat.Event {
 
 	for idx, logEvent := range request.LogEvents {
 		events[idx] = beat.Event{
-			Timestamp: time.Now(), // TODO: time.Unix(logEvent.Timestamp, 0),
+			Timestamp: time.Unix(0, logEvent.Timestamp * 1000000),
 			Fields: common.MapStr{
 				"message":              logEvent.Message,
 				"id":                   logEvent.ID,


### PR DESCRIPTION
… instead of record processing timestamp

The suggested TODO code passes the Cloudwatch timestamp as seconds. The Cloudwatch field value is milliseconds. Pass it as nanoseconds times 1000000.

Closes: #12412