### PR TITLE
Add input for Cloudwatch logs via Kinesis

### DIFF
--- a/x-pack/functionbeat/_meta/beat.reference.yml
+++ b/x-pack/functionbeat/_meta/beat.reference.yml
@@ -26,9 +26,6 @@ functionbeat.provider.aws.functions:
     # Description of the method to help identify them when you run multiples functions.
     description: "lambda function for cloudwatch logs"
 
-    # Set compress if events are encoded.
-    #compress: true
-
     # Concurrency, is the reserved number of instances for that function.
     # Default is 5.
     #
@@ -198,6 +195,9 @@ functionbeat.provider.aws.functions:
 
     # Description of the method to help identify them when you run multiples functions.
     description: "lambda function for Cloudwatch logs in Kinesis events"
+
+    # Set compress if events are encoded.
+    #compressed: true
 
     # Concurrency, is the reserved number of instances for that function.
     # Default is 5.

--- a/x-pack/functionbeat/_meta/beat.reference.yml
+++ b/x-pack/functionbeat/_meta/beat.reference.yml
@@ -196,7 +196,10 @@ functionbeat.provider.aws.functions:
     # Description of the method to help identify them when you run multiples functions.
     description: "lambda function for Cloudwatch logs in Kinesis events"
 
-    # Set compress if events are encoded.
+    # Set base64_encoded if your data is base64 encoded.
+    #base64_encoded: false
+
+    # Set compressed if your data is compressed with gzip.
     #compressed: true
 
     # Concurrency, is the reserved number of instances for that function.

--- a/x-pack/functionbeat/_meta/beat.reference.yml
+++ b/x-pack/functionbeat/_meta/beat.reference.yml
@@ -189,9 +189,9 @@ functionbeat.provider.aws.functions:
         #starting_position: "trim_horizon"
 
   # Create a function that accepts Cloudwatch logs from Kinesis streams.
-  - name: cloudwatch_kinesis
+  - name: cloudwatch_logs_kinesis
     enabled: false
-    type: cloudwatch_kinesis
+    type: cloudwatch_logs_kinesis
 
     # Description of the method to help identify them when you run multiples functions.
     description: "lambda function for Cloudwatch logs in Kinesis events"

--- a/x-pack/functionbeat/_meta/beat.reference.yml
+++ b/x-pack/functionbeat/_meta/beat.reference.yml
@@ -26,6 +26,9 @@ functionbeat.provider.aws.functions:
     # Description of the method to help identify them when you run multiples functions.
     description: "lambda function for cloudwatch logs"
 
+    # Set compress if events are encoded.
+    #compress: true
+
     # Concurrency, is the reserved number of instances for that function.
     # Default is 5.
     #

--- a/x-pack/functionbeat/_meta/beat.reference.yml
+++ b/x-pack/functionbeat/_meta/beat.reference.yml
@@ -189,7 +189,7 @@ functionbeat.provider.aws.functions:
         #starting_position: "trim_horizon"
 
   # Create a function that accepts Cloudwatch logs from Kinesis streams.
-  - name: cloudwatch_logs_kinesis
+  - name: cloudwatch-logs-kinesis
     enabled: false
     type: cloudwatch_logs_kinesis
 
@@ -214,6 +214,9 @@ functionbeat.provider.aws.functions:
 
     # Dead letter queue configuration, this must be set to an ARN pointing to a SQS queue.
     #dead_letter_config.target_arn:
+
+    # The amount of time the function is allowed to run.
+    #timeout: 3s
 
     # Execution role of the function.
     #role: arn:aws:iam::123456789012:role/MyFunction

--- a/x-pack/functionbeat/_meta/beat.reference.yml
+++ b/x-pack/functionbeat/_meta/beat.reference.yml
@@ -187,3 +187,60 @@ functionbeat.provider.aws.functions:
         # Starting position is where to start reading events from the Kinesis stream.
         # Default is trim_horizon.
         #starting_position: "trim_horizon"
