### PR TITLE
Restructure consul agent topic to fix URL for asciidoctor migration

### DIFF
--- a/metricbeat/docs/modules/beat.asciidoc
+++ b/metricbeat/docs/modules/beat.asciidoc
@@ -10,7 +10,7 @@ This is the Beat module.
 The default metricsets are `state` and `stats`.
 
 [float]
-=== Compability
+=== Compatibility
 
 The beat module is tested with metricbeat 7.3.0.
 

--- a/metricbeat/docs/modules/consul.asciidoc
+++ b/metricbeat/docs/modules/consul.asciidoc
@@ -15,20 +15,11 @@ This is the https://www.consul.io[Hashicorp's Consul] Metricbeat module. It is s
 The module is being tested with https://github.com/hashicorp/docker-consul/blob/9bd2aa7ecf2414b8712e055f2374699148e8941c/0.X/Dockerfile[1.4.2] version
 
 [float]
-== Metricsets
-
-The following Metricset is included:
-
-=== `agent`
-
-`agent` Metricset fetches information from a Consul Agent in 'Client' mode. It fetches information about the health of the autopilot, runtime metrics and raft data.
-
-[float]
 === Dashboard
 
-  The Consul module comes with a predefined dashboard:
+The Consul module comes with a predefined dashboard:
 
-  image::./images/metricbeat-consul.png[]
+image::./images/metricbeat-consul.png[]
 
 
 [float]

--- a/metricbeat/docs/modules/consul.asciidoc
+++ b/metricbeat/docs/modules/consul.asciidoc
@@ -10,7 +10,7 @@ beta[]
 This is the https://www.consul.io[Hashicorp's Consul] Metricbeat module. It is still in beta and under active development to add new Metricsets and introduce enhancements.
 
 [float]
-== Compatibility
+=== Compatibility
 
 The module is being tested with https://github.com/hashicorp/docker-consul/blob/9bd2aa7ecf2414b8712e055f2374699148e8941c/0.X/Dockerfile[1.4.2] version
 

--- a/metricbeat/docs/modules/docker.asciidoc
+++ b/metricbeat/docs/modules/docker.asciidoc
@@ -8,7 +8,7 @@ This file is generated! See scripts/mage/docs_collector.go
 This module fetches metrics from https://www.docker.com/[Docker] containers. The default metricsets are: `container`, `cpu`, `diskio`, `healthcheck`, `info`, `memory` and `network`. The `image` metricset is not enabled by default.
 
 [float]
-=== Compability
+=== Compatibility
 
 The Docker module is currently tested on Linux and Mac with the community
 edition engine, versions 1.11 and 17.09.0-ce. It is not tested on Windows,

--- a/metricbeat/docs/modules/dropwizard.asciidoc
+++ b/metricbeat/docs/modules/dropwizard.asciidoc
@@ -8,7 +8,7 @@ This file is generated! See scripts/mage/docs_collector.go
 This is the http://dropwizard.io[Dropwizard] module. The default metricset is `collector`.
 
 [float]
-=== Compability
+=== Compatibility
 
 The Dropwizard module is tested with dropwizard metrics 3.1.0.
 

--- a/metricbeat/docs/modules/elasticsearch.asciidoc
+++ b/metricbeat/docs/modules/elasticsearch.asciidoc
@@ -16,7 +16,7 @@ default metricsets in this module are `ccr`, `cluster_stats`, `index`,
 `index_recovery`, `index_summary`, `ml_job`, `node_stats`, and `shard`.
 
 [float]
-=== Compability
+=== Compatibility
 
 The Elasticsearch module is tested with Elasticsearch 6.3 and is expected to
 work with all 6.x versions.

--- a/metricbeat/docs/modules/envoyproxy.asciidoc
+++ b/metricbeat/docs/modules/envoyproxy.asciidoc
@@ -10,7 +10,7 @@ This is the envoyproxy module.
 The default metricset is `server`.
 
 [float]
-=== Compability
+=== Compatibility
 
 The envoyproxy module is tested with Envoy 1.7.0.
 

