### PR TITLE
Cherry-pick #13433 to 7.2: Fix conversions of events with module fields

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -45,6 +45,7 @@ https://github.com/elastic/beats/compare/v7.2.0...7.2[Check the HEAD diff]
 *Metricbeat*
 
 - Print errors that were being omitted in vSphere metricsets {pull}12816[12816]
+- Fix module-level fields in Kubernetes metricsets. {pull}13433[13433]
 
 *Packetbeat*
 

--- a/metricbeat/module/kubernetes/container/container.go
+++ b/metricbeat/module/kubernetes/container/container.go
@@ -99,7 +99,7 @@ func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
 	m.enricher.Enrich(events)
 
 	for _, e := range events {
-		reporter.Event(mb.Event{MetricSetFields: e})
+		reporter.Event(mb.TransformMapStrToEvent("kubernetes", e, nil))
 	}
 
 	return

--- a/metricbeat/module/kubernetes/node/node.go
+++ b/metricbeat/module/kubernetes/node/node.go
@@ -98,7 +98,7 @@ func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
 
 	m.enricher.Enrich([]common.MapStr{event})
 
-	reporter.Event(mb.Event{MetricSetFields: event})
+	reporter.Event(mb.TransformMapStrToEvent("kubernetes", event, nil))
 
 	return
 }

--- a/metricbeat/module/kubernetes/pod/pod.go
+++ b/metricbeat/module/kubernetes/pod/pod.go
@@ -98,7 +98,7 @@ func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
 	m.enricher.Enrich(events)
 
 	for _, e := range events {
-		reporter.Event(mb.Event{MetricSetFields: e})
+		reporter.Event(mb.TransformMapStrToEvent("kubernetes", e, nil))
 	}
 	return
 }

--- a/metricbeat/module/kubernetes/system/system.go
+++ b/metricbeat/module/kubernetes/system/system.go
@@ -89,7 +89,7 @@ func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
 	}
 
 	for _, e := range events {
-		reporter.Event(mb.Event{MetricSetFields: e})
+		reporter.Event(mb.TransformMapStrToEvent("kubernetes", e, nil))
 	}
 	return
 }

--- a/metricbeat/module/kubernetes/volume/volume.go
+++ b/metricbeat/module/kubernetes/volume/volume.go
@@ -83,7 +83,7 @@ func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
 
 	events, err := eventMapping(body)
 	for _, e := range events {
-		reporter.Event(mb.Event{MetricSetFields: e})
+		reporter.Event(mb.TransformMapStrToEvent("kubernetes", e, nil))
 	}
 
 	return


### PR DESCRIPTION
Cherry-pick of PR #13433 to 7.2 branch. Original message: 

Metricsets that use special fields like `ModuleDataKey` cannot be
directly used as metricset fields of `mb.Event`, they need to be
converted using something like the `mb.TransformMapStrToEvent()`
helper.

Fix elastic/beats#13432