### PR TITLE
filebeat: fix dropped errors

### DIFF
--- a/filebeat/autodiscover/builder/hints/logs_test.go
+++ b/filebeat/autodiscover/builder/hints/logs_test.go
@@ -622,6 +622,9 @@ func TestGenerateHints(t *testing.T) {
 		err := paths.InitPaths(&paths.Path{
 			Home: abs,
 		})
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		l, err := NewLogHints(test.config)
 		if err != nil {
@@ -854,6 +857,9 @@ func TestGenerateHintsWithPaths(t *testing.T) {
 		err := paths.InitPaths(&paths.Path{
 			Home: abs,
 		})
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		l, err := NewLogHints(cfg)
 		if err != nil {

--- a/filebeat/generator/fields/fields.go
+++ b/filebeat/generator/fields/fields.go
@@ -385,5 +385,5 @@ func (p *pipeline) toFieldsYml(noDoc bool) ([]byte, error) {
 	var d []byte
 	d, err = yaml.Marshal(&f)
 
-	return d, nil
+	return d, err
 }

--- a/filebeat/input/file/file_test.go
+++ b/filebeat/input/file/file_test.go
@@ -34,9 +34,11 @@ func TestIsSameFile(t *testing.T) {
 	assert.Nil(t, err)
 
 	fileInfo1, err := os.Stat(absPath + "/logs/test.log")
-	fileInfo2, err := os.Stat(absPath + "/logs/system.log")
-
 	assert.Nil(t, err)
+
+	fileInfo2, err := os.Stat(absPath + "/logs/system.log")
+	assert.Nil(t, err)
+
 	assert.NotNil(t, fileInfo1)
 	assert.NotNil(t, fileInfo2)
 


### PR DESCRIPTION
This PR fixes dropped errors within the `filebeat` hierarchy.