### PR TITLE
[libbeat] Update lookslike to 0.3.0

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -741,8 +741,8 @@ Elasticsearch, B.V. (https://www.elastic.co/).
 
 --------------------------------------------------------------------
 Dependency: github.com/elastic/go-lookslike
-Version: v0.2.0
-Revision: 807124eb9fc6684949aa99744577175fd6bac4fd
+Version: =v0.3.0
+Revision: 747dc7db1c961662d8e225a42af6c3859a1a0f1d
 License type (autodetected): Apache-2.0
 ./vendor/github.com/elastic/go-lookslike/LICENSE:
 --------------------------------------------------------------------

--- a/heartbeat/monitors/active/http/http_test.go
+++ b/heartbeat/monitors/active/http/http_test.go
@@ -31,6 +31,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/elastic/beats/heartbeat/hbtest"
 	"github.com/elastic/beats/heartbeat/monitors/wrappers"
 	"github.com/elastic/beats/libbeat/beat"
@@ -43,7 +45,6 @@ import (
 	"github.com/elastic/go-lookslike/llresult"
 	"github.com/elastic/go-lookslike/testslike"
 	"github.com/elastic/go-lookslike/validator"
-	"github.com/stretchr/testify/require"
 )
 
 func testRequest(t *testing.T, testURL string) *beat.Event {

--- a/heartbeat/monitors/active/http/http_test.go
+++ b/heartbeat/monitors/active/http/http_test.go
@@ -21,8 +21,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"github.com/elastic/go-lookslike/llpath"
-	"github.com/elastic/go-lookslike/llresult"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -33,8 +31,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/elastic/beats/heartbeat/hbtest"
 	"github.com/elastic/beats/heartbeat/monitors/wrappers"
 	"github.com/elastic/beats/libbeat/beat"
@@ -43,8 +39,11 @@ import (
 	btesting "github.com/elastic/beats/libbeat/testing"
 	"github.com/elastic/go-lookslike"
 	"github.com/elastic/go-lookslike/isdef"
+	"github.com/elastic/go-lookslike/llpath"
+	"github.com/elastic/go-lookslike/llresult"
 	"github.com/elastic/go-lookslike/testslike"
 	"github.com/elastic/go-lookslike/validator"
+	"github.com/stretchr/testify/require"
 )
 
 func testRequest(t *testing.T, testURL string) *beat.Event {
@@ -104,8 +103,8 @@ func respondingHTTPChecks(url string, statusCode int) validator.Validator {
 		httpBaseChecks(url),
 		lookslike.MustCompile(map[string]interface{}{
 			"http": map[string]interface{}{
-				"response.status_code":   statusCode,
-				"response.body.hash": isdef.IsString,
+				"response.status_code": statusCode,
+				"response.body.hash":   isdef.IsString,
 				// TODO add this isdef to lookslike in a robust way
 				"response.body.bytes": isdef.Is("an int64 greater than 0", func(path llpath.Path, v interface{}) *llresult.Results {
 					raw, ok := v.(int64)

--- a/vendor/github.com/elastic/go-lookslike/README.md
+++ b/vendor/github.com/elastic/go-lookslike/README.md
@@ -7,7 +7,7 @@ This library is here to help you with all your data validation needs. It's ideal
 ## Quick Links
 
 * [GoDoc](https://godoc.org/github.com/elastic/go-lookslike) for this library.
-* [Runnable Examples](https://github.com/elastic/go-lookslike/blob/master/lookslike/doc_test.go).
+* [Runnable Examples](https://github.com/elastic/go-lookslike/blob/master/doc_test.go).
 
 ## Install
 
@@ -25,7 +25,7 @@ If using govendor run:
 
 ## Real World Usage Examples
 
-lookslike was created to improve the testing of various structures in [elastic/beats](https://github.com/elastic/beats). Searching the tests for `lookslike` will show real world usage.
+lookslike was created to improve the testing of various structures in [elastic/beats](https://github.com/elastic/beats/search?q=lookslike.MustCompile&unscoped_q=lookslike.MustCompile). Searching the tests for `lookslike.MustCompile` will show real world usage.
 
 ## Call for More `isdef`s!
 

--- a/vendor/github.com/elastic/go-lookslike/compiled_schema.go
+++ b/vendor/github.com/elastic/go-lookslike/compiled_schema.go
@@ -21,6 +21,7 @@ import (
 	"github.com/elastic/go-lookslike/isdef"
 	"github.com/elastic/go-lookslike/llpath"
 	"github.com/elastic/go-lookslike/llresult"
+	"reflect"
 )
 
 type flatValidator struct {
@@ -35,11 +36,16 @@ type CompiledSchema []flatValidator
 func (cs CompiledSchema) Check(actual interface{}) *llresult.Results {
 	res := llresult.NewResults()
 	for _, pv := range cs {
-		actualV, actualKeyExists := pv.path.GetFrom(actual)
+		actualVal, actualKeyExists := pv.path.GetFrom(reflect.ValueOf(actual))
+		var actualInter interface{}
+		zero := reflect.Value{}
+		if actualVal != zero {
+			actualInter = actualVal.Interface()
+		}
 
 		if !pv.isDef.Optional || pv.isDef.Optional && actualKeyExists {
 			var checkRes *llresult.Results
-			checkRes = pv.isDef.Check(pv.path, actualV, actualKeyExists)
+			checkRes = pv.isDef.Check(pv.path, actualInter, actualKeyExists)
 			res.Merge(checkRes)
 		}
 	}

--- a/vendor/github.com/elastic/go-lookslike/internal/llreflect/chase.go
+++ b/vendor/github.com/elastic/go-lookslike/internal/llreflect/chase.go
@@ -1,0 +1,13 @@
+package llreflect
+
+import (
+	"reflect"
+)
+
+// ChaseValue takes a value and returns the underlying type even if it is nested inpointers or wrapped in interface{}
+func ChaseValue(v reflect.Value) reflect.Value {
+	for (v.Kind() == reflect.Ptr || v.Kind() == reflect.Interface) && !v.IsNil() {
+		v = v.Elem()
+	}
+	return v
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -980,13 +980,18 @@
 			"versionExact": "v0.4.0"
 		},
 		{
-			"checksumSHA1": "c54eehjtxPjBUbM4aQuDPgc7G9Q=",
+			"checksumSHA1": "+nIsRlnG94bUQI6IQd4Mcj4diTY=",
 			"path": "github.com/elastic/go-lookslike",
-			"revision": "807124eb9fc6684949aa99744577175fd6bac4fd",
-			"revisionTime": "2019-06-17T15:05:19Z",
+			"revision": "747dc7db1c961662d8e225a42af6c3859a1a0f1d",
+			"revisionTime": "2019-09-04T15:56:46Z",
 			"tree": true,
-			"version": "v0.2.0",
-			"versionExact": "v0.2.0"
+			"version": "=v0.3.0",
+			"versionExact": "v0.3.0"
+		},
+		{
+			"path": "github.com/elastic/go-lookslike^",
+			"revision": "=v0.3.0",
+			"version": "=v0.3.0"
 		},
 		{
 			"checksumSHA1": "3jizmlZPCyo6FAZY8Trk9jA8NH4=",


### PR DESCRIPTION
Updates the [go-lookslike](https://github.com/elastic/go-lookslike) library we maintain to 0.3.0 which uses a much improved reflection strategy. This fixed an issue in the last release where `Strict()` which checked for extra fields wasn't working. As a result some of our tests developed since then didn't assert that the new fields added in #13022 were actually valid. Those tests are fixed in this PR.