### PR TITLE
Use less restrictive API to check if template exists

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -263,6 +263,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Added `monitoring.cluster_uuid` setting to associate Beat data with specified ES cluster in Stack Monitoring UI. {pull}13182[13182]
 - Add autodetection mode for add_kubernetes_metadata and enable it by default in included configuration files. {pull}13473[13473]
 - Add `providers` setting to `add_cloud_metadata` processor. {pull}13812[13812]
+- Use less restrictive API to check if template exists. {pull}13847[13847]
 
 *Auditbeat*
 

--- a/libbeat/template/load.go
+++ b/libbeat/template/load.go
@@ -23,6 +23,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
@@ -124,11 +125,11 @@ func (l *ESLoader) templateExists(templateName string) bool {
 	if l.client == nil {
 		return false
 	}
-	status, _, _ := l.client.Request("HEAD", "/_template/"+templateName, "", nil, nil)
-	if status != http.StatusOK {
-		return false
+	status, body, _ := l.client.Request("GET", "/_cat/templates/"+templateName, "", nil, nil)
+	if status == http.StatusOK && strings.Contains(string(body), templateName) {
+		return true
 	}
-	return true
+	return false
 }
 
 // Load reads the template from the config, creates the template body and prints it to the configured file.

--- a/libbeat/template/load.go
+++ b/libbeat/template/load.go
@@ -125,11 +125,10 @@ func (l *ESLoader) templateExists(templateName string) bool {
 	if l.client == nil {
 		return false
 	}
+
 	status, body, _ := l.client.Request("GET", "/_cat/templates/"+templateName, "", nil, nil)
-	if status == http.StatusOK && strings.Contains(string(body), templateName) {
-		return true
-	}
-	return false
+
+	return status == http.StatusOK && strings.Contains(string(body), templateName)
 }
 
 // Load reads the template from the config, creates the template body and prints it to the configured file.


### PR DESCRIPTION
Switches from using `HEAD _template/{name}` to `GET _cat/templates/{name}` to check if a template exists before trying to load it.

The significance is that the `_cat/templates` API requires only the `monitor` cluster privilege and not the far more permissive `manage_index_templates`. With this change, the default Beats configuration works without any unnecessary write privileges for publishing. *(Note: The documentation recommended setting `setup.template.enabled` to `false` which turns off the template check completely.)*

This is one of three PRs to reduce the Beats privileges required in code and documentation:
1. Use less restrictive API to check if template exists (this PR)
2. Do not check for alias when setup.ilm.check_exists is false (https://github.com/elastic/beats/pull/13848)
3. Docs: Update writer role with least required privileges (https://github.com/elastic/beats/pull/13849)

Relates: https://github.com/elastic/beats/issues/10241