### PR TITLE
Fix markup issues for asciidoctor migration

### DIFF
--- a/auditbeat/docs/modules.asciidoc
+++ b/auditbeat/docs/modules.asciidoc
@@ -7,9 +7,4 @@ This section contains detailed information about the metric collecting modules
 contained in {beatname_uc}. More details about each module can be found under
 the links below.
 
-//pass macro block used here to remove Edit links from modules documentation because it is generated
-pass::[<?edit_url?>]
 include::modules_list.asciidoc[]
-
-
-

--- a/docs/devguide/newbeat.asciidoc
+++ b/docs/devguide/newbeat.asciidoc
@@ -44,7 +44,7 @@ branch ({branch} in the example below):
 
 ["source","sh",subs="attributes"]
 ----
-cd $\{GOPATH\}/src/github.com/elastic/beats
+cd ${GOPATH}/src/github.com/elastic/beats
 git checkout {branch}
 ----
 

--- a/filebeat/docs/autodiscover-hints.asciidoc
+++ b/filebeat/docs/autodiscover-hints.asciidoc
@@ -42,18 +42,18 @@ Instead of using raw `docker` input, specifies the module to use to parse logs f
 When module is configured, map container logs to module filesets. You can either configure
 a single fileset like this:
 
-["source","yaml",subs="attributes"]
--------------------------------------------------------------------------------------
+[source,yaml]
+-----
 co.elastic.logs/fileset: access
--------------------------------------------------------------------------------------
+-----
 
 Or configure a fileset per stream in the container (stdout and stderr):
 
-["source","yaml",subs="attributes"]
--------------------------------------------------------------------------------------
+[source,yaml]
+-----
 co.elastic.logs/fileset.stdout: access
 co.elastic.logs/fileset.stderr: error
--------------------------------------------------------------------------------------
+-----
 
 [float]
 ===== `co.elastic.logs/raw`
@@ -61,10 +61,10 @@ When an entire input/module configuration needs to be completely set the `raw` h
 stringified JSON of the input configuration. `raw` overrides every other hint and can be used to create both a single or
 a list of configurations.
 
-["source","yaml",subs="attributes"]
--------------------------------------------------------------------------------------
-co.elastic.logs/raw: "[{"containers\":{"ids\":[\"${data.container.id}"]},\"multiline\":{"negate\":\"true\",\"pattern\":\"^test\"},\"type\":\"docker\"}]"
--------------------------------------------------------------------------------------
+[source,yaml]
+-----
+co.elastic.logs/raw: "[{\"containers\":{\"ids\":[\"${data.container.id}\"]},\"multiline\":{\"negate\":\"true\",\"pattern\":\"^test\"},\"type\":\"docker\"}]"
+-----
 
 [float]
 ===== `co.elastic.logs/processors`
@@ -75,11 +75,11 @@ of supported processors.
 In order to provide ordering of the processor definition, numbers can be provided. If not, the hints builder will do
 arbitrary ordering:
 
-["source","yaml"]
--------------------------------------------------------------------------------------
+[source,yaml]
+-----
 co.elastic.logs/processors.1.dissect.tokenizer: "%{key1} %{key2}"
 co.elastic.logs/processors.dissect.tokenizer: "%{key2} %{key1}"
--------------------------------------------------------------------------------------
+-----
 
 In the above sample the processor definition tagged with `1` would be executed first.
 
@@ -88,18 +88,18 @@ In the above sample the processor definition tagged with `1` would be executed f
 
 Kubernetes autodiscover provider supports hints in Pod annotations. To enable it just set `hints.enabled`:
 
-["source","yaml",subs="attributes"]
--------------------------------------------------------------------------------------
+[source,yaml]
+-----
 filebeat.autodiscover:
   providers:
     - type: kubernetes
       hints.enabled: true
--------------------------------------------------------------------------------------
+-----
 
 You can configure the default config that will be launched when a new container is seen, like this:
 
-["source","yaml",subs="attributes"]
--------------------------------------------------------------------------------------
+[source,yaml]
+-----
 filebeat.autodiscover:
   providers:
     - type: kubernetes
