### PR TITLE
Adds troubleshooting topic about log rotation

### DIFF
--- a/filebeat/docs/configuring-howto.asciidoc
+++ b/filebeat/docs/configuring-howto.asciidoc
@@ -35,6 +35,7 @@ The following topics describe how to configure Filebeat:
 * <<configuring-ingest-node>>
 * <<{beatname_lc}-geoip>>
 * <<configuration-path>>
+* <<input-file-log-rotation>>
 * <<setup-kibana-endpoint>>
 * <<configuration-dashboards>>
 * <<configuration-template>>
@@ -76,6 +77,8 @@ include::{libbeat-dir}/docs/shared-config-ingest.asciidoc[]
 include::{libbeat-dir}/docs/shared-geoip.asciidoc[]
 
 include::{libbeat-dir}/docs/shared-path-config.asciidoc[]
+
+include::./filebeat-log-rotation.asciidoc[]
 
 include::{libbeat-dir}/docs/shared-kibana-config.asciidoc[]
 

--- a/filebeat/docs/configuring-howto.asciidoc
+++ b/filebeat/docs/configuring-howto.asciidoc
@@ -35,14 +35,12 @@ The following topics describe how to configure Filebeat:
 * <<configuring-ingest-node>>
 * <<{beatname_lc}-geoip>>
 * <<configuration-path>>
-* <<input-file-log-rotation>>
 * <<setup-kibana-endpoint>>
 * <<configuration-dashboards>>
 * <<configuration-template>>
 * <<configuration-logging>>
 * <<using-environ-vars>>
 * <<configuration-autodiscover>>
-//* <<configuration-central-management>>
 * <<yaml-tips>>
 * <<regexp-support>>
 * <<http-endpoint>>
@@ -77,8 +75,6 @@ include::{libbeat-dir}/docs/shared-config-ingest.asciidoc[]
 include::{libbeat-dir}/docs/shared-geoip.asciidoc[]
 
 include::{libbeat-dir}/docs/shared-path-config.asciidoc[]
-
-include::./filebeat-log-rotation.asciidoc[]
 
 include::{libbeat-dir}/docs/shared-kibana-config.asciidoc[]
 

--- a/filebeat/docs/faq.asciidoc
+++ b/filebeat/docs/faq.asciidoc
@@ -64,6 +64,8 @@ By default states are never removed from the registry file. To resolve the inode
 
 You can use <<{beatname_lc}-input-log-clean-removed,`clean_removed`>> for files that are removed from disk. Be aware that `clean_removed` cleans the file state from the registry whenever a file cannot be found during a scan. If the file shows up again later, it will be sent again from scratch.
 
+include::filebeat-log-rotation.asciidoc[]
+
 [[windows-file-rotation]]
 === Open file handlers cause issues with Windows file rotation
 
@@ -121,4 +123,5 @@ deleted before {beatname_uc} reaches the end of the file.
 
 
 include::{libbeat-dir}/docs/faq-limit-bandwidth.asciidoc[]
+
 include::{libbeat-dir}/docs/shared-faq.asciidoc[]

--- a/filebeat/docs/filebeat-log-rotation.asciidoc
+++ b/filebeat/docs/filebeat-log-rotation.asciidoc
@@ -1,0 +1,68 @@
+[[input-file-log-rotation]]
+== Configure logrotation for the input files of {beatname_uc}
+
+Incorrectly configured logrotation can result in either lost log messages or duplicated events when using {beatname_uc} to
+forward messages. When you see missing or duplicate events when running the Beat, be sure to check how input files are rotated.
+
+[float]
+[[log-rotation-strategies]]
+=== Logrotation strategies
+
+[float]
+[[log-rotation-truncate]]
+==== Truncating the input file
+
+In case of strategies which include copying and truncating the input file is going to result in sending duplicated events.
+It happens because {beatname_uc} identifies files by inode and device name. During rotation the already processed lines are
+moved to a new file. When {beatname_uc} encounters this new file, it is going to read it from the beginning, as previous state
+information (offset, read timestamp) are not found for this inode and device name combination in its state registry.
+Furthermore, when the input file is truncated it is possible that the application writing it might added new lines
+between the time of the copy and truncation. Those line get lost. We suggest you avoid using this method for rotating logs.
+
+[float]
+[[log-rotation-move]]
+==== Moving the input file
+
+When the input file is moved or renamed, {beatname_uc} is able to recognize that the file was already read. After the input is
+rotated, a new log file is created, so the application can continue logging. The Beat picks up the new file during the
+next scan. As it finds a new file, with new inode and device name, it starts reading it from the beginning.
+To avoid missing events from a rotated file, add the rotated files to the input.
+
+[float]
+[[log-rotate-example]]
+=== Example configurations
+
+In this section we choose to share a sample configuration of logrotate, as it is a popular tools to do log rotation.
+
+In this example {beatname_uc} reads the logs of a web server. The logs are rotated every day, and the new file is created
+with the specified permissions.
+
+[float]
+[[log-rotate-example-logrotate]]
+==== logrotate.conf
+
+[source,yaml]
+-----------------------------------------------------
+/var/log/my-server/my-server.log {
+    daily
+    missingok
+    rotate 7
+    notifempty
+    create 0640 www-data www-data
+}
+-----------------------------------------------------
+
+{beatname_uc} is configured to read all of the files to make sure it does not miss any event.
+
+[float]
+[[log-rotate-example-filebeat]]
+==== filebeat.yml
+
+[source,yaml]
+-----------------------------------------------------
+filebeat.inputs:
+- type: log
+  enabled: false
+  paths:
+  - /var/log/my-server/my-server.log*
+-----------------------------------------------------

