### PR TITLE
Make bulk_max_size configurable in outputs of Functionbeat

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -372,6 +372,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Configurable tags for Lambda functions. {pull}13352[13352]
 - Add input for Cloudwatch logs through Kinesis. {pull}13317[13317]
 - Enable Logstash output. {pull}13345[13345]
+- Make `bulk_max_size` configurable in outputs. {pull}13493[13493]
 
 *Winlogbeat*
 

--- a/x-pack/functionbeat/config/config.go
+++ b/x-pack/functionbeat/config/config.go
@@ -32,16 +32,8 @@ var (
 		"logging.to_stderr": true,
 		"logging.to_files":  false,
 	})
-	esOverrides = common.MustNewConfigFrom(map[string]interface{}{
-		"queue.mem.events":                   "${output.elasticsearch.bulk_max_size}",
-		"output.elasticsearch.bulk_max_size": 50,
-	})
 	logstashOverrides = common.MustNewConfigFrom(map[string]interface{}{
-		"queue.mem.events": "${output.logstash.bulk_max_size}",
-		"output.logstash": map[string]interface{}{
-			"bulk_max_size": 50,
-			"pipelining":    0,
-		},
+		"output.logstash.pipelining": 0,
 	})
 
 	// Overrides overrides the default configuration provided by libbeat.
@@ -53,10 +45,6 @@ var (
 		cfgfile.ConditionalOverride{
 			Check:  isLogstash,
 			Config: logstashOverrides,
-		},
-		cfgfile.ConditionalOverride{
-			Check:  isElasticsearch,
-			Config: esOverrides,
 		},
 	}
 
@@ -100,10 +88,6 @@ var always = func(_ *common.Config) bool {
 
 var isLogstash = func(cfg *common.Config) bool {
 	return isOutput(cfg, "logstash")
-}
-
-var isElasticsearch = func(cfg *common.Config) bool {
-	return isOutput(cfg, "elasticsearch")
 }
 
 func isOutput(cfg *common.Config, name string) bool {


### PR DESCRIPTION
Previously, `bulk_max_size` was set to 50 in Functionbeat. From now on it is configurable from `functionbeat.yml`.

The new default value for this option in case of LS output is 2048.