### PR TITLE
Statestore prototype

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -960,6 +960,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 --------------------------------------------------------------------
+Dependency: github.com/elastic/go-concert
+Revision: fde4d7dd2a8c9d3f3c1fc9d22c09dace470433ae
+License type (autodetected): Apache-2.0
+./vendor/github.com/elastic/go-concert/LICENSE:
+--------------------------------------------------------------------
+Apache License 2.0
+
+
+--------------------------------------------------------------------
 Dependency: github.com/elastic/go-libaudit
 Version: v0.4.0
 Revision: 39073a2988f718067d85d27a4d18b1b57de5d947

--- a/filebeat/input/v2/statestore/connector.go
+++ b/filebeat/input/v2/statestore/connector.go
@@ -1,0 +1,99 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package statestore
+
+import (
+	"sync"
+
+	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/registry"
+)
+
+// Connector is used to connect to a store backed by a registry.
+type Connector struct {
+	log      *logp.Logger
+	registry *registry.Registry
+
+	mux sync.Mutex
+
+	// set of stores currently with at least one active session.
+	stores map[string]*store
+}
+
+// NewConnector creates a new store connector for accessing a resource Store.
+func NewConnector(log *logp.Logger, reg *registry.Registry) *Connector {
+	invariant(log != nil, "missing logger")
+	invariant(reg != nil, "missing registry")
+
+	return &Connector{
+		log:      log,
+		registry: reg,
+		stores:   map[string]*store{},
+	}
+}
+
+// Open creates a connection to a named store.
+func (c *Connector) Open(name string) (*Store, error) {
+	ok := false
+
+	c.mux.Lock()
+	defer c.mux.Unlock()
+
+	persistentStore, err := c.registry.Get(name)
+	if err != nil {
+		return nil, err
+	}
+	defer ifNotOK(&ok, func() {
+		persistentStore.Close()
+	})
+
+	sharedStore := c.stores[name]
+	if sharedStore == nil {
+		sharedStore = &store{
+			parent:          c,
+			name:            name,
+			persistentStore: persistentStore,
+			resources:       table{},
+		}
+		c.stores[name] = sharedStore
+	} else {
+		sharedStore.refCount.Retain()
+	}
+
+	ok = true
+	return newStore(sharedStore), nil
+}
+
+func (c *Connector) releaseStore(store *store) {
+	c.mux.Lock()
+	released := store.refCount.Release()
+	if released {
+		delete(c.stores, store.name)
+	}
+	c.mux.Unlock()
+
+	if released {
+		store.close()
+	}
+}
+
+func ifNotOK(b *bool, fn func()) {
+	if !(*b) {
+		fn()
+	}
+}

--- a/filebeat/input/v2/statestore/errors.go
+++ b/filebeat/input/v2/statestore/errors.go
@@ -1,0 +1,90 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package statestore
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// error codes
+
+var (
+	ErrCodeOpFailed = errors.New("operation failed")
+)
+
+// predefined errors
+
+var (
+	ErrResourceInUse = errors.New("resource in use")
+)
+
+// Error provides a common error type used by the statestore package.  It
+// reports the failed operation, custom message and the root cause if
+// available.
+type Error struct {
+	op      string
+	code    error
+	message string
+	cause   error
+}
+
+// Op returns the name of the operation that failed.
+func (e *Error) Op() string {
+	return e.op
+}
+
+// Code returns a sentinal error that can be used for checking the error type.
+func (e *Error) Code() error {
+	return e.code
+}
+
+// Unwrap returns the cause if available.
+func (e *Error) Unwrap() error {
+	return e.cause
+}
+
+// Error builds the complete error string.
+func (e *Error) Error() string {
+	var buf strings.Builder
+
+	pad := func() {
+		if buf.Len() > 0 {
+			buf.WriteString(": ")
+		}
+	}
+
+	padOpt := func(err error) {
+		if err != nil {
+			pad()
+			fmt.Fprintf(&buf, "%+v", err)
+		}
+	}
+
+	if e.op != "" {
+		buf.WriteString(e.op)
+	}
+	padOpt(e.code)
+	if e.message != "" {
+		pad()
+		buf.WriteString(e.message)
+	}
+	padOpt(e.cause)
+	return buf.String()
+}

--- a/filebeat/input/v2/statestore/errors.go
+++ b/filebeat/input/v2/statestore/errors.go
@@ -26,14 +26,9 @@ import (
 // error codes
 
 var (
-	ErrCodeOpFailed = errors.New("operation failed")
-	ErrClosed       = errors.New("store is closed")
-)
-
-// predefined errors
-
-var (
-	ErrResourceInUse = errors.New("resource in use")
+	// ErrClosed error code indicates that the operation can not
+	// be executed, because the store has been closed already.
+	ErrClosed = errors.New("store is closed")
 )
 
 // Error provides a common error type used by the statestore package.  It

--- a/filebeat/input/v2/statestore/errors.go
+++ b/filebeat/input/v2/statestore/errors.go
@@ -27,6 +27,7 @@ import (
 
 var (
 	ErrCodeOpFailed = errors.New("operation failed")
+	ErrClosed       = errors.New("store is closed")
 )
 
 // predefined errors
@@ -87,4 +88,11 @@ func (e *Error) Error() string {
 	}
 	padOpt(e.cause)
 	return buf.String()
+}
+
+func raiseClosed(op string) *Error {
+	return &Error{
+		op:   op,
+		code: ErrClosed,
+	}
 }

--- a/filebeat/input/v2/statestore/lockmode.go
+++ b/filebeat/input/v2/statestore/lockmode.go
@@ -1,0 +1,46 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package statestore
+
+import (
+	"fmt"
+	"sync"
+)
+
+type lockMode int
+
+const (
+	lockRequired lockMode = iota
+	lockAlreadyTaken
+	lockMustRelease
+)
+
+func withLockMode(mux *sync.Mutex, lm lockMode, fn func() error) error {
+	switch lm {
+	case lockRequired:
+		mux.Lock()
+		defer mux.Unlock()
+	case lockMustRelease:
+		defer mux.Unlock()
+	case lockAlreadyTaken:
+	default:
+		panic(fmt.Errorf("unknown lock mode: %v", lm))
+	}
+
+	return fn()
+}

--- a/filebeat/input/v2/statestore/op.go
+++ b/filebeat/input/v2/statestore/op.go
@@ -1,0 +1,87 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package statestore
+
+import (
+	"runtime"
+
+	"github.com/elastic/beats/libbeat/registry"
+)
+
+// ResourceUpdateOp defers a state update to be written to the persistent store.
+// The operation can be applied to the registry using ApplyWith. Calling Close
+// will mark the operation as done.
+type ResourceUpdateOp struct {
+	store   *Store
+	key     ResourceKey
+	entry   *resourceEntry
+	updates interface{}
+}
+
+func newUpdateOp(store *Store, key ResourceKey, entry *resourceEntry, updates interface{}) *ResourceUpdateOp {
+	op := &ResourceUpdateOp{
+		store:   store,
+		key:     key,
+		entry:   entry,
+		updates: updates,
+	}
+	return op
+}
+
+// ApplyWith applies the operation using the withTx helper function. The helper
+// function is responsible for creating and maintaining a write transaction for
+// the provided store.  If possible the helper should keep the transaction open
+// if an array of operations are applied.
+func (op *ResourceUpdateOp) ApplyWith(withTx func(*registry.Store, func(*registry.Tx) error) error) error {
+	return withTx(op.store.persistentStore, func(tx *registry.Tx) error {
+		return tx.Update(registry.Key(op.key), op.updates)
+	})
+}
+
+// Close marks the operation as done. ApplyWith can not be run anymore
+// afterwards.  If all pending operations have been closed, the persistent
+// store is assumed to be in sync with the in memory state.
+func (op *ResourceUpdateOp) Close() {
+	op.closePending()
+	op.unlink()
+	runtime.SetFinalizer(op, nil)
+}
+
+func (op *ResourceUpdateOp) closePending() {
+	entry := op.entry
+
+	entry.value.mux.Lock()
+	defer entry.value.mux.Unlock()
+
+	invariant(entry.value.pending > 0, "there should be pending updates")
+	entry.value.pending--
+	if entry.value.pending == 0 {
+		// we are in sync now, let's remove duplicate data from main memory.
+		entry.value.cached = nil
+	}
+}
+
+func (op *ResourceUpdateOp) unlink() {
+	store, entry := op.store, op.entry
+
+	store.resourcesMux.Lock()
+	defer store.resourcesMux.Unlock()
+	if entry.Release() {
+		store.resources.Remove(op.key)
+	}
+}

--- a/filebeat/input/v2/statestore/op.go
+++ b/filebeat/input/v2/statestore/op.go
@@ -40,6 +40,8 @@ func newUpdateOp(store *Store, key ResourceKey, entry *resourceEntry, updates in
 		entry:   entry,
 		updates: updates,
 	}
+
+	runtime.SetFinalizer(op, (*ResourceUpdateOp).finalize)
 	return op
 }
 
