### PR TITLE
Fix race in publisher/pipeline retry loop

### DIFF
--- a/libbeat/publisher/pipeline/controller.go
+++ b/libbeat/publisher/pipeline/controller.go
@@ -84,6 +84,8 @@ func newOutputController(
 
 func (c *outputController) Close() error {
 	c.consumer.sigPause()
+	c.consumer.close()
+	c.retryer.close()
 
 	if c.out != nil {
 		for _, out := range c.out.outputs {
@@ -91,9 +93,6 @@ func (c *outputController) Close() error {
 		}
 		close(c.out.workQueue)
 	}
-
-	c.consumer.close()
-	c.retryer.close()
 
 	return nil
 }

--- a/libbeat/publisher/pipeline/retry.go
+++ b/libbeat/publisher/pipeline/retry.go
@@ -138,9 +138,7 @@ func (r *retryer) loop() {
 	for {
 		select {
 		case <-r.done:
-
 			return
-
 		case evt := <-r.in:
 			var (
 				countFailed  int


### PR DESCRIPTION
See #13892

I found this while working on the docker plugin. Thanks to @urso for the help tracking it down.

When we close a pipeline while there are still events attempting to be sent in a retry routine, we can run into a `send on closed channel` panic because the 'done' and 'send' portions of the retry select statement can be available at the same time, and by the time the pipline is closing, the send channel will be closed. Select branches are chosen at random if there's more than one available to be run.

This adds a WaitGroup to the retry struct, and also moves the send WorkQueue to the end of the pipeline close, so we're guaranteed to be out of the retry loop by the time the problematic channel has closed. 