### PR TITLE
[SIEM] [Filebeat] Fix Cisco FTD/ASA parsing of msg 302021

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -30,6 +30,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - `convert_timezone` option is removed and locale is always added to the event so timezone is used when parsing the timestamp, this behaviour can be overriden with processors. {pull}12410[12410]
 - Fix a race condition in the TCP input when close the client socket. {pull}13038[13038]
 - cisco/asa fileset: Renamed log.original to event.original and cisco.asa.list_id to cisco.asa.rule_name. {pull}13286[13286]
+- cisco/asa fileset: Fix parsing of 302021 message code. {pull}13476[13476]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/module/cisco/asa/test/hostnames.log
+++ b/x-pack/filebeat/module/cisco/asa/test/hostnames.log
@@ -1,0 +1,1 @@
+Oct 10 2019 10:21:36 localhost: %ASA-6-302021: Teardown ICMP connection for faddr target.destination.hostname.local/10005 gaddr 10.0.55.66/0 laddr Prod-host.name.addr/0

--- a/x-pack/filebeat/module/cisco/asa/test/hostnames.log-expected.json
+++ b/x-pack/filebeat/module/cisco/asa/test/hostnames.log-expected.json
@@ -1,0 +1,29 @@
+[
+    {
+        "@timestamp": "2019-10-10T10:21:36.000Z",
+        "cisco.asa.icmp_code": 0,
+        "cisco.asa.mapped_source_ip": "10.0.55.66",
+        "cisco.asa.message_id": "302021",
+        "destination.domain": "target.destination.hostname.local",
+        "event.action": "flow-expiration",
+        "event.code": 302021,
+        "event.dataset": "cisco.asa",
+        "event.module": "cisco",
+        "event.original": "%ASA-6-302021: Teardown ICMP connection for faddr target.destination.hostname.local/10005 gaddr 10.0.55.66/0 laddr Prod-host.name.addr/0",
+        "event.severity": 6,
+        "event.timezone": "+00:00",
+        "fileset.name": "asa",
+        "host.hostname": "localhost",
+        "input.type": "log",
+        "log.level": "informational",
+        "log.offset": 0,
+        "network.iana_number": 1,
+        "network.transport": "icmp",
+        "service.type": "cisco",
+        "source.domain": "Prod-host.name.addr",
+        "source.nat.ip": "10.0.55.66",
+        "tags": [
+            "cisco-asa"
+        ]
+    }
+]

