### PR TITLE
Add default indexer and matcher docs for k8s

### DIFF
--- a/libbeat/docs/processors-using.asciidoc
+++ b/libbeat/docs/processors-using.asciidoc
@@ -1322,6 +1322,20 @@ pod metadata based on all container IDs, and a `logs_path` matcher, which takes
 the `log.file.path` field, extracts the container ID, and uses it to retrieve
 metadata.
 
+
+#### Default Indexers/Matchers
+|===
+|Beat |Default Indexer |Default Matcher
+
+|Metricbeat
+|ip_port
+|fields.lookup_fields: ["metricset.host"]
+
+|Filebeat
+|container
+|logs_path
+|===
+
 The configuration below enables the processor when {beatname_lc} is run as a pod in
 Kubernetes.
 


### PR DESCRIPTION
This PR lists the defaults indexers and matchers for Filebeat and Metricbeat, as mentioned on #5566.

cc: @exekias @odacremolbap

Other stuff that could be added here is the description for each indexer/matcher:
```
- pod_name: PodNameIndexer implements default indexer based on pod name
- pod_uid: PodUIDIndexer indexes pods based on the pod UID
- container: ContainerIndexer indexes pods based on all their containers IDs
- ip_port: IPPortIndexer indexes pods based on all their host:port combinations

Matchers:

- fields:
  lookup_fields: 

- field_format:
  format:
```