### PR TITLE
Add more info about token authorization requirements

### DIFF
--- a/dev-tools/cherrypick_pr
+++ b/dev-tools/cherrypick_pr
@@ -28,7 +28,9 @@ This script does the following:
   remote
 * if the --create_pr flag is used, it uses the GitHub API to create the PR
   for you. Note that this requires you to have a Github token with the
-  public_repo scope in the `~/.elastic/github.token` file
+  public_repo scope in the `~/.elastic/github.token` file. This token
+  should be also authorized to Elastic organization so as to work with single-sign-on.
+  (see https://help.github.com/en/articles/authorizing-a-personal-access-token-for-use-with-saml-single-sign-on)
 
 Note that you need to take the commit hashes from `git log` on the
 from_branch, copying the IDs from Github doesn't work in case we squashed the


### PR DESCRIPTION
In my case I was not able to use this script for the whole process of cherry-picking.

After I investigating more I found that the problem was because my token was not properly configured. The error I was getting was:
```{u'documentation_url': u'https://help.github.com/articles/authenticating-to-a-github-organization-with-saml-single-sign-on/', u'message': u'Resource protected by organization SAML enforcement. You must grant your personal token access to this organization.'}```

After following the steps from the suggested article everything worked fine.