### PR TITLE
[Metricbeat] Ignore prometheus untyped metrics with NaN/Inf

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -180,7 +180,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - The `elasticsearch/index_summary` metricset gracefully handles an empty Elasticsearch cluster when `xpack.enabled: true` is set. {pull}12489[12489] {issue}12487[12487]
 - When TLS is configured for the http metricset and a `certificate_authorities` is configured we now default to `required` for the `client_authentication`. {pull}12584[12584]
 - Reuse connections in PostgreSQL metricsets. {issue}12504[12504] {pull}12603[12603]
-- PdhExpandWildCardPathW will not expand counter paths in 32 bit windows systems, workaround will use a different function.{issue}12590[12590]{pull}12622[12622]
+- PdhExpandWildCardPathW will not expand counter paths in 32 bit windows systems, workaround will use a different function. {issue}12590[12590] {pull}12622[12622]
 - In the elasticsearch/node_stats metricset, if xpack is enabled, make parsing of ES node load average optional as ES on Windows doesn't report load average. {pull}12866[12866]
 - Ramdisk is not filtered out when collecting disk performance counters in diskio metricset {issue}12814[12814] {pull}12829[12829]
 - Fix incoherent behaviour in redis key metricset when keyspace is specified both in host URL and key pattern {pull}12913[12913]
@@ -196,6 +196,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix reporting empty events in cloudwatch metricset. {pull}13458[13458]
 - Fix `docker.cpu.system.pct` calculation by using the reported number online cpus instead of the number of metrics per cpu. {pull}13691[13691]
 - Fix rds metricset dashboard. {pull}13721[13721]
+- Ignore prometheus untyped metrics with NaN value. {issue}13750[13750] {pull}13790[13790]
 
 *Packetbeat*
 

--- a/metricbeat/helper/prometheus/metric.go
+++ b/metricbeat/helper/prometheus/metric.go
@@ -195,6 +195,13 @@ func (m *commonMetric) GetValue(metric *dto.Metric) interface{} {
 		return value
 	}
 
+	untyped := metric.GetUntyped()
+	if untyped != nil {
+		if !math.IsNaN(untyped.GetValue()) && !math.IsInf(untyped.GetValue(), 0) {
+			return untyped.GetValue()
+		}
+	}
+
 	// Other types are not supported here
 	return nil
 }

--- a/metricbeat/helper/prometheus/metric.go
+++ b/metricbeat/helper/prometheus/metric.go
@@ -195,13 +195,6 @@ func (m *commonMetric) GetValue(metric *dto.Metric) interface{} {
 		return value
 	}
 
-	untyped := metric.GetUntyped()
-	if untyped != nil {
-		if !math.IsNaN(untyped.GetValue()) && !math.IsInf(untyped.GetValue(), 0) {
-			return untyped.GetValue()
-		}
-	}
-
 	// Other types are not supported here
 	return nil
 }

