### PR TITLE
[7.4][DOCS] Add hook to build Kafka input docs (#13454)

### DIFF
--- a/filebeat/docs/filebeat-options.asciidoc
+++ b/filebeat/docs/filebeat-options.asciidoc
@@ -45,6 +45,7 @@ You can configure {beatname_uc} to use the following inputs:
 * <<{beatname_lc}-input-log>>
 * <<{beatname_lc}-input-stdin>>
 * <<{beatname_lc}-input-container>>
+* <<{beatname_lc}-input-kafka>>
 * <<{beatname_lc}-input-redis>>
 * <<{beatname_lc}-input-udp>>
 * <<{beatname_lc}-input-docker>>
@@ -60,6 +61,8 @@ include::inputs/input-log.asciidoc[]
 include::inputs/input-stdin.asciidoc[]
 
 include::inputs/input-container.asciidoc[]
+
+include::inputs/input-kafka.asciidoc[]
 
 include::inputs/input-redis.asciidoc[]
 

--- a/filebeat/docs/inputs/input-kafka.asciidoc
+++ b/filebeat/docs/inputs/input-kafka.asciidoc
@@ -9,7 +9,7 @@
 
 Use the `kafka` input to read from topics in a Kafka cluster.
 
-To configure this input, specify a list of one or more <<hosts,`hosts`>> in the
+To configure this input, specify a list of one or more <<kafka-hosts,`hosts`>> in the
 cluster to bootstrap the connection with, a list of <<topics,`topics`>> to
 track, and a <<groupid,`group_id`>> for the connection.
 
@@ -35,7 +35,7 @@ The `kafka` input supports the following configuration options plus the
 <<{beatname_lc}-input-{type}-common-options>> described later.
 
 [float]
-[[hosts]]
+[[kafka-hosts]]
 ===== `hosts`
 
 A list of Kafka bootstrapping hosts (brokers) for this cluster.


### PR DESCRIPTION
Backports #13454 to the 7.4 branch