### PR TITLE
[SIEM][Auditbeat] System/socket: mount tracefs/debugfs

### DIFF
--- a/x-pack/auditbeat/seccomp_linux.go
+++ b/x-pack/auditbeat/seccomp_linux.go
@@ -21,7 +21,7 @@ func init() {
 		}
 
 		// The system/socket dataset uses additional syscalls
-		if err := seccomp.ModifyDefaultPolicy(seccomp.AddSyscall, "perf_event_open", "eventfd2", "ppoll", "mount", "mount2", "umount"); err != nil {
+		if err := seccomp.ModifyDefaultPolicy(seccomp.AddSyscall, "perf_event_open", "eventfd2", "ppoll", "mount", "umount2"); err != nil {
 			panic(err)
 		}
 	}

--- a/x-pack/auditbeat/seccomp_linux.go
+++ b/x-pack/auditbeat/seccomp_linux.go
@@ -21,7 +21,7 @@ func init() {
 		}
 
 		// The system/socket dataset uses additional syscalls
-		if err := seccomp.ModifyDefaultPolicy(seccomp.AddSyscall, "perf_event_open", "eventfd2", "ppoll"); err != nil {
+		if err := seccomp.ModifyDefaultPolicy(seccomp.AddSyscall, "perf_event_open", "eventfd2", "ppoll", "mount", "mount2", "umount"); err != nil {
 			panic(err)
 		}
 	}

--- a/x-pack/auditbeat/tracing/tracefs.go
+++ b/x-pack/auditbeat/tracing/tracefs.go
@@ -60,6 +60,24 @@ func NewTraceFSWithPath(path string) (*TraceFS, error) {
 	return &TraceFS{basePath: path}, nil
 }
 
+// IsTraceFSAvailableAt returns nil if the path passed is a mounted tracefs
+// or debugfs that supports KProbes. Otherwise returns an error.
+func IsTraceFSAvailableAt(path string) error {
+	_, err := os.Stat(filepath.Join(path, kprobeCfgFile))
+	return err
+}
+
+// IsTraceFSAvailable returns nil if a tracefs or debugfs supporting KProbes
+// is available at the well-known paths. Otherwise returns an error.
+func IsTraceFSAvailable() (err error) {
+	for _, path := range []string{traceFSPath, debugFSTracingPath} {
+		if err = IsTraceFSAvailableAt(path); err == nil {
+			break
+		}
+	}
+	return
+}
+
 // ListKProbes lists the currently installed kprobes / kretprobes
 func (dfs *TraceFS) ListKProbes() (kprobes []Probe, err error) {
 	return dfs.listProbes(kprobeCfgFile)


### PR DESCRIPTION
Make the dataset try to mount tracefs/debugfs in their default paths if not mounted already.

