### PR TITLE
Add `job` label by default when using Prometheus collector

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -384,6 +384,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add `docker.cpu.*.norm.pct` metrics for `cpu` metricset of Docker Metricbeat module. {pull}13695[13695]
 - Add `instance` label by default when using Prometheus collector. {pull}13737[13737]
 - Add Apache Tomcat module {pull}13491[13491]
+- Add `job` label by default when using Prometheus collector. {pull}13878[13878]
 
 
 *Packetbeat*

--- a/metricbeat/module/prometheus/collector/_meta/data.json
+++ b/metricbeat/module/prometheus/collector/_meta/data.json
@@ -11,6 +11,7 @@
     },
     "prometheus": {
         "labels": {
+            "job": "prometheus",
             "listener_name": "http"
         },
         "metrics": {

--- a/metricbeat/module/prometheus/collector/_meta/testdata/docs.plain-expected.json
+++ b/metricbeat/module/prometheus/collector/_meta/testdata/docs.plain-expected.json
@@ -11,7 +11,8 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:58011",
+                "instance": "127.0.0.1:54322",
+                "job": "prometheus",
                 "listener_name": "http"
             },
             "metrics": {

--- a/metricbeat/module/prometheus/collector/_meta/testdata/etcd-3.3.10-partial.plain-expected.json
+++ b/metricbeat/module/prometheus/collector/_meta/testdata/etcd-3.3.10-partial.plain-expected.json
@@ -11,104 +11,9 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:58013",
-                "server_version": "3.3.10"
-            },
-            "metrics": {
-                "etcd_server_version": 1
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "prometheus"
-        }
-    },
-    {
-        "event": {
-            "dataset": "prometheus.collector",
-            "duration": 115000,
-            "module": "prometheus"
-        },
-        "metricset": {
-            "name": "collector",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:58013",
-                "server_id": "8e9e05c52164694d"
-            },
-            "metrics": {
-                "etcd_server_id": 1
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "prometheus"
-        }
-    },
-    {
-        "event": {
-            "dataset": "prometheus.collector",
-            "duration": 115000,
-            "module": "prometheus"
-        },
-        "metricset": {
-            "name": "collector",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "action": "create",
-                "instance": "127.0.0.1:58013"
-            },
-            "metrics": {
-                "etcd_debugging_store_writes_total": 1
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "prometheus"
-        }
-    },
-    {
-        "event": {
-            "dataset": "prometheus.collector",
-            "duration": 115000,
-            "module": "prometheus"
-        },
-        "metricset": {
-            "name": "collector",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "action": "getRecursive",
-                "instance": "127.0.0.1:58013"
-            },
-            "metrics": {
-                "etcd_debugging_store_reads_total": 1
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "prometheus"
-        }
-    },
-    {
-        "event": {
-            "dataset": "prometheus.collector",
-            "duration": 115000,
-            "module": "prometheus"
-        },
-        "metricset": {
-            "name": "collector",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
                 "action": "set",
-                "instance": "127.0.0.1:58013"
+                "instance": "127.0.0.1:54324",
+                "job": "prometheus"
             },
             "metrics": {
                 "etcd_debugging_store_writes_total": 2
@@ -131,31 +36,8 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:58013",
-                "version": "go1.10.4"
-            },
-            "metrics": {
-                "go_info": 1
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "prometheus"
-        }
-    },
-    {
-        "event": {
-            "dataset": "prometheus.collector",
-            "duration": 115000,
-            "module": "prometheus"
-        },
-        "metricset": {
-            "name": "collector",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:58013"
+                "instance": "127.0.0.1:54324",
+                "job": "prometheus"
             },
             "metrics": {
                 "etcd_debugging_mvcc_db_compaction_keys_total": 0,
@@ -242,11 +124,137 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:58013",
+                "instance": "127.0.0.1:54324",
+                "job": "prometheus",
+                "version": "go1.10.4"
+            },
+            "metrics": {
+                "go_info": 1
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "prometheus"
+        }
+    },
+    {
+        "event": {
+            "dataset": "prometheus.collector",
+            "duration": 115000,
+            "module": "prometheus"
+        },
+        "metricset": {
+            "name": "collector",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "action": "getRecursive",
+                "instance": "127.0.0.1:54324",
+                "job": "prometheus"
+            },
+            "metrics": {
+                "etcd_debugging_store_reads_total": 1
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "prometheus"
+        }
+    },
+    {
+        "event": {
+            "dataset": "prometheus.collector",
+            "duration": 115000,
+            "module": "prometheus"
+        },
+        "metricset": {
+            "name": "collector",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54324",
+                "job": "prometheus",
                 "server_go_version": "go1.10.4"
             },
             "metrics": {
                 "etcd_server_go_version": 1
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "prometheus"
+        }
+    },
+    {
+        "event": {
+            "dataset": "prometheus.collector",
+            "duration": 115000,
+            "module": "prometheus"
+        },
+        "metricset": {
+            "name": "collector",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54324",
+                "job": "prometheus",
+                "server_id": "8e9e05c52164694d"
+            },
+            "metrics": {
+                "etcd_server_id": 1
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "prometheus"
+        }
+    },
+    {
+        "event": {
+            "dataset": "prometheus.collector",
+            "duration": 115000,
+            "module": "prometheus"
+        },
+        "metricset": {
+            "name": "collector",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54324",
+                "job": "prometheus",
+                "server_version": "3.3.10"
+            },
+            "metrics": {
+                "etcd_server_version": 1
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "prometheus"
+        }
+    },
+    {
+        "event": {
+            "dataset": "prometheus.collector",
+            "duration": 115000,
+            "module": "prometheus"
+        },
+        "metricset": {
+            "name": "collector",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "action": "create",
+                "instance": "127.0.0.1:54324",
+                "job": "prometheus"
+            },
+            "metrics": {
+                "etcd_debugging_store_writes_total": 1
             }
         },
         "service": {

--- a/metricbeat/module/prometheus/collector/_meta/testdata/metrics-with-naninf.plain-expected.json
+++ b/metricbeat/module/prometheus/collector/_meta/testdata/metrics-with-naninf.plain-expected.json
@@ -11,175 +11,8 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:58015",
-                "le": "2"
-            },
-            "metrics": {
-                "http_request_duration_seconds_bucket": 2
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "prometheus"
-        }
-    },
-    {
-        "event": {
-            "dataset": "prometheus.collector",
-            "duration": 115000,
-            "module": "prometheus"
-        },
-        "metricset": {
-            "name": "collector",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:58015",
-                "le": "3"
-            },
-            "metrics": {
-                "http_request_duration_seconds_bucket": 3
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "prometheus"
-        }
-    },
-    {
-        "event": {
-            "dataset": "prometheus.collector",
-            "duration": 115000,
-            "module": "prometheus"
-        },
-        "metricset": {
-            "name": "collector",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:58015",
-                "quantile": "1"
-            },
-            "metrics": {
-                "go_gc_duration_seconds": 0.011689149
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "prometheus"
-        }
-    },
-    {
-        "event": {
-            "dataset": "prometheus.collector",
-            "duration": 115000,
-            "module": "prometheus"
-        },
-        "metricset": {
-            "name": "collector",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:58015",
-                "method": "GET"
-            },
-            "metrics": {
-                "http_failures": 2
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "prometheus"
-        }
-    },
-    {
-        "event": {
-            "dataset": "prometheus.collector",
-            "duration": 115000,
-            "module": "prometheus"
-        },
-        "metricset": {
-            "name": "collector",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:58015",
-                "le": "1"
-            },
-            "metrics": {
-                "http_request_duration_seconds_bucket": 1
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "prometheus"
-        }
-    },
-    {
-        "event": {
-            "dataset": "prometheus.collector",
-            "duration": 115000,
-            "module": "prometheus"
-        },
-        "metricset": {
-            "name": "collector",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:58015",
-                "le": "+Inf"
-            },
-            "metrics": {
-                "http_request_duration_seconds_bucket": 3
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "prometheus"
-        }
-    },
-    {
-        "event": {
-            "dataset": "prometheus.collector",
-            "duration": 115000,
-            "module": "prometheus"
-        },
-        "metricset": {
-            "name": "collector",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:58015",
-                "listener_name": "http"
-            },
-            "metrics": {
-                "net_conntrack_listener_conn_accepted_total": 1568652315554
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "prometheus"
-        }
-    },
-    {
-        "event": {
-            "dataset": "prometheus.collector",
-            "duration": 115000,
-            "module": "prometheus"
-        },
-        "metricset": {
-            "name": "collector",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:58015"
+                "instance": "127.0.0.1:54326",
+                "job": "prometheus"
             },
             "metrics": {
                 "go_gc_duration_seconds_count": 13118,
@@ -205,8 +38,184 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:58015",
-                "le": "5"
+                "instance": "127.0.0.1:54326",
+                "job": "prometheus",
+                "le": "1"
+            },
+            "metrics": {
+                "http_request_duration_seconds_bucket": 1
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "prometheus"
+        }
+    },
+    {
+        "event": {
+            "dataset": "prometheus.collector",
+            "duration": 115000,
+            "module": "prometheus"
+        },
+        "metricset": {
+            "name": "collector",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54326",
+                "job": "prometheus",
+                "quantile": "1"
+            },
+            "metrics": {
+                "go_gc_duration_seconds": 0.011689149
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "prometheus"
+        }
+    },
+    {
+        "event": {
+            "dataset": "prometheus.collector",
+            "duration": 115000,
+            "module": "prometheus"
+        },
+        "metricset": {
+            "name": "collector",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54326",
+                "job": "prometheus",
+                "le": "+Inf"
+            },
+            "metrics": {
+                "http_request_duration_seconds_bucket": 3
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "prometheus"
+        }
+    },
+    {
+        "event": {
+            "dataset": "prometheus.collector",
+            "duration": 115000,
+            "module": "prometheus"
+        },
+        "metricset": {
+            "name": "collector",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54326",
+                "job": "prometheus",
+                "listener_name": "http"
+            },
+            "metrics": {
+                "net_conntrack_listener_conn_accepted_total": 1568652315554
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "prometheus"
+        }
+    },
+    {
+        "event": {
+            "dataset": "prometheus.collector",
+            "duration": 115000,
+            "module": "prometheus"
+        },
+        "metricset": {
+            "name": "collector",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54326",
+                "job": "prometheus",
+                "method": "GET"
+            },
+            "metrics": {
+                "http_failures": 2
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "prometheus"
+        }
+    },
+    {
+        "event": {
+            "dataset": "prometheus.collector",
+            "duration": 115000,
+            "module": "prometheus"
+        },
+        "metricset": {
+            "name": "collector",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54326",
+                "job": "prometheus",
+                "le": "2"
+            },
+            "metrics": {
+                "http_request_duration_seconds_bucket": 2
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "prometheus"
+        }
+    },
+    {
+        "event": {
+            "dataset": "prometheus.collector",
+            "duration": 115000,
+            "module": "prometheus"
+        },
+        "metricset": {
+            "name": "collector",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54326",
+                "job": "prometheus",
+                "quantile": "0.75"
+            },
+            "metrics": {
+                "go_gc_duration_seconds": 0.000098154
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "prometheus"
+        }
+    },
+    {
+        "event": {
+            "dataset": "prometheus.collector",
+            "duration": 115000,
+            "module": "prometheus"
+        },
+        "metricset": {
+            "name": "collector",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54326",
+                "job": "prometheus",
+                "le": "3"
             },
             "metrics": {
                 "http_request_duration_seconds_bucket": 3
@@ -230,7 +239,8 @@
         "prometheus": {
             "labels": {
                 "client_id": "consumer4",
-                "instance": "127.0.0.1:58015"
+                "instance": "127.0.0.1:54326",
+                "job": "prometheus"
             },
             "metrics": {
                 "kafka_consumer_records_lag_records": 5
@@ -253,11 +263,12 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:58015",
-                "quantile": "0.75"
+                "instance": "127.0.0.1:54326",
+                "job": "prometheus",
+                "le": "5"
             },
             "metrics": {
-                "go_gc_duration_seconds": 0.000098154
+                "http_request_duration_seconds_bucket": 3
             }
         },
         "service": {

--- a/metricbeat/module/prometheus/collector/_meta/testdata/prometheus-2.6.0-partial.plain-expected.json
+++ b/metricbeat/module/prometheus/collector/_meta/testdata/prometheus-2.6.0-partial.plain-expected.json
@@ -11,11 +11,12 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:58017",
-                "quantile": "0.25"
+                "instance": "127.0.0.1:54328",
+                "job": "prometheus",
+                "version": "go1.11.3"
             },
             "metrics": {
-                "go_gc_duration_seconds": 0.000042803
+                "go_info": 1
             }
         },
         "service": {
@@ -35,8 +36,9 @@
         },
         "prometheus": {
             "labels": {
-                "dialer_name": "alertmanager",
-                "instance": "127.0.0.1:58017"
+                "dialer_name": "default",
+                "instance": "127.0.0.1:54328",
+                "job": "prometheus"
             },
             "metrics": {
                 "net_conntrack_dialer_conn_attempted_total": 0,
@@ -61,7 +63,8 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:58017",
+                "instance": "127.0.0.1:54328",
+                "job": "prometheus",
                 "quantile": "0.75"
             },
             "metrics": {
@@ -85,32 +88,9 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:58017",
-                "version": "go1.11.3"
-            },
-            "metrics": {
-                "go_info": 1
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "prometheus"
-        }
-    },
-    {
-        "event": {
-            "dataset": "prometheus.collector",
-            "duration": 115000,
-            "module": "prometheus"
-        },
-        "metricset": {
-            "name": "collector",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
                 "dialer_name": "prometheus",
-                "instance": "127.0.0.1:58017"
+                "instance": "127.0.0.1:54328",
+                "job": "prometheus"
             },
             "metrics": {
                 "net_conntrack_dialer_conn_attempted_total": 1,
@@ -135,8 +115,84 @@
         },
         "prometheus": {
             "labels": {
-                "dialer_name": "default",
-                "instance": "127.0.0.1:58017"
+                "instance": "127.0.0.1:54328",
+                "job": "prometheus",
+                "quantile": "0.5"
+            },
+            "metrics": {
+                "go_gc_duration_seconds": 0.000060618
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "prometheus"
+        }
+    },
+    {
+        "event": {
+            "dataset": "prometheus.collector",
+            "duration": 115000,
+            "module": "prometheus"
+        },
+        "metricset": {
+            "name": "collector",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54328",
+                "job": "prometheus",
+                "quantile": "0.25"
+            },
+            "metrics": {
+                "go_gc_duration_seconds": 0.000042803
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "prometheus"
+        }
+    },
+    {
+        "event": {
+            "dataset": "prometheus.collector",
+            "duration": 115000,
+            "module": "prometheus"
+        },
+        "metricset": {
+            "name": "collector",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54328",
+                "job": "prometheus",
+                "quantile": "0"
+            },
+            "metrics": {
+                "go_gc_duration_seconds": 0.000038386
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "prometheus"
+        }
+    },
+    {
+        "event": {
+            "dataset": "prometheus.collector",
+            "duration": 115000,
+            "module": "prometheus"
+        },
+        "metricset": {
+            "name": "collector",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "dialer_name": "alertmanager",
+                "instance": "127.0.0.1:54328",
+                "job": "prometheus"
             },
             "metrics": {
                 "net_conntrack_dialer_conn_attempted_total": 0,
@@ -161,104 +217,8 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:58017",
-                "quantile": "0"
-            },
-            "metrics": {
-                "go_gc_duration_seconds": 0.000038386
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "prometheus"
-        }
-    },
-    {
-        "event": {
-            "dataset": "prometheus.collector",
-            "duration": 115000,
-            "module": "prometheus"
-        },
-        "metricset": {
-            "name": "collector",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:58017",
-                "listener_name": "http"
-            },
-            "metrics": {
-                "net_conntrack_listener_conn_accepted_total": 3,
-                "net_conntrack_listener_conn_closed_total": 0
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "prometheus"
-        }
-    },
-    {
-        "event": {
-            "dataset": "prometheus.collector",
-            "duration": 115000,
-            "module": "prometheus"
-        },
-        "metricset": {
-            "name": "collector",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:58017",
-                "quantile": "0.5"
-            },
-            "metrics": {
-                "go_gc_duration_seconds": 0.000060618
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "prometheus"
-        }
-    },
-    {
-        "event": {
-            "dataset": "prometheus.collector",
-            "duration": 115000,
-            "module": "prometheus"
-        },
-        "metricset": {
-            "name": "collector",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:58017",
-                "quantile": "1"
-            },
-            "metrics": {
-                "go_gc_duration_seconds": 0.004392391
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "prometheus"
-        }
-    },
-    {
-        "event": {
-            "dataset": "prometheus.collector",
-            "duration": 115000,
-            "module": "prometheus"
-        },
-        "metricset": {
-            "name": "collector",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:58017"
+                "instance": "127.0.0.1:54328",
+                "job": "prometheus"
             },
             "metrics": {
                 "go_gc_duration_seconds_count": 4,
@@ -297,6 +257,57 @@
                 "process_virtual_memory_bytes": 150646784,
                 "process_virtual_memory_max_bytes": -1,
                 "prometheus_api_remote_read_queries": 0
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "prometheus"
+        }
+    },
+    {
+        "event": {
+            "dataset": "prometheus.collector",
+            "duration": 115000,
+            "module": "prometheus"
+        },
+        "metricset": {
+            "name": "collector",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54328",
+                "job": "prometheus",
+                "quantile": "1"
+            },
+            "metrics": {
+                "go_gc_duration_seconds": 0.004392391
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "prometheus"
+        }
+    },
+    {
+        "event": {
+            "dataset": "prometheus.collector",
+            "duration": 115000,
+            "module": "prometheus"
+        },
+        "metricset": {
+            "name": "collector",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54328",
+                "job": "prometheus",
+                "listener_name": "http"
+            },
+            "metrics": {
+                "net_conntrack_listener_conn_accepted_total": 3,
+                "net_conntrack_listener_conn_closed_total": 0
             }
         },
         "service": {

--- a/metricbeat/module/prometheus/collector/collector.go
+++ b/metricbeat/module/prometheus/collector/collector.go
@@ -89,6 +89,10 @@ func (m *MetricSet) Fetch(reporter mb.ReporterV2) error {
 				if exists, _ := promEvent.labels.HasKey("instance"); !exists {
 					promEvent.labels.Put("instance", m.Host())
 				}
+				// Add default job label if not already there
+				if exists, _ := promEvent.labels.HasKey("job"); !exists {
+					promEvent.labels.Put("job", m.Module().Name())
+				}
 				// Add labels
 				if len(promEvent.labels) > 0 {
 					eventList[labelsHash]["labels"] = promEvent.labels

--- a/x-pack/metricbeat/module/cockroachdb/status/_meta/testdata/cockroachdb-status.v19.1.1.plain-expected.json
+++ b/x-pack/metricbeat/module/cockroachdb/status/_meta/testdata/cockroachdb-status.v19.1.1.plain-expected.json
@@ -11,12 +11,46 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "32767",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "1245183"
+            },
+            "metrics": {
+                "exec_latency_bucket": 128559,
+                "liveness_heartbeatlatency_bucket": 1392,
+                "round_trip_latency_bucket": 119141,
+                "sql_distsql_exec_latency_internal_bucket": 12519,
+                "sql_distsql_service_latency_internal_bucket": 880,
+                "sql_exec_latency_internal_bucket": 16602,
+                "sql_service_latency_internal_bucket": 1377,
+                "txn_durations_bucket": 23681
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "23551",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_commandcommit_latency_bucket": 127282
+                "raft_process_commandcommit_latency_bucket": 48454,
+                "raft_process_handleready_latency_bucket": 1359
             }
         },
         "service": {
@@ -36,13 +70,14 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "104857599"
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "94207",
+                "store": "1"
             },
             "metrics": {
-                "exec_latency_bucket": 470364,
-                "liveness_heartbeatlatency_bucket": 81081,
-                "txn_durations_bucket": 115978
+                "raft_process_applycommitted_latency_bucket": 8589,
+                "raft_process_commandcommit_latency_bucket": 292317
             }
         },
         "service": {
@@ -62,16 +97,17 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "4718591"
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "3407871"
             },
             "metrics": {
-                "exec_latency_bucket": 365742,
-                "liveness_heartbeatlatency_bucket": 67476,
-                "sql_distsql_service_latency_internal_bucket": 12429,
-                "sql_exec_latency_internal_bucket": 18607,
-                "sql_service_latency_internal_bucket": 17993,
-                "txn_durations_bucket": 101623
+                "exec_latency_bucket": 306613,
+                "liveness_heartbeatlatency_bucket": 50683,
+                "round_trip_latency_bucket": 122436,
+                "sql_distsql_service_latency_internal_bucket": 11073,
+                "sql_service_latency_internal_bucket": 15120,
+                "txn_durations_bucket": 85326
             }
         },
         "service": {
@@ -91,15 +127,14 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "8912895"
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "15728639",
+                "store": "1"
             },
             "metrics": {
-                "exec_latency_bucket": 433995,
-                "liveness_heartbeatlatency_bucket": 73311,
-                "round_trip_latency_bucket": 122483,
-                "sql_service_latency_internal_bucket": 18606,
-                "txn_durations_bucket": 107673
+                "raft_process_handleready_latency_bucket": 424989,
+                "raft_process_logcommit_latency_bucket": 423661
             }
         },
         "service": {
@@ -119,15 +154,14 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "311295"
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "352321535",
+                "store": "1"
             },
             "metrics": {
-                "exec_latency_bucket": 115436,
-                "round_trip_latency_bucket": 4865,
-                "sql_distsql_exec_latency_internal_bucket": 1232,
-                "sql_exec_latency_internal_bucket": 1744,
-                "txn_durations_bucket": 477
+                "raft_process_handleready_latency_bucket": 471537,
+                "raft_process_logcommit_latency_bucket": 470174
             }
         },
         "service": {
@@ -147,11 +181,15 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "1073741823"
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "11534335",
+                "store": "1"
             },
             "metrics": {
-                "exec_latency_bucket": 472310
+                "raft_process_applycommitted_latency_bucket": 470370,
+                "raft_process_handleready_latency_bucket": 424707,
+                "raft_process_logcommit_latency_bucket": 423517
             }
         },
         "service": {
@@ -171,11 +209,16 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "4487"
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "262143"
             },
             "metrics": {
-                "sql_mem_internal_max_bucket": 18523
+                "exec_latency_bucket": 110242,
+                "round_trip_latency_bucket": 92,
+                "sql_distsql_exec_latency_internal_bucket": 447,
+                "sql_exec_latency_internal_bucket": 718,
+                "txn_durations_bucket": 156
             }
         },
         "service": {
@@ -195,7 +238,1465 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "1275068415"
+            },
+            "metrics": {
+                "exec_latency_bucket": 472317
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "1006632959",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 471713,
+                "raft_process_logcommit_latency_bucket": 470350
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "1015807"
+            },
+            "metrics": {
+                "exec_latency_bucket": 120881,
+                "liveness_heartbeatlatency_bucket": 43,
+                "round_trip_latency_bucket": 109538,
+                "sql_distsql_exec_latency_internal_bucket": 12055,
+                "sql_distsql_service_latency_internal_bucket": 159,
+                "sql_exec_latency_internal_bucket": 15812,
+                "sql_service_latency_internal_bucket": 460,
+                "txn_durations_bucket": 18383
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "10200547327",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 471745,
+                "raft_process_logcommit_latency_bucket": 470382
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "96468991",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 469481,
+                "raft_process_logcommit_latency_bucket": 468190
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "130023423",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 470380,
+                "raft_process_logcommit_latency_bucket": 469030
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "34815"
+            },
+            "metrics": {
+                "exec_latency_bucket": 3169
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "335544319"
+            },
+            "metrics": {
+                "exec_latency_bucket": 472112,
+                "liveness_heartbeatlatency_bucket": 81640,
+                "txn_durations_bucket": 116554
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "20479"
+            },
+            "metrics": {
+                "exec_latency_bucket": 4
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "30719"
+            },
+            "metrics": {
+                "exec_latency_bucket": 2005
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "4456447",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 467849,
+                "raft_process_commandcommit_latency_bucket": 471445,
+                "raft_process_handleready_latency_bucket": 372147,
+                "raft_process_logcommit_latency_bucket": 418075
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "458751",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 267321,
+                "raft_process_commandcommit_latency_bucket": 347254
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "917503",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 357987,
+                "raft_process_commandcommit_latency_bucket": 369962,
+                "raft_process_handleready_latency_bucket": 11226,
+                "raft_process_logcommit_latency_bucket": 54776
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "1900543",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 401914,
+                "raft_process_commandcommit_latency_bucket": 417261,
+                "raft_process_handleready_latency_bucket": 218798,
+                "raft_process_logcommit_latency_bucket": 307583
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "60817407",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 464641,
+                "raft_process_logcommit_latency_bucket": 463763
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "1048575",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 363441,
+                "raft_process_commandcommit_latency_bucket": 374133,
+                "raft_process_handleready_latency_bucket": 22523,
+                "raft_process_logcommit_latency_bucket": 96484
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "226492415",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 471025,
+                "raft_process_logcommit_latency_bucket": 469669
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "59391",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 321,
+                "raft_process_commandcommit_latency_bucket": 252377
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "122879",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 18133,
+                "raft_process_commandcommit_latency_bucket": 302183
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "71303167"
+            },
+            "metrics": {
+                "exec_latency_bucket": 466848,
+                "liveness_heartbeatlatency_bucket": 79743,
+                "sql_exec_latency_internal_bucket": 18860,
+                "sql_service_latency_internal_bucket": 18858,
+                "txn_durations_bucket": 114589
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "2752511",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 441306,
+                "raft_process_commandcommit_latency_bucket": 455759,
+                "raft_process_handleready_latency_bucket": 300613,
+                "raft_process_logcommit_latency_bucket": 385739
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "21503"
+            },
+            "metrics": {
+                "exec_latency_bucket": 7
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "5505023",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 469691,
+                "raft_process_commandcommit_latency_bucket": 472202,
+                "raft_process_handleready_latency_bucket": 403399,
+                "raft_process_logcommit_latency_bucket": 420951
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "176160767"
+            },
+            "metrics": {
+                "exec_latency_bucket": 471392,
+                "liveness_heartbeatlatency_bucket": 81475,
+                "txn_durations_bucket": 116378
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "9437183",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 470351,
+                "raft_process_commandcommit_latency_bucket": 472456,
+                "raft_process_handleready_latency_bucket": 424086,
+                "raft_process_logcommit_latency_bucket": 423340
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "2047",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 90
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "54525951"
+            },
+            "metrics": {
+                "exec_latency_bucket": 460860,
+                "liveness_heartbeatlatency_bucket": 77816,
+                "sql_exec_latency_internal_bucket": 18848,
+                "sql_service_latency_internal_bucket": 18845,
+                "txn_durations_bucket": 112547
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "16106127359",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 471747,
+                "raft_process_logcommit_latency_bucket": 470384
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "458751"
+            },
+            "metrics": {
+                "exec_latency_bucket": 118492,
+                "round_trip_latency_bucket": 23716,
+                "sql_distsql_exec_latency_internal_bucket": 2902,
+                "sql_distsql_service_latency_internal_bucket": 16,
+                "sql_exec_latency_internal_bucket": 4107,
+                "sql_service_latency_internal_bucket": 16,
+                "txn_durations_bucket": 2872
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "278527",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 136299,
+                "raft_process_commandcommit_latency_bucket": 323272
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "1727",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 53
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "188415",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 67133,
+                "raft_process_commandcommit_latency_bucket": 311000
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "671088639"
+            },
+            "metrics": {
+                "exec_latency_bucket": 472287,
+                "liveness_heartbeatlatency_bucket": 81685,
+                "txn_durations_bucket": 116608
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "88080383",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 468858,
+                "raft_process_logcommit_latency_bucket": 467675
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "+Inf",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 470384,
+                "raft_process_commandcommit_latency_bucket": 472474,
+                "raft_process_handleready_latency_bucket": 471747,
+                "raft_process_logcommit_latency_bucket": 470384,
+                "txnwaitqueue_pusher_wait_time_bucket": 7,
+                "txnwaitqueue_query_wait_time_bucket": 0
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "14847",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_commandcommit_latency_bucket": 15116,
+                "raft_process_handleready_latency_bucket": 1343
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "37748735"
+            },
+            "metrics": {
+                "exec_latency_bucket": 448463,
+                "liveness_heartbeatlatency_bucket": 76161,
+                "sql_exec_latency_internal_bucket": 18807,
+                "sql_service_latency_internal_bucket": 18793,
+                "txn_durations_bucket": 110761
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "52428799"
+            },
+            "metrics": {
+                "exec_latency_bucket": 459350,
+                "liveness_heartbeatlatency_bucket": 77513,
+                "sql_exec_latency_internal_bucket": 18846,
+                "sql_service_latency_internal_bucket": 18844,
+                "txn_durations_bucket": 112219
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "134217727",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 470418,
+                "raft_process_logcommit_latency_bucket": 469081
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "45055",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 44,
+                "raft_process_commandcommit_latency_bucket": 210048
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "155647",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 36642,
+                "raft_process_commandcommit_latency_bucket": 307142
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "83886079",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 468490,
+                "raft_process_logcommit_latency_bucket": 467303
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "8388607",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 470330,
+                "raft_process_commandcommit_latency_bucket": 472444,
+                "raft_process_handleready_latency_bucket": 422898,
+                "raft_process_logcommit_latency_bucket": 422914
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "62914559",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 465304,
+                "raft_process_logcommit_latency_bucket": 464386
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "114687",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 15003,
+                "raft_process_commandcommit_latency_bucket": 300295
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "352321535"
+            },
+            "metrics": {
+                "exec_latency_bucket": 472149,
+                "liveness_heartbeatlatency_bucket": 81649,
+                "txn_durations_bucket": 116563
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "48234495",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 470383,
+                "raft_process_handleready_latency_bucket": 456484,
+                "raft_process_logcommit_latency_bucket": 456677
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "209715199"
+            },
+            "metrics": {
+                "exec_latency_bucket": 471585,
+                "liveness_heartbeatlatency_bucket": 81525,
+                "txn_durations_bucket": 116432
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "318767103",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 471466,
+                "raft_process_logcommit_latency_bucket": 470103
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "3583",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_commandcommit_latency_bucket": 1,
+                "raft_process_handleready_latency_bucket": 332
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "98303",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 9828,
+                "raft_process_commandcommit_latency_bucket": 294451
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "7247757311"
+            },
+            "metrics": {
+                "exec_latency_bucket": 472345
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "27262975"
+            },
+            "metrics": {
+                "exec_latency_bucket": 440879,
+                "liveness_heartbeatlatency_bucket": 74440,
+                "sql_exec_latency_internal_bucket": 18699,
+                "sql_service_latency_internal_bucket": 18656,
+                "txn_durations_bucket": 108954
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
                 "le": "245759"
             },
             "metrics": {
@@ -223,13 +1724,14 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "6655",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "49151",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_commandcommit_latency_bucket": 16,
-                "raft_process_handleready_latency_bucket": 1097
+                "raft_process_applycommitted_latency_bucket": 103,
+                "raft_process_commandcommit_latency_bucket": 225946
             }
         },
         "service": {
@@ -249,13 +1751,14 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "201326591"
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "122879"
             },
             "metrics": {
-                "exec_latency_bucket": 471550,
-                "liveness_heartbeatlatency_bucket": 81519,
-                "txn_durations_bucket": 116426
+                "exec_latency_bucket": 62938,
+                "sql_distsql_exec_latency_internal_bucket": 10,
+                "sql_exec_latency_internal_bucket": 10
             }
         },
         "service": {
@@ -275,42 +1778,14 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "475135"
-            },
-            "metrics": {
-                "exec_latency_bucket": 118561,
-                "round_trip_latency_bucket": 24576,
-                "sql_distsql_exec_latency_internal_bucket": 3031,
-                "sql_distsql_service_latency_internal_bucket": 21,
-                "sql_exec_latency_internal_bucket": 4407,
-                "sql_service_latency_internal_bucket": 21,
-                "txn_durations_bucket": 3146
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "1983",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "738197503",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_handleready_latency_bucket": 83
+                "raft_process_handleready_latency_bucket": 471692,
+                "raft_process_logcommit_latency_bucket": 470329
             }
         },
         "service": {
@@ -330,11 +1805,15 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "2952790015"
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "15204351"
             },
             "metrics": {
-                "liveness_heartbeatlatency_bucket": 81698
+                "exec_latency_bucket": 437266,
+                "liveness_heartbeatlatency_bucket": 73425,
+                "sql_service_latency_internal_bucket": 18612,
+                "txn_durations_bucket": 107821
             }
         },
         "service": {
@@ -354,12 +1833,41 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "3327",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "15728639"
+            },
+            "metrics": {
+                "exec_latency_bucket": 437288,
+                "liveness_heartbeatlatency_bucket": 73428,
+                "txn_durations_bucket": 107825
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "13311",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_handleready_latency_bucket": 275
+                "raft_process_commandcommit_latency_bucket": 10148,
+                "raft_process_handleready_latency_bucket": 1337
             }
         },
         "service": {
@@ -379,13 +1887,15 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "237567",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "23068671",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_applycommitted_latency_bucket": 107528,
-                "raft_process_commandcommit_latency_bucket": 317161
+                "raft_process_applycommitted_latency_bucket": 470377,
+                "raft_process_handleready_latency_bucket": 427150,
+                "raft_process_logcommit_latency_bucket": 426316
             }
         },
         "service": {
@@ -405,40 +1915,14 @@
         },
         "prometheus": {
             "labels": {
-                "advertise_addr": "roach1:26257",
-                "http_addr": "roach1:8080",
-                "instance": "127.0.0.1:50516"
-            },
-            "metrics": {
-                "node_id": 1
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "5767167",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "872415231",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_applycommitted_latency_bucket": 469849,
-                "raft_process_commandcommit_latency_bucket": 472296,
-                "raft_process_handleready_latency_bucket": 408159,
-                "raft_process_logcommit_latency_bucket": 421314
+                "raft_process_handleready_latency_bucket": 471701,
+                "raft_process_logcommit_latency_bucket": 470338
             }
         },
         "service": {
@@ -458,68 +1942,14 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "4063231"
-            },
-            "metrics": {
-                "exec_latency_bucket": 340382,
-                "liveness_heartbeatlatency_bucket": 59735,
-                "round_trip_latency_bucket": 122449,
-                "sql_distsql_service_latency_internal_bucket": 11980,
-                "sql_service_latency_internal_bucket": 16986,
-                "txn_durations_bucket": 94693
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "570425343"
-            },
-            "metrics": {
-                "exec_latency_bucket": 472271,
-                "liveness_heartbeatlatency_bucket": 81679,
-                "txn_durations_bucket": 116601
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "285212671",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "13107199",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_handleready_latency_bucket": 471373,
-                "raft_process_logcommit_latency_bucket": 470015
+                "raft_process_handleready_latency_bucket": 424856,
+                "raft_process_logcommit_latency_bucket": 423578
             }
         },
         "service": {
@@ -539,42 +1969,13 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "4980735"
-            },
-            "metrics": {
-                "exec_latency_bucket": 374158,
-                "liveness_heartbeatlatency_bucket": 69209,
-                "round_trip_latency_bucket": 122455,
-                "sql_distsql_service_latency_internal_bucket": 12524,
-                "sql_service_latency_internal_bucket": 18182,
-                "txn_durations_bucket": 103099
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "9727",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "28671",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_commandcommit_latency_bucket": 1240,
-                "raft_process_handleready_latency_bucket": 1291
+                "raft_process_commandcommit_latency_bucket": 89513
             }
         },
         "service": {
@@ -594,12 +1995,39 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "15359",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "1744830463"
+            },
+            "metrics": {
+                "liveness_heartbeatlatency_bucket": 81696
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "7247757311",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_commandcommit_latency_bucket": 16689
+                "raft_process_handleready_latency_bucket": 471743,
+                "raft_process_logcommit_latency_bucket": 470380
             }
         },
         "service": {
@@ -619,13 +2047,45 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "21503",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "192937983"
+            },
+            "metrics": {
+                "exec_latency_bucket": 471495,
+                "liveness_heartbeatlatency_bucket": 81505,
+                "sql_exec_latency_internal_bucket": 18866,
+                "sql_service_latency_internal_bucket": 18866,
+                "txn_durations_bucket": 116410
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "720895",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_commandcommit_latency_bucket": 37488,
-                "raft_process_handleready_latency_bucket": 1358
+                "raft_process_applycommitted_latency_bucket": 340938,
+                "raft_process_commandcommit_latency_bucket": 364822,
+                "raft_process_handleready_latency_bucket": 1713,
+                "raft_process_logcommit_latency_bucket": 10052
             }
         },
         "service": {
@@ -645,12 +2105,14 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "4351",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "90111",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_handleready_latency_bucket": 553
+                "raft_process_applycommitted_latency_bucket": 7312,
+                "raft_process_commandcommit_latency_bucket": 289881
             }
         },
         "service": {
@@ -670,215 +2132,8 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "4791"
-            },
-            "metrics": {
-                "sql_mem_distsql_max_bucket": 2453,
-                "sql_mem_internal_max_bucket": 18524,
-                "sql_mem_internal_txn_max_bucket": 7432
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "51199"
-            },
-            "metrics": {
-                "exec_latency_bucket": 8810
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "1919",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 77
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "38911"
-            },
-            "metrics": {
-                "exec_latency_bucket": 4556
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "18874367"
-            },
-            "metrics": {
-                "exec_latency_bucket": 437466,
-                "liveness_heartbeatlatency_bucket": 73476,
-                "round_trip_latency_bucket": 122496,
-                "sql_exec_latency_internal_bucket": 18615,
-                "txn_durations_bucket": 107878
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "243269631"
-            },
-            "metrics": {
-                "exec_latency_bucket": 471768,
-                "liveness_heartbeatlatency_bucket": 81567,
-                "sql_exec_latency_internal_bucket": 18867,
-                "sql_service_latency_internal_bucket": 18867,
-                "txn_durations_bucket": 116477
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "3199",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 249
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "10485759"
-            },
-            "metrics": {
-                "exec_latency_bucket": 436259,
-                "liveness_heartbeatlatency_bucket": 73373,
-                "round_trip_latency_bucket": 122488,
-                "sql_exec_latency_internal_bucket": 18612,
-                "txn_durations_bucket": 107761
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
                 "le": "753663"
             },
             "metrics": {
@@ -908,61 +2163,14 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "2684354559"
-            },
-            "metrics": {
-                "exec_latency_bucket": 472331
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "19455"
-            },
-            "metrics": {
-                "exec_latency_bucket": 3
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "344063",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "147455",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_applycommitted_latency_bucket": 185101,
-                "raft_process_commandcommit_latency_bucket": 332801
+                "raft_process_applycommitted_latency_bucket": 30681,
+                "raft_process_commandcommit_latency_bucket": 306129
             }
         },
         "service": {
@@ -982,13 +2190,16 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "131071",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "950271",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_applycommitted_latency_bucket": 21656,
-                "raft_process_commandcommit_latency_bucket": 303748
+                "raft_process_applycommitted_latency_bucket": 359543,
+                "raft_process_commandcommit_latency_bucket": 370943,
+                "raft_process_handleready_latency_bucket": 13745,
+                "raft_process_logcommit_latency_bucket": 65910
             }
         },
         "service": {
@@ -1008,7 +2219,672 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "19922943",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 470375,
+                "raft_process_commandcommit_latency_bucket": 472470,
+                "raft_process_handleready_latency_bucket": 425442,
+                "raft_process_logcommit_latency_bucket": 424236
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "79691775",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 468087,
+                "raft_process_logcommit_latency_bucket": 466919
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "524287"
+            },
+            "metrics": {
+                "exec_latency_bucket": 118701,
+                "round_trip_latency_bucket": 28175,
+                "sql_distsql_exec_latency_internal_bucket": 3786,
+                "sql_distsql_service_latency_internal_bucket": 34,
+                "sql_exec_latency_internal_bucket": 5663,
+                "sql_service_latency_internal_bucket": 34,
+                "txn_durations_bucket": 3935
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "81919"
+            },
+            "metrics": {
+                "exec_latency_bucket": 30481
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "570425343",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 471663,
+                "raft_process_logcommit_latency_bucket": 470300
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "12287",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_commandcommit_latency_bucket": 6970,
+                "raft_process_handleready_latency_bucket": 1329
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "8126463",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 470323,
+                "raft_process_handleready_latency_bucket": 422488,
+                "raft_process_logcommit_latency_bucket": 422705
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "229375",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 101518,
+                "raft_process_commandcommit_latency_bucket": 316056
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "3932159",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 465051,
+                "raft_process_commandcommit_latency_bucket": 470107,
+                "raft_process_handleready_latency_bucket": 352824,
+                "raft_process_logcommit_latency_bucket": 414696
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "720895"
+            },
+            "metrics": {
+                "exec_latency_bucket": 118842,
+                "round_trip_latency_bucket": 66901,
+                "sql_distsql_exec_latency_internal_bucket": 9360,
+                "sql_distsql_service_latency_internal_bucket": 77,
+                "sql_exec_latency_internal_bucket": 12681,
+                "sql_service_latency_internal_bucket": 79,
+                "txn_durations_bucket": 10782
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "6174015487"
+            },
+            "metrics": {
+                "exec_latency_bucket": 472344
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "41943039"
+            },
+            "metrics": {
+                "exec_latency_bucket": 451168,
+                "liveness_heartbeatlatency_bucket": 76401,
+                "sql_exec_latency_internal_bucket": 18820,
+                "sql_service_latency_internal_bucket": 18814,
+                "txn_durations_bucket": 111018
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "1769471"
+            },
+            "metrics": {
+                "exec_latency_bucket": 171923,
+                "liveness_heartbeatlatency_bucket": 9126,
+                "round_trip_latency_bucket": 122256,
+                "sql_distsql_exec_latency_internal_bucket": 12679,
+                "sql_distsql_service_latency_internal_bucket": 2580,
+                "sql_exec_latency_internal_bucket": 17856,
+                "sql_service_latency_internal_bucket": 3731,
+                "txn_durations_bucket": 40538
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "738197503"
+            },
+            "metrics": {
+                "exec_latency_bucket": 472292
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "603979775"
+            },
+            "metrics": {
+                "exec_latency_bucket": 472275,
+                "liveness_heartbeatlatency_bucket": 81680,
+                "txn_durations_bucket": 116603
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "3455",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 300
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "7423",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_commandcommit_latency_bucket": 25,
+                "raft_process_handleready_latency_bucket": 1160
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "92274687",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 469199,
+                "raft_process_logcommit_latency_bucket": 467982
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "63487",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 464,
+                "raft_process_commandcommit_latency_bucket": 259838
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "771751935"
+            },
+            "metrics": {
+                "exec_latency_bucket": 472293,
+                "liveness_heartbeatlatency_bucket": 81686,
+                "txn_durations_bucket": 116609
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "805306367",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 471698,
+                "raft_process_logcommit_latency_bucket": 470335
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "1040187391",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 471715,
+                "raft_process_logcommit_latency_bucket": 470352
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "3670015"
+            },
+            "metrics": {
+                "exec_latency_bucket": 320545,
+                "liveness_heartbeatlatency_bucket": 54185,
+                "sql_distsql_service_latency_internal_bucket": 11571,
+                "sql_service_latency_internal_bucket": 15950,
+                "txn_durations_bucket": 89085
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "30408703",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_commandcommit_latency_bucket": 472472,
+                "raft_process_handleready_latency_bucket": 439470,
+                "raft_process_logcommit_latency_bucket": 439253
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
                 "le": "6815743"
             },
             "metrics": {
@@ -1036,13 +2912,14 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "61439",
-                "store": "1"
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "100663295"
             },
             "metrics": {
-                "raft_process_applycommitted_latency_bucket": 389,
-                "raft_process_commandcommit_latency_bucket": 256228
+                "exec_latency_bucket": 470134,
+                "liveness_heartbeatlatency_bucket": 80997,
+                "txn_durations_bucket": 115891
             }
         },
         "service": {
@@ -1062,13 +2939,14 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "125829119",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "402653183",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_handleready_latency_bucket": 470326,
-                "raft_process_logcommit_latency_bucket": 468977
+                "raft_process_handleready_latency_bucket": 471601,
+                "raft_process_logcommit_latency_bucket": 470246
             }
         },
         "service": {
@@ -1088,12 +2966,12 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "1727",
-                "store": "1"
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "31743"
             },
             "metrics": {
-                "raft_process_handleready_latency_bucket": 53
+                "exec_latency_bucket": 2325
             }
         },
         "service": {
@@ -1113,13 +2991,18 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "369098751",
-                "store": "1"
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "4456447"
             },
             "metrics": {
-                "raft_process_handleready_latency_bucket": 471567,
-                "raft_process_logcommit_latency_bucket": 470204
+                "exec_latency_bucket": 356695,
+                "liveness_heartbeatlatency_bucket": 64846,
+                "round_trip_latency_bucket": 122453,
+                "sql_distsql_service_latency_internal_bucket": 12281,
+                "sql_exec_latency_internal_bucket": 18605,
+                "sql_service_latency_internal_bucket": 17704,
+                "txn_durations_bucket": 99500
             }
         },
         "service": {
@@ -1139,13 +3022,14 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "8191",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "43007",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_commandcommit_latency_bucket": 89,
-                "raft_process_handleready_latency_bucket": 1227
+                "raft_process_applycommitted_latency_bucket": 32,
+                "raft_process_commandcommit_latency_bucket": 200028
             }
         },
         "service": {
@@ -1165,15 +3049,16 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "1703935",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "3801087",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_applycommitted_latency_bucket": 392607,
-                "raft_process_commandcommit_latency_bucket": 406964,
-                "raft_process_handleready_latency_bucket": 173965,
-                "raft_process_logcommit_latency_bucket": 279460
+                "raft_process_applycommitted_latency_bucket": 464016,
+                "raft_process_commandcommit_latency_bucket": 469538,
+                "raft_process_handleready_latency_bucket": 347937,
+                "raft_process_logcommit_latency_bucket": 413347
             }
         },
         "service": {
@@ -1193,7 +3078,8 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
                 "le": "3014655"
             },
             "metrics": {
@@ -1223,13 +3109,15 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "113246207",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "86015",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_handleready_latency_bucket": 470084,
-                "raft_process_logcommit_latency_bucket": 468757
+                "raft_process_applycommitted_latency_bucket": 5944,
+                "raft_process_commandcommit_latency_bucket": 287064,
+                "raft_process_handleready_latency_bucket": 1363
             }
         },
         "service": {
@@ -1249,13 +3137,14 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "436207615",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "4607",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_handleready_latency_bucket": 471625,
-                "raft_process_logcommit_latency_bucket": 470262
+                "raft_process_commandcommit_latency_bucket": 4,
+                "raft_process_handleready_latency_bucket": 640
             }
         },
         "service": {
@@ -1275,13 +3164,43 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "13823",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "4791"
+            },
+            "metrics": {
+                "sql_mem_distsql_max_bucket": 2453,
+                "sql_mem_internal_max_bucket": 18524,
+                "sql_mem_internal_txn_max_bucket": 7432
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "2621439",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_commandcommit_latency_bucket": 11768,
-                "raft_process_handleready_latency_bucket": 1340
+                "raft_process_applycommitted_latency_bucket": 435523,
+                "raft_process_commandcommit_latency_bucket": 451840,
+                "raft_process_handleready_latency_bucket": 292876,
+                "raft_process_logcommit_latency_bucket": 378072
             }
         },
         "service": {
@@ -1301,12 +3220,18 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "26623",
-                "store": "1"
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "589823"
             },
             "metrics": {
-                "raft_process_commandcommit_latency_bucket": 71043
+                "exec_latency_bucket": 118789,
+                "round_trip_latency_bucket": 40605,
+                "sql_distsql_exec_latency_internal_bucket": 5268,
+                "sql_distsql_service_latency_internal_bucket": 46,
+                "sql_exec_latency_internal_bucket": 7857,
+                "sql_service_latency_internal_bucket": 46,
+                "txn_durations_bucket": 5809
             }
         },
         "service": {
@@ -1326,11 +3251,12 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "69631"
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "63487"
             },
             "metrics": {
-                "exec_latency_bucket": 18990
+                "exec_latency_bucket": 14789
             }
         },
         "service": {
@@ -1350,219 +3276,8 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "27262975",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 433726,
-                "raft_process_logcommit_latency_bucket": 433501
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "1677721599",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 471734,
-                "raft_process_logcommit_latency_bucket": 470371
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "507903"
-            },
-            "metrics": {
-                "exec_latency_bucket": 118671,
-                "round_trip_latency_bucket": 26542,
-                "sql_distsql_exec_latency_internal_bucket": 3479,
-                "sql_distsql_service_latency_internal_bucket": 27,
-                "sql_exec_latency_internal_bucket": 5172,
-                "sql_service_latency_internal_bucket": 27,
-                "txn_durations_bucket": 3636
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "109051903",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 469988,
-                "raft_process_logcommit_latency_bucket": 468660
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "69631",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 898,
-                "raft_process_commandcommit_latency_bucket": 269436
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "5637144575"
-            },
-            "metrics": {
-                "exec_latency_bucket": 472343
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "253951"
-            },
-            "metrics": {
-                "exec_latency_bucket": 108975,
-                "round_trip_latency_bucket": 25,
-                "sql_distsql_exec_latency_internal_bucket": 312,
-                "sql_exec_latency_internal_bucket": 530,
-                "txn_durations_bucket": 125
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "75497471",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 467642,
-                "raft_process_logcommit_latency_bucket": 466517
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
                 "le": "16777215"
             },
             "metrics": {
@@ -1589,13 +3304,18 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "104857599",
-                "store": "1"
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "688127"
             },
             "metrics": {
-                "raft_process_handleready_latency_bucket": 469859,
-                "raft_process_logcommit_latency_bucket": 468551
+                "exec_latency_bucket": 118835,
+                "round_trip_latency_bucket": 60828,
+                "sql_distsql_exec_latency_internal_bucket": 8542,
+                "sql_distsql_service_latency_internal_bucket": 72,
+                "sql_exec_latency_internal_bucket": 11755,
+                "sql_service_latency_internal_bucket": 72,
+                "txn_durations_bucket": 9577
             }
         },
         "service": {
@@ -1615,13 +3335,16 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "243269631",
-                "store": "1"
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "294911"
             },
             "metrics": {
-                "raft_process_handleready_latency_bucket": 471121,
-                "raft_process_logcommit_latency_bucket": 469762
+                "exec_latency_bucket": 114154,
+                "round_trip_latency_bucket": 2649,
+                "sql_distsql_exec_latency_internal_bucket": 963,
+                "sql_exec_latency_internal_bucket": 1394,
+                "txn_durations_bucket": 309
             }
         },
         "service": {
@@ -1641,7 +3364,453 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "251658239"
+            },
+            "metrics": {
+                "exec_latency_bucket": 471800,
+                "liveness_heartbeatlatency_bucket": 81573,
+                "sql_exec_latency_internal_bucket": 18868,
+                "sql_service_latency_internal_bucket": 18868,
+                "txn_durations_bucket": 116484
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "1835007",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 398728,
+                "raft_process_commandcommit_latency_bucket": 413884,
+                "raft_process_handleready_latency_bucket": 205457,
+                "raft_process_logcommit_latency_bucket": 298683
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "285212671"
+            },
+            "metrics": {
+                "exec_latency_bucket": 471987,
+                "liveness_heartbeatlatency_bucket": 81608,
+                "txn_durations_bucket": 116520
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "1114111"
+            },
+            "metrics": {
+                "exec_latency_bucket": 123490,
+                "liveness_heartbeatlatency_bucket": 396,
+                "round_trip_latency_bucket": 115252,
+                "sql_distsql_exec_latency_internal_bucket": 12309,
+                "sql_distsql_service_latency_internal_bucket": 348,
+                "sql_exec_latency_internal_bucket": 16238,
+                "sql_service_latency_internal_bucket": 761,
+                "txn_durations_bucket": 20294
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "102399"
+            },
+            "metrics": {
+                "exec_latency_bucket": 49403,
+                "sql_distsql_exec_latency_internal_bucket": 2,
+                "sql_exec_latency_internal_bucket": 2
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "4011"
+            },
+            "metrics": {
+                "sql_mem_distsql_max_bucket": 2452,
+                "sql_mem_internal_max_bucket": 17262,
+                "sql_mem_internal_session_max_bucket": 16068,
+                "sql_mem_internal_txn_max_bucket": 7426
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "221183",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 95235,
+                "raft_process_commandcommit_latency_bucket": 314935
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "28311551",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 435706,
+                "raft_process_logcommit_latency_bucket": 435547
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "83886079"
+            },
+            "metrics": {
+                "exec_latency_bucket": 468578,
+                "liveness_heartbeatlatency_bucket": 80351,
+                "txn_durations_bucket": 115225
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "1663",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 41
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "491519",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 282851,
+                "raft_process_commandcommit_latency_bucket": 351146
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "75497471",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 467642,
+                "raft_process_logcommit_latency_bucket": 466517
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "67108863"
+            },
+            "metrics": {
+                "exec_latency_bucket": 465970,
+                "liveness_heartbeatlatency_bucket": 79430,
+                "sql_exec_latency_internal_bucket": 18858,
+                "sql_service_latency_internal_bucket": 18856,
+                "txn_durations_bucket": 114247
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "1179647",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 368080,
+                "raft_process_commandcommit_latency_bucket": 379641,
+                "raft_process_handleready_latency_bucket": 43219,
+                "raft_process_logcommit_latency_bucket": 136343
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "369098751",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 471567,
+                "raft_process_logcommit_latency_bucket": 470204
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "134217727"
+            },
+            "metrics": {
+                "exec_latency_bucket": 471045,
+                "liveness_heartbeatlatency_bucket": 81344,
+                "txn_durations_bucket": 116245
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
                 "le": "221183"
             },
             "metrics": {
@@ -1668,15 +3837,13 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "46137343"
+                "advertise_addr": "roach1:26257",
+                "http_addr": "roach1:8080",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb"
             },
             "metrics": {
-                "exec_latency_bucket": 454376,
-                "liveness_heartbeatlatency_bucket": 76690,
-                "sql_exec_latency_internal_bucket": 18836,
-                "sql_service_latency_internal_bucket": 18826,
-                "txn_durations_bucket": 111341
+                "node_id": 1
             }
         },
         "service": {
@@ -1696,7 +3863,66 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "8126463"
+            },
+            "metrics": {
+                "exec_latency_bucket": 431543,
+                "liveness_heartbeatlatency_bucket": 73220,
+                "round_trip_latency_bucket": 122480,
+                "sql_distsql_service_latency_internal_bucket": 12694,
+                "sql_exec_latency_internal_bucket": 18610,
+                "sql_service_latency_internal_bucket": 18603,
+                "txn_durations_bucket": 107551
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "1677721599"
+            },
+            "metrics": {
+                "exec_latency_bucket": 472325,
+                "liveness_heartbeatlatency_bucket": 81695,
+                "txn_durations_bucket": 116617
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
                 "le": "3538943"
             },
             "metrics": {
@@ -1726,12 +3952,47 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "3711",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "475135"
+            },
+            "metrics": {
+                "exec_latency_bucket": 118561,
+                "round_trip_latency_bucket": 24576,
+                "sql_distsql_exec_latency_internal_bucket": 3031,
+                "sql_distsql_service_latency_internal_bucket": 21,
+                "sql_exec_latency_internal_bucket": 4407,
+                "sql_service_latency_internal_bucket": 21,
+                "txn_durations_bucket": 3146
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "33554431",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_handleready_latency_bucket": 369
+                "raft_process_applycommitted_latency_bucket": 470380,
+                "raft_process_commandcommit_latency_bucket": 472474,
+                "raft_process_handleready_latency_bucket": 443818,
+                "raft_process_logcommit_latency_bucket": 443713
             }
         },
         "service": {
@@ -1751,13 +4012,14 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "63487",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "24117247",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_applycommitted_latency_bucket": 464,
-                "raft_process_commandcommit_latency_bucket": 259838
+                "raft_process_handleready_latency_bucket": 428347,
+                "raft_process_logcommit_latency_bucket": 427756
             }
         },
         "service": {
@@ -1777,15 +4039,40 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "917503",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "402653183"
+            },
+            "metrics": {
+                "exec_latency_bucket": 472210,
+                "liveness_heartbeatlatency_bucket": 81661,
+                "txn_durations_bucket": 116577
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "3199",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_applycommitted_latency_bucket": 357987,
-                "raft_process_commandcommit_latency_bucket": 369962,
-                "raft_process_handleready_latency_bucket": 11226,
-                "raft_process_logcommit_latency_bucket": 54776
+                "raft_process_handleready_latency_bucket": 249
             }
         },
         "service": {
@@ -1805,14 +4092,14 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "52428799",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "14680063",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_handleready_latency_bucket": 459987,
-                "raft_process_logcommit_latency_bucket": 459888,
-                "txnwaitqueue_pusher_wait_time_bucket": 7
+                "raft_process_handleready_latency_bucket": 424946,
+                "raft_process_logcommit_latency_bucket": 423630
             }
         },
         "service": {
@@ -1832,16 +4119,14 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "3407871"
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "1543503871"
             },
             "metrics": {
-                "exec_latency_bucket": 306613,
-                "liveness_heartbeatlatency_bucket": 50683,
-                "round_trip_latency_bucket": 122436,
-                "sql_distsql_service_latency_internal_bucket": 11073,
-                "sql_service_latency_internal_bucket": 15120,
-                "txn_durations_bucket": 85326
+                "exec_latency_bucket": 472323,
+                "liveness_heartbeatlatency_bucket": 81692,
+                "txn_durations_bucket": 116616
             }
         },
         "service": {
@@ -1861,15 +4146,14 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "3670015",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "121634815",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_applycommitted_latency_bucket": 462590,
-                "raft_process_commandcommit_latency_bucket": 468838,
-                "raft_process_handleready_latency_bucket": 342969,
-                "raft_process_logcommit_latency_bucket": 411771
+                "raft_process_handleready_latency_bucket": 470257,
+                "raft_process_logcommit_latency_bucket": 468928
             }
         },
         "service": {
@@ -1889,7 +4173,1832 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "118783",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 16528,
+                "raft_process_commandcommit_latency_bucket": 301279
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "32767",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_commandcommit_latency_bucket": 127282
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "56623103"
+            },
+            "metrics": {
+                "exec_latency_bucket": 462143,
+                "liveness_heartbeatlatency_bucket": 78151,
+                "sql_exec_latency_internal_bucket": 18853,
+                "sql_service_latency_internal_bucket": 18848,
+                "txn_durations_bucket": 112910
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "950271"
+            },
+            "metrics": {
+                "exec_latency_bucket": 119677,
+                "round_trip_latency_bucket": 103438,
+                "sql_distsql_exec_latency_internal_bucket": 11769,
+                "sql_distsql_service_latency_internal_bucket": 126,
+                "sql_exec_latency_internal_bucket": 15424,
+                "sql_service_latency_internal_bucket": 362,
+                "txn_durations_bucket": 17310
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "6815743",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 470232,
+                "raft_process_commandcommit_latency_bucket": 472419,
+                "raft_process_handleready_latency_bucket": 418605,
+                "raft_process_logcommit_latency_bucket": 422123
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "671088639",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 471685,
+                "raft_process_logcommit_latency_bucket": 470322
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "311295"
+            },
+            "metrics": {
+                "exec_latency_bucket": 115436,
+                "round_trip_latency_bucket": 4865,
+                "sql_distsql_exec_latency_internal_bucket": 1232,
+                "sql_exec_latency_internal_bucket": 1744,
+                "txn_durations_bucket": 477
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "163839"
+            },
+            "metrics": {
+                "exec_latency_bucket": 82683,
+                "sql_distsql_exec_latency_internal_bucket": 45,
+                "sql_exec_latency_internal_bucket": 51,
+                "txn_durations_bucket": 1
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "180223",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 59212,
+                "raft_process_commandcommit_latency_bucket": 310067
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "150994943"
+            },
+            "metrics": {
+                "exec_latency_bucket": 471222,
+                "liveness_heartbeatlatency_bucket": 81422,
+                "sql_service_latency_internal_bucket": 18864,
+                "txn_durations_bucket": 116325
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "6911",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_commandcommit_latency_bucket": 18,
+                "raft_process_handleready_latency_bucket": 1116
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "1310719",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 373424,
+                "raft_process_commandcommit_latency_bucket": 386355,
+                "raft_process_handleready_latency_bucket": 75120,
+                "raft_process_logcommit_latency_bucket": 184907
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "2303",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 132
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "503316479",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 471652,
+                "raft_process_logcommit_latency_bucket": 470289
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "2559",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 182
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "29360127",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 437654,
+                "raft_process_logcommit_latency_bucket": 437450
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "26623",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_commandcommit_latency_bucket": 71043
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "1791",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 63
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "234881023"
+            },
+            "metrics": {
+                "exec_latency_bucket": 471733,
+                "liveness_heartbeatlatency_bucket": 81557,
+                "txn_durations_bucket": 116466
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "5767167",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 469849,
+                "raft_process_commandcommit_latency_bucket": 472296,
+                "raft_process_handleready_latency_bucket": 408159,
+                "raft_process_logcommit_latency_bucket": 421314
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "253951",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 119152,
+                "raft_process_commandcommit_latency_bucket": 319589
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "131071",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 21656,
+                "raft_process_commandcommit_latency_bucket": 303748
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "557055"
+            },
+            "metrics": {
+                "exec_latency_bucket": 118749,
+                "round_trip_latency_bucket": 33758,
+                "sql_distsql_exec_latency_internal_bucket": 4485,
+                "sql_distsql_service_latency_internal_bucket": 41,
+                "sql_exec_latency_internal_bucket": 6730,
+                "sql_service_latency_internal_bucket": 41,
+                "txn_durations_bucket": 4741
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "6291455"
+            },
+            "metrics": {
+                "exec_latency_bucket": 411358,
+                "liveness_heartbeatlatency_bucket": 72238,
+                "round_trip_latency_bucket": 122468,
+                "sql_distsql_service_latency_internal_bucket": 12670,
+                "sql_exec_latency_internal_bucket": 18609,
+                "sql_service_latency_internal_bucket": 18513,
+                "txn_durations_bucket": 106546
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "24575"
+            },
+            "metrics": {
+                "exec_latency_bucket": 171
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "486539263"
+            },
+            "metrics": {
+                "exec_latency_bucket": 472256
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "180223"
+            },
+            "metrics": {
+                "exec_latency_bucket": 89333,
+                "sql_distsql_exec_latency_internal_bucket": 60,
+                "sql_exec_latency_internal_bucket": 83,
+                "txn_durations_bucket": 3
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "53247",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 171,
+                "raft_process_commandcommit_latency_bucket": 238403
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "117440511",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 470171,
+                "raft_process_logcommit_latency_bucket": 468843
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "159383551"
+            },
+            "metrics": {
+                "exec_latency_bucket": 471283,
+                "liveness_heartbeatlatency_bucket": 81440,
+                "txn_durations_bucket": 116342
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "16777215",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 425068,
+                "raft_process_logcommit_latency_bucket": 423770
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "61439",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 389,
+                "raft_process_commandcommit_latency_bucket": 256228
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "301989887",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 471420,
+                "raft_process_logcommit_latency_bucket": 470062
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "4194303",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 466749,
+                "raft_process_commandcommit_latency_bucket": 470900,
+                "raft_process_handleready_latency_bucket": 362522,
+                "raft_process_logcommit_latency_bucket": 416658
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "110591",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 13657,
+                "raft_process_commandcommit_latency_bucket": 299094
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "1535",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 10
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "1207959551",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 471724,
+                "raft_process_logcommit_latency_bucket": 470361
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "167772159"
+            },
+            "metrics": {
+                "exec_latency_bucket": 471338,
+                "liveness_heartbeatlatency_bucket": 81462,
+                "txn_durations_bucket": 116365
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "77823",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 2927,
+                "raft_process_commandcommit_latency_bucket": 279625
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "39845887"
+            },
+            "metrics": {
+                "exec_latency_bucket": 449729,
+                "liveness_heartbeatlatency_bucket": 76266,
+                "sql_exec_latency_internal_bucket": 18815,
+                "sql_service_latency_internal_bucket": 18804,
+                "txn_durations_bucket": 110877
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "11534335"
+            },
+            "metrics": {
+                "exec_latency_bucket": 436774,
+                "liveness_heartbeatlatency_bucket": 73391,
+                "round_trip_latency_bucket": 122491,
+                "txn_durations_bucket": 107785
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "475135",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 275530,
+                "raft_process_commandcommit_latency_bucket": 349252
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "27647",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_commandcommit_latency_bucket": 80135,
+                "raft_process_handleready_latency_bucket": 1361
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "3145727",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 453965,
+                "raft_process_commandcommit_latency_bucket": 463533,
+                "raft_process_handleready_latency_bucket": 320782,
+                "raft_process_logcommit_latency_bucket": 401260,
+                "txnwaitqueue_pusher_wait_time_bucket": 5
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "819199",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 351677,
+                "raft_process_commandcommit_latency_bucket": 367460,
+                "raft_process_handleready_latency_bucket": 5082,
+                "raft_process_logcommit_latency_bucket": 26156
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "22020095",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 470376,
+                "raft_process_commandcommit_latency_bucket": 472471,
+                "raft_process_handleready_latency_bucket": 426361,
+                "raft_process_logcommit_latency_bucket": 425332
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "55295",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 215,
+                "raft_process_commandcommit_latency_bucket": 243569
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "14155775",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 470373,
+                "raft_process_handleready_latency_bucket": 424925,
+                "raft_process_logcommit_latency_bucket": 423614
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "17407",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_commandcommit_latency_bucket": 23033,
+                "raft_process_handleready_latency_bucket": 1350
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "17825791"
+            },
+            "metrics": {
+                "exec_latency_bucket": 437399,
+                "liveness_heartbeatlatency_bucket": 73455,
+                "round_trip_latency_bucket": 122495,
+                "sql_service_latency_internal_bucket": 18613,
+                "txn_durations_bucket": 107855
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "35651583",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 470382,
+                "raft_process_handleready_latency_bucket": 445891,
+                "raft_process_logcommit_latency_bucket": 445826
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "2943",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 227
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "7167",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 1145
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "486539263",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 471644,
+                "raft_process_logcommit_latency_bucket": 470281
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "786431"
+            },
+            "metrics": {
+                "exec_latency_bucket": 118854,
+                "round_trip_latency_bucket": 78060,
+                "sql_distsql_exec_latency_internal_bucket": 10515,
+                "sql_distsql_service_latency_internal_bucket": 91,
+                "sql_exec_latency_internal_bucket": 13952,
+                "sql_service_latency_internal_bucket": 141,
+                "txn_durations_bucket": 13114
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "3276799"
+            },
+            "metrics": {
+                "exec_latency_bucket": 299755,
+                "liveness_heartbeatlatency_bucket": 48802,
+                "round_trip_latency_bucket": 122435,
+                "sql_distsql_exec_latency_internal_bucket": 12695,
+                "sql_distsql_service_latency_internal_bucket": 10619,
+                "sql_exec_latency_internal_bucket": 18598,
+                "sql_service_latency_internal_bucket": 14498,
+                "txn_durations_bucket": 83510
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "9961471",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 470359,
+                "raft_process_commandcommit_latency_bucket": 472462,
+                "raft_process_handleready_latency_bucket": 424330,
+                "raft_process_logcommit_latency_bucket": 423404
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "503316479"
+            },
+            "metrics": {
+                "exec_latency_bucket": 472262,
+                "liveness_heartbeatlatency_bucket": 81674,
+                "txn_durations_bucket": 116595
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "59391"
+            },
+            "metrics": {
+                "exec_latency_bucket": 12449
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "7516192767",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 471744,
+                "raft_process_logcommit_latency_bucket": 470381
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "212991"
+            },
+            "metrics": {
+                "exec_latency_bucket": 100298,
+                "sql_distsql_exec_latency_internal_bucket": 96,
+                "sql_exec_latency_internal_bucket": 160,
+                "txn_durations_bucket": 24
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "65535"
+            },
+            "metrics": {
+                "exec_latency_bucket": 16026
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "11263",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_commandcommit_latency_bucket": 4206,
+                "raft_process_handleready_latency_bucket": 1319
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "7602175"
+            },
+            "metrics": {
+                "exec_latency_bucket": 428859,
+                "liveness_heartbeatlatency_bucket": 73107,
+                "round_trip_latency_bucket": 122474,
+                "sql_distsql_service_latency_internal_bucket": 12692,
+                "sql_service_latency_internal_bucket": 18592,
+                "txn_durations_bucket": 107420
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "393215"
+            },
+            "metrics": {
+                "exec_latency_bucket": 117973,
+                "round_trip_latency_bucket": 18236,
+                "sql_distsql_exec_latency_internal_bucket": 2341,
+                "sql_exec_latency_internal_bucket": 3097,
+                "txn_durations_bucket": 1880
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "285212671",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 471373,
+                "raft_process_logcommit_latency_bucket": 470015
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
                 "le": "262143",
                 "store": "1"
             },
