### PR TITLE
Cherry-pick #13426 to 7.4: Fix panic in Redis key metricset

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -180,6 +180,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix redis key metricset dashboard references to index pattern. {pull}13303[13303]
 - Check if fields in DBInstance is nil in rds metricset. {pull}13294[13294] {issue}13037[13037]
 - Fix silent failures in kafka and prometheus module. {pull}13353[13353] {issue}13252[13252]
+- Fix panic in Redis Key metricset when collecting information from a removed key. {pull}13426[13426]
 
 *Packetbeat*
 

--- a/metricbeat/module/redis/key/key.go
+++ b/metricbeat/module/redis/key/key.go
@@ -112,6 +112,10 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 				r.Error(err)
 				continue
 			}
+			if keyInfo == nil {
+				m.Logger().Debugf("Ignoring removed key %s from keyspace %d", key, keyspace)
+				continue
+			}
 			event := eventMapping(keyspace, keyInfo)
 			if !r.Event(event) {
 				m.Logger().Debug("Failed to report event, interrupting fetch")


### PR DESCRIPTION
Cherry-pick of PR #13426 to 7.4 branch. Original message: 

If a key is removed during a fetch, `FetchKeyInfo` returns a nil object,
this nil object should be ignored, if passed to `eventMapping` it
panics.

Reported in https://discuss.elastic.co/t/panic-in-redis-module/197253