### PR TITLE
Leverage KUBECONFIG when creating k8s client

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -409,6 +409,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add tags filter in ec2 metricset. {pull}13872[13872] {issue}13145[13145]
 - Add cloud.account.id and cloud.account.name into events from aws module. {issue}13551[13551] {pull}13558[13558]
 - Add `metrics_path` as known hint for autodiscovery {pull}13996[13996]
+- Leverage KUBECONFIG when creating k8s client. {pull}13916[13916]
 
 *Packetbeat*
 

--- a/libbeat/common/kubernetes/util.go
+++ b/libbeat/common/kubernetes/util.go
@@ -47,7 +47,7 @@ func GetKubernetesClient(kubeconfig string) (kubernetes.Interface, error) {
 	if kubeconfig == "" {
 		kubeconfig = getKubeConfigEnvironmentVariable()
 	}
-	logp.Debug("edooo", kubeconfig)
+
 	cfg, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
 	if err != nil {
 		return nil, fmt.Errorf("unable to build kube config due to error: %+v", err)
@@ -64,14 +64,8 @@ func GetKubernetesClient(kubeconfig string) (kubernetes.Interface, error) {
 // IsInCluster takes a kubeconfig file path as input and deduces if Beats is running in cluster or not,
 // taking into consideration the existence of KUBECONFIG variable
 func IsInCluster(kubeconfig string) bool {
-	if kubeconfig == "" {
-		if getKubeConfigEnvironmentVariable() != "" {
-			return false
-		}
-		return true
-	}
-
-	return false
+	if kubeconfig != "" || getKubeConfigEnvironmentVariable() != "" { return false }
+	return true
 }
 
 // DiscoverKubernetesNode figures out the Kubernetes node to use.

--- a/libbeat/common/kubernetes/util.go
+++ b/libbeat/common/kubernetes/util.go
@@ -64,7 +64,9 @@ func GetKubernetesClient(kubeconfig string) (kubernetes.Interface, error) {
 // IsInCluster takes a kubeconfig file path as input and deduces if Beats is running in cluster or not,
 // taking into consideration the existence of KUBECONFIG variable
 func IsInCluster(kubeconfig string) bool {
-	if kubeconfig != "" || getKubeConfigEnvironmentVariable() != "" { return false }
+	if kubeconfig != "" || getKubeConfigEnvironmentVariable() != "" {
+		return false
+	}
 	return true
 }
 

--- a/libbeat/docs/processors-using.asciidoc
+++ b/libbeat/docs/processors-using.asciidoc
@@ -1339,7 +1339,8 @@ the Kubernetes node.
 processors:
 - add_kubernetes_metadata:
     host: <hostname>
-    # It defaults to `KUBECONFIG` environment variable if present.
+    # If kube_config is not set, KUBECONFIG environment variable will be checked
+    # and if not present it will fall back to InCluster
     kube_config: ${HOME}/.kube/config
 -------------------------------------------------------------------------------
 
@@ -1351,7 +1352,8 @@ enables ones that the user is interested in.
 processors:
 - add_kubernetes_metadata:
     host: <hostname>
-    # It defaults to `KUBECONFIG` environment variable if present.
+    # If kube_config is not set, KUBECONFIG environment variable will be checked
+    # and if not present it will fall back to InCluster
     kube_config: ~/.kube/config
     default_indexers.enabled: false
     default_matchers.enabled: false

--- a/libbeat/docs/processors-using.asciidoc
+++ b/libbeat/docs/processors-using.asciidoc
@@ -1339,7 +1339,7 @@ the Kubernetes node.
 processors:
 - add_kubernetes_metadata:
     host: <hostname>
-    # It defaults to `KUBECONFIG` variable if present.
+    # It defaults to `KUBECONFIG` environment variable if present.
     kube_config: ${HOME}/.kube/config
 -------------------------------------------------------------------------------
 
@@ -1351,7 +1351,7 @@ enables ones that the user is interested in.
 processors:
 - add_kubernetes_metadata:
     host: <hostname>
-    # It defaults to `KUBECONFIG` variable if present.
+    # It defaults to `KUBECONFIG` environment variable if present.
     kube_config: ~/.kube/config
     default_indexers.enabled: false
     default_matchers.enabled: false
@@ -1371,7 +1371,7 @@ mode.
 metadata. If it is not set, the processor collects metadata from all namespaces.
 It is unset by default.
 `kube_config`:: (Optional) Use given config file as configuration for Kubernetes
-client. It defaults to `KUBECONFIG` variable if present.
+client. It defaults to `KUBECONFIG` environment variable if present.
 `default_indexers.enabled`:: (Optional) Enable/Disable default pod indexers, in
 case you want to specify your own.
 `default_matchers.enabled`:: (Optional) Enable/Disable default pod matchers, in

--- a/libbeat/docs/processors-using.asciidoc
+++ b/libbeat/docs/processors-using.asciidoc
@@ -1339,6 +1339,7 @@ the Kubernetes node.
 processors:
 - add_kubernetes_metadata:
     host: <hostname>
+    # It defaults to `KUBECONFIG` variable if present.
     kube_config: ${HOME}/.kube/config
 -------------------------------------------------------------------------------
 
@@ -1350,6 +1351,7 @@ enables ones that the user is interested in.
 processors:
 - add_kubernetes_metadata:
     host: <hostname>
+    # It defaults to `KUBECONFIG` variable if present.
     kube_config: ~/.kube/config
     default_indexers.enabled: false
     default_matchers.enabled: false
@@ -1369,7 +1371,7 @@ mode.
 metadata. If it is not set, the processor collects metadata from all namespaces.
 It is unset by default.
 `kube_config`:: (Optional) Use given config file as configuration for Kubernetes
-client.
+client. It defaults to `KUBECONFIG` variable if present.
 `default_indexers.enabled`:: (Optional) Enable/Disable default pod indexers, in
 case you want to specify your own.
 `default_matchers.enabled`:: (Optional) Enable/Disable default pod matchers, in

--- a/libbeat/docs/shared-autodiscover.asciidoc
+++ b/libbeat/docs/shared-autodiscover.asciidoc
@@ -186,7 +186,7 @@ The `kubernetes` autodiscover provider has the following configuration settings:
   metadata. If it is not set, the processor collects metadata from all
   namespaces. It is unset by default.
 `kube_config`:: (Optional) Use given config file as configuration for Kubernetes
-  client.
+  client. It defaults to `KUBECONFIG` variable if present.
 
 include::../../{beatname_lc}/docs/autodiscover-kubernetes-config.asciidoc[]
 

--- a/libbeat/docs/shared-autodiscover.asciidoc
+++ b/libbeat/docs/shared-autodiscover.asciidoc
@@ -186,7 +186,8 @@ The `kubernetes` autodiscover provider has the following configuration settings:
   metadata. If it is not set, the processor collects metadata from all
   namespaces. It is unset by default.
 `kube_config`:: (Optional) Use given config file as configuration for Kubernetes
-  client. It defaults to `KUBECONFIG` environment variable if present.
+  client. If kube_config is not set, KUBECONFIG environment variable will be
+  checked and if not present it will fall back to InCluster.
 
 include::../../{beatname_lc}/docs/autodiscover-kubernetes-config.asciidoc[]
 

--- a/libbeat/docs/shared-autodiscover.asciidoc
+++ b/libbeat/docs/shared-autodiscover.asciidoc
@@ -186,7 +186,7 @@ The `kubernetes` autodiscover provider has the following configuration settings:
   metadata. If it is not set, the processor collects metadata from all
   namespaces. It is unset by default.
 `kube_config`:: (Optional) Use given config file as configuration for Kubernetes
-  client. It defaults to `KUBECONFIG` variable if present.
+  client. It defaults to `KUBECONFIG` environment variable if present.
 
 include::../../{beatname_lc}/docs/autodiscover-kubernetes-config.asciidoc[]
 

--- a/libbeat/processors/add_kubernetes_metadata/kubernetes.go
+++ b/libbeat/processors/add_kubernetes_metadata/kubernetes.go
@@ -21,6 +21,7 @@ package add_kubernetes_metadata
 
 import (
 	"fmt"
+	"os"
 	"time"
 
 	k8sclient "k8s.io/client-go/kubernetes"
@@ -109,6 +110,8 @@ func New(cfg *common.Config) (processors.Processor, error) {
 	if err != nil {
 		if kubernetes.IsInCluster(config.KubeConfig) {
 			logp.Debug("kubernetes", "%v: could not create kubernetes client using in_cluster config", "add_kubernetes_metadata")
+		} else if config.KubeConfig == "" {
+			logp.Debug("kubernetes", "%v: could not create kubernetes client using config: %v", "add_kubernetes_metadata", os.Getenv("KUBECONFIG"))
 		} else {
 			logp.Debug("kubernetes", "%v: could not create kubernetes client using config: %v", "add_kubernetes_metadata", config.KubeConfig)
 		}

--- a/metricbeat/docs/modules/kubernetes.asciidoc
+++ b/metricbeat/docs/modules/kubernetes.asciidoc
@@ -79,7 +79,7 @@ metricbeat.modules:
   add_metadata: true
   # When used outside the cluster:
   #host: node_name
-  # It defaults to `KUBECONFIG` variable if present.
+  # It defaults to `KUBECONFIG` environment variable if present.
   #kube_config: ~/.kube/config
 
 # State metrics from kube-state-metrics service:
@@ -101,7 +101,7 @@ metricbeat.modules:
   add_metadata: true
   # When used outside the cluster:
   #host: node_name
-  # It defaults to `KUBECONFIG` variable if present.
+  # It defaults to `KUBECONFIG` environment variable if present.
   #kube_config: ~/.kube/config
 
 # Kubernetes events

--- a/metricbeat/docs/modules/kubernetes.asciidoc
+++ b/metricbeat/docs/modules/kubernetes.asciidoc
@@ -79,6 +79,7 @@ metricbeat.modules:
   add_metadata: true
   # When used outside the cluster:
   #host: node_name
+  # It defaults to `KUBECONFIG` variable if present.
   #kube_config: ~/.kube/config
 
 # State metrics from kube-state-metrics service:
@@ -100,6 +101,7 @@ metricbeat.modules:
   add_metadata: true
   # When used outside the cluster:
   #host: node_name
+  # It defaults to `KUBECONFIG` variable if present.
   #kube_config: ~/.kube/config
 
 # Kubernetes events

--- a/metricbeat/docs/modules/kubernetes.asciidoc
+++ b/metricbeat/docs/modules/kubernetes.asciidoc
@@ -79,7 +79,8 @@ metricbeat.modules:
   add_metadata: true
   # When used outside the cluster:
   #host: node_name
-  # It defaults to `KUBECONFIG` environment variable if present.
+  # If kube_config is not set, KUBECONFIG environment variable will be checked
+  # and if not present it will fall back to InCluster
   #kube_config: ~/.kube/config
 
 # State metrics from kube-state-metrics service:
@@ -101,7 +102,8 @@ metricbeat.modules:
   add_metadata: true
   # When used outside the cluster:
   #host: node_name
-  # It defaults to `KUBECONFIG` environment variable if present.
+  # If kube_config is not set, KUBECONFIG environment variable will be checked
+  # and if not present it will fall back to InCluster
   #kube_config: ~/.kube/config
 
 # Kubernetes events

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -435,7 +435,8 @@ metricbeat.modules:
   add_metadata: true
   # When used outside the cluster:
   #host: node_name
-  # It defaults to `KUBECONFIG` environment variable if present.
+  # If kube_config is not set, KUBECONFIG environment variable will be checked
+  # and if not present it will fall back to InCluster
   #kube_config: ~/.kube/config
 
 # State metrics from kube-state-metrics service:
@@ -457,7 +458,8 @@ metricbeat.modules:
   add_metadata: true
   # When used outside the cluster:
   #host: node_name
-  # It defaults to `KUBECONFIG` environment variable if present.
+  # If kube_config is not set, KUBECONFIG environment variable will be checked
+  # and if not present it will fall back to InCluster
   #kube_config: ~/.kube/config
 
 # Kubernetes events

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -435,6 +435,7 @@ metricbeat.modules:
   add_metadata: true
   # When used outside the cluster:
   #host: node_name
+  # It defaults to `KUBECONFIG` variable if present.
   #kube_config: ~/.kube/config
 
 # State metrics from kube-state-metrics service:
@@ -456,6 +457,7 @@ metricbeat.modules:
   add_metadata: true
   # When used outside the cluster:
   #host: node_name
+  # It defaults to `KUBECONFIG` variable if present.
   #kube_config: ~/.kube/config
 
 # Kubernetes events

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -435,7 +435,7 @@ metricbeat.modules:
   add_metadata: true
   # When used outside the cluster:
   #host: node_name
-  # It defaults to `KUBECONFIG` variable if present.
+  # It defaults to `KUBECONFIG` environment variable if present.
   #kube_config: ~/.kube/config
 
 # State metrics from kube-state-metrics service:
@@ -457,7 +457,7 @@ metricbeat.modules:
   add_metadata: true
   # When used outside the cluster:
   #host: node_name
-  # It defaults to `KUBECONFIG` variable if present.
+  # It defaults to `KUBECONFIG` environment variable if present.
   #kube_config: ~/.kube/config
 
 # Kubernetes events

--- a/metricbeat/module/kubernetes/_meta/config.reference.yml
+++ b/metricbeat/module/kubernetes/_meta/config.reference.yml
@@ -19,7 +19,7 @@
   add_metadata: true
   # When used outside the cluster:
   #host: node_name
-  # It defaults to `KUBECONFIG` variable if present.
+  # It defaults to `KUBECONFIG` environment variable if present.
   #kube_config: ~/.kube/config
 
 # State metrics from kube-state-metrics service:
@@ -41,7 +41,7 @@
   add_metadata: true
   # When used outside the cluster:
   #host: node_name
-  # It defaults to `KUBECONFIG` variable if present.
+  # It defaults to `KUBECONFIG` environment variable if present.
   #kube_config: ~/.kube/config
 
 # Kubernetes events

--- a/metricbeat/module/kubernetes/_meta/config.reference.yml
+++ b/metricbeat/module/kubernetes/_meta/config.reference.yml
@@ -19,6 +19,7 @@
   add_metadata: true
   # When used outside the cluster:
   #host: node_name
+  # It defaults to `KUBECONFIG` variable if present.
   #kube_config: ~/.kube/config
 
 # State metrics from kube-state-metrics service:
@@ -40,6 +41,7 @@
   add_metadata: true
   # When used outside the cluster:
   #host: node_name
+  # It defaults to `KUBECONFIG` variable if present.
   #kube_config: ~/.kube/config
 
 # Kubernetes events

--- a/metricbeat/module/kubernetes/_meta/config.reference.yml
+++ b/metricbeat/module/kubernetes/_meta/config.reference.yml
@@ -19,7 +19,8 @@
   add_metadata: true
   # When used outside the cluster:
   #host: node_name
-  # It defaults to `KUBECONFIG` environment variable if present.
+  # If kube_config is not set, KUBECONFIG environment variable will be checked
+  # and if not present it will fall back to InCluster
   #kube_config: ~/.kube/config
 
 # State metrics from kube-state-metrics service:
@@ -41,7 +42,8 @@
   add_metadata: true
   # When used outside the cluster:
   #host: node_name
-  # It defaults to `KUBECONFIG` environment variable if present.
+  # If kube_config is not set, KUBECONFIG environment variable will be checked
+  # and if not present it will fall back to InCluster
   #kube_config: ~/.kube/config
 
 # Kubernetes events

--- a/metricbeat/module/kubernetes/_meta/config.yml
+++ b/metricbeat/module/kubernetes/_meta/config.yml
@@ -20,6 +20,7 @@
   #annotations.dedot: true
   # When used outside the cluster:
   #host: node_name
+  # It defaults to `KUBECONFIG` variable if present.
   #kube_config: ~/.kube/config
 
 # State metrics from kube-state-metrics service:

--- a/metricbeat/module/kubernetes/_meta/config.yml
+++ b/metricbeat/module/kubernetes/_meta/config.yml
@@ -20,7 +20,8 @@
   #annotations.dedot: true
   # When used outside the cluster:
   #host: node_name
-  # It defaults to `KUBECONFIG` environment variable if present.
+  # If kube_config is not set, KUBECONFIG environment variable will be checked
+  # and if not present it will fall back to InCluster
   #kube_config: ~/.kube/config
 
 # State metrics from kube-state-metrics service:

--- a/metricbeat/module/kubernetes/_meta/config.yml
+++ b/metricbeat/module/kubernetes/_meta/config.yml
@@ -20,7 +20,7 @@
   #annotations.dedot: true
   # When used outside the cluster:
   #host: node_name
-  # It defaults to `KUBECONFIG` variable if present.
+  # It defaults to `KUBECONFIG` environment variable if present.
   #kube_config: ~/.kube/config
 
 # State metrics from kube-state-metrics service:

--- a/metricbeat/modules.d/kubernetes.yml.disabled
+++ b/metricbeat/modules.d/kubernetes.yml.disabled
@@ -23,7 +23,8 @@
   #annotations.dedot: true
   # When used outside the cluster:
   #host: node_name
-  # It defaults to `KUBECONFIG` environment variable if present.
+  # If kube_config is not set, KUBECONFIG environment variable will be checked
+  # and if not present it will fall back to InCluster
   #kube_config: ~/.kube/config
 
 # State metrics from kube-state-metrics service:

--- a/metricbeat/modules.d/kubernetes.yml.disabled
+++ b/metricbeat/modules.d/kubernetes.yml.disabled
@@ -23,6 +23,7 @@
   #annotations.dedot: true
   # When used outside the cluster:
   #host: node_name
+  # It defaults to `KUBECONFIG` variable if present.
   #kube_config: ~/.kube/config
 
 # State metrics from kube-state-metrics service:

--- a/metricbeat/modules.d/kubernetes.yml.disabled
+++ b/metricbeat/modules.d/kubernetes.yml.disabled
@@ -23,7 +23,7 @@
   #annotations.dedot: true
   # When used outside the cluster:
   #host: node_name
-  # It defaults to `KUBECONFIG` variable if present.
+  # It defaults to `KUBECONFIG` environment variable if present.
   #kube_config: ~/.kube/config
 
 # State metrics from kube-state-metrics service:

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -536,6 +536,7 @@ metricbeat.modules:
   add_metadata: true
   # When used outside the cluster:
   #host: node_name
+  # It defaults to `KUBECONFIG` variable if present.
   #kube_config: ~/.kube/config
 
 # State metrics from kube-state-metrics service:
@@ -557,6 +558,7 @@ metricbeat.modules:
   add_metadata: true
   # When used outside the cluster:
   #host: node_name
+  # It defaults to `KUBECONFIG` variable if present.
   #kube_config: ~/.kube/config
 
 # Kubernetes events

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -536,7 +536,8 @@ metricbeat.modules:
   add_metadata: true
   # When used outside the cluster:
   #host: node_name
-  # It defaults to `KUBECONFIG` environment variable if present.
+  # If kube_config is not set, KUBECONFIG environment variable will be checked
+  # and if not present it will fall back to InCluster
   #kube_config: ~/.kube/config
 
 # State metrics from kube-state-metrics service:
@@ -558,7 +559,8 @@ metricbeat.modules:
   add_metadata: true
   # When used outside the cluster:
   #host: node_name
-  # It defaults to `KUBECONFIG` environment variable if present.
+  # If kube_config is not set, KUBECONFIG environment variable will be checked
+  # and if not present it will fall back to InCluster
   #kube_config: ~/.kube/config
 
 # Kubernetes events

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -536,7 +536,7 @@ metricbeat.modules:
   add_metadata: true
   # When used outside the cluster:
   #host: node_name
-  # It defaults to `KUBECONFIG` variable if present.
+  # It defaults to `KUBECONFIG` environment variable if present.
   #kube_config: ~/.kube/config
 
 # State metrics from kube-state-metrics service:
@@ -558,7 +558,7 @@ metricbeat.modules:
   add_metadata: true
   # When used outside the cluster:
   #host: node_name
-  # It defaults to `KUBECONFIG` variable if present.
+  # It defaults to `KUBECONFIG` environment variable if present.
   #kube_config: ~/.kube/config
 
 # Kubernetes events


### PR DESCRIPTION
Closes #13648.

This PR changes the k8s Client creation so as:
1. if `kube_config` is provided return a client using it
2. if `KUBECONFIG` env var is present and points to a valid file return a client using it
3. then you are in an `in_cluster` mode so use `inClusterConfig` (this is implemented in `BuildConfigFromFlags` already)

cc: @exekias , @odacremolbap 