### PR TITLE
[AllBeats]Kubernetes - Travis tests: Remove 1.8 - Add 1.15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,171 +19,171 @@ env:
 
 jobs:
   include:
-    # General checks
-    - os: linux
-      env: TARGETS="check"
-      go: $TRAVIS_GO_VERSION
-      stage: check
+    # # General checks
+    # - os: linux
+    #   env: TARGETS="check"
+    #   go: $TRAVIS_GO_VERSION
+    #   stage: check
 
-    # Filebeat
-    - os: linux
-      env: TARGETS="-C filebeat testsuite"
-      go: $TRAVIS_GO_VERSION
-      stage: test
-    - os: osx
-      env: TARGETS="TEST_ENVIRONMENT=0 -C filebeat testsuite"
-      go: $TRAVIS_GO_VERSION
-      stage: test
-    - os: linux
-      env: TARGETS="-C x-pack/filebeat testsuite"
-      go: $(GO_VERSION)
-      stage: test
+    # # Filebeat
+    # - os: linux
+    #   env: TARGETS="-C filebeat testsuite"
+    #   go: $TRAVIS_GO_VERSION
+    #   stage: test
+    # - os: osx
+    #   env: TARGETS="TEST_ENVIRONMENT=0 -C filebeat testsuite"
+    #   go: $TRAVIS_GO_VERSION
+    #   stage: test
+    # - os: linux
+    #   env: TARGETS="-C x-pack/filebeat testsuite"
+    #   go: $(GO_VERSION)
+    #   stage: test
 
-    # Heartbeat
-    - os: linux
-      env: TARGETS="-C heartbeat testsuite"
-      go: $TRAVIS_GO_VERSION
-      stage: test
-    - os: osx
-      env: TARGETS="TEST_ENVIRONMENT=0 -C heartbeat testsuite"
-      go: $TRAVIS_GO_VERSION
-      stage: test
+    # # Heartbeat
+    # - os: linux
+    #   env: TARGETS="-C heartbeat testsuite"
+    #   go: $TRAVIS_GO_VERSION
+    #   stage: test
+    # - os: osx
+    #   env: TARGETS="TEST_ENVIRONMENT=0 -C heartbeat testsuite"
+    #   go: $TRAVIS_GO_VERSION
+    #   stage: test
 
-    # Auditbeat
-    - os: linux
-      env: TARGETS="-C auditbeat testsuite"
-      go: $TRAVIS_GO_VERSION
-      stage: test
-    - os: osx
-      env: TARGETS="TEST_ENVIRONMENT=0 -C auditbeat testsuite"
-      go: $TRAVIS_GO_VERSION
-      stage: test
-    - os: linux
-      env: TARGETS="-C auditbeat crosscompile"
-      go: $TRAVIS_GO_VERSION
-      stage: test
-    - os: linux
-      env: TARGETS="-C x-pack/auditbeat testsuite"
-      go: $TRAVIS_GO_VERSION
-      stage: test
+    # # Auditbeat
+    # - os: linux
+    #   env: TARGETS="-C auditbeat testsuite"
+    #   go: $TRAVIS_GO_VERSION
+    #   stage: test
+    # - os: osx
+    #   env: TARGETS="TEST_ENVIRONMENT=0 -C auditbeat testsuite"
+    #   go: $TRAVIS_GO_VERSION
+    #   stage: test
+    # - os: linux
+    #   env: TARGETS="-C auditbeat crosscompile"
+    #   go: $TRAVIS_GO_VERSION
+    #   stage: test
+    # - os: linux
+    #   env: TARGETS="-C x-pack/auditbeat testsuite"
+    #   go: $TRAVIS_GO_VERSION
+    #   stage: test
 
