### PR TITLE
Update path to the container logs in Kubernetes

### DIFF
--- a/filebeat/docs/autodiscover-kubernetes-config.asciidoc
+++ b/filebeat/docs/autodiscover-kubernetes-config.asciidoc
@@ -12,7 +12,7 @@ filebeat.autodiscover:
           config:
             - type: container
               paths:
-                - /var/log/container/*-${data.kubernetes.container.id}.log
+                - /var/log/containers/*-${data.kubernetes.container.id}.log
               exclude_lines: ["^\\s+[\\-`('.|_]"]  # drop asciiart lines
 -------------------------------------------------------------------------------------
 
@@ -36,5 +36,5 @@ filebeat.autodiscover:
                 input:
                   type: container
                   paths:
-                    - /var/log/container/*-${data.kubernetes.container.id}.log
+                    - /var/log/containers/*-${data.kubernetes.container.id}.log
 -------------------------------------------------------------------------------------


### PR DESCRIPTION
Hi there,

I've been using this particular configuration in one of our K8s clusters and I've found the path where those logs are stored is `/var/log/containers` rather than `/var/log/container`

For instance:

```
gke-observability-te-observability-te-b09c84cd-60p3 ~ # cd /var/log/container
-su: cd: /var/log/container: No such file or directory
gke-observability-te-observability-te-b09c84cd-60p3 ~ # cd /var/log/containers/
gke-observability-te-observability-te-b09c84cd-60p3 /var/log/containers # ls
auditbeat-p5v82_kube-system_auditbeat-a86da9acd471a41d190baed81984db5e0f57711e62af4488c825484f256dde6b.log
auditbeat-p5v82_kube-system_wait-for-service-aed60614bafac1f00efe5b3e8dcfc9696b3a64e9f5e2dff9471abd93b88f2bab.log
elasticsearch-master-4_default_configure-sysctl-a0eeb18f2b47e6d6ac5be9594735fe72fdd8b1ef11d54f02ad4d08648b08a703.log
....
```

I cannot find the official reference in the K8s documentation ...