@@ -1915,7 +6024,730 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "1140850687"
+            },
+            "metrics": {
+                "exec_latency_bucket": 472314
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "3801087"
+            },
+            "metrics": {
+                "exec_latency_bucket": 327474,
+                "liveness_heartbeatlatency_bucket": 56019,
+                "round_trip_latency_bucket": 122443,
+                "sql_distsql_service_latency_internal_bucket": 11722,
+                "sql_exec_latency_internal_bucket": 18603,
+                "sql_service_latency_internal_bucket": 16297,
+                "txn_durations_bucket": 91006
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "172031"
+            },
+            "metrics": {
+                "exec_latency_bucket": 86111,
+                "sql_distsql_exec_latency_internal_bucket": 52,
+                "sql_exec_latency_internal_bucket": 69
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "7077887"
+            },
+            "metrics": {
+                "exec_latency_bucket": 424304,
+                "liveness_heartbeatlatency_bucket": 72904,
+                "sql_distsql_service_latency_internal_bucket": 12686,
+                "sql_service_latency_internal_bucket": 18574,
+                "txn_durations_bucket": 107218
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "1599",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 26
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "2550136831",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 471735,
+                "raft_process_logcommit_latency_bucket": 470372
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "81919",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 4453,
+                "raft_process_commandcommit_latency_bucket": 283714
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "12348030975"
+            },
+            "metrics": {
+                "exec_latency_bucket": 472347,
+                "txn_durations_bucket": 116627
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "21503",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_commandcommit_latency_bucket": 37488,
+                "raft_process_handleready_latency_bucket": 1358
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "251658239",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 471166,
+                "raft_process_logcommit_latency_bucket": 469810
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "2684354559",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 471737,
+                "raft_process_logcommit_latency_bucket": 470374
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "58720255",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 463780,
+                "raft_process_logcommit_latency_bucket": 463033
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "917503"
+            },
+            "metrics": {
+                "exec_latency_bucket": 119248,
+                "round_trip_latency_bucket": 99397,
+                "sql_distsql_exec_latency_internal_bucket": 11626,
+                "sql_distsql_service_latency_internal_bucket": 121,
+                "sql_exec_latency_internal_bucket": 15227,
+                "sql_service_latency_internal_bucket": 322,
+                "txn_durations_bucket": 16694
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "3276799",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 456712,
+                "raft_process_commandcommit_latency_bucket": 465344,
+                "raft_process_handleready_latency_bucket": 326834,
+                "raft_process_logcommit_latency_bucket": 404595
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "507903"
+            },
+            "metrics": {
+                "exec_latency_bucket": 118671,
+                "round_trip_latency_bucket": 26542,
+                "sql_distsql_exec_latency_internal_bucket": 3479,
+                "sql_distsql_service_latency_internal_bucket": 27,
+                "sql_exec_latency_internal_bucket": 5172,
+                "sql_service_latency_internal_bucket": 27,
+                "txn_durations_bucket": 3636
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "29695",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_commandcommit_latency_bucket": 99081
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "192937983",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 470801,
+                "raft_process_logcommit_latency_bucket": 469447
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "1900543"
+            },
+            "metrics": {
+                "exec_latency_bucket": 187591,
+                "liveness_heartbeatlatency_bucket": 11700,
+                "round_trip_latency_bucket": 122316,
+                "sql_distsql_exec_latency_internal_bucket": 12687,
+                "sql_distsql_service_latency_internal_bucket": 2816,
+                "sql_exec_latency_internal_bucket": 18200,
+                "sql_service_latency_internal_bucket": 4326,
+                "txn_durations_bucket": 43816
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "86015"
+            },
+            "metrics": {
+                "exec_latency_bucket": 34536
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "31457279",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 470379,
+                "raft_process_handleready_latency_bucket": 441064,
+                "raft_process_logcommit_latency_bucket": 440886
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "131071"
+            },
+            "metrics": {
+                "exec_latency_bucket": 67524,
+                "sql_distsql_exec_latency_internal_bucket": 17,
+                "sql_exec_latency_internal_bucket": 17
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "622591"
+            },
+            "metrics": {
+                "exec_latency_bucket": 118808,
+                "round_trip_latency_bucket": 47657,
+                "sql_distsql_exec_latency_internal_bucket": 6400,
+                "sql_distsql_service_latency_internal_bucket": 53,
+                "sql_exec_latency_internal_bucket": 9264,
+                "sql_service_latency_internal_bucket": 53,
+                "txn_durations_bucket": 7009
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "6553599",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 470185,
+                "raft_process_commandcommit_latency_bucket": 472401,
+                "raft_process_handleready_latency_bucket": 416988,
+                "raft_process_logcommit_latency_bucket": 421976
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "15569256447"
+            },
+            "metrics": {
+                "exec_latency_bucket": 472350,
+                "liveness_heartbeatlatency_bucket": 81711
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "184549375",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 470764,
+                "raft_process_logcommit_latency_bucket": 469403
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "126975"
+            },
+            "metrics": {
+                "exec_latency_bucket": 65281,
+                "sql_distsql_exec_latency_internal_bucket": 13,
+                "sql_exec_latency_internal_bucket": 13
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
                 "le": "4095",
                 "store": "1"
             },
