### PR TITLE
Cherry-pick #13903 to 7.4: [SIEM] Fix Cisco ASA and FTD message 106001 producing bad network.direction

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -48,6 +48,9 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 - Fixed early expiration of templates (Netflow v9 and IPFIX). {pull}13821[13821]
 - Fixed bad handling of sequence numbers when multiple observation domains were exported by a single device (Netflow V9 and IPFIX). {pull}13821[13821]
+- Fix conditions and error checking of date processors in ingest pipelines that use `event.timezone` to parse dates. {pull}13883[13883]
+- Fix timezone parsing of logstash module ingest pipelines. {pull}13890[13890]
+- cisco asa and ftd filesets: Fix parsing of message 106001. {issue}13891[13891] {pull}13903[13903]
 
 *Heartbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -48,8 +48,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 - Fixed early expiration of templates (Netflow v9 and IPFIX). {pull}13821[13821]
 - Fixed bad handling of sequence numbers when multiple observation domains were exported by a single device (Netflow V9 and IPFIX). {pull}13821[13821]
-- Fix conditions and error checking of date processors in ingest pipelines that use `event.timezone` to parse dates. {pull}13883[13883]
-- Fix timezone parsing of logstash module ingest pipelines. {pull}13890[13890]
 - cisco asa and ftd filesets: Fix parsing of message 106001. {issue}13891[13891] {pull}13903[13903]
 
 *Heartbeat*

--- a/x-pack/filebeat/module/cisco/asa/test/filtered.log
+++ b/x-pack/filebeat/module/cisco/asa/test/filtered.log
@@ -1,2 +1,3 @@
 Jan  1 01:00:27 beats asa[1234]: %ASA-7-999999: This message is not filtered.
 Jan  1 01:00:30 beats asa[1234]: %ASA-8-999999: This phony message is dropped due to log level.
+Jan  1 01:02:12 beats asa[1234]: %ASA-2-106001: Inbound TCP connection denied from 10.13.12.11/45321 to 192.168.33.12/443 flags URG+SYN+RST on interface eth0

--- a/x-pack/filebeat/module/cisco/asa/test/filtered.log-expected.json
+++ b/x-pack/filebeat/module/cisco/asa/test/filtered.log-expected.json
@@ -20,5 +20,36 @@
         "tags": [
             "cisco-asa"
         ]
+    },
+    {
+        "@timestamp": "2019-01-01T01:02:12.000Z",
+        "cisco.asa.message_id": "106001",
+        "cisco.asa.source_interface": "eth0",
+        "destination.ip": "192.168.33.12",
+        "destination.port": 443,
+        "event.action": "firewall-rule",
+        "event.code": 106001,
+        "event.dataset": "cisco.asa",
+        "event.module": "cisco",
+        "event.original": "%ASA-2-106001: Inbound TCP connection denied from 10.13.12.11/45321 to 192.168.33.12/443 flags URG+SYN+RST on interface eth0",
+        "event.outcome": "deny",
+        "event.severity": 2,
+        "event.timezone": "+00:00",
+        "fileset.name": "asa",
+        "host.hostname": "beats",
+        "input.type": "log",
+        "log.level": "critical",
+        "log.offset": 174,
+        "network.direction": "inbound",
+        "network.iana_number": 6,
+        "network.transport": "tcp",
+        "process.name": "asa",
+        "process.pid": 1234,
+        "service.type": "cisco",
+        "source.ip": "10.13.12.11",
+        "source.port": 45321,
+        "tags": [
+            "cisco-asa"
+        ]
     }
 ]

--- a/x-pack/filebeat/module/cisco/shared/ingest/asa-ftd-pipeline.yml
+++ b/x-pack/filebeat/module/cisco/shared/ingest/asa-ftd-pipeline.yml
@@ -960,6 +960,9 @@ processors:
  - lowercase:
      field: "file.type"
      ignore_failure: true
+ - lowercase:
+     field: "network.direction"
+     ignore_failure: true
 
 #
 # Populate network.iana_number from network.transport. Also does reverse


### PR DESCRIPTION
Cherry-pick of PR #13903 to 7.4 branch. Original message: 

In some case network.direction can be `Inbound` instead of `inbound`
as expected. This happens only with message 106001 in the ASA and FTD.

Fixes #13891 