### PR TITLE
Fix doc build with wrongly formed IDs

### DIFF
--- a/x-pack/functionbeat/docs/config-options.asciidoc
+++ b/x-pack/functionbeat/docs/config-options.asciidoc
@@ -132,7 +132,7 @@ is a factor of 64. There is a hard limit of 3008 MiB for each function. The
 default is 128 MiB.
 
 [float]
-[id-"{beatname-lc}-role"]
+[id="{beatname-lc}-role"]
 ==== `role`
 
 //REVIEWERS: I think it's kind of odd to show examples here when we don't show
@@ -153,7 +153,7 @@ If `role` is not specified, the function uses the default role and policy
 created during deployment.
 
 [float]
-[id-"{beatname-lc}-virtual_private_cloud"]
+[id="{beatname-lc}-virtual_private_cloud"]
 
 ==== `virtual_private_cloud`
 


### PR DESCRIPTION
Fix an issue in https://github.com/elastic/beats/pull/13336 the weird things is the make docs doesn't  throw any errors.

Looking at the build log and the IDS appear to miss an "=".

```
12:37:42 INFO:build_docs:Error executing: xmllint --nonet --noout --valid /tmp/docsbuild/target_repo/raw/en/beats/functionbeat/master/index.xml
12:37:42 INFO:build_docs:
12:37:42 INFO:build_docs:---
12:37:42 INFO:build_docs:/tmp/docsbuild/target_repo/raw/en/beats/functionbeat/master/index.xml:1609: parser error : error parsing attribute name
12:37:42 INFO:build_docs:<id-"{beatname-lc}-role" id="_role">
12:37:42 INFO:build_docs:    ^
12:37:42 INFO:build_docs:/tmp/docsbuild/target_repo/raw/en/beats/functionbeat/master/index.xml:1609: parser error : attributes construct error
12:37:42 INFO:build_docs:<id-"{beatname-lc}-role" id="_role">
12:37:42 INFO:build_docs:    ^
12:37:42 INFO:build_docs:/tmp/docsbuild/target_repo/raw/en/beats/functionbeat/master/index.xml:1609: parser error : Couldn't find end of Start Tag id- line 1609
12:37:42 INFO:build_docs:<id-"{beatname-lc}-role" id="_role">
12:37:42 INFO:build_docs:    ^
12:37:42 INFO:build_docs:/tmp/docsbuild/target_repo/raw/en/beats/functionbeat/master/index.xml:1617: parser error : expected '>'
12:37:42 INFO:build_docs:</id-"{beatname-lc}-role">
12:37:42 INFO:build_docs:     ^
12:37:42 INFO:build_docs:/tmp/docsbuild/target_repo/raw/en/beats/functionbeat/master/index.xml:1617: parser error : Opening and ending tag mismatch: chapter line 1495 and id-
12:37:42 INFO:build_docs:</id-"{beatname-lc}-role">
12:37:42 INFO:build_docs:     ^
12:37:42 INFO:build_docs:/tmp/docsbuild/target_repo/raw/en/beats/functionbeat/master/index.xml:1618: parser error : error parsing attribute name
12:37:42 INFO:build_docs:<id-"{beatname-lc}-virtual_private_cloud" id="_virtual_private_cloud">
12:37:42 INFO:build_docs:    ^
12:37:42 INFO:build_docs:/tmp/docsbuild/target_repo/raw/en/beats/functionbeat/master/index.xml:1618: parser error : attributes construct error
12:37:42 INFO:build_docs:<id-"{beatname-lc}-virtual_private_cloud" id="_virtual_private_cloud">
12:37:42 INFO:build_docs:    ^
12:37:42 INFO:build_docs:/tmp/docsbuild/target_repo/raw/en/beats/functionbeat/master/index.xml:1618: parser error : Couldn't find end of Start Tag id- line 1618
12:37:42 INFO:build_docs:<id-"{beatname-lc}-virtual_private_cloud" id="_virtual_private_cloud">
12:37:42 INFO:build_docs:    ^
12:37:42 INFO:build_docs:/tmp/docsbuild/target_repo/raw/en/beats/functionbeat/master/index.xml:1637: parser error : expected '>'
12:37:42 INFO:build_docs:</id-"{beatname-lc}-virtual_private_cloud">
12:37:42 INFO:build_docs:     ^
12:37:42 INFO:build_docs:/tmp/docsbuild/target_repo/raw/en/beats/functionbeat/master/index.xml:1637: parser error : Opening and ending tag mismatch: part line 1427 and id-
12:37:42 INFO:build_docs:</id-"{beatname-lc}-virtual_private_cloud">
12:37:42 INFO:build_docs:     ^
```