### PR TITLE
[7.3] Document monitoring.cluster_uuid setting (#13999)

### DIFF
--- a/libbeat/docs/monitoring/monitoring-internal-collection.asciidoc
+++ b/libbeat/docs/monitoring/monitoring-internal-collection.asciidoc
@@ -60,12 +60,17 @@ configuration options. For example:
 --------------------
 monitoring:
   enabled: true
+  cluster_uuid: PRODUCTION_ES_CLUSTER_UUID <1>
   elasticsearch:
-    hosts: ["https://example.com:9200", "https://example2.com:9200"] <1>
+    hosts: ["https://example.com:9200", "https://example2.com:9200"] <2>
     username: {beat_monitoring_user}
     password: somepassword
 --------------------
-<1> This setting identifies the hosts and port numbers of {es} nodes
+<1> This setting identifies the {es} cluster under which the
+monitoring data for this {beatname_uc} instance will appear in the
+Stack Monitoring UI. To get a cluster's `cluster_uuid`,
+call the `GET /` API against that cluster.
+<2> This setting identifies the hosts and port numbers of {es} nodes
 that are part of the monitoring cluster.
 
 ifndef::serverless[]


### PR DESCRIPTION
Backports the following commits to 7.3:
 - Document monitoring.cluster_uuid setting  (#13999)