### PR TITLE
Cherry-pick #13544 to 7.3: Fix conversion of events with module fields

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -99,7 +99,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix `logstash/node_stats` metricset to also collect `logstash_stats.events.duration_in_millis` field when `xpack.enabled: true` is set. {pull}13082[13082]
 - Fix `logstash/node` metricset to also collect `logstash_state.pipeline.representation.{type,version,hash}` fields when `xpack.enabled: true` is set. {pull}13133[13133]
 - Check if fields in DBInstance is nil in rds metricset. {pull}13294[13294] {issue}13037[13037]
-- Fix module-level fields in Kubernetes metricsets. {pull}13433[13433]
+- Fix module-level fields in Kubernetes metricsets. {pull}13433[13433] {pull}13544[13544]
 - Fix panic in Redis Key metricset when collecting information from a removed key. {pull}13426[13426]
 
 *Packetbeat*

--- a/metricbeat/module/kubernetes/state_node/_meta/test/kube-state-metrics.expected
+++ b/metricbeat/module/kubernetes/state_node/_meta/test/kube-state-metrics.expected
@@ -1,49 +1,6 @@
 [
 	{
-		"RootFields": null,
-		"ModuleFields": null,
-		"MetricSetFields": {
-			"cpu": {
-				"allocatable": {
-					"cores": 3
-				},
-				"capacity": {
-					"cores": 4
-				}
-			},
-			"memory": {
-				"allocatable": {
-					"bytes": 3097786880
-				},
-				"capacity": {
-					"bytes": 4097786880
-				}
-			},
-			"name": "minikube-test",
-			"pod": {
-				"allocatable": {
-					"total": 210
-				},
-				"capacity": {
-					"total": 310
-				}
-			},
-			"status": {
-				"ready": "true",
-				"unschedulable": true
-			}
-		},
-		"Index": "",
-		"ID": "",
-		"Namespace": "kubernetes.node",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Service": "",
-		"Took": 0
-	},
-	{
-		"RootFields": null,
+		"RootFields": {},
 		"ModuleFields": null,
 		"MetricSetFields": {
 			"cpu": {
@@ -83,6 +40,53 @@
 		"Error": null,
 		"Host": "",
 		"Service": "",
-		"Took": 0
+		"Took": 0,
+		"Period": 0,
+		"DisableTimeSeries": false
+	},
+	{
+		"RootFields": {},
+		"ModuleFields": null,
+		"MetricSetFields": {
+			"cpu": {
+				"allocatable": {
+					"cores": 3
+				},
+				"capacity": {
+					"cores": 4
+				}
+			},
+			"memory": {
+				"allocatable": {
+					"bytes": 3097786880
+				},
+				"capacity": {
+					"bytes": 4097786880
+				}
+			},
+			"name": "minikube-test",
+			"pod": {
+				"allocatable": {
+					"total": 210
+				},
+				"capacity": {
+					"total": 310
+				}
+			},
+			"status": {
+				"ready": "true",
+				"unschedulable": true
+			}
+		},
+		"Index": "",
+		"ID": "",
+		"Namespace": "kubernetes.node",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Service": "",
+		"Took": 0,
+		"Period": 0,
+		"DisableTimeSeries": false
 	}
 ]

--- a/metricbeat/module/kubernetes/state_node/_meta/test/kube-state-metrics.v1.3.0.expected
+++ b/metricbeat/module/kubernetes/state_node/_meta/test/kube-state-metrics.v1.3.0.expected
@@ -1,6 +1,6 @@
 [
 	{
-		"RootFields": null,
+		"RootFields": {},
 		"ModuleFields": null,
 		"MetricSetFields": {
 			"cpu": {
@@ -40,6 +40,8 @@
 		"Error": null,
 		"Host": "",
 		"Service": "",
-		"Took": 0
+		"Took": 0,
+		"Period": 0,
+		"DisableTimeSeries": false
 	}
 ]

--- a/metricbeat/module/kubernetes/state_node/state_node.go
+++ b/metricbeat/module/kubernetes/state_node/state_node.go
@@ -108,10 +108,12 @@ func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
 
 	m.enricher.Enrich(events)
 	for _, event := range events {
-		reporter.Event(mb.Event{
-			MetricSetFields: event,
-			Namespace:       "kubernetes.node",
-		})
+		event[mb.NamespaceKey] = "node"
+		reported := reporter.Event(mb.TransformMapStrToEvent("kubernetes", event, nil))
+		if !reported {
+			m.Logger().Debug("error trying to emit event")
+			return
+		}
 	}
 }
 


### PR DESCRIPTION
Cherry-pick of PR #13544 to 7.3 branch. Original message: 

Apply elastic/beats#13433 also to the kubernetes `state_node` metricset.

Fix elastic/beats#13432