### PR TITLE
[WIP] Testing collecting PR details with travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -202,9 +202,9 @@ before_install:
   # collect PR details
   - |
     if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then
-      curl "https://api.github.com/repos/elastic/beats/${TRAVIS_PULL_REQUEST}" > .pr_details.json
-      cat .pr_details.json
-      git diff
+      # curl "https://api.github.com/repos/elastic/beats/${TRAVIS_PULL_REQUEST}" > .pr_details.json
+      # cat .pr_details.json
+      git diff ${TRAVIS_COMMIT_RANGE}
     fi
   # check we're testing the correct commit
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -196,8 +196,22 @@ addons:
 
 before_install:
   - python --version
+  - printenv
   - umask 022
   - chmod -R go-w $GOPATH/src/github.com/elastic/beats
+  # collect PR details
+  - |
+    if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then
+      curl "https://api.github.com/repos/elastic/beats/${TRAVIS_PULL_REQUEST}" > .pr_details.json
+      cat .pr_details.json
+      git diff
+    fi
+  # check we're testing the correct commit
+  - |
+    if [[ "$TRAVIS_COMMIT" != "$(git rev-parse HEAD)" ]]; then
+      echo "Commit $(git rev-parse HEAD) doesn't match expected commit $TRAVIS_COMMIT"
+      exit 1
+    fi
   # Docker-compose installation
   - sudo rm /usr/local/bin/docker-compose || true
   - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose

--- a/.travis.yml
+++ b/.travis.yml
@@ -204,7 +204,7 @@ before_install:
     if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then
       # curl "https://api.github.com/repos/elastic/beats/${TRAVIS_PULL_REQUEST}" > .pr_details.json
       # cat .pr_details.json
-      git diff ${TRAVIS_COMMIT_RANGE}
+      git log -p ${TRAVIS_COMMIT_RANGE}
     fi
   # check we're testing the correct commit
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -205,6 +205,8 @@ before_install:
       # curl "https://api.github.com/repos/elastic/beats/${TRAVIS_PULL_REQUEST}" > .pr_details.json
       # cat .pr_details.json
       git log -p ${TRAVIS_COMMIT_RANGE}
+      git diff --name-only ${TRAVIS_COMMIT_RANGE} > .pr_modified.txt
+      cat .pr_modified.txt
     fi
   # check we're testing the correct commit
   - |


### PR DESCRIPTION
Test travis support for leaning about the commit ranges in a PR. Travis does not provide many PR information. In order to check for changes and implement some form of selective testing we have to check the commit range.