### PR TITLE
Add autodetection mode for add_docker_metadata

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -244,7 +244,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - add_host_metadata is no GA. {pull}13148[13148]
 - Add `registered_domain` processor for deriving the registered domain from a given FQDN. {pull}13326[13326]
 - Add support for RFC3339 time zone offsets in JSON output. {pull}13227[13227]
-- Add autodetection mode for add_docker_metadata {pull}13374[13374]
+- Add autodetection mode for add_docker_metadata and enable it by default in included configuration files{pull}13374[13374]
 
 *Auditbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -244,6 +244,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - add_host_metadata is no GA. {pull}13148[13148]
 - Add `registered_domain` processor for deriving the registered domain from a given FQDN. {pull}13326[13326]
 - Add support for RFC3339 time zone offsets in JSON output. {pull}13227[13227]
+- Add autodetection mode for add_docker_metadata {pull}13374[13374]
 
 *Auditbeat*
 

--- a/auditbeat/auditbeat.docker.yml
+++ b/auditbeat/auditbeat.docker.yml
@@ -14,6 +14,7 @@ auditbeat.modules:
     - /etc
 processors:
 - add_cloud_metadata: ~
+- add_docker_metadata: ~
 
 output.elasticsearch:
   hosts: '${ELASTICSEARCH_HOSTS:elasticsearch:9200}'

--- a/auditbeat/auditbeat.yml
+++ b/auditbeat/auditbeat.yml
@@ -148,6 +148,7 @@ output.elasticsearch:
 processors:
   - add_host_metadata: ~
   - add_cloud_metadata: ~
+  - add_docker_metadata: ~
 
 #================================ Logging =====================================
 

--- a/filebeat/filebeat.docker.yml
+++ b/filebeat/filebeat.docker.yml
@@ -5,6 +5,7 @@ filebeat.config:
 
 processors:
 - add_cloud_metadata: ~
+- add_docker_metadata: ~
 
 output.elasticsearch:
   hosts: '${ELASTICSEARCH_HOSTS:elasticsearch:9200}'

--- a/filebeat/filebeat.yml
+++ b/filebeat/filebeat.yml
@@ -176,6 +176,7 @@ output.elasticsearch:
 processors:
   - add_host_metadata: ~
   - add_cloud_metadata: ~
+  - add_docker_metadata: ~
 
 #================================ Logging =====================================
 

--- a/heartbeat/heartbeat.docker.yml
+++ b/heartbeat/heartbeat.docker.yml
@@ -24,6 +24,7 @@ heartbeat.monitors:
 
 processors:
 - add_cloud_metadata: ~
+- add_docker_metadata: ~
 
 output.elasticsearch:
   hosts: '${ELASTICSEARCH_HOSTS:elasticsearch:9200}'

--- a/heartbeat/heartbeat.yml
+++ b/heartbeat/heartbeat.yml
@@ -117,9 +117,9 @@ output.elasticsearch:
 #================================ Processors =====================================
 
 processors:
-  - add_observer_metadata: 
+  - add_observer_metadata:
   # Optional, but recommended geo settings for the location Heartbeat is running in
-  #geo: 
+  #geo:
     # Token describing this location
     #name: us-east-1a
 

--- a/journalbeat/journalbeat.docker.yml
+++ b/journalbeat/journalbeat.docker.yml
@@ -4,6 +4,7 @@ journalbeat.inputs:
 
 processors:
 - add_cloud_metadata: ~
+- add_docker_metadata: ~
 
 output.elasticsearch:
   hosts: '${ELASTICSEARCH_HOSTS:elasticsearch:9200}'

--- a/journalbeat/journalbeat.yml
+++ b/journalbeat/journalbeat.yml
@@ -145,6 +145,7 @@ output.elasticsearch:
 processors:
   - add_host_metadata: ~
   - add_cloud_metadata: ~
+  - add_docker_metadata: ~
 
 #================================ Logging =====================================
 

--- a/libbeat/_meta/config.docker.yml
+++ b/libbeat/_meta/config.docker.yml
@@ -1,5 +1,6 @@
 processors:
 - add_cloud_metadata: ~
+- add_docker_metadata: ~
 
 output.elasticsearch:
   hosts: '${ELASTICSEARCH_HOSTS:elasticsearch:9200}'

--- a/libbeat/_meta/config.yml.tmpl
+++ b/libbeat/_meta/config.yml.tmpl
@@ -93,11 +93,12 @@ output.elasticsearch:
 processors:
   - add_host_metadata: ~
   - add_cloud_metadata: ~
