### PR TITLE
Update docs for metadata_processors

### DIFF
--- a/libbeat/docs/processors-using.asciidoc
+++ b/libbeat/docs/processors-using.asciidoc
@@ -1276,8 +1276,18 @@ section.
 === Add Kubernetes metadata
 
 The `add_kubernetes_metadata` processor annotates each event with relevant
-metadata based on which Kubernetes pod the event originated from. Each event is
-annotated with:
+metadata based on which Kubernetes pod the event originated from.
+At startup it will detect an `in_cluster` environment and cache the Kubernetes related metadata.
+
+The simple configuration below enables the processor.
+
+[source,yaml]
+-------------------------------------------------------------------------------
+processors:
+- add_kubernetes_metadata: ~
+-------------------------------------------------------------------------------
+
+Each event is annotated with:
 
 * Pod Name
 * Pod UID
@@ -1360,7 +1370,17 @@ case you want to specify your own.
 === Add Docker metadata
 
 The `add_docker_metadata` processor annotates each event with relevant metadata
-from Docker containers:
+from Docker containers. At startup it will detect a docker environment and cache the metadata.
+
+The simple configuration below enables the processor.
+
+[source,yaml]
+-------------------------------------------------------------------------------
+processors:
+- add_docker_metadata: ~
+-------------------------------------------------------------------------------
+
+Each event is annotated with:
 
 * Container ID
 * Name

--- a/libbeat/docs/processors-using.asciidoc
+++ b/libbeat/docs/processors-using.asciidoc
@@ -1277,10 +1277,10 @@ section.
 
 The `add_kubernetes_metadata` processor annotates each event with relevant
 metadata based on which Kubernetes pod the event originated from.
-At startup it will detect an `in_cluster` environment and cache the
-Kubernetes related metadata. If it's not able to detect a valid Kuberentes
-configuration, the events will not be annotated with Kubernetes related
-metadata. Events will be annotated only if a valid configuration was detected.
+At startup it detects an `in_cluster` environment and caches the
+Kubernetes-related metadata. Events are only annotated if a valid configuration
+is detected. If it's not able to detect a valid Kubernetes configuration,
+the events are not annotated with Kubernetes-related metadata.
 
 Each event is annotated with:
 
@@ -1365,9 +1365,9 @@ case you want to specify your own.
 === Add Docker metadata
 
 The `add_docker_metadata` processor annotates each event with relevant metadata
-from Docker containers. At startup it will detect a docker environment and cache the metadata.
-The events will be annotated with Docker metadata, only if a valid configuration
-was detected and the processor is able to reach Docker api.
+from Docker containers. At startup it detects a docker environment and caches the metadata.
+The events are annotated with Docker metadata, only if a valid configuration
+is detected and the processor is able to reach Docker API.
 
 Each event is annotated with:
 

--- a/libbeat/docs/processors-using.asciidoc
+++ b/libbeat/docs/processors-using.asciidoc
@@ -1277,15 +1277,10 @@ section.
 
 The `add_kubernetes_metadata` processor annotates each event with relevant
 metadata based on which Kubernetes pod the event originated from.
-At startup it will detect an `in_cluster` environment and cache the Kubernetes related metadata.
-
-The simple configuration below enables the processor.
-
-[source,yaml]
--------------------------------------------------------------------------------
-processors:
-- add_kubernetes_metadata: ~
--------------------------------------------------------------------------------
+At startup it will detect an `in_cluster` environment and cache the
+Kubernetes related metadata. If it's not able to detect a valid Kuberentes
+configuration, the events will not be annotated with Kubernetes related
+metadata. Events will be annotated only if a valid configuration was detected.
 
 Each event is annotated with:
 
@@ -1371,14 +1366,8 @@ case you want to specify your own.
 
 The `add_docker_metadata` processor annotates each event with relevant metadata
 from Docker containers. At startup it will detect a docker environment and cache the metadata.
-
-The simple configuration below enables the processor.
-
-[source,yaml]
--------------------------------------------------------------------------------
-processors:
-- add_docker_metadata: ~
--------------------------------------------------------------------------------
+The events will be annotated with Docker metadata, only if a valid configuration
+was detected and the processor is able to reach Docker api.
 
 Each event is annotated with:
 


### PR DESCRIPTION
This is a follow-up for the PRs that enabled auto-detection for `add_docker_metadata` and `add_kubernetes_metadata`. 

Part of: https://github.com/elastic/beats/issues/13068
Related to:

- https://github.com/elastic/beats/pull/13473
- #13374

cc: @odacremolbap , @jsoriano 