### PR TITLE
Docs: Update writer role with least required privileges

### DIFF
--- a/libbeat/docs/security/users.asciidoc
+++ b/libbeat/docs/security/users.asciidoc
@@ -56,7 +56,7 @@ endif::no_ilm[]
 ifdef::has_ml_jobs[]
 |Cluster
 |`manage_ml`
-|Set up machine learning job configurations
+|Set up Machine Learning job configurations
 endif::has_ml_jobs[]
 
 |Index
@@ -66,7 +66,7 @@ endif::has_ml_jobs[]
 ifdef::has_ml_jobs[]
 |Index
 |`read` on +{beat_default_index_prefix}-*+ indices
-|Read {beatname_uc} indices in order to set up machine learning jobs
+|Read {beatname_uc} indices in order to set up Machine Learning jobs
 endif::has_ml_jobs[]
 |====
 +

--- a/libbeat/docs/security/users.asciidoc
+++ b/libbeat/docs/security/users.asciidoc
@@ -214,7 +214,7 @@ To grant the required privileges:
 . Create a *writer role*, called something like +{beat_default_index_prefix}_writer+,
 that has the following privileges:
 +
-NOTE: The `monitor` cluster privilege and the `create` privilege on
+NOTE: The `monitor` cluster privilege and the `create_doc` privilege on
 +{beat_default_index_prefix}-*+ indices are required in every configuration.
 +
 [options="header"]
@@ -241,7 +241,7 @@ ifeval::["{beatname_lc}"=="filebeat"]
 endif::[]
 
 |Index
-|`create` on +{beat_default_index_prefix}-*+ indices
+|`create_doc` on +{beat_default_index_prefix}-*+ indices
 |Write events into {es}
 
 ifndef::no_ilm[]

--- a/libbeat/docs/security/users.asciidoc
+++ b/libbeat/docs/security/users.asciidoc
@@ -190,10 +190,10 @@ indices. To minimize the privileges required by the writer role, you can use the
 <<privileges-to-setup-beats,setup role>> to pre-load dependencies.
 
 ifndef::no_ilm[]
-[source,yaml]
 When using ILM, turn off the ILM setup check in the {beatname_uc} config file before
 running {beatname_uc} to publish events:
 
+[source,yaml]
 ----
 setup.ilm.check_exists: false
 ----
@@ -204,10 +204,10 @@ To grant the required privileges:
 . Create a *writer role*, called something like +{beat_default_index_prefix}_writer+,
 that has the following privileges:
 
++
 NOTE: Only the `monitor` cluster privilege and the `create` index privilege on
 +{beat_default_index_prefix}-*+ indices are required in every configuration.
 
-+
 [options="header"]
 |====
 |Privileges | Why needed?

--- a/libbeat/docs/security/users.asciidoc
+++ b/libbeat/docs/security/users.asciidoc
@@ -41,25 +41,30 @@ the following privileges:
 +
 [options="header"]
 |====
-|Privileges | Why needed?
+|Type | Privilege | Purpose
 
+|Cluster
 |`monitor`
-|Send monitoring data to the cluster
+|Retrieve cluster details (e.g. version)
 
 ifndef::no_ilm[]
+|Cluster
 |`manage_ilm`
 |Set up and manage index lifecycle management (ILM) policy
 endif::no_ilm[]
 
 ifdef::has_ml_jobs[]
+|Cluster
 |`manage_ml`
 |Set up machine learning job configurations
 endif::has_ml_jobs[]
 
+|Index
 |`manage` on +{beat_default_index_prefix}-*+ indices
 |Set up aliases used by ILM
  
 ifdef::has_ml_jobs[]
+|Index
 |`read` on +{beat_default_index_prefix}-*+ indices
 |Read {beatname_uc} indices in order to set up machine learning jobs
 endif::has_ml_jobs[]
@@ -76,7 +81,7 @@ need to set up {beatname_uc}:
 +
 [options="header"]
 |====
-|Roles | Why needed?
+|Role | Purpose
 
 |`kibana_user`
 |Load dependencies, such as example dashboards, if available, into {kib}
@@ -122,21 +127,22 @@ If you don't use the +{beat_default_index_prefix}_system+ user:
 +
 [options="header"]
 |====
-|Privileges | Why needed?
+|Type | Privilege | Purpose
 
+|Cluster
 |`monitor`
-|Send monitoring info
-
-|`kibana_user`
-|Use {kib}
+|Retrieve cluster details (e.g. version)
 |====
 
-. Assign the *monitoring role*, along with the following built-in role, to
+. Assign the *monitoring role*, along with the following built-in roles, to
 users who need to monitor {beatname_uc}: 
 +
 [options="header"]
 |====
