### PR TITLE
[SIEM][Auditbeat] Make socket dataset work with IPv6 disabled

### DIFF
--- a/x-pack/auditbeat/module/system/socket/_meta/docs.asciidoc
+++ b/x-pack/auditbeat/module/system/socket/_meta/docs.asciidoc
@@ -51,6 +51,7 @@ distributions under which the dataset is known to work:
 | CentOS 6.5     | 2.6.32-431.el6      | NO^<<anchor-1,[1]>>^
 | CentOS 6.9     | 2.6.32-696.30.1.el6 | &#10003;
 | CentOS 7.6     | 3.10.0-957.1.3.el7  | &#10003;
+| RHEL 8         | 4.18.0-80.rhel8     | &#10003;
 | Debian 8       | 3.16.0-6            | &#10003;
 | Debian 9       | 4.9.0-8             | &#10003;
 | Debian 10      | 4.19.0-5            | &#10003;
@@ -75,23 +76,25 @@ A kernel built with the following configuration options enabled is required:
 
 - `CONFIG_KPROBE_EVENTS`: Enables the KProbes subsystem.
 - `CONFIG_DEBUG_FS`: For kernels laking `tracefs` support (<4.1).
-- `CONFIG_IPV6`.
+- `CONFIG_IPV6`: IPv6 support in the kernel is needed even if disabled with
+`socket.enable_ipv6: false`.
 
 These settings are enabled by default in most distributions.
 
 The following configuration settings can prevent the dataset from starting:
 
 - `/sys/kernel/debug/kprobes/enabled` must be 1.
-- `/proc/sys/net/ipv6/conf/lo/disable_ipv6` must be 0
-(IPv6 enabled in the loopback device).
+- `/proc/sys/net/ipv6/conf/lo/disable_ipv6` (IPv6 enabled in loopback device) is
+required when running with IPv6 enabled.
+
 
 [float]
 ==== Running on docker
 
 The dataset can monitor the Docker host when running inside a container. However
-it needs to run on a `privileged` container with `CAP_NET_ADMIN` and IPv6
-support. The docker container running {beatname_uc} needs access to the host's
-tracefs or debugfs directory. This is achieved by bind-mounting `/sys`.
+it needs to run on a `privileged` container with `CAP_NET_ADMIN`. The docker
+container running {beatname_uc} needs access to the host's tracefs or debugfs
+directory. This is achieved by bind-mounting `/sys`.
 
 [float]
 === Configuration
@@ -105,6 +108,13 @@ Must point to the mount-point of `tracefs` or the `tracing` directory inside
 the default locations: `/sys/kernel/tracing` and `/sys/kernel/debug/tracing`.
 If not found, it will attempt to mount `tracefs` and `debugfs` at their
 default locations.
+
+- `socket.enable_ipv6` (default: unset)
+
+Determines whether IPv6 must be monitored. When unset (default), IPv6 support
+is automatically detected. Even when IPv6 is disabled, in order to run the
+dataset you still need a kernel with IPv6 support (the `ipv6` module must be
+loaded if compiled as a module).
 
 - `socket.flow_inactive_timeout` (default: 30s)
 

--- a/x-pack/auditbeat/module/system/socket/config.go
+++ b/x-pack/auditbeat/module/system/socket/config.go
@@ -54,6 +54,10 @@ type Config struct {
 	// DevelopmentMode is an undocumented flag to ignore SSH traffic so that the
 	// dataset can be run with debug output without creating a feedback loop.
 	DevelopmentMode bool `config:"socket.development_mode"`
+
+	// EnableIPv6 allows to control IPv6 support. When unset (default) IPv6
+	// will be automatically detected on runtime.
+	EnableIPv6 *bool `config:"socket.enable_ipv6"`
 }
 
 // Validate validates the host metricset config.

