### PR TITLE
Cherry-pick #13426 to 7.3: Fix panic in Redis key metricset

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -95,6 +95,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix `logstash/node_stats` metricset to also collect `logstash_stats.events.duration_in_millis` field when `xpack.enabled: true` is set. {pull}13082[13082]
 - Fix `logstash/node` metricset to also collect `logstash_state.pipeline.representation.{type,version,hash}` fields when `xpack.enabled: true` is set. {pull}13133[13133]
 - Check if fields in DBInstance is nil in rds metricset. {pull}13294[13294] {issue}13037[13037]
+- Fix panic in Redis Key metricset when collecting information from a removed key. {pull}13426[13426]
 
 *Packetbeat*
 

--- a/metricbeat/module/redis/key/key.go
+++ b/metricbeat/module/redis/key/key.go
@@ -112,6 +112,10 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 				r.Error(err)
 				continue
 			}
+			if keyInfo == nil {
+				m.Logger().Debugf("Ignoring removed key %s from keyspace %d", key, keyspace)
+				continue
+			}
 			event := eventMapping(keyspace, keyInfo)
 			if !r.Event(event) {
 				m.Logger().Debug("Failed to report event, interrupting fetch")


### PR DESCRIPTION
Cherry-pick of PR #13426 to 7.3 branch. Original message: 

If a key is removed during a fetch, `FetchKeyInfo` returns a nil object,
this nil object should be ignored, if passed to `eventMapping` it
panics.

Reported in https://discuss.elastic.co/t/panic-in-redis-module/197253