### PR TITLE
[DOCS] Add named anchor to fix links for asciidoctor migration

### DIFF
--- a/libbeat/docs/index.asciidoc
+++ b/libbeat/docs/index.asciidoc
@@ -1,4 +1,3 @@
-[[beats-reference]]
 = Beats Platform Reference
 
 include::./version.asciidoc[]

--- a/libbeat/docs/overview.asciidoc
+++ b/libbeat/docs/overview.asciidoc
@@ -1,7 +1,8 @@
-== Overview
+[[beats-reference]]
+== Beats overview
 
 ++++
-<titleabbrev>Beats overview</titleabbrev>
+<titleabbrev>Overview</titleabbrev>
 ++++
 
 {beats} are open source data shippers that you install as agents on your


### PR DESCRIPTION
Fixes links in the asciidoctor build.

This change works because the URL for the overview page seems to be derived from the ID specified for the level 1 in the book. The URL in the overview page in the published book is: https://www.elastic.co/guide/en/beats/libbeat/current/beats-reference.html.
