### PR TITLE
[Doc]Add ecs attribute and set to 1.0 for 7.0

### DIFF
--- a/libbeat/docs/version.asciidoc
+++ b/libbeat/docs/version.asciidoc
@@ -7,3 +7,4 @@
 :docker-compose: 1.11
 :branch: 7.0
 :major-version: 7.x
+:ecs_version: 1.0


### PR DESCRIPTION
Sets ecs version to 1.0

Backport of #13560