### PR TITLE
make locking more fine-grained on client close

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -265,6 +265,34 @@ This product includes software developed at
 the Microsoft Corporation (https://www.microsoft.com).
 
 --------------------------------------------------------------------
+Dependency: github.com/Azure/go-ansiterm
+Revision: d6e3b3328b783f23731bc4d058875b0371ff8109
+License type (autodetected): MIT
+./x-pack/dockerlogbeat/vendor/github.com/Azure/go-ansiterm/LICENSE:
+--------------------------------------------------------------------
+The MIT License (MIT)
+
+Copyright (c) 2015 Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+--------------------------------------------------------------------
 Dependency: github.com/Azure/go-autorest
 Revision: ba1147dc57f993013ef255c128ca1cac8a557409
 License type (autodetected): Apache-2.0
@@ -370,10 +398,45 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------
+Dependency: github.com/containerd/containerd
+Revision: 36cf5b690dcc00ff0f34ff7799209050c3d0c59a
+License type (autodetected): Apache-2.0
+./x-pack/dockerlogbeat/vendor/github.com/containerd/containerd/LICENSE:
+--------------------------------------------------------------------
+Apache License 2.0
+
+-------NOTICE-----
+Docker
+Copyright 2012-2015 Docker, Inc.
+
+This product includes software developed at Docker, Inc. (https://www.docker.com).
+
+The following is courtesy of our legal counsel:
+
+
+Use and transfer of Docker may be subject to certain restrictions by the
+United States and other governments.
+It is your responsibility to ensure that your use and/or transfer does not
+violate applicable laws.
+
+For more information, please see https://www.bis.doc.gov
+
+See also https://www.apache.org/dev/crypto.html and/or seek legal counsel.
+
+--------------------------------------------------------------------
 Dependency: github.com/containerd/continuity
 Revision: 75bee3e2ccb6402e3a986ab8bd3b17003fc0fdec
 License type (autodetected): Apache-2.0
 ./vendor/github.com/containerd/continuity/LICENSE:
+--------------------------------------------------------------------
+Apache License 2.0
+
+
+--------------------------------------------------------------------
+Dependency: github.com/containerd/fifo
+Revision: bda0ff6ed73c67bfb5e62bc9c697f146b7fd7f13
+License type (autodetected): Apache-2.0
+./x-pack/dockerlogbeat/vendor/github.com/containerd/fifo/LICENSE:
 --------------------------------------------------------------------
 Apache License 2.0
 
@@ -426,6 +489,21 @@ Version: v18
 Revision: 9002847aa1425fb6ac49077c0a630b3b67e0fbfd
 License type (autodetected): Apache-2.0
 ./vendor/github.com/coreos/go-systemd/LICENSE:
+--------------------------------------------------------------------
+Apache License 2.0
+
+-------NOTICE-----
+CoreOS Project
+Copyright 2018 CoreOS, Inc
+
+This product includes software developed at CoreOS, Inc.
+(http://www.coreos.com/).
+
+--------------------------------------------------------------------
+Dependency: github.com/coreos/go-systemd
+Revision: fd7a80b32e1fc73e890fde45604ed5009dc817a3
+License type (autodetected): Apache-2.0
+./x-pack/dockerlogbeat/vendor/github.com/coreos/go-systemd/LICENSE:
 --------------------------------------------------------------------
 Apache License 2.0
 
@@ -662,6 +740,64 @@ For more information, please see https://www.bis.doc.gov
 See also https://www.apache.org/dev/crypto.html and/or seek legal counsel.
 
 --------------------------------------------------------------------
+Dependency: github.com/docker/docker
+Revision: 5b57f41241cb0d8df5886a1db3d7920494a9e432
+License type (autodetected): Apache-2.0
+./x-pack/dockerlogbeat/vendor/github.com/docker/docker/LICENSE:
+--------------------------------------------------------------------
+Apache License 2.0
+
+-------NOTICE-----
+Docker
+Copyright 2012-2017 Docker, Inc.
+
+This product includes software developed at Docker, Inc. (https://www.docker.com).
+
+This product contains software (https://github.com/creack/pty) developed
+by Keith Rarick, licensed under the MIT License.
+
+The following is courtesy of our legal counsel:
+
+
+Use and transfer of Docker may be subject to certain restrictions by the
+United States and other governments.
+It is your responsibility to ensure that your use and/or transfer does not
+violate applicable laws.
+
+For more information, please see https://www.bis.doc.gov
+
+See also https://www.apache.org/dev/crypto.html and/or seek legal counsel.
+
+--------------------------------------------------------------------
+Dependency: github.com/docker/engine
+Revision: 5b57f41241cb0d8df5886a1db3d7920494a9e432
+License type (autodetected): Apache-2.0
+./x-pack/dockerlogbeat/vendor/github.com/docker/engine/LICENSE:
+--------------------------------------------------------------------
+Apache License 2.0
+
+-------NOTICE-----
+Docker
+Copyright 2012-2017 Docker, Inc.
+
+This product includes software developed at Docker, Inc. (https://www.docker.com).
+
+This product contains software (https://github.com/creack/pty) developed
+by Keith Rarick, licensed under the MIT License.
+
+The following is courtesy of our legal counsel:
+
+
+Use and transfer of Docker may be subject to certain restrictions by the
+United States and other governments.
+It is your responsibility to ensure that your use and/or transfer does not
+violate applicable laws.
+
+For more information, please see https://www.bis.doc.gov
+
+See also https://www.apache.org/dev/crypto.html and/or seek legal counsel.
+
+--------------------------------------------------------------------
 Dependency: github.com/docker/go-connections
 Version: v0.3.0
 Revision: 3ede32e2033de7505e6500d6c868c2b9ed9f169d
@@ -693,6 +829,60 @@ Docker
 Copyright 2012-2015 Docker, Inc.
 
 This product includes software developed at Docker, Inc. (https://www.docker.com).
+
+The following is courtesy of our legal counsel:
+
+
+Use and transfer of Docker may be subject to certain restrictions by the
+United States and other governments.
+It is your responsibility to ensure that your use and/or transfer does not
+violate applicable laws.
+
+For more information, please see https://www.bis.doc.gov
+
+See also https://www.apache.org/dev/crypto.html and/or seek legal counsel.
+
+--------------------------------------------------------------------
+Dependency: github.com/docker/go-metrics
+License type (autodetected): Apache-2.0
+./x-pack/dockerlogbeat/vendor/github.com/docker/go-metrics/LICENSE:
+--------------------------------------------------------------------
+Apache License 2.0
+
+-------NOTICE-----
+Docker
+Copyright 2012-2015 Docker, Inc.
+
+This product includes software developed at Docker, Inc. (https://www.docker.com).
+
+The following is courtesy of our legal counsel:
+
+
+Use and transfer of Docker may be subject to certain restrictions by the
+United States and other governments.
+It is your responsibility to ensure that your use and/or transfer does not
+violate applicable laws.
+
+For more information, please see https://www.bis.doc.gov
+
+See also https://www.apache.org/dev/crypto.html and/or seek legal counsel.
+
+--------------------------------------------------------------------
+Dependency: github.com/docker/go-plugins-helpers
+Revision: 1e6269c305b8c75cfda1c8aa91349c38d7335814
+License type (autodetected): Apache-2.0
+./x-pack/dockerlogbeat/vendor/github.com/docker/go-plugins-helpers/LICENSE:
+--------------------------------------------------------------------
+Apache License 2.0
+
+-------NOTICE-----
+Docker
+Copyright 2012-2015 Docker, Inc.
+
+This product includes software developed at Docker, Inc. (https://www.docker.com).
+
+This product contains software (https://github.com/kr/pty) developed
+by Keith Rarick, licensed under the MIT License.
 
 The following is courtesy of our legal counsel:
 
@@ -1792,6 +1982,48 @@ Protocol Buffers for Go with Gadgets
 
 Copyright (c) 2013, The GoGo Authors. All rights reserved.
 http://github.com/gogo/protobuf
+
+Go support for Protocol Buffers - Google's data interchange format
+
+Copyright 2010 The Go Authors.  All rights reserved.
+https://github.com/golang/protobuf
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+    * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+--------------------------------------------------------------------
+Dependency: github.com/gogo/protobuf
+Revision: 8a5ed79f688836cf007ca23aefe0299791e7bea5
+License type (autodetected): BSD-3-Clause
+./x-pack/dockerlogbeat/vendor/github.com/gogo/protobuf/LICENSE:
+--------------------------------------------------------------------
+Copyright (c) 2013, The GoGo Authors. All rights reserved.
+
+Protocol Buffers for Go with Gadgets
 
 Go support for Protocol Buffers - Google's data interchange format
 
@@ -4043,6 +4275,17 @@ Apache License 2.0
 Copyright 2012 Matt T. Proud (matt.proud@gmail.com)
 
 --------------------------------------------------------------------
+Dependency: github.com/matttproud/golang_protobuf_extensions
+Revision: c182affec369e30f25d3eb8cd8a478dee585ae7d
+License type (autodetected): Apache-2.0
+./x-pack/dockerlogbeat/vendor/github.com/matttproud/golang_protobuf_extensions/LICENSE:
+--------------------------------------------------------------------
+Apache License 2.0
+
+-------NOTICE-----
+Copyright 2012 Matt T. Proud (matt.proud@gmail.com)
+
+--------------------------------------------------------------------
 Dependency: github.com/Microsoft/go-winio
 Revision: f533f7a102197536779ea3a8cb881d639e21ec5a
 License type (autodetected): MIT
@@ -4241,6 +4484,34 @@ Apache License 2.0
 
 
 --------------------------------------------------------------------
+Dependency: github.com/morikuni/aec
+Revision: 39771216ff4c63d11f5e604076f9c45e8be1067b
+License type (autodetected): MIT
+./x-pack/dockerlogbeat/vendor/github.com/morikuni/aec/LICENSE:
+--------------------------------------------------------------------
+The MIT License (MIT)
+
+Copyright (c) 2016 Taihei Morikuni
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+--------------------------------------------------------------------
 Dependency: github.com/OneOfOne/xxhash
 Revision: 74ace4fe5525ef62ce28d5093d6b0faaa6a575f3
 License type (autodetected): Apache-2.0
@@ -4259,10 +4530,28 @@ Apache License 2.0
 
 
 --------------------------------------------------------------------
+Dependency: github.com/opencontainers/go-digest
+Revision: ac19fd6e7483ff933754af248d80be865e543d22
+License type (autodetected): Apache-2.0
+./x-pack/dockerlogbeat/vendor/github.com/opencontainers/go-digest/LICENSE:
+--------------------------------------------------------------------
+Apache License 2.0
+
+
+--------------------------------------------------------------------
 Dependency: github.com/opencontainers/image-spec
 Revision: 4038d4391fe912af1031db5a1f511cf07c07cbc8
 License type (autodetected): Apache-2.0
 ./vendor/github.com/opencontainers/image-spec/LICENSE:
+--------------------------------------------------------------------
+Apache License 2.0
+
+
+--------------------------------------------------------------------
+Dependency: github.com/opencontainers/image-spec
+Revision: 775207bd45b6cb8153ce218cc59351799217451f
+License type (autodetected): Apache-2.0
+./x-pack/dockerlogbeat/vendor/github.com/opencontainers/image-spec/LICENSE:
 --------------------------------------------------------------------
 Apache License 2.0
 
@@ -4476,6 +4765,39 @@ Copyright 2013 Matt T. Proud
 Licensed under the Apache License, Version 2.0
 
 --------------------------------------------------------------------
+Dependency: github.com/prometheus/client_golang
+Revision: 20428fa0bffcb4ee7a7941545ae0df9acdc9d8a7
+License type (autodetected): Apache-2.0
+./x-pack/dockerlogbeat/vendor/github.com/prometheus/client_golang/LICENSE:
+--------------------------------------------------------------------
+Apache License 2.0
+
+-------NOTICE-----
+Prometheus instrumentation library for Go applications
+Copyright 2012-2015 The Prometheus Authors
+
+This product includes software developed at
+SoundCloud Ltd. (http://soundcloud.com/).
+
+
+The following components are included in this product:
+
+perks - a fork of https://github.com/bmizerany/perks
+https://github.com/beorn7/perks
+Copyright 2013-2015 Blake Mizerany, Björn Rabenstein
+See https://github.com/beorn7/perks/blob/master/README.md for license details.
+
+Go support for Protocol Buffers - Google's data interchange format
+http://github.com/golang/protobuf/
+Copyright 2010 The Go Authors
+See source code for license details.
+
+Support for streaming Protocol Buffer messages for the Go language (golang).
+https://github.com/matttproud/golang_protobuf_extensions
+Copyright 2013 Matt T. Proud
+Licensed under the Apache License, Version 2.0
+
+--------------------------------------------------------------------
 Dependency: github.com/prometheus/client_model
 License type (autodetected): Apache-2.0
 ./vendor/github.com/prometheus/client_model/LICENSE:
@@ -4494,6 +4816,21 @@ Dependency: github.com/prometheus/client_model
 Revision: 99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c
 License type (autodetected): Apache-2.0
 ./metricbeat/vendor/github.com/prometheus/client_model/LICENSE:
+--------------------------------------------------------------------
+Apache License 2.0
+
+-------NOTICE-----
+Data model artifacts for Prometheus.
+Copyright 2012-2015 The Prometheus Authors
+
+This product includes software developed at
+SoundCloud Ltd. (http://soundcloud.com/).
+
+--------------------------------------------------------------------
+Dependency: github.com/prometheus/client_model
+Revision: 14fe0d1b01d4d5fc031dd4bec1823bd3ebbe8016
+License type (autodetected): Apache-2.0
+./x-pack/dockerlogbeat/vendor/github.com/prometheus/client_model/LICENSE:
 --------------------------------------------------------------------
 Apache License 2.0
 
@@ -4535,10 +4872,42 @@ This product includes software developed at
 SoundCloud Ltd. (http://soundcloud.com/).
 
 --------------------------------------------------------------------
+Dependency: github.com/prometheus/common
+Revision: 287d3e634a1e550c9e463dd7e5a75a422c614505
+License type (autodetected): Apache-2.0
+./x-pack/dockerlogbeat/vendor/github.com/prometheus/common/LICENSE:
+--------------------------------------------------------------------
+Apache License 2.0
+
+-------NOTICE-----
+Common libraries shared by Prometheus Go components.
+Copyright 2015 The Prometheus Authors
+
+This product includes software developed at
+SoundCloud Ltd. (http://soundcloud.com/).
+
+--------------------------------------------------------------------
 Dependency: github.com/prometheus/procfs
 Revision: 54d17b57dd7d4a3aa092476596b3f8a933bde349
 License type (autodetected): Apache-2.0
 ./vendor/github.com/prometheus/procfs/LICENSE:
+--------------------------------------------------------------------
+Apache License 2.0
+
+-------NOTICE-----
+procfs provides functions to retrieve system, kernel and process
+metrics from the pseudo-filesystem proc.
+
+Copyright 2014-2015 The Prometheus Authors
+
+This product includes software developed at
+SoundCloud Ltd. (http://soundcloud.com/).
+
+--------------------------------------------------------------------
+Dependency: github.com/prometheus/procfs
+Revision: de25ac347ef9305868b04dc42425c973b863b18c
+License type (autodetected): Apache-2.0
+./x-pack/dockerlogbeat/vendor/github.com/prometheus/procfs/LICENSE:
 --------------------------------------------------------------------
 Apache License 2.0
 
@@ -5045,6 +5414,15 @@ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
 CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+--------------------------------------------------------------------
+Dependency: github.com/tonistiigi/fifo
+Revision: bda0ff6ed73c67bfb5e62bc9c697f146b7fd7f13
+License type (autodetected): Apache-2.0
+./x-pack/dockerlogbeat/vendor/github.com/tonistiigi/fifo/LICENSE:
+--------------------------------------------------------------------
+Apache License 2.0
+
 
 --------------------------------------------------------------------
 Dependency: github.com/tsg/gopacket
@@ -5655,6 +6033,15 @@ Dependency: google.golang.org/genproto
 Revision: a7e196e89fd3a3c4d103ca540bd5dac3a736e375
 License type (autodetected): Apache-2.0
 ./vendor/google.golang.org/genproto/LICENSE:
+--------------------------------------------------------------------
+Apache License 2.0
+
+
+--------------------------------------------------------------------
+Dependency: google.golang.org/genproto
+Revision: 20e1ac93f88cf06d2b1defb90b9e9e126c7dfff6
+License type (autodetected): Apache-2.0
+./x-pack/dockerlogbeat/vendor/google.golang.org/genproto/LICENSE:
 --------------------------------------------------------------------
 Apache License 2.0
 

--- a/x-pack/dockerlogbeat/pipelinemanager/libbeattools.go
+++ b/x-pack/dockerlogbeat/pipelinemanager/libbeattools.go
@@ -1,0 +1,114 @@
+package pipelinemanager
+
+// makeConfigHash is the helper function that turns a user config into a hash
+import (
+	"crypto/sha1"
+	"fmt"
+	"sort"
+
+	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/idxmgmt"
+	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/outputs"
+	"github.com/elastic/beats/libbeat/publisher/pipeline"
+	"github.com/elastic/beats/libbeat/publisher/processing"
+	"github.com/pkg/errors"
+	yaml "gopkg.in/yaml.v2"
+)
+
+func makeConfigHash(cfg map[string]string) string {
+	var hashString string
+	var orderedVal []string
+
+	for _, val := range cfg {
+		orderedVal = append(orderedVal, val)
+	}
+
+	sort.Strings(orderedVal)
+
+	for _, val := range orderedVal {
+		hashString = hashString + val
+	}
+
+	sum := sha1.Sum([]byte(hashString))
+
+	return string(sum[:])
+}
+
+// load pipeline starts up a new pipeline with the given config
+func loadNewPipeline(logOptsConfig map[string]string, name string, log *logp.Logger) (*Pipeline, error) {
+	info := beat.Info{
+		Beat:     "dockerlogbeat",
+		Version:  "0",
+		Name:     name,
+		Hostname: "dockerbeat.test",
+	}
+
+	newCfg, err := parseCfgKeys(logOptsConfig)
+	if err != nil {
+		return nil, errors.Wrap(err, "error parsing config keys")
+	}
+
+	cfg, err := common.NewConfigFrom(newCfg)
+	if err != nil {
+		return nil, err
+	}
+	config := containerConfig{}
+	err = cfg.Unpack(&config)
+	if err != nil {
+		return nil, fmt.Errorf("unpacking config failed: %v", err)
+	}
+
+	processing, err := processing.MakeDefaultSupport(false)(info, log, cfg)
+	if err != nil {
+		return nil, errors.Wrap(err, "error in MakeDefaultSupport")
+	}
+
+	pipelineCfg := pipeline.Config{}
+	err = cfg.Unpack(&pipelineCfg)
+	if err != nil {
+		return nil, errors.Wrap(err, "error unpacking pipeline config")
+	}
+
+	idx, err := idxmgmt.DefaultSupport(log, info, config.Output.Config())
+	if err != nil {
+		return nil, errors.Wrap(err, "error making index manager")
+	}
+
+	pipeline, err := pipeline.Load(info,
+		pipeline.Monitors{
+			Metrics:   nil,
+			Telemetry: nil,
+			Logger:    log,
+		},
+		pipelineCfg,
+		processing,
+		func(stat outputs.Observer) (string, outputs.Group, error) {
+			cfg := config.Output
+			out, err := outputs.Load(idx, info, stat, cfg.Name(), cfg.Config())
+			return cfg.Name(), out, err
+		},
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "error in pipeline.Load")
+	}
+
+	return &Pipeline{pipeline: pipeline, refCount: 0}, nil
+}
+
+// parseCfgKeys helpfully parses the values in the map, so users can specify yml structures.
+func parseCfgKeys(cfg map[string]string) (map[string]interface{}, error) {
+
+	outMap := make(map[string]interface{})
+
+	for cfgKey, strVal := range cfg {
+		var parsed interface{}
+		if err := yaml.Unmarshal([]byte(strVal), &parsed); err != nil {
+			return nil, err
+		}
+		outMap[cfgKey] = parsed
+	}
+
+	return outMap, nil
+}

--- a/x-pack/dockerlogbeat/pipelinemanager/libbeattools.go
+++ b/x-pack/dockerlogbeat/pipelinemanager/libbeattools.go
@@ -1,6 +1,9 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 package pipelinemanager
 
-// makeConfigHash is the helper function that turns a user config into a hash
 import (
 	"crypto/sha1"
 	"fmt"
@@ -17,6 +20,7 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
+// makeConfigHash is the helper function that turns a user config into a hash
 func makeConfigHash(cfg map[string]string) string {
 	var hashString string
 	var orderedVal []string

--- a/x-pack/dockerlogbeat/pipelinemanager/pipelineManager.go
+++ b/x-pack/dockerlogbeat/pipelinemanager/pipelineManager.go
@@ -172,7 +172,6 @@ func (pm *PipelineManager) removeClient(file string) (*ClientLogger, error) {
 
 	cl, ok := pm.clients[file]
 	if !ok {
-		pm.mu.Unlock()
 		return nil, fmt.Errorf("No client for file %s", file)
 	}
 

--- a/x-pack/dockerlogbeat/pipelinemanager/pipelineManager.go
+++ b/x-pack/dockerlogbeat/pipelinemanager/pipelineManager.go
@@ -5,20 +5,13 @@
 package pipelinemanager
 
 import (
-	"crypto/sha1"
 	"fmt"
-	"sort"
 	"sync"
 
-	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/idxmgmt"
 	"github.com/elastic/beats/libbeat/logp"
-	"github.com/elastic/beats/libbeat/outputs"
 	"github.com/elastic/beats/libbeat/publisher/pipeline"
-	"github.com/elastic/beats/libbeat/publisher/processing"
 	"github.com/pkg/errors"
-	yaml "gopkg.in/yaml.v2"
 )
 
 // containerConfig is the common.Config unpacking type
@@ -55,38 +48,22 @@ func NewPipelineManager(logCfg *common.Config) *PipelineManager {
 
 // CloseClientWithFile closes the client with the associated file
 func (pm *PipelineManager) CloseClientWithFile(file string) error {
-	pm.mu.Lock()
 
-	cl, ok := pm.clients[file]
-	if !ok {
-		pm.mu.Unlock()
-		return fmt.Errorf("No client for file %s", file)
+	cl, err := pm.removeClient(file)
+	if err != nil {
+		return errors.Wrap(err, "Error removing client")
 	}
 
-	// deincrement the ref count
 	hash := cl.pipelineHash
-	pm.pipelines[hash].refCount--
-
-	//if the pipeline is no longer in use, clean up
-	if pm.pipelines[hash].refCount < 1 {
-		pipeline := pm.pipelines[hash].pipeline
-		delete(pm.pipelines, hash)
-		//pipelines must be closed after clients
-		defer func() {
-			pm.Logger.Debugf("Pipeline closing")
-			pipeline.Close()
-		}()
-	}
-
-	//mutex is just for the maps
-	//Client and pipeline close may block
-	pm.mu.Unlock()
 
 	pm.Logger.Debugf("Closing Client first from pipelineManager")
-	err := cl.Close()
+	err = cl.Close()
 	if err != nil {
 		return errors.Wrap(err, "error closing client")
 	}
+
+	//if the pipeline is no longer in use, clean up
+	pm.removePipelineIfNeeded(hash)
 
 	return nil
 }
@@ -94,140 +71,115 @@ func (pm *PipelineManager) CloseClientWithFile(file string) error {
 // CreateClientWithConfig gets the pipeline linked to the given config, and creates a client
 // If no pipeline for that config exists, it creates one.
 func (pm *PipelineManager) CreateClientWithConfig(logOptsConfig map[string]string, file string) (*ClientLogger, error) {
-	pm.mu.Lock()
-	defer pm.mu.Unlock()
 
-	// check to see if we have a pipeline
-	var err error
 	hashstring := makeConfigHash(logOptsConfig)
 
-	err = pm.makePipeline(logOptsConfig, file, hashstring)
-	if err != nil {
-		return nil, err
+	//If we don't have an existing pipeline for this hash, make one
+	exists := pm.checkIfHashExists(logOptsConfig)
+	var pipeline *Pipeline
+	var err error
+	if !exists {
+		pipeline, err = loadNewPipeline(logOptsConfig, file, pm.Logger)
+		if err != nil {
+			return nil, errors.Wrap(err, "error loading pipeline")
+		}
+		pm.registerPipeline(pipeline, hashstring)
+	} else {
+		pipeline, _ = pm.getPipeline(hashstring)
 	}
 
-	pipeline := pm.pipelines[hashstring]
-
+	//actually get to crafting the new client.
 	cl, err := newClientFromPipeline(pipeline.pipeline, file, hashstring)
 	if err != nil {
 		return nil, err
 	}
-	pm.clients[file] = cl
-	pm.pipelines[hashstring].refCount++
-	// before we finish, prune the client list async
+
+	pm.registerClient(cl, hashstring, file)
 
 	return cl, nil
 }
 
-// a wrapper for various public functions to create pipelines
-// assumes we have a mutex lock. If the pipeline exists, this does nothing.
-func (pm *PipelineManager) makePipeline(logOptsConfig map[string]string, name, hashstring string) error {
+//===================
+// Private methods
+
+// getPipeline gets a pipeline based on a confighash
+func (pm *PipelineManager) getPipeline(hashstring string) (*Pipeline, bool) {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+	pipeline, exists := pm.pipelines[hashstring]
+	return pipeline, exists
+}
+
+// getClient gets a pipeline client based on a file handle
+func (pm *PipelineManager) getClient(file string) (*ClientLogger, bool) {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+	cli, exists := pm.clients[file]
+	return cli, exists
+}
+
+// checkIfHashExists is a short atomic function to see if a pipeline alread exists inside the PM. Thread-safe.
+func (pm *PipelineManager) checkIfHashExists(logOptsConfig map[string]string) bool {
+	hashstring := makeConfigHash(logOptsConfig)
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
 	_, test := pm.pipelines[hashstring]
 	if test {
-		return nil
+		return true
 	}
-
-	pipeline, err := loadNewPipeline(logOptsConfig, name, pm.Logger)
-	if err != nil {
-		return errors.Wrap(err, "error loading pipeline")
-	}
-	pm.pipelines[hashstring] = &Pipeline{pipeline: pipeline, refCount: 0}
-	return nil
+	return false
 }
 
-// makeConfigHash is the helper function that turns a user config into a hash
-func makeConfigHash(cfg map[string]string) string {
-	var hashString string
-	var orderedVal []string
+// registerPipeline is a small atomic function that registers a new pipeline with the managers
+// TODO: What happens if we try to register a pipeline that already exists? Which pipeline "wins"?
+func (pm *PipelineManager) registerPipeline(pipeline *Pipeline, hashstring string) {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+	pm.pipelines[hashstring] = pipeline
 
-	for _, val := range cfg {
-		orderedVal = append(orderedVal, val)
-	}
-
-	sort.Strings(orderedVal)
-
-	for _, val := range orderedVal {
-		hashString = hashString + val
-	}
-
-	sum := sha1.Sum([]byte(hashString))
-
-	return string(sum[:])
 }
 
-// load pipeline starts up a new pipeline with the given config
-func loadNewPipeline(logOptsConfig map[string]string, name string, log *logp.Logger) (*pipeline.Pipeline, error) {
-	info := beat.Info{
-		Beat:     "dockerlogbeat",
-		Version:  "0",
-		Name:     name,
-		Hostname: "dockerbeat.test",
-	}
+// removePipeline removes a pipeline from the manager if it's refcount is zero.
+func (pm *PipelineManager) removePipelineIfNeeded(hash string) {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
 
-	newCfg, err := parseCfgKeys(logOptsConfig)
-	if err != nil {
-		return nil, errors.Wrap(err, "error parsing config keys")
+	//if the pipeline is no longer in use, clean up
+	if pm.pipelines[hash].refCount < 1 {
+		pipeline := pm.pipelines[hash].pipeline
+		delete(pm.pipelines, hash)
+		//pipelines must be closed after clients
+		//Just do this here, since the caller doesn't know if we need to close the libbeat pipeline
+		go func() {
+			pm.Logger.Debugf("Pipeline closing from removePipelineIfNeeded")
+			pipeline.Close()
+		}()
 	}
-
-	cfg, err := common.NewConfigFrom(newCfg)
-	if err != nil {
-		return nil, err
-	}
-	config := containerConfig{}
-	err = cfg.Unpack(&config)
-	if err != nil {
-		return nil, fmt.Errorf("unpacking config failed: %v", err)
-	}
-
-	processing, err := processing.MakeDefaultSupport(false)(info, log, cfg)
-	if err != nil {
-		return nil, errors.Wrap(err, "error in MakeDefaultSupport")
-	}
-
-	pipelineCfg := pipeline.Config{}
-	err = cfg.Unpack(&pipelineCfg)
-	if err != nil {
-		return nil, errors.Wrap(err, "error unpacking pipeline config")
-	}
-
-	idx, err := idxmgmt.DefaultSupport(log, info, config.Output.Config())
-	if err != nil {
-		return nil, errors.Wrap(err, "error making index manager")
-	}
-
-	pipeline, err := pipeline.Load(info,
-		pipeline.Monitors{
-			Metrics:   nil,
-			Telemetry: nil,
-			Logger:    log,
-		},
-		pipelineCfg,
-		processing,
-		func(stat outputs.Observer) (string, outputs.Group, error) {
-			cfg := config.Output
-			out, err := outputs.Load(idx, info, stat, cfg.Name(), cfg.Config())
-			return cfg.Name(), out, err
-		},
-	)
-	if err != nil {
-		return nil, errors.Wrap(err, "error in pipeline.Load")
-	}
-
-	return pipeline, nil
 }
 
-// parseCfgKeys helpfully parses the values in the map, so users can specify yml structures.
-func parseCfgKeys(cfg map[string]string) (map[string]interface{}, error) {
+// registerClient registers a new client with the manager. Up to the caller to  actually close the libbeat client
+func (pm *PipelineManager) registerClient(cl *ClientLogger, hashstring, clientFile string) {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+	pm.clients[clientFile] = cl
+	pm.pipelines[hashstring].refCount++
+}
 
-	outMap := make(map[string]interface{})
+// removeClient deregisters a client
+func (pm *PipelineManager) removeClient(file string) (*ClientLogger, error) {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
 
-	for cfgKey, strVal := range cfg {
-		var parsed interface{}
-		if err := yaml.Unmarshal([]byte(strVal), &parsed); err != nil {
-			return nil, err
-		}
-		outMap[cfgKey] = parsed
+	cl, ok := pm.clients[file]
+	if !ok {
+		pm.mu.Unlock()
+		return nil, fmt.Errorf("No client for file %s", file)
 	}
 
-	return outMap, nil
+	// deincrement the ref count
+	hash := cl.pipelineHash
+	pm.pipelines[hash].refCount--
+	delete(pm.clients, file)
+
+	return cl, nil
 }


### PR DESCRIPTION
This came out of a discussion with @urso -- Client and pipeline close operations on libbeat can block depending on `WaitClose` and other settings. We could potentially block _other_ client start operations while the pipelines drained. This attempts to make the locking more fine-grained so we don't hold a mutex while queues drain.
