### PR TITLE
Update metricbeat tests to use 7.4 version of the stack

### DIFF
--- a/metricbeat/docker-compose.yml
+++ b/metricbeat/docker-compose.yml
@@ -87,11 +87,11 @@ services:
       - 8080
 
   elasticsearch:
-    image: docker.elastic.co/observability-ci/beats-integration-elasticsearch:${ELASTICSEARCH_VERSION:-7.3.0}-1
+    image: docker.elastic.co/observability-ci/beats-integration-elasticsearch:${ELASTICSEARCH_VERSION:-7.4.0}-1
     build:
       context: ./module/elasticsearch/_meta
       args:
-        ELASTICSEARCH_VERSION: ${ELASTICSEARCH_VERSION:-7.3.0}
+        ELASTICSEARCH_VERSION: ${ELASTICSEARCH_VERSION:-7.4.0}
     environment:
       - "ES_JAVA_OPTS=-Xms256m -Xmx256m"
       - "network.host="
@@ -163,11 +163,11 @@ services:
       - 9092
 
   kibana:
-    image: docker.elastic.co/observability-ci/beats-integration-kibana:${KIBANA_VERSION:-7.3.0}-1
+    image: docker.elastic.co/observability-ci/beats-integration-kibana:${KIBANA_VERSION:-7.4.0}-1
     build:
       context: ./module/kibana/_meta
       args:
-        KIBANA_VERSION: ${KIBANA_VERSION:-7.3.0}
+        KIBANA_VERSION: ${KIBANA_VERSION:-7.4.0}
     depends_on:
       - elasticsearch
     ports:
@@ -196,7 +196,7 @@ services:
   #    - 18080
 
   logstash:
-    image: docker.elastic.co/observability-ci/beats-integration-logstash:${LOGSTASH_VERSION:-7.3.0}-1
+    image: docker.elastic.co/observability-ci/beats-integration-logstash:${LOGSTASH_VERSION:-7.4.0}-1
     build:
       context: ./module/logstash/_meta
       args:

--- a/testing/environments/latest.yml
+++ b/testing/environments/latest.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.3.2
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.4.0
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9200"]
       retries: 300
@@ -16,7 +16,7 @@ services:
       - "xpack.security.enabled=false"
 
   logstash:
-    image: docker.elastic.co/logstash/logstash:7.3.2
+    image: docker.elastic.co/logstash/logstash:7.4.0
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9600/_node/stats"]
       retries: 300
@@ -26,7 +26,7 @@ services:
       - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:7.3.2
+    image: docker.elastic.co/kibana/kibana:7.4.0
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:5601"]
       retries: 300

--- a/x-pack/metricbeat/docker-compose.yml
+++ b/x-pack/metricbeat/docker-compose.yml
@@ -38,11 +38,11 @@ services:
   kibana:
     # Copied configuration from OSS metricbeat because services with depends_on
     # cannot be extended with extends
-    image: docker.elastic.co/observability-ci/beats-integration-kibana:${KIBANA_VERSION:-7.3.0}-1
+    image: docker.elastic.co/observability-ci/beats-integration-kibana:${KIBANA_VERSION:-7.4.0}-1
     build:
       context: ../../metricbeat/module/kibana/_meta
       args:
-        KIBANA_VERSION: ${KIBANA_VERSION:-7.3.0}
+        KIBANA_VERSION: ${KIBANA_VERSION:-7.4.0}
     depends_on:
       - elasticsearch
     ports:


### PR DESCRIPTION
For instance, dashboards tests depend on these containers. So dashboards created with > 7.3.0 wouldn't pass tests without this change