### PR TITLE
[Metricbeat] Fix elb and ebs overview dashboard

### DIFF
--- a/x-pack/metricbeat/module/aws/_meta/kibana/7/dashboard/Metricbeat-aws-ebs-overview.json
+++ b/x-pack/metricbeat/module/aws/_meta/kibana/7/dashboard/Metricbeat-aws-ebs-overview.json
@@ -19,7 +19,9 @@
         },
         "panelsJSON": [
           {
-            "embeddableConfig": {},
+            "embeddableConfig": {
+              "title": "Volume Write Ops"
+            },
             "gridData": {
               "h": 10,
               "i": "1",
@@ -30,10 +32,12 @@
             "panelIndex": "1",
             "panelRefName": "panel_0",
             "title": "Volume Write Ops",
-            "version": "7.3.0"
+            "version": "7.4.0"
           },
           {
-            "embeddableConfig": {},
+            "embeddableConfig": {
+              "title": "Volume Read Ops"
+            },
             "gridData": {
               "h": 10,
               "i": "2",
@@ -44,10 +48,12 @@
             "panelIndex": "2",
             "panelRefName": "panel_1",
             "title": "Volume Read Ops",
-            "version": "7.3.0"
+            "version": "7.4.0"
           },
           {
-            "embeddableConfig": {},
+            "embeddableConfig": {
+              "title": "Volume Write Bytes"
+            },
             "gridData": {
               "h": 10,
               "i": "3",
@@ -58,10 +64,12 @@
             "panelIndex": "3",
             "panelRefName": "panel_2",
             "title": "Volume Write Bytes",
-            "version": "7.3.0"
+            "version": "7.4.0"
           },
           {
-            "embeddableConfig": {},
+            "embeddableConfig": {
+              "title": "Volume Read Bytes"
+            },
             "gridData": {
               "h": 10,
               "i": "4",
@@ -72,10 +80,12 @@
             "panelIndex": "4",
             "panelRefName": "panel_3",
             "title": "Volume Read Bytes",
-            "version": "7.3.0"
+            "version": "7.4.0"
           },
           {
-            "embeddableConfig": {},
+            "embeddableConfig": {
+              "title": "Volume Queue Length"
+            },
             "gridData": {
               "h": 10,
               "i": "5",
@@ -86,10 +96,12 @@
             "panelIndex": "5",
             "panelRefName": "panel_4",
             "title": "Volume Queue Length",
-            "version": "7.3.0"
+            "version": "7.4.0"
           },
           {
-            "embeddableConfig": {},
+            "embeddableConfig": {
+              "title": "Volume Total Write Time"
+            },
             "gridData": {
               "h": 10,
               "i": "6",
@@ -100,10 +112,12 @@
             "panelIndex": "6",
             "panelRefName": "panel_5",
             "title": "Volume Total Write Time",
-            "version": "7.3.0"
+            "version": "7.4.0"
           },
           {
-            "embeddableConfig": {},
+            "embeddableConfig": {
+              "title": "Volume Total Read Time"
+            },
             "gridData": {
               "h": 10,
               "i": "7",
@@ -114,10 +128,12 @@
             "panelIndex": "7",
             "panelRefName": "panel_6",
             "title": "Volume Total Read Time",
-            "version": "7.3.0"
+            "version": "7.4.0"
           },
           {
-            "embeddableConfig": {},
+            "embeddableConfig": {
+              "title": "Volume Idle Time"
+            },
             "gridData": {
               "h": 10,
               "i": "8",
@@ -128,10 +144,12 @@
             "panelIndex": "8",
             "panelRefName": "panel_7",
             "title": "Volume Idle Time",
-            "version": "7.3.0"
+            "version": "7.4.0"
           },
           {
-            "embeddableConfig": {},
+            "embeddableConfig": {
+              "title": "EBS Volume ID Filter"
+            },
             "gridData": {
               "h": 5,
               "i": "9",
@@ -142,7 +160,7 @@
             "panelIndex": "9",
             "panelRefName": "panel_8",
             "title": "EBS Volume ID Filter",
-            "version": "7.3.0"
+            "version": "7.4.0"
           },
           {
             "embeddableConfig": {},
@@ -155,7 +173,7 @@
             },
             "panelIndex": "10",
             "panelRefName": "panel_9",
-            "version": "7.3.0"
+            "version": "7.4.0"
           }
         ],
         "timeRestore": false,
@@ -219,8 +237,8 @@
         }
       ],
       "type": "dashboard",
-      "updated_at": "2019-08-07T23:07:01.848Z",
-      "version": "WzI1MiwxXQ=="
+      "updated_at": "2019-09-12T16:35:04.005Z",
+      "version": "WzYwMDMsN10="
     },
     {
       "attributes": {
@@ -241,6 +259,7 @@
           "aggs": [],
           "params": {
             "axis_formatter": "number",
+            "axis_min": "0",
             "axis_position": "left",
             "axis_scale": "normal",
             "default_index_pattern": "metricbeat-*",
@@ -248,6 +267,7 @@
             "id": "61ca57f0-469d-11e7-af02-69e470af7417",
             "index_pattern": "",
             "interval": "5m",
+            "isModelInvalid": false,
             "series": [
               {
                 "axis_position": "right",
@@ -285,12 +305,12 @@
       },
       "id": "f6831f30-b7b6-11e9-8349-f15f850c5cd0",
       "migrationVersion": {
-        "visualization": "7.3.0"
+        "visualization": "7.3.1"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-08-07T23:07:01.848Z",
-      "version": "WzI1MywxXQ=="
+      "updated_at": "2019-09-12T16:31:45.681Z",
+      "version": "WzU5ODMsN10="
     },
     {
       "attributes": {
@@ -311,6 +331,7 @@
           "aggs": [],
           "params": {
             "axis_formatter": "number",
+            "axis_min": "0",
             "axis_position": "left",
             "axis_scale": "normal",
             "default_index_pattern": "metricbeat-*",
@@ -318,6 +339,7 @@
             "id": "61ca57f0-469d-11e7-af02-69e470af7417",
             "index_pattern": "",
             "interval": "5m",
+            "isModelInvalid": false,
             "series": [
               {
                 "axis_position": "right",
@@ -355,12 +377,12 @@
       },
       "id": "bb3a6cd0-b7b6-11e9-8349-f15f850c5cd0",
       "migrationVersion": {
-        "visualization": "7.3.0"
+        "visualization": "7.3.1"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-08-07T23:07:01.848Z",
-      "version": "WzI1NCwxXQ=="
+      "updated_at": "2019-09-12T16:31:31.261Z",
+      "version": "WzU5ODEsN10="
     },
     {
       "attributes": {
@@ -381,6 +403,7 @@
           "aggs": [],
           "params": {
             "axis_formatter": "number",
+            "axis_min": "0",
             "axis_position": "left",
             "axis_scale": "normal",
             "default_index_pattern": "metricbeat-*",
@@ -388,6 +411,7 @@
             "id": "61ca57f0-469d-11e7-af02-69e470af7417",
             "index_pattern": "",
             "interval": "5m",
+            "isModelInvalid": false,
             "series": [
               {
                 "axis_position": "right",
@@ -425,12 +449,12 @@
       },
       "id": "c0e32d50-b7b8-11e9-8349-f15f850c5cd0",
       "migrationVersion": {
-        "visualization": "7.3.0"
+        "visualization": "7.3.1"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-08-07T23:07:01.848Z",
-      "version": "WzI1NSwxXQ=="
+      "updated_at": "2019-09-12T16:32:46.176Z",
+      "version": "WzU5OTAsN10="
     },
     {
       "attributes": {
@@ -451,6 +475,7 @@
           "aggs": [],
           "params": {
             "axis_formatter": "number",
+            "axis_min": "0",
             "axis_position": "left",
             "axis_scale": "normal",
             "default_index_pattern": "metricbeat-*",
@@ -458,6 +483,7 @@
             "id": "61ca57f0-469d-11e7-af02-69e470af7417",
             "index_pattern": "",
             "interval": "5m",
+            "isModelInvalid": false,
             "series": [
               {
                 "axis_position": "right",
@@ -495,12 +521,12 @@
       },
       "id": "b00c4390-b7b8-11e9-8349-f15f850c5cd0",
       "migrationVersion": {
-        "visualization": "7.3.0"
+        "visualization": "7.3.1"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-08-07T23:07:01.848Z",
-      "version": "WzI1NiwxXQ=="
+      "updated_at": "2019-09-12T16:32:02.907Z",
+      "version": "WzU5ODUsN10="
     },
     {
       "attributes": {
@@ -521,6 +547,7 @@
           "aggs": [],
           "params": {
             "axis_formatter": "number",
+            "axis_min": "0",
             "axis_position": "left",
             "axis_scale": "normal",
             "default_index_pattern": "metricbeat-*",
@@ -528,6 +555,7 @@
             "id": "61ca57f0-469d-11e7-af02-69e470af7417",
             "index_pattern": "",
             "interval": "5m",
+            "isModelInvalid": false,
             "series": [
               {
                 "axis_position": "right",
@@ -565,12 +593,12 @@
       },
       "id": "fe0581b0-b7b8-11e9-8349-f15f850c5cd0",
       "migrationVersion": {
-        "visualization": "7.3.0"
+        "visualization": "7.3.1"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-08-07T23:07:01.848Z",
-      "version": "WzI1NywxXQ=="
+      "updated_at": "2019-09-12T16:30:59.507Z",
+      "version": "WzU5NzgsN10="
     },
     {
       "attributes": {
@@ -591,6 +619,7 @@
           "aggs": [],
           "params": {
             "axis_formatter": "number",
+            "axis_min": "0",
             "axis_position": "left",
             "axis_scale": "normal",
             "default_index_pattern": "metricbeat-*",
@@ -598,6 +627,7 @@
             "id": "61ca57f0-469d-11e7-af02-69e470af7417",
             "index_pattern": "",
             "interval": "5m",
+            "isModelInvalid": false,
             "series": [
               {
                 "axis_position": "right",
@@ -635,12 +665,12 @@
       },
       "id": "25384bf0-b7b9-11e9-8349-f15f850c5cd0",
       "migrationVersion": {
-        "visualization": "7.3.0"
+        "visualization": "7.3.1"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-08-07T23:35:39.480Z",
-      "version": "WzU4MiwxXQ=="
+      "updated_at": "2019-09-12T16:32:19.881Z",
+      "version": "WzU5ODcsN10="
     },
     {
       "attributes": {
@@ -661,6 +691,7 @@
           "aggs": [],
           "params": {
             "axis_formatter": "number",
+            "axis_min": "0",
             "axis_position": "left",
             "axis_scale": "normal",
             "default_index_pattern": "metricbeat-*",
@@ -668,6 +699,7 @@
             "id": "61ca57f0-469d-11e7-af02-69e470af7417",
             "index_pattern": "",
             "interval": "5m",
+            "isModelInvalid": false,
             "series": [
               {
                 "axis_position": "right",
@@ -705,12 +737,12 @@
       },
       "id": "12eff7e0-b7b9-11e9-8349-f15f850c5cd0",
       "migrationVersion": {
-        "visualization": "7.3.0"
+        "visualization": "7.3.1"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-08-07T23:58:30.205Z",
-      "version": "WzU4NSwxXQ=="
+      "updated_at": "2019-09-12T16:33:13.538Z",
+      "version": "WzU5OTMsN10="
     },
     {
       "attributes": {
@@ -778,12 +810,12 @@
       },
       "id": "67f43080-b7b9-11e9-8349-f15f850c5cd0",
       "migrationVersion": {
-        "visualization": "7.3.0"
+        "visualization": "7.3.1"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-08-07T23:45:56.417Z",
-      "version": "WzU4NCwxXQ=="
+      "updated_at": "2019-09-12T16:31:19.709Z",
+      "version": "WzU5ODAsN10="
     },
     {
       "attributes": {
@@ -830,7 +862,7 @@
       },
       "id": "d045d120-b7b9-11e9-8349-f15f850c5cd0",
       "migrationVersion": {
-        "visualization": "7.3.0"
+        "visualization": "7.3.1"
       },
       "references": [
         {
@@ -840,8 +872,8 @@
         }
       ],
       "type": "visualization",
-      "updated_at": "2019-08-07T23:07:01.848Z",
-      "version": "WzI2MSwxXQ=="
+      "updated_at": "2019-09-12T16:29:31.115Z",
+      "version": "WzU2MTIsN10="
     },
     {
       "attributes": {
@@ -882,13 +914,13 @@
             "updateFiltersOnChange": true,
             "useTimeFilter": false
           },
-          "title": "Region Filter [Metricbeat AWS]",
+          "title": "AWS Region Filter",
           "type": "input_control_vis"
         }
       },
       "id": "b5308940-7347-11e9-816b-07687310a99a",
       "migrationVersion": {
-        "visualization": "7.3.0"
+        "visualization": "7.3.1"
       },
       "references": [
         {
@@ -898,9 +930,9 @@
         }
       ],
       "type": "visualization",
-      "updated_at": "2019-08-07T23:07:05.935Z",
-      "version": "WzMwMywxXQ=="
+      "updated_at": "2019-09-12T16:29:35.238Z",
+      "version": "WzU2NTQsN10="
     }
   ],
-  "version": "7.3.0"
+  "version": "7.4.0"
 }

--- a/x-pack/metricbeat/module/aws/_meta/kibana/7/dashboard/Metricbeat-aws-ebs-overview.json
+++ b/x-pack/metricbeat/module/aws/_meta/kibana/7/dashboard/Metricbeat-aws-ebs-overview.json
@@ -287,7 +287,7 @@
       },
       "id": "f6831f30-b7b6-11e9-8349-f15f850c5cd0",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.3.0"
       },
       "references": [],
       "type": "visualization",
@@ -359,7 +359,7 @@
       },
       "id": "bb3a6cd0-b7b6-11e9-8349-f15f850c5cd0",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.3.0"
       },
       "references": [],
       "type": "visualization",
@@ -431,7 +431,7 @@
       },
       "id": "c0e32d50-b7b8-11e9-8349-f15f850c5cd0",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.3.0"
       },
       "references": [],
       "type": "visualization",
@@ -503,7 +503,7 @@
       },
       "id": "b00c4390-b7b8-11e9-8349-f15f850c5cd0",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.3.0"
       },
       "references": [],
       "type": "visualization",
@@ -575,7 +575,7 @@
       },
       "id": "fe0581b0-b7b8-11e9-8349-f15f850c5cd0",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.3.0"
       },
       "references": [],
       "type": "visualization",
@@ -647,7 +647,7 @@
       },
       "id": "25384bf0-b7b9-11e9-8349-f15f850c5cd0",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.3.0"
       },
       "references": [],
       "type": "visualization",
@@ -719,7 +719,7 @@
       },
       "id": "12eff7e0-b7b9-11e9-8349-f15f850c5cd0",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.3.0"
       },
       "references": [],
       "type": "visualization",
@@ -792,7 +792,7 @@
       },
       "id": "67f43080-b7b9-11e9-8349-f15f850c5cd0",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.3.0"
       },
       "references": [],
       "type": "visualization",
@@ -844,7 +844,7 @@
       },
       "id": "d045d120-b7b9-11e9-8349-f15f850c5cd0",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.3.0"
       },
       "references": [
         {
@@ -902,7 +902,7 @@
       },
       "id": "b5308940-7347-11e9-816b-07687310a99a",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.3.0"
       },
       "references": [
         {

--- a/x-pack/metricbeat/module/aws/_meta/kibana/7/dashboard/Metricbeat-aws-ebs-overview.json
+++ b/x-pack/metricbeat/module/aws/_meta/kibana/7/dashboard/Metricbeat-aws-ebs-overview.json
@@ -19,9 +19,7 @@
         },
         "panelsJSON": [
           {
-            "embeddableConfig": {
-              "title": "Volume Write Ops"
-            },
+            "embeddableConfig": {},
             "gridData": {
               "h": 10,
               "i": "1",
@@ -35,9 +33,7 @@
             "version": "7.4.0"
           },
           {
-            "embeddableConfig": {
-              "title": "Volume Read Ops"
-            },
+            "embeddableConfig": {},
             "gridData": {
               "h": 10,
               "i": "2",
@@ -51,9 +47,7 @@
             "version": "7.4.0"
           },
           {
-            "embeddableConfig": {
-              "title": "Volume Write Bytes"
-            },
+            "embeddableConfig": {},
             "gridData": {
               "h": 10,
               "i": "3",
@@ -67,9 +61,7 @@
             "version": "7.4.0"
           },
           {
-            "embeddableConfig": {
-              "title": "Volume Read Bytes"
-            },
+            "embeddableConfig": {},
             "gridData": {
               "h": 10,
               "i": "4",
@@ -83,9 +75,7 @@
             "version": "7.4.0"
           },
           {
-            "embeddableConfig": {
-              "title": "Volume Queue Length"
-            },
+            "embeddableConfig": {},
             "gridData": {
               "h": 10,
               "i": "5",
@@ -99,9 +89,7 @@
             "version": "7.4.0"
           },
           {
-            "embeddableConfig": {
-              "title": "Volume Total Write Time"
-            },
+            "embeddableConfig": {},
             "gridData": {
               "h": 10,
               "i": "6",
@@ -115,9 +103,7 @@
             "version": "7.4.0"
           },
           {
-            "embeddableConfig": {
-              "title": "Volume Total Read Time"
-            },
+            "embeddableConfig": {},
             "gridData": {
               "h": 10,
               "i": "7",
@@ -131,9 +117,7 @@
             "version": "7.4.0"
           },
           {
-            "embeddableConfig": {
-              "title": "Volume Idle Time"
-            },
+            "embeddableConfig": {},
             "gridData": {
               "h": 10,
               "i": "8",
@@ -147,9 +131,7 @@
             "version": "7.4.0"
           },
           {
-            "embeddableConfig": {
-              "title": "EBS Volume ID Filter"
-            },
+            "embeddableConfig": {},
             "gridData": {
               "h": 5,
               "i": "9",

--- a/x-pack/metricbeat/module/aws/_meta/kibana/7/dashboard/Metricbeat-aws-elb-overview.json
+++ b/x-pack/metricbeat/module/aws/_meta/kibana/7/dashboard/Metricbeat-aws-elb-overview.json
@@ -19,9 +19,7 @@
         },
         "panelsJSON": [
           {
-            "embeddableConfig": {
-              "title": "HTTP 5XX Errors"
-            },
+            "embeddableConfig": {},
             "gridData": {
               "h": 9,
               "i": "2",
@@ -35,9 +33,7 @@
             "version": "7.4.0"
           },
           {
-            "embeddableConfig": {
-              "title": "Request Count"
-            },
+            "embeddableConfig": {},
             "gridData": {
               "h": 11,
               "i": "3",
@@ -51,9 +47,7 @@
             "version": "7.4.0"
           },
           {
-            "embeddableConfig": {
-              "title": "Unhealthy Host Count"
-            },
+            "embeddableConfig": {},
             "gridData": {
               "h": 8,
               "i": "4",
@@ -67,9 +61,7 @@
             "version": "7.4.0"
           },
           {
-            "embeddableConfig": {
-              "title": "Healthy Host Count"
-            },
+            "embeddableConfig": {},
             "gridData": {
               "h": 8,
               "i": "5",
@@ -83,9 +75,7 @@
             "version": "7.4.0"
           },
           {
-            "embeddableConfig": {
-              "title": "Latency in Seconds"
-            },
+            "embeddableConfig": {},
             "gridData": {
               "h": 12,
               "i": "6",
@@ -99,9 +89,7 @@
             "version": "7.4.0"
           },
           {
-            "embeddableConfig": {
-              "title": "HTTP Backend 4XX Errors"
-            },
+            "embeddableConfig": {},
             "gridData": {
               "h": 9,
               "i": "7",
@@ -115,9 +103,7 @@
             "version": "7.4.0"
           },
           {
-            "embeddableConfig": {
-              "title": "Backend Connection Errors"
-            },
+            "embeddableConfig": {},
             "gridData": {
               "h": 9,
               "i": "8",
@@ -144,9 +130,7 @@
             "version": "7.4.0"
           },
           {
-            "embeddableConfig": {
-              "title": "HTTP Backend 2XX"
-            },
+            "embeddableConfig": {},
             "gridData": {
               "h": 9,
               "i": "10",
@@ -253,7 +237,6 @@
             ],
             "default_index_pattern": "metricbeat-*",
             "default_timefield": "@timestamp",
-            "drop_last_bucket": 0,
             "filter": "",
             "gauge_color_rules": [
               {
@@ -346,7 +329,6 @@
             ],
             "default_index_pattern": "metricbeat-*",
             "default_timefield": "@timestamp",
-            "drop_last_bucket": 0,
             "filter": "",
             "gauge_color_rules": [
               {
@@ -630,7 +612,6 @@
             ],
             "default_index_pattern": "metricbeat-*",
             "default_timefield": "@timestamp",
-            "drop_last_bucket": 0,
             "filter": "",
             "gauge_color_rules": [
               {
@@ -723,7 +704,6 @@
             ],
             "default_index_pattern": "metricbeat-*",
             "default_timefield": "@timestamp",
-            "drop_last_bucket": 0,
             "filter": "",
             "gauge_color_rules": [
               {
@@ -816,7 +796,6 @@
             ],
             "default_index_pattern": "metricbeat-*",
             "default_timefield": "@timestamp",
-            "drop_last_bucket": 0,
             "filter": "",
             "gauge_color_rules": [
               {
@@ -968,7 +947,6 @@
             ],
             "default_index_pattern": "metricbeat-*",
             "default_timefield": "@timestamp",
-            "drop_last_bucket": 0,
             "filter": "",
             "gauge_color_rules": [
               {

--- a/x-pack/metricbeat/module/aws/_meta/kibana/7/dashboard/Metricbeat-aws-elb-overview.json
+++ b/x-pack/metricbeat/module/aws/_meta/kibana/7/dashboard/Metricbeat-aws-elb-overview.json
@@ -251,7 +251,7 @@
                 "id": "7db91990-b3c6-11e9-af6e-ef22c5680226"
               }
             ],
-            "default_index_pattern": "filebeat-*",
+            "default_index_pattern": "metricbeat-*",
             "default_timefield": "@timestamp",
             "drop_last_bucket": 0,
             "filter": "",
@@ -344,7 +344,7 @@
                 "id": "7db91990-b3c6-11e9-af6e-ef22c5680226"
               }
             ],
-            "default_index_pattern": "filebeat-*",
+            "default_index_pattern": "metricbeat-*",
             "default_timefield": "@timestamp",
             "drop_last_bucket": 0,
             "filter": "",
@@ -441,7 +441,7 @@
                 "id": "7db91990-b3c6-11e9-af6e-ef22c5680226"
               }
             ],
-            "default_index_pattern": "filebeat-*",
+            "default_index_pattern": "metricbeat-*",
             "default_timefield": "@timestamp",
             "filter": "",
             "gauge_color_rules": [
@@ -536,7 +536,7 @@
                 "id": "7db91990-b3c6-11e9-af6e-ef22c5680226"
               }
             ],
-            "default_index_pattern": "filebeat-*",
+            "default_index_pattern": "metricbeat-*",
             "default_timefield": "@timestamp",
             "filter": "",
             "gauge_color_rules": [
@@ -628,7 +628,7 @@
                 "id": "7db91990-b3c6-11e9-af6e-ef22c5680226"
               }
             ],
-            "default_index_pattern": "filebeat-*",
+            "default_index_pattern": "metricbeat-*",
             "default_timefield": "@timestamp",
             "drop_last_bucket": 0,
             "filter": "",
@@ -721,7 +721,7 @@
                 "id": "7db91990-b3c6-11e9-af6e-ef22c5680226"
               }
             ],
-            "default_index_pattern": "filebeat-*",
+            "default_index_pattern": "metricbeat-*",
             "default_timefield": "@timestamp",
             "drop_last_bucket": 0,
             "filter": "",
@@ -814,7 +814,7 @@
                 "id": "7db91990-b3c6-11e9-af6e-ef22c5680226"
               }
             ],
-            "default_index_pattern": "filebeat-*",
+            "default_index_pattern": "metricbeat-*",
             "default_timefield": "@timestamp",
             "drop_last_bucket": 0,
             "filter": "",
@@ -966,7 +966,7 @@
                 "id": "7db91990-b3c6-11e9-af6e-ef22c5680226"
               }
             ],
-            "default_index_pattern": "filebeat-*",
+            "default_index_pattern": "metricbeat-*",
             "default_timefield": "@timestamp",
             "drop_last_bucket": 0,
             "filter": "",

--- a/x-pack/metricbeat/module/aws/_meta/kibana/7/dashboard/Metricbeat-aws-elb-overview.json
+++ b/x-pack/metricbeat/module/aws/_meta/kibana/7/dashboard/Metricbeat-aws-elb-overview.json
@@ -150,7 +150,7 @@
       },
       "id": "e74bf320-b3ce-11e9-87a4-078dbbae220d",
       "migrationVersion": {
-        "dashboard": "7.3.0"
+        "dashboard": "7.2.0"
       },
       "references": [
         {
@@ -288,7 +288,7 @@
       },
       "id": "b9703dd0-b3c9-11e9-87a4-078dbbae220d",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.2.0"
       },
       "references": [],
       "type": "visualization",
@@ -381,7 +381,7 @@
       },
       "id": "d560de70-b3c7-11e9-87a4-078dbbae220d",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.2.0"
       },
       "references": [],
       "type": "visualization",
@@ -476,7 +476,7 @@
       },
       "id": "6fc1efd0-b3c9-11e9-87a4-078dbbae220d",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.2.0"
       },
       "references": [],
       "type": "visualization",
@@ -571,7 +571,7 @@
       },
       "id": "6392bc30-b3c9-11e9-87a4-078dbbae220d",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.2.0"
       },
       "references": [],
       "type": "visualization",
@@ -663,7 +663,7 @@
       },
       "id": "b2ea15a0-b3c7-11e9-87a4-078dbbae220d",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.2.0"
       },
       "references": [],
       "type": "visualization",
@@ -755,7 +755,7 @@
       },
       "id": "21f30090-b3ca-11e9-87a4-078dbbae220d",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.2.0"
       },
       "references": [],
       "type": "visualization",
@@ -848,7 +848,7 @@
       },
       "id": "572d40e0-b3ca-11e9-87a4-078dbbae220d",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.2.0"
       },
       "references": [],
       "type": "visualization",
@@ -900,7 +900,7 @@
       },
       "id": "b5308940-7347-11e9-816b-07687310a99a",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.2.0"
       },
       "references": [
         {
@@ -998,7 +998,7 @@
       },
       "id": "1f528f50-b3ce-11e9-87a4-078dbbae220d",
       "migrationVersion": {
-        "visualization": "7.3.1"
+        "visualization": "7.2.0"
       },
       "references": [],
       "type": "visualization",

--- a/x-pack/metricbeat/module/aws/_meta/kibana/7/dashboard/Metricbeat-aws-elb-overview.json
+++ b/x-pack/metricbeat/module/aws/_meta/kibana/7/dashboard/Metricbeat-aws-elb-overview.json
@@ -19,7 +19,9 @@
         },
         "panelsJSON": [
           {
-            "embeddableConfig": {},
+            "embeddableConfig": {
+              "title": "HTTP 5XX Errors"
+            },
             "gridData": {
               "h": 9,
               "i": "2",
@@ -30,10 +32,12 @@
             "panelIndex": "2",
             "panelRefName": "panel_0",
             "title": "HTTP 5XX Errors",
-            "version": "7.2.0"
+            "version": "7.4.0"
           },
           {
-            "embeddableConfig": {},
+            "embeddableConfig": {
+              "title": "Request Count"
+            },
             "gridData": {
               "h": 11,
               "i": "3",
@@ -44,10 +48,12 @@
             "panelIndex": "3",
             "panelRefName": "panel_1",
             "title": "Request Count",
-            "version": "7.2.0"
+            "version": "7.4.0"
           },
           {
-            "embeddableConfig": {},
+            "embeddableConfig": {
+              "title": "Unhealthy Host Count"
+            },
             "gridData": {
               "h": 8,
               "i": "4",
@@ -58,10 +64,12 @@
             "panelIndex": "4",
             "panelRefName": "panel_2",
             "title": "Unhealthy Host Count",
-            "version": "7.2.0"
+            "version": "7.4.0"
           },
           {
-            "embeddableConfig": {},
+            "embeddableConfig": {
+              "title": "Healthy Host Count"
+            },
             "gridData": {
               "h": 8,
               "i": "5",
@@ -72,10 +80,12 @@
             "panelIndex": "5",
             "panelRefName": "panel_3",
             "title": "Healthy Host Count",
-            "version": "7.2.0"
+            "version": "7.4.0"
           },
           {
-            "embeddableConfig": {},
+            "embeddableConfig": {
+              "title": "Latency in Seconds"
+            },
             "gridData": {
               "h": 12,
               "i": "6",
@@ -86,10 +96,12 @@
             "panelIndex": "6",
             "panelRefName": "panel_4",
             "title": "Latency in Seconds",
-            "version": "7.2.0"
+            "version": "7.4.0"
           },
           {
-            "embeddableConfig": {},
+            "embeddableConfig": {
+              "title": "HTTP Backend 4XX Errors"
+            },
             "gridData": {
               "h": 9,
               "i": "7",
@@ -100,10 +112,12 @@
             "panelIndex": "7",
             "panelRefName": "panel_5",
             "title": "HTTP Backend 4XX Errors",
-            "version": "7.2.0"
+            "version": "7.4.0"
           },
           {
-            "embeddableConfig": {},
+            "embeddableConfig": {
+              "title": "Backend Connection Errors"
+            },
             "gridData": {
               "h": 9,
               "i": "8",
@@ -114,7 +128,7 @@
             "panelIndex": "8",
             "panelRefName": "panel_6",
             "title": "Backend Connection Errors",
-            "version": "7.2.0"
+            "version": "7.4.0"
           },
           {
             "embeddableConfig": {},
@@ -127,10 +141,12 @@
             },
             "panelIndex": "9",
             "panelRefName": "panel_7",
-            "version": "7.2.0"
+            "version": "7.4.0"
           },
           {
-            "embeddableConfig": {},
+            "embeddableConfig": {
+              "title": "HTTP Backend 2XX"
+            },
             "gridData": {
               "h": 9,
               "i": "10",
@@ -141,7 +157,7 @@
             "panelIndex": "10",
             "panelRefName": "panel_8",
             "title": "HTTP Backend 2XX",
-            "version": "7.2.0"
+            "version": "7.4.0"
           }
         ],
         "timeRestore": false,
@@ -150,7 +166,7 @@
       },
       "id": "e74bf320-b3ce-11e9-87a4-078dbbae220d",
       "migrationVersion": {
-        "dashboard": "7.0.0"
+        "dashboard": "7.3.0"
       },
       "references": [
         {
@@ -200,8 +216,8 @@
         }
       ],
       "type": "dashboard",
-      "updated_at": "2019-08-01T15:09:06.696Z",
-      "version": "WzYzNSw4XQ=="
+      "updated_at": "2019-09-12T02:24:38.326Z",
+      "version": "WzI0MTYsN10="
     },
     {
       "attributes": {
@@ -222,6 +238,7 @@
           "aggs": [],
           "params": {
             "axis_formatter": "number",
+            "axis_min": "0",
             "axis_position": "left",
             "axis_scale": "normal",
             "background_color_rules": [
@@ -234,8 +251,9 @@
                 "id": "7db91990-b3c6-11e9-af6e-ef22c5680226"
               }
             ],
-            "default_index_pattern": "metricbeat-*",
+            "default_index_pattern": "filebeat-*",
             "default_timefield": "@timestamp",
+            "drop_last_bucket": 0,
             "filter": "",
             "gauge_color_rules": [
               {
@@ -248,6 +266,7 @@
             "id": "35d3cbc0-b3c6-11e9-bf3f-29d51aa3d971",
             "index_pattern": "metricbeat-*",
             "interval": "5m",
+            "isModelInvalid": false,
             "series": [
               {
                 "axis_position": "right",
@@ -286,12 +305,12 @@
       },
       "id": "b9703dd0-b3c9-11e9-87a4-078dbbae220d",
       "migrationVersion": {
-        "visualization": "7.2.0"
+        "visualization": "7.3.1"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-08-02T18:37:04.544Z",
-      "version": "WzY0NSw5XQ=="
+      "updated_at": "2019-09-12T02:24:22.066Z",
+      "version": "WzI0MTUsN10="
     },
     {
       "attributes": {
@@ -312,6 +331,7 @@
           "aggs": [],
           "params": {
             "axis_formatter": "number",
+            "axis_min": "0",
             "axis_position": "left",
             "axis_scale": "normal",
             "background_color_rules": [
@@ -324,8 +344,9 @@
                 "id": "7db91990-b3c6-11e9-af6e-ef22c5680226"
               }
             ],
-            "default_index_pattern": "metricbeat-*",
+            "default_index_pattern": "filebeat-*",
             "default_timefield": "@timestamp",
+            "drop_last_bucket": 0,
             "filter": "",
             "gauge_color_rules": [
               {
@@ -338,6 +359,7 @@
             "id": "35d3cbc0-b3c6-11e9-bf3f-29d51aa3d971",
             "index_pattern": "metricbeat-*",
             "interval": "5m",
+            "isModelInvalid": false,
             "series": [
               {
                 "axis_position": "right",
@@ -362,6 +384,7 @@
                 "stacked": "none",
                 "terms_field": "aws.cloudwatch.dimensions.LoadBalancerName",
                 "terms_order_by": "35d3cbc2-b3c6-11e9-bf3f-29d51aa3d971",
+                "type": "timeseries",
                 "value_template": "{{value}}"
               }
             ],
@@ -376,12 +399,12 @@
       },
       "id": "d560de70-b3c7-11e9-87a4-078dbbae220d",
       "migrationVersion": {
-        "visualization": "7.2.0"
+        "visualization": "7.3.1"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-08-02T18:24:52.316Z",
-      "version": "WzY0MCw5XQ=="
+      "updated_at": "2019-09-12T02:22:46.781Z",
+      "version": "WzI0MDgsN10="
     },
     {
       "attributes": {
@@ -418,7 +441,7 @@
                 "id": "7db91990-b3c6-11e9-af6e-ef22c5680226"
               }
             ],
-            "default_index_pattern": "metricbeat-*",
+            "default_index_pattern": "filebeat-*",
             "default_timefield": "@timestamp",
             "filter": "",
             "gauge_color_rules": [
@@ -432,6 +455,7 @@
             "id": "35d3cbc0-b3c6-11e9-bf3f-29d51aa3d971",
             "index_pattern": "metricbeat-*",
             "interval": "5m",
+            "isModelInvalid": false,
             "series": [
               {
                 "axis_position": "right",
@@ -446,7 +470,7 @@
                   {
                     "field": "aws.metrics.UnHealthyHostCount.max",
                     "id": "35d3cbc2-b3c6-11e9-bf3f-29d51aa3d971",
-                    "type": "sum"
+                    "type": "max"
                   }
                 ],
                 "point_size": 0,
@@ -470,12 +494,12 @@
       },
       "id": "6fc1efd0-b3c9-11e9-87a4-078dbbae220d",
       "migrationVersion": {
-        "visualization": "7.2.0"
+        "visualization": "7.3.1"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-08-02T18:24:16.077Z",
-      "version": "WzYzOCw5XQ=="
+      "updated_at": "2019-09-12T01:00:47.505Z",
+      "version": "WzIzOTYsN10="
     },
     {
       "attributes": {
@@ -512,7 +536,7 @@
                 "id": "7db91990-b3c6-11e9-af6e-ef22c5680226"
               }
             ],
-            "default_index_pattern": "metricbeat-*",
+            "default_index_pattern": "filebeat-*",
             "default_timefield": "@timestamp",
             "filter": "",
             "gauge_color_rules": [
@@ -526,6 +550,7 @@
             "id": "35d3cbc0-b3c6-11e9-bf3f-29d51aa3d971",
             "index_pattern": "metricbeat-*",
             "interval": "5m",
+            "isModelInvalid": false,
             "series": [
               {
                 "axis_position": "right",
@@ -540,7 +565,7 @@
                   {
                     "field": "aws.metrics.HealthyHostCount.max",
                     "id": "35d3cbc2-b3c6-11e9-bf3f-29d51aa3d971",
-                    "type": "sum"
+                    "type": "max"
                   }
                 ],
                 "point_size": 0,
@@ -564,12 +589,12 @@
       },
       "id": "6392bc30-b3c9-11e9-87a4-078dbbae220d",
       "migrationVersion": {
-        "visualization": "7.2.0"
+        "visualization": "7.3.1"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-08-02T18:24:30.551Z",
-      "version": "WzYzOSw5XQ=="
+      "updated_at": "2019-09-12T01:00:18.978Z",
+      "version": "WzIzOTMsN10="
     },
     {
       "attributes": {
@@ -590,6 +615,7 @@
           "aggs": [],
           "params": {
             "axis_formatter": "number",
+            "axis_min": "0",
             "axis_position": "left",
             "axis_scale": "normal",
             "background_color_rules": [
@@ -602,8 +628,9 @@
                 "id": "7db91990-b3c6-11e9-af6e-ef22c5680226"
               }
             ],
-            "default_index_pattern": "metricbeat-*",
+            "default_index_pattern": "filebeat-*",
             "default_timefield": "@timestamp",
+            "drop_last_bucket": 0,
             "filter": "",
             "gauge_color_rules": [
               {
@@ -616,6 +643,7 @@
             "id": "35d3cbc0-b3c6-11e9-bf3f-29d51aa3d971",
             "index_pattern": "metricbeat-*",
             "interval": "5m",
+            "isModelInvalid": false,
             "series": [
               {
                 "axis_position": "right",
@@ -654,12 +682,12 @@
       },
       "id": "b2ea15a0-b3c7-11e9-87a4-078dbbae220d",
       "migrationVersion": {
-        "visualization": "7.2.0"
+        "visualization": "7.3.1"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-08-02T18:36:49.424Z",
-      "version": "WzY0Myw5XQ=="
+      "updated_at": "2019-09-12T02:23:16.083Z",
+      "version": "WzI0MTAsN10="
     },
     {
       "attributes": {
@@ -680,6 +708,7 @@
           "aggs": [],
           "params": {
             "axis_formatter": "number",
+            "axis_min": "0",
             "axis_position": "left",
             "axis_scale": "normal",
             "background_color_rules": [
@@ -692,8 +721,9 @@
                 "id": "7db91990-b3c6-11e9-af6e-ef22c5680226"
               }
             ],
-            "default_index_pattern": "metricbeat-*",
+            "default_index_pattern": "filebeat-*",
             "default_timefield": "@timestamp",
+            "drop_last_bucket": 0,
             "filter": "",
             "gauge_color_rules": [
               {
@@ -706,6 +736,7 @@
             "id": "35d3cbc0-b3c6-11e9-bf3f-29d51aa3d971",
             "index_pattern": "metricbeat-*",
             "interval": "5m",
+            "isModelInvalid": false,
             "series": [
               {
                 "axis_position": "right",
@@ -744,12 +775,12 @@
       },
       "id": "21f30090-b3ca-11e9-87a4-078dbbae220d",
       "migrationVersion": {
-        "visualization": "7.2.0"
+        "visualization": "7.3.1"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-08-02T18:28:25.630Z",
-      "version": "WzY0Miw5XQ=="
+      "updated_at": "2019-09-12T02:24:09.023Z",
+      "version": "WzI0MTQsN10="
     },
     {
       "attributes": {
@@ -770,6 +801,7 @@
           "aggs": [],
           "params": {
             "axis_formatter": "number",
+            "axis_min": "0",
             "axis_position": "left",
             "axis_scale": "normal",
             "background_color_rules": [
@@ -782,8 +814,9 @@
                 "id": "7db91990-b3c6-11e9-af6e-ef22c5680226"
               }
             ],
-            "default_index_pattern": "metricbeat-*",
+            "default_index_pattern": "filebeat-*",
             "default_timefield": "@timestamp",
+            "drop_last_bucket": 0,
             "filter": "",
             "gauge_color_rules": [
               {
@@ -796,6 +829,7 @@
             "id": "35d3cbc0-b3c6-11e9-bf3f-29d51aa3d971",
             "index_pattern": "metricbeat-*",
             "interval": "5m",
+            "isModelInvalid": false,
             "series": [
               {
                 "axis_position": "right",
@@ -835,12 +869,12 @@
       },
       "id": "572d40e0-b3ca-11e9-87a4-078dbbae220d",
       "migrationVersion": {
-        "visualization": "7.2.0"
+        "visualization": "7.3.1"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-08-02T18:28:18.932Z",
-      "version": "WzY0MSw5XQ=="
+      "updated_at": "2019-09-12T02:22:28.366Z",
+      "version": "WzI0MDcsN10="
     },
     {
       "attributes": {
@@ -887,7 +921,7 @@
       },
       "id": "b5308940-7347-11e9-816b-07687310a99a",
       "migrationVersion": {
-        "visualization": "7.2.0"
+        "visualization": "7.3.1"
       },
       "references": [
         {
@@ -897,8 +931,8 @@
         }
       ],
       "type": "visualization",
-      "updated_at": "2019-07-23T20:30:59.432Z",
-      "version": "WzMwMSwzXQ=="
+      "updated_at": "2019-09-12T00:55:22.007Z",
+      "version": "WzIwNjgsN10="
     },
     {
       "attributes": {
@@ -919,6 +953,7 @@
           "aggs": [],
           "params": {
             "axis_formatter": "number",
+            "axis_min": "0",
             "axis_position": "left",
             "axis_scale": "normal",
             "background_color_rules": [
@@ -931,8 +966,9 @@
                 "id": "7db91990-b3c6-11e9-af6e-ef22c5680226"
               }
             ],
-            "default_index_pattern": "metricbeat-*",
+            "default_index_pattern": "filebeat-*",
             "default_timefield": "@timestamp",
+            "drop_last_bucket": 0,
             "filter": "",
             "gauge_color_rules": [
               {
@@ -945,6 +981,7 @@
             "id": "35d3cbc0-b3c6-11e9-bf3f-29d51aa3d971",
             "index_pattern": "metricbeat-*",
             "interval": "5m",
+            "isModelInvalid": false,
             "series": [
               {
                 "axis_position": "right",
@@ -983,13 +1020,13 @@
       },
       "id": "1f528f50-b3ce-11e9-87a4-078dbbae220d",
       "migrationVersion": {
-        "visualization": "7.2.0"
+        "visualization": "7.3.1"
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-08-02T18:36:56.883Z",
-      "version": "WzY0NCw5XQ=="
+      "updated_at": "2019-09-12T02:23:38.069Z",
+      "version": "WzI0MTIsN10="
     }
   ],
-  "version": "7.2.0"
+  "version": "7.4.0"
 }

--- a/x-pack/metricbeat/module/aws/cloudwatch/_meta/data.json
+++ b/x-pack/metricbeat/module/aws/cloudwatch/_meta/data.json
@@ -3,101 +3,58 @@
     "aws": {
         "cloudwatch": {
             "dimensions": {
-                "DBInstanceIdentifier": "test1"
+                "DatabaseClass": "db.t2.micro"
             },
             "namespace": "AWS/RDS"
         },
         "metrics": {
-            "ActiveTransactions": {
-                "avg": 0,
-                "count": 5,
-                "max": 0,
-                "min": 0,
-                "sum": 0
-            },
-            "AuroraBinlogReplicaLag": {
-                "avg": 0,
-                "count": 5,
-                "max": 0,
-                "min": 0,
-                "sum": 0
-            },
-            "AuroraReplicaLag": {
-                "avg": 17.945199999999996,
-                "count": 5,
-                "max": 20.299,
-                "min": 9.026,
-                "sum": 89.72599999999998
-            },
             "BinLogDiskUsage": {
-                "avg": 0,
+                "avg": 3109.2,
                 "count": 5,
-                "max": 0,
-                "min": 0,
-                "sum": 0
+                "max": 3518,
+                "min": 3007,
+                "sum": 15546
             },
-            "BlockedTransactions": {
-                "avg": 0,
-                "count": 5,
-                "max": 0,
-                "min": 0,
-                "sum": 0
-            },
-            "BufferCacheHitRatio": {
+            "BurstBalance": {
                 "avg": 100,
-                "count": 5,
+                "count": 1,
                 "max": 100,
                 "min": 100,
-                "sum": 500
+                "sum": 100
+            },
+            "CPUCreditBalance": {
+                "avg": 144,
+                "count": 1,
+                "max": 144,
+                "min": 144,
+                "sum": 144
+            },
+            "CPUCreditUsage": {
+                "avg": 0.059921,
+                "max": 0.059921,
+                "min": 0.059921,
+                "sum": 0.059921
+            },
+            "CPUSurplusCreditBalance": {
+                "avg": 0,
+                "count": 1,
+                "max": 0,
+                "min": 0,
+                "sum": 0
+            },
+            "CPUSurplusCreditsCharged": {
+                "avg": 0,
+                "count": 1,
+                "max": 0,
+                "min": 0,
+                "sum": 0
             },
             "CPUUtilization": {
-                "avg": 3,
+                "avg": 1.229508196720359,
                 "count": 5,
-                "max": 3,
-                "min": 3,
-                "sum": 15
-            },
-            "CommitLatency": {
-                "avg": 0,
-                "count": 5,
-                "max": 0,
-                "min": 0,
-                "sum": 0
-            },
-            "CommitThroughput": {
-                "avg": 0,
-                "count": 5,
-                "max": 0,
-                "min": 0,
-                "sum": 0
-            },
-            "DDLLatency": {
-                "avg": 0,
-                "count": 5,
-                "max": 0,
-                "min": 0,
-                "sum": 0
-            },
-            "DDLThroughput": {
-                "avg": 0,
-                "count": 5,
-                "max": 0,
-                "min": 0,
-                "sum": 0
-            },
-            "DMLLatency": {
-                "avg": 0,
-                "count": 5,
-                "max": 0,
-                "min": 0,
-                "sum": 0
-            },
-            "DMLThroughput": {
-                "avg": 0,
-                "count": 5,
-                "max": 0,
-                "min": 0,
-                "sum": 0
+                "max": 1.66666666666667,
+                "min": 0.999999999997575,
+                "sum": 6.147540983601795
             },
             "DatabaseConnections": {
                 "avg": 0,
@@ -106,136 +63,95 @@
                 "min": 0,
                 "sum": 0
             },
-            "Deadlocks": {
-                "avg": 0,
+            "DiskQueueDepth": {
+                "avg": 0.0002666653337629704,
                 "count": 5,
-                "max": 0,
+                "max": 0.0007999733342221926,
                 "min": 0,
-                "sum": 0
+                "sum": 0.001333326668814852
             },
-            "DeleteLatency": {
-                "avg": 0,
+            "FreeStorageSpace": {
+                "avg": 20402474188.8,
                 "count": 5,
-                "max": 0,
-                "min": 0,
-                "sum": 0
-            },
-            "DeleteThroughput": {
-                "avg": 0,
-                "count": 5,
-                "max": 0,
-                "min": 0,
-                "sum": 0
-            },
-            "EngineUptime": {
-                "avg": 2888753,
-                "count": 5,
-                "max": 2888873,
-                "min": 2888633,
-                "sum": 14443765
-            },
-            "FreeLocalStorage": {
-                "avg": 32949542912,
-                "count": 5,
-                "max": 32949567488,
-                "min": 32949518336,
-                "sum": 164747714560
+                "max": 20402475008,
+                "min": 20402470912,
+                "sum": 102012370944
             },
             "FreeableMemory": {
-                "avg": 4717250969.6,
+                "avg": 460385484.8,
                 "count": 5,
-                "max": 4717965312,
-                "min": 4716732416,
-                "sum": 23586254848
-            },
-            "InsertLatency": {
-                "avg": 0,
-                "count": 5,
-                "max": 0,
-                "min": 0,
-                "sum": 0
-            },
-            "InsertThroughput": {
-                "avg": 0,
-                "count": 5,
-                "max": 0,
-                "min": 0,
-                "sum": 0
-            },
-            "LoginFailures": {
-                "avg": 0,
-                "max": 0,
-                "min": 0,
-                "sum": 0
+                "max": 460492800,
+                "min": 460238848,
+                "sum": 2301927424
             },
             "NetworkReceiveThroughput": {
-                "avg": 0.6999860014776844,
+                "avg": 488.6774390824785,
                 "count": 5,
-                "max": 0.700023334111137,
-                "min": 0.6999416715273727,
-                "sum": 3.499930007388422
-            },
-            "NetworkThroughput": {
-                "avg": 1.3999720029553688,
-                "count": 5,
-                "max": 1.400046668222274,
-                "min": 1.3998833430547455,
-                "sum": 6.999860014776844
+                "max": 614.8064198930018,
+                "min": 440.9387136023468,
+                "sum": 2443.3871954123924
             },
             "NetworkTransmitThroughput": {
-                "avg": 0.6999860014776844,
+                "avg": 2629.716953080241,
                 "count": 5,
-                "max": 0.700023334111137,
-                "min": 0.6999416715273727,
-                "sum": 3.499930007388422
+                "max": 2771.060439377271,
+                "min": 2426.08797106522,
+                "sum": 13148.584765401207
             },
-            "Queries": {
-                "avg": 6.169305601785825,
+            "ReadIOPS": {
+                "avg": 0.23334111137037902,
                 "count": 5,
-                "max": 6.380462125376914,
-                "min": 6.031523876170482,
-                "sum": 30.846528008929127
+                "max": 1.1667055568518951,
+                "min": 0,
+                "sum": 1.1667055568518951
             },
-            "ResultSetCacheHitRatio": {
+            "ReadLatency": {
                 "avg": 0,
                 "count": 5,
                 "max": 0,
                 "min": 0,
                 "sum": 0
             },
-            "SelectLatency": {
-                "avg": 0.2314997785623484,
+            "ReadThroughput": {
+                "avg": 136.52878237392088,
                 "count": 5,
-                "max": 0.2420805369127517,
-                "min": 0.2227225806451613,
-                "sum": 1.157498892811742
-            },
-            "SelectThroughput": {
-                "avg": 2.529737853689286,
-                "count": 5,
-                "max": 2.600086669555652,
-                "min": 2.4822990420658058,
-                "sum": 12.648689268446429
-            },
-            "UpdateLatency": {
-                "avg": 0,
-                "count": 5,
-                "max": 0,
+                "max": 682.6439118696044,
                 "min": 0,
-                "sum": 0
+                "sum": 682.6439118696044
             },
-            "UpdateThroughput": {
-                "avg": 0,
+            "SwapUsage": {
+                "avg": 638976,
                 "count": 5,
-                "max": 0,
+                "max": 638976,
+                "min": 638976,
+                "sum": 3194880
+            },
+            "WriteIOPS": {
+                "avg": 0.3600156685816308,
+                "count": 5,
+                "max": 0.8833627787592919,
                 "min": 0,
-                "sum": 0
+                "sum": 1.800078342908154
+            },
+            "WriteLatency": {
+                "avg": 0.0005464870341466086,
+                "count": 5,
+                "max": 0.0015238095238095239,
+                "min": 0,
+                "sum": 0.0027324351707330432
+            },
+            "WriteThroughput": {
+                "avg": 3863.9343018441605,
+                "count": 5,
+                "max": 8055.198160061332,
+                "min": 0,
+                "sum": 19319.671509220803
             }
         }
     },
     "cloud": {
         "provider": "aws",
-        "region": "us-east-2"
+        "region": "ap-southeast-1"
     },
     "event": {
         "dataset": "aws.cloudwatch",
@@ -243,7 +159,8 @@
         "module": "aws"
     },
     "metricset": {
-        "name": "cloudwatch"
+        "name": "cloudwatch",
+        "period": 10000
     },
     "service": {
         "type": "aws"

--- a/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch.go
+++ b/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch.go
@@ -139,12 +139,16 @@ func (m *MetricSet) Fetch(report mb.ReporterV2) error {
 	}
 
 	// Create events based on namespaceDetailTotal from configuration
-	for _, namespaceResourceType := range namespaceDetailTotal {
-		for _, regionName := range m.MetricSet.RegionsList {
-			awsConfig := m.MetricSet.AwsConfig.Copy()
-			awsConfig.Region = regionName
-			svcCloudwatch := cloudwatch.New(awsConfig)
+	for _, regionName := range m.MetricSet.RegionsList {
+		awsConfig := m.MetricSet.AwsConfig.Copy()
+		awsConfig.Region = regionName
+		svcCloudwatch := cloudwatch.New(awsConfig)
+		svcResourceAPI := resourcegroupstaggingapi.New(awsConfig)
 
+		var filteredMetricWithStatsTotal []metricsWithStatistics
+		var resourceTypes []string
+
+		for _, namespaceResourceType := range namespaceDetailTotal {
 			listMetricsOutput, err := aws.GetListMetricsOutput(namespaceResourceType.namespace, regionName, svcCloudwatch)
 			if err != nil {
 				m.Logger().Info(err.Error())
@@ -154,9 +158,6 @@ func (m *MetricSet) Fetch(report mb.ReporterV2) error {
 			if listMetricsOutput == nil || len(listMetricsOutput) == 0 {
 				continue
 			}
-
-			var filteredMetricWithStatsTotal []metricsWithStatistics
-			var resourceTypes []string
 
 			if namespaceResourceType.metricNames != nil && namespaceResourceType.dimensions == nil {
 				for _, listMetric := range listMetricsOutput {
@@ -199,12 +200,11 @@ func (m *MetricSet) Fetch(report mb.ReporterV2) error {
 					resourceTypes = []string{namespaceResourceType.resourceTypeFilter}
 				}
 			}
+		}
 
-			svcResourceAPI := resourcegroupstaggingapi.New(awsConfig)
-			err = m.createEvents(svcCloudwatch, svcResourceAPI, filteredMetricWithStatsTotal, resourceTypes, regionName, startTime, endTime, report)
-			if err != nil {
-				return errors.Wrap(err, "createEvents failed for region "+regionName)
-			}
+		err := m.createEvents(svcCloudwatch, svcResourceAPI, filteredMetricWithStatsTotal, resourceTypes, regionName, startTime, endTime, report)
+		if err != nil {
+			return errors.Wrap(err, "createEvents failed for region "+regionName)
 		}
 	}
 
@@ -257,7 +257,6 @@ func (m *MetricSet) readCloudwatchConfig() (listMetricWithDetail, []namespaceWit
 			namespaceDetailTotal = append(namespaceDetailTotal, namespaceWithDetail{
 				namespace:          config.Namespace,
 				metricNames:        config.MetricName,
-				dimensions:         cloudwatchDimensions,
 				resourceTypeFilter: config.ResourceTypeFilter,
 				statistic:          config.Statistic,
 			})
@@ -266,7 +265,6 @@ func (m *MetricSet) readCloudwatchConfig() (listMetricWithDetail, []namespaceWit
 
 		namespaceDetailTotal = append(namespaceDetailTotal, namespaceWithDetail{
 			namespace:          config.Namespace,
-			dimensions:         cloudwatchDimensions,
 			resourceTypeFilter: config.ResourceTypeFilter,
 			statistic:          config.Statistic,
 		})

--- a/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch.go
+++ b/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch.go
@@ -138,7 +138,6 @@ func (m *MetricSet) Fetch(report mb.ReporterV2) error {
 		}
 	}
 
-	// Create events based on namespaceDetailTotal from configuration
 	for _, regionName := range m.MetricSet.RegionsList {
 		awsConfig := m.MetricSet.AwsConfig.Copy()
 		awsConfig.Region = regionName
@@ -148,6 +147,7 @@ func (m *MetricSet) Fetch(report mb.ReporterV2) error {
 		var filteredMetricWithStatsTotal []metricsWithStatistics
 		var resourceTypes []string
 
+		// Create events based on namespaceDetailTotal from configuration
 		for _, namespaceResourceType := range namespaceDetailTotal {
 			listMetricsOutput, err := aws.GetListMetricsOutput(namespaceResourceType.namespace, regionName, svcCloudwatch)
 			if err != nil {

--- a/x-pack/metricbeat/module/aws/ebs/_meta/data.json
+++ b/x-pack/metricbeat/module/aws/ebs/_meta/data.json
@@ -1,34 +1,34 @@
 {
     "@timestamp": "2017-10-12T08:05:34.853Z",
     "aws": {
-        "ebs": {
+        "cloudwatch": {
             "dimensions": {
-                "VolumeId": "vol-053e1fa82db46df30"
-            },
-            "metrics": {
-                "BurstBalance": {
-                    "avg": 99.9995555555556
-                },
-                "VolumeIdleTime": {
-                    "avg": 298.65
-                },
-                "VolumeQueueLength": {
-                    "avg": 0.0349
-                },
-                "VolumeReadOps": {
-                    "avg": 0
-                },
-                "VolumeTotalWriteTime": {
-                    "avg": 0.002053343792900569
-                },
-                "VolumeWriteBytes": {
-                    "avg": 31189.927436752303
-                },
-                "VolumeWriteOps": {
-                    "avg": 5099
-                }
+                "VolumeId": "vol-06ba46b489bbc0d96"
             },
             "namespace": "AWS/EBS"
+        },
+        "metrics": {
+            "BurstBalance": {
+                "avg": 100
+            },
+            "VolumeIdleTime": {
+                "sum": 300
+            },
+            "VolumeQueueLength": {
+                "avg": 0
+            },
+            "VolumeReadOps": {
+                "avg": 0
+            },
+            "VolumeTotalWriteTime": {
+                "sum": 0
+            },
+            "VolumeWriteBytes": {
+                "avg": 46421.333333333336
+            },
+            "VolumeWriteOps": {
+                "avg": 30
+            }
         }
     },
     "cloud": {
@@ -41,10 +41,10 @@
         "module": "aws"
     },
     "metricset": {
-        "name": "ebs"
+        "name": "ebs",
+        "period": 10000
     },
     "service": {
-        "name": "cloudwatch",
-        "type": "cloudwatch"
+        "type": "aws"
     }
 }

--- a/x-pack/metricbeat/module/aws/elb/_meta/data.json
+++ b/x-pack/metricbeat/module/aws/elb/_meta/data.json
@@ -3,17 +3,37 @@
     "aws": {
         "cloudwatch": {
             "dimensions": {
-                "AvailabilityZone": "us-east-1b",
-                "LoadBalancerName": "DockerReg-EcsElast-1UFCSV3UVE46A"
+                "Service": "ELB"
             },
             "namespace": "AWS/ELB"
         },
         "metrics": {
+            "BackendConnectionErrors": {
+                "sum": 18
+            },
+            "HTTPCode_Backend_2XX": {
+                "sum": 2
+            },
+            "HTTPCode_Backend_3XX": {
+                "sum": 2
+            },
+            "HTTPCode_Backend_4XX": {
+                "sum": 2
+            },
+            "HTTPCode_ELB_5XX": {
+                "sum": 4
+            },
             "HealthyHostCount": {
-                "avg": 2
+                "max": 2
+            },
+            "Latency": {
+                "avg": 0.001534899075826009
+            },
+            "RequestCount": {
+                "sum": 6
             },
             "UnHealthyHostCount": {
-                "avg": 0
+                "max": 1
             }
         }
     },
@@ -27,7 +47,8 @@
         "module": "aws"
     },
     "metricset": {
-        "name": "elb"
+        "name": "elb",
+        "period": 10000
     },
     "service": {
         "type": "aws"


### PR DESCRIPTION
This PR is to add axis_min = 0 to both elb and ebs dashboard. Also fixed the aggregation method used for both HealthyHostCount and UnhealthyHostCount in elb dashboard.

While testing dashboards, I found in cloudwatch metricset, for loop to go through each namespace and each region should be switched. `data.json` are updated to show it's working. Without this change, metrics in `elb` metricset (for example) will be reported into three differents events. One for statistic Sum, one for Maximum and another for Average. With this change, you can see in https://github.com/elastic/beats/pull/13640/files#diff-30cbed3a1b919647b6d2d2ad59e5292bR11, different statistic methods are all in the same event.