### PR TITLE
[DOCS] Fixes link to role mapping

### DIFF
--- a/libbeat/docs/security/basic-auth.asciidoc
+++ b/libbeat/docs/security/basic-auth.asciidoc
@@ -46,8 +46,8 @@ endif::apm-server[]
 configure the `certificate` and `key` settings. These settings assume that the
 distinguished name (DN) in the certificate is mapped to the appropriate roles in
 the `role_mapping.yml` file on each node in the {es} cluster. For more
-information, see {xpack-ref}/mapping-roles.html#mapping-roles-file[Using Role
-Mapping Files].
+information, see {ref}/mapping-roles.html#mapping-roles-file[Using role
+mapping files].
 +
 ["source","yaml",subs="attributes,callouts"]
 --------------------------------------------------


### PR DESCRIPTION
Related to elastic/elasticsearch#46880

This PR fixes a broken link to the security content in the Stack Overview, which has moved here:
https://www.elastic.co/guide/en/elasticsearch/reference/master/mapping-roles.html#mapping-roles-file