### PR TITLE
[Filebeat] Document parallel processing for s3 input

### DIFF
--- a/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
@@ -77,6 +77,12 @@ for more details.
 
 [float]
 === Parallel Processing
+Running multiple Filebeat instances in parallel to read from the same SQS queue
+is available for all users without any extra configuration for s3 input. This
+feature helps users to horizontally scale the processing when there are large
+amount of logs flowing into S3 bucket which leads to large amount of messages
+going through the queue.
+
 The usage of SQS ensures that each message in the queue is processed only once
 even with multiple Filebeat running in parallel. To prevent other consumers, which
 is Filebeat in this case, from processing the message again, visibility timeout
@@ -91,19 +97,6 @@ message becomes visible to other Filebeats and the message is received again.
 By default, visibility timeout is set to 5 minutes for s3 input in Filebeat.
 5-minute is high enough for SQS message to be read and related s3 log files to
 be processed.
-
-A basic test was done with three Filebeats running in parallel pointing to the same
-SQS queue in AWS. There were 1000 messages available in the queue and each message
-notifies a new S3 log has been generated. These S3 logs are simple .txt files and
-each contains 10 log lines. With three Filebeats, the messages were processed
-evenly without duplicating or missing messages. Test result looks like:
-
-|=======
-| Filebeat #  | Total # of Events | Total # of log files
-| 1 |  3350 |  335
-| 2| 3350 |  335
-| 3| 3300 |  330
-|=======
 
 [id="{beatname_lc}-input-{type}-common-options"]
 include::../../../../filebeat/docs/inputs/input-common-options.asciidoc[]

--- a/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
@@ -77,22 +77,25 @@ for more details.
 
 [float]
 === Parallel Processing
-Multiple Filebeat instances can read from the same SQS queues at the same time. This
-feature helps users to horizontally scale the processing when there are large
-amount of logs flowing into S3 bucket which leads to large amount of messages
-going through the queue. No additional configuration is needed for this.
+Multiple Filebeat instances can read from the same SQS queues at the same time.
+To horizontally scale processing when there are large amounts of log data
+flowing into an S3 bucket, you can run multiple {beatname_uc} instances that
+read from the same SQS queues at the same time. No additional configuration is
+required.
 
 Using SQS ensures that each message in the queue is processed only once
-even when multiple {beatname_uc} instances are running in parallel. To prevent {beatname_uc}
-from receiving and processing the message more than once, set the visibility timeout.
+even when multiple {beatname_uc} instances are running in parallel. To prevent
+{beatname_uc} from receiving and processing the message more than once, set the
+visibility timeout.
 
 The visibility timeout begins when SQS returns a message to Filebeat.
 During this time, Filebeat processes and deletes the message. However, if
 Filebeat fails before deleting the message and your system doesn't call the
 DeleteMessage action for that message before the visibility timeout expires, the
-message becomes visible to other {beatname_uc} instances, and the message is received again.
-By default, the visibility timeout is set to 5 minutes for s3 input in {beatname_uc}.
-5 minutes is sufficient time for {beatname_uc} to read SQS messages and process related s3 log files.
+message becomes visible to other {beatname_uc} instances, and the message is
+received again. By default, the visibility timeout is set to 5 minutes for s3
+input in {beatname_uc}. 5 minutes is sufficient time for {beatname_uc} to read
+SQS messages and process related s3 log files.
 
 [id="{beatname_lc}-input-{type}-common-options"]
 include::../../../../filebeat/docs/inputs/input-common-options.asciidoc[]

--- a/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
@@ -77,11 +77,10 @@ for more details.
 
 [float]
 === Parallel Processing
-Running multiple Filebeat instances in parallel to read from the same SQS queue
-is available for all users without any extra configuration for s3 input. This
+Multiple Filebeat instances can read from the same SQS queues at the same time. This
 feature helps users to horizontally scale the processing when there are large
 amount of logs flowing into S3 bucket which leads to large amount of messages
-going through the queue.
+going through the queue. No additional configuration is needed for this.
 
 The usage of SQS ensures that each message in the queue is processed only once
 even with multiple Filebeat running in parallel. To prevent other consumers, which

--- a/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
@@ -94,7 +94,7 @@ Filebeat fails before deleting the message and your system doesn't call the
 DeleteMessage action for that message before the visibility timeout expires, the
 message becomes visible to other Filebeats and the message is received again.
 By default, the visibility timeout is set to 5 minutes for s3 input in {beatname_uc}.
-5-minute is high enough for SQS message to be read and related s3 log files to
+5 minutes is sufficient time for {beatname_uc} to read SQS messages and process related s3 log files.
 be processed.
 
 [id="{beatname_lc}-input-{type}-common-options"]

--- a/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
@@ -82,7 +82,7 @@ feature helps users to horizontally scale the processing when there are large
 amount of logs flowing into S3 bucket which leads to large amount of messages
 going through the queue. No additional configuration is needed for this.
 
-The usage of SQS ensures that each message in the queue is processed only once
+Using SQS ensures that each message in the queue is processed only once
 even with multiple Filebeat running in parallel. To prevent other consumers, which
 is Filebeat in this case, from processing the message again, visibility timeout
 can be set to prevent other consumers from receiving and processing the same

--- a/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
@@ -83,19 +83,16 @@ amount of logs flowing into S3 bucket which leads to large amount of messages
 going through the queue. No additional configuration is needed for this.
 
 Using SQS ensures that each message in the queue is processed only once