--- a/metricbeat/module/prometheus/collector/_meta/testdata/docs.plain-expected.json
+++ b/metricbeat/module/prometheus/collector/_meta/testdata/docs.plain-expected.json
@@ -11,7 +11,7 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:51049",
+                "instance": "127.0.0.1:58011",
                 "listener_name": "http"
             },
             "metrics": {

--- a/metricbeat/module/prometheus/collector/_meta/testdata/etcd-3.3.10-partial.plain-expected.json
+++ b/metricbeat/module/prometheus/collector/_meta/testdata/etcd-3.3.10-partial.plain-expected.json
@@ -11,7 +11,31 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:51051",
+                "instance": "127.0.0.1:58013",
+                "server_version": "3.3.10"
+            },
+            "metrics": {
+                "etcd_server_version": 1
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "prometheus"
+        }
+    },
+    {
+        "event": {
+            "dataset": "prometheus.collector",
+            "duration": 115000,
+            "module": "prometheus"
+        },
+        "metricset": {
+            "name": "collector",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:58013",
                 "server_id": "8e9e05c52164694d"
             },
             "metrics": {
@@ -36,7 +60,7 @@
         "prometheus": {
             "labels": {
                 "action": "create",
-                "instance": "127.0.0.1:51051"
+                "instance": "127.0.0.1:58013"
             },
             "metrics": {
                 "etcd_debugging_store_writes_total": 1
@@ -59,35 +83,11 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:51051",
-                "server_version": "3.3.10"
+                "action": "getRecursive",
+                "instance": "127.0.0.1:58013"
             },
             "metrics": {
-                "etcd_server_version": 1
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "prometheus"
-        }
-    },
-    {
-        "event": {
-            "dataset": "prometheus.collector",
-            "duration": 115000,
-            "module": "prometheus"
-        },
-        "metricset": {
-            "name": "collector",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:51051",
-                "server_go_version": "go1.10.4"
-            },
-            "metrics": {
-                "etcd_server_go_version": 1
+                "etcd_debugging_store_reads_total": 1
             }
         },
         "service": {
@@ -108,7 +108,7 @@
         "prometheus": {
             "labels": {
                 "action": "set",
-                "instance": "127.0.0.1:51051"
+                "instance": "127.0.0.1:58013"
             },
             "metrics": {
                 "etcd_debugging_store_writes_total": 2
@@ -131,7 +131,7 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:51051",
+                "instance": "127.0.0.1:58013",
                 "version": "go1.10.4"
             },
             "metrics": {
@@ -155,7 +155,7 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:51051"
+                "instance": "127.0.0.1:58013"
             },
             "metrics": {
                 "etcd_debugging_mvcc_db_compaction_keys_total": 0,
@@ -242,11 +242,11 @@
         },
         "prometheus": {
             "labels": {
-                "action": "getRecursive",
-                "instance": "127.0.0.1:51051"
+                "instance": "127.0.0.1:58013",
+                "server_go_version": "go1.10.4"
             },
             "metrics": {
-                "etcd_debugging_store_reads_total": 1
+                "etcd_server_go_version": 1
             }
         },
         "service": {

--- a/metricbeat/module/prometheus/collector/_meta/testdata/metrics-with-naninf.plain
+++ b/metricbeat/module/prometheus/collector/_meta/testdata/metrics-with-naninf.plain
@@ -30,3 +30,9 @@ http_request_duration_seconds_bucket{le="5"} 3
 http_request_duration_seconds_bucket{le="+Inf"} 3
 http_request_duration_seconds_sum 6
 http_request_duration_seconds_count 3
+# HELP net_conntrack_listener_conn_accepted_total Total number of connections opened to the listener of a given name.
+# TYPE net_conntrack_listener_conn_accepted_total untyped
+net_conntrack_listener_conn_accepted_total{listener_name="http"} 1568652315554
+# HELP net_conntrack_listener_conn_closed_total Total number of connections closed that were made to the listener of a given name.
+# TYPE net_conntrack_listener_conn_closed_total untyped
+net_conntrack_listener_conn_closed_total{listener_name="http"} NaN

--- a/metricbeat/module/prometheus/collector/_meta/testdata/metrics-with-naninf.plain-expected.json
+++ b/metricbeat/module/prometheus/collector/_meta/testdata/metrics-with-naninf.plain-expected.json
@@ -11,79 +11,7 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:51053",
-                "le": "1"
-            },
-            "metrics": {
-                "http_request_duration_seconds_bucket": 1
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "prometheus"
-        }
-    },
-    {
-        "event": {
-            "dataset": "prometheus.collector",
-            "duration": 115000,
-            "module": "prometheus"
-        },
-        "metricset": {
-            "name": "collector",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:51053",
-                "quantile": "1"
-            },
-            "metrics": {
-                "go_gc_duration_seconds": 0.011689149
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "prometheus"
-        }
-    },
-    {
-        "event": {
-            "dataset": "prometheus.collector",
-            "duration": 115000,
-            "module": "prometheus"
-        },
-        "metricset": {
-            "name": "collector",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:51053",
-                "le": "+Inf"
-            },
-            "metrics": {
-                "http_request_duration_seconds_bucket": 3
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "prometheus"
-        }
-    },
-    {
-        "event": {
-            "dataset": "prometheus.collector",
-            "duration": 115000,
-            "module": "prometheus"
-        },
-        "metricset": {
-            "name": "collector",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:51053",
+                "instance": "127.0.0.1:58015",
                 "le": "2"
             },
             "metrics": {
@@ -107,8 +35,8 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:51053",
-                "le": "5"
+                "instance": "127.0.0.1:58015",
+                "le": "3"
             },
             "metrics": {
                 "http_request_duration_seconds_bucket": 3
@@ -131,7 +59,31 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:51053",
+                "instance": "127.0.0.1:58015",
+                "quantile": "1"
+            },
+            "metrics": {
+                "go_gc_duration_seconds": 0.011689149
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "prometheus"
+        }
+    },
+    {
+        "event": {
+            "dataset": "prometheus.collector",
+            "duration": 115000,
+            "module": "prometheus"
+        },
+        "metricset": {
+            "name": "collector",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:58015",
                 "method": "GET"
             },
             "metrics": {
@@ -155,11 +107,11 @@
         },
         "prometheus": {
             "labels": {
-                "client_id": "consumer4",
-                "instance": "127.0.0.1:51053"
+                "instance": "127.0.0.1:58015",
+                "le": "1"
             },
             "metrics": {
-                "kafka_consumer_records_lag_records": 5
+                "http_request_duration_seconds_bucket": 1
             }
         },
         "service": {
@@ -179,7 +131,55 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:51053"
+                "instance": "127.0.0.1:58015",
+                "le": "+Inf"
+            },
+            "metrics": {
+                "http_request_duration_seconds_bucket": 3
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "prometheus"
+        }
+    },
+    {
+        "event": {
+            "dataset": "prometheus.collector",
+            "duration": 115000,
+            "module": "prometheus"
+        },
+        "metricset": {
+            "name": "collector",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:58015",
+                "listener_name": "http"
+            },
+            "metrics": {
+                "net_conntrack_listener_conn_accepted_total": 1568652315554
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "prometheus"
+        }
+    },
+    {
+        "event": {
+            "dataset": "prometheus.collector",
+            "duration": 115000,
+            "module": "prometheus"
+        },
+        "metricset": {
+            "name": "collector",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:58015"
             },
             "metrics": {
                 "go_gc_duration_seconds_count": 13118,
@@ -205,31 +205,8 @@
         },
         "prometheus": {
             "labels": {
-                "listener_name": "http"
-            },
-            "metrics": {
-                "net_conntrack_listener_conn_accepted_total": 1568652315554
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "prometheus"
-        }
-    },
-    {
-        "event": {
-            "dataset": "prometheus.collector",
-            "duration": 115000,
-            "module": "prometheus"
-        },
-        "metricset": {
-            "name": "collector",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:51053",
-                "le": "3"
+                "instance": "127.0.0.1:58015",
+                "le": "5"
             },
             "metrics": {
                 "http_request_duration_seconds_bucket": 3
@@ -252,7 +229,31 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:51053",
+                "client_id": "consumer4",
+                "instance": "127.0.0.1:58015"
+            },
+            "metrics": {
+                "kafka_consumer_records_lag_records": 5
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "prometheus"
+        }
+    },
+    {
+        "event": {
+            "dataset": "prometheus.collector",
+            "duration": 115000,
+            "module": "prometheus"
+        },
+        "metricset": {
+            "name": "collector",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:58015",
                 "quantile": "0.75"
             },
             "metrics": {

--- a/metricbeat/module/prometheus/collector/_meta/testdata/metrics-with-naninf.plain-expected.json
+++ b/metricbeat/module/prometheus/collector/_meta/testdata/metrics-with-naninf.plain-expected.json
@@ -205,6 +205,29 @@
         },
         "prometheus": {
             "labels": {
+                "listener_name": "http"
+            },
+            "metrics": {
+                "net_conntrack_listener_conn_accepted_total": 1568652315554
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "prometheus"
+        }
+    },
+    {
+        "event": {
+            "dataset": "prometheus.collector",
+            "duration": 115000,
+            "module": "prometheus"
+        },
+        "metricset": {
+            "name": "collector",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
                 "instance": "127.0.0.1:51053",
                 "le": "3"
             },

--- a/metricbeat/module/prometheus/collector/_meta/testdata/prometheus-2.6.0-partial.plain-expected.json
+++ b/metricbeat/module/prometheus/collector/_meta/testdata/prometheus-2.6.0-partial.plain-expected.json
@@ -11,79 +11,7 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:51055",
-                "quantile": "0.75"
-            },
-            "metrics": {
-                "go_gc_duration_seconds": 0.004392391
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "prometheus"
-        }
-    },
-    {
-        "event": {
-            "dataset": "prometheus.collector",
-            "duration": 115000,
-            "module": "prometheus"
-        },
-        "metricset": {
-            "name": "collector",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:51055",
-                "version": "go1.11.3"
-            },
-            "metrics": {
-                "go_info": 1
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "prometheus"
-        }
-    },
-    {
-        "event": {
-            "dataset": "prometheus.collector",
-            "duration": 115000,
-            "module": "prometheus"
-        },
-        "metricset": {
-            "name": "collector",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:51055",
-                "quantile": "0.5"
-            },
-            "metrics": {
-                "go_gc_duration_seconds": 0.000060618
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "prometheus"
-        }
-    },
-    {
-        "event": {
-            "dataset": "prometheus.collector",
-            "duration": 115000,
-            "module": "prometheus"
-        },
-        "metricset": {
-            "name": "collector",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:51055",
+                "instance": "127.0.0.1:58017",
                 "quantile": "0.25"
             },
             "metrics": {
@@ -107,56 +35,8 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:51055",
-                "quantile": "1"
-            },
-            "metrics": {
-                "go_gc_duration_seconds": 0.004392391
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "prometheus"
-        }
-    },
-    {
-        "event": {
-            "dataset": "prometheus.collector",
-            "duration": 115000,
-            "module": "prometheus"
-        },
-        "metricset": {
-            "name": "collector",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:51055",
-                "quantile": "0"
-            },
-            "metrics": {
-                "go_gc_duration_seconds": 0.000038386
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "prometheus"
-        }
-    },
-    {
-        "event": {
-            "dataset": "prometheus.collector",
-            "duration": 115000,
-            "module": "prometheus"
-        },
-        "metricset": {
-            "name": "collector",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
                 "dialer_name": "alertmanager",
-                "instance": "127.0.0.1:51055"
+                "instance": "127.0.0.1:58017"
             },
             "metrics": {
                 "net_conntrack_dialer_conn_attempted_total": 0,
@@ -181,8 +61,56 @@
         },
         "prometheus": {
             "labels": {
+                "instance": "127.0.0.1:58017",
+                "quantile": "0.75"
+            },
+            "metrics": {
+                "go_gc_duration_seconds": 0.004392391
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "prometheus"
+        }
+    },
+    {
+        "event": {
+            "dataset": "prometheus.collector",
+            "duration": 115000,
+            "module": "prometheus"
+        },
+        "metricset": {
+            "name": "collector",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:58017",
+                "version": "go1.11.3"
+            },
+            "metrics": {
+                "go_info": 1
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "prometheus"
+        }
+    },
+    {
+        "event": {
+            "dataset": "prometheus.collector",
+            "duration": 115000,
+            "module": "prometheus"
+        },
+        "metricset": {
+            "name": "collector",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
                 "dialer_name": "prometheus",
-                "instance": "127.0.0.1:51055"
+                "instance": "127.0.0.1:58017"
             },
             "metrics": {
                 "net_conntrack_dialer_conn_attempted_total": 1,
@@ -208,7 +136,7 @@
         "prometheus": {
             "labels": {
                 "dialer_name": "default",
-                "instance": "127.0.0.1:51055"
+                "instance": "127.0.0.1:58017"
             },
             "metrics": {
                 "net_conntrack_dialer_conn_attempted_total": 0,
@@ -233,7 +161,104 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:51055"
+                "instance": "127.0.0.1:58017",
+                "quantile": "0"
+            },
+            "metrics": {
+                "go_gc_duration_seconds": 0.000038386
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "prometheus"
+        }
+    },
+    {
+        "event": {
+            "dataset": "prometheus.collector",
+            "duration": 115000,
+            "module": "prometheus"
+        },
+        "metricset": {
+            "name": "collector",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:58017",
+                "listener_name": "http"
+            },
+            "metrics": {
+                "net_conntrack_listener_conn_accepted_total": 3,
+                "net_conntrack_listener_conn_closed_total": 0
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "prometheus"
+        }
+    },
+    {
+        "event": {
+            "dataset": "prometheus.collector",
+            "duration": 115000,
+            "module": "prometheus"
+        },
+        "metricset": {
+            "name": "collector",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:58017",
+                "quantile": "0.5"
+            },
+            "metrics": {
+                "go_gc_duration_seconds": 0.000060618
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "prometheus"
+        }
+    },
+    {
+        "event": {
+            "dataset": "prometheus.collector",
+            "duration": 115000,
+            "module": "prometheus"
+        },
+        "metricset": {
+            "name": "collector",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:58017",
+                "quantile": "1"
+            },
+            "metrics": {
+                "go_gc_duration_seconds": 0.004392391
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "prometheus"
+        }
+    },
+    {
+        "event": {
+            "dataset": "prometheus.collector",
+            "duration": 115000,
+            "module": "prometheus"
+        },
+        "metricset": {
+            "name": "collector",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:58017"
             },
             "metrics": {
                 "go_gc_duration_seconds_count": 4,
@@ -272,31 +297,6 @@
                 "process_virtual_memory_bytes": 150646784,
                 "process_virtual_memory_max_bytes": -1,
                 "prometheus_api_remote_read_queries": 0
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "prometheus"
-        }
-    },
-    {
-        "event": {
-            "dataset": "prometheus.collector",
-            "duration": 115000,
-            "module": "prometheus"
-        },
-        "metricset": {
-            "name": "collector",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:51055",
-                "listener_name": "http"
-            },
-            "metrics": {
-                "net_conntrack_listener_conn_accepted_total": 3,
-                "net_conntrack_listener_conn_closed_total": 0
             }
         },
         "service": {

--- a/metricbeat/module/prometheus/collector/data.go
+++ b/metricbeat/module/prometheus/collector/data.go
@@ -136,12 +136,14 @@ func getPromEventsFromMetricFamily(mf *dto.MetricFamily) []PromEvent {
 
 		untyped := metric.GetUntyped()
 		if untyped != nil {
-			events = append(events, PromEvent{
-				data: common.MapStr{
-					name: untyped.GetValue(),
-				},
-				labels: labels,
-			})
+			if !math.IsNaN(untyped.GetValue()) && !math.IsInf(untyped.GetValue(), 0) {
+				events = append(events, PromEvent{
+					data: common.MapStr{
+						name: untyped.GetValue(),
+					},
+					labels: labels,
+				})
+			}
 		}
 	}
 	return events


### PR DESCRIPTION
If a metric with `untyped` type has NaN as value, metricbeat reports error `unsupported float value: NaN`. 

This is missed from https://github.com/elastic/beats/pull/12084 and also came up in Discuss Forum tickets.

closes https://github.com/elastic/beats/issues/13750 