### PR TITLE
update key type to string

### DIFF
--- a/libbeat/registry/backend/backend.go
+++ b/libbeat/registry/backend/backend.go
@@ -28,7 +28,8 @@ type Registry interface {
 }
 
 // Key represents the internal key.
-type Key []byte
+// type Key []byte
+type Key string
 
 // ValueDecoder is used to decode values into go structs or maps within a transaction.
 // A ValueDecoder must be invalidated once the owning transaction has been closed.

--- a/libbeat/registry/backend/backend.go
+++ b/libbeat/registry/backend/backend.go
@@ -28,7 +28,6 @@ type Registry interface {
 }
 
 // Key represents the internal key.
-// type Key []byte
 type Key string
 
 // ValueDecoder is used to decode values into go structs or maps within a transaction.

--- a/libbeat/registry/backend/cptest/cptest.go
+++ b/libbeat/registry/backend/cptest/cptest.go
@@ -401,7 +401,7 @@ func testUpdate(t *testing.T, factory BackendFactory) {
 func testIter(t *testing.T, factory BackendFactory) {
 	type entry struct{ A int }
 
-	insert := func(store *Store, keys [][]byte) {
+	insert := func(store *Store, keys []backend.Key) {
 		store.MustUpdate(func(tx *Tx) {
 			for i, k := range keys {
 				tx.MustSet(k, entry{i})

--- a/libbeat/registry/backend/cptest/reg.go
+++ b/libbeat/registry/backend/cptest/reg.go
@@ -139,12 +139,12 @@ func (s *Store) View(fn func(tx *Tx)) {
 }
 
 // Set sets a key-value using a temporary transaction.
-func (s *Store) Set(key []byte, val interface{}) {
+func (s *Store) Set(key backend.Key, val interface{}) {
 	s.MustUpdate(func(tx *Tx) { tx.MustSet(key, val) })
 }
 
 // UpdValue updates a key-value pair using a temporary write transaction.
-func (s *Store) UpdValue(key []byte, val interface{}) {
+func (s *Store) UpdValue(key backend.Key, val interface{}) {
 	s.MustUpdate(func(tx *Tx) {
 		t := s.Registry.T
 		must(t, tx.Update(key, val), "update failed")
@@ -152,7 +152,7 @@ func (s *Store) UpdValue(key []byte, val interface{}) {
 }
 
 // Remove removes a key-value pair using a temporary write transaction.
-func (s *Store) Remove(key []byte) {
+func (s *Store) Remove(key backend.Key) {
 	s.MustUpdate(func(tx *Tx) {
 		t := s.Registry.T
 		must(t, tx.Remove(key), "unexpected error on remove")
@@ -160,13 +160,13 @@ func (s *Store) Remove(key []byte) {
 }
 
 // Has checks if a key exists in the store, using a temporary readonly transaction.
-func (s *Store) Has(key []byte) (found bool) {
+func (s *Store) Has(key backend.Key) (found bool) {
 	s.View(func(tx *Tx) { found = tx.Has(key) })
 	return found
 }
 
 // GetValue decodes a key-value pair into to, using a temporary readonly transaction.
-func (s *Store) GetValue(k []byte, to interface{}) {
+func (s *Store) GetValue(k backend.Key, to interface{}) {
 	s.View(func(tx *Tx) {
 		tx.MustGetValue(k, to)
 	})
@@ -174,7 +174,7 @@ func (s *Store) GetValue(k []byte, to interface{}) {
 
 // Has checks if a key exists in the store or within the current transaction.
 // The test fails if the backend reports an error.
-func (tx *Tx) Has(k []byte) bool {
+func (tx *Tx) Has(k backend.Key) bool {
 	t := tx.Store.Registry.T
 	found, err := tx.Tx.Has(k)
 	must(t, err, "error testing for key presence")
@@ -183,7 +183,7 @@ func (tx *Tx) Has(k []byte) bool {
 
 // MustGet returns the value decoder for a key-value pair, or nil if the key is unknown.
 // The test fails if the backend reports an error.
-func (tx *Tx) MustGet(k []byte) backend.ValueDecoder {
+func (tx *Tx) MustGet(k backend.Key) backend.ValueDecoder {
 	dec, err := tx.Get(k)
 	must(tx.Store.Registry.T, err, "unknown key")
 	return dec
@@ -191,7 +191,7 @@ func (tx *Tx) MustGet(k []byte) backend.ValueDecoder {
 
 // GetValue decodes a key-value pair into to, only if the key exists.
 // Error returned by the backend will be returned.
-func (tx *Tx) GetValue(k []byte, to interface{}) error {
+func (tx *Tx) GetValue(k backend.Key, to interface{}) error {
 	dec, err := tx.Get(k)
 	if err == nil && dec != nil {
 		err = dec.Decode(to)
@@ -201,7 +201,7 @@ func (tx *Tx) GetValue(k []byte, to interface{}) error {
 
 // MustGetValue decodes a key-value pair into to, only if the key exists.
 // The test fails if the backend reports an error.
-func (tx *Tx) MustGetValue(k []byte, to interface{}) {
+func (tx *Tx) MustGetValue(k backend.Key, to interface{}) {
 	t := tx.Store.Registry.T
 
 	err := tx.GetValue(k, to)
@@ -212,7 +212,7 @@ func (tx *Tx) MustGetValue(k []byte, to interface{}) {
 
 // MustSet sets a key value pair in the current transaction.
 // The test fails if the backend reports an error.
-func (tx *Tx) MustSet(k []byte, v interface{}) {
+func (tx *Tx) MustSet(k backend.Key, v interface{}) {
 	t := tx.Store.Registry.T
 	must(t, tx.Tx.Set(k, v), "must set value")
 }

--- a/libbeat/registry/backend/cptest/util.go
+++ b/libbeat/registry/backend/cptest/util.go
@@ -22,6 +22,8 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
+
+	"github.com/elastic/beats/libbeat/registry/backend"
 )
 
 // RunWithPath uses the factory to create and configure a registry with a
@@ -82,12 +84,12 @@ func WithStore(factory BackendFactory, fn func(*testing.T, *Store)) func(*testin
 	})
 }
 
-func makeKey(s string) []byte {
-	return []byte(s)
+func makeKey(s string) backend.Key {
+	return backend.Key(s)
 }
 
-func makeKeys(n int) [][]byte {
-	keys := make([][]byte, n)
+func makeKeys(n int) []backend.Key {
+	keys := make([]backend.Key, n)
 	for i := range keys {
 		keys[i] = makeKey(fmt.Sprintf("key%v", i))
 	}

--- a/libbeat/registry/backend/memlog/hashtable_test.go
+++ b/libbeat/registry/backend/memlog/hashtable_test.go
@@ -23,17 +23,18 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/registry/backend"
 )
 
 func TestHashtable(t *testing.T) {
 	t.Run("find is Nil on empty table", func(t *testing.T) {
 		tbl := newHashtable()
-		ref := tbl.find(keyPair{1, []byte("a")})
+		ref := tbl.find(keyPair{1, backend.Key("a")})
 		assert.True(t, ref.IsNil())
 	})
 
 	t.Run("overwrite key", func(t *testing.T) {
-		key := []byte("k")
+		key := backend.Key("k")
 		pos := keyPair{1, key}
 		v1 := common.MapStr{"a": 1}
 		v2 := common.MapStr{"a": 2}
@@ -50,43 +51,43 @@ func TestHashtable(t *testing.T) {
 		t.Run("find key", func(t *testing.T) {
 			b := bin{
 				{
-					key:   []byte("a"),
+					key:   backend.Key("a"),
 					value: common.MapStr{"v": 1},
 				},
 				{
-					key:   []byte("b"),
+					key:   backend.Key("b"),
 					value: common.MapStr{"v": 2},
 				},
 			}
 
-			assert.Equal(t, 0, b.index([]byte("a")))
-			assert.Equal(t, 1, b.index([]byte("b")))
-			assert.Equal(t, -1, b.index([]byte("c")))
+			assert.Equal(t, 0, b.index(backend.Key("a")))
+			assert.Equal(t, 1, b.index(backend.Key("b")))
+			assert.Equal(t, -1, b.index(backend.Key("c")))
 		})
 
 		t.Run("remove", func(t *testing.T) {
 			b := bin{
 				{
-					key:   []byte("a"),
+					key:   backend.Key("a"),
 					value: common.MapStr{"v": 1},
 				},
 				{
-					key:   []byte("b"),
+					key:   backend.Key("b"),
 					value: common.MapStr{"v": 2},
 				},
 				{
-					key:   []byte("c"),
+					key:   backend.Key("c"),
 					value: common.MapStr{"v": 2},
 				},
 			}
 
-			idx := b.index([]byte("b"))
+			idx := b.index(backend.Key("b"))
 			b.remove(idx)
 
 			assert.Equal(t, 2, len(b))
-			assert.Equal(t, 0, b.index([]byte("a")))
-			assert.Equal(t, -1, b.index([]byte("b")))
-			assert.Equal(t, 1, b.index([]byte("c")))
+			assert.Equal(t, 0, b.index(backend.Key("a")))
+			assert.Equal(t, -1, b.index(backend.Key("b")))
+			assert.Equal(t, 1, b.index(backend.Key("c")))
 		})
 	})
 }

--- a/libbeat/registry/backend/memlog/store_test.go
+++ b/libbeat/registry/backend/memlog/store_test.go
@@ -105,7 +105,7 @@ func testLoadVersion1Case(t *testing.T, dataPath string) {
 		defer tx.Close()
 
 		for key, val := range expected.Entries {
-			dec, err := tx.Get([]byte(key))
+			dec, err := tx.Get(backend.Key(key))
 			require.NoError(t, err, "error reading entry")
 			assert.NotNil(t, dec, "entry is missing")
 

--- a/libbeat/registry/backend/memlog/tx_test.go
+++ b/libbeat/registry/backend/memlog/tx_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/registry/backend"
 )
 
 func TestTx(t *testing.T) {
@@ -31,13 +32,13 @@ func TestTx(t *testing.T) {
 
 		store := bin{
 			{
-				key:   []byte("a"),
+				key:   backend.Key("a"),
 				value: common.MapStr{"a": 1},
 			},
 		}
 		txCache := txCacheLine{
 			{
-				key:      []byte("b"),
+				key:      backend.Key("b"),
 				value:    common.MapStr{"b": 2},
 				exists:   true,
 				modified: true,

--- a/libbeat/registry/backend/memlog/util.go
+++ b/libbeat/registry/backend/memlog/util.go
@@ -94,12 +94,6 @@ func isRetryErr(err error) bool {
 	return err == syscall.EINTR || err == syscall.EAGAIN
 }
 
-func unsafeString(b []byte) string {
-	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&b))
-	str := reflect.StringHeader{Data: hdr.Data, Len: hdr.Len}
-	return *(*string)(unsafe.Pointer(&str))
-}
-
 func unsafeKeyRef(k backend.Key) []byte {
 	str := (*reflect.StringHeader)(unsafe.Pointer(&k))
 	hdr := reflect.SliceHeader{Data: str.Data, Len: str.Len, Cap: str.Len}

--- a/libbeat/registry/backend/memlog/util.go
+++ b/libbeat/registry/backend/memlog/util.go
@@ -25,11 +25,13 @@ import (
 	"reflect"
 	"syscall"
 	"unsafe"
+
+	"github.com/elastic/beats/libbeat/registry/backend"
 )
 
 var errno0 = syscall.Errno(0)
 
-type hashFn func(k []byte) uint64
+type hashFn func(k backend.Key) uint64
 
 type ensureWriter struct {
 	w io.Writer
@@ -53,8 +55,8 @@ func newHash() hash.Hash64 {
 
 func newHashFn() hashFn {
 	fn := newHash()
-	return func(k []byte) uint64 {
-		fn.Write(k)
+	return func(k backend.Key) uint64 {
+		fn.Write(unsafeKeyRef(k))
 		hash := fn.Sum64()
 		fn.Reset()
 		return hash
@@ -98,7 +100,7 @@ func unsafeString(b []byte) string {
 	return *(*string)(unsafe.Pointer(&str))
 }
 
-func unsafeKeyRef(k string) []byte {
+func unsafeKeyRef(k backend.Key) []byte {
 	str := (*reflect.StringHeader)(unsafe.Pointer(&k))
 	hdr := reflect.SliceHeader{Data: str.Data, Len: str.Len, Cap: str.Len}
 	return *(*[]byte)(unsafe.Pointer(&hdr))

--- a/libbeat/registry/id.go
+++ b/libbeat/registry/id.go
@@ -50,5 +50,5 @@ func (g *idGen) Make() Key {
 	if err != nil {
 		panic(err)
 	}
-	return k
+	return Key(k)
 }

--- a/libbeat/registry/registry.go
+++ b/libbeat/registry/registry.go
@@ -36,7 +36,8 @@ type Registry struct {
 }
 
 // Key is the type used for all keys in a store.
-type Key []byte
+// type Key []byte
+type Key string
 
 // ValueDecoder is used to decode retrieved from an actual store.  A
 // ValueDecoder instance is valid for the lifetime of the transaction only.

--- a/libbeat/registry/tx.go
+++ b/libbeat/registry/tx.go
@@ -128,7 +128,7 @@ func (tx *Tx) Insert(val interface{}) (Key, error) {
 		key = tx.gen.Make()
 		exists, err := tx.backend.Has(backend.Key(key))
 		if err != nil {
-			return key, err
+			return "", err
 		}
 
 		if !exists {
@@ -137,7 +137,10 @@ func (tx *Tx) Insert(val interface{}) (Key, error) {
 	}
 
 	err := tx.backend.Set(backend.Key(key), val)
-	return key, err
+	if err != nil {
+		return "", err
+	}
+	return key, nil
 }
 
 // Remove removes a key-value pair from the store.

--- a/libbeat/registry/tx.go
+++ b/libbeat/registry/tx.go
@@ -128,7 +128,7 @@ func (tx *Tx) Insert(val interface{}) (Key, error) {
 		key = tx.gen.Make()
 		exists, err := tx.backend.Has(backend.Key(key))
 		if err != nil {
-			return nil, err
+			return key, err
 		}
 
 		if !exists {
@@ -137,10 +137,7 @@ func (tx *Tx) Insert(val interface{}) (Key, error) {
 	}
 
 	err := tx.backend.Set(backend.Key(key), val)
-	if err != nil {
-		return nil, err
-	}
-	return key, nil
+	return key, err
 }
 
 // Remove removes a key-value pair from the store.


### PR DESCRIPTION
Update registry key type to string. Working with the registry I found it a little easier to work with strings (less copies, guarantees that string will not be tempered with).