### PR TITLE
Cherrypick #13458 to 7.4 [Metricbeat] Ignore empty events when reporting from cloudwatch metricset

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -188,6 +188,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix issue with aws cloudwatch module where dimensions and/or namespaces that contain space are not being parsed correctly {pull}13389[13389]
 - Fix module-level fields in Kubernetes metricsets. {pull}13433[13433]
 - Fix panic in Redis Key metricset when collecting information from a removed key. {pull}13426[13426]
+- Fix reporting empty events in cloudwatch metricset. {pull}13458[13458]
 
 *Packetbeat*
 

--- a/x-pack/metricbeat/module/aws/_meta/config.yml
+++ b/x-pack/metricbeat/module/aws/_meta/config.yml
@@ -11,7 +11,7 @@
   metrics:
     - namespace: AWS/EC2
       name: ["CPUUtilization", "DiskWriteOps"]
-      tags.resource_type_filter: ec2:intance
+      tags.resource_type_filter: ec2:instance
       #dimensions:
       #  - name: InstanceId
       #    value: i-0686946e22cf9494a

--- a/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch.go
+++ b/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch.go
@@ -323,39 +323,6 @@ func constructLabel(metric cloudwatch.Metric, statistic string) string {
 	return label
 }
 
-func getIdentifiers(metricsWithStatsTotal []metricsWithStatistics) map[string][]string {
-	if len(metricsWithStatsTotal) == 0 {
-		return nil
-	}
-
-	identifiers := map[string][]string{}
-	for _, metricsWithStats := range metricsWithStatsTotal {
-		identifierName := ""
-		identifierValue := ""
-		if len(metricsWithStats.cloudwatchMetric.Dimensions) == 0 {
-			continue
-		}
-
-		for i, dim := range metricsWithStats.cloudwatchMetric.Dimensions {
-			identifierName += *dim.Name
-			identifierValue += *dim.Value
-			if i != len(metricsWithStats.cloudwatchMetric.Dimensions)-1 {
-				identifierName += ","
-				identifierValue += ","
-			}
-		}
-
-		if identifiers[identifierName] != nil {
-			if !aws.StringInSlice(identifierValue, identifiers[identifierName]) {
-				identifiers[identifierName] = append(identifiers[identifierName], identifierValue)
-			}
-		} else {
-			identifiers[identifierName] = []string{identifierValue}
-		}
-	}
-	return identifiers
-}
-
 func statisticLookup(stat string) (string, bool) {
 	statisticLookupTable := map[string]string{
 		"Average":     "avg",
@@ -405,14 +372,9 @@ func (m *MetricSet) createEvents(svcCloudwatch cloudwatchiface.ClientAPI, svcRes
 		m.Logger().Info(errors.Wrap(err, "getResourcesTags failed, skipping region "+regionName))
 	}
 
-	identifiers := getIdentifiers(listMetricWithStatsTotal)
-	// Initialize events map per region, which stores one event per identifierValue
+	// Initialize events for each identifier.
 	events := map[string]mb.Event{}
-	for _, values := range identifiers {
-		for _, v := range values {
-			events[v] = aws.InitEvent(regionName)
-		}
-	}
+
 	// Initialize events for the ones without identifiers.
 	var eventsNoIdentifier []mb.Event
 
@@ -441,6 +403,10 @@ func (m *MetricSet) createEvents(svcCloudwatch cloudwatchiface.ClientAPI, svcRes
 				labels := strings.Split(*output.Label, labelSeperator)
 				if len(labels) == 5 {
 					identifierValue := labels[identifierValueIdx]
+					if _, ok := events[identifierValue]; !ok {
+						events[identifierValue] = aws.InitEvent(regionName)
+					}
+
 					events[identifierValue] = insertRootFields(events[identifierValue], output.Values[timestampIdx], labels)
 					tags := resourceTagMap[identifierValue]
 					for _, tag := range tags {

--- a/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch_test.go
+++ b/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch_test.go
@@ -167,12 +167,6 @@ var (
 	}
 )
 
-func TestGetIdentifiers(t *testing.T) {
-	listMetricDetailTotal := []metricsWithStatistics{metricsWithStat1, metricsWithStat2, metricsWithStat3, metricsWithStat4}
-	identifiers := getIdentifiers(listMetricDetailTotal)
-	assert.Equal(t, []string{instanceID1, instanceID2}, identifiers["InstanceId"])
-}
-
 func TestConstructLabel(t *testing.T) {
 	cases := []struct {
 		listMetricDetail cloudwatch.Metric

--- a/x-pack/metricbeat/modules.d/aws.yml.disabled
+++ b/x-pack/metricbeat/modules.d/aws.yml.disabled
@@ -14,7 +14,7 @@
   metrics:
     - namespace: AWS/EC2
       name: ["CPUUtilization", "DiskWriteOps"]
-      tags.resource_type_filter: ec2:intance
+      tags.resource_type_filter: ec2:instance
       #dimensions:
       #  - name: InstanceId
       #    value: i-0686946e22cf9494a


### PR DESCRIPTION
Cherry-pick of PR #13458 to 7.4 branch. Original message:

When testing cloudwatch metricset, found some empty events reported by cloudwatch metricset. The code should handle this by ignoring empty events. 

Also when testing tag collection, a typo in config example caused me to waste a lot of time 😂 This PR also will fix the typo in cloudwatch config example.

(cherry picked from commit 80a1a5aaec9cdcc5d7038c3b8e75242753ccf84e)