### PR TITLE
Add registered_domain processor

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -207,7 +207,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add `error.message` to events when `fail_on_error` is set in `rename` and `copy_fields` processors. {pull}11303[11303]
 - New processor: `truncate_fields`. {pull}11297[11297]
 - Allow a beat to ship monitoring data directly to an Elasticsearch monitoring cluster. {pull}9260[9260]
-- Updated go-seccomp-bpf library to v1.1.0 which updates syscall lists for Linux v5.0. {pull}NNNN[NNNN]
+- Updated go-seccomp-bpf library to v1.1.0 which updates syscall lists for Linux v5.0. {pull}11394[11394]
 - Add `add_observer_metadata` processor. {pull}11394[11394]
 - Add `decode_csv_fields` processor. {pull}11753[11753]
 - Add `convert` processor for converting data types of fields. {issue}8124[8124] {pull}11686[11686]
@@ -227,7 +227,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - add_host_metadata is now GA. {pull}13148[13148]
 - Add an `ignore_missing` configuration option the `drop_fields` processor. {pull}13318[13318]
 - add_host_metadata is no GA. {pull}13148[13148]
-- Add `registered_domain` processor for deriving the registered domain from a given FQDN. {pull}NNNN[NNNN]
+- Add `registered_domain` processor for deriving the registered domain from a given FQDN. {pull}13326[13326]
 
 *Auditbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -226,6 +226,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add support for unix epoch time values in the `timestamp` processor. {pull}13319[13319]
 - add_host_metadata is now GA. {pull}13148[13148]
 - Add an `ignore_missing` configuration option the `drop_fields` processor. {pull}13318[13318]
+- add_host_metadata is no GA. {pull}13148[13148]
+- Add `registered_domain` processor for deriving the registered domain from a given FQDN. {pull}NNNN[NNNN]
 
 *Auditbeat*
 

--- a/libbeat/cmd/instance/imports.go
+++ b/libbeat/cmd/instance/imports.go
@@ -36,5 +36,6 @@ import (
 	_ "github.com/elastic/beats/libbeat/processors/dissect"
 	_ "github.com/elastic/beats/libbeat/processors/dns"
 	_ "github.com/elastic/beats/libbeat/processors/extract_array"
+	_ "github.com/elastic/beats/libbeat/processors/registered_domain"
 	_ "github.com/elastic/beats/libbeat/publisher/includes" // Register publisher pipeline modules
 )

--- a/libbeat/docs/processors-using.asciidoc
+++ b/libbeat/docs/processors-using.asciidoc
@@ -222,6 +222,7 @@ endif::[]
  * <<drop-fields,`drop_fields`>>
  * <<extract-array,`extract_array`>>
  * <<include-fields,`include_fields`>>
+ * <<processor-registered-domain,`registered_domain`>>
  * <<rename-fields,`rename`>>
 ifdef::has_script_processor[]
  * <<processor-script,`script`>>
@@ -1151,6 +1152,38 @@ section.
 
 NOTE: If you define an empty list of fields under `include_fields`, then only
 the required fields, `@timestamp` and `type`, are exported.
+
+[[processor-registered-domain]]
+=== Registered Domain
+
+The `registered_domain` processor reads a field containing a hostname and then
+writes the "registered domain" contained in the hostname to the target field.
+For example, given `www.google.co.uk` the processor would output `google.co.uk`.
+In other words the "registered domain" is the effective top-level domain
+(`co.uk`) plus one level (`google`).
+
+[source,yaml]
+----
+processors:
+- registered_domain:
+    field: dns.question.name
+    target_field: dns.question.registered_domain
+    ignore_missing: true
+    ignore_failure: true
+----
+
+The `registered_domain` processor has the following configuration settings:
+
+.Registered Domain options
+[options="header"]
+|======
+| Name             | Required | Default    | Description                                                      |
+| `field`          | yes      |            | Source field containing a fully qualified domain name (FQDN).    |
+| `target_field`   | yes      |            | Target field for the registered domain value.                    |
+| `ignore_missing` | no       | false      | Ignore errors when the source field is missing.                  |
+| `ignore_failure` | no       | false      | Ignore all errors produced by the processor.                     |
+| `id`             | no       |            | An identifier for this processor instance. Useful for debugging. |
+|======
 
 [[rename-fields]]
 === Rename fields from events