--- a/filebeat/docs/filebeat-log-rotation.asciidoc
+++ b/filebeat/docs/filebeat-log-rotation.asciidoc
@@ -5,12 +5,16 @@ Incorrectly configured logrotation can result in either lost log messages or dup
 forward messages. When you see missing or duplicate events when running the Beat, be sure to check how input files are rotated.
 
 [float]
+[[log-rotation-linux]]
+=== Logrotation on Linux
+
+[float]
 [[log-rotation-strategies]]
 === Logrotation strategies
 
 [float]
 [[log-rotation-truncate]]
-==== Truncating the input file
+===== Truncating the input file
 
 In case of strategies which include copying and truncating the input file is going to result in sending duplicated events.
 It happens because {beatname_uc} identifies files by inode and device name. During rotation the already processed lines are
@@ -21,7 +25,7 @@ between the time of the copy and truncation. Those line get lost. We suggest you
 
 [float]
 [[log-rotation-move]]
-==== Moving the input file
+===== Moving the input file
 
 When the input file is moved or renamed, {beatname_uc} is able to recognize that the file was already read. After the input is
 rotated, a new log file is created, so the application can continue logging. The Beat picks up the new file during the
@@ -30,16 +34,16 @@ To avoid missing events from a rotated file, add the rotated files to the input.
 
 [float]
 [[log-rotate-example]]
-=== Example configurations
+==== Example configurations
 
-In this section we choose to share a sample configuration of logrotate, as it is a popular tools to do log rotation.
+In this section we choose to share a sample configuration of logrotate, as it is a popular tool to do log rotation.
 
 In this example {beatname_uc} reads the logs of a web server. The logs are rotated every day, and the new file is created
 with the specified permissions.
 
 [float]
 [[log-rotate-example-logrotate]]
-==== logrotate.conf
+===== logrotate.conf
 
 [source,yaml]
 -----------------------------------------------------
@@ -56,7 +60,7 @@ with the specified permissions.
 
 [float]
 [[log-rotate-example-filebeat]]
-==== filebeat.yml
+===== filebeat.yml
 
 [source,yaml]
 -----------------------------------------------------
@@ -66,3 +70,22 @@ filebeat.inputs:
   paths:
   - /var/log/my-server/my-server.log*
 -----------------------------------------------------
