### PR TITLE
[DOCS] Remove accidental include

### DIFF
--- a/x-pack/functionbeat/docs/configuring-howto.asciidoc
+++ b/x-pack/functionbeat/docs/configuring-howto.asciidoc
@@ -41,8 +41,6 @@ include::{libbeat-dir}/docs/queueconfig.asciidoc[]
 :allplatforms!:
 
 [role="xpack"]
-include::{libbeat-dir}/docs/outputs/output-logstash.asciidoc[tag=shared-logstash-config]
-
 include::{libbeat-dir}/docs/outputconfig.asciidoc[tag=shared-outputconfig]
 
 * <<elasticsearch-output>>


### PR DESCRIPTION
I must have pasted this include here by mistake because it doesn't belong there. :-) 