### PR TITLE
[Filebeat] Reduce memory usage of multiline

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -168,6 +168,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix delay in enforcing close_renamed and close_removed options. {issue}13488[13488] {pull}13907[13907]
 - Fix missing netflow fields in index template. {issue}13768[13768] {pull}13914[13914]
 - Fix cisco module's asa and ftd filesets parsing of domain names where an IP address is expected. {issue}14034[14034]
+- Fixed increased memory usage with large files when multiline pattern does not match. {issue}14068[14068]
 
 *Heartbeat*
 


### PR DESCRIPTION
The use of time.After when multiline is enabled and lines don't match the multiline pattern increases the memory usage (from 30MB to 1GB).

This extra memory is attributed to unexpired timers allocated internally by the Go runtime when time.After(duration) is used. According to the docs: _"If efficiency is a concern, use NewTimer instead and call Timer.Stop if the timer is no longer needed."._

It's not clear to me why this problem only appears when many lines on the input file don't match the pattern.

Reproduced with this config:
```yaml
multiline.pattern: '^\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\.d{3}'
multiline.negate: true
multiline.match: after
multiline.max_lines: 50
max_bytes: 1048576
```

and a random input file generated by:
```sh
cat <<EOF > genrandom.py
import base64
import os
import sys

LINE_SIZE = 160
RAW_SIZE = int(LINE_SIZE * 3 / 4)

if len(sys.argv) != 2:
    print 'Usage:', sys.argv[0], '<SIZE IN MEGABYTES>'
    sys.exit(1)

limit = int(sys.argv[1]) * 1024 * 1024
size = 0
f = open('/dev/urandom', 'rb')

while size < limit:
    os.write(2, '> written {0:.2f} MiB\r'.format(size / (1024.0 * 1024.0)))
    raw = f.read(RAW_SIZE * 100)
    while len(raw) >= RAW_SIZE:
        part, raw = raw[:RAW_SIZE], raw[RAW_SIZE:]
        line = base64.b64encode(part)
        print line
        size += len(line)
os.write(2, 'Done.\n')
EOF
python genrandom.py 1024 > 1gb.log
```