@@ -108,29 +108,29 @@ filebeat.autodiscover:
         type: container
         paths:
           - /var/log/container/*-${container.id}.log  # CRI path
--------------------------------------------------------------------------------------
+-----
 
 You can also disable default settings entirely, so only Pods annotated like `co.elastic.logs/enabled: true`
 will be retrieved:
 
-["source","yaml",subs="attributes"]
--------------------------------------------------------------------------------------
+[source,yaml]
+-----
 filebeat.autodiscover:
   providers:
     - type: kubernetes
       hints.enabled: true
       hints.default_config.enabled: false
--------------------------------------------------------------------------------------
+-----
 
 You can annotate Kubernetes Pods with useful info to spin up {beatname_uc} inputs or modules:
 
-["source","yaml",subs="attributes"]
--------------------------------------------------------------------------------------
+[source,yaml]
+-----
 annotations:
   co.elastic.logs/multiline.pattern: '^\['
   co.elastic.logs/multiline.negate: true
   co.elastic.logs/multiline.match: after
--------------------------------------------------------------------------------------
+-----
 
 
 [float]
@@ -141,14 +141,14 @@ hint. For example, these hints configure multiline settings for all containers i
 specific `exclude_lines` hint for the container called `sidecar`.
 
 
-["source","yaml",subs="attributes"]
--------------------------------------------------------------------------------------
+[source,yaml]
+-----
 annotations:
   co.elastic.logs/multiline.pattern: '^\['
   co.elastic.logs/multiline.negate: true
   co.elastic.logs/multiline.match: after
   co.elastic.logs.sidecar/exclude_lines: '^DBG'
--------------------------------------------------------------------------------------
+-----
 
 
 
@@ -157,18 +157,18 @@ annotations:
 
 Docker autodiscover provider supports hints in labels. To enable it just set `hints.enabled`:
 
-["source","yaml",subs="attributes"]
--------------------------------------------------------------------------------------
+[source,yaml]
+-----
 filebeat.autodiscover:
   providers:
     - type: docker
       hints.enabled: true
--------------------------------------------------------------------------------------
+-----
 
 You can configure the default config that will be launched when a new container is seen, like this:
 
-["source","yaml",subs="attributes"]
--------------------------------------------------------------------------------------
+[source,yaml]
+-----
 filebeat.autodiscover:
   providers:
     - type: docker
@@ -177,28 +177,28 @@ filebeat.autodiscover:
         type: container
         paths:
           - /var/log/container/*-${container.id}.log  # CRI path
--------------------------------------------------------------------------------------
+-----
 
 You can also disable default settings entirely, so only containers labeled with `co.elastic.logs/enabled: true`
 will be retrieved:
 
-["source","yaml",subs="attributes"]
--------------------------------------------------------------------------------------
+[source,yaml]
+-----
 filebeat.autodiscover:
   providers:
     - type: docker
       hints.enabled: true
       hints.default_config.enabled: false
--------------------------------------------------------------------------------------
+-----
 
 You can label Docker containers with useful info to spin up {beatname_uc} inputs, for example:
 
-["source","yaml",subs="attributes"]
--------------------------------------------------------------------------------------
+[source,yaml]
+-----
   co.elastic.logs/module: nginx
   co.elastic.logs/fileset.stdout: access
   co.elastic.logs/fileset.stderr: error
--------------------------------------------------------------------------------------
+-----
 
 The above labels configure {beatname_uc} to use the Nginx module to harvest logs for this container.
 Access logs will be retrieved from stdout stream, and error logs from stderr.

--- a/filebeat/docs/autodiscover-hints.asciidoc
+++ b/filebeat/docs/autodiscover-hints.asciidoc
@@ -63,7 +63,7 @@ a list of configurations.
 
 ["source","yaml",subs="attributes"]
 -------------------------------------------------------------------------------------
-co.elastic.logs/raw: "[{\"containers\":{\"ids\":[\"${data.container.id}\"]},\"multiline\":{\"negate\":\"true\",\"pattern\":\"^test\"},\"type\":\"docker\"}]"
+co.elastic.logs/raw: "[{"containers\":{"ids\":[\"${data.container.id}"]},\"multiline\":{"negate\":\"true\",\"pattern\":\"^test\"},\"type\":\"docker\"}]"
 -------------------------------------------------------------------------------------
 
 [float]

--- a/filebeat/docs/fields.asciidoc
+++ b/filebeat/docs/fields.asciidoc
@@ -13915,7 +13915,7 @@ Fields from the PostgreSQL log files.
 +
 --
 
-deprecated[7.3.0]
+deprecated:[7.3.0]
 
 The timestamp from the log line.
 

--- a/filebeat/docs/filebeat-general-options.asciidoc
+++ b/filebeat/docs/filebeat-general-options.asciidoc
@@ -95,7 +95,7 @@ directory format does not already exist.
 [float]
 ==== `config_dir`
 
-deprecated[6.0.0, Use <<load-input-config>> instead.]
+deprecated:[6.0.0, Use <<load-input-config>> instead.]
 
 The full path to the directory that contains additional input configuration files.
 Each configuration file must end with `.yml`. Each config file must also specify the full Filebeat

--- a/filebeat/docs/inputs/input-docker.asciidoc
+++ b/filebeat/docs/inputs/input-docker.asciidoc
@@ -7,7 +7,7 @@
 <titleabbrev>Docker</titleabbrev>
 ++++
 
-deprecated[7.2.0, Use `container` input instead.]
+deprecated:[7.2.0, Use `container` input instead.]
 
 Use the `docker` input to read logs from Docker containers.
 

--- a/filebeat/docs/inputs/input-redis.asciidoc
+++ b/filebeat/docs/inputs/input-redis.asciidoc
@@ -18,7 +18,7 @@ Example configuration:
 {beatname_lc}.inputs:
 - type: redis
   hosts: ["localhost:6379"]
-  password: "$\{redis_pwd\}"
+  password: "${redis_pwd}"
 ----
 
 

--- a/filebeat/docs/modules.asciidoc
+++ b/filebeat/docs/modules.asciidoc
@@ -9,6 +9,4 @@ modules.
 
 Filebeat modules require Elasticsearch 5.2 or later.
 
-//pass macro block used here to remove Edit links from modules documentation because it is generated
-pass::[<?edit_url?>]
 include::modules_list.asciidoc[]

--- a/filebeat/docs/modules/osquery.asciidoc
+++ b/filebeat/docs/modules/osquery.asciidoc
@@ -57,6 +57,8 @@ To specify the same settings at the command line, you use:
 -M "osquery.result.var.paths=[/path/to/osqueryd.results.log*]"
 -----
 
+//set the fileset name used in the included example
+:fileset_ex: result
 include::../include/config-option-intro.asciidoc[]
 
 [float]

--- a/filebeat/module/osquery/_meta/docs.asciidoc
+++ b/filebeat/module/osquery/_meta/docs.asciidoc
@@ -52,6 +52,8 @@ To specify the same settings at the command line, you use:
 -M "osquery.result.var.paths=[/path/to/osqueryd.results.log*]"
 -----
 
+//set the fileset name used in the included example
+:fileset_ex: result
 include::../include/config-option-intro.asciidoc[]
 
 [float]

--- a/heartbeat/docs/heartbeat-options.asciidoc
+++ b/heartbeat/docs/heartbeat-options.asciidoc
@@ -574,8 +574,7 @@ The timezone for the scheduler. By default the scheduler uses localtime.
 [[monitor-watch-poll-file]]
 ==== `watch.poll_file`
 
-deprecated[6.5.0,Replaced by using dynamic reloading via the
-`heartbeat.config.monitors` option.]
+deprecated:[6.5.0,Replaced by using dynamic reloading via the `heartbeat.config.monitors` option.]
 
 The JSON file to watch for additional monitor configurations. The JSON file can
 contain multiple objects, each of which specifies a different monitor config.

--- a/heartbeat/docs/heartbeat-options.asciidoc
+++ b/heartbeat/docs/heartbeat-options.asciidoc
@@ -1,8 +1,8 @@
 [[configuration-heartbeat-options]]
-== Set up monitors
+== Set up {beatname_uc} monitors
 
 ++++
-<titleabbrev>Set up {beatname_uc} monitors</titleabbrev>
+<titleabbrev>Set up monitors</titleabbrev>
 ++++
 
 To configure {beatname_uc} define a set of `monitors` to check your remote hosts.

--- a/journalbeat/docs/general-options.asciidoc
+++ b/journalbeat/docs/general-options.asciidoc
@@ -29,28 +29,28 @@ data path. See the <<directory-layout>> section for details. The default is `${p
 ----
 
 [float]
-==== `backoff` deprecated[5.6.1,Use the option under `paths` instead.]
+==== `backoff` deprecated:[5.6.1,Use the option under `paths` instead.]
 
 This option is valid as a global setting under the +{beatname_lc}+ namespace
 or under `paths`. For a description of this option, see
 <<{beatname_lc}-backoff,`backoff`>>.
 
 [float]
-==== `max_backoff` deprecated[5.6.1,Use the option under `paths` instead.]
+==== `max_backoff` deprecated:[5.6.1,Use the option under `paths` instead.]
 
 This option is valid as a global setting under the +{beatname_lc}+ namespace
 or under `paths`. For a description of this option, see
 <<{beatname_lc}-max-backoff,`max_backoff`>>.
 
 [float]
-==== `seek` deprecated[5.6.1,Use the option under `paths` instead.]
+==== `seek` deprecated:[5.6.1,Use the option under `paths` instead.]
 
 This option is valid as a global setting under the +{beatname_lc}+ namespace
 or under `paths`. For a description of this option, see
 <<seek,`seek`>>. 
 
 [float]
-==== `include_matches` deprecated[5.6.1,Use the option under `paths` instead.]
+==== `include_matches` deprecated:[5.6.1,Use the option under `paths` instead.]
 
 This option is valid as a global setting under the +{beatname_lc}+ namespace
 or under `paths`. For a description of this option, see

--- a/libbeat/docs/command-reference.asciidoc
+++ b/libbeat/docs/command-reference.asciidoc
@@ -686,12 +686,12 @@ Sets up components related to Elasticsearch index management including
 template, ILM policy, and write alias (if supported and configured).
 
 *`--template`*::
-deprecated[7.2]
+deprecated:[7.2]
 Sets up the index template only.
 It is recommended to use `--index-management` instead.
 
 *`--ilm-policy`*::
-deprecated[7.2]
+deprecated:[7.2]
 Sets up the index lifecycle management policy.
 It is recommended to use `--index-management` instead.
 

--- a/libbeat/docs/config-file-format.asciidoc
+++ b/libbeat/docs/config-file-format.asciidoc
@@ -12,27 +12,27 @@ have the same indentation level.
 Dictionaries are represented by simple `key: value` pairs all having the same
 indentation level. The colon after `key` must be followed by a space.
 
-["source","yaml",subs="attributes"]
-------------------------------------------------------------------------------
+[source,yaml]
+-----
 name: John Doe
 age: 34
 country: Canada
-------------------------------------------------------------------------------
+-----
 
 Lists are introduced by dashes `- `. All list members will be lines beginning
 with `- ` at the same indentation level.
 
-["source","yaml",subs="attributes"]
-------------------------------------------------------------------------------
+[source,yaml]
+-----
 - Red
 - Green
 - Blue
-------------------------------------------------------------------------------
+-----
 
 Lists and dictionaries are used in beats to build structured configurations.
 
-["source","yaml",subs="attributes"]
-------------------------------------------------------------------------------
+[source,yaml]
+-----
 filebeat:
   inputs:
     - type: log
@@ -41,16 +41,16 @@ filebeat:
       multiline:
         pattern: '^['
         match: after
-------------------------------------------------------------------------------
+-----
 
 Lists and dictionaries can also be represented in abbreviated form. Abbreviated
 form is somewhat similar to JSON using `{}` for dictionaries and `[]` for lists:
 
-["source","yaml",subs="attributes"]
-------------------------------------------------------------------------------
+[source,yaml]
+-----
 person: {name: "John Doe", age: 34, country: "Canada"}
 colors: ["Red", "Green", "Blue"]
-------------------------------------------------------------------------------
+-----
 
 The following topics provide more detail to help you understand and work with config files in YAML:
 
@@ -73,13 +73,11 @@ file.
 For example this setting:
 
 ["source","yaml",subs="attributes"]
-------------------------------------------------------------------------------
-
+-----
 output:
   elasticsearch:
     index: 'beat-%{[{beat_version_key}]}-%{+yyyy.MM.dd}'
-
-------------------------------------------------------------------------------
+-----
 
 gets collapsed into +output.elasticsearch.index: \'beat-%{[{beat_version_key}]}-%{+yyyy.MM.dd}'+. The
 full name of a setting is based on all parent structures involved.
@@ -88,14 +86,12 @@ Lists create numeric names starting with 0.
 
 For example this filebeat setting:
 
-["source","yaml",subs="attributes"]
-------------------------------------------------------------------------------
-
+[source,yaml]
+-----
 filebeat:
   inputs:
     - type: log
-
-------------------------------------------------------------------------------
+-----
 
 Gets collapsed into `filebeat.inputs.0.type: log`.
 
@@ -106,9 +102,8 @@ Note: having two settings with same fully collapsed path is invalid.
 Simple filebeat example with partially collapsed setting names and use of compact form:
 
 
-["source","yaml",subs="attributes"]
-------------------------------------------------------------------------------
-
+[source,yaml]
+-----
 filebeat.inputs:
 - type: log
   paths: ["/var/log/*.log"]
@@ -116,8 +111,7 @@ filebeat.inputs:
   multiline.match: after
 
 output.elasticsearch.hosts: ["http://localhost:9200"]
-
-------------------------------------------------------------------------------
+-----
 
 [[config-file-format-type]]
 === Config file data types
@@ -131,23 +125,23 @@ string is given when a number is required - the beat will fail to start up.
 Boolean values can be either `true` or `false`. Alternative names for `true` are
 `yes` and `on`. Instead of `false` the values `no` and `off` can be used.
 
-["source","yaml",subs="attributes"]
-------------------------------------------------------------------------------
+[source,yaml]
+-----
 enabled: true
 disabled: false
-------------------------------------------------------------------------------
+-----
 
 ==== Number
 
 Number values require you to enter the number to use without using single or
 double quotes. Some settings only support a restricted number range though.
 
-["source","yaml",subs="attributes"]
-------------------------------------------------------------------------------
+[source,yaml]
+-----
 integer: 123
 negative: -1
 float: 5.4
-------------------------------------------------------------------------------
+-----
 
 ==== String
 
@@ -174,12 +168,12 @@ Durations require a numeric value with optional fraction and required unit.
 Valid time units are `ns`, `us`, `ms`, `s`, `m`, `h`. Sometimes features based
 on durations can be disabled by using zero or negative durations.
 
-["source","yaml",subs="attributes"]
-------------------------------------------------------------------------------
+[source,yaml]
+-----
 duration1: 2.5s
 duration2: 6h
 duration_disabled: -1s
-------------------------------------------------------------------------------
+-----
 
 ==== Regular expression
 
@@ -203,12 +197,12 @@ You can also format time stored in the
 `@timestamp` field using the `+FORMAT` syntax where FORMAT is a valid https://godoc.org/github.com/elastic/beats/libbeat/common/dtfmt[time
 format].
 
-["source","yaml",subs="attributes"]
-------------------------------------------------------------------------------
+[source,yaml]
+-----
 constant-format-string: 'constant string'
 field-format-string: '%{[fieldname]} string'
 format-string-with-date: '%{[fieldname]}-%{+yyyy.MM.dd}'
-------------------------------------------------------------------------------
+-----
 
 
 [[config-file-format-env-vars]]
@@ -226,23 +220,23 @@ referenced to.
 
 For example the filebeat registry file defaults to:
 
-["source","yaml",subs="attributes"]
-------------------------------------------------------------------------------
+[source,yaml]
+-----
 filebeat.registry: ${path.data}/registry
-------------------------------------------------------------------------------
+-----
 
 With `path.data` being an implicit config setting, that is overridable from
 command line, as well as in the configuration file.
 
 Example referencing `es.host` in `output.elasticsearch.hosts`:
 
-["source","yaml",subs="attributes"]
-------------------------------------------------------------------------------
+[source,yaml]
+-----
 es.host: '${ES_HOST:localhost}'
 
 output.elasticsearch:
   hosts: ['http://${es.host}:9200']
-------------------------------------------------------------------------------
+-----
 
 Introducing `es.host`, the host can be overwritten from command line using
 `-E es.host=another-host`.
@@ -252,8 +246,8 @@ references or strings can reference complete namespaces.
 
 These setting with duplicate content:
 
-["source","yaml",subs="attributes"]
-------------------------------------------------------------------------------
+[source,yaml]
+-----
 namespace1:
   subnamespace:
     host: localhost
@@ -263,20 +257,20 @@ namespace2:
   subnamespace:
     host: localhost
     sleep: 1s
-------------------------------------------------------------------------------
+-----
 
 can be rewritten to
 
-["source","yaml",subs="attributes"]
-------------------------------------------------------------------------------
-namespace1: $\{shared}
-namespace2: $\{shared}
+[source,yaml]
+-----
+namespace1: ${shared}
+namespace2: ${shared}
 
 shared:
   subnamespace:
     host: localhost
     sleep: 1s
-------------------------------------------------------------------------------
+-----
 
 when using plain references.
 
@@ -299,21 +293,21 @@ file is owned by `root` and has file permissions of `0644` (`-rw-r--r--`).
 
 You may encounter the following errors if your config file fails these checks:
 
-["source","sh"]
---------------------------------------------------------------------------------
+[source,sh]
+-----
 Exiting: error loading config file: config file ("{beatname}.yml") must be
 owned by the beat user (uid=501) or root
---------------------------------------------------------------------------------
+-----
 
 To correct this problem you can use either `chown root {beatname}.yml` or
 `chown 501 {beatname}.yml` to change the owner of the configuration file.
 
-["source","sh"]
---------------------------------------------------------------------------------
+[source,sh]
+-----
 Exiting: error loading config file: config file ("{beatname}.yml") can only be
 writable by the owner but the permissions are "-rw-rw-r--" (to fix the
 permissions use: 'chmod go-w /etc/{beatname}/{beatname}.yml')
---------------------------------------------------------------------------------
+-----
 
 To correct this problem, use `chmod go-w /etc/{beatname}/{beatname}.yml` to
 remove write privileges from anyone other than the owner.
@@ -343,27 +337,27 @@ dictionary.
 
 For example, given the following configuration:
 
-["source","yaml"]
---------------------------------------------------------------------------------
+[source,yaml]
+-----
 output.elasticsearch:
   hosts: ["http://localhost:9200"]
   username: username
   password: password
---------------------------------------------------------------------------------
+-----
 
 You can disable the Elasticsearch output and write all events to the console by
 setting:
 
-["source","sh"]
---------------------------------------------------------------------------------
+[source,sh]
+-----
 -E output='{elasticsearch.enabled: false, console.pretty: true}'
---------------------------------------------------------------------------------
+-----
 
 Any complex objects that you specify at the command line are merged with the
 original configuration, and the following configuration is passed to the Beat:
 
-["source","yaml"]
---------------------------------------------------------------------------------
+[source,yaml]
+-----
 output.elasticsearch:
   enabled: false
   hosts: ["http://localhost:9200"]
@@ -372,7 +366,7 @@ output.elasticsearch:
 
 output.console:
   pretty: true
---------------------------------------------------------------------------------
+-----
 
 
 [[config-file-format-tips]]

--- a/libbeat/docs/config-file-format.asciidoc
+++ b/libbeat/docs/config-file-format.asciidoc
@@ -48,7 +48,7 @@ form is somewhat similar to JSON using `{}` for dictionaries and `[]` for lists:
 
 ["source","yaml",subs="attributes"]
 ------------------------------------------------------------------------------
-person: \{name: "John Doe", age: 34, country: "Canada"}
+person: {name: "John Doe", age: 34, country: "Canada"}
 colors: ["Red", "Green", "Blue"]
 ------------------------------------------------------------------------------
 
@@ -81,7 +81,7 @@ output:
 
 ------------------------------------------------------------------------------
 
-gets collapsed into +output.elasticsearch.index: \'beat-%{[{beat_version_key}]}-%{+yyyy.MM.dd}\'+. The
+gets collapsed into +output.elasticsearch.index: \'beat-%{[{beat_version_key}]}-%{+yyyy.MM.dd}'+. The
 full name of a setting is based on all parent structures involved.
 
 Lists create numeric names starting with 0.
@@ -228,7 +228,7 @@ For example the filebeat registry file defaults to:
 
 ["source","yaml",subs="attributes"]
 ------------------------------------------------------------------------------
-filebeat.registry: $\{path.data}/registry
+filebeat.registry: ${path.data}/registry
 ------------------------------------------------------------------------------
 
 With `path.data` being an implicit config setting, that is overridable from
@@ -238,10 +238,10 @@ Example referencing `es.host` in `output.elasticsearch.hosts`:
 
 ["source","yaml",subs="attributes"]
 ------------------------------------------------------------------------------
-es.host: '$\{ES_HOST:localhost}'
+es.host: '${ES_HOST:localhost}'
 
 output.elasticsearch:
-  hosts: ['http://$\{es.host}:9200']
+  hosts: ['http://${es.host}:9200']
 ------------------------------------------------------------------------------
 
 Introducing `es.host`, the host can be overwritten from command line using

--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -1378,19 +1378,19 @@ See <<configuration-output-codec>> for more information.
 
 ===== `host_topology`
 
-deprecated[5.0.0]
+deprecated:[5.0.0]
 
 The Redis host to connect to when using topology map support. Topology map support is disabled if this option is not set.
 
 ===== `password_topology`
 
-deprecated[5.0.0]
+deprecated:[5.0.0]
 
 The password to use for authenticating with the Redis topology server. The default is no authentication.
 
 ===== `db_topology`
 
-deprecated[5.0.0]
+deprecated:[5.0.0]
 
 The Redis database number where the topology information is stored. The default is 1.
 

--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -262,7 +262,7 @@ to set the index:
 ------------------------------------------------------------------------------
 output.elasticsearch:
   hosts: ["http://localhost:9200"]
-  index: "%{[fields.log_type]}-%{[{beat_version_key}]}-%{+yyyy.MM.dd}\" <1>
+  index: "%{[fields.log_type]}-%{[{beat_version_key}]}-%{+yyyy.MM.dd}" <1>
 ------------------------------------------------------------------------------
 
 <1> We recommend including +{beat_version_key}+ in the name to avoid mapping issues

--- a/libbeat/docs/outputconfig.asciidoc
+++ b/libbeat/docs/outputconfig.asciidoc
@@ -219,7 +219,7 @@ for more information about the environment variables.
 
 ifndef::apm-server[]
 The index name to write events to when you're using daily indices. The default is
-+"{beatname_lc}-%\{[{beat_version_key}]\}-%\{+yyyy.MM.dd\}"+ (for example,
++"{beatname_lc}-%{[{beat_version_key}]}-%{+yyyy.MM.dd}"+ (for example,
 +"{beatname_lc}-{version}-{localdate}"+). If you change this setting, you also
 need to configure the `setup.template.name` and `setup.template.pattern` options
 (see <<configuration-template>>).
@@ -227,7 +227,7 @@ endif::apm-server[]
 
 ifdef::apm-server[]
 The index name to write events to. The default is
-+"apm-%\{[{beat_version_key}]\}-{type\}-%\{+yyyy.MM.dd\}"+ (for example,
++"apm-%{[{beat_version_key}]}-{type}-%{+yyyy.MM.dd}"+ (for example,
 +"apm-{version}-transaction-{localdate}"+). See
 <<exploring-es-data,Exploring data in Elasticsearch>> for more information on
 default index configuration.
@@ -262,7 +262,7 @@ to set the index:
 ------------------------------------------------------------------------------
 output.elasticsearch:
   hosts: ["http://localhost:9200"]
-  index: "%\{[fields.log_type]\}-%\{[{beat_version_key}]\}-%\{+yyyy.MM.dd}\" <1>
+  index: "%{[fields.log_type]}-%{[{beat_version_key}]}-%{+yyyy.MM.dd}\" <1>
 ------------------------------------------------------------------------------
 
 <1> We recommend including +{beat_version_key}+ in the name to avoid mapping issues
@@ -283,7 +283,7 @@ to set the index:
 ------------------------------------------------------------------------------
 output.elasticsearch:
   hosts: ["http://localhost:9200"]
-  index: "apm-%\{[observer.version]\}-%\{[processor.event]\}-%\{+yyyy.MM.dd}\" <1>
+  index: "apm-%{[observer.version]}-%{[processor.event]}-%{+yyyy.MM.dd}\" <1>
 ------------------------------------------------------------------------------
 
 <1>  `observer` refers to {beatname_uc}. We recommend including
@@ -410,7 +410,7 @@ NOTE: `observer` refers to {beatname_uc}. We recommend including
 {beatname_uc}.
 
 This is the default configuration for {beatname_uc} and results in indices
-named in the following format: +"apm-%\{[{beat_version_key}]\}-{type\}-%\{+yyyy.MM.dd\}"+
+named in the following format: +"apm-%{[{beat_version_key}]}-{type}-%{+yyyy.MM.dd}"+
 For example: +"apm-{version}-transaction-{localdate}"+.
 
 The following example sets the index by taking the name returned by the `index`
@@ -473,7 +473,7 @@ access any event field. For example, this configuration uses a custom field,
 ------------------------------------------------------------------------------
 output.elasticsearch:
   hosts: ["http://localhost:9200"]
-  pipeline: "%\{[fields.log_type]\}_pipeline"
+  pipeline: "%{[fields.log_type]}_pipeline"
 ------------------------------------------------------------------------------
 
 
@@ -491,7 +491,7 @@ access any event field. For example, this configuration uses the field,
 ------------------------------------------------------------------------------
 output.elasticsearch:
   hosts: ["http://localhost:9200"]
-  pipeline: "%\{[processor.event]\}_pipeline"
+  pipeline: "%{[processor.event]}_pipeline"
 ------------------------------------------------------------------------------
 
 

--- a/libbeat/docs/processors-using.asciidoc
+++ b/libbeat/docs/processors-using.asciidoc
@@ -715,8 +715,8 @@ processors:
         with.dots: nested
       array:
         - do
-	- re
-	- with.field: mi
+        - re
+        - with.field: mi
 ------------------------------------------------------------------------------
 
 Adds these fields to every event:

--- a/libbeat/docs/processors-using.asciidoc
+++ b/libbeat/docs/processors-using.asciidoc
@@ -93,6 +93,20 @@ Processors are valid:
 collected by {beatname_uc}.
 * Under a specific {processor-scope}. The processor is applied to the data
 collected for that {processor-scope}.
+ifeval::["{beatname_lc}"=="winlogbeat"]
+For example:
++
+[source,yaml]
+----
+winlogbeat.event_logs:
+- name: <network_shipper_name>
+  processors:
+  - <processor_name>:
+      when:
+        <condition>
+      <parameters>
+----
+endif::[]
 ifeval::["{beatname_lc}"=="filebeat"]
 For example:
 +
@@ -170,20 +184,6 @@ For example:
 ----
 heartbeat.monitors:
 - type: <monitor_type>
-  processors:
-  - <processor_name>:
-      when:
-        <condition>
-      <parameters>
-----
-endif::[]
-ifeval::["{beatname_lc}"=="winlogbeat"]
-For example:
-+
-[source,yaml]
-----
-winlogbeat.event_logs:
-- name: <network_shipper_name>
   processors:
   - <processor_name>:
       when:

--- a/libbeat/docs/processors-using.asciidoc
+++ b/libbeat/docs/processors-using.asciidoc
@@ -93,22 +93,7 @@ Processors are valid:
 collected by {beatname_uc}.
 * Under a specific {processor-scope}. The processor is applied to the data
 collected for that {processor-scope}.
-ifeval::["{beatname_lc}"=="winlogbeat"]
-For example:
-+
-[source,yaml]
-----
-winlogbeat.event_logs:
-- name: <network_shipper_name>
-  processors:
-  - <processor_name>:
-      when:
-        <condition>
-      <parameters>
-----
-endif::[]
 ifeval::["{beatname_lc}"=="filebeat"]
-For example:
 +
 [source,yaml]
 ------
@@ -125,6 +110,7 @@ Similarly, for {beatname_uc} modules, you can define processors under the
 `input` section of the module definition.
 endif::[]
 ifeval::["{beatname_lc}"=="metricbeat"]
++
 [source,yaml]
 ----
 - module: <module_name>
@@ -137,7 +123,6 @@ ifeval::["{beatname_lc}"=="metricbeat"]
 ----
 endif::[]
 ifeval::["{beatname_lc}"=="auditbeat"]
-For example:
 +
 [source,yaml]
 ----
@@ -151,7 +136,6 @@ auditbeat.modules:
 ----
 endif::[]
 ifeval::["{beatname_lc}"=="packetbeat"]
-For example:
 +
 [source,yaml]
 ----
@@ -178,12 +162,24 @@ packetbeat.flows:
 ----
 endif::[]
 ifeval::["{beatname_lc}"=="heartbeat"]
-For example:
 +
 [source,yaml]
 ----
 heartbeat.monitors:
 - type: <monitor_type>
+  processors:
+  - <processor_name>:
+      when:
+        <condition>
+      <parameters>
+----
+endif::[]
+ifeval::["{beatname_lc}"=="winlogbeat"]
++
+[source,yaml]
+----
+winlogbeat.event_logs:
+- name: <network_shipper_name>
   processors:
   - <processor_name>:
       when:

--- a/libbeat/docs/regexp.asciidoc
+++ b/libbeat/docs/regexp.asciidoc
@@ -110,7 +110,7 @@ The following patterns are supported:
 |`[[:blank:]]`    |blank (same as `[\t ]`)
 |`[[:cntrl:]]`    |control (same as `[\x00-\x1F\x7F]`)
 |`[[:digit:]]`    |digits (same as `[0-9]`)
-|`[[:graph:]]`    |graphical (same as `[!-~] == [A-Za-z0-9!"#$%&'()*+,\-./:;<=>?@[\\\\]^_`` `{\|}~]`)
+|`[[:graph:]]`    |graphical (same as `[!-~] == [A-Za-z0-9!"#$%&'()*+,\-./:;<=>?@[\\\]^_`` `{\|}~]`)
 |`[[:lower:]]`    |lower case (same as `[a-z]`)
 |`[[:print:]]`    |printable (same as `[ -~] == [ [:graph:]]`)
 |`[[:punct:]]`    |punctuation (same as ++[!-/:-@[-`{-~]++)

--- a/libbeat/docs/shared-ilm.asciidoc
+++ b/libbeat/docs/shared-ilm.asciidoc
@@ -51,7 +51,7 @@ required license; otherwise, {beatname_uc} creates daily indices.
 ==== `setup.ilm.rollover_alias`
 
 The index lifecycle write alias name. The default is
-+{beatname_lc}-\{{beat_version_key}\}+. Setting this option changes the alias name.
++{beatname_lc}-%{{beat_version_key}}+. Setting this option changes the alias name.
 
 NOTE: If you modify this setting after loading the index template, you must
 overwrite the template to apply the changes.
@@ -81,7 +81,7 @@ overwrite the template to apply the changes.
 ==== `setup.ilm.policy_name`
 
 The name to use for the lifecycle policy. The default is
-+{beatname_lc}-%\{[{beat_version_key}]\}+.
++{beatname_lc}-%{[{beat_version_key}]}+.
 
 [float]
 [[setup-ilm-policy_file-option]]

--- a/libbeat/docs/shared-ssl-config.asciidoc
+++ b/libbeat/docs/shared-ssl-config.asciidoc
@@ -6,7 +6,7 @@ You can specify SSL options when you configure:
 * <<configuring-output,outputs>> that support SSL
 ifeval::["{beatname_lc}"!="apm-server"]
 * the <<setup-kibana-endpoint,Kibana endpoint>>
-endif::["{beatname_lc}"!="apm-server"]
+endif::[]
 ifeval::["{beatname_lc}"=="heartbeat"]
 * <<configuration-heartbeat-options,{beatname_uc} monitors>> that support SSL
 endif::[]

--- a/libbeat/docs/template-config.asciidoc
+++ b/libbeat/docs/template-config.asciidoc
@@ -24,18 +24,18 @@ you must <<load-template-manually,load the template manually>>.
 
 *`setup.template.name`*:: The name of the template. The default is
 +{beatname_lc}+. The {beatname_uc} version is always appended to the given
-name, so the final name is +{beatname_lc}-%\{[{beat_version_key}]\}+.
+name, so the final name is +{beatname_lc}-%{[{beat_version_key}]}+.
 
 // Maintainers: a backslash character is required to escape curly braces and
 // asterisks in inline code examples that contain asciidoc attributes. You'll
 // note that a backslash does not appear before the asterisk
-// in +{beatname_lc}-%\{[{beat_version_key}]\}-*+. This is intentional and formats
+// in +{beatname_lc}-%{[{beat_version_key}]}-*+. This is intentional and formats
 // the example as expected.
 
 *`setup.template.pattern`*:: The template pattern to apply to the default index
 settings. The default pattern is +{beat_default_index_prefix}-\*+. The {beatname_uc} version is always
 included in the pattern, so the final pattern is
-+{beat_default_index_prefix}-%\{[{beat_version_key}]\}-*+. The wildcard character `-*` is used to
++{beat_default_index_prefix}-%{[{beat_version_key}]}-*+. The wildcard character `-*` is used to
 match all daily indices.
 +
 Example:

--- a/libbeat/scripts/generate_fields_docs.py
+++ b/libbeat/scripts/generate_fields_docs.py
@@ -53,7 +53,7 @@ def document_field(output, field, field_path):
     output.write("*`{}`*::\n+\n--\n".format(field["field_path"]))
 
     if "deprecated" in field:
-        output.write("\ndeprecated[{}]\n\n".format(field["deprecated"]))
+        output.write("\ndeprecated:[{}]\n\n".format(field["deprecated"]))
 
     if "description" in field:
         output.write("{}\n\n".format(field["description"]))

--- a/metricbeat/docs/fields.asciidoc
+++ b/metricbeat/docs/fields.asciidoc
@@ -5070,7 +5070,7 @@ type: long
 +
 --
 
-deprecated[6.4]
+deprecated:[6.4]
 
 Number of current reads per second
 
@@ -5122,7 +5122,7 @@ type: long
 +
 --
 
-deprecated[6.4]
+deprecated:[6.4]
 
 Number of current writes per second
 
@@ -5174,7 +5174,7 @@ type: long
 +
 --
 
-deprecated[6.4]
+deprecated:[6.4]
 
 Number of reads and writes per second
 
@@ -13831,7 +13831,7 @@ type: keyword
 +
 --
 
-deprecated[6.5]
+deprecated:[6.5]
 
 Topic name
 
@@ -13843,7 +13843,7 @@ type: keyword
 +
 --
 
-deprecated[6.5]
+deprecated:[6.5]
 
 Partition ID
 
@@ -13958,7 +13958,7 @@ Partition data.
 +
 --
 
-deprecated[6.5]
+deprecated:[6.5]
 
 Partition id.
 
@@ -14031,7 +14031,7 @@ type: long
 +
 --
 
-deprecated[6.5]
+deprecated:[6.5]
 
 topic error code.
 
@@ -14044,7 +14044,7 @@ type: long
 +
 --
 
-deprecated[6.5]
+deprecated:[6.5]
 
 Topic name
 
@@ -14057,7 +14057,7 @@ type: keyword
 +
 --
 
-deprecated[6.5]
+deprecated:[6.5]
 
 Broker id
 
@@ -14070,7 +14070,7 @@ type: long
 +
 --
 
-deprecated[6.5]
+deprecated:[6.5]
 
 Broker address
 
@@ -16910,7 +16910,7 @@ type: float
 +
 --
 
-deprecated[6.4]
+deprecated:[6.4]
 
 Container CPU nanocores limit
 
@@ -16923,7 +16923,7 @@ type: long
 +
 --
 
-deprecated[6.4]
+deprecated:[6.4]
 
 Container CPU requested nanocores
 
@@ -25918,7 +25918,7 @@ type: long
 +
 --
 
-deprecated[6.5.0]
+deprecated:[6.5.0]
 
 Longest output list among current client connections (replaced by max_output_buffer).
 
@@ -25941,7 +25941,7 @@ type: long
 +
 --
 
-deprecated[6.5.0]
+deprecated:[6.5.0]
 
 Biggest input buffer among current client connections (replaced by max_input_buffer).
 
@@ -26538,7 +26538,7 @@ type: long
 +
 --
 
-deprecated[6.5]
+deprecated:[6.5]
 
 The server's current replication offset
 

--- a/metricbeat/docs/modules.asciidoc
+++ b/metricbeat/docs/modules.asciidoc
@@ -7,8 +7,6 @@ This section contains detailed information about the metric collecting modules
 contained in {beatname_uc}. Each module contains one or multiple metricsets. More details
 about each module can be found under the links below.
 
-//pass macro block used here to remove Edit links from modules documentation because it is generated
-pass::[<?edit_url?>]
 include::modules_list.asciidoc[]
 
 

--- a/packetbeat/docs/faq.asciidoc
+++ b/packetbeat/docs/faq.asciidoc
@@ -16,9 +16,9 @@ The index template might not be loaded correctly. See <<packetbeat-template>>.
 The interface needs to be set to promiscuous mode. Run the following command:
 
 ["source","sh",subs="attributes,callouts"]
-----------------------------------------------------------------------
+----
 ip link set <device_name> promisc on
-----------------------------------------------------------------------
+----
 
 For example: `ip link set enp5s0f1 promisc on`
 
@@ -36,14 +36,14 @@ For the list of devices shown here, you would configure {beatname_uc}
 to use device `4`:
 
 ["source","sh",subs="attributes"]
-----------------------------------------------------------------------
-PS C:\Program Files\{beatname_uc} .{backslash}{beatname_lc}.exe -devices
+----
+PS C:\Program Files{backslash}{beatname_uc} .{backslash}{beatname_lc}.exe -devices
 0: \Device\NPF_NdisWanBh (NdisWan Adapter)
 1: \Device\NPF_NdisWanIp (NdisWan Adapter)
 2: \Device\NPF_NdisWanIpv6 (NdisWan Adapter)
 3: \Device\NPF_{DD72B02C-4E48-4924-8D0F-F80EA2755534} (Intel(R) PRO/1000 MT Desktop Adapter)
 4: \Device\NPF_{77DFFCAF-1335-4B0D-AFD4-5A4685674FAA} (MS NDIS 6.0 LoopBack Driver)
-----------------------------------------------------------------------
+----
 
 [[packetbeat-missing-transactions]]
 === {beatname_uc} is missing long running transactions

--- a/winlogbeat/docs/modules.asciidoc
+++ b/winlogbeat/docs/modules.asciidoc
@@ -49,9 +49,5 @@ winlogbeat.event_logs:
 
 [float]
 === Modules
-//pass macro block used here to remove Edit links from modules documentation because it is generated
-pass::[<?edit_url?>]
+
 include::modules_list.asciidoc[]
-
-
-


### PR DESCRIPTION
This should be the final round of fixes on master.

MUST BE MERGED ALONG WITH elastic/docs#1178

These fixes need to be backported all the way back to 6.3.

Has been backported to:

- [x] 7.4 - https://github.com/elastic/beats/pull/13754
- [x] 7.3 - https://github.com/elastic/beats/pull/13759
- [x] 7.2 - https://github.com/elastic/beats/pull/13760
- [ ] 7.1
- [ ] 7.0
- [ ] 6.8
- [ ] 6.7
- [ ] 6.6
- [ ] 6.5
- [ ] 6.4
- [ ] 6.3