### PR TITLE
Increase fidelity of regexp example

### DIFF
--- a/libbeat/docs/processors-using.asciidoc
+++ b/libbeat/docs/processors-using.asciidoc
@@ -301,7 +301,7 @@ For example, the following condition checks if the process name starts with
 [source,yaml]
 -----
 regexp:
-  system.process.name: "foo.*"
+  system.process.name: "^foo.*"
 -----
 
 [float]


### PR DESCRIPTION
If the process name must _start with_ `foo`, the pattern should be prefixed with `^`.