### PR TITLE
Cherry-pick #13643 to 7.4: Add missing tags option to reference configuration

### DIFF
--- a/x-pack/functionbeat/_meta/beat.reference.yml
+++ b/x-pack/functionbeat/_meta/beat.reference.yml
@@ -227,6 +227,10 @@ functionbeat.provider.aws.functions:
     # Dead letter queue configuration, this must be set to an ARN pointing to a SQS queue.
     #dead_letter_config.target_arn:
 
+    # Tags are key-value pairs attached to the function.
+    #tags:
+    #  department: ops
+
     # The amount of time the function is allowed to run.
     #timeout: 3s
 

--- a/x-pack/functionbeat/functionbeat.reference.yml
+++ b/x-pack/functionbeat/functionbeat.reference.yml
@@ -227,6 +227,10 @@ functionbeat.provider.aws.functions:
     # Dead letter queue configuration, this must be set to an ARN pointing to a SQS queue.
     #dead_letter_config.target_arn:
 
+    # Tags are key-value pairs attached to the function.
+    #tags:
+    #  department: ops
+
     # The amount of time the function is allowed to run.
     #timeout: 3s
 


### PR DESCRIPTION
Cherry-pick of PR #13643 to 7.4 branch. Original message: 

The option `tags` was missing from the reference configuration of Functionbeat in case of `cloudwatch_logs_kinesis` input. Now it is fixed.