### PR TITLE
Cherry-pick #13667 to 7.4: [SIEM][Auditbeat] Make socket dataset work with IPv6 disabled

### DIFF
--- a/x-pack/auditbeat/module/system/socket/_meta/docs.asciidoc
+++ b/x-pack/auditbeat/module/system/socket/_meta/docs.asciidoc
@@ -51,6 +51,7 @@ distributions under which the dataset is known to work:
 | CentOS 6.5     | 2.6.32-431.el6      | NO^<<anchor-1,[1]>>^
 | CentOS 6.9     | 2.6.32-696.30.1.el6 | &#10003;
 | CentOS 7.6     | 3.10.0-957.1.3.el7  | &#10003;
+| RHEL 8         | 4.18.0-80.rhel8     | &#10003;
 | Debian 8       | 3.16.0-6            | &#10003;
 | Debian 9       | 4.9.0-8             | &#10003;
 | Debian 10      | 4.19.0-5            | &#10003;
@@ -75,23 +76,25 @@ A kernel built with the following configuration options enabled is required:
 
 - `CONFIG_KPROBE_EVENTS`: Enables the KProbes subsystem.
 - `CONFIG_DEBUG_FS`: For kernels laking `tracefs` support (<4.1).
-- `CONFIG_IPV6`.
+- `CONFIG_IPV6`: IPv6 support in the kernel is needed even if disabled with
+`socket.enable_ipv6: false`.
 
 These settings are enabled by default in most distributions.
 
 The following configuration settings can prevent the dataset from starting:
 
 - `/sys/kernel/debug/kprobes/enabled` must be 1.
-- `/proc/sys/net/ipv6/conf/lo/disable_ipv6` must be 0
-(IPv6 enabled in the loopback device).
+- `/proc/sys/net/ipv6/conf/lo/disable_ipv6` (IPv6 enabled in loopback device) is
+required when running with IPv6 enabled.
+
 
 [float]
 ==== Running on docker
 
 The dataset can monitor the Docker host when running inside a container. However
-it needs to run on a `privileged` container with `CAP_NET_ADMIN` and IPv6
-support. The docker container running {beatname_uc} needs access to the host's
-tracefs or debugfs directory. This is achieved by bind-mounting `/sys`.
+it needs to run on a `privileged` container with `CAP_NET_ADMIN`. The docker
+container running {beatname_uc} needs access to the host's tracefs or debugfs
+directory. This is achieved by bind-mounting `/sys`.
 
 [float]
 === Configuration
@@ -105,6 +108,13 @@ Must point to the mount-point of `tracefs` or the `tracing` directory inside
 the default locations: `/sys/kernel/tracing` and `/sys/kernel/debug/tracing`.
 If not found, it will attempt to mount `tracefs` and `debugfs` at their
 default locations.
+
+- `socket.enable_ipv6` (default: unset)
+
+Determines whether IPv6 must be monitored. When unset (default), IPv6 support
+is automatically detected. Even when IPv6 is disabled, in order to run the
+dataset you still need a kernel with IPv6 support (the `ipv6` module must be
+loaded if compiled as a module).
 
 - `socket.flow_inactive_timeout` (default: 30s)
 

--- a/x-pack/auditbeat/module/system/socket/config.go
+++ b/x-pack/auditbeat/module/system/socket/config.go
@@ -54,6 +54,10 @@ type Config struct {
 	// DevelopmentMode is an undocumented flag to ignore SSH traffic so that the
 	// dataset can be run with debug output without creating a feedback loop.
 	DevelopmentMode bool `config:"socket.development_mode"`
+
+	// EnableIPv6 allows to control IPv6 support. When unset (default) IPv6
+	// will be automatically detected on runtime.
+	EnableIPv6 *bool `config:"socket.enable_ipv6"`
 }
 
 // Validate validates the host metricset config.

