### PR TITLE
[7.4][DOCS] Backport: Change intro to avoid mentioning number of sniffer types

### DIFF
--- a/packetbeat/docs/packetbeat-options.asciidoc
+++ b/packetbeat/docs/packetbeat-options.asciidoc
@@ -135,7 +135,7 @@ packetbeat.interfaces.snaplen: 1514
 [float]
 ==== `type`
 
-Packetbeat supports two sniffer types:
+Packetbeat supports these sniffer types:
 
  * `pcap`, which uses the libpcap library and works on most platforms, but
    it's not the fastest option.


### PR DESCRIPTION
Backports #13794 to 7.4 branch.