### PR TITLE
Adding missed CHANGELOG entry

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -61,6 +61,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 *Metricbeat*
 
 - Ignore prometheus untyped metrics with NaN value. {issue}13750[13750] {pull}13790[13790]
+- Mark Kibana usage stats as collected only if API call succeeds. {pull}13881[13881]
 
 *Packetbeat*
 


### PR DESCRIPTION
This PR adds a missing CHANGELOG entry for https://github.com/elastic/beats/pull/13895.