### PR TITLE
Cherry-pick #13522 to 7.4: [SIEM][Auditbeat] System/socket: Fix detection of functions provided by modules

### DIFF
--- a/x-pack/auditbeat/module/system/socket/template.go
+++ b/x-pack/auditbeat/module/system/socket/template.go
@@ -7,6 +7,7 @@
 package socket
 
 import (
+	"strings"
 	"unsafe"
 
 	"github.com/elastic/beats/libbeat/common"
@@ -58,7 +59,12 @@ func LoadTracingFunctions(tfs *tracing.TraceFS) (common.StringSet, error) {
 	// doesn't allow to create empty sets.
 	functions := common.StringSet(make(map[string]struct{}, len(fnList)))
 	for _, fn := range fnList {
-		functions.Add(fn)
+		// Strip the module name (if any)
+		end := strings.IndexByte(fn, ' ')
+		if end == -1 {
+			end = len(fn)
+		}
+		functions.Add(fn[:end])
 	}
 	return functions, nil
 }


### PR DESCRIPTION
Cherry-pick of PR #13522 to 7.4 branch. Original message: 

Fix reading of `available_filter_functions` so that it parses functions that are provided by kernel modules, as is the case for example when ipv6 support is compiled as a module.
