### PR TITLE
[6.4][DOCS] Add named anchor to fix links for asciidoctor migration (#13608)

### DIFF
--- a/libbeat/docs/index.asciidoc
+++ b/libbeat/docs/index.asciidoc
@@ -1,4 +1,3 @@
-[[beats-reference]]
 = Beats Platform Reference
 
 include::./version.asciidoc[]

--- a/libbeat/docs/overview.asciidoc
+++ b/libbeat/docs/overview.asciidoc
@@ -1,7 +1,8 @@
-== Overview
+[[beats-reference]]
+== Beats overview
 
 ++++
-<titleabbrev>Beats overview</titleabbrev>
+<titleabbrev>Overview</titleabbrev>
 ++++
 
 {beats} are open source data shippers that you install as agents on your


### PR DESCRIPTION
Backports #13608 to 6.4 branch.