### PR TITLE
[metricbeat] Migrate nginx/substatus to reporterv2 with error

### DIFF
--- a/metricbeat/module/nginx/stubstatus/stubstatus.go
+++ b/metricbeat/module/nginx/stubstatus/stubstatus.go
@@ -23,6 +23,7 @@ import (
 	"github.com/elastic/beats/metricbeat/helper"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/mb/parse"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -73,15 +74,13 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // Fetch methods implements the data gathering and data conversion to the right
 // format. It publishes the event which is then forwarded to the output. In case
 // of an error set the Error field of mb.Event or simply call report.Error().
-func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
+func (m *MetricSet) Fetch(reporter mb.ReporterV2) error {
 	scanner, err := m.http.FetchScanner()
 	if err != nil {
-		logger.Error(err)
-		reporter.Error(err)
-		return
+		return errors.Wrap(err, "error fetching status")
 	}
 	event, _ := eventMapping(scanner, m)
 	reporter.Event(mb.Event{MetricSetFields: event})
 
-	return
+	return nil
 }

--- a/metricbeat/module/nginx/stubstatus/stubstatus.go
+++ b/metricbeat/module/nginx/stubstatus/stubstatus.go
@@ -19,11 +19,12 @@
 package stubstatus
 
 import (
+	"github.com/pkg/errors"
+
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/metricbeat/helper"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/mb/parse"
-	"github.com/pkg/errors"
 )
 
 const (

--- a/metricbeat/module/nginx/stubstatus/stubstatus_integration_test.go
+++ b/metricbeat/module/nginx/stubstatus/stubstatus_integration_test.go
@@ -31,8 +31,8 @@ import (
 func TestFetch(t *testing.T) {
 	service := compose.EnsureUp(t, "nginx")
 
-	f := mbtest.NewReportingMetricSetV2(t, getConfig(service.Host()))
-	events, errs := mbtest.ReportingFetchV2(f)
+	f := mbtest.NewReportingMetricSetV2Error(t, getConfig(service.Host()))
+	events, errs := mbtest.ReportingFetchV2Error(f)
 	if len(errs) > 0 {
 		t.Fatalf("Expected 0 error, had %d. %v\n", len(errs), errs)
 	}
@@ -48,8 +48,8 @@ func TestFetch(t *testing.T) {
 func TestData(t *testing.T) {
 	service := compose.EnsureUp(t, "nginx")
 
-	f := mbtest.NewReportingMetricSetV2(t, getConfig(service.Host()))
-	if err := mbtest.WriteEventsReporterV2(f, t, ""); err != nil {
+	f := mbtest.NewReportingMetricSetV2Error(t, getConfig(service.Host()))
+	if err := mbtest.WriteEventsReporterV2Error(f, t, ""); err != nil {
 		t.Fatal("write", err)
 	}
 }

--- a/metricbeat/tests/system/test_cmd.py
+++ b/metricbeat/tests/system/test_cmd.py
@@ -138,7 +138,7 @@ class TestCommands(metricbeat.BaseTest):
         assert exit_code == 0
         try:
             assert any((
-                self.log_contains("ERROR error making http request"),
+                self.log_contains("ERROR error fetching status"),
                 self.log_contains("ERROR timeout waiting for an event"),
             ))
         except:


### PR DESCRIPTION
See  #11374 

There was a community PR for this, but it's been abandoned so I'm just doing it myself. This one is a bit odd, since it requires changes to some other metricbeat tests, which will look for error strings.