--- a/x-pack/auditbeat/module/system/socket/guess/cskxmit6.go
+++ b/x-pack/auditbeat/module/system/socket/guess/cskxmit6.go
@@ -69,6 +69,11 @@ func (g *guessInet6CskXmit) Requires() []string {
 	}
 }
 
+// Condition allows this probe to run only when IPv6 is enabled.
+func (g *guessInet6CskXmit) Condition(ctx Context) (bool, error) {
+	return isIPv6Enabled(ctx.Vars)
+}
+
 // Probes returns 2 probes:
 //   - kretprobe on inet_csk_accept, which returns a struct sock*
 //   - kprobe on inet6_csk_xmit, returning 1st argument as pointer and dump.

--- a/x-pack/auditbeat/module/system/socket/guess/cskxmit6.go
+++ b/x-pack/auditbeat/module/system/socket/guess/cskxmit6.go
@@ -41,7 +41,7 @@ func init() {
 
 type guessInet6CskXmit struct {
 	ctx                    Context
-	loopback               ipv6loopback
+	loopback               helper.IPv6Loopback
 	clientAddr, serverAddr unix.SockaddrInet6
 	client, server         int
 	sock                   uintptr
@@ -99,7 +99,7 @@ func (g *guessInet6CskXmit) Probes() ([]helper.ProbeDef, error) {
 func (g *guessInet6CskXmit) Prepare(ctx Context) (err error) {
 	g.ctx = ctx
 	g.acceptedFd = -1
-	g.loopback, err = newIPv6Loopback()
+	g.loopback, err = helper.NewIPv6Loopback()
 	if err != nil {
 		return errors.Wrap(err, "detect IPv6 loopback failed")
 	}
@@ -108,11 +108,11 @@ func (g *guessInet6CskXmit) Prepare(ctx Context) (err error) {
 			g.loopback.Cleanup()
 		}
 	}()
-	clientIP, err := g.loopback.addRandomAddress()
+	clientIP, err := g.loopback.AddRandomAddress()
 	if err != nil {
 		return errors.Wrap(err, "failed adding first device address")
 	}
-	serverIP, err := g.loopback.addRandomAddress()
+	serverIP, err := g.loopback.AddRandomAddress()
 	if err != nil {
 		return errors.Wrap(err, "failed adding second device address")
 	}

--- a/x-pack/auditbeat/module/system/socket/guess/helpers.go
+++ b/x-pack/auditbeat/module/system/socket/guess/helpers.go
@@ -10,11 +10,7 @@ import (
 	"bytes"
 	"fmt"
 	"math/rand"
-	"net"
-	"time"
-	"unsafe"
 
-	"github.com/joeshaw/multierror"
 	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 
@@ -108,115 +104,6 @@ func getListField(m common.MapStr, key string) ([]int, error) {
 		return nil, fmt.Errorf("field %s not detected", key)
 	}
 	return list, nil
-}
-
-type ipv6loopback struct {
-	fd         int
-	deviceName string
-	addresses  []net.IP
-	ifreq      ifReq
-}
-
-type in6Ifreq struct {
-	addr    [16]byte
-	prefix  uint32
-	ifindex int32
-}
-
-const ifnamsiz = 16
-
-type ifReq struct {
-	name    [ifnamsiz]byte
-	index   int32
-	padding [128]byte
-}
-
-func newIPv6Loopback() (lo ipv6loopback, err error) {
-	lo.fd = -1
-	devs, err := net.Interfaces()
-	if err != nil {
-		return lo, errors.Wrap(err, "cannot list interfaces")
-	}
-	for _, dev := range devs {
-		addrs, err := dev.Addrs()
-		if err != nil || len(dev.Name) >= ifnamsiz {
-			continue
-		}
-		for _, addr := range addrs {
-			if ipnet, ok := addr.(*net.IPNet); ok && ipnet.IP.IsLoopback() {
-				lo.deviceName = dev.Name
-				lo.fd, err = unix.Socket(unix.AF_INET6, unix.SOCK_DGRAM, unix.IPPROTO_IP)
-				if err != nil {
-					lo.fd = -1
-					return lo, errors.Wrap(err, "ipv6 socket failed")
-				}
-				copy(lo.ifreq.name[:], dev.Name)
-				lo.ifreq.name[len(dev.Name)] = 0
-				_, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(lo.fd), unix.SIOCGIFINDEX, uintptr(unsafe.Pointer(&lo.ifreq)))
-				if errno != 0 {
-					unix.Close(lo.fd)
-					return lo, errors.Wrap(errno, "ioctl(SIOCGIFINDEX) failed")
-				}
-				return lo, nil
-			}
-		}
-	}
-	return lo, errors.New("no loopback interface detected")
-}
-
-// adds a randomly-generated address from the fd00::/8 prefix (Unique Local Address)
-func (lo *ipv6loopback) addRandomAddress() (addr net.IP, err error) {
-	addr = make(net.IP, 16)
-	addr[0] = 0xFD
-	rand.Read(addr[1:])
-	var req in6Ifreq
-	copy(req.addr[:], addr)
-	req.ifindex = lo.ifreq.index
-	req.prefix = 128
-	_, _, e := unix.Syscall(unix.SYS_IOCTL, uintptr(lo.fd), unix.SIOCSIFADDR, uintptr(unsafe.Pointer(&req)))
-	if e != 0 {
-		return nil, errors.Wrap(e, "ioctl SIOCSIFADDR failed")
-	}
-	lo.addresses = append(lo.addresses, addr)
-
-	// wait for the added address to be available. There seems to be a small
-	// delay in some systems between the time an address is added and it is
-	// available to bind.
-	fd, err := unix.Socket(unix.AF_INET6, unix.SOCK_DGRAM, 0)
-	if err != nil {
-		return addr, errors.Wrap(err, "socket ipv6 dgram failed")
-	}
-	defer unix.Close(fd)
-	var bindAddr unix.SockaddrInet6
-	copy(bindAddr.Addr[:], addr)
-	for i := 1; i < 50; i++ {
-		if err = unix.Bind(fd, &bindAddr); err == nil {
-			break
-		}
-		if errno, ok := err.(unix.Errno); !ok || errno != unix.EADDRNOTAVAIL {
-			break
-		}
-		time.Sleep(time.Millisecond * time.Duration(i))
-	}
-	return addr, errors.Wrap(err, "bind failed")
-}
-
-func (lo *ipv6loopback) Cleanup() error {
-	var errs multierror.Errors
-	var req in6Ifreq
-	req.ifindex = lo.ifreq.index
-	req.prefix = 128
-	for _, addr := range lo.addresses {
-		copy(req.addr[:], addr)
-		_, _, e := unix.Syscall(unix.SYS_IOCTL, uintptr(lo.fd), unix.SIOCDIFADDR, uintptr(unsafe.Pointer(&req)))
-		if e != 0 {
-			errs = append(errs, e)
-		}
-	}
-	if lo.fd != -1 {
-		unix.Close(lo.fd)
-	}
-	return errs.Err()
 }
 
 // consolidate takes a list of guess results in the form of maps with []int

--- a/x-pack/auditbeat/module/system/socket/guess/inetsock6.go
+++ b/x-pack/auditbeat/module/system/socket/guess/inetsock6.go
@@ -130,6 +130,7 @@ func (g *guessInetSockIPv6) Provides() []string {
 		"INET_SOCK_V6_RADDR_B",
 		"INET_SOCK_V6_LADDR_A",
 		"INET_SOCK_V6_LADDR_B",
+		"INET_SOCK_V6_LIMIT",
 	}
 }
 
@@ -139,6 +140,20 @@ func (g *guessInetSockIPv6) Requires() []string {
 		"RET",
 		"INET_SOCK_RADDR_LIST",
 	}
+}
+
+// Condition allows this probe to run only when IPv6 is enabled.
+func (g *guessInetSockIPv6) Condition(ctx Context) (bool, error) {
+	runs, err := isIPv6Enabled(ctx.Vars)
+	if err != nil {
+		return false, err
+	}
+	if !runs {
+		// Set a safe default for INET_SOCK_V6_LIMIT so that guesses
+		// depending on it can run.
+		ctx.Vars["INET_SOCK_V6_LIMIT"] = 2048
+	}
+	return runs, nil
 }
 
 // eventWrapper is used to wrap events from one of the probes for differentiation.

