### PR TITLE
Modify kafka input to include parsing multiple messages

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -333,6 +333,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add input httpjson. {issue}13545[13545] {pull}13546[13546]
 - Filebeat Netflow input: Remove beta label. {pull}13858[13858]
 - Remove `event.timezone` from events that don't need it in some modules that support log formats with and without timezones. {pull}13918[13918]
+- Add YieldEventsFromField config option in the kafka input. {pull}13965[13965]
 
 *Heartbeat*
 - Add non-privileged icmp on linux and darwin(mac). {pull}13795[13795] {issue}11498[11498]

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -333,7 +333,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add input httpjson. {issue}13545[13545] {pull}13546[13546]
 - Filebeat Netflow input: Remove beta label. {pull}13858[13858]
 - Remove `event.timezone` from events that don't need it in some modules that support log formats with and without timezones. {pull}13918[13918]
-- Add YieldEventsFromField config option in the kafka input. {pull}13965[13965]
+- Add ExpandEventListFromField config option in the kafka input. {pull}13965[13965]
 
 *Heartbeat*
 - Add non-privileged icmp on linux and darwin(mac). {pull}13795[13795] {issue}11498[11498]

--- a/filebeat/docs/inputs/input-kafka.asciidoc
+++ b/filebeat/docs/inputs/input-kafka.asciidoc
@@ -129,8 +129,8 @@ Kafka fetch settings:
 
 ===== `expand_event_list_from_field`
 
