### PR TITLE
Update NATS compatibility versions in docs for NATS Metricbeat module 

### DIFF
--- a/metricbeat/docs/modules/nats.asciidoc
+++ b/metricbeat/docs/modules/nats.asciidoc
@@ -12,7 +12,7 @@ The default metricsets are `stats`, `connections`, `routes` and `subscriptions`.
 [float]
 === Compatibility
 
-The Nats module is tested with Nats 1.3.0.
+The Nats module is tested with Nats 1.3.0 and 2.0.4
 
 
 [float]


### PR DESCRIPTION
This one is related to https://github.com/elastic/beats/issues/13599.

cc: @sorantis 