-even with multiple Filebeat running in parallel. To prevent other consumers, which
-is Filebeat in this case, from processing the message again, visibility timeout
-can be set to prevent other consumers from receiving and processing the same
-message again.
+even when multiple {beatname_uc} instances are running in parallel. To prevent {beatname_uc}
+from receiving and processing the message more than once, set the visibility timeout.
 
 The visibility timeout begins when SQS returns a message to Filebeat.
 During this time, Filebeat processes and deletes the message. However, if
 Filebeat fails before deleting the message and your system doesn't call the
 DeleteMessage action for that message before the visibility timeout expires, the
-message becomes visible to other Filebeats and the message is received again.
+message becomes visible to other {beatname_uc} instances, and the message is received again.
 By default, the visibility timeout is set to 5 minutes for s3 input in {beatname_uc}.
 5 minutes is sufficient time for {beatname_uc} to read SQS messages and process related s3 log files.
-be processed.
 
 [id="{beatname_lc}-input-{type}-common-options"]
 include::../../../../filebeat/docs/inputs/input-common-options.asciidoc[]

--- a/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
@@ -93,7 +93,7 @@ During this time, Filebeat processes and deletes the message. However, if
 Filebeat fails before deleting the message and your system doesn't call the
 DeleteMessage action for that message before the visibility timeout expires, the
 message becomes visible to other Filebeats and the message is received again.
-By default, visibility timeout is set to 5 minutes for s3 input in Filebeat.
+By default, the visibility timeout is set to 5 minutes for s3 input in {beatname_uc}.
 5-minute is high enough for SQS message to be read and related s3 log files to
 be processed.
 

--- a/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
@@ -75,6 +75,36 @@ create a notification through SQS. Please see
 https://docs.aws.amazon.com/AmazonS3/latest/dev/ways-to-add-notification-config-to-bucket.html#step1-create-sqs-queue-for-notification[create-sqs-queue-for-notification]
 for more details.
 
+[float]
+=== Parallel Processing
+The usage of SQS ensures that each message in the queue is processed only once
+even with multiple Filebeat running in parallel. To prevent other consumers, which
+is Filebeat in this case, from processing the message again, visibility timeout
+can be set to prevent other consumers from receiving and processing the same
+message again.
+
+The visibility timeout begins when SQS returns a message to Filebeat.
+During this time, Filebeat processes and deletes the message. However, if
+Filebeat fails before deleting the message and your system doesn't call the
+DeleteMessage action for that message before the visibility timeout expires, the
+message becomes visible to other Filebeats and the message is received again.
+By default, visibility timeout is set to 5 minutes for s3 input in Filebeat.
+5-minute is high enough for SQS message to be read and related s3 log files to
+be processed.
+
+A basic test was done with three Filebeats running in parallel pointing to the same
+SQS queue in AWS. There were 1000 messages available in the queue and each message
+notifies a new S3 log has been generated. These S3 logs are simple .txt files and
+each contains 10 log lines. With three Filebeats, the messages were processed
+evenly without duplicating or missing messages. Test result looks like:
+
+|=======
+| Filebeat #  | Total # of Events | Total # of log files
+| 1 |  3350 |  335
+| 2| 3350 |  335
+| 3| 3300 |  330
+|=======
+
 [id="{beatname_lc}-input-{type}-common-options"]
 include::../../../../filebeat/docs/inputs/input-common-options.asciidoc[]
 

--- a/x-pack/filebeat/input/s3/_meta/s3-input.asciidoc
+++ b/x-pack/filebeat/input/s3/_meta/s3-input.asciidoc
@@ -9,6 +9,7 @@ for more details.
 bucket and check if SQS gets a message showing that a new object is created with
 its name.
 
+[float]
 === Manual Testing
 1. Upload fake log files into the S3 bucket that has SQS notification enabled.
 2. Check from SQS if there are N messages received.
@@ -20,6 +21,7 @@ from all log files.
 5. Interrupt the s3 input process by killing filebeat during processing new S3 logs,
 check if messages in SQS are in flight instead of deleted.
 
+[float]
 === Run s3_test.go
 Instead of manual testing, `s3_test.go` includes some integration tests that can
 be used for validating s3 input. In order to run `s3_test.go`, an AWS environment
@@ -40,3 +42,21 @@ Some environment variables are needed for testing:
 | S3_BUCKET_NAME | test-s3
 | S3_BUCKET_REGION | us-west-1
 |===
+
+[float]
+=== Parallel Processing Test
+A basic test was done with three Filebeats running in parallel pointing to the same
+SQS queue in AWS. There were 1000 messages available in the queue and each message
+notifies a new S3 log has been generated. These S3 logs are simple .txt files and
+each contains 10 log lines. With three Filebeats, the messages were processed
+evenly without duplicating or missing messages. Test result looks like:
+
+|=======
+| Filebeat #  | Total # of Events | Total # of log files
+| 1 |  3350 |  335
+| 2| 3350 |  335
+| 3| 3300 |  330
+|=======
+
+Please see more details in https://github.com/elastic/beats/issues/13457 regarding
+to the test.


### PR DESCRIPTION
I don't think it's needed to document the whole test result here but a small section talking about parallel processing is definitely needed.

closes https://github.com/elastic/beats/issues/13457