-|Role | Why needed?
+|Role | Purpose
+|`kibana_user`
+|Use {kib}
+
 |`monitoring_user`
 |Use *Stack Monitoring* in {kib} to monitor {beatname_uc}
 |====
@@ -164,7 +170,7 @@ information.
 +
 [options="header"]
 |====
-|Role | Why needed?
+|Role | Purpose
 |`remote_monitoring_collector`
 |Collect monitoring metrics from {beatname_uc}
 |`remote_monitoring_agent`
@@ -176,7 +182,7 @@ information.
 
 [options="header"]
 |====
-|Role | Why needed?
+|Role | Purpose
 |`monitoring_user`
 |Use *Stack Monitoring* in {kib} to monitor {beatname_uc}
 |====
@@ -209,40 +215,40 @@ NOTE: The `monitor` cluster privilege and the `create` privilege on
 +
 [options="header"]
 |====
-|Privilege | Type | Purpose
+|Type | Privilege | Purpose
 
 ifndef::apm-server[]
+|Cluster
 |`monitor`
-|cluster
 |Retrieve cluster details (e.g. version) 
 endif::apm-server[]
 
 ifndef::no_ilm[]
+|Cluster
 |`read_ilm`
-|cluster
 | Read the ILM policy when connecting to clusters that support ILM.
 Not needed when `setup.ilm.check_exists` is `false`.
 endif::no_ilm[]
 
 ifeval::["{beatname_lc}"=="filebeat"]
+|Cluster
 |`cluster:admin/ingest/pipeline/get`
-|cluster
 |Check for ingest pipelines used by modules. Needed when using modules.
 endif::[]
 
+|Index
 |`create` on +{beat_default_index_prefix}-*+ indices
-|index
 |Write events into {es}
 
 ifndef::no_ilm[]
+|Index
 |`view_index_metadata` on +{beat_default_index_prefix}-*+ indices
-|index
 |Check for alias when connecting to clusters that support ILM.
 Not needed when `setup.ilm.check_exists` is `false`.
 endif::no_ilm[]
 
+|Index
 |`create_index` on +{beat_default_index_prefix}-*+ indices
-|index
 |Create daily indices when connecting to clusters that do not support ILM.
 Not needed when using ILM.
 |====
@@ -272,7 +278,7 @@ the following privilege:
 +
 [options="header"]
 |====
-|Privilege | Why needed?
+|Type | Privilege | Purpose
 
 |`read` on +{beat_default_index_prefix}-*+ indices
 |Read data indexed by {beatname_uc}
@@ -283,7 +289,7 @@ users who need to read {beatname_uc} data:
 +
 [options="header"]
 |====
-|Roles | Why needed?
+|Role | Purpose
 
 |`kibana_user` or `kibana_dashboard_only_user`
 |Use {kib}. `kibana_dashboard_only_user` grants read-only access to dashboards.
@@ -304,7 +310,7 @@ data:
 +
 [options="header"]
 |====
-|Roles | Why needed?
+|Role | Purpose
 
 |`kibana_user` and `apm_user`
 |Use the APM UI

--- a/libbeat/docs/security/users.asciidoc
+++ b/libbeat/docs/security/users.asciidoc
@@ -209,33 +209,39 @@ NOTE: The `monitor` cluster privilege and the `create` index privilege on
 +
 [options="header"]
 |====
-|Privileges | Why needed?
+|Type | Privilege | Purpose
 
 ifndef::apm-server[]
+|Cluster
 |`monitor`
-|Retrieve cluster details (e.g. version)
+|Retrieve cluster details (e.g. version) 
 endif::apm-server[]
 
 ifndef::no_ilm[]
+|Cluster
 |`read_ilm`
 | Read the ILM policy when connecting to clusters that support ILM.
 Not needed when `setup.ilm.check_exists` is `false`.
 endif::no_ilm[]
 
 ifeval::["{beatname_lc}"=="filebeat"]
+|Cluster
 |`cluster:admin/ingest/pipeline/get`
 |Check for ingest pipelines used by modules. Needed when using modules.
 endif::[]
 
+|Index
 |`create` on +{beat_default_index_prefix}-*+ indices
 |Write events into {es}
 
 ifndef::no_ilm[]
+|Index
 |`view_index_metadata` on +{beat_default_index_prefix}-*+ indices
 |Check for alias when connecting to clusters that support ILM.
 Not needed when `setup.ilm.check_exists` is `false`.
 endif::no_ilm[]
 
+|Index
 |`create_index` on +{beat_default_index_prefix}-*+ indices
 |Create daily indices when connecting to clusters that do not support ILM.
 Not needed when using ILM.

