### PR TITLE
[DOCS] config example for AD domain credential for MSSQL module

### DIFF
--- a/metricbeat/docs/modules/mssql.asciidoc
+++ b/metricbeat/docs/modules/mssql.asciidoc
@@ -30,7 +30,6 @@ The following Metricsets are already included:
 
 `performance` Metricset fetches information from what's commonly known as https://docs.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-os-performance-counters-transact-sql?view=sql-server-2017[Performance Counters] in MSSQL.
 
-[float]
 === Module-specific configuration notes
 
 When configuring the `hosts` option, you can specify native user credentials 
@@ -43,7 +42,6 @@ hosts: ["sqlserver://sa@localhost"]]
 To use Active Directory domain credentials, you can separately specify the username and password
 using the respective configuration options to allow the domain to be included in the username:
 
-[source,yaml]
 ----
 metricbeat.modules:
 - module: mssql

--- a/metricbeat/docs/modules/mssql.asciidoc
+++ b/metricbeat/docs/modules/mssql.asciidoc
@@ -30,6 +30,7 @@ The following Metricsets are already included:
 
 `performance` Metricset fetches information from what's commonly known as https://docs.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-os-performance-counters-transact-sql?view=sql-server-2017[Performance Counters] in MSSQL.
 
+[float]
 === Module-specific configuration notes
 
 When configuring the `hosts` option, you can specify native user credentials 
@@ -42,6 +43,7 @@ hosts: ["sqlserver://sa@localhost"]]
 To use Active Directory domain credentials, you can separately specify the username and password
 using the respective configuration options to allow the domain to be included in the username:
 
+[source,yaml]
 ----
 metricbeat.modules:
 - module: mssql

--- a/metricbeat/docs/modules/mssql.asciidoc
+++ b/metricbeat/docs/modules/mssql.asciidoc
@@ -30,6 +30,31 @@ The following Metricsets are already included:
 
 `performance` Metricset fetches information from what's commonly known as https://docs.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-os-performance-counters-transact-sql?view=sql-server-2017[Performance Counters] in MSSQL.
 
+=== Module-specific configuration notes
+
+When configuring the `hosts` option, you can specify native user credentials 
+as part of the host string with the following format:
+
+----
+hosts: ["sqlserver://sa@localhost"]]
+----
+
+To use Active Directory domain credentials, you can separately specify the username and password
+using the respective configuration options to allow the domain to be included in the username:
+
+----
+metricbeat.modules:
+- module: mssql
+  metricsets:
+    - "transaction_log"
+    - "performance"
+  hosts: ["sqlserver://localhost"]
+  username: domain\username
+  password: verysecurepassword
+  period: 10
+----
+
+Store sensitive values like passwords in the <<keystore,secrets keystore>>.
 
 [float]
 === Example configuration
@@ -44,7 +69,9 @@ metricbeat.modules:
   metricsets:
     - "transaction_log"
     - "performance"
-  hosts: ["sqlserver://sa@localhost"]
+  hosts: ["sqlserver://localhost"]
+  username: domain\username
+  password: verysecurepassword
   period: 10s
 
 ----

--- a/metricbeat/docs/modules/mssql.asciidoc
+++ b/metricbeat/docs/modules/mssql.asciidoc
@@ -11,22 +11,22 @@ beta[]
 This is the https://www.microsoft.com/en-us/sql-server/sql-server-2017[Microsoft SQL 2017] Metricbeat module. It is still in beta and under active development to add new Metricsets and introduce enhancements.
 
 [float]
-== Compatibility
+=== Compatibility
 
 The module is being tested with https://hub.docker.com/r/microsoft/mssql-server-linux/[2017 GA] version under Linux
 
 [float]
-== Metricsets
+=== Metricsets
 
 The following Metricsets are already included:
 
 [float]
-=== `transaction_log`
+==== `transaction_log`
 
 `transaction_log` Metricset fetches information about the operation and transaction log of each MSSQL database in the monitored instance. All data is extracted from the https://docs.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/database-related-dynamic-management-views-transact-sql?view=sql-server-2017[Database Dynamic Management Views]
 
 [float]
-=== `performance`
+==== `performance`
 
 `performance` Metricset fetches information from what's commonly known as https://docs.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-os-performance-counters-transact-sql?view=sql-server-2017[Performance Counters] in MSSQL.
 

