### PR TITLE
Add a warning for uncommitted changes in copy-vendor, and quiet git commit

### DIFF
--- a/generator/beat/{beat}/Makefile
+++ b/generator/beat/{beat}/Makefile
@@ -37,7 +37,7 @@ git-init:
 .PHONY: git-add
 git-add:
 	git add -A
-	git commit -m "Add generated {beat} files"
+	git commit -q -m "Add generated {beat} files"
 
 
 .PHONY: vendor-check

--- a/generator/beat/{beat}/Makefile
+++ b/generator/beat/{beat}/Makefile
@@ -24,7 +24,7 @@ pre-setup: copy-vendor git-init
 
 # Copy beats into vendor directory
 .PHONY: copy-vendor
-copy-vendor:
+copy-vendor: vendor-check
 	mkdir -p vendor/github.com/elastic/beats
 	git archive --remote ${BEAT_GOPATH}/src/github.com/elastic/beats HEAD | tar -x --exclude=x-pack -C vendor/github.com/elastic/beats
 	mkdir -p vendor/github.com/magefile
@@ -38,3 +38,8 @@ git-init:
 git-add:
 	git add -A
 	git commit -m "Add generated {beat} files"
+
+
+.PHONY: vendor-check
+vendor-check:
+	@if output=$$(git -C ${BEAT_GOPATH}/src/github.com/elastic/beats status --porcelain) && [ ! -z "$${output}" ]; then printf "\033[31mWARNING: elastic/beats has uncommitted changes, these will not be in the vendor directory!\033[0m\n"; fi

--- a/generator/metricbeat/{beat}/Makefile
+++ b/generator/metricbeat/{beat}/Makefile
@@ -21,7 +21,7 @@ setup: copy-vendor git-init
 
 # Copy beats into vendor directory
 .PHONY: copy-vendor
-copy-vendor:
+copy-vendor: vendor-check
 	mkdir -p vendor/github.com/elastic/beats
 	git archive --remote ${BEAT_GOPATH}/src/github.com/elastic/beats HEAD | tar -x --exclude=x-pack -C vendor/github.com/elastic/beats
 	ln -sf ${PWD}/vendor/github.com/elastic/beats/metricbeat/scripts/generate_imports_helper.py ${PWD}/vendor/github.com/elastic/beats/script/generate_imports_helper.py
@@ -36,4 +36,8 @@ git-init:
 .PHONY: git-add
 git-add:
 	git add -A
-	git commit -m "Add generated {beat} files"
+	git commit -q -m "Add generated {beat} files"
+
+.PHONY: vendor-check
+vendor-check:
+	@if output=$$(git -C ${BEAT_GOPATH}/src/github.com/elastic/beats status --porcelain) && [ ! -z "$${output}" ]; then printf "\033[31mWARNING: elastic/beats has uncommitted changes, these will not be in the vendor directory!\033[0m\n"; fi


### PR DESCRIPTION
This is the result of some absolutely maddening debugging on my part, after I was trying to fix various generator things, only to find inexplicable build failures because my changes suddenly didn't exist.

This adds a warning in red text if elastic/beats has uncommited changes that won't be reflected in the resulting vendor directory that the generated beat will use.

I also added a quiet flag to the initial git commit, as it just spams the user with everything in `vendor/`, which isn't helpful.

I might also want to add some hard `vendor-update` role that'll just copy everything, uncommited or not. I figure messing with the user's git history and committing stuff probably isn't a great idea.

Should we add this role to anything else?