### PR TITLE
Unskip close_* flaky tests

### DIFF
--- a/filebeat/tests/system/test_harvester.py
+++ b/filebeat/tests/system/test_harvester.py
@@ -78,7 +78,6 @@ class Test(BaseTest):
         data = self.get_registry()
         assert len(data) == 2
 
-    @unittest.skipIf(os.name == 'nt', 'flaky test https://github.com/elastic/beats/issues/9214')
     def test_close_removed(self):
         """
         Checks that a file is closed if removed

--- a/filebeat/tests/system/test_harvester.py
+++ b/filebeat/tests/system/test_harvester.py
@@ -17,7 +17,6 @@ Test Harvesters
 
 class Test(BaseTest):
 
-    @unittest.skip('flaky test https://github.com/elastic/beats/issues/12037')
     def test_close_renamed(self):
         """
         Checks that a file is closed when its renamed / rotated


### PR DESCRIPTION
Follow up to #13907 as it might have resolved the flakiness in various `close_*` tests.

Resolves #12037.
Resolves #9214.