--- a/libbeat/docs/security/users.asciidoc
+++ b/libbeat/docs/security/users.asciidoc
@@ -185,34 +185,28 @@ endif::serverless[]
 [[privileges-to-publish-events]]
 ==== Grant privileges and roles needed for publishing
 
-Users who publish events to {es} need to create and read from {beatname_uc}
+Users who publish events to {es} need to create and write to {beatname_uc}
 indices. To minimize the privileges required by the writer role, you can use the
-<<privileges-to-setup-beats,setup role>> to pre-load dependencies. Then turn off
-setup options in the  {beatname_uc} config file before running {beatname_uc} to
-publish events. For example:
+<<privileges-to-setup-beats,setup role>> to pre-load dependencies.
 
 ifndef::no_ilm[]
 [source,yaml]
-----
-setup.template.enabled: false
-setup.ilm.check_exists: false
-setup.ilm.overwrite: false <1>
-----
-<1> Omit `ilm.check_exists` and `ilm.overwrite` if ILM is disabled.
-endif::no_ilm[]
+When using ILM, turn off the ILM setup check in the {beatname_uc} config file before
+running {beatname_uc} to publish events:
 
-ifdef::no_ilm[]
-[source,yaml]
 ----
-setup.template.enabled: false
+setup.ilm.check_exists: false
 ----
 endif::no_ilm[]
 
 To grant the required privileges:
 
 . Create a *writer role*, called something like +{beat_default_index_prefix}_writer+, that has
-the following privileges (this list assumes the setup options shown earlier are
-set to `false`):
+the following privileges:
+
+NOTE: Only the `monitor` cluster privilege and the `create` index privilege on
++{beat_default_index_prefix}-*+ indices are needed in every configuration.
+
 +
 [options="header"]
 |====
@@ -220,36 +214,39 @@ set to `false`):
 
 ifndef::apm-server[]
 |`monitor`
-|Send monitoring info
+|Retrieve cluster details (e.g. version)
 endif::apm-server[]
 
-ifndef::no_ilm[]
-|`read_ilm`
-|Read the ILM policy when connecting to clusters that support ILM
-endif::no_ilm[]
+|`create` on +{beat_default_index_prefix}-*+ indices
+|Index events into {es}
 
 ifeval::["{beatname_lc}"=="filebeat"]
-|`manage_pipeline`
-|Load ingest pipelines used by modules
+|`cluster:admin/ingest/pipeline/get`
+|Check for ingest pipelines used by modules. Not needed when not using modules.
 endif::[]
 
 ifndef::no_ilm[]
-|`view_index_metadata` on +{beat_default_index_prefix}-*+ indices
-|Check for alias when connecting to clusters that support ILM
+|`read_ilm`
+|(Optional) Read the ILM policy when connecting to clusters that support ILM. Not needed when
+`setup.ilm.check_exists` is `false`.
 endif::no_ilm[]
 
-|`index` on +{beat_default_index_prefix}-*+ indices
-|Index events into {es}
+ifndef::no_ilm[]
+|`view_index_metadata` on +{beat_default_index_prefix}-*+ indices
+|(Optional) Check for alias when connecting to clusters that support ILM. Not needed when
+`setup.ilm.check_exists` is `false`.
+endif::no_ilm[]
 
 |`create_index` on +{beat_default_index_prefix}-*+ indices
-|Create daily indices when connecting to clusters that do not support ILM
+|(Optional) Create daily indices when connecting to clusters that do not support ILM. Not needed when
+using ILM.
 |====
 ifndef::apm-server[]
 +
 Omit any privileges that aren't relevant in your environment.
 endif::apm-server[]
 
-. Assign the *writer role* to users who will index events into {es}. 
+. Assign the *writer role* to users who will index events into {es}.
 
 [[kibana-user-privileges]]
 ==== Grant privileges and roles needed to read {beatname_uc} data

--- a/libbeat/docs/security/users.asciidoc
+++ b/libbeat/docs/security/users.asciidoc
@@ -204,45 +204,45 @@ To grant the required privileges:
 . Create a *writer role*, called something like +{beat_default_index_prefix}_writer+,
 that has the following privileges:
 +
-NOTE: The `monitor` cluster privilege and the `create` index privilege on
+NOTE: The `monitor` cluster privilege and the `create` privilege on
 +{beat_default_index_prefix}-*+ indices are required in every configuration.
 +
 [options="header"]
 |====
-|Type | Privilege | Purpose
+|Privilege | Type | Purpose
 
 ifndef::apm-server[]
-|Cluster
 |`monitor`
