### PR TITLE
Cherry-pick #13433 to 7.3: Fix conversions of events with module fields

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -95,6 +95,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix `logstash/node_stats` metricset to also collect `logstash_stats.events.duration_in_millis` field when `xpack.enabled: true` is set. {pull}13082[13082]
 - Fix `logstash/node` metricset to also collect `logstash_state.pipeline.representation.{type,version,hash}` fields when `xpack.enabled: true` is set. {pull}13133[13133]
 - Check if fields in DBInstance is nil in rds metricset. {pull}13294[13294] {issue}13037[13037]
+- Fix module-level fields in Kubernetes metricsets. {pull}13433[13433]
 
 *Packetbeat*
 

--- a/metricbeat/module/kubernetes/container/container.go
+++ b/metricbeat/module/kubernetes/container/container.go
@@ -99,7 +99,7 @@ func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
 	m.enricher.Enrich(events)
 
 	for _, e := range events {
-		reporter.Event(mb.Event{MetricSetFields: e})
+		reporter.Event(mb.TransformMapStrToEvent("kubernetes", e, nil))
 	}
 
 	return

--- a/metricbeat/module/kubernetes/node/node.go
+++ b/metricbeat/module/kubernetes/node/node.go
@@ -98,7 +98,7 @@ func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
 
 	m.enricher.Enrich([]common.MapStr{event})
 
-	reporter.Event(mb.Event{MetricSetFields: event})
+	reporter.Event(mb.TransformMapStrToEvent("kubernetes", event, nil))
 
 	return
 }

--- a/metricbeat/module/kubernetes/pod/pod.go
+++ b/metricbeat/module/kubernetes/pod/pod.go
@@ -98,7 +98,7 @@ func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
 	m.enricher.Enrich(events)
 
 	for _, e := range events {
-		reporter.Event(mb.Event{MetricSetFields: e})
+		reporter.Event(mb.TransformMapStrToEvent("kubernetes", e, nil))
 	}
 	return
 }

--- a/metricbeat/module/kubernetes/system/system.go
+++ b/metricbeat/module/kubernetes/system/system.go
@@ -89,7 +89,7 @@ func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
 	}
 
 	for _, e := range events {
-		reporter.Event(mb.Event{MetricSetFields: e})
+		reporter.Event(mb.TransformMapStrToEvent("kubernetes", e, nil))
 	}
 	return
 }

--- a/metricbeat/module/kubernetes/volume/volume.go
+++ b/metricbeat/module/kubernetes/volume/volume.go
@@ -83,7 +83,7 @@ func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
 
 	events, err := eventMapping(body)
 	for _, e := range events {
-		reporter.Event(mb.Event{MetricSetFields: e})
+		reporter.Event(mb.TransformMapStrToEvent("kubernetes", e, nil))
 	}
 
 	return


### PR DESCRIPTION
Cherry-pick of PR #13433 to 7.3 branch. Original message: 

Metricsets that use special fields like `ModuleDataKey` cannot be
directly used as metricset fields of `mb.Event`, they need to be
converted using something like the `mb.TransformMapStrToEvent()`
helper.

Fix elastic/beats#13432