### PR TITLE
Add more metrics to Filebeat harvesters

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -465,6 +465,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add dashboards for the ActiveMQ Filebeat module. {pull}14880[14880]
 - Add STAN Metricbeat module. {pull}14839[14839]
 - Add new fileset googlecloud/audit for ingesting Google Cloud Audit logs. {pull}15200[15200]
+- Expose more metrics of harvesters (e.g. `read_offset`, `start_time`). {pull}13395[13395]
 
 *Heartbeat*
 - Add non-privileged icmp on linux and darwin(mac). {pull}13795[13795] {issue}11498[11498]

--- a/filebeat/input/log/harvester.go
+++ b/filebeat/input/log/harvester.go
@@ -357,22 +357,18 @@ func (h *Harvester) Run() error {
 func (h *Harvester) monitorFileSize() {
 	ticker := time.NewTicker(30 * time.Second)
 	defer ticker.Stop()
-	logp.Info("INDULOK")
 
 	for {
 		select {
 		case <-h.done:
-			logp.Info("ELEG")
 			return
 		case <-ticker.C:
-			logp.Info("UPDATING II")
 			err := h.updateCurrentSize()
 			if err != nil {
 				logp.Err("Error updating file size: %v; File: %v", err, h.state.Source)
 			}
 		}
 	}
-	logp.Info("RETURNING")
 }
 
 // stop is intended for internal use and closed the done channel to stop execution

--- a/filebeat/input/log/harvester.go
+++ b/filebeat/input/log/harvester.go
@@ -359,11 +359,12 @@ func (h *Harvester) Run() error {
 
 func (h *Harvester) monitorFileSize() {
 	for {
+		timer := time.NewTimer(30 * time.Second)
 		select {
 		case <-h.done:
 			return
 		case <-h.checkSize:
-		case <-time.After(30 * time.Second):
+		case <-timer.C:
 			err := h.updateCurrentSize()
 			if err != nil {
 				logp.Err("Error updating file size: %v; File: %v", err, h.state.Source)

--- a/filebeat/input/log/harvester.go
+++ b/filebeat/input/log/harvester.go
@@ -101,8 +101,7 @@ type Harvester struct {
 	outletFactory OutletFactory
 	publishState  func(file.State) bool
 
-	metrics   *harvesterProgressMetrics
-	checkSize chan struct{}
+	metrics *harvesterProgressMetrics
 
 	onTerminate func()
 }
@@ -141,7 +140,6 @@ func NewHarvester(
 		stopWg:        &sync.WaitGroup{},
 		id:            id,
 		outletFactory: outletFactory,
-		checkSize:     make(chan struct{}),
 	}
 
 	if err := config.Unpack(&h.config); err != nil {
@@ -353,30 +351,28 @@ func (h *Harvester) Run() error {
 		h.metrics.readOffset.Set(state.Offset)
 		h.metrics.lastPublished.Set(time.Now())
 		h.metrics.lastPublishedEventTimestamp.Set(message.Ts)
-		h.checkSize <- struct{}{}
 	}
 }
 
 func (h *Harvester) monitorFileSize() {
 	ticker := time.NewTicker(30 * time.Second)
 	defer ticker.Stop()
+	logp.Info("INDULOK")
 
 	for {
 		select {
 		case <-h.done:
+			logp.Info("ELEG")
 			return
-		case <-h.checkSize:
-			err := h.updateCurrentSize()
-			if err != nil {
-				logp.Err("Error updating file size: %v; File: %v", err, h.state.Source)
-			}
 		case <-ticker.C:
+			logp.Info("UPDATING II")
 			err := h.updateCurrentSize()
 			if err != nil {
 				logp.Err("Error updating file size: %v; File: %v", err, h.state.Source)
 			}
 		}
 	}
+	logp.Info("RETURNING")
 }
 
 // stop is intended for internal use and closed the done channel to stop execution

--- a/filebeat/input/log/harvester.go
+++ b/filebeat/input/log/harvester.go
@@ -216,7 +216,7 @@ func newHarvesterProgressMetrics(id string) *harvesterProgressMetrics {
 		filename:                    monitoring.NewString(r, "name"),
 		started:                     monitoring.NewString(r, "start_time"),
 		lastPublished:               monitoring.NewString(r, "last_event_published_time"),
-		lastPublishedEventTimestamp: monitoring.NewString(r, "last_event_@timestamp"),
+		lastPublishedEventTimestamp: monitoring.NewString(r, "last_event_timestamp"),
 		currentSize:                 monitoring.NewInt(r, "size"),
 		readOffset:                  monitoring.NewInt(r, "read_offset"),
 	}

--- a/filebeat/input/log/harvester.go
+++ b/filebeat/input/log/harvester.go
@@ -112,8 +112,8 @@ type harvesterProgressMetrics struct {
 	metricsRegistry             *monitoring.Registry
 	filename                    *monitoring.String
 	started                     *monitoring.String
-	lastPublished               *monitoring.String
-	lastPublishedEventTimestamp *monitoring.String
+	lastPublished               *monitoring.Timestamp
+	lastPublishedEventTimestamp *monitoring.Timestamp
 	currentSize                 *monitoring.Int
 	readOffset                  *monitoring.Int
 }
@@ -215,8 +215,8 @@ func newHarvesterProgressMetrics(id string) *harvesterProgressMetrics {
 		metricsRegistry:             r,
 		filename:                    monitoring.NewString(r, "name"),
 		started:                     monitoring.NewString(r, "start_time"),
-		lastPublished:               monitoring.NewString(r, "last_event_published_time"),
-		lastPublishedEventTimestamp: monitoring.NewString(r, "last_event_timestamp"),
+		lastPublished:               monitoring.NewTimestamp(r, "last_event_published_time"),
+		lastPublishedEventTimestamp: monitoring.NewTimestamp(r, "last_event_timestamp"),
 		currentSize:                 monitoring.NewInt(r, "size"),
 		readOffset:                  monitoring.NewInt(r, "read_offset"),
 	}
@@ -351,8 +351,8 @@ func (h *Harvester) Run() error {
 
 		// Update metics of harvester as event was sent
 		h.metrics.readOffset.Set(state.Offset)
-		h.metrics.lastPublished.Set(common.Time(time.Now()).String())
-		h.metrics.lastPublishedEventTimestamp.Set(common.Time(message.Ts).String())
+		h.metrics.lastPublished.Set(time.Now())
+		h.metrics.lastPublishedEventTimestamp.Set(message.Ts)
 		h.checkSize <- struct{}{}
 	}
 }

--- a/filebeat/input/log/harvester.go
+++ b/filebeat/input/log/harvester.go
@@ -358,13 +358,19 @@ func (h *Harvester) Run() error {
 }
 
 func (h *Harvester) monitorFileSize() {
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+
 	for {
-		timer := time.NewTimer(30 * time.Second)
 		select {
 		case <-h.done:
 			return
 		case <-h.checkSize:
-		case <-timer.C:
+			err := h.updateCurrentSize()
+			if err != nil {
+				logp.Err("Error updating file size: %v; File: %v", err, h.state.Source)
+			}
+		case <-ticker.C:
 			err := h.updateCurrentSize()
 			if err != nil {
 				logp.Err("Error updating file size: %v; File: %v", err, h.state.Source)

--- a/libbeat/monitoring/metrics.go
+++ b/libbeat/monitoring/metrics.go
@@ -23,7 +23,9 @@ import (
 	"math"
 	"strconv"
 	"sync"
+	"time"
 
+	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/atomic"
 )
 
@@ -231,4 +233,49 @@ func fullName(r *Registry, name string) string {
 		return name
 	}
 	return r.name + "." + name
+}
+
+// Timestamp is a timestamp variable satisfying the Var interface.
+type Timestamp struct {
+	mu sync.RWMutex
+	ts time.Time
+}
+
+// NewTimestamp creates and registeres a new timestamp variable.
+func NewTimestamp(r *Registry, name string, opts ...Option) *Timestamp {
+	if r == nil {
+		r = Default
+	}
+
+	v := &Timestamp{}
+	addVar(r, name, opts, v, makeExpvar(func() string {
+		return v.toString()
+
+	}))
+	return v
+}
+
+func (v *Timestamp) Set(t time.Time) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+
+	v.ts = t
+}
+
+func (v *Timestamp) Get() time.Time {
+	v.mu.RLock()
+	defer v.mu.RUnlock()
+
+	return v.ts
+}
+
+func (v *Timestamp) Visit(_ Mode, vs Visitor) {
+	vs.OnString(v.toString())
+}
+
+func (v *Timestamp) toString() string {
+	if v.ts.IsZero() {
+		return ""
+	}
+	return v.ts.Format(common.TsLayout)
 }

--- a/libbeat/monitoring/metrics.go
+++ b/libbeat/monitoring/metrics.go
@@ -272,13 +272,13 @@ func (v *Timestamp) Get() time.Time {
 }
 
 func (v *Timestamp) Visit(_ Mode, vs Visitor) {
-	v.mu.RLock()
-	defer v.mu.RUnlock()
-
 	vs.OnString(v.toString())
 }
 
 func (v *Timestamp) toString() string {
+	v.mu.RLock()
+	defer v.mu.RUnlock()
+
 	if v.ts.IsZero() {
 		return ""
 	}

--- a/libbeat/monitoring/metrics.go
+++ b/libbeat/monitoring/metrics.go
@@ -272,6 +272,9 @@ func (v *Timestamp) Get() time.Time {
 }
 
 func (v *Timestamp) Visit(_ Mode, vs Visitor) {
+	v.mu.RLock()
+	defer v.mu.RUnlock()
+
 	vs.OnString(v.toString())
 }
 

--- a/libbeat/monitoring/metrics.go
+++ b/libbeat/monitoring/metrics.go
@@ -237,8 +237,9 @@ func fullName(r *Registry, name string) string {
 
 // Timestamp is a timestamp variable satisfying the Var interface.
 type Timestamp struct {
-	mu sync.RWMutex
-	ts time.Time
+	mu     sync.RWMutex
+	ts     time.Time
+	cached string
 }
 
 // NewTimestamp creates and registeres a new timestamp variable.
@@ -260,6 +261,7 @@ func (v *Timestamp) Set(t time.Time) {
 	defer v.mu.Unlock()
 
 	v.ts = t
+	v.cached = ""
 }
 
 func (v *Timestamp) Get() time.Time {
@@ -277,5 +279,9 @@ func (v *Timestamp) toString() string {
 	if v.ts.IsZero() {
 		return ""
 	}
-	return v.ts.Format(common.TsLayout)
+
+	if v.cached == "" {
+		v.cached = v.ts.Format(common.TsLayout)
+	}
+	return v.cached
 }


### PR DESCRIPTION
I have added a few new metrics to harvesters of Filebeat:

- `"last_event_timestamp"`: `@timestamp` of the last published event
- `"last_event_publised_time"`:  the time when the last event was published and the offset was updated
- `"size"`: file size in bytes
- `"read_offset"`: offset of the file
- `"start_time"`: harvester start time 

By reporting these metrics it is possible to create more complex checks in Kibana to help to diagnose issues in harvesters.

```
"harvester": {
    "files": {
        "0be8e828-e39f-42ba-8468-029a08451a37": {
            "last_event_timestamp": "2019-08-29T13:17:22.961Z",
            "last_event_published_time": "2019-08-29T13:17:22.961Z",
            "name": "/var/log/dpkg.log",
            "read_offset": 42417,
            "size": 42417,
            "start_time": "2019-08-29T13:17:19.908Z"
        },
        "6950906f-ef19-4d99-aff9-ca81b49e024f": {
            "last_event_timestamp": "",
            "last_event_published_time": "",
            "name": "/var/log/pm-powersave.log",
            "start_time": "2019-08-29T13:17:22.907Z"
        },
        "752bb2c3-2a61-4055-b3c6-5b8b87204f2b": {
            "last_event_timestamp": "2019-08-29T13:17:22.905Z",
            "last_event_published_time": "2019-08-29T13:17:22.905Z",
            "name": "/var/log/vbox-setup.log",
            "read_offset": 140,
            "size": 140,
            "start_time": "2019-08-29T13:17:19.908Z"
        },
        "c339d330-cfa6-41ae-8a77-83a019ca99ab": {
            "last_event_timestamp": "2019-08-29T13:17:22.924Z",
            "last_event_published_time": "2019-08-29T13:17:22.925Z",
            "name": "/var/log/fontconfig.log",
            "read_offset": 2269,
            "size": 2269,
            "start_time": "2019-08-29T13:17:22.915Z"
        },
        "edb8b270-904a-40dc-bb3b-e6ef278585a2": {
            "last_event_timestamp": "2019-08-29T13:17:22.915Z",
            "last_event_published_time": "2019-08-29T13:17:22.915Z",
            "name": "/var/log/alternatives.log",
            "read_offset": 5752,
            "size": 5752,
            "start_time": "2019-08-29T13:17:22.913Z"
        },
        "f63a4922-164b-47bb-9edd-1b446685090c": {
            "last_event_@timestamp": "",
            "last_event_published_time": "",
            "name": "/var/log/pm-suspend.log",
            "start_time": "2019-08-29T13:17:22.906Z"
        }
    },
    "open_files": 6,
    "running": 6,
    "started": 6
}
```

Closes elastic/beats#7743