@@ -1940,15 +6772,74 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "4456447",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "96468991"
+            },
+            "metrics": {
+                "exec_latency_bucket": 469896,
+                "liveness_heartbeatlatency_bucket": 80887,
+                "txn_durations_bucket": 115781
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "1310719"
+            },
+            "metrics": {
+                "exec_latency_bucket": 131722,
+                "liveness_heartbeatlatency_bucket": 2021,
+                "round_trip_latency_bucket": 120236,
+                "sql_distsql_exec_latency_internal_bucket": 12563,
+                "sql_distsql_service_latency_internal_bucket": 1123,
+                "sql_exec_latency_internal_bucket": 16691,
+                "sql_service_latency_internal_bucket": 1666,
+                "txn_durations_bucket": 25563
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "557055",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_applycommitted_latency_bucket": 467849,
-                "raft_process_commandcommit_latency_bucket": 471445,
-                "raft_process_handleready_latency_bucket": 372147,
-                "raft_process_logcommit_latency_bucket": 418075
+                "raft_process_applycommitted_latency_bucket": 306165,
+                "raft_process_commandcommit_latency_bucket": 357394,
+                "raft_process_logcommit_latency_bucket": 1
             }
         },
         "service": {
@@ -1968,13 +6859,14 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "20479",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "1610612735",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_commandcommit_latency_bucket": 33096,
-                "raft_process_handleready_latency_bucket": 1357
+                "raft_process_handleready_latency_bucket": 471733,
+                "raft_process_logcommit_latency_bucket": 470370
             }
         },
         "service": {
@@ -1994,15 +6886,14 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "6029311",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "7935",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_applycommitted_latency_bucket": 469987,
-                "raft_process_commandcommit_latency_bucket": 472341,
-                "raft_process_handleready_latency_bucket": 411887,
-                "raft_process_logcommit_latency_bucket": 421569
+                "raft_process_commandcommit_latency_bucket": 52,
+                "raft_process_handleready_latency_bucket": 1204
             }
         },
         "service": {
@@ -2022,13 +6913,77 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "15871",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "376831"
+            },
+            "metrics": {
+                "exec_latency_bucket": 117735,
+                "round_trip_latency_bucket": 16139,
+                "sql_distsql_exec_latency_internal_bucket": 2159,
+                "sql_distsql_service_latency_internal_bucket": 6,
+                "sql_exec_latency_internal_bucket": 2854,
+                "sql_service_latency_internal_bucket": 6,
+                "txn_durations_bucket": 1614
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "6029311"
+            },
+            "metrics": {
+                "exec_latency_bucket": 404970,
+                "liveness_heartbeatlatency_bucket": 71908,
+                "round_trip_latency_bucket": 122465,
+                "sql_distsql_service_latency_internal_bucket": 12665,
+                "sql_service_latency_internal_bucket": 18480,
+                "txn_durations_bucket": 106060
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "12058623",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_commandcommit_latency_bucket": 18288,
-                "raft_process_handleready_latency_bucket": 1346
+                "raft_process_applycommitted_latency_bucket": 470372,
+                "raft_process_commandcommit_latency_bucket": 472469,
+                "raft_process_handleready_latency_bucket": 424764,
+                "raft_process_logcommit_latency_bucket": 423542
             }
         },
         "service": {
@@ -2048,16 +7003,16 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "1966079",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "10485759",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_applycommitted_latency_bucket": 405016,
-                "raft_process_commandcommit_latency_bucket": 420592,
-                "raft_process_handleready_latency_bucket": 230462,
-                "raft_process_logcommit_latency_bucket": 315841,
-                "txnwaitqueue_pusher_wait_time_bucket": 1
+                "raft_process_applycommitted_latency_bucket": 470365,
+                "raft_process_commandcommit_latency_bucket": 472467,
+                "raft_process_handleready_latency_bucket": 424501,
+                "raft_process_logcommit_latency_bucket": 423442
             }
         },
         "service": {
@@ -2077,13 +7032,14 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "1040187391",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "212991",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_handleready_latency_bucket": 471715,
-                "raft_process_logcommit_latency_bucket": 470352
+                "raft_process_applycommitted_latency_bucket": 88794,
+                "raft_process_commandcommit_latency_bucket": 313937
             }
         },
         "service": {
@@ -2103,15 +7059,16 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "35651583"
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "46137343"
             },
             "metrics": {
-                "exec_latency_bucket": 447261,
-                "liveness_heartbeatlatency_bucket": 76010,
-                "sql_exec_latency_internal_bucket": 18795,
-                "sql_service_latency_internal_bucket": 18779,
-                "txn_durations_bucket": 110608
+                "exec_latency_bucket": 454376,
+                "liveness_heartbeatlatency_bucket": 76690,
+                "sql_exec_latency_internal_bucket": 18836,
+                "sql_service_latency_internal_bucket": 18826,
+                "txn_durations_bucket": 111341
             }
         },
         "service": {
@@ -2131,15 +7088,68 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "720895",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "536870911"
+            },
+            "metrics": {
+                "exec_latency_bucket": 472269,
+                "liveness_heartbeatlatency_bucket": 81678,
+                "txn_durations_bucket": 116600
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "570425343"
+            },
+            "metrics": {
+                "exec_latency_bucket": 472271,
+                "liveness_heartbeatlatency_bucket": 81679,
+                "txn_durations_bucket": 116601
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "469762047",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_applycommitted_latency_bucket": 340938,
-                "raft_process_commandcommit_latency_bucket": 364822,
-                "raft_process_handleready_latency_bucket": 1713,
-                "raft_process_logcommit_latency_bucket": 10052
+                "raft_process_handleready_latency_bucket": 471640,
+                "raft_process_logcommit_latency_bucket": 470277
             }
         },
         "service": {
@@ -2159,12 +7169,45 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "31743",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "344063"
+            },
+            "metrics": {
+                "exec_latency_bucket": 116938,
+                "round_trip_latency_bucket": 10558,
+                "sql_distsql_exec_latency_internal_bucket": 1714,
+                "sql_distsql_service_latency_internal_bucket": 1,
+                "sql_exec_latency_internal_bucket": 2330,
+                "sql_service_latency_internal_bucket": 1,
+                "txn_durations_bucket": 1045
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "27262975",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_commandcommit_latency_bucket": 118084
+                "raft_process_handleready_latency_bucket": 433726,
+                "raft_process_logcommit_latency_bucket": 433501
             }
         },
         "service": {
@@ -2184,15 +7227,41 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "4718591",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "4160749567"
+            },
+            "metrics": {
+                "liveness_heartbeatlatency_bucket": 81703
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "4980735",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_applycommitted_latency_bucket": 468610,
-                "raft_process_commandcommit_latency_bucket": 471770,
-                "raft_process_handleready_latency_bucket": 381235,
-                "raft_process_logcommit_latency_bucket": 419094
+                "raft_process_applycommitted_latency_bucket": 469166,
+                "raft_process_commandcommit_latency_bucket": 471949,
+                "raft_process_handleready_latency_bucket": 389769,
+                "raft_process_logcommit_latency_bucket": 419872
             }
         },
         "service": {
@@ -2212,7 +7281,339 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "23551"
+            },
+            "metrics": {
+                "exec_latency_bucket": 35
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "19922943"
+            },
+            "metrics": {
+                "exec_latency_bucket": 437534,
+                "liveness_heartbeatlatency_bucket": 73498,
+                "sql_exec_latency_internal_bucket": 18616,
+                "sql_service_latency_internal_bucket": 18614,
+                "txn_durations_bucket": 107903
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "753663",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 345224,
+                "raft_process_commandcommit_latency_bucket": 365723,
+                "raft_process_handleready_latency_bucket": 2374,
+                "raft_process_logcommit_latency_bucket": 14115
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "29695"
+            },
+            "metrics": {
+                "exec_latency_bucket": 1605
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "327679"
+            },
+            "metrics": {
+                "exec_latency_bucket": 116347,
+                "round_trip_latency_bucket": 7628,
+                "sql_distsql_exec_latency_internal_bucket": 1487,
+                "sql_exec_latency_internal_bucket": 2053,
+                "txn_durations_bucket": 765
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "3407871",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 459081,
+                "raft_process_commandcommit_latency_bucket": 466793,
+                "raft_process_handleready_latency_bucket": 332542,
+                "raft_process_logcommit_latency_bucket": 407424,
+                "txnwaitqueue_pusher_wait_time_bucket": 6
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "209715199",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 470909,
+                "raft_process_logcommit_latency_bucket": 469547
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "4563402751"
+            },
+            "metrics": {
+                "exec_latency_bucket": 472342,
+                "liveness_heartbeatlatency_bucket": 81709,
+                "txn_durations_bucket": 116625
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "3538943",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 460992,
+                "raft_process_commandcommit_latency_bucket": 467942,
+                "raft_process_handleready_latency_bucket": 337942,
+                "raft_process_logcommit_latency_bucket": 409771
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "260046847"
+            },
+            "metrics": {
+                "exec_latency_bucket": 471850,
+                "liveness_heartbeatlatency_bucket": 81584,
+                "txn_durations_bucket": 116495
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "2175",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 106
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "65011711",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 470384,
+                "raft_process_handleready_latency_bucket": 465874,
+                "raft_process_logcommit_latency_bucket": 464886
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
                 "store": "1"
             },
             "metrics": {
@@ -2418,178 +7819,14 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "536870911"
-            },
-            "metrics": {
-                "exec_latency_bucket": 472269,
-                "liveness_heartbeatlatency_bucket": 81678,
-                "txn_durations_bucket": 116600
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "1015807"
-            },
-            "metrics": {
-                "exec_latency_bucket": 120881,
-                "liveness_heartbeatlatency_bucket": 43,
-                "round_trip_latency_bucket": 109538,
-                "sql_distsql_exec_latency_internal_bucket": 12055,
-                "sql_distsql_service_latency_internal_bucket": 159,
-                "sql_exec_latency_internal_bucket": 15812,
-                "sql_service_latency_internal_bucket": 460,
-                "txn_durations_bucket": 18383
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "13631487"
-            },
-            "metrics": {
-                "exec_latency_bucket": 437150,
-                "liveness_heartbeatlatency_bucket": 73418,
-                "round_trip_latency_bucket": 122493,
-                "txn_durations_bucket": 107812
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "1048575"
-            },
-            "metrics": {
-                "exec_latency_bucket": 121628,
-                "liveness_heartbeatlatency_bucket": 125,
-                "round_trip_latency_bucket": 111823,
-                "sql_distsql_exec_latency_internal_bucket": 12156,
-                "sql_distsql_service_latency_internal_bucket": 189,
-                "sql_exec_latency_internal_bucket": 15981,
-                "sql_service_latency_internal_bucket": 531,
-                "txn_durations_bucket": 18928
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "2013265919"
-            },
-            "metrics": {
-                "exec_latency_bucket": 472326,
-                "liveness_heartbeatlatency_bucket": 81697,
-                "txn_durations_bucket": 116618
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "7247757311"
-            },
-            "metrics": {
-                "exec_latency_bucket": 472345
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "1275068415",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "18874367",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_handleready_latency_bucket": 471726,
-                "raft_process_logcommit_latency_bucket": 470363
+                "raft_process_handleready_latency_bucket": 425289,
+                "raft_process_logcommit_latency_bucket": 423989
             }
         },
         "service": {
@@ -2609,11 +7846,14 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "3087007743"
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "3355443199"
             },
             "metrics": {
-                "exec_latency_bucket": 472337
+                "exec_latency_bucket": 472338,
+                "liveness_heartbeatlatency_bucket": 81700,
+                "txn_durations_bucket": 116621
             }
         },
         "service": {
@@ -2633,13 +7873,76 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "6979321855",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "9961471"
+            },
+            "metrics": {
+                "exec_latency_bucket": 435775,
+                "liveness_heartbeatlatency_bucket": 73362,
+                "round_trip_latency_bucket": 122485,
+                "sql_service_latency_internal_bucket": 18609,
+                "txn_durations_bucket": 107742
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "2359295"
+            },
+            "metrics": {
+                "exec_latency_bucket": 241340,
+                "liveness_heartbeatlatency_bucket": 24018,
+                "round_trip_latency_bucket": 122390,
+                "sql_distsql_service_latency_internal_bucket": 4439,
+                "sql_exec_latency_internal_bucket": 18492,
+                "sql_service_latency_internal_bucket": 7366,
+                "txn_durations_bucket": 61388
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "11010047",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_handleready_latency_bucket": 471742,
-                "raft_process_logcommit_latency_bucket": 470379
+                "raft_process_applycommitted_latency_bucket": 470368,
+                "raft_process_commandcommit_latency_bucket": 472468,
+                "raft_process_handleready_latency_bucket": 424618,
+                "raft_process_logcommit_latency_bucket": 423491
             }
         },
         "service": {
@@ -2659,13 +7962,39 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "245759",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "2684354559"
+            },
+            "metrics": {
+                "exec_latency_bucket": 472331
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "46137343",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_applycommitted_latency_bucket": 113329,
-                "raft_process_commandcommit_latency_bucket": 318348
+                "raft_process_handleready_latency_bucket": 454638,
+                "raft_process_logcommit_latency_bucket": 455050
             }
         },
         "service": {
@@ -2685,70 +8014,16 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "83886079"
-            },
-            "metrics": {
-                "exec_latency_bucket": 468578,
-                "liveness_heartbeatlatency_bucket": 80351,
-                "txn_durations_bucket": 115225
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "1310719"
-            },
-            "metrics": {
-                "exec_latency_bucket": 131722,
-                "liveness_heartbeatlatency_bucket": 2021,
-                "round_trip_latency_bucket": 120236,
-                "sql_distsql_exec_latency_internal_bucket": 12563,
-                "sql_distsql_service_latency_internal_bucket": 1123,
-                "sql_exec_latency_internal_bucket": 16691,
-                "sql_service_latency_internal_bucket": 1666,
-                "txn_durations_bucket": 25563
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "1342177279",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "2359295",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_handleready_latency_bucket": 471732,
-                "raft_process_logcommit_latency_bucket": 470369
+                "raft_process_applycommitted_latency_bucket": 423159,
+                "raft_process_commandcommit_latency_bucket": 441039,
+                "raft_process_handleready_latency_bucket": 274571,
+                "raft_process_logcommit_latency_bucket": 357862
             }
         },
         "service": {
@@ -2768,13 +8043,14 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "79691775",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "12582911",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_handleready_latency_bucket": 468087,
-                "raft_process_logcommit_latency_bucket": 466919
+                "raft_process_handleready_latency_bucket": 424819,
+                "raft_process_logcommit_latency_bucket": 423559
             }
         },
         "service": {
@@ -2794,11 +8070,18 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "53247"
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "819199"
             },
             "metrics": {
-                "exec_latency_bucket": 9583
+                "exec_latency_bucket": 118872,
+                "round_trip_latency_bucket": 83831,
+                "sql_distsql_exec_latency_internal_bucket": 10905,
+                "sql_distsql_service_latency_internal_bucket": 100,
+                "sql_exec_latency_internal_bucket": 14391,
+                "sql_service_latency_internal_bucket": 188,
+                "txn_durations_bucket": 14160
             }
         },
         "service": {
@@ -2818,17 +8101,12 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "655359"
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "2550136831"
             },
             "metrics": {
-                "exec_latency_bucket": 118827,
-                "round_trip_latency_bucket": 54350,
-                "sql_distsql_exec_latency_internal_bucket": 7515,
-                "sql_distsql_service_latency_internal_bucket": 59,
-                "sql_exec_latency_internal_bucket": 10602,
-                "sql_service_latency_internal_bucket": 59,
-                "txn_durations_bucket": 8353
+                "exec_latency_bucket": 472329
             }
         },
         "service": {
@@ -2848,13 +8126,14 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "503316479"
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "6399",
+                "store": "1"
             },
             "metrics": {
-                "exec_latency_bucket": 472262,
-                "liveness_heartbeatlatency_bucket": 81674,
-                "txn_durations_bucket": 116595
+                "raft_process_commandcommit_latency_bucket": 15,
+                "raft_process_handleready_latency_bucket": 1071
             }
         },
         "service": {
@@ -2874,13 +8153,13 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "92274687"
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "3839",
+                "store": "1"
             },
             "metrics": {
-                "exec_latency_bucket": 469504,
-                "liveness_heartbeatlatency_bucket": 80719,
-                "txn_durations_bucket": 115601
+                "raft_process_handleready_latency_bucket": 405
             }
         },
         "service": {
@@ -2900,13 +8179,14 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "603979775"
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "335544319",
+                "store": "1"
             },
             "metrics": {
-                "exec_latency_bucket": 472275,
-                "liveness_heartbeatlatency_bucket": 81680,
-                "txn_durations_bucket": 116603
+                "raft_process_handleready_latency_bucket": 471499,
+                "raft_process_logcommit_latency_bucket": 470137
             }
         },
         "service": {
@@ -2926,37 +8206,8 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "360447"
-            },
-            "metrics": {
-                "exec_latency_bucket": 117373,
-                "round_trip_latency_bucket": 13536,
-                "sql_distsql_exec_latency_internal_bucket": 1964,
-                "sql_distsql_service_latency_internal_bucket": 3,
-                "sql_exec_latency_internal_bucket": 2622,
-                "sql_service_latency_internal_bucket": 3,
-                "txn_durations_bucket": 1340
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
                 "le": "3145727"
             },
             "metrics": {
@@ -2986,15 +8237,45 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "9437183",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "5242879"
+            },
+            "metrics": {
+                "exec_latency_bucket": 381962,
+                "liveness_heartbeatlatency_bucket": 70329,
+                "round_trip_latency_bucket": 122458,
+                "sql_distsql_service_latency_internal_bucket": 12581,
+                "sql_exec_latency_internal_bucket": 18608,
+                "sql_service_latency_internal_bucket": 18303,
+                "txn_durations_bucket": 104099
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "109051903",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_applycommitted_latency_bucket": 470351,
-                "raft_process_commandcommit_latency_bucket": 472456,
-                "raft_process_handleready_latency_bucket": 424086,
-                "raft_process_logcommit_latency_bucket": 423340
+                "raft_process_handleready_latency_bucket": 469988,
+                "raft_process_logcommit_latency_bucket": 468660
             }
         },
         "service": {
@@ -3014,36 +8295,14 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "29695"
-            },
-            "metrics": {
-                "exec_latency_bucket": 1605
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "30719",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "20479",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_commandcommit_latency_bucket": 108653
+                "raft_process_commandcommit_latency_bucket": 33096,
+                "raft_process_handleready_latency_bucket": 1357
             }
         },
         "service": {
@@ -3063,13 +8322,16 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "184549375",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "786431",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_handleready_latency_bucket": 470764,
-                "raft_process_logcommit_latency_bucket": 469403
+                "raft_process_applycommitted_latency_bucket": 348731,
+                "raft_process_commandcommit_latency_bucket": 366584,
+                "raft_process_handleready_latency_bucket": 3517,
+                "raft_process_logcommit_latency_bucket": 19327
             }
         },
         "service": {
@@ -3089,1350 +8351,8 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "59391",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 321,
-                "raft_process_commandcommit_latency_bucket": 252377
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "838860799",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 471699,
-                "raft_process_logcommit_latency_bucket": 470336
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "671088639",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 471685,
-                "raft_process_logcommit_latency_bucket": 470322
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "59391"
-            },
-            "metrics": {
-                "exec_latency_bucket": 12449
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "134217727"
-            },
-            "metrics": {
-                "exec_latency_bucket": 471045,
-                "liveness_heartbeatlatency_bucket": 81344,
-                "txn_durations_bucket": 116245
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "8388607"
-            },
-            "metrics": {
-                "exec_latency_bucket": 432497,
-                "liveness_heartbeatlatency_bucket": 73265,
-                "round_trip_latency_bucket": 122481,
-                "sql_exec_latency_internal_bucket": 18611,
-                "sql_service_latency_internal_bucket": 18604,
-                "txn_durations_bucket": 107601
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "7340031",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 470281,
-                "raft_process_commandcommit_latency_bucket": 472425,
-                "raft_process_handleready_latency_bucket": 420775,
-                "raft_process_logcommit_latency_bucket": 422350
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "720895"
-            },
-            "metrics": {
-                "exec_latency_bucket": 118842,
-                "round_trip_latency_bucket": 66901,
-                "sql_distsql_exec_latency_internal_bucket": 9360,
-                "sql_distsql_service_latency_internal_bucket": 77,
-                "sql_exec_latency_internal_bucket": 12681,
-                "sql_service_latency_internal_bucket": 79,
-                "txn_durations_bucket": 10782
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "1966079"
-            },
-            "metrics": {
-                "exec_latency_bucket": 195856,
-                "liveness_heartbeatlatency_bucket": 12859,
-                "round_trip_latency_bucket": 122332,
-                "sql_distsql_exec_latency_internal_bucket": 12690,
-                "sql_distsql_service_latency_internal_bucket": 2902,
-                "sql_exec_latency_internal_bucket": 18297,
-                "sql_service_latency_internal_bucket": 4604,
-                "txn_durations_bucket": 45816
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "27647",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_commandcommit_latency_bucket": 80135,
-                "raft_process_handleready_latency_bucket": 1361
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "11010047"
-            },
-            "metrics": {
-                "exec_latency_bucket": 436581,
-                "liveness_heartbeatlatency_bucket": 73385,
-                "round_trip_latency_bucket": 122490,
-                "sql_service_latency_internal_bucket": 18610,
-                "txn_durations_bucket": 107774
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "163839"
-            },
-            "metrics": {
-                "exec_latency_bucket": 82683,
-                "sql_distsql_exec_latency_internal_bucket": 45,
-                "sql_exec_latency_internal_bucket": 51,
-                "txn_durations_bucket": 1
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "27647"
-            },
-            "metrics": {
-                "exec_latency_bucket": 962
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "5375",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_commandcommit_latency_bucket": 10,
-                "raft_process_handleready_latency_bucket": 877
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "524287",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 295584,
-                "raft_process_commandcommit_latency_bucket": 354612
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "45055"
-            },
-            "metrics": {
-                "exec_latency_bucket": 6760
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "37748735"
-            },
-            "metrics": {
-                "exec_latency_bucket": 448463,
-                "liveness_heartbeatlatency_bucket": 76161,
-                "sql_exec_latency_internal_bucket": 18807,
-                "sql_service_latency_internal_bucket": 18793,
-                "txn_durations_bucket": 110761
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "122879"
-            },
-            "metrics": {
-                "exec_latency_bucket": 62938,
-                "sql_distsql_exec_latency_internal_bucket": 10,
-                "sql_exec_latency_internal_bucket": 10
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "637534207",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 471677,
-                "raft_process_logcommit_latency_bucket": 470314
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "3014655",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 450584,
-                "raft_process_commandcommit_latency_bucket": 461336,
-                "raft_process_handleready_latency_bucket": 314436,
-                "raft_process_logcommit_latency_bucket": 397196
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "3276799",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 456712,
-                "raft_process_commandcommit_latency_bucket": 465344,
-                "raft_process_handleready_latency_bucket": 326834,
-                "raft_process_logcommit_latency_bucket": 404595
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "27262975"
-            },
-            "metrics": {
-                "exec_latency_bucket": 440879,
-                "liveness_heartbeatlatency_bucket": 74440,
-                "sql_exec_latency_internal_bucket": 18699,
-                "sql_service_latency_internal_bucket": 18656,
-                "txn_durations_bucket": 108954
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "1855",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 71
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "29695",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_commandcommit_latency_bucket": 99081
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "335544319",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 471499,
-                "raft_process_logcommit_latency_bucket": 470137
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "63487"
-            },
-            "metrics": {
-                "exec_latency_bucket": 14789
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "5631",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_commandcommit_latency_bucket": 11,
-                "raft_process_handleready_latency_bucket": 934
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "570425343",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 471663,
-                "raft_process_logcommit_latency_bucket": 470300
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "25165823"
-            },
-            "metrics": {
-                "exec_latency_bucket": 439259,
-                "liveness_heartbeatlatency_bucket": 73958,
-                "round_trip_latency_bucket": 122497,
-                "sql_exec_latency_internal_bucket": 18659,
-                "sql_service_latency_internal_bucket": 18633,
-                "txn_durations_bucket": 108425
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "48234495",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 470383,
-                "raft_process_handleready_latency_bucket": 456484,
-                "raft_process_logcommit_latency_bucket": 456677
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "1275068415"
-            },
-            "metrics": {
-                "exec_latency_bucket": 472317
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "1638399",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 389451,
-                "raft_process_commandcommit_latency_bucket": 403563,
-                "raft_process_handleready_latency_bucket": 157100,
-                "raft_process_logcommit_latency_bucket": 268350
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "939524095",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 471703,
-                "raft_process_logcommit_latency_bucket": 470340
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "469762047"
-            },
-            "metrics": {
-                "exec_latency_bucket": 472253,
-                "liveness_heartbeatlatency_bucket": 81671,
-                "txn_durations_bucket": 116591
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "5505023",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 469691,
-                "raft_process_commandcommit_latency_bucket": 472202,
-                "raft_process_handleready_latency_bucket": 403399,
-                "raft_process_logcommit_latency_bucket": 420951
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "884735",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 356204,
-                "raft_process_commandcommit_latency_bucket": 369129,
-                "raft_process_handleready_latency_bucket": 8948,
-                "raft_process_logcommit_latency_bucket": 44345
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "491519"
-            },
-            "metrics": {
-                "exec_latency_bucket": 118613,
-                "round_trip_latency_bucket": 25464,
-                "sql_distsql_exec_latency_internal_bucket": 3214,
-                "sql_distsql_service_latency_internal_bucket": 25,
-                "sql_exec_latency_internal_bucket": 4748,
-                "sql_service_latency_internal_bucket": 25,
-                "txn_durations_bucket": 3377
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "7864319",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 470313,
-                "raft_process_commandcommit_latency_bucket": 472439,
-                "raft_process_handleready_latency_bucket": 422038,
-                "raft_process_logcommit_latency_bucket": 422573
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "278527",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 136299,
-                "raft_process_commandcommit_latency_bucket": 323272
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "209715199"
-            },
-            "metrics": {
-                "exec_latency_bucket": 471585,
-                "liveness_heartbeatlatency_bucket": 81525,
-                "txn_durations_bucket": 116432
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "53247",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 171,
-                "raft_process_commandcommit_latency_bucket": 238403
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "1179647",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 368080,
-                "raft_process_commandcommit_latency_bucket": 379641,
-                "raft_process_handleready_latency_bucket": 43219,
-                "raft_process_logcommit_latency_bucket": 136343
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "16252927",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 425016,
-                "raft_process_logcommit_latency_bucket": 423710
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "3407871",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 459081,
-                "raft_process_commandcommit_latency_bucket": 466793,
-                "raft_process_handleready_latency_bucket": 332542,
-                "raft_process_logcommit_latency_bucket": 407424,
-                "txnwaitqueue_pusher_wait_time_bucket": 6
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "262143"
-            },
-            "metrics": {
-                "exec_latency_bucket": 110242,
-                "round_trip_latency_bucket": 92,
-                "sql_distsql_exec_latency_internal_bucket": 447,
-                "sql_exec_latency_internal_bucket": 718,
-                "txn_durations_bucket": 156
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "4011"
-            },
-            "metrics": {
-                "sql_mem_distsql_max_bucket": 2452,
-                "sql_mem_internal_max_bucket": 17262,
-                "sql_mem_internal_session_max_bucket": 16068,
-                "sql_mem_internal_txn_max_bucket": 7426
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "44040191"
-            },
-            "metrics": {
-                "exec_latency_bucket": 452749,
-                "liveness_heartbeatlatency_bucket": 76521,
-                "sql_exec_latency_internal_bucket": 18827,
-                "sql_service_latency_internal_bucket": 18817,
-                "txn_durations_bucket": 111153
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "475135",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 275530,
-                "raft_process_commandcommit_latency_bucket": 349252
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "1376255"
-            },
-            "metrics": {
-                "exec_latency_bucket": 135639,
-                "liveness_heartbeatlatency_bucket": 2657,
-                "round_trip_latency_bucket": 120994,
-                "sql_distsql_exec_latency_internal_bucket": 12601,
-                "sql_distsql_service_latency_internal_bucket": 1361,
-                "sql_exec_latency_internal_bucket": 16776,
-                "sql_service_latency_internal_bucket": 1955,
-                "txn_durations_bucket": 27770
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "3071",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 237
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
                 "le": "425983"
             },
             "metrics": {
@@ -4462,68 +8382,14 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "3932159"
-            },
-            "metrics": {
-                "exec_latency_bucket": 334108,
-                "liveness_heartbeatlatency_bucket": 57903,
-                "round_trip_latency_bucket": 122446,
-                "sql_distsql_service_latency_internal_bucket": 11847,
-                "sql_service_latency_internal_bucket": 16643,
-                "txn_durations_bucket": 92840
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "167772159"
-            },
-            "metrics": {
-                "exec_latency_bucket": 471338,
-                "liveness_heartbeatlatency_bucket": 81462,
-                "txn_durations_bucket": 116365
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "1610612735",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "344063",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_handleready_latency_bucket": 471733,
-                "raft_process_logcommit_latency_bucket": 470370
+                "raft_process_applycommitted_latency_bucket": 185101,
+                "raft_process_commandcommit_latency_bucket": 332801
             }
         },
         "service": {
@@ -4543,40 +8409,16 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "50331647"
-            },
-            "metrics": {
-                "exec_latency_bucket": 457706,
-                "liveness_heartbeatlatency_bucket": 77187,
-                "sql_exec_latency_internal_bucket": 18845,
-                "sql_service_latency_internal_bucket": 18840,
-                "txn_durations_bucket": 111882
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "1471",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "1638399",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_handleready_latency_bucket": 1
+                "raft_process_applycommitted_latency_bucket": 389451,
+                "raft_process_commandcommit_latency_bucket": 403563,
+                "raft_process_handleready_latency_bucket": 157100,
+                "raft_process_logcommit_latency_bucket": 268350
             }
         },
         "service": {
@@ -4596,2810 +8438,8 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "204799",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 81796,
-                "raft_process_commandcommit_latency_bucket": 312920
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "3801087"
-            },
-            "metrics": {
-                "exec_latency_bucket": 327474,
-                "liveness_heartbeatlatency_bucket": 56019,
-                "round_trip_latency_bucket": 122443,
-                "sql_distsql_service_latency_internal_bucket": 11722,
-                "sql_exec_latency_internal_bucket": 18603,
-                "sql_service_latency_internal_bucket": 16297,
-                "txn_durations_bucket": 91006
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "5887",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_commandcommit_latency_bucket": 13,
-                "raft_process_handleready_latency_bucket": 984
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "6291455",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 470107,
-                "raft_process_commandcommit_latency_bucket": 472391,
-                "raft_process_handleready_latency_bucket": 414726,
-                "raft_process_logcommit_latency_bucket": 421798
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "113246207"
-            },
-            "metrics": {
-                "exec_latency_bucket": 470656,
-                "liveness_heartbeatlatency_bucket": 81195,
-                "txn_durations_bucket": 116094
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "2550136831"
-            },
-            "metrics": {
-                "exec_latency_bucket": 472329
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "17407",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_commandcommit_latency_bucket": 23033,
-                "raft_process_handleready_latency_bucket": 1350
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "9961471",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 470359,
-                "raft_process_commandcommit_latency_bucket": 472462,
-                "raft_process_handleready_latency_bucket": 424330,
-                "raft_process_logcommit_latency_bucket": 423404
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "1015807",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 362280,
-                "raft_process_commandcommit_latency_bucket": 373010,
-                "raft_process_handleready_latency_bucket": 19306,
-                "raft_process_logcommit_latency_bucket": 87091
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "229375",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 101518,
-                "raft_process_commandcommit_latency_bucket": 316056
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "57343",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 270,
-                "raft_process_commandcommit_latency_bucket": 248153
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "61439"
-            },
-            "metrics": {
-                "exec_latency_bucket": 13572
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "2621439",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 435523,
-                "raft_process_commandcommit_latency_bucket": 451840,
-                "raft_process_handleready_latency_bucket": 292876,
-                "raft_process_logcommit_latency_bucket": 378072
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "30408703",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_commandcommit_latency_bucket": 472472,
-                "raft_process_handleready_latency_bucket": 439470,
-                "raft_process_logcommit_latency_bucket": 439253
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "30719"
-            },
-            "metrics": {
-                "exec_latency_bucket": 2005
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "29360127"
-            },
-            "metrics": {
-                "exec_latency_bucket": 442682,
-                "liveness_heartbeatlatency_bucket": 74931,
-                "sql_exec_latency_internal_bucket": 18733,
-                "sql_service_latency_internal_bucket": 18687,
-                "txn_durations_bucket": 109481
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "96468991"
-            },
-            "metrics": {
-                "exec_latency_bucket": 469896,
-                "liveness_heartbeatlatency_bucket": 80887,
-                "txn_durations_bucket": 115781
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "16106127359",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 471747,
-                "raft_process_logcommit_latency_bucket": 470384
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "819199",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 351677,
-                "raft_process_commandcommit_latency_bucket": 367460,
-                "raft_process_handleready_latency_bucket": 5082,
-                "raft_process_logcommit_latency_bucket": 26156
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "180223",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 59212,
-                "raft_process_commandcommit_latency_bucket": 310067
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "75497471"
-            },
-            "metrics": {
-                "exec_latency_bucket": 467471,
-                "liveness_heartbeatlatency_bucket": 79948,
-                "sql_distsql_service_latency_internal_bucket": 12695,
-                "sql_exec_latency_internal_bucket": 18862,
-                "sql_service_latency_internal_bucket": 18861,
-                "txn_durations_bucket": 114805
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "126975",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 19849,
-                "raft_process_commandcommit_latency_bucket": 303042
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "25599",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_commandcommit_latency_bucket": 62774,
-                "raft_process_handleready_latency_bucket": 1360
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "155647",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 36642,
-                "raft_process_commandcommit_latency_bucket": 307142
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "17825791"
-            },
-            "metrics": {
-                "exec_latency_bucket": 437399,
-                "liveness_heartbeatlatency_bucket": 73455,
-                "round_trip_latency_bucket": 122495,
-                "sql_service_latency_internal_bucket": 18613,
-                "txn_durations_bucket": 107855
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "1572863"
-            },
-            "metrics": {
-                "exec_latency_bucket": 152133,
-                "liveness_heartbeatlatency_bucket": 5488,
-                "round_trip_latency_bucket": 122026,
-                "sql_distsql_exec_latency_internal_bucket": 12660,
-                "sql_distsql_service_latency_internal_bucket": 2093,
-                "sql_exec_latency_internal_bucket": 17133,
-                "sql_service_latency_internal_bucket": 2857,
-                "txn_durations_bucket": 34701
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "98303"
-            },
-            "metrics": {
-                "exec_latency_bucket": 46020
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "14680063",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 424946,
-                "raft_process_logcommit_latency_bucket": 423630
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "49151"
-            },
-            "metrics": {
-                "exec_latency_bucket": 8095
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "1900543",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 401914,
-                "raft_process_commandcommit_latency_bucket": 417261,
-                "raft_process_handleready_latency_bucket": 218798,
-                "raft_process_logcommit_latency_bucket": 307583
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "1900543"
-            },
-            "metrics": {
-                "exec_latency_bucket": 187591,
-                "liveness_heartbeatlatency_bucket": 11700,
-                "round_trip_latency_bucket": 122316,
-                "sql_distsql_exec_latency_internal_bucket": 12687,
-                "sql_distsql_service_latency_internal_bucket": 2816,
-                "sql_exec_latency_internal_bucket": 18200,
-                "sql_service_latency_internal_bucket": 4326,
-                "txn_durations_bucket": 43816
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "110591",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 13657,
-                "raft_process_commandcommit_latency_bucket": 299094
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "38911",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 11,
-                "raft_process_commandcommit_latency_bucket": 175932,
-                "raft_process_handleready_latency_bucket": 1362
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "81919",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 4453,
-                "raft_process_commandcommit_latency_bucket": 283714
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "14680063"
-            },
-            "metrics": {
-                "exec_latency_bucket": 437240,
-                "liveness_heartbeatlatency_bucket": 73421,
-                "sql_exec_latency_internal_bucket": 18613,
-                "txn_durations_bucket": 107818
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "14155775"
-            },
-            "metrics": {
-                "exec_latency_bucket": 437199,
-                "liveness_heartbeatlatency_bucket": 73419,
-                "round_trip_latency_bucket": 122494,
-                "sql_service_latency_internal_bucket": 18611,
-                "txn_durations_bucket": 107814
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "125829119"
-            },
-            "metrics": {
-                "exec_latency_bucket": 470943,
-                "liveness_heartbeatlatency_bucket": 81298,
-                "txn_durations_bucket": 116199
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "114687"
-            },
-            "metrics": {
-                "exec_latency_bucket": 57999,
-                "sql_distsql_exec_latency_internal_bucket": 6,
-                "sql_exec_latency_internal_bucket": 6
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "229375"
-            },
-            "metrics": {
-                "exec_latency_bucket": 104271,
-                "sql_distsql_exec_latency_internal_bucket": 112,
-                "sql_exec_latency_internal_bucket": 228,
-                "txn_durations_bucket": 49
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "50331647",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 458280,
-                "raft_process_logcommit_latency_bucket": 458438
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "3623878655"
-            },
-            "metrics": {
-                "liveness_heartbeatlatency_bucket": 81702
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "150994943",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 470542,
-                "raft_process_logcommit_latency_bucket": 469185
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "60817407"
-            },
-            "metrics": {
-                "exec_latency_bucket": 464133,
-                "liveness_heartbeatlatency_bucket": 78762,
-                "sql_service_latency_internal_bucket": 18854,
-                "txn_durations_bucket": 113560
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "100663295",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 469695,
-                "raft_process_logcommit_latency_bucket": 468399
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "109051903"
-            },
-            "metrics": {
-                "exec_latency_bucket": 470525,
-                "liveness_heartbeatlatency_bucket": 81142,
-                "txn_durations_bucket": 116038
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "139263",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 25759,
-                "raft_process_commandcommit_latency_bucket": 305002
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "6174015487",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 471740,
-                "raft_process_logcommit_latency_bucket": 470377
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "1703935"
-            },
-            "metrics": {
-                "exec_latency_bucket": 164915,
-                "liveness_heartbeatlatency_bucket": 7844,
-                "round_trip_latency_bucket": 122214,
-                "sql_distsql_exec_latency_internal_bucket": 12675,
-                "sql_distsql_service_latency_internal_bucket": 2435,
-                "sql_exec_latency_internal_bucket": 17624,
-                "sql_service_latency_internal_bucket": 3440,
-                "txn_durations_bucket": 38698
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "251658239",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 471166,
-                "raft_process_logcommit_latency_bucket": 469810
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "226492415",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 471025,
-                "raft_process_logcommit_latency_bucket": 469669
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "21503"
-            },
-            "metrics": {
-                "exec_latency_bucket": 7
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "2752511",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 441306,
-                "raft_process_commandcommit_latency_bucket": 455759,
-                "raft_process_handleready_latency_bucket": 300613,
-                "raft_process_logcommit_latency_bucket": 385739
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "622591",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 323067,
-                "raft_process_commandcommit_latency_bucket": 361233,
-                "raft_process_handleready_latency_bucket": 1364,
-                "raft_process_logcommit_latency_bucket": 1448
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "2097151",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 411113,
-                "raft_process_commandcommit_latency_bucket": 427438,
-                "raft_process_handleready_latency_bucket": 249049,
-                "raft_process_logcommit_latency_bucket": 331357
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "253951",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 119152,
-                "raft_process_commandcommit_latency_bucket": 319589
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "3355443199",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 471738,
-                "raft_process_logcommit_latency_bucket": 470375
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "32767"
-            },
-            "metrics": {
-                "exec_latency_bucket": 2614
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "94207",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 8589,
-                "raft_process_commandcommit_latency_bucket": 292317
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "14155775",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 470373,
-                "raft_process_handleready_latency_bucket": 424925,
-                "raft_process_logcommit_latency_bucket": 423614
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "163839",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 43694,
-                "raft_process_commandcommit_latency_bucket": 308119
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "60817407",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 464641,
-                "raft_process_logcommit_latency_bucket": 463763
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "2080374783"
-            },
-            "metrics": {
-                "exec_latency_bucket": 472327
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "196607"
-            },
-            "metrics": {
-                "exec_latency_bucket": 95233,
-                "sql_distsql_exec_latency_internal_bucket": 78,
-                "sql_exec_latency_internal_bucket": 111,
-                "txn_durations_bucket": 8
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "2490367",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 429273,
-                "raft_process_commandcommit_latency_bucket": 447005,
-                "raft_process_handleready_latency_bucket": 284293,
-                "raft_process_logcommit_latency_bucket": 368808,
-                "txnwaitqueue_pusher_wait_time_bucket": 3
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "520093695",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 471654,
-                "raft_process_logcommit_latency_bucket": 470291
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "20971519",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 425809,
-                "raft_process_logcommit_latency_bucket": 424696
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "56623103"
-            },
-            "metrics": {
-                "exec_latency_bucket": 462143,
-                "liveness_heartbeatlatency_bucket": 78151,
-                "sql_exec_latency_internal_bucket": 18853,
-                "sql_service_latency_internal_bucket": 18848,
-                "txn_durations_bucket": 112910
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "4160749567"
-            },
-            "metrics": {
-                "liveness_heartbeatlatency_bucket": 81703
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "352321535",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 471537,
-                "raft_process_logcommit_latency_bucket": 470174
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "5767167"
-            },
-            "metrics": {
-                "exec_latency_bucket": 397363,
-                "liveness_heartbeatlatency_bucket": 71541,
-                "sql_distsql_service_latency_internal_bucket": 12646,
-                "sql_service_latency_internal_bucket": 18435,
-                "txn_durations_bucket": 105536
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "10200547327",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 471745,
-                "raft_process_logcommit_latency_bucket": 470382
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "8912895",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 470342,
-                "raft_process_commandcommit_latency_bucket": 472453,
-                "raft_process_handleready_latency_bucket": 423688,
-                "raft_process_logcommit_latency_bucket": 423254
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "26214399"
-            },
-            "metrics": {
-                "exec_latency_bucket": 440017,
-                "liveness_heartbeatlatency_bucket": 74184,
-                "sql_exec_latency_internal_bucket": 18679,
-                "sql_service_latency_internal_bucket": 18645,
-                "txn_durations_bucket": 108689
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "13631487",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 424890,
-                "raft_process_logcommit_latency_bucket": 423594
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "1835007"
-            },
-            "metrics": {
-                "exec_latency_bucket": 179550,
-                "liveness_heartbeatlatency_bucket": 10382,
-                "round_trip_latency_bucket": 122289,
-                "sql_distsql_exec_latency_internal_bucket": 12683,
-                "sql_distsql_service_latency_internal_bucket": 2710,
-                "sql_exec_latency_internal_bucket": 18064,
-                "sql_service_latency_internal_bucket": 4024,
-                "txn_durations_bucket": 42173
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "318767103"
-            },
-            "metrics": {
-                "exec_latency_bucket": 472079,
-                "liveness_heartbeatlatency_bucket": 81635,
-                "txn_durations_bucket": 116548
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "212991"
-            },
-            "metrics": {
-                "exec_latency_bucket": 100298,
-                "sql_distsql_exec_latency_internal_bucket": 96,
-                "sql_exec_latency_internal_bucket": 160,
-                "txn_durations_bucket": 24
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "2752511"
-            },
-            "metrics": {
-                "exec_latency_bucket": 271267,
-                "liveness_heartbeatlatency_bucket": 38015,
-                "round_trip_latency_bucket": 122418,
-                "sql_distsql_exec_latency_internal_bucket": 12694,
-                "sql_distsql_service_latency_internal_bucket": 7017,
-                "sql_exec_latency_internal_bucket": 18574,
-                "sql_service_latency_internal_bucket": 10423,
-                "txn_durations_bucket": 74469
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "589823",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 315252,
-                "raft_process_commandcommit_latency_bucket": 359524,
-                "raft_process_logcommit_latency_bucket": 135
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "1140850687"
-            },
-            "metrics": {
-                "exec_latency_bucket": 472314
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "6143",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 1029
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "352321535"
-            },
-            "metrics": {
-                "exec_latency_bucket": 472149,
-                "liveness_heartbeatlatency_bucket": 81649,
-                "txn_durations_bucket": 116563
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "209715199",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 470909,
-                "raft_process_logcommit_latency_bucket": 469547
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "557055"
-            },
-            "metrics": {
-                "exec_latency_bucket": 118749,
-                "round_trip_latency_bucket": 33758,
-                "sql_distsql_exec_latency_internal_bucket": 4485,
-                "sql_distsql_service_latency_internal_bucket": 41,
-                "sql_exec_latency_internal_bucket": 6730,
-                "sql_service_latency_internal_bucket": 41,
-                "txn_durations_bucket": 4741
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "122879",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 18133,
-                "raft_process_commandcommit_latency_bucket": 302183
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "1006632959"
-            },
-            "metrics": {
-                "exec_latency_bucket": 472309,
-                "liveness_heartbeatlatency_bucket": 81688,
-                "sql_exec_latency_internal_bucket": 18870,
-                "sql_service_latency_internal_bucket": 18870,
-                "txn_durations_bucket": 116612
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "19455",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_commandcommit_latency_bucket": 29444,
-                "raft_process_handleready_latency_bucket": 1356
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "71303167",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 467092,
-                "raft_process_logcommit_latency_bucket": 465961
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "294911"
-            },
-            "metrics": {
-                "exec_latency_bucket": 114154,
-                "round_trip_latency_bucket": 2649,
-                "sql_distsql_exec_latency_internal_bucket": 963,
-                "sql_exec_latency_internal_bucket": 1394,
-                "txn_durations_bucket": 309
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "557055",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 306165,
-                "raft_process_commandcommit_latency_bucket": 357394,
-                "raft_process_logcommit_latency_bucket": 1
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "180223"
-            },
-            "metrics": {
-                "exec_latency_bucket": 89333,
-                "sql_distsql_exec_latency_internal_bucket": 60,
-                "sql_exec_latency_internal_bucket": 83,
-                "txn_durations_bucket": 3
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "1744830463"
-            },
-            "metrics": {
-                "liveness_heartbeatlatency_bucket": 81696
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "2815",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 212
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "704643071"
-            },
-            "metrics": {
-                "exec_latency_bucket": 472288
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "15204351"
-            },
-            "metrics": {
-                "exec_latency_bucket": 437266,
-                "liveness_heartbeatlatency_bucket": 73425,
-                "sql_service_latency_internal_bucket": 18612,
-                "txn_durations_bucket": 107821
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "3839",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 405
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "29360127",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 437654,
-                "raft_process_logcommit_latency_bucket": 437450
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "2031615",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 408069,
-                "raft_process_commandcommit_latency_bucket": 424030,
-                "raft_process_handleready_latency_bucket": 240333,
-                "raft_process_logcommit_latency_bucket": 323722
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "1769471",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 395636,
-                "raft_process_commandcommit_latency_bucket": 410496,
-                "raft_process_handleready_latency_bucket": 190145,
-                "raft_process_logcommit_latency_bucket": 289448
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "+Inf",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 470384,
-                "raft_process_commandcommit_latency_bucket": 472474,
-                "raft_process_handleready_latency_bucket": 471747,
-                "raft_process_logcommit_latency_bucket": 470384,
-                "txnwaitqueue_pusher_wait_time_bucket": 7,
-                "txnwaitqueue_query_wait_time_bucket": 0
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "13107199"
-            },
-            "metrics": {
-                "exec_latency_bucket": 437076,
-                "liveness_heartbeatlatency_bucket": 73414,
-                "txn_durations_bucket": 107807
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "409599"
-            },
-            "metrics": {
-                "exec_latency_bucket": 118136,
-                "round_trip_latency_bucket": 20031,
-                "sql_distsql_exec_latency_internal_bucket": 2487,
-                "sql_distsql_service_latency_internal_bucket": 10,
-                "sql_exec_latency_internal_bucket": 3311,
-                "sql_service_latency_internal_bucket": 10,
-                "txn_durations_bucket": 2091
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "176160767"
-            },
-            "metrics": {
-                "exec_latency_bucket": 471392,
-                "liveness_heartbeatlatency_bucket": 81475,
-                "txn_durations_bucket": 116378
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "458751",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 267321,
-                "raft_process_commandcommit_latency_bucket": 347254
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "2228223",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 417098,
-                "raft_process_commandcommit_latency_bucket": 434327,
-                "raft_process_handleready_latency_bucket": 263180,
-                "raft_process_logcommit_latency_bucket": 345442,
-                "txnwaitqueue_pusher_wait_time_bucket": 2
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
                 "le": "24117247"
             },
             "metrics": {
@@ -7427,13 +8467,39 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "507903",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "45055"
+            },
+            "metrics": {
+                "exec_latency_bucket": 6760
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "6655",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_applycommitted_latency_bucket": 289574,
-                "raft_process_commandcommit_latency_bucket": 352939
+                "raft_process_commandcommit_latency_bucket": 16,
+                "raft_process_handleready_latency_bucket": 1097
             }
         },
         "service": {
@@ -7453,41 +8519,16 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "9961471"
-            },
-            "metrics": {
-                "exec_latency_bucket": 435775,
-                "liveness_heartbeatlatency_bucket": 73362,
-                "round_trip_latency_bucket": 122485,
-                "sql_service_latency_internal_bucket": 18609,
-                "txn_durations_bucket": 107742
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "268435455",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "6029311",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_handleready_latency_bucket": 471266,
-                "raft_process_logcommit_latency_bucket": 469920
+                "raft_process_applycommitted_latency_bucket": 469987,
+                "raft_process_commandcommit_latency_bucket": 472341,
+                "raft_process_handleready_latency_bucket": 411887,
+                "raft_process_logcommit_latency_bucket": 421569
             }
         },
         "service": {
@@ -7507,17 +8548,14 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "2490367"
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "1342177279"
             },
             "metrics": {
-                "exec_latency_bucket": 252695,
-                "liveness_heartbeatlatency_bucket": 28960,
-                "round_trip_latency_bucket": 122403,
-                "sql_distsql_service_latency_internal_bucket": 5250,
-                "sql_exec_latency_internal_bucket": 18532,
-                "sql_service_latency_internal_bucket": 8376,
-                "txn_durations_bucket": 66660
+                "exec_latency_bucket": 472320,
+                "liveness_heartbeatlatency_bucket": 81690,
+                "txn_durations_bucket": 116614
             }
         },
         "service": {
@@ -7537,11 +8575,17 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "23551"
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "4980735"
             },
             "metrics": {
-                "exec_latency_bucket": 35
+                "exec_latency_bucket": 374158,
+                "liveness_heartbeatlatency_bucket": 69209,
+                "round_trip_latency_bucket": 122455,
+                "sql_distsql_service_latency_internal_bucket": 12524,
+                "sql_service_latency_internal_bucket": 18182,
+                "txn_durations_bucket": 103099
             }
         },
         "service": {
@@ -7561,41 +8605,14 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "301989887"
-            },
-            "metrics": {
-                "exec_latency_bucket": 472032,
-                "liveness_heartbeatlatency_bucket": 81619,
-                "txn_durations_bucket": 116532
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "3932159",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "142606335",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_applycommitted_latency_bucket": 465051,
-                "raft_process_commandcommit_latency_bucket": 470107,
-                "raft_process_handleready_latency_bucket": 352824,
-                "raft_process_logcommit_latency_bucket": 414696
+                "raft_process_handleready_latency_bucket": 470498,
+                "raft_process_logcommit_latency_bucket": 469155
             }
         },
         "service": {
@@ -7615,11 +8632,18 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "12884901887"
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "491519"
             },
             "metrics": {
-                "exec_latency_bucket": 472348
+                "exec_latency_bucket": 118613,
+                "round_trip_latency_bucket": 25464,
+                "sql_distsql_exec_latency_internal_bucket": 3214,
+                "sql_distsql_service_latency_internal_bucket": 25,
+                "sql_exec_latency_internal_bucket": 4748,
+                "sql_service_latency_internal_bucket": 25,
+                "txn_durations_bucket": 3377
             }
         },
         "service": {
@@ -7639,12 +8663,14 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "2303",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "65535",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_handleready_latency_bucket": 132
+                "raft_process_applycommitted_latency_bucket": 588,
+                "raft_process_commandcommit_latency_bucket": 263257
             }
         },
         "service": {
@@ -7664,13 +8690,76 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "409599",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "1006632959"
+            },
+            "metrics": {
+                "exec_latency_bucket": 472309,
+                "liveness_heartbeatlatency_bucket": 81688,
+                "sql_exec_latency_internal_bucket": 18870,
+                "sql_service_latency_internal_bucket": 18870,
+                "txn_durations_bucket": 116612
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "2883583"
+            },
+            "metrics": {
+                "exec_latency_bucket": 279037,
+                "liveness_heartbeatlatency_bucket": 41533,
+                "round_trip_latency_bucket": 122422,
+                "sql_distsql_service_latency_internal_bucket": 8073,
+                "sql_exec_latency_internal_bucket": 18586,
+                "sql_service_latency_internal_bucket": 11603,
+                "txn_durations_bucket": 77315
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "1572863",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_applycommitted_latency_bucket": 236720,
-                "raft_process_commandcommit_latency_bucket": 341024
+                "raft_process_applycommitted_latency_bucket": 386333,
+                "raft_process_commandcommit_latency_bucket": 400111,
+                "raft_process_handleready_latency_bucket": 139884,
+                "raft_process_logcommit_latency_bucket": 256469
             }
         },
         "service": {
@@ -7690,521 +8779,8 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "23068671"
-            },
-            "metrics": {
-                "exec_latency_bucket": 438191,
-                "liveness_heartbeatlatency_bucket": 73676,
-                "sql_exec_latency_internal_bucket": 18634,
-                "sql_service_latency_internal_bucket": 18617,
-                "txn_durations_bucket": 108104
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "1114111",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 365816,
-                "raft_process_commandcommit_latency_bucket": 376715,
-                "raft_process_handleready_latency_bucket": 30999,
-                "raft_process_logcommit_latency_bucket": 115130
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "393215",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 224062,
-                "raft_process_commandcommit_latency_bucket": 338997
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "31743"
-            },
-            "metrics": {
-                "exec_latency_bucket": 2325
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "376831",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 211145,
-                "raft_process_commandcommit_latency_bucket": 336999
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "32505855"
-            },
-            "metrics": {
-                "exec_latency_bucket": 445192,
-                "liveness_heartbeatlatency_bucket": 75582,
-                "sql_exec_latency_internal_bucket": 18773,
-                "sql_service_latency_internal_bucket": 18742,
-                "txn_durations_bucket": 110170
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "28311551"
-            },
-            "metrics": {
-                "exec_latency_bucket": 441818,
-                "liveness_heartbeatlatency_bucket": 74696,
-                "sql_exec_latency_internal_bucket": 18715,
-                "sql_service_latency_internal_bucket": 18673,
-                "txn_durations_bucket": 109249
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "32505855",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 442548,
-                "raft_process_logcommit_latency_bucket": 442380
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "536870911",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 471660,
-                "raft_process_logcommit_latency_bucket": 470297
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "62914559"
-            },
-            "metrics": {
-                "exec_latency_bucket": 464866,
-                "liveness_heartbeatlatency_bucket": 79017,
-                "sql_exec_latency_internal_bucket": 18856,
-                "txn_durations_bucket": 113817
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "2550136831",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 471735,
-                "raft_process_logcommit_latency_bucket": 470372
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "94207"
-            },
-            "metrics": {
-                "exec_latency_bucket": 42435
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "3276799"
-            },
-            "metrics": {
-                "exec_latency_bucket": 299755,
-                "liveness_heartbeatlatency_bucket": 48802,
-                "round_trip_latency_bucket": 122435,
-                "sql_distsql_exec_latency_internal_bucket": 12695,
-                "sql_distsql_service_latency_internal_bucket": 10619,
-                "sql_exec_latency_internal_bucket": 18598,
-                "sql_service_latency_internal_bucket": 14498,
-                "txn_durations_bucket": 83510
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "2883583",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 446308,
-                "raft_process_commandcommit_latency_bucket": 458845,
-                "raft_process_handleready_latency_bucket": 307662,
-                "raft_process_logcommit_latency_bucket": 392031,
-                "txnwaitqueue_pusher_wait_time_bucket": 4
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "3670015"
-            },
-            "metrics": {
-                "exec_latency_bucket": 320545,
-                "liveness_heartbeatlatency_bucket": 54185,
-                "sql_distsql_service_latency_internal_bucket": 11571,
-                "sql_service_latency_internal_bucket": 15950,
-                "txn_durations_bucket": 89085
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "14335",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_commandcommit_latency_bucket": 13454,
-                "raft_process_handleready_latency_bucket": 1342
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "6815743",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 470232,
-                "raft_process_commandcommit_latency_bucket": 472419,
-                "raft_process_handleready_latency_bucket": 418605,
-                "raft_process_logcommit_latency_bucket": 422123
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "110591"
-            },
-            "metrics": {
-                "exec_latency_bucket": 55320,
-                "sql_distsql_exec_latency_internal_bucket": 4,
-                "sql_exec_latency_internal_bucket": 4
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "7602175"
-            },
-            "metrics": {
-                "exec_latency_bucket": 428859,
-                "liveness_heartbeatlatency_bucket": 73107,
-                "round_trip_latency_bucket": 122474,
-                "sql_distsql_service_latency_internal_bucket": 12692,
-                "sql_service_latency_internal_bucket": 18592,
-                "txn_durations_bucket": 107420
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
                 "le": "851967"
             },
             "metrics": {
@@ -8235,13 +8811,16 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "114687",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "7602175",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_applycommitted_latency_bucket": 15003,
-                "raft_process_commandcommit_latency_bucket": 300295
+                "raft_process_applycommitted_latency_bucket": 470295,
+                "raft_process_commandcommit_latency_bucket": 472432,
+                "raft_process_handleready_latency_bucket": 421477,
+                "raft_process_logcommit_latency_bucket": 422462
             }
         },
         "service": {
@@ -8261,16 +8840,15 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "6029311"
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "188415"
             },
             "metrics": {
-                "exec_latency_bucket": 404970,
-                "liveness_heartbeatlatency_bucket": 71908,
-                "round_trip_latency_bucket": 122465,
-                "sql_distsql_service_latency_internal_bucket": 12665,
-                "sql_service_latency_internal_bucket": 18480,
-                "txn_durations_bucket": 106060
+                "exec_latency_bucket": 92349,
+                "sql_distsql_exec_latency_internal_bucket": 67,
+                "sql_exec_latency_internal_bucket": 97,
+                "txn_durations_bucket": 5
             }
         },
         "service": {
@@ -8290,7 +8868,535 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "385875967"
+            },
+            "metrics": {
+                "exec_latency_bucket": 472196,
+                "liveness_heartbeatlatency_bucket": 81658,
+                "txn_durations_bucket": 116574
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "14335",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_commandcommit_latency_bucket": 13454,
+                "raft_process_handleready_latency_bucket": 1342
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "376831",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 211145,
+                "raft_process_commandcommit_latency_bucket": 336999
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "50331647",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 458280,
+                "raft_process_logcommit_latency_bucket": 458438
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "147455"
+            },
+            "metrics": {
+                "exec_latency_bucket": 75546,
+                "sql_distsql_exec_latency_internal_bucket": 29,
+                "sql_exec_latency_internal_bucket": 29
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "360447",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 197900,
+                "raft_process_commandcommit_latency_bucket": 334903
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "939524095",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 471703,
+                "raft_process_logcommit_latency_bucket": 470340
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "1245183",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 370597,
+                "raft_process_commandcommit_latency_bucket": 382965,
+                "raft_process_handleready_latency_bucket": 58452,
+                "raft_process_logcommit_latency_bucket": 160203
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "1703935"
+            },
+            "metrics": {
+                "exec_latency_bucket": 164915,
+                "liveness_heartbeatlatency_bucket": 7844,
+                "round_trip_latency_bucket": 122214,
+                "sql_distsql_exec_latency_internal_bucket": 12675,
+                "sql_distsql_service_latency_internal_bucket": 2435,
+                "sql_exec_latency_internal_bucket": 17624,
+                "sql_service_latency_internal_bucket": 3440,
+                "txn_durations_bucket": 38698
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "2490367"
+            },
+            "metrics": {
+                "exec_latency_bucket": 252695,
+                "liveness_heartbeatlatency_bucket": 28960,
+                "round_trip_latency_bucket": 122403,
+                "sql_distsql_service_latency_internal_bucket": 5250,
+                "sql_exec_latency_internal_bucket": 18532,
+                "sql_service_latency_internal_bucket": 8376,
+                "txn_durations_bucket": 66660
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "260046847",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 471221,
+                "raft_process_logcommit_latency_bucket": 469862
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "7340031",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 470281,
+                "raft_process_commandcommit_latency_bucket": 472425,
+                "raft_process_handleready_latency_bucket": 420775,
+                "raft_process_logcommit_latency_bucket": 422350
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "90111"
+            },
+            "metrics": {
+                "exec_latency_bucket": 38640
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "1769471",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 395636,
+                "raft_process_commandcommit_latency_bucket": 410496,
+                "raft_process_handleready_latency_bucket": 190145,
+                "raft_process_logcommit_latency_bucket": 289448
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "57343"
+            },
+            "metrics": {
+                "exec_latency_bucket": 11426
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "125829119",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 470326,
+                "raft_process_logcommit_latency_bucket": 468977
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "243269631",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 471121,
+                "raft_process_logcommit_latency_bucket": 469762
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "2031615"
+            },
+            "metrics": {
+                "exec_latency_bucket": 204329,
+                "liveness_heartbeatlatency_bucket": 14156,
+                "round_trip_latency_bucket": 122345,
+                "sql_distsql_service_latency_internal_bucket": 3025,
+                "sql_exec_latency_internal_bucket": 18350,
+                "sql_service_latency_internal_bucket": 4971,
+                "txn_durations_bucket": 48034
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "2431",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 160
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
                 "le": "+Inf"
             },
             "metrics": {
@@ -8341,63 +9447,14 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "77823"
-            },
-            "metrics": {
-                "exec_latency_bucket": 26188
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "402653183"
-            },
-            "metrics": {
-                "exec_latency_bucket": 472210,
-                "liveness_heartbeatlatency_bucket": 81661,
-                "txn_durations_bucket": 116577
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "469762047",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "47103",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_handleready_latency_bucket": 471640,
-                "raft_process_logcommit_latency_bucket": 470277
+                "raft_process_applycommitted_latency_bucket": 70,
+                "raft_process_commandcommit_latency_bucket": 218550
             }
         },
         "service": {
@@ -8417,12 +9474,41 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "5119",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "1207959551"
+            },
+            "metrics": {
+                "exec_latency_bucket": 472316,
+                "liveness_heartbeatlatency_bucket": 81689,
+                "txn_durations_bucket": 116613
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "11775",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_handleready_latency_bucket": 810
+                "raft_process_commandcommit_latency_bucket": 5532,
+                "raft_process_handleready_latency_bucket": 1323
             }
         },
         "service": {
@@ -8442,43 +9528,14 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "19922943"
-            },
-            "metrics": {
-                "exec_latency_bucket": 437534,
-                "liveness_heartbeatlatency_bucket": 73498,
-                "sql_exec_latency_internal_bucket": 18616,
-                "sql_service_latency_internal_bucket": 18614,
-                "txn_durations_bucket": 107903
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "1507327",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "6979321855",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_applycommitted_latency_bucket": 382959,
-                "raft_process_commandcommit_latency_bucket": 396745,
-                "raft_process_handleready_latency_bucket": 123053,
-                "raft_process_logcommit_latency_bucket": 243194
+                "raft_process_handleready_latency_bucket": 471742,
+                "raft_process_logcommit_latency_bucket": 470379
             }
         },
         "service": {
@@ -8498,13 +9555,13 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "23551",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "1855",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_commandcommit_latency_bucket": 48454,
-                "raft_process_handleready_latency_bucket": 1359
+                "raft_process_handleready_latency_bucket": 71
             }
         },
         "service": {
@@ -8524,13 +9581,14 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "36863",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "10751",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_applycommitted_latency_bucket": 6,
-                "raft_process_commandcommit_latency_bucket": 161145
+                "raft_process_commandcommit_latency_bucket": 3032,
+                "raft_process_handleready_latency_bucket": 1312
             }
         },
         "service": {
@@ -8550,39 +9608,14 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "147455"
-            },
-            "metrics": {
-                "exec_latency_bucket": 75546,
-                "sql_distsql_exec_latency_internal_bucket": 29,
-                "sql_exec_latency_internal_bucket": 29
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "805306367",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "15871",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_handleready_latency_bucket": 471698,
-                "raft_process_logcommit_latency_bucket": 470335
+                "raft_process_commandcommit_latency_bucket": 18288,
+                "raft_process_handleready_latency_bucket": 1346
             }
         },
         "service": {
@@ -8602,13 +9635,67 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "13958643711",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "18431"
+            },
+            "metrics": {
+                "exec_latency_bucket": 1
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "104857599"
+            },
+            "metrics": {
+                "exec_latency_bucket": 470364,
+                "liveness_heartbeatlatency_bucket": 81081,
+                "txn_durations_bucket": 115978
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "15204351",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_handleready_latency_bucket": 471746,
-                "raft_process_logcommit_latency_bucket": 470383
+                "raft_process_applycommitted_latency_bucket": 470374,
+                "raft_process_handleready_latency_bucket": 424971,
+                "raft_process_logcommit_latency_bucket": 423649
             }
         },
         "service": {
@@ -8628,15 +9715,43 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "19922943",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "243269631"
+            },
+            "metrics": {
+                "exec_latency_bucket": 471768,
+                "liveness_heartbeatlatency_bucket": 81567,
+                "sql_exec_latency_internal_bucket": 18867,
+                "sql_service_latency_internal_bucket": 18867,
+                "txn_durations_bucket": 116477
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "172031",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_applycommitted_latency_bucket": 470375,
-                "raft_process_commandcommit_latency_bucket": 472470,
-                "raft_process_handleready_latency_bucket": 425442,
-                "raft_process_logcommit_latency_bucket": 424236
+                "raft_process_applycommitted_latency_bucket": 51365,
+                "raft_process_commandcommit_latency_bucket": 309077
             }
         },
         "service": {
@@ -8656,13 +9771,43 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "54525951",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "8912895"
+            },
+            "metrics": {
+                "exec_latency_bucket": 433995,
+                "liveness_heartbeatlatency_bucket": 73311,
+                "round_trip_latency_bucket": 122483,
+                "sql_service_latency_internal_bucket": 18606,
+                "txn_durations_bucket": 107673
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "67108863",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_handleready_latency_bucket": 461500,
-                "raft_process_logcommit_latency_bucket": 461122
+                "raft_process_handleready_latency_bucket": 466315,
+                "raft_process_logcommit_latency_bucket": 465289
             }
         },
         "service": {
@@ -8682,123 +9827,14 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "458751"
-            },
-            "metrics": {
-                "exec_latency_bucket": 118492,
-                "round_trip_latency_bucket": 23716,
-                "sql_distsql_exec_latency_internal_bucket": 2902,
-                "sql_distsql_service_latency_internal_bucket": 16,
-                "sql_exec_latency_internal_bucket": 4107,
-                "sql_service_latency_internal_bucket": 16,
-                "txn_durations_bucket": 2872
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "142606335"
-            },
-            "metrics": {
-                "exec_latency_bucket": 471154,
-                "liveness_heartbeatlatency_bucket": 81389,
-                "sql_exec_latency_internal_bucket": 18864,
-                "txn_durations_bucket": 116290
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "67108863"
-            },
-            "metrics": {
-                "exec_latency_bucket": 465970,
-                "liveness_heartbeatlatency_bucket": 79430,
-                "sql_exec_latency_internal_bucket": 18858,
-                "sql_service_latency_internal_bucket": 18856,
-                "txn_durations_bucket": 114247
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "2818572287"
-            },
-            "metrics": {
-                "exec_latency_bucket": 472334,
-                "txn_durations_bucket": 116620
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "6911",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "159383551",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_commandcommit_latency_bucket": 18,
-                "raft_process_handleready_latency_bucket": 1116
+                "raft_process_handleready_latency_bucket": 470600,
+                "raft_process_logcommit_latency_bucket": 469240
             }
         },
         "service": {
@@ -8818,13 +9854,128 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "44040191",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "32505855"
+            },
+            "metrics": {
+                "exec_latency_bucket": 445192,
+                "liveness_heartbeatlatency_bucket": 75582,
+                "sql_exec_latency_internal_bucket": 18773,
+                "sql_service_latency_internal_bucket": 18742,
+                "txn_durations_bucket": 110170
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "301989887"
+            },
+            "metrics": {
+                "exec_latency_bucket": 472032,
+                "liveness_heartbeatlatency_bucket": 81619,
+                "txn_durations_bucket": 116532
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "253951"
+            },
+            "metrics": {
+                "exec_latency_bucket": 108975,
+                "round_trip_latency_bucket": 25,
+                "sql_distsql_exec_latency_internal_bucket": 312,
+                "sql_exec_latency_internal_bucket": 530,
+                "txn_durations_bucket": 125
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "12582911"
+            },
+            "metrics": {
+                "exec_latency_bucket": 437012,
+                "liveness_heartbeatlatency_bucket": 73406,
+                "round_trip_latency_bucket": 122492,
+                "txn_durations_bucket": 107801
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "25165823",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_handleready_latency_bucket": 452842,
-                "raft_process_logcommit_latency_bucket": 453224
+                "raft_process_applycommitted_latency_bucket": 470378,
+                "raft_process_handleready_latency_bucket": 429952,
+                "raft_process_logcommit_latency_bucket": 429521
             }
         },
         "service": {
@@ -8844,13 +9995,44 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "294911",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "14680063"
+            },
+            "metrics": {
+                "exec_latency_bucket": 437240,
+                "liveness_heartbeatlatency_bucket": 73421,
+                "sql_exec_latency_internal_bucket": 18613,
+                "txn_durations_bucket": 107818
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "7864319",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_applycommitted_latency_bucket": 147953,
-                "raft_process_commandcommit_latency_bucket": 325741
+                "raft_process_applycommitted_latency_bucket": 470313,
+                "raft_process_commandcommit_latency_bucket": 472439,
+                "raft_process_handleready_latency_bucket": 422038,
+                "raft_process_logcommit_latency_bucket": 422573
             }
         },
         "service": {
@@ -8870,44 +10052,14 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "1507327"
-            },
-            "metrics": {
-                "exec_latency_bucket": 146093,
-                "liveness_heartbeatlatency_bucket": 4401,
-                "round_trip_latency_bucket": 121834,
-                "sql_distsql_exec_latency_internal_bucket": 12646,
-                "sql_distsql_service_latency_internal_bucket": 1853,
-                "sql_exec_latency_internal_bucket": 16976,
-                "sql_service_latency_internal_bucket": 2539,
-                "txn_durations_bucket": 32468
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "6399",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "139263",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_commandcommit_latency_bucket": 15,
-                "raft_process_handleready_latency_bucket": 1071
+                "raft_process_applycommitted_latency_bucket": 25759,
+                "raft_process_commandcommit_latency_bucket": 305002
             }
         },
         "service": {
@@ -8927,14 +10079,12 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "23068671",
-                "store": "1"
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "38911"
             },
             "metrics": {
-                "raft_process_applycommitted_latency_bucket": 470377,
-                "raft_process_handleready_latency_bucket": 427150,
-                "raft_process_logcommit_latency_bucket": 426316
+                "exec_latency_bucket": 4556
             }
         },
         "service": {
@@ -8954,245 +10104,8 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "90111",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 7312,
-                "raft_process_commandcommit_latency_bucket": 289881
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "12799",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_commandcommit_latency_bucket": 8545,
-                "raft_process_handleready_latency_bucket": 1332
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "2684354559",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 471737,
-                "raft_process_logcommit_latency_bucket": 470374
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "2175",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 106
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "851967",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 354151,
-                "raft_process_commandcommit_latency_bucket": 368305,
-                "raft_process_handleready_latency_bucket": 6911,
-                "raft_process_logcommit_latency_bucket": 34719
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "7679",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_commandcommit_latency_bucket": 34,
-                "raft_process_handleready_latency_bucket": 1181
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "22020095",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 470376,
-                "raft_process_commandcommit_latency_bucket": 472471,
-                "raft_process_handleready_latency_bucket": 426361,
-                "raft_process_logcommit_latency_bucket": 425332
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "3801087",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 464016,
-                "raft_process_commandcommit_latency_bucket": 469538,
-                "raft_process_handleready_latency_bucket": 347937,
-                "raft_process_logcommit_latency_bucket": 413347
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "520093695"
-            },
-            "metrics": {
-                "exec_latency_bucket": 472265,
-                "txn_durations_bucket": 116596
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
                 "le": "452984831"
             },
             "metrics": {
@@ -9220,13 +10133,43 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "73727",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "75497471"
+            },
+            "metrics": {
+                "exec_latency_bucket": 467471,
+                "liveness_heartbeatlatency_bucket": 79948,
+                "sql_distsql_service_latency_internal_bucket": 12695,
+                "sql_exec_latency_internal_bucket": 18862,
+                "sql_service_latency_internal_bucket": 18861,
+                "txn_durations_bucket": 114805
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "4351",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_applycommitted_latency_bucket": 1609,
-                "raft_process_commandcommit_latency_bucket": 274921
+                "raft_process_handleready_latency_bucket": 553
             }
         },
         "service": {
@@ -9246,15 +10189,13 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "3538943",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "1471",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_applycommitted_latency_bucket": 460992,
-                "raft_process_commandcommit_latency_bucket": 467942,
-                "raft_process_handleready_latency_bucket": 337942,
-                "raft_process_logcommit_latency_bucket": 409771
+                "raft_process_handleready_latency_bucket": 1
             }
         },
         "service": {
@@ -9274,15 +10215,16 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "58720255"
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "29360127"
             },
             "metrics": {
-                "exec_latency_bucket": 463192,
-                "liveness_heartbeatlatency_bucket": 78475,
-                "sql_exec_latency_internal_bucket": 18855,
-                "sql_service_latency_internal_bucket": 18852,
-                "txn_durations_bucket": 113245
+                "exec_latency_bucket": 442682,
+                "liveness_heartbeatlatency_bucket": 74931,
+                "sql_exec_latency_internal_bucket": 18733,
+                "sql_service_latency_internal_bucket": 18687,
+                "txn_durations_bucket": 109481
             }
         },
         "service": {
@@ -9302,13 +10244,41 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "17825791",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "318767103"
+            },
+            "metrics": {
+                "exec_latency_bucket": 472079,
+                "liveness_heartbeatlatency_bucket": 81635,
+                "txn_durations_bucket": 116548
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "39845887",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_handleready_latency_bucket": 425172,
-                "raft_process_logcommit_latency_bucket": 423872
+                "raft_process_handleready_latency_bucket": 449246,
+                "raft_process_logcommit_latency_bucket": 449564
             }
         },
         "service": {
@@ -9328,15 +10298,14 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "1245183",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "520093695",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_applycommitted_latency_bucket": 370597,
-                "raft_process_commandcommit_latency_bucket": 382965,
-                "raft_process_handleready_latency_bucket": 58452,
-                "raft_process_logcommit_latency_bucket": 160203
+                "raft_process_handleready_latency_bucket": 471654,
+                "raft_process_logcommit_latency_bucket": 470291
             }
         },
         "service": {
@@ -9356,352 +10325,8 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "5505023"
-            },
-            "metrics": {
-                "exec_latency_bucket": 389581,
-                "liveness_heartbeatlatency_bucket": 71037,
-                "round_trip_latency_bucket": 122462,
-                "sql_distsql_service_latency_internal_bucket": 12616,
-                "sql_service_latency_internal_bucket": 18375,
-                "txn_durations_bucket": 104857
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "176160767",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 470698,
-                "raft_process_logcommit_latency_bucket": 469341
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "139263"
-            },
-            "metrics": {
-                "exec_latency_bucket": 71685,
-                "sql_distsql_exec_latency_internal_bucket": 23,
-                "sql_exec_latency_internal_bucket": 23
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "10200547327"
-            },
-            "metrics": {
-                "exec_latency_bucket": 472346,
-                "txn_durations_bucket": 116626
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "126975"
-            },
-            "metrics": {
-                "exec_latency_bucket": 65281,
-                "sql_distsql_exec_latency_internal_bucket": 13,
-                "sql_exec_latency_internal_bucket": 13
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "7077887",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 470258,
-                "raft_process_commandcommit_latency_bucket": 472422,
-                "raft_process_handleready_latency_bucket": 419854,
-                "raft_process_logcommit_latency_bucket": 422243
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "11534335"
-            },
-            "metrics": {
-                "exec_latency_bucket": 436774,
-                "liveness_heartbeatlatency_bucket": 73391,
-                "round_trip_latency_bucket": 122491,
-                "txn_durations_bucket": 107785
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "771751935"
-            },
-            "metrics": {
-                "exec_latency_bucket": 472293,
-                "liveness_heartbeatlatency_bucket": 81686,
-                "txn_durations_bucket": 116609
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "218103807"
-            },
-            "metrics": {
-                "exec_latency_bucket": 471635,
-                "liveness_heartbeatlatency_bucket": 81543,
-                "txn_durations_bucket": 116451
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "1677721599"
-            },
-            "metrics": {
-                "exec_latency_bucket": 472325,
-                "liveness_heartbeatlatency_bucket": 81695,
-                "txn_durations_bucket": 116617
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "13107199",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 424856,
-                "raft_process_logcommit_latency_bucket": 423578
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "655359",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 329889,
-                "raft_process_commandcommit_latency_bucket": 362637,
-                "raft_process_handleready_latency_bucket": 1376,
-                "raft_process_logcommit_latency_bucket": 3624
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "83886079",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 468490,
-                "raft_process_logcommit_latency_bucket": 467303
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
                 "le": "167772159",
                 "store": "1"
             },
