### PR TITLE
[DOCS] Clarify how to disable the default system module metricsets

### DIFF
--- a/metricbeat/docs/faq-unexpected-metrics.asciidoc
+++ b/metricbeat/docs/faq-unexpected-metrics.asciidoc
@@ -1,0 +1,33 @@
+[[faq-unexpected-metrics]]
+=== {beatname_uc} collects system metrics for interfaces you didn't configure
+
+The <<metricbeat-module-system,`system`>> module specifies several metricsets
+that are enabled by default unless you explicitly disable them. To disable the
+default metricsets, comment them out in the `modules.d/system.yml` configuration
+file.
+
+For example, to disable the `network` metricset, comment it out:
+
+[source,yaml]
+----
+  - module: system
+    period: 10s
+    metricsets:
+      - cpu
+      - load
+      - memory
+      #- network
+      - process
+      - process_summary
+      - socket_summary
+      #- entropy
+      #- core
+      #- diskio
+      #- socket
+----
+
+You cannot override the default configuration by adding another module
+definition to the configuration. There is no concept of inheritance.
+{beatname_uc} combines all module configurations at runtime. This enables you to
+specify module definitions that use different combinations of metricsets,
+periods, and hosts.

--- a/metricbeat/docs/faq-unexpected-metrics.asciidoc
+++ b/metricbeat/docs/faq-unexpected-metrics.asciidoc
@@ -1,10 +1,11 @@
 [[faq-unexpected-metrics]]
 === {beatname_uc} collects system metrics for interfaces you didn't configure
 
-The <<metricbeat-module-system,`system`>> module specifies several metricsets
-that are enabled by default unless you explicitly disable them. To disable the
-default metricsets, comment them out in the `modules.d/system.yml` configuration
-file.
+The <<metricbeat-module-system,System>> module specifies several metricsets
+that are enabled by default unless you explicitly disable them. To disable a
+default metricset, comment it out in the `modules.d/system.yml` configuration
+file. If _all_ metricsets are commented out and the System module is enabled,
+{beatname_uc} uses the default metricsets.
 
 For example, to disable the `network` metricset, comment it out:
 

--- a/metricbeat/docs/faq.asciidoc
+++ b/metricbeat/docs/faq.asciidoc
@@ -20,6 +20,8 @@ sudo mkdir -p /compat/linux/proc
 sudo mount -t linprocfs /dev/null /compat/linux/proc
 ----
 
+include::faq-unexpected-metrics.asciidoc[]
+
 include::{libbeat-dir}/docs/faq-limit-bandwidth.asciidoc[]
 
 include::{libbeat-dir}/docs/shared-faq.asciidoc[]

--- a/metricbeat/docs/modules/system.asciidoc
+++ b/metricbeat/docs/modules/system.asciidoc
@@ -9,7 +9,8 @@ The System module allows you to monitor your servers. Because the System module
 always applies to the local server, the `hosts` config option is not needed.
 
 The default metricsets are `cpu`, `load`, `memory`, `network`, `process` and
-`process_summary`.
+`process_summary`. You can disable the default metricsets by commenting them out
+in the `modules.d/system.yml` file.
 
 Note that certain metricsets may access `/proc` to gather process information, and the resulting `ptrace_may_access()` call by the kernel to check for permissions can be blocked by https://gitlab.com/apparmor/apparmor/wikis/TechnicalDoc_Proc_and_ptrace[AppArmor and other LSM software], even though the system module doesn't use `ptrace` directly.
 

--- a/metricbeat/docs/modules/system.asciidoc
+++ b/metricbeat/docs/modules/system.asciidoc
@@ -8,11 +8,17 @@ This file is generated! See scripts/mage/docs_collector.go
 The System module allows you to monitor your servers. Because the System module
 always applies to the local server, the `hosts` config option is not needed.
 
-The default metricsets are `cpu`, `load`, `memory`, `network`, `process` and
-`process_summary`. You can disable the default metricsets by commenting them out
-in the `modules.d/system.yml` file.
+The default metricsets are `cpu`, `load`, `memory`, `network`, `process`, and
+`process_summary`. To disable a default metricset, comment it out in the
+`modules.d/system.yml` configuration file. If _all_ metricsets are commented out
+and the System module is enabled, {beatname_uc} uses the default metricsets.
 
-Note that certain metricsets may access `/proc` to gather process information, and the resulting `ptrace_may_access()` call by the kernel to check for permissions can be blocked by https://gitlab.com/apparmor/apparmor/wikis/TechnicalDoc_Proc_and_ptrace[AppArmor and other LSM software], even though the system module doesn't use `ptrace` directly.
+Note that certain metricsets may access `/proc` to gather process information,
+and the resulting `ptrace_may_access()` call by the kernel to check for
+permissions can be blocked by
+https://gitlab.com/apparmor/apparmor/wikis/TechnicalDoc_Proc_and_ptrace[AppArmor
+and other LSM software], even though the System module doesn't use `ptrace`
+directly.
 
 [float]
 === Dashboard

--- a/metricbeat/module/system/_meta/docs.asciidoc
+++ b/metricbeat/module/system/_meta/docs.asciidoc
@@ -2,7 +2,8 @@ The System module allows you to monitor your servers. Because the System module
 always applies to the local server, the `hosts` config option is not needed.
 
 The default metricsets are `cpu`, `load`, `memory`, `network`, `process` and
-`process_summary`.
+`process_summary`. You can disable the default metricsets by commenting them out
+in the `modules.d/system.yml` file.
 
 Note that certain metricsets may access `/proc` to gather process information, and the resulting `ptrace_may_access()` call by the kernel to check for permissions can be blocked by https://gitlab.com/apparmor/apparmor/wikis/TechnicalDoc_Proc_and_ptrace[AppArmor and other LSM software], even though the system module doesn't use `ptrace` directly.
 

--- a/metricbeat/module/system/_meta/docs.asciidoc
+++ b/metricbeat/module/system/_meta/docs.asciidoc
@@ -1,11 +1,17 @@
 The System module allows you to monitor your servers. Because the System module
 always applies to the local server, the `hosts` config option is not needed.
 
-The default metricsets are `cpu`, `load`, `memory`, `network`, `process` and
-`process_summary`. You can disable the default metricsets by commenting them out
-in the `modules.d/system.yml` file.
+The default metricsets are `cpu`, `load`, `memory`, `network`, `process`, and
+`process_summary`. To disable a default metricset, comment it out in the
+`modules.d/system.yml` configuration file. If _all_ metricsets are commented out
+and the System module is enabled, {beatname_uc} uses the default metricsets.
 
-Note that certain metricsets may access `/proc` to gather process information, and the resulting `ptrace_may_access()` call by the kernel to check for permissions can be blocked by https://gitlab.com/apparmor/apparmor/wikis/TechnicalDoc_Proc_and_ptrace[AppArmor and other LSM software], even though the system module doesn't use `ptrace` directly.
+Note that certain metricsets may access `/proc` to gather process information,
+and the resulting `ptrace_may_access()` call by the kernel to check for
+permissions can be blocked by
+https://gitlab.com/apparmor/apparmor/wikis/TechnicalDoc_Proc_and_ptrace[AppArmor
+and other LSM software], even though the System module doesn't use `ptrace`
+directly.
 
 [float]
 === Dashboard


### PR DESCRIPTION
Replaces the content pushed to the beats repo (without review) in this commit: https://github.com/elastic/beats/commit/d6906be1fc24b183a057270ac7ee52bde5903877

Why? The original content appears in a place where readers are unlikely to find it, and it's a bit confusing.