-    # Libbeat
-    - os: linux
-      env: TARGETS="-C libbeat testsuite"
-      go: $TRAVIS_GO_VERSION
-      stage: test
-    - os: linux
-      env: TARGETS="-C libbeat crosscompile"
-      go: $TRAVIS_GO_VERSION
-      stage: test
-    - os: linux
-      env: STRESS_TEST_OPTIONS="-timeout=20m -race -v -parallel 1" TARGETS="-C libbeat stress-tests"
-      go: $TRAVIS_GO_VERSION
-      stage: test
-    - os: linux
-      env: TARGETS="-C x-pack/libbeat testsuite"
-      go: $TRAVIS_GO_VERSION
-      stage: test
+    # # Libbeat
+    # - os: linux
+    #   env: TARGETS="-C libbeat testsuite"
+    #   go: $TRAVIS_GO_VERSION
+    #   stage: test
+    # - os: linux
+    #   env: TARGETS="-C libbeat crosscompile"
+    #   go: $TRAVIS_GO_VERSION
+    #   stage: test
+    # - os: linux
+    #   env: STRESS_TEST_OPTIONS="-timeout=20m -race -v -parallel 1" TARGETS="-C libbeat stress-tests"
+    #   go: $TRAVIS_GO_VERSION
+    #   stage: test
+    # - os: linux
+    #   env: TARGETS="-C x-pack/libbeat testsuite"
+    #   go: $TRAVIS_GO_VERSION
+    #   stage: test
 
-    # Metricbeat
-    - os: linux
-      env: TARGETS="-C metricbeat unit-tests coverage-report"
-      go: $TRAVIS_GO_VERSION
-      stage: test
-    - os: linux
-      env: TARGETS="-C metricbeat integration-tests-environment coverage-report"
-      go: $TRAVIS_GO_VERSION
-      stage: test
-    - os: linux
-      env: TARGETS="-C metricbeat update system-tests-environment coverage-report"
-      go: $TRAVIS_GO_VERSION
-      stage: test
+    # # Metricbeat
+    # - os: linux
+    #   env: TARGETS="-C metricbeat unit-tests coverage-report"
+    #   go: $TRAVIS_GO_VERSION
+    #   stage: test
+    # - os: linux
+    #   env: TARGETS="-C metricbeat integration-tests-environment coverage-report"
+    #   go: $TRAVIS_GO_VERSION
+    #   stage: test
+    # - os: linux
+    #   env: TARGETS="-C metricbeat update system-tests-environment coverage-report"
+    #   go: $TRAVIS_GO_VERSION
+    #   stage: test
 
-    - os: osx
-      env: TARGETS="TEST_ENVIRONMENT=0 -C metricbeat testsuite"
-      go: $TRAVIS_GO_VERSION
-      stage: test
-    - os: linux
-      env: TARGETS="-C metricbeat crosscompile"
-      go: $TRAVIS_GO_VERSION
-      stage: test
-    - os: linux
-      env: TARGETS="-C x-pack/metricbeat testsuite"
-      go: $TRAVIS_GO_VERSION
-      stage: test
+    # - os: osx
+    #   env: TARGETS="TEST_ENVIRONMENT=0 -C metricbeat testsuite"
+    #   go: $TRAVIS_GO_VERSION
+    #   stage: test
+    # - os: linux
+    #   env: TARGETS="-C metricbeat crosscompile"
+    #   go: $TRAVIS_GO_VERSION
+    #   stage: test
+    # - os: linux
+    #   env: TARGETS="-C x-pack/metricbeat testsuite"
+    #   go: $TRAVIS_GO_VERSION
+    #   stage: test
 
-    # Packetbeat
-    - os: linux
-      env: TARGETS="-C packetbeat testsuite"
-      go: $TRAVIS_GO_VERSION
-      stage: test
+    # # Packetbeat
+    # - os: linux
+    #   env: TARGETS="-C packetbeat testsuite"
+    #   go: $TRAVIS_GO_VERSION
+    #   stage: test
 
-    # Winlogbeat
-    - os: linux
-      env: TARGETS="-C winlogbeat crosscompile"
-      go: $TRAVIS_GO_VERSION
-      stage: test
+    # # Winlogbeat
+    # - os: linux
+    #   env: TARGETS="-C winlogbeat crosscompile"
+    #   go: $TRAVIS_GO_VERSION
+    #   stage: test
 
