### PR TITLE
[Doc]Add attribute for ecs_version and set value to 1.1

### DIFF
--- a/libbeat/docs/version.asciidoc
+++ b/libbeat/docs/version.asciidoc
@@ -7,3 +7,4 @@
 :docker-compose: 1.11
 :branch: master
 :major-version: 8.x
+:ecs_version: 1.1


### PR DESCRIPTION
Related to: 
* https://github.com/elastic/docs/pull/1170
* #13560

Sets ecs version to 1.0

Merge targets:
- [ ] master
- [ ] 7.x
- [ ] 7.4