+
+  # Create a function that accepts Cloudwatch logs from Kinesis streams.
+  - name: cloudwatch_kinesis
+    enabled: false
+    type: cloudwatch_kinesis
+
+    # Description of the method to help identify them when you run multiples functions.
+    description: "lambda function for Cloudwatch logs in Kinesis events"
+
+    # Concurrency, is the reserved number of instances for that function.
+    # Default is 5.
+    #
+    # Note: There is a hard limit of 1000 functions of any kind per account.
+    #concurrency: 5
+
+    # The maximum memory allocated for this function, the configured size must be a factor of 64.
+    # There is a hard limit of 3008MiB for each function. Default is 128MiB.
+    #memory_size: 128MiB
+
+    # Dead letter queue configuration, this must be set to an ARN pointing to a SQS queue.
+    #dead_letter_config.target_arn:
+
+    # Execution role of the function.
+    #role: arn:aws:iam::123456789012:role/MyFunction
+
+    # Connect to private resources in an Amazon VPC.
+    #virtual_private_cloud:
+    #  security_group_ids: []
+    #  subnet_ids: []
+
+    # Optional fields that you can specify to add additional information to the
+    # output. Fields can be scalar values, arrays, dictionaries, or any nested
+    # combination of these.
+    #fields:
+    #  env: staging
+
+    # Define custom processors for this function.
+    #processors:
+    #  - decode_json_fields:
+    #      fields: ["message"]
+    #      process_array: false
+    #      max_depth: 1
+    #      target: ""
+    #      overwrite_keys: false
+
+    # List of Kinesis streams.
+    triggers:
+        # Arn for the Kinesis stream.
+      - event_source_arn: arn:aws:sqs:us-east-1:xxxxx:myevents
+
+        # batch_size is the number of events read in a batch.
+        # Default is 10.
+        #batch_size: 100
+
+        # Starting position is where to start reading events from the Kinesis stream.
+        # Default is trim_horizon.
+        #starting_position: "trim_horizon"

--- a/x-pack/functionbeat/_meta/beat.yml
+++ b/x-pack/functionbeat/_meta/beat.yml
@@ -181,7 +181,7 @@ functionbeat.provider.aws.functions:
         #starting_position: "trim_horizon"
 
   # Create a function that accepts Cloudwatch logs from Kinesis streams.
-  - name: cloudwatch_logs_kinesis
+  - name: cloudwatch-logs-kinesis
     enabled: false
     type: cloudwatch_logs_kinesis
 

--- a/x-pack/functionbeat/_meta/beat.yml
+++ b/x-pack/functionbeat/_meta/beat.yml
@@ -188,7 +188,10 @@ functionbeat.provider.aws.functions:
     # Description of the method to help identify them when you run multiples functions.
     description: "lambda function for Cloudwatch logs in Kinesis events"
 
-    # Set compress if events are encoded.
+    # Set base64_encoded if your data is base64 encoded.
+    #base64_encoded: false
+
+    # Set compressed if your data is compressed with gzip.
     #compressed: true
 
     # Concurrency, is the reserved number of instances for that function.

--- a/x-pack/functionbeat/_meta/beat.yml
+++ b/x-pack/functionbeat/_meta/beat.yml
@@ -181,9 +181,9 @@ functionbeat.provider.aws.functions:
         #starting_position: "trim_horizon"
 
   # Create a function that accepts Cloudwatch logs from Kinesis streams.
-  - name: cloudwatch_kinesis
+  - name: cloudwatch_logs_kinesis
     enabled: false
-    type: cloudwatch_kinesis
+    type: cloudwatch_logs_kinesis
 
     # Description of the method to help identify them when you run multiples functions.
     description: "lambda function for Cloudwatch logs in Kinesis events"

--- a/x-pack/functionbeat/_meta/beat.yml
+++ b/x-pack/functionbeat/_meta/beat.yml
@@ -180,6 +180,63 @@ functionbeat.provider.aws.functions:
         # Default is trim_horizon.
         #starting_position: "trim_horizon"
 
+  # Create a function that accepts Cloudwatch logs from Kinesis streams.
+  - name: cloudwatch_kinesis
+    enabled: false
+    type: cloudwatch_kinesis
+
+    # Description of the method to help identify them when you run multiples functions.
+    description: "lambda function for Cloudwatch logs in Kinesis events"
+
+    # Concurrency, is the reserved number of instances for that function.
+    # Default is 5.
+    #
+    # Note: There is a hard limit of 1000 functions of any kind per account.
+    #concurrency: 5
+
+    # The maximum memory allocated for this function, the configured size must be a factor of 64.
+    # There is a hard limit of 3008MiB for each function. Default is 128MiB.
+    #memory_size: 128MiB
+
+    # Dead letter queue configuration, this must be set to an ARN pointing to a SQS queue.
+    #dead_letter_config.target_arn:
+
+    # Execution role of the function.
+    #role: arn:aws:iam::123456789012:role/MyFunction
+
+    # Connect to private resources in an Amazon VPC.
+    #virtual_private_cloud:
+    #  security_group_ids: []
+    #  subnet_ids: []
+
+    # Optional fields that you can specify to add additional information to the
+    # output. Fields can be scalar values, arrays, dictionaries, or any nested
+    # combination of these.
+    #fields:
+    #  env: staging
+
+    # Define custom processors for this function.
+    #processors:
+    #  - decode_json_fields:
+    #      fields: ["message"]
+    #      process_array: false
+    #      max_depth: 1
+    #      target: ""
+    #      overwrite_keys: false
+
+    # List of Kinesis streams.
+    triggers:
+        # Arn for the Kinesis stream.
+      - event_source_arn: arn:aws:sqs:us-east-1:xxxxx:myevents
+
+        # batch_size is the number of events read in a batch.
+        # Default is 10.
+        #batch_size: 100
+
+        # Starting position is where to start reading events from the Kinesis stream.
+        # Default is trim_horizon.
+        #starting_position: "trim_horizon"
+
 #==================== Elasticsearch template setting ==========================
 
 setup.template.settings:

