### PR TITLE
Add asciidoctor flag to mage docs script

### DIFF
--- a/dev-tools/mage/docs.go
+++ b/dev-tools/mage/docs.go
@@ -124,6 +124,8 @@ func (b docsBuilder) AsciidocBook(opts ...DocsOption) error {
 	htmlDir := CWD("build/html_docs", params.name)
 	buildDocsScript := filepath.Join(cloneDir, "build_docs")
 	args := []string{
+		"--asciidoctor",
+		"--respect_edit_url_overrides",
 		"--chunk=1",
 		"--doc", params.indexFile,
 		"--out", htmlDir,


### PR DESCRIPTION
Follows the change in #13772 to switch over local build to use asciidoctor and adds respect_edit_url_overrides flag.