### PR TITLE
[Doc]Add ecs attribute and set to 1.0 for 7.3

### DIFF
--- a/libbeat/docs/version.asciidoc
+++ b/libbeat/docs/version.asciidoc
@@ -7,3 +7,4 @@
 :docker-compose: 1.11
 :branch: 7.3
 :major-version: 7.x
+:ecs_version: 1.0


### PR DESCRIPTION
Related to: 
* https://github.com/elastic/docs/pull/1170
* #13561 

Sets ecs version to 1.0

Merge targets:
- [ ] 7.3
- [ ] 7.2
- [ ] 7.1
- [ ] 7.0