--- a/libbeat/docs/processors-using.asciidoc
+++ b/libbeat/docs/processors-using.asciidoc
@@ -1162,6 +1162,8 @@ For example, given `www.google.co.uk` the processor would output `google.co.uk`.
 In other words the "registered domain" is the effective top-level domain
 (`co.uk`) plus one level (`google`).
 
+This processor uses the Mozilla Public Suffix list to determine the value.
+
 [source,yaml]
 ----
 processors:

--- a/libbeat/processors/registered_domain/config.go
+++ b/libbeat/processors/registered_domain/config.go
@@ -1,0 +1,30 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package registered_domain
+
+type config struct {
+	Field         string `config:"field"        validate:"required"`
+	TargetField   string `config:"target_field" validate:"required"`
+	IgnoreMissing bool   `config:"ignore_missing"`
+	IgnoreFailure bool   `config:"ignore_failure"`
+	ID            string `config:"id"`
+}
+
+func defaultConfig() config {
+	return config{}
+}

--- a/libbeat/processors/registered_domain/registered_domain.go
+++ b/libbeat/processors/registered_domain/registered_domain.go
@@ -73,7 +73,7 @@ func (p *processor) String() string {
 func (p *processor) Run(event *beat.Event) (*beat.Event, error) {
 	v, err := event.GetValue(p.Field)
 	if err != nil {
-		if p.IgnoreMissing {
+		if p.IgnoreMissing || p.IgnoreFailure {
 			return event, nil
 		}
 		return event, errors.Wrapf(err, "registered_domain source field [%v] not found", p.Field)

--- a/libbeat/processors/registered_domain/registered_domain.go
+++ b/libbeat/processors/registered_domain/registered_domain.go
@@ -1,0 +1,107 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package registered_domain
+
+import (
+	"encoding/json"
+
+	"github.com/pkg/errors"
+	"golang.org/x/net/publicsuffix"
+
+	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
+	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/processors"
+)
+
+const (
+	procName = "registered_domain"
+	logName  = "processor." + procName
+)
+
+func init() {
+	processors.RegisterPlugin(procName, New)
+}
+
+type processor struct {
+	config
+	log *logp.Logger
+}
+
+// New constructs a new processor built from ucfg config.
+func New(cfg *common.Config) (processors.Processor, error) {
+	c := defaultConfig()
+	if err := cfg.Unpack(&c); err != nil {
+		return nil, errors.Wrap(err, "fail to unpack the "+procName+" processor configuration")
+	}
+
+	return newRegisteredDomain(c)
+}
+
+func newRegisteredDomain(c config) (*processor, error) {
+	cfgwarn.Beta("The " + procName + " processor is beta.")
+
+	log := logp.NewLogger(logName)
+	if c.ID != "" {
+		log = log.With("instance_id", c.ID)
+	}
+
+	return &processor{config: c, log: log}, nil
+}
+
+func (p *processor) String() string {
+	json, _ := json.Marshal(p.config)
+	return procName + "=" + string(json)
+}
+
+func (p *processor) Run(event *beat.Event) (*beat.Event, error) {
+	v, err := event.GetValue(p.Field)
+	if err != nil {
+		if p.IgnoreMissing {
+			return event, nil
+		}
+		return event, errors.Wrapf(err, "registered_domain source field [%v] not found", p.Field)
+	}
+
+	domain, ok := v.(string)
+	if !ok {
+		if p.IgnoreFailure {
+			return event, nil
+		}
+		return event, errors.Wrapf(err, "registered_domain source field [%v] is not a string", p.Field)
+	}
+
+	rd, err := publicsuffix.EffectiveTLDPlusOne(domain)
+	if err != nil {
+		if p.IgnoreFailure {
+			return event, nil
+		}
+		return event, errors.Wrap(err, "failed to determine the registered domain")
+	}
+
+	_, err = event.PutValue(p.TargetField, rd)
+	if err != nil {
+		if p.IgnoreFailure {
+			return event, nil
+		}
+		return event, errors.Wrapf(err, "failed to write registered domain to target field [%v]", p.TargetField)
+	}
+
+	return event, nil
+}

--- a/libbeat/processors/registered_domain/registered_domain_test.go
+++ b/libbeat/processors/registered_domain/registered_domain_test.go
@@ -41,6 +41,7 @@ func TestProcessorRun(t *testing.T) {
 
 		{true, "com", ""},
 		{true, "", ""},
+		{true, "localhost", ""},
 	}
 
 	c := defaultConfig()

--- a/libbeat/processors/registered_domain/registered_domain_test.go
+++ b/libbeat/processors/registered_domain/registered_domain_test.go
@@ -1,0 +1,74 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package registered_domain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/common"
+)
+
+func TestProcessorRun(t *testing.T) {
+	var testCases = []struct {
+		Error            bool
+		Domain           string
+		RegisteredDomain string
+	}{
+		{false, "www.google.com", "google.com"},
+		{false, "www.google.co.uk", "google.co.uk"},
+		{false, "google.com", "google.com"},
+		{false, "www.ak.local", "ak.local"},
+		{false, ".", "."},
+		{false, "www.navy.mil", "navy.mil"},
+
+		{true, "com", ""},
+		{true, "", ""},
+	}
+
+	c := defaultConfig()
+	c.Field = "domain"
+	c.TargetField = "registered_domain"
+	p, err := newRegisteredDomain(c)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range testCases {
+		evt := &beat.Event{
+			Fields: common.MapStr{
+				"domain": tc.Domain,
+			},
+		}
+
+		evt, err := p.Run(evt)
+		if tc.Error {
+			t.Logf("Received expected error on domain [%v]: %v", tc.Domain, err)
+			assert.Error(t, err)
+			continue
+		}
+		if err != nil {
+			t.Fatalf("Failed on domain [%v]: %v", tc.Domain, err)
+		}
+
+		rd, _ := evt.GetValue("registered_domain")
+		assert.Equal(t, tc.RegisteredDomain, rd)
+	}
+}

--- a/libbeat/processors/script/javascript/module/processor/processor.go
+++ b/libbeat/processors/script/javascript/module/processor/processor.go
@@ -37,6 +37,7 @@ import (
 	"github.com/elastic/beats/libbeat/processors/dissect"
 	"github.com/elastic/beats/libbeat/processors/dns"
 	"github.com/elastic/beats/libbeat/processors/extract_array"
+	"github.com/elastic/beats/libbeat/processors/registered_domain"
 	"github.com/elastic/beats/libbeat/processors/script/javascript"
 	"github.com/elastic/beats/libbeat/processors/timestamp"
 )
@@ -61,6 +62,7 @@ var constructors = map[string]processors.Constructor{
 	"Dissect":               dissect.NewProcessor,
 	"DNS":                   dns.New,
 	"ExtractArray":          extract_array.New,
+	"RegisteredDomain":      registered_domain.New,
 	"Rename":                actions.NewRenameFields,
 	"Timestamp":             timestamp.New,
 	"TruncateFields":        actions.NewTruncateFields,


### PR DESCRIPTION
The `registered_domain` processor reads a field containing a hostname and then
writes the "registered domain" contained in the hostname to the target field.
For example, given `www.google.co.uk` the processor would output `google.co.uk`.
In other words the "registered domain" is the effective top-level domain
(`co.uk`) plus one level (`google`).

This can be used to populate the ECS `dns.question.registered_domain` field.