### PR TITLE
Cherry-pick #13376 to 7.4: Add more error messages in kafka module

### DIFF
--- a/metricbeat/module/kafka/broker.go
+++ b/metricbeat/module/kafka/broker.go
@@ -110,7 +110,7 @@ func (b *Broker) Close() error {
 // Connect connects the broker to the configured host
 func (b *Broker) Connect() error {
 	if err := b.broker.Open(b.cfg); err != nil {
-		return err
+		return errors.Wrap(err, "broker.Open failed")
 	}
 
 	if b.id != noID || !b.matchID {
@@ -121,7 +121,7 @@ func (b *Broker) Connect() error {
 	meta, err := queryMetadataWithRetry(b.broker, b.cfg, nil)
 	if err != nil {
 		closeBroker(b.broker)
-		return err
+		return errors.Wrap(err, "failed to query metadata")
 	}
 
 	finder := brokerFinder{Net: &defaultNet{}}


### PR DESCRIPTION
Cherry-pick of PR #13376 to 7.4 branch. Original message:

When trying to debug this EOF error, there is no information on exactly where it happened. Hopefully adding these error messages will help when this problem happens again.
```
2019-08-01T20:31:02.479+0200    INFO    kafka/log.go:53 Connected to broker at localhost:9093 (unregistered)
2019-08-01T20:31:02.731+0200    INFO    kafka/log.go:53 Closed connection to broker localhost:9093
2019-08-01T20:31:02.731+0200    INFO    module/wrapper.go:244   Error fetching data for metricset kafka.consumergroup: error in connect: EOF
2019-08-01T20:31:10.539+0200    INFO    kafka/log.go:53 Connected to broker at localhost:9093 (unregistered)
2019-08-01T20:31:10.791+0200    INFO    kafka/log.go:53 Closed connection to broker localhost:9093
2019-08-01T20:31:10.791+0200    INFO    module/wrapper.go:244   Error fetching data for metricset kafka.partition: error in connect: EOF
```

(cherry picked from commit 1df429222328cb526592fd4ae2c57d69ec9743ba)