+
+[float]
+[[log-rotation-windows]]
+=== Logrotation on Windows
+
+Log rotation schemes deleting old files and renaming newer files to the old files might get blocked if old
+files are still processed by {beatname_uc}. This is due to Windows not deleting files and file meta-data,
+until the last process has closed the file. Unlike most *nix filesystems,
+one can not reuse a file name, until all processes accessing the file have closed the deleted file.
+
+For Windows users a better strategy is to use dates in the rotated file names.
+Thus, a file is never renamed to an older file, and the log writer cannot fail to open files
+(same for log rotator, if it's an external process).
+
+This highly reduces the chance of log writing, rotation, and collecting interfering with each other.
+
+Check out Frequently Asked Question about logrotation on Windows:
+
+* <<windows-file-rotation>>

--- a/filebeat/docs/filebeat-log-rotation.asciidoc
+++ b/filebeat/docs/filebeat-log-rotation.asciidoc
@@ -5,10 +5,6 @@ Incorrectly configured logrotation can result in either lost log messages or dup
 forward messages. When you see missing or duplicate events when running the Beat, be sure to check how input files are rotated.
 
 [float]
-[[log-rotation-linux]]
-=== Logrotation on Linux
-
-[float]
 [[log-rotation-strategies]]
 === Logrotation strategies
 
@@ -21,7 +17,7 @@ It happens because {beatname_uc} identifies files by inode and device name. Duri
 moved to a new file. When {beatname_uc} encounters this new file, it is going to read it from the beginning, as previous state
 information (offset, read timestamp) are not found for this inode and device name combination in its state registry.
 Furthermore, when the input file is truncated it is possible that the application writing it might added new lines
-between the time of the copy and truncation. Those line get lost. We suggest you avoid using this method for rotating logs.
+between the time of the copy and truncation. Those lines get lost. We suggest you avoid using this method for rotating logs.
 
 [float]
 [[log-rotation-move]]
@@ -36,7 +32,7 @@ To avoid missing events from a rotated file, add the rotated files to the input.
 [[log-rotate-example]]
 ==== Example configurations
 
-In this section we choose to share a sample configuration of logrotate, as it is a popular tool to do log rotation.
+In this section we choose to share a sample configuration of logrotate, as it is a popular tool to do log rotation on Linux.
 
 In this example {beatname_uc} reads the logs of a web server. The logs are rotated every day, and the new file is created
 with the specified permissions.
@@ -73,7 +69,7 @@ filebeat.inputs:
 
 [float]
 [[log-rotation-windows]]
-=== Logrotation on Windows
+=== Additional notes on logrotation on Windows
 
 Log rotation schemes deleting old files and renaming newer files to the old files might get blocked if old
 files are still processed by {beatname_uc}. This is due to Windows not deleting files and file meta-data,

--- a/filebeat/docs/filebeat-log-rotation.asciidoc
+++ b/filebeat/docs/filebeat-log-rotation.asciidoc
@@ -1,45 +1,53 @@
-[[input-file-log-rotation]]
-== Configure logrotation for the input files of {beatname_uc}
+[[file-log-rotation]]
+=== Log rotation results in lost or duplicate events
 
-Incorrectly configured logrotation can result in either lost log messages or duplicated events when using {beatname_uc} to
-forward messages. When you see missing or duplicate events when running the Beat, be sure to check how input files are rotated.
+{beatname_uc} supports reading from rotating log files. However, some log
+rotation strategies can result in lost or duplicate events when using
+{beatname_uc} to forward messages. To resolve this issue:
 
-[float]
-[[log-rotation-strategies]]
-=== Logrotation strategies
+* *Avoid log rotation strategies that copy and truncate log files* 
++
+Log rotation strategies that copy and truncate the input log file can result in
+{beatname_uc} sending duplicate events. This happens because {beatname_uc}
+identifies files by inode and device name. During log rotation, lines that
+{beatname_uc} has already processed are moved to a new file. When
+{beatname_uc} encounters the new file, it reads from the beginning because the
+previous state information (the offset and read timestamp) is associated with the
+inode and device name of the old file.
++
+Furthermore, strategies that copy and truncate the input log file can result in
+lost events if lines are written to the log file after it's copied, but before
+it's truncated.
 
-[float]
-[[log-rotation-truncate]]
-===== Truncating the input file
+* *Make sure {beatname_uc} is configured to read from all rotated logs*
++
+When an input log file is moved or renamed during log rotation, {beatname_uc} is
+able to recognize that the file has already been read. After the file is
+rotated, a new log file is created, and the application continues logging.
+{beatname_uc} picks up the new file during the next scan. Because the file
+has a new inode and device name, {beatname_uc} starts reading it from the
+beginning.
++
+To avoid missing events from a rotated file, configure the input to read from
+the log file and all the rotated files. For examples, see
+<<log-rotate-example>>.
 
-In case of strategies which include copying and truncating the input file is going to result in sending duplicated events.
-It happens because {beatname_uc} identifies files by inode and device name. During rotation the already processed lines are
-moved to a new file. When {beatname_uc} encounters this new file, it is going to read it from the beginning, as previous state
-information (offset, read timestamp) are not found for this inode and device name combination in its state registry.
-Furthermore, when the input file is truncated it is possible that the application writing it might added new lines
-between the time of the copy and truncation. Those lines get lost. We suggest you avoid using this method for rotating logs.
-
-[float]
-[[log-rotation-move]]
-===== Moving the input file
-
-When the input file is moved or renamed, {beatname_uc} is able to recognize that the file was already read. After the input is
-rotated, a new log file is created, so the application can continue logging. The Beat picks up the new file during the
-next scan. As it finds a new file, with new inode and device name, it starts reading it from the beginning.
-To avoid missing events from a rotated file, add the rotated files to the input.
+If you're using Windows, also see <<log-rotation-windows>>.
 
 [float]
 [[log-rotate-example]]
 ==== Example configurations
 
-In this section we choose to share a sample configuration of logrotate, as it is a popular tool to do log rotation on Linux.
-
-In this example {beatname_uc} reads the logs of a web server. The logs are rotated every day, and the new file is created
-with the specified permissions.
+This section shows a typical configuration for logrotate, a popular tool for
+doing log rotation on Linux, followed by a {beatname_uc} configuration that
+reads all the rotated logs.
 
 [float]
 [[log-rotate-example-logrotate]]
 ===== logrotate.conf
+
+In this example, {beatname_uc} reads web server log. The logs are rotated every
+day, and the new file is created with the specified permissions.
 
 [source,yaml]
 -----------------------------------------------------
@@ -52,11 +60,12 @@ with the specified permissions.
 }
 -----------------------------------------------------
 
