### PR TITLE
Add etherbeat to the list of community beats

### DIFF
--- a/libbeat/docs/communitybeats.asciidoc
+++ b/libbeat/docs/communitybeats.asciidoc
@@ -42,6 +42,7 @@ https://github.com/radoondas/earthquakebeat[earthquakebeat]:: Pulls data from ht
 https://github.com/radoondas/elasticbeat[elasticbeat]:: Reads status from an Elasticsearch cluster and indexes them in Elasticsearch.
 https://github.com/berfinsari/envoyproxybeat[envoyproxybeat]:: Reads stats from the Envoy Proxy and indexes them into Elasticsearch.
 https://github.com/gamegos/etcdbeat[etcdbeat]:: Reads stats from the Etcd v2 API and indexes them into Elasticsearch.
+https://gitlab.com/hatricker/etherbeat[etherbeat]:: Reads blocks from Ethereum compatible blockchain and indexes them into Elasticsearch.
 https://github.com/christiangalsterer/execbeat[execbeat]:: Periodically executes shell commands and sends the standard output and standard error to
 Logstash or Elasticsearch.
 https://github.com/jarpy/factbeat[factbeat]:: Collects facts from https://puppetlabs.com/facter[Facter].


### PR DESCRIPTION
[etherbeat](https://gitlab.com/hatricker/etherbeat) is an open source beat project which fetches the blocks from Ethereum or Ethereum compatible blockchain and indexes them into Elasticsearch. Please see [config part](https://gitlab.com/hatricker/etherbeat#config) of the project homepage to see how to use it.