### PR TITLE
Support usage of custom builders without hints and mappers

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -116,6 +116,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Kubernetes watcher at `add_kubernetes_metadata` fails with StatefulSets {pull}13905[13905]
 - Fix panics that could result from invalid TLS certificates. This can affect Beats that connect over
   TLS or Beats that accept connections over TLS and validate client certificates. {pull}14146[14146]
+- Support usage of custom builders without hints and mappers {pull}13839[13839]
 
 *Auditbeat*
 

--- a/libbeat/autodiscover/providers/kubernetes/config.go
+++ b/libbeat/autodiscover/providers/kubernetes/config.go
@@ -20,6 +20,7 @@
 package kubernetes
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/elastic/beats/libbeat/autodiscover/template"
@@ -50,9 +51,15 @@ func defaultConfig() *Config {
 }
 
 // Validate ensures correctness of config
-func (c *Config) Validate() {
+func (c *Config) Validate() error {
 	// Make sure that prefix doesn't ends with a '.'
 	if c.Prefix[len(c.Prefix)-1] == '.' && c.Prefix != "." {
 		c.Prefix = c.Prefix[:len(c.Prefix)-2]
 	}
+
+	if len(c.Templates) == 0 && !c.Hints.Enabled() && len(c.Builders) == 0 {
+		return fmt.Errorf("no configs or hints defined for autodiscover provider")
+	}
+
+	return nil
 }

--- a/libbeat/autodiscover/providers/kubernetes/config_test.go
+++ b/libbeat/autodiscover/providers/kubernetes/config_test.go
@@ -1,0 +1,65 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/libbeat/autodiscover"
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/bus"
+)
+
+func TestConfigWithCustomBuilders(t *testing.T) {
+	autodiscover.Registry.AddBuilder("mock", newMockBuilder)
+
+	cfg := common.MapStr{
+		"hints.enabled": false,
+		"builders": []common.MapStr{
+			{
+				"mock": common.MapStr{},
+			},
+		},
+	}
+
+	config := common.MustNewConfigFrom(&cfg)
+	c := defaultConfig()
+	err := config.Unpack(&c)
+	assert.Nil(t, err)
+
+	cfg1 := common.MapStr{
+		"hints.enabled": false,
+	}
+	config, err = common.NewConfigFrom(&cfg1)
+	c = defaultConfig()
+	err = config.Unpack(&c)
+	assert.NotNil(t, err)
+}
+
+type mockBuilder struct {
+}
+
+func newMockBuilder(_ *common.Config) (autodiscover.Builder, error) {
+	return &mockBuilder{}, nil
+}
+
+func (m *mockBuilder) CreateConfig(event bus.Event) []*common.Config {
+	return nil
+}

--- a/libbeat/autodiscover/providers/kubernetes/kubernetes.go
+++ b/libbeat/autodiscover/providers/kubernetes/kubernetes.go
@@ -96,9 +96,6 @@ func AutodiscoverBuilder(bus bus.Bus, uuid uuid.UUID, c *common.Config) (autodis
 	if err != nil {
 		return nil, errWrap(err)
 	}
-	if len(mapper) == 0 && !config.Hints.Enabled() && len(config.Builders) == 0 {
-		return nil, errWrap(fmt.Errorf("no configs or hints defined for autodiscover provider"))
-	}
 
 	builders, err := autodiscover.NewBuilders(config.Builders, config.Hints)
 	if err != nil {

--- a/libbeat/autodiscover/providers/kubernetes/kubernetes.go
+++ b/libbeat/autodiscover/providers/kubernetes/kubernetes.go
@@ -96,7 +96,7 @@ func AutodiscoverBuilder(bus bus.Bus, uuid uuid.UUID, c *common.Config) (autodis
 	if err != nil {
 		return nil, errWrap(err)
 	}
-	if len(mapper) == 0 && !config.Hints.Enabled() {
+	if len(mapper) == 0 && !config.Hints.Enabled() && len(config.Builders) == 0 {
 		return nil, errWrap(fmt.Errorf("no configs or hints defined for autodiscover provider"))
 	}
 


### PR DESCRIPTION
Currently the code expects for a mapping template or hints to be enabled. There are cases where custom builders can be used which is enough to make autodiscover work. This PR allows that. This used to work but for some reason it is broken now. 