### PR TITLE
Always use create op_type with ES 7.5+

### DIFF
--- a/libbeat/outputs/elasticsearch/client_test.go
+++ b/libbeat/outputs/elasticsearch/client_test.go
@@ -388,7 +388,7 @@ func TestBulkEncodeEvents(t *testing.T) {
 
 			recorder := &testBulkRecorder{}
 
-			encoded := bulkEncodePublishRequest(recorder, index, pipeline, test.docType, events)
+			encoded := bulkEncodePublishRequest(common.Version{Major: 7, Minor: 5}, recorder, index, pipeline, test.docType, events)
 			assert.Equal(t, len(events), len(encoded), "all events should have been encoded")
 			assert.False(t, recorder.inAction, "incomplete bulk")
 


### PR DESCRIPTION
Elasticsearch introduces the `create_doc` privilege, which always
requires the op_type to be `create`. We would like to take advantage of
this, in order to reduces the privileges Beats users have to set for
Beats.

In the future Elasticsearch will support `op_type == create` if
documents without ID are indexed, but older Elasticsearch versions
don't.

This change always uses `op_type == create` when the Elasticsearch
version is 7.5+.

Related ES changes:
- https://github.com/elastic/elasticsearch/pull/45806
- https://github.com/elastic/elasticsearch/pull/47169
- https://github.com/elastic/elasticsearch/pull/47353