--- a/metricbeat/docs/modules/kafka.asciidoc
+++ b/metricbeat/docs/modules/kafka.asciidoc
@@ -25,7 +25,7 @@ kafka-acls --authorizer-properties zookeeper.connect=localhost:2181 --add --allo
 -----
 
 [float]
-=== Compability
+=== Compatibility
 
 This module is tested with Kafka 0.10.2.1, 1.1.0 and 2.1.1.
 

--- a/metricbeat/docs/modules/kubernetes.asciidoc
+++ b/metricbeat/docs/modules/kubernetes.asciidoc
@@ -21,7 +21,7 @@ example configuration on how to do it.
 The default metricsets are `container`, `node`, `pod`, `system` and `volume`.
 
 [float]
-=== Compability
+=== Compatibility
 
 The Kubernetes module is tested with Kubernetes 1.13.x and 1.14.x
 

--- a/metricbeat/docs/modules/logstash.asciidoc
+++ b/metricbeat/docs/modules/logstash.asciidoc
@@ -10,7 +10,7 @@ This is the Logstash module.
 The default metricsets are `node` and `node_stats`.
 
 [float]
-=== Compability
+=== Compatibility
 
 The logstash module is tested with logstash 6.3.
 

--- a/metricbeat/module/beat/_meta/docs.asciidoc
+++ b/metricbeat/module/beat/_meta/docs.asciidoc
@@ -3,6 +3,6 @@ This is the Beat module.
 The default metricsets are `state` and `stats`.
 
 [float]
-=== Compability
+=== Compatibility
 
 The beat module is tested with metricbeat 7.3.0.

--- a/metricbeat/module/beat/docs.asciidoc
+++ b/metricbeat/module/beat/docs.asciidoc
@@ -4,6 +4,6 @@ multiple versions. To monitor more Beat metrics, use our {stack-ov}/xpack-monito
 The default metricset is `stats`.
 
 [float]
-=== Compability
+=== Compatibility
 
 The Beat module is tested with Metricbeat 7.2 and is expected to work with all 7.x versions.

--- a/metricbeat/module/consul/_meta/docs.asciidoc
+++ b/metricbeat/module/consul/_meta/docs.asciidoc
@@ -6,17 +6,8 @@ This is the https://www.consul.io[Hashicorp's Consul] Metricbeat module. It is s
 The module is being tested with https://github.com/hashicorp/docker-consul/blob/9bd2aa7ecf2414b8712e055f2374699148e8941c/0.X/Dockerfile[1.4.2] version
 
 [float]
-== Metricsets
-
-The following Metricset is included:
-
-=== `agent`
-
-`agent` Metricset fetches information from a Consul Agent in 'Client' mode. It fetches information about the health of the autopilot, runtime metrics and raft data.
-
-[float]
 === Dashboard
 
-  The Consul module comes with a predefined dashboard:
+The Consul module comes with a predefined dashboard:
 
-  image::./images/metricbeat-consul.png[]
+image::./images/metricbeat-consul.png[]

--- a/metricbeat/module/consul/_meta/docs.asciidoc
+++ b/metricbeat/module/consul/_meta/docs.asciidoc
@@ -1,7 +1,7 @@
 This is the https://www.consul.io[Hashicorp's Consul] Metricbeat module. It is still in beta and under active development to add new Metricsets and introduce enhancements.
 
 [float]
-== Compatibility
+=== Compatibility
 
 The module is being tested with https://github.com/hashicorp/docker-consul/blob/9bd2aa7ecf2414b8712e055f2374699148e8941c/0.X/Dockerfile[1.4.2] version
 

--- a/metricbeat/module/consul/agent/_meta/docs.asciidoc
+++ b/metricbeat/module/consul/agent/_meta/docs.asciidoc
@@ -1,4 +1,4 @@
-This is the 'agent' Metricset of the Hashicorp's Consul Metricbeat module.
+The `agent` metricset fetches information from a Hashicorp Consul agent in 'Client' mode. It fetches information about the health of the autopilot, runtime metrics, and raft data.
 
 * *agent.autopilot.healthy*: Tracks the overall health of the local server cluster. If all servers are considered healthy by Autopilot, this will be set to 1. If any are unhealthy, this will be 0.
 * *agent.raft.apply*: This metric gives the number of logs committed since the last interval.

