### PR TITLE
Cherry-pick #13313 to 7.3: Add explanations about timezone support to filebeat modules

### DIFF
--- a/filebeat/docs/modules/cisco.asciidoc
+++ b/filebeat/docs/modules/cisco.asciidoc
@@ -130,6 +130,8 @@ Set to 0.0.0.0 to bind to all available interfaces.
 
 The UDP port to listen for syslog traffic. Defaults to 9002.
 
+include::../include/timezone-support.asciidoc[]
+
 :has-dashboards!:
 
 :fileset_ex!:

--- a/filebeat/docs/modules/elasticsearch.asciidoc
+++ b/filebeat/docs/modules/elasticsearch.asciidoc
@@ -123,6 +123,8 @@ NOTE: If you're running against Elasticsearch >= 7.0.0, configure the
 `var.paths` setting to point to JSON logs. Otherwise, configure it
 to point to plain text logs.
 
+include::../include/timezone-support.asciidoc[]
+
 :has-dashboards!:
 
 :fileset_ex!:

--- a/filebeat/docs/modules/iptables.asciidoc
+++ b/filebeat/docs/modules/iptables.asciidoc
@@ -75,6 +75,8 @@ The UDP port to listen for syslog traffic. Defaults to `9001`
 
 NOTE: Ports below 1024 require Filebeat to run as root.
 
+include::../include/timezone-support.asciidoc[]
+
 :has-dashboards!:
 
 :fileset_ex!:

--- a/filebeat/docs/modules/logstash.asciidoc
+++ b/filebeat/docs/modules/logstash.asciidoc
@@ -94,6 +94,8 @@ include::../include/var-paths.asciidoc[]
 The configured Logstash log format. Possible values are: `json` or `plain`. The
 default is `plain`.
 
+include::../include/timezone-support.asciidoc[]
+
 :has-dashboards!:
 
 :fileset_ex!:

--- a/filebeat/docs/modules/mssql.asciidoc
+++ b/filebeat/docs/modules/mssql.asciidoc
@@ -48,6 +48,8 @@ include::../include/config-option-intro.asciidoc[]
 
 include::../include/var-paths.asciidoc[]
 
+include::../include/timezone-support.asciidoc[]
+
 :has-dashboards!:
 
 :fileset_ex!:

--- a/filebeat/docs/modules/nginx.asciidoc
+++ b/filebeat/docs/modules/nginx.asciidoc
@@ -74,6 +74,8 @@ include::../include/var-paths.asciidoc[]
 
 include::../include/var-paths.asciidoc[]
 
+include::../include/timezone-support.asciidoc[]
+
 :has-dashboards!:
 
 :fileset_ex!:

--- a/filebeat/docs/modules/panw.asciidoc
+++ b/filebeat/docs/modules/panw.asciidoc
@@ -177,6 +177,8 @@ The UDP port to listen for syslog traffic. Defaults to `9001`
 
 NOTE: Ports below 1024 require {beatname_uc} to run as root.
 
+include::../include/timezone-support.asciidoc[]
+
 :has-dashboards!:
 
 :fileset_ex!:

--- a/filebeat/module/elasticsearch/_meta/docs.asciidoc
+++ b/filebeat/module/elasticsearch/_meta/docs.asciidoc
@@ -118,6 +118,8 @@ NOTE: If you're running against Elasticsearch >= 7.0.0, configure the
 `var.paths` setting to point to JSON logs. Otherwise, configure it
 to point to plain text logs.
 
+include::../include/timezone-support.asciidoc[]
+
 :has-dashboards!:
 
 :fileset_ex!:

--- a/filebeat/module/logstash/_meta/docs.asciidoc
+++ b/filebeat/module/logstash/_meta/docs.asciidoc
@@ -89,6 +89,8 @@ include::../include/var-paths.asciidoc[]
 The configured Logstash log format. Possible values are: `json` or `plain`. The
 default is `plain`.
 
+include::../include/timezone-support.asciidoc[]
+
 :has-dashboards!:
 
 :fileset_ex!:

--- a/filebeat/module/nginx/_meta/docs.asciidoc
+++ b/filebeat/module/nginx/_meta/docs.asciidoc
@@ -69,6 +69,8 @@ include::../include/var-paths.asciidoc[]
 
 include::../include/var-paths.asciidoc[]
 
+include::../include/timezone-support.asciidoc[]
+
 :has-dashboards!:
 
 :fileset_ex!:

--- a/x-pack/filebeat/module/cisco/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/cisco/_meta/docs.asciidoc
@@ -125,6 +125,8 @@ Set to 0.0.0.0 to bind to all available interfaces.
 
 The UDP port to listen for syslog traffic. Defaults to 9002.
 
+include::../include/timezone-support.asciidoc[]
+
 :has-dashboards!:
 
 :fileset_ex!:

--- a/x-pack/filebeat/module/iptables/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/iptables/_meta/docs.asciidoc
@@ -70,6 +70,8 @@ The UDP port to listen for syslog traffic. Defaults to `9001`
 
 NOTE: Ports below 1024 require Filebeat to run as root.
 
+include::../include/timezone-support.asciidoc[]
+
 :has-dashboards!:
 
 :fileset_ex!:

--- a/x-pack/filebeat/module/mssql/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/mssql/_meta/docs.asciidoc
@@ -43,6 +43,8 @@ include::../include/config-option-intro.asciidoc[]
 
 include::../include/var-paths.asciidoc[]
 
+include::../include/timezone-support.asciidoc[]
+
 :has-dashboards!:
 
 :fileset_ex!:

--- a/x-pack/filebeat/module/panw/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/panw/_meta/docs.asciidoc
@@ -172,6 +172,8 @@ The UDP port to listen for syslog traffic. Defaults to `9001`
 
 NOTE: Ports below 1024 require {beatname_uc} to run as root.
 
+include::../include/timezone-support.asciidoc[]
+
 :has-dashboards!:
 
 :fileset_ex!:


### PR DESCRIPTION
Cherry-pick of PR #13313 to 7.3 branch. Original message: 

Add documentation about the use of `event.timezone` in modules that do
some kind of timestamp parsing in their pipelines.

It was added to some modules as part of #12469, but it was missing for others.