+|cluster
 |Retrieve cluster details (e.g. version) 
 endif::apm-server[]
 
 ifndef::no_ilm[]
-|Cluster
 |`read_ilm`
+|cluster
 | Read the ILM policy when connecting to clusters that support ILM.
 Not needed when `setup.ilm.check_exists` is `false`.
 endif::no_ilm[]
 
 ifeval::["{beatname_lc}"=="filebeat"]
-|Cluster
 |`cluster:admin/ingest/pipeline/get`
+|cluster
 |Check for ingest pipelines used by modules. Needed when using modules.
 endif::[]
 
-|Index
 |`create` on +{beat_default_index_prefix}-*+ indices
+|index
 |Write events into {es}
 
 ifndef::no_ilm[]
-|Index
 |`view_index_metadata` on +{beat_default_index_prefix}-*+ indices
+|index
 |Check for alias when connecting to clusters that support ILM.
 Not needed when `setup.ilm.check_exists` is `false`.
 endif::no_ilm[]
 
-|Index
 |`create_index` on +{beat_default_index_prefix}-*+ indices
+|index
 |Create daily indices when connecting to clusters that do not support ILM.
 Not needed when using ILM.
 |====

--- a/libbeat/docs/security/users.asciidoc
+++ b/libbeat/docs/security/users.asciidoc
@@ -203,11 +203,10 @@ To grant the required privileges:
 
 . Create a *writer role*, called something like +{beat_default_index_prefix}_writer+,
 that has the following privileges:
-
 +
 NOTE: Only the `monitor` cluster privilege and the `create` index privilege on
 +{beat_default_index_prefix}-*+ indices are required in every configuration.
-
++
 [options="header"]
 |====
 |Privileges | Why needed?
@@ -217,23 +216,23 @@ ifndef::apm-server[]
 |Retrieve cluster details (e.g. version)
 endif::apm-server[]
 
-|`create` on +{beat_default_index_prefix}-*+ indices
-|Index events into {es}
-
-ifeval::["{beatname_lc}"=="filebeat"]
-|`cluster:admin/ingest/pipeline/get`
-|Check for ingest pipelines used by modules. Not needed when not using modules.
-endif::[]
-
 ifndef::no_ilm[]
 |`read_ilm`
-|(Optional) Read the ILM policy when connecting to clusters that support ILM.
+| Read the ILM policy when connecting to clusters that support ILM.
 Not needed when `setup.ilm.check_exists` is `false`.
 endif::no_ilm[]
 
+ifeval::["{beatname_lc}"=="filebeat"]
+|`cluster:admin/ingest/pipeline/get`
+|Check for ingest pipelines used by modules. Needed when using modules.
+endif::[]
+
+|`create` on +{beat_default_index_prefix}-*+ indices
+|Index events into {es}
+
 ifndef::no_ilm[]
 |`view_index_metadata` on +{beat_default_index_prefix}-*+ indices
-|(Optional) Check for alias when connecting to clusters that support ILM.
+|Check for alias when connecting to clusters that support ILM.
 Not needed when `setup.ilm.check_exists` is `false`.
 endif::no_ilm[]
 

--- a/libbeat/docs/security/users.asciidoc
+++ b/libbeat/docs/security/users.asciidoc
@@ -204,7 +204,7 @@ To grant the required privileges:
 . Create a *writer role*, called something like +{beat_default_index_prefix}_writer+,
 that has the following privileges:
 +
-NOTE: Only the `monitor` cluster privilege and the `create` index privilege on
+NOTE: The `monitor` cluster privilege and the `create` index privilege on
 +{beat_default_index_prefix}-*+ indices are required in every configuration.
 +
 [options="header"]
@@ -228,7 +228,7 @@ ifeval::["{beatname_lc}"=="filebeat"]
 endif::[]
 
 |`create` on +{beat_default_index_prefix}-*+ indices
-|Index events into {es}
+|Write events into {es}
 
 ifndef::no_ilm[]
 |`view_index_metadata` on +{beat_default_index_prefix}-*+ indices
@@ -237,7 +237,7 @@ Not needed when `setup.ilm.check_exists` is `false`.
 endif::no_ilm[]
 
 |`create_index` on +{beat_default_index_prefix}-*+ indices
-|(Optional) Create daily indices when connecting to clusters that do not support ILM.
+|Create daily indices when connecting to clusters that do not support ILM.
 Not needed when using ILM.
 |====
 ifndef::apm-server[]

--- a/libbeat/docs/security/users.asciidoc
+++ b/libbeat/docs/security/users.asciidoc
@@ -201,11 +201,11 @@ endif::no_ilm[]
 
 To grant the required privileges:
 
