### PR TITLE
x-pack: fix dropped errors

### DIFF
--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -61,3 +61,4 @@ The list below covers the major changes between 7.0.0-rc2 and master only.
 - Compare event by event in `testadata` framework to avoid sorting problems {pull}13747[13747]
 - Added a `default_field` option to fields in fields.yml to offer a way to exclude fields from the default_field list. {issue}14262[14262] {pull}14341[14341]
 - `supported-versions.yml` can be used in metricbeat python system tests to obtain the build args for docker compose builds. {pull}14520[14520]
+- Fix dropped errors in the tests for the metricbeat Azure module. {pull}13773[13773]

--- a/x-pack/metricbeat/module/azure/compute_vm/compute_vm_test.go
+++ b/x-pack/metricbeat/module/azure/compute_vm/compute_vm_test.go
@@ -63,6 +63,9 @@ func TestFetch(t *testing.T) {
 		t.Fatal(err)
 	}
 	module, metricsets, err = mb.NewModule(c, mb.Registry)
+	if err != nil {
+		t.Fatal(err)
+	}
 	assert.NotNil(t, module)
 	assert.NotNil(t, metricsets)
 	ms, ok = metricsets[0].(*MetricSet)

--- a/x-pack/metricbeat/module/azure/compute_vm_scaleset/compute_vm_scaleset_test.go
+++ b/x-pack/metricbeat/module/azure/compute_vm_scaleset/compute_vm_scaleset_test.go
@@ -62,6 +62,9 @@ func TestFetch(t *testing.T) {
 		t.Fatal(err)
 	}
 	module, metricsets, err = mb.NewModule(c, mb.Registry)
+	if err != nil {
+		t.Fatal(err)
+	}
 	assert.NotNil(t, module)
 	assert.NotNil(t, metricsets)
 	ms, ok = metricsets[0].(*MetricSet)

--- a/x-pack/metricbeat/module/azure/monitor/monitor_test.go
+++ b/x-pack/metricbeat/module/azure/monitor/monitor_test.go
@@ -60,6 +60,9 @@ func TestFetch(t *testing.T) {
 		t.Fatal(err)
 	}
 	module, metricsets, err = mb.NewModule(c, mb.Registry)
+	if err != nil {
+		t.Fatal(err)
+	}
 	assert.NotNil(t, module)
 	assert.NotNil(t, metricsets)
 	ms, ok := metricsets[0].(*MetricSet)


### PR DESCRIPTION
This PR fixes some dropped errors in tests under the `x-pack` hierarchy.