### PR TITLE
Implement range condition on array size

### DIFF
--- a/libbeat/conditions/range.go
+++ b/libbeat/conditions/range.go
@@ -142,9 +142,8 @@ func (c Range) Check(event ValuesMap) bool {
 				count := reflect.ValueOf(value).Len()
 				if !checkValue(float64(count), rangeValue) {
 					return false
-				} else {
-					return true
 				}
+				return true
 			}
 
 			logp.L().Named(logName).Warnf("unexpected type %T in range condition.", value)

--- a/libbeat/conditions/range.go
+++ b/libbeat/conditions/range.go
@@ -137,6 +137,16 @@ func (c Range) Check(event ValuesMap) bool {
 			}
 
 		default:
+			// If it's an Slice, apply range on number of elements
+			if reflect.TypeOf(value).Kind() == reflect.Slice {
+				count := reflect.ValueOf(value).Len()
+				if !checkValue(float64(count), rangeValue) {
+					return false
+				} else {
+					return true
+				}
+			}
+
 			logp.L().Named(logName).Warnf("unexpected type %T in range condition.", value)
 			return false
 		}

--- a/libbeat/conditions/range_test.go
+++ b/libbeat/conditions/range_test.go
@@ -116,3 +116,35 @@ func TestOpenGteRangeConditionPositiveMatch(t *testing.T) {
 func TestOpenGteRangeConditionNegativeMatch(t *testing.T) {
 	testConfig(t, false, httpResponseTestEvent, procCPURangeConfig)
 }
+
+func TestRangeOnArrayConditionPositiveMatch(t *testing.T) {
+	httpResponseTestEventWithArray := &beat.Event{
+		Timestamp: time.Now(),
+		Fields: common.MapStr{
+			"tags":  []string{"auditbeat", "prod", "security"},
+		},
+	}
+
+	testConfig(t, true, httpResponseTestEventWithArray, &Config{
+		Range: &Fields{fields: map[string]interface{}{
+			"tags.gt": 0,
+			"tags.lt": 4,
+		}},
+	})
+}
+
+
+func TestRangeOnArrayConditionNegativeMatch(t *testing.T) {
+	httpResponseTestEventWithArray := &beat.Event{
+		Timestamp: time.Now(),
+		Fields: common.MapStr{
+			"tags":  []string{"auditbeat", "prod", "security"},
+		},
+	}
+
+	testConfig(t, false, httpResponseTestEventWithArray, &Config{
+		Range: &Fields{fields: map[string]interface{}{
+			"tags.lt": 2,
+		}},
+	})
+}

--- a/libbeat/conditions/range_test.go
+++ b/libbeat/conditions/range_test.go
@@ -121,7 +121,7 @@ func TestRangeOnArrayConditionPositiveMatch(t *testing.T) {
 	httpResponseTestEventWithArray := &beat.Event{
 		Timestamp: time.Now(),
 		Fields: common.MapStr{
-			"tags":  []string{"auditbeat", "prod", "security"},
+			"tags": []string{"auditbeat", "prod", "security"},
 		},
 	}
 
@@ -133,12 +133,11 @@ func TestRangeOnArrayConditionPositiveMatch(t *testing.T) {
 	})
 }
 
-
 func TestRangeOnArrayConditionNegativeMatch(t *testing.T) {
 	httpResponseTestEventWithArray := &beat.Event{
 		Timestamp: time.Now(),
 		Fields: common.MapStr{
-			"tags":  []string{"auditbeat", "prod", "security"},
+			"tags": []string{"auditbeat", "prod", "security"},
 		},
 	}
 

--- a/libbeat/docs/processors-using.asciidoc
+++ b/libbeat/docs/processors-using.asciidoc
@@ -314,7 +314,8 @@ regexp:
 
 The `range` condition checks if the field is in a certain range of values. The
 condition supports `lt`, `lte`, `gt` and `gte`. The condition accepts only
-integer or float values.
+integer, float values or arrays (in that case, the checked value is the 
+number of array entries).
 
 For example, the following condition checks for failed HTTP transactions by
 comparing the `http.response.code` field with 400.


### PR DESCRIPTION
That contribution add the capability to check the number of entries of an array with the range condition.

Our use case was to check that the response of a json API is not empty with heartbeat. 
We think that it can be pretty useful and the implementation is as simple as possible.

I'm not a natural go coder, so please do comments (negatives and positives 😄)

Thanks !