--- a/x-pack/functionbeat/_meta/beat.yml
+++ b/x-pack/functionbeat/_meta/beat.yml
@@ -188,6 +188,9 @@ functionbeat.provider.aws.functions:
     # Description of the method to help identify them when you run multiples functions.
     description: "lambda function for Cloudwatch logs in Kinesis events"
 
+    # Set compress if events are encoded.
+    #compress: true
+
     # Concurrency, is the reserved number of instances for that function.
     # Default is 5.
     #

--- a/x-pack/functionbeat/_meta/beat.yml
+++ b/x-pack/functionbeat/_meta/beat.yml
@@ -189,7 +189,7 @@ functionbeat.provider.aws.functions:
     description: "lambda function for Cloudwatch logs in Kinesis events"
 
     # Set compress if events are encoded.
-    #compress: true
+    #compressed: true
 
     # Concurrency, is the reserved number of instances for that function.
     # Default is 5.

--- a/x-pack/functionbeat/functionbeat.reference.yml
+++ b/x-pack/functionbeat/functionbeat.reference.yml
@@ -26,9 +26,6 @@ functionbeat.provider.aws.functions:
     # Description of the method to help identify them when you run multiples functions.
     description: "lambda function for cloudwatch logs"
 
-    # Set compress if events are encoded.
-    #compress: true
-
     # Concurrency, is the reserved number of instances for that function.
     # Default is 5.
     #
@@ -198,6 +195,9 @@ functionbeat.provider.aws.functions:
 
     # Description of the method to help identify them when you run multiples functions.
     description: "lambda function for Cloudwatch logs in Kinesis events"
+
+    # Set compress if events are encoded.
+    #compressed: true
 
     # Concurrency, is the reserved number of instances for that function.
     # Default is 5.

--- a/x-pack/functionbeat/functionbeat.reference.yml
+++ b/x-pack/functionbeat/functionbeat.reference.yml
@@ -196,7 +196,10 @@ functionbeat.provider.aws.functions:
     # Description of the method to help identify them when you run multiples functions.
     description: "lambda function for Cloudwatch logs in Kinesis events"
 
-    # Set compress if events are encoded.
+    # Set base64_encoded if your data is base64 encoded.
+    #base64_encoded: false
+
+    # Set compressed if your data is compressed with gzip.
     #compressed: true
 
     # Concurrency, is the reserved number of instances for that function.

--- a/x-pack/functionbeat/functionbeat.reference.yml
+++ b/x-pack/functionbeat/functionbeat.reference.yml
@@ -189,9 +189,9 @@ functionbeat.provider.aws.functions:
         #starting_position: "trim_horizon"
 
   # Create a function that accepts Cloudwatch logs from Kinesis streams.
-  - name: cloudwatch_kinesis
+  - name: cloudwatch_logs_kinesis
     enabled: false
-    type: cloudwatch_kinesis
+    type: cloudwatch_logs_kinesis
 
     # Description of the method to help identify them when you run multiples functions.
     description: "lambda function for Cloudwatch logs in Kinesis events"

--- a/x-pack/functionbeat/functionbeat.reference.yml
+++ b/x-pack/functionbeat/functionbeat.reference.yml
@@ -188,6 +188,63 @@ functionbeat.provider.aws.functions:
         # Default is trim_horizon.
         #starting_position: "trim_horizon"
 
