### PR TITLE
Document monitoring.cluster_uuid setting

### DIFF
--- a/libbeat/docs/monitoring/monitoring-internal-collection.asciidoc
+++ b/libbeat/docs/monitoring/monitoring-internal-collection.asciidoc
@@ -66,10 +66,10 @@ monitoring:
     username: {beat_monitoring_user}
     password: somepassword
 --------------------
-<1> This setting identifies the Elasticsearch cluster under which the
+<1> This setting identifies the {es} cluster under which the
 monitoring data for this {beatname_uc} instance will appear in the
-Stack Monitoring UI. An Elasticsearch cluster's `cluster_uuid` can be
-determined by calling the `GET /` API against that cluster.
+Stack Monitoring UI. To get a cluster's `cluster_uuid`,
+call the `GET /` API against that cluster.
 <2> This setting identifies the hosts and port numbers of {es} nodes
 that are part of the monitoring cluster.
 

--- a/libbeat/docs/monitoring/monitoring-internal-collection.asciidoc
+++ b/libbeat/docs/monitoring/monitoring-internal-collection.asciidoc
@@ -68,7 +68,8 @@ monitoring:
 --------------------
 <1> This setting identifies the Elasticsearch cluster under which the
 monitoring data for this {beatname_uc} instance will appear in the
-Stack Monitoring UI.
+Stack Monitoring UI. An Elasticsearch cluster's `cluster_uuid` can be
+determined by calling the `GET /` API against that cluster.
 <2> This setting identifies the hosts and port numbers of {es} nodes
 that are part of the monitoring cluster.
 

--- a/libbeat/docs/monitoring/monitoring-internal-collection.asciidoc
+++ b/libbeat/docs/monitoring/monitoring-internal-collection.asciidoc
@@ -60,12 +60,16 @@ configuration options. For example:
 --------------------
 monitoring:
   enabled: true
+  cluster_uuid: PRODUCTION_ES_CLUSTER_UUID <1>
   elasticsearch:
-    hosts: ["https://example.com:9200", "https://example2.com:9200"] <1>
+    hosts: ["https://example.com:9200", "https://example2.com:9200"] <2>
     username: {beat_monitoring_user}
     password: somepassword
 --------------------
-<1> This setting identifies the hosts and port numbers of {es} nodes
+<1> This setting identifies the Elasticsearch cluster under which the
+monitoring data for this {beatname_uc} instance will appear in the
+Stack Monitoring UI.
+<2> This setting identifies the hosts and port numbers of {es} nodes
 that are part of the monitoring cluster.
 
 ifndef::serverless[]


### PR DESCRIPTION
Follow up to #13182. In #13182 we introduced a new setting, `monitoring.cluster_uuid`. However, we didn't document it then so this PR fixes that.