### PR TITLE
[5.6][DOCS] Add named anchor to fix links for asciidoctor migration (#13608)

### DIFF
--- a/libbeat/docs/index.asciidoc
+++ b/libbeat/docs/index.asciidoc
@@ -1,4 +1,3 @@
-[[beats-reference]]
 = Beats Platform Reference
 
 include::./version.asciidoc[]

--- a/libbeat/docs/overview.asciidoc
+++ b/libbeat/docs/overview.asciidoc
@@ -1,4 +1,5 @@
-== Overview
+[[beats-reference]]
+== Beats overview
 
 The _Beats_ are open source data shippers that you install as _agents_ on
 your servers to send different types of operational data to


### PR DESCRIPTION
Backports #13608 to 5.6 branch.