### PR TITLE
Fix _source query in integration test.

### DIFF
--- a/libbeat/outputs/elasticsearch/api_integration_test.go
+++ b/libbeat/outputs/elasticsearch/api_integration_test.go
@@ -46,7 +46,7 @@ func TestIndex(t *testing.T) {
 	params := map[string]string{
 		"refresh": "true",
 	}
-	_, resp, err := client.Index(index, "", "1", params, body)
+	_, resp, err := client.Index(index, "test", "1", params, body)
 	if err != nil {
 		t.Fatalf("Index() returns error: %s", err)
 	}
@@ -138,7 +138,7 @@ func TestIngest(t *testing.T) {
 	}
 
 	params := map[string]string{"refresh": "true"}
-	_, resp, err = client.Ingest(index, "", pipeline, "1", params, obj{
+	_, resp, err = client.Ingest(index, "test", pipeline, "1", params, obj{
 		"testfield": "TEST",
 	})
 	if err != nil {
@@ -149,7 +149,7 @@ func TestIngest(t *testing.T) {
 	}
 
 	// get _source field from indexed document
-	_, docBody, err := client.apiCall("GET", index, "", "1/_source", "", nil, nil)
+	_, docBody, err := client.apiCall("GET", index, "", "_source/1", "", nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libbeat/outputs/elasticsearch/api_integration_test.go
+++ b/libbeat/outputs/elasticsearch/api_integration_test.go
@@ -46,7 +46,7 @@ func TestIndex(t *testing.T) {
 	params := map[string]string{
 		"refresh": "true",
 	}
-	_, resp, err := client.Index(index, "test", "1", params, body)
+	_, resp, err := client.Index(index, "", "1", params, body)
 	if err != nil {
 		t.Fatalf("Index() returns error: %s", err)
 	}

--- a/libbeat/outputs/elasticsearch/api_integration_test.go
+++ b/libbeat/outputs/elasticsearch/api_integration_test.go
@@ -138,7 +138,7 @@ func TestIngest(t *testing.T) {
 	}
 
 	params := map[string]string{"refresh": "true"}
-	_, resp, err = client.Ingest(index, "test", pipeline, "1", params, obj{
+	_, resp, err = client.Ingest(index, "", pipeline, "1", params, obj{
 		"testfield": "TEST",
 	})
 	if err != nil {
@@ -149,7 +149,7 @@ func TestIngest(t *testing.T) {
 	}
 
 	// get _source field from indexed document
-	_, docBody, err := client.apiCall("GET", index, "test", "1/_source", "", nil, nil)
+	_, docBody, err := client.apiCall("GET", index, "", "1/_source", "", nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Source queries must be typeless most recently. Update query to `<index>/_source/<id>` in integration test.