### PR TITLE
Add o365beat to community beats list.

### DIFF
--- a/libbeat/docs/communitybeats.asciidoc
+++ b/libbeat/docs/communitybeats.asciidoc
@@ -81,6 +81,7 @@ https://github.com/mrkschan/nginxbeat[nginxbeat]:: Reads status from Nginx.
 https://github.com/2Fast2BCn/nginxupstreambeat[nginxupstreambeat]:: Reads upstream status from nginx upstream module.
 https://github.com/mschneider82/nsqbeat[nsqbeat]:: Reads data from a NSQ topic.
 https://github.com/eBay/nvidiagpubeat[nvidiagpubeat]:: Uses nvidia-smi to grab metrics of NVIDIA GPUs.
+https://github.com/counteractive/o365beat[o365beat]:: Ships Office 365 logs from the O365 Management Activities API
 https://github.com/aristanetworks/openconfigbeat[openconfigbeat]:: Streams data from http://openconfig.net[OpenConfig]-enabled network devices
 https://github.com/radoondas/owmbeat[owmbeat]:: Open Weather Map beat to pull weather data from all around the world and store and visualize them in Elastic Stack
 https://github.com/joehillen/packagebeat[packagebeat]:: Collects information about system packages from package


### PR DESCRIPTION
This pull request adds [o365beat ](https://github.com/counteractive/o365beat) to the community beats list, per the instructions at https://www.elastic.co/guide/en/beats/libbeat/current/community-beats.html.  Please let me know if there's anything that needs to be modified before merging.  Thanks!