--- a/x-pack/filebeat/module/cisco/asa/test/sample.log-expected.json
+++ b/x-pack/filebeat/module/cisco/asa/test/sample.log-expected.json
@@ -329,9 +329,10 @@
     },
     {
         "@timestamp": "2011-06-04T21:59:52.000Z",
+        "cisco.asa.icmp_code": 17233,
+        "cisco.asa.mapped_source_ip": "192.168.132.46",
         "cisco.asa.message_id": "302021",
-        "destination.ip": "192.168.132.46",
-        "destination.port": 17233,
+        "destination.ip": "172.24.177.29",
         "event.action": "flow-expiration",
         "event.code": 302021,
         "event.dataset": "cisco.asa",
@@ -347,8 +348,7 @@
         "network.iana_number": 1,
         "network.transport": "icmp",
         "service.type": "cisco",
-        "source.ip": "172.24.177.29",
-        "source.port": 0,
+        "source.ip": "192.168.132.46",
         "tags": [
             "cisco-asa"
         ]

--- a/x-pack/filebeat/module/cisco/ftd/test/sample.log-expected.json
+++ b/x-pack/filebeat/module/cisco/ftd/test/sample.log-expected.json
@@ -329,9 +329,10 @@
     },
     {
         "@timestamp": "2011-06-04T21:59:52.000Z",
+        "cisco.ftd.icmp_code": 17233,
+        "cisco.ftd.mapped_source_ip": "192.168.132.46",
         "cisco.ftd.message_id": "302021",
-        "destination.ip": "192.168.132.46",
-        "destination.port": 17233,
+        "destination.ip": "172.24.177.29",
         "event.action": "flow-expiration",
         "event.code": 302021,
         "event.dataset": "cisco.ftd",
@@ -347,8 +348,7 @@
         "network.iana_number": 1,
         "network.transport": "icmp",
         "service.type": "cisco",
-        "source.ip": "172.24.177.29",
-        "source.port": 0,
+        "source.ip": "192.168.132.46",
         "tags": [
             "cisco-ftd"
         ]

--- a/x-pack/filebeat/module/cisco/shared/ingest/asa-ftd-pipeline.yml
+++ b/x-pack/filebeat/module/cisco/shared/ingest/asa-ftd-pipeline.yml
@@ -393,9 +393,12 @@ processors:
      if: "[\"302014\", \"302016\", \"302018\", \"302021\", \"302036\", \"302304\", \"302306\"].contains(ctx._temp_.cisco.message_id)"
      patterns:
       - "Teardown %{NOTSPACE:network.transport} (?:state-bypass )?connection %{NOTSPACE:_temp_.cisco.connection_id} (?:for|from) %{NOTCOLON:_temp_.cisco.source_interface}:%{IP:source.ip}/%{NUMBER:source.port:int} (?:%{NOTSPACE:_temp_.cisco.source_username} )?to %{NOTCOLON:_temp_.cisco.destination_interface}:%{IP:destination.ip}/%{NUMBER:destination.port:int} (?:%{NOTSPACE:_temp_.cisco.destination_username} )?(?:duration %{TIME:_temp_.duration_hms} bytes %{NUMBER:network.bytes:int})%{GREEDYDATA}"
-      - "Teardown %{NOTSPACE:network.transport} connection for faddr (?:%{NOTCOLON:_temp_.cisco.source_interface}:)?%{IP:source.ip}/%{NUMBER:source.port:int} (?:%{NOTSPACE:_temp_.cisco.source_username} )?gaddr (?:%{NOTCOLON}:)?%{IP}/%{NUMBER} laddr (?:%{NOTCOLON:_temp_.cisco.destination_interface}:)?%{IP:destination.ip}/%{NUMBER:destination.port:int}(?: %{NOTSPACE:_temp_.cisco.destination_username})?%{GREEDYDATA}"
+      - "Teardown %{NOTSPACE:network.transport} connection for faddr (?:%{NOTCOLON:_temp_.cisco.source_interface}:)?%{ECSDESTIPORHOST}/%{NUMBER} (?:%{NOTSPACE:_temp_.cisco.destination_username} )?gaddr (?:%{NOTCOLON}:)?%{MAPPEDSRC}/%{NUMBER} laddr (?:%{NOTCOLON:_temp_.cisco.source_interface}:)?%{ECSSOURCEIPORHOST}/%{NUMBER:_temp_.cisco.icmp_code:int}(?: %{NOTSPACE:_temp_.cisco.source_username})?%{GREEDYDATA}"
      pattern_definitions:
       NOTCOLON: "[^:]*"
+      ECSSOURCEIPORHOST: "(?:%{IP:source.ip}|%{HOSTNAME:source.domain})"
+      ECSDESTIPORHOST: "(?:%{IP:destination.ip}|%{HOSTNAME:destination.domain})"
+      MAPPEDSRC: "(?:%{IP:_temp_.cisco.mapped_source_ip}|%{HOSTNAME})"
 
 #
 # Decode FTD's Security Event Syslog Messages


### PR DESCRIPTION
The pattern for ASA [message 302021](https://www.cisco.com/c/en/us/td/docs/security/asa/syslog/b_syslog/syslogs3.html#con_8399919) contained a few errors:
- source and destination swapped.
- storing ICMP codes as port numbers.
- didn't support hostnames in place of IPs.

Fixes #13259