### PR TITLE
[7.x][DOCS] Backport: Add breaking changes and release highlights (#13803)

### DIFF
--- a/libbeat/docs/breaking-7.0.asciidoc
+++ b/libbeat/docs/breaking-7.0.asciidoc
@@ -2,8 +2,8 @@
 
 === Breaking changes in 7.0
 
-This section discusses the main changes that you should be aware of if you
-upgrade the Beats to version 7.0. {see-relnotes}
+This section discusses the main changes that you need to be aware of to
+migrate Beats to version 7.0. {see-relnotes}
 
 [float]
 ==== HTML escaping is disabled by default

--- a/libbeat/docs/breaking-7.2.asciidoc
+++ b/libbeat/docs/breaking-7.2.asciidoc
@@ -2,11 +2,6 @@
 
 === Breaking changes in 7.2
 
-// NOTE: Comment out this section if there are no breaking changes for 7.2.
-This section discusses the main changes that you should be aware of if you
-upgrade the Beats to version 7.2.
-
-// NOTE: Do not comment out
 {see-relnotes}
 
 //NOTE: The notable-breaking-changes tagged regions are re-used in the

--- a/libbeat/docs/breaking-7.3.asciidoc
+++ b/libbeat/docs/breaking-7.3.asciidoc
@@ -2,11 +2,6 @@
 
 === Breaking changes in 7.3
 
-// NOTE: Comment out this section if there are no breaking changes for 7.3.
-This section discusses the main changes that you should be aware of if you
-upgrade the Beats to version 7.3.
-
-// NOTE: Do not comment out
 {see-relnotes}
 
 //NOTE: The notable-breaking-changes tagged regions are re-used in the

--- a/libbeat/docs/breaking-7.4.asciidoc
+++ b/libbeat/docs/breaking-7.4.asciidoc
@@ -1,0 +1,38 @@
+[[breaking-changes-7.4]]
+
+=== Breaking changes in 7.4
+
+This section discusses the main changes that you need to be aware of to
+migrate Beats to version 7.4. {see-relnotes}
+
+//NOTE: The notable-breaking-changes tagged regions are re-used in the
+//Installation and Upgrade Guide
+
+//tag::notable-breaking-changes[]
+
+[float]
+==== Golang version update
+
+The Beats platform has been updated to use Golang 1.12.9.
+
+[float]
+==== {auditbeat} `system` module changes
+
+The `socket` dataset in the `system` module now uses Kprobes for finer-grained
+monitoring and UDP support. For more information, see
+{auditbeat-ref}/auditbeat-dataset-system-socket.html[System socket dataset].
+
+[float]
+==== {filebeat} field name changes
+
+Some field names exported by the `asa` fileset in the `cisco` module have
+changed:
+
+[options="header"]
+|====
+|Old field                 |New field
+|`log.original`            |`event.original`
+|`cisco.asa.list_id`       |`cisco.asa.rule_name`
+|====
+
+// end::notable-breaking-changes[]

--- a/libbeat/docs/breaking.asciidoc
+++ b/libbeat/docs/breaking.asciidoc
@@ -11,6 +11,8 @@ changes, but there are breaking changes between major versions (e.g. 6.x to
 
 See the following topics for a description of breaking changes:
 
+* <<breaking-changes-7.4>>
+
 * <<breaking-changes-7.3>>
 
 * <<breaking-changes-7.2>>
@@ -18,6 +20,8 @@ See the following topics for a description of breaking changes:
 * <<breaking-changes-7.1>>
 
 * <<breaking-changes-7.0>>
+
+include::breaking-7.4.asciidoc[]
 
 include::breaking-7.3.asciidoc[]
 

--- a/libbeat/docs/highlights-7.4.0.asciidoc
+++ b/libbeat/docs/highlights-7.4.0.asciidoc
@@ -1,0 +1,54 @@
+[[release-highlights-7.4.0]]
+=== 7.4.0 release highlights
+++++
+<titleabbrev>7.4.0</titleabbrev>
+++++
+
+Each release of {beats} brings new features and product improvements. 
+Here are the highlights of the new features and enhancements in 7.4.0.
+
+Refer to the {beats} <<breaking-changes-7.4, Breaking Changes>> and
+<<release-notes, Release Notes>> for a list of bug fixes and other changes.
+
+Also read the
+https://www.elastic.co/blog/beats-7-4-0-released[Beats release blog] for a full
+description of new features.
+
+//NOTE: The notable-highlights tagged regions are re-used in the
+//Installation and Upgrade Guide
+
+// tag::notable-highlights[]
+// ADD NOTABLE HIGHLIGHTS HERE
+[float]
+==== New {filebeat} inputs for ingesting S3 and Kafka logs
+
+The {filebeat-ref}/filebeat-input-s3.html[S3 input] in {filebeat} is a beta
+feature available under the Basic license, meaning it’s free to use. It ingests
+raw log lines from S3 buckets by leveraging SQS queues for scalable consumption.
+We recommend using this {filebeat} input instead of the {ls} S3 input if you are
+looking for a horizontally scalable solution for ingesting logs from S3.
+
+The {filebeat-ref}/filebeat-input-kafka.html[kafka input] in {filebeat} enables
+data consumption from Kafka topics. Multiple {filebeat} instances can subscribe
+to the same Kafka consumer group for parallel processing from topics.
+Additionally, the Kafka input can consume data from Azure Event Hubs given the
+service supports Kafka interface compatibility.
+// end::notable-highlights[]
+
+[float]
+==== {functionbeat} improvements
+
+{functionbeat} now supports {ls} as an output for data processing.
+
+We've also added configurable function tags that you can use for grouping,
+filtering, and cost allocation with AWS Lambda.
+
+[float]
+==== Expanded platform support
+In Beats 7.4.0, we’ve added support for the following platforms:
+
+* RHEL 8
+* Amazon Linux 2
+* Ubuntu 18.04
+* Windows Server 2019. 
+

--- a/libbeat/docs/highlights.asciidoc
+++ b/libbeat/docs/highlights.asciidoc
@@ -4,6 +4,8 @@
 This section summarizes the most important changes in each release. For the 
 full list, see <<release-notes>> and <<breaking-changes>>. 
 
+* <<release-highlights-7.4.0>>
+
 * <<release-highlights-7.3.0>>
 
 * <<release-highlights-7.2.0>>
@@ -11,6 +13,8 @@ full list, see <<release-notes>> and <<breaking-changes>>.
 * <<release-highlights-7.1.0>>
 
 * <<release-highlights-7.0.0>>
+
+include::highlights-7.4.0.asciidoc[]
 
 include::highlights-7.3.0.asciidoc[]
 


### PR DESCRIPTION
Backporting this PR to 7.x to support linking with the doc build.

Note that we do not usually backport to 7.x. We make an exception for docs that fix broken links.

@lcawl FYI