+  # Create a function that accepts Cloudwatch logs from Kinesis streams.
+  - name: cloudwatch_kinesis
+    enabled: false
+    type: cloudwatch_kinesis
+
+    # Description of the method to help identify them when you run multiples functions.
+    description: "lambda function for Cloudwatch logs in Kinesis events"
+
+    # Concurrency, is the reserved number of instances for that function.
+    # Default is 5.
+    #
+    # Note: There is a hard limit of 1000 functions of any kind per account.
+    #concurrency: 5
+
+    # The maximum memory allocated for this function, the configured size must be a factor of 64.
+    # There is a hard limit of 3008MiB for each function. Default is 128MiB.
+    #memory_size: 128MiB
+
+    # Dead letter queue configuration, this must be set to an ARN pointing to a SQS queue.
+    #dead_letter_config.target_arn:
+
+    # Execution role of the function.
+    #role: arn:aws:iam::123456789012:role/MyFunction
+
+    # Connect to private resources in an Amazon VPC.
+    #virtual_private_cloud:
+    #  security_group_ids: []
+    #  subnet_ids: []
+
+    # Optional fields that you can specify to add additional information to the
+    # output. Fields can be scalar values, arrays, dictionaries, or any nested
+    # combination of these.
+    #fields:
+    #  env: staging
+
+    # Define custom processors for this function.
+    #processors:
+    #  - decode_json_fields:
+    #      fields: ["message"]
+    #      process_array: false
+    #      max_depth: 1
+    #      target: ""
+    #      overwrite_keys: false
+
+    # List of Kinesis streams.
+    triggers:
+        # Arn for the Kinesis stream.
+      - event_source_arn: arn:aws:sqs:us-east-1:xxxxx:myevents
+
+        # batch_size is the number of events read in a batch.
+        # Default is 10.
+        #batch_size: 100
+
+        # Starting position is where to start reading events from the Kinesis stream.
+        # Default is trim_horizon.
+        #starting_position: "trim_horizon"
+
 #================================ General ======================================
 
 # The name of the shipper that publishes the network data. It can be used to group

--- a/x-pack/functionbeat/functionbeat.reference.yml
+++ b/x-pack/functionbeat/functionbeat.reference.yml
@@ -26,6 +26,9 @@ functionbeat.provider.aws.functions:
     # Description of the method to help identify them when you run multiples functions.
     description: "lambda function for cloudwatch logs"
 
+    # Set compress if events are encoded.
+    #compress: true
+
     # Concurrency, is the reserved number of instances for that function.
     # Default is 5.
     #

--- a/x-pack/functionbeat/functionbeat.reference.yml
+++ b/x-pack/functionbeat/functionbeat.reference.yml
@@ -189,7 +189,7 @@ functionbeat.provider.aws.functions:
         #starting_position: "trim_horizon"
 
   # Create a function that accepts Cloudwatch logs from Kinesis streams.
-  - name: cloudwatch_logs_kinesis
+  - name: cloudwatch-logs-kinesis
     enabled: false
     type: cloudwatch_logs_kinesis
 
@@ -214,6 +214,9 @@ functionbeat.provider.aws.functions:
 
     # Dead letter queue configuration, this must be set to an ARN pointing to a SQS queue.
     #dead_letter_config.target_arn:
+
+    # The amount of time the function is allowed to run.
+    #timeout: 3s
 
     # Execution role of the function.
     #role: arn:aws:iam::123456789012:role/MyFunction

--- a/x-pack/functionbeat/functionbeat.yml
+++ b/x-pack/functionbeat/functionbeat.yml
@@ -181,7 +181,7 @@ functionbeat.provider.aws.functions:
         #starting_position: "trim_horizon"
 
   # Create a function that accepts Cloudwatch logs from Kinesis streams.
-  - name: cloudwatch_logs_kinesis
+  - name: cloudwatch-logs-kinesis
     enabled: false
     type: cloudwatch_logs_kinesis
 

--- a/x-pack/functionbeat/functionbeat.yml
+++ b/x-pack/functionbeat/functionbeat.yml
@@ -188,7 +188,10 @@ functionbeat.provider.aws.functions:
     # Description of the method to help identify them when you run multiples functions.
     description: "lambda function for Cloudwatch logs in Kinesis events"
 
-    # Set compress if events are encoded.
+    # Set base64_encoded if your data is base64 encoded.
+    #base64_encoded: false
+
+    # Set compressed if your data is compressed with gzip.
     #compressed: true
 
     # Concurrency, is the reserved number of instances for that function.

--- a/x-pack/functionbeat/functionbeat.yml
+++ b/x-pack/functionbeat/functionbeat.yml
@@ -181,9 +181,9 @@ functionbeat.provider.aws.functions:
         #starting_position: "trim_horizon"
 
   # Create a function that accepts Cloudwatch logs from Kinesis streams.
-  - name: cloudwatch_kinesis
+  - name: cloudwatch_logs_kinesis
     enabled: false
-    type: cloudwatch_kinesis
+    type: cloudwatch_logs_kinesis
 
     # Description of the method to help identify them when you run multiples functions.
     description: "lambda function for Cloudwatch logs in Kinesis events"

