### PR TITLE
Remove in_cluster from doc examples

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -16,6 +16,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Default of output.kafka.metadata.full is set to false by now. This reduced the amount of metadata to be queried from a kafka cluster. {pull}12738[12738]
 - Fixed a crash under Windows when fetching processes information. {pull}12833[12833]
 - Update to Golang 1.12.7. {pull}12931[12931]
+- Remove `in_cluster` configuration parameter for Kuberentes {pull}13051[13051]
 
 *Auditbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -16,7 +16,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Default of output.kafka.metadata.full is set to false by now. This reduced the amount of metadata to be queried from a kafka cluster. {pull}12738[12738]
 - Fixed a crash under Windows when fetching processes information. {pull}12833[12833]
 - Update to Golang 1.12.7. {pull}12931[12931]
-- Remove `in_cluster` configuration parameter for Kuberentes {pull}13051[13051]
+- Remove `in_cluster` configuration parameter for Kuberentes, now in-cluster configuration is used only if no other kubeconfig is specified {pull}13051[13051]
 
 *Auditbeat*
 

--- a/deploy/kubernetes/filebeat-kubernetes.yaml
+++ b/deploy/kubernetes/filebeat-kubernetes.yaml
@@ -14,7 +14,6 @@ data:
         - /var/log/containers/*.log
       processors:
         - add_kubernetes_metadata:
-            in_cluster: true
             host: ${NODE_NAME}
             matchers:
             - logs_path:

--- a/deploy/kubernetes/filebeat/filebeat-configmap.yaml
+++ b/deploy/kubernetes/filebeat/filebeat-configmap.yaml
@@ -14,7 +14,6 @@ data:
         - /var/log/containers/*.log
       processors:
         - add_kubernetes_metadata:
-            in_cluster: true
             host: ${NODE_NAME}
             matchers:
             - logs_path:

--- a/metricbeat/module/kubernetes/state_cronjob/README.md
+++ b/metricbeat/module/kubernetes/state_cronjob/README.md
@@ -61,7 +61,6 @@ Kubernetes YAML chunk should look like:
     - state_cronjob
   period: 10s
   hosts: ["kube-state-metrics:8080"]
-  in_cluster: true
 ```
 
 Deploy kube-state-metrics. You can find the manifests [here](https://github.com/kubernetes/kube-state-metrics/tree/release-1.7/kubernetes)

--- a/x-pack/filebeat/module/coredns/README.md
+++ b/x-pack/filebeat/module/coredns/README.md
@@ -54,8 +54,7 @@ kubectl apply -f filebeat
         hints.default_config.enabled: false
 
   processors:
-    - add_kubernetes_metadata:
-        in_cluster: true
+    - add_kubernetes_metadata: ~
 ```
 
 This enables auto-discovery and hints for filebeat. When default.disable is set to true (default value is false), it will disable log harvesting for the pod/container, unless it has specific annotations enabled. This gives users more granular control on kubernetes log ingestion. The `add_kubernetes_metadata` processor will add enrichment data for Kubernetes to the ingest logs.

--- a/x-pack/filebeat/module/envoyproxy/README.md
+++ b/x-pack/filebeat/module/envoyproxy/README.md
@@ -49,8 +49,7 @@ kubectl apply -f filebeat
         hints.default_config.enabled: false
 
   processors:
-    - add_kubernetes_metadata:
-        in_cluster: true
+    - add_kubernetes_metadata: ~
 ```
 
 This enables auto-discovery and hints for filebeat. When default.disable is set to true (default value is false), it will disable log harvesting for the pod/container, unless it has specific annotations enabled. This gives users more granular control on kubernetes log ingestion. The `add_kubernetes_metadata` processor will add enrichment data for Kubernetes to the ingest logs.


### PR DESCRIPTION
This configuration was removed by https://github.com/elastic/beats/pull/13051.

This PR is clean up for any remaining references of this configuration filed.
Kudos to @jsoriano for bringing this up in https://github.com/elastic/beats/pull/13473

cc: @odacremolbap, @exekias 