+  - add_docker_metadata: ~
 {{else}}
 processors:
-  - add_observer_metadata: 
+  - add_observer_metadata:
   # Optional, but recommended geo settings for the location {{ .BeatName | title }} is running in
-  #geo: 
+  #geo:
     # Token describing this location
     #name: us-east-1a
 

--- a/libbeat/common/docker/watcher.go
+++ b/libbeat/common/docker/watcher.go
@@ -132,6 +132,12 @@ func NewWatcher(host string, tls *TLSConfig, storeShortID bool) (Watcher, error)
 		return nil, err
 	}
 
+	// extra check to confirm that Docker is available
+	_, err = client.Info(context.Background())
+	if err != nil {
+		return nil, err
+	}
+
 	return NewWatcherWithClient(client, 60*time.Second, storeShortID)
 }
 

--- a/libbeat/common/docker/watcher.go
+++ b/libbeat/common/docker/watcher.go
@@ -132,7 +132,7 @@ func NewWatcher(host string, tls *TLSConfig, storeShortID bool) (Watcher, error)
 		return nil, err
 	}
 
-	// extra check to confirm that Docker is available
+	// Extra check to confirm that Docker is available
 	_, err = client.Info(context.Background())
 	if err != nil {
 		return nil, err

--- a/libbeat/processors/add_docker_metadata/add_docker_metadata.go
+++ b/libbeat/processors/add_docker_metadata/add_docker_metadata.go
@@ -52,18 +52,6 @@ const (
 var processCgroupPaths = cgroup.ProcessCgroupPaths
 
 func init() {
-	// check if Docker is available in running environment
-	cli, err := client.NewEnvClient()
-	if err != nil {
-		logp.Info("%v: docker environment not detected.", processorName)
-		return
-	}
-	info, err := cli.Info(context.Background())
-	if err != nil {
-		logp.Info("%v: docker environment not detected.", processorName)
-		return
-	}
-	logp.Info("docker environment detected: %v", info)
 	processors.RegisterPlugin(processorName, New)
 }
 
@@ -81,6 +69,18 @@ type addDockerMetadata struct {
 
 // New constructs a new add_docker_metadata processor.
 func New(cfg *common.Config) (processors.Processor, error) {
+	// check if Docker is available in running environment
+	cli, err := client.NewEnvClient()
+	if err != nil {
+		logp.Info("%v: docker environment not detected.", processorName)
+		return nil, nil
+	}
+	info, err := cli.Info(context.Background())
+	if err != nil {
+		logp.Info("%v: docker environment not detected.", processorName)
+		return nil, nil
+	}
+	logp.Info("docker environment detected: %v", info)
 	return buildDockerMetadataProcessor(cfg, docker.NewWatcher)
 }
 

--- a/libbeat/processors/add_docker_metadata/add_docker_metadata.go
+++ b/libbeat/processors/add_docker_metadata/add_docker_metadata.go
@@ -67,20 +67,30 @@ type addDockerMetadata struct {
 	dedot     bool          // If set to true, replace dots in labels with `_`.
 }
 
-// New constructs a new add_docker_metadata processor.
-func New(cfg *common.Config) (processors.Processor, error) {
-	// check if Docker is available in running environment
+// checkForDockerEnvironment checks if Docker is available in running environment
+// and returns an error in case Docker is not detected
+func checkForDockerEnvironment() error {
 	cli, err := client.NewEnvClient()
+	errorMsg := fmt.Sprintf("%v: docker environment not detected.", processorName)
 	if err != nil {
-		logp.Info("%v: docker environment not detected.", processorName)
-		return nil, nil
+		logp.Info(errorMsg)
+		return fmt.Errorf(errorMsg)
 	}
 	info, err := cli.Info(context.Background())
 	if err != nil {
-		logp.Info("%v: docker environment not detected.", processorName)
-		return nil, nil
+		logp.Info(errorMsg)
+		return fmt.Errorf(errorMsg)
 	}
 	logp.Info("docker environment detected: %v", info)
+	return nil
+}
+
+// New constructs a new add_docker_metadata processor.
+func New(cfg *common.Config) (processors.Processor, error) {
+	err := checkForDockerEnvironment()
+	if err != nil {
+		return nil, nil
+	}
 	return buildDockerMetadataProcessor(cfg, docker.NewWatcher)
 }
 

--- a/libbeat/processors/add_docker_metadata/add_docker_metadata.go
+++ b/libbeat/processors/add_docker_metadata/add_docker_metadata.go
@@ -18,7 +18,11 @@
 package add_docker_metadata
 
 import (
+	"context"
 	"fmt"
+
+	"github.com/docker/docker/client"
+
 	"os"
 	"path/filepath"
 	"strings"
@@ -48,6 +52,18 @@ const (
 var processCgroupPaths = cgroup.ProcessCgroupPaths
 
 func init() {
+	// check if Docker is available in running environment
+	cli, err := client.NewEnvClient()
+	if err != nil {
+		logp.Info("%v: docker environment not detected.", processorName)
+		return
+	}
+	info, err := cli.Info(context.Background())
+	if err != nil {
+		logp.Info("%v: docker environment not detected.", processorName)
+		return
+	}
+	logp.Info("docker environment detected: %v", info)
 	processors.RegisterPlugin(processorName, New)
 }
 

--- a/libbeat/processors/add_docker_metadata/add_docker_metadata.go
+++ b/libbeat/processors/add_docker_metadata/add_docker_metadata.go
@@ -19,7 +19,6 @@ package add_docker_metadata
 
 import (
 	"fmt"
-
 	"os"
 	"path/filepath"
 	"strings"
@@ -87,7 +86,7 @@ func buildDockerMetadataProcessor(cfg *common.Config, watcherConstructor docker.
 		dockerAvailable = true
 		logp.Debug("add_docker_metadata", "%v: docker environment detected", processorName)
 		if err = watcher.Start(); err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "failed to start watcher")
 		}
 	}
 
@@ -130,11 +129,12 @@ func lazyCgroupCacheInit(d *addDockerMetadata) {
 }
 
 func (d *addDockerMetadata) Run(event *beat.Event) (*beat.Event, error) {
-	var cid string
-	var err error
 	if !d.dockerAvailable {
 		return event, nil
 	}
+	var cid string
+	var err error
+
 	// Extract CID from the filepath contained in the "log.file.path" field.
 	if d.sourceProcessor != nil {
 		lfp, _ := event.Fields.GetValue("log.file.path")

--- a/libbeat/processors/add_docker_metadata/add_docker_metadata_test.go
+++ b/libbeat/processors/add_docker_metadata/add_docker_metadata_test.go
@@ -52,6 +52,20 @@ func init() {
 	}
 }
 
+func TestInitializationNoDocker(t *testing.T) {
+	var testConfig = common.NewConfig()
+	testConfig.SetString("host", -1, "unix:///var/run42/docker.sock")
+
+	p, err := buildDockerMetadataProcessor(testConfig, docker.NewWatcher)
+	assert.NoError(t, err, "initializing add_docker_metadata processor")
+
+	input := common.MapStr{}
+	result, err := p.Run(&beat.Event{Fields: input})
+	assert.NoError(t, err, "processing an event")
+
+	assert.Equal(t, common.MapStr{}, result.Fields)
+}
+
 func TestInitialization(t *testing.T) {
 	var testConfig = common.NewConfig()
 

--- a/libbeat/processors/processor.go
+++ b/libbeat/processors/processor.go
@@ -79,9 +79,6 @@ func New(config PluginConfig) (*Processors, error) {
 
 		gen, exists := registry.reg[actionName]
 		if !exists {
-			if actionName == "add_docker_metadata" {
-				continue
-			}
 			var validActions []string
 			for k := range registry.reg {
 				validActions = append(validActions, k)

--- a/libbeat/processors/processor.go
+++ b/libbeat/processors/processor.go
@@ -79,6 +79,9 @@ func New(config PluginConfig) (*Processors, error) {
 
 		gen, exists := registry.reg[actionName]
 		if !exists {
+			if actionName == "add_docker_metadata" {
+				continue
+			}
 			var validActions []string
 			for k := range registry.reg {
 				validActions = append(validActions, k)

--- a/metricbeat/metricbeat.docker.yml
+++ b/metricbeat/metricbeat.docker.yml
@@ -4,6 +4,7 @@ metricbeat.config.modules:
 
 processors:
 - add_cloud_metadata: ~
+- add_docker_metadata: ~
 
 output.elasticsearch:
   hosts: '${ELASTICSEARCH_HOSTS:elasticsearch:9200}'

--- a/metricbeat/metricbeat.yml
+++ b/metricbeat/metricbeat.yml
@@ -120,6 +120,7 @@ output.elasticsearch:
 processors:
   - add_host_metadata: ~
   - add_cloud_metadata: ~
+  - add_docker_metadata: ~
 
 #================================ Logging =====================================
 

--- a/packetbeat/packetbeat.docker.yml
+++ b/packetbeat/packetbeat.docker.yml
@@ -39,6 +39,7 @@ packetbeat.protocols.tls:
 
 processors:
 - add_cloud_metadata: ~
+- add_docker_metadata: ~
 
 output.elasticsearch:
   hosts: '${ELASTICSEARCH_HOSTS:elasticsearch:9200}'

--- a/packetbeat/packetbeat.yml
+++ b/packetbeat/packetbeat.yml
@@ -202,6 +202,7 @@ output.elasticsearch:
 processors:
   - add_host_metadata: ~
   - add_cloud_metadata: ~
+  - add_docker_metadata: ~
 
 #================================ Logging =====================================
 

--- a/winlogbeat/winlogbeat.yml
+++ b/winlogbeat/winlogbeat.yml
@@ -127,6 +127,7 @@ output.elasticsearch:
 processors:
   - add_host_metadata: ~
   - add_cloud_metadata: ~
+  - add_docker_metadata: ~
 
 #================================ Logging =====================================
 

--- a/x-pack/auditbeat/auditbeat.docker.yml
+++ b/x-pack/auditbeat/auditbeat.docker.yml
@@ -14,6 +14,7 @@ auditbeat.modules:
     - /etc
 processors:
 - add_cloud_metadata: ~
+- add_docker_metadata: ~
 
 output.elasticsearch:
   hosts: '${ELASTICSEARCH_HOSTS:elasticsearch:9200}'

--- a/x-pack/auditbeat/auditbeat.yml
+++ b/x-pack/auditbeat/auditbeat.yml
@@ -170,6 +170,7 @@ output.elasticsearch:
 processors:
   - add_host_metadata: ~
   - add_cloud_metadata: ~
+  - add_docker_metadata: ~
 
 #================================ Logging =====================================
 

--- a/x-pack/filebeat/filebeat.docker.yml
+++ b/x-pack/filebeat/filebeat.docker.yml
@@ -5,6 +5,7 @@ filebeat.config:
 
 processors:
 - add_cloud_metadata: ~
+- add_docker_metadata: ~
 
 output.elasticsearch:
   hosts: '${ELASTICSEARCH_HOSTS:elasticsearch:9200}'

--- a/x-pack/filebeat/filebeat.yml
+++ b/x-pack/filebeat/filebeat.yml
@@ -176,6 +176,7 @@ output.elasticsearch:
 processors:
   - add_host_metadata: ~
   - add_cloud_metadata: ~
+  - add_docker_metadata: ~
 
 #================================ Logging =====================================
 

--- a/x-pack/functionbeat/functionbeat.yml
+++ b/x-pack/functionbeat/functionbeat.yml
@@ -344,6 +344,7 @@ output.elasticsearch:
 processors:
   - add_host_metadata: ~
   - add_cloud_metadata: ~
+  - add_docker_metadata: ~
 
 #================================ Logging =====================================
 

--- a/x-pack/metricbeat/metricbeat.docker.yml
+++ b/x-pack/metricbeat/metricbeat.docker.yml
@@ -4,6 +4,7 @@ metricbeat.config.modules:
 
 processors:
 - add_cloud_metadata: ~
+- add_docker_metadata: ~
 
 output.elasticsearch:
   hosts: '${ELASTICSEARCH_HOSTS:elasticsearch:9200}'

--- a/x-pack/metricbeat/metricbeat.yml
+++ b/x-pack/metricbeat/metricbeat.yml
@@ -120,6 +120,7 @@ output.elasticsearch:
 processors:
   - add_host_metadata: ~
   - add_cloud_metadata: ~
+  - add_docker_metadata: ~
 
 #================================ Logging =====================================
 

--- a/x-pack/winlogbeat/winlogbeat.yml
+++ b/x-pack/winlogbeat/winlogbeat.yml
@@ -139,6 +139,7 @@ output.elasticsearch:
 processors:
   - add_host_metadata: ~
   - add_cloud_metadata: ~
+  - add_docker_metadata: ~
 
 #================================ Logging =====================================
 


### PR DESCRIPTION
This PR is a proposal for enabling autodetection mode for `add_docker_metadata`.

Currently we configure `add_cloud_metadata` and `add_host_metadata` by default in all Beats.

`add_cloud_metadata` does autodetection, and it will only enrich events if the beat is running on a known public cloud.

It would be useful to have the same for Docker (and Kubernetes), so if Beats is started in a scenario where Docker is available, it automatically enables metadata for it. If Docker is not present nothing will happen.

In this PR only the Docker part is covered. After we conclude to a final approach, a follow-up PR will come for the Kubernetes part.