### PR TITLE
Cherry-pick #13426 to 6.8: Fix panic in Redis key metricset

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -46,6 +46,8 @@ https://github.com/elastic/beats/compare/v6.8.0...6.8.1[Check the HEAD diff]
 
 *Metricbeat*
 
+- Fix panic in Redis Key metricset when collecting information from a removed key. {pull}13426[13426]
+
 *Packetbeat*
 
 *Winlogbeat*

--- a/metricbeat/module/redis/key/key.go
+++ b/metricbeat/module/redis/key/key.go
@@ -95,6 +95,10 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) {
 				logp.Err("Failed to fetch key info for key %s in keyspace %d", key, p.Keyspace)
 				continue
 			}
+			if keyInfo == nil {
+				debugf("Ignoring removed key %s from keyspace %d", key, p.Keyspace)
+				continue
+			}
 			event := eventMapping(p.Keyspace, keyInfo)
 			if !r.Event(event) {
 				debugf("Failed to report event, interrupting Fetch")


### PR DESCRIPTION
Cherry-pick of PR #13426 to 6.8 branch. Original message: 

If a key is removed during a fetch, `FetchKeyInfo` returns a nil object,
this nil object should be ignored, if passed to `eventMapping` it
panics.

Reported in https://discuss.elastic.co/t/panic-in-redis-module/197253