### PR TITLE
update license check failure message

### DIFF
--- a/x-pack/libbeat/cmd/inject.go
+++ b/x-pack/libbeat/cmd/inject.go
@@ -20,6 +20,6 @@ const licenseDebugK = "license"
 
 // AddXPack extends the given root folder with XPack features
 func AddXPack(root *cmd.BeatsRootCmd, name string) {
-	licenser.Enforce(logp.NewLogger(licenseDebugK), licenser.BasicAndAboveOrTrial)
+	licenser.Enforce(logp.NewLogger(licenseDebugK), name, licenser.BasicAndAboveOrTrial)
 	root.AddCommand(genEnrollCmd(name, ""))
 }

--- a/x-pack/libbeat/licenser/es_callback.go
+++ b/x-pack/libbeat/licenser/es_callback.go
@@ -15,7 +15,7 @@ import (
 
 // Enforce setups the corresponding callbacks in libbeat to verify the license on the
 // remote elasticsearch cluster.
-func Enforce(log *logp.Logger, checks ...CheckFunc) {
+func Enforce(log *logp.Logger, name string, checks ...CheckFunc) {
 	cb := func(client *elasticsearch.Client) error {
 		fetcher := NewElasticFetcher(client)
 		license, err := fetcher.Fetch()
@@ -25,9 +25,9 @@ func Enforce(log *logp.Logger, checks ...CheckFunc) {
 		}
 
 		if license == OSSLicense {
-			return errors.New("This Beat requires the default distribution of Elasticsearch. Please " +
-				"install the default distribution of Elasticsearch from elastic.co, or install " +
-				"the oss-only distribution of beats")
+			return errors.Errorf("%s requires the default distribution of Elasticsearch. Please "+
+				"update to the default distribution of Elasticsearch for full access to all "+
+				"free features, or switch to the OSS distribution of %s.", name, name)
 		}
 
 		if !Validate(log, *license, checks...) {


### PR DESCRIPTION
now includes the product name instead of `This Beat`