### PR TITLE
Implement deep merging of fields

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -156,6 +156,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix conditions and error checking of date processors in ingest pipelines that use `event.timezone` to parse dates. {pull}13883[13883]
 - Fix timezone parsing of logstash module ingest pipelines. {pull}13890[13890]
 - cisco asa and ftd filesets: Fix parsing of message 106001. {issue}13891[13891] {pull}13903[13903]
+- Fix merging of fields specified in global scope with fields specified under an input's scope. {issue}3628[3628] {pull}13909[13909]
 
 *Heartbeat*
 

--- a/libbeat/common/mapstr.go
+++ b/libbeat/common/mapstr.go
@@ -268,55 +268,55 @@ func MapStrUnion(dict1 MapStr, dict2 MapStr) MapStr {
 // MergeFields merges the top-level keys and values in each source map (it does
 // not perform a deep merge). If the same key exists in both, the value in
 // fields takes precedence. If underRoot is true then the contents of the fields
-// MapStr is merged with the value of the 'fields' key in ms.
+// MapStr is merged with the value of the 'fields' key in target.
 //
 // An error is returned if underRoot is true and the value of ms.fields is not a
 // MapStr.
-func MergeFields(ms, fields MapStr, underRoot bool) error {
-	if ms == nil || len(fields) == 0 {
+func MergeFields(target, from MapStr, underRoot bool) error {
+	if target == nil || len(from) == 0 {
 		return nil
 	}
 
-	destMap, err := mergeFieldsGetDestMap(ms, fields, underRoot)
+	destMap, err := mergeFieldsGetDestMap(target, from, underRoot)
 	if err != nil {
 		return err
 	}
 
 	// Add fields and override.
-	for k, v := range fields {
+	for k, v := range from {
 		destMap[k] = v
 	}
 
 	return nil
 }
 
-// MergeFieldsDeep recursively merges the keys and values from fields into ms, either
+// MergeFieldsDeep recursively merges the keys and values from `from` into `target`, either
 // into ms itself (if underRoot == true) or into ms["fields"] (if underRoot == false). If
-// the same key exists in fields and the destination map, the value in fields takes precedence.
+// the same key exists in `from` and the destination map, the value in fields takes precedence.
 //
 // An error is returned if underRoot is true and the value of ms["fields"] is not a
 // MapStr.
-func MergeFieldsDeep(ms, fields MapStr, underRoot bool) error {
-	if ms == nil || len(fields) == 0 {
+func MergeFieldsDeep(target, from MapStr, underRoot bool) error {
+	if target == nil || len(from) == 0 {
 		return nil
 	}
 
-	destMap, err := mergeFieldsGetDestMap(ms, fields, underRoot)
+	destMap, err := mergeFieldsGetDestMap(target, from, underRoot)
 	if err != nil {
 		return err
 	}
 
-	destMap.DeepUpdate(fields)
+	destMap.DeepUpdate(from)
 	return nil
 }
 
-func mergeFieldsGetDestMap(ms, fields MapStr, underRoot bool) (MapStr, error) {
-	destMap := ms
+func mergeFieldsGetDestMap(target, from MapStr, underRoot bool) (MapStr, error) {
+	destMap := target
 	if !underRoot {
-		f, ok := ms[FieldsKey]
+		f, ok := target[FieldsKey]
 		if !ok {
-			destMap = make(MapStr, len(fields))
-			ms[FieldsKey] = destMap
+			destMap = make(MapStr, len(from))
+			target[FieldsKey] = destMap
 		} else {
 			// Use existing 'fields' value.
 			var err error

--- a/libbeat/common/mapstr_test.go
+++ b/libbeat/common/mapstr_test.go
@@ -486,6 +486,184 @@ func TestMergeFields(t *testing.T) {
 	}
 }
 
+func TestMergeFieldsDeep(t *testing.T) {
+	type io struct {
+		UnderRoot bool
+		Event     MapStr
+		Fields    MapStr
+		Output    MapStr
+		Err       string
+	}
+	tests := []io{
+		// underRoot = true, merges
+		{
+			UnderRoot: true,
+			Event: MapStr{
+				"a": "1",
+			},
+			Fields: MapStr{
+				"b": 2,
+			},
+			Output: MapStr{
+				"a": "1",
+				"b": 2,
+			},
+		},
+
+		// underRoot = true, overwrites existing
+		{
+			UnderRoot: true,
+			Event: MapStr{
+				"a": "1",
+			},
+			Fields: MapStr{
+				"a": 2,
+			},
+			Output: MapStr{
+				"a": 2,
+			},
+		},
+
+		// underRoot = false, adds new 'fields' when it doesn't exist
+		{
+			UnderRoot: false,
+			Event: MapStr{
+				"a": "1",
+			},
+			Fields: MapStr{
+				"a": 2,
+			},
+			Output: MapStr{
+				"a": "1",
+				"fields": MapStr{
+					"a": 2,
+				},
+			},
+		},
+
+		// underRoot = false, merge with existing 'fields' and overwrites existing keys
+		{
+			UnderRoot: false,
+			Event: MapStr{
+				"fields": MapStr{
+					"a": "1",
+					"b": 2,
+				},
+			},
+			Fields: MapStr{
+				"a": 3,
+				"c": 4,
+			},
+			Output: MapStr{
+				"fields": MapStr{
+					"a": 3,
+					"b": 2,
+					"c": 4,
+				},
+			},
+		},
+
+		// underRoot = false, error when 'fields' is wrong type
+		{
+			UnderRoot: false,
+			Event: MapStr{
+				"fields": "not a MapStr",
+			},
+			Fields: MapStr{
+				"a": 3,
+			},
+			Output: MapStr{
+				"fields": "not a MapStr",
+			},
+			Err: "expected map",
+		},
+
+		// underRoot = true, merges recursively
+		{
+			UnderRoot: true,
+			Event: MapStr{
+				"my": MapStr{
+					"field1": "field1",
+				},
+			},
+			Fields: MapStr{
+				"my": MapStr{
+					"field2": "field2",
+					"field3": "field3",
+				},
+			},
+			Output: MapStr{
+				"my": MapStr{
+					"field1": "field1",
+					"field2": "field2",
+					"field3": "field3",
+				},
+			},
+		},
+
+		// underRoot = true, merges recursively and overrides
+		{
+			UnderRoot: true,
+			Event: MapStr{
+				"my": MapStr{
+					"field1": "field1",
+					"field2": "field2",
+				},
+			},
+			Fields: MapStr{
+				"my": MapStr{
+					"field2": "fieldTWO",
+					"field3": "field3",
+				},
+			},
+			Output: MapStr{
+				"my": MapStr{
+					"field1": "field1",
+					"field2": "fieldTWO",
+					"field3": "field3",
+				},
+			},
+		},
+
+		// underRoot = false, merges recursively under existing 'fields'
+		{
+			UnderRoot: false,
+			Event: MapStr{
+				"fields": MapStr{
+					"my": MapStr{
+						"field1": "field1",
+					},
+				},
+			},
+			Fields: MapStr{
+				"my": MapStr{
+					"field2": "field2",
+					"field3": "field3",
+				},
+			},
+			Output: MapStr{
+				"fields": MapStr{
+					"my": MapStr{
+						"field1": "field1",
+						"field2": "field2",
+						"field3": "field3",
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		err := MergeFieldsDeep(test.Event, test.Fields, test.UnderRoot)
+		assert.Equal(t, test.Output, test.Event)
+		if test.Err != "" {
+			assert.Contains(t, err.Error(), test.Err)
+		} else {
+			assert.NoError(t, err)
+		}
+	}
+}
+
 func TestAddTag(t *testing.T) {
 	type io struct {
 		Event  MapStr

--- a/libbeat/publisher/processing/default.go
+++ b/libbeat/publisher/processing/default.go
@@ -286,7 +286,7 @@ func (b *builder) Create(cfg beat.ProcessingConfig, drop bool) (beat.Processor, 
 	fields := cfg.Fields.Clone()
 	fields.DeepUpdate(b.fields.Clone())
 	if em := cfg.EventMetadata; len(em.Fields) > 0 {
-		common.MergeFields(fields, em.Fields.Clone(), em.FieldsUnderRoot)
+		common.MergeFieldsDeep(fields, em.Fields.Clone(), em.FieldsUnderRoot)
 	}
 
 	if len(fields) > 0 {


### PR DESCRIPTION
Resolves #3628.

Consider the following Filebeat configuration:

```yml
fields_under_root: true
fields:
  my.field1: "field1"
  my.field2: "field2"

- type: stdin
  enabled: true

  fields_under_root: true
  fields:
    my.field3: "field3"
```

Prior to this PR, Filebeat would not merge general fields and per-input fields deeply. That is, the event resulting from the above configuration would look like:

```json
{
   "my": {
      "field3": "field3"
    }
}
```

With this PR, the resulting event looks like:
```json
{
   "my": {
      "field1": "field1",
      "field2": "field2",
      "field3": "field3"
    }
}
```
