### PR TITLE
[Metricbeat] Add tags as filter in ec2 metricset

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -400,6 +400,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add `job` label by default when using Prometheus collector. {pull}13878[13878]
 - Add `state_resourcequota` metricset for Kubernetes module. {pull}13693[13693]
 
+- Add tags filter in ec2 metricset. {pull}13872[13872] {issue}13145[13145]
+
 *Packetbeat*
 
 - Update DNS protocol plugin to produce events with ECS fields for DNS. {issue}13320[13320] {pull}13354[13354]

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -399,7 +399,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add ECS `container.id` and `container.runtime` to kubernetes `state_container` metricset. {pull}13884[13884]
 - Add `job` label by default when using Prometheus collector. {pull}13878[13878]
 - Add `state_resourcequota` metricset for Kubernetes module. {pull}13693[13693]
-
 - Add tags filter in ec2 metricset. {pull}13872[13872] {issue}13145[13145]
 
 *Packetbeat*

--- a/x-pack/metricbeat/module/aws/aws.go
+++ b/x-pack/metricbeat/module/aws/aws.go
@@ -107,16 +107,7 @@ func getRegions(svc ec2iface.ClientAPI) (completeRegionsList []string, err error
 	return
 }
 
-//// StringInSlice checks if a string is already exists in list
-//func StringInSlice(str string, list []string) bool {
-//	for _, v := range list {
-//		if v == str {
-//			return true
-//		}
-//	}
-//	return false
-//}
-
+// StringInSlice checks if a string is already exists in list
 func StringInSlice(str string, list []string) (bool, int) {
 	for idx, v := range list {
 		if v == str {

--- a/x-pack/metricbeat/module/aws/aws.go
+++ b/x-pack/metricbeat/module/aws/aws.go
@@ -107,14 +107,23 @@ func getRegions(svc ec2iface.ClientAPI) (completeRegionsList []string, err error
 	return
 }
 
-// StringInSlice checks if a string is already exists in list
-func StringInSlice(str string, list []string) bool {
-	for _, v := range list {
+//// StringInSlice checks if a string is already exists in list
+//func StringInSlice(str string, list []string) bool {
+//	for _, v := range list {
+//		if v == str {
+//			return true
+//		}
+//	}
+//	return false
+//}
+
+func StringInSlice(str string, list []string) (bool, int) {
+	for idx, v := range list {
 		if v == str {
-			return true
+			return true, idx
 		}
 	}
-	return false
+	return false, -1
 }
 
 // InitEvent initialize mb.Event with basic information like service.name, cloud.provider

--- a/x-pack/metricbeat/module/aws/aws.go
+++ b/x-pack/metricbeat/module/aws/aws.go
@@ -138,7 +138,9 @@ func InitEvent(regionName string) mb.Event {
 	return event
 }
 
-func CheckTagFiltersExist(tagFilters []Tag, tags interface{}) bool {
+// CheckTagFiltersExist compare tags filter with a set of tags to see if tags
+// filter is a subset of tags
+func CheckTagFiltersExist(tagsFilter []Tag, tags interface{}) bool {
 	var tagKeys []string
 	var tagValues []string
 
@@ -148,7 +150,7 @@ func CheckTagFiltersExist(tagFilters []Tag, tags interface{}) bool {
 			tagValues = append(tagValues, *tag.Value)
 		}
 
-		for _, tagFilter := range tagFilters {
+		for _, tagFilter := range tagsFilter {
 			if exists, idx := StringInSlice(tagFilter.Key, tagKeys); !exists || tagValues[idx] != tagFilter.Value {
 				return false
 			}
@@ -159,7 +161,7 @@ func CheckTagFiltersExist(tagFilters []Tag, tags interface{}) bool {
 			tagValues = append(tagValues, *tag.Value)
 		}
 
-		for _, tagFilter := range tagFilters {
+		for _, tagFilter := range tagsFilter {
 			if exists, idx := StringInSlice(tagFilter.Key, tagKeys); !exists || tagValues[idx] != tagFilter.Value {
 				return false
 			}

--- a/x-pack/metricbeat/module/aws/aws_test.go
+++ b/x-pack/metricbeat/module/aws/aws_test.go
@@ -11,6 +11,8 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi"
+
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/ec2iface"
@@ -49,4 +51,136 @@ func TestGetRegions(t *testing.T) {
 	}
 	assert.Equal(t, 1, len(regionsList))
 	assert.Equal(t, regionName, regionsList[0])
+}
+
+func TestStringInSlice(t *testing.T) {
+	cases := []struct {
+		target         string
+		slice          []string
+		expectedExists bool
+		expectedIdx    int
+	}{
+		{
+			"bar",
+			[]string{"foo", "bar", "baz"},
+			true,
+			1,
+		},
+		{
+			"test",
+			[]string{"foo", "bar", "baz"},
+			false,
+			-1,
+		},
+	}
+	for _, c := range cases {
+		exists, idx := StringInSlice(c.target, c.slice)
+		assert.Equal(t, c.expectedExists, exists)
+		assert.Equal(t, c.expectedIdx, idx)
+	}
+}
+
+var (
+	tagKey1   = "Name"
+	tagValue1 = "ECS Instance"
+	tagKey2   = "User"
+	tagValue2 = "foobar"
+	tagKey3   = "Organization"
+	tagValue3 = "Engineering"
+)
+
+func TestCheckTagFiltersExist(t *testing.T) {
+	cases := []struct {
+		title          string
+		tagFilters     []Tag
+		tags           interface{}
+		expectedExists bool
+	}{
+		{
+			"tagFilters are included in ec2 tags",
+			[]Tag{
+				{
+					Key:   "Name",
+					Value: "ECS Instance",
+				},
+				{
+					Key:   "Organization",
+					Value: "Engineering",
+				},
+			},
+			[]ec2.Tag{
+				{
+					Key:   awssdk.String(tagKey1),
+					Value: awssdk.String(tagValue1),
+				},
+				{
+					Key:   awssdk.String(tagKey2),
+					Value: awssdk.String(tagValue2),
+				},
+				{
+					Key:   awssdk.String(tagKey3),
+					Value: awssdk.String(tagValue3),
+				},
+			},
+			true,
+		},
+		{
+			"one set of tagFilters is included in resourcegroupstaggingapi tags",
+			[]Tag{
+				{
+					Key:   "Name",
+					Value: "test",
+				},
+				{
+					Key:   "Organization",
+					Value: "Engineering",
+				},
+			},
+			[]resourcegroupstaggingapi.Tag{
+				{
+					Key:   awssdk.String(tagKey1),
+					Value: awssdk.String(tagValue1),
+				},
+				{
+					Key:   awssdk.String(tagKey2),
+					Value: awssdk.String(tagValue2),
+				},
+				{
+					Key:   awssdk.String(tagKey3),
+					Value: awssdk.String(tagValue3),
+				},
+			},
+			false,
+		},
+		{
+			"tagFilters is not included in resourcegroupstaggingapi tags",
+			[]Tag{
+				{
+					Key:   "Name",
+					Value: "test",
+				},
+			},
+			[]resourcegroupstaggingapi.Tag{
+				{
+					Key:   awssdk.String(tagKey1),
+					Value: awssdk.String(tagValue1),
+				},
+				{
+					Key:   awssdk.String(tagKey2),
+					Value: awssdk.String(tagValue2),
+				},
+				{
+					Key:   awssdk.String(tagKey3),
+					Value: awssdk.String(tagValue3),
+				},
+			},
+			false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.title, func(t *testing.T) {
+			exists := CheckTagFiltersExist(c.tagFilters, c.tags)
+			assert.Equal(t, c.expectedExists, exists)
+		})
+	}
 }

--- a/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch.go
+++ b/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch.go
@@ -161,7 +161,7 @@ func (m *MetricSet) Fetch(report mb.ReporterV2) error {
 
 			if namespaceResourceType.metricNames != nil && namespaceResourceType.dimensions == nil {
 				for _, listMetric := range listMetricsOutput {
-					if !aws.StringInSlice(*listMetric.MetricName, namespaceResourceType.metricNames) {
+					if exists, _ := aws.StringInSlice(*listMetric.MetricName, namespaceResourceType.metricNames); !exists {
 						continue
 					}
 					filteredMetricWithStatsTotal = append(filteredMetricWithStatsTotal,
@@ -169,7 +169,9 @@ func (m *MetricSet) Fetch(report mb.ReporterV2) error {
 							cloudwatchMetric: listMetric,
 							statistic:        namespaceResourceType.statistic,
 						})
-					if namespaceResourceType.resourceTypeFilter != "" && !aws.StringInSlice(namespaceResourceType.resourceTypeFilter, resourceTypes) {
+
+					exists, _ := aws.StringInSlice(namespaceResourceType.resourceTypeFilter, resourceTypes)
+					if namespaceResourceType.resourceTypeFilter != "" && !exists {
 						resourceTypes = append(resourceTypes, namespaceResourceType.resourceTypeFilter)
 					}
 				}
@@ -183,7 +185,9 @@ func (m *MetricSet) Fetch(report mb.ReporterV2) error {
 							cloudwatchMetric: listMetric,
 							statistic:        namespaceResourceType.statistic,
 						})
-					if namespaceResourceType.resourceTypeFilter != "" && !aws.StringInSlice(namespaceResourceType.resourceTypeFilter, resourceTypes) {
+
+					exists, _ := aws.StringInSlice(namespaceResourceType.resourceTypeFilter, resourceTypes)
+					if namespaceResourceType.resourceTypeFilter != "" && !exists {
 						resourceTypes = append(resourceTypes, namespaceResourceType.resourceTypeFilter)
 					}
 				}
@@ -247,7 +251,8 @@ func (m *MetricSet) readCloudwatchConfig() (listMetricWithDetail, []namespaceWit
 				metricsWithStatsTotal = append(metricsWithStatsTotal, metricsWithStats)
 			}
 
-			if config.ResourceTypeFilter != "" && !aws.StringInSlice(config.ResourceTypeFilter, resourceTypes) {
+			exists, _ := aws.StringInSlice(config.ResourceTypeFilter, resourceTypes)
+			if config.ResourceTypeFilter != "" && !exists {
 				resourceTypes = append(resourceTypes, config.ResourceTypeFilter)
 			}
 			continue

--- a/x-pack/metricbeat/module/aws/ec2/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/aws/ec2/_meta/docs.asciidoc
@@ -58,4 +58,12 @@ image::./images/metricbeat-aws-ec2-overview.png[]
   access_key_id: '<access_key_id>'
   secret_access_key: '<secret_access_key>'
   session_token: '<session_token>'
+  tags_filter:
+    - key: "Organization"
+      value: "Engineering"
 ----
+
+`tags_filter` can be specified to only collect metrics with certain tag keys/values.
+For example, with the configuration example above, ec2 metricset will only collect
+metrics from EC2 instances that have tag key equals "Organization" and tag value
+equals to "Engineering".

--- a/x-pack/metricbeat/module/aws/ec2/ec2.go
+++ b/x-pack/metricbeat/module/aws/ec2/ec2.go
@@ -45,7 +45,7 @@ func init() {
 // interface methods except for Fetch.
 type MetricSet struct {
 	*aws.MetricSet
-	Tags []aws.Tag `config:"tags_filter"`
+	TagsFilter []aws.Tag `config:"tags_filter"`
 }
 
 // New creates a new instance of the MetricSet. New is responsible for unpacking
@@ -76,8 +76,8 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	}
 
 	return &MetricSet{
-		MetricSet: metricSet,
-		Tags:      config.Tags,
+		MetricSet:  metricSet,
+		TagsFilter: config.Tags,
 	}, nil
 }
 
@@ -192,11 +192,11 @@ func (m *MetricSet) createCloudWatchEvents(getMetricDataResults []cloudwatch.Met
 
 				// Add tags
 				tags := instanceOutput[instanceID].Tags
-				if m.Tags != nil {
+				if m.TagsFilter != nil {
 					// Check with each tag filter
 					// If tag filter doesn't exist in tagKeys/tagValues,
 					// then do not report this event/instance.
-					if exists := aws.CheckTagFiltersExist(m.Tags, tags); !exists {
+					if exists := aws.CheckTagFiltersExist(m.TagsFilter, tags); !exists {
 						continue
 					}
 				}
@@ -209,6 +209,7 @@ func (m *MetricSet) createCloudWatchEvents(getMetricDataResults []cloudwatch.Met
 				if err != nil {
 					return events, errors.Wrap(err, "instance.InstanceType.MarshalValue failed")
 				}
+
 				events[instanceID].RootFields.Put("cloud.instance.id", instanceID)
 				events[instanceID].RootFields.Put("cloud.machine.type", machineType)
 				events[instanceID].RootFields.Put("cloud.availability_zone", *instanceOutput[instanceID].Placement.AvailabilityZone)

--- a/x-pack/metricbeat/module/aws/ec2/ec2_test.go
+++ b/x-pack/metricbeat/module/aws/ec2/ec2_test.go
@@ -33,19 +33,19 @@ var (
 
 	id1         = "cpu1"
 	metricName1 = "CPUUtilization"
-	label1      = instanceID + " " + metricName1
+	label1      = instanceID + labelSeparator + metricName1
 
 	id2         = "status1"
 	metricName2 = "StatusCheckFailed"
-	label2      = instanceID + " " + metricName2
+	label2      = instanceID + labelSeparator + metricName2
 
 	id3         = "status2"
 	metricName3 = "StatusCheckFailed_System"
-	label3      = instanceID + " " + metricName3
+	label3      = instanceID + labelSeparator + metricName3
 
 	id4         = "status3"
 	metricName4 = "StatusCheckFailed_Instance"
-	label4      = instanceID + " " + metricName4
+	label4      = instanceID + labelSeparator + metricName4
 )
 
 func (m *MockEC2Client) DescribeRegionsRequest(input *ec2.DescribeRegionsInput) ec2.DescribeRegionsRequest {
@@ -216,7 +216,7 @@ func TestConstructMetricQueries(t *testing.T) {
 	listMetricsOutput := []cloudwatch.Metric{listMetric}
 	metricDataQuery := constructMetricQueries(listMetricsOutput, instanceID, 5*time.Minute)
 	assert.Equal(t, 1, len(metricDataQuery))
-	assert.Equal(t, "i-123 CPUUtilization", *metricDataQuery[0].Label)
+	assert.Equal(t, "i-123|CPUUtilization", *metricDataQuery[0].Label)
 	assert.Equal(t, "Average", *metricDataQuery[0].MetricStat.Stat)
 	assert.Equal(t, metricName1, *metricDataQuery[0].MetricStat.Metric.MetricName)
 	assert.Equal(t, namespace, *metricDataQuery[0].MetricStat.Metric.Namespace)

--- a/x-pack/metricbeat/module/aws/s3_daily_storage/s3_daily_storage.go
+++ b/x-pack/metricbeat/module/aws/s3_daily_storage/s3_daily_storage.go
@@ -126,7 +126,7 @@ func getBucketNames(listMetricsOutputs []cloudwatch.Metric) (bucketNames []strin
 	for _, output := range listMetricsOutputs {
 		for _, dim := range output.Dimensions {
 			if *dim.Name == "BucketName" {
-				if aws.StringInSlice(*dim.Value, bucketNames) {
+				if exists, _ := aws.StringInSlice(*dim.Value, bucketNames); exists {
 					continue
 				}
 				bucketNames = append(bucketNames, *dim.Value)
@@ -141,7 +141,7 @@ func constructMetricQueries(listMetricsOutputs []cloudwatch.Metric, period time.
 	metricDataQueryEmpty := cloudwatch.MetricDataQuery{}
 	metricNames := []string{"NumberOfObjects", "BucketSizeBytes"}
 	for i, listMetric := range listMetricsOutputs {
-		if !aws.StringInSlice(*listMetric.MetricName, metricNames) {
+		if exists, _ := aws.StringInSlice(*listMetric.MetricName, metricNames); !exists {
 			continue
 		}
 

--- a/x-pack/metricbeat/module/aws/s3_request/s3_request.go
+++ b/x-pack/metricbeat/module/aws/s3_request/s3_request.go
@@ -128,7 +128,7 @@ func getBucketNames(listMetricsOutputs []cloudwatch.Metric) (bucketNames []strin
 	for _, output := range listMetricsOutputs {
 		for _, dim := range output.Dimensions {
 			if *dim.Name == "BucketName" {
-				if aws.StringInSlice(*dim.Value, bucketNames) {
+				if exists, _ := aws.StringInSlice(*dim.Value, bucketNames); exists {
 					continue
 				}
 				bucketNames = append(bucketNames, *dim.Value)
@@ -171,7 +171,7 @@ func constructMetricQueries(listMetricsOutputs []cloudwatch.Metric, period time.
 	metricDataQueryEmpty := cloudwatch.MetricDataQuery{}
 	dailyMetricNames := []string{"NumberOfObjects", "BucketSizeBytes"}
 	for i, listMetric := range listMetricsOutputs {
-		if aws.StringInSlice(*listMetric.MetricName, dailyMetricNames) {
+		if exists, _ := aws.StringInSlice(*listMetric.MetricName, dailyMetricNames); exists {
 			continue
 		}
 


### PR DESCRIPTION
This PR is to add `tags_filter` in ec2 metricset configuration to filter what are the metrics to collect. This will help users to focus on metrics they are interested in without wasting resources to collect all metrics and filter on them later on.

This implements a part of elastic/beats#13145

## How to test this
With configuration below, ec2 metricset should only collect events/metrics with tag `Name: ECS Instance - DockerRegistryECSStack` from AWS Cloudwatch.
```
- module: aws
  period: 300s
  metricsets:
    - ec2
  credential_profile_name: test-mb
  tags_filter:
    - key: "Name"
      value: "ECS Instance - DockerRegistryECSStack"
```

Also if you specify some tag filters that doesn't exist, for example:
```
- module: aws
  period: 300s
  metricsets:
    - ec2
  credential_profile_name: test-mb
  tags_filter:
    - key: "Name"
      value: "ECS Instance - DockerRegistryECSStack"
    - key: "test"
      value: "test"
```
ec2 metricset should not report any event because there is no EC2 instance matches both tag filters.