### PR TITLE
[7.2][DOCS] Backport: keystore dir is path.data (#12222)

### DIFF
--- a/libbeat/docs/keystore.asciidoc
+++ b/libbeat/docs/keystore.asciidoc
@@ -64,7 +64,7 @@ To create a secrets keystore, use:
 ----------------------------------------------------------------
 
 
-{beatname_uc} creates the keystore in the directory defined by the `path.config`
+{beatname_uc} creates the keystore in the directory defined by the `path.data`
 configuration setting.
 
 [float]


### PR DESCRIPTION
Backports #12222 to 7.2