### PR TITLE
Cherry-pick #13497 to 7.4: [SIEM][Auditbeat] Fix IPv6 for kernels older than 3.13

### DIFF
--- a/x-pack/auditbeat/module/system/socket/guess/cskxmit6.go
+++ b/x-pack/auditbeat/module/system/socket/guess/cskxmit6.go
@@ -40,9 +40,12 @@ func init() {
 }
 
 type guessInet6CskXmit struct {
-	guessInetSockIPv6
-	sock       uintptr
-	acceptedFd int
+	ctx                    Context
+	loopback               ipv6loopback
+	clientAddr, serverAddr unix.SockaddrInet6
+	client, server         int
+	sock                   uintptr
+	acceptedFd             int
 }
 
 // Name of this guess.
@@ -93,12 +96,39 @@ func (g *guessInet6CskXmit) Probes() ([]helper.ProbeDef, error) {
 
 // Prepare setups an IPv6 TCP client/server where the server is listening
 // and the client is connecting to it.
-func (g *guessInet6CskXmit) Prepare(ctx Context) error {
+func (g *guessInet6CskXmit) Prepare(ctx Context) (err error) {
+	g.ctx = ctx
 	g.acceptedFd = -1
-	if err := g.guessInetSockIPv6.Prepare(ctx); err != nil {
-		return err
+	g.loopback, err = newIPv6Loopback()
+	if err != nil {
+		return errors.Wrap(err, "detect IPv6 loopback failed")
 	}
-	if err := unix.Connect(g.client, &g.serverAddr); err != nil {
+	defer func() {
+		if err != nil {
+			g.loopback.Cleanup()
+		}
+	}()
+	clientIP, err := g.loopback.addRandomAddress()
+	if err != nil {
+		return errors.Wrap(err, "failed adding first device address")
+	}
+	serverIP, err := g.loopback.addRandomAddress()
+	if err != nil {
+		return errors.Wrap(err, "failed adding second device address")
+	}
+	copy(g.clientAddr.Addr[:], clientIP)
+	copy(g.serverAddr.Addr[:], serverIP)
+
+	if g.client, g.clientAddr, err = createSocket6WithProto(unix.SOCK_STREAM, g.clientAddr); err != nil {
+		return errors.Wrap(err, "error creating server")
+	}
+	if g.server, g.serverAddr, err = createSocket6WithProto(unix.SOCK_STREAM, g.serverAddr); err != nil {
+		return errors.Wrap(err, "error creating client")
+	}
+	if err = unix.Listen(g.server, 1); err != nil {
+		return errors.Wrap(err, "error in listen")
+	}
+	if err = unix.Connect(g.client, &g.serverAddr); err != nil {
 		return errors.Wrap(err, "connect failed")
 	}
 	return nil
@@ -109,7 +139,9 @@ func (g *guessInet6CskXmit) Terminate() error {
 	if g.acceptedFd != -1 {
 		unix.Close(g.acceptedFd)
 	}
-	return g.guessInetSockIPv6.Terminate()
+	unix.Close(g.client)
+	unix.Close(g.server)
+	return g.loopback.Cleanup()
 }
 
 // Trigger accepts the client connection on the server, triggering a call

--- a/x-pack/auditbeat/module/system/socket/guess/inetsock.go
+++ b/x-pack/auditbeat/module/system/socket/guess/inetsock.go
@@ -30,6 +30,9 @@ import (
 // INET_SOCK_LPORT : 582
 // INET_SOCK_RADDR : 576
 // INET_SOCK_RPORT : 580
+// INET_SOCK_RADDR_LIST : [...array of offsets...]
+// INET_SOCK_RADDR_LIST is a list of all the offsets within the structure that
+// matched the remote address. This is used by guess_inet_sock6.
 
 func init() {
 	if err := Registry.AddGuess(&guessInetSockIPv4{}); err != nil {
@@ -55,6 +58,10 @@ func (g *guessInetSockIPv4) Provides() []string {
 		"INET_SOCK_LPORT",
 		"INET_SOCK_RADDR",
 		"INET_SOCK_RPORT",
+		"INET_SOCK_LADDR_LIST",
+		"INET_SOCK_LPORT_LIST",
+		"INET_SOCK_RADDR_LIST",
+		"INET_SOCK_RPORT_LIST",
 	}
 }
 
@@ -201,6 +208,7 @@ func (g *guessInetSockIPv4) Reduce(results []common.MapStr) (result common.MapSt
 		if err != nil {
 			return nil, err
 		}
+		result[key+"_LIST"] = list
 		result[key] = list[0]
 	}
 	return result, nil

--- a/x-pack/auditbeat/module/system/socket/guess/inetsock6.go
+++ b/x-pack/auditbeat/module/system/socket/guess/inetsock6.go
@@ -8,6 +8,8 @@ package guess
 
 import (
 	"bytes"
+	"fmt"
+	"strings"
 
 	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
@@ -19,14 +21,83 @@ import (
 
 /*
 	Guess the offset of local and remote IPv6 addresses on a struct inet_sock*.
-	This is an easy one as the addresses appear consecutive in memory.
+
+	This guess is a two-in-one as the IPv6 addresses can appear in two
+	different ways:
+
+	before 3.13:
+
+		IPv6 addresses are accessed via a pointer to an ipv6_pinfo structure:
+
+		struct inet_sock {
+			struct sock             sk;
+			#if defined(CONFIG_IPV6) || defined(CONFIG_IPV6_MODULE)
+			struct ipv6_pinfo       *pinet6;
+			#endif
+			__be32                  daddr;
+			[...]
+
+		struct ipv6_pinfo {
+			struct in6_addr 	saddr;
+			struct in6_addr 	rcv_saddr;
+			struct in6_addr		daddr;
+			[...]
+
+		The guess finds this pointer easily because it just the field just
+		before the IPv4 destination address.
+
+	after 3.13:
+
+		Both addresses are consecutive fields in struct sock_common:
+			struct in6_addr		skc_v6_daddr;
+			struct in6_addr		skc_v6_rcv_saddr;
+
+
+		So what it does is:
+		Probe #1 dumps the inet_sock structure, and looks for the concatenation
+		of destination and source addresses.
+
+		Probe #2 dumps the 16 bytes pointed to by the pointer-aligned address
+		before all known offsets of the IPv4 destination address.
+
+		If the addresses are found by #1 it keeps the offsets. Otherwise it
+		keeps the offsets from #2.
+
+		The results of this guess are not offsets because it needs to accommodate
+		for different levels of indirection depending on the target kernel.
+
+		A "termination" variable is used:
+
+		In 3.13+:
+			INET_SOCK_V6_RADDR_A: "+56"
+			INET_SOCK_V6_TERM: ":u64"
+
+			so that a kprobe can define:
+				"{{.INET_SOCK_V6_RADDR_A}}({{.RET}}){{.INET_SOCK_V6_TERM}}"
+			resulting in:
+				"+56($retval):u64"
+
+		while before 3.13 it will be:
+			INET_SOCK_V6_RADDR_A: "+8(+512"
+			INET_SOCK_V6_TERM: "):u64"
+
+			and the same kprobe will result in:
+				"+8(+512($retval)):u64"
+
+		The same result could've been achieved by having the templates be
+		functions that can be {{call'ed}} in the template but that cause a lot
+		of trouble on its own:
+			- functions need to be defined for kprobe validation
+				-> defining placeholders breaks the guesses dependency resolution.
+			- passing template variables as function arguments causes the
+			  templates to need to be resolved recursively.
 
 	Output:
 
-	INET_SOCK_V6_RADDR_A: 56
-	INET_SOCK_V6_RADDR_B: 64
-	INET_SOCK_V6_LADDR_A: 72
-	INET_SOCK_V6_LADDR_B: 80
+	INET_SOCK_V6_RADDR_A: +56
+	INET_SOCK_V6_RADDR_B: +64
+	INET_SOCK_V6_LADDR_A: +72
+	INET_SOCK_V6_LADDR_B: +80
 */
 
 const inetSockDumpSize = 8 * 256
@@ -42,6 +113,9 @@ type guessInetSockIPv6 struct {
 	loopback               ipv6loopback
 	clientAddr, serverAddr unix.SockaddrInet6
 	client, server         int
+	offsets                []int
+	fullDump               []byte
+	ptrDump                []byte
 }
 
 // Name of this guess.
@@ -63,23 +137,73 @@ func (g *guessInetSockIPv6) Provides() []string {
 func (g *guessInetSockIPv6) Requires() []string {
 	return []string{
 		"RET",
+		"INET_SOCK_RADDR_LIST",
 	}
 }
 
+// eventWrapper is used to wrap events from one of the probes for differentiation.
+type eventWrapper struct {
+	event interface{}
+}
+
+// decoderWrapper takes an inner decoder and wraps it so that the returned events
+// are wrapped with the eventWrapper type.
+type decoderWrapper struct {
+	inner tracing.Decoder
+}
+
+// Decode wraps events from the inner decoder into a the wrapper type.
+func (d *decoderWrapper) Decode(raw []byte, meta tracing.Metadata) (event interface{}, err error) {
+	if event, err = d.inner.Decode(raw, meta); err != nil {
+		return event, err
+	}
+	return eventWrapper{event}, nil
+}
+
 // Probes returns a kretprobe in inet_csk_accept that dumps the memory pointed
-// to by the return value (an inet_sock*).
-func (g *guessInetSockIPv6) Probes() ([]helper.ProbeDef, error) {
-	return []helper.ProbeDef{
-		{
-			Probe: tracing.Probe{
-				Type:      tracing.TypeKRetProbe,
-				Name:      "inet_sock_ipv6_guess",
-				Address:   "inet_csk_accept",
-				Fetchargs: helper.MakeMemoryDump("{{.RET}}", 0, inetSockDumpSize),
-			},
-			Decoder: tracing.NewDumpDecoder,
+// to by the return value (an inet_sock*) and a kretprobe that dumps various
+// candidates for the ipv6_pinfo struct.
+func (g *guessInetSockIPv6) Probes() (probes []helper.ProbeDef, err error) {
+	probes = append(probes, helper.ProbeDef{
+		Probe: tracing.Probe{
+			Type:      tracing.TypeKRetProbe,
+			Name:      "inet_sock_ipv6_guess",
+			Address:   "inet_csk_accept",
+			Fetchargs: helper.MakeMemoryDump("{{.RET}}", 0, inetSockDumpSize),
 		},
-	}, nil
+		Decoder: tracing.NewDumpDecoder,
+	})
+	raddrOffsets := g.offsets
+	g.offsets = nil
+	const sizePtr = int(sizeOfPtr)
+	var fetch []string
+	for _, off := range raddrOffsets {
+		// the pointer we're looking for is after a field of sizeof(struct sock)
+		if off < sizePtr*2 {
+			continue
+		}
+		// This is aligning to the nearest offset aligned to sizePtr and smaller
+		// than off.
+		off = alignTo(off-2*sizePtr+1, sizePtr)
+		g.offsets = append(g.offsets, off)
+		// dumps the rcv_saddr field of struct ipv6_pinfo
+		fetch = append(fetch, fmt.Sprintf("+16(+%d({{.RET}})):u64 +24(+%d({{.RET}})):u64", off, off))
+	}
+	probes = append(probes, helper.ProbeDef{
+		Probe: tracing.Probe{
+			Type:      tracing.TypeKRetProbe,
+			Name:      "inet_sock_ipv6_guess2",
+			Address:   "inet_csk_accept",
+			Fetchargs: strings.Join(fetch, " "),
+		},
+		Decoder: func(desc tracing.ProbeFormat) (decoder tracing.Decoder, err error) {
+			if decoder, err = tracing.NewDumpDecoder(desc); err != nil {
+				return nil, err
+			}
+			return &decoderWrapper{decoder}, nil
+		},
+	})
+	return probes, nil
 }
 
 // Prepare creates an IPv6 client/server bound to loopback.
@@ -88,6 +212,10 @@ func (g *guessInetSockIPv6) Probes() ([]helper.ProbeDef, error) {
 // random addresses in the fd00::/8 reserved network to the loopback device.
 func (g *guessInetSockIPv6) Prepare(ctx Context) (err error) {
 	g.ctx = ctx
+	g.offsets, err = getListField(g.ctx.Vars, "INET_SOCK_RADDR_LIST")
+	if err != nil {
+		return err
+	}
 	g.loopback, err = newIPv6Loopback()
 	if err != nil {
 		return errors.Wrap(err, "detect IPv6 loopback failed")
@@ -133,10 +261,26 @@ func (g *guessInetSockIPv6) Trigger() error {
 	return nil
 }
 
-// Extract scans the returned memory dump for the remote address followed
-// by the local address.
+// Extract scans stores the events from the two different kprobes and then
+// looks for the result in one of them.
 func (g *guessInetSockIPv6) Extract(event interface{}) (common.MapStr, bool) {
-	raw := event.([]byte)
+	if w, ok := event.(eventWrapper); ok {
+		g.ptrDump = w.event.([]byte)
+	} else {
+		g.fullDump = event.([]byte)
+	}
+	if g.ptrDump == nil || g.fullDump == nil {
+		return nil, false
+	}
+
+	result, ok := g.searchStructSock(g.fullDump)
+	if !ok {
+		result, ok = g.searchIPv6PInfo(g.ptrDump)
+	}
+	return result, ok
+}
+
+func (g *guessInetSockIPv6) searchStructSock(raw []byte) (common.MapStr, bool) {
 	var expected []byte
 	expected = append(expected, g.clientAddr.Addr[:]...) // sck_v6_daddr
 	expected = append(expected, g.serverAddr.Addr[:]...) // sck_v6_rcv_saddr
@@ -145,10 +289,32 @@ func (g *guessInetSockIPv6) Extract(event interface{}) (common.MapStr, bool) {
 		return nil, false
 	}
 	return common.MapStr{
-		"INET_SOCK_V6_RADDR_A": offset,
-		"INET_SOCK_V6_RADDR_B": offset + 8,
-		"INET_SOCK_V6_LADDR_A": offset + 16,
-		"INET_SOCK_V6_LADDR_B": offset + 24,
+		"INET_SOCK_V6_TERM":    ":u64",
+		"INET_SOCK_V6_RADDR_A": fmt.Sprintf("+%d", offset),
+		"INET_SOCK_V6_RADDR_B": fmt.Sprintf("+%d", offset+8),
+		"INET_SOCK_V6_LADDR_A": fmt.Sprintf("+%d", offset+16),
+		"INET_SOCK_V6_LADDR_B": fmt.Sprintf("+%d", offset+24),
+		"INET_SOCK_V6_LIMIT":   offset,
+	}, true
+}
+
+func (g *guessInetSockIPv6) searchIPv6PInfo(raw []byte) (common.MapStr, bool) {
+	offset := bytes.Index(raw, g.serverAddr.Addr[:])
+	if offset == -1 {
+		return nil, false
+	}
+	idx := offset / 16 // length of IPv6 address
+	if idx >= len(g.offsets) {
+		return nil, false
+	}
+	off := g.offsets[idx]
+	return common.MapStr{
+		"INET_SOCK_V6_TERM":    "):u64",
+		"INET_SOCK_V6_RADDR_A": fmt.Sprintf("+%d(+%d", 32, off),
+		"INET_SOCK_V6_RADDR_B": fmt.Sprintf("+%d(+%d", 40, off),
+		"INET_SOCK_V6_LADDR_A": fmt.Sprintf("+%d(+%d", 16, off),
+		"INET_SOCK_V6_LADDR_B": fmt.Sprintf("+%d(+%d", 24, off),
+		"INET_SOCK_V6_LIMIT":   off,
 	}, true
 }
 

--- a/x-pack/auditbeat/module/system/socket/guess/inetsockaf.go
+++ b/x-pack/auditbeat/module/system/socket/guess/inetsockaf.go
@@ -72,7 +72,7 @@ func (g *guessInetSockFamily) Provides() []string {
 func (g *guessInetSockFamily) Requires() []string {
 	return []string{
 		"SOCKET_SOCK",
-		"INET_SOCK_V6_RADDR_A",
+		"INET_SOCK_V6_LIMIT",
 		"P1",
 	}
 }
@@ -97,8 +97,11 @@ func (g *guessInetSockFamily) Probes() ([]helper.ProbeDef, error) {
 func (g *guessInetSockFamily) Prepare(ctx Context) error {
 	g.ctx = ctx
 	var ok bool
-	if g.limit, ok = g.ctx.Vars["INET_SOCK_V6_RADDR_A"].(int); !ok {
-		return errors.New("required variable INET_SOCK_V6_RADDR_A not found")
+	// limit is used as a reference point within struct sock_common to know where
+	// to stop looking for the skc_family field, as limit is part of the fields
+	// in inet_sock that are past struct sock.
+	if g.limit, ok = g.ctx.Vars["INET_SOCK_V6_LIMIT"].(int); !ok {
+		return errors.New("required variable INET_SOCK_V6_LIMIT not found")
 	}
 	return nil
 }

--- a/x-pack/auditbeat/module/system/socket/kprobes.go
+++ b/x-pack/auditbeat/module/system/socket/kprobes.go
@@ -260,7 +260,7 @@ var installKProbes = []helper.ProbeDef{
 			Name:    "inet_csk_accept_ret",
 			Address: "inet_csk_accept",
 			Fetchargs: "sock={{.RET}} laddr=+{{.INET_SOCK_LADDR}}({{.RET}}):u32 lport=+{{.INET_SOCK_LPORT}}({{.RET}}):u16 raddr=+{{.INET_SOCK_RADDR}}({{.RET}}):u32 rport=+{{.INET_SOCK_RPORT}}({{.RET}}):u16 " +
-				"family=+{{.INET_SOCK_AF}}({{.RET}}):u16 laddr6a=+{{.INET_SOCK_V6_LADDR_A}}({{.RET}}):u64 laddr6b=+{{.INET_SOCK_V6_LADDR_B}}({{.RET}}):u64 raddr6a=+{{.INET_SOCK_V6_RADDR_A}}({{.RET}}):u64 raddr6b=+{{.INET_SOCK_V6_RADDR_B}}({{.RET}}):u64",
+				"family=+{{.INET_SOCK_AF}}({{.RET}}):u16 laddr6a={{.INET_SOCK_V6_LADDR_A}}({{.RET}}){{.INET_SOCK_V6_TERM}} laddr6b={{.INET_SOCK_V6_LADDR_B}}({{.RET}}){{.INET_SOCK_V6_TERM}} raddr6a={{.INET_SOCK_V6_RADDR_A}}({{.RET}}){{.INET_SOCK_V6_TERM}} raddr6b={{.INET_SOCK_V6_RADDR_B}}({{.RET}}){{.INET_SOCK_V6_TERM}}",
 			Filter: "family=={{.AF_INET}} || family=={{.AF_INET6}}",
 		},
 		Decoder: helper.NewStructDecoder(func() interface{} { return new(tcpAcceptResult) }),
@@ -276,7 +276,7 @@ var installKProbes = []helper.ProbeDef{
 			Name:    "tcp_sendmsg_in",
 			Address: "tcp_sendmsg",
 			Fetchargs: "sock={{.TCP_SENDMSG_SOCK}} size={{.TCP_SENDMSG_LEN}} laddr=+{{.INET_SOCK_LADDR}}({{.TCP_SENDMSG_SOCK}}):u32 lport=+{{.INET_SOCK_LPORT}}({{.TCP_SENDMSG_SOCK}}):u16 raddr=+{{.INET_SOCK_RADDR}}({{.TCP_SENDMSG_SOCK}}):u32 rport=+{{.INET_SOCK_RPORT}}({{.TCP_SENDMSG_SOCK}}):u16 " +
-				"family=+{{.INET_SOCK_AF}}({{.TCP_SENDMSG_SOCK}}):u16 laddr6a=+{{.INET_SOCK_V6_LADDR_A}}({{.TCP_SENDMSG_SOCK}}):u64 laddr6b=+{{.INET_SOCK_V6_LADDR_B}}({{.TCP_SENDMSG_SOCK}}):u64 raddr6a=+{{.INET_SOCK_V6_RADDR_A}}({{.TCP_SENDMSG_SOCK}}):u64 raddr6b=+{{.INET_SOCK_V6_RADDR_B}}({{.TCP_SENDMSG_SOCK}}):u64",
+				"family=+{{.INET_SOCK_AF}}({{.TCP_SENDMSG_SOCK}}):u16 laddr6a={{.INET_SOCK_V6_LADDR_A}}({{.TCP_SENDMSG_SOCK}}){{.INET_SOCK_V6_TERM}} laddr6b={{.INET_SOCK_V6_LADDR_B}}({{.TCP_SENDMSG_SOCK}}){{.INET_SOCK_V6_TERM}} raddr6a={{.INET_SOCK_V6_RADDR_A}}({{.TCP_SENDMSG_SOCK}}){{.INET_SOCK_V6_TERM}} raddr6b={{.INET_SOCK_V6_RADDR_B}}({{.TCP_SENDMSG_SOCK}}){{.INET_SOCK_V6_TERM}}",
 		},
 		Decoder: helper.NewStructDecoder(func() interface{} { return new(tcpSendMsgCall) }),
 	},
@@ -372,7 +372,7 @@ var installKProbes = []helper.ProbeDef{
 		Probe: tracing.Probe{
 			Name:      "inet6_csk_xmit_call",
 			Address:   "inet6_csk_xmit",
-			Fetchargs: "sock={{.INET6_CSK_XMIT_SOCK}} size=+{{.SK_BUFF_LEN}}({{.INET6_CSK_XMIT_SKBUFF}}):u32 lport=+{{.INET_SOCK_LPORT}}({{.INET6_CSK_XMIT_SOCK}}):u16 rport=+{{.INET_SOCK_RPORT}}({{.INET6_CSK_XMIT_SOCK}}):u16 laddr6a=+{{.INET_SOCK_V6_LADDR_A}}({{.INET6_CSK_XMIT_SOCK}}):u64 laddr6b=+{{.INET_SOCK_V6_LADDR_B}}({{.INET6_CSK_XMIT_SOCK}}):u64 raddr6a=+{{.INET_SOCK_V6_RADDR_A}}({{.INET6_CSK_XMIT_SOCK}}):u64 raddr6b=+{{.INET_SOCK_V6_RADDR_B}}({{.INET6_CSK_XMIT_SOCK}}):u64",
+			Fetchargs: "sock={{.INET6_CSK_XMIT_SOCK}} size=+{{.SK_BUFF_LEN}}({{.INET6_CSK_XMIT_SKBUFF}}):u32 lport=+{{.INET_SOCK_LPORT}}({{.INET6_CSK_XMIT_SOCK}}):u16 rport=+{{.INET_SOCK_RPORT}}({{.INET6_CSK_XMIT_SOCK}}):u16 laddr6a={{.INET_SOCK_V6_LADDR_A}}({{.INET6_CSK_XMIT_SOCK}}){{.INET_SOCK_V6_TERM}} laddr6b={{.INET_SOCK_V6_LADDR_B}}({{.INET6_CSK_XMIT_SOCK}}){{.INET_SOCK_V6_TERM}} raddr6a={{.INET_SOCK_V6_RADDR_A}}({{.INET6_CSK_XMIT_SOCK}}){{.INET_SOCK_V6_TERM}} raddr6b={{.INET_SOCK_V6_RADDR_B}}({{.INET6_CSK_XMIT_SOCK}}){{.INET_SOCK_V6_TERM}}",
 		},
 		Decoder: helper.NewStructDecoder(func() interface{} { return new(inet6CskXmitCall) }),
 	},
@@ -384,7 +384,7 @@ var installKProbes = []helper.ProbeDef{
 		Probe: tracing.Probe{
 			Name:      "tcp_v6_do_rcv_call",
 			Address:   "tcp_v6_do_rcv",
-			Fetchargs: "sock={{.P1}} size=+{{.SK_BUFF_LEN}}({{.P2}}):u32 lport=+{{.INET_SOCK_LPORT}}({{.P1}}):u16 rport=+{{.INET_SOCK_RPORT}}({{.P1}}):u16 laddr6a=+{{.INET_SOCK_V6_LADDR_A}}({{.P1}}):u64 laddr6b=+{{.INET_SOCK_V6_LADDR_B}}({{.P1}}):u64 raddr6a=+{{.INET_SOCK_V6_RADDR_A}}({{.P1}}):u64 raddr6b=+{{.INET_SOCK_V6_RADDR_B}}({{.P1}}):u64",
+			Fetchargs: "sock={{.P1}} size=+{{.SK_BUFF_LEN}}({{.P2}}):u32 lport=+{{.INET_SOCK_LPORT}}({{.P1}}):u16 rport=+{{.INET_SOCK_RPORT}}({{.P1}}):u16 laddr6a={{.INET_SOCK_V6_LADDR_A}}({{.P1}}){{.INET_SOCK_V6_TERM}} laddr6b={{.INET_SOCK_V6_LADDR_B}}({{.P1}}){{.INET_SOCK_V6_TERM}} raddr6a={{.INET_SOCK_V6_RADDR_A}}({{.P1}}){{.INET_SOCK_V6_TERM}} raddr6b={{.INET_SOCK_V6_RADDR_B}}({{.P1}}){{.INET_SOCK_V6_TERM}}",
 		},
 		Decoder: helper.NewStructDecoder(func() interface{} { return new(tcpV6DoRcv) }),
 	},
@@ -396,7 +396,7 @@ var installKProbes = []helper.ProbeDef{
 		Probe: tracing.Probe{
 			Name:      "tcp6_connect_in",
 			Address:   "tcp_v6_connect",
-			Fetchargs: "sock={{.P1}} laddra=+{{.INET_SOCK_V6_LADDR_A}}({{.P1}}):u64 laddrb=+{{.INET_SOCK_V6_LADDR_B}}({{.P1}}):u64 lport=+{{.INET_SOCK_LPORT}}({{.P1}}):u16 af=+{{.SOCKADDR_IN6_AF}}({{.P2}}):u16 addra=+{{.SOCKADDR_IN6_ADDRA}}({{.P2}}):u64 addrb=+{{.SOCKADDR_IN6_ADDRB}}({{.P2}}):u64 port=+{{.SOCKADDR_IN6_PORT}}({{.P2}}):u16",
+			Fetchargs: "sock={{.P1}} laddra={{.INET_SOCK_V6_LADDR_A}}({{.P1}}){{.INET_SOCK_V6_TERM}} laddrb={{.INET_SOCK_V6_LADDR_B}}({{.P1}}){{.INET_SOCK_V6_TERM}} lport=+{{.INET_SOCK_LPORT}}({{.P1}}):u16 af=+{{.SOCKADDR_IN6_AF}}({{.P2}}):u16 addra=+{{.SOCKADDR_IN6_ADDRA}}({{.P2}}):u64 addrb=+{{.SOCKADDR_IN6_ADDRB}}({{.P2}}):u64 port=+{{.SOCKADDR_IN6_PORT}}({{.P2}}):u16",
 			Filter:    "af=={{.AF_INET6}}",
 		},
 		Decoder: helper.NewStructDecoder(func() interface{} { return new(tcpIPv6ConnectCall) }),
@@ -430,7 +430,7 @@ var installKProbes = []helper.ProbeDef{
 		Probe: tracing.Probe{
 			Name:      "udpv6_sendmsg_in",
 			Address:   "udpv6_sendmsg",
-			Fetchargs: "sock={{.UDP_SENDMSG_SOCK}} size={{.UDP_SENDMSG_LEN}} laddra=+{{.INET_SOCK_V6_LADDR_A}}({{.UDP_SENDMSG_SOCK}}):u64 laddrb=+{{.INET_SOCK_V6_LADDR_B}}({{.UDP_SENDMSG_SOCK}}):u64 lport=+{{.INET_SOCK_LPORT}}({{.UDP_SENDMSG_SOCK}}):u16 raddra=+{{.SOCKADDR_IN6_ADDRA}}(+0({{.UDP_SENDMSG_MSG}})):u64 raddrb=+{{.SOCKADDR_IN6_ADDRB}}(+0({{.UDP_SENDMSG_MSG}})):u64 rport=+{{.SOCKADDR_IN6_PORT}}(+0({{.UDP_SENDMSG_MSG}})):u16 altraddra=+{{.INET_SOCK_V6_RADDR_A}}({{.UDP_SENDMSG_SOCK}}):u64 altraddrb=+{{.INET_SOCK_V6_RADDR_B}}({{.UDP_SENDMSG_SOCK}}):u64 altrport=+{{.INET_SOCK_RPORT}}({{.UDP_SENDMSG_SOCK}}):u16",
+			Fetchargs: "sock={{.UDP_SENDMSG_SOCK}} size={{.UDP_SENDMSG_LEN}} laddra={{.INET_SOCK_V6_LADDR_A}}({{.UDP_SENDMSG_SOCK}}){{.INET_SOCK_V6_TERM}} laddrb={{.INET_SOCK_V6_LADDR_B}}({{.UDP_SENDMSG_SOCK}}){{.INET_SOCK_V6_TERM}} lport=+{{.INET_SOCK_LPORT}}({{.UDP_SENDMSG_SOCK}}):u16 raddra=+{{.SOCKADDR_IN6_ADDRA}}(+0({{.UDP_SENDMSG_MSG}})):u64 raddrb=+{{.SOCKADDR_IN6_ADDRB}}(+0({{.UDP_SENDMSG_MSG}})):u64 rport=+{{.SOCKADDR_IN6_PORT}}(+0({{.UDP_SENDMSG_MSG}})):u16 altraddra={{.INET_SOCK_V6_RADDR_A}}({{.UDP_SENDMSG_SOCK}}){{.INET_SOCK_V6_TERM}} altraddrb={{.INET_SOCK_V6_RADDR_B}}({{.UDP_SENDMSG_SOCK}}){{.INET_SOCK_V6_TERM}} altrport=+{{.INET_SOCK_RPORT}}({{.UDP_SENDMSG_SOCK}}):u16",
 		},
 		Decoder: helper.NewStructDecoder(func() interface{} { return new(udpv6SendMsgCall) }),
 	},
@@ -440,7 +440,7 @@ var installKProbes = []helper.ProbeDef{
 		Probe: tracing.Probe{
 			Name:      "udpv6_queue_rcv_skb",
 			Address:   "udpv6_queue_rcv_skb",
-			Fetchargs: "sock={{.P1}} size=+{{.SK_BUFF_LEN}}({{.P2}}):u32 laddra=+{{.INET_SOCK_V6_LADDR_A}}({{.P1}}):u64 laddrb=+{{.INET_SOCK_V6_LADDR_B}}({{.P1}}):u64 lport=+{{.INET_SOCK_LPORT}}({{.P1}}):u16 iphdr=+{{.SK_BUFF_NETWORK}}({{.P2}}):u16 udphdr=+{{.SK_BUFF_TRANSPORT}}({{.P2}}):u16 base=+{{.SK_BUFF_HEAD}}({{.P2}}) packet=" + helper.MakeMemoryDump("+{{.SK_BUFF_HEAD}}({{.P2}})", 0, pktHeaderDumpBytes),
+			Fetchargs: "sock={{.P1}} size=+{{.SK_BUFF_LEN}}({{.P2}}):u32 laddra={{.INET_SOCK_V6_LADDR_A}}({{.P1}}){{.INET_SOCK_V6_TERM}} laddrb={{.INET_SOCK_V6_LADDR_B}}({{.P1}}){{.INET_SOCK_V6_TERM}} lport=+{{.INET_SOCK_LPORT}}({{.P1}}):u16 iphdr=+{{.SK_BUFF_NETWORK}}({{.P2}}):u16 udphdr=+{{.SK_BUFF_TRANSPORT}}({{.P2}}):u16 base=+{{.SK_BUFF_HEAD}}({{.P2}}) packet=" + helper.MakeMemoryDump("+{{.SK_BUFF_HEAD}}({{.P2}})", 0, pktHeaderDumpBytes),
 		},
 		Decoder: helper.NewStructDecoder(func() interface{} { return new(udpv6QueueRcvSkb) }),
 	},

--- a/x-pack/auditbeat/module/system/socket/template.go
+++ b/x-pack/auditbeat/module/system/socket/template.go
@@ -34,11 +34,11 @@ var baseTemplateVars = common.MapStr{
 // These functions names vary between kernel versions. The first available one
 // will be selected during setup.
 var functionAlternatives = map[string][]string{
-	"SYS_UNAME":         syscallAlternatives("newuname"),
-	"SYS_EXECVE":        syscallAlternatives("execve"),
 	"IP_LOCAL_OUT":      {"ip_local_out", "ip_local_out_sk"},
+	"RECV_UDP_DATAGRAM": {"__skb_recv_udp", "__skb_recv_datagram", "skb_recv_datagram"},
+	"SYS_EXECVE":        syscallAlternatives("execve"),
 	"SYS_GETTIMEOFDAY":  syscallAlternatives("gettimeofday"),
-	"RECV_UDP_DATAGRAM": {"__skb_recv_udp", "__skb_recv_datagram"},
+	"SYS_UNAME":         syscallAlternatives("newuname"),
 }
 
 func syscallAlternatives(syscall string) []string {


### PR DESCRIPTION
Cherry-pick of PR #13497 to 7.4 branch. Original message: 

This fixes a known problem with the system/socket dataset. Before 3.13 an extra level of indirection is needed to access IPv6 addresses from a struct inet_sock.

Relates #13058