--- a/x-pack/auditbeat/module/system/socket/guess/inetsock6.go
+++ b/x-pack/auditbeat/module/system/socket/guess/inetsock6.go
@@ -110,7 +110,7 @@ func init() {
 
 type guessInetSockIPv6 struct {
 	ctx                    Context
-	loopback               ipv6loopback
+	loopback               helper.IPv6Loopback
 	clientAddr, serverAddr unix.SockaddrInet6
 	client, server         int
 	offsets                []int
@@ -216,7 +216,7 @@ func (g *guessInetSockIPv6) Prepare(ctx Context) (err error) {
 	if err != nil {
 		return err
 	}
-	g.loopback, err = newIPv6Loopback()
+	g.loopback, err = helper.NewIPv6Loopback()
 	if err != nil {
 		return errors.Wrap(err, "detect IPv6 loopback failed")
 	}
@@ -225,11 +225,11 @@ func (g *guessInetSockIPv6) Prepare(ctx Context) (err error) {
 			g.loopback.Cleanup()
 		}
 	}()
-	clientIP, err := g.loopback.addRandomAddress()
+	clientIP, err := g.loopback.AddRandomAddress()
 	if err != nil {
 		return errors.Wrap(err, "failed adding first device address")
 	}
-	serverIP, err := g.loopback.addRandomAddress()
+	serverIP, err := g.loopback.AddRandomAddress()
 	if err != nil {
 		return errors.Wrap(err, "failed adding second device address")
 	}

--- a/x-pack/auditbeat/module/system/socket/guess/skbuff.go
+++ b/x-pack/auditbeat/module/system/socket/guess/skbuff.go
@@ -235,7 +235,7 @@ type guessSkBuffProto struct {
 	ctx                    Context
 	doIPv6                 bool
 	cs                     inetClientServer
-	loopback               ipv6loopback
+	loopback               helper.IPv6Loopback
 	clientAddr, serverAddr unix.SockaddrInet6
 	client, server         int
 	msg                    []byte
@@ -280,7 +280,7 @@ func (g *guessSkBuffProto) Prepare(ctx Context) (err error) {
 	g.doIPv6 = !g.doIPv6
 	g.msg = make([]byte, 0x123)
 	if g.doIPv6 {
-		g.loopback, err = newIPv6Loopback()
+		g.loopback, err = helper.NewIPv6Loopback()
 		if err != nil {
 			return errors.Wrap(err, "detect IPv6 loopback failed")
 		}
@@ -289,11 +289,11 @@ func (g *guessSkBuffProto) Prepare(ctx Context) (err error) {
 				g.loopback.Cleanup()
 			}
 		}()
-		clientIP, err := g.loopback.addRandomAddress()
+		clientIP, err := g.loopback.AddRandomAddress()
 		if err != nil {
 			return errors.Wrap(err, "failed adding first device address")
 		}
-		serverIP, err := g.loopback.addRandomAddress()
+		serverIP, err := g.loopback.AddRandomAddress()
 		if err != nil {
 			return errors.Wrap(err, "failed adding second device address")
 		}

--- a/x-pack/auditbeat/module/system/socket/guess/skbuff.go
+++ b/x-pack/auditbeat/module/system/socket/guess/skbuff.go
@@ -234,6 +234,7 @@ func (g *guessSkBuffLen) Reduce(results []common.MapStr) (result common.MapStr, 
 type guessSkBuffProto struct {
 	ctx                    Context
 	doIPv6                 bool
+	hasIPv6                bool
 	cs                     inetClientServer
 	loopback               helper.IPv6Loopback
 	clientAddr, serverAddr unix.SockaddrInet6
@@ -277,7 +278,11 @@ func (g *guessSkBuffProto) Requires() []string {
 // Prepare sets up either two UDP sockets, using either IPv4 or IPv6.
 func (g *guessSkBuffProto) Prepare(ctx Context) (err error) {
 	g.ctx = ctx
-	g.doIPv6 = !g.doIPv6
+	g.hasIPv6, err = isIPv6Enabled(ctx.Vars)
+	if err != nil {
+		return errors.Wrap(err, "unable to determine if IPv6 is enabled")
+	}
+	g.doIPv6 = g.hasIPv6 && !g.doIPv6
 	g.msg = make([]byte, 0x123)
 	if g.doIPv6 {
 		g.loopback, err = helper.NewIPv6Loopback()

--- a/x-pack/auditbeat/module/system/socket/guess/sockaddrin6.go
+++ b/x-pack/auditbeat/module/system/socket/guess/sockaddrin6.go
@@ -67,6 +67,11 @@ func (g *guessSockaddrIn6) Requires() []string {
 	}
 }
 
+// Condition allows this probe to run only when IPv6 is enabled.
+func (g *guessSockaddrIn6) Condition(ctx Context) (bool, error) {
+	return isIPv6Enabled(ctx.Vars)
+}
+
 // Probes returns a probe on tcp_v6_connect, dumping its second argument,
 // a struct sockaddr* (struct sockaddr_in6* for AF_INET6).
 func (g *guessSockaddrIn6) Probes() ([]helper.ProbeDef, error) {

--- a/x-pack/auditbeat/module/system/socket/helper/loopback.go
+++ b/x-pack/auditbeat/module/system/socket/helper/loopback.go
@@ -1,0 +1,127 @@
+package helper
+
+import (
+	"math/rand"
+	"net"
+	"time"
+	"unsafe"
+
+	"github.com/joeshaw/multierror"
+	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
+)
+
+// IPv6Loopback is a helper to add random link-local IPv6 addresses to the
+// loopback interface.
+type IPv6Loopback struct {
+	fd         int
+	deviceName string
+	addresses  []net.IP
+	ifreq      ifReq
+}
+
+type in6Ifreq struct {
+	addr    [16]byte
+	prefix  uint32
+	ifindex int32
+}
+
+const ifnamsiz = 16
+
+type ifReq struct {
+	name    [ifnamsiz]byte
+	index   int32
+	padding [128]byte
+}
+
+// NewIPv6Loopback detects the loopback interface and creates an IPv6Loopback
+// to add and remove link-local IPv6 addresses.
+func NewIPv6Loopback() (lo IPv6Loopback, err error) {
+	lo.fd = -1
+	devs, err := net.Interfaces()
+	if err != nil {
+		return lo, errors.Wrap(err, "cannot list interfaces")
+	}
+	for _, dev := range devs {
+		addrs, err := dev.Addrs()
+		if err != nil || len(dev.Name) >= ifnamsiz {
+			continue
+		}
+		for _, addr := range addrs {
+			if ipnet, ok := addr.(*net.IPNet); ok && ipnet.IP.IsLoopback() {
+				lo.deviceName = dev.Name
+				lo.fd, err = unix.Socket(unix.AF_INET6, unix.SOCK_DGRAM, unix.IPPROTO_IP)
+				if err != nil {
+					lo.fd = -1
+					return lo, errors.Wrap(err, "ipv6 socket failed")
+				}
+				copy(lo.ifreq.name[:], dev.Name)
+				lo.ifreq.name[len(dev.Name)] = 0
+				_, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(lo.fd), unix.SIOCGIFINDEX, uintptr(unsafe.Pointer(&lo.ifreq)))
+				if errno != 0 {
+					unix.Close(lo.fd)
+					return lo, errors.Wrap(errno, "ioctl(SIOCGIFINDEX) failed")
+				}
+				return lo, nil
+			}
+		}
+	}
+	return lo, errors.New("no loopback interface detected")
+}
+
+// AddRandomAddress adds a randomly-generated address
+// from the fd00::/8 prefix (Unique Local Address)
+func (lo *IPv6Loopback) AddRandomAddress() (addr net.IP, err error) {
+	addr = make(net.IP, 16)
+	addr[0] = 0xFD
+	rand.Read(addr[1:])
+	var req in6Ifreq
+	copy(req.addr[:], addr)
+	req.ifindex = lo.ifreq.index
+	req.prefix = 128
+	_, _, e := unix.Syscall(unix.SYS_IOCTL, uintptr(lo.fd), unix.SIOCSIFADDR, uintptr(unsafe.Pointer(&req)))
+	if e != 0 {
+		return nil, errors.Wrap(e, "ioctl SIOCSIFADDR failed")
+	}
+	lo.addresses = append(lo.addresses, addr)
+
+	// wait for the added address to be available. There seems to be a small
+	// delay in some systems between the time an address is added and it is
+	// available to bind.
+	fd, err := unix.Socket(unix.AF_INET6, unix.SOCK_DGRAM, 0)
+	if err != nil {
+		return addr, errors.Wrap(err, "socket ipv6 dgram failed")
+	}
+	defer unix.Close(fd)
+	var bindAddr unix.SockaddrInet6
+	copy(bindAddr.Addr[:], addr)
+	for i := 1; i < 50; i++ {
+		if err = unix.Bind(fd, &bindAddr); err == nil {
+			break
+		}
+		if errno, ok := err.(unix.Errno); !ok || errno != unix.EADDRNOTAVAIL {
+			break
+		}
+		time.Sleep(time.Millisecond * time.Duration(i))
+	}
+	return addr, errors.Wrap(err, "bind failed")
+}
+
+// Cleanup removes the addresses registered to this loopback.
+func (lo *IPv6Loopback) Cleanup() error {
+	var errs multierror.Errors
+	var req in6Ifreq
+	req.ifindex = lo.ifreq.index
+	req.prefix = 128
+	for _, addr := range lo.addresses {
+		copy(req.addr[:], addr)
+		_, _, e := unix.Syscall(unix.SYS_IOCTL, uintptr(lo.fd), unix.SIOCDIFADDR, uintptr(unsafe.Pointer(&req)))
+		if e != 0 {
+			errs = append(errs, e)
+		}
+	}
+	if lo.fd != -1 {
+		unix.Close(lo.fd)
+	}
+	return errs.Err()
+}

--- a/x-pack/auditbeat/module/system/socket/kprobes_test.go
+++ b/x-pack/auditbeat/module/system/socket/kprobes_test.go
@@ -61,7 +61,7 @@ func validateProbeList(t *testing.T, probes []helper.ProbeDef) {
 }
 
 func TestRuntimeKProbesAreBackwardsCompatible(t *testing.T) {
-	validateProbeList(t, installKProbes)
+	validateProbeList(t, getAllKProbes())
 }
 
 func TestGuessKProbesAreBackwardsCompatible(t *testing.T) {

--- a/x-pack/auditbeat/module/system/socket/socket_linux.go
+++ b/x-pack/auditbeat/module/system/socket/socket_linux.go
@@ -234,6 +234,24 @@ func (m *MetricSet) Setup() (err error) {
 	m.templateVars.Update(archVariables)
 
 	//
+	// Detect IPv6 support
+	//
+
+	hasIPv6, err := detectIPv6()
+	if err != nil {
+		return errors.Wrap(err, "error detecting IPv6 support")
+	}
+	m.log.Debugf("IPv6 supported: %v", hasIPv6)
+	if m.config.EnableIPv6 != nil {
+		if *m.config.EnableIPv6 && !hasIPv6 {
+			return errors.New("requested IPv6 support but IPv6 is disabled in the system.")
+		}
+		hasIPv6 = *m.config.EnableIPv6
+	}
+	m.log.Debugf("IPv6 enabled: %v", hasIPv6)
+	m.templateVars["HAS_IPV6"] = hasIPv6
+
+	//
 	// Create probe installer
 	//
 	extra := WithNoOp()
@@ -291,7 +309,7 @@ func (m *MetricSet) Setup() (err error) {
 	//
 	// Make sure all the required kernel functions are available
 	//
-	for _, probeDef := range installKProbes {
+	for _, probeDef := range getKProbes(hasIPv6) {
 		probeDef = probeDef.ApplyTemplate(m.templateVars)
 		name := probeDef.Probe.Address
 		if !m.isKernelFunctionAvailable(name, functions) {
@@ -340,7 +358,7 @@ func (m *MetricSet) Setup() (err error) {
 	//
 	// Register Kprobes
 	//
-	for _, probeDef := range installKProbes {
+	for _, probeDef := range getKProbes(hasIPv6) {
 		format, decoder, err := m.installer.Install(probeDef)
 		if err != nil {
 			return errors.Wrapf(err, "unable to register probe %s", probeDef.Probe.String())
@@ -438,4 +456,15 @@ func (m mountPoint) unmount() error {
 
 func (m *mountPoint) String() string {
 	return m.fsType + " at " + m.path
+}
+
+func detectIPv6() (bool, error) {
+	loopback, err := helper.NewIPv6Loopback()
+	if err != nil {
+		return false, err
+	}
+	defer loopback.Cleanup()
+	_, err = loopback.AddRandomAddress()
+	// Assume that all failures for Add..() are caused by missing IPv6 support.
+	return err == nil, nil
 }

--- a/x-pack/auditbeat/tests/system/test_system_socket.py
+++ b/x-pack/auditbeat/tests/system/test_system_socket.py
@@ -79,16 +79,32 @@ class Test(AuditbeatXPackTest):
         """
         self.with_runner(MultiUDP4TestCase())
 
-    def with_runner(self, test):
+    def test_udp_ipv6_disabled(self):
+        """
+        test IPv4/UDP with IPv6 disabled
+        """
+        self.with_runner(MultiUDP4TestCase(),
+                         extra_conf={'socket.enable_ipv6': False})
+
+    def test_tcp_ipv6_disabled(self):
+        """
+        test IPv4/TCP with IPv6 disabled
+        """
+        self.with_runner(TCP4TestCase(),
+                         extra_conf={'socket.enable_ipv6': False})
+
+    def with_runner(self, test, extra_conf=dict()):
         enable_ipv6_loopback()
+        conf = {
+            "socket.flow_inactive_timeout": "2s",
+            "socket.flow_termination_timeout": "5s",
+            "socket.development_mode": "true",
+        }
+        conf.update(extra_conf)
         self.render_config_template(modules=[{
             "name": "system",
             "datasets": ["socket"],
-            "extras": {
-                "socket.flow_inactive_timeout": "2s",
-                "socket.flow_termination_timeout": "5s",
-                "socket.development_mode": "true",
-            }
+            "extras": conf,
         }])
         proc = self.start_beat()
         try:


### PR DESCRIPTION
This allows the dataset to run when IPv6 is not available, that is, has been disabled in `/proc/net/ipv6/conf/lo/disable_ipv6`, which is the default in Docker containers and RHEL 8 distro and possibly others.

This behavior is controlled by a new configuration option, `socket.enable_ipv6`:
- When true, it works as before. IPv6 is required to be enabled in
loopback.
- When false, IPv6 is not required in order to run.
- When unset (default), the dataset will detect if IPv6 support is present or not.

Note that this still needs IPv6 support in the kernel (CONFIG_IPV6=y or
=m).

Fixes #13658