### PR TITLE
Cherry-pick #13746 to 7.4: Add panic recover to JS script processor

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -40,6 +40,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 *Affecting all Beats*
 
 - Fix a race condition with the Kafka pipeline client, it is possible that `Close()` get called before `Connect()` . {issue}11945[11945]
+- Recover from panics in the javascript process and log details about the failure to aid in future debugging. {pull}13690[13690]
 
 *Auditbeat*
 


### PR DESCRIPTION
Cherry-pick of PR #13746 to 7.4 branch. Original message: 

To help debug panics in the script processor add a `recover()` statement that will log the event being processed.