@@ -62,6 +64,10 @@ func (op *ResourceUpdateOp) Close() {
 	runtime.SetFinalizer(op, nil)
 }
 
+func (op *ResourceUpdateOp) finalize() {
+	op.unlink()
+}
+
 func (op *ResourceUpdateOp) closePending() {
 	entry := op.entry
 
@@ -82,6 +88,6 @@ func (op *ResourceUpdateOp) unlink() {
 	store.resourcesMux.Lock()
 	defer store.resourcesMux.Unlock()
 	if entry.Release() {
-		store.resources.Remove(op.key)
+		store.remove(op.key)
 	}
 }

--- a/filebeat/input/v2/statestore/resource.go
+++ b/filebeat/input/v2/statestore/resource.go
@@ -1,0 +1,313 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package statestore
+
+import (
+	"errors"
+	"runtime"
+
+	"github.com/elastic/beats/libbeat/common/transform/typeconv"
+	"github.com/elastic/beats/libbeat/registry"
+)
+
+// Resource is used to lock and modify a resource its registry contents in a
+// store.
+type Resource struct {
+	store    *Store
+	isLocked bool
+
+	key   ResourceKey
+	entry *resourceEntry
+}
+
+func newResource(store *Store, key ResourceKey) *Resource {
+	res := &Resource{
+		store:    store,
+		isLocked: false,
+		key:      key,
+	}
+
+	// in case we miss an unlock operation (programmer error or panic that hash
+	// been caught) we set a finalizer to eventually free the resource.
+	// The Unlock operation will unsert the finalizer.
+	runtime.SetFinalizer(res, (*Resource).finalize)
+	return res
+}
+
+func (r *Resource) close() {
+	runtime.SetFinalizer(r, nil)
+	r.finalize()
+}
+
+func (r *Resource) finalize() {
+	defer r.unlink()
+
+	if r.IsLocked() {
+		r.doUnlock()
+	}
+}
+
+func (r *Resource) link(create bool) {
+	if r.entry != nil {
+		return
+	}
+
+	store := r.store
+	store.resourcesMux.Lock()
+	defer store.resourcesMux.Unlock()
+
+	entry := store.resources.Find(r.key)
+	if entry == nil && create {
+		entry = store.resources.Create(r.key)
+	}
+	r.entry = entry
+}
+
+// unlink removes the pointer to the memory backed resource.
+// If the in memory resource entry is not used by any other Resource,
+// then we will remove it from the table.
+func (r *Resource) unlink() {
+	if r.entry == nil {
+		return
+	}
+
+	entry := r.entry
+	r.entry = nil
+
+	store := r.store
+	store.resourcesMux.Lock()
+	defer store.resourcesMux.Unlock()
+	if entry.Release() {
+		store.resources.Remove(r.key)
+	}
+}
+
+// Lock locks a resource held by the store. It blocks until the lock becomes
+// available.
+func (r *Resource) Lock() {
+	checkNotLocked(r.IsLocked())
+
+	r.link(true)
+	r.entry.Lock()
+	r.isLocked = true
+}
+
+// TryLock attempts to lock the resource. It returns true if the lock has been
+// acquired successfully.
+func (r *Resource) TryLock() bool {
+	checkNotLocked(r.IsLocked())
+
+	r.link(true)
+	r.isLocked = r.entry.TryLock()
+	if !r.isLocked {
+		r.unlink()
+	}
+	return r.isLocked
+}
+
+// Unlock releases a resource.
+func (r *Resource) Unlock() {
+	checkLocked(r.IsLocked())
+
+	r.doUnlock()
+	r.close()
+}
+
+func (r *Resource) doUnlock() {
+	r.entry.Unlock()
+	r.markUnlocked()
+}
+
+// IsLocked checks if the resource currently holds the lock to the shared
+// registry entry.
+func (r *Resource) IsLocked() bool {
+	return r.isLocked
+}
+
+func (r *Resource) markLocked() {
+	r.isLocked = true
+}
+
+func (r *Resource) markUnlocked() {
+	r.isLocked = false
+}
+
+// Has check if resource is already in registry.
+// Has does not require the lock to be taken.
+func (r *Resource) Has() (bool, error) {
+	has := false
+	err := r.store.persistentStore.View(func(tx *registry.Tx) error {
+		found, err := tx.Has(registry.Key(r.key))
+		if err == nil {
+			has = found
+		}
+		return err
+	})
+
+	if err != nil {
+		err = &Error{
+			op:      "resource/has",
+			message: "failed to lookup resource",
+			cause:   err,
+		}
+	}
+	return has, err
+}
+
+// Update the registry state with fields in val.
+// If the resource key is unknown, then a new document is inserted into the
+// registry.
+// Update requires the resource to be locked.
+//
+// It is recommended to use Update only for resource meta-data updates,
+// that allow us to track and identify a resource. Read state updates
+// should be handled by UpdateOp.
+//
+// The update call is thread-safe, as the update operation itself is protected.
+// But data races are still possible, if any two go-routines update
+// an overlapping set of fields.
+func (r *Resource) Update(val interface{}) error {
+	const op = "resource/update"
+
+	checkLocked(r.IsLocked())
+
+	entry := r.entry
+	invariant(entry != nil, "in memory state is not linked as expected")
+
+	// update cached state if in-memory and persistent state are not in sync.
+	entry.value.mux.Lock()
+	defer entry.value.mux.Unlock()
+	if entry.value.pending != 0 {
+		if err := typeconv.Convert(&entry.value.cached, val); err != nil {
+			return &Error{op: op, message: "failed to update in memory state", cause: err}
+		}
+	}
+
+	err := r.store.persistentStore.Update(func(tx *registry.Tx) error {
+		return tx.Update(registry.Key(r.key), val)
+	})
+	if err != nil {
+		return &Error{op: op, message: "failed to update persistent store", cause: err}
+	}
+	return nil
+}
+
+// read current state of resource. If there are pending operations, this is
+// the last in-memory state. If there are no operations, or all pending operations have been acked, we read directly from the registry.
+// Read does not require the resource to be locked. But if the lock is
+// not taken, you are subject to data races as the go-routine holding a lock on the resource
+// can update its contents.
+func (r *Resource) Read(to interface{}) error {
+	const op = "resource/read"
+
+	r.link(false)
+	entry := r.entry
+
+	if entry != nil {
+		entry.value.mux.Lock()
+
+		// If in-memory and persistent store are not in sync, we require
+		// the in-memory store to be the most authorative.
+		if entry.value.pending != 0 {
+			defer entry.value.mux.Unlock()
+			if err := typeconv.Convert(to, entry.value.cached); err != nil {
+				return &Error{op: op, message: "failed to read in-memory state", cause: err}
+			}
+			return nil
+		}
+
+		entry.value.mux.Unlock()
+	}
+
+	err := r.store.persistentStore.View(func(tx *registry.Tx) error {
+		vd, err := tx.Get(registry.Key(r.key))
+		if err != nil || vd == nil {
+			return err
+		}
+		return vd.Decode(to)
+	})
+	if err != nil {
+		return &Error{op: op, message: "failed to read state from persistent store", cause: err}
+	}
+	return nil
+}
+
+// UpdateOp creates a resource update operation.
+// The in memory state of the resource is updated right away, but the
+// persistent registry state is not updated yet.
+// Executing the returned operation updates the persistent state and
+// invalidates the operation.
+// As long as there are active operations, the in-memory state and the
+// persistent state are not in sync yet.
+// If in-memory state and active operations are not in sync, then
+// read operations will use the in-memory state only.
+//
+// It is recommended to use UpdateOp for read state updates only. Resource
+// metadata should be updated using Update instead.
+func (r *Resource) UpdateOp(val interface{}) (*ResourceUpdateOp, error) {
+	const op = "resource/create-update-op"
+
+	checkLocked(r.IsLocked())
+
+	entry := r.entry
+	invariant(entry != nil, "in memory state is not linked to the resource")
+
+	entry.value.mux.Lock()
+	defer entry.value.mux.Unlock()
+
+	// load current state from persistent store if there is no cached entry in
+	// the resource.
+	if entry.value.pending == 0 {
+		err := r.store.persistentStore.View(func(tx *registry.Tx) error {
+			vd, err := tx.Get(registry.Key(r.key))
+			if err != nil || vd == nil {
+				return err
+			}
+			return vd.Decode(&entry.value.cached)
+		})
+		if err != nil {
+			return nil, &Error{op: op, message: "failed to load state from persistent store", cause: err}
+		}
+	}
+
+	if err := typeconv.Convert(&entry.value.cached, val); err != nil {
+		return nil, &Error{op: op, message: "failed to apply the update to in-memory state", cause: err}
+	}
+
+	entry.value.pending++
+	entry.Retain()
+	return newUpdateOp(r.store, r.key, entry, val), nil
+}
+
+func checkLocked(b bool) {
+	invariant(!b, "try to access unlocked resource")
+}
+
+func checkNotLocked(b bool) {
+	invariant(b, "invalid operation on locked resource")
+}
+
+func invariant(b bool, message string) {
+	if !b {
+		panic(errors.New(message))
+	}
+}
+
+func implementMe() error {
+	panic("TODO: implement me")
+}

--- a/filebeat/input/v2/statestore/resource.go
+++ b/filebeat/input/v2/statestore/resource.go
@@ -71,9 +71,9 @@ func (r *Resource) link(create bool) {
 	store.resourcesMux.Lock()
 	defer store.resourcesMux.Unlock()
 
-	entry := store.resources.Find(r.key)
+	entry := store.find(r.key)
 	if entry == nil && create {
-		entry = store.resources.Create(r.key)
+		entry = store.create(r.key)
 	}
 	r.entry = entry
 }
@@ -93,7 +93,7 @@ func (r *Resource) unlink() {
 	store.resourcesMux.Lock()
 	defer store.resourcesMux.Unlock()
 	if entry.Release() {
-		store.resources.Remove(r.key)
+		store.remove(r.key)
 	}
 }
 

--- a/filebeat/input/v2/statestore/resource.go
+++ b/filebeat/input/v2/statestore/resource.go
@@ -90,7 +90,7 @@ func (r *Resource) unlink() {
 	entry := r.entry
 	r.entry = nil
 
-	r.store.releaseEntry(entry)
+	r.store.shared.releaseEntry(entry)
 }
 
 // Lock locks a resource held by the store. It blocks until the lock becomes
@@ -154,7 +154,7 @@ func (r *Resource) Has() (bool, error) {
 
 	has := false
 
-	err := r.store.persistentStore.View(func(tx *registry.Tx) error {
+	err := r.store.shared.persistentStore.View(func(tx *registry.Tx) error {
 		found, err := tx.Has(registry.Key(r.key))
 		if err == nil {
 			has = found
@@ -205,7 +205,7 @@ func (r *Resource) Update(val interface{}) error {
 		}
 	}
 
-	err := r.store.persistentStore.Update(func(tx *registry.Tx) error {
+	err := r.store.shared.persistentStore.Update(func(tx *registry.Tx) error {
 		return tx.Update(registry.Key(r.key), val)
 	})
 	if err != nil {
@@ -246,7 +246,7 @@ func (r *Resource) Read(to interface{}) error {
 		entry.value.mux.Unlock()
 	}
 
-	err := r.store.persistentStore.View(func(tx *registry.Tx) error {
+	err := r.store.shared.persistentStore.View(func(tx *registry.Tx) error {
 		vd, err := tx.Get(registry.Key(r.key))
 		if err != nil || vd == nil {
 			return err
@@ -289,7 +289,7 @@ func (r *Resource) UpdateOp(val interface{}) (*ResourceUpdateOp, error) {
 	// load current state from persistent store if there is no cached entry in
 	// the resource.
 	if entry.value.pending == 0 {
-		err := r.store.persistentStore.View(func(tx *registry.Tx) error {
+		err := r.store.shared.persistentStore.View(func(tx *registry.Tx) error {
 			vd, err := tx.Get(registry.Key(r.key))
 			if err != nil || vd == nil {
 				return err

--- a/filebeat/input/v2/statestore/statestore.go
+++ b/filebeat/input/v2/statestore/statestore.go
@@ -1,0 +1,44 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package statestore provides coordinated access to entries in the registry
+// via resources.
+//
+// A Store supports selective update of fields using go structures.
+// Data to be stored in the registry should be split into resource identifying
+// meta-data and read state data. This allows inputs to have separate
+// go-routines for updating resource tracking meta-data (like file path upon
+// file renames) and for read state updates (like file offset).
+//
+// The registry is only eventually consistent to the current state of the
+// store. When using (*Resource).Update, both the in-memory state and the
+// registry state will be updated immediately. But when using
+// (*Resource).UpdateOp, only the in memory state will be updated. The
+// registry state must be updated using the ResourceUpdateOp, after the
+// associated events have been ACKed by the outputs. Once all pending update operations have been applied
+// the in-memory state and the persistent state are assumed to be in-sync, and
+// the in-memory state is dropped so to free some memory.
+//
+// The eventual consistency allows resources to be Unlocked and Locked by another go-routine
+// immediately, as the final read state from the former go-routine is available
+// right away. The lock guarantees exclusive access. In the meantime older
+// updates might still be applied to the registry file, while the new
+// go-routine can start creating new update operations concurrently to be
+// applied to after already pending updates.
+package statestore
+
+type ResourceKey string

--- a/filebeat/input/v2/statestore/statestore.go
+++ b/filebeat/input/v2/statestore/statestore.go
@@ -41,4 +41,5 @@
 // applied to after already pending updates.
 package statestore
 
+// ResourceKey is used to describe an unique resource to be stored in the registry.
 type ResourceKey string

--- a/filebeat/input/v2/statestore/store.go
+++ b/filebeat/input/v2/statestore/store.go
@@ -1,0 +1,72 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package statestore
+
+import (
+	"sync"
+
+	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/registry"
+)
+
+// Store provides some coordinates access to a registry.Store.
+// All update and read operations require users to acquire an resource first.
+// A Resource must be locked before it can be modified. This ensures that at most
+// one go-routine has access to a resource. Lock/TryLock/Unlack can be used to
+// coordinate resource access even between independent components.
+type Store struct {
+	log *logp.Logger
+
+	persistentStore *registry.Store
+
+	resourcesMux sync.Mutex
+	resources    table
+}
+
+// NewStore creates a new state Store that is backed by a persistent store.
+func NewStore(log *logp.Logger, store *registry.Store) *Store {
+	invariant(log != nil, "missing a logger")
+	invariant(store != nil, "missing a persistent store")
+
+	return &Store{
+		log:             log,
+		persistentStore: store,
+		resources:       table{},
+	}
+}
+
+// Access an unlocked resource. This creates a handle to a resource that may
+// not yet exist in the persistent registry.
+func (s *Store) Access(key ResourceKey) *Resource {
+	return newResource(s, key)
+}
+
+// Lock locks and returns the resource for a given key.
+func (s *Store) Lock(key ResourceKey) *Resource {
+	res := s.Access(key)
+	res.Lock()
+	return res
+}
+
+// TryLock locks and returns the resource for a given key.
+// The locked return value is set to false if TryLock failed, but the resource
+// itself is always returned.
+func (s *Store) TryLock(key ResourceKey) (res *Resource, locked bool) {
+	res = s.Access(key)
+	return res, res.TryLock()
+}

--- a/filebeat/input/v2/statestore/table.go
+++ b/filebeat/input/v2/statestore/table.go
@@ -1,0 +1,101 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package statestore
+
+import (
+	"sync"
+
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/go-concert/atomic"
+)
+
+// In memory registry state table. Updates are written directly to this table.
+// As long as there are pending operations, we read the state from this table.
+// If there is no entry with cached value present, we assume the registry to be
+// in sync with all updates applied.
+// Entries are reference counted allowing us to free space in the table if there is
+// no more go-routine potentially accessing a resource.
+type table map[ResourceKey]*resourceEntry
+
+// resourceEntry keeps track of actual resource locks and pending updates.
+type resourceEntry struct {
+	key      ResourceKey
+	refCount atomic.Uint
+	lock     chan struct{}
+	value    valueState
+}
+
+// valueState keeps track of pending updates to a value.
+// As long as there are pending updates, cached holds the last known correct value
+// and pending will be > 0.
+// If `pending` is 0, then the state store and the persistent registry are in sync.
+// In this case `cached` will be nil and the registry is used for reading a value.
+type valueState struct {
+	mux     sync.Mutex
+	pending uint          // pending updates until value is in sync
+	cached  common.MapStr // current value if state == valueOutOfSync
+}
+
+func (t table) Create(k ResourceKey) *resourceEntry {
+	lock := make(chan struct{}, 1)
+	lock <- struct{}{}
+	r := &resourceEntry{
+		key:      k,
+		lock:     lock,
+		refCount: atomic.MakeUint(1),
+	}
+	t[k] = r
+	return r
+}
+
+func (t table) Find(k ResourceKey) *resourceEntry {
+	r := t[k]
+	if r != nil {
+		r.Retain()
+	}
+	return r
+}
+
+func (t table) Remove(k ResourceKey) {
+	delete(t, k)
+}
+
+func (r *resourceEntry) Retain() {
+	r.refCount.Inc()
+}
+
+func (r *resourceEntry) Release() bool {
+	return r.refCount.Dec() == 0
+}
+
+func (r *resourceEntry) Lock() {
+	<-r.lock
+}
+
+func (r *resourceEntry) TryLock() bool {
+	select {
+	case <-r.lock:
+		return true
+	default:
+		return false
+	}
+}
+
+func (r *resourceEntry) Unlock() {
+	r.lock <- struct{}{}
+}

--- a/vendor/github.com/elastic/go-concert/LICENSE
+++ b/vendor/github.com/elastic/go-concert/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/elastic/go-concert/atomic/atomic.go
+++ b/vendor/github.com/elastic/go-concert/atomic/atomic.go
@@ -1,0 +1,94 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package atomic provides common primitive types with atomic accessors.
+package atomic
+
+import a "sync/atomic"
+
+// Bool provides an atomic boolean type.
+type Bool struct{ u Uint32 }
+
+// Int32 provides an atomic int32 type.
+type Int32 struct{ value int32 }
+
+// Int64 provides an atomic int64 type.
+type Int64 struct{ value int64 }
+
+// Uint32 provides an atomic uint32 type.
+type Uint32 struct{ value uint32 }
+
+// Uint64 provides an atomic uint64 type.
+type Uint64 struct{ value uint64 }
+
+func MakeBool(v bool) Bool             { return Bool{MakeUint32(encBool(v))} }
+func NewBool(v bool) *Bool             { return &Bool{MakeUint32(encBool(v))} }
+func (b *Bool) Load() bool             { return b.u.Load() == 1 }
+func (b *Bool) Store(v bool)           { b.u.Store(encBool(v)) }
+func (b *Bool) Swap(new bool) bool     { return b.u.Swap(encBool(new)) == 1 }
+func (b *Bool) CAS(old, new bool) bool { return b.u.CAS(encBool(old), encBool(new)) }
+
+func MakeInt32(v int32) Int32            { return Int32{v} }
+func NewInt32(v int32) *Int32            { return &Int32{v} }
+func (i *Int32) Load() int32             { return a.LoadInt32(&i.value) }
+func (i *Int32) Store(v int32)           { a.StoreInt32(&i.value, v) }
+func (i *Int32) Swap(new int32) int32    { return a.SwapInt32(&i.value, new) }
+func (i *Int32) Add(delta int32) int32   { return a.AddInt32(&i.value, delta) }
+func (i *Int32) Sub(delta int32) int32   { return a.AddInt32(&i.value, -delta) }
+func (i *Int32) Inc() int32              { return i.Add(1) }
+func (i *Int32) Dec() int32              { return i.Add(-1) }
+func (i *Int32) CAS(old, new int32) bool { return a.CompareAndSwapInt32(&i.value, old, new) }
+
+func MakeInt64(v int64) Int64            { return Int64{v} }
+func NewInt64(v int64) *Int64            { return &Int64{v} }
+func (i *Int64) Load() int64             { return a.LoadInt64(&i.value) }
+func (i *Int64) Store(v int64)           { a.StoreInt64(&i.value, v) }
+func (i *Int64) Swap(new int64) int64    { return a.SwapInt64(&i.value, new) }
+func (i *Int64) Add(delta int64) int64   { return a.AddInt64(&i.value, delta) }
+func (i *Int64) Sub(delta int64) int64   { return a.AddInt64(&i.value, -delta) }
+func (i *Int64) Inc() int64              { return i.Add(1) }
+func (i *Int64) Dec() int64              { return i.Add(-1) }
+func (i *Int64) CAS(old, new int64) bool { return a.CompareAndSwapInt64(&i.value, old, new) }
+
+func MakeUint32(v uint32) Uint32           { return Uint32{v} }
+func NewUint32(v uint32) *Uint32           { return &Uint32{v} }
+func (u *Uint32) Load() uint32             { return a.LoadUint32(&u.value) }
+func (u *Uint32) Store(v uint32)           { a.StoreUint32(&u.value, v) }
+func (u *Uint32) Swap(new uint32) uint32   { return a.SwapUint32(&u.value, new) }
+func (u *Uint32) Add(delta uint32) uint32  { return a.AddUint32(&u.value, delta) }
+func (u *Uint32) Sub(delta uint32) uint32  { return a.AddUint32(&u.value, ^uint32(delta-1)) }
+func (u *Uint32) Inc() uint32              { return u.Add(1) }
+func (u *Uint32) Dec() uint32              { return u.Add(^uint32(0)) }
+func (u *Uint32) CAS(old, new uint32) bool { return a.CompareAndSwapUint32(&u.value, old, new) }
+
+func MakeUint64(v uint64) Uint64           { return Uint64{v} }
+func NewUint64(v uint64) *Uint64           { return &Uint64{v} }
+func (u *Uint64) Load() uint64             { return a.LoadUint64(&u.value) }
+func (u *Uint64) Store(v uint64)           { a.StoreUint64(&u.value, v) }
+func (u *Uint64) Swap(new uint64) uint64   { return a.SwapUint64(&u.value, new) }
+func (u *Uint64) Add(delta uint64) uint64  { return a.AddUint64(&u.value, delta) }
+func (u *Uint64) Sub(delta uint64) uint64  { return a.AddUint64(&u.value, ^uint64(delta-1)) }
+func (u *Uint64) Inc() uint64              { return u.Add(1) }
+func (u *Uint64) Dec() uint64              { return u.Add(^uint64(0)) }
+func (u *Uint64) CAS(old, new uint64) bool { return a.CompareAndSwapUint64(&u.value, old, new) }
+
+func encBool(b bool) uint32 {
+	if b {
+		return 1
+	}
+	return 0
+}

--- a/vendor/github.com/elastic/go-concert/atomic/atomic32.go
+++ b/vendor/github.com/elastic/go-concert/atomic/atomic32.go
@@ -1,0 +1,50 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// +build 386 arm mips mipsle
+
+package atomic
+
+// atomic Uint/Int for 32bit systems
+
+// Uint provides an architecture specific atomic uint.
+type Uint struct{ a Uint32 }
+
+// Int provides an architecture specific atomic uint.
+type Int struct{ a Int32 }
+
+func MakeUint(v uint) Uint             { return Uint{MakeUint32(uint32(v))} }
+func NewUint(v uint) *Uint             { return &Uint{MakeUint32(uint32(v))} }
+func (u *Uint) Load() uint             { return uint(u.a.Load()) }
+func (u *Uint) Store(v uint)           { u.a.Store(uint32(v)) }
+func (u *Uint) Swap(new uint) uint     { return uint(u.a.Swap(uint32(new))) }
+func (u *Uint) Add(delta uint) uint    { return uint(u.a.Add(uint32(delta))) }
+func (u *Uint) Sub(delta uint) uint    { return uint(u.a.Add(uint32(-delta))) }
+func (u *Uint) Inc() uint              { return uint(u.a.Inc()) }
+func (u *Uint) Dec() uint              { return uint(u.a.Dec()) }
+func (u *Uint) CAS(old, new uint) bool { return u.a.CAS(uint32(old), uint32(new)) }
+
+func MakeInt(v int) Int              { return Int{MakeInt32(int32(v))} }
+func NewInt(v int) *Int              { return &Int{MakeInt32(int32(v))} }
+func (i *Int) Load() int             { return int(i.a.Load()) }
+func (i *Int) Store(v int)           { i.a.Store(int32(v)) }
+func (i *Int) Swap(new int) int      { return int(i.a.Swap(int32(new))) }
+func (i *Int) Add(delta int) int     { return int(i.a.Add(int32(delta))) }
+func (i *Int) Sub(delta int) int     { return int(i.a.Add(int32(-delta))) }
+func (i *Int) Inc() int              { return int(i.a.Inc()) }
+func (i *Int) Dec() int              { return int(i.a.Dec()) }
+func (i *Int) CAS(old, new int) bool { return i.a.CAS(int32(old), int32(new)) }

--- a/vendor/github.com/elastic/go-concert/atomic/atomic64.go
+++ b/vendor/github.com/elastic/go-concert/atomic/atomic64.go
@@ -1,0 +1,50 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// +build amd64 arm64 ppc64 ppc64le mips64 mips64le s390x
+
+package atomic
+
+// atomic Uint/Int for 64bit systems
+
+// Uint provides an architecture specific atomic uint.
+type Uint struct{ a Uint64 }
+
+// Int provides an architecture specific atomic uint.
+type Int struct{ a Int64 }
+
+func MakeUint(v uint) Uint             { return Uint{MakeUint64(uint64(v))} }
+func NewUint(v uint) *Uint             { return &Uint{MakeUint64(uint64(v))} }
+func (u *Uint) Load() uint             { return uint(u.a.Load()) }
+func (u *Uint) Store(v uint)           { u.a.Store(uint64(v)) }
+func (u *Uint) Swap(new uint) uint     { return uint(u.a.Swap(uint64(new))) }
+func (u *Uint) Add(delta uint) uint    { return uint(u.a.Add(uint64(delta))) }
+func (u *Uint) Sub(delta uint) uint    { return uint(u.a.Add(uint64(-delta))) }
+func (u *Uint) Inc() uint              { return uint(u.a.Inc()) }
+func (u *Uint) Dec() uint              { return uint(u.a.Dec()) }
+func (u *Uint) CAS(old, new uint) bool { return u.a.CAS(uint64(old), uint64(new)) }
+
+func MakeInt(v int) Int              { return Int{MakeInt64(int64(v))} }
+func NewInt(v int) *Int              { return &Int{MakeInt64(int64(v))} }
+func (i *Int) Load() int             { return int(i.a.Load()) }
+func (i *Int) Store(v int)           { i.a.Store(int64(v)) }
+func (i *Int) Swap(new int) int      { return int(i.a.Swap(int64(new))) }
+func (i *Int) Add(delta int) int     { return int(i.a.Add(int64(delta))) }
+func (i *Int) Sub(delta int) int     { return int(i.a.Add(int64(-delta))) }
+func (i *Int) Inc() int              { return int(i.a.Inc()) }
+func (i *Int) Dec() int              { return int(i.a.Dec()) }
+func (i *Int) CAS(old, new int) bool { return i.a.CAS(int64(old), int64(new)) }

--- a/vendor/github.com/elastic/go-concert/chorus/closeref.go
+++ b/vendor/github.com/elastic/go-concert/chorus/closeref.go
@@ -1,0 +1,143 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package chorus
+
+import (
+	"errors"
+	"sync"
+	"time"
+)
+
+// CloserFunc is the function called by the Closer on `Close()`.
+type CloserFunc func()
+
+// ErrClosed is returned when the Closer is closed.
+var ErrClosed = errors.New("closer is closed")
+
+// CloseRef implements a subset of the context.Context interface and it's use to synchronize
+// the shutdown of multiple go-routines.
+type CloseRef interface {
+	Done() <-chan struct{}
+	Err() error
+	Deadline() (time.Time, bool)
+	Value(key interface{}) interface{}
+}
+
+// Closer implements a shutdown strategy when dealing with multiples go-routines, it creates a tree
+// of Closer, when you call `Close()` on a parent the `Close()` method will be called on the current
+// closer and any of the childs it may have and will remove the current node from the parent.
+//
+// NOTE: The `Close()` is reentrant but will propagate the close only once.
+type Closer struct {
+	mu       sync.Mutex
+	done     chan struct{}
+	err      error
+	parent   *Closer
+	children map[*Closer]struct{}
+	callback CloserFunc
+}
+
+// Close closes the closes and propagates the close to any child, on close the close callback will
+// be called, this can be used for custom cleanup like closing a TCP socket.
+func (c *Closer) Close() {
+	c.mu.Lock()
+	if c.err != nil {
+		c.mu.Unlock()
+		return
+	}
+
+	if c.callback != nil {
+		c.callback()
+	}
+
+	close(c.done)
+
+	// propagate close to children.
+	if c.children != nil {
+		for child := range c.children {
+			child.Close()
+		}
+		c.children = nil
+	}
+
+	c.err = ErrClosed
+	c.mu.Unlock()
+
+	if c.parent != nil {
+		c.removeChild(c)
+	}
+}
+
+// Done returns the synchronization channel, the channel will be closed if `Close()` was called on
+// the current node or any parent it may have.
+func (c *Closer) Done() <-chan struct{} {
+	return c.done
+}
+
+// Err returns an error if the Closer was already closed.
+func (c *Closer) Err() error {
+	c.mu.Lock()
+	err := c.err
+	c.mu.Unlock()
+	return err
+}
+
+// Deadline implements the Deadline() method of the context.Context interface but will always return
+// false.
+func (c *Closer) Deadline() (time.Time, bool) {
+	return time.Time{}, false
+}
+
+// Value implements the Value() method of the contxt.Context interface
+func (c *Closer) Value(key interface{}) interface{} {
+	return nil
+}
+
+func (c *Closer) removeChild(child *Closer) {
+	c.mu.Lock()
+	delete(c.children, child)
+	c.mu.Unlock()
+}
+
+func (c *Closer) addChild(child *Closer) {
+	c.mu.Lock()
+	if c.children == nil {
+		c.children = make(map[*Closer]struct{})
+	}
+	c.children[child] = struct{}{}
+	c.mu.Unlock()
+}
+
+// WithCloser wraps a new closer into a child of an existing closer.
+func WithCloser(parent *Closer, fn CloserFunc) *Closer {
+	child := &Closer{
+		done:     make(chan struct{}),
+		parent:   parent,
+		callback: fn,
+	}
+	parent.addChild(child)
+	return child
+}
+
+// NewCloser creates a new Closer.
+func NewCloser(fn CloserFunc) *Closer {
+	return &Closer{
+		done:     make(chan struct{}),
+		callback: fn,
+	}
+}

--- a/vendor/github.com/elastic/go-concert/go.mod
+++ b/vendor/github.com/elastic/go-concert/go.mod
@@ -1,0 +1,5 @@
+module github.com/elastic/go-concert
+
+go 1.12
+
+require github.com/stretchr/testify v1.3.0

--- a/vendor/github.com/elastic/go-concert/go.sum
+++ b/vendor/github.com/elastic/go-concert/go.sum
@@ -1,0 +1,7 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/vendor/github.com/elastic/go-concert/nocopy.go
+++ b/vendor/github.com/elastic/go-concert/nocopy.go
@@ -1,0 +1,24 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package concert
+
+// Types using with noCopy will be flagged by `go vet`.
+// See: https://github.com/golang/go/issues/8005#issuecomment-190753527
+type noCopy struct{}
+
+func (*noCopy) Lock() {}

--- a/vendor/github.com/elastic/go-concert/refcount.go
+++ b/vendor/github.com/elastic/go-concert/refcount.go
@@ -1,0 +1,101 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package concert
+
+import (
+	"sync"
+
+	"github.com/elastic/go-concert/atomic"
+)
+
+// RefCount is an atomic reference counter. It can be used to track a shared
+// resource it's lifetime and execute an action once it is clear the resource is
+// not needed anymore.
+//
+// The zero value of RefCount is already in a valid state, which can be
+// Released already.
+type RefCount struct {
+	count atomic.Uint32
+
+	errMux sync.Mutex
+	err    error
+
+	Action  func(err error)
+	OnError func(old, new error) error
+}
+
+// refCountFree indicates when a RefCount.Release shall return true.  It's
+// chosen such that the zero value of RefCount is a valid value which will
+// return true if Release is called without calling Retain before.
+const refCountFree uint32 = ^uint32(0)
+const refCountOops uint32 = refCountFree - 1
+
+// Retain increases the ref count.
+func (c *RefCount) Retain() {
+	if c.count.Inc() == 0 {
+		panic("retaining released ref count")
+	}
+}
+
+// Release decreases the reference count. It returns true, if the reference count
+// has reached a 'free' state.
+// Releasing a reference count in a free state will trigger a panic.
+// If an Action is configured, then this action will be run once the
+// refcount becomes free.
+func (c *RefCount) Release() bool {
+	switch c.count.Dec() {
+	case refCountFree:
+		if c.Action != nil {
+			c.Action(c.err)
+		}
+		return true
+	case refCountOops:
+		panic("ref count released too often")
+	default:
+		return false
+	}
+}
+
+// Err returns the current error stored by the reference counter.
+func (c *RefCount) Err() error {
+	c.errMux.Lock()
+	defer c.errMux.Unlock()
+	return c.err
+}
+
+// Fail adds an error to the reference counter.
+// OnError will be called if configured, so to compute the actual error.
+// If OnError is not configured, the first error reported will be stored by
+// the reference counter only.
+//
+// Fail releases the reference counter.
+func (c *RefCount) Fail(err error) bool {
+	// use dummy function to handle the error, ensuring errMux.Unlock will be
+	// executed before the call to Release or in case OnError panics.
+	func() {
+		c.errMux.Lock()
+		defer c.errMux.Unlock()
+		if c.OnError != nil {
+			c.err = c.OnError(c.err, err)
+		} else if c.err == nil {
+			c.err = err
+		}
+	}()
+
+	return c.Release()
+}

--- a/vendor/github.com/elastic/go-concert/unison/txlock.go
+++ b/vendor/github.com/elastic/go-concert/unison/txlock.go
@@ -1,0 +1,192 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package unison
+
+import "sync"
+
+// TxLock provides locking support for transactional updates with multiple concurrent readers
+// and one writer. Unlike sync.RWLock, the writer and readers can coexist.
+// Users of TxLock must ensure proper isolation, between writers/readers.
+// Changes by the writer must not be accessible by readers yet. A writer should
+// hold the exclusive lock before making the changes available to others.
+//
+// Lock types:
+//   - Shared: Shared locks are used by readonly loads. Multiple readers
+//             can co-exist with one active writer.
+//   - Reserved: Writer use the reserved lock. Once locked no other
+//               writer can acquire the Reserved lock. The shared lock can
+//               still be locked by concurrent readers.
+//   - Pending: The pending lock is used by the writer to signal
+//              a write is about to be committed.  After acquiring the pending
+//              lock no new reader is allowed to acquire the shared lock.
+//              Readers will have to wait until the pending lock is released.
+//              Existing readers can still coexist, but no new reader is
+//              allowed.
+//   - Exclusive: Once the exclusive lock is acquired by a write transaction,
+//                No other active transactions/locks exist anymore.
+//                Locking the exclusive lock blocks until the shared lock has been
+//                released by all readers.
+//
+// Each Locktype can be accessed using `(*lock).<Type>()`. Each lock type
+// implements a `Lock` and `Unlock` method.
+//
+// The zero value of TxLock must not be used.
+type TxLock struct {
+	mu sync.Mutex
+
+	// conditions + mutexes
+	shared    *sync.Cond
+	exclusive *sync.Cond
+	reserved  sync.Mutex
+
+	// state
+	sharedCount uint
+	reservedSet bool
+	pendingSet  bool
+}
+
+// TxSharedLock is used by readers to lock the shared lock on a TxLock.
+type TxSharedLock TxLock
+
+// TxReservedLock is used by writers to lock the reserved lock on a TxLock.
+// Only one go-routine is allowed to acquire the reserved lock at a time.
+type TxReservedLock TxLock
+
+// TxPendingLock is used by writers to signal the TxLock that the shared lock
+// can not be acquired anymore. Readers will unblock once Unlock on the pending
+// lock is called.
+type TxPendingLock TxLock
+
+// TxExclusiveLock is used by writers to wait for exclusive access to all resources.
+// The writer should make changes visible to future readers only after acquiring the
+// exclusive lock.
+type TxExclusiveLock TxLock
+
+// NewTxLock creates a new initialized TxLock instance.
+func NewTxLock() *TxLock {
+	l := &TxLock{}
+	l.shared = sync.NewCond(&l.mu)
+	l.exclusive = sync.NewCond(&l.mu)
+	return l
+}
+
+// Get returns the standard Locker for the given transaction type.
+func (l *TxLock) Get(readonly bool) sync.Locker {
+	if readonly {
+		return l.Shared()
+	}
+	return l.Reserved()
+}
+
+// Shared returns the files shared locker.
+func (l *TxLock) Shared() *TxSharedLock { return (*TxSharedLock)(l) }
+
+// Reserved returns the files reserved locker.
+func (l *TxLock) Reserved() *TxReservedLock { return (*TxReservedLock)(l) }
+
+// Pending returns the files pending locker.
+func (l *TxLock) Pending() *TxPendingLock { return (*TxPendingLock)(l) }
+
+// Exclusive returns the files exclusive locker.
+func (l *TxLock) Exclusive() *TxExclusiveLock { return (*TxExclusiveLock)(l) }
+
+// Lock locks the shared lock. It blocks as long as the pending lock
+// is in use.
+func (l *TxSharedLock) Lock() {
+	waitCond(l.shared, l.check, l.inc)
+}
+
+// Unlock unlocks the shared lock. Unlocking potentially unblocks a waiting
+// exclusive lock.
+func (l *TxSharedLock) Unlock() {
+	withLocker(&l.mu, l.dec)
+}
+
+func (l *TxSharedLock) check() bool { return !l.pendingSet }
+func (l *TxSharedLock) inc()        { l.sharedCount++ }
+func (l *TxSharedLock) dec() {
+	l.sharedCount--
+	if l.sharedCount == 0 {
+		l.exclusive.Signal()
+	}
+}
+
+// Lock acquires the reserved lock. Only one go-routine can hold the reserved
+// lock at a time.  The reserved lock should only be acquire by writers.
+// Writers must not acquire the shared lock.
+func (l *TxReservedLock) Lock() {
+	l.reserved.Lock()
+	l.reservedSet = true
+}
+
+// Unlock releases the reserved lock.
+func (l *TxReservedLock) Unlock() {
+	l.reservedSet = false
+	l.reserved.Unlock()
+}
+
+// Lock acquires the pending lock. The reserved lock must be acquired before.
+func (l *TxPendingLock) Lock() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if !l.reservedSet {
+		panic("reserved lock must be set when acquiring the pending lock")
+	}
+
+	l.pendingSet = true
+}
+
+// Unlock releases the pending lock, potentially unblocking waiting readers.
+func (l *TxPendingLock) Unlock() {
+	l.mu.Lock()
+	l.pendingSet = false
+	l.mu.Unlock()
+	l.shared.Broadcast()
+}
+
+// Lock acquires the exclusive lock. Once acquired it is guaranteed that no
+// other reader or writer go-routine exists.
+func (l *TxExclusiveLock) Lock() {
+	if !l.pendingSet {
+		panic("the pending lock must be set when acquiring the exclusive lock")
+	}
+	waitCond(l.exclusive, l.check, func() {})
+}
+
+// Unlock is a noop. It guarantees that TxExclusiveLock is compatible to sync.Locker.
+func (l *TxExclusiveLock) Unlock() {}
+
+func (l *TxExclusiveLock) check() bool {
+	return l.sharedCount == 0
+}
+
+func waitCond(c *sync.Cond, check func() bool, upd func()) {
+	withLocker(c.L, func() {
+		for !check() {
+			c.Wait()
+		}
+		upd()
+	})
+}
+
+func withLocker(l sync.Locker, fn func()) {
+	l.Lock()
+	defer l.Unlock()
+	fn()
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1478,6 +1478,30 @@
 			"versionExact": "v1.2.0"
 		},
 		{
+			"checksumSHA1": "V+r7NSRZqAx2HLhhvOfw9+ctIlI=",
+			"path": "github.com/elastic/go-concert",
+			"revision": "fde4d7dd2a8c9d3f3c1fc9d22c09dace470433ae",
+			"revisionTime": "2019-09-11T17:14:06Z"
+		},
+		{
+			"checksumSHA1": "6FjgowCMg4JtLjSvnbVilbRlNu4=",
+			"path": "github.com/elastic/go-concert/atomic",
+			"revision": "fde4d7dd2a8c9d3f3c1fc9d22c09dace470433ae",
+			"revisionTime": "2019-09-11T17:14:06Z"
+		},
+		{
+			"checksumSHA1": "RErDB+9dmVYyDazSPDeRZ+L5Blo=",
+			"path": "github.com/elastic/go-concert/chorus",
+			"revision": "fde4d7dd2a8c9d3f3c1fc9d22c09dace470433ae",
+			"revisionTime": "2019-09-11T17:14:06Z"
+		},
+		{
+			"checksumSHA1": "Ft8EkWsK3G7gCn093PmgwDtqwyw=",
+			"path": "github.com/elastic/go-concert/unison",
+			"revision": "fde4d7dd2a8c9d3f3c1fc9d22c09dace470433ae",
+			"revisionTime": "2019-09-11T17:14:06Z"
+		},
+		{
 			"checksumSHA1": "vNnw1bUS8Ct+8H64QuA2DWRJ9SQ=",
 			"path": "github.com/elastic/go-libaudit",
 			"revision": "39073a2988f718067d85d27a4d18b1b57de5d947",


### PR DESCRIPTION
Requires: elastic/beats#14144 

The change introduces the statestore package that provides some coordinated access to the registry file.

The store does not implement removal yet. I'm thinking to rather have some GC based approach. This would make it easier to clean stale entries of configs that have gone. Well, and I didn't want the PR to grow too much :)

Go doc:
```
Package statestore provides coordinated access to entries in the registry
via resources.

A Store supports selective update of fields using go structures. Data to be
stored in the registry should be split into resource identifying meta-data
and read state data. This allows inputs to have separate go-routines for
updating resource tracking meta-data (like file path upon file renames) and
for read state updates (like file offset).

The registry is only eventually consistent to the current state of the
store. When using (*Resource).Update, both the in-memory state and the
registry state will be updated immediately. But when using
(*Resource).UpdateOp, only the in memory state will be updated. The registry
state must be updated using the ResourceUpdateOp, after the associated
events have been ACKed by the outputs. Once all pending update operations
have been applied the in-memory state and the persistent state are assumed
to be in-sync, and the in-memory state is dropped so to free some memory.

The eventual consistency allows resources to be Unlocked and Locked by
another go-routine immediately, as the final read state from the former
go-routine is available right away. The lock guarantees exclusive access. In
the meantime older updates might still be applied to the registry file,
while the new go-routine can start creating new update operations
concurrently to be applied to after already pending updates.

VARIABLES

var (
	ErrCodeOpFailed = errors.New("operation failed")
)
var (
	ErrResourceInUse = errors.New("resource in use")
)

TYPES

type Error struct {
	// Has unexported fields.
}
    Error provides a common error type used by the statestore package. It
    reports the failed operation, custom message and the root cause if
    available.

func (e *Error) Code() error
    Code returns a sentinal error that can be used for checking the error type.

func (e *Error) Error() string
    Error builds the complete error string.

func (e *Error) Op() string
    Op returns the name of the operation that failed.

func (e *Error) Unwrap() error
    Unwrap returns the cause if available.

type Resource struct {
	// Has unexported fields.
}
    Resource is used to lock and modify a resource its registry contents in a
    store.

func (r *Resource) Has() (bool, error)
    Has check if resource is already in registry. Has does not require the lock
    to be taken.

func (r *Resource) IsLocked() bool
    IsLocked checks if the resource currently holds the lock to the shared
    registry entry.

func (r *Resource) Lock()
    Lock locks a resource held by the store. It blocks until the lock becomes
    available.

func (r *Resource) Read(to interface{}) error
    read current state of resource. If there are pending operations, this is the
    last in-memory state. If there are no operations, or all pending operations
    have been acked, we read directly from the registry. Read does not require
    the resource to be locked. But if the lock is not taken, you are subject to
    data races as the go-routine holding a lock on the resource can update its
    contents.

func (r *Resource) TryLock() bool
    TryLock attempts to lock the resource. It returns true if the lock has been
    acquired successfully.

func (r *Resource) Unlock()
    Unlock releases a resource.

func (r *Resource) Update(val interface{}) error
    Update the registry state with fields in val. If the resource key is
    unknown, then a new document is inserted into the registry. Update requires
    the resource to be locked.

    It is recommended to use Update only for resource meta-data updates, that
    allow us to track and identify a resource. Read state updates should be
    handled by UpdateOp.

    The update call is thread-safe, as the update operation itself is protected.
    But data races are still possible, if any two go-routines update an
    overlapping set of fields.

func (r *Resource) UpdateOp(val interface{}) (*ResourceUpdateOp, error)
    UpdateOp creates a resource update operation. The in memory state of the
    resource is updated right away, but the persistent registry state is not
    updated yet. Executing the returned operation updates the persistent state
    and invalidates the operation. As long as there are active operations, the
    in-memory state and the persistent state are not in sync yet. If in-memory
    state and active operations are not in sync, then read operations will use
    the in-memory state only.

    It is recommended to use UpdateOp for read state updates only. Resource
    metadata should be updated using Update instead.

type ResourceKey string

type ResourceUpdateOp struct {
	// Has unexported fields.
}
    ResourceUpdateOp defers a state update to be written to the persistent
    store. The operation can be applied to the registry using ApplyWith. Calling
    Close will mark the operation as done.

func (op *ResourceUpdateOp) ApplyWith(withTx func(*registry.Store, func(*registry.Tx) error) error) error
    ApplyWith applies the operation using the withTx helper function. The helper
    function is responsible for creating and maintaining a write transaction for
    the provided store. If possible the helper should keep the transaction open
    if an array of operations are applied.

func (op *ResourceUpdateOp) Close()
    Close marks the operation as done. ApplyWith can not be run anymore
    afterwards. If all pending operations have been closed, the persistent store
    is assumed to be in sync with the in memory state.

type Store struct {
	// Has unexported fields.
}
    Store provides some coordinates access to a registry.Store. All update and
    read operations require users to acquire an resource first. A Resource must
    be locked before it can be modified. This ensures that at most one
    go-routine has access to a resource. Lock/TryLock/Unlack can be used to
    coordinate resource access even between independent components.

func NewStore(log *logp.Logger, store *registry.Store) *Store
    NewStore creates a new state Store that is backed by a persistent store.

func (s *Store) Access(key ResourceKey) *Resource
    Access an unlocked resource. This creates a handle to a resource that may
    not yet exist in the persistent registry.

func (s *Store) Lock(key ResourceKey) *Resource
    Lock locks and returns the resource for a given key.

func (s *Store) TryLock(key ResourceKey) (res *Resource, locked bool)
    TryLock locks and returns the resource for a given key. The locked return
    value is set to false if TryLock failed, but the resource itself is always
    returned.
```

