### PR TITLE
[metricbeat] Migrate prometheus/collector to reporterv2 with error

### DIFF
--- a/metricbeat/module/prometheus/collector/collector.go
+++ b/metricbeat/module/prometheus/collector/collector.go
@@ -70,7 +70,7 @@ func (m *MetricSet) Fetch(reporter mb.ReporterV2) error {
 	families, err := m.prometheus.GetFamilies()
 
 	if err != nil {
-		return fmt.Errorf("Unable to decode response from prometheus endpoint")
+		return fmt.Errorf("unable to decode response from prometheus endpoint")
 	}
 
 	eventList := map[string]common.MapStr{}

--- a/metricbeat/module/prometheus/collector/collector.go
+++ b/metricbeat/module/prometheus/collector/collector.go
@@ -46,11 +46,13 @@ func init() {
 	)
 }
 
+// MetricSet for fetching prometheus data
 type MetricSet struct {
 	mb.BaseMetricSet
 	prometheus p.Prometheus
 }
 
+// New creates a new metricset
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	prometheus, err := p.NewPrometheusClient(base)
 	if err != nil {
@@ -63,12 +65,12 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	}, nil
 }
 
-func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
+// Fetch fetches data and reports it
+func (m *MetricSet) Fetch(reporter mb.ReporterV2) error {
 	families, err := m.prometheus.GetFamilies()
 
 	if err != nil {
-		reporter.Error(fmt.Errorf("Unable to decode response from prometheus endpoint"))
-		return
+		return fmt.Errorf("Unable to decode response from prometheus endpoint")
 	}
 
 	eventList := map[string]common.MapStr{}
@@ -97,8 +99,13 @@ func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
 
 	// Converts hash list to slice
 	for _, e := range eventList {
-		reporter.Event(mb.Event{
+		isOpen := reporter.Event(mb.Event{
 			RootFields: common.MapStr{"prometheus": e},
 		})
+		if !isOpen {
+			break
+		}
 	}
+
+	return nil
 }

--- a/x-pack/metricbeat/module/cockroachdb/status/status_integration_test.go
+++ b/x-pack/metricbeat/module/cockroachdb/status/status_integration_test.go
@@ -31,8 +31,8 @@ func init() {
 func TestFetch(t *testing.T) {
 	service := compose.EnsureUp(t, "cockroachdb")
 
-	f := mbtest.NewReportingMetricSetV2(t, getConfig(service.Host()))
-	events, errs := mbtest.ReportingFetchV2(f)
+	f := mbtest.NewReportingMetricSetV2Error(t, getConfig(service.Host()))
+	events, errs := mbtest.ReportingFetchV2Error(f)
 	if len(errs) > 0 {
 		t.Fatalf("Expected 0 error, had %d. %v\n", len(errs), errs)
 	}

--- a/x-pack/metricbeat/module/cockroachdb/status/status_integration_test.go
+++ b/x-pack/metricbeat/module/cockroachdb/status/status_integration_test.go
@@ -31,8 +31,8 @@ func init() {
 func TestFetch(t *testing.T) {
 	service := compose.EnsureUp(t, "cockroachdb")
 
-	f := mbtest.NewReportingMetricSetV2Error(t, getConfig(service.Host()))
-	events, errs := mbtest.ReportingFetchV2Error(f)
+	f := mbtest.NewFetcher(t, getConfig(service.Host()))
+	events, errs := f.FetchEvents()
 	if len(errs) > 0 {
 		t.Fatalf("Expected 0 error, had %d. %v\n", len(errs), errs)
 	}


### PR DESCRIPTION
See elastic/beats#11374

Considering how big and important a lot of the core Prometheus stuff, I'm surprised this is such a small PR. 