### PR TITLE
[6.8] Remove CAP_AUDIT_READ from docker-compose.yml (#13077)

### DIFF
--- a/auditbeat/docker-compose.yml
+++ b/auditbeat/docker-compose.yml
@@ -19,7 +19,6 @@ services:
     pid: host
     cap_add:
       - AUDIT_CONTROL
-      - AUDIT_READ
 
   # This is a proxy used to block beats until all services are healthy.
   # See: https://github.com/docker/compose/issues/4369

--- a/x-pack/auditbeat/docker-compose.yml
+++ b/x-pack/auditbeat/docker-compose.yml
@@ -10,4 +10,3 @@ services:
     pid: host
     cap_add:
       - AUDIT_CONTROL
-      - AUDIT_READ


### PR DESCRIPTION
Backports the following commits to 6.8:
 - Remove CAP_AUDIT_READ from docker-compose.yml  (#13077)

Resolves #14014.