### PR TITLE
[docs] mention different levels of update commands

### DIFF
--- a/docs/devguide/contributing.asciidoc
+++ b/docs/devguide/contributing.asciidoc
@@ -96,8 +96,8 @@ and documentation. The primary command used for this is:
 --------------------------------------------------------------------------------
 make update
 --------------------------------------------------------------------------------
-Each beat has its own `update` target, as well as a master `update` in the repository root. 
-If a PR adds or removes a dependency, `update` should be run in both the individual beat directory, and the root `beats` directory.
+Each Beat has its own `update` target, as well as a master `update` in the repository root. 
+If a PR adds or removes a dependency, run `make update` in the root `beats` directory.
 
 Another command properly formats go source files and adds a copyright header:
 

--- a/docs/devguide/contributing.asciidoc
+++ b/docs/devguide/contributing.asciidoc
@@ -90,12 +90,14 @@ recommend that you install it.
 === Update scripts
 
 The Beats use a variety of scripts based on Python, make and mage to generate configuration files
-and documentation. The primary command used for this is:
+and documentation. The primary command used for this is: 
 
 [source,shell]
 --------------------------------------------------------------------------------
 make update
 --------------------------------------------------------------------------------
+Each beat has its own `update` target, as well as a master `update` in the repository root. 
+If a PR adds or removes a dependency, `update` should be run in both the individual beat directory, and the root `beats` directory.
 
 Another command properly formats go source files and adds a copyright header:
 

--- a/docs/devguide/contributing.asciidoc
+++ b/docs/devguide/contributing.asciidoc
@@ -90,7 +90,7 @@ recommend that you install it.
 === Update scripts
 
 The Beats use a variety of scripts based on Python, make and mage to generate configuration files
-and documentation. The primary command used for this is: 
+and documentation. The primary command used for this is:
 
 [source,shell]
 --------------------------------------------------------------------------------


### PR DESCRIPTION
This came out of a discussion on slack. The root `update` command is a tad non-obvious, and errors related to the `notice.txt` changes that happen when a dependency is added or removed is also _very_ non-obvious.