### PR TITLE
Filebeat Netflow input: Remove beta label

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -318,6 +318,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Parse query steps in PostgreSQL slowlogs. {issue}13496[13496] {pull}13701[13701]
 - Add support to set the document id in the json reader. {pull}5844[5844]
 - Add input httpjson. {issue}13545[13545] {pull}13546[13546]
+- Filebeat Netflow input: Remove beta label. {pull}13858[13858]
 
 *Heartbeat*
 - Add non-privileged icmp on linux and darwin(mac). {pull}13795[13795] {issue}11498[11498]

--- a/x-pack/filebeat/docs/inputs/input-netflow.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-netflow.asciidoc
@@ -9,8 +9,6 @@
 <titleabbrev>NetFlow</titleabbrev>
 ++++
 
-beta[]
-
 Use the `netflow` input to read NetFlow and IPFIX exported flows
 and options records over UDP.
 


### PR DESCRIPTION
Removes the `beta` label from the Netflow input. This input and the Netflow module using it have existed since December 2018 and February 2019, respectively, and have seen some healthy PR activity and adoption since then.

