### PR TITLE
[Filebeat] Fix bugs in Netflow input

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -148,6 +148,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Change iis url path grok pattern from URIPATH to NOTSPACE. {issue}12710[12710] {pull}13225[13225] {issue}7951[7951] {pull}13378[13378]
 - Fix timezone parsing of nginx module ingest pipelines. {pull}13369[13369]
 - Fix incorrect field references in envoyproxy dashboard {issue}13420[13420] {pull}13421[13421]
+- Fixed early expiration of templates (Netflow v9 and IPFIX). {pull}13821[13821]
+- Fixed bad handling of sequence numbers when multiple observation domains were exported by a single device (Netflow V9 and IPFIX). {pull}13821[13821]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/input/netflow/decoder/ipfix/ipfix_test.go
+++ b/x-pack/filebeat/input/netflow/decoder/ipfix/ipfix_test.go
@@ -81,7 +81,7 @@ func TestMessageWithOptions(t *testing.T) {
 
 func TestOptionTemplates(t *testing.T) {
 	addr := test.MakeAddress(t, "127.0.0.1:12345")
-	key := v9.MakeSessionKey(addr)
+	key := v9.MakeSessionKey(addr, 1234)
 
 	t.Run("Single options template", func(t *testing.T) {
 		proto := New(config.Defaults())
@@ -107,7 +107,7 @@ func TestOptionTemplates(t *testing.T) {
 		s, found := v9proto.Session.Sessions[key]
 		assert.True(t, found)
 		assert.Len(t, s.Templates, 1)
-		opt := s.GetTemplate(1234, 999)
+		opt := s.GetTemplate(999)
 		assert.NotNil(t, opt)
 		assert.Equal(t, 1, opt.ScopeFields)
 	})
@@ -144,7 +144,7 @@ func TestOptionTemplates(t *testing.T) {
 		assert.True(t, found)
 		assert.Len(t, s.Templates, 2)
 		for _, id := range []uint16{998, 999} {
-			opt := s.GetTemplate(1234, id)
+			opt := s.GetTemplate(id)
 			assert.NotNil(t, opt)
 			assert.True(t, opt.ScopeFields > 0)
 		}

--- a/x-pack/filebeat/input/netflow/decoder/v9/session.go
+++ b/x-pack/filebeat/input/netflow/decoder/v9/session.go
@@ -168,7 +168,6 @@ func (m *SessionMap) CleanupLoop(interval time.Duration, done <-chan struct{}) {
 
 		case <-t.C:
 			aliveS, removedS, aliveT, removedT := m.cleanup()
-			m.cleanup()
 			if removedS > 0 || removedT > 0 {
 				m.logger.Printf("Expired %d sessions (%d remain) / %d templates (%d remain)", removedS, aliveS, removedT, aliveT)
 			}

--- a/x-pack/filebeat/input/netflow/decoder/v9/v9_test.go
+++ b/x-pack/filebeat/input/netflow/decoder/v9/v9_test.go
@@ -5,6 +5,7 @@
 package v9
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -27,8 +28,9 @@ func TestNetflowProtocol_New(t *testing.T) {
 }
 
 func TestOptionTemplates(t *testing.T) {
+	const sourceID = 1234
 	addr := test.MakeAddress(t, "127.0.0.1:12345")
-	key := MakeSessionKey(addr)
+	key := MakeSessionKey(addr, sourceID)
 
 	t.Run("Single options template", func(t *testing.T) {
 		proto := New(config.Defaults())
@@ -54,7 +56,7 @@ func TestOptionTemplates(t *testing.T) {
 		s, found := v9proto.Session.Sessions[key]
 		assert.True(t, found)
 		assert.Len(t, s.Templates, 1)
-		opt := s.GetTemplate(1234, 999)
+		opt := s.GetTemplate(999)
 		assert.NotNil(t, opt)
 		assert.True(t, opt.ScopeFields > 0)
 	})
@@ -90,7 +92,7 @@ func TestOptionTemplates(t *testing.T) {
 		assert.True(t, found)
 		assert.Len(t, s.Templates, 2)
 		for _, id := range []uint16{998, 999} {
-			opt := s.GetTemplate(1234, id)
+			opt := s.GetTemplate(id)
 			assert.NotNil(t, opt)
 			assert.True(t, opt.ScopeFields > 0)
 		}
@@ -179,6 +181,32 @@ func TestSessionReset(t *testing.T) {
 		flows, err = proto.OnPacket(test.MakePacket(flowsPacket), addr)
 		assert.NoError(t, err)
 		assert.Empty(t, flows)
+	})
+	t.Run("No cross-domain reset", func(t *testing.T) {
+		mkPack := func(source []uint16, sourceID, seqNo uint32) *bytes.Buffer {
+			tmp := make([]uint16, len(source))
+			copy(tmp, source)
+			tmp[6] = uint16(seqNo >> 16)
+			tmp[7] = uint16(seqNo & 0xffff)
+			tmp[8] = uint16(sourceID >> 16)
+			tmp[9] = uint16(sourceID & 0xffff)
+			return test.MakePacket(tmp)
+		}
+		cfg := config.Defaults()
+		cfg.WithSequenceResetEnabled(true).WithLogOutput(test.TestLogWriter{TB: t})
+		proto := New(cfg)
+		flows, err := proto.OnPacket(mkPack(templatePacket, 1, 1000), addr)
+		assert.NoError(t, err)
+		assert.Empty(t, flows)
+		flows, err = proto.OnPacket(mkPack(templatePacket, 2, 500), addr)
+		assert.NoError(t, err)
+		assert.Empty(t, flows)
+		flows, err = proto.OnPacket(mkPack(flowsPacket, 1, 1001), addr)
+		assert.NoError(t, err)
+		assert.Len(t, flows, 1)
+		flows, err = proto.OnPacket(mkPack(flowsPacket, 2, 501), addr)
+		assert.NoError(t, err)
+		assert.Len(t, flows, 1)
 	})
 }
 

--- a/x-pack/filebeat/input/netflow/input.go
+++ b/x-pack/filebeat/input/netflow/input.go
@@ -63,6 +63,23 @@ func init() {
 	}
 }
 
+// An adapter so that logp.Logger can be used as a log.Logger.
+type logDebugWrapper struct {
+	Logger *logp.Logger
+	buf    []byte
+}
+
+// Write writes messages to the log.
+func (w *logDebugWrapper) Write(p []byte) (n int, err error) {
+	n = len(p)
+	w.buf = append(w.buf, p...)
+	for endl := bytes.IndexByte(w.buf, '\n'); endl != -1; endl = bytes.IndexByte(w.buf, '\n') {
+		w.Logger.Debug(string(w.buf[:endl]))
+		w.buf = w.buf[endl+1:]
+	}
+	return n, nil
+}
+
 // NewInput creates a new Netflow input
 func NewInput(
 	cfg *common.Config,
@@ -99,6 +116,7 @@ func NewInput(
 	decoder, err := decoder.NewDecoder(decoder.NewConfig().
 		WithProtocols(config.Protocols...).
 		WithExpiration(config.ExpirationTimeout).
+		WithLogOutput(&logDebugWrapper{Logger: logger}).
 		WithCustomFields(customFields...))
 	if err != nil {
 		return nil, errors.Wrapf(err, "error initializing netflow decoder")


### PR DESCRIPTION
This PR fixes a couple bugs in the Netflow input causing flow loss in Netflow V9 and IPFIX:
- Bad expiration of templates caused all templates to be removed after each expiration_timeout elapsed.
- Incorrect handling of sequence numbers caused all templates to be removed if a device exported packets from different Observation Domains.

It's easier to review by looking at the individual commits.