### PR TITLE
Improve logging and docs regarding Kubernetes watchers' scope

### DIFF
--- a/libbeat/autodiscover/providers/kubernetes/kubernetes.go
+++ b/libbeat/autodiscover/providers/kubernetes/kubernetes.go
@@ -57,6 +57,7 @@ type Provider struct {
 // AutodiscoverBuilder builds and returns an autodiscover provider
 func AutodiscoverBuilder(bus bus.Bus, uuid uuid.UUID, c *common.Config) (autodiscover.Provider, error) {
 	cfgwarn.Beta("The kubernetes autodiscover is beta")
+	logger := logp.NewLogger("autodiscover")
 
 	errWrap := func(err error) error {
 		return errors.Wrap(err, "error setting up kubernetes autodiscover provider")
@@ -79,6 +80,8 @@ func AutodiscoverBuilder(bus bus.Bus, uuid uuid.UUID, c *common.Config) (autodis
 	}
 
 	config.Host = kubernetes.DiscoverKubernetesNode(config.Host, kubernetes.IsInCluster(config.KubeConfig), client)
+
+	logger.Debugf("Initializing a new Kubernetes watcher using host: %v", config.Host)
 
 	watcher, err := kubernetes.NewWatcher(client, &kubernetes.Pod{}, kubernetes.WatchOptions{
 		SyncTimeout: config.SyncPeriod,
@@ -116,7 +119,7 @@ func AutodiscoverBuilder(bus bus.Bus, uuid uuid.UUID, c *common.Config) (autodis
 		appenders: appenders,
 		metagen:   metagen,
 		watcher:   watcher,
-		logger:    logp.NewLogger("kubernetes"),
+		logger:    logger,
 	}
 
 	watcher.AddEventHandler(kubernetes.ResourceEventHandlerFuncs{

--- a/libbeat/docs/processors-using.asciidoc
+++ b/libbeat/docs/processors-using.asciidoc
@@ -1362,7 +1362,7 @@ processors:
 
 The `add_kubernetes_metadata` processor has the following configuration settings:
 
-`host`:: (Optional) Identify the node where {beatname_lc} is running in case it
+`host`:: (Optional) Specify the node to scope {beatname_lc} to in case it
 cannot be accurately detected, as when running {beatname_lc} in host network
 mode.
 `namespace`:: (Optional) Select the namespace from which to collect the

--- a/libbeat/docs/shared-autodiscover.asciidoc
+++ b/libbeat/docs/shared-autodiscover.asciidoc
@@ -179,7 +179,7 @@ contain variables from the autodiscover event. They can be accessed under data n
 
 The `kubernetes` autodiscover provider has the following configuration settings:
 
-`host`:: (Optional) Identify the node where {beatname_lc} is running in case it
+`host`:: (Optional) Specify the node to scope {beatname_lc} to in case it
   cannot be accurately detected, as when running {beatname_lc} in host network
   mode.
 `namespace`:: (Optional) Select the namespace from which to collect the

--- a/libbeat/processors/add_kubernetes_metadata/kubernetes.go
+++ b/libbeat/processors/add_kubernetes_metadata/kubernetes.go
@@ -132,8 +132,7 @@ func New(cfg *common.Config) (processors.Processor, error) {
 
 	config.Host = kubernetes.DiscoverKubernetesNode(config.Host, kubernetes.IsInCluster(config.KubeConfig), client)
 
-	logp.Debug("kubernetes", "Using host: %s", config.Host)
-	logp.Debug("kubernetes", "Initializing watcher")
+	logp.Debug("kubernetes", "Initializing a new Kubernetes watcher using host: %s", config.Host)
 
 	watcher, err := kubernetes.NewWatcher(client, &kubernetes.Pod{}, kubernetes.WatchOptions{
 		SyncTimeout: config.SyncPeriod,

--- a/metricbeat/module/kubernetes/util/kubernetes.go
+++ b/metricbeat/module/kubernetes/util/kubernetes.go
@@ -92,6 +92,8 @@ func GetWatcher(base mb.BaseMetricSet, resource kubernetes.Resource, nodeScope b
 		options.Node = kubernetes.DiscoverKubernetesNode(config.Host, kubernetes.IsInCluster(config.KubeConfig), client)
 	}
 
+	logp.Debug("kubernetes", "Initializing a new Kubernetes watcher using host: %v", config.Host)
+
 	return kubernetes.NewWatcher(client, resource, options)
 }
 


### PR DESCRIPTION
This PR improves logging and docs regarding Kubernetes watchers' scope.

Trying to reproduce a scenario with autodiscover events for #13996, I fall into a situation where events where not being able to be detected. I was running Metricbeat as a daemonset inside k8s and I had autodicover part configured with the following:
```
metricbeat.autodiscover:
  providers:
    - type: kubernetes
      hints.enabled: true
```
as proposed on https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-autodiscover-hints.html#_kubernetes_2.

The problem was that the scope of the watchers' was automatically being set to `localhost` and not `minikube` which was the actual node name of my local k8s cluster.
The proper configuration should look like:
```
metricbeat.autodiscover:
  providers:
    - type: kubernetes
      host: ${NODE_NAME}
      hints.enabled: true
```

Of course it was me that misconfigured the autodiscover part but the logging was not so helpful in this situation.
In this regard this PR improves the logging along with the perspective docs to make more clear how  `host` setting is used.

cc: @exekias 