--- a/x-pack/functionbeat/functionbeat.yml
+++ b/x-pack/functionbeat/functionbeat.yml
@@ -180,6 +180,63 @@ functionbeat.provider.aws.functions:
         # Default is trim_horizon.
         #starting_position: "trim_horizon"
 
+  # Create a function that accepts Cloudwatch logs from Kinesis streams.
+  - name: cloudwatch_kinesis
+    enabled: false
+    type: cloudwatch_kinesis
+
+    # Description of the method to help identify them when you run multiples functions.
+    description: "lambda function for Cloudwatch logs in Kinesis events"
+
+    # Concurrency, is the reserved number of instances for that function.
+    # Default is 5.
+    #
+    # Note: There is a hard limit of 1000 functions of any kind per account.
+    #concurrency: 5
+
+    # The maximum memory allocated for this function, the configured size must be a factor of 64.
+    # There is a hard limit of 3008MiB for each function. Default is 128MiB.
+    #memory_size: 128MiB
+
+    # Dead letter queue configuration, this must be set to an ARN pointing to a SQS queue.
+    #dead_letter_config.target_arn:
+
+    # Execution role of the function.
+    #role: arn:aws:iam::123456789012:role/MyFunction
+
+    # Connect to private resources in an Amazon VPC.
+    #virtual_private_cloud:
+    #  security_group_ids: []
+    #  subnet_ids: []
+
+    # Optional fields that you can specify to add additional information to the
+    # output. Fields can be scalar values, arrays, dictionaries, or any nested
+    # combination of these.
+    #fields:
+    #  env: staging
+
+    # Define custom processors for this function.
+    #processors:
+    #  - decode_json_fields:
+    #      fields: ["message"]
+    #      process_array: false
+    #      max_depth: 1
+    #      target: ""
+    #      overwrite_keys: false
+
+    # List of Kinesis streams.
+    triggers:
+        # Arn for the Kinesis stream.
+      - event_source_arn: arn:aws:sqs:us-east-1:xxxxx:myevents
+
+        # batch_size is the number of events read in a batch.
+        # Default is 10.
+        #batch_size: 100
+
+        # Starting position is where to start reading events from the Kinesis stream.
+        # Default is trim_horizon.
+        #starting_position: "trim_horizon"
+
 #==================== Elasticsearch template setting ==========================
 
 setup.template.settings:

--- a/x-pack/functionbeat/functionbeat.yml
+++ b/x-pack/functionbeat/functionbeat.yml
@@ -188,6 +188,9 @@ functionbeat.provider.aws.functions:
     # Description of the method to help identify them when you run multiples functions.
     description: "lambda function for Cloudwatch logs in Kinesis events"
 
+    # Set compress if events are encoded.
+    #compress: true
+
     # Concurrency, is the reserved number of instances for that function.
     # Default is 5.
     #

--- a/x-pack/functionbeat/functionbeat.yml
+++ b/x-pack/functionbeat/functionbeat.yml
@@ -189,7 +189,7 @@ functionbeat.provider.aws.functions:
     description: "lambda function for Cloudwatch logs in Kinesis events"
 
     # Set compress if events are encoded.
-    #compress: true
+    #compressed: true
 
     # Concurrency, is the reserved number of instances for that function.
     # Default is 5.

--- a/x-pack/functionbeat/manager/aws/aws.go
+++ b/x-pack/functionbeat/manager/aws/aws.go
@@ -27,7 +27,7 @@ var Bundle = provider.MustCreate(
 ).MustAddFunction("sqs",
 	aws.NewSQS,
 	aws.SQSDetails(),
-).MustAddFunction("cloudwatch_kinesis",
+).MustAddFunction("cloudwatch_logs_kinesis",
 	aws.NewCloudwatchKinesis,
 	aws.CloudwatchKinesisDetails(),
 ).Bundle()

--- a/x-pack/functionbeat/manager/aws/aws.go
+++ b/x-pack/functionbeat/manager/aws/aws.go
@@ -27,4 +27,7 @@ var Bundle = provider.MustCreate(
 ).MustAddFunction("sqs",
 	aws.NewSQS,
 	aws.SQSDetails(),
+).MustAddFunction("cloudwatch_kinesis",
+	aws.NewCloudwatchKinesis,
+	aws.CloudwatchKinesisDetails(),
 ).Bundle()

