### PR TITLE
[Libbeat] Log debug message if the Kibana dashboard can not be imported from the archive (#12211)

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -61,6 +61,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Affecting all Beats*
 
+- Log debug message if the Kibana dashboard can not be imported from the archive because of the invalid archive directory structure {issue}12211[12211], {pull}13387[13387]
 - Fix typo in TLS renegotiation configuration and setting the option correctly {issue}10871[10871], {pull}12354[12354]
 - Ensure all beat commands respect configured settings. {pull}10721[10721]
 - Add missing fields and test cases for libbeat add_kubernetes_metadata processor. {issue}11133[11133], {pull}11134[11134]

--- a/libbeat/dashboards/importer.go
+++ b/libbeat/dashboards/importer.go
@@ -241,6 +241,8 @@ func (imp Importer) ImportArchive() error {
 			if err != nil {
 				return err
 			}
+		} else {
+			imp.loader.statusMsg("Skipping import of %s directory. Beat name: %s, base dir name: %s.", dir, imp.cfg.Beat, filepath.Base(dir))
 		}
 	}
 	return nil


### PR DESCRIPTION
Fixes #12211  

As described in #12211, depending on the value of _setup.dashboards.beat_ there is a required directory structure for successful import of the Kibana dashboards from the archive file.

This PR adds additional path in case when no Kibana dashboards can be imported from the archive file, which logs debug message as shown below:

```
2019-08-29T22:40:00.122+0200    DEBUG   [dashboards]    dashboards/kibana_loader.go:146 Unzip archive /tmp/tmp263803916
2019-08-29T22:40:00.126+0200    DEBUG   [dashboards]    dashboards/kibana_loader.go:146 Importing Kibana from /tmp/tmp263803916/kibana/filebeat
.. 
// this is added 
2019-08-29T22:40:00.126+0200    DEBUG   [dashboards]    dashboards/kibana_loader.go:146 Skipping import of /tmp/tmp263803916/kibana/filebeat directory. Beat name: metricbeat, base dir name: filebeat.
// end

2019-08-29T22:40:00.126+0200    INFO    instance/beat.go:776    Kibana dashboards successfully loaded.
```

Implementation of point 2 from #12211  proposal.

There is a table in elastic/beats#12211 that contains test cases for this issue, but I currently don't know how to mock all necessary dependencies and implement unit tests for this without too much changes in libbeat/dashboards/importer.go.

I see that there are some integration tests for loading dashboards in libbeat/tests/system/test_dashboard.py so I'll check those out.