### PR TITLE
Cherry-pick #13534 to 7.4: Update aws credentials for s3 input

### DIFF
--- a/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
@@ -59,6 +59,16 @@ In order to make AWS API calls, `s3` input requires AWS credentials.Please see
  <<aws-credentials-config,AWS credentials options>> for more details.
 
 [float]
+=== AWS Permissions
+Specific AWS permissions are required for IAM user to access SQS and S3:
+----
+s3:GetObject
+sqs:ReceiveMessage
+sqs:ChangeMessageVisibility
+sqs:DeleteMessage
+----
+
+[float]
 === S3 and SQS setup
 Enable bucket notification: any new object creation in S3 bucket will also
 create a notification through SQS. Please see


### PR DESCRIPTION
Cherry-pick of PR #13534 to 7.4 branch. Original message:

This PR is to add the permissions for using s3 input.

(cherry picked from commit bdc95ba54a80a33a81bee0f9015467c2517de8a9)