### PR TITLE
Compare event by event in `testdata` framework to avoid sorting problems

### DIFF
--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -53,3 +53,4 @@ The list below covers the major changes between 7.0.0-rc2 and master only.
 - Add checks for types and formats used in fields definitions in `fields.yml` files. {pull}13188[13188]
 - Makefile included in generator copies files from beats repository using `git archive` instead of cp. {pull}13193[13193]
 - Strip debug symbols from binaries to reduce binary sizes. {issue}12768[12768]
+- Compare event by event in `testadata` framework to avoid sorting problems {pull}13747[13747]

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -255,7 +255,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add autodetection mode for add_docker_metadata and enable it by default in included configuration files{pull}13374[13374]
 - Added `monitoring.cluster_uuid` setting to associate Beat data with specified ES cluster in Stack Monitoring UI. {pull}13182[13182]
 - Add autodetection mode for add_kubernetes_metadata and enable it by default in included configuration files. {pull}13473[13473]
-
+- Compare event by event in `testadata` framework to avoid sorting problems {pull}13747[13747]
 
 *Auditbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -255,7 +255,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add autodetection mode for add_docker_metadata and enable it by default in included configuration files{pull}13374[13374]
 - Added `monitoring.cluster_uuid` setting to associate Beat data with specified ES cluster in Stack Monitoring UI. {pull}13182[13182]
 - Add autodetection mode for add_kubernetes_metadata and enable it by default in included configuration files. {pull}13473[13473]
-- Compare event by event in `testadata` framework to avoid sorting problems {pull}13747[13747]
 
 *Auditbeat*
 


### PR DESCRIPTION
In `testdata` we currently assert the final lists of events, which need to be sorted otherwise the assertion will fail. This leads to problematic situations when one want to use `remove_fields_from_comparison` in long lists of events since the sorting are not working properly.

In this regard, it might be safer in the long run to compare event by event the lists, as we do in https://github.com/elastic/beats/blob/8ce4b7c269cb688770637d74388a80cbc452d415/metricbeat/helper/prometheus/ptest/ptest.go#L105