--- a/metricbeat/module/docker/_meta/docs.asciidoc
+++ b/metricbeat/module/docker/_meta/docs.asciidoc
@@ -1,7 +1,7 @@
 This module fetches metrics from https://www.docker.com/[Docker] containers. The default metricsets are: `container`, `cpu`, `diskio`, `healthcheck`, `info`, `memory` and `network`. The `image` metricset is not enabled by default.
 
 [float]
-=== Compability
+=== Compatibility
 
 The Docker module is currently tested on Linux and Mac with the community
 edition engine, versions 1.11 and 17.09.0-ce. It is not tested on Windows,

--- a/metricbeat/module/dropwizard/_meta/docs.asciidoc
+++ b/metricbeat/module/dropwizard/_meta/docs.asciidoc
@@ -1,6 +1,6 @@
 This is the http://dropwizard.io[Dropwizard] module. The default metricset is `collector`.
 
 [float]
-=== Compability
+=== Compatibility
 
 The Dropwizard module is tested with dropwizard metrics 3.1.0.

--- a/metricbeat/module/elasticsearch/_meta/docs.asciidoc
+++ b/metricbeat/module/elasticsearch/_meta/docs.asciidoc
@@ -9,7 +9,7 @@ default metricsets in this module are `ccr`, `cluster_stats`, `index`,
 `index_recovery`, `index_summary`, `ml_job`, `node_stats`, and `shard`.
 
 [float]
-=== Compability
+=== Compatibility
 
 The Elasticsearch module is tested with Elasticsearch 6.3 and is expected to
 work with all 6.x versions.

--- a/metricbeat/module/envoyproxy/_meta/docs.asciidoc
+++ b/metricbeat/module/envoyproxy/_meta/docs.asciidoc
@@ -3,6 +3,6 @@ This is the envoyproxy module.
 The default metricset is `server`.
 
 [float]
-=== Compability
+=== Compatibility
 
 The envoyproxy module is tested with Envoy 1.7.0.

--- a/metricbeat/module/kafka/_meta/docs.asciidoc
+++ b/metricbeat/module/kafka/_meta/docs.asciidoc
@@ -18,6 +18,6 @@ kafka-acls --authorizer-properties zookeeper.connect=localhost:2181 --add --allo
 -----
 
 [float]
-=== Compability
+=== Compatibility
 
 This module is tested with Kafka 0.10.2.1, 1.1.0 and 2.1.1.

--- a/metricbeat/module/kubernetes/_meta/docs.asciidoc
+++ b/metricbeat/module/kubernetes/_meta/docs.asciidoc
@@ -14,7 +14,7 @@ example configuration on how to do it.
 The default metricsets are `container`, `node`, `pod`, `system` and `volume`.
 
 [float]
-=== Compability
+=== Compatibility
 
 The Kubernetes module is tested with Kubernetes 1.13.x and 1.14.x
 

--- a/metricbeat/module/logstash/_meta/docs.asciidoc
+++ b/metricbeat/module/logstash/_meta/docs.asciidoc
@@ -3,6 +3,6 @@ This is the Logstash module.
 The default metricsets are `node` and `node_stats`.
 
 [float]
-=== Compability
+=== Compatibility
 
 The logstash module is tested with logstash 6.3.


### PR DESCRIPTION
The docs were formatted incorrectly, which resulted in the wrong URL for the `agent` metricset. I've restructured the content to follow the format that we use for other modules.

The section [here](https://github.com/elastic/beats/compare/master...dedemorton:fix_asciidoctor_link_problem?expand=1#diff-2b8b2fced54020887ca16137cabadddeL13) is problematic because it has no ID (plus it duplicates content). 

This is not good for SEO *and* causes problems when I build the docs in asciidoctor because asciidoc has a slightly different naming pattern for the URL. It becomes html/en/beats/metricbeat/master/_agent.html.

I also fixed some typos that I noticed. 