--- a/x-pack/functionbeat/provider/aws/aws/cloudwatch_kinesis.go
+++ b/x-pack/functionbeat/provider/aws/aws/cloudwatch_kinesis.go
@@ -1,0 +1,143 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package aws
+
+import (
+	"context"
+	"sort"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/awslabs/goformation/cloudformation"
+
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/feature"
+	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/x-pack/functionbeat/function/core"
+	"github.com/elastic/beats/x-pack/functionbeat/function/provider"
+	"github.com/elastic/beats/x-pack/functionbeat/provider/aws/aws/transformer"
+)
+
+// CloudwatchKinesis receives events from a kinesis stream and forward them to elasticsearch.
+type CloudwatchKinesis struct {
+	log    *logp.Logger
+	config *CloudwatchKinesisConfig
+}
+
+type CloudwatchKinesisConfig struct {
+	*KinesisConfig `config:",inline"`
+	Compressed     bool `config:"compressed"`
+}
+
+func defaultCloudwatchKinesisConfig() *CloudwatchKinesisConfig {
+	return &CloudwatchKinesisConfig{
+		&KinesisConfig{
+			LambdaConfig: DefaultLambdaConfig,
+		},
+		false,
+	}
+}
+
+// NewCloudwatchKinesis creates a new function to receives events from a kinesis stream.
+func NewCloudwatchKinesis(provider provider.Provider, cfg *common.Config) (provider.Function, error) {
+	config := defaultCloudwatchKinesisConfig()
+	if err := cfg.Unpack(config); err != nil {
+		return nil, err
+	}
+	return &CloudwatchKinesis{log: logp.NewLogger("cloudwatch_kinesis"), config: config}, nil
+}
+
+// CloudwatchKinesisDetails returns the details of the feature.
+func CloudwatchKinesisDetails() *feature.Details {
+	return feature.NewDetails("Cloudwatch logs via Kinesis trigger", "receive Cloudwatch logs from a Kinesis stream", feature.Experimental)
+}
+
+// Run starts the lambda function and wait for web triggers.
+func (k *CloudwatchKinesis) Run(_ context.Context, client core.Client) error {
+	lambda.Start(k.createHandler(client))
+	return nil
+}
+
+func (k *CloudwatchKinesis) createHandler(client core.Client) func(request events.KinesisEvent) error {
+	return func(request events.KinesisEvent) error {
+		k.log.Debugf("The handler receives %d events", len(request.Records))
+
+		events, err := transformer.CloudwatchKinesisEvent(request, k.config.Compressed)
+		if err != nil {
+			return err
+		}
+
+		if err := client.PublishAll(events); err != nil {
+			k.log.Errorf("Could not publish events to the pipeline, error: %+v", err)
+			return err
+		}
+		client.Wait()
+		return nil
+	}
+}
+
+// Name return the name of the lambda function.
+func (k *CloudwatchKinesis) Name() string {
+	return "cloudwatch_kinesis"
+}
+
+// LambdaConfig returns the configuration to use when creating the lambda.
+func (k *CloudwatchKinesis) LambdaConfig() *LambdaConfig {
+	return k.config.LambdaConfig
+}
+
+// Template returns the cloudformation template for configuring the service with the specified
+// triggers.
+func (k *CloudwatchKinesis) Template() *cloudformation.Template {
+	template := cloudformation.NewTemplate()
+	prefix := func(suffix string) string {
+		return NormalizeResourceName("fnb" + k.config.Name + suffix)
+	}
+
+	for _, trigger := range k.config.Triggers {
+		resourceName := prefix(k.Name() + trigger.EventSourceArn)
+		template.Resources[resourceName] = &cloudformation.AWSLambdaEventSourceMapping{
+			BatchSize:        trigger.BatchSize,
+			EventSourceArn:   trigger.EventSourceArn,
+			FunctionName:     cloudformation.GetAtt(prefix(""), "Arn"),
+			StartingPosition: trigger.StartingPosition.String(),
+		}
+	}
+
+	return template
+}
+
+// Policies returns a slice of policy to add to the lambda role.
+func (k *CloudwatchKinesis) Policies() []cloudformation.AWSIAMRole_Policy {
+	resources := make([]string, len(k.config.Triggers))
+	for idx, trigger := range k.config.Triggers {
+		resources[idx] = trigger.EventSourceArn
+	}
+
+	// Give us a chance to generate the same document indenpendant of the changes,
+	// to help with updates.
+	sort.Strings(resources)
+
+	policies := []cloudformation.AWSIAMRole_Policy{
+		cloudformation.AWSIAMRole_Policy{
+			PolicyName: cloudformation.Join("-", []string{"fnb", "kinesis", k.config.Name}),
+			PolicyDocument: map[string]interface{}{
+				"Statement": []map[string]interface{}{
+					map[string]interface{}{
+						"Action": []string{
+							"kinesis:GetRecords",
+							"kinesis:GetShardIterator",
+							"Kinesis:DescribeStream",
+						},
+						"Effect":   "Allow",
+						"Resource": resources,
+					},
+				},
+			},
+		},
+	}
+
+	return policies
+}

