### PR TITLE
Fix timezone parsing of Cisco module ingest pipelines

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -153,6 +153,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fixed early expiration of templates (Netflow v9 and IPFIX). {pull}13821[13821]
 - Fixed bad handling of sequence numbers when multiple observation domains were exported by a single device (Netflow V9 and IPFIX). {pull}13821[13821]
 - Fix conditions and error checking of date processors in ingest pipelines that use `event.timezone` to parse dates. {pull}13883[13883]
+- Fix timezone parsing of Cisco module ingest pipelines. {pull}13893[13893]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/module/cisco/asa/test/asa.log-expected.json
+++ b/x-pack/filebeat/module/cisco/asa/test/asa.log-expected.json
@@ -1,6 +1,6 @@
 [
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.message_id": "305011",
         "event.action": "firewall-rule",
         "event.code": 305011,
@@ -22,7 +22,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.message_id": "302013",
         "event.action": "firewall-rule",
         "event.code": 302013,
@@ -44,7 +44,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.connection_id": "11749",
         "cisco.asa.destination_interface": "inside",
         "cisco.asa.message_id": "302014",
@@ -55,11 +55,11 @@
         "event.code": 302014,
         "event.dataset": "cisco.asa",
         "event.duration": 67000000000,
-        "event.end": "2018-10-10T10:34:56.000-02:00",
+        "event.end": "2018-10-10T12:34:56.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302014: Teardown TCP connection 11749 for outside:100.66.211.242/80 to inside:172.31.98.44/1758 duration 0:01:07 bytes 38110 TCP Reset-I",
         "event.severity": 6,
-        "event.start": "2018-10-10T12:33:49.000Z",
+        "event.start": "2018-10-10T14:33:49.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "asa",
         "host.hostname": "localhost",
@@ -79,7 +79,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.connection_id": "11748",
         "cisco.asa.destination_interface": "inside",
         "cisco.asa.message_id": "302014",
@@ -90,11 +90,11 @@
         "event.code": 302014,
         "event.dataset": "cisco.asa",
         "event.duration": 67000000000,
-        "event.end": "2018-10-10T10:34:56.000-02:00",
+        "event.end": "2018-10-10T12:34:56.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302014: Teardown TCP connection 11748 for outside:100.66.211.242/80 to inside:172.31.98.44/1757 duration 0:01:07 bytes 44010 TCP Reset-I",
         "event.severity": 6,
-        "event.start": "2018-10-10T12:33:49.000Z",
+        "event.start": "2018-10-10T14:33:49.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "asa",
         "host.hostname": "localhost",
@@ -114,7 +114,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.connection_id": "11745",
         "cisco.asa.destination_interface": "inside",
         "cisco.asa.message_id": "302014",
@@ -125,11 +125,11 @@
         "event.code": 302014,
         "event.dataset": "cisco.asa",
         "event.duration": 67000000000,
-        "event.end": "2018-10-10T10:34:56.000-02:00",
+        "event.end": "2018-10-10T12:34:56.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302014: Teardown TCP connection 11745 for outside:100.66.185.90/80 to inside:172.31.98.44/1755 duration 0:01:07 bytes 7652 TCP Reset-I",
         "event.severity": 6,
-        "event.start": "2018-10-10T12:33:49.000Z",
+        "event.start": "2018-10-10T14:33:49.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "asa",
         "host.hostname": "localhost",
@@ -149,7 +149,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.connection_id": "11744",
         "cisco.asa.destination_interface": "inside",
         "cisco.asa.message_id": "302014",
@@ -160,11 +160,11 @@
         "event.code": 302014,
         "event.dataset": "cisco.asa",
         "event.duration": 67000000000,
-        "event.end": "2018-10-10T10:34:56.000-02:00",
+        "event.end": "2018-10-10T12:34:56.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302014: Teardown TCP connection 11744 for outside:100.66.185.90/80 to inside:172.31.98.44/1754 duration 0:01:07 bytes 7062 TCP Reset-I",
         "event.severity": 6,
-        "event.start": "2018-10-10T12:33:49.000Z",
+        "event.start": "2018-10-10T14:33:49.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "asa",
         "host.hostname": "localhost",
@@ -184,7 +184,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.connection_id": "11742",
         "cisco.asa.destination_interface": "inside",
         "cisco.asa.message_id": "302014",
@@ -195,11 +195,11 @@
         "event.code": 302014,
         "event.dataset": "cisco.asa",
         "event.duration": 68000000000,
-        "event.end": "2018-10-10T10:34:56.000-02:00",
+        "event.end": "2018-10-10T12:34:56.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302014: Teardown TCP connection 11742 for outside:100.66.160.197/80 to inside:172.31.98.44/1752 duration 0:01:08 bytes 5738 TCP Reset-I",
         "event.severity": 6,
-        "event.start": "2018-10-10T12:33:48.000Z",
+        "event.start": "2018-10-10T14:33:48.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "asa",
         "host.hostname": "localhost",
@@ -219,7 +219,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.connection_id": "11738",
         "cisco.asa.destination_interface": "inside",
         "cisco.asa.message_id": "302014",
@@ -230,11 +230,11 @@
         "event.code": 302014,
         "event.dataset": "cisco.asa",
         "event.duration": 68000000000,
-        "event.end": "2018-10-10T10:34:56.000-02:00",
+        "event.end": "2018-10-10T12:34:56.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302014: Teardown TCP connection 11738 for outside:100.66.205.14/80 to inside:172.31.98.44/1749 duration 0:01:08 bytes 4176 TCP Reset-I",
         "event.severity": 6,
-        "event.start": "2018-10-10T12:33:48.000Z",
+        "event.start": "2018-10-10T14:33:48.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "asa",
         "host.hostname": "localhost",
@@ -254,7 +254,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.connection_id": "11739",
         "cisco.asa.destination_interface": "inside",
         "cisco.asa.message_id": "302014",
@@ -265,11 +265,11 @@
         "event.code": 302014,
         "event.dataset": "cisco.asa",
         "event.duration": 68000000000,
-        "event.end": "2018-10-10T10:34:56.000-02:00",
+        "event.end": "2018-10-10T12:34:56.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302014: Teardown TCP connection 11739 for outside:100.66.124.33/80 to inside:172.31.98.44/1750 duration 0:01:08 bytes 1715 TCP Reset-I",
         "event.severity": 6,
-        "event.start": "2018-10-10T12:33:48.000Z",
+        "event.start": "2018-10-10T14:33:48.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "asa",
         "host.hostname": "localhost",
@@ -289,7 +289,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.connection_id": "11731",
         "cisco.asa.destination_interface": "inside",
         "cisco.asa.message_id": "302014",
@@ -300,11 +300,11 @@
         "event.code": 302014,
         "event.dataset": "cisco.asa",
         "event.duration": 69000000000,
-        "event.end": "2018-10-10T10:34:56.000-02:00",
+        "event.end": "2018-10-10T12:34:56.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302014: Teardown TCP connection 11731 for outside:100.66.35.9/80 to inside:172.31.98.44/1747 duration 0:01:09 bytes 45595 TCP Reset-I",
         "event.severity": 6,
-        "event.start": "2018-10-10T12:33:47.000Z",
+        "event.start": "2018-10-10T14:33:47.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "asa",
         "host.hostname": "localhost",
@@ -324,7 +324,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.connection_id": "11723",
         "cisco.asa.destination_interface": "inside",
         "cisco.asa.message_id": "302014",
@@ -335,11 +335,11 @@
         "event.code": 302014,
         "event.dataset": "cisco.asa",
         "event.duration": 69000000000,
-        "event.end": "2018-10-10T10:34:56.000-02:00",
+        "event.end": "2018-10-10T12:34:56.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302014: Teardown TCP connection 11723 for outside:100.66.211.242/80 to inside:172.31.98.44/1742 duration 0:01:09 bytes 27359 TCP Reset-I",
         "event.severity": 6,
-        "event.start": "2018-10-10T12:33:47.000Z",
+        "event.start": "2018-10-10T14:33:47.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "asa",
         "host.hostname": "localhost",
@@ -359,7 +359,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.connection_id": "11715",
         "cisco.asa.destination_interface": "inside",
         "cisco.asa.message_id": "302014",
@@ -370,11 +370,11 @@
         "event.code": 302014,
         "event.dataset": "cisco.asa",
         "event.duration": 69000000000,
-        "event.end": "2018-10-10T10:34:56.000-02:00",
+        "event.end": "2018-10-10T12:34:56.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302014: Teardown TCP connection 11715 for outside:100.66.218.21/80 to inside:172.31.98.44/1741 duration 0:01:09 bytes 4457 TCP Reset-I",
         "event.severity": 6,
-        "event.start": "2018-10-10T12:33:47.000Z",
+        "event.start": "2018-10-10T14:33:47.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "asa",
         "host.hostname": "localhost",
@@ -394,7 +394,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.connection_id": "11711",
         "cisco.asa.destination_interface": "inside",
         "cisco.asa.message_id": "302014",
@@ -405,11 +405,11 @@
         "event.code": 302014,
         "event.dataset": "cisco.asa",
         "event.duration": 69000000000,
-        "event.end": "2018-10-10T10:34:56.000-02:00",
+        "event.end": "2018-10-10T12:34:56.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302014: Teardown TCP connection 11711 for outside:100.66.198.27/80 to inside:172.31.98.44/1739 duration 0:01:09 bytes 26709 TCP Reset-I",
         "event.severity": 6,
-        "event.start": "2018-10-10T12:33:47.000Z",
+        "event.start": "2018-10-10T14:33:47.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "asa",
         "host.hostname": "localhost",
@@ -429,7 +429,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.connection_id": "11712",
         "cisco.asa.destination_interface": "inside",
         "cisco.asa.message_id": "302014",
@@ -440,11 +440,11 @@
         "event.code": 302014,
         "event.dataset": "cisco.asa",
         "event.duration": 69000000000,
-        "event.end": "2018-10-10T10:34:56.000-02:00",
+        "event.end": "2018-10-10T12:34:56.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302014: Teardown TCP connection 11712 for outside:100.66.198.27/80 to inside:172.31.98.44/1740 duration 0:01:09 bytes 22097 TCP Reset-I",
         "event.severity": 6,
-        "event.start": "2018-10-10T12:33:47.000Z",
+        "event.start": "2018-10-10T14:33:47.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "asa",
         "host.hostname": "localhost",
@@ -464,7 +464,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.connection_id": "11708",
         "cisco.asa.destination_interface": "inside",
         "cisco.asa.message_id": "302014",
@@ -475,11 +475,11 @@
         "event.code": 302014,
         "event.dataset": "cisco.asa",
         "event.duration": 70000000000,
-        "event.end": "2018-10-10T10:34:56.000-02:00",
+        "event.end": "2018-10-10T12:34:56.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302014: Teardown TCP connection 11708 for outside:100.66.202.211/80 to inside:172.31.98.44/1738 duration 0:01:10 bytes 2209 TCP Reset-I",
         "event.severity": 6,
-        "event.start": "2018-10-10T12:33:46.000Z",
+        "event.start": "2018-10-10T14:33:46.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "asa",
         "host.hostname": "localhost",
@@ -499,7 +499,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.connection_id": "11746",
         "cisco.asa.destination_interface": "inside",
         "cisco.asa.message_id": "302014",
@@ -510,11 +510,11 @@
         "event.code": 302014,
         "event.dataset": "cisco.asa",
         "event.duration": 67000000000,
-        "event.end": "2018-10-10T10:34:56.000-02:00",
+        "event.end": "2018-10-10T12:34:56.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302014: Teardown TCP connection 11746 for outside:100.66.124.15/80 to inside:172.31.98.44/1756 duration 0:01:07 bytes 10404 TCP Reset-I",
         "event.severity": 6,
-        "event.start": "2018-10-10T12:33:49.000Z",
+        "event.start": "2018-10-10T14:33:49.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "asa",
         "host.hostname": "localhost",
@@ -534,7 +534,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.connection_id": "11706",
         "cisco.asa.destination_interface": "inside",
         "cisco.asa.message_id": "302014",
@@ -545,11 +545,11 @@
         "event.code": 302014,
         "event.dataset": "cisco.asa",
         "event.duration": 70000000000,
-        "event.end": "2018-10-10T10:34:56.000-02:00",
+        "event.end": "2018-10-10T12:34:56.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302014: Teardown TCP connection 11706 for outside:100.66.124.15/80 to inside:172.31.98.44/1737 duration 0:01:10 bytes 123694 TCP Reset-I",
         "event.severity": 6,
-        "event.start": "2018-10-10T12:33:46.000Z",
+        "event.start": "2018-10-10T14:33:46.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "asa",
         "host.hostname": "localhost",
@@ -569,7 +569,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.connection_id": "11702",
         "cisco.asa.destination_interface": "inside",
         "cisco.asa.message_id": "302014",
@@ -580,11 +580,11 @@
         "event.code": 302014,
         "event.dataset": "cisco.asa",
         "event.duration": 71000000000,
-        "event.end": "2018-10-10T10:34:56.000-02:00",
+        "event.end": "2018-10-10T12:34:56.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302014: Teardown TCP connection 11702 for outside:100.66.209.247/80 to inside:172.31.98.44/1736 duration 0:01:11 bytes 35835 TCP Reset-I",
         "event.severity": 6,
-        "event.start": "2018-10-10T12:33:45.000Z",
+        "event.start": "2018-10-10T14:33:45.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "asa",
         "host.hostname": "localhost",
@@ -604,7 +604,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.connection_id": "11753",
         "cisco.asa.destination_interface": "inside",
         "cisco.asa.message_id": "302014",
@@ -615,11 +615,11 @@
         "event.code": 302014,
         "event.dataset": "cisco.asa",
         "event.duration": 30000000000,
-        "event.end": "2018-10-10T10:34:56.000-02:00",
+        "event.end": "2018-10-10T12:34:56.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302014: Teardown TCP connection 11753 for outside:100.66.35.162/80 to inside:172.31.98.44/1765 duration 0:00:30 bytes 0 SYN Timeout",
         "event.severity": 6,
-        "event.start": "2018-10-10T12:34:26.000Z",
+        "event.start": "2018-10-10T14:34:26.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "asa",
         "host.hostname": "localhost",
@@ -639,7 +639,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.message_id": "305011",
         "event.action": "firewall-rule",
         "event.code": 305011,
@@ -661,7 +661,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.message_id": "302015",
         "event.action": "firewall-rule",
         "event.code": 302015,
@@ -683,7 +683,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.connection_id": "11758",
         "cisco.asa.destination_interface": "inside",
         "cisco.asa.message_id": "302016",
@@ -694,11 +694,11 @@
         "event.code": 302016,
         "event.dataset": "cisco.asa",
         "event.duration": 0,
-        "event.end": "2018-10-10T10:34:56.000-02:00",
+        "event.end": "2018-10-10T12:34:56.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302016: Teardown UDP connection 11758 for outside:100.66.80.32/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 148",
         "event.severity": 6,
-        "event.start": "2018-10-10T12:34:56.000Z",
+        "event.start": "2018-10-10T14:34:56.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "asa",
         "host.hostname": "localhost",
@@ -718,7 +718,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.message_id": "302015",
         "event.action": "firewall-rule",
         "event.code": 302015,
@@ -740,7 +740,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.connection_id": "11759",
         "cisco.asa.destination_interface": "inside",
         "cisco.asa.message_id": "302016",
@@ -751,11 +751,11 @@
         "event.code": 302016,
         "event.dataset": "cisco.asa",
         "event.duration": 0,
-        "event.end": "2018-10-10T10:34:56.000-02:00",
+        "event.end": "2018-10-10T12:34:56.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302016: Teardown UDP connection 11759 for outside:100.66.252.6/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 164",
         "event.severity": 6,
-        "event.start": "2018-10-10T12:34:56.000Z",
+        "event.start": "2018-10-10T14:34:56.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "asa",
         "host.hostname": "localhost",
@@ -775,7 +775,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.message_id": "305011",
         "event.action": "firewall-rule",
         "event.code": 305011,
@@ -797,7 +797,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.message_id": "302013",
         "event.action": "firewall-rule",
         "event.code": 302013,
@@ -819,7 +819,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.message_id": "305011",
         "event.action": "firewall-rule",
         "event.code": 305011,
@@ -841,7 +841,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.message_id": "302013",
         "event.action": "firewall-rule",
         "event.code": 302013,
@@ -863,7 +863,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.message_id": "302015",
         "event.action": "firewall-rule",
         "event.code": 302015,
@@ -885,7 +885,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.message_id": "302015",
         "event.action": "firewall-rule",
         "event.code": 302015,
@@ -907,7 +907,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.connection_id": "11762",
         "cisco.asa.destination_interface": "inside",
         "cisco.asa.message_id": "302016",
@@ -918,11 +918,11 @@
         "event.code": 302016,
         "event.dataset": "cisco.asa",
         "event.duration": 0,
-        "event.end": "2018-10-10T10:34:56.000-02:00",
+        "event.end": "2018-10-10T12:34:56.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302016: Teardown UDP connection 11762 for outside:100.66.238.126/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 111",
         "event.severity": 6,
-        "event.start": "2018-10-10T12:34:56.000Z",
+        "event.start": "2018-10-10T14:34:56.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "asa",
         "host.hostname": "localhost",
@@ -942,7 +942,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.connection_id": "11763",
         "cisco.asa.destination_interface": "inside",
         "cisco.asa.message_id": "302016",
@@ -953,11 +953,11 @@
         "event.code": 302016,
         "event.dataset": "cisco.asa",
         "event.duration": 0,
-        "event.end": "2018-10-10T10:34:56.000-02:00",
+        "event.end": "2018-10-10T12:34:56.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302016: Teardown UDP connection 11763 for outside:100.66.93.51/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 237",
         "event.severity": 6,
-        "event.start": "2018-10-10T12:34:56.000Z",
+        "event.start": "2018-10-10T14:34:56.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "asa",
         "host.hostname": "localhost",
@@ -977,7 +977,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.message_id": "305011",
         "event.action": "firewall-rule",
         "event.code": 305011,
@@ -999,7 +999,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.message_id": "302013",
         "event.action": "firewall-rule",
         "event.code": 302013,
@@ -1021,7 +1021,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.message_id": "305011",
         "event.action": "firewall-rule",
         "event.code": 305011,
@@ -1043,7 +1043,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.message_id": "302015",
         "event.action": "firewall-rule",
         "event.code": 302015,
@@ -1065,7 +1065,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.message_id": "302015",
         "event.action": "firewall-rule",
         "event.code": 302015,
@@ -1087,7 +1087,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.connection_id": "11772",
         "cisco.asa.destination_interface": "inside",
         "cisco.asa.message_id": "302016",
@@ -1098,11 +1098,11 @@
         "event.code": 302016,
         "event.dataset": "cisco.asa",
         "event.duration": 0,
-        "event.end": "2018-10-10T10:34:56.000-02:00",
+        "event.end": "2018-10-10T12:34:56.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302016: Teardown UDP connection 11772 for outside:100.66.240.126/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 87",
         "event.severity": 6,
-        "event.start": "2018-10-10T12:34:56.000Z",
+        "event.start": "2018-10-10T14:34:56.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "asa",
         "host.hostname": "localhost",
@@ -1122,7 +1122,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.connection_id": "11773",
         "cisco.asa.destination_interface": "inside",
         "cisco.asa.message_id": "302016",
@@ -1133,11 +1133,11 @@
         "event.code": 302016,
         "event.dataset": "cisco.asa",
         "event.duration": 0,
-        "event.end": "2018-10-10T10:34:56.000-02:00",
+        "event.end": "2018-10-10T12:34:56.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302016: Teardown UDP connection 11773 for outside:100.66.44.45/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 221",
         "event.severity": 6,
-        "event.start": "2018-10-10T12:34:56.000Z",
+        "event.start": "2018-10-10T14:34:56.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "asa",
         "host.hostname": "localhost",
@@ -1157,7 +1157,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.message_id": "305011",
         "event.action": "firewall-rule",
         "event.code": 305011,
@@ -1179,7 +1179,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.message_id": "302013",
         "event.action": "firewall-rule",
         "event.code": 302013,
@@ -1201,7 +1201,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.message_id": "302015",
         "event.action": "firewall-rule",
         "event.code": 302015,
@@ -1223,7 +1223,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.message_id": "302015",
         "event.action": "firewall-rule",
         "event.code": 302015,
@@ -1245,7 +1245,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.connection_id": "11775",
         "cisco.asa.destination_interface": "inside",
         "cisco.asa.message_id": "302016",
@@ -1256,11 +1256,11 @@
         "event.code": 302016,
         "event.dataset": "cisco.asa",
         "event.duration": 0,
-        "event.end": "2018-10-10T10:34:56.000-02:00",
+        "event.end": "2018-10-10T12:34:56.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302016: Teardown UDP connection 11775 for outside:100.66.157.232/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 101",
         "event.severity": 6,
-        "event.start": "2018-10-10T12:34:56.000Z",
+        "event.start": "2018-10-10T14:34:56.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "asa",
         "host.hostname": "localhost",
@@ -1280,7 +1280,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.connection_id": "11776",
         "cisco.asa.destination_interface": "inside",
         "cisco.asa.message_id": "302016",
@@ -1291,11 +1291,11 @@
         "event.code": 302016,
         "event.dataset": "cisco.asa",
         "event.duration": 0,
-        "event.end": "2018-10-10T10:34:56.000-02:00",
+        "event.end": "2018-10-10T12:34:56.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302016: Teardown UDP connection 11776 for outside:100.66.178.133/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 126",
         "event.severity": 6,
-        "event.start": "2018-10-10T12:34:56.000Z",
+        "event.start": "2018-10-10T14:34:56.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "asa",
         "host.hostname": "localhost",
@@ -1315,7 +1315,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.message_id": "305011",
         "event.action": "firewall-rule",
         "event.code": 305011,
@@ -1337,7 +1337,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.message_id": "302013",
         "event.action": "firewall-rule",
         "event.code": 302013,
@@ -1359,7 +1359,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.connection_id": "11777",
         "cisco.asa.destination_interface": "inside",
         "cisco.asa.message_id": "302014",
@@ -1370,11 +1370,11 @@
         "event.code": 302014,
         "event.dataset": "cisco.asa",
         "event.duration": 0,
-        "event.end": "2018-10-10T10:34:56.000-02:00",
+        "event.end": "2018-10-10T12:34:56.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302014: Teardown TCP connection 11777 for outside:100.66.133.112/80 to inside:172.31.98.44/1453 duration 0:00:00 bytes 862 TCP FINs",
         "event.severity": 6,
-        "event.start": "2018-10-10T12:34:56.000Z",
+        "event.start": "2018-10-10T14:34:56.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "asa",
         "host.hostname": "localhost",
@@ -1394,7 +1394,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.message_id": "302015",
         "event.action": "firewall-rule",
         "event.code": 302015,
@@ -1416,7 +1416,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.connection_id": "11778",
         "cisco.asa.destination_interface": "inside",
         "cisco.asa.message_id": "302016",
@@ -1427,11 +1427,11 @@
         "event.code": 302016,
         "event.dataset": "cisco.asa",
         "event.duration": 0,
-        "event.end": "2018-10-10T10:34:56.000-02:00",
+        "event.end": "2018-10-10T12:34:56.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302016: Teardown UDP connection 11778 for outside:100.66.157.232/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 104",
         "event.severity": 6,
-        "event.start": "2018-10-10T12:34:56.000Z",
+        "event.start": "2018-10-10T14:34:56.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "asa",
         "host.hostname": "localhost",
@@ -1451,7 +1451,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.connection_id": "11779",
         "cisco.asa.destination_interface": "inside",
         "cisco.asa.message_id": "302016",
@@ -1462,11 +1462,11 @@
         "event.code": 302016,
         "event.dataset": "cisco.asa",
         "event.duration": 0,
-        "event.end": "2018-10-10T10:34:56.000-02:00",
+        "event.end": "2018-10-10T12:34:56.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302016: Teardown UDP connection 11779 for outside:100.66.204.197/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 176",
         "event.severity": 6,
-        "event.start": "2018-10-10T12:34:56.000Z",
+        "event.start": "2018-10-10T14:34:56.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "asa",
         "host.hostname": "localhost",
@@ -1486,7 +1486,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.message_id": "305011",
         "event.action": "firewall-rule",
         "event.code": 305011,
@@ -1508,7 +1508,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.message_id": "302013",
         "event.action": "firewall-rule",
         "event.code": 302013,
@@ -1530,7 +1530,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.message_id": "305011",
         "event.action": "firewall-rule",
         "event.code": 305011,
@@ -1552,7 +1552,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.message_id": "302013",
         "event.action": "firewall-rule",
         "event.code": 302013,
@@ -1574,7 +1574,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.message_id": "305011",
         "event.action": "firewall-rule",
         "event.code": 305011,
@@ -1596,7 +1596,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.message_id": "302013",
         "event.action": "firewall-rule",
         "event.code": 302013,
@@ -1618,7 +1618,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.message_id": "302015",
         "event.action": "firewall-rule",
         "event.code": 302015,
@@ -1640,7 +1640,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.connection_id": "11783",
         "cisco.asa.destination_interface": "inside",
         "cisco.asa.message_id": "302016",
@@ -1651,11 +1651,11 @@
         "event.code": 302016,
         "event.dataset": "cisco.asa",
         "event.duration": 0,
-        "event.end": "2018-10-10T10:34:56.000-02:00",
+        "event.end": "2018-10-10T12:34:56.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302016: Teardown UDP connection 11783 for outside:100.66.100.4/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 104",
         "event.severity": 6,
-        "event.start": "2018-10-10T12:34:56.000Z",
+        "event.start": "2018-10-10T14:34:56.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "asa",
         "host.hostname": "localhost",
@@ -1675,7 +1675,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.message_id": "305011",
         "event.action": "firewall-rule",
         "event.code": 305011,
@@ -1697,7 +1697,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.message_id": "302013",
         "event.action": "firewall-rule",
         "event.code": 302013,
@@ -1719,7 +1719,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.message_id": "305011",
         "event.action": "firewall-rule",
         "event.code": 305011,
@@ -1741,7 +1741,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.message_id": "302013",
         "event.action": "firewall-rule",
         "event.code": 302013,
@@ -1763,7 +1763,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.message_id": "302015",
         "event.action": "firewall-rule",
         "event.code": 302015,
@@ -1785,7 +1785,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.connection_id": "11784",
         "cisco.asa.destination_interface": "inside",
         "cisco.asa.message_id": "302014",
@@ -1796,11 +1796,11 @@
         "event.code": 302014,
         "event.dataset": "cisco.asa",
         "event.duration": 0,
-        "event.end": "2018-10-10T10:34:56.000-02:00",
+        "event.end": "2018-10-10T12:34:56.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302014: Teardown TCP connection 11784 for outside:100.66.198.40/80 to inside:172.31.98.44/1457 duration 0:00:00 bytes 593 TCP FINs",
         "event.severity": 6,
-        "event.start": "2018-10-10T12:34:56.000Z",
+        "event.start": "2018-10-10T14:34:56.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "asa",
         "host.hostname": "localhost",
@@ -1820,7 +1820,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.message_id": "305011",
         "event.action": "firewall-rule",
         "event.code": 305011,
@@ -1842,7 +1842,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.message_id": "302013",
         "event.action": "firewall-rule",
         "event.code": 302013,
@@ -1864,7 +1864,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.connection_id": "11786",
         "cisco.asa.destination_interface": "inside",
         "cisco.asa.message_id": "302016",
@@ -1875,11 +1875,11 @@
         "event.code": 302016,
         "event.dataset": "cisco.asa",
         "event.duration": 0,
-        "event.end": "2018-10-10T10:34:56.000-02:00",
+        "event.end": "2018-10-10T12:34:56.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302016: Teardown UDP connection 11786 for outside:100.66.1.107/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 375",
         "event.severity": 6,
-        "event.start": "2018-10-10T12:34:56.000Z",
+        "event.start": "2018-10-10T14:34:56.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "asa",
         "host.hostname": "localhost",
@@ -1899,7 +1899,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.message_id": "305011",
         "event.action": "firewall-rule",
         "event.code": 305011,
@@ -1921,7 +1921,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.message_id": "302013",
         "event.action": "firewall-rule",
         "event.code": 302013,
@@ -1943,7 +1943,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.message_id": "305012",
         "event.action": "firewall-rule",
         "event.code": 305012,
@@ -1965,7 +1965,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.message_id": "305011",
         "event.action": "firewall-rule",
         "event.code": 305011,
@@ -1987,7 +1987,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.message_id": "302013",
         "event.action": "firewall-rule",
         "event.code": 302013,
@@ -2009,7 +2009,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.message_id": "305012",
         "event.action": "firewall-rule",
         "event.code": 305012,
@@ -2031,7 +2031,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.message_id": "305012",
         "event.action": "firewall-rule",
         "event.code": 305012,
@@ -2053,7 +2053,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.message_id": "305012",
         "event.action": "firewall-rule",
         "event.code": 305012,
@@ -2075,7 +2075,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.message_id": "305012",
         "event.action": "firewall-rule",
         "event.code": 305012,
@@ -2097,7 +2097,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.message_id": "305012",
         "event.action": "firewall-rule",
         "event.code": 305012,
@@ -2119,7 +2119,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.message_id": "305012",
         "event.action": "firewall-rule",
         "event.code": 305012,
@@ -2141,7 +2141,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.connection_id": "11564",
         "cisco.asa.destination_interface": "inside",
         "cisco.asa.message_id": "302014",
@@ -2152,11 +2152,11 @@
         "event.code": 302014,
         "event.dataset": "cisco.asa",
         "event.duration": 325000000000,
-        "event.end": "2018-10-10T10:34:56.000-02:00",
+        "event.end": "2018-10-10T12:34:56.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302014: Teardown TCP connection 11564 for outside:100.66.115.46/80 to inside:172.31.156.80/1382 duration 0:05:25 bytes 575 TCP FINs",
         "event.severity": 6,
-        "event.start": "2018-10-10T12:29:31.000Z",
+        "event.start": "2018-10-10T14:29:31.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "asa",
         "host.hostname": "localhost",
@@ -2176,7 +2176,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.connection_id": "11797",
         "cisco.asa.destination_interface": "inside",
         "cisco.asa.message_id": "302014",
@@ -2187,11 +2187,11 @@
         "event.code": 302014,
         "event.dataset": "cisco.asa",
         "event.duration": 0,
-        "event.end": "2018-10-10T10:34:56.000-02:00",
+        "event.end": "2018-10-10T12:34:56.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302014: Teardown TCP connection 11797 for outside:100.66.19.254/80 to inside:172.31.156.80/1385 duration 0:00:00 bytes 5391 TCP Reset-I",
         "event.severity": 6,
-        "event.start": "2018-10-10T12:34:56.000Z",
+        "event.start": "2018-10-10T14:34:56.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "asa",
         "host.hostname": "localhost",
@@ -2211,7 +2211,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.message_id": "305011",
         "event.action": "firewall-rule",
         "event.code": 305011,
@@ -2233,7 +2233,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.message_id": "302013",
         "event.action": "firewall-rule",
         "event.code": 302013,
@@ -2255,7 +2255,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.destination_interface": "inside",
         "cisco.asa.message_id": "106023",
         "cisco.asa.rule_name": "inbound",
@@ -2287,7 +2287,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.destination_interface": "inside",
         "cisco.asa.message_id": "106023",
         "cisco.asa.rule_name": "inbound",
@@ -2319,7 +2319,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.destination_interface": "inside",
         "cisco.asa.message_id": "106023",
         "cisco.asa.rule_name": "inbound",
@@ -2351,7 +2351,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.destination_interface": "inside",
         "cisco.asa.message_id": "106023",
         "cisco.asa.rule_name": "inbound",
@@ -2383,7 +2383,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.destination_interface": "inside",
         "cisco.asa.message_id": "106023",
         "cisco.asa.rule_name": "inbound",
@@ -2415,7 +2415,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.destination_interface": "inside",
         "cisco.asa.message_id": "106023",
         "cisco.asa.rule_name": "inbound",
@@ -2447,7 +2447,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.destination_interface": "inside",
         "cisco.asa.message_id": "106023",
         "cisco.asa.rule_name": "inbound",
@@ -2479,7 +2479,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.destination_interface": "inside",
         "cisco.asa.message_id": "106023",
         "cisco.asa.rule_name": "inbound",
@@ -2511,7 +2511,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.destination_interface": "inside",
         "cisco.asa.message_id": "106023",
         "cisco.asa.rule_name": "inbound",
@@ -2543,7 +2543,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.destination_interface": "inside",
         "cisco.asa.message_id": "106023",
         "cisco.asa.rule_name": "inbound",
@@ -2575,7 +2575,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.destination_interface": "inside",
         "cisco.asa.message_id": "106023",
         "cisco.asa.rule_name": "inbound",
@@ -2607,7 +2607,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.destination_interface": "inside",
         "cisco.asa.message_id": "106023",
         "cisco.asa.rule_name": "inbound",
@@ -2639,7 +2639,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.destination_interface": "inside",
         "cisco.asa.message_id": "106023",
         "cisco.asa.rule_name": "inbound",
@@ -2671,7 +2671,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.message_id": "305011",
         "event.action": "firewall-rule",
         "event.code": 305011,
@@ -2693,7 +2693,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.message_id": "302013",
         "event.action": "firewall-rule",
         "event.code": 302013,
@@ -2715,7 +2715,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.message_id": "305011",
         "event.action": "firewall-rule",
         "event.code": 305011,
@@ -2737,7 +2737,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.asa.message_id": "302015",
         "event.action": "firewall-rule",
         "event.code": 302015,

--- a/x-pack/filebeat/module/cisco/asa/test/filtered.log-expected.json
+++ b/x-pack/filebeat/module/cisco/asa/test/filtered.log-expected.json
@@ -1,6 +1,6 @@
 [
     {
-        "@timestamp": "2018-12-31T23:00:27.000-02:00",
+        "@timestamp": "2019-01-01T01:00:27.000-02:00",
         "cisco.asa.message_id": "999999",
         "event.action": "firewall-rule",
         "event.code": 999999,

--- a/x-pack/filebeat/module/cisco/asa/test/filtered.log-expected.json
+++ b/x-pack/filebeat/module/cisco/asa/test/filtered.log-expected.json
@@ -22,7 +22,7 @@
         ]
     },
     {
-        "@timestamp": "2018-12-31T23:02:12.000-02:00",
+        "@timestamp": "2019-01-01T01:02:12.000-02:00",
         "cisco.asa.message_id": "106001",
         "cisco.asa.source_interface": "eth0",
         "destination.ip": "192.168.33.12",

--- a/x-pack/filebeat/module/cisco/asa/test/hostnames.log-expected.json
+++ b/x-pack/filebeat/module/cisco/asa/test/hostnames.log-expected.json
@@ -1,6 +1,6 @@
 [
     {
-        "@timestamp": "2019-10-10T08:21:36.000-02:00",
+        "@timestamp": "2019-10-10T10:21:36.000-02:00",
         "cisco.asa.icmp_code": 0,
         "cisco.asa.mapped_source_ip": "10.0.55.66",
         "cisco.asa.message_id": "302021",

--- a/x-pack/filebeat/module/cisco/asa/test/sample.log-expected.json
+++ b/x-pack/filebeat/module/cisco/asa/test/sample.log-expected.json
@@ -1,6 +1,6 @@
 [
     {
-        "@timestamp": "2013-04-15T07:36:50.000-02:00",
+        "@timestamp": "2013-04-15T09:36:50.000-02:00",
         "cisco.asa.destination_interface": "outside",
         "cisco.asa.message_id": "106023",
         "cisco.asa.rule_name": "acl_dmz",
@@ -29,7 +29,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-15T07:36:50.000-02:00",
+        "@timestamp": "2013-04-15T09:36:50.000-02:00",
         "cisco.asa.destination_interface": "outside",
         "cisco.asa.message_id": "106023",
         "cisco.asa.rule_name": "acl_dmz",
@@ -58,7 +58,7 @@
         ]
     },
     {
-        "@timestamp": "2014-04-15T11:34:34.000-02:00",
+        "@timestamp": "2014-04-15T09:34:34.000-04:00",
         "cisco.asa.destination_interface": "outside",
         "cisco.asa.message_id": "106100",
         "cisco.asa.rule_name": "acl_in",
@@ -88,7 +88,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-24T14:00:28.000-02:00",
+        "@timestamp": "2013-04-24T16:00:28.000-02:00",
         "cisco.asa.destination_interface": "outside",
         "cisco.asa.message_id": "106100",
         "cisco.asa.rule_name": "inside",
@@ -118,7 +118,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-24T14:00:27.000-02:00",
+        "@timestamp": "2013-04-24T16:00:27.000-02:00",
         "cisco.asa.destination_interface": "outside",
         "cisco.asa.message_id": "106100",
         "cisco.asa.rule_name": "inside",
@@ -148,7 +148,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-29T10:59:50.000-02:00",
+        "@timestamp": "2013-04-29T12:59:50.000-02:00",
         "cisco.asa.message_id": "305011",
         "event.action": "firewall-rule",
         "event.code": 305011,
@@ -167,7 +167,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-29T10:59:50.000-02:00",
+        "@timestamp": "2013-04-29T12:59:50.000-02:00",
         "cisco.asa.message_id": "302013",
         "event.action": "firewall-rule",
         "event.code": 302013,
@@ -186,7 +186,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-29T10:59:50.000-02:00",
+        "@timestamp": "2013-04-29T12:59:50.000-02:00",
         "cisco.asa.message_id": "305011",
         "event.action": "firewall-rule",
         "event.code": 305011,
@@ -205,7 +205,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-29T10:59:50.000-02:00",
+        "@timestamp": "2013-04-29T12:59:50.000-02:00",
         "cisco.asa.message_id": "302015",
         "event.action": "firewall-rule",
         "event.code": 302015,
@@ -224,7 +224,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-29T10:59:50.000-02:00",
+        "@timestamp": "2013-04-29T12:59:50.000-02:00",
         "cisco.asa.message_id": "305011",
         "event.action": "firewall-rule",
         "event.code": 305011,
@@ -243,7 +243,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-29T10:59:50.000-02:00",
+        "@timestamp": "2013-04-29T12:59:50.000-02:00",
         "cisco.asa.message_id": "302013",
         "event.action": "firewall-rule",
         "event.code": 302013,
@@ -262,7 +262,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-29T10:59:50.000-02:00",
+        "@timestamp": "2013-04-29T12:59:50.000-02:00",
         "cisco.asa.connection_id": "89743275",
         "cisco.asa.destination_interface": "inside",
         "cisco.asa.message_id": "302016",
@@ -273,11 +273,11 @@
         "event.code": 302016,
         "event.dataset": "cisco.asa",
         "event.duration": 5025000000000,
-        "event.end": "2013-04-29T10:59:50.000-02:00",
+        "event.end": "2013-04-29T12:59:50.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302016: Teardown UDP connection 89743275 for outside:192.0.2.222/53 to inside:10.123.1.35/52925 duration 1:23:45 bytes 140",
         "event.severity": 6,
-        "event.start": "2013-04-29T11:36:05.000Z",
+        "event.start": "2013-04-29T13:36:05.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "asa",
         "input.type": "log",
@@ -294,7 +294,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-29T10:59:50.000-02:00",
+        "@timestamp": "2013-04-29T12:59:50.000-02:00",
         "cisco.asa.connection_id": "666",
         "cisco.asa.destination_interface": "inside",
         "cisco.asa.destination_username": "user2",
@@ -307,11 +307,11 @@
         "event.code": 302016,
         "event.dataset": "cisco.asa",
         "event.duration": 36000000000000,
-        "event.end": "2013-04-29T10:59:50.000-02:00",
+        "event.end": "2013-04-29T12:59:50.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302016: Teardown UDP connection 666 for outside:192.0.2.222/53 user1 to inside:10.123.1.35/52925 user2 duration 10:00:00 bytes 9999999",
         "event.severity": 6,
-        "event.start": "2013-04-29T02:59:50.000Z",
+        "event.start": "2013-04-29T04:59:50.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "asa",
         "input.type": "log",
@@ -328,7 +328,7 @@
         ]
     },
     {
-        "@timestamp": "2011-06-04T19:59:52.000-02:00",
+        "@timestamp": "2011-06-04T21:59:52.000-02:00",
         "cisco.asa.icmp_code": 17233,
         "cisco.asa.mapped_source_ip": "192.168.132.46",
         "cisco.asa.message_id": "302021",
@@ -354,7 +354,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-29T10:59:50.000-02:00",
+        "@timestamp": "2013-04-29T12:59:50.000-02:00",
         "cisco.asa.message_id": "305011",
         "event.action": "firewall-rule",
         "event.code": 305011,
@@ -373,7 +373,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-29T10:59:50.000-02:00",
+        "@timestamp": "2013-04-29T12:59:50.000-02:00",
         "cisco.asa.message_id": "302013",
         "event.action": "firewall-rule",
         "event.code": 302013,
@@ -392,7 +392,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-30T07:22:33.000-02:00",
+        "@timestamp": "2013-04-30T09:22:33.000-02:00",
         "cisco.asa.message_id": "106007",
         "destination.ip": "10.1.2.60",
         "destination.port": 53,
@@ -420,7 +420,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-30T07:22:38.000-02:00",
+        "@timestamp": "2013-04-30T09:22:38.000-02:00",
         "cisco.asa.destination_interface": "outside",
         "cisco.asa.message_id": "106100",
         "cisco.asa.rule_name": "acl_in",
@@ -449,7 +449,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-30T07:22:38.000-02:00",
+        "@timestamp": "2013-04-30T09:22:38.000-02:00",
         "cisco.asa.destination_interface": "outside",
         "cisco.asa.message_id": "106100",
         "cisco.asa.rule_name": "acl_in",
@@ -478,7 +478,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-30T07:22:39.000-02:00",
+        "@timestamp": "2013-04-30T09:22:39.000-02:00",
         "cisco.asa.destination_interface": "outside",
         "cisco.asa.message_id": "106100",
         "cisco.asa.rule_name": "acl_in",
@@ -507,7 +507,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-30T07:22:39.000-02:00",
+        "@timestamp": "2013-04-30T09:22:39.000-02:00",
         "cisco.asa.destination_interface": "outside",
         "cisco.asa.message_id": "106100",
         "cisco.asa.rule_name": "acl_in",
@@ -536,7 +536,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-30T07:22:39.000-02:00",
+        "@timestamp": "2013-04-30T09:22:39.000-02:00",
         "cisco.asa.destination_interface": "outside",
         "cisco.asa.message_id": "106100",
         "cisco.asa.rule_name": "acl_in",
@@ -565,7 +565,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-30T07:22:40.000-02:00",
+        "@timestamp": "2013-04-30T09:22:40.000-02:00",
         "cisco.asa.destination_interface": "outside",
         "cisco.asa.message_id": "106100",
         "cisco.asa.rule_name": "acl_in",
@@ -594,7 +594,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-30T07:22:41.000-02:00",
+        "@timestamp": "2013-04-30T09:22:41.000-02:00",
         "cisco.asa.destination_interface": "outside",
         "cisco.asa.message_id": "106100",
         "cisco.asa.rule_name": "acl_in",
@@ -623,7 +623,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-30T07:22:47.000-02:00",
+        "@timestamp": "2013-04-30T09:22:47.000-02:00",
         "cisco.asa.destination_interface": "outside",
         "cisco.asa.message_id": "106100",
         "cisco.asa.rule_name": "acl_in",
@@ -652,7 +652,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-30T07:22:48.000-02:00",
+        "@timestamp": "2013-04-30T09:22:48.000-02:00",
         "cisco.asa.destination_interface": "dmz",
         "cisco.asa.message_id": "106100",
         "cisco.asa.rule_name": "acl_in",
@@ -681,7 +681,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-30T07:22:56.000-02:00",
+        "@timestamp": "2013-04-30T09:22:56.000-02:00",
         "cisco.asa.destination_interface": "outside",
         "cisco.asa.message_id": "106100",
         "cisco.asa.rule_name": "acl_in",
@@ -710,7 +710,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-30T07:23:02.000-02:00",
+        "@timestamp": "2013-04-30T09:23:02.000-02:00",
         "cisco.asa.message_id": "106006",
         "cisco.asa.source_interface": "inside",
         "destination.ip": "10.1.2.42",
@@ -738,7 +738,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-30T07:23:03.000-02:00",
+        "@timestamp": "2013-04-30T09:23:03.000-02:00",
         "cisco.asa.message_id": "106007",
         "destination.ip": "10.1.5.60",
         "destination.port": 53,
@@ -766,7 +766,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-30T07:23:06.000-02:00",
+        "@timestamp": "2013-04-30T09:23:06.000-02:00",
         "cisco.asa.destination_interface": "outside",
         "cisco.asa.message_id": "106100",
         "cisco.asa.rule_name": "acl_in",
@@ -795,7 +795,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-30T07:23:08.000-02:00",
+        "@timestamp": "2013-04-30T09:23:08.000-02:00",
         "cisco.asa.destination_interface": "outside",
         "cisco.asa.message_id": "106100",
         "cisco.asa.rule_name": "acl_in",
@@ -824,7 +824,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-30T07:23:15.000-02:00",
+        "@timestamp": "2013-04-30T09:23:15.000-02:00",
         "cisco.asa.destination_interface": "outside",
         "cisco.asa.message_id": "106100",
         "cisco.asa.rule_name": "acl_in",
@@ -853,7 +853,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-30T07:23:24.000-02:00",
+        "@timestamp": "2013-04-30T09:23:24.000-02:00",
         "cisco.asa.destination_interface": "outside",
         "cisco.asa.message_id": "106100",
         "cisco.asa.rule_name": "acl_in",
@@ -882,7 +882,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-30T07:23:34.000-02:00",
+        "@timestamp": "2013-04-30T09:23:34.000-02:00",
         "cisco.asa.destination_interface": "outside",
         "cisco.asa.message_id": "106100",
         "cisco.asa.rule_name": "acl_in",
@@ -911,7 +911,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-30T07:23:40.000-02:00",
+        "@timestamp": "2013-04-30T09:23:40.000-02:00",
         "cisco.asa.destination_interface": "inside",
         "cisco.asa.message_id": "106023",
         "cisco.asa.rule_name": "acl_out",
@@ -940,7 +940,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-30T07:23:41.000-02:00",
+        "@timestamp": "2013-04-30T09:23:41.000-02:00",
         "cisco.asa.destination_interface": "inside",
         "cisco.asa.message_id": "106023",
         "cisco.asa.rule_name": "acl_out",
@@ -969,7 +969,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-30T07:23:43.000-02:00",
+        "@timestamp": "2013-04-30T09:23:43.000-02:00",
         "cisco.asa.destination_interface": "outside",
         "cisco.asa.message_id": "106100",
         "cisco.asa.rule_name": "acl_in",
@@ -998,7 +998,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-30T07:23:43.000-02:00",
+        "@timestamp": "2013-04-30T09:23:43.000-02:00",
         "cisco.asa.destination_interface": "outside",
         "cisco.asa.message_id": "106100",
         "cisco.asa.rule_name": "acl_in",
@@ -1027,7 +1027,7 @@
         ]
     },
     {
-        "@timestamp": "2018-04-15T11:34:34.000-02:00",
+        "@timestamp": "2018-04-15T09:34:34.000-04:00",
         "cisco.asa.destination_interface": "outside",
         "cisco.asa.message_id": "106100",
         "cisco.asa.rule_name": "acl_in",
@@ -1057,7 +1057,7 @@
         ]
     },
     {
-        "@timestamp": "2018-12-11T06:01:24.000-02:00",
+        "@timestamp": "2018-12-11T08:01:24.000-02:00",
         "cisco.asa.message_id": "302015",
         "event.action": "firewall-rule",
         "event.code": 302015,
@@ -1077,7 +1077,7 @@
         ]
     },
     {
-        "@timestamp": "2018-12-11T06:01:24.000-02:00",
+        "@timestamp": "2018-12-11T08:01:24.000-02:00",
         "cisco.asa.message_id": "302015",
         "event.action": "firewall-rule",
         "event.code": 302015,
@@ -1097,7 +1097,7 @@
         ]
     },
     {
-        "@timestamp": "2018-12-11T06:01:24.000-02:00",
+        "@timestamp": "2018-12-11T08:01:24.000-02:00",
         "cisco.asa.destination_interface": "outside",
         "cisco.asa.message_id": "106023",
         "cisco.asa.rule_name": "dmz",
@@ -1127,7 +1127,7 @@
         ]
     },
     {
-        "@timestamp": "2018-12-11T06:01:24.000-02:00",
+        "@timestamp": "2018-12-11T08:01:24.000-02:00",
         "cisco.asa.destination_interface": "outside",
         "cisco.asa.message_id": "106023",
         "cisco.asa.rule_name": "dmz",
@@ -1157,7 +1157,7 @@
         ]
     },
     {
-        "@timestamp": "2018-12-11T06:01:31.000-02:00",
+        "@timestamp": "2018-12-11T08:01:31.000-02:00",
         "cisco.asa.message_id": "302013",
         "event.action": "firewall-rule",
         "event.code": 302013,
@@ -1177,7 +1177,7 @@
         ]
     },
     {
-        "@timestamp": "2018-12-11T06:01:31.000-02:00",
+        "@timestamp": "2018-12-11T08:01:31.000-02:00",
         "cisco.asa.message_id": "302013",
         "event.action": "firewall-rule",
         "event.code": 302013,
@@ -1197,7 +1197,7 @@
         ]
     },
     {
-        "@timestamp": "2018-12-11T06:01:31.000-02:00",
+        "@timestamp": "2018-12-11T08:01:31.000-02:00",
         "cisco.asa.connection_id": "447236",
         "cisco.asa.destination_interface": "dmz",
         "cisco.asa.message_id": "302014",
@@ -1208,11 +1208,11 @@
         "event.code": 302014,
         "event.dataset": "cisco.asa",
         "event.duration": 0,
-        "event.end": "2018-12-11T06:01:31.000-02:00",
+        "event.end": "2018-12-11T08:01:31.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302014: Teardown TCP connection 447236 for outside:192.0.2.222/1234 to dmz:192.168.1.34/5678 duration 0:00:00 bytes 14804 TCP FINs",
         "event.severity": 6,
-        "event.start": "2018-12-11T08:01:31.000Z",
+        "event.start": "2018-12-11T10:01:31.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "asa",
         "input.type": "log",
@@ -1230,7 +1230,7 @@
         ]
     },
     {
-        "@timestamp": "2018-12-11T06:01:38.000-02:00",
+        "@timestamp": "2018-12-11T08:01:38.000-02:00",
         "cisco.asa.connection_id": "447234",
         "cisco.asa.destination_interface": "dmz",
         "cisco.asa.message_id": "302014",
@@ -1241,11 +1241,11 @@
         "event.code": 302014,
         "event.dataset": "cisco.asa",
         "event.duration": 68000000000,
-        "event.end": "2018-12-11T06:01:38.000-02:00",
+        "event.end": "2018-12-11T08:01:38.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302014: Teardown TCP connection 447234 for outside:192.0.2.222/1234 to dmz:192.168.1.35/5678 duration 0:01:08 bytes 134781 TCP FINs",
         "event.severity": 6,
-        "event.start": "2018-12-11T08:00:30.000Z",
+        "event.start": "2018-12-11T10:00:30.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "asa",
         "input.type": "log",
@@ -1263,7 +1263,7 @@
         ]
     },
     {
-        "@timestamp": "2018-12-11T06:01:38.000-02:00",
+        "@timestamp": "2018-12-11T08:01:38.000-02:00",
         "cisco.asa.connection_id": "447234",
         "cisco.asa.destination_interface": "dmz",
         "cisco.asa.message_id": "302014",
@@ -1274,11 +1274,11 @@
         "event.code": 302014,
         "event.dataset": "cisco.asa",
         "event.duration": 68000000000,
-        "event.end": "2018-12-11T06:01:38.000-02:00",
+        "event.end": "2018-12-11T08:01:38.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302014: Teardown TCP connection 447234 for outside:192.0.2.222/1234 to dmz:192.168.1.35/5678 duration 0:01:08 bytes 134781 TCP FINs",
         "event.severity": 6,
-        "event.start": "2018-12-11T08:00:30.000Z",
+        "event.start": "2018-12-11T10:00:30.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "asa",
         "input.type": "log",
@@ -1296,7 +1296,7 @@
         ]
     },
     {
-        "@timestamp": "2018-12-11T06:01:38.000-02:00",
+        "@timestamp": "2018-12-11T08:01:38.000-02:00",
         "cisco.asa.message_id": "106015",
         "cisco.asa.source_interface": "outside",
         "destination.ip": "192.168.1.34",
@@ -1324,7 +1324,7 @@
         ]
     },
     {
-        "@timestamp": "2018-12-11T06:01:38.000-02:00",
+        "@timestamp": "2018-12-11T08:01:38.000-02:00",
         "cisco.asa.message_id": "106015",
         "cisco.asa.source_interface": "outside",
         "destination.ip": "192.168.1.34",
@@ -1352,7 +1352,7 @@
         ]
     },
     {
-        "@timestamp": "2018-12-11T06:01:39.000-02:00",
+        "@timestamp": "2018-12-11T08:01:39.000-02:00",
         "cisco.asa.destination_interface": "outside",
         "cisco.asa.message_id": "106023",
         "cisco.asa.rule_name": "dmz",
@@ -1382,7 +1382,7 @@
         ]
     },
     {
-        "@timestamp": "2018-12-11T06:01:53.000-02:00",
+        "@timestamp": "2018-12-11T08:01:53.000-02:00",
         "cisco.asa.message_id": "302013",
         "event.action": "firewall-rule",
         "event.code": 302013,
@@ -1402,7 +1402,7 @@
         ]
     },
     {
-        "@timestamp": "2018-12-11T06:01:53.000-02:00",
+        "@timestamp": "2018-12-11T08:01:53.000-02:00",
         "cisco.asa.message_id": "302013",
         "event.action": "firewall-rule",
         "event.code": 302013,
@@ -1422,7 +1422,7 @@
         ]
     },
     {
-        "@timestamp": "2018-12-11T06:01:53.000-02:00",
+        "@timestamp": "2018-12-11T08:01:53.000-02:00",
         "cisco.asa.connection_id": "447237",
         "cisco.asa.destination_interface": "dmz",
         "cisco.asa.message_id": "302014",
@@ -1433,11 +1433,11 @@
         "event.code": 302014,
         "event.dataset": "cisco.asa",
         "event.duration": 86399000000000,
-        "event.end": "2018-12-11T06:01:53.000-02:00",
+        "event.end": "2018-12-11T08:01:53.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302014: Teardown TCP connection 447237 for outside:192.0.2.222/1234 to dmz:10.10.10.10/1235 duration 23:59:59 bytes 11420 TCP FINs",
         "event.severity": 6,
-        "event.start": "2018-12-10T08:01:54.000Z",
+        "event.start": "2018-12-10T10:01:54.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "asa",
         "input.type": "log",
@@ -1455,7 +1455,7 @@
         ]
     },
     {
-        "@timestamp": "2012-08-15T21:30:09.000-02:00",
+        "@timestamp": "2012-08-15T23:30:09.000-02:00",
         "cisco.asa.connection_id": "40",
         "cisco.asa.destination_interface": "inside",
         "cisco.asa.message_id": "302016",
@@ -1466,11 +1466,11 @@
         "event.code": 302016,
         "event.dataset": "cisco.asa",
         "event.duration": 122000000000,
-        "event.end": "2012-08-15T21:30:09.000-02:00",
+        "event.end": "2012-08-15T23:30:09.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302016 Teardown UDP connection 40 for outside:10.44.4.4/500 to inside:10.44.2.2/500 duration 0:02:02 bytes 1416",
         "event.severity": 6,
-        "event.start": "2012-08-15T23:28:07.000Z",
+        "event.start": "2012-08-16T01:28:07.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "asa",
         "input.type": "log",
@@ -1487,7 +1487,7 @@
         ]
     },
     {
-        "@timestamp": "2014-09-12T04:50:53.000-02:00",
+        "@timestamp": "2014-09-12T06:50:53.000-02:00",
         "cisco.asa.message_id": "106016",
         "cisco.asa.source_interface": "Mobile_Traffic",
         "destination.ip": "192.88.99.47",
@@ -1511,7 +1511,7 @@
         ]
     },
     {
-        "@timestamp": "2014-09-12T04:51:01.000-02:00",
+        "@timestamp": "2014-09-12T06:51:01.000-02:00",
         "cisco.asa.message_id": "106016",
         "cisco.asa.source_interface": "Mobile_Traffic",
         "destination.ip": "192.88.99.57",
@@ -1535,7 +1535,7 @@
         ]
     },
     {
-        "@timestamp": "2014-09-12T04:51:05.000-02:00",
+        "@timestamp": "2014-09-12T06:51:05.000-02:00",
         "cisco.asa.message_id": "106016",
         "cisco.asa.source_interface": "Mobile_Traffic",
         "destination.ip": "192.88.99.47",
@@ -1559,7 +1559,7 @@
         ]
     },
     {
-        "@timestamp": "2014-09-12T04:51:05.000-02:00",
+        "@timestamp": "2014-09-12T06:51:05.000-02:00",
         "cisco.asa.message_id": "106016",
         "cisco.asa.source_interface": "Mobile_Traffic",
         "destination.ip": "192.88.99.47",
@@ -1583,7 +1583,7 @@
         ]
     },
     {
-        "@timestamp": "2014-09-12T04:51:06.000-02:00",
+        "@timestamp": "2014-09-12T06:51:06.000-02:00",
         "cisco.asa.message_id": "106016",
         "cisco.asa.source_interface": "Mobile_Traffic",
         "destination.ip": "192.88.99.57",
@@ -1607,7 +1607,7 @@
         ]
     },
     {
-        "@timestamp": "2014-09-12T04:51:17.000-02:00",
+        "@timestamp": "2014-09-12T06:51:17.000-02:00",
         "cisco.asa.message_id": "106016",
         "cisco.asa.source_interface": "Mobile_Traffic",
         "destination.ip": "192.88.99.57",
@@ -1631,7 +1631,7 @@
         ]
     },
     {
-        "@timestamp": "2014-09-12T04:52:48.000-02:00",
+        "@timestamp": "2014-09-12T06:52:48.000-02:00",
         "cisco.asa.message_id": "106016",
         "cisco.asa.source_interface": "Mobile_Traffic",
         "destination.ip": "192.168.1.255",
@@ -1655,7 +1655,7 @@
         ]
     },
     {
-        "@timestamp": "2014-09-12T04:53:00.000-02:00",
+        "@timestamp": "2014-09-12T06:53:00.000-02:00",
         "cisco.asa.message_id": "106016",
         "cisco.asa.source_interface": "Mobile_Traffic",
         "destination.ip": "192.168.1.255",
@@ -1679,7 +1679,7 @@
         ]
     },
     {
-        "@timestamp": "2014-09-12T04:53:01.000-02:00",
+        "@timestamp": "2014-09-12T06:53:01.000-02:00",
         "cisco.asa.destination_interface": "inside",
         "cisco.asa.message_id": "106023",
         "cisco.asa.rule_name": "PERMIT_IN",
@@ -1709,7 +1709,7 @@
         ]
     },
     {
-        "@timestamp": "2014-09-12T04:53:02.000-02:00",
+        "@timestamp": "2014-09-12T06:53:02.000-02:00",
         "cisco.asa.icmp_code": 3,
         "cisco.asa.icmp_type": 3,
         "cisco.asa.message_id": "313001",
@@ -1736,7 +1736,7 @@
         ]
     },
     {
-        "@timestamp": "2015-01-14T11:16:13.000-02:00",
+        "@timestamp": "2015-01-14T13:16:13.000-02:00",
         "cisco.asa.icmp_type": 0,
         "cisco.asa.message_id": "313004",
         "cisco.asa.source_interface": "inside",
@@ -1762,7 +1762,7 @@
         ]
     },
     {
-        "@timestamp": "2015-01-14T11:16:14.000-02:00",
+        "@timestamp": "2015-01-14T13:16:14.000-02:00",
         "cisco.asa.destination_interface": "outside",
         "cisco.asa.mapped_destination_ip": "192.88.99.129",
         "cisco.asa.mapped_destination_port": 80,
@@ -1799,7 +1799,7 @@
         ]
     },
     {
-        "@timestamp": "2015-01-14T11:16:14.000-02:00",
+        "@timestamp": "2015-01-14T13:16:14.000-02:00",
         "cisco.asa.destination_interface": "outsidet",
         "cisco.asa.mapped_destination_ip": "192.0.2.223",
         "cisco.asa.mapped_destination_port": 80,
@@ -1836,7 +1836,7 @@
         ]
     },
     {
-        "@timestamp": "2015-01-14T11:16:14.000-02:00",
+        "@timestamp": "2015-01-14T13:16:14.000-02:00",
         "cisco.asa.destination_interface": "outsidet",
         "cisco.asa.mapped_destination_ip": "192.0.2.223",
         "cisco.asa.mapped_destination_port": 80,
@@ -1873,7 +1873,7 @@
         ]
     },
     {
-        "@timestamp": "2009-11-16T12:12:35.000-02:00",
+        "@timestamp": "2009-11-16T14:12:35.000-02:00",
         "cisco.asa.message_id": "304001",
         "destination.ip": "192.0.2.1",
         "event.action": "firewall-rule",
@@ -1896,7 +1896,7 @@
         "url.original": "/app"
     },
     {
-        "@timestamp": "2009-11-16T12:12:36.000-02:00",
+        "@timestamp": "2009-11-16T14:12:36.000-02:00",
         "cisco.asa.message_id": "304001",
         "destination.ip": "192.0.2.32",
         "event.action": "firewall-rule",
@@ -1919,7 +1919,7 @@
         "url.original": "http://example.com"
     },
     {
-        "@timestamp": "2009-11-16T12:12:37.000-02:00",
+        "@timestamp": "2009-11-16T14:12:37.000-02:00",
         "cisco.asa.message_id": "304002",
         "cisco.asa.source_interface": "inside",
         "destination.ip": "192.0.0.19",

--- a/x-pack/filebeat/module/cisco/ftd/test/asa.log-expected.json
+++ b/x-pack/filebeat/module/cisco/ftd/test/asa.log-expected.json
@@ -1,6 +1,6 @@
 [
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.message_id": "305011",
         "event.action": "firewall-rule",
         "event.code": 305011,
@@ -22,7 +22,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.message_id": "302013",
         "event.action": "firewall-rule",
         "event.code": 302013,
@@ -44,7 +44,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.connection_id": "11749",
         "cisco.ftd.destination_interface": "inside",
         "cisco.ftd.message_id": "302014",
@@ -55,11 +55,11 @@
         "event.code": 302014,
         "event.dataset": "cisco.ftd",
         "event.duration": 67000000000,
-        "event.end": "2018-10-10T10:34:56.000-02:00",
+        "event.end": "2018-10-10T12:34:56.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302014: Teardown TCP connection 11749 for outside:100.66.211.242/80 to inside:172.31.98.44/1758 duration 0:01:07 bytes 38110 TCP Reset-I",
         "event.severity": 6,
-        "event.start": "2018-10-10T12:33:49.000Z",
+        "event.start": "2018-10-10T14:33:49.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "ftd",
         "host.hostname": "localhost",
@@ -79,7 +79,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.connection_id": "11748",
         "cisco.ftd.destination_interface": "inside",
         "cisco.ftd.message_id": "302014",
@@ -90,11 +90,11 @@
         "event.code": 302014,
         "event.dataset": "cisco.ftd",
         "event.duration": 67000000000,
-        "event.end": "2018-10-10T10:34:56.000-02:00",
+        "event.end": "2018-10-10T12:34:56.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302014: Teardown TCP connection 11748 for outside:100.66.211.242/80 to inside:172.31.98.44/1757 duration 0:01:07 bytes 44010 TCP Reset-I",
         "event.severity": 6,
-        "event.start": "2018-10-10T12:33:49.000Z",
+        "event.start": "2018-10-10T14:33:49.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "ftd",
         "host.hostname": "localhost",
@@ -114,7 +114,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.connection_id": "11745",
         "cisco.ftd.destination_interface": "inside",
         "cisco.ftd.message_id": "302014",
@@ -125,11 +125,11 @@
         "event.code": 302014,
         "event.dataset": "cisco.ftd",
         "event.duration": 67000000000,
-        "event.end": "2018-10-10T10:34:56.000-02:00",
+        "event.end": "2018-10-10T12:34:56.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302014: Teardown TCP connection 11745 for outside:100.66.185.90/80 to inside:172.31.98.44/1755 duration 0:01:07 bytes 7652 TCP Reset-I",
         "event.severity": 6,
-        "event.start": "2018-10-10T12:33:49.000Z",
+        "event.start": "2018-10-10T14:33:49.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "ftd",
         "host.hostname": "localhost",
@@ -149,7 +149,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.connection_id": "11744",
         "cisco.ftd.destination_interface": "inside",
         "cisco.ftd.message_id": "302014",
@@ -160,11 +160,11 @@
         "event.code": 302014,
         "event.dataset": "cisco.ftd",
         "event.duration": 67000000000,
-        "event.end": "2018-10-10T10:34:56.000-02:00",
+        "event.end": "2018-10-10T12:34:56.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302014: Teardown TCP connection 11744 for outside:100.66.185.90/80 to inside:172.31.98.44/1754 duration 0:01:07 bytes 7062 TCP Reset-I",
         "event.severity": 6,
-        "event.start": "2018-10-10T12:33:49.000Z",
+        "event.start": "2018-10-10T14:33:49.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "ftd",
         "host.hostname": "localhost",
@@ -184,7 +184,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.connection_id": "11742",
         "cisco.ftd.destination_interface": "inside",
         "cisco.ftd.message_id": "302014",
@@ -195,11 +195,11 @@
         "event.code": 302014,
         "event.dataset": "cisco.ftd",
         "event.duration": 68000000000,
-        "event.end": "2018-10-10T10:34:56.000-02:00",
+        "event.end": "2018-10-10T12:34:56.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302014: Teardown TCP connection 11742 for outside:100.66.160.197/80 to inside:172.31.98.44/1752 duration 0:01:08 bytes 5738 TCP Reset-I",
         "event.severity": 6,
-        "event.start": "2018-10-10T12:33:48.000Z",
+        "event.start": "2018-10-10T14:33:48.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "ftd",
         "host.hostname": "localhost",
@@ -219,7 +219,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.connection_id": "11738",
         "cisco.ftd.destination_interface": "inside",
         "cisco.ftd.message_id": "302014",
@@ -230,11 +230,11 @@
         "event.code": 302014,
         "event.dataset": "cisco.ftd",
         "event.duration": 68000000000,
-        "event.end": "2018-10-10T10:34:56.000-02:00",
+        "event.end": "2018-10-10T12:34:56.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302014: Teardown TCP connection 11738 for outside:100.66.205.14/80 to inside:172.31.98.44/1749 duration 0:01:08 bytes 4176 TCP Reset-I",
         "event.severity": 6,
-        "event.start": "2018-10-10T12:33:48.000Z",
+        "event.start": "2018-10-10T14:33:48.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "ftd",
         "host.hostname": "localhost",
@@ -254,7 +254,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.connection_id": "11739",
         "cisco.ftd.destination_interface": "inside",
         "cisco.ftd.message_id": "302014",
@@ -265,11 +265,11 @@
         "event.code": 302014,
         "event.dataset": "cisco.ftd",
         "event.duration": 68000000000,
-        "event.end": "2018-10-10T10:34:56.000-02:00",
+        "event.end": "2018-10-10T12:34:56.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302014: Teardown TCP connection 11739 for outside:100.66.124.33/80 to inside:172.31.98.44/1750 duration 0:01:08 bytes 1715 TCP Reset-I",
         "event.severity": 6,
-        "event.start": "2018-10-10T12:33:48.000Z",
+        "event.start": "2018-10-10T14:33:48.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "ftd",
         "host.hostname": "localhost",
@@ -289,7 +289,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.connection_id": "11731",
         "cisco.ftd.destination_interface": "inside",
         "cisco.ftd.message_id": "302014",
@@ -300,11 +300,11 @@
         "event.code": 302014,
         "event.dataset": "cisco.ftd",
         "event.duration": 69000000000,
-        "event.end": "2018-10-10T10:34:56.000-02:00",
+        "event.end": "2018-10-10T12:34:56.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302014: Teardown TCP connection 11731 for outside:100.66.35.9/80 to inside:172.31.98.44/1747 duration 0:01:09 bytes 45595 TCP Reset-I",
         "event.severity": 6,
-        "event.start": "2018-10-10T12:33:47.000Z",
+        "event.start": "2018-10-10T14:33:47.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "ftd",
         "host.hostname": "localhost",
@@ -324,7 +324,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.connection_id": "11723",
         "cisco.ftd.destination_interface": "inside",
         "cisco.ftd.message_id": "302014",
@@ -335,11 +335,11 @@
         "event.code": 302014,
         "event.dataset": "cisco.ftd",
         "event.duration": 69000000000,
-        "event.end": "2018-10-10T10:34:56.000-02:00",
+        "event.end": "2018-10-10T12:34:56.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302014: Teardown TCP connection 11723 for outside:100.66.211.242/80 to inside:172.31.98.44/1742 duration 0:01:09 bytes 27359 TCP Reset-I",
         "event.severity": 6,
-        "event.start": "2018-10-10T12:33:47.000Z",
+        "event.start": "2018-10-10T14:33:47.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "ftd",
         "host.hostname": "localhost",
@@ -359,7 +359,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.connection_id": "11715",
         "cisco.ftd.destination_interface": "inside",
         "cisco.ftd.message_id": "302014",
@@ -370,11 +370,11 @@
         "event.code": 302014,
         "event.dataset": "cisco.ftd",
         "event.duration": 69000000000,
-        "event.end": "2018-10-10T10:34:56.000-02:00",
+        "event.end": "2018-10-10T12:34:56.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302014: Teardown TCP connection 11715 for outside:100.66.218.21/80 to inside:172.31.98.44/1741 duration 0:01:09 bytes 4457 TCP Reset-I",
         "event.severity": 6,
-        "event.start": "2018-10-10T12:33:47.000Z",
+        "event.start": "2018-10-10T14:33:47.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "ftd",
         "host.hostname": "localhost",
@@ -394,7 +394,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.connection_id": "11711",
         "cisco.ftd.destination_interface": "inside",
         "cisco.ftd.message_id": "302014",
@@ -405,11 +405,11 @@
         "event.code": 302014,
         "event.dataset": "cisco.ftd",
         "event.duration": 69000000000,
-        "event.end": "2018-10-10T10:34:56.000-02:00",
+        "event.end": "2018-10-10T12:34:56.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302014: Teardown TCP connection 11711 for outside:100.66.198.27/80 to inside:172.31.98.44/1739 duration 0:01:09 bytes 26709 TCP Reset-I",
         "event.severity": 6,
-        "event.start": "2018-10-10T12:33:47.000Z",
+        "event.start": "2018-10-10T14:33:47.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "ftd",
         "host.hostname": "localhost",
@@ -429,7 +429,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.connection_id": "11712",
         "cisco.ftd.destination_interface": "inside",
         "cisco.ftd.message_id": "302014",
@@ -440,11 +440,11 @@
         "event.code": 302014,
         "event.dataset": "cisco.ftd",
         "event.duration": 69000000000,
-        "event.end": "2018-10-10T10:34:56.000-02:00",
+        "event.end": "2018-10-10T12:34:56.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302014: Teardown TCP connection 11712 for outside:100.66.198.27/80 to inside:172.31.98.44/1740 duration 0:01:09 bytes 22097 TCP Reset-I",
         "event.severity": 6,
-        "event.start": "2018-10-10T12:33:47.000Z",
+        "event.start": "2018-10-10T14:33:47.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "ftd",
         "host.hostname": "localhost",
@@ -464,7 +464,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.connection_id": "11708",
         "cisco.ftd.destination_interface": "inside",
         "cisco.ftd.message_id": "302014",
@@ -475,11 +475,11 @@
         "event.code": 302014,
         "event.dataset": "cisco.ftd",
         "event.duration": 70000000000,
-        "event.end": "2018-10-10T10:34:56.000-02:00",
+        "event.end": "2018-10-10T12:34:56.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302014: Teardown TCP connection 11708 for outside:100.66.202.211/80 to inside:172.31.98.44/1738 duration 0:01:10 bytes 2209 TCP Reset-I",
         "event.severity": 6,
-        "event.start": "2018-10-10T12:33:46.000Z",
+        "event.start": "2018-10-10T14:33:46.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "ftd",
         "host.hostname": "localhost",
@@ -499,7 +499,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.connection_id": "11746",
         "cisco.ftd.destination_interface": "inside",
         "cisco.ftd.message_id": "302014",
@@ -510,11 +510,11 @@
         "event.code": 302014,
         "event.dataset": "cisco.ftd",
         "event.duration": 67000000000,
-        "event.end": "2018-10-10T10:34:56.000-02:00",
+        "event.end": "2018-10-10T12:34:56.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302014: Teardown TCP connection 11746 for outside:100.66.124.15/80 to inside:172.31.98.44/1756 duration 0:01:07 bytes 10404 TCP Reset-I",
         "event.severity": 6,
-        "event.start": "2018-10-10T12:33:49.000Z",
+        "event.start": "2018-10-10T14:33:49.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "ftd",
         "host.hostname": "localhost",
@@ -534,7 +534,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.connection_id": "11706",
         "cisco.ftd.destination_interface": "inside",
         "cisco.ftd.message_id": "302014",
@@ -545,11 +545,11 @@
         "event.code": 302014,
         "event.dataset": "cisco.ftd",
         "event.duration": 70000000000,
-        "event.end": "2018-10-10T10:34:56.000-02:00",
+        "event.end": "2018-10-10T12:34:56.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302014: Teardown TCP connection 11706 for outside:100.66.124.15/80 to inside:172.31.98.44/1737 duration 0:01:10 bytes 123694 TCP Reset-I",
         "event.severity": 6,
-        "event.start": "2018-10-10T12:33:46.000Z",
+        "event.start": "2018-10-10T14:33:46.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "ftd",
         "host.hostname": "localhost",
@@ -569,7 +569,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.connection_id": "11702",
         "cisco.ftd.destination_interface": "inside",
         "cisco.ftd.message_id": "302014",
@@ -580,11 +580,11 @@
         "event.code": 302014,
         "event.dataset": "cisco.ftd",
         "event.duration": 71000000000,
-        "event.end": "2018-10-10T10:34:56.000-02:00",
+        "event.end": "2018-10-10T12:34:56.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302014: Teardown TCP connection 11702 for outside:100.66.209.247/80 to inside:172.31.98.44/1736 duration 0:01:11 bytes 35835 TCP Reset-I",
         "event.severity": 6,
-        "event.start": "2018-10-10T12:33:45.000Z",
+        "event.start": "2018-10-10T14:33:45.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "ftd",
         "host.hostname": "localhost",
@@ -604,7 +604,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.connection_id": "11753",
         "cisco.ftd.destination_interface": "inside",
         "cisco.ftd.message_id": "302014",
@@ -615,11 +615,11 @@
         "event.code": 302014,
         "event.dataset": "cisco.ftd",
         "event.duration": 30000000000,
-        "event.end": "2018-10-10T10:34:56.000-02:00",
+        "event.end": "2018-10-10T12:34:56.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302014: Teardown TCP connection 11753 for outside:100.66.35.162/80 to inside:172.31.98.44/1765 duration 0:00:30 bytes 0 SYN Timeout",
         "event.severity": 6,
-        "event.start": "2018-10-10T12:34:26.000Z",
+        "event.start": "2018-10-10T14:34:26.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "ftd",
         "host.hostname": "localhost",
@@ -639,7 +639,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.message_id": "305011",
         "event.action": "firewall-rule",
         "event.code": 305011,
@@ -661,7 +661,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.message_id": "302015",
         "event.action": "firewall-rule",
         "event.code": 302015,
@@ -683,7 +683,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.connection_id": "11758",
         "cisco.ftd.destination_interface": "inside",
         "cisco.ftd.message_id": "302016",
@@ -694,11 +694,11 @@
         "event.code": 302016,
         "event.dataset": "cisco.ftd",
         "event.duration": 0,
-        "event.end": "2018-10-10T10:34:56.000-02:00",
+        "event.end": "2018-10-10T12:34:56.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302016: Teardown UDP connection 11758 for outside:100.66.80.32/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 148",
         "event.severity": 6,
-        "event.start": "2018-10-10T12:34:56.000Z",
+        "event.start": "2018-10-10T14:34:56.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "ftd",
         "host.hostname": "localhost",
@@ -718,7 +718,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.message_id": "302015",
         "event.action": "firewall-rule",
         "event.code": 302015,
@@ -740,7 +740,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.connection_id": "11759",
         "cisco.ftd.destination_interface": "inside",
         "cisco.ftd.message_id": "302016",
@@ -751,11 +751,11 @@
         "event.code": 302016,
         "event.dataset": "cisco.ftd",
         "event.duration": 0,
-        "event.end": "2018-10-10T10:34:56.000-02:00",
+        "event.end": "2018-10-10T12:34:56.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302016: Teardown UDP connection 11759 for outside:100.66.252.6/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 164",
         "event.severity": 6,
-        "event.start": "2018-10-10T12:34:56.000Z",
+        "event.start": "2018-10-10T14:34:56.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "ftd",
         "host.hostname": "localhost",
@@ -775,7 +775,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.message_id": "305011",
         "event.action": "firewall-rule",
         "event.code": 305011,
@@ -797,7 +797,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.message_id": "302013",
         "event.action": "firewall-rule",
         "event.code": 302013,
@@ -819,7 +819,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.message_id": "305011",
         "event.action": "firewall-rule",
         "event.code": 305011,
@@ -841,7 +841,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.message_id": "302013",
         "event.action": "firewall-rule",
         "event.code": 302013,
@@ -863,7 +863,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.message_id": "302015",
         "event.action": "firewall-rule",
         "event.code": 302015,
@@ -885,7 +885,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.message_id": "302015",
         "event.action": "firewall-rule",
         "event.code": 302015,
@@ -907,7 +907,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.connection_id": "11762",
         "cisco.ftd.destination_interface": "inside",
         "cisco.ftd.message_id": "302016",
@@ -918,11 +918,11 @@
         "event.code": 302016,
         "event.dataset": "cisco.ftd",
         "event.duration": 0,
-        "event.end": "2018-10-10T10:34:56.000-02:00",
+        "event.end": "2018-10-10T12:34:56.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302016: Teardown UDP connection 11762 for outside:100.66.238.126/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 111",
         "event.severity": 6,
-        "event.start": "2018-10-10T12:34:56.000Z",
+        "event.start": "2018-10-10T14:34:56.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "ftd",
         "host.hostname": "localhost",
@@ -942,7 +942,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.connection_id": "11763",
         "cisco.ftd.destination_interface": "inside",
         "cisco.ftd.message_id": "302016",
@@ -953,11 +953,11 @@
         "event.code": 302016,
         "event.dataset": "cisco.ftd",
         "event.duration": 0,
-        "event.end": "2018-10-10T10:34:56.000-02:00",
+        "event.end": "2018-10-10T12:34:56.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302016: Teardown UDP connection 11763 for outside:100.66.93.51/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 237",
         "event.severity": 6,
-        "event.start": "2018-10-10T12:34:56.000Z",
+        "event.start": "2018-10-10T14:34:56.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "ftd",
         "host.hostname": "localhost",
@@ -977,7 +977,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.message_id": "305011",
         "event.action": "firewall-rule",
         "event.code": 305011,
@@ -999,7 +999,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.message_id": "302013",
         "event.action": "firewall-rule",
         "event.code": 302013,
@@ -1021,7 +1021,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.message_id": "305011",
         "event.action": "firewall-rule",
         "event.code": 305011,
@@ -1043,7 +1043,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.message_id": "302015",
         "event.action": "firewall-rule",
         "event.code": 302015,
@@ -1065,7 +1065,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.message_id": "302015",
         "event.action": "firewall-rule",
         "event.code": 302015,
@@ -1087,7 +1087,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.connection_id": "11772",
         "cisco.ftd.destination_interface": "inside",
         "cisco.ftd.message_id": "302016",
@@ -1098,11 +1098,11 @@
         "event.code": 302016,
         "event.dataset": "cisco.ftd",
         "event.duration": 0,
-        "event.end": "2018-10-10T10:34:56.000-02:00",
+        "event.end": "2018-10-10T12:34:56.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302016: Teardown UDP connection 11772 for outside:100.66.240.126/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 87",
         "event.severity": 6,
-        "event.start": "2018-10-10T12:34:56.000Z",
+        "event.start": "2018-10-10T14:34:56.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "ftd",
         "host.hostname": "localhost",
@@ -1122,7 +1122,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.connection_id": "11773",
         "cisco.ftd.destination_interface": "inside",
         "cisco.ftd.message_id": "302016",
@@ -1133,11 +1133,11 @@
         "event.code": 302016,
         "event.dataset": "cisco.ftd",
         "event.duration": 0,
-        "event.end": "2018-10-10T10:34:56.000-02:00",
+        "event.end": "2018-10-10T12:34:56.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302016: Teardown UDP connection 11773 for outside:100.66.44.45/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 221",
         "event.severity": 6,
-        "event.start": "2018-10-10T12:34:56.000Z",
+        "event.start": "2018-10-10T14:34:56.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "ftd",
         "host.hostname": "localhost",
@@ -1157,7 +1157,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.message_id": "305011",
         "event.action": "firewall-rule",
         "event.code": 305011,
@@ -1179,7 +1179,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.message_id": "302013",
         "event.action": "firewall-rule",
         "event.code": 302013,
@@ -1201,7 +1201,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.message_id": "302015",
         "event.action": "firewall-rule",
         "event.code": 302015,
@@ -1223,7 +1223,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.message_id": "302015",
         "event.action": "firewall-rule",
         "event.code": 302015,
@@ -1245,7 +1245,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.connection_id": "11775",
         "cisco.ftd.destination_interface": "inside",
         "cisco.ftd.message_id": "302016",
@@ -1256,11 +1256,11 @@
         "event.code": 302016,
         "event.dataset": "cisco.ftd",
         "event.duration": 0,
-        "event.end": "2018-10-10T10:34:56.000-02:00",
+        "event.end": "2018-10-10T12:34:56.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302016: Teardown UDP connection 11775 for outside:100.66.157.232/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 101",
         "event.severity": 6,
-        "event.start": "2018-10-10T12:34:56.000Z",
+        "event.start": "2018-10-10T14:34:56.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "ftd",
         "host.hostname": "localhost",
@@ -1280,7 +1280,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.connection_id": "11776",
         "cisco.ftd.destination_interface": "inside",
         "cisco.ftd.message_id": "302016",
@@ -1291,11 +1291,11 @@
         "event.code": 302016,
         "event.dataset": "cisco.ftd",
         "event.duration": 0,
-        "event.end": "2018-10-10T10:34:56.000-02:00",
+        "event.end": "2018-10-10T12:34:56.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302016: Teardown UDP connection 11776 for outside:100.66.178.133/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 126",
         "event.severity": 6,
-        "event.start": "2018-10-10T12:34:56.000Z",
+        "event.start": "2018-10-10T14:34:56.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "ftd",
         "host.hostname": "localhost",
@@ -1315,7 +1315,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.message_id": "305011",
         "event.action": "firewall-rule",
         "event.code": 305011,
@@ -1337,7 +1337,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.message_id": "302013",
         "event.action": "firewall-rule",
         "event.code": 302013,
@@ -1359,7 +1359,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.connection_id": "11777",
         "cisco.ftd.destination_interface": "inside",
         "cisco.ftd.message_id": "302014",
@@ -1370,11 +1370,11 @@
         "event.code": 302014,
         "event.dataset": "cisco.ftd",
         "event.duration": 0,
-        "event.end": "2018-10-10T10:34:56.000-02:00",
+        "event.end": "2018-10-10T12:34:56.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302014: Teardown TCP connection 11777 for outside:100.66.133.112/80 to inside:172.31.98.44/1453 duration 0:00:00 bytes 862 TCP FINs",
         "event.severity": 6,
-        "event.start": "2018-10-10T12:34:56.000Z",
+        "event.start": "2018-10-10T14:34:56.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "ftd",
         "host.hostname": "localhost",
@@ -1394,7 +1394,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.message_id": "302015",
         "event.action": "firewall-rule",
         "event.code": 302015,
@@ -1416,7 +1416,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.connection_id": "11778",
         "cisco.ftd.destination_interface": "inside",
         "cisco.ftd.message_id": "302016",
@@ -1427,11 +1427,11 @@
         "event.code": 302016,
         "event.dataset": "cisco.ftd",
         "event.duration": 0,
-        "event.end": "2018-10-10T10:34:56.000-02:00",
+        "event.end": "2018-10-10T12:34:56.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302016: Teardown UDP connection 11778 for outside:100.66.157.232/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 104",
         "event.severity": 6,
-        "event.start": "2018-10-10T12:34:56.000Z",
+        "event.start": "2018-10-10T14:34:56.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "ftd",
         "host.hostname": "localhost",
@@ -1451,7 +1451,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.connection_id": "11779",
         "cisco.ftd.destination_interface": "inside",
         "cisco.ftd.message_id": "302016",
@@ -1462,11 +1462,11 @@
         "event.code": 302016,
         "event.dataset": "cisco.ftd",
         "event.duration": 0,
-        "event.end": "2018-10-10T10:34:56.000-02:00",
+        "event.end": "2018-10-10T12:34:56.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302016: Teardown UDP connection 11779 for outside:100.66.204.197/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 176",
         "event.severity": 6,
-        "event.start": "2018-10-10T12:34:56.000Z",
+        "event.start": "2018-10-10T14:34:56.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "ftd",
         "host.hostname": "localhost",
@@ -1486,7 +1486,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.message_id": "305011",
         "event.action": "firewall-rule",
         "event.code": 305011,
@@ -1508,7 +1508,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.message_id": "302013",
         "event.action": "firewall-rule",
         "event.code": 302013,
@@ -1530,7 +1530,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.message_id": "305011",
         "event.action": "firewall-rule",
         "event.code": 305011,
@@ -1552,7 +1552,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.message_id": "302013",
         "event.action": "firewall-rule",
         "event.code": 302013,
@@ -1574,7 +1574,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.message_id": "305011",
         "event.action": "firewall-rule",
         "event.code": 305011,
@@ -1596,7 +1596,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.message_id": "302013",
         "event.action": "firewall-rule",
         "event.code": 302013,
@@ -1618,7 +1618,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.message_id": "302015",
         "event.action": "firewall-rule",
         "event.code": 302015,
@@ -1640,7 +1640,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.connection_id": "11783",
         "cisco.ftd.destination_interface": "inside",
         "cisco.ftd.message_id": "302016",
@@ -1651,11 +1651,11 @@
         "event.code": 302016,
         "event.dataset": "cisco.ftd",
         "event.duration": 0,
-        "event.end": "2018-10-10T10:34:56.000-02:00",
+        "event.end": "2018-10-10T12:34:56.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302016: Teardown UDP connection 11783 for outside:100.66.100.4/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 104",
         "event.severity": 6,
-        "event.start": "2018-10-10T12:34:56.000Z",
+        "event.start": "2018-10-10T14:34:56.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "ftd",
         "host.hostname": "localhost",
@@ -1675,7 +1675,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.message_id": "305011",
         "event.action": "firewall-rule",
         "event.code": 305011,
@@ -1697,7 +1697,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.message_id": "302013",
         "event.action": "firewall-rule",
         "event.code": 302013,
@@ -1719,7 +1719,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.message_id": "305011",
         "event.action": "firewall-rule",
         "event.code": 305011,
@@ -1741,7 +1741,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.message_id": "302013",
         "event.action": "firewall-rule",
         "event.code": 302013,
@@ -1763,7 +1763,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.message_id": "302015",
         "event.action": "firewall-rule",
         "event.code": 302015,
@@ -1785,7 +1785,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.connection_id": "11784",
         "cisco.ftd.destination_interface": "inside",
         "cisco.ftd.message_id": "302014",
@@ -1796,11 +1796,11 @@
         "event.code": 302014,
         "event.dataset": "cisco.ftd",
         "event.duration": 0,
-        "event.end": "2018-10-10T10:34:56.000-02:00",
+        "event.end": "2018-10-10T12:34:56.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302014: Teardown TCP connection 11784 for outside:100.66.198.40/80 to inside:172.31.98.44/1457 duration 0:00:00 bytes 593 TCP FINs",
         "event.severity": 6,
-        "event.start": "2018-10-10T12:34:56.000Z",
+        "event.start": "2018-10-10T14:34:56.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "ftd",
         "host.hostname": "localhost",
@@ -1820,7 +1820,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.message_id": "305011",
         "event.action": "firewall-rule",
         "event.code": 305011,
@@ -1842,7 +1842,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.message_id": "302013",
         "event.action": "firewall-rule",
         "event.code": 302013,
@@ -1864,7 +1864,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.connection_id": "11786",
         "cisco.ftd.destination_interface": "inside",
         "cisco.ftd.message_id": "302016",
@@ -1875,11 +1875,11 @@
         "event.code": 302016,
         "event.dataset": "cisco.ftd",
         "event.duration": 0,
-        "event.end": "2018-10-10T10:34:56.000-02:00",
+        "event.end": "2018-10-10T12:34:56.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302016: Teardown UDP connection 11786 for outside:100.66.1.107/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 375",
         "event.severity": 6,
-        "event.start": "2018-10-10T12:34:56.000Z",
+        "event.start": "2018-10-10T14:34:56.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "ftd",
         "host.hostname": "localhost",
@@ -1899,7 +1899,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.message_id": "305011",
         "event.action": "firewall-rule",
         "event.code": 305011,
@@ -1921,7 +1921,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.message_id": "302013",
         "event.action": "firewall-rule",
         "event.code": 302013,
@@ -1943,7 +1943,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.message_id": "305012",
         "event.action": "firewall-rule",
         "event.code": 305012,
@@ -1965,7 +1965,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.message_id": "305011",
         "event.action": "firewall-rule",
         "event.code": 305011,
@@ -1987,7 +1987,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.message_id": "302013",
         "event.action": "firewall-rule",
         "event.code": 302013,
@@ -2009,7 +2009,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.message_id": "305012",
         "event.action": "firewall-rule",
         "event.code": 305012,
@@ -2031,7 +2031,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.message_id": "305012",
         "event.action": "firewall-rule",
         "event.code": 305012,
@@ -2053,7 +2053,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.message_id": "305012",
         "event.action": "firewall-rule",
         "event.code": 305012,
@@ -2075,7 +2075,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.message_id": "305012",
         "event.action": "firewall-rule",
         "event.code": 305012,
@@ -2097,7 +2097,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.message_id": "305012",
         "event.action": "firewall-rule",
         "event.code": 305012,
@@ -2119,7 +2119,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.message_id": "305012",
         "event.action": "firewall-rule",
         "event.code": 305012,
@@ -2141,7 +2141,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.connection_id": "11564",
         "cisco.ftd.destination_interface": "inside",
         "cisco.ftd.message_id": "302014",
@@ -2152,11 +2152,11 @@
         "event.code": 302014,
         "event.dataset": "cisco.ftd",
         "event.duration": 325000000000,
-        "event.end": "2018-10-10T10:34:56.000-02:00",
+        "event.end": "2018-10-10T12:34:56.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302014: Teardown TCP connection 11564 for outside:100.66.115.46/80 to inside:172.31.156.80/1382 duration 0:05:25 bytes 575 TCP FINs",
         "event.severity": 6,
-        "event.start": "2018-10-10T12:29:31.000Z",
+        "event.start": "2018-10-10T14:29:31.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "ftd",
         "host.hostname": "localhost",
@@ -2176,7 +2176,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.connection_id": "11797",
         "cisco.ftd.destination_interface": "inside",
         "cisco.ftd.message_id": "302014",
@@ -2187,11 +2187,11 @@
         "event.code": 302014,
         "event.dataset": "cisco.ftd",
         "event.duration": 0,
-        "event.end": "2018-10-10T10:34:56.000-02:00",
+        "event.end": "2018-10-10T12:34:56.000-02:00",
         "event.module": "cisco",
         "event.original": "%ASA-6-302014: Teardown TCP connection 11797 for outside:100.66.19.254/80 to inside:172.31.156.80/1385 duration 0:00:00 bytes 5391 TCP Reset-I",
         "event.severity": 6,
-        "event.start": "2018-10-10T12:34:56.000Z",
+        "event.start": "2018-10-10T14:34:56.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "ftd",
         "host.hostname": "localhost",
@@ -2211,7 +2211,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.message_id": "305011",
         "event.action": "firewall-rule",
         "event.code": 305011,
@@ -2233,7 +2233,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.message_id": "302013",
         "event.action": "firewall-rule",
         "event.code": 302013,
@@ -2255,7 +2255,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.destination_interface": "inside",
         "cisco.ftd.message_id": "106023",
         "cisco.ftd.rule_name": "inbound",
@@ -2287,7 +2287,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.destination_interface": "inside",
         "cisco.ftd.message_id": "106023",
         "cisco.ftd.rule_name": "inbound",
@@ -2319,7 +2319,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.destination_interface": "inside",
         "cisco.ftd.message_id": "106023",
         "cisco.ftd.rule_name": "inbound",
@@ -2351,7 +2351,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.destination_interface": "inside",
         "cisco.ftd.message_id": "106023",
         "cisco.ftd.rule_name": "inbound",
@@ -2383,7 +2383,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.destination_interface": "inside",
         "cisco.ftd.message_id": "106023",
         "cisco.ftd.rule_name": "inbound",
@@ -2415,7 +2415,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.destination_interface": "inside",
         "cisco.ftd.message_id": "106023",
         "cisco.ftd.rule_name": "inbound",
@@ -2447,7 +2447,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.destination_interface": "inside",
         "cisco.ftd.message_id": "106023",
         "cisco.ftd.rule_name": "inbound",
@@ -2479,7 +2479,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.destination_interface": "inside",
         "cisco.ftd.message_id": "106023",
         "cisco.ftd.rule_name": "inbound",
@@ -2511,7 +2511,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.destination_interface": "inside",
         "cisco.ftd.message_id": "106023",
         "cisco.ftd.rule_name": "inbound",
@@ -2543,7 +2543,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.destination_interface": "inside",
         "cisco.ftd.message_id": "106023",
         "cisco.ftd.rule_name": "inbound",
@@ -2575,7 +2575,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.destination_interface": "inside",
         "cisco.ftd.message_id": "106023",
         "cisco.ftd.rule_name": "inbound",
@@ -2607,7 +2607,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.destination_interface": "inside",
         "cisco.ftd.message_id": "106023",
         "cisco.ftd.rule_name": "inbound",
@@ -2639,7 +2639,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.destination_interface": "inside",
         "cisco.ftd.message_id": "106023",
         "cisco.ftd.rule_name": "inbound",
@@ -2671,7 +2671,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.message_id": "305011",
         "event.action": "firewall-rule",
         "event.code": 305011,
@@ -2693,7 +2693,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.message_id": "302013",
         "event.action": "firewall-rule",
         "event.code": 302013,
@@ -2715,7 +2715,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.message_id": "305011",
         "event.action": "firewall-rule",
         "event.code": 305011,
@@ -2737,7 +2737,7 @@
         ]
     },
     {
-        "@timestamp": "2018-10-10T10:34:56.000-02:00",
+        "@timestamp": "2018-10-10T12:34:56.000-02:00",
         "cisco.ftd.message_id": "302015",
         "event.action": "firewall-rule",
         "event.code": 302015,

--- a/x-pack/filebeat/module/cisco/ftd/test/filtered.log-expected.json
+++ b/x-pack/filebeat/module/cisco/ftd/test/filtered.log-expected.json
@@ -1,6 +1,6 @@
 [
     {
-        "@timestamp": "2018-12-31T23:00:27.000-02:00",
+        "@timestamp": "2019-01-01T01:00:27.000-02:00",
         "cisco.ftd.message_id": "999999",
         "event.action": "firewall-rule",
         "event.code": 999999,

--- a/x-pack/filebeat/module/cisco/ftd/test/firepower-management.log-expected.json
+++ b/x-pack/filebeat/module/cisco/ftd/test/firepower-management.log-expected.json
@@ -1,6 +1,6 @@
 [
     {
-        "@timestamp": "2019-08-14T11:56:30.000-02:00",
+        "@timestamp": "2019-08-14T13:56:30.000-02:00",
         "event.dataset": "cisco.ftd",
         "event.module": "cisco",
         "event.original": "siem-management: admin@10.0.255.31, System > Configuration > Configuration > /platinum/platformSettingEdit.cgi?type=AuditLog, Page View\u0000x0a\u0000x00",
@@ -18,7 +18,7 @@
         ]
     },
     {
-        "@timestamp": "2019-08-14T11:57:19.000-02:00",
+        "@timestamp": "2019-08-14T13:57:19.000-02:00",
         "event.dataset": "cisco.ftd",
         "event.module": "cisco",
         "event.original": "siem-management: admin@10.0.255.31, System > Configuration > Configuration > /platinum/platformSettingEdit.cgi?type=Banner, Page View\u0000x0a\u0000x00",
@@ -36,7 +36,7 @@
         ]
     },
     {
-        "@timestamp": "2019-08-14T11:57:26.000-02:00",
+        "@timestamp": "2019-08-14T13:57:26.000-02:00",
         "event.dataset": "cisco.ftd",
         "event.module": "cisco",
         "event.original": "siem-management: admin@10.0.255.31, System > Configuration > Configuration > /platinum/ChangeReconciliation.cgi, Page View\u0000x0a\u0000x00",
@@ -54,7 +54,7 @@
         ]
     },
     {
-        "@timestamp": "2019-08-14T11:57:34.000-02:00",
+        "@timestamp": "2019-08-14T13:57:34.000-02:00",
         "event.dataset": "cisco.ftd",
         "event.module": "cisco",
         "event.original": "siem-management: admin@10.0.255.31, System > Configuration > Configuration > /platinum/platformSettingEdit.cgi?type=IntrusionPolicyPrefs, Page View\u0000x0a\u0000x00",
@@ -72,7 +72,7 @@
         ]
     },
     {
-        "@timestamp": "2019-08-14T11:57:43.000-02:00",
+        "@timestamp": "2019-08-14T13:57:43.000-02:00",
         "event.dataset": "cisco.ftd",
         "event.module": "cisco",
         "event.original": "siem-management: admin@10.0.255.31, System > Configuration > Configuration > /admin/lights_out_mgmt.cgi, Page View\u0000x0a\u0000x00",
@@ -90,7 +90,7 @@
         ]
     },
     {
-        "@timestamp": "2019-08-14T11:58:02.000-02:00",
+        "@timestamp": "2019-08-14T13:58:02.000-02:00",
         "event.dataset": "cisco.ftd",
         "event.module": "cisco",
         "event.original": "siem-management: admin@10.0.255.31, Cloud Services, View url filtering settings\u0000x0a\u0000x00",
@@ -108,7 +108,7 @@
         ]
     },
     {
-        "@timestamp": "2019-08-14T11:58:02.000-02:00",
+        "@timestamp": "2019-08-14T13:58:02.000-02:00",
         "event.dataset": "cisco.ftd",
         "event.module": "cisco",
         "event.original": "siem-management: admin@10.0.255.31, Cloud Services, View amp settings\u0000x0a\u0000x00",
@@ -126,7 +126,7 @@
         ]
     },
     {
-        "@timestamp": "2019-08-14T11:58:20.000-02:00",
+        "@timestamp": "2019-08-14T13:58:20.000-02:00",
         "event.dataset": "cisco.ftd",
         "event.module": "cisco",
         "event.original": "siem-management: admin@10.0.255.31, System > Monitoring > Syslog, Page View\u0000x0a\u0000x00",
@@ -144,7 +144,7 @@
         ]
     },
     {
-        "@timestamp": "2019-08-14T11:58:41.000-02:00",
+        "@timestamp": "2019-08-14T13:58:41.000-02:00",
         "event.dataset": "cisco.ftd",
         "event.module": "cisco",
         "event.original": "siem-management: admin@10.0.255.31, Devices > Device Management, Page View\u0000x0a\u0000x00",
@@ -162,7 +162,7 @@
         ]
     },
     {
-        "@timestamp": "2019-08-14T11:58:47.000-02:00",
+        "@timestamp": "2019-08-14T13:58:47.000-02:00",
         "event.dataset": "cisco.ftd",
         "event.module": "cisco",
         "event.original": "siem-management: admin@10.0.255.31, Devices > Device Management > NGFW Interfaces, Page View\u0000x0a\u0000x00",
@@ -180,7 +180,7 @@
         ]
     },
     {
-        "@timestamp": "2019-08-14T11:58:52.000-02:00",
+        "@timestamp": "2019-08-14T13:58:52.000-02:00",
         "event.dataset": "cisco.ftd",
         "event.module": "cisco",
         "event.original": "siem-management: admin@10.0.255.31, Devices > Device Management > NGFW Device Summary, Page View\u0000x0a\u0000x00",
@@ -198,7 +198,7 @@
         ]
     },
     {
-        "@timestamp": "2019-08-14T11:58:54.000-02:00",
+        "@timestamp": "2019-08-14T13:58:54.000-02:00",
         "event.dataset": "cisco.ftd",
         "event.module": "cisco",
         "event.original": "siem-management: admin@10.0.255.31, Devices > Device Management > NGFW Device Summary, Page View\u0000x0a\u0000x00",
@@ -216,7 +216,7 @@
         ]
     },
     {
-        "@timestamp": "2019-08-14T11:59:10.000-02:00",
+        "@timestamp": "2019-08-14T13:59:10.000-02:00",
         "event.dataset": "cisco.ftd",
         "event.module": "cisco",
         "event.original": "siem-management: admin@10.0.255.31, Devices > Platform Settings, Page View\u0000x0a\u0000x00",
@@ -234,7 +234,7 @@
         ]
     },
     {
-        "@timestamp": "2019-08-14T11:59:15.000-02:00",
+        "@timestamp": "2019-08-14T13:59:15.000-02:00",
         "event.dataset": "cisco.ftd",
         "event.module": "cisco",
         "event.original": "siem-management: admin@10.0.255.31, Devices > Platform Settings > Platform Settings Editor, Page View\u0000x0a\u0000x00",
@@ -252,7 +252,7 @@
         ]
     },
     {
-        "@timestamp": "2019-08-14T12:00:37.000-02:00",
+        "@timestamp": "2019-08-14T14:00:37.000-02:00",
         "event.dataset": "cisco.ftd",
         "event.module": "cisco",
         "event.original": "siem-management: admin@10.0.255.31, Devices > Platform Settings > Platform Settings Editor, Save Policy ftd-policy\u0000x0a\u0000x00",
@@ -270,7 +270,7 @@
         ]
     },
     {
-        "@timestamp": "2019-08-14T12:00:37.000-02:00",
+        "@timestamp": "2019-08-14T14:00:37.000-02:00",
         "event.dataset": "cisco.ftd",
         "event.module": "cisco",
         "event.original": "siem-management: admin@10.0.255.31, Devices > Platform Settings > Platform Settings Editor, Modified: Syslog\u0000x0a\u0000x00",
@@ -288,7 +288,7 @@
         ]
     },
     {
-        "@timestamp": "2019-08-14T12:00:37.000-02:00",
+        "@timestamp": "2019-08-14T14:00:37.000-02:00",
         "event.dataset": "cisco.ftd",
         "event.module": "cisco",
         "event.original": "siem-management: admin@10.0.255.31, Devices > Platform Settings > Platform Settings Editor, Page View\u0000x0a\u0000x00",
@@ -306,7 +306,7 @@
         ]
     },
     {
-        "@timestamp": "2019-08-14T12:01:12.000-02:00",
+        "@timestamp": "2019-08-14T14:01:12.000-02:00",
         "event.dataset": "cisco.ftd",
         "event.module": "cisco",
         "event.original": "siem-management: admin@10.0.255.31, Devices > Platform Settings > Platform Settings Editor, Save Policy ftd-policy\u0000x0a\u0000x00",
@@ -324,7 +324,7 @@
         ]
     },
     {
-        "@timestamp": "2019-08-14T12:01:12.000-02:00",
+        "@timestamp": "2019-08-14T14:01:12.000-02:00",
         "event.dataset": "cisco.ftd",
         "event.module": "cisco",
         "event.original": "siem-management: admin@10.0.255.31, Devices > Platform Settings > Platform Settings Editor, Modified: Syslog\u0000x0a\u0000x00",
@@ -342,7 +342,7 @@
         ]
     },
     {
-        "@timestamp": "2019-08-14T12:01:13.000-02:00",
+        "@timestamp": "2019-08-14T14:01:13.000-02:00",
         "event.dataset": "cisco.ftd",
         "event.module": "cisco",
         "event.original": "siem-management: admin@10.0.255.31, Devices > Platform Settings > Platform Settings Editor, Page View\u0000x0a\u0000x00",
@@ -360,7 +360,7 @@
         ]
     },
     {
-        "@timestamp": "2019-08-14T12:01:20.000-02:00",
+        "@timestamp": "2019-08-14T14:01:20.000-02:00",
         "event.dataset": "cisco.ftd",
         "event.module": "cisco",
         "event.original": "siem-management: csm_processes@Default User IP, Login, Login Success\u0000x0a\u0000x00",
@@ -378,7 +378,7 @@
         ]
     },
     {
-        "@timestamp": "2019-08-14T12:01:31.000-02:00",
+        "@timestamp": "2019-08-14T14:01:31.000-02:00",
         "event.dataset": "cisco.ftd",
         "event.module": "cisco",
         "event.original": "siem-management: csm_processes@Default User IP, Login, Login Success\u0000x0a\u0000x00",
@@ -396,7 +396,7 @@
         ]
     },
     {
-        "@timestamp": "2019-08-14T12:01:31.000-02:00",
+        "@timestamp": "2019-08-14T14:01:31.000-02:00",
         "event.dataset": "cisco.ftd",
         "event.module": "cisco",
         "event.original": "siem-management: admin@localhost, Task Queue, Successful task completion : Pre-deploy Global Configuration Generation\u0000x0a\u0000x00",
@@ -414,7 +414,7 @@
         ]
     },
     {
-        "@timestamp": "2019-08-14T12:01:35.000-02:00",
+        "@timestamp": "2019-08-14T14:01:35.000-02:00",
         "event.dataset": "cisco.ftd",
         "event.module": "cisco",
         "event.original": "siem-management: csm_processes@Default User IP, Login, Login Success\u0000x0a\u0000x00",
@@ -432,7 +432,7 @@
         ]
     },
     {
-        "@timestamp": "2019-08-14T12:01:36.000-02:00",
+        "@timestamp": "2019-08-14T14:01:36.000-02:00",
         "event.dataset": "cisco.ftd",
         "event.module": "cisco",
         "event.original": "siem-management: admin@localhost, Task Queue, Successful task completion : Pre-deploy Device Configuration for siem-ftd\u0000x0a\u0000x00",
@@ -450,7 +450,7 @@
         ]
     },
     {
-        "@timestamp": "2019-08-14T12:01:55.000-02:00",
+        "@timestamp": "2019-08-14T14:01:55.000-02:00",
         "event.dataset": "cisco.ftd",
         "event.module": "cisco",
         "event.original": "siem-management: admin@10.0.255.31, System > Configuration > Configuration, Page View\u0000x0a\u0000x00",
@@ -468,7 +468,7 @@
         ]
     },
     {
-        "@timestamp": "2019-08-14T12:01:56.000-02:00",
+        "@timestamp": "2019-08-14T14:01:56.000-02:00",
         "event.dataset": "cisco.ftd",
         "event.module": "cisco",
         "event.original": "siem-management: admin@localhost, Task Queue, Policy Deployment to siem-ftd - SUCCESS\u0000x0a\u0000x00",
@@ -486,7 +486,7 @@
         ]
     },
     {
-        "@timestamp": "2019-08-14T12:01:57.000-02:00",
+        "@timestamp": "2019-08-14T14:01:57.000-02:00",
         "event.dataset": "cisco.ftd",
         "event.module": "cisco",
         "event.original": "siem-management: csm_processes@Default User IP, Login, Login Success\u0000x0a\u0000x00",
@@ -504,7 +504,7 @@
         ]
     },
     {
-        "@timestamp": "2019-08-14T12:02:03.000-02:00",
+        "@timestamp": "2019-08-14T14:02:03.000-02:00",
         "event.dataset": "cisco.ftd",
         "event.module": "cisco",
         "event.original": "siem-management: admin@10.0.255.31, System > Monitoring > Syslog, Page View\u0000x0a\u0000x00",
@@ -522,7 +522,7 @@
         ]
     },
     {
-        "@timestamp": "2019-08-14T12:02:11.000-02:00",
+        "@timestamp": "2019-08-14T14:02:11.000-02:00",
         "event.dataset": "cisco.ftd",
         "event.module": "cisco",
         "event.original": "siem-management: admin@10.0.255.31, System > Monitoring > Audit, Page View\u0000x0a\u0000x00",
@@ -540,7 +540,7 @@
         ]
     },
     {
-        "@timestamp": "2019-08-14T12:02:19.000-02:00",
+        "@timestamp": "2019-08-14T14:02:19.000-02:00",
         "event.dataset": "cisco.ftd",
         "event.module": "cisco",
         "event.original": "siem-management: admin@10.0.255.31, System > Configuration > Configuration, Page View\u0000x0a\u0000x00",
@@ -558,7 +558,7 @@
         ]
     },
     {
-        "@timestamp": "2019-08-14T12:02:31.000-02:00",
+        "@timestamp": "2019-08-14T14:02:31.000-02:00",
         "event.dataset": "cisco.ftd",
         "event.module": "cisco",
         "event.original": "siem-management: admin@10.0.255.31, System > Configuration > Configuration > /platinum/platformSettingEdit.cgi?type=AuditLog, Page View\u0000x0a\u0000x00",
@@ -576,7 +576,7 @@
         ]
     },
     {
-        "@timestamp": "2019-08-14T12:02:38.000-02:00",
+        "@timestamp": "2019-08-14T14:02:38.000-02:00",
         "event.dataset": "cisco.ftd",
         "event.module": "cisco",
         "event.original": "siem-management: admin@10.0.255.31, Devices > Platform Settings > Local System Configuration, Save Local System Configuration\u0000x0a\u0000x00",
@@ -594,7 +594,7 @@
         ]
     },
     {
-        "@timestamp": "2019-08-14T12:02:38.000-02:00",
+        "@timestamp": "2019-08-14T14:02:38.000-02:00",
         "event.dataset": "cisco.ftd",
         "event.module": "cisco",
         "event.original": "siem-management: admin@10.0.255.31, Devices > Platform Settings > Audit Log Settings >  Modified: Send Audit Log to Syslog enabled > Disabled",

--- a/x-pack/filebeat/module/cisco/ftd/test/no-type-id.log-expected.json
+++ b/x-pack/filebeat/module/cisco/ftd/test/no-type-id.log-expected.json
@@ -1,6 +1,6 @@
 [
     {
-        "@timestamp": "2018-01-10T23:00:27.000-02:00",
+        "@timestamp": "2018-01-11T01:00:27.000-02:00",
         "cisco.ftd.message_id": "430001",
         "cisco.ftd.security.application_protocol": "http",
         "cisco.ftd.security.client": "webserver",
@@ -32,7 +32,7 @@
         ]
     },
     {
-        "@timestamp": "2018-01-10T23:00:27.000-02:00",
+        "@timestamp": "2018-01-11T01:00:27.000-02:00",
         "cisco.ftd.message_id": "430001",
         "cisco.ftd.security.http_response": "404",
         "cisco.ftd.security.message": "Some message here (1:36330:2).",
@@ -58,7 +58,7 @@
         ]
     },
     {
-        "@timestamp": "2018-01-10T23:00:27.000-02:00",
+        "@timestamp": "2018-01-11T01:00:27.000-02:00",
         "cisco.ftd.message_id": "430002",
         "cisco.ftd.security.http_response": "404",
         "cisco.ftd.security.message": "Some message here (1:36330:2)",
@@ -84,7 +84,7 @@
         ]
     },
     {
-        "@timestamp": "2018-01-10T23:00:27.000-02:00",
+        "@timestamp": "2018-01-11T01:00:27.000-02:00",
         "cisco.ftd.message_id": "430005",
         "cisco.ftd.security.dst_ip": "192.168.3.33",
         "cisco.ftd.security.dst_port": "64311",

--- a/x-pack/filebeat/module/cisco/ftd/test/sample.log-expected.json
+++ b/x-pack/filebeat/module/cisco/ftd/test/sample.log-expected.json
@@ -1,6 +1,6 @@
 [
     {
-        "@timestamp": "2013-04-15T07:36:50.000-02:00",
+        "@timestamp": "2013-04-15T09:36:50.000-02:00",
         "cisco.ftd.destination_interface": "outside",
         "cisco.ftd.message_id": "106023",
         "cisco.ftd.rule_name": "acl_dmz",
@@ -29,7 +29,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-15T07:36:50.000-02:00",
+        "@timestamp": "2013-04-15T09:36:50.000-02:00",
         "cisco.ftd.destination_interface": "outside",
         "cisco.ftd.message_id": "106023",
         "cisco.ftd.rule_name": "acl_dmz",
@@ -58,7 +58,7 @@
         ]
     },
     {
-        "@timestamp": "2014-04-15T11:34:34.000-02:00",
+        "@timestamp": "2014-04-15T09:34:34.000-04:00",
         "cisco.ftd.destination_interface": "outside",
         "cisco.ftd.message_id": "106100",
         "cisco.ftd.rule_name": "acl_in",
@@ -88,7 +88,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-24T14:00:28.000-02:00",
+        "@timestamp": "2013-04-24T16:00:28.000-02:00",
         "cisco.ftd.destination_interface": "outside",
         "cisco.ftd.message_id": "106100",
         "cisco.ftd.rule_name": "inside",
@@ -118,7 +118,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-24T14:00:27.000-02:00",
+        "@timestamp": "2013-04-24T16:00:27.000-02:00",
         "cisco.ftd.destination_interface": "outside",
         "cisco.ftd.message_id": "106100",
         "cisco.ftd.rule_name": "inside",
@@ -148,7 +148,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-29T10:59:50.000-02:00",
+        "@timestamp": "2013-04-29T12:59:50.000-02:00",
         "cisco.ftd.message_id": "305011",
         "event.action": "firewall-rule",
         "event.code": 305011,
@@ -167,7 +167,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-29T10:59:50.000-02:00",
+        "@timestamp": "2013-04-29T12:59:50.000-02:00",
         "cisco.ftd.message_id": "302013",
         "event.action": "firewall-rule",
         "event.code": 302013,
@@ -186,7 +186,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-29T10:59:50.000-02:00",
+        "@timestamp": "2013-04-29T12:59:50.000-02:00",
         "cisco.ftd.message_id": "305011",
         "event.action": "firewall-rule",
         "event.code": 305011,
@@ -205,7 +205,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-29T10:59:50.000-02:00",
+        "@timestamp": "2013-04-29T12:59:50.000-02:00",
         "cisco.ftd.message_id": "302015",
         "event.action": "firewall-rule",
         "event.code": 302015,
@@ -224,7 +224,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-29T10:59:50.000-02:00",
+        "@timestamp": "2013-04-29T12:59:50.000-02:00",
         "cisco.ftd.message_id": "305011",
         "event.action": "firewall-rule",
         "event.code": 305011,
@@ -243,7 +243,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-29T10:59:50.000-02:00",
+        "@timestamp": "2013-04-29T12:59:50.000-02:00",
         "cisco.ftd.message_id": "302013",
         "event.action": "firewall-rule",
         "event.code": 302013,
@@ -262,7 +262,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-29T10:59:50.000-02:00",
+        "@timestamp": "2013-04-29T12:59:50.000-02:00",
         "cisco.ftd.connection_id": "89743275",
         "cisco.ftd.destination_interface": "inside",
         "cisco.ftd.message_id": "302016",
@@ -273,11 +273,11 @@
         "event.code": 302016,
         "event.dataset": "cisco.ftd",
         "event.duration": 5025000000000,
-        "event.end": "2013-04-29T10:59:50.000-02:00",
+        "event.end": "2013-04-29T12:59:50.000-02:00",
         "event.module": "cisco",
         "event.original": "%FTD-6-302016: Teardown UDP connection 89743275 for outside:192.0.2.222/53 to inside:10.123.1.35/52925 duration 1:23:45 bytes 140",
         "event.severity": 6,
-        "event.start": "2013-04-29T11:36:05.000Z",
+        "event.start": "2013-04-29T13:36:05.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "ftd",
         "input.type": "log",
@@ -294,7 +294,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-29T10:59:50.000-02:00",
+        "@timestamp": "2013-04-29T12:59:50.000-02:00",
         "cisco.ftd.connection_id": "666",
         "cisco.ftd.destination_interface": "inside",
         "cisco.ftd.destination_username": "user2",
@@ -307,11 +307,11 @@
         "event.code": 302016,
         "event.dataset": "cisco.ftd",
         "event.duration": 36000000000000,
-        "event.end": "2013-04-29T10:59:50.000-02:00",
+        "event.end": "2013-04-29T12:59:50.000-02:00",
         "event.module": "cisco",
         "event.original": "%FTD-6-302016: Teardown UDP connection 666 for outside:192.0.2.222/53 user1 to inside:10.123.1.35/52925 user2 duration 10:00:00 bytes 9999999",
         "event.severity": 6,
-        "event.start": "2013-04-29T02:59:50.000Z",
+        "event.start": "2013-04-29T04:59:50.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "ftd",
         "input.type": "log",
@@ -328,7 +328,7 @@
         ]
     },
     {
-        "@timestamp": "2011-06-04T19:59:52.000-02:00",
+        "@timestamp": "2011-06-04T21:59:52.000-02:00",
         "cisco.ftd.icmp_code": 17233,
         "cisco.ftd.mapped_source_ip": "192.168.132.46",
         "cisco.ftd.message_id": "302021",
@@ -354,7 +354,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-29T10:59:50.000-02:00",
+        "@timestamp": "2013-04-29T12:59:50.000-02:00",
         "cisco.ftd.message_id": "305011",
         "event.action": "firewall-rule",
         "event.code": 305011,
@@ -373,7 +373,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-29T10:59:50.000-02:00",
+        "@timestamp": "2013-04-29T12:59:50.000-02:00",
         "cisco.ftd.message_id": "302013",
         "event.action": "firewall-rule",
         "event.code": 302013,
@@ -392,7 +392,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-30T07:22:33.000-02:00",
+        "@timestamp": "2013-04-30T09:22:33.000-02:00",
         "cisco.ftd.message_id": "106007",
         "destination.ip": "10.1.2.60",
         "destination.port": 53,
@@ -420,7 +420,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-30T07:22:38.000-02:00",
+        "@timestamp": "2013-04-30T09:22:38.000-02:00",
         "cisco.ftd.destination_interface": "outside",
         "cisco.ftd.message_id": "106100",
         "cisco.ftd.rule_name": "acl_in",
@@ -449,7 +449,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-30T07:22:38.000-02:00",
+        "@timestamp": "2013-04-30T09:22:38.000-02:00",
         "cisco.ftd.destination_interface": "outside",
         "cisco.ftd.message_id": "106100",
         "cisco.ftd.rule_name": "acl_in",
@@ -478,7 +478,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-30T07:22:39.000-02:00",
+        "@timestamp": "2013-04-30T09:22:39.000-02:00",
         "cisco.ftd.destination_interface": "outside",
         "cisco.ftd.message_id": "106100",
         "cisco.ftd.rule_name": "acl_in",
@@ -507,7 +507,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-30T07:22:39.000-02:00",
+        "@timestamp": "2013-04-30T09:22:39.000-02:00",
         "cisco.ftd.destination_interface": "outside",
         "cisco.ftd.message_id": "106100",
         "cisco.ftd.rule_name": "acl_in",
@@ -536,7 +536,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-30T07:22:39.000-02:00",
+        "@timestamp": "2013-04-30T09:22:39.000-02:00",
         "cisco.ftd.destination_interface": "outside",
         "cisco.ftd.message_id": "106100",
         "cisco.ftd.rule_name": "acl_in",
@@ -565,7 +565,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-30T07:22:40.000-02:00",
+        "@timestamp": "2013-04-30T09:22:40.000-02:00",
         "cisco.ftd.destination_interface": "outside",
         "cisco.ftd.message_id": "106100",
         "cisco.ftd.rule_name": "acl_in",
@@ -594,7 +594,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-30T07:22:41.000-02:00",
+        "@timestamp": "2013-04-30T09:22:41.000-02:00",
         "cisco.ftd.destination_interface": "outside",
         "cisco.ftd.message_id": "106100",
         "cisco.ftd.rule_name": "acl_in",
@@ -623,7 +623,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-30T07:22:47.000-02:00",
+        "@timestamp": "2013-04-30T09:22:47.000-02:00",
         "cisco.ftd.destination_interface": "outside",
         "cisco.ftd.message_id": "106100",
         "cisco.ftd.rule_name": "acl_in",
@@ -652,7 +652,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-30T07:22:48.000-02:00",
+        "@timestamp": "2013-04-30T09:22:48.000-02:00",
         "cisco.ftd.destination_interface": "dmz",
         "cisco.ftd.message_id": "106100",
         "cisco.ftd.rule_name": "acl_in",
@@ -681,7 +681,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-30T07:22:56.000-02:00",
+        "@timestamp": "2013-04-30T09:22:56.000-02:00",
         "cisco.ftd.destination_interface": "outside",
         "cisco.ftd.message_id": "106100",
         "cisco.ftd.rule_name": "acl_in",
@@ -710,7 +710,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-30T07:23:02.000-02:00",
+        "@timestamp": "2013-04-30T09:23:02.000-02:00",
         "cisco.ftd.message_id": "106006",
         "cisco.ftd.source_interface": "inside",
         "destination.ip": "10.1.2.42",
@@ -738,7 +738,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-30T07:23:03.000-02:00",
+        "@timestamp": "2013-04-30T09:23:03.000-02:00",
         "cisco.ftd.message_id": "106007",
         "destination.ip": "10.1.5.60",
         "destination.port": 53,
@@ -766,7 +766,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-30T07:23:06.000-02:00",
+        "@timestamp": "2013-04-30T09:23:06.000-02:00",
         "cisco.ftd.destination_interface": "outside",
         "cisco.ftd.message_id": "106100",
         "cisco.ftd.rule_name": "acl_in",
@@ -795,7 +795,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-30T07:23:08.000-02:00",
+        "@timestamp": "2013-04-30T09:23:08.000-02:00",
         "cisco.ftd.destination_interface": "outside",
         "cisco.ftd.message_id": "106100",
         "cisco.ftd.rule_name": "acl_in",
@@ -824,7 +824,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-30T07:23:15.000-02:00",
+        "@timestamp": "2013-04-30T09:23:15.000-02:00",
         "cisco.ftd.destination_interface": "outside",
         "cisco.ftd.message_id": "106100",
         "cisco.ftd.rule_name": "acl_in",
@@ -853,7 +853,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-30T07:23:24.000-02:00",
+        "@timestamp": "2013-04-30T09:23:24.000-02:00",
         "cisco.ftd.destination_interface": "outside",
         "cisco.ftd.message_id": "106100",
         "cisco.ftd.rule_name": "acl_in",
@@ -882,7 +882,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-30T07:23:34.000-02:00",
+        "@timestamp": "2013-04-30T09:23:34.000-02:00",
         "cisco.ftd.destination_interface": "outside",
         "cisco.ftd.message_id": "106100",
         "cisco.ftd.rule_name": "acl_in",
@@ -911,7 +911,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-30T07:23:40.000-02:00",
+        "@timestamp": "2013-04-30T09:23:40.000-02:00",
         "cisco.ftd.destination_interface": "inside",
         "cisco.ftd.message_id": "106023",
         "cisco.ftd.rule_name": "acl_out",
@@ -940,7 +940,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-30T07:23:41.000-02:00",
+        "@timestamp": "2013-04-30T09:23:41.000-02:00",
         "cisco.ftd.destination_interface": "inside",
         "cisco.ftd.message_id": "106023",
         "cisco.ftd.rule_name": "acl_out",
@@ -969,7 +969,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-30T07:23:43.000-02:00",
+        "@timestamp": "2013-04-30T09:23:43.000-02:00",
         "cisco.ftd.destination_interface": "outside",
         "cisco.ftd.message_id": "106100",
         "cisco.ftd.rule_name": "acl_in",
@@ -998,7 +998,7 @@
         ]
     },
     {
-        "@timestamp": "2013-04-30T07:23:43.000-02:00",
+        "@timestamp": "2013-04-30T09:23:43.000-02:00",
         "cisco.ftd.destination_interface": "outside",
         "cisco.ftd.message_id": "106100",
         "cisco.ftd.rule_name": "acl_in",
@@ -1027,7 +1027,7 @@
         ]
     },
     {
-        "@timestamp": "2018-04-15T11:34:34.000-02:00",
+        "@timestamp": "2018-04-15T09:34:34.000-04:00",
         "cisco.ftd.destination_interface": "outside",
         "cisco.ftd.message_id": "106100",
         "cisco.ftd.rule_name": "acl_in",
@@ -1057,7 +1057,7 @@
         ]
     },
     {
-        "@timestamp": "2018-12-11T06:01:24.000-02:00",
+        "@timestamp": "2018-12-11T08:01:24.000-02:00",
         "cisco.ftd.message_id": "302015",
         "event.action": "firewall-rule",
         "event.code": 302015,
@@ -1077,7 +1077,7 @@
         ]
     },
     {
-        "@timestamp": "2018-12-11T06:01:24.000-02:00",
+        "@timestamp": "2018-12-11T08:01:24.000-02:00",
         "cisco.ftd.message_id": "302015",
         "event.action": "firewall-rule",
         "event.code": 302015,
@@ -1097,7 +1097,7 @@
         ]
     },
     {
-        "@timestamp": "2018-12-11T06:01:24.000-02:00",
+        "@timestamp": "2018-12-11T08:01:24.000-02:00",
         "cisco.ftd.destination_interface": "outside",
         "cisco.ftd.message_id": "106023",
         "cisco.ftd.rule_name": "dmz",
@@ -1127,7 +1127,7 @@
         ]
     },
     {
-        "@timestamp": "2018-12-11T06:01:24.000-02:00",
+        "@timestamp": "2018-12-11T08:01:24.000-02:00",
         "cisco.ftd.destination_interface": "outside",
         "cisco.ftd.message_id": "106023",
         "cisco.ftd.rule_name": "dmz",
@@ -1157,7 +1157,7 @@
         ]
     },
     {
-        "@timestamp": "2018-12-11T06:01:31.000-02:00",
+        "@timestamp": "2018-12-11T08:01:31.000-02:00",
         "cisco.ftd.message_id": "302013",
         "event.action": "firewall-rule",
         "event.code": 302013,
@@ -1177,7 +1177,7 @@
         ]
     },
     {
-        "@timestamp": "2018-12-11T06:01:31.000-02:00",
+        "@timestamp": "2018-12-11T08:01:31.000-02:00",
         "cisco.ftd.message_id": "302013",
         "event.action": "firewall-rule",
         "event.code": 302013,
@@ -1197,7 +1197,7 @@
         ]
     },
     {
-        "@timestamp": "2018-12-11T06:01:31.000-02:00",
+        "@timestamp": "2018-12-11T08:01:31.000-02:00",
         "cisco.ftd.connection_id": "447236",
         "cisco.ftd.destination_interface": "dmz",
         "cisco.ftd.message_id": "302014",
@@ -1208,11 +1208,11 @@
         "event.code": 302014,
         "event.dataset": "cisco.ftd",
         "event.duration": 0,
-        "event.end": "2018-12-11T06:01:31.000-02:00",
+        "event.end": "2018-12-11T08:01:31.000-02:00",
         "event.module": "cisco",
         "event.original": "%FTD-6-302014: Teardown TCP connection 447236 for outside:192.0.2.222/1234 to dmz:192.168.1.34/5678 duration 0:00:00 bytes 14804 TCP FINs",
         "event.severity": 6,
-        "event.start": "2018-12-11T08:01:31.000Z",
+        "event.start": "2018-12-11T10:01:31.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "ftd",
         "host.hostname": "127.0.0.1",
@@ -1230,7 +1230,7 @@
         ]
     },
     {
-        "@timestamp": "2018-12-11T06:01:38.000-02:00",
+        "@timestamp": "2018-12-11T08:01:38.000-02:00",
         "cisco.ftd.connection_id": "447234",
         "cisco.ftd.destination_interface": "dmz",
         "cisco.ftd.message_id": "302014",
@@ -1241,11 +1241,11 @@
         "event.code": 302014,
         "event.dataset": "cisco.ftd",
         "event.duration": 68000000000,
-        "event.end": "2018-12-11T06:01:38.000-02:00",
+        "event.end": "2018-12-11T08:01:38.000-02:00",
         "event.module": "cisco",
         "event.original": "%FTD-6-302014: Teardown TCP connection 447234 for outside:192.0.2.222/1234 to dmz:192.168.1.35/5678 duration 0:01:08 bytes 134781 TCP FINs",
         "event.severity": 6,
-        "event.start": "2018-12-11T08:00:30.000Z",
+        "event.start": "2018-12-11T10:00:30.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "ftd",
         "host.hostname": "127.0.0.1",
@@ -1263,7 +1263,7 @@
         ]
     },
     {
-        "@timestamp": "2018-12-11T06:01:38.000-02:00",
+        "@timestamp": "2018-12-11T08:01:38.000-02:00",
         "cisco.ftd.connection_id": "447234",
         "cisco.ftd.destination_interface": "dmz",
         "cisco.ftd.message_id": "302014",
@@ -1274,11 +1274,11 @@
         "event.code": 302014,
         "event.dataset": "cisco.ftd",
         "event.duration": 68000000000,
-        "event.end": "2018-12-11T06:01:38.000-02:00",
+        "event.end": "2018-12-11T08:01:38.000-02:00",
         "event.module": "cisco",
         "event.original": "%FTD-6-302014: Teardown TCP connection 447234 for outside:192.0.2.222/1234 to dmz:192.168.1.35/5678 duration 0:01:08 bytes 134781 TCP FINs",
         "event.severity": 6,
-        "event.start": "2018-12-11T08:00:30.000Z",
+        "event.start": "2018-12-11T10:00:30.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "ftd",
         "host.hostname": "127.0.0.1",
@@ -1296,7 +1296,7 @@
         ]
     },
     {
-        "@timestamp": "2018-12-11T06:01:38.000-02:00",
+        "@timestamp": "2018-12-11T08:01:38.000-02:00",
         "cisco.ftd.message_id": "106015",
         "cisco.ftd.source_interface": "outside",
         "destination.ip": "192.168.1.34",
@@ -1324,7 +1324,7 @@
         ]
     },
     {
-        "@timestamp": "2018-12-11T06:01:38.000-02:00",
+        "@timestamp": "2018-12-11T08:01:38.000-02:00",
         "cisco.ftd.message_id": "106015",
         "cisco.ftd.source_interface": "outside",
         "destination.ip": "192.168.1.34",
@@ -1352,7 +1352,7 @@
         ]
     },
     {
-        "@timestamp": "2018-12-11T06:01:39.000-02:00",
+        "@timestamp": "2018-12-11T08:01:39.000-02:00",
         "cisco.ftd.destination_interface": "outside",
         "cisco.ftd.message_id": "106023",
         "cisco.ftd.rule_name": "dmz",
@@ -1382,7 +1382,7 @@
         ]
     },
     {
-        "@timestamp": "2018-12-11T06:01:53.000-02:00",
+        "@timestamp": "2018-12-11T08:01:53.000-02:00",
         "cisco.ftd.message_id": "302013",
         "event.action": "firewall-rule",
         "event.code": 302013,
@@ -1402,7 +1402,7 @@
         ]
     },
     {
-        "@timestamp": "2018-12-11T06:01:53.000-02:00",
+        "@timestamp": "2018-12-11T08:01:53.000-02:00",
         "cisco.ftd.message_id": "302013",
         "event.action": "firewall-rule",
         "event.code": 302013,
@@ -1422,7 +1422,7 @@
         ]
     },
     {
-        "@timestamp": "2018-12-11T06:01:53.000-02:00",
+        "@timestamp": "2018-12-11T08:01:53.000-02:00",
         "cisco.ftd.connection_id": "447237",
         "cisco.ftd.destination_interface": "dmz",
         "cisco.ftd.message_id": "302014",
@@ -1433,11 +1433,11 @@
         "event.code": 302014,
         "event.dataset": "cisco.ftd",
         "event.duration": 86399000000000,
-        "event.end": "2018-12-11T06:01:53.000-02:00",
+        "event.end": "2018-12-11T08:01:53.000-02:00",
         "event.module": "cisco",
         "event.original": "%FTD-6-302014: Teardown TCP connection 447237 for outside:192.0.2.222/1234 to dmz:10.10.10.10/1235 duration 23:59:59 bytes 11420 TCP FINs",
         "event.severity": 6,
-        "event.start": "2018-12-10T08:01:54.000Z",
+        "event.start": "2018-12-10T10:01:54.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "ftd",
         "host.hostname": "127.0.0.1",
@@ -1455,7 +1455,7 @@
         ]
     },
     {
-        "@timestamp": "2012-08-15T21:30:09.000-02:00",
+        "@timestamp": "2012-08-15T23:30:09.000-02:00",
         "cisco.ftd.connection_id": "40",
         "cisco.ftd.destination_interface": "inside",
         "cisco.ftd.message_id": "302016",
@@ -1466,11 +1466,11 @@
         "event.code": 302016,
         "event.dataset": "cisco.ftd",
         "event.duration": 122000000000,
-        "event.end": "2012-08-15T21:30:09.000-02:00",
+        "event.end": "2012-08-15T23:30:09.000-02:00",
         "event.module": "cisco",
         "event.original": "%FTD-6-302016: Teardown UDP connection 40 for outside:10.44.4.4/500 to inside:10.44.2.2/500 duration 0:02:02 bytes 1416",
         "event.severity": 6,
-        "event.start": "2012-08-15T23:28:07.000Z",
+        "event.start": "2012-08-16T01:28:07.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "ftd",
         "input.type": "log",
@@ -1487,7 +1487,7 @@
         ]
     },
     {
-        "@timestamp": "2014-09-12T04:50:53.000-02:00",
+        "@timestamp": "2014-09-12T06:50:53.000-02:00",
         "cisco.ftd.message_id": "106016",
         "cisco.ftd.source_interface": "Mobile_Traffic",
         "destination.ip": "192.88.99.47",
@@ -1511,7 +1511,7 @@
         ]
     },
     {
-        "@timestamp": "2014-09-12T04:51:01.000-02:00",
+        "@timestamp": "2014-09-12T06:51:01.000-02:00",
         "cisco.ftd.message_id": "106016",
         "cisco.ftd.source_interface": "Mobile_Traffic",
         "destination.ip": "192.88.99.57",
@@ -1535,7 +1535,7 @@
         ]
     },
     {
-        "@timestamp": "2014-09-12T04:51:05.000-02:00",
+        "@timestamp": "2014-09-12T06:51:05.000-02:00",
         "cisco.ftd.message_id": "106016",
         "cisco.ftd.source_interface": "Mobile_Traffic",
         "destination.ip": "192.88.99.47",
@@ -1559,7 +1559,7 @@
         ]
     },
     {
-        "@timestamp": "2014-09-12T04:51:05.000-02:00",
+        "@timestamp": "2014-09-12T06:51:05.000-02:00",
         "cisco.ftd.message_id": "106016",
         "cisco.ftd.source_interface": "Mobile_Traffic",
         "destination.ip": "192.88.99.47",
@@ -1583,7 +1583,7 @@
         ]
     },
     {
-        "@timestamp": "2014-09-12T04:51:06.000-02:00",
+        "@timestamp": "2014-09-12T06:51:06.000-02:00",
         "cisco.ftd.message_id": "106016",
         "cisco.ftd.source_interface": "Mobile_Traffic",
         "destination.ip": "192.88.99.57",
@@ -1607,7 +1607,7 @@
         ]
     },
     {
-        "@timestamp": "2014-09-12T04:51:17.000-02:00",
+        "@timestamp": "2014-09-12T06:51:17.000-02:00",
         "cisco.ftd.message_id": "106016",
         "cisco.ftd.source_interface": "Mobile_Traffic",
         "destination.ip": "192.88.99.57",
@@ -1631,7 +1631,7 @@
         ]
     },
     {
-        "@timestamp": "2014-09-12T04:52:48.000-02:00",
+        "@timestamp": "2014-09-12T06:52:48.000-02:00",
         "cisco.ftd.message_id": "106016",
         "cisco.ftd.source_interface": "Mobile_Traffic",
         "destination.ip": "192.168.1.255",
@@ -1655,7 +1655,7 @@
         ]
     },
     {
-        "@timestamp": "2014-09-12T04:53:00.000-02:00",
+        "@timestamp": "2014-09-12T06:53:00.000-02:00",
         "cisco.ftd.message_id": "106016",
         "cisco.ftd.source_interface": "Mobile_Traffic",
         "destination.ip": "192.168.1.255",
@@ -1679,7 +1679,7 @@
         ]
     },
     {
-        "@timestamp": "2014-09-12T04:53:01.000-02:00",
+        "@timestamp": "2014-09-12T06:53:01.000-02:00",
         "cisco.ftd.destination_interface": "inside",
         "cisco.ftd.message_id": "106023",
         "cisco.ftd.rule_name": "PERMIT_IN",
@@ -1709,7 +1709,7 @@
         ]
     },
     {
-        "@timestamp": "2014-09-12T04:53:02.000-02:00",
+        "@timestamp": "2014-09-12T06:53:02.000-02:00",
         "cisco.ftd.icmp_code": 3,
         "cisco.ftd.icmp_type": 3,
         "cisco.ftd.message_id": "313001",
@@ -1736,7 +1736,7 @@
         ]
     },
     {
-        "@timestamp": "2015-01-14T11:16:13.000-02:00",
+        "@timestamp": "2015-01-14T13:16:13.000-02:00",
         "cisco.ftd.icmp_type": 0,
         "cisco.ftd.message_id": "313004",
         "cisco.ftd.source_interface": "inside",
@@ -1762,7 +1762,7 @@
         ]
     },
     {
-        "@timestamp": "2015-01-14T11:16:14.000-02:00",
+        "@timestamp": "2015-01-14T13:16:14.000-02:00",
         "cisco.ftd.destination_interface": "outside",
         "cisco.ftd.mapped_destination_ip": "192.88.99.129",
         "cisco.ftd.mapped_destination_port": 80,
@@ -1799,7 +1799,7 @@
         ]
     },
     {
-        "@timestamp": "2015-01-14T11:16:14.000-02:00",
+        "@timestamp": "2015-01-14T13:16:14.000-02:00",
         "cisco.ftd.destination_interface": "outsidet",
         "cisco.ftd.mapped_destination_ip": "192.0.2.225",
         "cisco.ftd.mapped_destination_port": 80,
@@ -1838,7 +1838,7 @@
         ]
     },
     {
-        "@timestamp": "2015-01-14T11:16:14.000-02:00",
+        "@timestamp": "2015-01-14T13:16:14.000-02:00",
         "cisco.ftd.destination_interface": "outsidet",
         "cisco.ftd.mapped_destination_ip": "192.0.2.223",
         "cisco.ftd.mapped_destination_port": 8080,
@@ -1877,7 +1877,7 @@
         ]
     },
     {
-        "@timestamp": "2009-11-16T12:12:35.000-02:00",
+        "@timestamp": "2009-11-16T14:12:35.000-02:00",
         "cisco.ftd.message_id": "304001",
         "destination.ip": "192.0.2.1",
         "event.action": "firewall-rule",
@@ -1900,7 +1900,7 @@
         "url.original": "/app"
     },
     {
-        "@timestamp": "2009-11-16T12:12:36.000-02:00",
+        "@timestamp": "2009-11-16T14:12:36.000-02:00",
         "cisco.ftd.message_id": "304001",
         "destination.ip": "192.0.2.32",
         "event.action": "firewall-rule",
@@ -1923,7 +1923,7 @@
         "url.original": "http://example.com"
     },
     {
-        "@timestamp": "2009-11-16T12:12:37.000-02:00",
+        "@timestamp": "2009-11-16T14:12:37.000-02:00",
         "cisco.ftd.message_id": "304002",
         "cisco.ftd.source_interface": "inside",
         "destination.ip": "192.0.0.19",

--- a/x-pack/filebeat/module/cisco/ftd/test/security-connection.log-expected.json
+++ b/x-pack/filebeat/module/cisco/ftd/test/security-connection.log-expected.json
@@ -638,7 +638,7 @@
         "user.name": "No Authentication Required"
     },
     {
-        "@timestamp": "2019-08-14T13:09:41.000-02:00",
+        "@timestamp": "2019-08-14T15:09:41.000-02:00",
         "cisco.ftd.destination_interface": "output",
         "cisco.ftd.message_id": "430003",
         "cisco.ftd.rule_name": [
@@ -683,12 +683,12 @@
         "event.code": 430003,
         "event.dataset": "cisco.ftd",
         "event.duration": 1000000000,
-        "event.end": "2019-08-14T13:09:41.000-02:00",
+        "event.end": "2019-08-14T15:09:41.000-02:00",
         "event.module": "cisco",
         "event.original": "%FTD-1-430003: AccessControlRuleAction: Block, AccessControlRuleReason: File Block, SrcIP: 10.0.1.20, DstIP: 10.0.100.30, SrcPort: 41544, DstPort: 8000, Protocol: tcp, IngressInterface: input, EgressInterface: output, IngressZone: input-zone, EgressZone: output-zone, ACPolicy: default, AccessControlRuleName: Intrusion-Rule, Prefilter Policy: Default Prefilter Policy, User: No Authentication Required, UserAgent: curl/7.58.0, Client: cURL, ClientVersion: 7.58.0, ApplicationProtocol: HTTP, ConnectionDuration: 1, FileCount: 1, InitiatorPackets: 4, ResponderPackets: 7, InitiatorBytes: 365, ResponderBytes: 1927, NAPPolicy: Balanced Security and Connectivity, HTTPResponse: 200, ReferencedHost: 10.0.100.30:8000, URL: http://10.0.100.30:8000/eicar_com.zip",
         "event.outcome": "block",
         "event.severity": 1,
-        "event.start": "2019-08-14T15:09:40.000Z",
+        "event.start": "2019-08-14T17:09:40.000Z",
         "event.timezone": "-02:00",
         "fileset.name": "ftd",
         "host.hostname": "siem-ftd",

--- a/x-pack/filebeat/module/cisco/ftd/test/security-file-malware.log-expected.json
+++ b/x-pack/filebeat/module/cisco/ftd/test/security-file-malware.log-expected.json
@@ -1,6 +1,6 @@
 [
     {
-        "@timestamp": "2019-08-14T12:54:25.000-02:00",
+        "@timestamp": "2019-08-14T14:54:25.000-02:00",
         "cisco.ftd.message_id": "430004",
         "cisco.ftd.rule_name": "malware-and-file-policy",
         "cisco.ftd.security.application_protocol": "HTTP",
@@ -50,7 +50,7 @@
         "user.name": "No Authentication Required"
     },
     {
-        "@timestamp": "2019-08-14T12:55:02.000-02:00",
+        "@timestamp": "2019-08-14T14:55:02.000-02:00",
         "cisco.ftd.message_id": "430004",
         "cisco.ftd.rule_name": "malware-and-file-policy",
         "cisco.ftd.security.application_protocol": "HTTP",
@@ -100,7 +100,7 @@
         "user.name": "No Authentication Required"
     },
     {
-        "@timestamp": "2019-08-14T13:00:29.000-02:00",
+        "@timestamp": "2019-08-14T15:00:29.000-02:00",
         "cisco.ftd.message_id": "430004",
         "cisco.ftd.rule_name": "malware-and-file-policy",
         "cisco.ftd.security.application_protocol": "HTTP",
@@ -150,7 +150,7 @@
         "user.name": "No Authentication Required"
     },
     {
-        "@timestamp": "2019-08-14T13:01:41.000-02:00",
+        "@timestamp": "2019-08-14T15:01:41.000-02:00",
         "cisco.ftd.message_id": "430004",
         "cisco.ftd.rule_name": "malware-and-file-policy",
         "cisco.ftd.security.application_protocol": "HTTP",
@@ -200,7 +200,7 @@
         "user.name": "No Authentication Required"
     },
     {
-        "@timestamp": "2019-08-14T13:03:28.000-02:00",
+        "@timestamp": "2019-08-14T15:03:28.000-02:00",
         "cisco.ftd.message_id": "430004",
         "cisco.ftd.rule_name": "malware-and-file-policy",
         "cisco.ftd.security.application_protocol": "HTTP",
@@ -256,7 +256,7 @@
         "user.name": "No Authentication Required"
     },
     {
-        "@timestamp": "2019-08-14T13:03:33.000-02:00",
+        "@timestamp": "2019-08-14T15:03:33.000-02:00",
         "cisco.ftd.message_id": "430004",
         "cisco.ftd.rule_name": "malware-and-file-policy",
         "cisco.ftd.security.application_protocol": "HTTP",
@@ -312,7 +312,7 @@
         "user.name": "No Authentication Required"
     },
     {
-        "@timestamp": "2019-08-14T13:09:43.000-02:00",
+        "@timestamp": "2019-08-14T15:09:43.000-02:00",
         "cisco.ftd.message_id": "430005",
         "cisco.ftd.rule_name": "malware-and-file-policy",
         "cisco.ftd.security.application_protocol": "HTTP",

--- a/x-pack/filebeat/module/cisco/ios/config/input.yml
+++ b/x-pack/filebeat/module/cisco/ios/config/input.yml
@@ -18,6 +18,7 @@ exclude_files: [".gz$"]
 tags: {{.tags}}
 
 processors:
+  - add_locale: ~
   - script:
       lang: javascript
       id: cisco_ios

--- a/x-pack/filebeat/module/cisco/ios/config/pipeline.js
+++ b/x-pack/filebeat/module/cisco/ios/config/pipeline.js
@@ -101,14 +101,17 @@ var ciscoIOS = (function() {
             ],
             ignore_missing: true,
         })
-        .Timestamp({
-            field: "_tmp.timestamp",
-            target_field: "@timestamp",
-            layouts: [
-                'Jan _2 15:04:05.999',
-                'Jan _2 15:04:05.999 MST',
-            ],
-            ignore_missing: true,
+        .Add(function(evt) {
+            processor.Timestamp({
+                field: "_tmp.timestamp",
+                target_field: "@timestamp",
+                timezone: evt.Get("event.timezone"),
+                layouts: [
+                    'Jan _2 15:04:05.999',
+                    'Jan _2 15:04:05.999 MST',
+                ],
+                ignore_missing: true,
+            }).Run(evt);
         })
         .Add(function(evt) {
             evt.Delete("_tmp");

--- a/x-pack/filebeat/module/cisco/ios/test/cisco-ios-syslog.log-expected.json
+++ b/x-pack/filebeat/module/cisco/ios/test/cisco-ios-syslog.log-expected.json
@@ -1,6 +1,6 @@
 [
     {
-        "@timestamp": "2019-02-08T04:00:47.272Z",
+        "@timestamp": "2019-02-08T06:00:47.272Z",
         "cisco.ios.access_list": "177",
         "cisco.ios.facility": "SEC",
         "destination.address": "224.0.0.22",
@@ -12,6 +12,7 @@
         "event.outcome": "deny",
         "event.sequence": 585917,
         "event.severity": 6,
+        "event.timezone": "-02:00",
         "event.type": "firewall",
         "fileset.name": "ios",
         "input.type": "log",
@@ -37,7 +38,7 @@
         ]
     },
     {
-        "@timestamp": "2019-02-09T04:00:47.272Z",
+        "@timestamp": "2019-02-09T06:00:47.272Z",
         "cisco.ios.access_list": "INBOUND-ON-F11",
         "cisco.ios.facility": "SEC",
         "destination.address": "224.0.0.2",
@@ -49,6 +50,7 @@
         "event.outcome": "deny",
         "event.sequence": 585918,
         "event.severity": 6,
+        "event.timezone": "-02:00",
         "event.type": "firewall",
         "fileset.name": "ios",
         "igmp.type": 20,
@@ -75,7 +77,7 @@
         ]
     },
     {
-        "@timestamp": "2019-02-10T04:00:47.272Z",
+        "@timestamp": "2019-02-10T06:00:47.272Z",
         "cisco.ios.access_list": "171",
         "cisco.ios.facility": "SEC",
         "destination.address": "255.255.255.255",
@@ -87,6 +89,7 @@
         "event.outcome": "deny",
         "event.sequence": 585919,
         "event.severity": 6,
+        "event.timezone": "-02:00",
         "event.type": "firewall",
         "fileset.name": "ios",
         "input.type": "log",
@@ -112,7 +115,7 @@
         ]
     },
     {
-        "@timestamp": "2019-05-03T19:11:32.619Z",
+        "@timestamp": "2019-05-03T21:11:32.619Z",
         "cisco.ios.access_list": "ACL-IPv6-E0/0-IN/10",
         "cisco.ios.facility": "IPV6",
         "destination.address": "2001:DB8:1000::1",
@@ -125,6 +128,7 @@
         "event.outcome": "allow",
         "event.sequence": 585920,
         "event.severity": 6,
+        "event.timezone": "-02:00",
         "event.type": "firewall",
         "fileset.name": "ios",
         "input.type": "log",
@@ -151,7 +155,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-20T02:41:39.326Z",
+        "@timestamp": "2019-06-20T04:41:39.326Z",
         "cisco.ios.access_list": "177",
         "cisco.ios.facility": "SEC",
         "destination.address": "198.51.100.255",
@@ -164,6 +168,7 @@
         "event.outcome": "deny",
         "event.sequence": 1663303,
         "event.severity": 6,
+        "event.timezone": "-02:00",
         "event.type": "firewall",
         "fileset.name": "ios",
         "input.type": "log",
@@ -190,7 +195,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-20T02:41:44.921Z",
+        "@timestamp": "2019-06-20T04:41:44.921Z",
         "cisco.ios.access_list": "151",
         "cisco.ios.facility": "SEC",
         "destination.address": "198.51.100.2",
@@ -202,6 +207,7 @@
         "event.outcome": "deny",
         "event.sequence": 1663304,
         "event.severity": 6,
+        "event.timezone": "-02:00",
         "event.type": "firewall",
         "fileset.name": "ios",
         "icmp.code": 4,
@@ -229,7 +235,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-20T02:41:51.330Z",
+        "@timestamp": "2019-06-20T04:41:51.330Z",
         "cisco.ios.access_list": "177",
         "cisco.ios.facility": "SEC",
         "destination.address": "198.51.100.255",
@@ -242,6 +248,7 @@
         "event.outcome": "deny",
         "event.sequence": 1663305,
         "event.severity": 6,
+        "event.timezone": "-02:00",
         "event.type": "firewall",
         "fileset.name": "ios",
         "input.type": "log",
@@ -268,7 +275,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-20T02:41:55.222Z",
+        "@timestamp": "2019-06-20T04:41:55.222Z",
         "cisco.ios.access_list": "150",
         "cisco.ios.facility": "SEC",
         "destination.address": "172.217.10.46",
@@ -287,6 +294,7 @@
         "event.outcome": "deny",
         "event.sequence": 1663306,
         "event.severity": 6,
+        "event.timezone": "-02:00",
         "event.type": "firewall",
         "fileset.name": "ios",
         "input.type": "log",
@@ -313,7 +321,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-20T02:41:57.328Z",
+        "@timestamp": "2019-06-20T04:41:57.328Z",
         "cisco.ios.access_list": "177",
         "cisco.ios.facility": "SEC",
         "destination.address": "198.51.100.255",
@@ -326,6 +334,7 @@
         "event.outcome": "deny",
         "event.sequence": 1663307,
         "event.severity": 6,
+        "event.timezone": "-02:00",
         "event.type": "firewall",
         "fileset.name": "ios",
         "input.type": "log",
@@ -352,7 +361,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-20T02:42:03.334Z",
+        "@timestamp": "2019-06-20T04:42:03.334Z",
         "cisco.ios.access_list": "177",
         "cisco.ios.facility": "SEC",
         "destination.address": "198.51.100.255",
@@ -365,6 +374,7 @@
         "event.outcome": "deny",
         "event.sequence": 1663308,
         "event.severity": 6,
+        "event.timezone": "-02:00",
         "event.type": "firewall",
         "fileset.name": "ios",
         "input.type": "log",
@@ -391,7 +401,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-20T02:42:09.332Z",
+        "@timestamp": "2019-06-20T04:42:09.332Z",
         "cisco.ios.access_list": "177",
         "cisco.ios.facility": "SEC",
         "destination.address": "198.51.100.255",
@@ -404,6 +414,7 @@
         "event.outcome": "deny",
         "event.sequence": 1663309,
         "event.severity": 6,
+        "event.timezone": "-02:00",
         "event.type": "firewall",
         "fileset.name": "ios",
         "input.type": "log",
@@ -430,7 +441,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-20T02:42:15.330Z",
+        "@timestamp": "2019-06-20T04:42:15.330Z",
         "cisco.ios.access_list": "177",
         "cisco.ios.facility": "SEC",
         "destination.address": "198.51.100.255",
@@ -443,6 +454,7 @@
         "event.outcome": "deny",
         "event.sequence": 1663310,
         "event.severity": 6,
+        "event.timezone": "-02:00",
         "event.type": "firewall",
         "fileset.name": "ios",
         "input.type": "log",
@@ -469,7 +481,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-20T02:42:21.336Z",
+        "@timestamp": "2019-06-20T04:42:21.336Z",
         "cisco.ios.access_list": "177",
         "cisco.ios.facility": "SEC",
         "destination.address": "198.51.100.255",
@@ -482,6 +494,7 @@
         "event.outcome": "deny",
         "event.sequence": 1663311,
         "event.severity": 6,
+        "event.timezone": "-02:00",
         "event.type": "firewall",
         "fileset.name": "ios",
         "input.type": "log",
@@ -508,7 +521,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-20T02:42:27.342Z",
+        "@timestamp": "2019-06-20T04:42:27.342Z",
         "cisco.ios.access_list": "177",
         "cisco.ios.facility": "SEC",
         "destination.address": "198.51.100.255",
@@ -521,6 +534,7 @@
         "event.outcome": "deny",
         "event.sequence": 1663312,
         "event.severity": 6,
+        "event.timezone": "-02:00",
         "event.type": "firewall",
         "fileset.name": "ios",
         "input.type": "log",
@@ -547,13 +561,14 @@
         ]
     },
     {
-        "@timestamp": "2019-06-20T02:42:28.374Z",
+        "@timestamp": "2019-06-20T04:42:28.374Z",
         "cisco.ios.facility": "SEC",
         "event.code": "IPACCESSLOGRL",
         "event.dataset": "cisco.ios",
         "event.module": "cisco",
         "event.sequence": 1663313,
         "event.severity": 6,
+        "event.timezone": "-02:00",
         "fileset.name": "ios",
         "input.type": "log",
         "log.level": "informational",
@@ -567,7 +582,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-20T02:42:33.340Z",
+        "@timestamp": "2019-06-20T04:42:33.340Z",
         "cisco.ios.access_list": "177",
         "cisco.ios.facility": "SEC",
         "destination.address": "198.51.100.255",
@@ -580,6 +595,7 @@
         "event.outcome": "deny",
         "event.sequence": 1663314,
         "event.severity": 6,
+        "event.timezone": "-02:00",
         "event.type": "firewall",
         "fileset.name": "ios",
         "input.type": "log",
@@ -606,7 +622,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-20T02:42:39.338Z",
+        "@timestamp": "2019-06-20T04:42:39.338Z",
         "cisco.ios.access_list": "177",
         "cisco.ios.facility": "SEC",
         "destination.address": "198.51.100.255",
@@ -619,6 +635,7 @@
         "event.outcome": "deny",
         "event.sequence": 1663315,
         "event.severity": 6,
+        "event.timezone": "-02:00",
         "event.type": "firewall",
         "fileset.name": "ios",
         "input.type": "log",
@@ -645,7 +662,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-20T02:42:45.336Z",
+        "@timestamp": "2019-06-20T04:42:45.336Z",
         "cisco.ios.access_list": "177",
         "cisco.ios.facility": "SEC",
         "destination.address": "198.51.100.255",
@@ -658,6 +675,7 @@
         "event.outcome": "deny",
         "event.sequence": 1663316,
         "event.severity": 6,
+        "event.timezone": "-02:00",
         "event.type": "firewall",
         "fileset.name": "ios",
         "input.type": "log",
@@ -684,7 +702,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-20T02:42:47.466Z",
+        "@timestamp": "2019-06-20T04:42:47.466Z",
         "cisco.ios.access_list": "150",
         "cisco.ios.facility": "SEC",
         "destination.address": "172.217.10.46",
@@ -703,6 +721,7 @@
         "event.outcome": "deny",
         "event.sequence": 1663317,
         "event.severity": 6,
+        "event.timezone": "-02:00",
         "event.type": "firewall",
         "fileset.name": "ios",
         "input.type": "log",
@@ -729,7 +748,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-20T02:42:51.342Z",
+        "@timestamp": "2019-06-20T04:42:51.342Z",
         "cisco.ios.access_list": "177",
         "cisco.ios.facility": "SEC",
         "destination.address": "198.51.100.255",
@@ -742,6 +761,7 @@
         "event.outcome": "deny",
         "event.sequence": 1663318,
         "event.severity": 6,
+        "event.timezone": "-02:00",
         "event.type": "firewall",
         "fileset.name": "ios",
         "input.type": "log",
@@ -768,7 +788,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-20T02:42:57.340Z",
+        "@timestamp": "2019-06-20T04:42:57.340Z",
         "cisco.ios.access_list": "177",
         "cisco.ios.facility": "SEC",
         "destination.address": "198.51.100.255",
@@ -781,6 +801,7 @@
         "event.outcome": "deny",
         "event.sequence": 1663319,
         "event.severity": 6,
+        "event.timezone": "-02:00",
         "event.type": "firewall",
         "fileset.name": "ios",
         "input.type": "log",
@@ -807,7 +828,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-20T02:43:03.346Z",
+        "@timestamp": "2019-06-20T04:43:03.346Z",
         "cisco.ios.access_list": "177",
         "cisco.ios.facility": "SEC",
         "destination.address": "198.51.100.255",
@@ -820,6 +841,7 @@
         "event.outcome": "deny",
         "event.sequence": 1663320,
         "event.severity": 6,
+        "event.timezone": "-02:00",
         "event.type": "firewall",
         "fileset.name": "ios",
         "input.type": "log",
@@ -846,7 +868,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-20T02:43:08.454Z",
+        "@timestamp": "2019-06-20T04:43:08.454Z",
         "cisco.ios.access_list": "150",
         "cisco.ios.facility": "SEC",
         "destination.address": "172.217.10.46",
@@ -865,6 +887,7 @@
         "event.outcome": "deny",
         "event.sequence": 1663321,
         "event.severity": 6,
+        "event.timezone": "-02:00",
         "event.type": "firewall",
         "fileset.name": "ios",
         "input.type": "log",
@@ -891,7 +914,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-20T02:43:15.350Z",
+        "@timestamp": "2019-06-20T04:43:15.350Z",
         "cisco.ios.access_list": "177",
         "cisco.ios.facility": "SEC",
         "destination.address": "198.51.100.255",
@@ -904,6 +927,7 @@
         "event.outcome": "deny",
         "event.sequence": 1663322,
         "event.severity": 6,
+        "event.timezone": "-02:00",
         "event.type": "firewall",
         "fileset.name": "ios",
         "input.type": "log",
@@ -930,7 +954,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-20T02:43:20.346Z",
+        "@timestamp": "2019-06-20T04:43:20.346Z",
         "cisco.ios.access_list": "177",
         "cisco.ios.facility": "SEC",
         "destination.address": "8.8.8.8",
@@ -949,6 +973,7 @@
         "event.outcome": "deny",
         "event.sequence": 1663323,
         "event.severity": 6,
+        "event.timezone": "-02:00",
         "event.type": "firewall",
         "fileset.name": "ios",
         "input.type": "log",
@@ -975,7 +1000,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-20T02:43:21.348Z",
+        "@timestamp": "2019-06-20T04:43:21.348Z",
         "cisco.ios.access_list": "177",
         "cisco.ios.facility": "SEC",
         "destination.address": "198.51.100.195",
@@ -988,6 +1013,7 @@
         "event.outcome": "deny",
         "event.sequence": 1663324,
         "event.severity": 6,
+        "event.timezone": "-02:00",
         "event.type": "firewall",
         "fileset.name": "ios",
         "input.type": "log",
@@ -1020,13 +1046,14 @@
         ]
     },
     {
-        "@timestamp": "2019-06-20T02:43:28.403Z",
+        "@timestamp": "2019-06-20T04:43:28.403Z",
         "cisco.ios.facility": "SEC",
         "event.code": "IPACCESSLOGRL",
         "event.dataset": "cisco.ios",
         "event.module": "cisco",
         "event.sequence": 1663325,
         "event.severity": 6,
+        "event.timezone": "-02:00",
         "fileset.name": "ios",
         "input.type": "log",
         "log.level": "informational",
@@ -1040,7 +1067,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-20T02:43:28.403Z",
+        "@timestamp": "2019-06-20T04:43:28.403Z",
         "cisco.ios.access_list": "150",
         "cisco.ios.facility": "SEC",
         "destination.address": "198.51.100.1",
@@ -1052,6 +1079,7 @@
         "event.outcome": "deny",
         "event.sequence": 1663326,
         "event.severity": 6,
+        "event.timezone": "-02:00",
         "event.type": "firewall",
         "fileset.name": "ios",
         "icmp.code": 3,
@@ -1079,7 +1107,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-20T02:43:29.451Z",
+        "@timestamp": "2019-06-20T04:43:29.451Z",
         "cisco.ios.access_list": "150",
         "cisco.ios.facility": "SEC",
         "destination.address": "172.217.10.46",
@@ -1098,6 +1126,7 @@
         "event.outcome": "deny",
         "event.sequence": 1663327,
         "event.severity": 6,
+        "event.timezone": "-02:00",
         "event.type": "firewall",
         "fileset.name": "ios",
         "input.type": "log",
@@ -1124,7 +1153,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-20T02:43:33.352Z",
+        "@timestamp": "2019-06-20T04:43:33.352Z",
         "cisco.ios.access_list": "177",
         "cisco.ios.facility": "SEC",
         "destination.address": "198.51.100.255",
@@ -1137,6 +1166,7 @@
         "event.outcome": "deny",
         "event.sequence": 1663328,
         "event.severity": 6,
+        "event.timezone": "-02:00",
         "event.type": "firewall",
         "fileset.name": "ios",
         "input.type": "log",
@@ -1163,7 +1193,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-20T02:43:39.350Z",
+        "@timestamp": "2019-06-20T04:43:39.350Z",
         "cisco.ios.access_list": "177",
         "cisco.ios.facility": "SEC",
         "destination.address": "198.51.100.255",
@@ -1176,6 +1206,7 @@
         "event.outcome": "deny",
         "event.sequence": 1663329,
         "event.severity": 6,
+        "event.timezone": "-02:00",
         "event.type": "firewall",
         "fileset.name": "ios",
         "input.type": "log",
@@ -1202,7 +1233,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-20T02:43:44.173Z",
+        "@timestamp": "2019-06-20T04:43:44.173Z",
         "cisco.ios.access_list": "150",
         "cisco.ios.facility": "SEC",
         "destination.address": "198.51.100.255",
@@ -1215,6 +1246,7 @@
         "event.outcome": "deny",
         "event.sequence": 1663330,
         "event.severity": 6,
+        "event.timezone": "-02:00",
         "event.type": "firewall",
         "fileset.name": "ios",
         "input.type": "log",
@@ -1241,7 +1273,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-20T02:43:45.356Z",
+        "@timestamp": "2019-06-20T04:43:45.356Z",
         "cisco.ios.access_list": "177",
         "cisco.ios.facility": "SEC",
         "destination.address": "198.51.100.255",
@@ -1254,6 +1286,7 @@
         "event.outcome": "deny",
         "event.sequence": 1663331,
         "event.severity": 6,
+        "event.timezone": "-02:00",
         "event.type": "firewall",
         "fileset.name": "ios",
         "input.type": "log",
@@ -1280,7 +1313,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-20T02:43:50.473Z",
+        "@timestamp": "2019-06-20T04:43:50.473Z",
         "cisco.ios.access_list": "150",
         "cisco.ios.facility": "SEC",
         "destination.address": "172.217.10.46",
@@ -1299,6 +1332,7 @@
         "event.outcome": "deny",
         "event.sequence": 1663332,
         "event.severity": 6,
+        "event.timezone": "-02:00",
         "event.type": "firewall",
         "fileset.name": "ios",
         "input.type": "log",

--- a/x-pack/filebeat/module/cisco/shared/ingest/asa-ftd-pipeline.yml
+++ b/x-pack/filebeat/module/cisco/shared/ingest/asa-ftd-pipeline.yml
@@ -65,8 +65,9 @@ processors:
 # Parse the date included in FTD logs
 #
  - date:
+     if: "ctx.event.timezone == null"
      field: "_temp_.raw_date"
-     ignore_failure: true
+     target_field: "@timestamp"
      formats:
       - "ISO8601"
       - "MMM  d HH:mm:ss"
@@ -85,11 +86,30 @@ processors:
       - "MMM dd yyyy HH:mm:ss z"
       - "EEE MMM  d yyyy HH:mm:ss z"
       - "EEE MMM dd yyyy HH:mm:ss z"
+     on_failure: [{"append": {"field": "error.message", "value": "{{ _ingest.on_failure_message }}"}}]
  - date:
      if: "ctx.event.timezone != null"
-     field: "@timestamp"
-     formats: ["ISO8601"]
      timezone: "{{ event.timezone }}"
+     field: "_temp_.raw_date"
+     target_field: "@timestamp"
+     formats:
+      - "ISO8601"
+      - "MMM  d HH:mm:ss"
+      - "MMM dd HH:mm:ss"
+      - "EEE MMM  d HH:mm:ss"
+      - "EEE MMM dd HH:mm:ss"
+      - "MMM  d HH:mm:ss z"
+      - "MMM dd HH:mm:ss z"
+      - "EEE MMM  d HH:mm:ss z"
+      - "EEE MMM dd HH:mm:ss z"
+      - "MMM  d yyyy HH:mm:ss"
+      - "MMM dd yyyy HH:mm:ss"
+      - "EEE MMM  d yyyy HH:mm:ss"
+      - "EEE MMM dd yyyy HH:mm:ss"
+      - "MMM  d yyyy HH:mm:ss z"
+      - "MMM dd yyyy HH:mm:ss z"
+      - "EEE MMM  d yyyy HH:mm:ss z"
+      - "EEE MMM dd yyyy HH:mm:ss z"
      on_failure: [{"append": {"field": "error.message", "value": "{{ _ingest.on_failure_message }}"}}]
 
 #


### PR DESCRIPTION
Fixes ingest pipelines, and add timezone handling to javascript
pipeline of ios metricset.

Similar to #13308, part of #13877.