### PR TITLE
Fix flaky test_beat.test_xpack Metricbeat system test

### DIFF
--- a/libbeat/tests/system/beat/compose.py
+++ b/libbeat/tests/system/beat/compose.py
@@ -215,3 +215,17 @@ class ComposeMixin(object):
             class_dir, current = os.path.split(class_dir)
             if current == '':  # We have reached root
                 raise Exception("failed to find a docker-compose.yml file")
+
+    @classmethod
+    def get_service_log(cls, service):
+        container = cls.compose_project().containers(service_names=[service])[0]
+        return container.logs()
+
+    @classmethod
+    def service_log_contains(cls, service, msg):
+        log = cls.get_service_log(service)
+        counter = 0
+        for line in log.splitlines():
+            if line.find(msg) >= 0:
+                counter += 1
+        return counter > 0

--- a/metricbeat/docker-compose.yml
+++ b/metricbeat/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       context: ./module/beat/_meta
       args:
         BEAT_VERSION: ${BEAT_VERSION:-7.3.0}
+    command: '-e'
     ports:
       - 5066
 

--- a/metricbeat/tests/system/test_beat.py
+++ b/metricbeat/tests/system/test_beat.py
@@ -40,7 +40,7 @@ class Test(metricbeat.BaseTest):
         # it's cluster UUID in the process. Otherwise, the monitoring Metricbeat instance will
         # show errors in its log about not being able to determine the Elasticsearch cluster UUID
         # to be associated with the monitored Metricbeat instance.
-        self.wait_until(cond: self.mb_index_exists, max_timeout: 60)
+        self.wait_until(cond=self.mb_index_exists, max_timeout=60)
 
         proc = self.start_beat()
         self.wait_until(lambda: self.output_lines() > 0)

--- a/metricbeat/tests/system/test_beat.py
+++ b/metricbeat/tests/system/test_beat.py
@@ -31,8 +31,7 @@ class Test(metricbeat.BaseTest):
         # it's cluster UUID in the process. Otherwise, the monitoring Metricbeat instance will
         # show errors in its log about not being able to determine the Elasticsearch cluster UUID
         # to be associated with the monitored Metricbeat instance.
-        self.delete_mb_indices()
-        self.wait_until(cond=self.mb_index_exists, max_timeout=60)
+        self.wait_until(cond=self.mb_connected_to_es, max_timeout=30)
 
         self.render_config_template(modules=[{
             "name": "beat",
@@ -49,13 +48,5 @@ class Test(metricbeat.BaseTest):
         proc.check_kill_and_wait()
         self.assert_no_logged_warnings()
 
-    def delete_mb_indices(self):
-        es = Elasticsearch([self.get_elasticsearch_url()])
-        return es.indices.delete("metricbeat-*")
-
-    def mb_index_exists(self):
-        es = Elasticsearch([self.get_elasticsearch_url()])
-        return len(es.cat.indices(index='metricbeat-*')) > 0
-
-    def get_elasticsearch_url(self):
-        return "http://" + self.compose_host("elasticsearch")
+    def mb_connected_to_es(self):
+        return self.service_log_contains('metricbeat', 'Connection to backoff(elasticsearch(')

--- a/metricbeat/tests/system/test_beat.py
+++ b/metricbeat/tests/system/test_beat.py
@@ -53,4 +53,3 @@ class Test(metricbeat.BaseTest):
 
     def get_elasticsearch_url(self):
         return "http://" + self.compose_host("elasticsearch")
-

--- a/metricbeat/tests/system/test_beat.py
+++ b/metricbeat/tests/system/test_beat.py
@@ -18,7 +18,7 @@ class Test(metricbeat.BaseTest):
         """
         beat metricset tests
         """
-        self.check_metricset("beat", metricset, self.get_hosts(), self.FIELDS + ["service"])
+        self.check_metricset("beat", metricset, [self.compose_host("metricbeat")], self.FIELDS + ["service"])
 
     @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
     def test_xpack(self):
@@ -28,7 +28,7 @@ class Test(metricbeat.BaseTest):
         self.render_config_template(modules=[{
             "name": "beat",
             "metricsets": self.METRICSETS,
-            "hosts": self.get_hosts(),
+            "hosts": [self.compose_host("metricbeat")],
             "period": "1s",
             "extras": {
                 "xpack.enabled": "true"
@@ -49,4 +49,8 @@ class Test(metricbeat.BaseTest):
 
     def mb_index_exists(self):
         es = Elasticsearch([self.get_elasticsearch_url()])
-        return len(es.cat.indices(index='metricbeat-*', h='index')) > 0
+        return len(es.cat.indices(index='metricbeat-*')) > 0
+
+    def get_elasticsearch_url(self):
+        return "http://" + self.compose_host("elasticsearch")
+


### PR DESCRIPTION
Resolves #13947.

This PR:
* fixes the hostnames used to refer to the **monitored** Metricbeat service in the **monitoring** Metricbeat instance's `beat` module configuration.
* removes the naive `sleep` and uses a `wait_until` approach instead.