### PR TITLE
Retrieve aws credentials and check error

### DIFF
--- a/x-pack/filebeat/input/s3/input.go
+++ b/x-pack/filebeat/input/s3/input.go
@@ -151,7 +151,12 @@ func NewInput(cfg *common.Config, connector channel.Connector, context input.Con
 
 	awsConfig, err := awscommon.GetAWSCredentials(config.AwsConfig)
 	if err != nil {
-		return nil, errors.Wrap(err, "getAWSCredentials failed")
+		return nil, errors.Wrap(err, "failed to get aws credentials, please check AWS credential in config")
+	}
+
+	_, err = awsConfig.Credentials.Retrieve()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to retrieve aws credentials, please check AWS credential in config")
 	}
 
 	closeChannel := make(chan struct{})

--- a/x-pack/filebeat/input/s3/input.go
+++ b/x-pack/filebeat/input/s3/input.go
@@ -151,12 +151,7 @@ func NewInput(cfg *common.Config, connector channel.Connector, context input.Con
 
 	awsConfig, err := awscommon.GetAWSCredentials(config.AwsConfig)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get aws credentials, please check AWS credential in config")
-	}
-
-	_, err = awsConfig.Credentials.Retrieve()
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to retrieve aws credentials, please check AWS credential in config")
+		return nil, errors.Wrap(err, "getAWSCredentials failed")
 	}
 
 	closeChannel := make(chan struct{})

--- a/x-pack/metricbeat/module/aws/aws.go
+++ b/x-pack/metricbeat/module/aws/aws.go
@@ -60,7 +60,12 @@ func NewMetricSet(base mb.BaseMetricSet) (*MetricSet, error) {
 
 	awsConfig, err := awscommon.GetAWSCredentials(config.AWSConfig)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get aws credentials")
+		return nil, errors.Wrap(err, "failed to get aws credentials, please check AWS credential in config")
+	}
+
+	_, err = awsConfig.Credentials.Retrieve()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to retrieve aws credentials, please check AWS credential in config")
 	}
 
 	metricSet := MetricSet{


### PR DESCRIPTION
When using credential_profile_name, if a profile name is given in the config file but has a typo in there, metricbeat will not report error immediately. This fix is to add error check for credentials to make sure credentials retrieved using a given profile name doesn't have an error.

