### PR TITLE
Cherry-pick #14068 to 7.4: [Filebeat] Reduce memory usage of multiline

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -47,6 +47,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Filebeat*
 
+- Fixed increased memory usage with large files when multiline pattern does not match. {issue}14068[14068]
 
 *Heartbeat*
 

--- a/libbeat/reader/readfile/timeout.go
+++ b/libbeat/reader/readfile/timeout.go
@@ -28,7 +28,7 @@ var (
 	errTimeout = errors.New("timeout")
 )
 
-// timeoutProcessor will signal some configurable timeout error if no
+// TimeoutReader will signal some configurable timeout error if no
 // new line can be returned in time.
 type TimeoutReader struct {
 	reader  reader.Reader
@@ -43,7 +43,7 @@ type lineMessage struct {
 	err  error
 }
 
-// New returns a new timeout reader from an input line reader.
+// NewTimeoutReader returns a new timeout reader from an input line reader.
 func NewTimeoutReader(reader reader.Reader, signal error, t time.Duration) *TimeoutReader {
 	if signal == nil {
 		signal = errTimeout
@@ -75,14 +75,15 @@ func (r *TimeoutReader) Next() (reader.Message, error) {
 			}
 		}()
 	}
-
+	timer := time.NewTimer(r.timeout)
 	select {
 	case msg := <-r.ch:
 		if msg.err != nil {
 			r.running = false
 		}
+		timer.Stop()
 		return msg.line, msg.err
-	case <-time.After(r.timeout):
+	case <-timer.C:
 		return reader.Message{}, r.signal
 	}
 }


### PR DESCRIPTION
Cherry-pick of PR #14068 to 7.4 branch. Original message: 

The use of time.After when multiline is enabled and lines don't match the multiline pattern increases the memory usage (from 30MB to 1GB).

This extra memory is attributed to unexpired timers allocated internally by the Go runtime when time.After(duration) is used. According to the docs: _"If efficiency is a concern, use NewTimer instead and call Timer.Stop if the timer is no longer needed."._

It's not clear to me why this problem only appears when many lines on the input file don't match the pattern.

Reproduced with this config:
```yaml
multiline.pattern: '^\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\.d{3}'
multiline.negate: true
multiline.match: after
multiline.max_lines: 50
max_bytes: 1048576
```

and a random input file generated by:
```sh
cat <<EOF > genrandom.py
import base64
import os
import sys

LINE_SIZE = 160
RAW_SIZE = int(LINE_SIZE * 3 / 4)

if len(sys.argv) != 2:
    print 'Usage:', sys.argv[0], '<SIZE IN MEGABYTES>'
    sys.exit(1)

limit = int(sys.argv[1]) * 1024 * 1024
size = 0
f = open('/dev/urandom', 'rb')

while size < limit:
    os.write(2, '> written {0:.2f} MiB\r'.format(size / (1024.0 * 1024.0)))
    raw = f.read(RAW_SIZE * 100)
    while len(raw) >= RAW_SIZE:
        part, raw = raw[:RAW_SIZE], raw[RAW_SIZE:]
        line = base64.b64encode(part)
        print line
        size += len(line)
os.write(2, 'Done.\n')
EOF
python genrandom.py 1024 > 1gb.log
```