### PR TITLE
Cherry-pick #13402 to 7.4: Disable freebsd cross-compile

### DIFF
--- a/libbeat/Makefile
+++ b/libbeat/Makefile
@@ -1,6 +1,7 @@
 BEAT_NAME=libbeat
 TEST_ENVIRONMENT?=true
 SYSTEM_TESTS=true
+GOX_OS=linux darwin windows netbsd openbsd
 
 include scripts/Makefile
 


### PR DESCRIPTION
Cherry-pick of PR #13402 to 7.4 branch. Original message: 

Addresses https://github.com/elastic/beats/issues/13400 until moby/moby fixes the issue and we update our vendor copy.