### PR TITLE
Update processors-using.asciidoc

### DIFF
--- a/libbeat/docs/processors-using.asciidoc
+++ b/libbeat/docs/processors-using.asciidoc
@@ -28,7 +28,7 @@ of action, such as selecting the fields that are exported or adding metadata to
 the event.
 * `<condition>` specifies an optional <<conditions,condition>>. If the
 condition is present, then the action is executed only if the condition is
-fulfilled. If no condition is passed, then the action is always executed.
+fulfilled. If no condition is set, then the action is always executed.
 * `<parameters>` is the list of parameters to pass to the processor.
 
 More complex conditional processing can be accomplished by using the


### PR DESCRIPTION
This could make people wonder about it.
“pass” means that "there is condition, and the condition is
fulfilled."
"set" is better, we usually use "set a configuration"