-    # Functionbeat
-    - os: linux
-      env: TARGETS="-C x-pack/functionbeat testsuite"
-      go: $TRAVIS_GO_VERSION
-      stage: test
-    - os: osx
-      env: TARGETS="TEST_ENVIRONMENT=0 -C x-pack/functionbeat testsuite"
-      go: $TRAVIS_GO_VERSION
-      stage: test
+    # # Functionbeat
+    # - os: linux
+    #   env: TARGETS="-C x-pack/functionbeat testsuite"
+    #   go: $TRAVIS_GO_VERSION
+    #   stage: test
+    # - os: osx
+    #   env: TARGETS="TEST_ENVIRONMENT=0 -C x-pack/functionbeat testsuite"
+    #   go: $TRAVIS_GO_VERSION
+    #   stage: test
 
-    # Journalbeat
-    - os: linux
-      env: TARGETS="-C journalbeat testsuite"
-      go: $TRAVIS_GO_VERSION
-      stage: test
+    # # Journalbeat
+    # - os: linux
+    #   env: TARGETS="-C journalbeat testsuite"
+    #   go: $TRAVIS_GO_VERSION
+    #   stage: test
 
-    # Generators
-    - os: linux
-      env: TARGETS="-C generator/metricbeat test"
-      go: $TRAVIS_GO_VERSION
-      stage: test
-    - os: linux
-      env: TARGETS="-C generator/beat test"
-      go: $TRAVIS_GO_VERSION
-      stage: test
+    # # Generators
+    # - os: linux
+    #   env: TARGETS="-C generator/metricbeat test"
+    #   go: $TRAVIS_GO_VERSION
+    #   stage: test
+    # - os: linux
+    #   env: TARGETS="-C generator/beat test"
+    #   go: $TRAVIS_GO_VERSION
+    #   stage: test
 
-    - os: osx
-      env: TARGETS="-C generator/metricbeat test"
-      go: $TRAVIS_GO_VERSION
-      stage: test
-    - os: osx
-      env: TARGETS="-C generator/beat test"
-      go: $TRAVIS_GO_VERSION
-      stage: test
+    # - os: osx
+    #   env: TARGETS="-C generator/metricbeat test"
+    #   go: $TRAVIS_GO_VERSION
+    #   stage: test
+    # - os: osx
+    #   env: TARGETS="-C generator/beat test"
+    #   go: $TRAVIS_GO_VERSION
+    #   stage: test
 
-    # Docs
-    - os: linux
-      env: TARGETS="docs"
-      go: $TRAVIS_GO_VERSION
-      stage: test
+    # # Docs
+    # - os: linux
+    #   env: TARGETS="docs"
+    #   go: $TRAVIS_GO_VERSION
+    #   stage: test
 
-    # Kubernetes
+    # # Kubernetes
+    # - os: linux
+    #   install: deploy/kubernetes/.travis/setup.sh
+    #   env:
+    #     - TARGETS="-C deploy/kubernetes test"
+    #     - TRAVIS_K8S_VERSION=v1.9.4
+    #   stage: test
+    # - os: linux
+    #   install: deploy/kubernetes/.travis/setup.sh
+    #   env:
+    #     - TARGETS="-C deploy/kubernetes test"
+    #     - TRAVIS_K8S_VERSION=v1.10.0
+    #   stage: test
     - os: linux
       install: deploy/kubernetes/.travis/setup.sh
       env:
         - TARGETS="-C deploy/kubernetes test"
-        - TRAVIS_K8S_VERSION=v1.9.4
-      stage: test
-    - os: linux
-      install: deploy/kubernetes/.travis/setup.sh
-      env:
-        - TARGETS="-C deploy/kubernetes test"
-        - TRAVIS_K8S_VERSION=v1.10.0
-      stage: test
-    - os: linux
-      install: deploy/kubernetes/.travis/setup.sh
-      env:
-        - TARGETS="-C deploy/kubernetes test"
-        - TRAVIS_K8S_VERSION=v1.16.0
-        - TRAVIS_MINIKUBE_VERSION=v1.4.0
+        - TRAVIS_K8S_VERSION=v1.15.0
+        - TRAVIS_MINIKUBE_VERSION=v1.3.1
       stage: test
     # TODO include 1.11 once minikube supports it
     #- os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,172 +19,172 @@ env:
 
 jobs:
   include:
