### PR TITLE
trim_leading_whitespace is an unexpected property

### DIFF
--- a/libbeat/docs/processors-using.asciidoc
+++ b/libbeat/docs/processors-using.asciidoc
@@ -811,7 +811,7 @@ processors:
      separator: ,
      ignore_missing: false
      overwrite_keys: true
-     trim_leading_whitespace: false
+     trim_leading_space: false
      fail_on_error: true
 -----------------------------------------------------
 


### PR DESCRIPTION
 `trim_leading_whitespace` in the example was unexpected as it is renamed to `trim_leading_space`