### PR TITLE
Cherry-pick #13369 to 7.3: Fix filebeat nginx module ingest timezone

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -79,6 +79,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Reduce memory usage if long lines are truncated to fit `max_bytes` limit. The line buffer is copied into a smaller buffer now. This allows the runtime to release unused memory earlier. {pull}11524[11524]
 - Fix filebeat autodiscover fileset hint for container input. {pull}13296[13296]
 - Fix timezone parsing of system module ingest pipelines. {pull}13308[13308]
+- Fix timezone parsing of nginx module ingest pipelines. {pull}13369[13369]
 - Fix incorrect field references in envoyproxy dashboard {issue}13420[13420] {pull}13421[13421]
 
 *Heartbeat*

--- a/filebeat/module/nginx/access/ingest/default.json
+++ b/filebeat/module/nginx/access/ingest/default.json
@@ -89,15 +89,6 @@
                 "formats": [
                     "dd/MMM/yyyy:H:m:s Z"
                 ],
-                "ignore_failure": true
-            }
-        },
-        {
-            "date": {
-                "if": "ctx.event.timezone != null",
-                "field": "@timestamp",
-                "formats": ["ISO8601"],
-                "timezone": "{{ event.timezone }}",
                 "on_failure": [{"append": {"field": "error.message", "value": "{{ _ingest.on_failure_message }}"}}]
             }
         },

--- a/filebeat/module/nginx/error/ingest/pipeline.json
+++ b/filebeat/module/nginx/error/ingest/pipeline.json
@@ -23,8 +23,9 @@
   }, {
     "date": {
       "if": "ctx.event.timezone != null",
-      "field": "@timestamp",
-      "formats": ["ISO8601"],
+      "field": "nginx.error.time",
+      "target_field": "@timestamp",
+      "formats": ["yyyy/MM/dd H:m:s"],
       "timezone": "{{ event.timezone }}",
       "on_failure": [{"append": {"field": "error.message", "value": "{{ _ingest.on_failure_message }}"}}]
     }


### PR DESCRIPTION
Cherry-pick of PR #13369 to 7.3 branch. Original message: 

This pull request fixes timezone parsing for nginx module.

Just like elastic/beats#13308 fixes ingest timezone parsing for system module.