### PR TITLE
Cherry-pick #13396 to 7.4: Fix keystore name

### DIFF
--- a/x-pack/functionbeat/config/config.go
+++ b/x-pack/functionbeat/config/config.go
@@ -21,7 +21,7 @@ var (
 	configOverrides = common.MustNewConfigFrom(map[string]interface{}{
 		"path.data":              "/tmp",
 		"path.logs":              "/tmp/logs",
-		"keystore.path":          "/tmp/beats.keystore",
+		"keystore.path":          "/tmp/functionbeat.keystore",
 		"setup.template.enabled": true,
 		"queue.mem": map[string]interface{}{
 			"flush.min_events": 10,


### PR DESCRIPTION
Cherry-pick of PR #13396 to 7.4 branch. Original message: 

