### PR TITLE
[7.4] Mark usage as collected only if API call succeeds (#13881)

### DIFF
--- a/metricbeat/module/kibana/mtest/testing.go
+++ b/metricbeat/module/kibana/mtest/testing.go
@@ -18,10 +18,15 @@
 package mtest
 
 // GetConfig returns config for kibana module
-func GetConfig(metricset string, host string) map[string]interface{} {
-	return map[string]interface{}{
+func GetConfig(metricset string, host string, xpackEnabled bool) map[string]interface{} {
+	config := map[string]interface{}{
 		"module":     "kibana",
 		"metricsets": []string{metricset},
 		"hosts":      []string{host},
 	}
+	if xpackEnabled {
+		config["xpack.enabled"] = true
+	}
+
+	return config
 }

--- a/metricbeat/module/kibana/stats/stats.go
+++ b/metricbeat/module/kibana/stats/stats.go
@@ -147,21 +147,31 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 }
 
 func (m *MetricSet) fetchStats(r mb.ReporterV2, now time.Time) error {
+
+	var content []byte
+	var err error
+
 	// Collect usage stats only once every usageCollectionPeriod
 	if m.isUsageExcludable {
 		origURI := m.statsHTTP.GetURI()
 		defer m.statsHTTP.SetURI(origURI)
 
 		shouldCollectUsage := m.shouldCollectUsage(now)
+		m.statsHTTP.SetURI(origURI + "&exclude_usage=" + strconv.FormatBool(!shouldCollectUsage))
+
+		content, err = m.statsHTTP.FetchContent()
+		if err != nil {
+			return err
+		}
+
 		if shouldCollectUsage {
 			m.usageLastCollectedOn = now
 		}
-		m.statsHTTP.SetURI(origURI + "&exclude_usage=" + strconv.FormatBool(!shouldCollectUsage))
-	}
-
-	content, err := m.statsHTTP.FetchContent()
-	if err != nil {
-		return err
+	} else {
+		content, err = m.statsHTTP.FetchContent()
+		if err != nil {
+			return err
+		}
 	}
 
 	if m.XPackEnabled {

--- a/metricbeat/module/kibana/stats/stats_integration_test.go
+++ b/metricbeat/module/kibana/stats/stats_integration_test.go
@@ -38,7 +38,7 @@ import (
 func TestFetch(t *testing.T) {
 	service := compose.EnsureUpWithTimeout(t, 570, "kibana")
 
-	config := mtest.GetConfig("stats", service.Host())
+	config := mtest.GetConfig("stats", service.Host(), false)
 	host := config["hosts"].([]string)[0]
 	version, err := getKibanaVersion(t, host)
 	if err != nil {
@@ -69,7 +69,7 @@ func TestFetch(t *testing.T) {
 func TestData(t *testing.T) {
 	service := compose.EnsureUp(t, "kibana")
 
-	config := mtest.GetConfig("stats", service.Host())
+	config := mtest.GetConfig("stats", service.Host(), false)
 	host := config["hosts"].([]string)[0]
 	version, err := getKibanaVersion(t, host)
 	if err != nil {

--- a/metricbeat/module/kibana/stats/stats_test.go
+++ b/metricbeat/module/kibana/stats/stats_test.go
@@ -1,0 +1,78 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// +build !integration
+
+package stats
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
+	"github.com/elastic/beats/metricbeat/module/kibana/mtest"
+)
+
+func TestFetchUsage(t *testing.T) {
+	// Spin up mock Kibana server
+	numStatsRequests := 0
+	kib := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/status":
+			w.Write([]byte("{ \"version\": { \"number\": \"7.5.0\" }}"))
+
+		case "/api/stats":
+			excludeUsage := r.FormValue("exclude_usage")
+
+			// Make GET /api/stats return 503 for first call, 200 for subsequent calls
+			switch numStatsRequests {
+			case 0: // first call
+				assert.Equal(t, "false", excludeUsage)
+				w.WriteHeader(503)
+
+			case 1: // second call
+				// Make sure exclude_usage is still false since first call failed
+				assert.Equal(t, "false", excludeUsage)
+				w.WriteHeader(200)
+
+			case 2: // third call
+				// Make sure exclude_usage is now true since second call succeeded
+				assert.Equal(t, "true", excludeUsage)
+				w.WriteHeader(200)
+			}
+
+			numStatsRequests++
+		}
+	}))
+	defer kib.Close()
+
+	config := mtest.GetConfig("stats", kib.URL, true)
+
+	f := mbtest.NewReportingMetricSetV2Error(t, config)
+
+	// First fetch
+	mbtest.ReportingFetchV2Error(f)
+
+	// Second fetch
+	mbtest.ReportingFetchV2Error(f)
+
+	// Third fetch
+	mbtest.ReportingFetchV2Error(f)
+}

--- a/metricbeat/module/kibana/status/status_integration_test.go
+++ b/metricbeat/module/kibana/status/status_integration_test.go
@@ -32,7 +32,7 @@ import (
 func TestFetch(t *testing.T) {
 	service := compose.EnsureUpWithTimeout(t, 570, "kibana")
 
-	f := mbtest.NewReportingMetricSetV2Error(t, mtest.GetConfig("status", service.Host()))
+	f := mbtest.NewReportingMetricSetV2Error(t, mtest.GetConfig("status", service.Host(), false))
 	events, errs := mbtest.ReportingFetchV2Error(f)
 
 	assert.Empty(t, errs)


### PR DESCRIPTION
Backports the following commits to 7.4:
 - Mark usage as collected only if API call succeeds  (#13881)