### PR TITLE
Cherry-pick #13640 to 7.4: [Metricbeat] Fix elb and ebs overview dashboard

### DIFF
--- a/x-pack/metricbeat/module/aws/_meta/kibana/7/dashboard/Metricbeat-aws-ebs-overview.json
+++ b/x-pack/metricbeat/module/aws/_meta/kibana/7/dashboard/Metricbeat-aws-ebs-overview.json
@@ -30,7 +30,7 @@
             "panelIndex": "1",
             "panelRefName": "panel_0",
             "title": "Volume Write Ops",
-            "version": "7.3.0"
+            "version": "7.4.0"
           },
           {
             "embeddableConfig": {},
@@ -44,7 +44,7 @@
             "panelIndex": "2",
             "panelRefName": "panel_1",
             "title": "Volume Read Ops",
-            "version": "7.3.0"
+            "version": "7.4.0"
           },
           {
             "embeddableConfig": {},
@@ -58,7 +58,7 @@
             "panelIndex": "3",
             "panelRefName": "panel_2",
             "title": "Volume Write Bytes",
-            "version": "7.3.0"
+            "version": "7.4.0"
           },
           {
             "embeddableConfig": {},
@@ -72,7 +72,7 @@
             "panelIndex": "4",
             "panelRefName": "panel_3",
             "title": "Volume Read Bytes",
-            "version": "7.3.0"
+            "version": "7.4.0"
           },
           {
             "embeddableConfig": {},
@@ -86,7 +86,7 @@
             "panelIndex": "5",
             "panelRefName": "panel_4",
             "title": "Volume Queue Length",
-            "version": "7.3.0"
+            "version": "7.4.0"
           },
           {
             "embeddableConfig": {},
@@ -100,7 +100,7 @@
             "panelIndex": "6",
             "panelRefName": "panel_5",
             "title": "Volume Total Write Time",
-            "version": "7.3.0"
+            "version": "7.4.0"
           },
           {
             "embeddableConfig": {},
@@ -114,7 +114,7 @@
             "panelIndex": "7",
             "panelRefName": "panel_6",
             "title": "Volume Total Read Time",
-            "version": "7.3.0"
+            "version": "7.4.0"
           },
           {
             "embeddableConfig": {},
@@ -128,7 +128,7 @@
             "panelIndex": "8",
             "panelRefName": "panel_7",
             "title": "Volume Idle Time",
-            "version": "7.3.0"
+            "version": "7.4.0"
           },
           {
             "embeddableConfig": {},
@@ -142,7 +142,7 @@
             "panelIndex": "9",
             "panelRefName": "panel_8",
             "title": "EBS Volume ID Filter",
-            "version": "7.3.0"
+            "version": "7.4.0"
           },
           {
             "embeddableConfig": {},
@@ -155,7 +155,7 @@
             },
             "panelIndex": "10",
             "panelRefName": "panel_9",
-            "version": "7.3.0"
+            "version": "7.4.0"
           }
         ],
         "timeRestore": false,
@@ -219,8 +219,8 @@
         }
       ],
       "type": "dashboard",