-    # # General checks
-    # - os: linux
-    #   env: TARGETS="check"
-    #   go: $TRAVIS_GO_VERSION
-    #   stage: check
+    # General checks
+    - os: linux
+      env: TARGETS="check"
+      go: $TRAVIS_GO_VERSION
+      stage: check
 
-    # # Filebeat
-    # - os: linux
-    #   env: TARGETS="-C filebeat testsuite"
-    #   go: $TRAVIS_GO_VERSION
-    #   stage: test
-    # - os: osx
-    #   env: TARGETS="TEST_ENVIRONMENT=0 -C filebeat testsuite"
-    #   go: $TRAVIS_GO_VERSION
-    #   stage: test
-    # - os: linux
-    #   env: TARGETS="-C x-pack/filebeat testsuite"
-    #   go: $(GO_VERSION)
-    #   stage: test
+    # Filebeat
+    - os: linux
+      env: TARGETS="-C filebeat testsuite"
+      go: $TRAVIS_GO_VERSION
+      stage: test
+    - os: osx
+      env: TARGETS="TEST_ENVIRONMENT=0 -C filebeat testsuite"
+      go: $TRAVIS_GO_VERSION
+      stage: test
+    - os: linux
+      env: TARGETS="-C x-pack/filebeat testsuite"
+      go: $(GO_VERSION)
+      stage: test
 
-    # # Heartbeat
-    # - os: linux
-    #   env: TARGETS="-C heartbeat testsuite"
-    #   go: $TRAVIS_GO_VERSION
-    #   stage: test
-    # - os: osx
-    #   env: TARGETS="TEST_ENVIRONMENT=0 -C heartbeat testsuite"
-    #   go: $TRAVIS_GO_VERSION
-    #   stage: test
+    # Heartbeat
+    - os: linux
+      env: TARGETS="-C heartbeat testsuite"
+      go: $TRAVIS_GO_VERSION
+      stage: test
+    - os: osx
+      env: TARGETS="TEST_ENVIRONMENT=0 -C heartbeat testsuite"
+      go: $TRAVIS_GO_VERSION
+      stage: test
 
-    # # Auditbeat
-    # - os: linux
-    #   env: TARGETS="-C auditbeat testsuite"
-    #   go: $TRAVIS_GO_VERSION
-    #   stage: test
-    # - os: osx
-    #   env: TARGETS="TEST_ENVIRONMENT=0 -C auditbeat testsuite"
-    #   go: $TRAVIS_GO_VERSION
-    #   stage: test
-    # - os: linux
-    #   env: TARGETS="-C auditbeat crosscompile"
-    #   go: $TRAVIS_GO_VERSION
-    #   stage: test
-    # - os: linux
-    #   env: TARGETS="-C x-pack/auditbeat testsuite"
-    #   go: $TRAVIS_GO_VERSION
-    #   stage: test
+    # Auditbeat
+    - os: linux
+      env: TARGETS="-C auditbeat testsuite"
+      go: $TRAVIS_GO_VERSION
+      stage: test
+    - os: osx
+      env: TARGETS="TEST_ENVIRONMENT=0 -C auditbeat testsuite"
+      go: $TRAVIS_GO_VERSION
+      stage: test
+    - os: linux
+      env: TARGETS="-C auditbeat crosscompile"
+      go: $TRAVIS_GO_VERSION
+      stage: test
+    - os: linux
+      env: TARGETS="-C x-pack/auditbeat testsuite"
+      go: $TRAVIS_GO_VERSION
+      stage: test
 
