### PR TITLE
[build] tell generate_imports.py to skip empty files

### DIFF
--- a/script/generate_imports.py
+++ b/script/generate_imports.py
@@ -42,6 +42,8 @@ def generate_and_write_to_file(outfile, go_beat_path):
     outputs = get_importable_lines(go_beat_path, import_line_format)
 
     for output_data in outputs:
+        if output_data["imported_lines"]:
+            continue
         imported_lines = "\n".join(output_data["imported_lines"])
         package = basename(dirname(outfile))
         list_go = import_template.format(package=package,

--- a/script/generate_imports.py
+++ b/script/generate_imports.py
@@ -42,7 +42,7 @@ def generate_and_write_to_file(outfile, go_beat_path):
     outputs = get_importable_lines(go_beat_path, import_line_format)
 
     for output_data in outputs:
-        if output_data["imported_lines"]:
+        if len(output_data["imported_lines"]) == 0:
             continue
         imported_lines = "\n".join(output_data["imported_lines"])
         package = basename(dirname(outfile))


### PR DESCRIPTION
 In a custom beat, if you run `make update` it'll generate an `include/list_docker.go` file with an empty include statement. This will fail the` fmt` part of make check.
The `fmt` will fix it, and then the next `make update` will un-fix it. 

The custom beat test seems like it should test for this, but for some reason it doesn't. Currently working on that.

This just adds a check to generate_imports.py that'll skip the file generation if it has nothing to import.