-      "updated_at": "2019-08-07T23:07:01.848Z",
-      "version": "WzI1MiwxXQ=="
+      "updated_at": "2019-09-12T16:35:04.005Z",
+      "version": "WzYwMDMsN10="
     },
     {
       "attributes": {
@@ -241,6 +241,7 @@
           "aggs": [],
           "params": {
             "axis_formatter": "number",
+            "axis_min": "0",
             "axis_position": "left",
             "axis_scale": "normal",
             "default_index_pattern": "metricbeat-*",
@@ -248,6 +249,7 @@
             "id": "61ca57f0-469d-11e7-af02-69e470af7417",
             "index_pattern": "",
             "interval": "5m",
+            "isModelInvalid": false,
             "series": [
               {
                 "axis_position": "right",
@@ -289,8 +291,8 @@
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-08-07T23:07:01.848Z",
-      "version": "WzI1MywxXQ=="
+      "updated_at": "2019-09-12T16:31:45.681Z",
+      "version": "WzU5ODMsN10="
     },
     {
       "attributes": {
@@ -311,6 +313,7 @@
           "aggs": [],
           "params": {
             "axis_formatter": "number",
+            "axis_min": "0",
             "axis_position": "left",
             "axis_scale": "normal",
             "default_index_pattern": "metricbeat-*",
@@ -318,6 +321,7 @@
             "id": "61ca57f0-469d-11e7-af02-69e470af7417",
             "index_pattern": "",
             "interval": "5m",
+            "isModelInvalid": false,
             "series": [
               {
                 "axis_position": "right",
@@ -359,8 +363,8 @@
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-08-07T23:07:01.848Z",
-      "version": "WzI1NCwxXQ=="
+      "updated_at": "2019-09-12T16:31:31.261Z",
+      "version": "WzU5ODEsN10="
     },
     {
       "attributes": {
@@ -381,6 +385,7 @@
           "aggs": [],
           "params": {
             "axis_formatter": "number",
+            "axis_min": "0",
             "axis_position": "left",
             "axis_scale": "normal",
             "default_index_pattern": "metricbeat-*",
@@ -388,6 +393,7 @@
             "id": "61ca57f0-469d-11e7-af02-69e470af7417",
             "index_pattern": "",
             "interval": "5m",
+            "isModelInvalid": false,
             "series": [
               {
                 "axis_position": "right",
@@ -429,8 +435,8 @@
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-08-07T23:07:01.848Z",
-      "version": "WzI1NSwxXQ=="
+      "updated_at": "2019-09-12T16:32:46.176Z",
+      "version": "WzU5OTAsN10="
     },
     {
       "attributes": {
@@ -451,6 +457,7 @@
           "aggs": [],
           "params": {
             "axis_formatter": "number",
+            "axis_min": "0",
             "axis_position": "left",
             "axis_scale": "normal",
             "default_index_pattern": "metricbeat-*",
@@ -458,6 +465,7 @@
             "id": "61ca57f0-469d-11e7-af02-69e470af7417",
             "index_pattern": "",
             "interval": "5m",
+            "isModelInvalid": false,
             "series": [
               {
                 "axis_position": "right",
@@ -499,8 +507,8 @@
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-08-07T23:07:01.848Z",
-      "version": "WzI1NiwxXQ=="
+      "updated_at": "2019-09-12T16:32:02.907Z",
+      "version": "WzU5ODUsN10="
     },
     {
       "attributes": {
@@ -521,6 +529,7 @@
           "aggs": [],
           "params": {
             "axis_formatter": "number",
+            "axis_min": "0",
             "axis_position": "left",
             "axis_scale": "normal",
             "default_index_pattern": "metricbeat-*",
@@ -528,6 +537,7 @@
             "id": "61ca57f0-469d-11e7-af02-69e470af7417",
             "index_pattern": "",
             "interval": "5m",
+            "isModelInvalid": false,
             "series": [
               {
                 "axis_position": "right",
@@ -569,8 +579,8 @@
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-08-07T23:07:01.848Z",
-      "version": "WzI1NywxXQ=="
+      "updated_at": "2019-09-12T16:30:59.507Z",
+      "version": "WzU5NzgsN10="
     },
     {
       "attributes": {
@@ -591,6 +601,7 @@
           "aggs": [],
           "params": {
             "axis_formatter": "number",
+            "axis_min": "0",
             "axis_position": "left",
             "axis_scale": "normal",
             "default_index_pattern": "metricbeat-*",
@@ -598,6 +609,7 @@
             "id": "61ca57f0-469d-11e7-af02-69e470af7417",
             "index_pattern": "",
             "interval": "5m",
+            "isModelInvalid": false,
             "series": [
               {
                 "axis_position": "right",
@@ -639,8 +651,8 @@
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-08-07T23:35:39.480Z",
-      "version": "WzU4MiwxXQ=="
+      "updated_at": "2019-09-12T16:32:19.881Z",
+      "version": "WzU5ODcsN10="
     },
     {
       "attributes": {
@@ -661,6 +673,7 @@
           "aggs": [],
           "params": {
             "axis_formatter": "number",
+            "axis_min": "0",
             "axis_position": "left",
             "axis_scale": "normal",
             "default_index_pattern": "metricbeat-*",
@@ -668,6 +681,7 @@
             "id": "61ca57f0-469d-11e7-af02-69e470af7417",
             "index_pattern": "",
             "interval": "5m",
+            "isModelInvalid": false,
             "series": [
               {
                 "axis_position": "right",
@@ -709,8 +723,8 @@
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-08-07T23:58:30.205Z",
-      "version": "WzU4NSwxXQ=="
+      "updated_at": "2019-09-12T16:33:13.538Z",
+      "version": "WzU5OTMsN10="
     },
     {
       "attributes": {
@@ -782,8 +796,8 @@
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-08-07T23:45:56.417Z",
-      "version": "WzU4NCwxXQ=="
+      "updated_at": "2019-09-12T16:31:19.709Z",
+      "version": "WzU5ODAsN10="
     },
     {
       "attributes": {
@@ -840,8 +854,8 @@
         }
       ],
       "type": "visualization",
-      "updated_at": "2019-08-07T23:07:01.848Z",
-      "version": "WzI2MSwxXQ=="
+      "updated_at": "2019-09-12T16:29:31.115Z",
+      "version": "WzU2MTIsN10="
     },
     {
       "attributes": {
@@ -882,7 +896,7 @@
             "updateFiltersOnChange": true,
             "useTimeFilter": false
           },
-          "title": "Region Filter [Metricbeat AWS]",
+          "title": "AWS Region Filter",
           "type": "input_control_vis"
         }
       },
@@ -898,9 +912,9 @@
         }
       ],
       "type": "visualization",
-      "updated_at": "2019-08-07T23:07:05.935Z",
-      "version": "WzMwMywxXQ=="
+      "updated_at": "2019-09-12T16:29:35.238Z",
+      "version": "WzU2NTQsN10="
     }
   ],
-  "version": "7.3.0"
+  "version": "7.4.0"
 }

--- a/x-pack/metricbeat/module/aws/_meta/kibana/7/dashboard/Metricbeat-aws-elb-overview.json
+++ b/x-pack/metricbeat/module/aws/_meta/kibana/7/dashboard/Metricbeat-aws-elb-overview.json
@@ -30,7 +30,7 @@
             "panelIndex": "2",
             "panelRefName": "panel_0",
             "title": "HTTP 5XX Errors",
-            "version": "7.2.0"
+            "version": "7.4.0"
           },
           {
             "embeddableConfig": {},
@@ -44,7 +44,7 @@
             "panelIndex": "3",
             "panelRefName": "panel_1",
             "title": "Request Count",
-            "version": "7.2.0"
+            "version": "7.4.0"
           },
           {
             "embeddableConfig": {},
@@ -58,7 +58,7 @@
             "panelIndex": "4",
             "panelRefName": "panel_2",
             "title": "Unhealthy Host Count",
-            "version": "7.2.0"
+            "version": "7.4.0"
           },
           {
             "embeddableConfig": {},
@@ -72,7 +72,7 @@
             "panelIndex": "5",
             "panelRefName": "panel_3",
             "title": "Healthy Host Count",
-            "version": "7.2.0"
+            "version": "7.4.0"
           },
           {
             "embeddableConfig": {},
@@ -86,7 +86,7 @@
             "panelIndex": "6",
             "panelRefName": "panel_4",
             "title": "Latency in Seconds",
-            "version": "7.2.0"
+            "version": "7.4.0"
           },
           {
             "embeddableConfig": {},
@@ -100,7 +100,7 @@
             "panelIndex": "7",
             "panelRefName": "panel_5",
             "title": "HTTP Backend 4XX Errors",
-            "version": "7.2.0"
+            "version": "7.4.0"
           },
           {
             "embeddableConfig": {},
@@ -114,7 +114,7 @@
             "panelIndex": "8",
             "panelRefName": "panel_6",
             "title": "Backend Connection Errors",
-            "version": "7.2.0"
+            "version": "7.4.0"
           },
           {
             "embeddableConfig": {},
@@ -127,7 +127,7 @@
             },
             "panelIndex": "9",
             "panelRefName": "panel_7",
-            "version": "7.2.0"
+            "version": "7.4.0"
           },
           {
             "embeddableConfig": {},
@@ -141,7 +141,7 @@
             "panelIndex": "10",
             "panelRefName": "panel_8",
             "title": "HTTP Backend 2XX",
-            "version": "7.2.0"
+            "version": "7.4.0"
           }
         ],
         "timeRestore": false,
@@ -150,7 +150,7 @@
       },
       "id": "e74bf320-b3ce-11e9-87a4-078dbbae220d",
       "migrationVersion": {
-        "dashboard": "7.0.0"
+        "dashboard": "7.2.0"
       },
       "references": [
         {
@@ -200,8 +200,8 @@
         }
       ],
       "type": "dashboard",
-      "updated_at": "2019-08-01T15:09:06.696Z",
-      "version": "WzYzNSw4XQ=="
+      "updated_at": "2019-09-12T02:24:38.326Z",
+      "version": "WzI0MTYsN10="
     },
     {
       "attributes": {
@@ -222,6 +222,7 @@
           "aggs": [],
           "params": {
             "axis_formatter": "number",
+            "axis_min": "0",
             "axis_position": "left",
             "axis_scale": "normal",
             "background_color_rules": [
@@ -248,6 +249,7 @@
             "id": "35d3cbc0-b3c6-11e9-bf3f-29d51aa3d971",
             "index_pattern": "metricbeat-*",
             "interval": "5m",
+            "isModelInvalid": false,
             "series": [
               {
                 "axis_position": "right",
@@ -290,8 +292,8 @@
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-08-02T18:37:04.544Z",
-      "version": "WzY0NSw5XQ=="
+      "updated_at": "2019-09-12T02:24:22.066Z",
+      "version": "WzI0MTUsN10="
     },
     {
       "attributes": {
@@ -312,6 +314,7 @@
           "aggs": [],
           "params": {
             "axis_formatter": "number",
+            "axis_min": "0",
             "axis_position": "left",
             "axis_scale": "normal",
             "background_color_rules": [
@@ -338,6 +341,7 @@
             "id": "35d3cbc0-b3c6-11e9-bf3f-29d51aa3d971",
             "index_pattern": "metricbeat-*",
             "interval": "5m",
+            "isModelInvalid": false,
             "series": [
               {
                 "axis_position": "right",
@@ -362,6 +366,7 @@
                 "stacked": "none",
                 "terms_field": "aws.cloudwatch.dimensions.LoadBalancerName",
                 "terms_order_by": "35d3cbc2-b3c6-11e9-bf3f-29d51aa3d971",
+                "type": "timeseries",
                 "value_template": "{{value}}"
               }
             ],
@@ -380,8 +385,8 @@
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-08-02T18:24:52.316Z",
-      "version": "WzY0MCw5XQ=="
+      "updated_at": "2019-09-12T02:22:46.781Z",
+      "version": "WzI0MDgsN10="
     },
     {
       "attributes": {
@@ -432,6 +437,7 @@
             "id": "35d3cbc0-b3c6-11e9-bf3f-29d51aa3d971",
             "index_pattern": "metricbeat-*",
             "interval": "5m",
+            "isModelInvalid": false,
             "series": [
               {
                 "axis_position": "right",
@@ -446,7 +452,7 @@
                   {
                     "field": "aws.metrics.UnHealthyHostCount.max",
                     "id": "35d3cbc2-b3c6-11e9-bf3f-29d51aa3d971",
-                    "type": "sum"
+                    "type": "max"
                   }
                 ],
                 "point_size": 0,
@@ -474,8 +480,8 @@
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-08-02T18:24:16.077Z",
-      "version": "WzYzOCw5XQ=="
+      "updated_at": "2019-09-12T01:00:47.505Z",
+      "version": "WzIzOTYsN10="
     },
     {
       "attributes": {
@@ -526,6 +532,7 @@
             "id": "35d3cbc0-b3c6-11e9-bf3f-29d51aa3d971",
             "index_pattern": "metricbeat-*",
             "interval": "5m",
+            "isModelInvalid": false,
             "series": [
               {
                 "axis_position": "right",
@@ -540,7 +547,7 @@
                   {
                     "field": "aws.metrics.HealthyHostCount.max",
                     "id": "35d3cbc2-b3c6-11e9-bf3f-29d51aa3d971",
-                    "type": "sum"
+                    "type": "max"
                   }
                 ],
                 "point_size": 0,
@@ -568,8 +575,8 @@
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-08-02T18:24:30.551Z",
-      "version": "WzYzOSw5XQ=="
+      "updated_at": "2019-09-12T01:00:18.978Z",
+      "version": "WzIzOTMsN10="
     },
     {
       "attributes": {
@@ -590,6 +597,7 @@
           "aggs": [],
           "params": {
             "axis_formatter": "number",
+            "axis_min": "0",
             "axis_position": "left",
             "axis_scale": "normal",
             "background_color_rules": [
@@ -616,6 +624,7 @@
             "id": "35d3cbc0-b3c6-11e9-bf3f-29d51aa3d971",
             "index_pattern": "metricbeat-*",
             "interval": "5m",
+            "isModelInvalid": false,
             "series": [
               {
                 "axis_position": "right",
@@ -658,8 +667,8 @@
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-08-02T18:36:49.424Z",
-      "version": "WzY0Myw5XQ=="
+      "updated_at": "2019-09-12T02:23:16.083Z",
+      "version": "WzI0MTAsN10="
     },
     {
       "attributes": {
@@ -680,6 +689,7 @@
           "aggs": [],
           "params": {
             "axis_formatter": "number",
+            "axis_min": "0",
             "axis_position": "left",
             "axis_scale": "normal",
             "background_color_rules": [
@@ -706,6 +716,7 @@
             "id": "35d3cbc0-b3c6-11e9-bf3f-29d51aa3d971",
             "index_pattern": "metricbeat-*",
             "interval": "5m",
+            "isModelInvalid": false,
             "series": [
               {
                 "axis_position": "right",
@@ -748,8 +759,8 @@
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-08-02T18:28:25.630Z",
-      "version": "WzY0Miw5XQ=="
+      "updated_at": "2019-09-12T02:24:09.023Z",
+      "version": "WzI0MTQsN10="
     },
     {
       "attributes": {
@@ -770,6 +781,7 @@
           "aggs": [],
           "params": {
             "axis_formatter": "number",
+            "axis_min": "0",
             "axis_position": "left",
             "axis_scale": "normal",
             "background_color_rules": [
@@ -796,6 +808,7 @@
             "id": "35d3cbc0-b3c6-11e9-bf3f-29d51aa3d971",
             "index_pattern": "metricbeat-*",
             "interval": "5m",
+            "isModelInvalid": false,
             "series": [
               {
                 "axis_position": "right",
@@ -839,8 +852,8 @@
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-08-02T18:28:18.932Z",
-      "version": "WzY0MSw5XQ=="
+      "updated_at": "2019-09-12T02:22:28.366Z",
+      "version": "WzI0MDcsN10="
     },
     {
       "attributes": {
@@ -897,8 +910,8 @@
         }
       ],
       "type": "visualization",
-      "updated_at": "2019-07-23T20:30:59.432Z",
-      "version": "WzMwMSwzXQ=="
+      "updated_at": "2019-09-12T00:55:22.007Z",
+      "version": "WzIwNjgsN10="
     },
     {
       "attributes": {
@@ -919,6 +932,7 @@
           "aggs": [],
           "params": {
             "axis_formatter": "number",
+            "axis_min": "0",
             "axis_position": "left",
             "axis_scale": "normal",
             "background_color_rules": [
@@ -945,6 +959,7 @@
             "id": "35d3cbc0-b3c6-11e9-bf3f-29d51aa3d971",
             "index_pattern": "metricbeat-*",
             "interval": "5m",
+            "isModelInvalid": false,
             "series": [
               {
                 "axis_position": "right",
@@ -987,9 +1002,9 @@
       },
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-08-02T18:36:56.883Z",
-      "version": "WzY0NCw5XQ=="
+      "updated_at": "2019-09-12T02:23:38.069Z",
+      "version": "WzI0MTIsN10="
     }
   ],
-  "version": "7.2.0"
+  "version": "7.4.0"
 }

--- a/x-pack/metricbeat/module/aws/cloudwatch/_meta/data.json
+++ b/x-pack/metricbeat/module/aws/cloudwatch/_meta/data.json
@@ -3,101 +3,58 @@
     "aws": {
         "cloudwatch": {
             "dimensions": {
-                "DBInstanceIdentifier": "test1"
+                "DatabaseClass": "db.t2.micro"
             },
             "namespace": "AWS/RDS"
         },
         "metrics": {
-            "ActiveTransactions": {
-                "avg": 0,
-                "count": 5,
-                "max": 0,
-                "min": 0,
-                "sum": 0
-            },
-            "AuroraBinlogReplicaLag": {
-                "avg": 0,
-                "count": 5,
-                "max": 0,
-                "min": 0,
-                "sum": 0
-            },
-            "AuroraReplicaLag": {
-                "avg": 17.945199999999996,
-                "count": 5,
-                "max": 20.299,
-                "min": 9.026,
-                "sum": 89.72599999999998
-            },
             "BinLogDiskUsage": {
-                "avg": 0,
+                "avg": 3109.2,
                 "count": 5,
-                "max": 0,
-                "min": 0,
-                "sum": 0
+                "max": 3518,
+                "min": 3007,
+                "sum": 15546
             },
-            "BlockedTransactions": {
-                "avg": 0,
-                "count": 5,
-                "max": 0,
-                "min": 0,
-                "sum": 0
-            },
-            "BufferCacheHitRatio": {
+            "BurstBalance": {
                 "avg": 100,
-                "count": 5,
+                "count": 1,
                 "max": 100,
                 "min": 100,
-                "sum": 500
+                "sum": 100
+            },
+            "CPUCreditBalance": {
+                "avg": 144,
+                "count": 1,
+                "max": 144,
+                "min": 144,
+                "sum": 144
+            },
+            "CPUCreditUsage": {
+                "avg": 0.059921,
+                "max": 0.059921,
+                "min": 0.059921,
+                "sum": 0.059921
+            },
+            "CPUSurplusCreditBalance": {
+                "avg": 0,
+                "count": 1,
+                "max": 0,
+                "min": 0,
+                "sum": 0
+            },
+            "CPUSurplusCreditsCharged": {
+                "avg": 0,
+                "count": 1,
+                "max": 0,
+                "min": 0,
+                "sum": 0
             },
             "CPUUtilization": {
-                "avg": 3,
+                "avg": 1.229508196720359,
                 "count": 5,
-                "max": 3,
-                "min": 3,
-                "sum": 15
-            },
-            "CommitLatency": {
-                "avg": 0,
-                "count": 5,
-                "max": 0,
-                "min": 0,
-                "sum": 0
-            },
-            "CommitThroughput": {
-                "avg": 0,
-                "count": 5,
-                "max": 0,
-                "min": 0,
-                "sum": 0
-            },
-            "DDLLatency": {
-                "avg": 0,
-                "count": 5,
-                "max": 0,
-                "min": 0,
-                "sum": 0
-            },
-            "DDLThroughput": {
-                "avg": 0,
-                "count": 5,
-                "max": 0,
-                "min": 0,
-                "sum": 0
-            },
-            "DMLLatency": {
-                "avg": 0,
-                "count": 5,
-                "max": 0,
-                "min": 0,
-                "sum": 0
-            },
-            "DMLThroughput": {
-                "avg": 0,
-                "count": 5,
-                "max": 0,
-                "min": 0,
-                "sum": 0
+                "max": 1.66666666666667,
+                "min": 0.999999999997575,
+                "sum": 6.147540983601795
             },
             "DatabaseConnections": {
                 "avg": 0,
@@ -106,136 +63,95 @@
                 "min": 0,
                 "sum": 0
             },
-            "Deadlocks": {
-                "avg": 0,
+            "DiskQueueDepth": {
+                "avg": 0.0002666653337629704,
                 "count": 5,
-                "max": 0,
+                "max": 0.0007999733342221926,
                 "min": 0,
-                "sum": 0
+                "sum": 0.001333326668814852
             },
-            "DeleteLatency": {
-                "avg": 0,
+            "FreeStorageSpace": {
+                "avg": 20402474188.8,
                 "count": 5,
-                "max": 0,
-                "min": 0,
-                "sum": 0
-            },
-            "DeleteThroughput": {
-                "avg": 0,
-                "count": 5,
-                "max": 0,
-                "min": 0,
-                "sum": 0
-            },
-            "EngineUptime": {
-                "avg": 2888753,
-                "count": 5,
-                "max": 2888873,
-                "min": 2888633,
-                "sum": 14443765
-            },
-            "FreeLocalStorage": {
-                "avg": 32949542912,
-                "count": 5,
-                "max": 32949567488,
-                "min": 32949518336,
-                "sum": 164747714560
+                "max": 20402475008,
+                "min": 20402470912,
+                "sum": 102012370944
             },
             "FreeableMemory": {
-                "avg": 4717250969.6,
+                "avg": 460385484.8,
                 "count": 5,
-                "max": 4717965312,
-                "min": 4716732416,
-                "sum": 23586254848
-            },
-            "InsertLatency": {
-                "avg": 0,
-                "count": 5,
-                "max": 0,
-                "min": 0,
-                "sum": 0
-            },
-            "InsertThroughput": {
-                "avg": 0,
-                "count": 5,
-                "max": 0,
-                "min": 0,
-                "sum": 0
-            },
-            "LoginFailures": {
-                "avg": 0,
-                "max": 0,
-                "min": 0,
-                "sum": 0
+                "max": 460492800,
+                "min": 460238848,
+                "sum": 2301927424
             },
             "NetworkReceiveThroughput": {
-                "avg": 0.6999860014776844,
+                "avg": 488.6774390824785,
                 "count": 5,
-                "max": 0.700023334111137,
-                "min": 0.6999416715273727,
-                "sum": 3.499930007388422
-            },
-            "NetworkThroughput": {
-                "avg": 1.3999720029553688,
-                "count": 5,
-                "max": 1.400046668222274,
-                "min": 1.3998833430547455,
-                "sum": 6.999860014776844
+                "max": 614.8064198930018,
+                "min": 440.9387136023468,
+                "sum": 2443.3871954123924
             },
             "NetworkTransmitThroughput": {
-                "avg": 0.6999860014776844,
+                "avg": 2629.716953080241,
                 "count": 5,
-                "max": 0.700023334111137,
-                "min": 0.6999416715273727,
-                "sum": 3.499930007388422
+                "max": 2771.060439377271,
+                "min": 2426.08797106522,
+                "sum": 13148.584765401207
             },
-            "Queries": {
-                "avg": 6.169305601785825,
+            "ReadIOPS": {
+                "avg": 0.23334111137037902,
                 "count": 5,
-                "max": 6.380462125376914,
-                "min": 6.031523876170482,
-                "sum": 30.846528008929127
+                "max": 1.1667055568518951,
+                "min": 0,
+                "sum": 1.1667055568518951
             },
-            "ResultSetCacheHitRatio": {
+            "ReadLatency": {
                 "avg": 0,
                 "count": 5,
                 "max": 0,
                 "min": 0,
                 "sum": 0
             },
-            "SelectLatency": {
-                "avg": 0.2314997785623484,
+            "ReadThroughput": {
+                "avg": 136.52878237392088,
                 "count": 5,
-                "max": 0.2420805369127517,
-                "min": 0.2227225806451613,
-                "sum": 1.157498892811742
-            },
-            "SelectThroughput": {
-                "avg": 2.529737853689286,
-                "count": 5,
-                "max": 2.600086669555652,
-                "min": 2.4822990420658058,
-                "sum": 12.648689268446429
-            },
-            "UpdateLatency": {
-                "avg": 0,
-                "count": 5,
-                "max": 0,
+                "max": 682.6439118696044,
                 "min": 0,
-                "sum": 0
+                "sum": 682.6439118696044
             },
-            "UpdateThroughput": {
-                "avg": 0,
+            "SwapUsage": {
+                "avg": 638976,
                 "count": 5,
-                "max": 0,
+                "max": 638976,
+                "min": 638976,
+                "sum": 3194880
+            },
+            "WriteIOPS": {
+                "avg": 0.3600156685816308,
+                "count": 5,
+                "max": 0.8833627787592919,
                 "min": 0,
-                "sum": 0
+                "sum": 1.800078342908154
+            },
+            "WriteLatency": {
+                "avg": 0.0005464870341466086,
+                "count": 5,
+                "max": 0.0015238095238095239,
+                "min": 0,
+                "sum": 0.0027324351707330432
+            },
+            "WriteThroughput": {
+                "avg": 3863.9343018441605,
+                "count": 5,
+                "max": 8055.198160061332,
+                "min": 0,
+                "sum": 19319.671509220803
             }
         }
     },
     "cloud": {
         "provider": "aws",
-        "region": "us-east-2"
+        "region": "ap-southeast-1"
     },
     "event": {
         "dataset": "aws.cloudwatch",
@@ -243,7 +159,8 @@
         "module": "aws"
     },
     "metricset": {
-        "name": "cloudwatch"
+        "name": "cloudwatch",
+        "period": 10000
     },
     "service": {
         "type": "aws"

--- a/x-pack/metricbeat/module/aws/ebs/_meta/data.json
+++ b/x-pack/metricbeat/module/aws/ebs/_meta/data.json
@@ -1,34 +1,34 @@
 {
     "@timestamp": "2017-10-12T08:05:34.853Z",
     "aws": {
-        "ebs": {
+        "cloudwatch": {
             "dimensions": {
-                "VolumeId": "vol-053e1fa82db46df30"
-            },
-            "metrics": {
-                "BurstBalance": {
-                    "avg": 99.9995555555556
-                },
-                "VolumeIdleTime": {
-                    "avg": 298.65
-                },
-                "VolumeQueueLength": {
-                    "avg": 0.0349
-                },
-                "VolumeReadOps": {
-                    "avg": 0
-                },
-                "VolumeTotalWriteTime": {
-                    "avg": 0.002053343792900569
-                },
-                "VolumeWriteBytes": {
-                    "avg": 31189.927436752303
-                },
-                "VolumeWriteOps": {
-                    "avg": 5099
-                }
+                "VolumeId": "vol-06ba46b489bbc0d96"
             },
             "namespace": "AWS/EBS"
+        },
+        "metrics": {
+            "BurstBalance": {
+                "avg": 100
+            },
+            "VolumeIdleTime": {
+                "sum": 300
+            },
+            "VolumeQueueLength": {
+                "avg": 0
+            },
+            "VolumeReadOps": {
+                "avg": 0
+            },
+            "VolumeTotalWriteTime": {
+                "sum": 0
+            },
+            "VolumeWriteBytes": {
+                "avg": 46421.333333333336
+            },
+            "VolumeWriteOps": {
+                "avg": 30
+            }
         }
     },
     "cloud": {
@@ -41,10 +41,10 @@
         "module": "aws"
     },
     "metricset": {
-        "name": "ebs"
+        "name": "ebs",
+        "period": 10000
     },
     "service": {
-        "name": "cloudwatch",
-        "type": "cloudwatch"
+        "type": "aws"
     }
 }

--- a/x-pack/metricbeat/module/aws/elb/_meta/data.json
+++ b/x-pack/metricbeat/module/aws/elb/_meta/data.json
@@ -3,17 +3,37 @@
     "aws": {
         "cloudwatch": {
             "dimensions": {
-                "AvailabilityZone": "us-east-1b",
-                "LoadBalancerName": "DockerReg-EcsElast-1UFCSV3UVE46A"
+                "Service": "ELB"
             },
             "namespace": "AWS/ELB"
         },
         "metrics": {
+            "BackendConnectionErrors": {
+                "sum": 18
+            },
+            "HTTPCode_Backend_2XX": {
+                "sum": 2
+            },
+            "HTTPCode_Backend_3XX": {
+                "sum": 2
+            },
+            "HTTPCode_Backend_4XX": {
+                "sum": 2
+            },
+            "HTTPCode_ELB_5XX": {
+                "sum": 4
+            },
             "HealthyHostCount": {
-                "avg": 2
+                "max": 2
+            },
+            "Latency": {
+                "avg": 0.001534899075826009
+            },
+            "RequestCount": {
+                "sum": 6
             },
             "UnHealthyHostCount": {
-                "avg": 0
+                "max": 1
             }
         }
     },
@@ -27,7 +47,8 @@
         "module": "aws"
     },
     "metricset": {
-        "name": "elb"
+        "name": "elb",
+        "period": 10000
     },
     "service": {
         "type": "aws"


### PR DESCRIPTION
Cherry-pick of PR #13640 to 7.4 branch. Original message: 

This PR is to add axis_min = 0 to both elb and ebs dashboard. Also fixed the aggregation method used for both HealthyHostCount and UnhealthyHostCount in elb dashboard.

While testing dashboards, I found in cloudwatch metricset, for loop to go through each namespace and each region should be switched. `data.json` are updated to show it's working. Without this change, metrics in `elb` metricset (for example) will be reported into three differents events. One for statistic Sum, one for Maximum and another for Average. With this change, you can see in https://github.com/elastic/beats/pull/13640/files#diff-30cbed3a1b919647b6d2d2ad59e5292bR11, different statistic methods are all in the same event.