-    # # Libbeat
-    # - os: linux
-    #   env: TARGETS="-C libbeat testsuite"
-    #   go: $TRAVIS_GO_VERSION
-    #   stage: test
-    # - os: linux
-    #   env: TARGETS="-C libbeat crosscompile"
-    #   go: $TRAVIS_GO_VERSION
-    #   stage: test
-    # - os: linux
-    #   env: STRESS_TEST_OPTIONS="-timeout=20m -race -v -parallel 1" TARGETS="-C libbeat stress-tests"
-    #   go: $TRAVIS_GO_VERSION
-    #   stage: test
-    # - os: linux
-    #   env: TARGETS="-C x-pack/libbeat testsuite"
-    #   go: $TRAVIS_GO_VERSION
-    #   stage: test
+    # Libbeat
+    - os: linux
+      env: TARGETS="-C libbeat testsuite"
+      go: $TRAVIS_GO_VERSION
+      stage: test
+    - os: linux
+      env: TARGETS="-C libbeat crosscompile"
+      go: $TRAVIS_GO_VERSION
+      stage: test
+    - os: linux
+      env: STRESS_TEST_OPTIONS="-timeout=20m -race -v -parallel 1" TARGETS="-C libbeat stress-tests"
+      go: $TRAVIS_GO_VERSION
+      stage: test
+    - os: linux
+      env: TARGETS="-C x-pack/libbeat testsuite"
+      go: $TRAVIS_GO_VERSION
+      stage: test
 
-    # # Metricbeat
-    # - os: linux
-    #   env: TARGETS="-C metricbeat unit-tests coverage-report"
-    #   go: $TRAVIS_GO_VERSION
-    #   stage: test
-    # - os: linux
-    #   env: TARGETS="-C metricbeat integration-tests-environment coverage-report"
-    #   go: $TRAVIS_GO_VERSION
-    #   stage: test
-    # - os: linux
-    #   env: TARGETS="-C metricbeat update system-tests-environment coverage-report"
-    #   go: $TRAVIS_GO_VERSION
-    #   stage: test
+    # Metricbeat
+    - os: linux
+      env: TARGETS="-C metricbeat unit-tests coverage-report"
+      go: $TRAVIS_GO_VERSION
+      stage: test
+    - os: linux
+      env: TARGETS="-C metricbeat integration-tests-environment coverage-report"
+      go: $TRAVIS_GO_VERSION
+      stage: test
+    - os: linux
+      env: TARGETS="-C metricbeat update system-tests-environment coverage-report"
+      go: $TRAVIS_GO_VERSION
+      stage: test
 
-    # - os: osx
-    #   env: TARGETS="TEST_ENVIRONMENT=0 -C metricbeat testsuite"
-    #   go: $TRAVIS_GO_VERSION
-    #   stage: test
-    # - os: linux
-    #   env: TARGETS="-C metricbeat crosscompile"
-    #   go: $TRAVIS_GO_VERSION
-    #   stage: test
-    # - os: linux
-    #   env: TARGETS="-C x-pack/metricbeat testsuite"
-    #   go: $TRAVIS_GO_VERSION
-    #   stage: test
+    - os: osx
+      env: TARGETS="TEST_ENVIRONMENT=0 -C metricbeat testsuite"
+      go: $TRAVIS_GO_VERSION
+      stage: test
+    - os: linux
+      env: TARGETS="-C metricbeat crosscompile"
+      go: $TRAVIS_GO_VERSION
+      stage: test
+    - os: linux
+      env: TARGETS="-C x-pack/metricbeat testsuite"
+      go: $TRAVIS_GO_VERSION
+      stage: test
 
-    # # Packetbeat
-    # - os: linux
-    #   env: TARGETS="-C packetbeat testsuite"
-    #   go: $TRAVIS_GO_VERSION
-    #   stage: test
+    # Packetbeat
+    - os: linux
+      env: TARGETS="-C packetbeat testsuite"
+      go: $TRAVIS_GO_VERSION
+      stage: test
 
-    # # Winlogbeat
-    # - os: linux
-    #   env: TARGETS="-C winlogbeat crosscompile"
-    #   go: $TRAVIS_GO_VERSION
-    #   stage: test
+    # Winlogbeat
+    - os: linux
+      env: TARGETS="-C winlogbeat crosscompile"
+      go: $TRAVIS_GO_VERSION
+      stage: test
 
