### PR TITLE
[6.8] Mark usage as collected only if API call succeeds (#13881)

### DIFF
--- a/metricbeat/module/kibana/mtest/testing.go
+++ b/metricbeat/module/kibana/mtest/testing.go
@@ -43,10 +43,15 @@ func GetEnvPort() string {
 }
 
 // GetConfig returns config for kibana module
-func GetConfig(metricset string) map[string]interface{} {
-	return map[string]interface{}{
+func GetConfig(metricset string, xpackEnabled bool) map[string]interface{} {
+	config := map[string]interface{}{
 		"module":     "kibana",
 		"metricsets": []string{metricset},
 		"hosts":      []string{net.JoinHostPort(GetEnvHost(), GetEnvPort())},
 	}
+	if xpackEnabled {
+		config["xpack.enabled"] = true
+	}
+
+	return config
 }

--- a/metricbeat/module/kibana/stats/stats_integration_test.go
+++ b/metricbeat/module/kibana/stats/stats_integration_test.go
@@ -38,7 +38,7 @@ import (
 func TestFetch(t *testing.T) {
 	compose.EnsureUpWithTimeout(t, 600, "elasticsearch", "kibana")
 
-	config := mtest.GetConfig("stats")
+	config := mtest.GetConfig("stats", false)
 	host := config["hosts"].([]string)[0]
 	version, err := getKibanaVersion(host)
 	if err != nil {
@@ -69,7 +69,7 @@ func TestFetch(t *testing.T) {
 func TestData(t *testing.T) {
 	compose.EnsureUp(t, "kibana")
 
-	config := mtest.GetConfig("stats")
+	config := mtest.GetConfig("stats", false)
 	host := config["hosts"].([]string)[0]
 	version, err := getKibanaVersion(host)
 	if err != nil {

--- a/metricbeat/module/kibana/stats/stats_test.go
+++ b/metricbeat/module/kibana/stats/stats_test.go
@@ -1,0 +1,78 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// +build !integration
+
+package stats
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	mbtest "github.com/elastic/beats/metricbeat/mb/testing"
+	"github.com/elastic/beats/metricbeat/module/kibana/mtest"
+)
+
+func TestFetchUsage(t *testing.T) {
+	// Spin up mock Kibana server
+	numStatsRequests := 0
+	kib := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/status":
+			w.Write([]byte("{ \"version\": { \"number\": \"7.5.0\" }}"))
+
+		case "/api/stats":
+			excludeUsage := r.FormValue("exclude_usage")
+
+			// Make GET /api/stats return 503 for first call, 200 for subsequent calls
+			switch numStatsRequests {
+			case 0: // first call
+				assert.Equal(t, "false", excludeUsage)
+				w.WriteHeader(503)
+
+			case 1: // second call
+				// Make sure exclude_usage is still false since first call failed
+				assert.Equal(t, "false", excludeUsage)
+				w.WriteHeader(200)
+
+			case 2: // third call
+				// Make sure exclude_usage is now true since second call succeeded
+				assert.Equal(t, "true", excludeUsage)
+				w.WriteHeader(200)
+			}
+
+			numStatsRequests++
+		}
+	}))
+	defer kib.Close()
+
+	config := mtest.GetConfig("stats", kib.URL, true)
+
+	f := mbtest.NewReportingMetricSetV2Error(t, config)
+
+	// First fetch
+	mbtest.ReportingFetchV2Error(f)
+
+	// Second fetch
+	mbtest.ReportingFetchV2Error(f)
+
+	// Third fetch
+	mbtest.ReportingFetchV2Error(f)
+}

--- a/metricbeat/module/kibana/stats/stats_test.go
+++ b/metricbeat/module/kibana/stats/stats_test.go
@@ -65,14 +65,14 @@ func TestFetchUsage(t *testing.T) {
 
 	config := mtest.GetConfig("stats", true)
 
-	f := mbtest.NewReportingMetricSetV2Error(t, config)
+	f := mbtest.NewReportingMetricSetV2(t, config)
 
 	// First fetch
-	mbtest.ReportingFetchV2Error(f)
+	mbtest.ReportingFetchV2(f)
 
 	// Second fetch
-	mbtest.ReportingFetchV2Error(f)
+	mbtest.ReportingFetchV2(f)
 
 	// Third fetch
-	mbtest.ReportingFetchV2Error(f)
+	mbtest.ReportingFetchV2(f)
 }

--- a/metricbeat/module/kibana/stats/stats_test.go
+++ b/metricbeat/module/kibana/stats/stats_test.go
@@ -63,7 +63,7 @@ func TestFetchUsage(t *testing.T) {
 	}))
 	defer kib.Close()
 
-	config := mtest.GetConfig("stats", kib.URL, true)
+	config := mtest.GetConfig("stats", true)
 
 	f := mbtest.NewReportingMetricSetV2Error(t, config)
 

--- a/metricbeat/module/kibana/stats/stats_test.go
+++ b/metricbeat/module/kibana/stats/stats_test.go
@@ -22,6 +22,8 @@ package stats
 import (
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -63,6 +65,7 @@ func TestFetchUsage(t *testing.T) {
 	}))
 	defer kib.Close()
 
+	os.Setenv("KIBANA_PORT", strings.Split(kib.URL, ":")[2])
 	config := mtest.GetConfig("stats", true)
 
 	f := mbtest.NewReportingMetricSetV2(t, config)

--- a/metricbeat/module/kibana/status/status_integration_test.go
+++ b/metricbeat/module/kibana/status/status_integration_test.go
@@ -47,7 +47,7 @@ func TestFetch(t *testing.T) {
 func TestData(t *testing.T) {
 	compose.EnsureUp(t, "elasticsearch", "kibana")
 
-	config := mtest.GetConfig("status")
+	config := mtest.GetConfig("status", false)
 	f := mbtest.NewReportingMetricSetV2(t, config)
 	err := mbtest.WriteEventsReporterV2(f, t, "")
 	if err != nil {

--- a/metricbeat/module/kibana/status/status_integration_test.go
+++ b/metricbeat/module/kibana/status/status_integration_test.go
@@ -32,7 +32,7 @@ import (
 func TestFetch(t *testing.T) {
 	compose.EnsureUpWithTimeout(t, 600, "elasticsearch", "kibana")
 
-	f := mbtest.NewReportingMetricSetV2(t, mtest.GetConfig("status"))
+	f := mbtest.NewReportingMetricSetV2(t, mtest.GetConfig("status", false))
 	events, errs := mbtest.ReportingFetchV2(f)
 
 	assert.Empty(t, errs)


### PR DESCRIPTION
Backports the following commits to 6.8:
 - Mark usage as collected only if API call succeeds  (#13881)