### PR TITLE
[DOCS] Fix typo in Graphite module docs

### DIFF
--- a/metricbeat/docs/modules/graphite.asciidoc
+++ b/metricbeat/docs/modules/graphite.asciidoc
@@ -5,7 +5,7 @@ This file is generated! See scripts/mage/docs_collector.go
 [[metricbeat-module-graphite]]
 == Graphite module
 
-This is the graphite Module.
+This is the Graphite module.
 
 The default metricset is `server`.
 

--- a/metricbeat/module/graphite/_meta/docs.asciidoc
+++ b/metricbeat/module/graphite/_meta/docs.asciidoc
@@ -1,3 +1,3 @@
-This is the graphite Module.
+This is the Graphite module.
 
 The default metricset is `server`.


### PR DESCRIPTION
Closes #13237 

@Titch990 Sorry this got lost in the GitHub queue. I fixed this to give you an example of how you fix errors in the module docs. There are quite a few nits like this across the module docs that need to be fixed.

After updating the docs.asciidoc file under the _meta directory, you need to run `make update`. To do this, you need to have your development environment properly set up.

