### PR TITLE
Allow `hosts` to be used to configure http monitors

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -315,6 +315,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 - Enable `add_observer_metadata` processor in default config. {pull}11394[11394]
 - Record HTTP body metadata and optionally contents in `http.response.body.*` fields. {pull}13022[13022]
+- Allow `hosts` to be used to configure http monitors {pull}13703[13703]
 
 *Journalbeat*
 

--- a/heartbeat/docs/autodiscover-kubernetes-config.asciidoc
+++ b/heartbeat/docs/autodiscover-kubernetes-config.asciidoc
@@ -12,7 +12,7 @@ heartbeat.autodiscover:
               kubernetes.annotations.prometheus.io.scrape: "true"
           config:
             - type: http
-              urls: ["${data.host}:${data.port}"]
+              hosts: ["${data.host}:${data.port}"]
               schedule: "@every 1s"
               timeout: 1s
 -------------------------------------------------------------------------------------

--- a/heartbeat/docs/heartbeat-options.asciidoc
+++ b/heartbeat/docs/heartbeat-options.asciidoc
@@ -33,7 +33,7 @@ heartbeat.monitors:
   check.receive: "Check"
 - type: http
   schedule: '@every 5s'
-  urls: ["http://localhost:80/service/status"]
+  hosts: ["http://localhost:80/service/status"]
   check.response.status: 200
 heartbeat.scheduler:
   limit: 10
@@ -68,7 +68,7 @@ monitor definitions only, e.g. what is normally under the `heartbeat.monitors` s
 # /path/to/my/monitors.d/localhost_service_check.yml
 - type: http
   schedule: '@every 5s'
-  urls: ["http://localhost:80/service/status"]
+  hosts: ["http://localhost:80/service/status"]
   check.response.status: 200
 ----------------------------------------------------------------------
 
@@ -368,7 +368,7 @@ the host returns the expected response. These options are valid when the
 
 [float]
 [[monitor-http-urls]]
-==== `urls`
+==== `hosts`
 
 A list of URLs to ping.
 
@@ -378,7 +378,7 @@ Example configuration:
 -------------------------------------------------------------------------------
 - type: http
   schedule: '@every 5s'
-  urls: ["http://myhost:80"]
+  hosts: ["http://myhost:80"]
 -------------------------------------------------------------------------------
 
 
@@ -419,7 +419,7 @@ Example configuration:
 -------------------------------------------------------------------------------
 - type: http
   schedule: '@every 5s'
-  urls: ["https://myhost:443"]
+  hosts: ["https://myhost:443"]
   ssl:
     certificate_authorities: ['/etc/ca.crt']
     supported_protocols: ["TLSv1.0", "TLSv1.1", "TLSv1.2"]
@@ -454,7 +454,7 @@ Example configuration:
 -------------------------------------------------------------------------------
 - type: http
   schedule: '@every 5s'
-  urls: ["http://myhost:80"]
+  hosts: ["http://myhost:80"]
   check.request.method: HEAD
   check.response.status: 200
 -------------------------------------------------------------------------------
@@ -481,7 +481,7 @@ contains JSON:
 -------------------------------------------------------------------------------
 - type: http
   schedule: '@every 5s'
-  urls: ["https://myhost:80"]
+  hosts: ["https://myhost:80"]
   check.request:
     method: GET
     headers:
@@ -502,7 +502,7 @@ patterns:
 -------------------------------------------------------------------------------
 - type: http
   schedule: '@every 5s'
-  urls: ["https://myhost:80"]
+  hosts: ["https://myhost:80"]
   check.request:
     method: GET
     headers:
@@ -521,7 +521,7 @@ regex:
 -------------------------------------------------------------------------------
 - type: http
   schedule: '@every 5s'
-  urls: ["https://myhost:80"]
+  hosts: ["https://myhost:80"]
   check.request:
     method: GET
     headers:

--- a/heartbeat/monitors.d/sample.http.yml.disabled
+++ b/heartbeat/monitors.d/sample.http.yml.disabled
@@ -15,7 +15,7 @@
   schedule: '@every 5s' # every 5 seconds from start of beat
 
   # Configure URLs to ping
-  urls: ["http://localhost:9200"]
+  hosts: ["http://localhost:9200"]
 
   # Configure IP protocol types to ping on if hostnames are configured.
   # Ping all resolvable IPs if `mode` is `all`, or only one IP if `mode` is `any`.

