### PR TITLE
Cherry-pick #13368 to 7.4: Fix filebeat kafka module ingest timezone

### DIFF
--- a/filebeat/module/kafka/log/ingest/pipeline.json
+++ b/filebeat/module/kafka/log/ingest/pipeline.json
@@ -68,11 +68,12 @@
     {
       "date": {
         "if": "ctx.event.timezone != null",
-        "field": "@timestamp",
-        "formats": ["ISO8601"],
+        "field": "kafka.log.timestamp",
+        "target_field": "@timestamp",
+        "formats": ["yyyy-MM-dd HH:mm:ss,SSS"],
         "timezone": "{{ event.timezone }}",
-          "on_failure": [{"append": {"field": "error.message", "value": "{{ _ingest.on_failure_message }}"}}]
-        }
+        "on_failure": [{"append": {"field": "error.message", "value": "{{ _ingest.on_failure_message }}"}}]
+      }
     },
     {"remove": {"field": "kafka.log.timestamp" }}
   ],


### PR DESCRIPTION
Cherry-pick of PR #13368 to 7.4 branch. Original message: 

This pull request fixes timezone parsing for kafka module.

Just like #13308 fixes ingest timezone parsing for system module.