-. Create a *writer role*, called something like +{beat_default_index_prefix}_writer+, that has
-the following privileges:
+. Create a *writer role*, called something like +{beat_default_index_prefix}_writer+,
+that has the following privileges:
 
 NOTE: Only the `monitor` cluster privilege and the `create` index privilege on
-+{beat_default_index_prefix}-*+ indices are needed in every configuration.
++{beat_default_index_prefix}-*+ indices are required in every configuration.
 
 +
 [options="header"]
@@ -227,19 +227,19 @@ endif::[]
 
 ifndef::no_ilm[]
 |`read_ilm`
-|(Optional) Read the ILM policy when connecting to clusters that support ILM. Not needed when
-`setup.ilm.check_exists` is `false`.
+|(Optional) Read the ILM policy when connecting to clusters that support ILM.
+Not needed when `setup.ilm.check_exists` is `false`.
 endif::no_ilm[]
 
 ifndef::no_ilm[]
 |`view_index_metadata` on +{beat_default_index_prefix}-*+ indices
-|(Optional) Check for alias when connecting to clusters that support ILM. Not needed when
-`setup.ilm.check_exists` is `false`.
+|(Optional) Check for alias when connecting to clusters that support ILM.
+Not needed when `setup.ilm.check_exists` is `false`.
 endif::no_ilm[]
 
 |`create_index` on +{beat_default_index_prefix}-*+ indices
-|(Optional) Create daily indices when connecting to clusters that do not support ILM. Not needed when
-using ILM.
+|(Optional) Create daily indices when connecting to clusters that do not support ILM.
+Not needed when using ILM.
 |====
 ifndef::apm-server[]
 +

--- a/libbeat/docs/security/users.asciidoc
+++ b/libbeat/docs/security/users.asciidoc
@@ -140,6 +140,7 @@ users who need to monitor {beatname_uc}:
 [options="header"]
 |====
 |Role | Purpose
+
 |`kibana_user`
 |Use {kib}
 
@@ -171,18 +172,21 @@ information.
 [options="header"]
 |====
 |Role | Purpose
+
 |`remote_monitoring_collector`
 |Collect monitoring metrics from {beatname_uc}
+
 |`remote_monitoring_agent`
 |Send monitoring data to the monitoring cluster
 |====
 
 . Assign the following role to users who will view the monitoring data in
 {kib}:
-
++
 [options="header"]
 |====
 |Role | Purpose
+
 |`monitoring_user`
 |Use *Stack Monitoring* in {kib} to monitor {beatname_uc}
 |====
@@ -280,6 +284,7 @@ the following privilege:
 |====
 |Type | Privilege | Purpose
 
+|Index
 |`read` on +{beat_default_index_prefix}-*+ indices
 |Read data indexed by {beatname_uc}
 |====
@@ -314,6 +319,7 @@ data:
 
 |`kibana_user` and `apm_user`
 |Use the APM UI
+
 |`admin`
 |Read and update APM Agent configuration via Kibana
 |====


### PR DESCRIPTION
Updates the writer role documentation based on https://github.com/elastic/beats/pull/13847 and https://github.com/elastic/beats/pull/13848. Also corrects some mistakes.
1. Changes `read from` to the correct `write to` (Beats does not read from indices).
2. Setting `setup.template.enabled` to `false` is no longer necessary after https://github.com/elastic/beats/pull/13847.
3. Setting `setup.ilm.overwrite` to `false` is unnecessary if `setup.ilm.check_exists` is already `false` (even today).
4. Adds a note about only `monitor` and `create_doc` being always necessary, explicitly calling out the most secure configuration (following https://github.com/elastic/beats/pull/13847 and https://github.com/elastic/beats/pull/13848).
5. Correct what `monitor` is for: It's for checking things like cluster version and license, not "sending monitor info".
6. Replaces `manage_pipeline` with the read-only `cluster:admin/ingest/pipeline/get`. Unfortunately, there is no read-only cluster role for pipelines, so it requires this privilege. But better than the very permissive `manage_pipeline` that allows changing any pipeline.
7. Changes `index` to the more restrictive, append-only `create_doc` (introduced in https://github.com/elastic/elasticsearch/pull/45806).

This is one of three PRs to reduce the Beats privileges required in code and documentation:
1. Use less restrictive API to check if template exists (https://github.com/elastic/beats/pull/13847)
2. Do not check for alias when setup.ilm.check_exists is false (https://github.com/elastic/beats/pull/13848)
3. Docs: Update writer role with least required privileges (this PR)

Relates: https://github.com/elastic/beats/issues/10241