@@ -9727,12 +10352,14 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "7167",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "1275068415",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_handleready_latency_bucket": 1145
+                "raft_process_handleready_latency_bucket": 471726,
+                "raft_process_logcommit_latency_bucket": 470363
             }
         },
         "service": {
@@ -9752,13 +10379,16 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "234881023"
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "9437183"
             },
             "metrics": {
-                "exec_latency_bucket": 471733,
-                "liveness_heartbeatlatency_bucket": 81557,
-                "txn_durations_bucket": 116466
+                "exec_latency_bucket": 435121,
+                "liveness_heartbeatlatency_bucket": 73342,
+                "round_trip_latency_bucket": 122484,
+                "sql_service_latency_internal_bucket": 18608,
+                "txn_durations_bucket": 107714
             }
         },
         "service": {
@@ -9778,7 +10408,1037 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "3355443199",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 471738,
+                "raft_process_logcommit_latency_bucket": 470375
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "12884901887"
+            },
+            "metrics": {
+                "exec_latency_bucket": 472348
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "37748735",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 447628,
+                "raft_process_logcommit_latency_bucket": 447681
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "139263"
+            },
+            "metrics": {
+                "exec_latency_bucket": 71685,
+                "sql_distsql_exec_latency_internal_bucket": 23,
+                "sql_exec_latency_internal_bucket": 23
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "204799",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 81796,
+                "raft_process_commandcommit_latency_bucket": 312920
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "637534207"
+            },
+            "metrics": {
+                "exec_latency_bucket": 472282,
+                "liveness_heartbeatlatency_bucket": 81684,
+                "txn_durations_bucket": 116607
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "36863"
+            },
+            "metrics": {
+                "exec_latency_bucket": 3791
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "704643071"
+            },
+            "metrics": {
+                "exec_latency_bucket": 472288
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "536870911",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 471660,
+                "raft_process_logcommit_latency_bucket": 470297
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "704643071",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 471688,
+                "raft_process_logcommit_latency_bucket": 470325
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "41943039",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 450935,
+                "raft_process_logcommit_latency_bucket": 451321
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "218103807"
+            },
+            "metrics": {
+                "exec_latency_bucket": 471635,
+                "liveness_heartbeatlatency_bucket": 81543,
+                "txn_durations_bucket": 116451
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "8388607"
+            },
+            "metrics": {
+                "exec_latency_bucket": 432497,
+                "liveness_heartbeatlatency_bucket": 73265,
+                "round_trip_latency_bucket": 122481,
+                "sql_exec_latency_internal_bucket": 18611,
+                "sql_service_latency_internal_bucket": 18604,
+                "txn_durations_bucket": 107601
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "1140850687",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 471722,
+                "raft_process_logcommit_latency_bucket": 470359
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "973078527",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 471704,
+                "raft_process_logcommit_latency_bucket": 470342
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "113246207"
+            },
+            "metrics": {
+                "exec_latency_bucket": 470656,
+                "liveness_heartbeatlatency_bucket": 81195,
+                "txn_durations_bucket": 116094
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "77823"
+            },
+            "metrics": {
+                "exec_latency_bucket": 26188
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "184549375"
+            },
+            "metrics": {
+                "exec_latency_bucket": 471458,
+                "liveness_heartbeatlatency_bucket": 81492,
+                "sql_exec_latency_internal_bucket": 18865,
+                "sql_service_latency_internal_bucket": 18865,
+                "txn_durations_bucket": 116397
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "507903",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 289574,
+                "raft_process_commandcommit_latency_bucket": 352939
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "57343",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 270,
+                "raft_process_commandcommit_latency_bucket": 248153
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "49151"
+            },
+            "metrics": {
+                "exec_latency_bucket": 8095
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "5242879",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 469491,
+                "raft_process_commandcommit_latency_bucket": 472077,
+                "raft_process_handleready_latency_bucket": 397349,
+                "raft_process_logcommit_latency_bucket": 420486
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "10239",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_commandcommit_latency_bucket": 2034,
+                "raft_process_handleready_latency_bucket": 1303
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "5637144575"
+            },
+            "metrics": {
+                "exec_latency_bucket": 472343
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "2490367",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 429273,
+                "raft_process_commandcommit_latency_bucket": 447005,
+                "raft_process_handleready_latency_bucket": 284293,
+                "raft_process_logcommit_latency_bucket": 368808,
+                "txnwaitqueue_pusher_wait_time_bucket": 3
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "88080383"
+            },
+            "metrics": {
+                "exec_latency_bucket": 469072,
+                "liveness_heartbeatlatency_bucket": 80559,
+                "sql_exec_latency_internal_bucket": 18863,
+                "sql_service_latency_internal_bucket": 18863,
+                "txn_durations_bucket": 115436
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "30408703"
+            },
+            "metrics": {
+                "exec_latency_bucket": 443563,
+                "liveness_heartbeatlatency_bucket": 75168,
+                "sql_exec_latency_internal_bucket": 18745,
+                "sql_service_latency_internal_bucket": 18711,
+                "txn_durations_bucket": 109739
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "51199",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 135,
+                "raft_process_commandcommit_latency_bucket": 232584
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "92274687"
+            },
+            "metrics": {
+                "exec_latency_bucket": 469504,
+                "liveness_heartbeatlatency_bucket": 80719,
+                "txn_durations_bucket": 115601
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "884735"
+            },
+            "metrics": {
+                "exec_latency_bucket": 119032,
+                "round_trip_latency_bucket": 94717,
+                "sql_distsql_exec_latency_internal_bucket": 11427,
+                "sql_distsql_service_latency_internal_bucket": 112,
+                "sql_exec_latency_internal_bucket": 14981,
+                "sql_service_latency_internal_bucket": 275,
+                "txn_durations_bucket": 15986
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "163839",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 43694,
+                "raft_process_commandcommit_latency_bucket": 308119
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "5375",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_commandcommit_latency_bucket": 10,
+                "raft_process_handleready_latency_bucket": 877
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "3327",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 275
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "1073741823",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 471719,
+                "raft_process_logcommit_latency_bucket": 470356
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "1507327",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 382959,
+                "raft_process_commandcommit_latency_bucket": 396745,
+                "raft_process_handleready_latency_bucket": 123053,
+                "raft_process_logcommit_latency_bucket": 243194
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "25599"
+            },
+            "metrics": {
+                "exec_latency_bucket": 381
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "425983",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 247888,
+                "raft_process_commandcommit_latency_bucket": 343073
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "2080374783"
+            },
+            "metrics": {
+                "exec_latency_bucket": 472327
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
                 "le": "983039"
             },
             "metrics": {
@@ -9809,1328 +11469,8 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "234881023",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 471078,
-                "raft_process_logcommit_latency_bucket": 469721
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "26623"
-            },
-            "metrics": {
-                "exec_latency_bucket": 674
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "40959"
-            },
-            "metrics": {
-                "exec_latency_bucket": 5308
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "43007"
-            },
-            "metrics": {
-                "exec_latency_bucket": 6044
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "33554431",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 470380,
-                "raft_process_commandcommit_latency_bucket": 472474,
-                "raft_process_handleready_latency_bucket": 443818,
-                "raft_process_logcommit_latency_bucket": 443713
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "1791",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 63
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "278527"
-            },
-            "metrics": {
-                "exec_latency_bucket": 112495,
-                "round_trip_latency_bucket": 911,
-                "sql_distsql_exec_latency_internal_bucket": 724,
-                "sql_exec_latency_internal_bucket": 1072,
-                "txn_durations_bucket": 214
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "753663",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 345224,
-                "raft_process_commandcommit_latency_bucket": 365723,
-                "raft_process_handleready_latency_bucket": 2374,
-                "raft_process_logcommit_latency_bucket": 14115
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "147455",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 30681,
-                "raft_process_commandcommit_latency_bucket": 306129
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "7602175",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 470295,
-                "raft_process_commandcommit_latency_bucket": 472432,
-                "raft_process_handleready_latency_bucket": 421477,
-                "raft_process_logcommit_latency_bucket": 422462
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "2097151"
-            },
-            "metrics": {
-                "exec_latency_bucket": 212745,
-                "liveness_heartbeatlatency_bucket": 15882,
-                "round_trip_latency_bucket": 122355,
-                "sql_distsql_exec_latency_internal_bucket": 12691,
-                "sql_distsql_service_latency_internal_bucket": 3186,
-                "sql_exec_latency_internal_bucket": 18392,
-                "sql_service_latency_internal_bucket": 5375,
-                "txn_durations_bucket": 50399
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "10751",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_commandcommit_latency_bucket": 3032,
-                "raft_process_handleready_latency_bucket": 1312
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "118783"
-            },
-            "metrics": {
-                "exec_latency_bucket": 60542,
-                "sql_distsql_exec_latency_internal_bucket": 9,
-                "sql_exec_latency_internal_bucket": 9
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "33554431"
-            },
-            "metrics": {
-                "exec_latency_bucket": 445935,
-                "liveness_heartbeatlatency_bucket": 75761,
-                "sql_exec_latency_internal_bucket": 18784,
-                "sql_service_latency_internal_bucket": 18756,
-                "txn_durations_bucket": 110360
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "49151",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 103,
-                "raft_process_commandcommit_latency_bucket": 225946
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "46137343",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 454638,
-                "raft_process_logcommit_latency_bucket": 455050
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "335544319"
-            },
-            "metrics": {
-                "exec_latency_bucket": 472112,
-                "liveness_heartbeatlatency_bucket": 81640,
-                "txn_durations_bucket": 116554
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "25165823",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 470378,
-                "raft_process_handleready_latency_bucket": 429952,
-                "raft_process_logcommit_latency_bucket": 429521
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "6553599",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 470185,
-                "raft_process_commandcommit_latency_bucket": 472401,
-                "raft_process_handleready_latency_bucket": 416988,
-                "raft_process_logcommit_latency_bucket": 421976
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "11775",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_commandcommit_latency_bucket": 5532,
-                "raft_process_handleready_latency_bucket": 1323
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "8126463",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 470323,
-                "raft_process_handleready_latency_bucket": 422488,
-                "raft_process_logcommit_latency_bucket": 422705
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "134217727",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 470418,
-                "raft_process_logcommit_latency_bucket": 469081
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "486539263",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 471644,
-                "raft_process_logcommit_latency_bucket": 470281
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "671088639"
-            },
-            "metrics": {
-                "exec_latency_bucket": 472287,
-                "liveness_heartbeatlatency_bucket": 81685,
-                "txn_durations_bucket": 116608
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "950271",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 359543,
-                "raft_process_commandcommit_latency_bucket": 370943,
-                "raft_process_handleready_latency_bucket": 13745,
-                "raft_process_logcommit_latency_bucket": 65910
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "3145727",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 453965,
-                "raft_process_commandcommit_latency_bucket": 463533,
-                "raft_process_handleready_latency_bucket": 320782,
-                "raft_process_logcommit_latency_bucket": 401260,
-                "txnwaitqueue_pusher_wait_time_bucket": 5
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "2559",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 182
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "192937983"
-            },
-            "metrics": {
-                "exec_latency_bucket": 471495,
-                "liveness_heartbeatlatency_bucket": 81505,
-                "sql_exec_latency_internal_bucket": 18866,
-                "sql_service_latency_internal_bucket": 18866,
-                "txn_durations_bucket": 116410
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "1572863",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 386333,
-                "raft_process_commandcommit_latency_bucket": 400111,
-                "raft_process_handleready_latency_bucket": 139884,
-                "raft_process_logcommit_latency_bucket": 256469
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "8126463"
-            },
-            "metrics": {
-                "exec_latency_bucket": 431543,
-                "liveness_heartbeatlatency_bucket": 73220,
-                "round_trip_latency_bucket": 122480,
-                "sql_distsql_service_latency_internal_bucket": 12694,
-                "sql_exec_latency_internal_bucket": 18610,
-                "sql_service_latency_internal_bucket": 18603,
-                "txn_durations_bucket": 107551
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "12582911"
-            },
-            "metrics": {
-                "exec_latency_bucket": 437012,
-                "liveness_heartbeatlatency_bucket": 73406,
-                "round_trip_latency_bucket": 122492,
-                "txn_durations_bucket": 107801
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "55295",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 215,
-                "raft_process_commandcommit_latency_bucket": 243569
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "212991",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 88794,
-                "raft_process_commandcommit_latency_bucket": 313937
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "838860799"
-            },
-            "metrics": {
-                "exec_latency_bucket": 472295
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "45055",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 44,
-                "raft_process_commandcommit_latency_bucket": 210048
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "172031"
-            },
-            "metrics": {
-                "exec_latency_bucket": 86111,
-                "sql_distsql_exec_latency_internal_bucket": 52,
-                "sql_exec_latency_internal_bucket": 69
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "11010047",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 470368,
-                "raft_process_commandcommit_latency_bucket": 472468,
-                "raft_process_handleready_latency_bucket": 424618,
-                "raft_process_logcommit_latency_bucket": 423491
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "7077887"
-            },
-            "metrics": {
-                "exec_latency_bucket": 424304,
-                "liveness_heartbeatlatency_bucket": 72904,
-                "sql_distsql_service_latency_internal_bucket": 12686,
-                "sql_service_latency_internal_bucket": 18574,
-                "txn_durations_bucket": 107218
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "6291455"
-            },
-            "metrics": {
-                "exec_latency_bucket": 411358,
-                "liveness_heartbeatlatency_bucket": 72238,
-                "round_trip_latency_bucket": 122468,
-                "sql_distsql_service_latency_internal_bucket": 12670,
-                "sql_exec_latency_internal_bucket": 18609,
-                "sql_service_latency_internal_bucket": 18513,
-                "txn_durations_bucket": 106546
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "327679",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 172369,
-                "raft_process_commandcommit_latency_bucket": 330548
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "1835007",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 398728,
-                "raft_process_commandcommit_latency_bucket": 413884,
-                "raft_process_handleready_latency_bucket": 205457,
-                "raft_process_logcommit_latency_bucket": 298683
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "204799"
-            },
-            "metrics": {
-                "exec_latency_bucket": 97958,
-                "sql_distsql_exec_latency_internal_bucket": 89,
-                "sql_exec_latency_internal_bucket": 134,
-                "txn_durations_bucket": 19
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "121634815"
-            },
-            "metrics": {
-                "exec_latency_bucket": 470850,
-                "liveness_heartbeatlatency_bucket": 81259,
-                "txn_durations_bucket": 116160
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "7340031"
-            },
-            "metrics": {
-                "exec_latency_bucket": 426863,
-                "liveness_heartbeatlatency_bucket": 73029,
-                "round_trip_latency_bucket": 122472,
-                "sql_distsql_service_latency_internal_bucket": 12691,
-                "sql_service_latency_internal_bucket": 18588,
-                "txn_durations_bucket": 107340
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "1245183"
-            },
-            "metrics": {
-                "exec_latency_bucket": 128559,
-                "liveness_heartbeatlatency_bucket": 1392,
-                "round_trip_latency_bucket": 119141,
-                "sql_distsql_exec_latency_internal_bucket": 12519,
-                "sql_distsql_service_latency_internal_bucket": 880,
-                "sql_exec_latency_internal_bucket": 16602,
-                "sql_service_latency_internal_bucket": 1377,
-                "txn_durations_bucket": 23681
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "4456447"
-            },
-            "metrics": {
-                "exec_latency_bucket": 356695,
-                "liveness_heartbeatlatency_bucket": 64846,
-                "round_trip_latency_bucket": 122453,
-                "sql_distsql_service_latency_internal_bucket": 12281,
-                "sql_exec_latency_internal_bucket": 18605,
-                "sql_service_latency_internal_bucket": 17704,
-                "txn_durations_bucket": 99500
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "1207959551"
-            },
-            "metrics": {
-                "exec_latency_bucket": 472316,
-                "liveness_heartbeatlatency_bucket": 81689,
-                "txn_durations_bucket": 116613
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "65011711",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 470384,
-                "raft_process_handleready_latency_bucket": 465874,
-                "raft_process_logcommit_latency_bucket": 464886
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "226492415"
-            },
-            "metrics": {
-                "exec_latency_bucket": 471687,
-                "liveness_heartbeatlatency_bucket": 81548,
-                "txn_durations_bucket": 116457
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
                 "le": "1610612735"
             },
             "metrics": {
@@ -11154,13 +11494,13 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "452984831",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "22527",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_handleready_latency_bucket": 471632,
-                "raft_process_logcommit_latency_bucket": 470269
+                "raft_process_commandcommit_latency_bucket": 42618
             }
         },
         "service": {
@@ -11180,662 +11520,8 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "344063"
-            },
-            "metrics": {
-                "exec_latency_bucket": 116938,
-                "round_trip_latency_bucket": 10558,
-                "sql_distsql_exec_latency_internal_bucket": 1714,
-                "sql_distsql_service_latency_internal_bucket": 1,
-                "sql_exec_latency_internal_bucket": 2330,
-                "sql_service_latency_internal_bucket": 1,
-                "txn_durations_bucket": 1045
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "73727"
-            },
-            "metrics": {
-                "exec_latency_bucket": 22440
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "16777215",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 425068,
-                "raft_process_logcommit_latency_bucket": 423770
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "41943039"
-            },
-            "metrics": {
-                "exec_latency_bucket": 451168,
-                "liveness_heartbeatlatency_bucket": 76401,
-                "sql_exec_latency_internal_bucket": 18820,
-                "sql_service_latency_internal_bucket": 18814,
-                "txn_durations_bucket": 111018
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "48234495"
-            },
-            "metrics": {
-                "exec_latency_bucket": 456044,
-                "liveness_heartbeatlatency_bucket": 76919,
-                "round_trip_latency_bucket": 122498,
-                "sql_exec_latency_internal_bucket": 18840,
-                "sql_service_latency_internal_bucket": 18835,
-                "txn_durations_bucket": 111581
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "31457279"
-            },
-            "metrics": {
-                "exec_latency_bucket": 444428,
-                "liveness_heartbeatlatency_bucket": 75397,
-                "sql_exec_latency_internal_bucket": 18759,
-                "sql_service_latency_internal_bucket": 18731,
-                "txn_durations_bucket": 109971
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "150994943"
-            },
-            "metrics": {
-                "exec_latency_bucket": 471222,
-                "liveness_heartbeatlatency_bucket": 81422,
-                "sql_service_latency_internal_bucket": 18864,
-                "txn_durations_bucket": 116325
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "go_version": "go1.11.6",
-                "instance": "127.0.0.1:50516",
-                "tag": "v19.1.1"
-            },
-            "metrics": {
-                "build_timestamp": 1557952020
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "503316479",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 471652,
-                "raft_process_logcommit_latency_bucket": 470289
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "12058623",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 470372,
-                "raft_process_commandcommit_latency_bucket": 472469,
-                "raft_process_handleready_latency_bucket": 424764,
-                "raft_process_logcommit_latency_bucket": 423542
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "71303167"
-            },
-            "metrics": {
-                "exec_latency_bucket": 466848,
-                "liveness_heartbeatlatency_bucket": 79743,
-                "sql_exec_latency_internal_bucket": 18860,
-                "sql_service_latency_internal_bucket": 18858,
-                "txn_durations_bucket": 114589
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "1441791",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 379692,
-                "raft_process_commandcommit_latency_bucket": 393345,
-                "raft_process_handleready_latency_bucket": 107287,
-                "raft_process_logcommit_latency_bucket": 227664
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "196607",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 74611,
-                "raft_process_commandcommit_latency_bucket": 311957
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "237567"
-            },
-            "metrics": {
-                "exec_latency_bucket": 105960,
-                "sql_distsql_exec_latency_internal_bucket": 137,
-                "sql_exec_latency_internal_bucket": 283,
-                "txn_durations_bucket": 76
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "79691775"
-            },
-            "metrics": {
-                "exec_latency_bucket": 468040,
-                "liveness_heartbeatlatency_bucket": 80151,
-                "sql_service_latency_internal_bucket": 18862,
-                "txn_durations_bucket": 115019
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "4607",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_commandcommit_latency_bucket": 4,
-                "raft_process_handleready_latency_bucket": 640
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "285212671"
-            },
-            "metrics": {
-                "exec_latency_bucket": 471987,
-                "liveness_heartbeatlatency_bucket": 81608,
-                "txn_durations_bucket": 116520
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "5242879"
-            },
-            "metrics": {
-                "exec_latency_bucket": 381962,
-                "liveness_heartbeatlatency_bucket": 70329,
-                "round_trip_latency_bucket": 122458,
-                "sql_distsql_service_latency_internal_bucket": 12581,
-                "sql_exec_latency_internal_bucket": 18608,
-                "sql_service_latency_internal_bucket": 18303,
-                "txn_durations_bucket": 104099
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "172031",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 51365,
-                "raft_process_commandcommit_latency_bucket": 309077
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "1769471"
-            },
-            "metrics": {
-                "exec_latency_bucket": 171923,
-                "liveness_heartbeatlatency_bucket": 9126,
-                "round_trip_latency_bucket": 122256,
-                "sql_distsql_exec_latency_internal_bucket": 12679,
-                "sql_distsql_service_latency_internal_bucket": 2580,
-                "sql_exec_latency_internal_bucket": 17856,
-                "sql_service_latency_internal_bucket": 3731,
-                "txn_durations_bucket": 40538
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "16252927"
-            },
-            "metrics": {
-                "exec_latency_bucket": 437309,
-                "liveness_heartbeatlatency_bucket": 73430,
-                "txn_durations_bucket": 107827
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "20971519"
-            },
-            "metrics": {
-                "exec_latency_bucket": 437659,
-                "liveness_heartbeatlatency_bucket": 73526,
-                "sql_exec_latency_internal_bucket": 18617,
-                "txn_durations_bucket": 107935
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "2031615"
-            },
-            "metrics": {
-                "exec_latency_bucket": 204329,
-                "liveness_heartbeatlatency_bucket": 14156,
-                "round_trip_latency_bucket": 122345,
-                "sql_distsql_service_latency_internal_bucket": 3025,
-                "sql_exec_latency_internal_bucket": 18350,
-                "sql_service_latency_internal_bucket": 4971,
-                "txn_durations_bucket": 48034
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "1476395007"
-            },
-            "metrics": {
-                "exec_latency_bucket": 472322,
-                "liveness_heartbeatlatency_bucket": 81691,
-                "txn_durations_bucket": 116615
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
                 "le": "34815",
                 "store": "1"
             },
