### PR TITLE
Disable `add_kubernetes_metadata` if no matchers found

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -101,6 +101,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Load DLLs only from Windows system directory. {pull}13234[13234] {pull}13384[13384]
 - Fix mapping for kubernetes.labels and kubernetes.annotations in add_kubernetes_metadata. {issue}12638[12638] {pull}13226[13226]
 - Fix case insensitive regular expressions not working correctly. {pull}13250[13250]
+- Disable `add_kubernetes_metadata` if no matchers found. {pull}13709[13709]
 
 *Auditbeat*
 


### PR DESCRIPTION
Fixes https://github.com/elastic/beats/issues/13705

As far as I can see, the problem with Beats other than Filebeat and Metricbeat is that they do not have default matchers. In the [docs](https://github.com/elastic/beats/issues/13705) is mentioned that Filebeat enables `logs_path` matcher by default (Metricbeat, enables `field` matcher).

I'm not sure if we should add default matchers for all other Beats.
I think that ignoring that error and just disable the processor should be ok.
@jsoriano how it sounds to you?

cc: @andrewkroh 