### PR TITLE
Check if file has disappeared sooner in Log reader

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -158,6 +158,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix timezone parsing of logstash module ingest pipelines. {pull}13890[13890]
 - cisco asa and ftd filesets: Fix parsing of message 106001. {issue}13891[13891] {pull}13903[13903]
 - Fix merging of fields specified in global scope with fields specified under an input's scope. {issue}3628[3628] {pull}13909[13909]
+- Fix delay in enforcing close_renamed and close_removed options. {issue}13488[13488] {pull}13907[13907]
 
 *Heartbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -159,7 +159,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - cisco asa and ftd filesets: Fix parsing of message 106001. {issue}13891[13891] {pull}13903[13903]
 - Fix merging of fields specified in global scope with fields specified under an input's scope. {issue}3628[3628] {pull}13909[13909]
 - Fix delay in enforcing close_renamed and close_removed options. {issue}13488[13488] {pull}13907[13907]
-- Fix delay in enforcing close_renamed and close_removed options. {issue}13889[13889] {pull}13907[13907]
 
 *Heartbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -159,6 +159,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - cisco asa and ftd filesets: Fix parsing of message 106001. {issue}13891[13891] {pull}13903[13903]
 - Fix merging of fields specified in global scope with fields specified under an input's scope. {issue}3628[3628] {pull}13909[13909]
 - Fix delay in enforcing close_renamed and close_removed options. {issue}13488[13488] {pull}13907[13907]
+- Fix delay in enforcing close_renamed and close_removed options. {issue}13889[13889] {pull}13907[13907]
 
 *Heartbeat*
 

--- a/filebeat/input/log/log.go
+++ b/filebeat/input/log/log.go
@@ -73,7 +73,7 @@ func (f *Log) Read(buf []byte) (int, error) {
 		default:
 		}
 
-		err := f.checkFileErrors()
+		err := f.checkFileDisappearedErrors()
 		if err != nil {
 			return totalN, err
 		}
@@ -154,7 +154,8 @@ func (f *Log) errorChecks(err error) error {
 	return nil
 }
 
-func (f *Log) checkFileErrors() error {
+// checkFileDisappearedErrors checks if the log file has been removed or renamed (rotated).
+func (f *Log) checkFileDisappearedErrors() error {
 	// No point doing a stat call on the file if configuration options are
 	// not enabled
 	if !f.config.CloseRenamed && !f.config.CloseRemoved {

--- a/filebeat/input/log/log.go
+++ b/filebeat/input/log/log.go
@@ -128,10 +128,6 @@ func (f *Log) errorChecks(err error) error {
 		return err
 	}
 
-	return nil
-}
-
-func (f *Log) checkFileErrors() error {
 	// Refetch fileinfo to check if the file was truncated or disappeared.
 	// Errors if the file was removed/rotated after reading and before
 	// calling the stat function
@@ -152,6 +148,19 @@ func (f *Log) checkFileErrors() error {
 	age := time.Since(f.lastTimeRead)
 	if age > f.config.CloseInactive {
 		return ErrInactive
+	}
+
+	return nil
+}
+
+func (f *Log) checkFileErrors() error {
+	// Refetch fileinfo to check if the file was truncated or disappeared.
+	// Errors if the file was removed/rotated after reading and before
+	// calling the stat function
+	info, statErr := f.fs.Stat()
+	if statErr != nil {
+		logp.Err("Unexpected error reading from %s; error: %s", f.fs.Name(), statErr)
+		return statErr
 	}
 
 	if f.config.CloseRenamed {

--- a/filebeat/input/log/log.go
+++ b/filebeat/input/log/log.go
@@ -148,6 +148,7 @@ func (f *Log) errorChecks(err error) error {
 	if f.config.CloseRenamed {
 		// Check if the file can still be found under the same path
 		if !file.IsSameFile(f.fs.Name(), info) {
+			logp.Debug("harvester", "close_renamed is enabled and file %s has been renamed", f.fs.Name())
 			return ErrRenamed
 		}
 	}
@@ -155,6 +156,7 @@ func (f *Log) errorChecks(err error) error {
 	if f.config.CloseRemoved {
 		// Check if the file name exists. See https://github.com/elastic/filebeat/issues/93
 		if f.fs.Removed() {
+			logp.Debug("harvester", "close_removed is enabled and file %s has been removed", f.fs.Name())
 			return ErrRemoved
 		}
 	}

--- a/filebeat/input/log/log.go
+++ b/filebeat/input/log/log.go
@@ -111,13 +111,15 @@ func (f *Log) errorChecks(err error) error {
 		return err
 	}
 
+	// At this point we have hit EOF!
+
 	// Stdin is not continuable
 	if !f.fs.Continuable() {
 		logp.Debug("harvester", "Source is not continuable: %s", f.fs.Name())
 		return err
 	}
 
-	if err == io.EOF && f.config.CloseEOF {
+	if f.config.CloseEOF {
 		return err
 	}
 

--- a/filebeat/input/log/log.go
+++ b/filebeat/input/log/log.go
@@ -154,6 +154,12 @@ func (f *Log) errorChecks(err error) error {
 }
 
 func (f *Log) checkFileErrors() error {
+	// No point doing a stat call on the file if configuration options are
+	// not enabled
+	if !f.config.CloseRenamed && !f.config.CloseRemoved {
+		return nil
+	}
+
 	// Refetch fileinfo to check if the file was truncated or disappeared.
 	// Errors if the file was removed/rotated after reading and before
 	// calling the stat function

--- a/filebeat/input/log/log.go
+++ b/filebeat/input/log/log.go
@@ -109,7 +109,8 @@ func (f *Log) Read(buf []byte) (int, error) {
 	}
 }
 
-// errorChecks checks how the given error should be handled based on the config options
+// errorChecks determines the cause for EOF errors, and how the EOF event should be handled
+// based on the config options.
 func (f *Log) errorChecks(err error) error {
 	if err != io.EOF {
 		logp.Err("Unexpected state reading from %s; error: %s", f.fs.Name(), err)
@@ -128,7 +129,7 @@ func (f *Log) errorChecks(err error) error {
 		return err
 	}
 
-	// Refetch fileinfo to check if the file was truncated or disappeared.
+	// Refetch fileinfo to check if the file was truncated.
 	// Errors if the file was removed/rotated after reading and before
 	// calling the stat function
 	info, statErr := f.fs.Stat()
@@ -160,7 +161,7 @@ func (f *Log) checkFileErrors() error {
 		return nil
 	}
 
-	// Refetch fileinfo to check if the file was truncated or disappeared.
+	// Refetch fileinfo to check if the file was renamed or removed.
 	// Errors if the file was removed/rotated after reading and before
 	// calling the stat function
 	info, statErr := f.fs.Stat()


### PR DESCRIPTION
Resolves #13889.

This PR teach the Log reader to check file stat related changes, e.g. a file being moved or renamed, more aggressively than before. As a result a slow or flaky output can no longer hold up these checks from being performed.