@@ -11861,64 +11547,16 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "939524095"
-            },
-            "metrics": {
-                "exec_latency_bucket": 472298,
-                "liveness_heartbeatlatency_bucket": 81687,
-                "txn_durations_bucket": 116610
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "260046847"
-            },
-            "metrics": {
-                "exec_latency_bucket": 471850,
-                "liveness_heartbeatlatency_bucket": 81584,
-                "txn_durations_bucket": 116495
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "2047",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "622591",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_handleready_latency_bucket": 90
+                "raft_process_applycommitted_latency_bucket": 323067,
+                "raft_process_commandcommit_latency_bucket": 361233,
+                "raft_process_handleready_latency_bucket": 1364,
+                "raft_process_logcommit_latency_bucket": 1448
             }
         },
         "service": {
@@ -11938,67 +11576,16 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "442367"
-            },
-            "metrics": {
-                "exec_latency_bucket": 118398,
-                "round_trip_latency_bucket": 22718,
-                "sql_distsql_exec_latency_internal_bucket": 2778,
-                "sql_distsql_service_latency_internal_bucket": 14,
-                "sql_exec_latency_internal_bucket": 3836,
-                "sql_service_latency_internal_bucket": 14,
-                "txn_durations_bucket": 2614
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "86015"
-            },
-            "metrics": {
-                "exec_latency_bucket": 34536
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "425983",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "983039",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_applycommitted_latency_bucket": 247888,
-                "raft_process_commandcommit_latency_bucket": 343073
+                "raft_process_applycommitted_latency_bucket": 360920,
+                "raft_process_commandcommit_latency_bucket": 371928,
+                "raft_process_handleready_latency_bucket": 16441,
+                "raft_process_logcommit_latency_bucket": 76932
             }
         },
         "service": {
@@ -12018,319 +11605,8 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "11263",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_commandcommit_latency_bucket": 4206,
-                "raft_process_handleready_latency_bucket": 1319
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "738197503"
-            },
-            "metrics": {
-                "exec_latency_bucket": 472292
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "65535",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 588,
-                "raft_process_commandcommit_latency_bucket": 263257
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "6553599"
-            },
-            "metrics": {
-                "exec_latency_bucket": 416508,
-                "liveness_heartbeatlatency_bucket": 72547,
-                "round_trip_latency_bucket": 122469,
-                "sql_distsql_service_latency_internal_bucket": 12677,
-                "sql_service_latency_internal_bucket": 18546,
-                "txn_durations_bucket": 106855
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "131071"
-            },
-            "metrics": {
-                "exec_latency_bucket": 67524,
-                "sql_distsql_exec_latency_internal_bucket": 17,
-                "sql_exec_latency_internal_bucket": 17
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "3455",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 300
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "2687",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 200
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "1342177279"
-            },
-            "metrics": {
-                "exec_latency_bucket": 472320,
-                "liveness_heartbeatlatency_bucket": 81690,
-                "txn_durations_bucket": 116614
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "11534335",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 470370,
-                "raft_process_handleready_latency_bucket": 424707,
-                "raft_process_logcommit_latency_bucket": 423517
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "385875967",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 471582,
-                "raft_process_logcommit_latency_bucket": 470227
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "10485759",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 470365,
-                "raft_process_commandcommit_latency_bucket": 472467,
-                "raft_process_handleready_latency_bucket": 424501,
-                "raft_process_logcommit_latency_bucket": 423442
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "55295"
-            },
-            "metrics": {
-                "exec_latency_bucket": 10453
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
                 "le": "1179647"
             },
             "metrics": {
@@ -12361,37 +11637,14 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "1409286143"
-            },
-            "metrics": {
-                "exec_latency_bucket": 472321
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "360447",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "69631",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_applycommitted_latency_bucket": 197900,
-                "raft_process_commandcommit_latency_bucket": 334903
+                "raft_process_applycommitted_latency_bucket": 898,
+                "raft_process_commandcommit_latency_bucket": 269436
             }
         },
         "service": {
@@ -12411,37 +11664,16 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "36863"
-            },
-            "metrics": {
-                "exec_latency_bucket": 3791
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "1140850687",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "1114111",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_handleready_latency_bucket": 471722,
-                "raft_process_logcommit_latency_bucket": 470359
+                "raft_process_applycommitted_latency_bucket": 365816,
+                "raft_process_commandcommit_latency_bucket": 376715,
+                "raft_process_handleready_latency_bucket": 30999,
+                "raft_process_logcommit_latency_bucket": 115130
             }
         },
         "service": {
@@ -12461,7 +11693,424 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "385875967",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 471582,
+                "raft_process_logcommit_latency_bucket": 470227
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "113246207",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 470084,
+                "raft_process_logcommit_latency_bucket": 468757
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "1376255",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 376505,
+                "raft_process_commandcommit_latency_bucket": 389868,
+                "raft_process_handleready_latency_bucket": 91465,
+                "raft_process_logcommit_latency_bucket": 208097
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "58720255"
+            },
+            "metrics": {
+                "exec_latency_bucket": 463192,
+                "liveness_heartbeatlatency_bucket": 78475,
+                "sql_exec_latency_internal_bucket": 18855,
+                "sql_service_latency_internal_bucket": 18852,
+                "txn_durations_bucket": 113245
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "2752511"
+            },
+            "metrics": {
+                "exec_latency_bucket": 271267,
+                "liveness_heartbeatlatency_bucket": 38015,
+                "round_trip_latency_bucket": 122418,
+                "sql_distsql_exec_latency_internal_bucket": 12694,
+                "sql_distsql_service_latency_internal_bucket": 7017,
+                "sql_exec_latency_internal_bucket": 18574,
+                "sql_service_latency_internal_bucket": 10423,
+                "txn_durations_bucket": 74469
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "589823",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 315252,
+                "raft_process_commandcommit_latency_bucket": 359524,
+                "raft_process_logcommit_latency_bucket": 135
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "2952790015"
+            },
+            "metrics": {
+                "liveness_heartbeatlatency_bucket": 81698
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "43007"
+            },
+            "metrics": {
+                "exec_latency_bucket": 6044
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "688127",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 335861,
+                "raft_process_commandcommit_latency_bucket": 363781,
+                "raft_process_handleready_latency_bucket": 1439,
+                "raft_process_logcommit_latency_bucket": 6521
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "2687",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 200
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "872415231"
+            },
+            "metrics": {
+                "exec_latency_bucket": 472296
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "294911",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 147953,
+                "raft_process_commandcommit_latency_bucket": 325741
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "1703935",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 392607,
+                "raft_process_commandcommit_latency_bucket": 406964,
+                "raft_process_handleready_latency_bucket": 173965,
+                "raft_process_logcommit_latency_bucket": 279460
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "1441791"
+            },
+            "metrics": {
+                "exec_latency_bucket": 140480,
+                "liveness_heartbeatlatency_bucket": 3407,
+                "round_trip_latency_bucket": 121500,
+                "sql_distsql_exec_latency_internal_bucket": 12630,
+                "sql_distsql_service_latency_internal_bucket": 1612,
+                "sql_exec_latency_internal_bucket": 16863,
+                "sql_service_latency_internal_bucket": 2246,
+                "txn_durations_bucket": 30082
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "30719",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_commandcommit_latency_bucket": 108653
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
                 "le": "16383",
                 "store": "1"
             },
