### PR TITLE
Fix conversions of events with module fields

### DIFF
--- a/metricbeat/module/kubernetes/container/container.go
+++ b/metricbeat/module/kubernetes/container/container.go
@@ -99,7 +99,7 @@ func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
 	m.enricher.Enrich(events)
 
 	for _, e := range events {
-		reporter.Event(mb.Event{MetricSetFields: e})
+		reporter.Event(mb.TransformMapStrToEvent("kubernetes", e, nil))
 	}
 
 	return

--- a/metricbeat/module/kubernetes/node/node.go
+++ b/metricbeat/module/kubernetes/node/node.go
@@ -98,7 +98,7 @@ func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
 
 	m.enricher.Enrich([]common.MapStr{event})
 
-	reporter.Event(mb.Event{MetricSetFields: event})
+	reporter.Event(mb.TransformMapStrToEvent("kubernetes", event, nil))
 
 	return
 }

--- a/metricbeat/module/kubernetes/pod/pod.go
+++ b/metricbeat/module/kubernetes/pod/pod.go
@@ -98,7 +98,7 @@ func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
 	m.enricher.Enrich(events)
 
 	for _, e := range events {
-		reporter.Event(mb.Event{MetricSetFields: e})
+		reporter.Event(mb.TransformMapStrToEvent("kubernetes", e, nil))
 	}
 	return
 }

--- a/metricbeat/module/kubernetes/system/system.go
+++ b/metricbeat/module/kubernetes/system/system.go
@@ -89,7 +89,7 @@ func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
 	}
 
 	for _, e := range events {
-		reporter.Event(mb.Event{MetricSetFields: e})
+		reporter.Event(mb.TransformMapStrToEvent("kubernetes", e, nil))
 	}
 	return
 }

--- a/metricbeat/module/kubernetes/volume/volume.go
+++ b/metricbeat/module/kubernetes/volume/volume.go
@@ -83,7 +83,7 @@ func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
 
 	events, err := eventMapping(body)
 	for _, e := range events {
-		reporter.Event(mb.Event{MetricSetFields: e})
+		reporter.Event(mb.TransformMapStrToEvent("kubernetes", e, nil))
 	}
 
 	return


### PR DESCRIPTION
Metricsets that use special fields like `ModuleDataKey` cannot be
directly used as metricset fields of `mb.Event`, they need to be
converted using something like the `mb.TransformMapStrToEvent()`
helper.

Fix #13432