### PR TITLE
[metricbeat] Migrate k8s modules to reporterv2 with error

### DIFF
--- a/metricbeat/helper/prometheus/module.go
+++ b/metricbeat/helper/prometheus/module.go
@@ -57,6 +57,5 @@ type prometheusMetricSet struct {
 }
 
 func (m *prometheusMetricSet) Fetch(r mb.ReporterV2) error {
-	m.prometheus.ReportProcessedMetrics(m.mapping, r)
-	return nil
+	return m.prometheus.ReportProcessedMetrics(m.mapping, r)
 }

--- a/metricbeat/helper/prometheus/module.go
+++ b/metricbeat/helper/prometheus/module.go
@@ -56,6 +56,7 @@ type prometheusMetricSet struct {
 	mapping    *MetricsMapping
 }
 
-func (m *prometheusMetricSet) Fetch(r mb.ReporterV2) {
+func (m *prometheusMetricSet) Fetch(r mb.ReporterV2) error {
 	m.prometheus.ReportProcessedMetrics(m.mapping, r)
+	return nil
 }

--- a/metricbeat/helper/prometheus/prometheus.go
+++ b/metricbeat/helper/prometheus/prometheus.go
@@ -38,7 +38,7 @@ type Prometheus interface {
 
 	GetProcessedMetrics(mapping *MetricsMapping) ([]common.MapStr, error)
 
-	ReportProcessedMetrics(mapping *MetricsMapping, r mb.ReporterV2)
+	ReportProcessedMetrics(mapping *MetricsMapping, r mb.ReporterV2) error
 }
 
 type prometheus struct {
@@ -214,11 +214,10 @@ type infoMetricData struct {
 	Meta   common.MapStr
 }
 
-func (p *prometheus) ReportProcessedMetrics(mapping *MetricsMapping, r mb.ReporterV2) {
+func (p *prometheus) ReportProcessedMetrics(mapping *MetricsMapping, r mb.ReporterV2) error {
 	events, err := p.GetProcessedMetrics(mapping)
 	if err != nil {
-		r.Error(err)
-		return
+		return errors.Wrap(err, "error getting processed metrics")
 	}
 	for _, event := range events {
 		r.Event(mb.Event{
@@ -226,6 +225,8 @@ func (p *prometheus) ReportProcessedMetrics(mapping *MetricsMapping, r mb.Report
 			Namespace:       mapping.Namespace,
 		})
 	}
+
+	return nil
 }
 
 func getEvent(m map[string]common.MapStr, labels common.MapStr) common.MapStr {

--- a/metricbeat/helper/prometheus/ptest/ptest.go
+++ b/metricbeat/helper/prometheus/ptest/ptest.go
@@ -156,10 +156,10 @@ func TestMetricSet(t *testing.T, module, metricset string, cases TestCases) {
 			"hosts":      []string{server.URL},
 		}
 
-		f := mbtest.NewReportingMetricSetV2Error(t, config)
+		f := mbtest.NewFetcher(t, config)
 		reporter := &mbtest.CapturingReporterV2{}
-		f.Fetch(reporter)
-		assert.Nil(t, reporter.GetErrors(), "Errors while fetching metrics")
+		_, errs := f.FetchEvents()
+		assert.Nil(t, errs, "Errors while fetching metrics")
 
 		if *expectedFlag {
 			events := reporter.GetEvents()

--- a/metricbeat/helper/prometheus/ptest/ptest.go
+++ b/metricbeat/helper/prometheus/ptest/ptest.go
@@ -156,7 +156,7 @@ func TestMetricSet(t *testing.T, module, metricset string, cases TestCases) {
 			"hosts":      []string{server.URL},
 		}
 
-		f := mbtest.NewReportingMetricSetV2(t, config)
+		f := mbtest.NewReportingMetricSetV2Error(t, config)
 		reporter := &mbtest.CapturingReporterV2{}
 		f.Fetch(reporter)
 		assert.Nil(t, reporter.GetErrors(), "Errors while fetching metrics")

--- a/metricbeat/helper/prometheus/ptest/ptest.go
+++ b/metricbeat/helper/prometheus/ptest/ptest.go
@@ -157,12 +157,10 @@ func TestMetricSet(t *testing.T, module, metricset string, cases TestCases) {
 		}
 
 		f := mbtest.NewFetcher(t, config)
-		reporter := &mbtest.CapturingReporterV2{}
-		_, errs := f.FetchEvents()
+		events, errs := f.FetchEvents()
 		assert.Nil(t, errs, "Errors while fetching metrics")
 
 		if *expectedFlag {
-			events := reporter.GetEvents()
 			sort.SliceStable(events, func(i, j int) bool {
 				h1, _ := hashstructure.Hash(events[i], nil)
 				h2, _ := hashstructure.Hash(events[j], nil)
@@ -185,7 +183,7 @@ func TestMetricSet(t *testing.T, module, metricset string, cases TestCases) {
 			t.Fatal(err)
 		}
 
-		for _, event := range reporter.GetEvents() {
+		for _, event := range events {
 			// ensure the event is in expected list
 			found := -1
 			for i, expectedEvent := range expectedEvents {

--- a/metricbeat/module/kubernetes/apiserver/metricset.go
+++ b/metricbeat/module/kubernetes/apiserver/metricset.go
@@ -18,9 +18,10 @@
 package apiserver
 
 import (
+	"github.com/pkg/errors"
+
 	"github.com/elastic/beats/metricbeat/helper/prometheus"
 	"github.com/elastic/beats/metricbeat/mb"
-	"github.com/pkg/errors"
 )
 
 // Metricset for apiserver is a prometheus based metricset

--- a/metricbeat/module/kubernetes/apiserver/metricset.go
+++ b/metricbeat/module/kubernetes/apiserver/metricset.go
@@ -20,6 +20,7 @@ package apiserver
 import (
 	"github.com/elastic/beats/metricbeat/helper/prometheus"
 	"github.com/elastic/beats/metricbeat/mb"
+	"github.com/pkg/errors"
 )
 
 // Metricset for apiserver is a prometheus based metricset
@@ -29,7 +30,7 @@ type metricset struct {
 	prometheusMappings *prometheus.MetricsMapping
 }
 
-var _ mb.ReportingMetricSetV2 = (*metricset)(nil)
+var _ mb.ReportingMetricSetV2Error = (*metricset)(nil)
 
 // getMetricsetFactory as required by` mb.Registry.MustAddMetricSet`
 func getMetricsetFactory(prometheusMappings *prometheus.MetricsMapping) mb.MetricSetFactory {
@@ -47,11 +48,10 @@ func getMetricsetFactory(prometheusMappings *prometheus.MetricsMapping) mb.Metri
 }
 
 // Fetch as expected by `mb.EventFetcher`
-func (m *metricset) Fetch(reporter mb.ReporterV2) {
+func (m *metricset) Fetch(reporter mb.ReporterV2) error {
 	events, err := m.prometheusClient.GetProcessedMetrics(m.prometheusMappings)
 	if err != nil {
-		reporter.Error(err)
-		return
+		return errors.Wrap(err, "error getting metrics")
 	}
 
 	rcPost14 := false
@@ -88,4 +88,6 @@ func (m *metricset) Fetch(reporter mb.ReporterV2) {
 			Namespace:       m.prometheusMappings.Namespace,
 		})
 	}
+
+	return nil
 }

--- a/metricbeat/module/kubernetes/container/container.go
+++ b/metricbeat/module/kubernetes/container/container.go
@@ -78,31 +78,30 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // Fetch methods implements the data gathering and data conversion to the right
 // format. It publishes the event which is then forwarded to the output. In case
 // of an error set the Error field of mb.Event or simply call report.Error().
-func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
+func (m *MetricSet) Fetch(reporter mb.ReporterV2) error {
 	m.enricher.Start()
 
 	body, err := m.http.FetchContent()
 	if err != nil {
-		err = errors.Wrap(err, "error doing HTTP request to fetch 'container' Metricset data")
-		logger.Error(err)
-		reporter.Error(err)
-		return
+		return errors.Wrap(err, "error doing HTTP request to fetch 'container' Metricset data")
+
 	}
 
 	events, err := eventMapping(body, util.PerfMetrics)
 	if err != nil {
-		logger.Error(err)
-		reporter.Error(err)
-		return
+		return errors.Wrap(err, "error in mapping")
 	}
 
 	m.enricher.Enrich(events)
 
 	for _, e := range events {
-		reporter.Event(mb.TransformMapStrToEvent("kubernetes", e, nil))
+		isOpen := reporter.Event(mb.TransformMapStrToEvent("kubernetes", e, nil))
+		if !isOpen {
+			return nil
+		}
 	}
 
-	return
+	return nil
 }
 
 // Close stops this metricset

--- a/metricbeat/module/kubernetes/pod/pod.go
+++ b/metricbeat/module/kubernetes/pod/pod.go
@@ -18,6 +18,8 @@
 package pod
 
 import (
+	"github.com/pkg/errors"
+
 	"github.com/elastic/beats/libbeat/common/kubernetes"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/metricbeat/helper"
@@ -78,29 +80,28 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // Fetch methods implements the data gathering and data conversion to the right
 // format. It publishes the event which is then forwarded to the output. In case
 // of an error set the Error field of mb.Event or simply call report.Error().
-func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
+func (m *MetricSet) Fetch(reporter mb.ReporterV2) error {
 	m.enricher.Start()
 
 	body, err := m.http.FetchContent()
 	if err != nil {
-		logger.Error(err)
-		reporter.Error(err)
-		return
+		return errors.Wrap(err, "error doing HTTP request to fetch 'pod' Metricset data")
 	}
 
 	events, err := eventMapping(body, util.PerfMetrics)
 	if err != nil {
-		logger.Error(err)
-		reporter.Error(err)
-		return
+		return errors.Wrap(err, "error in mapping")
 	}
 
 	m.enricher.Enrich(events)
 
 	for _, e := range events {
-		reporter.Event(mb.TransformMapStrToEvent("kubernetes", e, nil))
+		isOpen := reporter.Event(mb.TransformMapStrToEvent("kubernetes", e, nil))
+		if !isOpen {
+			return nil
+		}
 	}
-	return
+	return nil
 }
 
 // Close stops this metricset

--- a/metricbeat/module/kubernetes/state_container/state_container.go
+++ b/metricbeat/module/kubernetes/state_container/state_container.go
@@ -18,12 +18,13 @@
 package state_container
 
 import (
+	"github.com/pkg/errors"
+
 	"github.com/elastic/beats/libbeat/common"
 	p "github.com/elastic/beats/metricbeat/helper/prometheus"
 	"github.com/elastic/beats/metricbeat/mb"
 	"github.com/elastic/beats/metricbeat/mb/parse"
 	"github.com/elastic/beats/metricbeat/module/kubernetes/util"
-	"github.com/pkg/errors"
 )
 
 const (

--- a/metricbeat/module/kubernetes/state_cronjob/state_cronjob.go
+++ b/metricbeat/module/kubernetes/state_cronjob/state_cronjob.go
@@ -18,10 +18,11 @@
 package state_cronjob
 
 import (
+	"github.com/pkg/errors"
+
 	"github.com/elastic/beats/libbeat/common"
 	p "github.com/elastic/beats/metricbeat/helper/prometheus"
 	"github.com/elastic/beats/metricbeat/mb"
-	"github.com/pkg/errors"
 )
 
 func init() {

--- a/metricbeat/module/kubernetes/state_cronjob/state_cronjob.go
+++ b/metricbeat/module/kubernetes/state_cronjob/state_cronjob.go
@@ -21,6 +21,7 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 	p "github.com/elastic/beats/metricbeat/helper/prometheus"
 	"github.com/elastic/beats/metricbeat/mb"
+	"github.com/pkg/errors"
 )
 
 func init() {
@@ -74,12 +75,10 @@ func NewCronJobMetricSet(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // module rooted fields at the event that gets reported
 //
 // Copied from other kube state metrics.
-func (m *CronJobMetricSet) Fetch(reporter mb.ReporterV2) {
+func (m *CronJobMetricSet) Fetch(reporter mb.ReporterV2) error {
 	events, err := m.prometheus.GetProcessedMetrics(m.mapping)
 	if err != nil {
-		m.Logger().Error(err)
-		reporter.Error(err)
-		return
+		return errors.Wrap(err, "error getting metrics")
 	}
 
 	for _, event := range events {
@@ -98,10 +97,9 @@ func (m *CronJobMetricSet) Fetch(reporter mb.ReporterV2) {
 			ModuleFields:    moduleFieldsMapStr,
 			Namespace:       "kubernetes.cronjob",
 		}); !reported {
-			m.Logger().Debug("error trying to emit event")
-			return
+			return nil
 		}
 	}
 
-	return
+	return nil
 }

--- a/metricbeat/module/kubernetes/state_node/state_node.go
+++ b/metricbeat/module/kubernetes/state_node/state_node.go
@@ -18,6 +18,8 @@
 package state_node
 
 import (
+	"github.com/pkg/errors"
+
 	"github.com/elastic/beats/libbeat/common/kubernetes"
 	p "github.com/elastic/beats/metricbeat/helper/prometheus"
 	"github.com/elastic/beats/metricbeat/mb"
@@ -96,14 +98,12 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // Fetch methods implements the data gathering and data conversion to the right
 // format. It publishes the event which is then forwarded to the output. In case
 // of an error set the Error field of mb.Event or simply call report.Error().
-func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
+func (m *MetricSet) Fetch(reporter mb.ReporterV2) error {
 	m.enricher.Start()
 
 	events, err := m.prometheus.GetProcessedMetrics(mapping)
 	if err != nil {
-		m.Logger().Error(err)
-		reporter.Error(err)
-		return
+		return errors.Wrap(err, "error doing HTTP request to fetch 'state_node' Metricset data")
 	}
 
 	m.enricher.Enrich(events)
@@ -111,10 +111,11 @@ func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
 		event[mb.NamespaceKey] = "node"
 		reported := reporter.Event(mb.TransformMapStrToEvent("kubernetes", event, nil))
 		if !reported {
-			m.Logger().Debug("error trying to emit event")
-			return
+			return nil
 		}
 	}
+
+	return nil
 }
 
 // Close stops this metricset

--- a/metricbeat/module/kubernetes/system/system.go
+++ b/metricbeat/module/kubernetes/system/system.go
@@ -18,6 +18,8 @@
 package system
 
 import (
+	"github.com/pkg/errors"
+
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/metricbeat/helper"
 	"github.com/elastic/beats/metricbeat/mb"
@@ -73,23 +75,22 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // Fetch methods implements the data gathering and data conversion to the right
 // format. It publishes the event which is then forwarded to the output. In case
 // of an error set the Error field of mb.Event or simply call report.Error().
-func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
+func (m *MetricSet) Fetch(reporter mb.ReporterV2) error {
 	body, err := m.http.FetchContent()
 	if err != nil {
-		logger.Error(err)
-		reporter.Error(err)
-		return
+		return errors.Wrap(err, "error doing HTTP request to fetch 'system' Metricset data")
 	}
 
 	events, err := eventMapping(body)
 	if err != nil {
-		logger.Error(err)
-		reporter.Error(err)
-		return
+		return errors.Wrap(err, "error in mapping")
 	}
 
 	for _, e := range events {
-		reporter.Event(mb.TransformMapStrToEvent("kubernetes", e, nil))
+		isOpen := reporter.Event(mb.TransformMapStrToEvent("kubernetes", e, nil))
+		if !isOpen {
+			return nil
+		}
 	}
-	return
+	return nil
 }

--- a/metricbeat/module/kubernetes/volume/volume.go
+++ b/metricbeat/module/kubernetes/volume/volume.go
@@ -18,6 +18,8 @@
 package volume
 
 import (
+	"github.com/pkg/errors"
+
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/metricbeat/helper"
 	"github.com/elastic/beats/metricbeat/mb"
@@ -73,18 +75,19 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // Fetch methods implements the data gathering and data conversion to the right
 // format. It publishes the event which is then forwarded to the output. In case
 // of an error set the Error field of mb.Event or simply call report.Error().
-func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
+func (m *MetricSet) Fetch(reporter mb.ReporterV2) error {
 	body, err := m.http.FetchContent()
 	if err != nil {
-		logger.Error(err)
-		reporter.Error(err)
-		return
+		return errors.Wrap(err, "error doing HTTP request to fetch 'volume' Metricset data")
 	}
 
 	events, err := eventMapping(body)
 	for _, e := range events {
-		reporter.Event(mb.TransformMapStrToEvent("kubernetes", e, nil))
+		isOpen := reporter.Event(mb.TransformMapStrToEvent("kubernetes", e, nil))
+		if !isOpen {
+			return nil
+		}
 	}
 
-	return
+	return nil
 }

--- a/x-pack/metricbeat/module/coredns/stats/stats_integration_test.go
+++ b/x-pack/metricbeat/module/coredns/stats/stats_integration_test.go
@@ -18,7 +18,7 @@ import (
 func TestFetch(t *testing.T) {
 	service := compose.EnsureUp(t, "coredns")
 
-	f := mbtest.NewFetcher(t, getConfig(service.Host()))
+	f := mbtest.NewReportingMetricSetV2Error(t, getConfig(service.Host()))
 	events, errs := mbtest.ReportingFetchV2Error(f)
 	if len(errs) > 0 {
 		t.Fatalf("Expected 0 error, had %d. %v\n", len(errs), errs)

--- a/x-pack/metricbeat/module/coredns/stats/stats_integration_test.go
+++ b/x-pack/metricbeat/module/coredns/stats/stats_integration_test.go
@@ -18,8 +18,8 @@ import (
 func TestFetch(t *testing.T) {
 	service := compose.EnsureUp(t, "coredns")
 
-	f := mbtest.NewReportingMetricSetV2(t, getConfig(service.Host()))
-	events, errs := mbtest.ReportingFetchV2(f)
+	f := mbtest.NewFetcher(t, getConfig(service.Host()))
+	events, errs := mbtest.ReportingFetchV2Error(f)
 	if len(errs) > 0 {
 		t.Fatalf("Expected 0 error, had %d. %v\n", len(errs), errs)
 	}

--- a/x-pack/metricbeat/module/coredns/stats/stats_integration_test.go
+++ b/x-pack/metricbeat/module/coredns/stats/stats_integration_test.go
@@ -18,8 +18,8 @@ import (
 func TestFetch(t *testing.T) {
 	service := compose.EnsureUp(t, "coredns")
 
-	f := mbtest.NewReportingMetricSetV2Error(t, getConfig(service.Host()))
-	events, errs := mbtest.ReportingFetchV2Error(f)
+	f := mbtest.NewFetcher(t, getConfig(service.Host()))
+	events, errs := f.FetchEvents()
 	if len(errs) > 0 {
 		t.Fatalf("Expected 0 error, had %d. %v\n", len(errs), errs)
 	}


### PR DESCRIPTION
See  elastic/beats#11374

This is one of the last big ones. I feel like the k8s module is one of those things that's imported by lots of other chunks of beats, so lets see how CI feels and go from there.