### PR TITLE
Adding missing CHANGELOG entries

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -68,6 +68,9 @@ https://github.com/elastic/beats/compare/v6.8.0...6.8.1[Check the HEAD diff]
 
 *Metricbeat*
 
+- Remove _nodes field from under cluster_stats as it's not being used. {pull}13010[13010]
+- Collect license expiry date fields as well. {pull}11652[11652]
+
 *Packetbeat*
 
 *Winlogbeat*


### PR DESCRIPTION
This PR adds missing CHANGELOG entries for https://github.com/elastic/beats/pull/13010 and https://github.com/elastic/beats/pull/13011.