### PR TITLE
Correct port inconsistency in documentation

### DIFF
--- a/metricbeat/docs/autodiscover-hints.asciidoc
+++ b/metricbeat/docs/autodiscover-hints.asciidoc
@@ -12,7 +12,7 @@ it. Hints tell {beatname_uc} how to get metrics for the given container. This is
 ===== `co.elastic.metrics/hosts`
 
 Hosts setting to use with the given module. Hosts can include `${data.host}` and `${data.port}`
-values from the autodiscover event, ie: `${data.host}:80`.
+values from the autodiscover event, ie: `${data.host}:9090`.
 
 [float]
 ===== `co.elastic.metrics/metricsets`
@@ -107,7 +107,7 @@ hint. For example, these hints configure a common behavior for all containers in
 -------------------------------------------------------------------------------------
 annotations:
   co.elastic.metrics/module: apache
-  co.elastic.metrics/hosts: '${data.host}:80'
+  co.elastic.metrics/hosts: '${data.host}:9090'
   co.elastic.metrics.sidecar/hosts: '${data.host}:8080'
 -------------------------------------------------------------------------------------
 
@@ -130,7 +130,7 @@ You can label Docker containers with useful info to spin up {beatname_uc} module
 -------------------------------------------------------------------------------------
   co.elastic.metrics/module: nginx
   co.elastic.metrics/metricsets: stubstatus
-  co.elastic.metrics/hosts: '${data.host}:80'
+  co.elastic.metrics/hosts: '${data.host}:9090'
   co.elastic.metrics/period: 10s
 -------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Correct port inconsistency in documentation to refer to port 9090 instead of a mix of 80 & 9090, as port 80 is generally used for a web service and a prometheus endpoint is likely to be separate from a service's primary purpose.