### PR TITLE
Do not check for alias when setup.ilm.check_exists is false

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -264,6 +264,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add autodetection mode for add_kubernetes_metadata and enable it by default in included configuration files. {pull}13473[13473]
 - Add `providers` setting to `add_cloud_metadata` processor. {pull}13812[13812]
 - Use less restrictive API to check if template exists. {pull}13847[13847]
+- Do not check for alias when setup.ilm.check_exists is false. {pull}13848[13848]
 
 *Auditbeat*
 

--- a/libbeat/idxmgmt/ilm/std.go
+++ b/libbeat/idxmgmt/ilm/std.go
@@ -102,16 +102,20 @@ func (m *stdManager) Enabled() (bool, error) {
 }
 
 func (m *stdManager) EnsureAlias() error {
-	b, err := m.client.HasAlias(m.alias.Name)
-	if err != nil {
-		return err
-	}
-	if b {
+	if !m.checkExists {
 		return nil
-	}
+	} else {
+		b, err := m.client.HasAlias(m.alias.Name)
+		if err != nil {
+			return err
+		}
+		if b {
+			return nil
+		}
 
-	// This always assume it's a date pattern by sourrounding it by <...>
-	return m.client.CreateAlias(m.alias)
+		// This always assume it's a date pattern by sourrounding it by <...>
+		return m.client.CreateAlias(m.alias)
+	}
 }
 
 func (m *stdManager) EnsurePolicy(overwrite bool) (bool, error) {

--- a/libbeat/idxmgmt/ilm/std.go
+++ b/libbeat/idxmgmt/ilm/std.go
@@ -104,18 +104,18 @@ func (m *stdManager) Enabled() (bool, error) {
 func (m *stdManager) EnsureAlias() error {
 	if !m.checkExists {
 		return nil
-	} else {
-		b, err := m.client.HasAlias(m.alias.Name)
-		if err != nil {
-			return err
-		}
-		if b {
-			return nil
-		}
-
-		// This always assume it's a date pattern by sourrounding it by <...>
-		return m.client.CreateAlias(m.alias)
 	}
+
+	b, err := m.client.HasAlias(m.alias.Name)
+	if err != nil {
+		return err
+	}
+	if b {
+		return nil
+	}
+
+	// This always assume it's a date pattern by sourrounding it by <...>
+	return m.client.CreateAlias(m.alias)
 }
 
 func (m *stdManager) EnsurePolicy(overwrite bool) (bool, error) {


### PR DESCRIPTION
Currently, setting `setup.ilm.check_exists` to `false` only turns off checking if the ILM policy exists (`GET _ilm/policy/{name}`).

This would expand that to also turn off checking if an alias exists (`GET _alias/{name}`).

The advantage would be that with `setup.ilm.check_exists` set to `false` the `view_index_metadata` privilege would no longer be required, leaving only the `monitor` cluster privilege and `create` index privileges as the only privileges that are always required to publish data from Beats.

Instead of changing the behavior of `setup.ilm.check_exists` we could also introduce a new configuration option. I like keeping it simple though, so only a single change to the config file is necessary for minimal privileges.

This is one of three PRs to reduce the Beats privileges required in code and documentation:
1. Use less restrictive API to check if template exists (https://github.com/elastic/beats/pull/13847)
2. Do not check for alias when setup.ilm.check_exists is false (this PR)
3. Docs: Update writer role with least required privileges (https://github.com/elastic/beats/pull/13849)

Relates: https://github.com/elastic/beats/issues/10241