@@ -12487,13 +12136,96 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "24117247",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "60817407"
+            },
+            "metrics": {
+                "exec_latency_bucket": 464133,
+                "liveness_heartbeatlatency_bucket": 78762,
+                "sql_service_latency_internal_bucket": 18854,
+                "txn_durations_bucket": 113560
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "73727"
+            },
+            "metrics": {
+                "exec_latency_bucket": 22440
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "10485759"
+            },
+            "metrics": {
+                "exec_latency_bucket": 436259,
+                "liveness_heartbeatlatency_bucket": 73373,
+                "round_trip_latency_bucket": 122488,
+                "sql_exec_latency_internal_bucket": 18612,
+                "txn_durations_bucket": 107761
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "9215",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_handleready_latency_bucket": 428347,
-                "raft_process_logcommit_latency_bucket": 427756
+                "raft_process_commandcommit_latency_bucket": 640,
+                "raft_process_handleready_latency_bucket": 1275
             }
         },
         "service": {
@@ -12513,43 +12245,14 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "2883583"
-            },
-            "metrics": {
-                "exec_latency_bucket": 279037,
-                "liveness_heartbeatlatency_bucket": 41533,
-                "round_trip_latency_bucket": 122422,
-                "sql_distsql_service_latency_internal_bucket": 8073,
-                "sql_exec_latency_internal_bucket": 18586,
-                "sql_service_latency_internal_bucket": 11603,
-                "txn_durations_bucket": 77315
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "192937983",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "25599",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_handleready_latency_bucket": 470801,
-                "raft_process_logcommit_latency_bucket": 469447
+                "raft_process_commandcommit_latency_bucket": 62774,
+                "raft_process_handleready_latency_bucket": 1360
             }
         },
         "service": {
@@ -12569,17 +12272,19 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "688127"
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "2097151"
             },
             "metrics": {
-                "exec_latency_bucket": 118835,
-                "round_trip_latency_bucket": 60828,
-                "sql_distsql_exec_latency_internal_bucket": 8542,
-                "sql_distsql_service_latency_internal_bucket": 72,
-                "sql_exec_latency_internal_bucket": 11755,
-                "sql_service_latency_internal_bucket": 72,
-                "txn_durations_bucket": 9577
+                "exec_latency_bucket": 212745,
+                "liveness_heartbeatlatency_bucket": 15882,
+                "round_trip_latency_bucket": 122355,
+                "sql_distsql_exec_latency_internal_bucket": 12691,
+                "sql_distsql_service_latency_internal_bucket": 3186,
+                "sql_exec_latency_internal_bucket": 18392,
+                "sql_service_latency_internal_bucket": 5375,
+                "txn_durations_bucket": 50399
             }
         },
         "service": {
@@ -12599,13 +12304,73 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "77823",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "201326591"
+            },
+            "metrics": {
+                "exec_latency_bucket": 471550,
+                "liveness_heartbeatlatency_bucket": 81519,
+                "txn_durations_bucket": 116426
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "4718591"
+            },
+            "metrics": {
+                "exec_latency_bucket": 365742,
+                "liveness_heartbeatlatency_bucket": 67476,
+                "sql_distsql_service_latency_internal_bucket": 12429,
+                "sql_exec_latency_internal_bucket": 18607,
+                "sql_service_latency_internal_bucket": 17993,
+                "txn_durations_bucket": 101623
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "655359",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_applycommitted_latency_bucket": 2927,
-                "raft_process_commandcommit_latency_bucket": 279625
+                "raft_process_applycommitted_latency_bucket": 329889,
+                "raft_process_commandcommit_latency_bucket": 362637,
+                "raft_process_handleready_latency_bucket": 1376,
+                "raft_process_logcommit_latency_bucket": 3624
             }
         },
         "service": {
@@ -12625,7 +12390,293 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "48234495"
+            },
+            "metrics": {
+                "exec_latency_bucket": 456044,
+                "liveness_heartbeatlatency_bucket": 76919,
+                "round_trip_latency_bucket": 122498,
+                "sql_exec_latency_internal_bucket": 18840,
+                "sql_service_latency_internal_bucket": 18835,
+                "txn_durations_bucket": 111581
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "18874367"
+            },
+            "metrics": {
+                "exec_latency_bucket": 437466,
+                "liveness_heartbeatlatency_bucket": 73476,
+                "round_trip_latency_bucket": 122496,
+                "sql_exec_latency_internal_bucket": 18615,
+                "txn_durations_bucket": 107878
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "1376255"
+            },
+            "metrics": {
+                "exec_latency_bucket": 135639,
+                "liveness_heartbeatlatency_bucket": 2657,
+                "round_trip_latency_bucket": 120994,
+                "sql_distsql_exec_latency_internal_bucket": 12601,
+                "sql_distsql_service_latency_internal_bucket": 1361,
+                "sql_exec_latency_internal_bucket": 16776,
+                "sql_service_latency_internal_bucket": 1955,
+                "txn_durations_bucket": 27770
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "53247"
+            },
+            "metrics": {
+                "exec_latency_bucket": 9583
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "50331647"
+            },
+            "metrics": {
+                "exec_latency_bucket": 457706,
+                "liveness_heartbeatlatency_bucket": 77187,
+                "sql_exec_latency_internal_bucket": 18845,
+                "sql_service_latency_internal_bucket": 18840,
+                "txn_durations_bucket": 111882
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "419430399"
+            },
+            "metrics": {
+                "exec_latency_bucket": 472235,
+                "liveness_heartbeatlatency_bucket": 81666,
+                "txn_durations_bucket": 116584
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "1966079"
+            },
+            "metrics": {
+                "exec_latency_bucket": 195856,
+                "liveness_heartbeatlatency_bucket": 12859,
+                "round_trip_latency_bucket": 122332,
+                "sql_distsql_exec_latency_internal_bucket": 12690,
+                "sql_distsql_service_latency_internal_bucket": 2902,
+                "sql_exec_latency_internal_bucket": 18297,
+                "sql_service_latency_internal_bucket": 4604,
+                "txn_durations_bucket": 45816
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "110591"
+            },
+            "metrics": {
+                "exec_latency_bucket": 55320,
+                "sql_distsql_exec_latency_internal_bucket": 4,
+                "sql_exec_latency_internal_bucket": 4
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "311295",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 160014,
+                "raft_process_commandcommit_latency_bucket": 328198
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "245759",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 113329,
+                "raft_process_commandcommit_latency_bucket": 318348
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
                 "le": "24575",
                 "store": "1"
             },
