### PR TITLE
[Metricbeat] Add permissions for getting account id and name

### DIFF
--- a/x-pack/metricbeat/module/aws/aws.go
+++ b/x-pack/metricbeat/module/aws/aws.go
@@ -90,7 +90,7 @@ func NewMetricSet(base mb.BaseMetricSet) (*MetricSet, error) {
 	req := svcIam.ListAccountAliasesRequest(&iam.ListAccountAliasesInput{})
 	output, err := req.Send(context.TODO())
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to list account aliases")
+		base.Logger().Warn("failed to list account aliases, please check permission setting: ", err)
 	}
 
 	// There can be more than one aliases for each account, for now we are only
@@ -104,7 +104,7 @@ func NewMetricSet(base mb.BaseMetricSet) (*MetricSet, error) {
 	reqIdentity := svcSts.GetCallerIdentityRequest(&sts.GetCallerIdentityInput{})
 	outputIdentity, err := reqIdentity.Send(context.TODO())
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get caller identity")
+		base.Logger().Warn("failed to get caller identity, please check permission setting: ", err)
 	}
 	metricSet.AccountID = *outputIdentity.Account
 

--- a/x-pack/metricbeat/module/aws/cloudwatch/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/aws/cloudwatch/_meta/docs.asciidoc
@@ -10,6 +10,8 @@ ec2:DescribeRegions
 cloudwatch:GetMetricData
 cloudwatch:ListMetrics
 tag:getResources
+sts:GetCallerIdentity
+iam:ListAccountAliases
 ----
 
 [float]

--- a/x-pack/metricbeat/module/aws/ebs/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/aws/ebs/_meta/docs.asciidoc
@@ -1,0 +1,55 @@
+Amazon Elastic Block Store (Amazon EBS) sends data points to CloudWatch for
+several metrics. Most EBS volumes automatically send five-minute metrics to
+CloudWatch only when the volume is attached to an instance. This aws `ebs`
+metricset collects these Cloudwatch metrics for monitoring purposes.
+
+[float]
+=== AWS Permissions
+Some specific AWS permissions are required for IAM user to collect AWS EBS metrics.
+----
+ec2:DescribeRegions
+cloudwatch:GetMetricData
+cloudwatch:ListMetrics
+tag:getResources
+sts:GetCallerIdentity
+iam:ListAccountAliases
+----
+
+[float]
+=== Dashboard
+
+The aws ebs metricset comes with a predefined dashboard. For example:
+
+image::./images/metricbeat-aws-ebs-overview.png[]
+
+[float]
+=== Configuration example
+[source,yaml]
+----
+- module: aws
+  period: 300s
+  metricsets:
+    - ebs
+  # This module uses the aws cloudwatch metricset, all
+  # the options for this metricset are also available here.
+----
+
+[float]
+=== Metrics
+Please see more details for each metric in
+https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using_cloudwatch_ebs.html[ebs-cloudwatch-metric].
+
+|===
+|Metric Name|Statistic Method
+|VolumeReadBytes | Average
+|VolumeWriteBytes | Average
+|VolumeReadOps | Average
+|VolumeWriteOps | Average
+|VolumeQueueLength | Average
+|VolumeThroughputPercentage | Average
+|VolumeConsumedReadWriteOps | Average
+|BurstBalance | Average
+|VolumeTotalReadTime | Sum
+|VolumeTotalWriteTime | Sum
+|VolumeIdleTime | Sum
+|===

--- a/x-pack/metricbeat/module/aws/ec2/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/aws/ec2/_meta/docs.asciidoc
@@ -38,6 +38,8 @@ ec2:DescribeInstances
 ec2:DescribeRegions
 cloudwatch:GetMetricData
 cloudwatch:ListMetrics
+sts:GetCallerIdentity
+iam:ListAccountAliases
 ----
 
 [float]

--- a/x-pack/metricbeat/module/aws/elb/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/aws/elb/_meta/docs.asciidoc
@@ -10,6 +10,8 @@ ec2:DescribeRegions
 cloudwatch:GetMetricData
 cloudwatch:ListMetrics
 tag:getResources
+sts:GetCallerIdentity
+iam:ListAccountAliases
 ----
 
 [float]

--- a/x-pack/metricbeat/module/aws/rds/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/aws/rds/_meta/docs.asciidoc
@@ -9,6 +9,8 @@ Some specific AWS permissions are required for IAM user to collect AWS RDS metri
 cloudwatch:GetMetricData
 ec2:DescribeRegions
 rds:DescribeDBInstances
+sts:GetCallerIdentity
+iam:ListAccountAliases
 ----
 
 [float]

--- a/x-pack/metricbeat/module/aws/s3_daily_storage/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/aws/s3_daily_storage/_meta/docs.asciidoc
@@ -9,6 +9,8 @@ Some specific AWS permissions are required for IAM user to collect AWS s3_daily_
 ec2:DescribeRegions
 cloudwatch:GetMetricData
 cloudwatch:ListMetrics
+sts:GetCallerIdentity
+iam:ListAccountAliases
 ----
 
 [float]

--- a/x-pack/metricbeat/module/aws/s3_request/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/aws/s3_request/_meta/docs.asciidoc
@@ -9,6 +9,8 @@ Some specific AWS permissions are required for IAM user to collect AWS s3_reques
 ec2:DescribeRegions
 cloudwatch:GetMetricData
 cloudwatch:ListMetrics
+sts:GetCallerIdentity
+iam:ListAccountAliases
 ----
 
 [float]

--- a/x-pack/metricbeat/module/aws/sqs/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/aws/sqs/_meta/docs.asciidoc
@@ -10,6 +10,8 @@ cloudwatch:GetMetricData
 cloudwatch:ListMetrics
 ec2:DescribeRegions
 sqs:ListQueues
+sts:GetCallerIdentity
+iam:ListAccountAliases
 ----
 
 [float]


### PR DESCRIPTION
Changes done in this PR:
1. Add permissions for each metricset in aws module to get account id and account name
2. If the permissions are not set correctly for getting account id/name, aws module should log a warning and continue 
3. ebs metricset doesn't have any documentation for some reason, this PR also added documentation for ebs metricset