-If the fileset using this input expects to receive multiple messages bundled under a specific field then the config option `expand_event_list_from_field` value can be assigned the name of the json group object.
-For example in the case of azure fielsets the events are found under the json object "records".
+If the fileset using this input expects to receive multiple messages bundled under a specific field then the config option `expand_event_list_from_field` value can be assigned the name of the field.
+For example in the case of azure filesets the events are found under the json object "records".
 ```
 {
 "records": [ {event1}, {event2}]

--- a/filebeat/docs/inputs/input-kafka.asciidoc
+++ b/filebeat/docs/inputs/input-kafka.asciidoc
@@ -127,6 +127,17 @@ Kafka fetch settings:
 *`max`*:: The maximum number of bytes to read per request. Defaults to 0
 (no limit).
 
+===== `expand_event_list_from_field`
+
+If the fileset using this input expects to receive multiple messages bundled under a specific field then the config option `expand_event_list_from_field` value can be assigned the name of the json group object.
+For example in the case of azure fielsets the events are found under the json object "records".
+```
+{
+"records": [ {event1}, {event2}]
+}
+```
+This setting will be able to split the messages under the group value ('records') into separate events.
+
 ===== `rebalance`
 
 Kafka rebalance settings:

--- a/filebeat/input/kafka/config.go
+++ b/filebeat/input/kafka/config.go
@@ -34,22 +34,23 @@ import (
 
 type kafkaInputConfig struct {
 	// Kafka hosts with port, e.g. "localhost:9092"
-	Hosts          []string          `config:"hosts" validate:"required"`
-	Topics         []string          `config:"topics" validate:"required"`
-	GroupID        string            `config:"group_id" validate:"required"`
-	ClientID       string            `config:"client_id"`
-	Version        kafka.Version     `config:"version"`
-	InitialOffset  initialOffset     `config:"initial_offset"`
-	ConnectBackoff time.Duration     `config:"connect_backoff" validate:"min=0"`
-	ConsumeBackoff time.Duration     `config:"consume_backoff" validate:"min=0"`
-	WaitClose      time.Duration     `config:"wait_close" validate:"min=0"`
-	MaxWaitTime    time.Duration     `config:"max_wait_time"`
-	IsolationLevel isolationLevel    `config:"isolation_level"`
-	Fetch          kafkaFetch        `config:"fetch"`
-	Rebalance      kafkaRebalance    `config:"rebalance"`
-	TLS            *tlscommon.Config `config:"ssl"`
-	Username       string            `config:"username"`
-	Password       string            `config:"password"`
+	Hosts                []string          `config:"hosts" validate:"required"`
+	Topics               []string          `config:"topics" validate:"required"`
+	GroupID              string            `config:"group_id" validate:"required"`
+	ClientID             string            `config:"client_id"`
+	Version              kafka.Version     `config:"version"`
+	InitialOffset        initialOffset     `config:"initial_offset"`
+	ConnectBackoff       time.Duration     `config:"connect_backoff" validate:"min=0"`
+	ConsumeBackoff       time.Duration     `config:"consume_backoff" validate:"min=0"`
+	WaitClose            time.Duration     `config:"wait_close" validate:"min=0"`
+	MaxWaitTime          time.Duration     `config:"max_wait_time"`
+	IsolationLevel       isolationLevel    `config:"isolation_level"`
+	Fetch                kafkaFetch        `config:"fetch"`
+	Rebalance            kafkaRebalance    `config:"rebalance"`
+	TLS                  *tlscommon.Config `config:"ssl"`
+	Username             string            `config:"username"`
+	Password             string            `config:"password"`
+	YieldEventsFromField string            `config:"yield_events_from_field"`
 }
 
 type kafkaFetch struct {

--- a/filebeat/input/kafka/config.go
+++ b/filebeat/input/kafka/config.go
@@ -34,23 +34,23 @@ import (
 
 type kafkaInputConfig struct {
 	// Kafka hosts with port, e.g. "localhost:9092"
-	Hosts                []string          `config:"hosts" validate:"required"`
-	Topics               []string          `config:"topics" validate:"required"`
-	GroupID              string            `config:"group_id" validate:"required"`
-	ClientID             string            `config:"client_id"`
-	Version              kafka.Version     `config:"version"`
-	InitialOffset        initialOffset     `config:"initial_offset"`
-	ConnectBackoff       time.Duration     `config:"connect_backoff" validate:"min=0"`
-	ConsumeBackoff       time.Duration     `config:"consume_backoff" validate:"min=0"`
-	WaitClose            time.Duration     `config:"wait_close" validate:"min=0"`
-	MaxWaitTime          time.Duration     `config:"max_wait_time"`
-	IsolationLevel       isolationLevel    `config:"isolation_level"`
-	Fetch                kafkaFetch        `config:"fetch"`
-	Rebalance            kafkaRebalance    `config:"rebalance"`
-	TLS                  *tlscommon.Config `config:"ssl"`
-	Username             string            `config:"username"`
-	Password             string            `config:"password"`
-	YieldEventsFromField string            `config:"yield_events_from_field"`
+	Hosts                    []string          `config:"hosts" validate:"required"`
+	Topics                   []string          `config:"topics" validate:"required"`
+	GroupID                  string            `config:"group_id" validate:"required"`
+	ClientID                 string            `config:"client_id"`
+	Version                  kafka.Version     `config:"version"`
+	InitialOffset            initialOffset     `config:"initial_offset"`
+	ConnectBackoff           time.Duration     `config:"connect_backoff" validate:"min=0"`
+	ConsumeBackoff           time.Duration     `config:"consume_backoff" validate:"min=0"`
+	WaitClose                time.Duration     `config:"wait_close" validate:"min=0"`
+	MaxWaitTime              time.Duration     `config:"max_wait_time"`
+	IsolationLevel           isolationLevel    `config:"isolation_level"`
+	Fetch                    kafkaFetch        `config:"fetch"`
+	Rebalance                kafkaRebalance    `config:"rebalance"`
+	TLS                      *tlscommon.Config `config:"ssl"`
+	Username                 string            `config:"username"`
+	Password                 string            `config:"password"`
+	ExpandEventListFromField string            `config:"expand_events_from_field"`
 }
 
 type kafkaFetch struct {

--- a/filebeat/input/kafka/config.go
+++ b/filebeat/input/kafka/config.go
@@ -50,7 +50,7 @@ type kafkaInputConfig struct {
 	TLS                      *tlscommon.Config `config:"ssl"`
 	Username                 string            `config:"username"`
 	Password                 string            `config:"password"`
-	ExpandEventListFromField string            `config:"expand_events_from_field"`
+	ExpandEventListFromField string            `config:"expand_event_list_from_field"`
 }
 
 type kafkaFetch struct {

--- a/filebeat/input/kafka/input.go
+++ b/filebeat/input/kafka/input.go
@@ -108,7 +108,7 @@ func (input *kafkaInput) runConsumerGroup(
 	handler := &groupHandler{
 		version: input.config.Version,
 		outlet:  input.outlet,
-		// expandEventListFromField will be assigned the configuration option yield_events_from_field
+		// expandEventListFromField will be assigned the configuration option expand_event_list_from_field
 		expandEventListFromField: input.config.ExpandEventListFromField,
 		log:                      input.log,
 	}

--- a/filebeat/input/kafka/kafka_integration_test.go
+++ b/filebeat/input/kafka/kafka_integration_test.go
@@ -197,10 +197,10 @@ func TestInputWithMultipleEvents(t *testing.T) {
 
 	// Setup the input config
 	config := common.MustNewConfigFrom(common.MapStr{
-		"hosts":                    getTestKafkaHost(),
-		"topics":                   []string{testTopic},
-		"group_id":                 "filebeat",
-		"wait_close":               0,
+		"hosts":                        getTestKafkaHost(),
+		"topics":                       []string{testTopic},
+		"group_id":                     "filebeat",
+		"wait_close":                   0,
 		"expand_event_list_from_field": "records",
 	})
 

--- a/filebeat/input/kafka/kafka_integration_test.go
+++ b/filebeat/input/kafka/kafka_integration_test.go
@@ -201,7 +201,7 @@ func TestInputWithMultipleEvents(t *testing.T) {
 		"topics":                   []string{testTopic},
 		"group_id":                 "filebeat",
 		"wait_close":               0,
-		"expand_events_from_field": "records",
+		"expand_event_list_from_field": "records",
 	})
 
 	// Route input events through our capturer instead of sending through ES.

--- a/filebeat/input/kafka/kafka_integration_test.go
+++ b/filebeat/input/kafka/kafka_integration_test.go
@@ -188,7 +188,7 @@ func TestInputWithMultipleEvents(t *testing.T) {
 
 	// Send test messages to the topic for the input to read.
 	message := testMessage{
-		message: "{\"records\": [{\"val\": \"val1\"}, {\"val\": \"val2\"}]}",
+		message: "{\"records\": [{\"val\":\"val1\"}, {\"val\":\"val2\"}]}",
 		headers: []sarama.RecordHeader{
 			recordHeader("X-Test-Header", "test header value"),
 		},
@@ -197,11 +197,11 @@ func TestInputWithMultipleEvents(t *testing.T) {
 
 	// Setup the input config
 	config := common.MustNewConfigFrom(common.MapStr{
-		"hosts":                   getTestKafkaHost(),
-		"topics":                  []string{testTopic},
-		"group_id":                "filebeat",
-		"wait_close":              0,
-		"yield_events_from_field": "records",
+		"hosts":                    getTestKafkaHost(),
+		"topics":                   []string{testTopic},
+		"group_id":                 "filebeat",
+		"wait_close":               0,
+		"expand_events_from_field": "records",
 	})
 
 	// Route input events through our capturer instead of sending through ES.
@@ -228,8 +228,8 @@ func TestInputWithMultipleEvents(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		msgs := []string{"{\"val\": \"val1\"}", "{\"val\": \"val2\"}"}
-		assert.Contains(t, text, msgs)
+		msgs := []string{"{\"val\":\"val1\"}", "{\"val\":\"val2\"}"}
+		assert.Contains(t, msgs, text)
 		checkMatchingHeaders(t, event, message.headers)
 	case <-timeout:
 		t.Fatal("timeout waiting for incoming events")


### PR DESCRIPTION
If the fileset using this input expects to receive multiple messages bundled under a specific field then the config option ExpandEventListFromField value can be assigned the name of the json group object.
For example in the case of azure fielsets the events are found under the json object "records".
```
 {
"records": [ {event1}, {event2}]
}
```

Initial draft PR https://github.com/elastic/beats/pull/13776