### PR TITLE
Fix performance counter values 

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -171,7 +171,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix NPEs / resource leaks when executing config checks. {pull}11165[11165]
 - Fix duplicated IPs on `mode: all` monitors. {pull}12458[12458]
 - Fix integer comparison on JSON responses. {pull}13348[13348]
-- Fix performance counter values for windows/perfmon metricset.{issue}14036[14036] {pull}14039[14039]
 
 *Journalbeat*
 
@@ -217,6 +216,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix rds metricset dashboard. {pull}13721[13721]
 - Ignore prometheus untyped metrics with NaN value. {issue}13750[13750] {pull}13790[13790]
 - Change kubernetes.event.message to text {pull}13964[13964]
+- Fix performance counter values for windows/perfmon metricset.{issue}14036[14036] {pull}14039[14039]
 
 *Packetbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -171,6 +171,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix NPEs / resource leaks when executing config checks. {pull}11165[11165]
 - Fix duplicated IPs on `mode: all` monitors. {pull}12458[12458]
 - Fix integer comparison on JSON responses. {pull}13348[13348]
+- Fix performance counter values for windows/perfmon metricset.{issue}14036[14036] {pull}14039[14039]
 
 *Journalbeat*
 

--- a/metricbeat/module/windows/perfmon/reader.go
+++ b/metricbeat/module/windows/perfmon/reader.go
@@ -124,16 +124,14 @@ func (r *Reader) RefreshCounterPaths() error {
 	if err != nil {
 		return errors.Wrap(err, "failed removing unused counter values")
 	}
-	// Some counters, such as rate counters, require two counter values in order to compute a displayable value. In this case we must call PdhCollectQueryData twice before calling PdhGetFormattedCounterValue.
-	// For more information, see Collecting Performance Data (https://docs.microsoft.com/en-us/windows/desktop/PerfCtrs/collecting-performance-data).
-	if err = r.query.CollectData(); err != nil {
-		return errors.Wrap(err, "failed querying counter values")
-	}
+
 	return nil
 }
 
 // Read executes a query and returns those values in an event.
 func (r *Reader) Read() ([]mb.Event, error) {
+	// Some counters, such as rate counters, require two counter values in order to compute a displayable value. In this case we must call PdhCollectQueryData twice before calling PdhGetFormattedCounterValue.
+	// For more information, see Collecting Performance Data (https://docs.microsoft.com/en-us/windows/desktop/PerfCtrs/collecting-performance-data).
 	if err := r.query.CollectData(); err != nil {
 		return nil, errors.Wrap(err, "failed querying counter values")
 	}


### PR DESCRIPTION
Should fix https://github.com/elastic/beats/issues/14036.
Calling PdhCollectQueryData a second time in less than one sec before retrieving counter values will affect the values returned.