### PR TITLE
Remove subcommand run from manager

### DIFF
--- a/x-pack/functionbeat/manager/cmd/root.go
+++ b/x-pack/functionbeat/manager/cmd/root.go
@@ -5,6 +5,10 @@
 package cmd
 
 import (
+	"os"
+
+	"github.com/spf13/cobra"
+
 	cmd "github.com/elastic/beats/libbeat/cmd"
 	"github.com/elastic/beats/libbeat/cmd/instance"
 	"github.com/elastic/beats/x-pack/functionbeat/config"
@@ -22,6 +26,12 @@ func init() {
 		Name:            Name,
 		ConfigOverrides: config.Overrides,
 	})
+
+	RootCmd.RemoveCommand(RootCmd.RunCmd)
+	RootCmd.Run = func(_ *cobra.Command, _ []string) {
+		RootCmd.Usage()
+		os.Exit(1)
+	}
 
 	RootCmd.AddCommand(genDeployCmd())
 	RootCmd.AddCommand(genUpdateCmd())


### PR DESCRIPTION
Removed run subcommand from Functionbeat, as it does not do anything. It was just a leftover from other Beats. This also needs to be followed up in the docs.

When someone wants to run it, help is displayed and 1 is returned. 

```
$ ./functionbeat
Usage:
  functionbeat [flags]
  functionbeat [command]

Available Commands:
  deploy      Deploy a function
  export      Export current config, index template or function
  help        Help about any command
  keystore    Manage secrets keystore
  package     Package the configuration and the executable in a zip
  remove      Remove a function
  setup       Setup index template, dashboards and ML jobs
  test        Test config
  update      Update a function
  version     Show current version info

Flags:
  -E, --E setting=value      Configuration overwrite
  -N, --N                    Disable actual publishing for testing
  -c, --c string             Configuration file, relative to path.config (default "functionbeat.yml")
      --cpuprofile string    Write cpu profile to file
  -d, --d string             Enable certain debug selectors
  -e, --e                    Log to stderr and disable syslog/file output
  -h, --help                 help for functionbeat
      --httpprof string      Start pprof http server
      --memprofile string    Write memory profile to this file
      --path.config string   Configuration path
      --path.data string     Data path
      --path.home string     Home path
      --path.logs string     Logs path
      --plugin pluginList    Load additional plugins
      --strict.perms         Strict permission checking on config files (default true)
  -v, --v                    Log at INFO level

Use "functionbeat [command] --help" for more information about a command.

$ echo $?
1
```

Output of running `run` subcommand:
```
$ ./functionbeat run
Error: unknown command "run" for "functionbeat"
Run 'functionbeat --help' for usage.
```