@@ -12650,13 +12701,13 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "14847",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "3711",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_commandcommit_latency_bucket": 15116,
-                "raft_process_handleready_latency_bucket": 1343
+                "raft_process_handleready_latency_bucket": 369
             }
         },
         "service": {
@@ -12676,13 +12727,14 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "117440511",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "3967",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_handleready_latency_bucket": 470171,
-                "raft_process_logcommit_latency_bucket": 468843
+                "raft_process_commandcommit_latency_bucket": 2,
+                "raft_process_handleready_latency_bucket": 437
             }
         },
         "service": {
@@ -12702,11 +12754,17 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "24575"
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "25165823"
             },
             "metrics": {
-                "exec_latency_bucket": 171
+                "exec_latency_bucket": 439259,
+                "liveness_heartbeatlatency_bucket": 73958,
+                "round_trip_latency_bucket": 122497,
+                "sql_exec_latency_internal_bucket": 18659,
+                "sql_service_latency_internal_bucket": 18633,
+                "txn_durations_bucket": 108425
             }
         },
         "service": {
@@ -12726,13 +12784,72 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "10239",
+                "go_version": "go1.11.6",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "tag": "v19.1.1"
+            },
+            "metrics": {
+                "build_timestamp": 1557952020
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "1048575"
+            },
+            "metrics": {
+                "exec_latency_bucket": 121628,
+                "liveness_heartbeatlatency_bucket": 125,
+                "round_trip_latency_bucket": 111823,
+                "sql_distsql_exec_latency_internal_bucket": 12156,
+                "sql_distsql_service_latency_internal_bucket": 189,
+                "sql_exec_latency_internal_bucket": 15981,
+                "sql_service_latency_internal_bucket": 531,
+                "txn_durations_bucket": 18928
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "452984831",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_commandcommit_latency_bucket": 2034,
-                "raft_process_handleready_latency_bucket": 1303
+                "raft_process_handleready_latency_bucket": 471632,
+                "raft_process_logcommit_latency_bucket": 470269
             }
         },
         "service": {
@@ -12752,13 +12869,16 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "704643071",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "3670015",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_handleready_latency_bucket": 471688,
-                "raft_process_logcommit_latency_bucket": 470325
+                "raft_process_applycommitted_latency_bucket": 462590,
+                "raft_process_commandcommit_latency_bucket": 468838,
+                "raft_process_handleready_latency_bucket": 342969,
+                "raft_process_logcommit_latency_bucket": 411771
             }
         },
         "service": {
@@ -12778,15 +12898,44 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "1310719",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "3932159"
+            },
+            "metrics": {
+                "exec_latency_bucket": 334108,
+                "liveness_heartbeatlatency_bucket": 57903,
+                "round_trip_latency_bucket": 122446,
+                "sql_distsql_service_latency_internal_bucket": 11847,
+                "sql_service_latency_internal_bucket": 16643,
+                "txn_durations_bucket": 92840
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "19455",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_applycommitted_latency_bucket": 373424,
-                "raft_process_commandcommit_latency_bucket": 386355,
-                "raft_process_handleready_latency_bucket": 75120,
-                "raft_process_logcommit_latency_bucket": 184907
+                "raft_process_commandcommit_latency_bucket": 29444,
+                "raft_process_handleready_latency_bucket": 1356
             }
         },
         "service": {
@@ -12806,13 +12955,42 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "96468991",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "20971519"
+            },
+            "metrics": {
+                "exec_latency_bucket": 437659,
+                "liveness_heartbeatlatency_bucket": 73526,
+                "sql_exec_latency_internal_bucket": 18617,
+                "txn_durations_bucket": 107935
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "201326591",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_handleready_latency_bucket": 469481,
-                "raft_process_logcommit_latency_bucket": 468190
+                "raft_process_handleready_latency_bucket": 470860,
+                "raft_process_logcommit_latency_bucket": 469506
             }
         },
         "service": {
@@ -12832,15 +13010,16 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "983039",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "3014655",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_applycommitted_latency_bucket": 360920,
-                "raft_process_commandcommit_latency_bucket": 371928,
-                "raft_process_handleready_latency_bucket": 16441,
-                "raft_process_logcommit_latency_bucket": 76932
+                "raft_process_applycommitted_latency_bucket": 450584,
+                "raft_process_commandcommit_latency_bucket": 461336,
+                "raft_process_handleready_latency_bucket": 314436,
+                "raft_process_logcommit_latency_bucket": 397196
             }
         },
         "service": {
@@ -12860,13 +13039,16 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "142606335",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "4063231",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_handleready_latency_bucket": 470498,
-                "raft_process_logcommit_latency_bucket": 469155
+                "raft_process_applycommitted_latency_bucket": 465970,
+                "raft_process_commandcommit_latency_bucket": 470528,
+                "raft_process_handleready_latency_bucket": 357652,
+                "raft_process_logcommit_latency_bucket": 415818
             }
         },
         "service": {
@@ -12886,12 +13068,15 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "4311"
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "79691775"
             },
             "metrics": {
-                "sql_mem_internal_max_bucket": 18522,
-                "sql_mem_internal_txn_max_bucket": 7430
+                "exec_latency_bucket": 468040,
+                "liveness_heartbeatlatency_bucket": 80151,
+                "sql_service_latency_internal_bucket": 18862,
+                "txn_durations_bucket": 115019
             }
         },
         "service": {
@@ -12911,7 +13096,195 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "1983",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 83
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "2818572287"
+            },
+            "metrics": {
+                "exec_latency_bucket": 472334,
+                "txn_durations_bucket": 116620
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "851967",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 354151,
+                "raft_process_commandcommit_latency_bucket": 368305,
+                "raft_process_handleready_latency_bucket": 6911,
+                "raft_process_logcommit_latency_bucket": 34719
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "268435455",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 471266,
+                "raft_process_logcommit_latency_bucket": 469920
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "117440511"
+            },
+            "metrics": {
+                "exec_latency_bucket": 470748,
+                "liveness_heartbeatlatency_bucket": 81231,
+                "txn_durations_bucket": 116127
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "5887",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_commandcommit_latency_bucket": 13,
+                "raft_process_handleready_latency_bucket": 984
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "22527"
+            },
+            "metrics": {
+                "exec_latency_bucket": 10
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
                 "le": "436207615"
             },
             "metrics": {
@@ -12936,15 +13309,48 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "1048575",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "1572863"
+            },
+            "metrics": {
+                "exec_latency_bucket": 152133,
+                "liveness_heartbeatlatency_bucket": 5488,
+                "round_trip_latency_bucket": 122026,
+                "sql_distsql_exec_latency_internal_bucket": 12660,
+                "sql_distsql_service_latency_internal_bucket": 2093,
+                "sql_exec_latency_internal_bucket": 17133,
+                "sql_service_latency_internal_bucket": 2857,
+                "txn_durations_bucket": 34701
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "2097151",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_applycommitted_latency_bucket": 363441,
-                "raft_process_commandcommit_latency_bucket": 374133,
-                "raft_process_handleready_latency_bucket": 22523,
-                "raft_process_logcommit_latency_bucket": 96484
+                "raft_process_applycommitted_latency_bucket": 411113,
+                "raft_process_commandcommit_latency_bucket": 427438,
+                "raft_process_handleready_latency_bucket": 249049,
+                "raft_process_logcommit_latency_bucket": 331357
             }
         },
         "service": {
@@ -12964,13 +13370,13 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "872415231",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "5119",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_handleready_latency_bucket": 471701,
-                "raft_process_logcommit_latency_bucket": 470338
+                "raft_process_handleready_latency_bucket": 810
             }
         },
         "service": {
@@ -12990,13 +13396,68 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "771751935",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "2013265919"
+            },
+            "metrics": {
+                "exec_latency_bucket": 472326,
+                "liveness_heartbeatlatency_bucket": 81697,
+                "txn_durations_bucket": 116618
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "114687"
+            },
+            "metrics": {
+                "exec_latency_bucket": 57999,
+                "sql_distsql_exec_latency_internal_bucket": 6,
+                "sql_exec_latency_internal_bucket": 6
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "36863",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_handleready_latency_bucket": 471695,
-                "raft_process_logcommit_latency_bucket": 470333
+                "raft_process_applycommitted_latency_bucket": 6,
+                "raft_process_commandcommit_latency_bucket": 161145
             }
         },
         "service": {
@@ -13016,12 +13477,46 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "2431",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "2621439"
+            },
+            "metrics": {
+                "exec_latency_bucket": 262466,
+                "liveness_heartbeatlatency_bucket": 33719,
+                "round_trip_latency_bucket": 122409,
+                "sql_distsql_exec_latency_internal_bucket": 12692,
+                "sql_distsql_service_latency_internal_bucket": 6083,
+                "sql_exec_latency_internal_bucket": 18556,
+                "sql_service_latency_internal_bucket": 9357,
+                "txn_durations_bucket": 71009
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "17825791",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_handleready_latency_bucket": 160
+                "raft_process_handleready_latency_bucket": 425172,
+                "raft_process_logcommit_latency_bucket": 423872
             }
         },
         "service": {
@@ -13041,11 +13536,12 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "34815"
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "3087007743"
             },
             "metrics": {
-                "exec_latency_bucket": 3169
+                "exec_latency_bucket": 472337
             }
         },
         "service": {
@@ -13065,7 +13561,498 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "5767167"
+            },
+            "metrics": {
+                "exec_latency_bucket": 397363,
+                "liveness_heartbeatlatency_bucket": 71541,
+                "sql_distsql_service_latency_internal_bucket": 12646,
+                "sql_service_latency_internal_bucket": 18435,
+                "txn_durations_bucket": 105536
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "360447"
+            },
+            "metrics": {
+                "exec_latency_bucket": 117373,
+                "round_trip_latency_bucket": 13536,
+                "sql_distsql_exec_latency_internal_bucket": 1964,
+                "sql_distsql_service_latency_internal_bucket": 3,
+                "sql_exec_latency_internal_bucket": 2622,
+                "sql_service_latency_internal_bucket": 3,
+                "txn_durations_bucket": 1340
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "12058623"
+            },
+            "metrics": {
+                "exec_latency_bucket": 436905,
+                "liveness_heartbeatlatency_bucket": 73399,
+                "txn_durations_bucket": 107792
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "32505855",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 442548,
+                "raft_process_logcommit_latency_bucket": 442380
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "1073741823"
+            },
+            "metrics": {
+                "exec_latency_bucket": 472310
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "15359",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_commandcommit_latency_bucket": 16689
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "805306367"
+            },
+            "metrics": {
+                "exec_latency_bucket": 472294
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "6174015487",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 471740,
+                "raft_process_logcommit_latency_bucket": 470377
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "9727",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_commandcommit_latency_bucket": 1240,
+                "raft_process_handleready_latency_bucket": 1291
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "26623"
+            },
+            "metrics": {
+                "exec_latency_bucket": 674
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "62914559"
+            },
+            "metrics": {
+                "exec_latency_bucket": 464866,
+                "liveness_heartbeatlatency_bucket": 79017,
+                "sql_exec_latency_internal_bucket": 18856,
+                "txn_durations_bucket": 113817
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "838860799",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 471699,
+                "raft_process_logcommit_latency_bucket": 470336
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "16252927"
+            },
+            "metrics": {
+                "exec_latency_bucket": 437309,
+                "liveness_heartbeatlatency_bucket": 73430,
+                "txn_durations_bucket": 107827
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "442367",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 258229,
+                "raft_process_commandcommit_latency_bucket": 345150
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "71303167",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 467092,
+                "raft_process_logcommit_latency_bucket": 465961
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "1507327"
+            },
+            "metrics": {
+                "exec_latency_bucket": 146093,
+                "liveness_heartbeatlatency_bucket": 4401,
+                "round_trip_latency_bucket": 121834,
+                "sql_distsql_exec_latency_internal_bucket": 12646,
+                "sql_distsql_service_latency_internal_bucket": 1853,
+                "sql_exec_latency_internal_bucket": 16976,
+                "sql_service_latency_internal_bucket": 2539,
+                "txn_durations_bucket": 32468
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "6143",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 1029
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "56623103",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 462749,
+                "raft_process_logcommit_latency_bucket": 462169
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
                 "le": "47103"
             },
             "metrics": {
@@ -13089,11 +14076,14 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "25599"
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "54525951",
+                "store": "1"
             },
             "metrics": {
-                "exec_latency_bucket": 381
+                "raft_process_handleready_latency_bucket": 461500,
+                "raft_process_logcommit_latency_bucket": 461122
             }
         },
         "service": {
@@ -13113,7 +14103,1132 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "469762047"
+            },
+            "metrics": {
+                "exec_latency_bucket": 472253,
+                "liveness_heartbeatlatency_bucket": 81671,
+                "txn_durations_bucket": 116591
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "55295"
+            },
+            "metrics": {
+                "exec_latency_bucket": 10453
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "1409286143"
+            },
+            "metrics": {
+                "exec_latency_bucket": 472321
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "98303"
+            },
+            "metrics": {
+                "exec_latency_bucket": 46020
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "8191",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_commandcommit_latency_bucket": 89,
+                "raft_process_handleready_latency_bucket": 1227
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "8703",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_commandcommit_latency_bucket": 275,
+                "raft_process_handleready_latency_bucket": 1252
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "237567",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 107528,
+                "raft_process_commandcommit_latency_bucket": 317161
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "121634815"
+            },
+            "metrics": {
+                "exec_latency_bucket": 470850,
+                "liveness_heartbeatlatency_bucket": 81259,
+                "txn_durations_bucket": 116160
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "7679",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_commandcommit_latency_bucket": 34,
+                "raft_process_handleready_latency_bucket": 1181
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "7340031"
+            },
+            "metrics": {
+                "exec_latency_bucket": 426863,
+                "liveness_heartbeatlatency_bucket": 73029,
+                "round_trip_latency_bucket": 122472,
+                "sql_distsql_service_latency_internal_bucket": 12691,
+                "sql_service_latency_internal_bucket": 18588,
+                "txn_durations_bucket": 107340
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "7864319"
+            },
+            "metrics": {
+                "exec_latency_bucket": 430399,
+                "liveness_heartbeatlatency_bucket": 73175,
+                "round_trip_latency_bucket": 122477,
+                "sql_service_latency_internal_bucket": 18598,
+                "txn_durations_bucket": 107492
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "28671"
+            },
+            "metrics": {
+                "exec_latency_bucket": 1270
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "1638399"
+            },
+            "metrics": {
+                "exec_latency_bucket": 158338,
+                "liveness_heartbeatlatency_bucket": 6660,
+                "round_trip_latency_bucket": 122145,
+                "sql_distsql_exec_latency_internal_bucket": 12668,
+                "sql_distsql_service_latency_internal_bucket": 2293,
+                "sql_exec_latency_internal_bucket": 17351,
+                "sql_service_latency_internal_bucket": 3169,
+                "txn_durations_bucket": 36778
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "1919",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 77
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "20971519",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 425809,
+                "raft_process_logcommit_latency_bucket": 424696
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "33554431"
+            },
+            "metrics": {
+                "exec_latency_bucket": 445935,
+                "liveness_heartbeatlatency_bucket": 75761,
+                "sql_exec_latency_internal_bucket": 18784,
+                "sql_service_latency_internal_bucket": 18756,
+                "txn_durations_bucket": 110360
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "13107199"
+            },
+            "metrics": {
+                "exec_latency_bucket": 437076,
+                "liveness_heartbeatlatency_bucket": 73414,
+                "txn_durations_bucket": 107807
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "204799"
+            },
+            "metrics": {
+                "exec_latency_bucket": 97958,
+                "sql_distsql_exec_latency_internal_bucket": 89,
+                "sql_exec_latency_internal_bucket": 134,
+                "txn_durations_bucket": 19
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "1441791",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 379692,
+                "raft_process_commandcommit_latency_bucket": 393345,
+                "raft_process_handleready_latency_bucket": 107287,
+                "raft_process_logcommit_latency_bucket": 227664
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "393215",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 224062,
+                "raft_process_commandcommit_latency_bucket": 338997
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "61439"
+            },
+            "metrics": {
+                "exec_latency_bucket": 13572
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "327679",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 172369,
+                "raft_process_commandcommit_latency_bucket": 330548
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "4063231"
+            },
+            "metrics": {
+                "exec_latency_bucket": 340382,
+                "liveness_heartbeatlatency_bucket": 59735,
+                "round_trip_latency_bucket": 122449,
+                "sql_distsql_service_latency_internal_bucket": 11980,
+                "sql_service_latency_internal_bucket": 16986,
+                "txn_durations_bucket": 94693
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "409599"
+            },
+            "metrics": {
+                "exec_latency_bucket": 118136,
+                "round_trip_latency_bucket": 20031,
+                "sql_distsql_exec_latency_internal_bucket": 2487,
+                "sql_distsql_service_latency_internal_bucket": 10,
+                "sql_exec_latency_internal_bucket": 3311,
+                "sql_service_latency_internal_bucket": 10,
+                "txn_durations_bucket": 2091
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "118783"
+            },
+            "metrics": {
+                "exec_latency_bucket": 60542,
+                "sql_distsql_exec_latency_internal_bucket": 9,
+                "sql_exec_latency_internal_bucket": 9
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "27647"
+            },
+            "metrics": {
+                "exec_latency_bucket": 962
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "11010047"
+            },
+            "metrics": {
+                "exec_latency_bucket": 436581,
+                "liveness_heartbeatlatency_bucket": 73385,
+                "round_trip_latency_bucket": 122490,
+                "sql_service_latency_internal_bucket": 18610,
+                "txn_durations_bucket": 107774
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "884735",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 356204,
+                "raft_process_commandcommit_latency_bucket": 369129,
+                "raft_process_handleready_latency_bucket": 8948,
+                "raft_process_logcommit_latency_bucket": 44345
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "16252927",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 425016,
+                "raft_process_logcommit_latency_bucket": 423710
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "6553599"
+            },
+            "metrics": {
+                "exec_latency_bucket": 416508,
+                "liveness_heartbeatlatency_bucket": 72547,
+                "round_trip_latency_bucket": 122469,
+                "sql_distsql_service_latency_internal_bucket": 12677,
+                "sql_service_latency_internal_bucket": 18546,
+                "txn_durations_bucket": 106855
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "126975",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 19849,
+                "raft_process_commandcommit_latency_bucket": 303042
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "18431",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_commandcommit_latency_bucket": 26149,
+                "raft_process_handleready_latency_bucket": 1353
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "1342177279",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 471732,
+                "raft_process_logcommit_latency_bucket": 470369
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "26214399"
+            },
+            "metrics": {
+                "exec_latency_bucket": 440017,
+                "liveness_heartbeatlatency_bucket": 74184,
+                "sql_exec_latency_internal_bucket": 18679,
+                "sql_service_latency_internal_bucket": 18645,
+                "txn_durations_bucket": 108689
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "419430399",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 471620,
+                "raft_process_logcommit_latency_bucket": 470257
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "637534207",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 471677,
+                "raft_process_logcommit_latency_bucket": 470314
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "31743",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_commandcommit_latency_bucket": 118084
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "150994943",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 470542,
+                "raft_process_logcommit_latency_bucket": 469185
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "12799",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_commandcommit_latency_bucket": 8545,
+                "raft_process_handleready_latency_bucket": 1332
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "838860799"
+            },
+            "metrics": {
+                "exec_latency_bucket": 472295
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "23068671"
+            },
+            "metrics": {
+                "exec_latency_bucket": 438191,
+                "liveness_heartbeatlatency_bucket": 73676,
+                "sql_exec_latency_internal_bucket": 18634,
+                "sql_service_latency_internal_bucket": 18617,
+                "txn_durations_bucket": 108104
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
                 "le": "4194303"
             },
             "metrics": {
@@ -13142,13 +15257,14 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "41943039",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "234881023",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_handleready_latency_bucket": 450935,
-                "raft_process_logcommit_latency_bucket": 451321
+                "raft_process_handleready_latency_bucket": 471078,
+                "raft_process_logcommit_latency_bucket": 469721
             }
         },
         "service": {
@@ -13168,13 +15284,16 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "7935",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "2031615",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_commandcommit_latency_bucket": 52,
-                "raft_process_handleready_latency_bucket": 1204
+                "raft_process_applycommitted_latency_bucket": 408069,
+                "raft_process_commandcommit_latency_bucket": 424030,
+                "raft_process_handleready_latency_bucket": 240333,
+                "raft_process_logcommit_latency_bucket": 323722
             }
         },
         "service": {
@@ -13194,12 +15313,15 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "12348030975"
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "22020095"
             },
             "metrics": {
-                "exec_latency_bucket": 472347,
-                "txn_durations_bucket": 116627
+                "exec_latency_bucket": 437874,
+                "liveness_heartbeatlatency_bucket": 73584,
+                "sql_exec_latency_internal_bucket": 18625,
+                "txn_durations_bucket": 108002
             }
         },
         "service": {
@@ -13219,42 +15341,17 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "917503"
-            },
-            "metrics": {
-                "exec_latency_bucket": 119248,
-                "round_trip_latency_bucket": 99397,
-                "sql_distsql_exec_latency_internal_bucket": 11626,
-                "sql_distsql_service_latency_internal_bucket": 121,
-                "sql_exec_latency_internal_bucket": 15227,
-                "sql_service_latency_internal_bucket": 322,
-                "txn_durations_bucket": 16694
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "1599",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "2228223",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_handleready_latency_bucket": 26
+                "raft_process_applycommitted_latency_bucket": 417098,
+                "raft_process_commandcommit_latency_bucket": 434327,
+                "raft_process_handleready_latency_bucket": 263180,
+                "raft_process_logcommit_latency_bucket": 345442,
+                "txnwaitqueue_pusher_wait_time_bucket": 2
             }
         },
         "service": {
@@ -13274,7 +15371,712 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "100663295",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 469695,
+                "raft_process_logcommit_latency_bucket": 468399
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "5505023"
+            },
+            "metrics": {
+                "exec_latency_bucket": 389581,
+                "liveness_heartbeatlatency_bucket": 71037,
+                "round_trip_latency_bucket": 122462,
+                "sql_distsql_service_latency_internal_bucket": 12616,
+                "sql_service_latency_internal_bucket": 18375,
+                "txn_durations_bucket": 104857
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "109051903"
+            },
+            "metrics": {
+                "exec_latency_bucket": 470525,
+                "liveness_heartbeatlatency_bucket": 81142,
+                "txn_durations_bucket": 116038
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "40959"
+            },
+            "metrics": {
+                "exec_latency_bucket": 5308
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "94207"
+            },
+            "metrics": {
+                "exec_latency_bucket": 42435
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "2815",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 212
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "4487"
+            },
+            "metrics": {
+                "sql_mem_internal_max_bucket": 18523
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "3623878655"
+            },
+            "metrics": {
+                "liveness_heartbeatlatency_bucket": 81702
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "44040191",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 452842,
+                "raft_process_logcommit_latency_bucket": 453224
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "125829119"
+            },
+            "metrics": {
+                "exec_latency_bucket": 470943,
+                "liveness_heartbeatlatency_bucket": 81298,
+                "txn_durations_bucket": 116199
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "13958643711",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 471746,
+                "raft_process_logcommit_latency_bucket": 470383
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "13631487",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 424890,
+                "raft_process_logcommit_latency_bucket": 423594
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "35651583"
+            },
+            "metrics": {
+                "exec_latency_bucket": 447261,
+                "liveness_heartbeatlatency_bucket": 76010,
+                "sql_exec_latency_internal_bucket": 18795,
+                "sql_service_latency_internal_bucket": 18779,
+                "txn_durations_bucket": 110608
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "5631",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_commandcommit_latency_bucket": 11,
+                "raft_process_handleready_latency_bucket": 934
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "218103807",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 470967,
+                "raft_process_logcommit_latency_bucket": 469610
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "106495"
+            },
+            "metrics": {
+                "exec_latency_bucket": 52406,
+                "sql_distsql_exec_latency_internal_bucket": 3,
+                "sql_exec_latency_internal_bucket": 3
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "268435455"
+            },
+            "metrics": {
+                "exec_latency_bucket": 471890,
+                "liveness_heartbeatlatency_bucket": 81592,
+                "txn_durations_bucket": 116503
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "278527"
+            },
+            "metrics": {
+                "exec_latency_bucket": 112495,
+                "round_trip_latency_bucket": 911,
+                "sql_distsql_exec_latency_internal_bucket": 724,
+                "sql_exec_latency_internal_bucket": 1072,
+                "txn_durations_bucket": 214
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "939524095"
+            },
+            "metrics": {
+                "exec_latency_bucket": 472298,
+                "liveness_heartbeatlatency_bucket": 81687,
+                "txn_durations_bucket": 116610
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "31457279"
+            },
+            "metrics": {
+                "exec_latency_bucket": 444428,
+                "liveness_heartbeatlatency_bucket": 75397,
+                "sql_exec_latency_internal_bucket": 18759,
+                "sql_service_latency_internal_bucket": 18731,
+                "txn_durations_bucket": 109971
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "13823",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_commandcommit_latency_bucket": 11768,
+                "raft_process_handleready_latency_bucket": 1340
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "229375"
+            },
+            "metrics": {
+                "exec_latency_bucket": 104271,
+                "sql_distsql_exec_latency_internal_bucket": 112,
+                "sql_exec_latency_internal_bucket": 228,
+                "txn_durations_bucket": 49
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "1966079",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 405016,
+                "raft_process_commandcommit_latency_bucket": 420592,
+                "raft_process_handleready_latency_bucket": 230462,
+                "raft_process_logcommit_latency_bucket": 315841,
+                "txnwaitqueue_pusher_wait_time_bucket": 1
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "436207615",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 471625,
+                "raft_process_logcommit_latency_bucket": 470262
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "19455"
+            },
+            "metrics": {
+                "exec_latency_bucket": 3
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "176160767",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 470698,
+                "raft_process_logcommit_latency_bucket": 469341
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
                 "le": "130023423"
             },
             "metrics": {
@@ -13300,13 +16102,14 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "117440511"
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "603979775",
+                "store": "1"
             },
             "metrics": {
-                "exec_latency_bucket": 470748,
-                "liveness_heartbeatlatency_bucket": 81231,
-                "txn_durations_bucket": 116127
+                "raft_process_handleready_latency_bucket": 471672,
+                "raft_process_logcommit_latency_bucket": 470309
             }
         },
         "service": {
@@ -13326,7 +16129,951 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516"
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "226492415"
+            },
+            "metrics": {
+                "exec_latency_bucket": 471687,
+                "liveness_heartbeatlatency_bucket": 81548,
+                "txn_durations_bucket": 116457
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "2228223"
+            },
+            "metrics": {
+                "exec_latency_bucket": 228186,
+                "liveness_heartbeatlatency_bucket": 19658,
+                "round_trip_latency_bucket": 122374,
+                "sql_distsql_service_latency_internal_bucket": 3684,
+                "sql_exec_latency_internal_bucket": 18446,
+                "sql_service_latency_internal_bucket": 6293,
+                "txn_durations_bucket": 55820
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "1677721599",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 471734,
+                "raft_process_logcommit_latency_bucket": 470371
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "44040191"
+            },
+            "metrics": {
+                "exec_latency_bucket": 452749,
+                "liveness_heartbeatlatency_bucket": 76521,
+                "sql_exec_latency_internal_bucket": 18827,
+                "sql_service_latency_internal_bucket": 18817,
+                "txn_durations_bucket": 111153
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "28311551"
+            },
+            "metrics": {
+                "exec_latency_bucket": 441818,
+                "liveness_heartbeatlatency_bucket": 74696,
+                "sql_exec_latency_internal_bucket": 18715,
+                "sql_service_latency_internal_bucket": 18673,
+                "txn_durations_bucket": 109249
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "102399",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 11080,
+                "raft_process_commandcommit_latency_bucket": 296240
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "196607"
+            },
+            "metrics": {
+                "exec_latency_bucket": 95233,
+                "sql_distsql_exec_latency_internal_bucket": 78,
+                "sql_exec_latency_internal_bucket": 111,
+                "txn_durations_bucket": 8
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "524287",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 295584,
+                "raft_process_commandcommit_latency_bucket": 354612
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "4863",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_commandcommit_latency_bucket": 7,
+                "raft_process_handleready_latency_bucket": 725
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "106495",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 12317,
+                "raft_process_commandcommit_latency_bucket": 297790
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "4718591",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 468610,
+                "raft_process_commandcommit_latency_bucket": 471770,
+                "raft_process_handleready_latency_bucket": 381235,
+                "raft_process_logcommit_latency_bucket": 419094
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "52428799",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 459987,
+                "raft_process_logcommit_latency_bucket": 459888,
+                "txnwaitqueue_pusher_wait_time_bucket": 7
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "14155775"
+            },
+            "metrics": {
+                "exec_latency_bucket": 437199,
+                "liveness_heartbeatlatency_bucket": 73419,
+                "round_trip_latency_bucket": 122494,
+                "sql_service_latency_internal_bucket": 18611,
+                "txn_durations_bucket": 107814
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "142606335"
+            },
+            "metrics": {
+                "exec_latency_bucket": 471154,
+                "liveness_heartbeatlatency_bucket": 81389,
+                "sql_exec_latency_internal_bucket": 18864,
+                "txn_durations_bucket": 116290
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "4311"
+            },
+            "metrics": {
+                "sql_mem_internal_max_bucket": 18522,
+                "sql_mem_internal_txn_max_bucket": 7430
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "104857599",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 469859,
+                "raft_process_logcommit_latency_bucket": 468551
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "69631"
+            },
+            "metrics": {
+                "exec_latency_bucket": 18990
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "3071",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 237
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "1835007"
+            },
+            "metrics": {
+                "exec_latency_bucket": 179550,
+                "liveness_heartbeatlatency_bucket": 10382,
+                "round_trip_latency_bucket": 122289,
+                "sql_distsql_exec_latency_internal_bucket": 12683,
+                "sql_distsql_service_latency_internal_bucket": 2710,
+                "sql_exec_latency_internal_bucket": 18064,
+                "sql_service_latency_internal_bucket": 4024,
+                "txn_durations_bucket": 42173
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "32767"
+            },
+            "metrics": {
+                "exec_latency_bucket": 2614
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "38911",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 11,
+                "raft_process_commandcommit_latency_bucket": 175932,
+                "raft_process_handleready_latency_bucket": 1362
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "771751935",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_handleready_latency_bucket": 471695,
+                "raft_process_logcommit_latency_bucket": 470333
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "40959",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 18,
+                "raft_process_commandcommit_latency_bucket": 188814
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "1015807",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 362280,
+                "raft_process_commandcommit_latency_bucket": 373010,
+                "raft_process_handleready_latency_bucket": 19306,
+                "raft_process_logcommit_latency_bucket": 87091
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "2883583",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 446308,
+                "raft_process_commandcommit_latency_bucket": 458845,
+                "raft_process_handleready_latency_bucket": 307662,
+                "raft_process_logcommit_latency_bucket": 392031,
+                "txnwaitqueue_pusher_wait_time_bucket": 4
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "8912895",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 470342,
+                "raft_process_commandcommit_latency_bucket": 472453,
+                "raft_process_handleready_latency_bucket": 423688,
+                "raft_process_logcommit_latency_bucket": 423254
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "520093695"
+            },
+            "metrics": {
+                "exec_latency_bucket": 472265,
+                "txn_durations_bucket": 116596
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "196607",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 74611,
+                "raft_process_commandcommit_latency_bucket": 311957
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "10200547327"
+            },
+            "metrics": {
+                "exec_latency_bucket": 472346,
+                "txn_durations_bucket": 116626
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "13631487"
+            },
+            "metrics": {
+                "exec_latency_bucket": 437150,
+                "liveness_heartbeatlatency_bucket": 73418,
+                "round_trip_latency_bucket": 122493,
+                "txn_durations_bucket": 107812
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "73727",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 1609,
+                "raft_process_commandcommit_latency_bucket": 274921
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "7077887",
+                "store": "1"
+            },
+            "metrics": {
+                "raft_process_applycommitted_latency_bucket": 470258,
+                "raft_process_commandcommit_latency_bucket": 472422,
+                "raft_process_handleready_latency_bucket": 419854,
+                "raft_process_logcommit_latency_bucket": 422243
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "51199"
+            },
+            "metrics": {
+                "exec_latency_bucket": 8810
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "442367"
+            },
+            "metrics": {
+                "exec_latency_bucket": 118398,
+                "round_trip_latency_bucket": 22718,
+                "sql_distsql_exec_latency_internal_bucket": 2778,
+                "sql_distsql_service_latency_internal_bucket": 14,
+                "sql_exec_latency_internal_bucket": 3836,
+                "sql_service_latency_internal_bucket": 14,
+                "txn_durations_bucket": 2614
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb"
             },
             "metrics": {
                 "changefeed_buffer_entries_in": 0,
@@ -13550,13 +17297,18 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "100663295"
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "655359"
             },
             "metrics": {
-                "exec_latency_bucket": 470134,
-                "liveness_heartbeatlatency_bucket": 80997,
-                "txn_durations_bucket": 115891
+                "exec_latency_bucket": 118827,
+                "round_trip_latency_bucket": 54350,
+                "sql_distsql_exec_latency_internal_bucket": 7515,
+                "sql_distsql_service_latency_internal_bucket": 59,
+                "sql_exec_latency_internal_bucket": 10602,
+                "sql_service_latency_internal_bucket": 59,
+                "txn_durations_bucket": 8353
             }
         },
         "service": {
@@ -13576,13 +17328,15 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "260046847",
-                "store": "1"
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "237567"
             },
             "metrics": {
-                "raft_process_handleready_latency_bucket": 471221,
-                "raft_process_logcommit_latency_bucket": 469862
+                "exec_latency_bucket": 105960,
+                "sql_distsql_exec_latency_internal_bucket": 137,
+                "sql_exec_latency_internal_bucket": 283,
+                "txn_durations_bucket": 76
             }
         },
         "service": {
@@ -13602,802 +17356,8 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "8703",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_commandcommit_latency_bucket": 275,
-                "raft_process_handleready_latency_bucket": 1252
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "12287",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_commandcommit_latency_bucket": 6970,
-                "raft_process_handleready_latency_bucket": 1329
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "39845887"
-            },
-            "metrics": {
-                "exec_latency_bucket": 449729,
-                "liveness_heartbeatlatency_bucket": 76266,
-                "sql_exec_latency_internal_bucket": 18815,
-                "sql_service_latency_internal_bucket": 18804,
-                "txn_durations_bucket": 110877
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "251658239"
-            },
-            "metrics": {
-                "exec_latency_bucket": 471800,
-                "liveness_heartbeatlatency_bucket": 81573,
-                "sql_exec_latency_internal_bucket": 18868,
-                "sql_service_latency_internal_bucket": 18868,
-                "txn_durations_bucket": 116484
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "1376255",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 376505,
-                "raft_process_commandcommit_latency_bucket": 389868,
-                "raft_process_handleready_latency_bucket": 91465,
-                "raft_process_logcommit_latency_bucket": 208097
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "1543503871"
-            },
-            "metrics": {
-                "exec_latency_bucket": 472323,
-                "liveness_heartbeatlatency_bucket": 81692,
-                "txn_durations_bucket": 116616
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "159383551",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 470600,
-                "raft_process_logcommit_latency_bucket": 469240
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "39845887",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 449246,
-                "raft_process_logcommit_latency_bucket": 449564
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "65535"
-            },
-            "metrics": {
-                "exec_latency_bucket": 16026
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "884735"
-            },
-            "metrics": {
-                "exec_latency_bucket": 119032,
-                "round_trip_latency_bucket": 94717,
-                "sql_distsql_exec_latency_internal_bucket": 11427,
-                "sql_distsql_service_latency_internal_bucket": 112,
-                "sql_exec_latency_internal_bucket": 14981,
-                "sql_service_latency_internal_bucket": 275,
-                "txn_durations_bucket": 15986
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "1441791"
-            },
-            "metrics": {
-                "exec_latency_bucket": 140480,
-                "liveness_heartbeatlatency_bucket": 3407,
-                "round_trip_latency_bucket": 121500,
-                "sql_distsql_exec_latency_internal_bucket": 12630,
-                "sql_distsql_service_latency_internal_bucket": 1612,
-                "sql_exec_latency_internal_bucket": 16863,
-                "sql_service_latency_internal_bucket": 2246,
-                "txn_durations_bucket": 30082
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "15728639"
-            },
-            "metrics": {
-                "exec_latency_bucket": 437288,
-                "liveness_heartbeatlatency_bucket": 73428,
-                "txn_durations_bucket": 107825
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "201326591",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 470860,
-                "raft_process_logcommit_latency_bucket": 469506
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "419430399",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 471620,
-                "raft_process_logcommit_latency_bucket": 470257
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "118783",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 16528,
-                "raft_process_commandcommit_latency_bucket": 301279
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "159383551"
-            },
-            "metrics": {
-                "exec_latency_bucket": 471283,
-                "liveness_heartbeatlatency_bucket": 81440,
-                "txn_durations_bucket": 116342
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "102399"
-            },
-            "metrics": {
-                "exec_latency_bucket": 49403,
-                "sql_distsql_exec_latency_internal_bucket": 2,
-                "sql_exec_latency_internal_bucket": 2
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "40959",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 18,
-                "raft_process_commandcommit_latency_bucket": 188814
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "4980735",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 469166,
-                "raft_process_commandcommit_latency_bucket": 471949,
-                "raft_process_handleready_latency_bucket": 389769,
-                "raft_process_logcommit_latency_bucket": 419872
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "67108863",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 466315,
-                "raft_process_logcommit_latency_bucket": 465289
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "268435455"
-            },
-            "metrics": {
-                "exec_latency_bucket": 471890,
-                "liveness_heartbeatlatency_bucket": 81592,
-                "txn_durations_bucket": 116503
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "102399",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 11080,
-                "raft_process_commandcommit_latency_bucket": 296240
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "872415231"
-            },
-            "metrics": {
-                "exec_latency_bucket": 472296
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "92274687",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 469199,
-                "raft_process_logcommit_latency_bucket": 467982
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "184549375"
-            },
-            "metrics": {
-                "exec_latency_bucket": 471458,
-                "liveness_heartbeatlatency_bucket": 81492,
-                "sql_exec_latency_internal_bucket": 18865,
-                "sql_service_latency_internal_bucket": 18865,
-                "txn_durations_bucket": 116397
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "973078527",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 471704,
-                "raft_process_logcommit_latency_bucket": 470342
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "13311",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_commandcommit_latency_bucket": 10148,
-                "raft_process_handleready_latency_bucket": 1337
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "188415",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 67133,
-                "raft_process_commandcommit_latency_bucket": 311000
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "18874367",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 425289,
-                "raft_process_logcommit_latency_bucket": 423989
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "369098751"
-            },
-            "metrics": {
-                "exec_latency_bucket": 472175,
-                "liveness_heartbeatlatency_bucket": 81655,
-                "txn_durations_bucket": 116569
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
                 "le": "65011711"
             },
             "metrics": {
@@ -14424,920 +17384,8 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "1114111"
-            },
-            "metrics": {
-                "exec_latency_bucket": 123490,
-                "liveness_heartbeatlatency_bucket": 396,
-                "round_trip_latency_bucket": 115252,
-                "sql_distsql_exec_latency_internal_bucket": 12309,
-                "sql_distsql_service_latency_internal_bucket": 348,
-                "sql_exec_latency_internal_bucket": 16238,
-                "sql_service_latency_internal_bucket": 761,
-                "txn_durations_bucket": 20294
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "15728639",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 424989,
-                "raft_process_logcommit_latency_bucket": 423661
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "524287"
-            },
-            "metrics": {
-                "exec_latency_bucket": 118701,
-                "round_trip_latency_bucket": 28175,
-                "sql_distsql_exec_latency_internal_bucket": 3786,
-                "sql_distsql_service_latency_internal_bucket": 34,
-                "sql_exec_latency_internal_bucket": 5663,
-                "sql_service_latency_internal_bucket": 34,
-                "txn_durations_bucket": 3935
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "98303",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 9828,
-                "raft_process_commandcommit_latency_bucket": 294451
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "51199",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 135,
-                "raft_process_commandcommit_latency_bucket": 232584
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "4563402751"
-            },
-            "metrics": {
-                "exec_latency_bucket": 472342,
-                "liveness_heartbeatlatency_bucket": 81709,
-                "txn_durations_bucket": 116625
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "5242879",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 469491,
-                "raft_process_commandcommit_latency_bucket": 472077,
-                "raft_process_handleready_latency_bucket": 397349,
-                "raft_process_logcommit_latency_bucket": 420486
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "2943",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 227
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "603979775",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 471672,
-                "raft_process_logcommit_latency_bucket": 470309
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "88080383"
-            },
-            "metrics": {
-                "exec_latency_bucket": 469072,
-                "liveness_heartbeatlatency_bucket": 80559,
-                "sql_exec_latency_internal_bucket": 18863,
-                "sql_service_latency_internal_bucket": 18863,
-                "txn_durations_bucket": 115436
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "393215"
-            },
-            "metrics": {
-                "exec_latency_bucket": 117973,
-                "round_trip_latency_bucket": 18236,
-                "sql_distsql_exec_latency_internal_bucket": 2341,
-                "sql_exec_latency_internal_bucket": 3097,
-                "txn_durations_bucket": 1880
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "442367",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 258229,
-                "raft_process_commandcommit_latency_bucket": 345150
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "18431",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_commandcommit_latency_bucket": 26149,
-                "raft_process_handleready_latency_bucket": 1353
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "589823"
-            },
-            "metrics": {
-                "exec_latency_bucket": 118789,
-                "round_trip_latency_bucket": 40605,
-                "sql_distsql_exec_latency_internal_bucket": 5268,
-                "sql_distsql_service_latency_internal_bucket": 46,
-                "sql_exec_latency_internal_bucket": 7857,
-                "sql_service_latency_internal_bucket": 46,
-                "txn_durations_bucket": 5809
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "52428799"
-            },
-            "metrics": {
-                "exec_latency_bucket": 459350,
-                "liveness_heartbeatlatency_bucket": 77513,
-                "sql_exec_latency_internal_bucket": 18846,
-                "sql_service_latency_internal_bucket": 18844,
-                "txn_durations_bucket": 112219
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "311295",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 160014,
-                "raft_process_commandcommit_latency_bucket": 328198
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "47103",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 70,
-                "raft_process_commandcommit_latency_bucket": 218550
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "2621439"
-            },
-            "metrics": {
-                "exec_latency_bucket": 262466,
-                "liveness_heartbeatlatency_bucket": 33719,
-                "round_trip_latency_bucket": 122409,
-                "sql_distsql_exec_latency_internal_bucket": 12692,
-                "sql_distsql_service_latency_internal_bucket": 6083,
-                "sql_exec_latency_internal_bucket": 18556,
-                "sql_service_latency_internal_bucket": 9357,
-                "txn_durations_bucket": 71009
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "155647"
-            },
-            "metrics": {
-                "exec_latency_bucket": 79156,
-                "sql_distsql_exec_latency_internal_bucket": 38,
-                "sql_exec_latency_internal_bucket": 41
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "486539263"
-            },
-            "metrics": {
-                "exec_latency_bucket": 472256
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "805306367"
-            },
-            "metrics": {
-                "exec_latency_bucket": 472294
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "9215",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_commandcommit_latency_bucket": 640,
-                "raft_process_handleready_latency_bucket": 1275
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "1073741823",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 471719,
-                "raft_process_logcommit_latency_bucket": 470356
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "221183",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 95235,
-                "raft_process_commandcommit_latency_bucket": 314935
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "2228223"
-            },
-            "metrics": {
-                "exec_latency_bucket": 228186,
-                "liveness_heartbeatlatency_bucket": 19658,
-                "round_trip_latency_bucket": 122374,
-                "sql_distsql_service_latency_internal_bucket": 3684,
-                "sql_exec_latency_internal_bucket": 18446,
-                "sql_service_latency_internal_bucket": 6293,
-                "txn_durations_bucket": 55820
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "7864319"
-            },
-            "metrics": {
-                "exec_latency_bucket": 430399,
-                "liveness_heartbeatlatency_bucket": 73175,
-                "round_trip_latency_bucket": 122477,
-                "sql_service_latency_internal_bucket": 18598,
-                "txn_durations_bucket": 107492
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "28671",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_commandcommit_latency_bucket": 89513
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "106495"
-            },
-            "metrics": {
-                "exec_latency_bucket": 52406,
-                "sql_distsql_exec_latency_internal_bucket": 3,
-                "sql_exec_latency_internal_bucket": 3
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "1006632959",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 471713,
-                "raft_process_logcommit_latency_bucket": 470350
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "402653183",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 471601,
-                "raft_process_logcommit_latency_bucket": 470246
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "106495",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 12317,
-                "raft_process_commandcommit_latency_bucket": 297790
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "28311551",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 435706,
-                "raft_process_logcommit_latency_bucket": 435547
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "8388607",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 470330,
-                "raft_process_commandcommit_latency_bucket": 472444,
-                "raft_process_handleready_latency_bucket": 422898,
-                "raft_process_logcommit_latency_bucket": 422914
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "15204351",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 470374,
-                "raft_process_handleready_latency_bucket": 424971,
-                "raft_process_logcommit_latency_bucket": 423649
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
                 "le": "26214399",
                 "store": "1"
             },
