### PR TITLE
[Libbeat]Kubernetes: fix statefulset watcher typo

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -106,6 +106,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Better wording for xpack beats when the _xpack endpoint is not reachable. {pull}13771[13771]
 - Recover from panics in the javascript process and log details about the failure to aid in future debugging. {pull}13690[13690]
 - Make the script processor concurrency-safe. {issue}13690[13690] {pull}13857[13857]
+- Kubernetes watcher at `add_kubernetes_metadata` fails with StatefulSets {pull}13905[13905]
 
 *Auditbeat*
 

--- a/libbeat/common/kubernetes/watcher.go
+++ b/libbeat/common/kubernetes/watcher.go
@@ -162,7 +162,7 @@ func NewWatcher(client kubernetes.Interface, resource Resource, opts WatchOption
 
 		objType = "replicaset"
 	case *StatefulSet:
-		ss := client.AppsV1().ReplicaSets(opts.Namespace)
+		ss := client.AppsV1().StatefulSets(opts.Namespace)
 		listwatch = &cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				return ss.List(options)


### PR DESCRIPTION

As stated in this https://github.com/elastic/beats/issues/13850#issuecomment-537609821
there is an issue when watching `StatefulSets` changes due to a typo at the watcher function.

This PR looks for the expected type when the watchers receives the event