-{beatname_uc} is configured to read all of the files to make sure it does not miss any event.
-
 [float]
 [[log-rotate-example-filebeat]]
 ===== filebeat.yml
+
+In this example, {beatname_uc} is configured to read all log files to make
+sure it does not miss any events.
 
 [source,yaml]
 -----------------------------------------------------
@@ -69,21 +78,21 @@ filebeat.inputs:
 
 [float]
 [[log-rotation-windows]]
-=== Additional notes on logrotation on Windows
+==== More about log rotation on Windows
 
-Log rotation schemes deleting old files and renaming newer files to the old files might get blocked if old
-files are still processed by {beatname_uc}. This is due to Windows not deleting files and file meta-data,
-until the last process has closed the file. Unlike most *nix filesystems,
-one can not reuse a file name, until all processes accessing the file have closed the deleted file.
+On Windows, log rotation schemes that delete old files and rename newer
+files to old filenames might get blocked if the old files are being processed by
+{beatname_uc}. This happens because Windows does not delete files and file
+metadata until the last process has closed the file. Unlike most *nix
+filesystems, a Windows filename cannot be reused until all processes accessing
+the file have closed the deleted file.
 
-For Windows users a better strategy is to use dates in the rotated file names.
-Thus, a file is never renamed to an older file, and the log writer cannot fail to open files
-(same for log rotator, if it's an external process).
+To avoid this problem, use dates in rotated filenames. The file will never
+be renamed to an older filename, and the log writer and log rotator will always
+be able to open the file. This approach also highly reduces the chance of
+log writing, rotation, and collection interfering with each other.
 
-This highly reduces the chance of log writing, rotation, and collecting interfering with each other.
+Because log rotation is typically handled by the logging application, we are
+not providing an example configuration for Windows.
 
-As it's usually the logging application doing the rotation, we are not providing an example configuration for Windows.
-
-To learn more the topic check out Frequently Asked Question about logrotation on Windows:
-
-* <<windows-file-rotation>>
+Also read <<windows-file-rotation>>.

--- a/filebeat/docs/filebeat-log-rotation.asciidoc
+++ b/filebeat/docs/filebeat-log-rotation.asciidoc
@@ -82,6 +82,8 @@ Thus, a file is never renamed to an older file, and the log writer cannot fail t
 
 This highly reduces the chance of log writing, rotation, and collecting interfering with each other.
 
-Check out Frequently Asked Question about logrotation on Windows:
+As it's usually the logging application doing the rotation, we are not providing an example configuration for Windows.
+
+To learn more the topic check out Frequently Asked Question about logrotation on Windows:
 
 * <<windows-file-rotation>>

--- a/filebeat/docs/inputs/input-log.asciidoc
+++ b/filebeat/docs/inputs/input-log.asciidoc
@@ -57,10 +57,14 @@ multiple input sections:
 IMPORTANT: Make sure a file is not defined more than once across all inputs
 because this can lead to unexpected behaviour.
 
-NOTE: When dealing with file rotation, avoid harvesting symlinks. Instead
+[[rotating-logs]]
+==== Reading from rotating logs
+
+When dealing with file rotation, avoid harvesting symlinks. Instead
 use the <<input-paths>> setting to point to the original file, and specify
 a pattern that matches the file you want to harvest and all of its rotated
-files.  
+files. Also make sure your log rotation strategy prevents lost or duplicate
+messages. For more information, see <<file-log-rotation>>.
 
 [id="{beatname_lc}-input-{type}-options"]
 ==== Configuration options


### PR DESCRIPTION
This PR is built on top of the commits in https://github.com/elastic/beats/pull/12719.

It adds a short section about reading from rotating logs to the input docs, but moves the bulk of the content to the troubleshooting section.

@kvch I created a new PR because I had to rebase to test the asciidoctor build and didn't want to force push to your fork. If you'd prefer to keep the original PR, you can cherry-pick my commit into your branch. Either way, please review my changes.