### PR TITLE
Update Example of Configuring Elastic Cloud Auth

### DIFF
--- a/x-pack/functionbeat/docs/getting-started.asciidoc
+++ b/x-pack/functionbeat/docs/getting-started.asciidoc
@@ -106,9 +106,8 @@ events from CloudWatch Logs and forwards the events to {es}.
     description: "lambda function for cloudwatch logs"
     triggers:
       - log_group_name: /aws/lambda/my-lambda-function
-output.elasticsearch:
-  cloud.id: "MyESDeployment:SomeLongString=="
-  cloud.auth: "elastic:SomeLongString"
+cloud.id: "MyESDeployment:SomeLongString=="
+cloud.auth: "elastic:SomeLongString"
 -------------------------------------------------------------------------------------
 
 To configure {beatname_uc}:


### PR DESCRIPTION
This reflects how the `functionbeat.reference.yml` shows and the only way I could get it to work when I was getting started with it today. I had to remove that `output.elasticsearch` and adjust the indentation of `cloud.x` settings to be at the top level.

I assume this reflects some minor change from a recent update.

I downloaded 7.3.1 on Mac today.