### PR TITLE
[7.4][DOCS] Backport: Example functionbeat.yml is wrong and misleading (#12620)

### DIFF
--- a/x-pack/functionbeat/docs/getting-started.asciidoc
+++ b/x-pack/functionbeat/docs/getting-started.asciidoc
@@ -106,9 +106,8 @@ events from CloudWatch Logs and forwards the events to {es}.
     description: "lambda function for cloudwatch logs"
     triggers:
       - log_group_name: /aws/lambda/my-lambda-function
-output.elasticsearch:
-  cloud.id: "MyESDeployment:SomeLongString=="
-  cloud.auth: "elastic:SomeLongString"
+cloud.id: "MyESDeployment:SomeLongString=="
+cloud.auth: "elastic:SomeLongString"
 -------------------------------------------------------------------------------------
 
 To configure {beatname_uc}:


### PR DESCRIPTION
Backports https://github.com/elastic/beats/pull/12620 to 7.4 branch.