### PR TITLE
Remove space between PR number and link

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -362,7 +362,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add rate metrics for ec2 metricset. {pull}13203[13203]
 - Add Performance metricset to Oracle module {pull}12547[12547]
 - Add proc/vmstat data to the system/memory metricset on linux {pull}13322[13322]
-- Use DefaultMetaGeneratorConfig in MetadataEnrichers to initialize configurations {pull}13414 [13414]
+- Use DefaultMetaGeneratorConfig in MetadataEnrichers to initialize configurations {pull}13414[13414]
 - Add module for statsd. {pull}13109[13109]
 
 


### PR DESCRIPTION
Remove a space that cause the MD syntax to be broken.