### PR TITLE
[DOCS] Remove run command from functionbeat

### DIFF
--- a/libbeat/docs/command-reference.asciidoc
+++ b/libbeat/docs/command-reference.asciidoc
@@ -105,7 +105,9 @@ endif::[]
 ifdef::has_modules_command[]
 |<<modules-command,`modules`>> |{modules-command-short-desc}.
 endif::[]
+ifndef::serverless[]
 |<<run-command,`run`>> |{run-command-short-desc}.
+endif::[]
 |<<setup-command,`setup`>> |{setup-command-short-desc}.
 |<<test-command,`test`>> |{test-command-short-desc}.
 ifeval::["{beatname_lc}"=="functionbeat"]
@@ -286,8 +288,10 @@ endif::serverless[]
 [[help-command]]
 ==== `help` command
 
-{help-command-short-desc}. If no command is specified, shows help for the
-`run` command.
+{help-command-short-desc}.
+ifndef::serverless[]
+If no command is specified, shows help for the `run` command.
+endif::[]
 
 *SYNOPSIS*
 
@@ -488,7 +492,7 @@ ifeval::["{beatname_lc}"=="metricbeat"]
 endif::[]
 endif::[]
 
-
+ifndef::serverless[]
 [[run-command]]
 ==== `run` command
 
@@ -618,6 +622,8 @@ Or:
 -----
 {beatname_lc} -e
 -----
+endif::[]
+
 
 [[setup-command]]
 ==== `setup` command


### PR DESCRIPTION
Adds conditional coding to remove run command from the Functionbeat docs.

This doc change is required for https://github.com/elastic/beats/pull/13514.

This needs to be backported to 7.4.