### PR TITLE
Look for keystore under the correct path

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -195,6 +195,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 - Fix function name reference for Kinesis streams in CloudFormation templates {pull}11646[11646]
 - Fix Cloudwatch logs timestamp to use timestamp of the log record instead of when the record was processed {pull}13291[13291]
+- Look for the keystore under the correct path. {pull}13332[13332]
 
 ==== Added
 

--- a/libbeat/keystore/file_keystore.go
+++ b/libbeat/keystore/file_keystore.go
@@ -415,6 +415,11 @@ func (k *FileKeystore) Package() ([]byte, error) {
 	return k.loadRaw()
 }
 
+// ConfiguredPath returns the path to the keystore.
+func (k *FileKeystore) ConfiguredPath() string {
+	return k.Path
+}
+
 func (k *FileKeystore) hashPassword(password, salt []byte) []byte {
 	return pbkdf2.Key(password, salt, iterationsCount, keyLength, sha512.New)
 }

--- a/libbeat/keystore/keystore.go
+++ b/libbeat/keystore/keystore.go
@@ -67,6 +67,7 @@ type Keystore interface {
 // Packager defines a keystore that we can read the raw bytes and be packaged in an artifact.
 type Packager interface {
 	Package() ([]byte, error)
+	ConfiguredPath() string
 }
 
 // Factory Create the right keystore with the configured options.

--- a/x-pack/functionbeat/config/config.go
+++ b/x-pack/functionbeat/config/config.go
@@ -21,6 +21,7 @@ var (
 	configOverrides = common.MustNewConfigFrom(map[string]interface{}{
 		"path.data":              "/tmp",
 		"path.logs":              "/tmp/logs",
+		"keystore.path":          "/tmp/beats.keystore",
 		"setup.template.enabled": true,
 		"queue.mem": map[string]interface{}{
 			"flush.min_events": 10,
@@ -63,6 +64,7 @@ var (
 		Check:  always,
 		Config: functionLoggingOverrides,
 	}
+
 	// FunctionOverrides contain logging settings
 	FunctionOverrides = append(Overrides, functionOverride)
 )


### PR DESCRIPTION
Previously, Functionbeat put the keystore file under `/tmp` due to the overrides of the function. But when loading the keystore file before packaging the Beat, data path was not yet initialized, so it looked for the file under the incorrect folder. Furthermore, the file in the compressed package was hardcoded to `data/functionbeat.keystore`. So there was no way for functionbeat to find the keystore when loaded to the cloud provider.

Closes #13079
Depends on #13345