--- a/heartbeat/monitors/active/http/config.go
+++ b/heartbeat/monitors/active/http/config.go
@@ -112,6 +112,7 @@ var defaultConfig = Config{
 	},
 }
 
+// Validate validates of the responseConfig object is valid or not
 func (r *responseConfig) Validate() error {
 	switch strings.ToLower(r.IncludeBody) {
 	case "always", "on_error", "never":
@@ -126,6 +127,7 @@ func (r *responseConfig) Validate() error {
 	return nil
 }
 
+// Validate validates of the requestParameters object is valid or not
 func (r *requestParameters) Validate() error {
 	switch strings.ToUpper(r.Method) {
 	case "HEAD", "GET", "POST":
@@ -136,6 +138,7 @@ func (r *requestParameters) Validate() error {
 	return nil
 }
 
+// Validate validates of the compressionConfig object is valid or not
 func (c *compressionConfig) Validate() error {
 	t := strings.ToLower(c.Type)
 	if t != "" && t != "gzip" {
@@ -153,6 +156,7 @@ func (c *compressionConfig) Validate() error {
 	return nil
 }
 
+// Validate validates of the Config object is valid or not
 func (c *Config) Validate() error {
 	if len(c.Hosts) == 0 && len(c.URLs) == 0 {
 		return fmt.Errorf("hosts is a mandatory parameter")

--- a/heartbeat/monitors/active/http/config.go
+++ b/heartbeat/monitors/active/http/config.go
@@ -19,6 +19,7 @@ package http
 
 import (
 	"fmt"
+	"net/url"
 	"strings"
 	"time"
 
@@ -164,6 +165,17 @@ func (c *Config) Validate() error {
 
 	if len(c.URLs) != 0 {
 		c.Hosts = append(c.Hosts, c.URLs...)
+	}
+
+	for i := 0; i < len(c.Hosts); i ++ {
+		host := c.Hosts[i]
+		if _, err := url.ParseRequestURI(host); err != nil {
+			if c.TLS != nil && *c.TLS.Enabled == true {
+				c.Hosts[i] = fmt.Sprint("https://", host)
+			} else {
+				c.Hosts[i] = fmt.Sprint("http://", host)
+			}
+		}
 	}
 
 	return nil

--- a/heartbeat/monitors/active/http/config.go
+++ b/heartbeat/monitors/active/http/config.go
@@ -22,16 +22,15 @@ import (
 	"strings"
 	"time"
 
-	"github.com/elastic/beats/libbeat/conditions"
-
+	"github.com/elastic/beats/heartbeat/monitors"
 	"github.com/elastic/beats/libbeat/common/match"
 	"github.com/elastic/beats/libbeat/common/transport/tlscommon"
-
-	"github.com/elastic/beats/heartbeat/monitors"
+	"github.com/elastic/beats/libbeat/conditions"
 )
 
 type Config struct {
-	URLs         []string       `config:"urls" validate:"required"`
+	URLs         []string       `config:"urls"`
+	Hosts        []string       `config:"hosts"`
 	ProxyURL     string         `config:"proxy_url"`
 	Timeout      time.Duration  `config:"timeout"`
 	MaxRedirects int            `config:"max_redirects"`
@@ -149,6 +148,18 @@ func (c *compressionConfig) Validate() error {
 
 	if !(0 <= c.Level && c.Level <= 9) {
 		return fmt.Errorf("compression level %v invalid", c.Level)
+	}
+
+	return nil
+}
+
+func (c *Config) Validate() error {
+	if len(c.Hosts) == 0 && len(c.URLs) == 0 {
+		return fmt.Errorf("hosts is a mandatory parameter")
+	}
+
+	if len(c.URLs) != 0 {
+		c.Hosts = append(c.Hosts, c.URLs...)
 	}
 
 	return nil

--- a/heartbeat/monitors/active/http/config_test.go
+++ b/heartbeat/monitors/active/http/config_test.go
@@ -1,0 +1,99 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package http
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var tests = []struct {
+	description   string
+	host          string
+	url           string
+	convertedHost string
+	result        bool
+}{
+	{
+		"Validate if neither urls nor host specified returns error",
+		"",
+		"",
+		"",
+		false,
+	},
+	{
+		"Validate if only urls are present then the config is moved to hosts",
+		"",
+		"http://localhost:8080",
+		"http://localhost:8080",
+		true,
+	},
+	{
+		"Validate if only hosts are present then the config is valid",
+		"http://localhost:8080",
+		"",
+		"http://localhost:8080",
+		true,
+	},
+	{
+		"Validate if no scheme is present then it is added correctly",
+		"localhost",
+		"",
+		"http://localhost",
+		true,
+	},
+	{
+		"Validate if no scheme is present but has a port then it is added correctly",
+		"localhost:8080",
+		"",
+		"http://localhost:8080",
+		true,
+	},
+	{
+		"Validate if schemes like unix are honored",
+		"unix://localhost:8080",
+		"",
+		"unix://localhost:8080",
+		true,
+	},
+}
+
+func TestConfigValidate(t *testing.T) {
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			config := Config{}
+			if test.host != "" {
+				config.Hosts = []string{test.host}
+			}
+
+			if test.url != "" {
+				config.URLs = []string{test.url}
+			}
+
+			err := config.Validate()
+			if test.result {
+				assert.Nil(t, err)
+				assert.Equal(t, test.convertedHost, config.Hosts[0])
+			} else {
+				assert.NotNil(t, err)
+			}
+
+		})
+	}
+}

--- a/heartbeat/monitors/active/http/http.go
+++ b/heartbeat/monitors/active/http/http.go
@@ -95,8 +95,8 @@ func create(
 		}
 	}
 
-	js = make([]jobs.Job, len(config.URLs))
-	for i, urlStr := range config.URLs {
+	js = make([]jobs.Job, len(config.Hosts))
+	for i, urlStr := range config.Hosts {
 		u, _ := url.Parse(urlStr)
 		if err != nil {
 			return nil, 0, err
@@ -112,7 +112,7 @@ func create(
 		js[i] = wrappers.WithURLField(u, job)
 	}
 
-	return js, len(config.URLs), nil
+	return js, len(config.Hosts), nil
 }
 
 func newRoundTripper(config *Config, tls *transport.TLSConfig) (*http.Transport, error) {

--- a/heartbeat/monitors/active/http/http_test.go
+++ b/heartbeat/monitors/active/http/http_test.go
@@ -55,7 +55,7 @@ func testRequest(t *testing.T, testURL string) *beat.Event {
 // an empty string no cert will be set.
 func testTLSRequest(t *testing.T, testURL string, extraConfig map[string]interface{}) *beat.Event {
 	configSrc := map[string]interface{}{
-		"urls":    testURL,
+		"hosts":   testURL,
 		"timeout": "1s",
 	}
 
@@ -260,7 +260,7 @@ func TestLargeResponse(t *testing.T) {
 	defer server.Close()
 
 	configSrc := map[string]interface{}{
-		"urls":                server.URL,
+		"hosts":               server.URL,
 		"timeout":             "1s",
 		"check.response.body": "x",
 	}

--- a/heartbeat/monitors/active/http/http_test.go
+++ b/heartbeat/monitors/active/http/http_test.go
@@ -47,16 +47,21 @@ import (
 	"github.com/elastic/go-lookslike/validator"
 )
 
-func testRequest(t *testing.T, testURL string) *beat.Event {
-	return testTLSRequest(t, testURL, nil)
+func testRequest(t *testing.T, testURL string, useUrls bool) *beat.Event {
+	return testTLSRequest(t, testURL, useUrls, nil)
 }
 
 // testTLSRequest tests the given request. certPath is optional, if given
 // an empty string no cert will be set.
-func testTLSRequest(t *testing.T, testURL string, extraConfig map[string]interface{}) *beat.Event {
+func testTLSRequest(t *testing.T, testURL string, useUrls bool, extraConfig map[string]interface{}) *beat.Event {
 	configSrc := map[string]interface{}{
-		"hosts":   testURL,
 		"timeout": "1s",
+	}
+
+	if useUrls {
+		configSrc["urls"] = testURL
+	} else {
+		configSrc["hosts"] = testURL
 	}
 
 	if extraConfig != nil {
@@ -82,10 +87,10 @@ func testTLSRequest(t *testing.T, testURL string, extraConfig map[string]interfa
 	return event
 }
 
-func checkServer(t *testing.T, handlerFunc http.HandlerFunc) (*httptest.Server, *beat.Event) {
+func checkServer(t *testing.T, handlerFunc http.HandlerFunc, useUrls bool) (*httptest.Server, *beat.Event) {
 	server := httptest.NewServer(handlerFunc)
 	defer server.Close()
-	event := testRequest(t, server.URL)
+	event := testRequest(t, server.URL, useUrls)
 
 	return server, event
 }
@@ -217,7 +222,27 @@ func TestUpStatuses(t *testing.T) {
 	for _, status := range upStatuses {
 		status := status
 		t.Run(fmt.Sprintf("Test OK HTTP status %d", status), func(t *testing.T) {
-			server, event := checkServer(t, hbtest.HelloWorldHandler(status))
+			server, event := checkServer(t, hbtest.HelloWorldHandler(status), false)
+
+			testslike.Test(
+				t,
+				lookslike.Strict(lookslike.Compose(
+					hbtest.BaseChecks("127.0.0.1", "up", "http"),
+					hbtest.RespondingTCPChecks(),
+					hbtest.SummaryChecks(1, 0),
+					respondingHTTPChecks(server.URL, status),
+				)),
+				event.Fields,
+			)
+		})
+	}
+}
+
+func TestUpStatusesWithUrlsConfig(t *testing.T) {
+	for _, status := range upStatuses {
+		status := status
+		t.Run(fmt.Sprintf("Test OK HTTP status %d", status), func(t *testing.T) {
+			server, event := checkServer(t, hbtest.HelloWorldHandler(status), true)
 
 			testslike.Test(
 				t,
@@ -237,7 +262,7 @@ func TestDownStatuses(t *testing.T) {
 	for _, status := range downStatuses {
 		status := status
 		t.Run(fmt.Sprintf("test down status %d", status), func(t *testing.T) {
-			server, event := checkServer(t, hbtest.HelloWorldHandler(status))
+			server, event := checkServer(t, hbtest.HelloWorldHandler(status), false)
 
 			testslike.Test(
 				t,
@@ -312,7 +337,7 @@ func runHTTPSServerCheck(
 	// we give it a few attempts to see if the server can come up before we run the real assertions.
 	var event *beat.Event
 	for i := 0; i < 10; i++ {
-		event = testTLSRequest(t, server.URL, mergedExtraConfig)
+		event = testTLSRequest(t, server.URL, false, mergedExtraConfig)
 		if v, err := event.GetValue("monitor.status"); err == nil && reflect.DeepEqual(v, "up") {
 			break
 		}
@@ -383,7 +408,7 @@ func TestConnRefusedJob(t *testing.T) {
 
 	url := fmt.Sprintf("http://%s:%d", ip, port)
 
-	event := testRequest(t, url)
+	event := testRequest(t, url, false)
 
 	testslike.Test(
 		t,
@@ -405,7 +430,7 @@ func TestUnreachableJob(t *testing.T) {
 	port := uint16(1234)
 	url := fmt.Sprintf("http://%s:%d", ip, port)
 
-	event := testRequest(t, url)
+	event := testRequest(t, url, false)
 
 	testslike.Test(
 		t,

--- a/heartbeat/tests/system/test_monitor.py
+++ b/heartbeat/tests/system/test_monitor.py
@@ -18,7 +18,7 @@ class Test(BaseTest):
         server = self.start_server("hello world", status_code)
 
         self.render_http_config(
-            ["http://localhost:{}".format(server.server_port)])
+            ["localhost:{}".format(server.server_port)])
 
         proc = self.start_beat()
         self.wait_until(lambda: self.log_contains("heartbeat is running"))
@@ -74,7 +74,7 @@ class Test(BaseTest):
             self.render_config_template(
                 monitors=[{
                     "type": "http",
-                    "urls": ["http://localhost:{}".format(server.server_port)],
+                    "hosts": ["http://localhost:{}".format(server.server_port)],
                     "check_response_json": [{
                         "description": "foo equals bar",
                         "condition": {
@@ -111,7 +111,7 @@ class Test(BaseTest):
             self.render_config_template(
                 monitors=[{
                     "type": "http",
-                    "urls": ["http://localhost:{}".format(server.server_port)],
+                    "hosts": ["http://localhost:{}".format(server.server_port)],
                     "check_response_json": [{
                         "description": body,
                         "condition": {
@@ -176,6 +176,6 @@ class Test(BaseTest):
         self.render_config_template(
             monitors=[{
                 "type": "http",
-                "urls": urls,
+                "hosts": urls,
             }]
         )


### PR DESCRIPTION
Currently only the http monitor allows configuring endpoints to hit via `urls`. Everyone else relies on `hosts` similar to metricbeat. This PR ensures that we also allow configuration with `hosts`. Eventually, the `urls` field can be deprecated. 