### PR TITLE
Cherry-pick #13426 to 7.2: Fix panic in Redis key metricset

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -45,6 +45,7 @@ https://github.com/elastic/beats/compare/v7.2.0...7.2[Check the HEAD diff]
 *Metricbeat*
 
 - Print errors that were being omitted in vSphere metricsets {pull}12816[12816]
+- Fix panic in Redis Key metricset when collecting information from a removed key. {pull}13426[13426]
 
 *Packetbeat*
 

--- a/metricbeat/module/redis/key/key.go
+++ b/metricbeat/module/redis/key/key.go
@@ -104,9 +104,14 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 				r.Error(err)
 				continue
 			}
+			if keyInfo == nil {
+				m.Logger().Debugf("Ignoring removed key %s from keyspace %d", key, p.Keyspace)
+				continue
+			}
 			event := eventMapping(p.Keyspace, keyInfo)
 			if !r.Event(event) {
-				return errors.New("metricset has closed")
+				m.Logger().Debug("Failed to report event, interrupting fetch")
+				return nil
 			}
 		}
 	}


### PR DESCRIPTION
Cherry-pick of PR #13426 to 7.2 branch. Original message: 

If a key is removed during a fetch, `FetchKeyInfo` returns a nil object,
this nil object should be ignored, if passed to `eventMapping` it
panics.

Reported in https://discuss.elastic.co/t/panic-in-redis-module/197253