-    # # Functionbeat
-    # - os: linux
-    #   env: TARGETS="-C x-pack/functionbeat testsuite"
-    #   go: $TRAVIS_GO_VERSION
-    #   stage: test
-    # - os: osx
-    #   env: TARGETS="TEST_ENVIRONMENT=0 -C x-pack/functionbeat testsuite"
-    #   go: $TRAVIS_GO_VERSION
-    #   stage: test
+    # Functionbeat
+    - os: linux
+      env: TARGETS="-C x-pack/functionbeat testsuite"
+      go: $TRAVIS_GO_VERSION
+      stage: test
+    - os: osx
+      env: TARGETS="TEST_ENVIRONMENT=0 -C x-pack/functionbeat testsuite"
+      go: $TRAVIS_GO_VERSION
+      stage: test
 
-    # # Journalbeat
-    # - os: linux
-    #   env: TARGETS="-C journalbeat testsuite"
-    #   go: $TRAVIS_GO_VERSION
-    #   stage: test
+    # Journalbeat
+    - os: linux
+      env: TARGETS="-C journalbeat testsuite"
+      go: $TRAVIS_GO_VERSION
+      stage: test
 
-    # # Generators
-    # - os: linux
-    #   env: TARGETS="-C generator/metricbeat test"
-    #   go: $TRAVIS_GO_VERSION
-    #   stage: test
-    # - os: linux
-    #   env: TARGETS="-C generator/beat test"
-    #   go: $TRAVIS_GO_VERSION
-    #   stage: test
+    # Generators
+    - os: linux
+      env: TARGETS="-C generator/metricbeat test"
+      go: $TRAVIS_GO_VERSION
+      stage: test
+    - os: linux
+      env: TARGETS="-C generator/beat test"
+      go: $TRAVIS_GO_VERSION
+      stage: test
 
-    # - os: osx
-    #   env: TARGETS="-C generator/metricbeat test"
-    #   go: $TRAVIS_GO_VERSION
-    #   stage: test
-    # - os: osx
-    #   env: TARGETS="-C generator/beat test"
-    #   go: $TRAVIS_GO_VERSION
-    #   stage: test
+    - os: osx
+      env: TARGETS="-C generator/metricbeat test"
+      go: $TRAVIS_GO_VERSION
+      stage: test
+    - os: osx
+      env: TARGETS="-C generator/beat test"
+      go: $TRAVIS_GO_VERSION
+      stage: test
 
-    # # Docs
-    # - os: linux
-    #   env: TARGETS="docs"
-    #   go: $TRAVIS_GO_VERSION
-    #   stage: test
+    # Docs
+    - os: linux
+      env: TARGETS="docs"
+      go: $TRAVIS_GO_VERSION
+      stage: test
 
-    # # Kubernetes
-    # - os: linux
-    #   install: deploy/kubernetes/.travis/setup.sh
-    #   env:
-    #     - TARGETS="-C deploy/kubernetes test"
-    #     - TRAVIS_K8S_VERSION=v1.9.4
-    #   stage: test
-    # - os: linux
-    #   install: deploy/kubernetes/.travis/setup.sh
-    #   env:
-    #     - TARGETS="-C deploy/kubernetes test"
-    #     - TRAVIS_K8S_VERSION=v1.10.0
-    #   stage: test
+    # Kubernetes
+    - os: linux
+      install: deploy/kubernetes/.travis/setup.sh
+      env:
+        - TARGETS="-C deploy/kubernetes test"
+        - TRAVIS_K8S_VERSION=v1.9.4
+      stage: test
+    - os: linux
+      install: deploy/kubernetes/.travis/setup.sh
+      env:
+        - TARGETS="-C deploy/kubernetes test"
+        - TRAVIS_K8S_VERSION=v1.10.0
+      stage: test
     - os: linux
       dist: xenial
       install: deploy/kubernetes/.travis/setup.sh
       env:
         - TARGETS="-C deploy/kubernetes test"
