### PR TITLE
Cherry-pick #13914 to 7.4: Field registry: Don't overwrite fields with same name

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -51,6 +51,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - cisco asa and ftd filesets: Fix parsing of message 106001. {issue}13891[13891] {pull}13903[13903]
 - Fix merging of fields specified in global scope with fields specified under an input's scope. {issue}3628[3628] {pull}13909[13909]
 - Fix delay in enforcing close_renamed and close_removed options. {issue}13488[13488] {pull}13907[13907]
+- Fix missing netflow fields in index template. {issue}13768[13768] {pull}13914[13914]
 
 *Heartbeat*
 


### PR DESCRIPTION
Cherry-pick of PR #13914 to 7.4 branch. Original message: 

When fields are registered (fields.go, autogenerated), they are grouped by (Beatname, Name and Priority). Currently, if the same triplet is used more than once, the previous asset is overwritten. This causes the internal template inside the Beat to lose fields, and its hard to detect because the generated `fields.yml` contains all the fields.

This is the case with Filebeat inputs and modules sharing the same name:

module/netflow/fields.go:
>  asset.SetFields("filebeat", "netflow", asset.ModuleFieldsPri, AssetNetflow)

input/netflow/fields.go:
>  asset.SetFields("filebeat", "netflow", asset.ModuleFieldsPri, AssetNetflow)

Also this introduces an inconsistence as the order of registration can vary, so a build might or might not have the fields depending on the order the packages are built.

Fixes #13768