### PR TITLE
Adding missed CHANGELOG entry

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -46,6 +46,7 @@ https://github.com/elastic/beats/compare/v6.8.0...6.8.1[Check the HEAD diff]
 *Metricbeat*
 
 - Fix panic in Redis Key metricset when collecting information from a removed key. {pull}13426[13426]
+- Mark Kibana usage stats as collected only if API call succeeds. {pull}13881[13881]
 
 *Packetbeat*
 


### PR DESCRIPTION
This PR adds a missing CHANGELOG entry for https://github.com/elastic/beats/pull/13896.