### PR TITLE
Add support for numeric time zone offsets in timestamp processor

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -266,6 +266,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add `providers` setting to `add_cloud_metadata` processor. {pull}13812[13812]
 - Use less restrictive API to check if template exists. {pull}13847[13847]
 - Do not check for alias when setup.ilm.check_exists is false. {pull}13848[13848]
+- Add support for numeric time zone offsets in timestamp processor. {pull}13902[13902]
 
 *Auditbeat*
 

--- a/libbeat/processors/timestamp/timestamp.go
+++ b/libbeat/processors/timestamp/timestamp.go
@@ -84,8 +84,9 @@ func newFromConfig(c config) (*processor, error) {
 	return p, nil
 }
 
+var timezoneFormats = []string{"-07", "-0700", "-07:00"}
+
 func loadLocation(timezone string) (*time.Location, error) {
-	timezoneFormats := []string{"-07", "-0700", "-07:00"}
 	for _, format := range timezoneFormats {
 		t, err := time.Parse(format, timezone)
 		if err == nil {

--- a/libbeat/processors/timestamp/timestamp.go
+++ b/libbeat/processors/timestamp/timestamp.go
@@ -57,7 +57,7 @@ func New(cfg *common.Config) (processors.Processor, error) {
 }
 
 func newFromConfig(c config) (*processor, error) {
-	loc, err := tz.LoadLocation(c.Timezone)
+	loc, err := loadLocation(c.Timezone)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to load timezone")
 	}
@@ -82,6 +82,20 @@ func newFromConfig(c config) (*processor, error) {
 	}
 
 	return p, nil
+}
+
+func loadLocation(timezone string) (*time.Location, error) {
+	timezoneFormats := []string{"-07", "-0700", "-07:00"}
+	for _, format := range timezoneFormats {
+		t, err := time.Parse(format, timezone)
+		if err == nil {
+			name, offset := t.Zone()
+			return time.FixedZone(name, offset), nil
+		}
+	}
+
+	// Rest of location formats
+	return tz.LoadLocation(timezone)
 }
 
 func (p *processor) String() string {

--- a/libbeat/processors/timestamp/timestamp_test.go
+++ b/libbeat/processors/timestamp/timestamp_test.go
@@ -199,3 +199,87 @@ func TestBuiltInTest(t *testing.T) {
 		assert.Contains(t, err.Error(), "failed to parse test timestamp")
 	}
 }
+
+func TestTimezone(t *testing.T) {
+	cases := map[string]struct {
+		Timezone string
+		Expected time.Time
+	}{
+		"no timezone": {
+			Expected: expected,
+		},
+		"location label": {
+			// Use a location without DST to avoid surprises
+			Timezone: "America/Panama",
+			Expected: expected.Add(5 * time.Hour),
+		},
+		"UTC label": {
+			Timezone: "Etc/UTC",
+			Expected: expected,
+		},
+		"GMT label": {
+			Timezone: "Etc/GMT+2",
+			Expected: expected.Add(2 * time.Hour),
+		},
+		"UTC as standard offset": {
+			Timezone: "+0000",
+			Expected: expected,
+		},
+		"standard offset": {
+			Timezone: "+0430",
+			Expected: expected.Add(-4*time.Hour - 30*time.Minute),
+		},
+		"hour and minute offset": {
+			Timezone: "+03:00",
+			Expected: expected.Add(-3 * time.Hour),
+		},
+		"minute offset": {
+			Timezone: "+00:30",
+			Expected: expected.Add(-30 * time.Minute),
+		},
+		"abbreviated hour offset": {
+			Timezone: "+04",
+			Expected: expected.Add(-4 * time.Hour),
+		},
+		"negative hour and minute offset": {
+			Timezone: "-03:30",
+			Expected: expected.Add(3*time.Hour + 30*time.Minute),
+		},
+		"negative minute offset": {
+			Timezone: "-00:30",
+			Expected: expected.Add(30 * time.Minute),
+		},
+		"negative abbreviated hour offset": {
+			Timezone: "-04",
+			Expected: expected.Add(4 * time.Hour),
+		},
+	}
+
+	for title, c := range cases {
+		t.Run(title, func(t *testing.T) {
+			config := defaultConfig()
+			config.Field = "ts"
+			config.Timezone = c.Timezone
+			config.Layouts = append(config.Layouts, time.ANSIC)
+
+			processor, err := newFromConfig(config)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			originalTimestamp := expected.Format(time.ANSIC)
+			t.Logf("Original timestamp: %+v", originalTimestamp)
+			t.Logf("Timezone: %s", c.Timezone)
+
+			event := &beat.Event{
+				Fields: common.MapStr{
+					config.Field: originalTimestamp,
+				},
+			}
+
+			event, err = processor.Run(event)
+			assert.NoError(t, err)
+			assert.Equal(t, c.Expected, event.Timestamp)
+		})
+	}
+}


### PR DESCRIPTION
The ingest node `date` processor supports numeric time zone offsets,
and the `add_locale` Beat processor adds the numeric timezone in numeric
formats. Add support for these formats to the timestamp processor for
consistency with the other processors.

This is needed in #13893, where a javascript pipeline needs the timezone
set by the `add_locale` processor to generate the timestamp using the
`timestamp` processor.