### PR TITLE
Add timeout option to reference configuration

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -340,6 +340,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - New options to configure roles and VPC. {pull}11779[11779]
 - Export automation templates used to create functions. {pull}11923[11923]
 - Configurable Amazon endpoint. {pull}12369[12369]
+- Add timeout option to reference configuration. {pull}13351[13351]
 
 *Winlogbeat*
 

--- a/x-pack/functionbeat/_meta/beat.reference.yml
+++ b/x-pack/functionbeat/_meta/beat.reference.yml
@@ -36,6 +36,9 @@ functionbeat.provider.aws.functions:
     # There is a hard limit of 3008MiB for each function. Default is 128MiB.
     #memory_size: 128MiB
 
+    # The amount of time the function is allowed to run.
+    #timeout: 3s
+
     # Execution role of the function.
     #role: arn:aws:iam::123456789012:role/MyFunction
 
@@ -80,6 +83,9 @@ functionbeat.provider.aws.functions:
     # The maximum memory allocated for this function, the configured size must be a factor of 64.
     # There is a hard limit of 3008MiB for each function. Default is 128MiB.
     #memory_size: 128MiB
+
+    # The amount of time the function is allowed to run.
+    #timeout: 3s
 
     # Execution role of the function.
     #role: arn:aws:iam::123456789012:role/MyFunction
@@ -130,6 +136,9 @@ functionbeat.provider.aws.functions:
     # The maximum memory allocated for this function, the configured size must be a factor of 64.
     # There is a hard limit of 3008MiB for each function. Default is 128MiB.
     #memory_size: 128MiB
+
+    # The amount of time the function is allowed to run.
+    #timeout: 3s
 
     # Execution role of the function.
     #role: arn:aws:iam::123456789012:role/MyFunction

--- a/x-pack/functionbeat/functionbeat.reference.yml
+++ b/x-pack/functionbeat/functionbeat.reference.yml
@@ -36,6 +36,9 @@ functionbeat.provider.aws.functions:
     # There is a hard limit of 3008MiB for each function. Default is 128MiB.
     #memory_size: 128MiB
 
+    # The amount of time the function is allowed to run.
+    #timeout: 3s
+
     # Execution role of the function.
     #role: arn:aws:iam::123456789012:role/MyFunction
 
@@ -80,6 +83,9 @@ functionbeat.provider.aws.functions:
     # The maximum memory allocated for this function, the configured size must be a factor of 64.
     # There is a hard limit of 3008MiB for each function. Default is 128MiB.
     #memory_size: 128MiB
+
+    # The amount of time the function is allowed to run.
+    #timeout: 3s
 
     # Execution role of the function.
     #role: arn:aws:iam::123456789012:role/MyFunction
@@ -130,6 +136,9 @@ functionbeat.provider.aws.functions:
     # The maximum memory allocated for this function, the configured size must be a factor of 64.
     # There is a hard limit of 3008MiB for each function. Default is 128MiB.
     #memory_size: 128MiB
+
+    # The amount of time the function is allowed to run.
+    #timeout: 3s
 
     # Execution role of the function.
     #role: arn:aws:iam::123456789012:role/MyFunction


### PR DESCRIPTION
The option was missing from the reference configuration.

Closes #13267