### PR TITLE
[DOCS] Change intro to avoid mentioning number of sniffer types

### DIFF
--- a/packetbeat/docs/packetbeat-options.asciidoc
+++ b/packetbeat/docs/packetbeat-options.asciidoc
@@ -135,7 +135,7 @@ packetbeat.interfaces.snaplen: 1514
 [float]
 ==== `type`
 
-Packetbeat supports two sniffer types:
+Packetbeat supports these sniffer types:
 
  * `pcap`, which uses the libpcap library and works on most platforms, but
    it's not the fastest option.


### PR DESCRIPTION
Avoid mentioning the number of items in the list of sniffer types (people forget to update intros like this, so it's better not to list a specific number).