### PR TITLE
Cherry-pick #13876 to 7.4: Fix bad variable in Netflow docs

### DIFF
--- a/x-pack/filebeat/docs/inputs/input-netflow.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-netflow.asciidoc
@@ -73,7 +73,7 @@ NetFlow/IPFIX fields with vendor extensions and to override existing fields.
 The expected format is the same as used by Logstash's NetFlow codec
 {logstash-ref}/plugins-codecs-netflow.html#plugins-codecs-netflow-ipfix_definitions[ipfix_definitions]
 and {logstash-ref}/plugins-codecs-netflow.html#plugins-codecs-netflow-netflow_definitions[netflow_definitions].
-{beatname} will detect which of the two formats is used.
+{beatname_uc} will detect which of the two formats is used.
 
 NetFlow format example:
 ["source","yaml",subs="attributes"]


### PR DESCRIPTION
Cherry-pick of PR #13876 to 7.4 branch. Original message: 

`{beatname}` used instead of `{beatname_uc}`