@@ -15363,13 +17411,41 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "7516192767",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "155647"
+            },
+            "metrics": {
+                "exec_latency_bucket": 79156,
+                "sql_distsql_exec_latency_internal_bucket": 38,
+                "sql_exec_latency_internal_bucket": 41
+            }
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "cockroachdb"
+        }
+    },
+    {
+        "event": {
+            "dataset": "cockroachdb.status",
+            "duration": 115000,
+            "module": "cockroachdb"
+        },
+        "metricset": {
+            "name": "status",
+            "period": 10000
+        },
+        "prometheus": {
+            "labels": {
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "409599",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_handleready_latency_bucket": 471744,
-                "raft_process_logcommit_latency_bucket": 470381
+                "raft_process_applycommitted_latency_bucket": 236720,
+                "raft_process_commandcommit_latency_bucket": 341024
             }
         },
         "service": {
@@ -15389,37 +17465,16 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "81919"
-            },
-            "metrics": {
-                "exec_latency_bucket": 30481
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "43007",
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "6291455",
                 "store": "1"
             },
             "metrics": {
-                "raft_process_applycommitted_latency_bucket": 32,
-                "raft_process_commandcommit_latency_bucket": 200028
+                "raft_process_applycommitted_latency_bucket": 470107,
+                "raft_process_commandcommit_latency_bucket": 472391,
+                "raft_process_handleready_latency_bucket": 414726,
+                "raft_process_logcommit_latency_bucket": 421798
             }
         },
         "service": {
@@ -15439,13 +17494,14 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "12058623"
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "369098751"
             },
             "metrics": {
-                "exec_latency_bucket": 436905,
-                "liveness_heartbeatlatency_bucket": 73399,
-                "txn_durations_bucket": 107792
+                "exec_latency_bucket": 472175,
+                "liveness_heartbeatlatency_bucket": 81655,
+                "txn_durations_bucket": 116569
             }
         },
         "service": {
@@ -15465,1451 +17521,14 @@
         },
         "prometheus": {
             "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "622591"
+                "instance": "127.0.0.1:54420",
+                "job": "cockroachdb",
+                "le": "1476395007"
             },
             "metrics": {
-                "exec_latency_bucket": 118808,
-                "round_trip_latency_bucket": 47657,
-                "sql_distsql_exec_latency_internal_bucket": 6400,
-                "sql_distsql_service_latency_internal_bucket": 53,
-                "sql_exec_latency_internal_bucket": 9264,
-                "sql_service_latency_internal_bucket": 53,
-                "txn_durations_bucket": 7009
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "88080383",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 468858,
-                "raft_process_logcommit_latency_bucket": 467675
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "15569256447"
-            },
-            "metrics": {
-                "exec_latency_bucket": 472350,
-                "liveness_heartbeatlatency_bucket": 81711
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "31457279",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 470379,
-                "raft_process_handleready_latency_bucket": 441064,
-                "raft_process_logcommit_latency_bucket": 440886
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "58720255",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 463780,
-                "raft_process_logcommit_latency_bucket": 463033
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "18431"
-            },
-            "metrics": {
-                "exec_latency_bucket": 1
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "3355443199"
-            },
-            "metrics": {
-                "exec_latency_bucket": 472338,
-                "liveness_heartbeatlatency_bucket": 81700,
-                "txn_durations_bucket": 116621
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "3583",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_commandcommit_latency_bucket": 1,
-                "raft_process_handleready_latency_bucket": 332
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "327679"
-            },
-            "metrics": {
-                "exec_latency_bucket": 116347,
-                "round_trip_latency_bucket": 7628,
-                "sql_distsql_exec_latency_internal_bucket": 1487,
-                "sql_exec_latency_internal_bucket": 2053,
-                "txn_durations_bucket": 765
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "4863",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_commandcommit_latency_bucket": 7,
-                "raft_process_handleready_latency_bucket": 725
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "738197503",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 471692,
-                "raft_process_logcommit_latency_bucket": 470329
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "1535",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 10
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "385875967"
-            },
-            "metrics": {
-                "exec_latency_bucket": 472196,
-                "liveness_heartbeatlatency_bucket": 81658,
-                "txn_durations_bucket": 116574
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "819199"
-            },
-            "metrics": {
-                "exec_latency_bucket": 118872,
-                "round_trip_latency_bucket": 83831,
-                "sql_distsql_exec_latency_internal_bucket": 10905,
-                "sql_distsql_service_latency_internal_bucket": 100,
-                "sql_exec_latency_internal_bucket": 14391,
-                "sql_service_latency_internal_bucket": 188,
-                "txn_durations_bucket": 14160
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "419430399"
-            },
-            "metrics": {
-                "exec_latency_bucket": 472235,
-                "liveness_heartbeatlatency_bucket": 81666,
-                "txn_durations_bucket": 116584
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "54525951"
-            },
-            "metrics": {
-                "exec_latency_bucket": 460860,
-                "liveness_heartbeatlatency_bucket": 77816,
-                "sql_exec_latency_internal_bucket": 18848,
-                "sql_service_latency_internal_bucket": 18845,
-                "txn_durations_bucket": 112547
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "1638399"
-            },
-            "metrics": {
-                "exec_latency_bucket": 158338,
-                "liveness_heartbeatlatency_bucket": 6660,
-                "round_trip_latency_bucket": 122145,
-                "sql_distsql_exec_latency_internal_bucket": 12668,
-                "sql_distsql_service_latency_internal_bucket": 2293,
-                "sql_exec_latency_internal_bucket": 17351,
-                "sql_service_latency_internal_bucket": 3169,
-                "txn_durations_bucket": 36778
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "86015",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 5944,
-                "raft_process_commandcommit_latency_bucket": 287064,
-                "raft_process_handleready_latency_bucket": 1363
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "22020095"
-            },
-            "metrics": {
-                "exec_latency_bucket": 437874,
-                "liveness_heartbeatlatency_bucket": 73584,
-                "sql_exec_latency_internal_bucket": 18625,
-                "txn_durations_bucket": 108002
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "1663",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 41
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "35651583",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 470382,
-                "raft_process_handleready_latency_bucket": 445891,
-                "raft_process_logcommit_latency_bucket": 445826
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "786431",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 348731,
-                "raft_process_commandcommit_latency_bucket": 366584,
-                "raft_process_handleready_latency_bucket": 3517,
-                "raft_process_logcommit_latency_bucket": 19327
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "130023423",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 470380,
-                "raft_process_logcommit_latency_bucket": 469030
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "3967",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_commandcommit_latency_bucket": 2,
-                "raft_process_handleready_latency_bucket": 437
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "90111"
-            },
-            "metrics": {
-                "exec_latency_bucket": 38640
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "188415"
-            },
-            "metrics": {
-                "exec_latency_bucket": 92349,
-                "sql_distsql_exec_latency_internal_bucket": 67,
-                "sql_exec_latency_internal_bucket": 97,
-                "txn_durations_bucket": 5
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "62914559",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 465304,
-                "raft_process_logcommit_latency_bucket": 464386
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "4063231",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 465970,
-                "raft_process_commandcommit_latency_bucket": 470528,
-                "raft_process_handleready_latency_bucket": 357652,
-                "raft_process_logcommit_latency_bucket": 415818
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "2359295",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 423159,
-                "raft_process_commandcommit_latency_bucket": 441039,
-                "raft_process_handleready_latency_bucket": 274571,
-                "raft_process_logcommit_latency_bucket": 357862
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "22527"
-            },
-            "metrics": {
-                "exec_latency_bucket": 10
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "12582911",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 424819,
-                "raft_process_logcommit_latency_bucket": 423559
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "37748735",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 447628,
-                "raft_process_logcommit_latency_bucket": 447681
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "4194303",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 466749,
-                "raft_process_commandcommit_latency_bucket": 470900,
-                "raft_process_handleready_latency_bucket": 362522,
-                "raft_process_logcommit_latency_bucket": 416658
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "950271"
-            },
-            "metrics": {
-                "exec_latency_bucket": 119677,
-                "round_trip_latency_bucket": 103438,
-                "sql_distsql_exec_latency_internal_bucket": 11769,
-                "sql_distsql_service_latency_internal_bucket": 126,
-                "sql_exec_latency_internal_bucket": 15424,
-                "sql_service_latency_internal_bucket": 362,
-                "txn_durations_bucket": 17310
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "1207959551",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 471724,
-                "raft_process_logcommit_latency_bucket": 470361
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "7247757311",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 471743,
-                "raft_process_logcommit_latency_bucket": 470380
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "491519",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 282851,
-                "raft_process_commandcommit_latency_bucket": 351146
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "318767103",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 471466,
-                "raft_process_logcommit_latency_bucket": 470103
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "301989887",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 471420,
-                "raft_process_logcommit_latency_bucket": 470062
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "57343"
-            },
-            "metrics": {
-                "exec_latency_bucket": 11426
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "9437183"
-            },
-            "metrics": {
-                "exec_latency_bucket": 435121,
-                "liveness_heartbeatlatency_bucket": 73342,
-                "round_trip_latency_bucket": 122484,
-                "sql_service_latency_internal_bucket": 18608,
-                "txn_durations_bucket": 107714
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "7423",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_commandcommit_latency_bucket": 25,
-                "raft_process_handleready_latency_bucket": 1160
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "56623103",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 462749,
-                "raft_process_logcommit_latency_bucket": 462169
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "688127",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_applycommitted_latency_bucket": 335861,
-                "raft_process_commandcommit_latency_bucket": 363781,
-                "raft_process_handleready_latency_bucket": 1439,
-                "raft_process_logcommit_latency_bucket": 6521
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "637534207"
-            },
-            "metrics": {
-                "exec_latency_bucket": 472282,
-                "liveness_heartbeatlatency_bucket": 81684,
-                "txn_durations_bucket": 116607
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "786431"
-            },
-            "metrics": {
-                "exec_latency_bucket": 118854,
-                "round_trip_latency_bucket": 78060,
-                "sql_distsql_exec_latency_internal_bucket": 10515,
-                "sql_distsql_service_latency_internal_bucket": 91,
-                "sql_exec_latency_internal_bucket": 13952,
-                "sql_service_latency_internal_bucket": 141,
-                "txn_durations_bucket": 13114
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "121634815",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 470257,
-                "raft_process_logcommit_latency_bucket": 468928
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "28671"
-            },
-            "metrics": {
-                "exec_latency_bucket": 1270
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "22527",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_commandcommit_latency_bucket": 42618
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "376831"
-            },
-            "metrics": {
-                "exec_latency_bucket": 117735,
-                "round_trip_latency_bucket": 16139,
-                "sql_distsql_exec_latency_internal_bucket": 2159,
-                "sql_distsql_service_latency_internal_bucket": 6,
-                "sql_exec_latency_internal_bucket": 2854,
-                "sql_service_latency_internal_bucket": 6,
-                "txn_durations_bucket": 1614
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "218103807",
-                "store": "1"
-            },
-            "metrics": {
-                "raft_process_handleready_latency_bucket": 470967,
-                "raft_process_logcommit_latency_bucket": 469610
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "2359295"
-            },
-            "metrics": {
-                "exec_latency_bucket": 241340,
-                "liveness_heartbeatlatency_bucket": 24018,
-                "round_trip_latency_bucket": 122390,
-                "sql_distsql_service_latency_internal_bucket": 4439,
-                "sql_exec_latency_internal_bucket": 18492,
-                "sql_service_latency_internal_bucket": 7366,
-                "txn_durations_bucket": 61388
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "6174015487"
-            },
-            "metrics": {
-                "exec_latency_bucket": 472344
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "20479"
-            },
-            "metrics": {
-                "exec_latency_bucket": 4
-            }
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "cockroachdb"
-        }
-    },
-    {
-        "event": {
-            "dataset": "cockroachdb.status",
-            "duration": 115000,
-            "module": "cockroachdb"
-        },
-        "metricset": {
-            "name": "status",
-            "period": 10000
-        },
-        "prometheus": {
-            "labels": {
-                "instance": "127.0.0.1:50516",
-                "le": "30408703"
-            },
-            "metrics": {
-                "exec_latency_bucket": 443563,
-                "liveness_heartbeatlatency_bucket": 75168,
-                "sql_exec_latency_internal_bucket": 18745,
-                "sql_service_latency_internal_bucket": 18711,
-                "txn_durations_bucket": 109739
+                "exec_latency_bucket": 472322,
+                "liveness_heartbeatlatency_bucket": 81691,
+                "txn_durations_bucket": 116615
             }
         },
         "service": {


### PR DESCRIPTION
This PR adds `job` label by default when using prometheus collector. So when using raw Prometheus collector it will always be `prometheus`. 

When using lightweight modules it is the name of the lightweight module ie `cockroachdb`

Closes #12739
### Testing:
1. Try the module with `metrics_path: /metrics` in the configuration and collect metrics from a `node-exporter` directly.
2. Try the module with `metrics_path: '/federate'` and collect metrics from Prometheus server.

In both cases label `job` should be present.
https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-metricset-prometheus-collector.html

Extra: Try the same with `cockroachdb` lightweight module. Unitest's testdata cover this case too.