### PR TITLE
Cherry-pick #13715 to 7.4: [Filebeat] Document parallel processing for s3 input

### DIFF
--- a/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
@@ -75,6 +75,28 @@ create a notification through SQS. Please see
 https://docs.aws.amazon.com/AmazonS3/latest/dev/ways-to-add-notification-config-to-bucket.html#step1-create-sqs-queue-for-notification[create-sqs-queue-for-notification]
 for more details.
 
+[float]
+=== Parallel Processing
+Multiple Filebeat instances can read from the same SQS queues at the same time.
+To horizontally scale processing when there are large amounts of log data
+flowing into an S3 bucket, you can run multiple {beatname_uc} instances that
+read from the same SQS queues at the same time. No additional configuration is
+required.
+
+Using SQS ensures that each message in the queue is processed only once
+even when multiple {beatname_uc} instances are running in parallel. To prevent
+{beatname_uc} from receiving and processing the message more than once, set the
+visibility timeout.
+
+The visibility timeout begins when SQS returns a message to Filebeat.
+During this time, Filebeat processes and deletes the message. However, if
+Filebeat fails before deleting the message and your system doesn't call the
+DeleteMessage action for that message before the visibility timeout expires, the
+message becomes visible to other {beatname_uc} instances, and the message is
+received again. By default, the visibility timeout is set to 5 minutes for s3
+input in {beatname_uc}. 5 minutes is sufficient time for {beatname_uc} to read
+SQS messages and process related s3 log files.
+
 [id="{beatname_lc}-input-{type}-common-options"]
 include::../../../../filebeat/docs/inputs/input-common-options.asciidoc[]
 

--- a/x-pack/filebeat/input/s3/_meta/s3-input.asciidoc
+++ b/x-pack/filebeat/input/s3/_meta/s3-input.asciidoc
@@ -9,6 +9,7 @@ for more details.
 bucket and check if SQS gets a message showing that a new object is created with
 its name.
 
+[float]
 === Manual Testing
 1. Upload fake log files into the S3 bucket that has SQS notification enabled.
 2. Check from SQS if there are N messages received.
@@ -20,6 +21,7 @@ from all log files.
 5. Interrupt the s3 input process by killing filebeat during processing new S3 logs,
 check if messages in SQS are in flight instead of deleted.
 
+[float]
 === Run s3_test.go
 Instead of manual testing, `s3_test.go` includes some integration tests that can
 be used for validating s3 input. In order to run `s3_test.go`, an AWS environment
@@ -40,3 +42,21 @@ Some environment variables are needed for testing:
 | S3_BUCKET_NAME | test-s3
 | S3_BUCKET_REGION | us-west-1
 |===
+
+[float]
+=== Parallel Processing Test
+A basic test was done with three Filebeats running in parallel pointing to the same
+SQS queue in AWS. There were 1000 messages available in the queue and each message
+notifies a new S3 log has been generated. These S3 logs are simple .txt files and
+each contains 10 log lines. With three Filebeats, the messages were processed
+evenly without duplicating or missing messages. Test result looks like:
+
+|=======
+| Filebeat #  | Total # of Events | Total # of log files
+| 1 |  3350 |  335
+| 2| 3350 |  335
+| 3| 3300 |  330
+|=======
+
+Please see more details in https://github.com/elastic/beats/issues/13457 regarding
+to the test.


### PR DESCRIPTION
Cherry-pick of PR #13715 to 7.4 branch. Original message: 

I don't think it's needed to document the whole test result here but a small section talking about parallel processing is definitely needed.

closes https://github.com/elastic/beats/issues/13457