### PR TITLE
Remove/replace _type in tests

### DIFF
--- a/libbeat/outputs/elasticsearch/api_integration_test.go
+++ b/libbeat/outputs/elasticsearch/api_integration_test.go
@@ -46,7 +46,7 @@ func TestIndex(t *testing.T) {
 	params := map[string]string{
 		"refresh": "true",
 	}
-	_, resp, err := client.Index(index, "test", "1", params, body)
+	_, resp, err := client.Index(index, "_doc", "1", params, body)
 	if err != nil {
 		t.Fatalf("Index() returns error: %s", err)
 	}
@@ -78,7 +78,7 @@ func TestIndex(t *testing.T) {
 		t.Errorf("Wrong number of search results: %d", result.Hits.Total.Value)
 	}
 
-	_, resp, err = client.Delete(index, "test", "1", nil)
+	_, resp, err = client.Delete(index, "_doc", "1", nil)
 	if err != nil {
 		t.Errorf("Delete() returns error: %s", err)
 	}
@@ -138,7 +138,7 @@ func TestIngest(t *testing.T) {
 	}
 
 	params := map[string]string{"refresh": "true"}
-	_, resp, err = client.Ingest(index, "test", pipeline, "1", params, obj{
+	_, resp, err = client.Ingest(index, "_doc", pipeline, "1", params, obj{
 		"testfield": "TEST",
 	})
 	if err != nil {

--- a/libbeat/outputs/elasticsearch/bulkapi_integration_test.go
+++ b/libbeat/outputs/elasticsearch/bulkapi_integration_test.go
@@ -37,7 +37,6 @@ func TestBulk(t *testing.T) {
 		{
 			"index": map[string]interface{}{
 				"_index": index,
-				"_type":  "type1",
 				"_id":    "1",
 			},
 		},
@@ -54,7 +53,7 @@ func TestBulk(t *testing.T) {
 	params := map[string]string{
 		"refresh": "true",
 	}
-	_, err := client.Bulk(index, "type1", params, body)
+	_, err := client.Bulk(index, "", params, body)
 	if err != nil {
 		t.Fatalf("Bulk() returned error: %s", err)
 	}
@@ -87,7 +86,7 @@ func TestEmptyBulk(t *testing.T) {
 	params := map[string]string{
 		"refresh": "true",
 	}
-	resp, err := client.Bulk(index, "type1", params, body)
+	resp, err := client.Bulk(index, "", params, body)
 	if err != nil {
 		t.Fatalf("Bulk() returned error: %s", err)
 	}
@@ -106,7 +105,6 @@ func TestBulkMoreOperations(t *testing.T) {
 		{
 			"index": map[string]interface{}{
 				"_index": index,
-				"_type":  "type1",
 				"_id":    "1",
 			},
 		},
@@ -117,7 +115,6 @@ func TestBulkMoreOperations(t *testing.T) {
 		{
 			"delete": map[string]interface{}{
 				"_index": index,
-				"_type":  "type1",
 				"_id":    "2",
 			},
 		},
@@ -125,7 +122,6 @@ func TestBulkMoreOperations(t *testing.T) {
 		{
 			"create": map[string]interface{}{
 				"_index": index,
-				"_type":  "type1",
 				"_id":    "3",
 			},
 		},
@@ -137,7 +133,6 @@ func TestBulkMoreOperations(t *testing.T) {
 			"update": map[string]interface{}{
 				"_id":    "1",
 				"_index": index,
-				"_type":  "type1",
 			},
 		},
 		{
@@ -155,7 +150,7 @@ func TestBulkMoreOperations(t *testing.T) {
 	params := map[string]string{
 		"refresh": "true",
 	}
-	resp, err := client.Bulk(index, "type1", params, body)
+	resp, err := client.Bulk(index, "", params, body)
 	if err != nil {
 		t.Fatalf("Bulk() returned error: %s [%s]", err, resp)
 	}


### PR DESCRIPTION
As Elasticsearch removes support for document types from master / 8.0.0, Elasticsearch output integration tests in libbeat are failing like so:

```
08:27:24 command [go test -race -tags integration -cover -coverprofile /tmp/gotestcover-197489031 github.com/elastic/beats/libbeat/outputs/elasticsearch]: exit status 1
08:27:24 --- FAIL: TestIndex (0.04s)
08:27:24     api_integration_test.go:51: Index() returns error: Elasticsearch response: {"error":"no handler found for uri [/beats-test-index-21951/test/1?refresh=true] and method [PUT]"}: 400 Bad Request: {"error":"no handler found for uri [/beats-test-index-21951/test/1?refresh=true] and method [PUT]"}
08:27:24 --- FAIL: TestIngest (0.12s)
08:27:24     api_integration_test.go:145: Ingest() returns error: Elasticsearch response: {"error":"no handler found for uri [/beats-test-ingest-21951/test/1?pipeline=beats-test-pipeline-21951&refresh=true] and method [PUT]"}: 400 Bad Request: {"error":"no handler found for uri [/beats-test-ingest-21951/test/1?pipeline=beats-test-pipeline-21951&refresh=true] and method [PUT]"}
08:27:24 --- FAIL: TestBulk (0.06s)
08:27:24     bulkapi_integration_test.go:59: Bulk() returned error: 400 Bad Request: {"error":"no handler found for uri [/packetbeat-unittest-21951/type1/_bulk?refresh=true] and method [POST]"}
08:27:24 --- FAIL: TestBulkMoreOperations (0.02s)
08:27:24     bulkapi_integration_test.go:160: Bulk() returned error: 400 Bad Request: {"error":"no handler found for uri [/packetbeat-unittest-21951/type1/_bulk?refresh=true] and method [POST]"} [<nil>]
08:27:24 FAIL
```

This PR updates these tests to conform to the new typeless Elasticsearch APIs.