-        - TRAVIS_K8S_VERSION=v1.15.0
-        - TRAVIS_MINIKUBE_VERSION=v1.3.1
+        - TRAVIS_K8S_VERSION=v1.16.0
+        - TRAVIS_MINIKUBE_VERSION=v1.4.0
       stage: test
       addons:
         apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -183,6 +183,7 @@ jobs:
       env:
         - TARGETS="-C deploy/kubernetes test"
         - TRAVIS_K8S_VERSION=v1.16.0
+        - TRAVIS_MINIKUBE_VERSION=v1.4.0
       stage: test
     # TODO include 1.11 once minikube supports it
     #- os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -183,8 +183,8 @@ jobs:
       install: deploy/kubernetes/.travis/setup.sh
       env:
         - TARGETS="-C deploy/kubernetes test"
-        - TRAVIS_K8S_VERSION=v1.16.0
-        - TRAVIS_MINIKUBE_VERSION=v1.4.0
+        - TRAVIS_K8S_VERSION=v1.15.3
+        - TRAVIS_MINIKUBE_VERSION=v1.3.1
       stage: test
       addons:
         apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -170,12 +170,6 @@ jobs:
       install: deploy/kubernetes/.travis/setup.sh
       env:
         - TARGETS="-C deploy/kubernetes test"
-        - TRAVIS_K8S_VERSION=v1.8.0
-      stage: test
-    - os: linux
-      install: deploy/kubernetes/.travis/setup.sh
-      env:
-        - TARGETS="-C deploy/kubernetes test"
         - TRAVIS_K8S_VERSION=v1.9.4
       stage: test
     - os: linux
@@ -183,6 +177,12 @@ jobs:
       env:
         - TARGETS="-C deploy/kubernetes test"
         - TRAVIS_K8S_VERSION=v1.10.0
+      stage: test
+    - os: linux
+      install: deploy/kubernetes/.travis/setup.sh
+      env:
+        - TARGETS="-C deploy/kubernetes test"
+        - TRAVIS_K8S_VERSION=v1.16.0
       stage: test
     # TODO include 1.11 once minikube supports it
     #- os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -179,6 +179,7 @@ jobs:
     #     - TRAVIS_K8S_VERSION=v1.10.0
     #   stage: test
     - os: linux
+      dist: xenial
       install: deploy/kubernetes/.travis/setup.sh
       env:
         - TARGETS="-C deploy/kubernetes test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -186,6 +186,16 @@ jobs:
         - TRAVIS_K8S_VERSION=v1.15.0
         - TRAVIS_MINIKUBE_VERSION=v1.3.1
       stage: test
+      addons:
+        apt:
+          update: true
+          packages:
+            - python-virtualenv
+            - libpcap-dev
+            - xsltproc
+            - libxml2-utils
+            - librpm-dev
+
     # TODO include 1.11 once minikube supports it
     #- os: linux
     #  install: deploy/kubernetes/.travis/setup.sh

--- a/deploy/kubernetes/.travis/setup.sh
+++ b/deploy/kubernetes/.travis/setup.sh
@@ -9,6 +9,8 @@ export CHANGE_MINIKUBE_NONE_USER=true
 curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/$TRAVIS_K8S_VERSION/bin/linux/amd64/kubectl && \
       chmod +x kubectl && sudo mv kubectl /usr/local/bin/
 curl -Lo minikube https://storage.googleapis.com/minikube/releases/$TRAVIS_MINIKUBE_VERSION/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
+mkdir -p $HOME/.kube $HOME/.minikube
+touch $HOME/.kube/config
 sudo minikube start --vm-driver=none --kubernetes-version=$TRAVIS_K8S_VERSION --logtostderr
 sudo minikube update-context
 JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; \


### PR DESCRIPTION
Remove 1.8 from the supported set of kubernetes versions.
Add 1.15 (most recent + less disrupting at this moment) to the travis test set.

- https://github.com/elastic/beats/issues/13850
- https://github.com/elastic/beats/pull/13851

_**Edit**: while this issue was targeting kubernetes 1.16, it looks like bootstrapping using our scripting needed some tweaking. I have set the target to 1.15 instead, which will serve well as a recent version replacement fot 1.8_
 