--- a/metricbeat/docs/modules/mssql.asciidoc
+++ b/metricbeat/docs/modules/mssql.asciidoc
@@ -30,6 +30,7 @@ The following Metricsets are already included:
 
 `performance` Metricset fetches information from what's commonly known as https://docs.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-os-performance-counters-transact-sql?view=sql-server-2017[Performance Counters] in MSSQL.
 
+[float]
 === Module-specific configuration notes
 
 When configuring the `hosts` option, you can specify native user credentials 

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -734,7 +734,9 @@ metricbeat.modules:
   metricsets:
     - "transaction_log"
     - "performance"
-  hosts: ["sqlserver://sa@localhost"]
+  hosts: ["sqlserver://localhost"]
+  username: domain\username
+  password: verysecurepassword
   period: 10s
 
 

--- a/x-pack/metricbeat/module/mssql/_meta/config.yml
+++ b/x-pack/metricbeat/module/mssql/_meta/config.yml
@@ -2,6 +2,8 @@
   metricsets:
     - "transaction_log"
     - "performance"
-  hosts: ["sqlserver://sa@localhost"]
+  hosts: ["sqlserver://localhost"]
+  username: domain\username
+  password: verysecurepassword
   period: 10s
 

--- a/x-pack/metricbeat/module/mssql/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/mssql/_meta/docs.asciidoc
@@ -20,6 +20,7 @@ The following Metricsets are already included:
 
 `performance` Metricset fetches information from what's commonly known as https://docs.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-os-performance-counters-transact-sql?view=sql-server-2017[Performance Counters] in MSSQL.
 
+[float]
 === Module-specific configuration notes
 
 When configuring the `hosts` option, you can specify native user credentials 

--- a/x-pack/metricbeat/module/mssql/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/mssql/_meta/docs.asciidoc
@@ -19,3 +19,29 @@ The following Metricsets are already included:
 === `performance`
 
 `performance` Metricset fetches information from what's commonly known as https://docs.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-os-performance-counters-transact-sql?view=sql-server-2017[Performance Counters] in MSSQL.
+
+=== Module-specific configuration notes
+
+When configuring the `hosts` option, you can specify native user credentials 
+as part of the host string with the following format:
+
+----
+hosts: ["sqlserver://sa@localhost"]]
+----
+
+To use Active Directory domain credentials, you can separately specify the username and password
+using the respective configuration options to allow the domain to be included in the username:
+
+----
+metricbeat.modules:
+- module: mssql
+  metricsets:
+    - "transaction_log"
+    - "performance"
+  hosts: ["sqlserver://localhost"]
+  username: domain\username
+  password: verysecurepassword
+  period: 10
+----
+
+Store sensitive values like passwords in the <<keystore,secrets keystore>>.

--- a/x-pack/metricbeat/module/mssql/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/mssql/_meta/docs.asciidoc
@@ -1,22 +1,22 @@
 This is the https://www.microsoft.com/en-us/sql-server/sql-server-2017[Microsoft SQL 2017] Metricbeat module. It is still in beta and under active development to add new Metricsets and introduce enhancements.
 
 [float]
-== Compatibility
+=== Compatibility
 
 The module is being tested with https://hub.docker.com/r/microsoft/mssql-server-linux/[2017 GA] version under Linux
 
 [float]
-== Metricsets
+=== Metricsets
 
 The following Metricsets are already included:
 
 [float]
-=== `transaction_log`
+==== `transaction_log`
 
 `transaction_log` Metricset fetches information about the operation and transaction log of each MSSQL database in the monitored instance. All data is extracted from the https://docs.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/database-related-dynamic-management-views-transact-sql?view=sql-server-2017[Database Dynamic Management Views]
 
 [float]
-=== `performance`
+==== `performance`
 
 `performance` Metricset fetches information from what's commonly known as https://docs.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-os-performance-counters-transact-sql?view=sql-server-2017[Performance Counters] in MSSQL.
 

--- a/x-pack/metricbeat/modules.d/mssql.yml.disabled
+++ b/x-pack/metricbeat/modules.d/mssql.yml.disabled
@@ -5,6 +5,8 @@
   metricsets:
     - "transaction_log"
     - "performance"
-  hosts: ["sqlserver://sa@localhost"]
+  hosts: ["sqlserver://localhost"]
+  username: domain\username
+  password: verysecurepassword
   period: 10s
 


### PR DESCRIPTION
Provide an example of using credentials with a domain for the MSSQL Metricbeat module.
Potentially addresses elastic/beats#13006 and elastic/beats#12267
Backport to 7.x minor version branches