--- a/x-pack/functionbeat/provider/aws/aws/transformer/transformer.go
+++ b/x-pack/functionbeat/provider/aws/aws/transformer/transformer.go
@@ -107,12 +107,11 @@ func CloudwatchKinesisEvent(request events.KinesisEvent, base64Encoded, compress
 
 		kinesisData := record.Kinesis.Data
 		if base64Encoded {
-			decoded := make([]byte, 0)
-			n, err := base64.StdEncoding.Decode(decoded, kinesisData)
+			var err error
+			kinesisData, err = base64.StdEncoding.DecodeString(string(kinesisData))
 			if err != nil {
 				return nil, err
 			}
-			kinesisData = decoded[:n]
 		}
 
 		if compressed {

--- a/x-pack/functionbeat/provider/aws/aws/transformer/transformer_test.go
+++ b/x-pack/functionbeat/provider/aws/aws/transformer/transformer_test.go
@@ -53,3 +53,92 @@ func TestKinesis(t *testing.T) {
 
 	assert.Equal(t, fields, events[0].Fields)
 }
+
+func TestCloudwatchKinesis(t *testing.T) {
+	request := events.KinesisEvent{
+		Records: []events.KinesisEventRecord{
+			events.KinesisEventRecord{
+				AwsRegion:      "us-east-1",
+				EventID:        "1234",
+				EventName:      "connect",
+				EventSource:    "web",
+				EventVersion:   "1.0",
+				EventSourceArn: "arn:aws:iam::00000000:role/functionbeat",
+				Kinesis: events.KinesisRecord{
+					Data: []byte(`eyJtZXNzYWdlVHlwZSI6IkRBVEFfTUVTU0FHRSIsIm93bmVyIjoiMDc5NzA5NzYxMTUyIiwibG9n
+R3JvdXAiOiJ0ZXN0ZW0iLCJsb2dTdHJlYW0iOiJmb2x5b21hbnkiLCJzdWJzY3JpcHRpb25GaWx0
+ZXJzIjpbIk1pbmRlbiJdLCJsb2dFdmVudHMiOlt7ImlkIjoiMzQ5MzM1ODk4NzM5NzIwNDAzMDgy
+ODAzMDIzMTg1MjMxODU5NjA1NTQxODkxNjg4NzMyNDI2MjQiLCJ0aW1lc3RhbXAiOjE1NjY0NzYz
+NDcwMDAsIm1lc3NhZ2UiOiJUZXN0IGV2ZW50IDMifSx7ImlkIjoiMzQ5MzM1ODk4NzM5OTQzNDEw
+NTM0Nzg4MzI5NDE2NjQ3MjE2Nzg4MjY4Mzc1MzAzNzkyMjMwNDEiLCJ0aW1lc3RhbXAiOjE1NjY0
+NzYzNDcwMDEsIm1lc3NhZ2UiOiJUZXN0IGV2ZW50IDQifSx7ImlkIjoiMzQ5MzM1ODk4NzQwMTY2
+NDE3OTg2NzczNjM1NjQ4MDYyNTczOTcwOTk0ODU4OTE4ODUyMDM0NTgiLCJ0aW1lc3RhbXAiOjE1
+NjY0NzYzNDcwMDIsIm1lc3NhZ2UiOiJUaGlzIG1lc3NhZ2UgYWxzbyBjb250YWlucyBhbiBFcnJv
+ciJ9XX0=`),
+					PartitionKey:         "abc123",
+					SequenceNumber:       "12345",
+					KinesisSchemaVersion: "1.0",
+					EncryptionType:       "test",
+				},
+			},
+		},
+	}
+
+	events, err := CloudwatchKinesisEvent(request, true, false)
+	assert.Nil(t, err)
+	assert.Equal(t, 3, len(events))
+
+	envelopeFields := common.MapStr{
+		"event_id":                "1234",
+		"event_name":              "connect",
+		"event_source":            "web",
+		"event_source_arn":        "arn:aws:iam::00000000:role/functionbeat",
+		"event_version":           "1.0",
+		"aws_region":              "us-east-1",
+		"kinesis_partition_key":   "abc123",
+		"kinesis_schema_version":  "1.0",
+		"kinesis_sequence_number": "12345",
+		"kinesis_encryption_type": "test",
+	}
+
+	expectedInnerFields := []common.MapStr{
+		common.MapStr{
+			"id":           "34933589873972040308280302318523185960554189168873242624",
+			"log_group":    "testem",
+			"log_stream":   "folyomany",
+			"owner":        "079709761152",
+			"message":      "Test event 3",
+			"message_type": "DATA_MESSAGE",
+			"subscription_filters": []string{
+				"Minden",
+			},
+		},
+		common.MapStr{
+			"id":           "34933589873994341053478832941664721678826837530379223041",
+			"log_group":    "testem",
+			"log_stream":   "folyomany",
+			"owner":        "079709761152",
+			"message":      "Test event 4",
+			"message_type": "DATA_MESSAGE",
+			"subscription_filters": []string{
+				"Minden",
+			},
+		},
+		common.MapStr{
+			"id":           "34933589874016641798677363564806257397099485891885203458",
+			"log_group":    "testem",
+			"log_stream":   "folyomany",
+			"owner":        "079709761152",
+			"message":      "This message also contains an Error",
+			"message_type": "DATA_MESSAGE",
+			"subscription_filters": []string{
+				"Minden",
+			},
+		},
+	}
+
+	for i, expectedFields := range expectedInnerFields {
+		expectedFields.Update(envelopeFields)
+		assert.Equal(t, expectedFields, events[i].Fields)
+	}
+}

--- a/x-pack/functionbeat/provider/aws/include/feature.go
+++ b/x-pack/functionbeat/provider/aws/include/feature.go
@@ -27,6 +27,9 @@ var bundle = provider.MustCreate(
 ).MustAddFunction("sqs",
 	aws.NewSQS,
 	aws.SQSDetails(),
+).MustAddFunction("cloudwatch_kinesis",
+	aws.NewCloudwatchKinesis,
+	aws.CloudwatchKinesisDetails(),
 ).Bundle()
 
 func init() {

--- a/x-pack/functionbeat/provider/aws/include/feature.go
+++ b/x-pack/functionbeat/provider/aws/include/feature.go
@@ -27,7 +27,7 @@ var bundle = provider.MustCreate(
 ).MustAddFunction("sqs",
 	aws.NewSQS,
 	aws.SQSDetails(),
-).MustAddFunction("cloudwatch_kinesis",
+).MustAddFunction("cloudwatch_logs_kinesis",
 	aws.NewCloudwatchKinesis,
 	aws.CloudwatchKinesisDetails(),
 ).Bundle()


### PR DESCRIPTION
New **experimental** input is added to Functionbeat to read logs from Cloudwatch coming through Kinesis.

I have tested the input manually.

#### Configuration

The configuration is similar to the existing Kinesis function. It has two additional options, `base64_encoded` and `compressed`. If these options are set first base64 decode takes place, then gzip decompression. If your data is just gzipped, only set `compressed` option.

```yaml
  # Create a function that accepts Cloudwatch logs from Kinesis streams.
  - name: cloudwatch-logs-kinesis
    enabled: false
    type: cloudwatch_logs_kinesis

    # Description of the method to help identify them when you run multiples functions.
    description: "lambda function for Cloudwatch logs in Kinesis events"

    # Set base64_encoded if your data is base64 encoded.
    #base64_encoded: false

    # Set compressed if your data is compressed with gzip.
    #compressed: true

    # Concurrency, is the reserved number of instances for that function.
    # Default is 5.
    #
    # Note: There is a hard limit of 1000 functions of any kind per account.
    #concurrency: 5

    # The maximum memory allocated for this function, the configured size must be a factor of 64.
    # There is a hard limit of 3008MiB for each function. Default is 128MiB.
    #memory_size: 128MiB

    # Dead letter queue configuration, this must be set to an ARN pointing to a SQS queue.
    #dead_letter_config.target_arn:

    # Execution role of the function.
    #role: arn:aws:iam::123456789012:role/MyFunction

    # Connect to private resources in an Amazon VPC.
    #virtual_private_cloud:
    #  security_group_ids: []
    #  subnet_ids: []

    # Optional fields that you can specify to add additional information to the
    # output. Fields can be scalar values, arrays, dictionaries, or any nested
    # combination of these.
    #fields:
    #  env: staging

    # Define custom processors for this function.
    #processors:
    #  - decode_json_fields:
    #      fields: ["message"]
    #      process_array: false
    #      max_depth: 1
    #      target: ""
    #      overwrite_keys: false

    # List of Kinesis streams.
    triggers:
        # Arn for the Kinesis stream.
      - event_source_arn: arn:aws:sqs:us-east-1:xxxxx:myevents

        # batch_size is the number of events read in a batch.
        # Default is 10.
        #batch_size: 100

        # Starting position is where to start reading events from the Kinesis stream.
        # Default is trim_horizon.
        #starting_position: "trim_horizon"
```

TODO
- [x] better PR description
- [x] more tests