--- a/x-pack/auditbeat/module/system/socket/guess/cskxmit6.go
+++ b/x-pack/auditbeat/module/system/socket/guess/cskxmit6.go
@@ -41,7 +41,7 @@ func init() {
 
 type guessInet6CskXmit struct {
 	ctx                    Context
-	loopback               ipv6loopback
+	loopback               helper.IPv6Loopback
 	clientAddr, serverAddr unix.SockaddrInet6
 	client, server         int
 	sock                   uintptr
@@ -67,6 +67,11 @@ func (g *guessInet6CskXmit) Requires() []string {
 		"RET",
 		"P1",
 	}
+}
+
+// Condition allows this probe to run only when IPv6 is enabled.
+func (g *guessInet6CskXmit) Condition(ctx Context) (bool, error) {
+	return isIPv6Enabled(ctx.Vars)
 }
 
 // Probes returns 2 probes:
@@ -99,7 +104,7 @@ func (g *guessInet6CskXmit) Probes() ([]helper.ProbeDef, error) {
 func (g *guessInet6CskXmit) Prepare(ctx Context) (err error) {
 	g.ctx = ctx
 	g.acceptedFd = -1
-	g.loopback, err = newIPv6Loopback()
+	g.loopback, err = helper.NewIPv6Loopback()
 	if err != nil {
 		return errors.Wrap(err, "detect IPv6 loopback failed")
 	}
@@ -108,11 +113,11 @@ func (g *guessInet6CskXmit) Prepare(ctx Context) (err error) {
 			g.loopback.Cleanup()
 		}
 	}()
-	clientIP, err := g.loopback.addRandomAddress()
+	clientIP, err := g.loopback.AddRandomAddress()
 	if err != nil {
 		return errors.Wrap(err, "failed adding first device address")
 	}
-	serverIP, err := g.loopback.addRandomAddress()
+	serverIP, err := g.loopback.AddRandomAddress()
 	if err != nil {
 		return errors.Wrap(err, "failed adding second device address")
 	}

--- a/x-pack/auditbeat/module/system/socket/guess/guess.go
+++ b/x-pack/auditbeat/module/system/socket/guess/guess.go
@@ -72,6 +72,16 @@ type EventualGuesser interface {
 	MaxRepeats() int
 }
 
+// ConditionalGuesser is a guess that might only need to run under certain
+// conditions (i.e. when IPv6 is enabled).
+type ConditionalGuesser interface {
+	Guesser
+	// Condition returns if this guess has to be run.
+	// When false, it must set all its Provides() to dummy values to ensure that
+	// dependent guesses are run.
+	Condition(ctx Context) (bool, error)
+}
+
 // Guess is a helper function to easily determine memory layouts of kernel
 // structs and similar tasks. It installs the guesser's Probe, starts a perf
 // channel and executes the Trigger function. Each record received through the
@@ -251,6 +261,16 @@ func GuessAll(installer helper.ProbeInstaller, ctx Context) (err error) {
 	for len(list) > 0 {
 		var next []Guesser
 		for _, guesser := range list {
+			if cond, isCond := guesser.(ConditionalGuesser); isCond {
+				mustRun, err := cond.Condition(ctx)
+				if err != nil {
+					return errors.Wrapf(err, "condition failed for %s", cond.Name())
+				}
+				if !mustRun {
+					ctx.Log.Debugf("Guess %s skipped.", cond.Name())
+					continue
+				}
+			}
 			if !containsAll(guesser.Requires(), ctx.Vars) {
 				next = append(next, guesser)
 				continue
@@ -267,10 +287,33 @@ func GuessAll(installer helper.ProbeInstaller, ctx Context) (err error) {
 			ctx.Log.Debugf("Guess %s completed: %v", guesser.Name(), result)
 		}
 		if len(next) == len(list) {
+			ctx.Log.Warnf("Internal error: No guess can be run (%d pending):", len(list))
+			for _, guess := range list {
+				requires := guess.Requires()
+				var missing []string
+				for _, req := range requires {
+					if _, found := ctx.Vars[req]; !found {
+						missing = append(missing, req)
+					}
+				}
+				ctx.Log.Warnf("   guess '%s' requires missing vars: %v", guess.Name(), missing)
+			}
 			return errors.New("no guess can be run")
 		}
 		list = next
 	}
 	ctx.Log.Infof("Guessing done after %v", time.Since(start))
 	return nil
+}
+
+func isIPv6Enabled(vars common.MapStr) (bool, error) {
+	iface, err := vars.GetValue("HAS_IPV6")
+	if err != nil {
+		return false, err
+	}
+	hasIPv6, ok := iface.(bool)
+	if !ok {
+		return false, errors.New("HAS_IPV6 is not a bool")
+	}
+	return hasIPv6, nil
 }

--- a/x-pack/auditbeat/module/system/socket/guess/helpers.go
+++ b/x-pack/auditbeat/module/system/socket/guess/helpers.go
@@ -10,11 +10,7 @@ import (
 	"bytes"
 	"fmt"
 	"math/rand"
-	"net"
-	"time"
-	"unsafe"
 
-	"github.com/joeshaw/multierror"
 	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 
@@ -108,115 +104,6 @@ func getListField(m common.MapStr, key string) ([]int, error) {
 		return nil, fmt.Errorf("field %s not detected", key)
 	}
 	return list, nil
-}
-
-type ipv6loopback struct {
-	fd         int
-	deviceName string
-	addresses  []net.IP
-	ifreq      ifReq
-}
-
-type in6Ifreq struct {
-	addr    [16]byte
-	prefix  uint32
-	ifindex int32
-}
-
-const ifnamsiz = 16
-
-type ifReq struct {
-	name    [ifnamsiz]byte
-	index   int32
-	padding [128]byte
-}
-
-func newIPv6Loopback() (lo ipv6loopback, err error) {
-	lo.fd = -1
-	devs, err := net.Interfaces()
-	if err != nil {
-		return lo, errors.Wrap(err, "cannot list interfaces")
-	}
-	for _, dev := range devs {
-		addrs, err := dev.Addrs()
-		if err != nil || len(dev.Name) >= ifnamsiz {
-			continue
-		}
-		for _, addr := range addrs {
-			if ipnet, ok := addr.(*net.IPNet); ok && ipnet.IP.IsLoopback() {
-				lo.deviceName = dev.Name
-				lo.fd, err = unix.Socket(unix.AF_INET6, unix.SOCK_DGRAM, unix.IPPROTO_IP)
-				if err != nil {
-					lo.fd = -1
-					return lo, errors.Wrap(err, "ipv6 socket failed")
-				}
-				copy(lo.ifreq.name[:], dev.Name)
-				lo.ifreq.name[len(dev.Name)] = 0
-				_, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(lo.fd), unix.SIOCGIFINDEX, uintptr(unsafe.Pointer(&lo.ifreq)))
-				if errno != 0 {
-					unix.Close(lo.fd)
-					return lo, errors.Wrap(errno, "ioctl(SIOCGIFINDEX) failed")
-				}
-				return lo, nil
-			}
-		}
-	}
-	return lo, errors.New("no loopback interface detected")
-}
-
-// adds a randomly-generated address from the fd00::/8 prefix (Unique Local Address)
-func (lo *ipv6loopback) addRandomAddress() (addr net.IP, err error) {
-	addr = make(net.IP, 16)
-	addr[0] = 0xFD
-	rand.Read(addr[1:])
-	var req in6Ifreq
-	copy(req.addr[:], addr)
-	req.ifindex = lo.ifreq.index
-	req.prefix = 128
-	_, _, e := unix.Syscall(unix.SYS_IOCTL, uintptr(lo.fd), unix.SIOCSIFADDR, uintptr(unsafe.Pointer(&req)))
-	if e != 0 {
-		return nil, errors.Wrap(e, "ioctl SIOCSIFADDR failed")
-	}
-	lo.addresses = append(lo.addresses, addr)
-
-	// wait for the added address to be available. There seems to be a small
-	// delay in some systems between the time an address is added and it is
-	// available to bind.
-	fd, err := unix.Socket(unix.AF_INET6, unix.SOCK_DGRAM, 0)
-	if err != nil {
-		return addr, errors.Wrap(err, "socket ipv6 dgram failed")
-	}
-	defer unix.Close(fd)
-	var bindAddr unix.SockaddrInet6
-	copy(bindAddr.Addr[:], addr)
-	for i := 1; i < 50; i++ {
-		if err = unix.Bind(fd, &bindAddr); err == nil {
-			break
-		}
-		if errno, ok := err.(unix.Errno); !ok || errno != unix.EADDRNOTAVAIL {
-			break
-		}
-		time.Sleep(time.Millisecond * time.Duration(i))
-	}
-	return addr, errors.Wrap(err, "bind failed")
-}
-
-func (lo *ipv6loopback) Cleanup() error {
-	var errs multierror.Errors
-	var req in6Ifreq
-	req.ifindex = lo.ifreq.index
-	req.prefix = 128
-	for _, addr := range lo.addresses {
-		copy(req.addr[:], addr)
-		_, _, e := unix.Syscall(unix.SYS_IOCTL, uintptr(lo.fd), unix.SIOCDIFADDR, uintptr(unsafe.Pointer(&req)))
-		if e != 0 {
-			errs = append(errs, e)
-		}
-	}
-	if lo.fd != -1 {
-		unix.Close(lo.fd)
-	}
-	return errs.Err()
 }
 
 // consolidate takes a list of guess results in the form of maps with []int

--- a/x-pack/auditbeat/module/system/socket/guess/skbuff.go
+++ b/x-pack/auditbeat/module/system/socket/guess/skbuff.go
@@ -234,8 +234,9 @@ func (g *guessSkBuffLen) Reduce(results []common.MapStr) (result common.MapStr, 
 type guessSkBuffProto struct {
 	ctx                    Context
 	doIPv6                 bool
+	hasIPv6                bool
 	cs                     inetClientServer
-	loopback               ipv6loopback
+	loopback               helper.IPv6Loopback
 	clientAddr, serverAddr unix.SockaddrInet6
 	client, server         int
 	msg                    []byte
@@ -277,10 +278,14 @@ func (g *guessSkBuffProto) Requires() []string {
 // Prepare sets up either two UDP sockets, using either IPv4 or IPv6.
 func (g *guessSkBuffProto) Prepare(ctx Context) (err error) {
 	g.ctx = ctx
-	g.doIPv6 = !g.doIPv6
+	g.hasIPv6, err = isIPv6Enabled(ctx.Vars)
+	if err != nil {
+		return errors.Wrap(err, "unable to determine if IPv6 is enabled")
+	}
+	g.doIPv6 = g.hasIPv6 && !g.doIPv6
 	g.msg = make([]byte, 0x123)
 	if g.doIPv6 {
-		g.loopback, err = newIPv6Loopback()
+		g.loopback, err = helper.NewIPv6Loopback()
 		if err != nil {
 			return errors.Wrap(err, "detect IPv6 loopback failed")
 		}
@@ -289,11 +294,11 @@ func (g *guessSkBuffProto) Prepare(ctx Context) (err error) {
 				g.loopback.Cleanup()
 			}
 		}()
-		clientIP, err := g.loopback.addRandomAddress()
+		clientIP, err := g.loopback.AddRandomAddress()
 		if err != nil {
 			return errors.Wrap(err, "failed adding first device address")
 		}
-		serverIP, err := g.loopback.addRandomAddress()
+		serverIP, err := g.loopback.AddRandomAddress()
 		if err != nil {
 			return errors.Wrap(err, "failed adding second device address")
 		}

--- a/x-pack/auditbeat/module/system/socket/guess/sockaddrin6.go
+++ b/x-pack/auditbeat/module/system/socket/guess/sockaddrin6.go
@@ -67,6 +67,11 @@ func (g *guessSockaddrIn6) Requires() []string {
 	}
 }
 
+// Condition allows this probe to run only when IPv6 is enabled.
+func (g *guessSockaddrIn6) Condition(ctx Context) (bool, error) {
+	return isIPv6Enabled(ctx.Vars)
+}
+
 // Probes returns a probe on tcp_v6_connect, dumping its second argument,
 // a struct sockaddr* (struct sockaddr_in6* for AF_INET6).
 func (g *guessSockaddrIn6) Probes() ([]helper.ProbeDef, error) {

--- a/x-pack/auditbeat/module/system/socket/helper/loopback.go
+++ b/x-pack/auditbeat/module/system/socket/helper/loopback.go
@@ -1,0 +1,133 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+// +build linux,386 linux,amd64
+
+package helper
+
+import (
+	"math/rand"
+	"net"
+	"time"
+	"unsafe"
+
+	"github.com/joeshaw/multierror"
+	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
+)
+
+// IPv6Loopback is a helper to add random link-local IPv6 addresses to the
+// loopback interface.
+type IPv6Loopback struct {
+	fd         int
+	deviceName string
+	addresses  []net.IP
+	ifreq      ifReq
+}
+
+type in6Ifreq struct {
+	addr    [16]byte
+	prefix  uint32
+	ifindex int32
+}
+
+const ifnamsiz = 16
+
+type ifReq struct {
+	name    [ifnamsiz]byte
+	index   int32
+	padding [128]byte
+}
+
+// NewIPv6Loopback detects the loopback interface and creates an IPv6Loopback
+// to add and remove link-local IPv6 addresses.
+func NewIPv6Loopback() (lo IPv6Loopback, err error) {
+	lo.fd = -1
+	devs, err := net.Interfaces()
+	if err != nil {
+		return lo, errors.Wrap(err, "cannot list interfaces")
+	}
+	for _, dev := range devs {
+		addrs, err := dev.Addrs()
+		if err != nil || len(dev.Name) >= ifnamsiz {
+			continue
+		}
+		for _, addr := range addrs {
+			if ipnet, ok := addr.(*net.IPNet); ok && ipnet.IP.IsLoopback() {
+				lo.deviceName = dev.Name
+				lo.fd, err = unix.Socket(unix.AF_INET6, unix.SOCK_DGRAM, unix.IPPROTO_IP)
+				if err != nil {
+					lo.fd = -1
+					return lo, errors.Wrap(err, "ipv6 socket failed")
+				}
+				copy(lo.ifreq.name[:], dev.Name)
+				lo.ifreq.name[len(dev.Name)] = 0
+				_, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(lo.fd), unix.SIOCGIFINDEX, uintptr(unsafe.Pointer(&lo.ifreq)))
+				if errno != 0 {
+					unix.Close(lo.fd)
+					return lo, errors.Wrap(errno, "ioctl(SIOCGIFINDEX) failed")
+				}
+				return lo, nil
+			}
+		}
+	}
+	return lo, errors.New("no loopback interface detected")
+}
+
+// AddRandomAddress adds a randomly-generated address
+// from the fd00::/8 prefix (Unique Local Address)
+func (lo *IPv6Loopback) AddRandomAddress() (addr net.IP, err error) {
+	addr = make(net.IP, 16)
+	addr[0] = 0xFD
+	rand.Read(addr[1:])
+	var req in6Ifreq
+	copy(req.addr[:], addr)
+	req.ifindex = lo.ifreq.index
+	req.prefix = 128
+	_, _, e := unix.Syscall(unix.SYS_IOCTL, uintptr(lo.fd), unix.SIOCSIFADDR, uintptr(unsafe.Pointer(&req)))
+	if e != 0 {
+		return nil, errors.Wrap(e, "ioctl SIOCSIFADDR failed")
+	}
+	lo.addresses = append(lo.addresses, addr)
+
+	// wait for the added address to be available. There seems to be a small
+	// delay in some systems between the time an address is added and it is
+	// available to bind.
+	fd, err := unix.Socket(unix.AF_INET6, unix.SOCK_DGRAM, 0)
+	if err != nil {
+		return addr, errors.Wrap(err, "socket ipv6 dgram failed")
+	}
+	defer unix.Close(fd)
+	var bindAddr unix.SockaddrInet6
+	copy(bindAddr.Addr[:], addr)
+	for i := 1; i < 50; i++ {
+		if err = unix.Bind(fd, &bindAddr); err == nil {
+			break
+		}
+		if errno, ok := err.(unix.Errno); !ok || errno != unix.EADDRNOTAVAIL {
+			break
+		}
+		time.Sleep(time.Millisecond * time.Duration(i))
+	}
+	return addr, errors.Wrap(err, "bind failed")
+}
+
+// Cleanup removes the addresses registered to this loopback.
+func (lo *IPv6Loopback) Cleanup() error {
+	var errs multierror.Errors
+	var req in6Ifreq
+	req.ifindex = lo.ifreq.index
+	req.prefix = 128
+	for _, addr := range lo.addresses {
+		copy(req.addr[:], addr)
+		_, _, e := unix.Syscall(unix.SYS_IOCTL, uintptr(lo.fd), unix.SIOCDIFADDR, uintptr(unsafe.Pointer(&req)))
+		if e != 0 {
+			errs = append(errs, e)
+		}
+	}
+	if lo.fd != -1 {
+		unix.Close(lo.fd)
+	}
+	return errs.Err()
+}

--- a/x-pack/auditbeat/module/system/socket/kprobes_test.go
+++ b/x-pack/auditbeat/module/system/socket/kprobes_test.go
@@ -61,7 +61,7 @@ func validateProbeList(t *testing.T, probes []helper.ProbeDef) {
 }
 
 func TestRuntimeKProbesAreBackwardsCompatible(t *testing.T) {
-	validateProbeList(t, installKProbes)
+	validateProbeList(t, getAllKProbes())
 }
 
 func TestGuessKProbesAreBackwardsCompatible(t *testing.T) {

--- a/x-pack/auditbeat/tests/system/test_system_socket.py
+++ b/x-pack/auditbeat/tests/system/test_system_socket.py
@@ -79,16 +79,32 @@ class Test(AuditbeatXPackTest):
         """
         self.with_runner(MultiUDP4TestCase())
 
-    def with_runner(self, test):
+    def test_udp_ipv6_disabled(self):
+        """
+        test IPv4/UDP with IPv6 disabled
+        """
+        self.with_runner(MultiUDP4TestCase(),
+                         extra_conf={'socket.enable_ipv6': False})
+
+    def test_tcp_ipv6_disabled(self):
+        """
+        test IPv4/TCP with IPv6 disabled
+        """
+        self.with_runner(TCP4TestCase(),
+                         extra_conf={'socket.enable_ipv6': False})
+
+    def with_runner(self, test, extra_conf=dict()):
         enable_ipv6_loopback()
+        conf = {
+            "socket.flow_inactive_timeout": "2s",
+            "socket.flow_termination_timeout": "5s",
+            "socket.development_mode": "true",
+        }
+        conf.update(extra_conf)
         self.render_config_template(modules=[{
             "name": "system",
             "datasets": ["socket"],
-            "extras": {
-                "socket.flow_inactive_timeout": "2s",
-                "socket.flow_termination_timeout": "5s",
-                "socket.development_mode": "true",
-            }
+            "extras": conf,
         }])
         proc = self.start_beat()
         try:


### PR DESCRIPTION
Cherry-pick of PR #13667 to 7.4 branch. Original message: 

This allows the dataset to run when IPv6 is not available, that is, has been disabled in `/proc/net/ipv6/conf/lo/disable_ipv6`, which is the default in Docker containers and RHEL 8 distro and possibly others.

This behavior is controlled by a new configuration option, `socket.enable_ipv6`:
- When true, it works as before. IPv6 is required to be enabled in
loopback.
- When false, IPv6 is not required in order to run.
- When unset (default), the dataset will detect if IPv6 support is present or not.

Note that this still needs IPv6 support in the kernel (CONFIG_IPV6=y or
=m).

Fixes #13658